### PR TITLE
replaced unittest assertions pytest assertions (5)

### DIFF
--- a/scripts/xsslint/tests/test_linters.py
+++ b/scripts/xsslint/tests/test_linters.py
@@ -71,9 +71,9 @@ class TestLinter(TestCase):
             for violation in results.violations:
                 print("Found violation: {}".format(violation.rule))
 
-        self.assertEqual(len(results.violations), len(rules))
+        assert len(results.violations) == len(rules)
         for violation, rule in zip(results.violations, rules):
-            self.assertEqual(violation.rule, rule)
+            assert violation.rule == rule
 
 
 @ddt
@@ -99,7 +99,7 @@ class TestUnderscoreTemplateLinter(TestLinter):
 
         linter.check_underscore_file_is_safe(template, results)
 
-        self.assertEqual(len(results.violations), 0)
+        assert len(results.violations) == 0
 
     def test_check_underscore_file_is_not_safe(self):
         """
@@ -118,9 +118,9 @@ class TestUnderscoreTemplateLinter(TestLinter):
 
         linter.check_underscore_file_is_safe(template, results)
 
-        self.assertEqual(len(results.violations), 2)
-        self.assertEqual(results.violations[0].rule, UNDERSCORE_LINTER_RULESET.underscore_not_escaped)
-        self.assertEqual(results.violations[1].rule, UNDERSCORE_LINTER_RULESET.underscore_not_escaped)
+        assert len(results.violations) == 2
+        assert results.violations[0].rule == UNDERSCORE_LINTER_RULESET.underscore_not_escaped
+        assert results.violations[1].rule == UNDERSCORE_LINTER_RULESET.underscore_not_escaped
 
     @data(
         {
@@ -182,9 +182,9 @@ class TestUnderscoreTemplateLinter(TestLinter):
         linter.check_underscore_file_is_safe(data['template'], results)
 
         violation_count = len(data['is_disabled'])
-        self.assertEqual(len(results.violations), violation_count)
+        assert len(results.violations) == violation_count
         for index in range(0, violation_count - 1):
-            self.assertEqual(results.violations[index].is_disabled, data['is_disabled'][index])
+            assert results.violations[index].is_disabled == data['is_disabled'][index]
 
     def test_check_underscore_file_disables_one_violation(self):
         """
@@ -202,9 +202,9 @@ class TestUnderscoreTemplateLinter(TestLinter):
 
         linter.check_underscore_file_is_safe(template, results)
 
