### PR TITLE
AA-635: learner dashboard course card image bug

### DIFF
--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -196,8 +196,10 @@ from common.djangoapps.student.models import CourseEnrollment
                     enrollment = CourseEnrollment(user=user, course=CourseOverview.get_from_id(pseudo_key), mode=pseudo_session['type'])
                   # We only show email settings for entitlement cards if the entitlement has an associated enrollment
                   show_email_settings = is_fulfilled_entitlement and (entitlement_session.course_id in show_email_settings_for)
+                  course_overview = enrollment.course_overview
                 else:
                   show_email_settings = (enrollment.course_id in show_email_settings_for)
+                  course_overview = CourseOverview.get_from_id(enrollment.course_id)
 
                 session_id = enrollment.course_id
                 show_courseware_link = show_courseware_links_for.get(session_id, False)
@@ -212,7 +214,6 @@ from common.djangoapps.student.models import CourseEnrollment
                 course_requirements = courses_requirements_not_met.get(session_id)
                 related_programs = inverted_programs.get(six.text_type(entitlement.course_uuid if is_unfulfilled_entitlement else session_id))
                 show_consent_link = (session_id in consent_required_courses)
-                course_overview = enrollment.course_overview
                 resume_button_url = resume_button_urls[dashboard_index]
               %>
               <%include file='dashboard/_dashboard_course_listing.html' args='course_overview=course_overview, course_card_index=dashboard_index, enrollment=enrollment, is_unfulfilled_entitlement=is_unfulfilled_entitlement, is_fulfilled_entitlement=is_fulfilled_entitlement, entitlement=entitlement, entitlement_session=entitlement_session, entitlement_available_sessions=entitlement_available_sessions, entitlement_expiration_date=entitlement_expiration_date, entitlement_expired_at=entitlement_expired_at, show_courseware_link=show_courseware_link, cert_status=cert_status, can_refund_entitlement=can_refund_entitlement, can_unenroll=can_unenroll, credit_status=credit_status, show_email_settings=show_email_settings, course_mode_info=course_mode_info, is_paid_course=is_paid_course, verification_status=course_verification_status, course_requirements=course_requirements, dashboard_index=dashboard_index, share_settings=share_settings, user=user, related_programs=related_programs, display_course_modes_on_dashboard=display_course_modes_on_dashboard, show_consent_link=show_consent_link, enterprise_customer_name=enterprise_customer_name, resume_button_url=resume_button_url, partner_managed_enrollment=partner_managed_enrollment' />

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -372,8 +372,14 @@ class CourseOverview(TimeStampedModel):
         # Regenerate the thumbnail images if they're missing (either because
         # they were never generated, or because they were flushed out after
         # a change to CourseOverviewImageConfig.
-        if course_overview and not hasattr(course_overview, 'image_set'):
-            CourseOverviewImageSet.create(course_overview)
+        if course_overview:
+            if hasattr(course_overview, 'image_set'):
+                image_set = course_overview.image_set
+                if not image_set.small_url or not image_set.large_url:
+                    CourseOverviewImageSet.objects.filter(course_overview=course_overview).delete()
+                    CourseOverviewImageSet.create(course_overview)
+            else:
+                CourseOverviewImageSet.create(course_overview)
 
         return course_overview or cls.load_from_module_store(course_id)
 


### PR DESCRIPTION
## Description

- Updates the learner dashboard to pass a Course Overview object for enrollments (this was previously only being done for entitlements, so `course_overview` would be null). The `CourseOverview.get_from_id()` call pulls the most updated course card image.
- Updates `get_from_id` in the CourseOverview model to not only check for an existing `image_set` attribute, but to check if that `image_set` has empty strings. If the `image_set` has empty strings, the CourseOverviewImageSet object should be deleted and re-created.

This fix will hopefully mitigate the issue of missing course card images.