### PR TITLE
feat: Changed username max_length to the specified by django

### DIFF
--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -25,6 +25,7 @@ from social_core.utils import module_member
 
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.theming.helpers import get_current_request
+from openedx.core.djangoapps.user_api.accounts import USERNAME_MAX_LENGTH
 from openedx.core.lib.hash_utils import create_hash256
 
 from .lti import LTI_PARAMS_KEY, LTIAuthBackend
@@ -68,7 +69,7 @@ def clean_json(value, of_type):
 
 def clean_username(username=''):
     """ Simple helper method to ensure a username is compatible with our system requirements. """
-    return re.sub(r'[^-\w]+', '_', username)[:30]
+    return re.sub(r'[^-\w]+', '_', username)[:USERNAME_MAX_LENGTH]
 
 
 class AuthNotConfigured(SocialAuthBaseException):

--- a/openedx/core/djangoapps/user_api/accounts/__init__.py
+++ b/openedx/core/djangoapps/user_api/accounts/__init__.py
@@ -2,7 +2,7 @@
 Account constants
 """
 
-
+from django.conf import settings
 from django.utils.text import format_lazy
 from django.utils.translation import ugettext_lazy as _
 
@@ -15,7 +15,8 @@ NAME_MAX_LENGTH = 255
 
 # The minimum and maximum length for the username account field
 USERNAME_MIN_LENGTH = 2
-USERNAME_MAX_LENGTH = 30
+# Note: 30 chars is the default for historical reasons. Django uses 150 as the username length since 1.10
+USERNAME_MAX_LENGTH = getattr(settings, 'USERNAME_MAX_LENGTH', 30)
 
 # The minimum and maximum length for the email account field
 EMAIL_MIN_LENGTH = 3


### PR DESCRIPTION
Changed USERNAME_MAX_LENGTH  to the max specified by Django.

## Description

This PR changes the maximum length for usernames defined using [USERNAME_MAX_LENGTH](https://github.com/edx/edx-platform/blob/ef77ddc18db5a8cbe2f90efe18b0386649368c1b/openedx/core/djangoapps/user_api/accounts/__init__.py#L18) in the accounts constants, it was changed from 30 chars to 150 chars following the max stated by the Django documentation. 

This change affects the user creation, given that a username with more than 30 chars won't be cut off or rejected, instead, this will happen only with usernames with more than 150 chars.

## Supporting information

Username max length stated by Django docs: https://docs.djangoproject.com/en/2.2/ref/contrib/auth/#django.contrib.auth.models.User.username

## Testing instructions

1. Go to /register
2. Fill the registration form with a username larger than 30 thars, e.g, usernameusernameusernameusername
3. The registration must end successfully and if you check the user, it will have the same username defined above.
4. If you register a username with length greater than 150 chars, the username will be cut off. 

## Deadline

None

## Other information

Commit that sets USERNAME_MAX_LENGTH to 30 chars: https://github.com/edx/edx-platform/commit/6976a33a8521d0fc8089d418a6a5efb1e7915d89

