### PR TITLE
upgrades xblock-drag-and-drop-v2 dependency to 2.3.1

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -26,7 +26,7 @@ attrs==20.3.0             # via -r requirements/edx/base.in, edx-ace
 babel==2.9.0              # via -r requirements/edx/base.in, enmerkar, enmerkar-underscore
 beautifulsoup4==4.9.3     # via pynliner
 billiard==3.6.3.0         # via celery
-bleach==3.3.0             # via -r requirements/edx/base.in, django-wiki, edx-enterprise, lti-consumer-xblock, ora2, xblock-poll
+bleach==3.3.0             # via -r requirements/edx/base.in, django-wiki, edx-enterprise, lti-consumer-xblock, ora2, xblock-drag-and-drop-v2, xblock-poll
 boto3==1.4.8              # via -r requirements/edx/base.in, django-ses, fs-s3fs, ora2
 boto==2.39.0              # via -r requirements/edx/base.in, edxval
 botocore==1.8.17          # via -r requirements/edx/base.in, boto3, s3transfer
@@ -131,6 +131,7 @@ help-tokens==2.0.0        # via -r requirements/edx/base.in
 html5lib==1.1             # via -r requirements/edx/base.in, ora2
 icalendar==4.0.7          # via -r requirements/edx/base.in
 idna==2.10                # via -r requirements/edx/paver.txt, requests
+importlib-metadata==1.7.0  # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt, kombu, markdown, path
 inflection==0.5.1         # via drf-yasg
 ipaddress==1.0.23         # via -r requirements/edx/base.in
 isodate==0.6.0            # via edx-event-routing-backends, python3-saml
@@ -156,6 +157,7 @@ maxminddb==1.5.4          # via -c requirements/edx/../constraints.txt, geoip2
 mock==3.0.5               # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt, xblock-drag-and-drop-v2, xblock-poll
 git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2  # via -r requirements/edx/github.in
 mongoengine==0.22.1       # via -r requirements/edx/base.in
+more-itertools==8.7.0     # via -r requirements/edx/paver.txt, zipp
 mpmath==1.2.1             # via sympy
 mysqlclient==2.0.3        # via -r requirements/edx/base.in
 newrelic==6.0.1.155       # via -r requirements/edx/base.in, edx-django-utils
@@ -163,7 +165,7 @@ nltk==3.5                 # via -r requirements/edx/../edx-sandbox/shared.txt, c
 nodeenv==1.5.0            # via -r requirements/edx/base.in
 numpy==1.18.5             # via -c requirements/edx/../constraints.txt, chem, openedx-calc, scipy
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
-openedx-calc==2.0.0       # via -r requirements/edx/base.in
+openedx-calc==1.0.9       # via -r requirements/edx/base.in
 ora2==3.1.1               # via -r requirements/edx/base.in
 packaging==20.9           # via bleach, drf-yasg
 path.py==12.5.0           # via edx-enterprise, edx-i18n-tools, ora2, staff-graded-xblock, xmodule
@@ -212,7 +214,7 @@ scipy==1.4.1              # via -c requirements/edx/../constraints.txt, chem, op
 semantic-version==2.8.5   # via edx-drf-extensions
 shapely==1.7.1            # via -r requirements/edx/base.in
 simplejson==3.17.2        # via -r requirements/edx/base.in, sailthru-client, super-csv, xblock-utils
