### PR TITLE
BOM-2340

### DIFF
--- a/openedx/core/djangoapps/util/tests/test_update_fixtures.py
+++ b/openedx/core/djangoapps/util/tests/test_update_fixtures.py
@@ -12,19 +12,19 @@ from django.core.management import call_command
 
 
 @pytest.fixture(scope='function')
-def sites(db):  # pylint: disable=unused-argument
+def sites(db):
     Site.objects.create(name='cms', domain='localhost:8031')
     Site.objects.create(name='lms', domain='localhost:8003')
 
 
-def test_localhost(db, monkeypatch, sites):  # pylint: disable=redefined-outer-name,unused-argument
+def test_localhost(db, monkeypatch, sites):
     monkeypatch.delitem(os.environ, 'BOK_CHOY_HOSTNAME', raising=False)
     call_command('update_fixtures')
     assert Site.objects.get(name='cms').domain == 'localhost:8031'
     assert Site.objects.get(name='lms').domain == 'localhost:8003'
 
 
-def test_devstack_cms(db, monkeypatch, sites):  # pylint: disable=redefined-outer-name,unused-argument
+def test_devstack_cms(db, monkeypatch, sites):
     monkeypatch.setitem(os.environ, 'BOK_CHOY_HOSTNAME', 'edx.devstack.cms')
     monkeypatch.setitem(os.environ, 'BOK_CHOY_CMS_PORT', '18031')
     monkeypatch.setitem(os.environ, 'BOK_CHOY_LMS_PORT', '18003')
@@ -33,7 +33,7 @@ def test_devstack_cms(db, monkeypatch, sites):  # pylint: disable=redefined-oute
     assert Site.objects.get(name='lms').domain == 'edx.devstack.cms:18003'
 
 
-def test_devstack_lms(db, monkeypatch, sites):  # pylint: disable=redefined-outer-name,unused-argument
+def test_devstack_lms(db, monkeypatch, sites):
     monkeypatch.setitem(os.environ, 'BOK_CHOY_HOSTNAME', 'edx.devstack.lms')
     monkeypatch.setitem(os.environ, 'BOK_CHOY_CMS_PORT', '18031')
     monkeypatch.setitem(os.environ, 'BOK_CHOY_LMS_PORT', '18003')

--- a/pylintrc
+++ b/pylintrc
@@ -72,7 +72,7 @@
 [MASTER]
 ignore = ,.git,.tox,migrations,node_modules,.pycharm_helpers
 persistent = yes
-load-plugins = edx_lint.pylint,pylint_django_settings,pylint_django,pylint_celery
+load-plugins = edx_lint.pylint,pylint_django_settings,pylint_django,pylint_celery,pylint_pytest
 
 [MESSAGES CONTROL]
 enable =

--- a/requirements/edx/testing.in
+++ b/requirements/edx/testing.in
@@ -48,3 +48,5 @@ tox                       # virtualenv management for tests
 tox-battery               # Makes tox aware of requirements file changes
 transifex-client          # Command-line interface for the Transifex localization service
 unidiff                   # Required by coverage_pytest_plugin
+pylint-pytest             # A Pylint plugin to suppress pytest-related false positives.
+

--- a/requirements/edx/testing.in
+++ b/requirements/edx/testing.in
@@ -48,5 +48,5 @@ tox                       # virtualenv management for tests
 tox-battery               # Makes tox aware of requirements file changes
 transifex-client          # Command-line interface for the Transifex localization service
 unidiff                   # Required by coverage_pytest_plugin
-pylint-pytest             # A Pylint plugin to suppress pytest-related false positives.
+pylint-pytest==0.3.0      # A Pylint plugin to suppress pytest-related false positives.
 

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -301,6 +301,7 @@ xblock==1.4.0             # via -r requirements/edx/base.txt, acid-xblock, crowd
 xmlsec==1.3.9             # via -r requirements/edx/base.txt, python3-saml
 xss-utils==0.2.0          # via -r requirements/edx/base.txt
 zipp==1.0.0               # via -c requirements/edx/../constraints.txt, -r requirements/edx/coverage.txt, importlib-metadata
+pylint-pytest==0.3.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
https://openedx.atlassian.net/browse/BOM-2340

Testing `pylint-pytest` package to suppress pylint warnings related to pytest.


Locally I have verified with this following example. Without this plugin following code generates few 

```
class TestClass(object):
    """ABC"""
    @staticmethod
    @pytest.fixture(scope='class', autouse=True)
    def setup_class(request):
        cls = request.cls
        cls.defined_in_setup_class = True

    def test_foo(self):
        assert self.defined_in_setup_class  # <- Instance of 'TestClass' has no 'defined_in_setup_class' member
```

wanrings
```
openedx/core/djangoapps/util/tests/test_update_fixtures.py:37:22: W0613: Unused argument 'db' (unused-argument)
openedx/core/djangoapps/util/tests/test_update_fixtures.py:37:39: W0613: Unused argument 'sites' (unused-argument)
openedx/core/djangoapps/util/tests/test_update_fixtures.py:55:15: E1101: Instance of 'TestClass' has no 'defined_in_setup_class' member (no-member)
```