-        self.assertEqual(len(results.violations), 2)
-        self.assertEqual(results.violations[0].is_disabled, True)
-        self.assertEqual(results.violations[1].is_disabled, False)
+        assert len(results.violations) == 2
+        assert results.violations[0].is_disabled is True
+        assert results.violations[1].is_disabled is False
 
     @data(
         {'template': '<%= edx.HtmlUtils.ensureHtml(message) %>'},
@@ -221,7 +221,7 @@ class TestUnderscoreTemplateLinter(TestLinter):
 
         linter.check_underscore_file_is_safe(data['template'], results)
 
-        self.assertEqual(len(results.violations), 0)
+        assert len(results.violations) == 0
 
 
 @ddt
@@ -468,8 +468,8 @@ class TestPythonLinter(TestLinter):
 
         linter.check_python_file_is_safe(python_file, results)
 
-        self.assertEqual(len(results.violations), 1)
-        self.assertEqual(results.violations[0].rule, PYTHON_LINTER_RULESET.python_deprecated_display_name)
+        assert len(results.violations) == 1
+        assert results.violations[0].rule == PYTHON_LINTER_RULESET.python_deprecated_display_name
 
     def test_check_custom_escaping(self):
         """
@@ -484,8 +484,8 @@ class TestPythonLinter(TestLinter):
 
         linter.check_python_file_is_safe(python_file, results)
 
-        self.assertEqual(len(results.violations), 1)
-        self.assertEqual(results.violations[0].rule, PYTHON_LINTER_RULESET.python_custom_escape)
+        assert len(results.violations) == 1
+        assert results.violations[0].rule == PYTHON_LINTER_RULESET.python_custom_escape
 
     @data(
         {
@@ -663,12 +663,12 @@ class TestPythonLinter(TestLinter):
 
         results.violations.sort(key=lambda violation: violation.sort_key())
 
-        self.assertEqual(len(results.violations), 5)
-        self.assertEqual(results.violations[0].rule, PYTHON_LINTER_RULESET.python_wrap_html)
-        self.assertEqual(results.violations[1].rule, PYTHON_LINTER_RULESET.python_requires_html_or_text)
-        self.assertEqual(results.violations[2].rule, PYTHON_LINTER_RULESET.python_close_before_format)
-        self.assertEqual(results.violations[3].rule, PYTHON_LINTER_RULESET.python_wrap_html)
-        self.assertEqual(results.violations[4].rule, PYTHON_LINTER_RULESET.python_interpolate_html)
+        assert len(results.violations) == 5
+        assert results.violations[0].rule == PYTHON_LINTER_RULESET.python_wrap_html
+        assert results.violations[1].rule == PYTHON_LINTER_RULESET.python_requires_html_or_text
+        assert results.violations[2].rule == PYTHON_LINTER_RULESET.python_close_before_format
+        assert results.violations[3].rule == PYTHON_LINTER_RULESET.python_wrap_html
+        assert results.violations[4].rule == PYTHON_LINTER_RULESET.python_interpolate_html
 
     @data(
         {
@@ -742,7 +742,7 @@ class TestPythonLinter(TestLinter):
         linter.check_python_file_is_safe(file_content, results)
 
         self._validate_data_rules(data, results)
-        self.assertEqual(results.violations[0].start_line, data['start_line'])
+        assert results.violations[0].start_line == data['start_line']
 
 
 @ddt
@@ -766,7 +766,7 @@ class TestMakoTemplateLinter(TestLinter):
         linter = _build_mako_linter()
         linter._skip_mako_dirs = ('test_root',)
 
-        self.assertEqual(linter._is_valid_directory(data['directory']), data['expected'])
+        assert linter._is_valid_directory(data['directory']) == data['expected']
 
     @data(
         {
@@ -818,9 +818,9 @@ class TestMakoTemplateLinter(TestLinter):
         linter._check_mako_file_is_safe(data['template'], results)
 
         num_violations = 0 if data['rule'] is None else 1
-        self.assertEqual(len(results.violations), num_violations)
+        assert len(results.violations) == num_violations
         if num_violations > 0:
-            self.assertEqual(results.violations[0].rule, data['rule'])
+            assert results.violations[0].rule == data['rule']
 
     @data(
         {'expression': '${x}', 'rule': None},
@@ -862,8 +862,8 @@ class TestMakoTemplateLinter(TestLinter):
 
         linter._check_mako_file_is_safe(mako_template, results)
 
-        self.assertEqual(len(results.violations), 1)
-        self.assertEqual(results.violations[0].rule, MAKO_LINTER_RULESET.python_deprecated_display_name)
+        assert len(results.violations) == 1
+        assert results.violations[0].rule == MAKO_LINTER_RULESET.python_deprecated_display_name
 
     @data(
         {
@@ -1022,8 +1022,8 @@ class TestMakoTemplateLinter(TestLinter):
 
         linter._check_mako_file_is_safe(mako_template, results)
 
-        self.assertEqual(len(results.violations), 1)
-        self.assertEqual(results.violations[0].rule, MAKO_LINTER_RULESET.mako_missing_default)
+        assert len(results.violations) == 1
+        assert results.violations[0].rule == MAKO_LINTER_RULESET.mako_missing_default
 
     def test_check_mako_expression_default_disabled(self):
         """
@@ -1042,8 +1042,8 @@ class TestMakoTemplateLinter(TestLinter):
 
         linter._check_mako_file_is_safe(mako_template, results)
 
-        self.assertEqual(len(results.violations), 1)
-        self.assertTrue(results.violations[0].is_disabled)
+        assert len(results.violations) == 1
+        assert results.violations[0].is_disabled
 
     def test_check_mako_expression_disabled(self):
         """
@@ -1061,8 +1061,8 @@ class TestMakoTemplateLinter(TestLinter):
 
         linter._check_mako_file_is_safe(mako_template, results)
 
-        self.assertEqual(len(results.violations), 1)
-        self.assertTrue(results.violations[0].is_disabled)
+        assert len(results.violations) == 1
+        assert results.violations[0].is_disabled
 
     @data(
         {'template': '{% extends "wiki/base.html" %}'},
@@ -1079,7 +1079,7 @@ class TestMakoTemplateLinter(TestLinter):
 
         linter._check_mako_file_is_safe(data['template'], results)
 
-        self.assertEqual(len(results.violations), 0)
+        assert len(results.violations) == 0
 
     def test_check_mako_expressions_in_html_with_escape_filter(self):
         """
@@ -1095,7 +1095,7 @@ class TestMakoTemplateLinter(TestLinter):
         """)
 
         linter._check_mako_file_is_safe(mako_template, results)
-        self.assertEqual(len(results.violations), 0)
+        assert len(results.violations) == 0
 
     def test_check_mako_expressions_in_html_without_default(self):
         """
@@ -1111,8 +1111,8 @@ class TestMakoTemplateLinter(TestLinter):
 
         linter._check_mako_file_is_safe(mako_template, results)
 
-        self.assertEqual(len(results.violations), 1)
-        self.assertEqual(results.violations[0].rule, MAKO_LINTER_RULESET.mako_missing_default)
+        assert len(results.violations) == 1
+        assert results.violations[0].rule == MAKO_LINTER_RULESET.mako_missing_default
 
     @data(
         {'expression': '${x}', 'rule': MAKO_LINTER_RULESET.mako_invalid_js_filter},
@@ -1254,14 +1254,14 @@ class TestMakoTemplateLinter(TestLinter):
 
         linter._check_mako_file_is_safe(mako_template, results)
 
-        self.assertEqual(len(results.violations), 7)
-        self.assertEqual(results.violations[0].rule, MAKO_LINTER_RULESET.mako_unwanted_html_filter)
-        self.assertEqual(results.violations[1].rule, MAKO_LINTER_RULESET.mako_invalid_js_filter)
-        self.assertEqual(results.violations[2].rule, MAKO_LINTER_RULESET.mako_unwanted_html_filter)
-        self.assertEqual(results.violations[3].rule, MAKO_LINTER_RULESET.mako_invalid_js_filter)
-        self.assertEqual(results.violations[4].rule, MAKO_LINTER_RULESET.mako_unwanted_html_filter)
-        self.assertEqual(results.violations[5].rule, MAKO_LINTER_RULESET.mako_invalid_js_filter)
-        self.assertEqual(results.violations[6].rule, MAKO_LINTER_RULESET.mako_unwanted_html_filter)
+        assert len(results.violations) == 7
+        assert results.violations[0].rule == MAKO_LINTER_RULESET.mako_unwanted_html_filter
+        assert results.violations[1].rule == MAKO_LINTER_RULESET.mako_invalid_js_filter
+        assert results.violations[2].rule == MAKO_LINTER_RULESET.mako_unwanted_html_filter
+        assert results.violations[3].rule == MAKO_LINTER_RULESET.mako_invalid_js_filter
+        assert results.violations[4].rule == MAKO_LINTER_RULESET.mako_unwanted_html_filter
+        assert results.violations[5].rule == MAKO_LINTER_RULESET.mako_invalid_js_filter
+        assert results.violations[6].rule == MAKO_LINTER_RULESET.mako_unwanted_html_filter
 
     def test_check_mako_expressions_javascript_strings(self):
         """
@@ -1294,10 +1294,10 @@ class TestMakoTemplateLinter(TestLinter):
 
         linter._check_mako_file_is_safe(mako_template, results)
 
-        self.assertEqual(len(results.violations), 3)
-        self.assertEqual(results.violations[0].rule, MAKO_LINTER_RULESET.mako_js_missing_quotes)
-        self.assertEqual(results.violations[1].rule, MAKO_LINTER_RULESET.mako_js_html_string)
-        self.assertEqual(results.violations[2].rule, MAKO_LINTER_RULESET.mako_js_html_string)
+        assert len(results.violations) == 3
+        assert results.violations[0].rule == MAKO_LINTER_RULESET.mako_js_missing_quotes
+        assert results.violations[1].rule == MAKO_LINTER_RULESET.mako_js_html_string
+        assert results.violations[2].rule == MAKO_LINTER_RULESET.mako_js_html_string
 
     def test_check_javascript_in_mako_javascript_context(self):
         """
@@ -1316,9 +1316,9 @@ class TestMakoTemplateLinter(TestLinter):
 
         linter._check_mako_file_is_safe(mako_template, results)
 
-        self.assertEqual(len(results.violations), 1)
-        self.assertEqual(results.violations[0].rule, MAKO_LINTER_RULESET.javascript_concat_html)
-        self.assertEqual(results.violations[0].start_line, 4)
+        assert len(results.violations) == 1
+        assert results.violations[0].rule == MAKO_LINTER_RULESET.javascript_concat_html
+        assert results.violations[0].start_line == 4
 
     @data(
         {'template': "\n${x | n}", 'parseable': True},
@@ -1343,22 +1343,22 @@ class TestMakoTemplateLinter(TestLinter):
 
         linter._check_mako_file_is_safe(data['template'], results)
 
-        self.assertEqual(len(results.violations), 2)
-        self.assertEqual(results.violations[0].rule, MAKO_LINTER_RULESET.mako_missing_default)
+        assert len(results.violations) == 2
+        assert results.violations[0].rule == MAKO_LINTER_RULESET.mako_missing_default
 
         violation = results.violations[1]
         lines = list(data['template'].splitlines())
-        self.assertTrue("${" in lines[violation.start_line - 1])
-        self.assertTrue(lines[violation.start_line - 1].startswith("${", violation.start_column - 1))
+        assert ('${' in lines[(violation.start_line - 1)])
+        assert lines[(violation.start_line - 1)].startswith('${', (violation.start_column - 1))
         if data['parseable']:
-            self.assertTrue("}" in lines[violation.end_line - 1])
-            self.assertTrue(lines[violation.end_line - 1].startswith("}", violation.end_column - len("}") - 1))
+            assert ('}' in lines[(violation.end_line - 1)])
+            assert lines[(violation.end_line - 1)].startswith('}', ((violation.end_column - len('}')) - 1))
         else:
-            self.assertEqual(violation.start_line, violation.end_line)
-            self.assertEqual(violation.end_column, "?")
-        self.assertEqual(len(violation.lines), violation.end_line - violation.start_line + 1)
+            assert violation.start_line == violation.end_line
+            assert violation.end_column == '?'
+        assert len(violation.lines) == ((violation.end_line - violation.start_line) + 1)
         for line_index in range(0, len(violation.lines)):
-            self.assertEqual(violation.lines[line_index], lines[line_index + violation.start_line - 1])
+            assert violation.lines[line_index] == lines[((line_index + violation.start_line) - 1)]
 
     @data(
         {'template': "${x}"},
@@ -1377,11 +1377,11 @@ class TestMakoTemplateLinter(TestLinter):
 
         expressions = linter._find_mako_expressions(data['template'])
 
-        self.assertEqual(len(expressions), 1)
+        assert len(expressions) == 1
         start_index = expressions[0].start_index
         end_index = expressions[0].end_index
-        self.assertEqual(data['template'][start_index:end_index], data['template'].strip())
-        self.assertEqual(expressions[0].expression, data['template'].strip())
+        assert data['template'][start_index:end_index] == data['template'].strip()
+        assert expressions[0].expression == data['template'].strip()
 
     @data(
         {'template': " ${{unparseable} ${}", 'start_index': 1},
@@ -1394,9 +1394,9 @@ class TestMakoTemplateLinter(TestLinter):
         linter = _build_mako_linter()
 
         expressions = linter._find_mako_expressions(data['template'])
-        self.assertTrue(2 <= len(expressions))
-        self.assertEqual(expressions[0].start_index, data['start_index'])
-        self.assertIsNone(expressions[0].expression)
+        assert (2 <= len(expressions))
+        assert expressions[0].start_index == data['start_index']
+        assert expressions[0].expression is None
 
     @data(
         {
@@ -1439,10 +1439,10 @@ class TestMakoTemplateLinter(TestLinter):
 
         self.assertDictEqual(string_dict, data['result'])
         if parse_string.end_index is not None:
-            self.assertEqual(data['template'][parse_string.start_index:parse_string.end_index], parse_string.string)
+            assert data['template'][parse_string.start_index:parse_string.end_index] == parse_string.string
             start_inner_index = parse_string.start_index + parse_string.quote_length
             end_inner_index = parse_string.end_index - parse_string.quote_length
-            self.assertEqual(data['template'][start_inner_index:end_inner_index], parse_string.string_inner)
+            assert data['template'][start_inner_index:end_inner_index] == parse_string.string_inner
 
 
 @ddt
@@ -1589,8 +1589,8 @@ class TestDjangoTemplateLinter(TestLinter):
 
         linter._check_django_file_is_safe(django_template, results)
 
-        self.assertEqual(len(results.violations), 1)
-        self.assertTrue(results.violations[0].is_disabled)
+        assert len(results.violations) == 1
+        assert results.violations[0].is_disabled
 
         def test_check_django_blocktrans_expression_disabled(self):
             """
@@ -1616,8 +1616,8 @@ class TestDjangoTemplateLinter(TestLinter):
 
             linter._check_django_file_is_safe(django_template, results)
 
-            self.assertEqual(len(results.violations), 1)
-            self.assertTrue(results.violations[0].is_disabled)
+            assert len(results.violations) == 1
+            assert results.violations[0].is_disabled
 
     def test_check_django_trans_expression_commented(self):
         """
@@ -1640,7 +1640,7 @@ class TestDjangoTemplateLinter(TestLinter):
 
         linter._check_django_file_is_safe(django_template, results)
 
-        self.assertEqual(len(results.violations), 0)
+        assert len(results.violations) == 0
 
     def test_check_django_blocktrans_expression_commented(self):
         """
@@ -1666,7 +1666,7 @@ class TestDjangoTemplateLinter(TestLinter):
 
         linter._check_django_file_is_safe(django_template, results)
 
-        self.assertEqual(len(results.violations), 0)
+        assert len(results.violations) == 0
 
     def test_check_django_interpolate_tag_expression_commented(self):
         """
@@ -1691,4 +1691,4 @@ class TestDjangoTemplateLinter(TestLinter):
 
         linter._check_django_file_is_safe(django_template, results)
 
-        self.assertEqual(len(results.violations), 0)
+        assert len(results.violations) == 0

--- a/scripts/xsslint/tests/test_main.py
+++ b/scripts/xsslint/tests/test_main.py
@@ -79,9 +79,9 @@ class TestXSSLinter(TestCase):
 
         output = self.out.getvalue()
         # Assert violation details are displayed.
-        self.assertIsNotNone(re.search(r'test\.html.*{}'.format(self.ruleset.mako_missing_default.rule_id), output))
-        self.assertIsNotNone(re.search(r'test\.js.*{}'.format(self.ruleset.javascript_concat_html.rule_id), output))
-        self.assertIsNotNone(re.search(r'test\.js.*{}'.format(self.ruleset.underscore_not_escaped.rule_id), output))
+        assert re.search('test\\.html.*{}'.format(self.ruleset.mako_missing_default.rule_id), output) is not None
+        assert re.search('test\\.js.*{}'.format(self.ruleset.javascript_concat_html.rule_id), output) is not None
+        assert re.search('test\\.js.*{}'.format(self.ruleset.underscore_not_escaped.rule_id), output) is not None
         lines_with_rule = 0
         lines_without_rule = 0  # Output with verbose setting only.
         for underscore_match in re.finditer(r'test\.underscore:.*\n', output):
@@ -89,14 +89,14 @@ class TestXSSLinter(TestCase):
                 lines_with_rule += 1
             else:
                 lines_without_rule += 1
-        self.assertGreaterEqual(lines_with_rule, 1)
-        self.assertEqual(lines_without_rule, 0)
-        self.assertIsNone(re.search(r'test\.py.*{}'.format(self.ruleset.python_parse_error.rule_id), output))
-        self.assertIsNotNone(re.search(r'test\.py.*{}'.format(self.ruleset.python_wrap_html.rule_id), output))
+        assert lines_with_rule >= 1
+        assert lines_without_rule == 0
+        assert re.search('test\\.py.*{}'.format(self.ruleset.python_parse_error.rule_id), output) is None
+        assert re.search('test\\.py.*{}'.format(self.ruleset.python_wrap_html.rule_id), output) is not None
         # Assert no rule totals.
-        self.assertIsNone(re.search(r'{}:\s*{} violations'.format(self.ruleset.python_parse_error.rule_id, 0), output))
+        assert re.search('{}:\\s*{} violations'.format(self.ruleset.python_parse_error.rule_id, 0), output) is None
         # Assert final total
-        self.assertIsNotNone(re.search(r'{} violations total'.format(5), output))
+        assert re.search('{} violations total'.format(5), output) is not None
 
     def test_lint_with_verbose(self):
         """
@@ -124,12 +124,12 @@ class TestXSSLinter(TestCase):
                 lines_with_rule += 1
             else:
                 lines_without_rule += 1
-        self.assertGreaterEqual(lines_with_rule, 1)
-        self.assertGreaterEqual(lines_without_rule, 1)
+        assert lines_with_rule >= 1
+        assert lines_without_rule >= 1
         # Assert no rule totals.
-        self.assertIsNone(re.search(r'{}:\s*{} violations'.format(self.ruleset.python_parse_error.rule_id, 0), output))
+        assert re.search('{}:\\s*{} violations'.format(self.ruleset.python_parse_error.rule_id, 0), output) is None
         # Assert final total
-        self.assertIsNotNone(re.search(r'{} violations total'.format(5), output))
+        assert re.search('{} violations total'.format(5), output) is not None
 
     def test_lint_with_rule_totals(self):
         """
@@ -150,12 +150,12 @@ class TestXSSLinter(TestCase):
         )
 
         output = self.out.getvalue()
-        self.assertIsNotNone(re.search(r'test\.py.*{}'.format(self.ruleset.python_wrap_html.rule_id), output))
+        assert re.search('test\\.py.*{}'.format(self.ruleset.python_wrap_html.rule_id), output) is not None
 
         # Assert totals output.
-        self.assertIsNotNone(re.search(r'{}:\s*{} violations'.format(self.ruleset.python_parse_error.rule_id, 0), output))
-        self.assertIsNotNone(re.search(r'{}:\s*{} violations'.format(self.ruleset.python_wrap_html.rule_id, 1), output))
-        self.assertIsNotNone(re.search(r'{} violations total'.format(5), output))
+        assert re.search('{}:\\s*{} violations'.format(self.ruleset.python_parse_error.rule_id, 0), output) is not None
+        assert re.search('{}:\\s*{} violations'.format(self.ruleset.python_wrap_html.rule_id, 1), output) is not None
+        assert re.search('{} violations total'.format(5), output) is not None
 
     def test_lint_with_json_output(self):
         """
@@ -176,16 +176,16 @@ class TestXSSLinter(TestCase):
         )
 
         output = self.out.getvalue()
-        self.assertIsNotNone(re.search(r'test\.py.*{}'.format(self.ruleset.python_wrap_html.rule_id), output))
+        assert re.search('test\\.py.*{}'.format(self.ruleset.python_wrap_html.rule_id), output) is not None
 
         # Find something that looks like pretty-printed JSON
         json_match = re.search(r'\n\{.*\n\}', output, re.DOTALL)
-        self.assertIsNotNone(json_match)
+        assert json_match is not None
         data = json.loads(json_match.group())
         # Check for rule counts (including zero-instance ones) and total
-        self.assertEqual(1, data['rules']['javascript-concat-html'])
-        self.assertEqual(0, data['rules']['python-concat-html'])
-        self.assertEqual(5, data['total'])
+        assert 1 == data['rules']['javascript-concat-html']
+        assert 0 == data['rules']['python-concat-html']
+        assert 5 == data['total']
 
     def test_lint_with_list_files(self):
         """
@@ -207,10 +207,10 @@ class TestXSSLinter(TestCase):
 
         output = self.out.getvalue()
         # Assert file with rule is not output.
-        self.assertIsNone(re.search(r'test\.py.*{}'.format(self.ruleset.python_wrap_html.rule_id), output))
+        assert re.search('test\\.py.*{}'.format(self.ruleset.python_wrap_html.rule_id), output) is None
         # Assert file is output.
-        self.assertIsNotNone(re.search(r'test\.py', output))
+        assert re.search('test\\.py', output) is not None
 
         # Assert no totals.
-        self.assertIsNone(re.search(r'{}:\s*{} violations'.format(self.ruleset.python_parse_error.rule_id, 0), output))
-        self.assertIsNone(re.search(r'{} violations total'.format(7), output))
+        assert re.search('{}:\\s*{} violations'.format(self.ruleset.python_parse_error.rule_id, 0), output) is None
+        assert re.search('{} violations total'.format(7), output) is None

--- a/scripts/xsslint/tests/test_utils.py
+++ b/scripts/xsslint/tests/test_utils.py
@@ -27,8 +27,8 @@ class TestStringLines(TestCase):
         Test StringLines index_to_line_start_index and index_to_line_end_index.
         """
         lines = StringLines(data['string'])
-        self.assertEqual(lines.index_to_line_start_index(data['index']), data['line_start_index'])
-        self.assertEqual(lines.index_to_line_end_index(data['index']), data['line_end_index'])
+        assert lines.index_to_line_start_index(data['index']) == data['line_start_index']
+        assert lines.index_to_line_end_index(data['index']) == data['line_end_index']
 
     @data(
         {'string': 'test', 'line_number': 1, 'line': 'test'},
@@ -43,4 +43,4 @@ class TestStringLines(TestCase):
         Test line_number_to_line.
         """
         lines = StringLines(data['string'])
-        self.assertEqual(lines.line_number_to_line(data['line_number']), data['line'])
+        assert lines.line_number_to_line(data['line_number']) == data['line']


### PR DESCRIPTION
## Description
This PR is using `codemod-unittest-to-pytest-asserts` to automatically replace `unittest` assertions with `pytest` 
for following module:
```
scripts
```
assertions. I've used one of the forks (PR with changes: https://github.com/mraarif/codemod-unittest-to-pytest-asserts/pull/1) of this codemod that handles a few scenarios that seem to be missing in the upstream repo.
Relevant JIRA issue here: https://openedx.atlassian.net/browse/BOM-2295

