### PR TITLE
fix: Always save generated anonymous user ID in DB; ignore save=False

### DIFF
--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -999,7 +999,7 @@ class AnonymousLookupTable(ModuleStoreTestCase):
         anonymous_id = anonymous_id_for_user(self.user, self.course.id)
         real_user = user_by_anonymous_id(anonymous_id)
         self.assertEqual(self.user, real_user)
-        self.assertEqual(anonymous_id, anonymous_id_for_user(self.user, self.course.id, save=False))
+        self.assertEqual(anonymous_id, anonymous_id_for_user(self.user, self.course.id))
 
     def test_roundtrip_with_unicode_course_id(self):
         course2 = CourseFactory.create(display_name=u"Omega Course Ω")
@@ -1007,7 +1007,7 @@ class AnonymousLookupTable(ModuleStoreTestCase):
         anonymous_id = anonymous_id_for_user(self.user, course2.id)
         real_user = user_by_anonymous_id(anonymous_id)
         self.assertEqual(self.user, real_user)
-        self.assertEqual(anonymous_id, anonymous_id_for_user(self.user, course2.id, save=False))
+        self.assertEqual(anonymous_id, anonymous_id_for_user(self.user, course2.id))
 
     def test_anonymous_id_secret_key_changes_do_not_change_existing_anonymous_ids(self):
         """Test that a same anonymous id is returned when the SECRET_KEY changes."""

--- a/common/djangoapps/xblock_django/tests/test_user_service.py
+++ b/common/djangoapps/xblock_django/tests/test_user_service.py
@@ -105,8 +105,7 @@ class UserServiceTestCase(TestCase):
         course_key = CourseKey.from_string('edX/toy/2012_Fall')
         anon_user_id = anonymous_id_for_user(
             user=self.user,
-            course_id=course_key,
-            save=True
+            course_id=course_key
         )
 
         django_user_service = DjangoXBlockUserService(self.user, user_is_staff=True)

--- a/common/djangoapps/xblock_django/user_service.py
+++ b/common/djangoapps/xblock_django/user_service.py
@@ -66,7 +66,7 @@ class DjangoXBlockUserService(UserService):
             return None
 
         course_id = CourseKey.from_string(course_id)
-        return anonymous_id_for_user(user=user, course_id=course_id, save=False)
+        return anonymous_id_for_user(user=user, course_id=course_id)
 
     def _convert_django_user_to_xblock_user(self, django_user):
         """

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1411,7 +1411,7 @@ def get_anon_ids(request, course_id):
         courseenrollment__course_id=course_id,
     ).order_by('id')
     header = ['User ID', 'Anonymized User ID', 'Course Specific Anonymized User ID']
-    rows = [[s.id, unique_id_for_user(s, save=False), anonymous_id_for_user(s, course_id, save=False)]
+    rows = [[s.id, unique_id_for_user(s), anonymous_id_for_user(s, course_id)]
             for s in students]
     return csv_response(text_type(course_id).replace('/', '-') + '-anon-ids.csv', header, rows)
 

--- a/lms/djangoapps/teams/api.py
+++ b/lms/djangoapps/teams/api.py
@@ -392,7 +392,7 @@ def anonymous_user_ids_for_team(user, team):
         ))
 
     return sorted([
-        anonymous_id_for_user(user=team_member, course_id=team.course_id, save=True)
+        anonymous_id_for_user(user=team_member, course_id=team.course_id)
         for team_member in team.users.all()
     ])
 


### PR DESCRIPTION
## Description

Now that we have refactored `anonymous_id_for_user` to always prefer retrieving an existing ID from the database -- and observed that only a small fraction of calls pass save=False -- we can stop respecting save=False. This opens the door for future improvements, such as generating random IDs or switching to the external user ID system.

Metrics: I observe that 1 in 16 requests for new, non-request-cached anon user IDs are made with save=False. But 71% of all calls are served from the request cache, and 99.7% of the misses are served from the DB. save=False only appear to come from intermittent spikes as reports are generated and are low in absolute number.

This should have little to no visible impact. Certain reports might take slightly longer to generate the first time, but the refactor of this function to query the DB first would have had a larger perf impact already.

Also documents usage/risk/rotation of secret in anonymous user ID generation as indicated by `docs/decisions/0008-secret-key-usage.rst` ADR on `SECRET_KEY` usage.

## Supporting information

ref: ARCHBOM-1683

## Deadline

None

## Other information

- This deprecates `save=False` for several functions and removes all known usages of the parameter but does not actually remove the parameter. Instead, it will emit a deprecation warning if the parameter is used. We can remove the parameter as soon as we feel sure nothing is using it.
- [x] Hold off on merging until https://github.com/edx/edx-platform/pull/26392 is merged