-six==1.15.0               # via -r requirements/edx/../edx-sandbox/shared.txt, -r requirements/edx/base.in, -r requirements/edx/paver.txt, analytics-python, bleach, chem, codejail, crowdsourcehinter-xblock, cryptography, django-countries, django-simple-history, edx-ace, edx-bulk-grades, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-milestones, edx-rbac, event-tracking, fs, fs-s3fs, html5lib, isodate, libsass, mock, paver, pycontracts, pyjwkest, python-dateutil, python-memcached, python-swiftclient, social-auth-app-django, social-auth-core, stevedore, xblock
+six==1.15.0               # via -r requirements/edx/../edx-sandbox/shared.txt, -r requirements/edx/base.in, -r requirements/edx/paver.txt, analytics-python, bleach, chem, codejail, crowdsourcehinter-xblock, cryptography, django-countries, django-simple-history, edx-ace, edx-bulk-grades, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-milestones, edx-rbac, event-tracking, fs, fs-s3fs, html5lib, isodate, libsass, mock, openedx-calc, paver, pycontracts, pyjwkest, python-dateutil, python-memcached, python-swiftclient, social-auth-app-django, social-auth-core, stevedore, xblock
 slumber==0.7.1            # via edx-bulk-grades, edx-enterprise, edx-rest-api-client
 social-auth-app-django==4.0.0  # via -r requirements/edx/base.in
 social-auth-core==4.0.2   # via -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt, -r requirements/edx/base.in, social-auth-app-django
@@ -241,12 +243,13 @@ web-fragments==1.0.0      # via -r requirements/edx/base.in, crowdsourcehinter-x
 webencodings==0.5.1       # via bleach, html5lib
 webob==1.8.6              # via xblock, xmodule
 wrapt==1.11.2             # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.10#egg=xblock-drag-and-drop-v2==2.2.10  # via -r requirements/edx/github.in
+git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@2.3.1#egg=xblock-drag-and-drop-v2==2.3.1  # via -r requirements/edx/github.in
 git+https://github.com/open-craft/xblock-poll@922cd36fb1c3cfe00b4ce03b19a13185d136447d#egg=xblock-poll==1.10.2  # via -r requirements/edx/github.in
 xblock-utils==2.1.2       # via -r requirements/edx/base.in, edx-sga, lti-consumer-xblock, staff-graded-xblock, xblock-drag-and-drop-v2, xblock-google-drive
 xblock==1.4.0             # via -r requirements/edx/base.in, acid-xblock, crowdsourcehinter-xblock, done-xblock, edx-completion, edx-sga, edx-user-state-client, edx-when, lti-consumer-xblock, ora2, rate-xblock, staff-graded-xblock, xblock-discussion, xblock-drag-and-drop-v2, xblock-google-drive, xblock-poll, xblock-utils
 xmlsec==1.3.9             # via python3-saml
 xss-utils==0.2.0          # via -r requirements/edx/base.in
+zipp==1.0.0               # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -7,7 +7,7 @@
 chardet==4.0.0            # via diff-cover
 coverage==5.4             # via -r requirements/edx/coverage.in
 diff-cover==4.2.1         # via -r requirements/edx/coverage.in
-importlib-metadata==1.7.0  # via -c requirements/edx/../constraints.txt, inflect
+importlib-metadata==1.7.0  # via -c requirements/edx/../constraints.txt, inflect, pluggy
 inflect==3.0.2            # via -c requirements/edx/../constraints.txt, jinja2-pluralize
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.11.3            # via diff-cover, jinja2-pluralize

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -29,7 +29,7 @@ attrs==20.3.0             # via -r requirements/edx/testing.txt, edx-ace, jsonsc
 babel==2.9.0              # via -r requirements/edx/testing.txt, enmerkar, enmerkar-underscore, sphinx
 beautifulsoup4==4.9.3     # via -r requirements/edx/testing.txt, pynliner
 billiard==3.6.3.0         # via -r requirements/edx/testing.txt, celery
-bleach==3.3.0             # via -r requirements/edx/testing.txt, django-wiki, edx-enterprise, lti-consumer-xblock, ora2, xblock-poll
+bleach==3.3.0             # via -r requirements/edx/testing.txt, django-wiki, edx-enterprise, lti-consumer-xblock, ora2, xblock-drag-and-drop-v2, xblock-poll
 bok-choy==1.1.1           # via -r requirements/edx/testing.txt
 boto3==1.4.8              # via -r requirements/edx/testing.txt, django-ses, fs-s3fs, ora2
 boto==2.39.0              # via -r requirements/edx/testing.txt, edxval
