### PR TITLE
fix: Add DiscussionsConfiguration.enabled to admin page

### DIFF
--- a/openedx/core/djangoapps/discussions/models.py
+++ b/openedx/core/djangoapps/discussions/models.py
@@ -81,6 +81,7 @@ class ProviderFilter(StackedConfigurationModel):
     )
 
     STACKABLE_FIELDS = (
+        'enabled',
         'allow',
         'deny',
     )


### PR DESCRIPTION
## Description

Without this, we can't edit it via the default view.

## Testing instructions

- Go to http://127.0.0.1:18000/admin/discussions/providerfilter/add/
- Notice that the `Enabled` dropdown is now editable.

## Deadline

None