### PR TITLE
ARCHBOM-1667: feat: log 403s for /oauth2/exchange_access_token/

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1898,6 +1898,8 @@ MIDDLEWARE = [
 
     # Cookie monitoring
     'openedx.core.lib.request_utils.CookieMonitoringMiddleware',
+    # Temporary middleware to determine where 403s are coming from for /oauth2/exchange_access_token/
+    'openedx.core.lib.request_utils.Monitor403Middleware',
 
     'lms.djangoapps.mobile_api.middleware.AppVersionUpgrade',
     'openedx.core.djangoapps.header_control.middleware.HeaderControlMiddleware',


### PR DESCRIPTION
## Description

The mobile app is getting unexpected 403s from
/oauth2/exchange_access_token/, but we have been unable
to pinpoint from where they are coming. This commit
introduces a temporary middleware to provide stack info
for 403s on this endpoint to try to track down the source.

Requires the ENABLE_403_MONITORING setting to be set to
True to enable the logging.

## Supporting information

ARCHBOM-1667