@@ -153,7 +153,8 @@ httpretty==0.9.7          # via -c requirements/edx/../constraints.txt, -r requi
 icalendar==4.0.7          # via -r requirements/edx/testing.txt
 idna==2.10                # via -r requirements/edx/testing.txt, requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.7.0  # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, inflect
+importlib-metadata==1.7.0  # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, inflect, jsonschema, kombu, markdown, path, pluggy, pytest, pytest-randomly, tox, virtualenv
+importlib-resources==5.1.0  # via -r requirements/edx/testing.txt, virtualenv
 inflect==3.0.2            # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, jinja2-pluralize
 inflection==0.5.1         # via -r requirements/edx/testing.txt, drf-yasg
 iniconfig==1.1.1          # via -r requirements/edx/testing.txt, pytest
@@ -196,7 +197,7 @@ nltk==3.5                 # via -r requirements/edx/testing.txt, chem
 nodeenv==1.5.0            # via -r requirements/edx/testing.txt
 numpy==1.18.5             # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, chem, openedx-calc, scipy
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
-openedx-calc==2.0.0       # via -r requirements/edx/testing.txt
+openedx-calc==1.0.9       # via -r requirements/edx/testing.txt
 ora2==3.1.1               # via -r requirements/edx/testing.txt
 packaging==20.9           # via -r requirements/edx/testing.txt, bleach, drf-yasg, pytest, sphinx, tox
 path.py==12.5.0           # via -r requirements/edx/testing.txt, edx-enterprise, edx-i18n-tools, ora2, staff-graded-xblock, xmodule
@@ -267,7 +268,7 @@ semantic-version==2.8.5   # via -r requirements/edx/testing.txt, edx-drf-extensi
 shapely==1.7.1            # via -r requirements/edx/testing.txt
 simplejson==3.17.2        # via -r requirements/edx/testing.txt, sailthru-client, super-csv, xblock-utils
 singledispatch==3.4.0.3   # via -r requirements/edx/testing.txt
-six==1.15.0               # via -r requirements/edx/pip-tools.txt, -r requirements/edx/testing.txt, analytics-python, astroid, bleach, bok-choy, chem, codejail, crowdsourcehinter-xblock, cryptography, django-countries, django-simple-history, edx-ace, edx-bulk-grades, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-lint, edx-milestones, edx-rbac, edx-sphinx-theme, event-tracking, freezegun, fs, fs-s3fs, html5lib, httpretty, isodate, jsonschema, libsass, mock, paver, pip-tools, pycontracts, pyjwkest, python-dateutil, python-memcached, python-swiftclient, singledispatch, social-auth-app-django, social-auth-core, sphinxcontrib-httpdomain, stevedore, tox, transifex-client, virtualenv, xblock
+six==1.15.0               # via -r requirements/edx/pip-tools.txt, -r requirements/edx/testing.txt, analytics-python, astroid, bleach, bok-choy, chem, codejail, crowdsourcehinter-xblock, cryptography, django-countries, django-simple-history, edx-ace, edx-bulk-grades, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-lint, edx-milestones, edx-rbac, edx-sphinx-theme, event-tracking, freezegun, fs, fs-s3fs, html5lib, httpretty, isodate, jsonschema, libsass, mock, openedx-calc, paver, pip-tools, pycontracts, pyjwkest, python-dateutil, python-memcached, python-swiftclient, singledispatch, social-auth-app-django, social-auth-core, sphinxcontrib-httpdomain, stevedore, tox, transifex-client, virtualenv, xblock
 slumber==0.7.1            # via -r requirements/edx/testing.txt, edx-bulk-grades, edx-enterprise, edx-rest-api-client
 smmap==3.0.5              # via -r requirements/edx/testing.txt, gitdb
 snowballstemmer==2.1.0    # via sphinx
@@ -299,6 +300,7 @@ tox-battery==0.6.1        # via -r requirements/edx/testing.txt
 tox==3.21.4               # via -r requirements/edx/testing.txt, tox-battery
 tqdm==4.56.2              # via -r requirements/edx/testing.txt, nltk
 transifex-client==0.14.2  # via -r requirements/edx/testing.txt
