### PR TITLE
[TSD] Annotate schedules debugging toggle

### DIFF
--- a/openedx/core/djangoapps/schedules/config.py
+++ b/openedx/core/djangoapps/schedules/config.py
@@ -4,7 +4,7 @@ Contains configuration for schedules app
 
 
 from edx_toggles.toggles import (
-    LegacyWaffleFlag,
+    WaffleFlag,
     LegacyWaffleFlagNamespace,
     LegacyWaffleSwitch,
     LegacyWaffleSwitchNamespace
@@ -27,7 +27,13 @@ COURSE_UPDATE_WAFFLE_FLAG = CourseWaffleFlag(
     module_name=__name__,
 )
 
-DEBUG_MESSAGE_WAFFLE_FLAG = LegacyWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'enable_debugging', __name__)
+# .. toggle_name: schedules.enable_debugging
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Enable debug level of logging for schedules messages.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2017-09-17
+DEBUG_MESSAGE_WAFFLE_FLAG = WaffleFlag('schedules.enable_debugging', __name__)
 
 COURSE_UPDATE_SHOW_UNSUBSCRIBE_WAFFLE_SWITCH = LegacyWaffleSwitch(
     WAFFLE_SWITCH_NAMESPACE,


### PR DESCRIPTION
## Description

- Annotate schedules debugging toggle.
- Refactor to replace LegacyWaffleFlag.

## Supporting information

Commit introducing the toggle [4c500331](https://github.com/edx/edx-platform/commit/813007bb4972a79a6e20f34b9b6b57ff4c500331)
