### PR TITLE
[BD-21] Upgrade usage of edx_toggles.toggles

### DIFF
--- a/openedx/core/djangoapps/content/block_structure/config/__init__.py
+++ b/openedx/core/djangoapps/content/block_structure/config/__init__.py
@@ -3,7 +3,7 @@ This module contains various configuration settings via
 waffle switches for the Block Structure framework.
 """
 from edx_django_utils.cache import RequestCache
-from edx_toggles.toggles.__future__ import WaffleSwitch
+from edx_toggles.toggles import WaffleSwitch
 
 from openedx.core.lib.cache_utils import request_cached
 


### PR DESCRIPTION

<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

The waffle classes previously in future are now available directly from
edx_toggles.toggles. Since this future module is going to be removed soon,
we become future-proof by getting rid of it.

## Supporting information

https://openedx.atlassian.net/wiki/spaces/COMM/pages/1596358943/BD-21+Toggles+Settings+Documentation

This should be ready for review @robrap.
