### PR TITLE
fix: reduce the size of the commons.js asset.

### DIFF
--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -167,7 +167,7 @@ module.exports = Merge.smart({
                 // common/djangoapps/pipeline_mako/templates/static_content.html
                 name: 'commons',
                 filename: 'commons.js',
-                minChunks: 3
+                minChunks: 10
             })
         ],
 


### PR DESCRIPTION
## Description

The size of commons.js has gradually grown until it is now 4 MB in dev mode. This change brings it back down to 880 KB. This does cause the size of some other JS assets to increase, some by as much as 500 KB. This still seemed like a worthwhile tradeoff, to reduce first-load time in highly used areas of the site.

The goal is to make certain small pages (e.g. an individual HTMLBlock) load more quickly to clients.