+typed-ast==1.4.2          # via -r requirements/edx/testing.txt, astroid
 ua-parser==0.10.0         # via -r requirements/edx/testing.txt, django-cookies-samesite
 unicodecsv==0.14.1        # via -r requirements/edx/testing.txt, edx-enterprise
 unidiff==0.6.0            # via -r requirements/edx/testing.txt, coverage-pytest-plugin
@@ -314,13 +316,13 @@ web-fragments==1.0.0      # via -r requirements/edx/testing.txt, crowdsourcehint
 webencodings==0.5.1       # via -r requirements/edx/testing.txt, bleach, html5lib
 webob==1.8.6              # via -r requirements/edx/testing.txt, xblock, xmodule
 wrapt==1.11.2             # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, astroid
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.10#egg=xblock-drag-and-drop-v2==2.2.10  # via -r requirements/edx/testing.txt
+git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@2.3.1#egg=xblock-drag-and-drop-v2==2.3.1  # via -r requirements/edx/testing.txt
 git+https://github.com/open-craft/xblock-poll@922cd36fb1c3cfe00b4ce03b19a13185d136447d#egg=xblock-poll==1.10.2  # via -r requirements/edx/testing.txt
 xblock-utils==2.1.2       # via -r requirements/edx/testing.txt, edx-sga, lti-consumer-xblock, staff-graded-xblock, xblock-drag-and-drop-v2, xblock-google-drive
 xblock==1.4.0             # via -r requirements/edx/testing.txt, acid-xblock, crowdsourcehinter-xblock, done-xblock, edx-completion, edx-sga, edx-user-state-client, edx-when, lti-consumer-xblock, ora2, rate-xblock, staff-graded-xblock, xblock-discussion, xblock-drag-and-drop-v2, xblock-google-drive, xblock-poll, xblock-utils
 xmlsec==1.3.9             # via -r requirements/edx/testing.txt, python3-saml
 xss-utils==0.2.0          # via -r requirements/edx/testing.txt
-zipp==1.0.0               # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, importlib-metadata
+zipp==1.0.0               # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -25,7 +25,7 @@ pygments==2.7.4           # via sphinx
 pyparsing==2.4.7          # via packaging
 python-slugify==4.0.1     # via code-annotations
 pytz==2021.1              # via babel, django
-pyyaml==5.4.1             # via code-annotations
+pyyaml==5.3.1             # via code-annotations
 requests==2.25.1          # via sphinx
 six==1.15.0               # via edx-sphinx-theme, stevedore
 smmap==3.0.5              # via gitdb

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -72,4 +72,4 @@ git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a5#egg=django-rate
 # Third Party XBlocks
 
 git+https://github.com/open-craft/xblock-poll@922cd36fb1c3cfe00b4ce03b19a13185d136447d#egg=xblock-poll==1.10.2
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.10#egg=xblock-drag-and-drop-v2==2.2.10
+git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@2.3.1#egg=xblock-drag-and-drop-v2==2.3.1

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -8,10 +8,12 @@ certifi==2020.12.5        # via requests
 chardet==4.0.0            # via requests
 edx-opaque-keys==2.2.0    # via -r requirements/edx/paver.in
 idna==2.10                # via requests
+importlib-metadata==1.7.0  # via -c requirements/edx/../constraints.txt, path
 lazy==1.4                 # via -r requirements/edx/paver.in
 libsass==0.10.0           # via -r requirements/edx/paver.in
 markupsafe==1.1.1         # via -r requirements/edx/paver.in
 mock==3.0.5               # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.in
+more-itertools==8.7.0     # via zipp
 path==13.1.0              # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.in
 paver==1.3.4              # via -r requirements/edx/paver.in
 pbr==5.5.1                # via stevedore
@@ -24,3 +26,4 @@ stevedore==1.32.0         # via -c requirements/edx/../constraints.txt, -r requi
 urllib3==1.26.3           # via requests
 watchdog==2.0.0           # via -r requirements/edx/paver.in
 wrapt==1.11.2             # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.in
