### PR TITLE
[feat]: Don't use Mathjax if an HTMLBlock has no math.

### DIFF
--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -115,6 +115,21 @@ EXAM_RESUME_PROCTORING_IMPROVEMENTS = CourseWaffleFlag(
     WAFFLE_FLAG_NAMESPACE, 'exam_resume_proctoring_improvements', __name__
 )
 
+# .. toggle_name: courseware.optimized_render_xblock
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Waffle flag that determines whether we speed up the render_xblock for browsers by
+#   removing unnecessary JavaScript and CSS. It is possible that this could introduce edge cases with content
+#   that relies on these assets, so being a CourseWaffleFlag will give us the flexibility to exempt courses
+#   from these optimizations.
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2021-02-09
+# .. toggle_target_removal_date: 2021-05-01
+# .. toggle_warnings: None
+COURSEWARE_OPTIMIZED_RENDER_XBLOCK = CourseWaffleFlag(
+    WAFFLE_FLAG_NAMESPACE, 'optimized_render_xblock', __name__
+)
+
 
 def course_exit_page_is_active(course_key):
     return (

--- a/lms/templates/courseware/courseware-chromeless.html
+++ b/lms/templates/courseware/courseware-chromeless.html
@@ -59,7 +59,9 @@ ${static.get_page_title_breadcrumbs(course_name())}
 
   <%static:js group='courseware'/>
 
-  <%include file="/mathjax_include.html" args="disable_fast_preview=True"/>
+  % if enable_mathjax:
+    <%include file="/mathjax_include.html" args="disable_fast_preview=True"/>
+  % endif
   % if staff_access:
   	<%include file="xqa_interface.html"/>
   % endif


### PR DESCRIPTION
## Description

Mobile apps load HTML (and other) XBlocks individually using the
render_xblock endpoint. This is an attmept to reduce the number
of requests and JS processing needed to do so by detecting when
we have math content in HTMLBlocks and only adding the Mathjax
resources when necessary.

This is controlled by the "courseware.optimized_render_xblock"
CourseWaffleFlag. For maximum safety, we currently only optimize
in this way when directly hitting HTMLBlocks, and not for
ProblemBlock or VerticalBlock.

This was made as part of edX's Hackathon XXV.

## Testing instructions

You can test by checking your network tab and going to the LMS url /xblock/{usage_key_of_html_block}.

It should automatically send or not send Mathjax depending on whether you've written any in your HTML.

