### PR TITLE
fix: rename send_activation_email task (step 2/3)

### DIFF
--- a/common/djangoapps/student/tasks.py
+++ b/common/djangoapps/student/tasks.py
@@ -78,8 +78,8 @@ _NEW_TASK_NAME = 'common.djangoapps.student.tasks.send_activation_email'
 
 
 # Register task under both its old and new names,
-# but expose only the old-named task for invocation.
-# -> Next step: Once we deploy and teach Celery workers the new name,
-#    set `send_activation_email` to the new-named task.
-send_activation_email = shared_task(bind=True, name=_OLD_TASK_NAME)(_send_activation_email)
-shared_task(bind=True, name=_NEW_TASK_NAME)(_send_activation_email)
+# but expose only the new-named task for invocation.
+# -> Next step: Once we deploy and stop using the old task name,
+#    stop registering the task under the old name.
+shared_task(bind=True, name=_OLD_TASK_NAME)(_send_activation_email)
+send_activation_email = shared_task(bind=True, name=_NEW_TASK_NAME)(_send_activation_email)


### PR DESCRIPTION
## Description

The old name is
`student.send_activation_email`.

The new name is
`common.djangoapps.student.tasks.send_activation_email`.

We currently register both the old and the new task names,
such that Celery workers recognize the task by both names.
This commit switches us from the old name to the new name.

## Supporting information

Step 1 of renaming: https://github.com/edx/edx-platform/pull/26236
Step 2 of renaming: (this PR)
Step 3 of renaming: https://github.com/edx/edx-platform/pull/26329

_This is related to the [import shims removal](https://github.com/edx/edx-platform/pull/25932)_ See that PR for more context.

## Testing instructions

### Confirm the task works and is renamed
* Create a new account.
* Confirm that a single activation email was a received.
* Look at the logs.
* Confirm that the task was named `common.djangoapps.student.tasks.send_activation_email`.

### Confirm the task is still registered twice

Check registered tasks. Note that we expect the email task to be registered twice (once under its old name, once under its new name), and the other two tasks each registered once (under their new names)
```
> make lms-shell
>> ./manage.py lms shell
>>> from lms.celery import APP
>>> print(*(
        task for task in APP.tasks if task.split('.')[-1] in {
            'send_activation_email'
        }
    ), sep="\n")
# Expected:
#   common.djangoapps.student.tasks.send_activation_email
#   student.send_activation_email
```

## Deadline

None