+zipp==1.0.0               # via -c requirements/edx/../constraints.txt, importlib-metadata

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -28,7 +28,7 @@ attrs==20.3.0             # via -r requirements/edx/base.txt, edx-ace, pytest
 babel==2.9.0              # via -r requirements/edx/base.txt, enmerkar, enmerkar-underscore
 beautifulsoup4==4.9.3     # via -r requirements/edx/base.txt, -r requirements/edx/testing.in, pynliner
 billiard==3.6.3.0         # via -r requirements/edx/base.txt, celery
-bleach==3.3.0             # via -r requirements/edx/base.txt, django-wiki, edx-enterprise, lti-consumer-xblock, ora2, xblock-poll
+bleach==3.3.0             # via -r requirements/edx/base.txt, django-wiki, edx-enterprise, lti-consumer-xblock, ora2, xblock-drag-and-drop-v2, xblock-poll
 bok-choy==1.1.1           # via -r requirements/edx/testing.in
 boto3==1.4.8              # via -r requirements/edx/base.txt, django-ses, fs-s3fs, ora2
 boto==2.39.0              # via -r requirements/edx/base.txt, edxval
@@ -148,7 +148,8 @@ html5lib==1.1             # via -r requirements/edx/base.txt, ora2
 httpretty==0.9.7          # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.in
 icalendar==4.0.7          # via -r requirements/edx/base.txt
 idna==2.10                # via -r requirements/edx/base.txt, requests
-importlib-metadata==1.7.0  # via -c requirements/edx/../constraints.txt, -r requirements/edx/coverage.txt, inflect
+importlib-metadata==1.7.0  # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, -r requirements/edx/coverage.txt, inflect, kombu, markdown, path, pluggy, pytest, pytest-randomly, tox, virtualenv
+importlib-resources==5.1.0  # via virtualenv
 inflect==3.0.2            # via -c requirements/edx/../constraints.txt, -r requirements/edx/coverage.txt, jinja2-pluralize
 inflection==0.5.1         # via -r requirements/edx/base.txt, drf-yasg
 iniconfig==1.1.1          # via pytest
@@ -180,7 +181,7 @@ mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, xblock-drag-and-drop-v2, xblock-poll
 git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2  # via -r requirements/edx/base.txt
 mongoengine==0.22.1       # via -r requirements/edx/base.txt
-more-itertools==8.7.0     # via -r requirements/edx/coverage.txt, zipp
+more-itertools==8.7.0     # via -r requirements/edx/base.txt, -r requirements/edx/coverage.txt, zipp
 mpmath==1.2.1             # via -r requirements/edx/base.txt, sympy
 mysqlclient==2.0.3        # via -r requirements/edx/base.txt
 newrelic==6.0.1.155       # via -r requirements/edx/base.txt, edx-django-utils
@@ -188,7 +189,7 @@ nltk==3.5                 # via -r requirements/edx/base.txt, chem
 nodeenv==1.5.0            # via -r requirements/edx/base.txt
 numpy==1.18.5             # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, chem, openedx-calc, scipy
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
-openedx-calc==2.0.0       # via -r requirements/edx/base.txt
+openedx-calc==1.0.9       # via -r requirements/edx/base.txt
 ora2==3.1.1               # via -r requirements/edx/base.txt
 packaging==20.9           # via -r requirements/edx/base.txt, bleach, drf-yasg, pytest, tox
 path.py==12.5.0           # via -r requirements/edx/base.txt, edx-enterprise, edx-i18n-tools, ora2, staff-graded-xblock, xmodule
@@ -256,7 +257,7 @@ semantic-version==2.8.5   # via -r requirements/edx/base.txt, edx-drf-extensions
 shapely==1.7.1            # via -r requirements/edx/base.txt
 simplejson==3.17.2        # via -r requirements/edx/base.txt, sailthru-client, super-csv, xblock-utils
 singledispatch==3.4.0.3   # via -r requirements/edx/testing.in
