### PR TITLE
Feanil/rate limit anon csv

### DIFF
--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -34,6 +34,7 @@ from edx_rest_framework_extensions.auth.session.authentication import SessionAut
 from edx_when.api import get_date_for_block
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, UsageKey
+from ratelimit.decorators import ratelimit
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated, IsAdminUser
 from rest_framework.response import Response
@@ -1381,6 +1382,7 @@ def get_proctored_exam_results(request, course_id):
 
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
+@ratelimit(key="user", rate="1/5m", block=True)
 @require_course_permission(permissions.CAN_RESEARCH)
 def get_anon_ids(request, course_id):
     """


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This PR adds rate limiting to the `get_anon_ids` endpoint which generates a CSV mapping learner IDs to their anonymous_ids.  It also makes some improvements to the ratelimiting error handling in the LMS and makes it easier to view error pages.

Impact: Data researchers will not be able to execute this request more than once every 5 minutes.

## Supporting information

Jira Ticket: [ARCHBOM-1682](https://openedx.atlassian.net/browse/ARCHBOM-1682)

## Testing instructions

1. Go to the "Data Download" tab in a course with the `staff` or `Data Researcher` role.
2. Click the `Get Student Anonymized IDs CSV` button.
3. Dowload the CSV
4. Immediately Click the button again.
5. See the 429 page indicating that you have been rate limited.

## Deadline

None

## Other information

Include anything else that will help reviewers and consumers understand the change.
- There is a small concern that having an easy way to cause 500s in production is risky, but I think if it becomes a problem, we can filter out 500s from that specific URL without any issue.
