### PR TITLE
replaced unittest assertions pytest assertions (6)

### DIFF
--- a/lms/djangoapps/tests/test_utils.py
+++ b/lms/djangoapps/tests/test_utils.py
@@ -26,4 +26,4 @@ class UtilsTests(TestCase):
     )
     @ddt.unpack
     def test_get_key(self, input_key, output_key, key_cls):
-        self.assertEqual(_get_key(input_key, key_cls), output_key)
+        assert _get_key(input_key, key_cls) == output_key

--- a/openedx/core/djangoapps/waffle_utils/tests/test_init.py
+++ b/openedx/core/djangoapps/waffle_utils/tests/test_init.py
@@ -57,8 +57,8 @@ class TestCourseWaffleFlag(TestCase):
         with patch.object(WaffleFlagCourseOverrideModel, 'override_value', return_value=data['course_override']):
             with override_flag(self.NAMESPACED_FLAG_NAME, active=data['waffle_enabled']):
                 # check twice to test that the result is properly cached
-                self.assertEqual(self.TEST_COURSE_FLAG.is_enabled(self.TEST_COURSE_KEY), data['result'])
-                self.assertEqual(self.TEST_COURSE_FLAG.is_enabled(self.TEST_COURSE_KEY), data['result'])
+                assert self.TEST_COURSE_FLAG.is_enabled(self.TEST_COURSE_KEY) == data['result']
+                assert self.TEST_COURSE_FLAG.is_enabled(self.TEST_COURSE_KEY) == data['result']
                 # result is cached, so override check should happen once
                 # pylint: disable=no-member
                 WaffleFlagCourseOverrideModel.override_value.assert_called_once_with(
@@ -71,12 +71,12 @@ class TestCourseWaffleFlag(TestCase):
             # When course override wasn't set for the first course, the second course will get the same
             # cached value from waffle.
             second_value = data['waffle_enabled']
-            self.assertEqual(self.TEST_COURSE_FLAG.is_enabled(self.TEST_COURSE_2_KEY), second_value)
+            assert self.TEST_COURSE_FLAG.is_enabled(self.TEST_COURSE_2_KEY) == second_value
         else:
             # When course override was set for the first course, it should not apply to the second
             # course which should get the default value of False.
             second_value = False
-            self.assertEqual(self.TEST_COURSE_FLAG.is_enabled(self.TEST_COURSE_2_KEY), second_value)
+            assert self.TEST_COURSE_FLAG.is_enabled(self.TEST_COURSE_2_KEY) == second_value
 
     def test_undefined_waffle_flag(self):
         """
@@ -94,8 +94,8 @@ class TestCourseWaffleFlag(TestCase):
             return_value=WaffleFlagCourseOverrideModel.ALL_CHOICES.unset
         ):
             # check twice to test that the result is properly cached
-            self.assertEqual(test_course_flag.is_enabled(self.TEST_COURSE_KEY), False)
-            self.assertEqual(test_course_flag.is_enabled(self.TEST_COURSE_KEY), False)
+            assert test_course_flag.is_enabled(self.TEST_COURSE_KEY) is False
+            assert test_course_flag.is_enabled(self.TEST_COURSE_KEY) is False
             # result is cached, so override check should happen once
             # pylint: disable=no-member
             WaffleFlagCourseOverrideModel.override_value.assert_called_once_with(
@@ -113,7 +113,7 @@ class TestCourseWaffleFlag(TestCase):
             self.FLAG_NAME,
             __name__,
         )
-        self.assertEqual(test_course_flag.is_enabled(self.TEST_COURSE_KEY), False)
+        assert test_course_flag.is_enabled(self.TEST_COURSE_KEY) is False
 
     def test_without_request_and_everyone_active_waffle(self):
         """
@@ -126,7 +126,7 @@ class TestCourseWaffleFlag(TestCase):
             __name__,
         )
         with override_flag(self.NAMESPACED_FLAG_NAME, active=True):
-            self.assertEqual(test_course_flag.is_enabled(self.TEST_COURSE_KEY), True)
+            assert test_course_flag.is_enabled(self.TEST_COURSE_KEY) is True
 
 
 class DeprecatedWaffleFlagTests(TestCase):
@@ -137,4 +137,4 @@ class DeprecatedWaffleFlagTests(TestCase):
     def test_waffle_switch_namespace_override(self):
         namespace = WaffleSwitchNamespace("namespace")
         with namespace.override("waffle_switch1", True):
-            self.assertTrue(namespace.is_enabled("waffle_switch1"))
+            assert namespace.is_enabled('waffle_switch1')

--- a/openedx/core/djangoapps/waffle_utils/tests/test_models.py
+++ b/openedx/core/djangoapps/waffle_utils/tests/test_models.py
@@ -31,7 +31,7 @@ class WaffleFlagCourseOverrideTests(TestCase):
         override_value = WaffleFlagCourseOverrideModel.override_value(
             self.WAFFLE_TEST_NAME, self.TEST_COURSE_KEY
         )
-        self.assertEqual(override_value, expected_result)
+        assert override_value == expected_result
 
     def test_setting_override_multiple_times(self):
         RequestCache.clear_all_namespaces()
@@ -40,7 +40,7 @@ class WaffleFlagCourseOverrideTests(TestCase):
         override_value = WaffleFlagCourseOverrideModel.override_value(
             self.WAFFLE_TEST_NAME, self.TEST_COURSE_KEY
         )
-        self.assertEqual(override_value, self.OVERRIDE_CHOICES.off)
+        assert override_value == self.OVERRIDE_CHOICES.off
 
     def set_waffle_course_override(self, override_choice, is_enabled=True):
         WaffleFlagCourseOverrideModel.objects.create(


### PR DESCRIPTION
## Description
This PR is using `codemod-unittest-to-pytest-asserts` to automatically replace `unittest` assertions with `pytest` 
for following modules:
```
lms/djangoapps/tests
```
```
openedx/core/djangoapps/waffle_utils
```
assertions.
Relevant JIRA issue here: https://openedx.atlassian.net/browse/BOM-2318

