### PR TITLE
AA-511: update dashboard certificate button styling

### DIFF
--- a/lms/templates/dashboard/_dashboard_certificate_information.html
+++ b/lms/templates/dashboard/_dashboard_certificate_information.html
@@ -89,29 +89,29 @@ else:
                 </span>
               </li>
             % elif cert_status['status'] == 'downloadable' and cert_status.get('show_cert_web_view', False):
-              <li class="action action-certificate">
-                <a class="btn" href="${cert_status['cert_web_view_url']}" rel="noopener" target="_blank"
+              <li>
+                <a class="btn btn-primary" href="${cert_status['cert_web_view_url']}" rel="noopener" target="_blank"
                    title="${_('This link will open the certificate web view')}">
                   ${_("View {cert_name_short}").format(cert_name_short=cert_name_short,)}
                 </a>
               </li>
             % elif cert_status['status'] == 'downloadable' and enrollment.mode in CourseMode.NON_VERIFIED_MODES:
-              <li class="action action-certificate">
-                <a class="btn" href="${cert_status['download_url']}"
+              <li>
+                <a class="btn btn-primary" href="${cert_status['download_url']}"
                    title="${_('This link will open/download a PDF document')}">
                   ${_("Download {cert_name_short} (PDF)").format(cert_name_short=cert_name_short,)}
                 </a>
               </li>
             % elif cert_status['status'] == 'downloadable' and enrollment.mode == 'verified' and cert_status['mode'] == 'honor':
-              <li class="action">
-                <a class="btn" href="${cert_status['download_url']}"
+              <li>
+                <a class="btn btn-primary" href="${cert_status['download_url']}"
                    title="${_('This link will open/download a PDF document')}">
                   ${_("Download Your {cert_name_short} (PDF)").format(cert_name_short=cert_name_short)}
                 </a>
               </li>
             % elif cert_status['status'] == 'downloadable' and enrollment.mode in CourseMode.VERIFIED_MODES:
-              <li class="action">
-                <a class="btn" href="${cert_status['download_url']}"
+              <li>
+                <a class="btn btn-primary" href="${cert_status['download_url']}"
                    title="${_('This link will open/download a PDF document of your verified {cert_name_long}.').format(cert_name_long=cert_name_long)}">
                   ${_("Download Your ID Verified {cert_name_short} (PDF)").format(cert_name_short=cert_name_short)}
                 </a>


### PR DESCRIPTION
## Description
_Before_
<img width="874" alt="AA-511_Dashboard_CourseCard_Before" src="https://user-images.githubusercontent.com/25124041/107394945-611a8c80-6aca-11eb-9fff-8e1d17f63b27.png">
_After_
<img width="879" alt="AA-511_Dashboard_CourseCard_After" src="https://user-images.githubusercontent.com/25124041/107394951-62e45000-6aca-11eb-8c27-63a8aa4511c2.png">

