### PR TITLE
AA-650: block deprecated keys from course home MFE

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/tests/factories.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/factories.py
@@ -363,6 +363,9 @@ class ItemFactory(XModuleFactory):
         location = kwargs.pop('location')
         user_id = kwargs.pop('user_id', ModuleStoreEnum.UserID.test)
         publish_item = kwargs.pop('publish_item', True)
+        has_score = kwargs.pop('has_score', None)
+        submission_start = kwargs.pop('submission_start', None)
+        submission_end = kwargs.pop('submission_end', None)
 
         # Remove the descriptive_tag, it's just for generating display_name,
         # and doesn't need to be passed into the object constructor
@@ -404,6 +407,13 @@ class ItemFactory(XModuleFactory):
                 runtime=parent.runtime,
                 fields=kwargs,
             )
+
+            if has_score:
+                module.has_score = has_score
+            if submission_start:
+                module.submission_start = submission_start
+            if submission_end:
+                module.submission_end = submission_end
 
             # VS[compat] cdodge: This is a hack because static_tabs also have references from the course module, so
             # if we add one then we need to also add it to the policy information (i.e. metadata)

--- a/lms/djangoapps/course_home_api/outline/v1/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/outline/v1/tests/test_views.py
@@ -246,13 +246,13 @@ class OutlineTabTestViews(BaseCourseHomeTests):
             graded=True,
             is_time_limited=True,
             default_time_limit_minutes=10,
-            is_proctored_exam=True,
             is_practice_exam=True,
             due=datetime.now(),
             exam_review_rules='allow_use_of_paper',
             hide_after_due=False,
             is_onboarding_exam=False,
         )
+        sequence.is_proctored_exam = True
         mock_summary.return_value = {
             'short_description': 'My Exam',
             'suggested_icon': 'fa-foo-bar',
@@ -284,9 +284,11 @@ class OutlineTabTestViews(BaseCourseHomeTests):
                                           parent_location=sequential.location)
             sequential2 = ItemFactory.create(display_name='Ungraded', category='sequential',
                                              parent_location=chapter.location)
+            problem3 = ItemFactory.create(category='problem', parent_location=sequential2.location)
         course.children = [chapter]
         chapter.children = [sequential, sequential2]
         sequential.children = [problem1, problem2]
+        sequential2.children = [problem3]
         url = reverse('course-home-outline-tab', args=[course.id])
 
         CourseEnrollment.enroll(self.user, course.id)

--- a/lms/djangoapps/course_home_api/tests/utils.py
+++ b/lms/djangoapps/course_home_api/tests/utils.py
@@ -23,6 +23,8 @@ class BaseCourseHomeTests(ModuleStoreTestCase, MasqueradeMixin):
 
     Creates a course to
     """
+    MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
+
     def setUp(self):
         super().setUp()
 

--- a/lms/djangoapps/course_home_api/toggles.py
+++ b/lms/djangoapps/course_home_api/toggles.py
@@ -15,15 +15,22 @@ COURSE_HOME_MICROFRONTEND_DATES_TAB = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'c
 COURSE_HOME_MICROFRONTEND_OUTLINE_TAB = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'course_home_mfe_outline_tab', __name__)
 
 
-def course_home_mfe_dates_tab_is_active(course_key):
+def course_home_mfe_is_active(course_key):
     return (
         COURSE_HOME_MICROFRONTEND.is_enabled(course_key) and
+        not course_key.deprecated
+    )
+
+
+def course_home_mfe_dates_tab_is_active(course_key):
+    return (
+        course_home_mfe_is_active(course_key) and
         COURSE_HOME_MICROFRONTEND_DATES_TAB.is_enabled(course_key)
     )
 
 
 def course_home_mfe_outline_tab_is_active(course_key):
     return (
-        COURSE_HOME_MICROFRONTEND.is_enabled(course_key) and
+        course_home_mfe_is_active(course_key) and
         COURSE_HOME_MICROFRONTEND_OUTLINE_TAB.is_enabled(course_key)
     )

--- a/lms/djangoapps/courseware/tests/test_date_summary.py
+++ b/lms/djangoapps/courseware/tests/test_date_summary.py
@@ -53,13 +53,14 @@ from openedx.features.course_experience import (
 )
 from common.djangoapps.student.tests.factories import TEST_PASSWORD, CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore import ModuleStoreEnum
-from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
 
 @ddt.ddt
 class CourseDateSummaryTest(SharedModuleStoreTestCase):
     """Tests for course date summary blocks."""
+    MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
 
     def setUp(self):
         super(CourseDateSummaryTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments


### PR DESCRIPTION
## Description

Courses with deprecated keys cannot be accessed in frontend-app-learning due to the parsing strategy of the page router. This is a quick fix to address [this CR](https://openedx.atlassian.net/browse/AA-650), and a conversation with TNL will follow about the state of supporting mongo courses in frontend-app-learning.
