### PR TITLE
BOM-2278 : Pylint amnesty in discussion, dashboard

### DIFF
--- a/lms/djangoapps/dashboard/git_import.py
+++ b/lms/djangoapps/dashboard/git_import.py
@@ -35,7 +35,7 @@ class GitImportError(Exception):
     def __init__(self, message=None):
         if message is None:
             message = self.MESSAGE
-        super(GitImportError, self).__init__(message)
+        super(GitImportError, self).__init__(message)  # lint-amnesty, pylint: disable=super-with-arguments
 
 
 class GitImportErrorNoDir(GitImportError):
@@ -43,7 +43,7 @@ class GitImportErrorNoDir(GitImportError):
     GitImportError when no directory exists at the specified path.
     """
     def __init__(self, repo_dir):
-        super(GitImportErrorNoDir, self).__init__(
+        super(GitImportErrorNoDir, self).__init__(  # lint-amnesty, pylint: disable=super-with-arguments
             _(
                 u"Path {0} doesn't exist, please create it, "
                 u"or configure a different path with "
@@ -136,7 +136,7 @@ def switch_branch(branch, rdir):
         cmd_log(['git', 'fetch', ], rdir)
     except subprocess.CalledProcessError as ex:
         log.exception(u'Unable to fetch remote: %r', ex.output)
-        raise GitImportErrorCannotBranch()
+        raise GitImportErrorCannotBranch()  # lint-amnesty, pylint: disable=raise-missing-from
 
     # Check if the branch is available from the remote.
     cmd = ['git', 'ls-remote', 'origin', '-h', 'refs/heads/{0}'.format(branch), ]
@@ -144,7 +144,7 @@ def switch_branch(branch, rdir):
         output = cmd_log(cmd, rdir)
     except subprocess.CalledProcessError as ex:
         log.exception(u'Getting a list of remote branches failed: %r', ex.output)
-        raise GitImportErrorCannotBranch()
+        raise GitImportErrorCannotBranch()  # lint-amnesty, pylint: disable=raise-missing-from
     if branch not in output:
         raise GitImportErrorRemoteBranchMissing()
     # Check it the remote branch has already been made locally
@@ -153,7 +153,7 @@ def switch_branch(branch, rdir):
         output = cmd_log(cmd, rdir)
     except subprocess.CalledProcessError as ex:
         log.exception(u'Getting a list of local branches failed: %r', ex.output)
-        raise GitImportErrorCannotBranch()
+        raise GitImportErrorCannotBranch()  # lint-amnesty, pylint: disable=raise-missing-from
     branches = []
     for line in output.split('\n'):
         branches.append(line.replace('*', '').strip())
@@ -166,14 +166,14 @@ def switch_branch(branch, rdir):
             cmd_log(cmd, rdir)
         except subprocess.CalledProcessError as ex:
             log.exception(u'Unable to checkout remote branch: %r', ex.output)
-            raise GitImportErrorCannotBranch()
+            raise GitImportErrorCannotBranch()  # lint-amnesty, pylint: disable=raise-missing-from
     # Go ahead and reset hard to the newest version of the branch now that we know
     # it is local.
     try:
         cmd_log(['git', 'reset', '--hard', 'origin/{0}'.format(branch), ], rdir)
     except subprocess.CalledProcessError as ex:
         log.exception(u'Unable to reset to branch: %r', ex.output)
-        raise GitImportErrorCannotBranch()
+        raise GitImportErrorCannotBranch()  # lint-amnesty, pylint: disable=raise-missing-from
 
 
 def add_repo(repo, rdir_in, branch=None):
@@ -232,7 +232,7 @@ def add_repo(repo, rdir_in, branch=None):
         ret_git = cmd_log(cmd, cwd=cwd)
     except subprocess.CalledProcessError as ex:
         log.exception(u'Error running git pull: %r', ex.output)
-        raise GitImportErrorCannotPull()
+        raise GitImportErrorCannotPull()  # lint-amnesty, pylint: disable=raise-missing-from
 
     if branch:
         switch_branch(branch, rdirp)
@@ -243,7 +243,7 @@ def add_repo(repo, rdir_in, branch=None):
         commit_id = cmd_log(cmd, cwd=rdirp)
     except subprocess.CalledProcessError as ex:
         log.exception(u'Unable to get git log: %r', ex.output)
-        raise GitImportErrorBadRepo()
+        raise GitImportErrorBadRepo()  # lint-amnesty, pylint: disable=raise-missing-from
 
     ret_git += u'\nCommit ID: {0}'.format(commit_id)
 
@@ -255,7 +255,7 @@ def add_repo(repo, rdir_in, branch=None):
         # I can't discover a way to excercise this, but git is complex
         # so still logging and raising here in case.
         log.exception(u'Unable to determine branch: %r', ex.output)
-        raise GitImportErrorBadRepo()
+        raise GitImportErrorBadRepo()  # lint-amnesty, pylint: disable=raise-missing-from
 
     ret_git += u'{0}Branch: {1}'.format('   \n', branch)
 
@@ -281,9 +281,9 @@ def add_repo(repo, rdir_in, branch=None):
             python_lib_filename=python_lib_filename
         )
     except CommandError:
-        raise GitImportErrorXmlImportFailed()
+        raise GitImportErrorXmlImportFailed()  # lint-amnesty, pylint: disable=raise-missing-from
     except NotImplementedError:
-        raise GitImportErrorUnsupportedStore()
+        raise GitImportErrorUnsupportedStore()  # lint-amnesty, pylint: disable=raise-missing-from
 
     ret_import = output.getvalue()
 

--- a/lms/djangoapps/dashboard/management/commands/git_add_course.py
+++ b/lms/djangoapps/dashboard/management/commands/git_add_course.py
@@ -51,4 +51,4 @@ class Command(BaseCommand):
         try:
             git_import.add_repo(options['repository_url'], rdir_arg, branch)
         except git_import.GitImportError as ex:
-            raise CommandError(str(ex))
+            raise CommandError(str(ex))  # lint-amnesty, pylint: disable=raise-missing-from

--- a/lms/djangoapps/dashboard/management/commands/tests/test_git_add_course.py
+++ b/lms/djangoapps/dashboard/management/commands/tests/test_git_add_course.py
@@ -59,7 +59,7 @@ class TestGitAddCourse(SharedModuleStoreTestCase):
     ENABLED_CACHES = ['default', 'mongo_metadata_inheritance', 'loc_cache']
 
     def setUp(self):
-        super(TestGitAddCourse, self).setUp()
+        super(TestGitAddCourse, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         self.git_repo_dir = settings.GIT_REPO_DIR
 
     def assertCommandFailureRegexp(self, regex, *args):

--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -13,7 +13,7 @@ import warnings
 import mongoengine
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db import IntegrityError
 from django.http import Http404
@@ -58,7 +58,7 @@ class SysadminDashboardView(TemplateView):
         self.def_ms = modulestore()
         self.msg = u''
         self.datatable = []
-        super(SysadminDashboardView, self).__init__(**kwargs)
+        super(SysadminDashboardView, self).__init__(**kwargs)  # lint-amnesty, pylint: disable=super-with-arguments
 
     @method_decorator(ensure_csrf_cookie)
     @method_decorator(login_required)
@@ -66,7 +66,7 @@ class SysadminDashboardView(TemplateView):
                                     must_revalidate=True))
     @method_decorator(condition(etag_func=None))
     def dispatch(self, *args, **kwargs):
-        return super(SysadminDashboardView, self).dispatch(*args, **kwargs)
+        return super(SysadminDashboardView, self).dispatch(*args, **kwargs)  # lint-amnesty, pylint: disable=super-with-arguments
 
     def get_courses(self):
         """ Get an iterable list of courses."""
@@ -162,7 +162,7 @@ class Users(SysadminDashboardView):
         }
         return datatable
 
-    def get(self, request):
+    def get(self, request):  # lint-amnesty, pylint: disable=arguments-differ
         if not request.user.is_staff:
             raise Http404
         context = {
@@ -314,7 +314,7 @@ class Courses(SysadminDashboardView):
                     title=_('Information about all courses'),
                     data=data)
 
-    def get(self, request):
+    def get(self, request):  # lint-amnesty, pylint: disable=arguments-differ
         """Displays forms and course information"""
 
         if not request.user.is_staff:
@@ -356,7 +356,7 @@ class Courses(SysadminDashboardView):
                     course = get_course_by_id(course_key)
                     course_found = True
                 except Exception as err:   # pylint: disable=broad-except
-                    self.msg += _(
+                    self.msg += _(  # lint-amnesty, pylint: disable=translation-of-non-string
                         HTML(u'Error - cannot get course with ID {0}<br/><pre>{1}</pre>')
                     ).format(
                         course_key,
@@ -386,7 +386,7 @@ class Staffing(SysadminDashboardView):
     courses.
     """
 
-    def get(self, request):
+    def get(self, request):  # lint-amnesty, pylint: disable=arguments-differ
         """Displays course Enrollment and staffing course statistics"""
 
         if not request.user.is_staff:
@@ -458,7 +458,7 @@ class GitLogs(TemplateView):
                 mdb = mongoengine.connect(mongo_db['db'], host=mongouri)
             else:
                 mdb = mongoengine.connect(mongo_db['db'], host=mongo_db['host'])
-        except mongoengine.connection.ConnectionError:
+        except mongoengine.connection.ConnectionError:  # lint-amnesty, pylint: disable=no-member
             log.exception('Unable to connect to mongodb to save log, '
                           'please check MONGODB_LOG settings.')
 

--- a/lms/djangoapps/dashboard/tests/test_sysadmin.py
+++ b/lms/djangoapps/dashboard/tests/test_sysadmin.py
@@ -52,7 +52,7 @@ class SysadminBaseTestCase(SharedModuleStoreTestCase):
 
     def setUp(self):
         """Setup test case by adding primary user."""