-six==1.15.0               # via -r requirements/edx/base.txt, analytics-python, astroid, bleach, bok-choy, chem, codejail, crowdsourcehinter-xblock, cryptography, django-countries, django-simple-history, edx-ace, edx-bulk-grades, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-lint, edx-milestones, edx-rbac, event-tracking, freezegun, fs, fs-s3fs, html5lib, httpretty, isodate, libsass, mock, paver, pycontracts, pyjwkest, python-dateutil, python-memcached, python-swiftclient, singledispatch, social-auth-app-django, social-auth-core, stevedore, tox, transifex-client, virtualenv, xblock
+six==1.15.0               # via -r requirements/edx/base.txt, analytics-python, astroid, bleach, bok-choy, chem, codejail, crowdsourcehinter-xblock, cryptography, django-countries, django-simple-history, edx-ace, edx-bulk-grades, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-lint, edx-milestones, edx-rbac, event-tracking, freezegun, fs, fs-s3fs, html5lib, httpretty, isodate, libsass, mock, openedx-calc, paver, pycontracts, pyjwkest, python-dateutil, python-memcached, python-swiftclient, singledispatch, social-auth-app-django, social-auth-core, stevedore, tox, transifex-client, virtualenv, xblock
 slumber==0.7.1            # via -r requirements/edx/base.txt, edx-bulk-grades, edx-enterprise, edx-rest-api-client
 smmap==3.0.5              # via gitdb
 social-auth-app-django==4.0.0  # via -r requirements/edx/base.txt
@@ -278,6 +279,7 @@ tox-battery==0.6.1        # via -r requirements/edx/testing.in
 tox==3.21.4               # via -r requirements/edx/testing.in, tox-battery
 tqdm==4.56.2              # via -r requirements/edx/base.txt, nltk
 transifex-client==0.14.2  # via -r requirements/edx/testing.in
+typed-ast==1.4.2          # via astroid
 ua-parser==0.10.0         # via -r requirements/edx/base.txt, django-cookies-samesite
 unicodecsv==0.14.1        # via -r requirements/edx/base.txt, edx-enterprise
 unidiff==0.6.0            # via -r requirements/edx/testing.in, coverage-pytest-plugin
@@ -292,13 +294,13 @@ web-fragments==1.0.0      # via -r requirements/edx/base.txt, crowdsourcehinter-
 webencodings==0.5.1       # via -r requirements/edx/base.txt, bleach, html5lib
 webob==1.8.6              # via -r requirements/edx/base.txt, xblock, xmodule
 wrapt==1.11.2             # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, astroid
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.10#egg=xblock-drag-and-drop-v2==2.2.10  # via -r requirements/edx/base.txt
+git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@2.3.1#egg=xblock-drag-and-drop-v2==2.3.1  # via -r requirements/edx/base.txt
 git+https://github.com/open-craft/xblock-poll@922cd36fb1c3cfe00b4ce03b19a13185d136447d#egg=xblock-poll==1.10.2  # via -r requirements/edx/base.txt
 xblock-utils==2.1.2       # via -r requirements/edx/base.txt, edx-sga, lti-consumer-xblock, staff-graded-xblock, xblock-drag-and-drop-v2, xblock-google-drive
 xblock==1.4.0             # via -r requirements/edx/base.txt, acid-xblock, crowdsourcehinter-xblock, done-xblock, edx-completion, edx-sga, edx-user-state-client, edx-when, lti-consumer-xblock, ora2, rate-xblock, staff-graded-xblock, xblock-discussion, xblock-drag-and-drop-v2, xblock-google-drive, xblock-poll, xblock-utils
 xmlsec==1.3.9             # via -r requirements/edx/base.txt, python3-saml
 xss-utils==0.2.0          # via -r requirements/edx/base.txt
-zipp==1.0.0               # via -c requirements/edx/../constraints.txt, -r requirements/edx/coverage.txt, importlib-metadata
+zipp==1.0.0               # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, -r requirements/edx/coverage.txt, importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
## Description

This Pull Request upgrades the xblock-drag-and-drop-v2 dependency to 2.3.1, which improves i18n support for the xblock (improved in this PR https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/266)
