### PR TITLE
fix: Studio setting descriptions shouldn't mention edx.org

### DIFF
--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -374,7 +374,7 @@ class CourseFields(object):
         scope=Scope.settings
     )
     display_name = String(
-        help=_("Enter the name of the course as it should appear in the edX.org course list."),
+        help=_("Enter the name of the course as it should appear in the course list."),
         default="Empty",
         display_name=_("Course Display Name"),
         scope=Scope.settings,
@@ -443,7 +443,7 @@ class CourseFields(object):
     is_new = Boolean(
         display_name=_("Course Is New"),
         help=_(
-            "Enter true or false. If true, the course appears in the list of new courses on edx.org, and a New! "
+            "Enter true or false. If true, the course appears in the list of new courses, and a New! "
             "badge temporarily appears next to the course image."
         ),
         scope=Scope.settings
@@ -742,7 +742,7 @@ class CourseFields(object):
     allow_public_wiki_access = Boolean(
         display_name=_("Allow Public Wiki Access"),
         help=_(
-            "Enter true or false. If true, edX users can view the course wiki even "
+            "Enter true or false. If true, students can view the course wiki even "
             "if they're not enrolled in the course."
         ),
         default=False,


### PR DESCRIPTION
These messages appear on 1000 other sites that are not publishing to
edx.org.  There's no need to be so specific.

## Description

Some Studio settings mention edx.org specifically.  In Open edX environments, those settings won't affect edx.org.  We should make the wording more appropriate for all uses of the software.

This only affect instructional teams, since they are Studio messages.

Old messages:
<img width="894" alt="image" src="https://user-images.githubusercontent.com/23789/106462563-45790b80-6464-11eb-9d4b-d77cbae09f22.png">
<img width="895" alt="image" src="https://user-images.githubusercontent.com/23789/106462595-51fd6400-6464-11eb-9ce8-76e4896b37c2.png">
<img width="893" alt="image" src="https://user-images.githubusercontent.com/23789/106462634-5d508f80-6464-11eb-8cd9-008b0b28b747.png">

New messages:
<img width="896" alt="image" src="https://user-images.githubusercontent.com/23789/106462810-91c44b80-6464-11eb-9017-ab9b73e1122e.png">
<img width="894" alt="image" src="https://user-images.githubusercontent.com/23789/106462850-9be64a00-6464-11eb-9330-5622a11b703d.png">
<img width="892" alt="image" src="https://user-images.githubusercontent.com/23789/106462867-a1dc2b00-6464-11eb-96bf-af6c7e95d042.png">

## Other information

Because these messages are translated, they will need to be re-translated before appearing in the local language.  Studio's translation needs are less stringent than the LMS.