### PR TITLE
MICROBA-918 Separate cert generation from celery task to schedule generation

### DIFF
--- a/lms/djangoapps/certificates/generation.py
+++ b/lms/djangoapps/certificates/generation.py
@@ -6,7 +6,7 @@ existing cert if it does already exist).
 
 For now, these methods deal primarily with allowlist certificates, and are part of the V2 certificates revamp.
 
-These method should be called from tasks.
+These methods should be called from tasks.
 """
 
 import logging
@@ -18,8 +18,11 @@ from xmodule.modulestore.django import modulestore
 
 from common.djangoapps.student.models import CourseEnrollment, UserProfile
 from lms.djangoapps.certificates.models import CertificateStatuses, GeneratedCertificate
+from lms.djangoapps.certificates.queue import XQueueCertInterface
 from lms.djangoapps.certificates.utils import emit_certificate_event
+from lms.djangoapps.certificates.utils import has_html_certificates_enabled
 from lms.djangoapps.grades.api import CourseGradeFactory
+from lms.djangoapps.instructor.access import list_with_level
 
 log = logging.getLogger(__name__)
 
@@ -86,3 +89,74 @@ def _generate_certificate(user, course_id):
             created_msg=created_msg
         ))
     return cert
+
+
+def generate_user_certificates(student, course_key, course=None, insecure=False, generation_mode='batch',
+                               forced_grade=None):
+    """
+    It will add the add-cert request into the xqueue.
+
+    A new record will be created to track the certificate
+    generation task.  If an error occurs while adding the certificate
+    to the queue, the task will have status 'error'. It also emits
+    `edx.certificate.created` event for analytics.
+
+    This method has not yet been updated (it predates the certificates revamp). If modifying this method,
+    see also generate_user_certificates() in generation_handler.py (which is very similar but is not called from a
+    celery task). In the future these methods will be unified.
+
+   Args:
+        student (User)
+        course_key (CourseKey)
+
+    Keyword Arguments:
+        course (Course): Optionally provide the course object; if not provided
+            it will be loaded.
+        insecure - (Boolean)
+        generation_mode - who has requested certificate generation. Its value should `batch`
+        in case of django command and `self` if student initiated the request.
+        forced_grade - a string indicating to replace grade parameter. if present grading
+                       will be skipped.
+    """
+
+    if not course:
+        course = modulestore().get_course(course_key, depth=0)
+
+    beta_testers_queryset = list_with_level(course, 'beta')
+
+    if beta_testers_queryset.filter(username=student.username):
+        message = 'Cancelling course certificate generation for user [{}] against course [{}], user is a Beta Tester.'
+        log.info(message.format(student.username, course_key))
+        return
+
+    xqueue = XQueueCertInterface()
+    if insecure:
+        xqueue.use_https = False
+
+    generate_pdf = not has_html_certificates_enabled(course)
+
+    cert = xqueue.add_cert(
+        student,
+        course_key,
+        course=course,
+        generate_pdf=generate_pdf,
+        forced_grade=forced_grade
+    )
+
+    message = 'Queued Certificate Generation task for {user} : {course}'
+    log.info(message.format(user=student.id, course=course_key))
+
+    # If cert_status is not present in certificate valid_statuses (for example unverified) then
+    # add_cert returns None and raises AttributeError while accessing cert attributes.
+    if cert is None:
+        return
+
+    if CertificateStatuses.is_passing_status(cert.status):
+        emit_certificate_event('created', student, course_key, course, {
+            'user_id': student.id,
+            'course_id': str(course_key),
+            'certificate_id': cert.verify_uuid,
+            'enrollment_mode': cert.mode,
+            'generation_mode': generation_mode
+        })
+    return cert.status

--- a/lms/djangoapps/certificates/generation_handler.py
+++ b/lms/djangoapps/certificates/generation_handler.py
@@ -4,13 +4,12 @@ Course certificate generation handler.
 These methods check to see if a certificate can be generated (created if it does not already exist, or updated if it
 exists but its state can be altered). If so, a celery task is launched to do the generation. If the certificate
 cannot be generated, a message is logged and no further action is taken.
-
-For now, these methods deal primarily with allowlist certificates, and are part of the V2 certificates revamp.
 """
 
 import logging
 
 from edx_toggles.toggles import LegacyWaffleFlagNamespace
