### PR TITLE
reset-password-success-email

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/password_reset.py
+++ b/openedx/core/djangoapps/user_authn/views/password_reset.py
@@ -715,10 +715,10 @@ class LogistrationPasswordResetView(APIView):  # lint-amnesty, pylint: disable=m
                             }
                         )
                         user.save()
-                        send_password_reset_success_email(user, request)
                     except ObjectDoesNotExist:
                         err = 'Account recovery process initiated without AccountRecovery instance for user {username}'
                         log.error(err.format(username=user.username))
+                send_password_reset_success_email(user, request)
         except ValidationError as err:
             AUDIT_LOG.exception("Password validation failed")
             error_status = {

--- a/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
@@ -824,12 +824,13 @@ class ResetPasswordAPITests(EventTestMixin, CacheIsolationTestCase):
             new=updated_user.email
         )
 
-    def test_password_reset_email_sent_on_account_recovery_email(self):
+    @ddt.data(True, False)
+    def test_password_reset_email_successfully_sent(self, is_account_recovery):
         """
         Test that with is_account_recovery query param available, password
         reset email is sent to newly updated email address.
         """
-        post_request = self.create_reset_request(self.uidb36, self.token, True)
+        post_request = self.create_reset_request(self.uidb36, self.token, is_account_recovery)
         post_request.user = AnonymousUser()
         post_request.site = Mock(domain='example.com')
         reset_view = LogistrationPasswordResetView.as_view()


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Password reset success email must be sent whether in account recovery or in a normal flow.

[VAN-292](https://openedx.atlassian.net/browse/VAN-72)