### PR TITLE
feat: allow notify_credentials to take a list of usernames

### DIFF
--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -157,7 +157,7 @@ def get_certificates_for_user_by_course_keys(user, course_keys):
     }
 
 
-def get_recently_modified_certificates(course_keys=None, start_date=None, end_date=None, username=None):
+def get_recently_modified_certificates(course_keys=None, start_date=None, end_date=None, usernames=None):
     """
     Returns a QuerySet of GeneratedCertificate objects filtered by the input
     parameters and ordered by modified_date.
@@ -173,8 +173,8 @@ def get_recently_modified_certificates(course_keys=None, start_date=None, end_da
     if end_date:
         cert_filter_args['modified_date__lte'] = end_date
 
-    if username:
-        cert_filter_args['user__username'] = username
+    if usernames:
+        cert_filter_args['user__username__in'] = usernames
 
     return GeneratedCertificate.objects.filter(**cert_filter_args).order_by('modified_date')
 

--- a/lms/djangoapps/grades/models_api.py
+++ b/lms/djangoapps/grades/models_api.py
@@ -35,7 +35,7 @@ def clear_prefetched_course_and_subsection_grades(course_key):
     _PersistentCourseGrade.clear_prefetched_data(course_key)
 
 
-def get_recently_modified_grades(course_keys, start_date, end_date, user=None):
+def get_recently_modified_grades(course_keys, start_date, end_date, users=None):
     """
     Returns a QuerySet of PersistentCourseGrade objects filtered by the input
     parameters and ordered by modified date.
@@ -47,8 +47,8 @@ def get_recently_modified_grades(course_keys, start_date, end_date, user=None):
         grade_filter_args['modified__gte'] = start_date
     if end_date:
         grade_filter_args['modified__lte'] = end_date
-    if user:
-        grade_filter_args['user_id'] = user.id
+    if users:
+        grade_filter_args['user_id__in'] = [u.id for u in users]
 
     return _PersistentCourseGrade.objects.filter(**grade_filter_args).order_by('modified')
 

--- a/openedx/core/djangoapps/credentials/management/commands/tests/test_notify_credentials.py
+++ b/openedx/core/djangoapps/credentials/management/commands/tests/test_notify_credentials.py
@@ -126,7 +126,7 @@ class TestNotifyCredentials(TestCase):
     @mock.patch(COMMAND_MODULE + '.Command.send_notifications')
     def test_username_arg(self, mock_send):
         call_command(
-            Command(), '--start-date', '2017-02-01', '--end-date', '2017-02-02', '--username', self.user2.username
+            Command(), '--start-date', '2017-02-01', '--end-date', '2017-02-02', '--usernames', self.user2.username
         )
         self.assertTrue(mock_send.called)
         self.assertListEqual(list(mock_send.call_args[0][0]), [self.cert4])
@@ -134,7 +134,7 @@ class TestNotifyCredentials(TestCase):
         mock_send.reset_mock()
 
         call_command(
-            Command(), '--username', self.user2.username
+            Command(), '--usernames', self.user2.username
         )
         self.assertTrue(mock_send.called)
         self.assertListEqual(list(mock_send.call_args[0][0]), [self.cert4])
@@ -142,7 +142,7 @@ class TestNotifyCredentials(TestCase):
         mock_send.reset_mock()
 
         call_command(
-            Command(), '--start-date', '2017-02-01', '--end-date', '2017-02-02', '--username', self.user.username
+            Command(), '--start-date', '2017-02-01', '--end-date', '2017-02-02', '--usernames', self.user.username
         )
         self.assertTrue(mock_send.called)
         self.assertListEqual(list(mock_send.call_args[0][0]), [self.cert2])
@@ -150,11 +150,19 @@ class TestNotifyCredentials(TestCase):
         mock_send.reset_mock()
 
         call_command(
-            Command(), '--username', self.user2.username
+            Command(), '--usernames', self.user.username
         )
         self.assertTrue(mock_send.called)
-        self.assertListEqual(list(mock_send.call_args[0][0]), [self.cert4])
-        self.assertListEqual(list(mock_send.call_args[0][1]), [self.grade4])
+        self.assertListEqual(list(mock_send.call_args[0][0]), [self.cert1, self.cert2, self.cert3])
+        self.assertListEqual(list(mock_send.call_args[0][1]), [self.grade1, self.grade2, self.grade3])
+        mock_send.reset_mock()
+
+        call_command(
+            Command(), '--usernames', self.user.username, self.user2.username
+        )
+        self.assertTrue(mock_send.called)
+        self.assertListEqual(list(mock_send.call_args[0][0]), [self.cert1, self.cert2, self.cert4, self.cert3])
+        self.assertListEqual(list(mock_send.call_args[0][1]), [self.grade1, self.grade2, self.grade4, self.grade3])
         mock_send.reset_mock()
 
     @mock.patch(COMMAND_MODULE + '.Command.send_notifications')


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

The `notify_credentials` management command helps us sync data (like course certificates and grades) between the LMS and Credentials service. This command takes a variety of arguments: we can trigger a re-sending of the data for a given time period, for a given course run (or runs), or for a given user.

This change allows the `notify_credentials` command to take a _list_ of usernames, similar to how it could already take a list of courses. (Previously, this command could take only one username at a time.)

This change affects anyone who manually runs the `notify_credentials` jenkins job (which appears to be only Aperture team members for the past several months).

❗ Anyone who has previously run this command should note that this changes the flag from `--username` (singular) to `--usernames` (plural). It can still take a single username, and now also a list of usernames (separated by spaces). (I made this choice to follow the `--courses` flag pattern.) **HOWEVER:** because of [argument abbreviations and prefix matching](https://docs.python.org/3/library/argparse.html#argument-abbreviations-prefix-matching), `--username` will still work.

## Supporting information

Fulfills [MICROBA-989: Modify `notify_credentials` to take a list of usernames](https://openedx.atlassian.net/browse/MICROBA-989).

## Testing instructions

1. Go to the notify_credentials arguments page in the django admin: https://courses-internal.edx.org/admin/credentials/notifycredentialsconfig/
2. Add a new entry with at least two usernames; something like this: 
`--page-size 25 --delay 5 --username <username1> <username2> --notify_programs`
(replace `<username1>` and `<username2>` with real users).
3. Run the `notify_credentials` job in jenkins: https://tools-edx-jenkins.edx.org/job/grading/job/prod-edx-notify_credentials/

## Deadline

None.
