### PR TITLE
replace bulk transmission task to intended single learner task

### DIFF
--- a/lms/djangoapps/grades/subsection_grade_factory.py
+++ b/lms/djangoapps/grades/subsection_grade_factory.py
@@ -107,8 +107,9 @@ class SubsectionGradeFactory(object):
             self._update_saved_subsection_grade(subsection.location, grade_model)
 
             if settings.FEATURES.get('ENABLE_COURSE_ASSESSMENT_GRADE_CHANGE_SIGNAL'):
-                COURSE_ASSESSMENT_GRADE_CHANGED.send_robust(
+                COURSE_ASSESSMENT_GRADE_CHANGED.send(
                     sender=self,
+                    course_id=self.course_data.course_key,
                     user=self.student,
                     subsection_id=calculated_grade.location,
                     subsection_grade=calculated_grade.graded_total.earned

--- a/lms/djangoapps/grades/tests/test_subsection_grade_factory.py
+++ b/lms/djangoapps/grades/tests/test_subsection_grade_factory.py
@@ -57,7 +57,7 @@ class TestSubsectionGradeFactory(ProblemSubmissionTestMixin, GradeTestBase):
         """
         with mock_get_score(1, 2):
             with patch(
-                'openedx.core.djangoapps.signals.signals.COURSE_ASSESSMENT_GRADE_CHANGED.send_robust'
+                'openedx.core.djangoapps.signals.signals.COURSE_ASSESSMENT_GRADE_CHANGED.send'
             ) as mock_update_grades_signal:
                 grade = self.subsection_grade_factory.update(self.sequence)
         self.assert_grade(grade, 1, 2)

--- a/openedx/features/enterprise_support/signals.py
+++ b/openedx/features/enterprise_support/signals.py
@@ -11,7 +11,10 @@ from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imp
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 from enterprise.models import EnterpriseCourseEnrollment, EnterpriseCustomer, EnterpriseCustomerUser
-from integrated_channels.integrated_channel.tasks import transmit_single_learner_data, transmit_subsection_learner_data
+from integrated_channels.integrated_channel.tasks import (
+    transmit_single_learner_data,
+    transmit_single_subsection_learner_data
+)
 from slumber.exceptions import HttpClientError
 
 from lms.djangoapps.email_marketing.tasks import update_user
@@ -99,7 +102,7 @@ def handle_enterprise_learner_subsection(sender, user, course_id, subsection_id,
             'grade': str(subsection_grade),
         }
 
-        transmit_subsection_learner_data.apply_async(kwargs=kwargs)
+        transmit_single_subsection_learner_data.apply_async(kwargs=kwargs)
 
 
 @receiver(UNENROLL_DONE)

--- a/openedx/features/enterprise_support/tests/test_signals.py
+++ b/openedx/features/enterprise_support/tests/test_signals.py
@@ -213,7 +213,7 @@ class EnterpriseSupportSignals(SharedModuleStoreTestCase):
         Test to assert transmit_subsection_learner_data is called when COURSE_ASSESSMENT_GRADE_CHANGED signal is fired.
         """
         with patch(
-            'integrated_channels.integrated_channel.tasks.transmit_subsection_learner_data.apply_async',
+            'integrated_channels.integrated_channel.tasks.transmit_single_subsection_learner_data.apply_async',
             return_value=None
         ) as mock_task_apply:
             course_key = CourseKey.from_string(self.course_id)


### PR DESCRIPTION
Jira: https://openedx.atlassian.net/browse/ENT-4101

Hehe, this was on me. We don't want to perform a bulk transmission when a single learner updates their subsection grade, we want to only transmit for that learner. Luckily, there's (already) a task for that. 🤦 

In a similar, equally as saddening case, we're also not properly sending this signal- we need to add the course key to the parameters passed to the receiver.
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
