### PR TITLE
[MST-572] Add onboarding status view to instructor dashboard

### DIFF
--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -20,6 +20,7 @@ from django.utils.translation import ugettext_noop
 from django.views.decorators.cache import cache_control
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_POST
+from edx_proctoring.api import does_backend_support_onboarding
 from edx_when.api import is_enabled_for_course
 from mock import patch
 from opaque_keys import InvalidKeyError
@@ -277,6 +278,7 @@ def _section_special_exams(course, access):
         'course_id': course_key,
         'escalation_email': escalation_email,
         'show_dashboard': is_backend_dashboard_available(course_key),
+        'show_onboarding': does_backend_support_onboarding(course.proctoring_provider),
         'enable_exam_resume_proctoring_improvements': EXAM_RESUME_PROCTORING_IMPROVEMENTS.is_enabled(course.id),
     }
     return section_data

--- a/lms/static/js/instructor_dashboard/instructor_dashboard.js
+++ b/lms/static/js/instructor_dashboard/instructor_dashboard.js
@@ -204,6 +204,9 @@ such that the value can be defined later than this assignment (file load order).
                     constructor: edx.instructor_dashboard.proctoring.ProctoredExamAllowanceView,
                     $element: idashContent.find('.' + CSS_IDASH_SECTION + '#special_exams')
                 }, {
+                    constructor: edx.instructor_dashboard.proctoring.ProctoredExamOnboardingView,
+                    $element: idashContent.find('.' + CSS_IDASH_SECTION + '#special_exams')
+                }, {
                     constructor: edx.instructor_dashboard.proctoring.ProctoredExamAttemptView,
                     $element: idashContent.find('.' + CSS_IDASH_SECTION + '#special_exams')
                 }, {

--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -2587,9 +2587,11 @@ input[name="subject"] {
 }
 
 .special-allowance-container,
+.student-onboarding-status-container,
 .student-proctored-exam-container {
   .allowance-table,
-  .exam-attempts-table {
+  .exam-attempts-table,
+  .onboarding-status-table {
     width: 100%;
 
     tr:nth-child(even) {
@@ -2598,7 +2600,8 @@ input[name="subject"] {
     }
 
     .allowance-headings,
-    .exam-attempt-headings {
+    .exam-attempt-headings,
+    .onboarding-status-headings {
       height: 40px;
       border-bottom: 1px solid #bebebe;
 
@@ -2718,7 +2721,8 @@ input[name="subject"] {
   }
 
   .exam-attempts-content,
-  .exam-allowances-content {
+  .exam-allowances-content,
+  .onboarding-status-content {
     padding-left: 0;
     padding-right: 0;
   }
@@ -2727,7 +2731,8 @@ input[name="subject"] {
     margin-top: -30px;
     margin-bottom: 20px;
 
-    .search-attempts {
+    .search-attempts,
+    .search-onboarding {
       border: 1px solid #ccc;
       display: inline-block;
       border-radius: 5px;

--- a/lms/templates/instructor/instructor_dashboard_2/special_exams.html
+++ b/lms/templates/instructor/instructor_dashboard_2/special_exams.html
@@ -10,16 +10,22 @@ import pytz
   % endif
   <div id="proctoring-accordion">
     <div class="wrap">
-       <h3 class="hd hd-3">${_('Allowance Section')}</h3>
+      <h3 class="hd hd-3">${_('Allowance Section')}</h3>
       <div class="special-allowance-container" data-course-id="${ section_data['course_id'] }"></div>
     </div>
+    % if section_data['show_onboarding'] and section_data['enable_exam_resume_proctoring_improvements']:
     <div class="wrap">
-       <h3 class="hd hd-3">${_('Student Special Exam Attempts')}</h3>
+      <h3 class="hd hd-3">${_('Student Onboarding Status')}</h3>
+      <div class="student-onboarding-status-container" data-course-id="${ section_data['course_id'] }"></div>
+    </div>
+    % endif
+    <div class="wrap">
+      <h3 class="hd hd-3">${_('Student Special Exam Attempts')}</h3>
       <div class="student-proctored-exam-container" data-course-id="${ section_data['course_id'] }" data-enable-exam-resume-proctoring-improvements="${ section_data['enable_exam_resume_proctoring_improvements'] }"></div>
     </div>
     % if section_data['show_dashboard']:
     <div class="wrap">
-       <h3 class="hd hd-3">${_('Review Dashboard')}</h3>
+      <h3 class="hd hd-3">${_('Review Dashboard')}</h3>
       <div class="student-review-dashboard-container" data-course-id="${ section_data['course_id'] }"></div>
     </div>
     % endif

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -106,7 +106,7 @@ edx-milestones==0.3.0     # via -r requirements/edx/base.in
 edx-opaque-keys[django]==2.2.0  # via -r requirements/edx/paver.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, lti-consumer-xblock, xmodule
 edx-organizations==6.9.0  # via -r requirements/edx/base.in
 edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/base.in
-edx-proctoring==3.2.1     # via -r requirements/edx/base.in, edx-proctoring-proctortrack
+edx-proctoring==3.3.0     # via -r requirements/edx/base.in, edx-proctoring-proctortrack
 edx-rbac==1.4.1           # via edx-enterprise
 edx-rest-api-client==5.3.0  # via -r requirements/edx/base.in, edx-enterprise, edx-proctoring
 edx-search==3.0.0         # via -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -118,7 +118,7 @@ edx-milestones==0.3.0     # via -r requirements/edx/testing.txt
 edx-opaque-keys[django]==2.2.0  # via -r requirements/edx/testing.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, lti-consumer-xblock, xmodule
 edx-organizations==6.9.0  # via -r requirements/edx/testing.txt
 edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/testing.txt
-edx-proctoring==3.2.1     # via -r requirements/edx/testing.txt, edx-proctoring-proctortrack
+edx-proctoring==3.3.0     # via -r requirements/edx/testing.txt, edx-proctoring-proctortrack
 edx-rbac==1.4.1           # via -r requirements/edx/testing.txt, edx-enterprise
 edx-rest-api-client==5.3.0  # via -r requirements/edx/testing.txt, edx-enterprise, edx-proctoring
 edx-search==3.0.0         # via -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -115,7 +115,7 @@ edx-milestones==0.3.0     # via -r requirements/edx/base.txt
 edx-opaque-keys[django]==2.2.0  # via -r requirements/edx/base.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, lti-consumer-xblock, xmodule
 edx-organizations==6.9.0  # via -r requirements/edx/base.txt
 edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/base.txt
-edx-proctoring==3.2.1     # via -r requirements/edx/base.txt, edx-proctoring-proctortrack
+edx-proctoring==3.3.0     # via -r requirements/edx/base.txt, edx-proctoring-proctortrack
 edx-rbac==1.4.1           # via -r requirements/edx/base.txt, edx-enterprise
 edx-rest-api-client==5.3.0  # via -r requirements/edx/base.txt, edx-enterprise, edx-proctoring
 edx-search==3.0.0         # via -r requirements/edx/base.txt


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Implements an instructor-facing proctored exam onboarding view. This section only appears if the proctoring provider supports onboarding, and the `EXAM_RESUME_PROCTORING_IMPROVEMENTS` course waffle flag is enabled.

## Supporting information

Related PR: https://github.com/edx/edx-proctoring/pull/772
Jira Ticket: [MST-572](https://openedx.atlassian.net/browse/MST-572)