### PR TITLE
fix: Rename send_activation_email task (step 3/3)

### DIFF
--- a/common/djangoapps/student/tasks.py
+++ b/common/djangoapps/student/tasks.py
@@ -20,13 +20,9 @@ from openedx.core.lib.celery.task_utils import emulate_http_request
 log = logging.getLogger('edx.celery.task')
 
 
-# This is a task function that is in the process of being renamed.
-# In order to avoid dropping tasks during deployment, we have to register it twice,
-# once under each name. This allows us to cut from one name to the other safely.
-# Once we have fully switched to the new name, we can go back to registering
-# this task function with a simple decorator.
+@shared_task(bind=True)
 @set_code_owner_attribute
-def _send_activation_email(self, msg_string, from_address=None):
+def send_activation_email(self, msg_string, from_address=None):
     """
     Sending an activation email to the user.
     """
@@ -71,15 +67,3 @@ def _send_activation_email(self, msg_string, from_address=None):
             dest_addr,
         )
         raise Exception  # lint-amnesty, pylint: disable=raise-missing-from
-
-
-_OLD_TASK_NAME = 'student.send_activation_email'
-_NEW_TASK_NAME = 'common.djangoapps.student.tasks.send_activation_email'
-
-
-# Register task under both its old and new names,
-# but expose only the new-named task for invocation.
-# -> Next step: Once we deploy and stop using the old task name,
-#    stop registering the task under the old name.
-shared_task(bind=True, name=_OLD_TASK_NAME)(_send_activation_email)
-send_activation_email = shared_task(bind=True, name=_NEW_TASK_NAME)(_send_activation_email)


### PR DESCRIPTION
## Description

The old name was
`student.send_activation_email`.

The new name is now
`common.djangoapps.student.tasks.send_activation_email`.

We no longer user the old task name,
so we can safely stop registering it with Celery
workers, without fear of dropping any lingering
tasks under the old name.

## Supporting information

Step 1 of renaming: https://github.com/edx/edx-platform/pull/26236
Step 2 of renaming: https://github.com/edx/edx-platform/pull/26328 (this PR blocked by merge of Step 2)
Step 3 of renaming: (this PR)

_This is related to the [import shims removal](https://github.com/edx/edx-platform/pull/25932)_ See that PR for more context.

## Testing instructions

### Confirm the task works and is renamed
* Create a new account.
* Confirm that a single activation email was a received.
* Look at the logs.
* Confirm that the task was named `common.djangoapps.student.tasks.send_activation_email`.

## Deadline

None

