### PR TITLE
fix(notes): XSS vector for a11y text attached to notes editor

### DIFF
--- a/lms/static/js/edxnotes/views/shim.js
+++ b/lms/static/js/edxnotes/views/shim.js
@@ -165,7 +165,7 @@
             .addField({
                 load: function(field, annotation) {
                     if (annotation.text) {
-                        $(field).html(HtmlUtils.HTML(Utils.nl2br(annotation.text)).toString());
+                        $(field).html(HtmlUtils.HTML(Utils.nl2br(Annotator.Util.escape(annotation.text))).toString());
                     } else {
                         // eslint-disable-next-line max-len
                         $(field).html(HtmlUtils.joinHtml(HtmlUtils.HTML('<i>'), _t('No Comment'), HtmlUtils.HTML('</i>')).toString());


### PR DESCRIPTION
JIRA:SEC-1164

## Description

This addresses an XSS concern for learner-submitted notes contents, which could allow the execution of injected code within a user's web browser.

This was reviewed elsewhere via (internal to edX, sorry open-source contributors): https://github.com/edx/edx-platform-private/pull/219