### PR TITLE
LEARNER-8191 - Added first_component_block_id in dates api

### DIFF
--- a/lms/djangoapps/course_home_api/dates/v1/serializers.py
+++ b/lms/djangoapps/course_home_api/dates/v1/serializers.py
@@ -24,6 +24,7 @@ class DateSummarySerializer(serializers.Serializer):
     link_text = serializers.CharField()
     title = serializers.CharField()
     extra_info = serializers.CharField()
+    first_component_block_id = serializers.SerializerMethodField()
 
     def get_learner_has_access(self, block):
         learner_is_full_access = self.context.get('learner_is_full_access', False)
@@ -36,6 +37,9 @@ class DateSummarySerializer(serializers.Serializer):
             request = self.context.get('request')
             return request.build_absolute_uri(block.link)
         return ''
+
+    def get_first_component_block_id(self, block):
+        return getattr(block, 'first_component_block_id', '')
 
 
 class DatesTabSerializer(DatesBannerSerializerMixin, serializers.Serializer):

--- a/lms/djangoapps/courseware/date_summary.py
+++ b/lms/djangoapps/courseware/date_summary.py
@@ -388,6 +388,7 @@ class CourseAssignmentDate(DateSummary):
         self.assignment_link = ''
         self.assignment_title = None
         self.assignment_title_html = None
+        self.first_component_block_id = None
         self.contains_gated_content = False
         self.complete = None
         self.past_due = None

--- a/openedx/features/calendar_sync/tests/test_ics.py
+++ b/openedx/features/calendar_sync/tests/test_ics.py
@@ -41,7 +41,7 @@ class TestIcsGeneration(TestCase):
 
     def make_assigment(
         self, block_key=None, title=None, url=None, date=None, contains_gated_content=False, complete=False,
-        past_due=False, assignment_type=None, extra_info=None
+        past_due=False, assignment_type=None, extra_info=None, first_component_block_id=None
     ):
         """ Bundles given info into a namedtupled like get_course_assignments returns """
         return _Assignment(
@@ -53,7 +53,8 @@ class TestIcsGeneration(TestCase):
             complete,
             past_due,
             assignment_type,
-            extra_info
+            extra_info,
+            first_component_block_id
         )
 
     def expected_ics(self, *assignments):


### PR DESCRIPTION
LEARNER-8191

## Description

Added first_component_block_id in dates api

- Return first component or leaf block from a subsection in dates api.
