### PR TITLE
Fixed import error on pre tag

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_import_export.py
+++ b/cms/djangoapps/contentstore/views/tests/test_import_export.py
@@ -1086,19 +1086,19 @@ class TestCourseExportImportProblem(CourseTestCase):
 
     @ddt.data(
         [
-            '<problem><pre><code>x=10 print("hello \n")</code></pre>'
-            '<pre><div><pre><code>x=10 print("hello \n")</code></pre></div></pre>'
+            '<problem><pre><code>x=10 print("hello")[]</code></pre>'
+            '<pre><div><pre><code>x=10 print("hello")</code></pre></div></pre>'
             '<multiplechoiceresponse></multiplechoiceresponse></problem>',
 
-            '<problem>\n  <pre>\n    <code>x=10 print("hello \n")</code>\n  </pre>\n  <pre>\n    <div>\n      <pre>\n '
-            '       <code>x=10 print("hello \n")</code>\n      </pre>\n    </div>\n  </pre>\n  '
-            '<multiplechoiceresponse/>\n</problem>\n'
+            '<problem>\n  <pre><code>x=10 print("hello")[]</code></pre>\n  '
+            '<pre>\n    <div>\n      <pre><code>x=10 print("hello")</code></pre>\n    </div>\n  '
+            '</pre>\n  <multiplechoiceresponse/>\n</problem>\n'
         ],
         [
             '<problem><pre><code>x=10 print("hello \n")</code></pre>'
             '<multiplechoiceresponse></multiplechoiceresponse></problem>',
 
-            '<problem>\n  <pre>\n    <code>x=10 print("hello \n")</code>\n  </pre>\n  '
+            '<problem>\n  <pre><code>x=10 print("hello \n")</code></pre>\n  '
             '<multiplechoiceresponse/>\n</problem>\n'
         ]
     )
@@ -1111,7 +1111,7 @@ class TestCourseExportImportProblem(CourseTestCase):
         self._setup_source_course_with_problem_content(problem_data)
 
         dest_course = CourseFactory.create(default_store=ModuleStoreEnum.Type.split)
-
+        # import pdb;pdb.set_trace()
         export_course_to_xml(
             self.store,
             contentstore(),

--- a/cms/djangoapps/contentstore/views/tests/test_import_export.py
+++ b/cms/djangoapps/contentstore/views/tests/test_import_export.py
@@ -1111,7 +1111,6 @@ class TestCourseExportImportProblem(CourseTestCase):
         self._setup_source_course_with_problem_content(problem_data)
 
         dest_course = CourseFactory.create(default_store=ModuleStoreEnum.Type.split)
-        # import pdb;pdb.set_trace()
         export_course_to_xml(
             self.store,
             contentstore(),

--- a/common/lib/xmodule/xmodule/raw_module.py
+++ b/common/lib/xmodule/xmodule/raw_module.py
@@ -34,7 +34,7 @@ class RawMixin(object):
             if pre_tag_data:
                 matches = re.finditer(PRE_TAG_REGEX, data)
                 for match_num, match in enumerate(matches):
-                    data = re.sub(match.group(), pre_tag_data[match_num].decode(), data)
+                    data = re.sub(re.escape(match.group()), pre_tag_data[match_num].decode(), data)
             etree.XML(data)  # it just checks if generated string is valid xml
             return {'data': data}, []
         except etree.XMLSyntaxError:


### PR DESCRIPTION
## Description

In case that Problem contains `square brackets [ ] `  like in line 2 `String[] ` inside pre tag  This cause error because it is invalid regex .  This is fixed by escaping problem text before comparison.

For stack trace please refer to [TNL-7964](https://openedx.atlassian.net/browse/TNL-7964)
<pre>
public class Hailstone {
    public static void main(String[] args) {
        int n = 3;
        while (n != 1) {
            if (n % 2 == 0) {
                n = n / 2;
            } else {
                n = 3 * n + 1;
            }
        }
    }
}
</pre>`


