### PR TITLE
MICROBA-918 Remove unused variables and use factories

### DIFF
--- a/lms/djangoapps/certificates/management/commands/tests/test_cert_allowlist_generation.py
+++ b/lms/djangoapps/certificates/management/commands/tests/test_cert_allowlist_generation.py
@@ -13,8 +13,10 @@ from xmodule.modulestore.tests.factories import CourseFactory
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
 from lms.djangoapps.certificates.generation_handler import CERTIFICATES_USE_ALLOWLIST
 from lms.djangoapps.certificates.tests.factories import CertificateWhitelistFactory
-from lms.djangoapps.certificates.tests.test_generation_handler import AUTO_GENERATION_SWITCH_NAME, \
+from lms.djangoapps.certificates.tests.test_generation_handler import (
+    AUTO_GENERATION_SWITCH_NAME,
     ID_VERIFIED_METHOD
+)
 
 
 @override_switch(AUTO_GENERATION_SWITCH_NAME, active=True)

--- a/lms/djangoapps/certificates/signals.py
+++ b/lms/djangoapps/certificates/signals.py
@@ -24,7 +24,6 @@ from lms.djangoapps.certificates.tasks import CERTIFICATE_DELAY_SECONDS, generat
 from lms.djangoapps.grades.api import CourseGradeFactory
 from lms.djangoapps.verify_student.services import IDVerificationService
 from openedx.core.djangoapps.certificates.api import auto_certificate_generation_enabled
