### PR TITLE
style: Fix pylint issues in discussions app

### DIFF
--- a/openedx/core/djangoapps/discussions/admin.py
+++ b/openedx/core/djangoapps/discussions/admin.py
@@ -12,6 +12,10 @@ from .models import ProviderFilter
 
 
 class DiscussionsConfigurationAdmin(SimpleHistoryAdmin):
+    """
+    Customize the admin interface for the discussions configuration
+    """
+
     search_fields = (
         'context_key',
         'enabled',

--- a/openedx/core/djangoapps/discussions/models.py
+++ b/openedx/core/djangoapps/discussions/models.py
@@ -130,7 +130,9 @@ class DiscussionsConfiguration(TimeStampedModel):
         db_index=True,
         unique=True,
         max_length=255,
-        # Translators: A key specifying a course, library, program, website, or some other collection of content where learning happens.
+        # Translators: A key specifying a course, library, program,
+        # website, or some other collection of content where learning
+        # happens.
         verbose_name=_("Learning Context Key"),
     )
     enabled = models.BooleanField(
@@ -184,6 +186,7 @@ class DiscussionsConfiguration(TimeStampedModel):
         configuration = cls.get(context_key)
         return configuration.enabled
 
+    # pylint: disable=undefined-variable
     @classmethod
     def get(cls, context_key) -> cls:
         """
@@ -194,6 +197,7 @@ class DiscussionsConfiguration(TimeStampedModel):
         except cls.DoesNotExist:
             configuration = cls(context_key=context_key, enabled=False)
         return configuration
+    # pylint: enable=undefined-variable
 
     @property
     def available_providers(self) -> List[str]:

--- a/openedx/core/djangoapps/discussions/tests/test_models.py
+++ b/openedx/core/djangoapps/discussions/tests/test_models.py
@@ -124,6 +124,7 @@ class DiscussionsConfigurationModelTest(TestCase):
         """
         Configure shared test data (configuration, course_key, etc.)
         """
+        super().setUp()
         self.course_key_with_defaults = CourseKey.from_string("course-v1:TestX+Course+Configured")
         self.course_key_without_config = CourseKey.from_string("course-v1:TestX+Course+NoConfig")
         self.course_key_with_values = CourseKey.from_string("course-v1:TestX+Course+Values")
@@ -140,14 +141,13 @@ class DiscussionsConfigurationModelTest(TestCase):
             },
         )
         self.configuration_with_values.save()
-        pass
 
     def test_get_nonexistent(self):
         """
         Assert we can not fetch a non-existent record
         """
         with self.assertRaises(DiscussionsConfiguration.DoesNotExist):
-            configuration = DiscussionsConfiguration.objects.get(
+            DiscussionsConfiguration.objects.get(
                 context_key=self.course_key_without_config,
             )
 
@@ -170,7 +170,9 @@ class DiscussionsConfigurationModelTest(TestCase):
         assert configuration is not None
         assert not configuration.enabled
         assert configuration.lti_configuration is None
-        assert configuration.plugin_configuration['url'] == self.configuration_with_values.plugin_configuration['url']
+        actual_url = configuration.plugin_configuration.get('url')
+        expected_url = self.configuration_with_values.plugin_configuration.get('url')
+        assert actual_url == expected_url
         assert configuration.provider_type == self.configuration_with_values.provider_type
 
     def test_update_defaults(self):
@@ -212,7 +214,7 @@ class DiscussionsConfigurationModelTest(TestCase):
         is_enabled = DiscussionsConfiguration.is_enabled(self.course_key_with_values)
         assert not is_enabled
 
-    def test_get_nonexistent(self):
+    def test_get_nonexistent_empty(self):
         """
         Assert we get an "empty" model back for nonexistent records
         """


### PR DESCRIPTION
## Description

This addresses some pylint errors that were apparently not flagged during their creation, perhaps because they were new files that didn't exist yet on master?! :shrug: 
Anyway, this fixes them, so other PRs that touch these files don't get caught in the `diff-lint` crossfire.

## Deadline

This will presumably block subsequent PRs to the discussions app, due to linting failures,
first noticed here: https://github.com/edx/edx-platform/pull/26335