+from xmodule.modulestore.django import modulestore
 
 from common.djangoapps.student.models import CourseEnrollment
 from lms.djangoapps.certificates.models import (
@@ -19,7 +18,10 @@ from lms.djangoapps.certificates.models import (
     CertificateWhitelist,
     GeneratedCertificate
 )
+from lms.djangoapps.certificates.queue import XQueueCertInterface
 from lms.djangoapps.certificates.tasks import CERTIFICATE_DELAY_SECONDS, generate_certificate
+from lms.djangoapps.certificates.utils import emit_certificate_event, has_html_certificates_enabled
+from lms.djangoapps.instructor.access import list_with_level
 from lms.djangoapps.verify_student.services import IDVerificationService
 from openedx.core.djangoapps.certificates.api import auto_certificate_generation_enabled
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
@@ -162,3 +164,119 @@ def _can_generate_allowlist_certificate_for_status(cert):
              'generation'
              .format(status=cert.status, user=cert.user.id, course=cert.course_id))
     return True
+
+
+def generate_user_certificates(student, course_key, course=None, insecure=False, generation_mode='batch',
+                               forced_grade=None):
+    """
+    It will add the add-cert request into the xqueue.
+
+    A new record will be created to track the certificate
+    generation task.  If an error occurs while adding the certificate
+    to the queue, the task will have status 'error'. It also emits
+    `edx.certificate.created` event for analytics.
+
+    This method has not yet been updated (it predates the certificates revamp). If modifying this method,
+    see also generate_user_certificates() in generation.py (which is very similar but is called from a celery task).
+    In the future these methods will be unified.
+
+    Args:
+        student (User)
+        course_key (CourseKey)
+
+    Keyword Arguments:
+        course (Course): Optionally provide the course object; if not provided
+            it will be loaded.
+        insecure - (Boolean)
+        generation_mode - who has requested certificate generation. Its value should `batch`
+        in case of django command and `self` if student initiated the request.
+        forced_grade - a string indicating to replace grade parameter. if present grading
+                       will be skipped.
+    """
+
+    if not course:
+        course = modulestore().get_course(course_key, depth=0)
+
+    beta_testers_queryset = list_with_level(course, 'beta')
+
+    if beta_testers_queryset.filter(username=student.username):
+        message = 'Cancelling course certificate generation for user [{}] against course [{}], user is a Beta Tester.'
+        log.info(message.format(student.username, course_key))
+        return
+
+    xqueue = XQueueCertInterface()
+    if insecure:
+        xqueue.use_https = False
+
+    generate_pdf = not has_html_certificates_enabled(course)
+
+    cert = xqueue.add_cert(
+        student,
+        course_key,
+        course=course,
+        generate_pdf=generate_pdf,
+        forced_grade=forced_grade
+    )
+
+    message = 'Queued Certificate Generation task for {user} : {course}'
+    log.info(message.format(user=student.id, course=course_key))
+
+    # If cert_status is not present in certificate valid_statuses (for example unverified) then
+    # add_cert returns None and raises AttributeError while accessing cert attributes.
+    if cert is None:
+        return
+
+    if CertificateStatuses.is_passing_status(cert.status):
+        emit_certificate_event('created', student, course_key, course, {
+            'user_id': student.id,
+            'course_id': str(course_key),
+            'certificate_id': cert.verify_uuid,
+            'enrollment_mode': cert.mode,
+            'generation_mode': generation_mode
+        })
+    return cert.status
+
+
+def regenerate_user_certificates(student, course_key, course=None,
+                                 forced_grade=None, template_file=None, insecure=False):
+    """
+    Add the regen-cert request into the xqueue.
+
+    A new record will be created to track the certificate
+    generation task.  If an error occurs while adding the certificate
+    to the queue, the task will have status 'error'.
+
+    This method has not yet been updated (it predates the certificates revamp).
+
+    Args:
+        student (User)
+        course_key (CourseKey)
+
+    Keyword Arguments:
+        course (Course): Optionally provide the course object; if not provided
+            it will be loaded.
+        grade_value - The grade string, such as "Distinction"
+        template_file - The template file used to render this certificate
+        insecure - (Boolean)
+    """
+    xqueue = XQueueCertInterface()
+    if insecure:
+        xqueue.use_https = False
+
+    if not course:
+        course = modulestore().get_course(course_key, depth=0)
+
+    generate_pdf = not has_html_certificates_enabled(course)
+    log.info(
+        "Started regenerating certificates for user %s in course %s with generate_pdf status: %s",
+        student.username, str(course_key), generate_pdf
+    )
+
+    return xqueue.regen_cert(
+        student,
+        course_key,
+        course=course,
+        forced_grade=forced_grade,
+        template_file=template_file,
+        generate_pdf=generate_pdf
+    )