-        super(SysadminBaseTestCase, self).setUp()
+        super(SysadminBaseTestCase, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         self.user = UserFactory.create(username='test_user',
                                        email='test_user+sysadmin@edx.org',
                                        password='foo')
@@ -99,7 +99,7 @@ class SysadminBaseTestCase(SharedModuleStoreTestCase):
         Create a shell expansion of passed in parameter and iteratively
         remove them.  Must only expand to directories.
         """
-        for path in glob.glob(path):
+        for path in glob.glob(path):  # lint-amnesty, pylint: disable=redefined-argument-from-local
             shutil.rmtree(path)
 
     def _mkdir(self, path):
@@ -243,7 +243,7 @@ class TestSysAdminMongoCourseImport(SysadminBaseTestCase):
         date = CourseImportLog.objects.first().created.replace(tzinfo=UTC)
 
         for timezone in tz_names:
-            with (override_settings(TIME_ZONE=timezone)):
+            with (override_settings(TIME_ZONE=timezone)):  # lint-amnesty, pylint: disable=superfluous-parens
                 date_text = get_time_display(date, tz_format, settings.TIME_ZONE)
                 response = self.client.get(reverse('gitlogs'))
                 self.assertContains(response, date_text)

--- a/lms/djangoapps/discussion/django_comment_client/base/__init__.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/__init__.py
@@ -1,3 +1,3 @@
-# This import registers the ForumThreadViewedEventTransformer
+# This import registers the ForumThreadViewedEventTransformer  # lint-amnesty, pylint: disable=missing-module-docstring
 
 from . import event_transformers

--- a/lms/djangoapps/discussion/django_comment_client/base/__init__.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/__init__.py
@@ -1,3 +1,4 @@
-# This import registers the ForumThreadViewedEventTransformer  # lint-amnesty, pylint: disable=missing-module-docstring
+# lint-amnesty, pylint: disable=missing-module-docstring
+# This import registers the ForumThreadViewedEventTransformer
 
 from . import event_transformers

--- a/lms/djangoapps/discussion/django_comment_client/base/views.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/views.py
@@ -10,7 +10,7 @@ import time
 import eventtracking
 import six
 from django.contrib.auth.decorators import login_required
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.core import exceptions
 from django.http import Http404, HttpResponse, HttpResponseServerError
 from django.utils.translation import ugettext as _
@@ -693,7 +693,7 @@ def un_pin_thread(request, course_id, thread_id):
 @require_POST
 @login_required
 @permitted
-def follow_thread(request, course_id, thread_id):
+def follow_thread(request, course_id, thread_id):  # lint-amnesty, pylint: disable=missing-function-docstring, unused-argument
     user = cc.User.from_django_user(request.user)
     thread = cc.Thread.find(thread_id)
     user.follow(thread)
@@ -704,7 +704,7 @@ def follow_thread(request, course_id, thread_id):
 @require_POST
 @login_required
 @permitted
-def follow_commentable(request, course_id, commentable_id):
+def follow_commentable(request, course_id, commentable_id):  # lint-amnesty, pylint: disable=unused-argument
     """
     given a course_id and commentable id, follow this commentable
     ajax only
@@ -718,7 +718,7 @@ def follow_commentable(request, course_id, commentable_id):
 @require_POST
 @login_required
 @permitted
-def unfollow_thread(request, course_id, thread_id):
+def unfollow_thread(request, course_id, thread_id):  # lint-amnesty, pylint: disable=unused-argument
     """
     given a course id and thread id, stop following this thread
     ajax only
@@ -733,7 +733,7 @@ def unfollow_thread(request, course_id, thread_id):
 @require_POST
 @login_required
 @permitted
-def unfollow_commentable(request, course_id, commentable_id):
+def unfollow_commentable(request, course_id, commentable_id):  # lint-amnesty, pylint: disable=unused-argument
     """
     given a course id and commentable id stop following commentable
     ajax only
@@ -748,7 +748,7 @@ def unfollow_commentable(request, course_id, commentable_id):
 @login_required
 @csrf.csrf_exempt
 @xframe_options_exempt
-def upload(request, course_id):  # ajax upload file to a question or answer
+def upload(request, course_id):  # ajax upload file to a question or answer  # lint-amnesty, pylint: disable=unused-argument
     """view that handles file upload via Ajax
     """
 
@@ -796,7 +796,7 @@ def upload(request, course_id):  # ajax upload file to a question or answer
     # Using content-type of text/plain here instead of JSON because
     # IE doesn't know how to handle the JSON response and prompts the
     # user to save the JSON as a file instead of passing it to the callback.
-    return HttpResponse(json.dumps({
+    return HttpResponse(json.dumps({  # lint-amnesty, pylint: disable=http-response-with-json-dumps
         'result': {
             'msg': result,
             'error': error,

--- a/lms/djangoapps/discussion/django_comment_client/middleware.py
+++ b/lms/djangoapps/discussion/django_comment_client/middleware.py
@@ -1,4 +1,4 @@
-import json
+import json  # lint-amnesty, pylint: disable=missing-module-docstring
 import logging
 
 from django.utils.deprecation import MiddlewareMixin

--- a/lms/djangoapps/discussion/django_comment_client/middleware.py
+++ b/lms/djangoapps/discussion/django_comment_client/middleware.py
@@ -1,4 +1,5 @@
-import json  # lint-amnesty, pylint: disable=missing-module-docstring
+# lint-amnesty, pylint: disable=missing-module-docstring
+import json
 import logging
 
 from django.utils.deprecation import MiddlewareMixin

--- a/lms/djangoapps/discussion/django_comment_client/permissions.py
+++ b/lms/djangoapps/discussion/django_comment_client/permissions.py
@@ -19,7 +19,7 @@ from openedx.core.djangoapps.django_comment_common.utils import get_course_discu
 from openedx.core.lib.cache_utils import request_cached
 
 
-def has_permission(user, permission, course_id=None):
+def has_permission(user, permission, course_id=None):  # lint-amnesty, pylint: disable=missing-function-docstring
     assert isinstance(course_id, (type(None), CourseKey))
     request_cache_dict = DEFAULT_REQUEST_CACHE.data
     cache_key = "django_comment_client.permissions.has_permission.all_permissions.{}.{}".format(

--- a/lms/djangoapps/discussion/django_comment_client/tests/factories.py
+++ b/lms/djangoapps/discussion/django_comment_client/tests/factories.py
@@ -1,9 +1,9 @@
-from factory.django import DjangoModelFactory
+from factory.django import DjangoModelFactory  # lint-amnesty, pylint: disable=missing-module-docstring
 
 from openedx.core.djangoapps.django_comment_common.models import Permission, Role
 
 
-class RoleFactory(DjangoModelFactory):
+class RoleFactory(DjangoModelFactory):  # lint-amnesty, pylint: disable=missing-class-docstring
     class Meta(object):
         model = Role
 

--- a/lms/djangoapps/discussion/django_comment_client/tests/factories.py
+++ b/lms/djangoapps/discussion/django_comment_client/tests/factories.py
@@ -1,4 +1,5 @@
-from factory.django import DjangoModelFactory  # lint-amnesty, pylint: disable=missing-module-docstring
+# lint-amnesty, pylint: disable=missing-module-docstring
+from factory.django import DjangoModelFactory
 
 from openedx.core.djangoapps.django_comment_common.models import Permission, Role
 

--- a/lms/djangoapps/discussion/django_comment_client/tests/group_id.py
+++ b/lms/djangoapps/discussion/django_comment_client/tests/group_id.py
@@ -66,7 +66,7 @@ class CohortedTopicGroupIdTestMixin(GroupIdAssertionMixin):
         Call the view for the implementing test class, constructing a request
         from the parameters.
         """
-        pass
+        pass  # lint-amnesty, pylint: disable=unnecessary-pass
 
     def test_cohorted_topic_student_without_group_id(self, mock_request):
         self.call_view(mock_request, "cohorted_topic", self.student, '', pass_group_id=False)
@@ -102,7 +102,7 @@ class CohortedTopicGroupIdTestMixin(GroupIdAssertionMixin):
 
     def test_cohorted_topic_moderator_with_invalid_group_id(self, mock_request):
         invalid_id = self.student_cohort.id + self.moderator_cohort.id
-        response = self.call_view(mock_request, "cohorted_topic", self.moderator, invalid_id)
+        response = self.call_view(mock_request, "cohorted_topic", self.moderator, invalid_id)  # lint-amnesty, pylint: disable=assignment-from-no-return
         self.assertEqual(response.status_code, 500)
 
     def test_cohorted_topic_enrollment_track_invalid_group_id(self, mock_request):
@@ -116,7 +116,7 @@ class CohortedTopicGroupIdTestMixin(GroupIdAssertionMixin):
         )
 
         invalid_id = -1000
-        response = self.call_view(mock_request, "cohorted_topic", self.moderator, invalid_id)
+        response = self.call_view(mock_request, "cohorted_topic", self.moderator, invalid_id)  # lint-amnesty, pylint: disable=assignment-from-no-return
         self.assertEqual(response.status_code, 500)
 
 
@@ -130,7 +130,7 @@ class NonCohortedTopicGroupIdTestMixin(GroupIdAssertionMixin):
         Call the view for the implementing test class, constructing a request
         from the parameters.
         """
-        pass
+        pass  # lint-amnesty, pylint: disable=unnecessary-pass
 
     def test_non_cohorted_topic_student_without_group_id(self, mock_request):
         self.call_view(mock_request, "non_cohorted_topic", self.student, '', pass_group_id=False)

--- a/lms/djangoapps/discussion/django_comment_client/tests/mock_cs_server/test_mock_cs_server.py
+++ b/lms/djangoapps/discussion/django_comment_client/tests/mock_cs_server/test_mock_cs_server.py
@@ -1,4 +1,4 @@
-import json
+import json  # lint-amnesty, pylint: disable=missing-module-docstring
 import threading
 import unittest
 
@@ -14,7 +14,7 @@ class MockCommentServiceServerTest(unittest.TestCase):
     '''
 
     def setUp(self):
-        super(MockCommentServiceServerTest, self).setUp()
+        super(MockCommentServiceServerTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
 
         # This is a test of the test setup,
         # so it does not need to run as part of the unit test suite
@@ -47,10 +47,10 @@ class MockCommentServiceServerTest(unittest.TestCase):
                   'external_id': '4', 'email': u'user100@edx.org'}
         data = json.dumps(values)
         headers = {'Content-Type': 'application/json', 'Content-Length': len(data), 'X-Edx-Api-Key': 'TEST_API_KEY'}
-        req = six.moves.urllib.request.Request(self.server_url + '/api/v1/users/4', data, headers)
+        req = six.moves.urllib.request.Request(self.server_url + '/api/v1/users/4', data, headers)  # lint-amnesty, pylint: disable=undefined-variable
 
         # Send the request to the mock cs server
-        response = six.moves.urllib.request.urlopen(req)
+        response = six.moves.urllib.request.urlopen(req)  # lint-amnesty, pylint: disable=undefined-variable
 
         # Receive the reply from the mock cs server
         response_dict = json.loads(response.read())

--- a/lms/djangoapps/discussion/django_comment_client/tests/mock_cs_server/test_mock_cs_server.py
+++ b/lms/djangoapps/discussion/django_comment_client/tests/mock_cs_server/test_mock_cs_server.py
@@ -1,4 +1,5 @@
-import json  # lint-amnesty, pylint: disable=missing-module-docstring
+# lint-amnesty, pylint: disable=missing-module-docstring
+import json
 import threading
 import unittest
 

--- a/lms/djangoapps/discussion/django_comment_client/tests/test_middleware.py
+++ b/lms/djangoapps/discussion/django_comment_client/tests/test_middleware.py
@@ -1,4 +1,4 @@
-import json
+import json  # lint-amnesty, pylint: disable=missing-module-docstring
 
 import django.http
 from django.test import TestCase
@@ -8,10 +8,10 @@ import lms.djangoapps.discussion.django_comment_client.middleware as middleware
 import openedx.core.djangoapps.django_comment_common.comment_client as comment_client
 
 
-class AjaxExceptionTestCase(TestCase):
+class AjaxExceptionTestCase(TestCase):  # lint-amnesty, pylint: disable=missing-class-docstring
 
     def setUp(self):
-        super(AjaxExceptionTestCase, self).setUp()
+        super(AjaxExceptionTestCase, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         self.a = middleware.AjaxExceptionMiddleware()
         self.request1 = django.http.HttpRequest()
         self.request0 = django.http.HttpRequest()

--- a/lms/djangoapps/discussion/django_comment_client/tests/test_middleware.py
+++ b/lms/djangoapps/discussion/django_comment_client/tests/test_middleware.py
@@ -1,4 +1,5 @@
-import json  # lint-amnesty, pylint: disable=missing-module-docstring
+# lint-amnesty, pylint: disable=missing-module-docstring
+import json
 
 import django.http
 from django.test import TestCase

--- a/lms/djangoapps/discussion/django_comment_client/tests/test_models.py
+++ b/lms/djangoapps/discussion/django_comment_client/tests/test_models.py
@@ -18,7 +18,7 @@ class RoleClassTestCase(ModuleStoreTestCase):
     MODULESTORE = TEST_DATA_MIXED_MODULESTORE
 
     def setUp(self):
-        super(RoleClassTestCase, self).setUp()
+        super(RoleClassTestCase, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
 
         # For course ID, syntax edx/classname/classdate is important
         # because xmodel.course_module.id_to_location looks for a string to split
@@ -58,7 +58,7 @@ class PermissionClassTestCase(TestCase):
     """
 
     def setUp(self):
-        super(PermissionClassTestCase, self).setUp()
+        super(PermissionClassTestCase, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         self.permission = models.Permission.objects.get_or_create(name="test")[0]
 
     def test_unicode(self):

--- a/lms/djangoapps/discussion/django_comment_client/tests/unicode.py
+++ b/lms/djangoapps/discussion/django_comment_client/tests/unicode.py
@@ -1,7 +1,7 @@
-# coding=utf-8
+# coding=utf-8  # lint-amnesty, pylint: disable=missing-module-docstring
 
 
-class UnicodeTestMixin(object):
+class UnicodeTestMixin(object):  # lint-amnesty, pylint: disable=missing-class-docstring
     def test_ascii(self):
         self._test_unicode_data(u"This post contains ASCII.")
 

--- a/lms/djangoapps/discussion/django_comment_client/tests/unicode.py
+++ b/lms/djangoapps/discussion/django_comment_client/tests/unicode.py
@@ -1,4 +1,4 @@
-# coding=utf-8  # lint-amnesty, pylint: disable=missing-module-docstring
+# lint-amnesty, pylint: disable=missing-module-docstring
 
 
 class UnicodeTestMixin(object):  # lint-amnesty, pylint: disable=missing-class-docstring

--- a/lms/djangoapps/discussion/django_comment_client/tests/utils.py
+++ b/lms/djangoapps/discussion/django_comment_client/tests/utils.py
@@ -26,7 +26,7 @@ class ForumsEnableMixin(object):
     Ensures that the forums are enabled for a given test class.
     """
     def setUp(self):
-        super(ForumsEnableMixin, self).setUp()
+        super(ForumsEnableMixin, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
 
         config = ForumsConfig.current()
         config.enabled = True
@@ -61,7 +61,7 @@ class CohortedTestCase(ForumsEnableMixin, UrlResetMixin, SharedModuleStoreTestCa
 
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
-        super(CohortedTestCase, self).setUp()
+        super(CohortedTestCase, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
 
         seed_permissions_roles(self.course.id)
         self.student = UserFactory.create()

--- a/lms/djangoapps/discussion/exceptions.py
+++ b/lms/djangoapps/discussion/exceptions.py
@@ -8,4 +8,4 @@ class TeamDiscussionHiddenFromUserException(BaseException):
     This is the exception raised when a user is not
     permitted to view the discussion thread
     """
-    pass
+    pass  # lint-amnesty, pylint: disable=unnecessary-pass

--- a/lms/djangoapps/discussion/management/commands/assign_role.py
+++ b/lms/djangoapps/discussion/management/commands/assign_role.py
@@ -1,10 +1,10 @@
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user, missing-module-docstring
 from django.core.management.base import BaseCommand
 
 from openedx.core.djangoapps.django_comment_common.models import Role
 
 
-class Command(BaseCommand):
+class Command(BaseCommand):  # lint-amnesty, pylint: disable=missing-class-docstring
     help = 'Assign a discussion forum role to a user.'
 
     def add_arguments(self, parser):

--- a/lms/djangoapps/discussion/management/commands/assign_role.py
+++ b/lms/djangoapps/discussion/management/commands/assign_role.py
@@ -1,4 +1,5 @@
-from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user, missing-module-docstring
+# lint-amnesty, pylint: disable=imported-auth-user, missing-module-docstring
+from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand
 
 from openedx.core.djangoapps.django_comment_common.models import Role

--- a/lms/djangoapps/discussion/management/commands/assign_roles_for_course.py
+++ b/lms/djangoapps/discussion/management/commands/assign_roles_for_course.py
@@ -12,7 +12,7 @@ from openedx.core.djangoapps.django_comment_common.models import assign_default_
 from common.djangoapps.student.models import CourseEnrollment
 
 
-class Command(BaseCommand):
+class Command(BaseCommand):  # lint-amnesty, pylint: disable=missing-class-docstring
     help = 'Add roles for all users in a course.'
 
     def add_arguments(self, parser):

--- a/lms/djangoapps/discussion/management/commands/create_roles_for_existing.py
+++ b/lms/djangoapps/discussion/management/commands/create_roles_for_existing.py
@@ -12,7 +12,7 @@ from openedx.core.djangoapps.django_comment_common.models import assign_default_
 from common.djangoapps.student.models import CourseEnrollment
 
 
-class Command(BaseCommand):
+class Command(BaseCommand):  # lint-amnesty, pylint: disable=missing-class-docstring
     help = 'Seed default permisssions and roles.'
 
     def handle(self, *args, **options):

--- a/lms/djangoapps/discussion/management/commands/get_discussion_link.py
+++ b/lms/djangoapps/discussion/management/commands/get_discussion_link.py
@@ -1,10 +1,10 @@
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand, CommandError  # lint-amnesty, pylint: disable=missing-module-docstring
 from opaque_keys.edx.keys import CourseKey
 
 from lms.djangoapps.courseware.courses import get_course
 
 
-class Command(BaseCommand):
+class Command(BaseCommand):  # lint-amnesty, pylint: disable=missing-class-docstring
     help = 'Write a discussion link for a given course on standard output.'
 
     def add_arguments(self, parser):

--- a/lms/djangoapps/discussion/management/commands/get_discussion_link.py
+++ b/lms/djangoapps/discussion/management/commands/get_discussion_link.py
@@ -1,4 +1,5 @@
-from django.core.management.base import BaseCommand, CommandError  # lint-amnesty, pylint: disable=missing-module-docstring
+# lint-amnesty, pylint: disable=missing-module-docstring
+from django.core.management.base import BaseCommand, CommandError
 from opaque_keys.edx.keys import CourseKey
 
 from lms.djangoapps.courseware.courses import get_course

--- a/lms/djangoapps/discussion/management/commands/reload_forum_users.py
+++ b/lms/djangoapps/discussion/management/commands/reload_forum_users.py
@@ -3,13 +3,13 @@ Reload forum (comment client) users from existing users.
 """
 
 
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.core.management.base import BaseCommand
 
 import openedx.core.djangoapps.django_comment_common.comment_client as cc
 
 
-class Command(BaseCommand):
+class Command(BaseCommand):  # lint-amnesty, pylint: disable=missing-class-docstring
     help = 'Reload forum (comment client) users from existing users.'
 
     def add_arguments(self, parser):
@@ -18,12 +18,12 @@ class Command(BaseCommand):
                             metavar='username',
                             help='zero or more usernames (zero implies all users)')
 
-    def adduser(self, user):
+    def adduser(self, user):  # lint-amnesty, pylint: disable=missing-function-docstring
         print(user)
         try:
             cc_user = cc.User.from_django_user(user)
             cc_user.save()
-        except Exception as err:
+        except Exception as err:  # lint-amnesty, pylint: disable=broad-except
             print(u'update user info to discussion failed for user with id: {}, error={}'.format(user, str(err)))
 
     def handle(self, *args, **options):

--- a/lms/djangoapps/discussion/management/commands/seed_permissions_roles.py
+++ b/lms/djangoapps/discussion/management/commands/seed_permissions_roles.py
@@ -9,7 +9,7 @@ from opaque_keys.edx.keys import CourseKey
 from openedx.core.djangoapps.django_comment_common.utils import seed_permissions_roles
 
 
-class Command(BaseCommand):
+class Command(BaseCommand):  # lint-amnesty, pylint: disable=missing-class-docstring
     help = 'Seed default permisssions and roles.'
 
     def add_arguments(self, parser):

--- a/lms/djangoapps/discussion/management/commands/show_permissions.py
+++ b/lms/djangoapps/discussion/management/commands/show_permissions.py
@@ -1,11 +1,11 @@
 # pylint: disable=missing-module-docstring,too-many-format-args
 
 
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.core.management.base import BaseCommand
 
 
-class Command(BaseCommand):
+class Command(BaseCommand):  # lint-amnesty, pylint: disable=missing-class-docstring
     help = "Show a user's roles and permissions."
 
     def add_arguments(self, parser):

--- a/lms/djangoapps/discussion/management/commands/sync_user_info.py
+++ b/lms/djangoapps/discussion/management/commands/sync_user_info.py
@@ -4,7 +4,7 @@ discussion service (later info will be synced automatically)
 """
 
 
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.core.management.base import BaseCommand
 
 import openedx.core.djangoapps.django_comment_common.comment_client as cc

--- a/lms/djangoapps/discussion/notification_prefs/__init__.py
+++ b/lms/djangoapps/discussion/notification_prefs/__init__.py
@@ -1,1 +1,1 @@
-NOTIFICATION_PREF_KEY = "notification_pref"
+NOTIFICATION_PREF_KEY = "notification_pref"  # lint-amnesty, pylint: disable=missing-module-docstring

--- a/lms/djangoapps/discussion/notification_prefs/__init__.py
+++ b/lms/djangoapps/discussion/notification_prefs/__init__.py
@@ -1,1 +1,2 @@
-NOTIFICATION_PREF_KEY = "notification_pref"  # lint-amnesty, pylint: disable=missing-module-docstring
+# lint-amnesty, pylint: disable=missing-module-docstring
+NOTIFICATION_PREF_KEY = "notification_pref"

--- a/lms/djangoapps/discussion/notification_prefs/tests.py
+++ b/lms/djangoapps/discussion/notification_prefs/tests.py
@@ -27,12 +27,12 @@ from common.djangoapps.util.testing import UrlResetMixin
 
 
 @override_settings(SECRET_KEY="test secret key")
-class NotificationPrefViewTest(UrlResetMixin, TestCase):
+class NotificationPrefViewTest(UrlResetMixin, TestCase):  # lint-amnesty, pylint: disable=missing-class-docstring
     INITIALIZATION_VECTOR = b"\x00" * 16
 
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
-        super(NotificationPrefViewTest, self).setUp()
+        super(NotificationPrefViewTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         self.user = UserFactory.create(username="testuser")
         # Tokens are intentionally hard-coded instead of computed to help us
         # avoid breaking existing links.

--- a/lms/djangoapps/discussion/notification_prefs/views.py
+++ b/lms/djangoapps/discussion/notification_prefs/views.py
@@ -15,7 +15,7 @@ from cryptography.hazmat.primitives.ciphers.algorithms import AES
 from cryptography.hazmat.primitives.ciphers.modes import CBC
 from cryptography.hazmat.primitives.padding import PKCS7
 from django.conf import settings
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.core.exceptions import PermissionDenied
 from django.http import Http404, HttpResponse
 from django.views.decorators.http import require_GET, require_POST
@@ -60,7 +60,7 @@ class UsernameCipher(object):
         return Cipher(AES(hash_.digest()), CBC(initialization_vector), backend=default_backend())
 
     @staticmethod
-    def encrypt(username):
+    def encrypt(username):  # lint-amnesty, pylint: disable=missing-function-docstring
         initialization_vector = os.urandom(AES_BLOCK_SIZE_BYTES)
 
         if not isinstance(initialization_vector, (bytes, bytearray)):
@@ -73,11 +73,11 @@ class UsernameCipher(object):
         return urlsafe_b64encode(initialization_vector + encryptor.update(padded) + encryptor.finalize()).decode()
 
     @staticmethod
-    def decrypt(token):
+    def decrypt(token):  # lint-amnesty, pylint: disable=missing-function-docstring
         try:
             base64_decoded = urlsafe_b64decode(token)
         except (TypeError, Error):
-            raise UsernameDecryptionException("base64url")
+            raise UsernameDecryptionException("base64url")  # lint-amnesty, pylint: disable=raise-missing-from
 
         if len(base64_decoded) < AES_BLOCK_SIZE_BYTES:
             raise UsernameDecryptionException("initialization_vector")
@@ -91,7 +91,7 @@ class UsernameCipher(object):
         try:
             decrypted = decryptor.update(aes_encrypted) + decryptor.finalize()
         except ValueError:
-            raise UsernameDecryptionException("aes")
+            raise UsernameDecryptionException("aes")  # lint-amnesty, pylint: disable=raise-missing-from
 
         try:
             unpadded = unpadder.update(decrypted) + unpadder.finalize()
@@ -99,7 +99,7 @@ class UsernameCipher(object):
                 raise UsernameDecryptionException("padding")
             return unpadded
         except ValueError:
-            raise UsernameDecryptionException("padding")
+            raise UsernameDecryptionException("padding")  # lint-amnesty, pylint: disable=raise-missing-from
 
 
 def enable_notifications(user):
@@ -168,7 +168,7 @@ def ajax_status(request):
         key=NOTIFICATION_PREF_KEY
     )
 
-    return HttpResponse(json.dumps({"status": len(qs)}), content_type="application/json")
+    return HttpResponse(json.dumps({"status": len(qs)}), content_type="application/json")  # lint-amnesty, pylint: disable=http-response-with-content-type-json, http-response-with-json-dumps
 
 
 @require_GET
@@ -189,11 +189,11 @@ def set_subscription(request, token, subscribe):
         username = UsernameCipher().decrypt(token.encode()).decode()
         user = User.objects.get(username=username)
     except UnicodeDecodeError:
-        raise Http404("base64url")
+        raise Http404("base64url")  # lint-amnesty, pylint: disable=raise-missing-from
     except UsernameDecryptionException as exn:
-        raise Http404(text_type(exn))
+        raise Http404(text_type(exn))  # lint-amnesty, pylint: disable=raise-missing-from
     except User.DoesNotExist:
-        raise Http404("username")
+        raise Http404("username")  # lint-amnesty, pylint: disable=raise-missing-from
 
     # Calling UserPreference directly because the fact that the user is passed in the token implies
     # that it may not match request.user.

--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -62,7 +62,7 @@ from openedx.core.djangoapps.django_comment_common.signals import (
 )
 from openedx.core.djangoapps.django_comment_common.utils import get_course_discussion_settings
 from openedx.core.djangoapps.user_api.accounts.api import get_account_settings
-from openedx.core.djangoapps.user_api.accounts.views import AccountViewSet
+from openedx.core.djangoapps.user_api.accounts.views import AccountViewSet  # lint-amnesty, pylint: disable=unused-import
 from openedx.core.lib.exceptions import CourseNotFoundError, DiscussionNotFoundError, PageNotFoundError
 
 
@@ -96,11 +96,11 @@ def _get_course(course_key, user):
         course = get_course_with_access(user, 'load', course_key, check_if_enrolled=True)
     except Http404:
         # Convert 404s into CourseNotFoundErrors.
-        raise CourseNotFoundError("Course not found.")
+        raise CourseNotFoundError("Course not found.")  # lint-amnesty, pylint: disable=raise-missing-from
     except CourseAccessRedirect:
         # Raise course not found if the user cannot access the course
         # since it doesn't make sense to redirect an API.
-        raise CourseNotFoundError("Course not found.")
+        raise CourseNotFoundError("Course not found.")  # lint-amnesty, pylint: disable=raise-missing-from
     if not any([tab.type == 'discussion' and tab.is_enabled(course, user) for tab in course.tabs]):
         raise DiscussionDisabledError("Discussion is disabled for the course.")
     return course
@@ -137,7 +137,7 @@ def _get_thread_and_context(request, thread_id, retrieve_kwargs=None):
     except CommentClientRequestError:
         # params are validated at a higher level, so the only possible request
         # error is if the thread doesn't exist
-        raise ThreadNotFoundError("Thread not found.")
+        raise ThreadNotFoundError("Thread not found.")  # lint-amnesty, pylint: disable=raise-missing-from
 
 
 def _get_comment_and_context(request, comment_id):
@@ -153,7 +153,7 @@ def _get_comment_and_context(request, comment_id):
         _, context = _get_thread_and_context(request, cc_comment["thread_id"])
         return cc_comment, context
     except CommentClientRequestError:
-        raise CommentNotFoundError("Comment not found.")
+        raise CommentNotFoundError("Comment not found.")  # lint-amnesty, pylint: disable=raise-missing-from
 
 
 def _is_user_author_or_privileged(cc_content, context):
@@ -677,7 +677,7 @@ def get_comment_list(request, thread_id, endorsed, page, page_size, requested_fi
     # responses to question threads must be separated by endorsed due to the
     # existing comments service interface
     if cc_thread["thread_type"] == "question":
-        if endorsed is None:
+        if endorsed is None:  # lint-amnesty, pylint: disable=no-else-raise
             raise ValidationError({"endorsed": ["This field is required for question threads."]})
         elif endorsed:
             # CS does not apply resp_skip and resp_limit to endorsed responses
@@ -827,7 +827,7 @@ def _handle_voted_field(form_value, cc_content, api_content, request, context):
         context["cc_requester"].unvote(cc_content)
         api_content["vote_count"] -= 1
     track_voted_event(
-        request, context["course"], cc_content, vote_value="up", undo_vote=False if form_value else True
+        request, context["course"], cc_content, vote_value="up", undo_vote=False if form_value else True  # lint-amnesty, pylint: disable=simplifiable-if-expression
     )
 
 
@@ -866,7 +866,7 @@ def create_thread(request, thread_data):
         course_key = CourseKey.from_string(course_id)
         course = _get_course(course_key, user)
     except InvalidKeyError:
-        raise ValidationError({"course_id": ["Invalid value."]})
+        raise ValidationError({"course_id": ["Invalid value."]})  # lint-amnesty, pylint: disable=raise-missing-from
 
     context = get_context(course, request)
     _check_initializable_thread_fields(thread_data, context)
@@ -1100,7 +1100,7 @@ def get_response_comments(request, comment_id, page, page_size, requested_fields
         paginator = DiscussionAPIPagination(request, page, num_pages, comments_count)
         return paginator.get_paginated_response(results)
     except CommentClientRequestError:
-        raise CommentNotFoundError("Comment not found")
+        raise CommentNotFoundError("Comment not found")  # lint-amnesty, pylint: disable=raise-missing-from
 
 
 def delete_thread(request, thread_id):

--- a/lms/djangoapps/discussion/rest_api/exceptions.py
+++ b/lms/djangoapps/discussion/rest_api/exceptions.py
@@ -6,14 +6,14 @@ from django.core.exceptions import ObjectDoesNotExist
 
 class DiscussionDisabledError(ObjectDoesNotExist):
     """ Discussion is disabled. """
-    pass
+    pass  # lint-amnesty, pylint: disable=unnecessary-pass
 
 
 class ThreadNotFoundError(ObjectDoesNotExist):
     """ Thread was not found. """
-    pass
+    pass  # lint-amnesty, pylint: disable=unnecessary-pass
 
 
 class CommentNotFoundError(ObjectDoesNotExist):
     """ Comment was not found. """
-    pass
+    pass  # lint-amnesty, pylint: disable=unnecessary-pass

--- a/lms/djangoapps/discussion/rest_api/forms.py
+++ b/lms/djangoapps/discussion/rest_api/forms.py
@@ -75,18 +75,18 @@ class ThreadListGetForm(_PaginationForm):
         try:
             return CourseLocator.from_string(value)
         except InvalidKeyError:
-            raise ValidationError(u"'{}' is not a valid course id".format(value))
+            raise ValidationError(u"'{}' is not a valid course id".format(value))  # lint-amnesty, pylint: disable=raise-missing-from
 
     def clean_following(self):
         """Validate following"""
         value = self.cleaned_data["following"]
-        if value is False:
+        if value is False:  # lint-amnesty, pylint: disable=no-else-raise
             raise ValidationError("The value of the 'following' parameter must be true.")
         else:
             return value
 
     def clean(self):
-        cleaned_data = super(ThreadListGetForm, self).clean()
+        cleaned_data = super(ThreadListGetForm, self).clean()  # lint-amnesty, pylint: disable=super-with-arguments
         exclusive_params_count = sum(
             1 for param in self.EXCLUSIVE_PARAMS if cleaned_data.get(param)
         )
@@ -143,7 +143,7 @@ class CourseDiscussionSettingsForm(Form):
 
     def __init__(self, *args, **kwargs):
         self.request_user = kwargs.pop('request_user')
-        super(CourseDiscussionSettingsForm, self).__init__(*args, **kwargs)
+        super(CourseDiscussionSettingsForm, self).__init__(*args, **kwargs)  # lint-amnesty, pylint: disable=super-with-arguments
 
     def clean_course_id(self):
         """Validate the 'course_id' value"""
@@ -154,7 +154,7 @@ class CourseDiscussionSettingsForm(Form):
             self.cleaned_data['course_key'] = course_key
             return course_id
         except InvalidKeyError:
-            raise ValidationError(u"'{}' is not a valid course key".format(text_type(course_id)))
+            raise ValidationError(u"'{}' is not a valid course key".format(text_type(course_id)))  # lint-amnesty, pylint: disable=raise-missing-from
 
 
 class CourseDiscussionRolesForm(CourseDiscussionSettingsForm):
@@ -179,7 +179,7 @@ class CourseDiscussionRolesForm(CourseDiscussionSettingsForm):
             try:
                 role = Role.objects.get(name=rolename, course_id=course_id)
             except Role.DoesNotExist:
-                raise ValidationError(u"Role '{}' does not exist".format(rolename))
+                raise ValidationError(u"Role '{}' does not exist".format(rolename))  # lint-amnesty, pylint: disable=raise-missing-from
 
             self.cleaned_data['role'] = role
             return rolename

--- a/lms/djangoapps/discussion/rest_api/pagination.py
+++ b/lms/djangoapps/discussion/rest_api/pagination.py
@@ -51,7 +51,7 @@ class DiscussionAPIPagination(NamespacedPageNumberPagination):
         self.base_url = request.build_absolute_uri()
         self.count = result_count
 
-        super(DiscussionAPIPagination, self).__init__()
+        super(DiscussionAPIPagination, self).__init__()  # lint-amnesty, pylint: disable=super-with-arguments
 
     def get_result_count(self):
         """

--- a/lms/djangoapps/discussion/rest_api/serializers.py
+++ b/lms/djangoapps/discussion/rest_api/serializers.py
@@ -3,7 +3,7 @@ Discussion API serializers
 """
 
 
-from django.contrib.auth.models import User as DjangoUser
+from django.contrib.auth.models import User as DjangoUser  # lint-amnesty, pylint: disable=imported-auth-user
 from django.core.exceptions import ValidationError
 from django.urls import reverse
 from rest_framework import serializers
@@ -103,7 +103,7 @@ class _ContentSerializer(serializers.Serializer):
     non_updatable_fields = set()
 
     def __init__(self, *args, **kwargs):
-        super(_ContentSerializer, self).__init__(*args, **kwargs)
+        super(_ContentSerializer, self).__init__(*args, **kwargs)  # lint-amnesty, pylint: disable=super-with-arguments
 
         for field in self.non_updatable_fields:
             setattr(self, "validate_{}".format(field), self._validate_non_updatable)
@@ -223,7 +223,7 @@ class ThreadSerializer(_ContentSerializer):
     non_updatable_fields = NON_UPDATABLE_THREAD_FIELDS
 
     def __init__(self, *args, **kwargs):
-        super(ThreadSerializer, self).__init__(*args, **kwargs)
+        super(ThreadSerializer, self).__init__(*args, **kwargs)  # lint-amnesty, pylint: disable=super-with-arguments
         # Compensate for the fact that some threads in the comments service do
         # not have the pinned field set
         if self.instance and self.instance.get("pinned") is None:
@@ -329,7 +329,7 @@ class CommentSerializer(_ContentSerializer):
 
     def __init__(self, *args, **kwargs):
         remove_fields = kwargs.pop('remove_fields', None)
-        super(CommentSerializer, self).__init__(*args, **kwargs)
+        super(CommentSerializer, self).__init__(*args, **kwargs)  # lint-amnesty, pylint: disable=super-with-arguments
 
         if remove_fields:
             # for multiple fields in a list
@@ -379,7 +379,7 @@ class CommentSerializer(_ContentSerializer):
 
     def to_representation(self, data):
         # pylint: disable=arguments-differ
-        data = super(CommentSerializer, self).to_representation(data)
+        data = super(CommentSerializer, self).to_representation(data)  # lint-amnesty, pylint: disable=super-with-arguments
 
         # Django Rest Framework v3 no longer includes None values
         # in the representation.  To maintain the previous behavior,
@@ -453,13 +453,13 @@ class DiscussionTopicSerializer(serializers.Serializer):
         """
         Overriden create abstract method
         """
-        pass
+        pass  # lint-amnesty, pylint: disable=unnecessary-pass
 
     def update(self, instance, validated_data):
         """
         Overriden update abstract method
         """
-        pass
+        pass  # lint-amnesty, pylint: disable=unnecessary-pass
 
 
 class DiscussionSettingsSerializer(serializers.Serializer):
@@ -478,7 +478,7 @@ class DiscussionSettingsSerializer(serializers.Serializer):
     def __init__(self, *args, **kwargs):
         self.course = kwargs.pop('course')
         self.discussion_settings = kwargs.pop('discussion_settings')
-        super(DiscussionSettingsSerializer, self).__init__(*args, **kwargs)
+        super(DiscussionSettingsSerializer, self).__init__(*args, **kwargs)  # lint-amnesty, pylint: disable=super-with-arguments
 
     def validate(self, attrs):
         """
@@ -510,13 +510,13 @@ class DiscussionSettingsSerializer(serializers.Serializer):
         """
         Overriden create abstract method
         """
-        pass
+        pass  # lint-amnesty, pylint: disable=unnecessary-pass
 
     def update(self, instance, validated_data):
         """
         Overriden update abstract method
         """
-        pass
+        pass  # lint-amnesty, pylint: disable=unnecessary-pass
 
 
 class DiscussionRolesSerializer(serializers.Serializer):
@@ -532,15 +532,15 @@ class DiscussionRolesSerializer(serializers.Serializer):
     user_id = serializers.CharField()
 
     def __init__(self, *args, **kwargs):
-        super(DiscussionRolesSerializer, self).__init__(*args, **kwargs)
+        super(DiscussionRolesSerializer, self).__init__(*args, **kwargs)  # lint-amnesty, pylint: disable=super-with-arguments
         self.user = None
 
-    def validate_user_id(self, user_id):
+    def validate_user_id(self, user_id):  # lint-amnesty, pylint: disable=missing-function-docstring
         try:
             self.user = get_user_by_username_or_email(user_id)
             return user_id
         except DjangoUser.DoesNotExist:
-            raise ValidationError(u"'{}' is not a valid student identifier".format(user_id))
+            raise ValidationError(u"'{}' is not a valid student identifier".format(user_id))  # lint-amnesty, pylint: disable=raise-missing-from
 
     def validate(self, attrs):
         """Validate the data at an object level."""
@@ -554,13 +554,13 @@ class DiscussionRolesSerializer(serializers.Serializer):
         """
         Overriden create abstract method
         """
-        pass
+        pass  # lint-amnesty, pylint: disable=unnecessary-pass
 
     def update(self, instance, validated_data):
         """
         Overriden update abstract method
         """
-        pass
+        pass  # lint-amnesty, pylint: disable=unnecessary-pass
 
 
 class DiscussionRolesMemberSerializer(serializers.Serializer):
@@ -574,7 +574,7 @@ class DiscussionRolesMemberSerializer(serializers.Serializer):
     group_name = serializers.SerializerMethodField()
 
     def __init__(self, *args, **kwargs):
-        super(DiscussionRolesMemberSerializer, self).__init__(*args, **kwargs)
+        super(DiscussionRolesMemberSerializer, self).__init__(*args, **kwargs)  # lint-amnesty, pylint: disable=super-with-arguments
         self.course_discussion_settings = self.context['course_discussion_settings']
 
     def get_group_name(self, instance):
@@ -587,13 +587,13 @@ class DiscussionRolesMemberSerializer(serializers.Serializer):
         """
         Overriden create abstract method
         """
-        pass
+        pass  # lint-amnesty, pylint: disable=unnecessary-pass
 
     def update(self, instance, validated_data):
         """
         Overriden update abstract method
         """
-        pass
+        pass  # lint-amnesty, pylint: disable=unnecessary-pass
 
 
 class DiscussionRolesListSerializer(serializers.Serializer):
@@ -621,10 +621,10 @@ class DiscussionRolesListSerializer(serializers.Serializer):
         """
         Overriden create abstract method
         """
-        pass
+        pass  # lint-amnesty, pylint: disable=unnecessary-pass
 
     def update(self, instance, validated_data):
         """
         Overriden update abstract method
         """
-        pass
+        pass  # lint-amnesty, pylint: disable=unnecessary-pass

--- a/lms/djangoapps/discussion/rest_api/tests/test_api.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api.py
@@ -117,7 +117,7 @@ class GetCourseTest(ForumsEnableMixin, UrlResetMixin, SharedModuleStoreTestCase)
 
     @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
-        super(GetCourseTest, self).setUp()
+        super(GetCourseTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         self.user = UserFactory.create()
         CourseEnrollmentFactory.create(user=self.user, course_id=self.course.id)
         self.request = RequestFactory().get("/dummy")
@@ -161,7 +161,7 @@ class GetCourseTestBlackouts(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCa
 
     @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
-        super(GetCourseTestBlackouts, self).setUp()
+        super(GetCourseTestBlackouts, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         self.course = CourseFactory.create(org="x", course="y", run="z")
         self.user = UserFactory.create()
         CourseEnrollmentFactory.create(user=self.user, course_id=self.course.id)
@@ -201,7 +201,7 @@ class GetCourseTopicsTest(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCase)
     """Test for get_course_topics"""
     @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
-        super(GetCourseTopicsTest, self).setUp()
+        super(GetCourseTopicsTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         self.maxDiff = None  # pylint: disable=invalid-name
         self.partition = UserPartition(
             0,
@@ -581,7 +581,7 @@ class GetThreadListTest(ForumsEnableMixin, CommentsServiceMockMixin, UrlResetMix
 
     @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
-        super(GetThreadListTest, self).setUp()
+        super(GetThreadListTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         httpretty.reset()
         httpretty.enable()
         self.addCleanup(httpretty.reset)
@@ -645,7 +645,7 @@ class GetThreadListTest(ForumsEnableMixin, CommentsServiceMockMixin, UrlResetMix
 
     def test_get_threads_by_topic_id(self):
         self.get_thread_list([], topic_id_list=["topic_x", "topic_meow"])
-        self.assertEqual(urlparse(httpretty.last_request().path).path, "/api/v1/threads")
+        self.assertEqual(urlparse(httpretty.last_request().path).path, "/api/v1/threads")  # lint-amnesty, pylint: disable=no-member
         self.assert_last_query_params({
             "user_id": [six.text_type(self.user.id)],
             "course_id": [six.text_type(self.course.id)],
@@ -769,7 +769,7 @@ class GetThreadListTest(ForumsEnableMixin, CommentsServiceMockMixin, UrlResetMix
         role = Role.objects.create(name=role_name, course_id=cohort_course.id)
         role.users.set([self.user])
         self.get_thread_list([], course=cohort_course)
-        actual_has_group = "group_id" in httpretty.last_request().querystring
+        actual_has_group = "group_id" in httpretty.last_request().querystring  # lint-amnesty, pylint: disable=no-member
         expected_has_group = (course_is_cohorted and role_name == FORUM_ROLE_STUDENT)
         self.assertEqual(actual_has_group, expected_has_group)
 
@@ -856,7 +856,7 @@ class GetThreadListTest(ForumsEnableMixin, CommentsServiceMockMixin, UrlResetMix
             expected_result
         )
         self.assertEqual(
-            urlparse(httpretty.last_request().path).path,
+            urlparse(httpretty.last_request().path).path,  # lint-amnesty, pylint: disable=no-member
             "/api/v1/users/{}/subscribed_threads".format(self.user.id)
         )
         self.assert_last_query_params({
@@ -887,7 +887,7 @@ class GetThreadListTest(ForumsEnableMixin, CommentsServiceMockMixin, UrlResetMix
             expected_result
         )
         self.assertEqual(
-            urlparse(httpretty.last_request().path).path,
+            urlparse(httpretty.last_request().path).path,  # lint-amnesty, pylint: disable=no-member
             "/api/v1/threads"
         )
         self.assert_last_query_params({
@@ -928,7 +928,7 @@ class GetThreadListTest(ForumsEnableMixin, CommentsServiceMockMixin, UrlResetMix
         expected_result.update({"text_search_rewrite": None})
         self.assertEqual(result, expected_result)
         self.assertEqual(
-            urlparse(httpretty.last_request().path).path,
+            urlparse(httpretty.last_request().path).path,  # lint-amnesty, pylint: disable=no-member
             "/api/v1/threads"
         )
         self.assert_last_query_params({
@@ -959,7 +959,7 @@ class GetThreadListTest(ForumsEnableMixin, CommentsServiceMockMixin, UrlResetMix
         expected_result.update({"text_search_rewrite": None})
         self.assertEqual(result, expected_result)
         self.assertEqual(
-            urlparse(httpretty.last_request().path).path,
+            urlparse(httpretty.last_request().path).path,  # lint-amnesty, pylint: disable=no-member
             "/api/v1/threads"
         )
         self.assert_last_query_params({
@@ -998,7 +998,7 @@ class GetCommentListTest(ForumsEnableMixin, CommentsServiceMockMixin, SharedModu
 
     @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
-        super(GetCommentListTest, self).setUp()
+        super(GetCommentListTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         httpretty.reset()
         httpretty.enable()
         self.addCleanup(httpretty.reset)
@@ -1477,7 +1477,7 @@ class CreateThreadTest(
 
     @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
-        super(CreateThreadTest, self).setUp()
+        super(CreateThreadTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         httpretty.reset()
         httpretty.enable()
         self.addCleanup(httpretty.reset)
@@ -1513,7 +1513,7 @@ class CreateThreadTest(
         })
         self.assertEqual(actual, expected)
         self.assertEqual(
-            httpretty.last_request().parsed_body,
+            httpretty.last_request().parsed_body,  # lint-amnesty, pylint: disable=no-member
             {
                 "course_id": [six.text_type(self.course.id)],
                 "commentable_id": ["test_topic"],
@@ -1633,7 +1633,7 @@ class CreateThreadTest(
         try:
             create_thread(self.request, data)
             self.assertFalse(expected_error)
-            actual_post_data = httpretty.last_request().parsed_body
+            actual_post_data = httpretty.last_request().parsed_body  # lint-amnesty, pylint: disable=no-member
             if data_group_state == "group_is_set":
                 self.assertEqual(actual_post_data["group_id"], [str(data["group_id"])])
             elif data_group_state == "no_group_set" and course_is_cohorted and topic_is_cohorted:
@@ -1653,12 +1653,12 @@ class CreateThreadTest(
         self.assertEqual(result["following"], True)
         cs_request = httpretty.last_request()
         self.assertEqual(
-            urlparse(cs_request.path).path,
+            urlparse(cs_request.path).path,  # lint-amnesty, pylint: disable=no-member
             "/api/v1/users/{}/subscriptions".format(self.user.id)
         )
         self.assertEqual(cs_request.method, "POST")
         self.assertEqual(
-            cs_request.parsed_body,
+            cs_request.parsed_body,  # lint-amnesty, pylint: disable=no-member
             {"source_type": ["thread"], "source_id": ["test_id"]}
         )
 
@@ -1671,10 +1671,10 @@ class CreateThreadTest(
             result = create_thread(self.request, data)
         self.assertEqual(result["voted"], True)
         cs_request = httpretty.last_request()
-        self.assertEqual(urlparse(cs_request.path).path, "/api/v1/threads/test_id/votes")
+        self.assertEqual(urlparse(cs_request.path).path, "/api/v1/threads/test_id/votes")  # lint-amnesty, pylint: disable=no-member
         self.assertEqual(cs_request.method, "PUT")
         self.assertEqual(
-            cs_request.parsed_body,
+            cs_request.parsed_body,  # lint-amnesty, pylint: disable=no-member
             {"user_id": [str(self.user.id)], "value": ["up"]}
         )
 
@@ -1686,9 +1686,9 @@ class CreateThreadTest(
         result = create_thread(self.request, data)
         self.assertEqual(result["abuse_flagged"], True)
         cs_request = httpretty.last_request()
-        self.assertEqual(urlparse(cs_request.path).path, "/api/v1/threads/test_id/abuse_flag")
+        self.assertEqual(urlparse(cs_request.path).path, "/api/v1/threads/test_id/abuse_flag")  # lint-amnesty, pylint: disable=no-member
         self.assertEqual(cs_request.method, "PUT")
-        self.assertEqual(cs_request.parsed_body, {"user_id": [str(self.user.id)]})
+        self.assertEqual(cs_request.parsed_body, {"user_id": [str(self.user.id)]})  # lint-amnesty, pylint: disable=no-member
 
     def test_course_id_missing(self):
         with self.assertRaises(ValidationError) as assertion:
@@ -1741,7 +1741,7 @@ class CreateCommentTest(
 
     @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
-        super(CreateCommentTest, self).setUp()
+        super(CreateCommentTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         httpretty.reset()
         httpretty.enable()
         self.addCleanup(httpretty.reset)
@@ -1810,11 +1810,11 @@ class CreateCommentTest(
             "/api/v1/threads/test_thread/comments"
         )
         self.assertEqual(
-            urlparse(httpretty.last_request().path).path,
+            urlparse(httpretty.last_request().path).path,  # lint-amnesty, pylint: disable=no-member
             expected_url
         )
         self.assertEqual(
-            httpretty.last_request().parsed_body,
+            httpretty.last_request().parsed_body,  # lint-amnesty, pylint: disable=no-member
             {
                 "course_id": [six.text_type(self.course.id)],
                 "body": ["Test body"],
@@ -1875,7 +1875,7 @@ class CreateCommentTest(
         )
         try:
             create_comment(self.request, data)
-            self.assertEqual(httpretty.last_request().parsed_body["endorsed"], ["True"])
+            self.assertEqual(httpretty.last_request().parsed_body["endorsed"], ["True"])  # lint-amnesty, pylint: disable=no-member
             self.assertFalse(expected_error)
         except ValidationError:
             self.assertTrue(expected_error)
@@ -1889,10 +1889,10 @@ class CreateCommentTest(
             result = create_comment(self.request, data)
         self.assertEqual(result["voted"], True)
         cs_request = httpretty.last_request()
-        self.assertEqual(urlparse(cs_request.path).path, "/api/v1/comments/test_comment/votes")
+        self.assertEqual(urlparse(cs_request.path).path, "/api/v1/comments/test_comment/votes")  # lint-amnesty, pylint: disable=no-member
         self.assertEqual(cs_request.method, "PUT")
         self.assertEqual(
-            cs_request.parsed_body,
+            cs_request.parsed_body,  # lint-amnesty, pylint: disable=no-member
             {"user_id": [str(self.user.id)], "value": ["up"]}
         )
 
@@ -1904,9 +1904,9 @@ class CreateCommentTest(
         result = create_comment(self.request, data)
         self.assertEqual(result["abuse_flagged"], True)
         cs_request = httpretty.last_request()
-        self.assertEqual(urlparse(cs_request.path).path, "/api/v1/comments/test_comment/abuse_flag")
+        self.assertEqual(urlparse(cs_request.path).path, "/api/v1/comments/test_comment/abuse_flag")  # lint-amnesty, pylint: disable=no-member
         self.assertEqual(cs_request.method, "PUT")
-        self.assertEqual(cs_request.parsed_body, {"user_id": [str(self.user.id)]})
+        self.assertEqual(cs_request.parsed_body, {"user_id": [str(self.user.id)]})  # lint-amnesty, pylint: disable=no-member
 
     def test_thread_id_missing(self):
         with self.assertRaises(ValidationError) as assertion:
@@ -2006,7 +2006,7 @@ class UpdateThreadTest(
 
     @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
-        super(UpdateThreadTest, self).setUp()
+        super(UpdateThreadTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         httpretty.reset()
         httpretty.enable()
         self.addCleanup(httpretty.reset)
@@ -2060,7 +2060,7 @@ class UpdateThreadTest(
             "title": "Original Title",
         }))
         self.assertEqual(
-            httpretty.last_request().parsed_body,
+            httpretty.last_request().parsed_body,  # lint-amnesty, pylint: disable=no-member
             {
                 "course_id": [six.text_type(self.course.id)],
                 "commentable_id": ["original_topic"],
@@ -2174,7 +2174,7 @@ class UpdateThreadTest(
         data = {"following": new_following}
         result = update_thread(self.request, "test_thread", data)
         self.assertEqual(result["following"], new_following)
-        last_request_path = urlparse(httpretty.last_request().path).path
+        last_request_path = urlparse(httpretty.last_request().path).path  # lint-amnesty, pylint: disable=no-member
         subscription_url = "/api/v1/users/{}/subscriptions".format(self.user.id)
         if old_following == new_following:
             self.assertNotEqual(last_request_path, subscription_url)
@@ -2185,8 +2185,8 @@ class UpdateThreadTest(
                 "POST" if new_following else "DELETE"
             )
             request_data = (
-                httpretty.last_request().parsed_body if new_following else
-                parse_qs(urlparse(httpretty.last_request().path).query)
+                httpretty.last_request().parsed_body if new_following else  # lint-amnesty, pylint: disable=no-member
+                parse_qs(urlparse(httpretty.last_request().path).query)  # lint-amnesty, pylint: disable=no-member
             )
             request_data.pop("request_id", None)
             self.assertEqual(
@@ -2214,7 +2214,7 @@ class UpdateThreadTest(
         data = {"voted": new_vote_status}
         result = update_thread(self.request, "test_thread", data)
         self.assertEqual(result["voted"], new_vote_status)
-        last_request_path = urlparse(httpretty.last_request().path).path
+        last_request_path = urlparse(httpretty.last_request().path).path  # lint-amnesty, pylint: disable=no-member
         votes_url = "/api/v1/threads/test_thread/votes"
         if current_vote_status == new_vote_status:
             self.assertNotEqual(last_request_path, votes_url)
@@ -2225,8 +2225,8 @@ class UpdateThreadTest(
                 "PUT" if new_vote_status else "DELETE"
             )
             actual_request_data = (
-                httpretty.last_request().parsed_body if new_vote_status else
-                parse_qs(urlparse(httpretty.last_request().path).query)
+                httpretty.last_request().parsed_body if new_vote_status else  # lint-amnesty, pylint: disable=no-member
+                parse_qs(urlparse(httpretty.last_request().path).query)  # lint-amnesty, pylint: disable=no-member
             )
             actual_request_data.pop("request_id", None)
             expected_request_data = {"user_id": [str(self.user.id)]}
@@ -2340,7 +2340,7 @@ class UpdateThreadTest(
         data = {"abuse_flagged": new_flagged}
         result = update_thread(self.request, "test_thread", data)
         self.assertEqual(result["abuse_flagged"], new_flagged)
-        last_request_path = urlparse(httpretty.last_request().path).path
+        last_request_path = urlparse(httpretty.last_request().path).path  # lint-amnesty, pylint: disable=no-member
         flag_url = "/api/v1/threads/test_thread/abuse_flag"
         unflag_url = "/api/v1/threads/test_thread/abuse_unflag"
         if old_flagged == new_flagged:
@@ -2353,7 +2353,7 @@ class UpdateThreadTest(
             )
             self.assertEqual(httpretty.last_request().method, "PUT")
             self.assertEqual(
-                httpretty.last_request().parsed_body,
+                httpretty.last_request().parsed_body,  # lint-amnesty, pylint: disable=no-member
                 {"user_id": [str(self.user.id)]}
             )
 
@@ -2387,7 +2387,7 @@ class UpdateCommentTest(
 
     @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
-        super(UpdateCommentTest, self).setUp()
+        super(UpdateCommentTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
 
         httpretty.reset()
         httpretty.enable()
@@ -2464,7 +2464,7 @@ class UpdateCommentTest(
         }
         self.assertEqual(actual, expected)
         self.assertEqual(
-            httpretty.last_request().parsed_body,
+            httpretty.last_request().parsed_body,  # lint-amnesty, pylint: disable=no-member
             {
                 "body": ["Edited body"],
                 "course_id": [six.text_type(self.course.id)],
@@ -2625,7 +2625,7 @@ class UpdateCommentTest(
         result = update_comment(self.request, "test_comment", data)
         self.assertEqual(result["vote_count"], 1 if new_vote_status else 0)
         self.assertEqual(result["voted"], new_vote_status)
-        last_request_path = urlparse(httpretty.last_request().path).path
+        last_request_path = urlparse(httpretty.last_request().path).path  # lint-amnesty, pylint: disable=no-member
         votes_url = "/api/v1/comments/test_comment/votes"
         if current_vote_status == new_vote_status:
             self.assertNotEqual(last_request_path, votes_url)
@@ -2636,8 +2636,8 @@ class UpdateCommentTest(
                 "PUT" if new_vote_status else "DELETE"
             )
             actual_request_data = (
-                httpretty.last_request().parsed_body if new_vote_status else
-                parse_qs(urlparse(httpretty.last_request().path).query)
+                httpretty.last_request().parsed_body if new_vote_status else  # lint-amnesty, pylint: disable=no-member
+                parse_qs(urlparse(httpretty.last_request().path).query)  # lint-amnesty, pylint: disable=no-member
             )
             actual_request_data.pop("request_id", None)
             expected_request_data = {"user_id": [str(self.user.id)]}
@@ -2751,7 +2751,7 @@ class UpdateCommentTest(
         data = {"abuse_flagged": new_flagged}
         result = update_comment(self.request, "test_comment", data)
         self.assertEqual(result["abuse_flagged"], new_flagged)
-        last_request_path = urlparse(httpretty.last_request().path).path
+        last_request_path = urlparse(httpretty.last_request().path).path  # lint-amnesty, pylint: disable=no-member
         flag_url = "/api/v1/comments/test_comment/abuse_flag"
         unflag_url = "/api/v1/comments/test_comment/abuse_unflag"
         if old_flagged == new_flagged:
@@ -2764,7 +2764,7 @@ class UpdateCommentTest(
             )
             self.assertEqual(httpretty.last_request().method, "PUT")
             self.assertEqual(
-                httpretty.last_request().parsed_body,
+                httpretty.last_request().parsed_body,  # lint-amnesty, pylint: disable=no-member
                 {"user_id": [str(self.user.id)]}
             )
 
@@ -2787,7 +2787,7 @@ class DeleteThreadTest(
 
     @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
-        super(DeleteThreadTest, self).setUp()
+        super(DeleteThreadTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         httpretty.reset()
         httpretty.enable()
         self.addCleanup(httpretty.reset)
@@ -2819,7 +2819,7 @@ class DeleteThreadTest(
         with self.assert_signal_sent(api, 'thread_deleted', sender=None, user=self.user, exclude_args=('post',)):
             self.assertIsNone(delete_thread(self.request, self.thread_id))
         self.assertEqual(
-            urlparse(httpretty.last_request().path).path,
+            urlparse(httpretty.last_request().path).path,  # lint-amnesty, pylint: disable=no-member
             "/api/v1/threads/{}".format(self.thread_id)
         )
         self.assertEqual(httpretty.last_request().method, "DELETE")
@@ -2924,7 +2924,7 @@ class DeleteCommentTest(
 
     @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
-        super(DeleteCommentTest, self).setUp()
+        super(DeleteCommentTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         httpretty.reset()
         httpretty.enable()
         self.addCleanup(httpretty.reset)
@@ -2965,7 +2965,7 @@ class DeleteCommentTest(
         with self.assert_signal_sent(api, 'comment_deleted', sender=None, user=self.user, exclude_args=('post',)):
             self.assertIsNone(delete_comment(self.request, self.comment_id))
         self.assertEqual(
-            urlparse(httpretty.last_request().path).path,
+            urlparse(httpretty.last_request().path).path,  # lint-amnesty, pylint: disable=no-member
             "/api/v1/comments/{}".format(self.comment_id)
         )
         self.assertEqual(httpretty.last_request().method, "DELETE")
@@ -3078,7 +3078,7 @@ class RetrieveThreadTest(
 
     @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
-        super(RetrieveThreadTest, self).setUp()
+        super(RetrieveThreadTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         httpretty.reset()
         httpretty.enable()
         self.addCleanup(httpretty.reset)

--- a/lms/djangoapps/discussion/rest_api/tests/test_forms.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_forms.py
@@ -45,7 +45,7 @@ class ThreadListGetFormTest(FormTestMixin, PaginationTestMixin, TestCase):
     FORM_CLASS = ThreadListGetForm
 
     def setUp(self):
-        super(ThreadListGetFormTest, self).setUp()
+        super(ThreadListGetFormTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         self.form_data = QueryDict(
             urlencode(
                 {
@@ -171,7 +171,7 @@ class CommentListGetFormTest(FormTestMixin, PaginationTestMixin, TestCase):
     FORM_CLASS = CommentListGetForm
 
     def setUp(self):
-        super(CommentListGetFormTest, self).setUp()
+        super(CommentListGetFormTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         self.form_data = {
             "thread_id": "deadbeef",
             "endorsed": "False",

--- a/lms/djangoapps/discussion/rest_api/tests/test_serializers.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_serializers.py
@@ -50,7 +50,7 @@ class SerializerTestMixin(ForumsEnableMixin, CommentsServiceMockMixin, UrlResetM
 
     @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
-        super(SerializerTestMixin, self).setUp()
+        super(SerializerTestMixin, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         httpretty.reset()
         httpretty.enable()
         self.addCleanup(httpretty.reset)
@@ -246,7 +246,7 @@ class ThreadSerializerSerializationTest(SerializerTestMixin, SharedModuleStoreTe
 class CommentSerializerTest(SerializerTestMixin, SharedModuleStoreTestCase):
     """Tests for CommentSerializer."""
     def setUp(self):
-        super(CommentSerializerTest, self).setUp()
+        super(CommentSerializerTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         self.endorser = UserFactory.create()
         self.endorsed_at = "2015-05-18T12:34:56Z"
 
@@ -417,7 +417,7 @@ class ThreadSerializerDeserializationTest(
 
     @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
-        super(ThreadSerializerDeserializationTest, self).setUp()
+        super(ThreadSerializerDeserializationTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         httpretty.reset()
         httpretty.enable()
         self.addCleanup(httpretty.reset)
@@ -466,11 +466,11 @@ class ThreadSerializerDeserializationTest(
         self.register_post_thread_response({"id": "test_id", "username": self.user.username})
         saved = self.save_and_reserialize(self.minimal_data)
         self.assertEqual(
-            urlparse(httpretty.last_request().path).path,
+            urlparse(httpretty.last_request().path).path,  # lint-amnesty, pylint: disable=no-member
             "/api/v1/test_topic/threads"
         )
         self.assertEqual(
-            httpretty.last_request().parsed_body,
+            httpretty.last_request().parsed_body,  # lint-amnesty, pylint: disable=no-member
             {
                 "course_id": [six.text_type(self.course.id)],
                 "commentable_id": ["test_topic"],
@@ -488,7 +488,7 @@ class ThreadSerializerDeserializationTest(
         data["group_id"] = 42
         self.save_and_reserialize(data)
         self.assertEqual(
-            httpretty.last_request().parsed_body,
+            httpretty.last_request().parsed_body,  # lint-amnesty, pylint: disable=no-member
             {
                 "course_id": [six.text_type(self.course.id)],
                 "commentable_id": ["test_topic"],
@@ -536,7 +536,7 @@ class ThreadSerializerDeserializationTest(
         self.register_put_thread_response(self.existing_thread.attributes)
         self.save_and_reserialize({}, self.existing_thread)
         self.assertEqual(
-            httpretty.last_request().parsed_body,
+            httpretty.last_request().parsed_body,  # lint-amnesty, pylint: disable=no-member
             {
                 "course_id": [six.text_type(self.course.id)],
                 "commentable_id": ["original_topic"],
@@ -564,7 +564,7 @@ class ThreadSerializerDeserializationTest(
         }
         saved = self.save_and_reserialize(data, self.existing_thread)
         self.assertEqual(
-            httpretty.last_request().parsed_body,
+            httpretty.last_request().parsed_body,  # lint-amnesty, pylint: disable=no-member
             {
                 "course_id": [six.text_type(self.course.id)],
                 "commentable_id": ["edited_topic"],
@@ -619,7 +619,7 @@ class CommentSerializerDeserializationTest(ForumsEnableMixin, CommentsServiceMoc
         cls.course = CourseFactory.create()
 
     def setUp(self):
-        super(CommentSerializerDeserializationTest, self).setUp()
+        super(CommentSerializerDeserializationTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         httpretty.reset()
         httpretty.enable()
         self.addCleanup(httpretty.reset)
@@ -677,9 +677,9 @@ class CommentSerializerDeserializationTest(ForumsEnableMixin, CommentsServiceMoc
             "/api/v1/comments/{}".format(parent_id) if parent_id else
             "/api/v1/threads/test_thread/comments"
         )
-        self.assertEqual(urlparse(httpretty.last_request().path).path, expected_url)
+        self.assertEqual(urlparse(httpretty.last_request().path).path, expected_url)  # lint-amnesty, pylint: disable=no-member
         self.assertEqual(
-            httpretty.last_request().parsed_body,
+            httpretty.last_request().parsed_body,  # lint-amnesty, pylint: disable=no-member
             {
                 "course_id": [six.text_type(self.course.id)],
                 "body": ["Test body"],
@@ -701,7 +701,7 @@ class CommentSerializerDeserializationTest(ForumsEnableMixin, CommentsServiceMoc
         )
         self.save_and_reserialize(data)
         self.assertEqual(
-            httpretty.last_request().parsed_body,
+            httpretty.last_request().parsed_body,  # lint-amnesty, pylint: disable=no-member
             {
                 "course_id": [six.text_type(self.course.id)],
                 "body": ["Test body"],
@@ -795,7 +795,7 @@ class CommentSerializerDeserializationTest(ForumsEnableMixin, CommentsServiceMoc
         data["endorsed"] = True
         saved = self.save_and_reserialize(data)
         self.assertEqual(
-            httpretty.last_request().parsed_body,
+            httpretty.last_request().parsed_body,  # lint-amnesty, pylint: disable=no-member
             {
                 "course_id": [six.text_type(self.course.id)],
                 "body": ["Test body"],
@@ -812,7 +812,7 @@ class CommentSerializerDeserializationTest(ForumsEnableMixin, CommentsServiceMoc
         self.register_put_comment_response(self.existing_comment.attributes)
         self.save_and_reserialize({}, instance=self.existing_comment)
         self.assertEqual(
-            httpretty.last_request().parsed_body,
+            httpretty.last_request().parsed_body,  # lint-amnesty, pylint: disable=no-member
             {
                 "body": ["Original body"],
                 "course_id": [six.text_type(self.course.id)],
@@ -833,7 +833,7 @@ class CommentSerializerDeserializationTest(ForumsEnableMixin, CommentsServiceMoc
         data = {"raw_body": "Edited body", "endorsed": True}
         saved = self.save_and_reserialize(data, instance=self.existing_comment)
         self.assertEqual(
-            httpretty.last_request().parsed_body,
+            httpretty.last_request().parsed_body,  # lint-amnesty, pylint: disable=no-member
             {
                 "body": ["Edited body"],
                 "course_id": [six.text_type(self.course.id)],

--- a/lms/djangoapps/discussion/rest_api/tests/test_views.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views.py
@@ -61,7 +61,7 @@ class DiscussionAPIViewTestMixin(ForumsEnableMixin, CommentsServiceMockMixin, Ur
 
     @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
-        super(DiscussionAPIViewTestMixin, self).setUp()
+        super(DiscussionAPIViewTestMixin, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         self.maxDiff = None  # pylint: disable=invalid-name
         self.course = CourseFactory.create(
             org="x",
@@ -139,7 +139,7 @@ class DiscussionAPIViewTestMixin(ForumsEnableMixin, CommentsServiceMockMixin, Ur
 class CourseViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
     """Tests for CourseView"""
     def setUp(self):
-        super(CourseViewTest, self).setUp()
+        super(CourseViewTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         self.url = reverse("discussion_course", kwargs={"course_id": text_type(self.course.id)})
 
     def test_404(self):
@@ -174,7 +174,7 @@ class CourseViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
 class RetireViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
     """Tests for CourseView"""
     def setUp(self):
-        super(RetireViewTest, self).setUp()
+        super(RetireViewTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         RetirementState.objects.create(state_name='PENDING', state_execution_order=1)
         self.retire_forums_state = RetirementState.objects.create(state_name='RETIRE_FORUMS', state_execution_order=11)
 
@@ -238,7 +238,7 @@ class RetireViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         """
         Override the parent implementation of this, we JWT auth for this API
         """
-        pass
+        pass  # lint-amnesty, pylint: disable=unnecessary-pass
 
 
 @ddt.ddt
@@ -248,7 +248,7 @@ class RetireViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
 class ReplaceUsernamesViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
     """Tests for ReplaceUsernamesView"""
     def setUp(self):
-        super(ReplaceUsernamesViewTest, self).setUp()
+        super(ReplaceUsernamesViewTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         self.client_user = UserFactory()
         self.client_user.username = "test_replace_username_service_worker"
         self.new_username = "test_username_replacement"
@@ -332,7 +332,7 @@ class ReplaceUsernamesViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         """
         Override the parent implementation of this, we JWT auth for this API
         """
-        pass
+        pass  # lint-amnesty, pylint: disable=unnecessary-pass
 
 
 @ddt.ddt
@@ -342,7 +342,7 @@ class CourseTopicsViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
     Tests for CourseTopicsView
     """
     def setUp(self):
-        super(CourseTopicsViewTest, self).setUp()
+        super(CourseTopicsViewTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         self.url = reverse("course_topics", kwargs={"course_id": text_type(self.course.id)})
 
     def create_course(self, modules_count, module_store, topics):
@@ -495,7 +495,7 @@ class CourseTopicsViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
 class ThreadViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase, ProfileImageTestMixin):
     """Tests for ThreadViewSet list"""
     def setUp(self):
-        super(ThreadViewSetListTest, self).setUp()
+        super(ThreadViewSetListTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         self.author = UserFactory.create()
         self.url = reverse("thread-list")
 
@@ -664,7 +664,7 @@ class ThreadViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase, Pro
             expected_response
         )
         self.assertEqual(
-            urlparse(httpretty.last_request().path).path,
+            urlparse(httpretty.last_request().path).path,  # lint-amnesty, pylint: disable=no-member
             "/api/v1/users/{}/subscribed_threads".format(self.user.id)
         )
 
@@ -835,7 +835,7 @@ class ThreadViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase, Pro
 class ThreadViewSetCreateTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
     """Tests for ThreadViewSet create"""
     def setUp(self):
-        super(ThreadViewSetCreateTest, self).setUp()
+        super(ThreadViewSetCreateTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         self.url = reverse("thread-list")
 
     def test_basic(self):
@@ -862,7 +862,7 @@ class ThreadViewSetCreateTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         response_data = json.loads(response.content.decode('utf-8'))
         self.assertEqual(response_data, self.expected_thread_data({"read": True}))
         self.assertEqual(
-            httpretty.last_request().parsed_body,
+            httpretty.last_request().parsed_body,  # lint-amnesty, pylint: disable=no-member
             {
                 "course_id": [text_type(self.course.id)],
                 "commentable_id": ["test_topic"],
@@ -901,7 +901,7 @@ class ThreadViewSetPartialUpdateTest(DiscussionAPIViewTestMixin, ModuleStoreTest
     """Tests for ThreadViewSet partial_update"""
     def setUp(self):
         self.unsupported_media_type = JSONParser.media_type
-        super(ThreadViewSetPartialUpdateTest, self).setUp()
+        super(ThreadViewSetPartialUpdateTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         self.url = reverse("thread-detail", kwargs={"thread_id": "test_thread"})
 
     def test_basic(self):
@@ -932,7 +932,7 @@ class ThreadViewSetPartialUpdateTest(DiscussionAPIViewTestMixin, ModuleStoreTest
             })
         )
         self.assertEqual(
-            httpretty.last_request().parsed_body,
+            httpretty.last_request().parsed_body,  # lint-amnesty, pylint: disable=no-member
             {
                 "course_id": [text_type(self.course.id)],
                 "commentable_id": ["test_topic"],
@@ -1056,7 +1056,7 @@ class ThreadViewSetPartialUpdateTest(DiscussionAPIViewTestMixin, ModuleStoreTest
 class ThreadViewSetDeleteTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
     """Tests for ThreadViewSet delete"""
     def setUp(self):
-        super(ThreadViewSetDeleteTest, self).setUp()
+        super(ThreadViewSetDeleteTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         self.url = reverse("thread-detail", kwargs={"thread_id": "test_thread"})
         self.thread_id = "test_thread"
 
@@ -1074,7 +1074,7 @@ class ThreadViewSetDeleteTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         self.assertEqual(response.status_code, 204)
         self.assertEqual(response.content, b"")
         self.assertEqual(
-            urlparse(httpretty.last_request().path).path,
+            urlparse(httpretty.last_request().path).path,  # lint-amnesty, pylint: disable=no-member
             "/api/v1/threads/{}".format(self.thread_id)
         )
         self.assertEqual(httpretty.last_request().method, "DELETE")
@@ -1091,7 +1091,7 @@ class ThreadViewSetDeleteTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
 class CommentViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase, ProfileImageTestMixin):
     """Tests for CommentViewSet list"""
     def setUp(self):
-        super(CommentViewSetListTest, self).setUp()
+        super(CommentViewSetListTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         self.author = UserFactory.create()
         self.url = reverse("comment-list")
         self.thread_id = "test_thread"
@@ -1466,7 +1466,7 @@ class CommentViewSetDeleteTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
     """Tests for ThreadViewSet delete"""
 
     def setUp(self):
-        super(CommentViewSetDeleteTest, self).setUp()
+        super(CommentViewSetDeleteTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         self.url = reverse("comment-detail", kwargs={"comment_id": "test_comment"})
         self.comment_id = "test_comment"
 
@@ -1490,7 +1490,7 @@ class CommentViewSetDeleteTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         self.assertEqual(response.status_code, 204)
         self.assertEqual(response.content, b"")
         self.assertEqual(
-            urlparse(httpretty.last_request().path).path,
+            urlparse(httpretty.last_request().path).path,  # lint-amnesty, pylint: disable=no-member
             "/api/v1/comments/{}".format(self.comment_id)
         )
         self.assertEqual(httpretty.last_request().method, "DELETE")
@@ -1507,7 +1507,7 @@ class CommentViewSetDeleteTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
 class CommentViewSetCreateTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
     """Tests for CommentViewSet create"""
     def setUp(self):
-        super(CommentViewSetCreateTest, self).setUp()
+        super(CommentViewSetCreateTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         self.url = reverse("comment-list")
 
     def test_basic(self):
@@ -1548,11 +1548,11 @@ class CommentViewSetCreateTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         response_data = json.loads(response.content.decode('utf-8'))
         self.assertEqual(response_data, expected_response_data)
         self.assertEqual(
-            urlparse(httpretty.last_request().path).path,
+            urlparse(httpretty.last_request().path).path,  # lint-amnesty, pylint: disable=no-member
             "/api/v1/threads/test_thread/comments"
         )
         self.assertEqual(
-            httpretty.last_request().parsed_body,
+            httpretty.last_request().parsed_body,  # lint-amnesty, pylint: disable=no-member
             {
                 "course_id": [text_type(self.course.id)],
                 "body": ["Test body"],
@@ -1596,7 +1596,7 @@ class CommentViewSetPartialUpdateTest(DiscussionAPIViewTestMixin, ModuleStoreTes
     """Tests for CommentViewSet partial_update"""
     def setUp(self):
         self.unsupported_media_type = JSONParser.media_type
-        super(CommentViewSetPartialUpdateTest, self).setUp()
+        super(CommentViewSetPartialUpdateTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         httpretty.reset()
         httpretty.enable()
         self.addCleanup(httpretty.reset)
@@ -1650,7 +1650,7 @@ class CommentViewSetPartialUpdateTest(DiscussionAPIViewTestMixin, ModuleStoreTes
             })
         )
         self.assertEqual(
-            httpretty.last_request().parsed_body,
+            httpretty.last_request().parsed_body,  # lint-amnesty, pylint: disable=no-member
             {
                 "body": ["Edited body"],
                 "course_id": [text_type(self.course.id)],
@@ -1713,7 +1713,7 @@ class CommentViewSetPartialUpdateTest(DiscussionAPIViewTestMixin, ModuleStoreTes
 class ThreadViewSetRetrieveTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase, ProfileImageTestMixin):
     """Tests for ThreadViewSet Retrieve"""
     def setUp(self):
-        super(ThreadViewSetRetrieveTest, self).setUp()
+        super(ThreadViewSetRetrieveTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         self.url = reverse("thread-detail", kwargs={"thread_id": "test_thread"})
         self.thread_id = "test_thread"
 
@@ -1767,7 +1767,7 @@ class ThreadViewSetRetrieveTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase,
 class CommentViewSetRetrieveTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase, ProfileImageTestMixin):
     """Tests for CommentViewSet Retrieve"""
     def setUp(self):
-        super(CommentViewSetRetrieveTest, self).setUp()
+        super(CommentViewSetRetrieveTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         self.url = reverse("comment-detail", kwargs={"comment_id": "test_comment"})
         self.thread_id = "test_thread"
         self.comment_id = "test_comment"
@@ -1892,7 +1892,7 @@ class CourseDiscussionSettingsAPIViewTest(APITestCase, UrlResetMixin, ModuleStor
     """
     @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
-        super(CourseDiscussionSettingsAPIViewTest, self).setUp()
+        super(CourseDiscussionSettingsAPIViewTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         self.course = CourseFactory.create(
             org="x",
             course="y",
@@ -2135,7 +2135,7 @@ class CourseDiscussionRolesAPIViewTest(APITestCase, UrlResetMixin, ModuleStoreTe
     """
     @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
-        super(CourseDiscussionRolesAPIViewTest, self).setUp()
+        super(CourseDiscussionRolesAPIViewTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         self.course = CourseFactory.create(
             org="x",
             course="y",

--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -5,8 +5,8 @@ Discussion API views
 
 import logging
 
-from django.conf import settings
-from django.contrib.auth.models import User
+from django.conf import settings  # lint-amnesty, pylint: disable=unused-import
+from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.core.exceptions import ValidationError
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
@@ -824,7 +824,7 @@ class CourseDiscussionSettingsAPIView(DeveloperErrorViewMixin, APIView):
         try:
             discussion_settings = set_course_discussion_settings(course_key, **settings_to_change)
         except ValueError as e:
-            raise ValidationError(text_type(e))
+            raise ValidationError(text_type(e))  # lint-amnesty, pylint: disable=raise-missing-from
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 
@@ -937,7 +937,7 @@ class CourseDiscussionRolesAPIView(DeveloperErrorViewMixin, APIView):
         try:
             update_forum_role(course_id, user, rolename, action)
         except Role.DoesNotExist:
-            raise ValidationError(u"Role '{}' does not exist".format(rolename))
+            raise ValidationError(u"Role '{}' does not exist".format(rolename))  # lint-amnesty, pylint: disable=raise-missing-from
 
         role = form.cleaned_data['role']
         data = {'course_id': course_id, 'users': role.users.all()}

--- a/lms/djangoapps/discussion/signals/handlers.py
+++ b/lms/djangoapps/discussion/signals/handlers.py
@@ -42,7 +42,7 @@ def update_discussions_on_course_publish(sender, course_key, **kwargs):  # pylin
 
 
 @receiver(signals.comment_created)
-def send_discussion_email_notification(sender, user, post, **kwargs):
+def send_discussion_email_notification(sender, user, post, **kwargs):  # lint-amnesty, pylint: disable=missing-function-docstring, unused-argument
     current_site = get_current_site()
     if current_site is None:
         log.info(u'Discussion: No current site, not sending notification about post: %s.', post.id)
@@ -61,7 +61,7 @@ def send_discussion_email_notification(sender, user, post, **kwargs):
     send_message(post, current_site)
 
 
-def send_message(comment, site):
+def send_message(comment, site):  # lint-amnesty, pylint: disable=missing-function-docstring
     thread = comment.thread
     context = {
         'course_id': six.text_type(thread.course_id),

--- a/lms/djangoapps/discussion/tasks.py
+++ b/lms/djangoapps/discussion/tasks.py
@@ -9,8 +9,8 @@ import logging
 import six
 from celery import shared_task
 from celery_utils.logged_task import LoggedTask
-from django.conf import settings
-from django.contrib.auth.models import User
+from django.conf import settings  # lint-amnesty, pylint: disable=unused-import
+from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.contrib.sites.models import Site
 from edx_ace import ace
 from edx_ace.recipient import Recipient
@@ -63,7 +63,7 @@ class ResponseNotification(BaseMessageType):
 
 @shared_task(base=LoggedTask)
 @set_code_owner_attribute
-def send_ace_message(context):
+def send_ace_message(context):  # lint-amnesty, pylint: disable=missing-function-docstring
     context['course_id'] = CourseKey.from_string(context['course_id'])
 
     if _should_send_message(context):
@@ -125,7 +125,7 @@ def _is_not_subcomment(comment_id):
     return not getattr(comment, 'parent_id', None)
 
 
-def _is_first_comment(comment_id, thread_id):
+def _is_first_comment(comment_id, thread_id):  # lint-amnesty, pylint: disable=missing-function-docstring
     thread = cc.Thread.find(id=thread_id).retrieve(with_responses=True)
     if getattr(thread, 'children', None):
         first_comment = thread.children[0]
@@ -134,7 +134,7 @@ def _is_first_comment(comment_id, thread_id):
         return False
 
 
-def _is_user_subscribed_to_thread(cc_user, thread_id):
+def _is_user_subscribed_to_thread(cc_user, thread_id):  # lint-amnesty, pylint: disable=missing-function-docstring
     paginated_result = cc_user.subscribed_threads()
     thread_ids = {thread['id'] for thread in paginated_result.collection}
 
@@ -152,7 +152,7 @@ def _get_course_language(course_id):
     return language
 
 
-def _build_message_context(context):
+def _build_message_context(context):  # lint-amnesty, pylint: disable=missing-function-docstring
     message_context = get_base_template_context(context['site'])
     message_context.update(context)
     thread_author = User.objects.get(id=context['thread_author_id'])
@@ -167,7 +167,7 @@ def _build_message_context(context):
     return message_context
 
 
-def _get_thread_url(context):
+def _get_thread_url(context):  # lint-amnesty, pylint: disable=missing-function-docstring
     thread_content = {
         'type': 'thread',
         'course_id': context['course_id'],

--- a/lms/djangoapps/discussion/tests/test_signals.py
+++ b/lms/djangoapps/discussion/tests/test_signals.py
@@ -14,9 +14,9 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
 
-class SendMessageHandlerTestCase(TestCase):
+class SendMessageHandlerTestCase(TestCase):  # lint-amnesty, pylint: disable=missing-class-docstring
 
-    def setUp(self):
+    def setUp(self):  # lint-amnesty, pylint: disable=super-method-not-called
         self.sender = mock.Mock()
         self.user = mock.Mock()
         self.post = mock.Mock()
@@ -38,7 +38,7 @@ class SendMessageHandlerTestCase(TestCase):
 
     @mock.patch('lms.djangoapps.discussion.signals.handlers.get_current_site', return_value=None)
     @mock.patch('lms.djangoapps.discussion.signals.handlers.send_message')
-    def test_comment_created_signal_message_not_sent_without_site(self, mock_send_message, mock_get_current_site):
+    def test_comment_created_signal_message_not_sent_without_site(self, mock_send_message, mock_get_current_site):  # lint-amnesty, pylint: disable=unused-argument
         signals.comment_created.send(sender=self.sender, user=self.user, post=self.post)
 
         self.assertFalse(mock_send_message.called)

--- a/lms/djangoapps/discussion/tests/test_tasks.py
+++ b/lms/djangoapps/discussion/tests/test_tasks.py
@@ -33,8 +33,8 @@ ONE_HOUR_AGO = NOW - timedelta(hours=1)
 TWO_HOURS_AGO = NOW - timedelta(hours=2)
 
 
-def make_mock_responder(subscribed_thread_ids=None, thread_data=None, comment_data=None, per_page=1):
-    def mock_subscribed_threads(method, url, **kwargs):
+def make_mock_responder(subscribed_thread_ids=None, thread_data=None, comment_data=None, per_page=1):  # lint-amnesty, pylint: disable=missing-function-docstring
+    def mock_subscribed_threads(method, url, **kwargs):  # lint-amnesty, pylint: disable=unused-argument
         subscribed_thread_collection = [
             {'id': thread_id} for thread_id in subscribed_thread_ids
         ]
@@ -49,10 +49,10 @@ def make_mock_responder(subscribed_thread_ids=None, thread_data=None, comment_da
         }
         return mock.Mock(status_code=200, text=json.dumps(data), json=mock.Mock(return_value=data))
 
-    def mock_comment_find(method, url, **kwargs):
+    def mock_comment_find(method, url, **kwargs):  # lint-amnesty, pylint: disable=unused-argument
         return mock.Mock(status_code=200, text=json.dumps(comment_data), json=mock.Mock(return_value=comment_data))
 
-    def mock_thread_find(method, url, **kwargs):
+    def mock_thread_find(method, url, **kwargs):  # lint-amnesty, pylint: disable=unused-argument
         return mock.Mock(status_code=200, text=json.dumps(thread_data), json=mock.Mock(return_value=thread_data))
 
     def mock_request(method, url, **kwargs):
@@ -67,7 +67,7 @@ def make_mock_responder(subscribed_thread_ids=None, thread_data=None, comment_da
 
 
 @ddt.ddt
-class TaskTestCase(ModuleStoreTestCase):
+class TaskTestCase(ModuleStoreTestCase):  # lint-amnesty, pylint: disable=missing-class-docstring
 
     @classmethod
     @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
@@ -106,7 +106,7 @@ class TaskTestCase(ModuleStoreTestCase):
         cls.create_thread_and_comments()
 
     @classmethod
-    def create_thread_and_comments(cls):
+    def create_thread_and_comments(cls):  # lint-amnesty, pylint: disable=missing-function-docstring
         cls.thread = {
             'id': cls.discussion_id,
             'course_id': six.text_type(cls.course.id),
@@ -156,7 +156,7 @@ class TaskTestCase(ModuleStoreTestCase):
         }
 
     def setUp(self):
-        super(TaskTestCase, self).setUp()
+        super(TaskTestCase, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         self.request_patcher = mock.patch('requests.request')
         self.mock_request = self.request_patcher.start()
 
@@ -168,7 +168,7 @@ class TaskTestCase(ModuleStoreTestCase):
         self.mock_permalink = self.permalink_patcher.start()
 
     def tearDown(self):
-        super(TaskTestCase, self).tearDown()
+        super(TaskTestCase, self).tearDown()  # lint-amnesty, pylint: disable=super-with-arguments
         self.request_patcher.stop()
         self.ace_send_patcher.stop()
         self.permalink_patcher.stop()
@@ -227,7 +227,7 @@ class TaskTestCase(ModuleStoreTestCase):
         else:
             self.assertFalse(self.mock_ace_send.called)
 
-    def _assert_rendered_email(self, message):
+    def _assert_rendered_email(self, message):  # lint-amnesty, pylint: disable=missing-function-docstring
         # check that we can actually render the message
         with emulate_http_request(
             site=message.context['site'], user=self.thread_author

--- a/lms/djangoapps/discussion/tests/test_views.py
+++ b/lms/djangoapps/discussion/tests/test_views.py
@@ -73,7 +73,7 @@ log = logging.getLogger(__name__)
 QUERY_COUNT_TABLE_BLACKLIST = WAFFLE_TABLES
 
 
-class ViewsExceptionTestCase(UrlResetMixin, ModuleStoreTestCase):
+class ViewsExceptionTestCase(UrlResetMixin, ModuleStoreTestCase):  # lint-amnesty, pylint: disable=missing-class-docstring
 
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
@@ -81,7 +81,7 @@ class ViewsExceptionTestCase(UrlResetMixin, ModuleStoreTestCase):
         # Patching the ENABLE_DISCUSSION_SERVICE value affects the contents of urls.py,
         # so we need to call super.setUp() which reloads urls.py (because
         # of the UrlResetMixin)
-        super(ViewsExceptionTestCase, self).setUp()
+        super(ViewsExceptionTestCase, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
 
         # create a course
         self.course = CourseFactory.create(org='MITx', course='999',
@@ -143,7 +143,7 @@ class ViewsExceptionTestCase(UrlResetMixin, ModuleStoreTestCase):
         self.assertEqual(response.status_code, 404)
 
 
-def make_mock_thread_data(
+def make_mock_thread_data(  # lint-amnesty, pylint: disable=missing-function-docstring
         course,
         text,
         thread_id,
@@ -183,7 +183,7 @@ def make_mock_thread_data(
     return thread_data
 
 
-def make_mock_collection_data(
+def make_mock_collection_data(  # lint-amnesty, pylint: disable=missing-function-docstring
     course,
     text,
     thread_id,
@@ -210,7 +210,7 @@ def make_mock_collection_data(
         ]
 
 
-def make_mock_perform_request_impl(
+def make_mock_perform_request_impl(  # lint-amnesty, pylint: disable=missing-function-docstring
         course,
         text,
         thread_id="dummy_thread_id",
@@ -255,7 +255,7 @@ def make_mock_perform_request_impl(
     return mock_perform_request_impl
 
 
-def make_mock_request_impl(
+def make_mock_request_impl(  # lint-amnesty, pylint: disable=missing-function-docstring
         course,
         text,
         thread_id="dummy_thread_id",
@@ -283,7 +283,7 @@ def make_mock_request_impl(
     return mock_request_impl
 
 
-class StringEndsWithMatcher(object):
+class StringEndsWithMatcher(object):  # lint-amnesty, pylint: disable=missing-class-docstring
     def __init__(self, suffix):
         self.suffix = suffix
 
@@ -291,7 +291,7 @@ class StringEndsWithMatcher(object):
         return other.endswith(self.suffix)
 
 
-class PartialDictMatcher(object):
+class PartialDictMatcher(object):  # lint-amnesty, pylint: disable=missing-class-docstring
     def __init__(self, expected_values):
         self.expected_values = expected_values
 
@@ -303,12 +303,12 @@ class PartialDictMatcher(object):
 
 
 @patch('requests.request', autospec=True)
-class SingleThreadTestCase(ForumsEnableMixin, ModuleStoreTestCase):
+class SingleThreadTestCase(ForumsEnableMixin, ModuleStoreTestCase):  # lint-amnesty, pylint: disable=missing-class-docstring
 
     CREATE_USER = False
 
     def setUp(self):
-        super(SingleThreadTestCase, self).setUp()
+        super(SingleThreadTestCase, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
 
         self.course = CourseFactory.create(discussion_topics={'dummy discussion': {'id': 'dummy_discussion_id'}})
         self.student = UserFactory.create()
@@ -556,9 +556,9 @@ class SingleThreadQueryCountTestCase(ForumsEnableMixin, ModuleStoreTestCase):
 
 
 @patch('requests.request', autospec=True)
-class SingleCohortedThreadTestCase(CohortedTestCase):
+class SingleCohortedThreadTestCase(CohortedTestCase):  # lint-amnesty, pylint: disable=missing-class-docstring
 
-    def _create_mock_cohorted_thread(self, mock_request):
+    def _create_mock_cohorted_thread(self, mock_request):  # lint-amnesty, pylint: disable=missing-function-docstring
         mock_text = "dummy content"
         mock_thread_id = "test_thread_id"
         mock_request.side_effect = make_mock_request_impl(
@@ -621,9 +621,9 @@ class SingleCohortedThreadTestCase(CohortedTestCase):
 
 
 @patch('openedx.core.djangoapps.django_comment_common.comment_client.utils.requests.request', autospec=True)
-class SingleThreadAccessTestCase(CohortedTestCase):
+class SingleThreadAccessTestCase(CohortedTestCase):  # lint-amnesty, pylint: disable=missing-class-docstring
 
-    def call_view(self, mock_request, commentable_id, user, group_id, thread_group_id=None, pass_group_id=True):
+    def call_view(self, mock_request, commentable_id, user, group_id, thread_group_id=None, pass_group_id=True):  # lint-amnesty, pylint: disable=missing-function-docstring
         thread_id = "test_thread_id"
         mock_request.side_effect = make_mock_request_impl(
             course=self.course, text="dummy context", thread_id=thread_id, group_id=thread_group_id
@@ -728,10 +728,10 @@ class SingleThreadAccessTestCase(CohortedTestCase):
 
 
 @patch('openedx.core.djangoapps.django_comment_common.comment_client.utils.requests.request', autospec=True)
-class SingleThreadGroupIdTestCase(CohortedTestCase, GroupIdAssertionMixin):
+class SingleThreadGroupIdTestCase(CohortedTestCase, GroupIdAssertionMixin):  # lint-amnesty, pylint: disable=missing-class-docstring
     cs_endpoint = "/threads/dummy_thread_id"
 
-    def call_view(self, mock_request, commentable_id, user, group_id, pass_group_id=True, is_ajax=False):
+    def call_view(self, mock_request, commentable_id, user, group_id, pass_group_id=True, is_ajax=False):  # lint-amnesty, pylint: disable=missing-function-docstring
         mock_request.side_effect = make_mock_request_impl(
             course=self.course, text="dummy context", group_id=self.student_cohort.id
         )
@@ -785,7 +785,7 @@ class ForumFormDiscussionContentGroupTestCase(ForumsEnableMixin, ContentGroupTes
 
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
-        super(ForumFormDiscussionContentGroupTestCase, self).setUp()
+        super(ForumFormDiscussionContentGroupTestCase, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         self.thread_list = [
             {"thread_id": "test_general_thread_id"},
             {"thread_id": "test_global_group_thread_id", "commentable_id": self.global_module.discussion_id},
@@ -803,7 +803,7 @@ class ForumFormDiscussionContentGroupTestCase(ForumsEnableMixin, ContentGroupTes
         discussion_data = json.loads(response.content.decode('utf-8'))['discussion_data']
         self.assertEqual(len(discussion_data), expected_discussion_threads)
 
-    def call_view(self, mock_request, user):
+    def call_view(self, mock_request, user):  # lint-amnesty, pylint: disable=missing-function-docstring
         mock_request.side_effect = make_mock_request_impl(
             course=self.course,
             text="dummy content",
@@ -861,11 +861,11 @@ class ForumFormDiscussionContentGroupTestCase(ForumsEnableMixin, ContentGroupTes
 
 
 @patch('requests.request', autospec=True)
-class SingleThreadContentGroupTestCase(ForumsEnableMixin, UrlResetMixin, ContentGroupTestCase):
+class SingleThreadContentGroupTestCase(ForumsEnableMixin, UrlResetMixin, ContentGroupTestCase):  # lint-amnesty, pylint: disable=missing-class-docstring
 
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
-        super(SingleThreadContentGroupTestCase, self).setUp()
+        super(SingleThreadContentGroupTestCase, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
 
     def assert_can_access(self, user, discussion_id, thread_id, should_have_access):
         """
@@ -971,10 +971,10 @@ class SingleThreadContentGroupTestCase(ForumsEnableMixin, UrlResetMixin, Content
 
 
 @patch('openedx.core.djangoapps.django_comment_common.comment_client.utils.requests.request', autospec=True)
-class InlineDiscussionContextTestCase(ForumsEnableMixin, ModuleStoreTestCase):
+class InlineDiscussionContextTestCase(ForumsEnableMixin, ModuleStoreTestCase):  # lint-amnesty, pylint: disable=missing-class-docstring
 
     def setUp(self):
-        super(InlineDiscussionContextTestCase, self).setUp()
+        super(InlineDiscussionContextTestCase, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         self.course = CourseFactory.create()
         CourseEnrollmentFactory(user=self.user, course_id=self.course.id)
         self.discussion_topic_id = "dummy_topic"
@@ -1031,7 +1031,7 @@ class InlineDiscussionContextTestCase(ForumsEnableMixin, ModuleStoreTestCase):
 
 
 @patch('openedx.core.djangoapps.django_comment_common.comment_client.utils.requests.request', autospec=True)
-class InlineDiscussionGroupIdTestCase(
+class InlineDiscussionGroupIdTestCase(  # lint-amnesty, pylint: disable=missing-class-docstring
         CohortedTestCase,
         CohortedTopicGroupIdTestMixin,
         NonCohortedTopicGroupIdTestMixin
@@ -1039,7 +1039,7 @@ class InlineDiscussionGroupIdTestCase(
     cs_endpoint = "/threads"
 
     def setUp(self):
-        super(InlineDiscussionGroupIdTestCase, self).setUp()
+        super(InlineDiscussionGroupIdTestCase, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         self.cohorted_commentable_id = 'cohorted_topic'
 
     def call_view(self, mock_request, commentable_id, user, group_id, pass_group_id=True):
@@ -1082,7 +1082,7 @@ class InlineDiscussionGroupIdTestCase(
 
 
 @patch('openedx.core.djangoapps.django_comment_common.comment_client.utils.requests.request', autospec=True)
-class ForumFormDiscussionGroupIdTestCase(CohortedTestCase, CohortedTopicGroupIdTestMixin):
+class ForumFormDiscussionGroupIdTestCase(CohortedTestCase, CohortedTopicGroupIdTestMixin):  # lint-amnesty, pylint: disable=missing-class-docstring
     cs_endpoint = "/threads"
 
     def call_view(self, mock_request, commentable_id, user, group_id, pass_group_id=True, is_ajax=False):  # pylint: disable=arguments-differ
@@ -1128,7 +1128,7 @@ class ForumFormDiscussionGroupIdTestCase(CohortedTestCase, CohortedTopicGroupIdT
 
 
 @patch('openedx.core.djangoapps.django_comment_common.comment_client.utils.requests.request', autospec=True)
-class UserProfileDiscussionGroupIdTestCase(CohortedTestCase, CohortedTopicGroupIdTestMixin):
+class UserProfileDiscussionGroupIdTestCase(CohortedTestCase, CohortedTopicGroupIdTestMixin):  # lint-amnesty, pylint: disable=missing-class-docstring
     cs_endpoint = "/active_threads"
 
     def call_view_for_profiled_user(
@@ -1286,7 +1286,7 @@ class UserProfileDiscussionGroupIdTestCase(CohortedTestCase, CohortedTopicGroupI
 
 
 @patch('openedx.core.djangoapps.django_comment_common.comment_client.utils.requests.request', autospec=True)
-class FollowedThreadsDiscussionGroupIdTestCase(CohortedTestCase, CohortedTopicGroupIdTestMixin):
+class FollowedThreadsDiscussionGroupIdTestCase(CohortedTestCase, CohortedTopicGroupIdTestMixin):  # lint-amnesty, pylint: disable=missing-class-docstring
     cs_endpoint = "/subscribed_threads"
 
     def call_view(self, mock_request, commentable_id, user, group_id, pass_group_id=True):
@@ -1323,10 +1323,10 @@ class FollowedThreadsDiscussionGroupIdTestCase(CohortedTestCase, CohortedTopicGr
 
 
 @patch('openedx.core.djangoapps.django_comment_common.comment_client.utils.requests.request', autospec=True)
-class InlineDiscussionTestCase(ForumsEnableMixin, ModuleStoreTestCase):
+class InlineDiscussionTestCase(ForumsEnableMixin, ModuleStoreTestCase):  # lint-amnesty, pylint: disable=missing-class-docstring
 
     def setUp(self):
-        super(InlineDiscussionTestCase, self).setUp()
+        super(InlineDiscussionTestCase, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
 
         self.course = CourseFactory.create(
             org="TestX",
@@ -1380,14 +1380,14 @@ class InlineDiscussionTestCase(ForumsEnableMixin, ModuleStoreTestCase):
 
 
 @patch('requests.request', autospec=True)
-class UserProfileTestCase(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCase):
+class UserProfileTestCase(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCase):  # lint-amnesty, pylint: disable=missing-class-docstring
 
     TEST_THREAD_TEXT = 'userprofile-test-text'
     TEST_THREAD_ID = 'userprofile-test-thread-id'
 
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
-        super(UserProfileTestCase, self).setUp()
+        super(UserProfileTestCase, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
 
         self.course = CourseFactory.create()
         self.student = UserFactory.create()
@@ -1395,7 +1395,7 @@ class UserProfileTestCase(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCase)
         CourseEnrollmentFactory.create(user=self.student, course_id=self.course.id)
         CourseEnrollmentFactory.create(user=self.profiled_user, course_id=self.course.id)
 
-    def get_response(self, mock_request, params, **headers):
+    def get_response(self, mock_request, params, **headers):  # lint-amnesty, pylint: disable=missing-function-docstring
         mock_request.side_effect = make_mock_request_impl(
             course=self.course, text=self.TEST_THREAD_TEXT, thread_id=self.TEST_THREAD_ID
         )
@@ -1423,7 +1423,7 @@ class UserProfileTestCase(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCase)
         )
         return response
 
-    def check_html(self, mock_request, **params):
+    def check_html(self, mock_request, **params):  # lint-amnesty, pylint: disable=missing-function-docstring
         response = self.get_response(mock_request, params)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['Content-Type'], 'text/html; charset=utf-8')
@@ -1440,7 +1440,7 @@ class UserProfileTestCase(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCase)
         else:
             self.assertRegex(html, u'&#39;username&#39;: &#39;{}&#39;'.format(self.student.username))
 
-    def check_ajax(self, mock_request, **params):
+    def check_ajax(self, mock_request, **params):  # lint-amnesty, pylint: disable=missing-function-docstring
         response = self.get_response(mock_request, params, HTTP_X_REQUESTED_WITH="XMLHttpRequest")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['Content-Type'], 'application/json; charset=utf-8')
@@ -1512,19 +1512,19 @@ class UserProfileTestCase(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCase)
 
 
 @patch('requests.request', autospec=True)
-class CommentsServiceRequestHeadersTestCase(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCase):
+class CommentsServiceRequestHeadersTestCase(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCase):  # lint-amnesty, pylint: disable=missing-class-docstring
 
     CREATE_USER = False
 
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
-        super(CommentsServiceRequestHeadersTestCase, self).setUp()
+        super(CommentsServiceRequestHeadersTestCase, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
 
         username = "foo"
         password = "bar"
 
         # Invoke UrlResetMixin
-        super(CommentsServiceRequestHeadersTestCase, self).setUp()
+        super(CommentsServiceRequestHeadersTestCase, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         self.course = CourseFactory.create(discussion_topics={'dummy discussion': {'id': 'dummy_discussion_id'}})
         self.student = UserFactory.create(username=username, password=password)
         CourseEnrollmentFactory.create(user=self.student, course_id=self.course.id)
@@ -1534,7 +1534,7 @@ class CommentsServiceRequestHeadersTestCase(ForumsEnableMixin, UrlResetMixin, Mo
 
         self.addCleanup(translation.deactivate)
 
-    def assert_all_calls_have_header(self, mock_request, key, value):
+    def assert_all_calls_have_header(self, mock_request, key, value):  # lint-amnesty, pylint: disable=missing-function-docstring
         expected = call(
             ANY,  # method
             ANY,  # url
@@ -1578,7 +1578,7 @@ class CommentsServiceRequestHeadersTestCase(ForumsEnableMixin, UrlResetMixin, Mo
         self.assert_all_calls_have_header(mock_request, "X-Edx-Api-Key", "test_api_key")
 
 
-class InlineDiscussionUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, UnicodeTestMixin):
+class InlineDiscussionUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, UnicodeTestMixin):  # lint-amnesty, pylint: disable=missing-class-docstring
 
     @classmethod
     def setUpClass(cls):
@@ -1594,7 +1594,7 @@ class InlineDiscussionUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTestCa
         CourseEnrollmentFactory(user=cls.student, course_id=cls.course.id)
 
     @patch('openedx.core.djangoapps.django_comment_common.comment_client.utils.requests.request', autospec=True)
-    def _test_unicode_data(self, text, mock_request):
+    def _test_unicode_data(self, text, mock_request):  # lint-amnesty, pylint: disable=missing-function-docstring
         mock_request.side_effect = make_mock_request_impl(course=self.course, text=text)
         request = RequestFactory().get("dummy_url")
         request.user = self.student
@@ -1608,7 +1608,7 @@ class InlineDiscussionUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTestCa
         self.assertEqual(response_data["discussion_data"][0]["body"], text)
 
 
-class ForumFormDiscussionUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, UnicodeTestMixin):
+class ForumFormDiscussionUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, UnicodeTestMixin):  # lint-amnesty, pylint: disable=missing-class-docstring
 
     @classmethod
     def setUpClass(cls):
@@ -1624,7 +1624,7 @@ class ForumFormDiscussionUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTes
         CourseEnrollmentFactory(user=cls.student, course_id=cls.course.id)
 
     @patch('openedx.core.djangoapps.django_comment_common.comment_client.utils.requests.request', autospec=True)
-    def _test_unicode_data(self, text, mock_request):
+    def _test_unicode_data(self, text, mock_request):  # lint-amnesty, pylint: disable=missing-function-docstring
         mock_request.side_effect = make_mock_request_impl(course=self.course, text=text)
         request = RequestFactory().get("dummy_url")
         request.user = self.student
@@ -1639,11 +1639,11 @@ class ForumFormDiscussionUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTes
 
 @ddt.ddt
 @patch('openedx.core.djangoapps.django_comment_common.comment_client.utils.requests.request', autospec=True)
-class ForumDiscussionXSSTestCase(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCase):
+class ForumDiscussionXSSTestCase(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCase):  # lint-amnesty, pylint: disable=missing-class-docstring
 
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
-        super(ForumDiscussionXSSTestCase, self).setUp()
+        super(ForumDiscussionXSSTestCase, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
 
         username = "foo"
         password = "bar"
@@ -1692,7 +1692,7 @@ class ForumDiscussionXSSTestCase(ForumsEnableMixin, UrlResetMixin, ModuleStoreTe
         self.assertNotContains(resp, malicious_code)
 
 
-class ForumDiscussionSearchUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, UnicodeTestMixin):
+class ForumDiscussionSearchUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, UnicodeTestMixin):  # lint-amnesty, pylint: disable=missing-class-docstring
 
     @classmethod
     def setUpClass(cls):
@@ -1708,7 +1708,7 @@ class ForumDiscussionSearchUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreT
         CourseEnrollmentFactory(user=cls.student, course_id=cls.course.id)
 
     @patch('openedx.core.djangoapps.django_comment_common.comment_client.utils.requests.request', autospec=True)
-    def _test_unicode_data(self, text, mock_request):
+    def _test_unicode_data(self, text, mock_request):  # lint-amnesty, pylint: disable=missing-function-docstring
         mock_request.side_effect = make_mock_request_impl(course=self.course, text=text)
         data = {
             "ajax": 1,
@@ -1725,7 +1725,7 @@ class ForumDiscussionSearchUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreT
         self.assertEqual(response_data["discussion_data"][0]["body"], text)
 
 
-class SingleThreadUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, UnicodeTestMixin):
+class SingleThreadUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, UnicodeTestMixin):  # lint-amnesty, pylint: disable=missing-class-docstring
 
     @classmethod
     def setUpClass(cls):
@@ -1741,7 +1741,7 @@ class SingleThreadUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, 
         CourseEnrollmentFactory(user=cls.student, course_id=cls.course.id)
 
     @patch('openedx.core.djangoapps.django_comment_common.comment_client.utils.requests.request', autospec=True)
-    def _test_unicode_data(self, text, mock_request):
+    def _test_unicode_data(self, text, mock_request):  # lint-amnesty, pylint: disable=missing-function-docstring
         thread_id = "test_thread_id"
         mock_request.side_effect = make_mock_request_impl(course=self.course, text=text, thread_id=thread_id)
         request = RequestFactory().get("dummy_url")
@@ -1755,7 +1755,7 @@ class SingleThreadUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, 
         self.assertEqual(response_data["content"]["body"], text)
 
 
-class UserProfileUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, UnicodeTestMixin):
+class UserProfileUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, UnicodeTestMixin):  # lint-amnesty, pylint: disable=missing-class-docstring
 
     @classmethod
     def setUpClass(cls):
@@ -1771,7 +1771,7 @@ class UserProfileUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, U
         CourseEnrollmentFactory(user=cls.student, course_id=cls.course.id)
 
     @patch('openedx.core.djangoapps.django_comment_common.comment_client.utils.requests.request', autospec=True)
-    def _test_unicode_data(self, text, mock_request):
+    def _test_unicode_data(self, text, mock_request):  # lint-amnesty, pylint: disable=missing-function-docstring
         mock_request.side_effect = make_mock_request_impl(course=self.course, text=text)
         request = RequestFactory().get("dummy_url")
         request.user = self.student
@@ -1784,7 +1784,7 @@ class UserProfileUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, U
         self.assertEqual(response_data["discussion_data"][0]["body"], text)
 
 
-class FollowedThreadsUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, UnicodeTestMixin):
+class FollowedThreadsUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, UnicodeTestMixin):  # lint-amnesty, pylint: disable=missing-class-docstring
 
     @classmethod
     def setUpClass(cls):
@@ -1800,7 +1800,7 @@ class FollowedThreadsUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTestCas
         CourseEnrollmentFactory(user=cls.student, course_id=cls.course.id)
 
     @patch('openedx.core.djangoapps.django_comment_common.comment_client.utils.requests.request', autospec=True)
-    def _test_unicode_data(self, text, mock_request):
+    def _test_unicode_data(self, text, mock_request):  # lint-amnesty, pylint: disable=missing-function-docstring
         mock_request.side_effect = make_mock_request_impl(course=self.course, text=text)
         request = RequestFactory().get("dummy_url")
         request.user = self.student
@@ -1821,7 +1821,7 @@ class EnrollmentTestCase(ForumsEnableMixin, ModuleStoreTestCase):
 
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
-        super(EnrollmentTestCase, self).setUp()
+        super(EnrollmentTestCase, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         self.course = CourseFactory.create()
         self.student = UserFactory.create()
 
@@ -1845,7 +1845,7 @@ class EnterpriseConsentTestCase(EnterpriseTestConsentRequired, ForumsEnableMixin
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
         # Invoke UrlResetMixin setUp
-        super(EnterpriseConsentTestCase, self).setUp()
+        super(EnterpriseConsentTestCase, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
 
         username = "foo"
         password = "bar"
@@ -1881,7 +1881,7 @@ class EnterpriseConsentTestCase(EnterpriseTestConsentRequired, ForumsEnableMixin
             self.verify_consent_required(self.client, url)  # pylint: disable=no-value-for-parameter
 
 
-class DividedDiscussionsTestCase(CohortViewsTestCase):
+class DividedDiscussionsTestCase(CohortViewsTestCase):  # lint-amnesty, pylint: disable=missing-class-docstring
 
     def create_divided_discussions(self):
         """
@@ -2180,7 +2180,7 @@ class ThreadViewedEventTestCase(EventTestMixin, ForumsEnableMixin, UrlResetMixin
 
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):  # pylint: disable=arguments-differ
-        super(ThreadViewedEventTestCase, self).setUp('eventtracking.tracker')
+        super(ThreadViewedEventTestCase, self).setUp('eventtracking.tracker')  # lint-amnesty, pylint: disable=super-with-arguments
 
         self.course = CourseFactory.create(
             teams_configuration=TeamsConfig({

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -9,7 +9,7 @@ from functools import wraps
 import six
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.http import Http404, HttpResponseForbidden, HttpResponseServerError
 from django.shortcuts import render_to_response
@@ -446,7 +446,7 @@ def _create_base_discussion_view_context(request, course_key):
 
 
 def _get_discussion_default_topic_id(course):
-    for topic, entry in course.discussion_topics.items():
+    for topic, entry in course.discussion_topics.items():  # lint-amnesty, pylint: disable=unused-variable
         if entry.get('default') is True:
             return entry['id']
 
@@ -470,7 +470,7 @@ def _create_discussion_board_context(request, base_context, thread=None):
         # we need only return the thread information for this one.
         threads = [thread.to_dict()]
 
-        for thread in threads:
+        for thread in threads:  # lint-amnesty, pylint: disable=redefined-argument-from-local
             # patch for backward compatibility with comments service
             if "pinned" not in thread:
                 thread["pinned"] = False
@@ -610,7 +610,7 @@ def user_profile(request, course_key, user_id):
 
             return tab_view.get(request, six.text_type(course_key), 'discussion', profile_page_context=context)
     except User.DoesNotExist:
-        raise Http404
+        raise Http404  # lint-amnesty, pylint: disable=raise-missing-from
     except ValueError:
         return HttpResponseServerError("Invalid group_id")
 
@@ -690,7 +690,7 @@ def followed_threads(request, course_key, user_id):
 
             return render_to_response('discussion/user_profile.html', context)
     except User.DoesNotExist:
-        raise Http404
+        raise Http404  # lint-amnesty, pylint: disable=raise-missing-from
 
 
 class DiscussionBoardFragmentView(EdxFragmentView):
@@ -698,7 +698,7 @@ class DiscussionBoardFragmentView(EdxFragmentView):
     Component implementation of the discussion board.
     """
 
-    def render_to_fragment(
+    def render_to_fragment(  # lint-amnesty, pylint: disable=arguments-differ
         self,
         request,
         course_id=None,
@@ -867,7 +867,7 @@ def discussion_topics(request, course_key_string):
     course_key = CourseKey.from_string(course_key_string)
     course = get_course_with_access(request.user, 'staff', course_key)
 
-    discussion_topics = {}
+    discussion_topics = {}  # lint-amnesty, pylint: disable=redefined-outer-name
     discussion_category_map = utils.get_discussion_category_map(
         course, request.user, divided_only_if_explicit=True, exclude_unstarted=False
     )


### PR DESCRIPTION
In this PR we are adding pylint amnesty for existing warnings and failures in discussion, and dashboard apps using the command in the following doc
https://github.com/edx/edx-lint#using-lint-amnesty 

Relevant JIRAs :
https://openedx.atlassian.net/browse/BOM-2278