### PR TITLE
Created separate view for library

### DIFF
--- a/cms/djangoapps/contentstore/toggles.py
+++ b/cms/djangoapps/contentstore/toggles.py
@@ -1,8 +1,7 @@
 """
 CMS feature toggles.
 """
-from edx_toggles.toggles import SettingDictToggle
-
+from edx_toggles.toggles import SettingDictToggle, LegacyWaffleFlag, LegacyWaffleFlagNamespace
 
 # .. toggle_name: FEATURES['ENABLE_EXPORT_GIT']
 # .. toggle_implementation: SettingDictToggle
@@ -18,3 +17,30 @@ from edx_toggles.toggles import SettingDictToggle
 EXPORT_GIT = SettingDictToggle(
     "FEATURES", "ENABLE_EXPORT_GIT", default=False, module_name=__name__
 )
+
+# Namespace for studio dashboard waffle flags.
+WAFFLE_NAMESPACE = 'contentstore'
+WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name=WAFFLE_NAMESPACE, log_prefix=u'Contentstore: ')
+
+# Waffle flag to split library to new view.
+# .. toggle_name: split_library_on_studio_dashboard
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Studio dashboard
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2020-07-8
+# .. toggle_target_removal_date: None
+# .. toggle_warnings: ??
+# .. toggle_tickets: TNL-7536
+SPLIT_LIBRARY_ON_DASHBOARD = LegacyWaffleFlag(
+    waffle_namespace=LegacyWaffleFlagNamespace(name=WAFFLE_NAMESPACE),
+    flag_name='split_library_on_studio_dashboard',
+    module_name=__name__
+)
+
+
+def split_library_view_on_dashboard():
+    """
+    check if data new view for library is enabled on studio dashboard.
+    """
+    return SPLIT_LIBRARY_ON_DASHBOARD.is_enabled()

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -521,7 +521,6 @@ def course_listing(request):
     org = request.GET.get('org', '') if optimization_enabled else None
     courses_iter, in_process_course_actions = get_courses_accessible_to_user(request, org)
     user = request.user
