### PR TITLE
replaced unittest assertions pytest assertions

### DIFF
--- a/openedx/core/djangoapps/cache_toolbox/tests/test_middleware.py
+++ b/openedx/core/djangoapps/cache_toolbox/tests/test_middleware.py
@@ -29,7 +29,7 @@ class CachedAuthMiddlewareTestCase(TestCase):
         different URLconfs.
         """
         response = self.client.get(test_url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         with patch.object(User, 'get_session_auth_hash', return_value='abc123'):
             response = self.client.get(test_url)
             self.assertRedirects(response, redirect_url, target_status_code=target_status_code)


### PR DESCRIPTION
## Description
This PR is using `codemod-unittest-to-pytest-asserts` to automatically replace `unittest` assertions with `pytest` 
for following module:
```
openedx/core/djangoapps/cache_toolbox
```
assertions. I've used one of the forks (PR with changes: https://github.com/mraarif/codemod-unittest-to-pytest-asserts/pull/1) of this codemod that handles a few scenarios that seem to be missing in the upstream repo.
Relevant JIRA issue here: https://openedx.atlassian.net/browse/BOM-2298

