### PR TITLE
test: Don't add a delta to ensure we get rate limited.

### DIFF
--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -2803,7 +2803,9 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         # depending on the number of enrollments in a course.  We are rate limiting it to
         # prevent too many concurrent calls which could result in a denial of service for
         # other users of the lms.
-        with freeze_time(base_time + datetime.timedelta(minutes=1)):
+        # Note: We use the base_time exactly so that we don't accidentally end up on the wrong
+        # side of the rate limit time chunking boundary.
+        with freeze_time(base_time):
             response = self.client.post(url, {})
             assert response.status_code == 429
 


### PR DESCRIPTION
## Description

The rate limiting library computes the rate limit by chunking time since
the epoch into chunks of whatever your period is. It then adds some
consistent offset based on your key.  This means that at certain times,
you are closer to the end of your rate limit time period than others.
So moving 1 minute into the future would put you into the next time
chunk and your rate limit would be reset.

I updated the test to test rate limit at the same time as the initial
call to ensure that it's working.  We were seeing times in CI where it
would occasionally fail because time chunking wasn't in our favor.

Impact;
- edx-platform developers should have fewer flaky tests to deal with speeding up development.

## Supporting information

* [The rate limiting windowing logic](https://github.com/jsocol/django-ratelimit/blob/cc1c3d707a53c4a3035fa7323bceabda125fa68c/ratelimit/core.py#L91-L100).

## Deadline

ASAP - To reduce python test flakiness.