### PR TITLE
Updated Pylint Warnings

### DIFF
--- a/lms/djangoapps/certificates/tests/test_queue.py
+++ b/lms/djangoapps/certificates/tests/test_queue.py
@@ -16,12 +16,12 @@ import six
 # and verify that items are being correctly added to the queue
 # in our `XQueueCertInterface` implementation.
 from capa.xqueue_interface import XQueueInterface
-from django.conf import settings
-from django.test import TestCase
-from django.test.utils import override_settings
-from mock import Mock, patch
-from opaque_keys.edx.locator import CourseLocator
-from testfixtures import LogCapture
+from django.conf import settings  # lint-amnesty, pylint: disable=wrong-import-order
+from django.test import TestCase  # lint-amnesty, pylint: disable=wrong-import-order
+from django.test.utils import override_settings  # lint-amnesty, pylint: disable=wrong-import-order
+from mock import Mock, patch  # lint-amnesty, pylint: disable=wrong-import-order
+from opaque_keys.edx.locator import CourseLocator  # lint-amnesty, pylint: disable=wrong-import-order
+from testfixtures import LogCapture  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -19,15 +19,15 @@ from datetime import datetime, timedelta
 import ddt
 import unicodecsv
 from capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
-from django.conf import settings
-from django.test.utils import override_settings
-from edx_django_utils.cache import RequestCache
-from freezegun import freeze_time
-from mock import ANY, MagicMock, Mock, patch
-from pytz import UTC
-from six import text_type
-from six.moves import range, zip
-from six.moves.urllib.parse import quote
+from django.conf import settings  # lint-amnesty, pylint: disable=wrong-import-order
+from django.test.utils import override_settings  # lint-amnesty, pylint: disable=wrong-import-order
+from edx_django_utils.cache import RequestCache  # lint-amnesty, pylint: disable=wrong-import-order
+from freezegun import freeze_time  # lint-amnesty, pylint: disable=wrong-import-order
+from mock import ANY, MagicMock, Mock, patch  # lint-amnesty, pylint: disable=wrong-import-order
+from pytz import UTC  # lint-amnesty, pylint: disable=wrong-import-order
+from six import text_type  # lint-amnesty, pylint: disable=wrong-import-order
+from six.moves import range, zip  # lint-amnesty, pylint: disable=wrong-import-order
+from six.moves.urllib.parse import quote  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, check_mongo_calls

--- a/openedx/core/djangoapps/bookmarks/settings/common.py
+++ b/openedx/core/djangoapps/bookmarks/settings/common.py
@@ -1,3 +1,4 @@
+# lint-amnesty, pylint: disable=missing-module-docstring
 def plugin_settings(settings):
     # Course Content Bookmarks Settings
     settings.MAX_BOOKMARKS_PER_COURSE = 100

--- a/pylintrc
+++ b/pylintrc
@@ -75,10 +75,10 @@ persistent = yes
 load-plugins = edx_lint.pylint,pylint_django,pylint_celery
 
 [MESSAGES CONTROL]
-enable = 
+enable =
 	blacklisted-name,
 	line-too-long,
-	
+
 	abstract-class-instantiated,
 	abstract-method,
 	access-member-before-definition,
@@ -215,7 +215,7 @@ enable =
 	using-constant-test,
 	yield-outside-function,
 	zip-builtin-not-iterating,
-	
+
 	astroid-error,
 	django-not-available-placeholder,
 	django-not-available,
@@ -223,20 +223,20 @@ enable =
 	method-check-failed,
 	parse-error,
 	raw-checker-failed,
-	
+
 	empty-docstring,
 	invalid-characters-in-docstring,
 	missing-docstring,
 	wrong-spelling-in-comment,
 	wrong-spelling-in-docstring,
-	
+
 	unused-argument,
 	unused-import,
 	unused-variable,
-	
+
 	eval-used,
 	exec-used,
-	
+
 	bad-classmethod-argument,
 	bad-mcs-classmethod-argument,
 	bad-mcs-method-argument,
@@ -248,7 +248,6 @@ enable =
 	global-at-module-level,
 	global-variable-not-assigned,
 	literal-used-as-attribute,
-	logging-format-interpolation,
 	logging-not-lazy,
 	metaclass-assignment,
 	model-has-unicode,
@@ -274,31 +273,31 @@ enable =
 	unneeded-not,
 	useless-else-on-loop,
 	wrong-assert-type,
-	
+
 	deprecated-method,
 	deprecated-module,
-	
+
 	too-many-boolean-expressions,
 	too-many-nested-blocks,
 	too-many-statements,
