### PR TITLE
[MST-636] Add additional check for proctoring requirements

### DIFF
--- a/common/djangoapps/student/email_helpers.py
+++ b/common/djangoapps/student/email_helpers.py
@@ -9,6 +9,7 @@ from django.conf import settings
 
 from lms.djangoapps.verify_student.services import IDVerificationService
 from openedx.core.djangoapps.ace_common.template_context import get_base_template_context
+from openedx.core.djangoapps.enrollments.api import is_enrollment_valid_for_proctoring
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from xmodule.modulestore.django import modulestore
 
@@ -51,3 +52,26 @@ def generate_proctoring_requirements_email_context(user, course_id):
         'proctoring_requirements_url': settings.PROCTORING_SETTINGS.get('LINK_URLS', {}).get('faq', ''),
         'id_verification_url': IDVerificationService.get_verify_location(),
     }
+
+
+def should_send_proctoring_requirements_email(username, course_id):
+    """
+    Returns a boolean whether a proctoring requirements email should be sent.
+
+    Arguments:
+        * username (str): The user associated with the enrollment.
+        * course_id (str): The course id associated with the enrollment.
+    """
+    if not is_enrollment_valid_for_proctoring(username, course_id):
+        return False
+
+    # Only send if a proctored exam is found in the course
+    timed_exams = modulestore().get_items(
+        course_id,
+        qualifiers={'category': 'sequential'},
+        settings={'is_time_limited': True}
+    )
+
+    has_proctored_exam = any([exam.is_proctored_exam for exam in timed_exams])
+
+    return has_proctored_exam

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -59,7 +59,10 @@ from user_util import user_util
 import openedx.core.djangoapps.django_comment_common.comment_client as cc
 from common.djangoapps.course_modes.models import CourseMode, get_cosmetic_verified_display_price
 from common.djangoapps.student.emails import send_proctoring_requirements_email
-from common.djangoapps.student.email_helpers import generate_proctoring_requirements_email_context
+from common.djangoapps.student.email_helpers import (
+    generate_proctoring_requirements_email_context,
+    should_send_proctoring_requirements_email
+)
 from common.djangoapps.student.signals import ENROLL_STATUS_CHANGE, ENROLLMENT_TRACK_UPDATED, UNENROLL_DONE
 from common.djangoapps.track import contexts, segment
 from common.djangoapps.util.model_utils import emit_field_changed_events, get_changed_fields_dict
@@ -76,7 +79,6 @@ from openedx.core.djangoapps.content.course_overviews.models import CourseOvervi
 from openedx.core.djangoapps.enrollments.api import (
     _default_course_mode,
     get_enrollment_attributes,
-    is_enrollment_valid_for_proctoring,
     set_enrollment_attributes,
 )
 from openedx.core.djangoapps.signals.signals import USER_ACCOUNT_ACTIVATED
@@ -1461,7 +1463,7 @@ class CourseEnrollment(models.Model):
         if mode_changed:
             if COURSEWARE_PROCTORING_IMPROVEMENTS.is_enabled(self.course_id):
                 # If mode changed to one that requires proctoring, send proctoring requirements email
-                if is_enrollment_valid_for_proctoring(self.user.username, self.course_id):
+                if should_send_proctoring_requirements_email(self.user.username, self.course_id):
                     email_context = generate_proctoring_requirements_email_context(self.user, self.course_id)
                     send_proctoring_requirements_email(context=email_context)
 

--- a/openedx/core/djangoapps/enrollments/api.py
+++ b/openedx/core/djangoapps/enrollments/api.py
@@ -497,25 +497,32 @@ def serialize_enrollments(enrollments):
 
 def is_enrollment_valid_for_proctoring(username, course_id):
     """
-    Returns a boolean value regarding whether user's course enrollment is eligible for proctoring. Returns
-    False if the enrollment is not active, special exams aren't enabled, proctored exams aren't enabled
-    for the course, or if the course mode is audit.
+    Returns a boolean value regarding whether user's course enrollment is eligible for proctoring.
+
+    Returns false if:
+        * special exams aren't enabled
+        * the enrollment is not active
+        * proctored exams aren't enabled for the course
+        * the course mode is audit
 
     Arguments:
-        username: The user associated with the enrollment.
-        course_id (str): The course id associated with the enrollment.
+        * username (str): The user associated with the enrollment.
+        * course_id (str): The course id associated with the enrollment.
     """
     if not settings.FEATURES.get('ENABLE_SPECIAL_EXAMS'):
         return False
 
+    # Verify that the learner's enrollment is active
     enrollment = _data_api().get_course_enrollment(username, str(course_id))
     if not enrollment['is_active']:
         return False
 
+    # Check that the course has proctored exams enabled
     course_module = modulestore().get_course(course_id)
     if not course_module.enable_proctored_exams:
         return False
 
+    # Only allow verified modes
     appropriate_modes = [
         CourseMode.VERIFIED, CourseMode.MASTERS, CourseMode.PROFESSIONAL, CourseMode.EXECUTIVE_EDUCATION
     ]


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

If a course has proctoring enabled, verified learners are sent a proctoring requirements email when they enroll in the course. However, a course can have proctoring enabled without ever having a proctored exam set up. This implements an additional check for an existing exam.

## Supporting information

[MST-636](https://openedx.atlassian.net/browse/MST-636)