-    # import pdb;pdb.set_trace()
     libraries = []
     if not split_library_view_on_dashboard() and LIBRARIES_ENABLED:
         libraries = _accessible_libraries_iter(request.user)

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -90,6 +90,7 @@ from ..course_group_config import (
 from ..course_info_model import delete_course_update, get_course_updates, update_course_updates
 from ..courseware_index import CoursewareSearchIndexer, SearchIndexingError
 from ..tasks import rerun_course as rerun_course_task
+from ..toggles import split_library_view_on_dashboard
 from ..utils import (
     add_instructor,
     get_lms_link_for_item,
@@ -119,6 +120,7 @@ __all__ = ['course_info_handler', 'course_handler', 'course_listing',
            'course_info_update_handler', 'course_search_index_handler',
            'course_rerun_handler',
            'settings_handler',
+           'library_listing',
            'grading_handler',
            'advanced_settings_handler',
            'course_notifications_handler',
@@ -519,7 +521,10 @@ def course_listing(request):
     org = request.GET.get('org', '') if optimization_enabled else None
     courses_iter, in_process_course_actions = get_courses_accessible_to_user(request, org)
     user = request.user
-    libraries = _accessible_libraries_iter(request.user, org) if LIBRARIES_ENABLED else []
+    # import pdb;pdb.set_trace()
+    libraries = []
+    if not split_library_view_on_dashboard() and LIBRARIES_ENABLED:
+        libraries = _accessible_libraries_iter(request.user)
 
     def format_in_process_course_view(uca):
         """
@@ -542,41 +547,70 @@ def course_listing(request):
             ) if uca.state == CourseRerunUIStateManager.State.FAILED else u''
         }
 
-    def format_library_for_view(library):
-        """
-        Return a dict of the data which the view requires for each library
-        """
-
-        return {
-            u'display_name': library.display_name,
-            u'library_key': six.text_type(library.location.library_key),
-            u'url': reverse_library_url(u'library_handler', six.text_type(library.location.library_key)),
-            u'org': library.display_org_with_default,
-            u'number': library.display_number_with_default,
-            u'can_edit': has_studio_write_access(request.user, library.location.library_key),
-        }
-
     split_archived = settings.FEATURES.get(u'ENABLE_SEPARATE_ARCHIVED_COURSES', False)
     active_courses, archived_courses = _process_courses_list(courses_iter, in_process_course_actions, split_archived)
     in_process_course_actions = [format_in_process_course_view(uca) for uca in in_process_course_actions]
 
     return render_to_response(u'index.html', {
-        u'courses': active_courses,
-        u'archived_courses': archived_courses,
-        u'in_process_course_actions': in_process_course_actions,
-        u'libraries_enabled': LIBRARIES_ENABLED,
-        u'redirect_to_library_authoring_mfe': should_redirect_to_library_authoring_mfe(),
-        u'library_authoring_mfe_url': LIBRARY_AUTHORING_MICROFRONTEND_URL,
-        u'libraries': [format_library_for_view(lib) for lib in libraries],
-        u'show_new_library_button': get_library_creator_status(user) and not should_redirect_to_library_authoring_mfe(),
-        u'user': user,
-        u'request_course_creator_url': reverse('request_course_creator'),
-        u'course_creator_status': _get_course_creator_status(user),
-        u'rerun_creator_status': GlobalStaff().has_user(user),
-        u'allow_unicode_course_id': settings.FEATURES.get(u'ALLOW_UNICODE_COURSE_ID', False),
-        u'allow_course_reruns': settings.FEATURES.get(u'ALLOW_COURSE_RERUNS', True),
-        u'optimization_enabled': optimization_enabled
+        'courses': active_courses,
+        'split_studio_home': split_library_view_on_dashboard(),
+        'archived_courses': archived_courses,
+        'in_process_course_actions': in_process_course_actions,
+        'libraries_enabled': LIBRARIES_ENABLED,
+        'redirect_to_library_authoring_mfe': should_redirect_to_library_authoring_mfe(),
+        'library_authoring_mfe_url': LIBRARY_AUTHORING_MICROFRONTEND_URL,
+        'libraries': [_format_library_for_view(lib, request) for lib in libraries],
+        'show_new_library_button': get_library_creator_status(user) and not should_redirect_to_library_authoring_mfe(),
+        'user': user,
+        'request_course_creator_url': reverse('request_course_creator'),
+        'course_creator_status': _get_course_creator_status(user),
+        'rerun_creator_status': GlobalStaff().has_user(user),
+        'allow_unicode_course_id': settings.FEATURES.get(u'ALLOW_UNICODE_COURSE_ID', False),
+        'allow_course_reruns': settings.FEATURES.get(u'ALLOW_COURSE_RERUNS', True),
+        'optimization_enabled': optimization_enabled,
+        'active_tab': 'courses'
     })
+
+
+@login_required
+@ensure_csrf_cookie
+def library_listing(request):
+    """
+    List all Libraries available to the logged in user
+    """
+    libraries = _accessible_libraries_iter(request.user) if LIBRARIES_ENABLED else []
+    data = {
+        'in_process_course_actions': [],
+        'courses': [],
+        'libraries_enabled': LIBRARIES_ENABLED,
+        'libraries': [_format_library_for_view(lib, request) for lib in libraries],
+        'show_new_library_button': LIBRARIES_ENABLED and request.user.is_active,
+        'user': request.user,
+        'request_course_creator_url': reverse('request_course_creator'),
+        'course_creator_status': _get_course_creator_status(request.user),
+        'allow_unicode_course_id': settings.FEATURES.get('ALLOW_UNICODE_COURSE_ID', False),
+        'archived_courses': True,
+        'allow_course_reruns': settings.FEATURES.get(u'ALLOW_COURSE_RERUNS', True),
+        'rerun_creator_status': GlobalStaff().has_user(request.user),
+        'split_studio_home': split_library_view_on_dashboard(),
+        'active_tab': 'libraries'
+    }
+    return render_to_response('index.html', data)
+
+
+def _format_library_for_view(library, request):
+    """
+    Return a dict of the data which the view requires for each library
+    """
+
+    return {
+        'display_name': library.display_name,
+        'library_key': six.text_type(library.location.library_key),
+        'url': reverse_library_url(u'library_handler', six.text_type(library.location.library_key)),
+        'org': library.display_org_with_default,
+        'number': library.display_number_with_default,
+        'can_edit': has_studio_write_access(request.user, library.location.library_key),
+    }
 
 
 def _get_rerun_link_for_item(course_key):

--- a/cms/static/js/index.js
+++ b/cms/static/js/index.js
@@ -162,9 +162,10 @@ define(['domReady', 'jquery', 'underscore', 'js/utils/cancel_on_escape', 'js/vie
         var showTab = function(tab) {
             return function(e) {
                 e.preventDefault();
-                $('.courses-tab').toggleClass('active', tab === 'courses');
-                $('.archived-courses-tab').toggleClass('active', tab === 'archived-courses');
-                $('.libraries-tab').toggleClass('active', tab === 'libraries');
+                window.location.hash = tab;
+                $('.courses-tab').toggleClass('active', tab === 'courses-tab');
+                $('.archived-courses-tab').toggleClass('active', tab === 'archived-courses-tab');
+                $('.libraries-tab').toggleClass('active', tab === 'libraries-tab');
 
             // Also toggle this course-related notice shown below the course tab, if it is present:
                 $('.wrapper-creationrights').toggleClass('is-hidden', tab !== 'courses');
@@ -172,6 +173,10 @@ define(['domReady', 'jquery', 'underscore', 'js/utils/cancel_on_escape', 'js/vie
         };
 
         var onReady = function() {
+            var courseTabHref = $('#course-index-tabs .courses-tab a').attr('href');
+            var libraryTabHref = $('#course-index-tabs .libraries-tab a').attr('href');
+            var ArchivedTabHref = $('#course-index-tabs .archived-courses-tab a').attr('href');
+
             $('.new-course-button').bind('click', addNewCourse);
             $('.new-library-button').bind('click', addNewLibrary);
 
@@ -181,9 +186,20 @@ define(['domReady', 'jquery', 'underscore', 'js/utils/cancel_on_escape', 'js/vie
 
             $('.action-reload').bind('click', ViewUtils.reload);
 
-            $('#course-index-tabs .courses-tab').bind('click', showTab('courses'));
-            $('#course-index-tabs .archived-courses-tab').bind('click', showTab('archived-courses'));
-            $('#course-index-tabs .libraries-tab').bind('click', showTab('libraries'));
+            if (courseTabHref === '#') {
+                $('#course-index-tabs .courses-tab').bind('click', showTab('courses-tab'));
+            }
+
+            if (libraryTabHref === '#') {
+                $('#course-index-tabs .libraries-tab').bind('click', showTab('libraries-tab'));
+            }
+
+            if (ArchivedTabHref === '#') {
+                $('#course-index-tabs .archived-courses-tab').bind('click', showTab('archived-courses-tab'));
+            }
+            if (window.location.hash) {
+                $(window.location.hash.replace('#', '.')).first('a').trigger('click');
+            }
         };
 
         domReady(onReady);

--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -1,6 +1,7 @@
 <%page expression_filter="h"/>
 <%!
 from django.utils.translation import ugettext as _
+from django.urls import reverse
 
 from openedx.core.djangolib.markup import HTML, Text
 from openedx.core.djangolib.js_utils import (
@@ -313,22 +314,41 @@ from openedx.core.djangolib.js_utils import (
 
       % if libraries_enabled or archived_courses:
       <ul id="course-index-tabs">
-        <li class="courses-tab active"><a>${_("Courses")}</a></li>
+      <li class="courses-tab ${ 'active' if active_tab == 'courses' else ''}">
+          % if split_studio_home and active_tab == 'libraries':
+            <a href="${reverse('home')}">${_("Courses")}</a>
+          % else:
+            <a href="#">${_("Courses")}</a>
+          % endif
+       </li>
         % if archived_courses:
-        <li class="archived-courses-tab"><a>${_("Archived Courses")}</a></li>
+        <li class="archived-courses-tab">
+            % if split_studio_home and active_tab == 'libraries':
+                <a href="${reverse('home') + '#archived-courses-tab' } " >${_("Archived Courses")}</a>
+            % else:
+                <a href="#" >${_("Archived Courses")}</a>
+            % endif
+        </li>
         % endif
+
         % if libraries_enabled:
-        % if redirect_to_library_authoring_mfe:
-        <li><a href="${library_authoring_mfe_url}">${_("Libraries")}</a></li>
-        %else:
-        <li class="libraries-tab"><a>${_("Libraries")}</a></li>
-        % endif
+            % if redirect_to_library_authoring_mfe:
+            <li><a href="${library_authoring_mfe_url}">${_("Libraries")}</a></li>
+            %else:
+             <li class="libraries-tab ${ 'active' if active_tab == 'libraries' else ''}">
+                % if split_studio_home:
+                  <a href="${reverse('home_library')}">${_("Libraries")}</a>
+                % else:
+                  <a href="#" >${_("Libraries")}sss</a>
+                % endif
+             </li>
+            % endif
         % endif
       </ul>
       % endif
 
       %if len(courses) > 0 or optimization_enabled:
-      <div class="courses courses-tab react-course-listing active">
+      <div class="courses courses-tab react-course-listing ${ 'active' if active_tab == 'courses' else ''}">
         ${static.renderReact(
           component="CourseOrLibraryListing",
           id="react-course-listing",
@@ -342,7 +362,7 @@ from openedx.core.djangolib.js_utils import (
       </div>
 
       %else:
-      <div class="notice notice-incontext notice-instruction notice-instruction-nocourses list-notices courses-tab active">
+      <div class="notice notice-incontext notice-instruction notice-instruction-nocourses list-notices courses-tab ${ 'active' if active_tab == 'courses' else ''}">
         <div class="notice-item">
           <div class="msg">
             <h3 class="title">${_("Are you staff on an existing {studio_name} course?").format(studio_name=settings.STUDIO_SHORT_NAME)}</h3>
@@ -458,6 +478,7 @@ from openedx.core.djangolib.js_utils import (
 
       %if archived_courses:
       <div class="archived-courses react-archived-course-listing archived-courses-tab">
+        % if type(archived_courses) is list:
         ${static.renderReact(
           component="CourseOrLibraryListing",
           id="react-archived-course-listing",
@@ -468,11 +489,12 @@ from openedx.core.djangolib.js_utils import (
             'allowReruns': allow_course_reruns and rerun_creator_status and course_creator_status=='granted'
           }
         )}
+        % endif
       </div>
       %endif
 
       %if len(libraries) > 0 or optimization_enabled:
-      <div class="libraries react-library-listing libraries-tab">
+      <div class="libraries react-library-listing libraries-tab ${ 'active' if active_tab == 'libraries' else ''}">
         ${static.renderReact(
           component="CourseOrLibraryListing",
           id="react-library-listing",

--- a/cms/templates/js/mock/mock-index-page.underscore
+++ b/cms/templates/js/mock/mock-index-page.underscore
@@ -209,8 +209,8 @@
       </div>
 
       <ul id="course-index-tabs">
-        <li class="courses-tab active"><a>Courses</a></li>
-        <li class="libraries-tab"><a>Libraries</a></li>
+        <li class="courses-tab active"><a href='#'>Courses</a></li>
+        <li class="libraries-tab"><a href='#'>Libraries</a></li>
       </ul>
 
       <div class="courses courses-tab active">

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -97,6 +97,7 @@ urlpatterns = [
         contentstore_views.course_info_update_handler, name='course_info_update_handler'
         ),
     url(r'^home/?$', contentstore_views.course_listing, name='home'),
+    url(r'^home_library/?$', contentstore_views.library_listing, name='home_library'),
     url(r'^course/{}/search_reindex?$'.format(settings.COURSE_KEY_PATTERN),
         contentstore_views.course_search_index_handler,
         name='course_search_index_handler'


### PR DESCRIPTION
## Description

On the studio Homepage, all libraries and courses are listed which is data-intensive , by this changing view for libraries page is separated from home view. All changes are behind a flag.

## Supporting information
- Staff users have minor noticeable effect ie page reload on click of library button.
- To activate this feature switch is needed to be enabled ie. `contentstore.split_library_on_studio_dashboard`


## Testing instructions
Sandbox
https://tnl7536.sandbox.edx.org/

1. Log into Studio with staff account.
2. Click on Libraries button.
3. Observe the page relodes and libraries are listed