-	
+
 	wildcard-import,
 	wrong-import-order,
 	wrong-import-position,
-	
+
 	missing-final-newline,
 	mixed-indentation,
 	mixed-line-endings,
 	trailing-newlines,
 	trailing-whitespace,
 	unexpected-line-ending-format,
-	
+
 	bad-inline-option,
 	bad-option-value,
 	deprecated-pragma,
 	unrecognized-inline-option,
 	useless-suppression,
-	
+
 	cmp-method,
 	coerce-method,
 	delslice-method,
@@ -315,7 +314,7 @@ enable =
 	rdiv-method,
 	setslice-method,
 	using-cmp-argument,
-disable = 
+disable =
 	bad-continuation,
 	bad-indentation,
 	duplicate-code,
@@ -342,10 +341,10 @@ disable =
 	too-many-return-statements,
 	ungrouped-imports,
 	unused-wildcard-import,
-	
+
 	feature-toggle-needs-doc,
 	illegal-waffle-usage,
-	
+
 	apply-builtin,
 	backtick,
 	bad-python3-import,
@@ -383,7 +382,7 @@ disable =
 	unicode-builtin,
 	unpacking-in-except,
 	xrange-builtin,
-	
+
 	logging-fstring-interpolation,
 	native-string,
 	import-outside-toplevel,
@@ -393,6 +392,7 @@ disable =
 	useless-object-inheritance,
 	useless-suppression,
 	cyclic-import,
+	logging-format-interpolation,
 
 [REPORTS]
 output-format = text
@@ -438,7 +438,7 @@ ignore-imports = no
 ignore-mixin-members = yes
 ignored-classes = SQLObject
 unsafe-load-any-extension = yes
-generated-members = 
+generated-members =
 	REQUEST,
 	acl_users,
 	aq_parent,
@@ -464,7 +464,7 @@ generated-members =
 [VARIABLES]
 init-import = no
 dummy-variables-rgx = _|dummy|unused|.*_unused
-additional-builtins = 
+additional-builtins =
 
 [CLASSES]
 defining-attr-methods = __init__,__new__,setUp
@@ -485,11 +485,11 @@ max-public-methods = 20
 
 [IMPORTS]
 deprecated-modules = regsub,TERMIOS,Bastion,rexec
-import-graph = 
-ext-import-graph = 
-int-import-graph = 
+import-graph =
+ext-import-graph =
+int-import-graph =
 
 [EXCEPTIONS]
 overgeneral-exceptions = Exception
 
-# 6d9127c8d4b551af88b2a1f3a9b2642a3a853452
+# 63eee6a406604bde1c7e8e5cbdddcd7f173ccdef

--- a/pylintrc_tweaks
+++ b/pylintrc_tweaks
@@ -14,6 +14,7 @@ disable+ =
     useless-object-inheritance,
     useless-suppression,
     cyclic-import,
+    logging-format-interpolation,
 
 [BASIC]
 attr-rgx = [a-z_][a-z0-9_]{2,40}$

--- a/scripts/show_events.py
+++ b/scripts/show_events.py
@@ -1,3 +1,4 @@
+# lint-amnesty, pylint: disable=django-not-configured
 """
 Show Event outputs.
 """
@@ -10,7 +11,7 @@ import traceback
 try:
     import dateutil.parser
 except ImportError:
-    def date_string(ds, fmt=''):
+    def date_string(ds, fmt=''):  # lint-amnesty, pylint: disable=unused-argument
         return ds
 else:
     def date_string(ds, fmt='%Y-%m-%d %H:%M:%S.%f'):
@@ -18,7 +19,7 @@ else:
         return d.strftime(fmt)
 
 
-def display(message):
+def display(message):  # lint-amnesty, pylint: disable=missing-function-docstring
     print('{} - {}'.format(date_string(message['time']), message['event_type']))
     if message.get('event'):
         event = json.loads(message['event'])
@@ -33,6 +34,6 @@ while 1:
     try:
         obj = json.loads(line)
         display(obj)
-    except Exception:
+    except Exception:  # lint-amnesty, pylint: disable=broad-except
         traceback.print_exc()
         continue

--- a/scripts/xsslint_config.py
+++ b/scripts/xsslint_config.py
@@ -1,3 +1,4 @@
+# lint-amnesty, pylint: disable=django-not-configured, missing-module-docstring
 # xsslint config module for edx-platform
 
 


### PR DESCRIPTION
- Disabled `logging-format-interpolation` warning.
- Apply `lint-amnesty` to suppress `convention` type `Pylint` warnings.