### PR TITLE
update enterprise to 3.17.22

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -34,7 +34,7 @@ django-storages<1.9
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==3.17.21
+edx-enterprise==3.17.22
 
 # Upgrading to 2.12.0 breaks several test classes due to API changes, need to update our code accordingly
 factory-boy==2.8.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -99,7 +99,7 @@ edx-django-release-util==1.0.0  # via -r requirements/edx/base.in
 edx-django-sites-extensions==3.0.0  # via -r requirements/edx/base.in
 edx-django-utils==3.13.0  # via -r requirements/edx/base.in, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-toggles, edx-when, ora2, super-csv
 edx-drf-extensions==6.4.0  # via -r requirements/edx/base.in, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
-edx-enterprise==3.17.21   # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
+edx-enterprise==3.17.22   # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
 edx-event-routing-backends==4.0.1  # via -r requirements/edx/base.in
 edx-i18n-tools==0.5.3     # via ora2
 edx-milestones==0.3.0     # via -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -110,7 +110,7 @@ edx-django-release-util==1.0.0  # via -r requirements/edx/testing.txt
 edx-django-sites-extensions==3.0.0  # via -r requirements/edx/testing.txt
 edx-django-utils==3.13.0  # via -r requirements/edx/testing.txt, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-toggles, edx-when, ora2, super-csv
 edx-drf-extensions==6.4.0  # via -r requirements/edx/testing.txt, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
-edx-enterprise==3.17.21   # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
+edx-enterprise==3.17.22   # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
 edx-event-routing-backends==4.0.1  # via -r requirements/edx/testing.txt
 edx-i18n-tools==0.5.3     # via -r requirements/edx/testing.txt, ora2
 edx-lint==3.0.2           # via -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -107,7 +107,7 @@ edx-django-release-util==1.0.0  # via -r requirements/edx/base.txt
 edx-django-sites-extensions==3.0.0  # via -r requirements/edx/base.txt
 edx-django-utils==3.13.0  # via -r requirements/edx/base.txt, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-toggles, edx-when, ora2, super-csv
 edx-drf-extensions==6.4.0  # via -r requirements/edx/base.txt, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
-edx-enterprise==3.17.21   # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt
+edx-enterprise==3.17.22   # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt
 edx-event-routing-backends==4.0.1  # via -r requirements/edx/base.txt
 edx-i18n-tools==0.5.3     # via -r requirements/edx/base.txt, -r requirements/edx/testing.in, ora2
 edx-lint==3.0.2           # via -r requirements/edx/testing.in


### PR DESCRIPTION
## Description

This version of edx-enterprise adds a new Django Admin table for integrated channel's content metadata item transmission table. It also allows deletion of this data (this is needed for developers to clean stage and production data when our demo LMS instances get out of sync (ie have already deleted content metadata))

The table view in admin:
![Screen Shot 2021-02-04 at 11 13 00 AM](https://user-images.githubusercontent.com/66267747/106927426-2686ad80-66e0-11eb-831c-3fb6723e1a4a.png)

## Testing instructions

- In Django Admin, there should now be a "ENTERPRISE INTEGRATED CHANNELS" section with a "Content metadata item transmissions" line item. Click on this.
- Assuming your local environment has transmissions, you should be able to see them listed here and can even delete them. (You should not be able to edit or add them) (Note: Please do not do this on stage or prod simply for testing purposes)

## Deadline

ASAP - this allows us to clean our demo Moodle instance (currently blocked on the edX side by the data in the database this allows us to delete) which marketing needs configured...days ago.