-from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.content.course_overviews.signals import COURSE_PACING_CHANGED
 from openedx.core.djangoapps.signals.signals import (
     COURSE_GRADE_NOW_FAILED,
@@ -52,7 +51,6 @@ def _update_cert_settings_on_pacing_change(sender, updated_course_overview, **kw
 
 @receiver(post_save, sender=CertificateWhitelist, dispatch_uid="append_certificate_whitelist")
 def _listen_for_certificate_whitelist_append(sender, instance, **kwargs):  # pylint: disable=unused-argument
-    course = CourseOverview.get_from_id(instance.course_id)
     if not auto_certificate_generation_enabled():
         return
 
@@ -69,7 +67,6 @@ def listen_for_passing_grade(sender, user, course_id, **kwargs):  # pylint: disa
     Listen for a learner passing a course, send cert generation task,
     downstream signal from COURSE_GRADE_CHANGED
     """
-    course = CourseOverview.get_from_id(course_id)
     if not auto_certificate_generation_enabled():
         return
 

--- a/lms/djangoapps/certificates/tests/test_cert_management.py
+++ b/lms/djangoapps/certificates/tests/test_cert_management.py
@@ -9,16 +9,17 @@ from mock import patch
 from opaque_keys.edx.locator import CourseLocator
 from six import text_type
 from six.moves import range
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, check_mongo_calls
 
+from common.djangoapps.course_modes.models import CourseMode
+from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
 from lms.djangoapps.badges.events.course_complete import get_completion_badge
 from lms.djangoapps.badges.models import BadgeAssertion
 from lms.djangoapps.badges.tests.factories import BadgeAssertionFactory, CourseCompleteImageConfigurationFactory
-from common.djangoapps.course_modes.models import CourseMode
 from lms.djangoapps.certificates.models import CertificateStatuses, GeneratedCertificate
+from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
 from lms.djangoapps.grades.tests.utils import mock_passing_grade
-from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, check_mongo_calls
 
 
 class CertificateManagementTest(ModuleStoreTestCase):
@@ -50,7 +51,7 @@ class CertificateManagementTest(ModuleStoreTestCase):
         )
 
         # Create the certificate
-        GeneratedCertificate.eligible_certificates.create(
+        GeneratedCertificateFactory(
             user=user,
             course_id=course_key,
             status=status

--- a/lms/djangoapps/certificates/tests/test_signals.py
+++ b/lms/djangoapps/certificates/tests/test_signals.py
@@ -19,11 +19,12 @@ from lms.djangoapps.certificates.generation_handler import CERTIFICATES_USE_ALLO
 from lms.djangoapps.certificates.models import (
     CertificateGenerationConfiguration,
     CertificateStatuses,
-    CertificateWhitelist,
     GeneratedCertificate
 )
 from lms.djangoapps.certificates.signals import fire_ungenerated_certificate_task
 from lms.djangoapps.certificates.tasks import CERTIFICATE_DELAY_SECONDS
+from lms.djangoapps.certificates.tests.factories import CertificateWhitelistFactory
+from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
 from lms.djangoapps.grades.course_grade_factory import CourseGradeFactory
 from lms.djangoapps.grades.tests.utils import mock_passing_grade
 from lms.djangoapps.verify_student.models import IDVerificationAttempt, SoftwareSecurePhotoVerification
@@ -92,13 +93,13 @@ class WhitelistGeneratedCertificatesTest(ModuleStoreTestCase):
             return_value=None
         ) as mock_generate_certificate_apply_async:
             with override_waffle_switch(AUTO_CERTIFICATE_GENERATION_SWITCH, active=False):
-                CertificateWhitelist.objects.create(
+                CertificateWhitelistFactory(
                     user=self.user,
                     course_id=self.course.id
                 )
                 mock_generate_certificate_apply_async.assert_not_called()
             with override_waffle_switch(AUTO_CERTIFICATE_GENERATION_SWITCH, active=True):
-                CertificateWhitelist.objects.create(
+                CertificateWhitelistFactory(
                     user=self.user,
                     course_id=self.course.id
                 )
@@ -120,13 +121,13 @@ class WhitelistGeneratedCertificatesTest(ModuleStoreTestCase):
                 return_value=None
         ) as mock_generate_certificate_apply_async:
             with override_waffle_switch(AUTO_CERTIFICATE_GENERATION_SWITCH, active=False):
-                CertificateWhitelist.objects.create(
+                CertificateWhitelistFactory(
                     user=self.user,
                     course_id=self.ip_course.id
                 )
                 mock_generate_certificate_apply_async.assert_not_called()
             with override_waffle_switch(AUTO_CERTIFICATE_GENERATION_SWITCH, active=True):
-                CertificateWhitelist.objects.create(
+                CertificateWhitelistFactory(
                     user=self.user,
                     course_id=self.ip_course.id
                 )
@@ -151,7 +152,7 @@ class WhitelistGeneratedCertificatesTest(ModuleStoreTestCase):
                 'lms.djangoapps.certificates.signals.generate_allowlist_certificate_task',
                 return_value=None
             ) as mock_generate_allowlist_task:
-                CertificateWhitelist.objects.create(
+                CertificateWhitelistFactory(
                     user=self.user,
                     course_id=self.ip_course.id,
                     whitelist=True
@@ -173,7 +174,7 @@ class WhitelistGeneratedCertificatesTest(ModuleStoreTestCase):
                 'lms.djangoapps.certificates.signals.generate_allowlist_certificate_task',
                 return_value=None
             ) as mock_generate_allowlist_task:
-                CertificateWhitelist.objects.create(
+                CertificateWhitelistFactory(
                     user=self.user,
                     course_id=self.ip_course.id,
                     whitelist=True
@@ -269,7 +270,7 @@ class PassingGradeCertsTest(ModuleStoreTestCase):
         ) as mock_generate_certificate_apply_async:
             grade_factory = CourseGradeFactory()
             # Create the certificate
-            GeneratedCertificate.eligible_certificates.create(
+            GeneratedCertificateFactory(
                 user=self.user,
                 course_id=self.course.id,
                 status=CertificateStatuses.downloadable
@@ -327,7 +328,7 @@ class FailingGradeCertsTest(ModuleStoreTestCase):
             expected_status = CertificateStatuses.notpassing
         else:
             expected_status = status
-        GeneratedCertificate.eligible_certificates.create(
+        GeneratedCertificateFactory(
             user=self.user,
             course_id=self.course.id,
             status=status

--- a/lms/djangoapps/certificates/tests/test_views.py
+++ b/lms/djangoapps/certificates/tests/test_views.py
@@ -14,19 +14,19 @@ from django.test.utils import override_settings
 from django.urls import reverse
 from opaque_keys.edx.locator import CourseLocator
 from six.moves import range
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
 
+from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.certificates.models import (
     CertificateHtmlViewConfiguration,
     ExampleCertificate,
-    ExampleCertificateSet,
-    GeneratedCertificate
+    ExampleCertificateSet
 )
+from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
 from lms.djangoapps.certificates.utils import get_certificate_url
 from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
-from common.djangoapps.student.tests.factories import UserFactory
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory
 
 FEATURES_WITH_CERTS_ENABLED = settings.FEATURES.copy()
 FEATURES_WITH_CERTS_ENABLED['CERTIFICATES_HTML_VIEW'] = True
@@ -226,7 +226,7 @@ class CertificatesViewsSiteTests(ModuleStoreTestCase):
         self.user.profile.name = "Joe User"
         self.user.profile.save()
         self.client.login(username=self.user.username, password='foo')
-        self.cert = GeneratedCertificate.eligible_certificates.create(
+        self.cert = GeneratedCertificateFactory(
             user=self.user,
             course_id=self.course_id,
             download_uuid=uuid4().hex,


### PR DESCRIPTION
Code cleanup.

Remove unused variables, standardize imports, and use factories in tests.