--- a/lms/djangoapps/certificates/management/commands/resubmit_error_certificates.py
+++ b/lms/djangoapps/certificates/management/commands/resubmit_error_certificates.py
@@ -25,10 +25,10 @@ from django.core.management.base import BaseCommand, CommandError
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from six import text_type
-
-from lms.djangoapps.certificates import api as certs_api
-from lms.djangoapps.certificates.models import CertificateStatuses, GeneratedCertificate
 from xmodule.modulestore.django import modulestore
+
+from lms.djangoapps.certificates.api import generate_user_certificates
+from lms.djangoapps.certificates.models import CertificateStatuses, GeneratedCertificate
 
 LOGGER = logging.getLogger(__name__)
 
@@ -96,7 +96,7 @@ class Command(BaseCommand):
             course = self._load_course_with_cache(course_key, course_cache)
 
             if course is not None:
-                certs_api.generate_user_certificates(user, course_key, course=course)
+                generate_user_certificates(user, course_key, course=course)
                 resubmit_count += 1
                 LOGGER.info(
                     (

--- a/lms/djangoapps/certificates/tasks.py
+++ b/lms/djangoapps/certificates/tasks.py
@@ -10,8 +10,7 @@ from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imp
 from edx_django_utils.monitoring import set_code_owner_attribute
 from opaque_keys.edx.keys import CourseKey
 
-from lms.djangoapps.certificates.api import generate_user_certificates
-from lms.djangoapps.certificates.generation import generate_allowlist_certificate
+from lms.djangoapps.certificates.generation import generate_allowlist_certificate, generate_user_certificates
 from lms.djangoapps.verify_student.services import IDVerificationService
 
 logger = getLogger(__name__)

--- a/lms/djangoapps/certificates/tests/test_cert_management.py
+++ b/lms/djangoapps/certificates/tests/test_cert_management.py
@@ -167,7 +167,7 @@ class RegenerateCertificatesTest(CertificateManagementTest):
     @ddt.data(True, False)
     @override_settings(CERT_QUEUE='test-queue')
     @patch.dict('django.conf.settings.FEATURES', {'ENABLE_OPENBADGES': True})
-    @patch('lms.djangoapps.certificates.api.XQueueCertInterface', spec=True)
+    @patch('lms.djangoapps.certificates.generation_handler.XQueueCertInterface', spec=True)
     def test_clear_badge(self, issue_badges, xqueue):
         """
         Given that I have a user with a badge

--- a/lms/djangoapps/certificates/tests/test_signals.py
+++ b/lms/djangoapps/certificates/tests/test_signals.py
@@ -14,7 +14,7 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
-from lms.djangoapps.certificates import api as certs_api
+from lms.djangoapps.certificates.api import cert_generation_enabled
 from lms.djangoapps.certificates.generation_handler import CERTIFICATES_USE_ALLOWLIST
 from lms.djangoapps.certificates.models import (
     CertificateGenerationConfiguration,
@@ -49,15 +49,15 @@ class SelfGeneratedCertsSignalTest(ModuleStoreTestCase):
         according to course-pacing.
         """
         self.course = CourseFactory.create(self_paced=False, emit_signals=True)  # lint-amnesty, pylint: disable=attribute-defined-outside-init
-        self.assertFalse(certs_api.cert_generation_enabled(self.course.id))
+        self.assertFalse(cert_generation_enabled(self.course.id))
 
         self.course.self_paced = True
         self.store.update_item(self.course, self.user.id)
-        self.assertTrue(certs_api.cert_generation_enabled(self.course.id))
+        self.assertTrue(cert_generation_enabled(self.course.id))
 
         self.course.self_paced = False
         self.store.update_item(self.course, self.user.id)
-        self.assertFalse(certs_api.cert_generation_enabled(self.course.id))
+        self.assertFalse(cert_generation_enabled(self.course.id))
 
 
 class WhitelistGeneratedCertificatesTest(ModuleStoreTestCase):

--- a/lms/djangoapps/certificates/tests/test_support_views.py
+++ b/lms/djangoapps/certificates/tests/test_support_views.py
@@ -8,23 +8,22 @@ from uuid import uuid4
 
 import ddt
 import six
-
 from django.conf import settings
 from django.test.utils import override_settings
 from django.urls import reverse
 from mock import patch
 from opaque_keys.edx.keys import CourseKey
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
 
-from lms.djangoapps.certificates import api
+from common.djangoapps.student.models import CourseEnrollment
+from common.djangoapps.student.roles import GlobalStaff, SupportStaffRole
+from common.djangoapps.student.tests.factories import UserFactory
+from lms.djangoapps.certificates.api import regenerate_user_certificates
 from lms.djangoapps.certificates.models import CertificateInvalidation, CertificateStatuses, GeneratedCertificate
 from lms.djangoapps.certificates.tests.factories import CertificateInvalidationFactory
 from lms.djangoapps.grades.tests.utils import mock_passing_grade
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
-from common.djangoapps.student.models import CourseEnrollment
-from common.djangoapps.student.roles import GlobalStaff, SupportStaffRole
-from common.djangoapps.student.tests.factories import UserFactory
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory
 
 FEATURES_WITH_CERTS_ENABLED = settings.FEATURES.copy()
 FEATURES_WITH_CERTS_ENABLED['CERTIFICATES_HTML_VIEW'] = True
@@ -113,7 +112,7 @@ class CertificateSearchTests(CertificateSupportTestCase):
         )
         self.course.cert_html_view_enabled = True
 
-        #course certificate configurations
+        # Course certificate configurations
         certificates = [
             {
                 'id': 1,
@@ -316,8 +315,8 @@ class CertificateRegenerateTests(CertificateSupportTestCase):
         with mock_passing_grade(percent=0.75):
             with patch('common.djangoapps.course_modes.models.CourseMode.mode_for_course') as mock_mode_for_course:
                 mock_mode_for_course.return_value = 'honor'
-                api.regenerate_user_certificates(self.student, self.course.id,  # lint-amnesty, pylint: disable=no-member
-                                                 course=self.course)
+                regenerate_user_certificates(self.student, self.course.id,  # lint-amnesty, pylint: disable=no-member
+                                             course=self.course)
 
                 mock_generate_cert.assert_called()
 

--- a/lms/djangoapps/certificates/views/support.py
+++ b/lms/djangoapps/certificates/views/support.py
@@ -18,15 +18,15 @@ from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_GET, require_POST
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
+from xmodule.modulestore.django import modulestore
 
-from lms.djangoapps.certificates import api
+from common.djangoapps.student.models import CourseEnrollment, User
+from common.djangoapps.util.json_request import JsonResponse
+from lms.djangoapps.certificates.api import get_certificates_for_user, regenerate_user_certificates
 from lms.djangoapps.certificates.models import CertificateInvalidation
 from lms.djangoapps.certificates.permissions import GENERATE_ALL_CERTIFICATES, VIEW_ALL_CERTIFICATES
 from lms.djangoapps.instructor_task.api import generate_certificates_for_students
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
-from common.djangoapps.student.models import CourseEnrollment, User
-from common.djangoapps.util.json_request import JsonResponse
-from xmodule.modulestore.django import modulestore
 
 log = logging.getLogger(__name__)
 
@@ -100,7 +100,7 @@ def search_certificates(request):
     except User.DoesNotExist:
         return HttpResponseBadRequest(_(u"user '{user}' does not exist").format(user=user_filter))
 
-    certificates = api.get_certificates_for_user(user.username)
+    certificates = get_certificates_for_user(user.username)
     for cert in certificates:
         cert["course_key"] = six.text_type(cert["course_key"])
         cert["created"] = cert["created"].isoformat()
@@ -201,7 +201,7 @@ def regenerate_certificate_for_user(request):
 
     # Attempt to regenerate certificates
     try:
-        certificate = api.regenerate_user_certificates(params["user"], params["course_key"], course=course)
+        certificate = regenerate_user_certificates(params["user"], params["course_key"], course=course)
     except:  # pylint: disable=bare-except
         # We are pessimistic about the kinds of errors that might get thrown by the
         # certificates API.  This may be overkill, but we're logging everything so we can

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -1970,7 +1970,7 @@ class TestInstructorAPIBulkBetaEnrollment(SharedModuleStoreTestCase, LoginEnroll
             message = message.format(self.beta_tester.username, self.course.id)
 
             generate_user_certificates(self.beta_tester, self.course.id, self.course)
-            capture.check_present(('edx.certificate', 'INFO', message))
+            capture.check_present(('lms.djangoapps.certificates.generation_handler', 'INFO', message))
 
     def test_missing_params(self):
         """ Test missing all query parameters. """


### PR DESCRIPTION
Move methods to separate certificate generation from celery task to schedule certificate generation. 

Standardizes imports for readability.