### PR TITLE
[MST-645] Account for no enrollment in courseware rules

### DIFF
--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -329,3 +329,6 @@ REGISTRATION_VALIDATION_RATELIMIT = '5/minute'
 
 # Don't tolerate deprecated edx-platform import usage in tests.
 ERROR_ON_DEPRECATED_EDX_PLATFORM_IMPORTS = True
+
+############### Settings for proctoring  ###############
+PROCTORING_USER_OBFUSCATION_KEY = 'test_key'

--- a/lms/djangoapps/courseware/tests/test_rules.py
+++ b/lms/djangoapps/courseware/tests/test_rules.py
@@ -53,6 +53,16 @@ class PermissionTests(ModuleStoreTestCase):
         )
         assert has_perm == should_have_perm
 
+    def test_proctoring_perm_no_enrollment(self):
+        """
+        Test that the user does not have the edx_proctoring.can_take_proctored_exam permission if they
+        are not enrolled in the course
+        """
+        has_perm = self.user.has_perm(
+            'edx_proctoring.can_take_proctored_exam', {'course_id': str(self.course_id)}
+        )
+        self.assertFalse(has_perm)
+
     @patch.dict(
         'django.conf.settings.PROCTORING_BACKENDS',
         {'mock_proctoring_allow_honor_mode': {'allow_honor_mode': True}}
@@ -70,6 +80,11 @@ class PermissionTests(ModuleStoreTestCase):
         CourseEnrollment.enroll(self.user, course_allow_honor.id, mode='honor')
         self.assertTrue(
             self.user.has_perm(
-                'edx_proctoring.can_take_proctored_exam', {'course_id': str(course_allow_honor.id)}
+                'edx_proctoring.can_take_proctored_exam',
+                {
+                    'course_id': str(course_allow_honor.id),
+                    'backend': 'mock_proctoring_allow_honor_mode',
+                    'is_proctored': True,
+                },
             )
         )

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -577,11 +577,13 @@ LEARNING_MICROFRONTEND_URL = "http://learning-mfe"
 
 DASHBOARD_COURSE_LIMIT = 250
 
+########################## Settings for proctoring ######################
 PROCTORING_SETTINGS = {
     'LINK_URLS': {
         'faq': 'https://support.example.com/proctoring-faq.html'
     }
 }
+PROCTORING_USER_OBFUSCATION_KEY = 'test_key'
 
 ############### Settings for Django Rate limit #####################
 

--- a/openedx/core/djangoapps/enrollments/api.py
+++ b/openedx/core/djangoapps/enrollments/api.py
@@ -509,11 +509,11 @@ def is_enrollment_valid_for_proctoring(username, course_id):
         return False
 
     enrollment = _data_api().get_course_enrollment(username, str(course_id))
-    if not enrollment['is_active']:
+    if not enrollment or not enrollment['is_active']:
         return False
 
     course_module = modulestore().get_course(course_id)
-    if not course_module.enable_proctored_exams:
+    if not course_module or not course_module.enable_proctored_exams:
         return False
 
     appropriate_modes = [


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description
https://github.com/edx/edx-platform/pull/26182 introduced a bug where staff are prevented from viewing a course outline without first enrolling. This PR adds an additional condition for no existing enrollment to `is_enrollment_valid_for_proctoring` in order to prevent the error.

## Supporting information

[MST-645](https://openedx.atlassian.net/browse/MST-645)