### PR TITLE
VAN-311: Add multiple enterprise support for Authn MFE

### DIFF
--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -229,7 +229,7 @@ def get_redirect_url_with_host(root_url, redirect_to):
     """
     Adds host to the redirect url
     """
-    (scheme, netloc, path, query, fragment) = list(urllib.parse.urlsplit(redirect_to))
+    (_, netloc, path, query, fragment) = list(urllib.parse.urlsplit(redirect_to))
     if not netloc:
         parse_root_url = urllib.parse.urlsplit(root_url)
         redirect_to = urllib.parse.urlunsplit((parse_root_url.scheme, parse_root_url.netloc, path, query, fragment))

--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -225,6 +225,18 @@ def check_verify_status_by_course(user, course_enrollments):
 POST_AUTH_PARAMS = ('course_id', 'enrollment_action', 'course_mode', 'email_opt_in', 'purchase_workflow')
 
 
+def get_redirect_url_with_host(root_url, redirect_to):
+    """
+    Adds host to the redirect url
+    """
+    (scheme, netloc, path, query, fragment) = list(urllib.parse.urlsplit(redirect_to))
+    if not netloc:
+        parse_root_url = urllib.parse.urlsplit(root_url)
+        redirect_to = urllib.parse.urlunsplit((parse_root_url.scheme, parse_root_url.netloc, path, query, fragment))
+
+    return redirect_to
+
+
 def get_next_url_for_login_page(request, include_host=False):
     """
     Determine the URL to redirect to following login/registration/third_party_auth
@@ -283,13 +295,6 @@ def get_next_url_for_login_page(request, include_host=False):
         # be saved in the session as part of the pipeline state. That URL will take priority
         # over this one.
 
-    if include_host:
-        (scheme, netloc, path, query, fragment) = list(urllib.parse.urlsplit(redirect_to))
-        if not netloc:
-            parse_root_url = urllib.parse.urlsplit(root_url)
-            redirect_to = urllib.parse.urlunsplit((parse_root_url.scheme, parse_root_url.netloc,
-                                                   path, query, fragment))
-
     # Append a tpa_hint query parameter, if one is configured
     tpa_hint = configuration_helpers.get_value(
         "THIRD_PARTY_AUTH_HINT",
@@ -305,6 +310,9 @@ def get_next_url_for_login_page(request, include_host=False):
             params['tpa_hint'] = [tpa_hint]
             query = urllib.parse.urlencode(params, doseq=True)
             redirect_to = urllib.parse.urlunsplit((scheme, netloc, path, query, fragment))
+
+    if include_host:
+        return redirect_to, root_url
 
     return redirect_to
 

--- a/openedx/core/djangoapps/courseware_api/tests/test_views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/test_views.py
@@ -131,7 +131,7 @@ class CourseApiTestViews(BaseCoursewareTests):
                                               'The audit track does not include a certificate.')
                     assert response.data['certificate_data']['msg'] == expected_audit_message
                     assert response.data['verify_identity_url'] is None
-                    assert response.data['verification_status'] is 'none'  # lint-amnesty, pylint: disable=literal-comparison
+                    assert response.data['verification_status'] == 'none'  # lint-amnesty, pylint: disable=literal-comparison
                     assert response.data['linkedin_add_to_profile_url'] is None
                 else:
                     assert response.data['certificate_data']['cert_status'] == 'earned_but_not_available'
@@ -140,7 +140,7 @@ class CourseApiTestViews(BaseCoursewareTests):
                     )
                     # The response contains an absolute URL so this is only checking the path of the final
                     assert expected_verify_identity_url in response.data['verify_identity_url']
-                    assert response.data['verification_status'] is 'none'  # lint-amnesty, pylint: disable=literal-comparison
+                    assert response.data['verification_status'] == 'none'  # lint-amnesty, pylint: disable=literal-comparison
 
                     request = RequestFactory().request()
                     cert_url = get_certificate_url(course_id=self.course.id, uuid=cert.verify_uuid)

--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -509,16 +509,19 @@ def login_user(request):
 
         _handle_successful_authentication_and_login(possibly_authenticated_user, request)
 
-        redirect_url = None  # The AJAX method calling should know the default destination upon success
-        if is_user_third_party_authenticated:
-            running_pipeline = pipeline.get(request)
-            redirect_url = pipeline.get_complete_url(backend_name=running_pipeline['backend'])
+        # The AJAX method calling should know the default destination upon success
+        redirect_url, finish_auth_url = None, ''
+        running_pipeline = pipeline.get(request)
+        if running_pipeline:
+            finish_auth_url = pipeline.get_complete_url(backend_name=running_pipeline['backend'])
 
+        if is_user_third_party_authenticated:
+            redirect_url = finish_auth_url
         elif should_redirect_to_authn_microfrontend():
             next_url, root_url = get_next_url_for_login_page(request, include_host=True)
             redirect_url = get_redirect_url_with_host(
                 root_url,
-                enterprise_selection_page(request, possibly_authenticated_user, next_url)
+                enterprise_selection_page(request, possibly_authenticated_user, finish_auth_url or next_url)
             )
 
         response = JsonResponse({

--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -409,7 +409,7 @@ def enterprise_selection_page(request, user, next_url):
         if re.match(r'/enterprise/.*/course/.*/enroll', next_url):
             enterprise_in_url = next_url.split('/')[2]
             for enterprise in response:
-                if enterprise_in_url == enterprise['enterprise_customer']['uuid']:
+                if enterprise_in_url == str(enterprise['enterprise_customer']['uuid']):
                     is_activated_successfully = activate_learner_enterprise(request, user, enterprise_in_url)
                     if is_activated_successfully:
                         redirect_url = next_url

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -35,7 +35,7 @@ from social_django import utils as social_utils
 from common.djangoapps import third_party_auth
 # Note that this lives in LMS, so this dependency should be refactored.
 # TODO Have the discussions code subscribe to the REGISTER_USER signal instead.
-from common.djangoapps.student.helpers import get_next_url_for_login_page
+from common.djangoapps.student.helpers import get_next_url_for_login_page, get_redirect_url_with_host
 from lms.djangoapps.discussion.notification_prefs.views import enable_notifications
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
@@ -506,7 +506,8 @@ class RegistrationView(APIView):
         if response:
             return response
 
-        redirect_url = get_next_url_for_login_page(request, include_host=True)
+        redirect_to, root_url = get_next_url_for_login_page(request, include_host=True)
+        redirect_url = get_redirect_url_with_host(root_url, redirect_to)
         response = self._create_response(request, {}, status_code=200, redirect_url=redirect_url)
         set_logged_in_cookies(request, response, user)
         return response

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -39,7 +39,9 @@ from openedx.core.djangoapps.user_authn.views.login import (
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_unless_lms
 from openedx.core.djangoapps.site_configuration.tests.mixins import SiteMixin
 from openedx.core.lib.api.test_utils import ApiTestCase
+from openedx.features.enterprise_support.tests.factories import EnterpriseCustomerUserFactory
 from common.djangoapps.util.password_policy_validators import DEFAULT_MAX_PASSWORD_LENGTH
+from waffle.testutils import override_switch
 
 
 @ddt.ddt
@@ -178,6 +180,73 @@ class LoginTest(SiteMixin, CacheIsolationTestCase):
         )
         self._assert_response(response, success=True)
         self._assert_redirect_url(response, expected_redirect)
+
+    @ddt.data(('/dashboard', False), ('/enterprise/select/active/?success_url=/dashboard', True))
+    @ddt.unpack
+    @patch.dict(settings.FEATURES, {
+        'ENABLE_AUTHN_MICROFRONTEND': True,
+        'ENABLE_ENTERPRISE_INTEGRATION': True,
+    })
+    @override_settings(LOGIN_REDIRECT_WHITELIST=['openedx.service'])
+    @override_waffle_flag(REDIRECT_TO_AUTHN_MICROFRONTEND, active=True)
+    @patch('openedx.features.enterprise_support.api.EnterpriseApiClient')
+    @skip_unless_lms
+    def test_login_success_for_multiple_enterprises(
+        self, expected_redirect, user_has_multiple_enterprises, mock_api_client_class
+    ):
+        """
+        Test that if multiple enterprise feature is enabled, user is redirected
+        to correct page
+        """
+        api_response = {'results': []}
+        enterprise = EnterpriseCustomerUserFactory(user_id=self.user.id).enterprise_customer
+        api_response['results'].append(
+            {
+                "enterprise_customer": {
+                    "uuid": enterprise.uuid,
+                    "name": enterprise.name,
+                    "active": enterprise.active,
+                }
+            }
+        )
+
+        if user_has_multiple_enterprises:
+            enterprise = EnterpriseCustomerUserFactory(user_id=self.user.id).enterprise_customer
+            api_response['results'].append(
+                {
+                    "enterprise_customer": {
+                        "uuid": enterprise.uuid,
+                        "name": enterprise.name,
+                        "active": enterprise.active,
+                    }
+                }
+            )
+
+        mock_client = mock_api_client_class.return_value
+        mock_client.fetch_enterprise_learner_data.return_value = api_response
+
+        response, _ = self._login_response(
+            self.user.email,
+            self.password,
+            HTTP_ACCEPT='*/*',
+        )
+        self._assert_response(response, success=True)
+        self._assert_redirect_url(response, settings.LMS_ROOT_URL + expected_redirect)
+
+    @patch.dict(settings.FEATURES, {
+        'ENABLE_AUTHN_MICROFRONTEND': True,
+        'ENABLE_ENTERPRISE_INTEGRATION': True,
+    })
+    @override_settings(LOGIN_REDIRECT_WHITELIST=['openedx.service'])
+    @override_waffle_flag(REDIRECT_TO_AUTHN_MICROFRONTEND, active=True)
+    @patch('openedx.features.enterprise_support.api.EnterpriseApiClient')
+    @skip_unless_lms
+    def test_enterprise_in_url(self, mock_api_client_class):
+        """
+        If user has multiple enterprises and the enterprise is present in url,
+        activate that url
+        """
+        pass
 
     @patch.dict("django.conf.settings.FEATURES", {'SQUELCH_PII_IN_LOGS': True})
     def test_login_success_no_pii(self):

--- a/openedx/features/enterprise_support/api.py
+++ b/openedx/features/enterprise_support/api.py
@@ -28,6 +28,7 @@ from openedx.features.enterprise_support.utils import get_data_consent_share_cac
 from common.djangoapps.third_party_auth.pipeline import get as get_partial_pipeline
 from common.djangoapps.third_party_auth.provider import Registry
 
+
 try:
     from enterprise.models import (
         EnterpriseCustomer,
@@ -35,7 +36,9 @@ try:
         EnterpriseCustomerUser,
         PendingEnterpriseCustomerUser
     )
-    from enterprise.api.v1.serializers import EnterpriseCustomerUserReadOnlySerializer
+    from enterprise.api.v1.serializers import (
+        EnterpriseCustomerUserReadOnlySerializer, EnterpriseCustomerUserWriteSerializer
+    )
     from consent.models import DataSharingConsent, DataSharingConsentTextOverrides
 except ImportError:  # pragma: no cover
     pass
@@ -299,6 +302,32 @@ class EnterpriseApiServiceClient(EnterpriseServiceClientMixin, EnterpriseApiClie
                 cache_enterprise(enterprise_customer)
 
         return enterprise_customer
+
+
+def activate_learner_enterprise(request, user, enterprise_customer):
+    """
+    Allow an enterprise learner to activate one of learner's linked enterprises.
+    """
+    serializer = EnterpriseCustomerUserWriteSerializer(data={
+        'enterprise_customer': enterprise_customer,
+        'username': user.username,
+        'active': True
+    })
+    if serializer.is_valid():
+        serializer.save()
+        enterprise_customer_user = EnterpriseCustomerUser.objects.get(
+            user_id=user.id,
+            enterprise_customer=enterprise_customer
+        )
+        enterprise_customer_user.update_session(request)
+        LOGGER.info(
+            '[Enterprise Selection Page] Learner activated an enterprise. User: %s, EnterpriseCustomer: %s',
+            user.username,
+            enterprise_customer,
+        )
+        return True
+
+    return False
 
 
 def data_sharing_consent_required(view_func):

--- a/openedx/features/enterprise_support/tests/test_api.py
+++ b/openedx/features/enterprise_support/tests/test_api.py
@@ -20,6 +20,7 @@ from slumber.exceptions import HttpClientError
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_unless_lms
 from openedx.features.enterprise_support.api import (
+    activate_learner_enterprise,
     _CACHE_MISS,
     ENTERPRISE_CUSTOMER_KEY_NAME,
     EnterpriseApiException,
@@ -381,6 +382,17 @@ class TestEnterpriseApi(EnterpriseServiceMockMixin, CacheIsolationTestCase):
         assert 'the-learner-data' == learner_data
         mock_api_client_class.assert_called_once_with(user=user)
         mock_client.fetch_enterprise_learner_data.assert_called_once_with(user)
+
+    def test_activate_learner_enterprise(self):
+        """
+        Test enterprise is activated successfully for user
+        """
+        request_mock = mock.MagicMock(session={}, user=self.user)
+        enterprise_customer_user = EnterpriseCustomerUserFactory(user_id=self.user.id)
+        enterprise_customer_uuid = enterprise_customer_user.enterprise_customer.uuid
+
+        activate_learner_enterprise(request_mock, self.user, enterprise_customer_uuid)
+        assert request_mock.session['enterprise_customer']['uuid'] == str(enterprise_customer_uuid)
 
     def test_get_enterprise_learner_data_from_db_no_data(self):
         assert [] == get_enterprise_learner_data_from_db(self.user)


### PR DESCRIPTION
## Multiple Enterprises
This workflow only works when Authn MFE is enabled, otherwise the previous logic is used.

### workflows

- user has one or no enterprise, redirect to next url after successful login
- user has multiple enterprises and no enterprise in url, redirect to enterprise selection page
- user has multiple enterprises and an enterprise in url:
  * if enterprise in url matches one of the enterprise of users, activate the enterprise and redirect to next url 
  * if enterprise in url does not match any enterprise of user, redirect to selection page
- user completing TPA auth for first time for an existing account, is redirected to enterprise selection page

**Ticket**: [VAN-311](https://openedx.atlassian.net/browse/VAN-311)