### PR TITLE
fix: Correct logging message to match function

### DIFF
--- a/openedx/core/djangoapps/programs/tasks.py
+++ b/openedx/core/djangoapps/programs/tasks.py
@@ -307,7 +307,7 @@ def award_course_certificate(self, username, course_run_key):
     """
     def _retry_with_custom_exception(username, course_run_key, reason, countdown):
         exception = MaxRetriesExceededError(
-            f"Failed to revoke program certificate for user {username} for course {course_run_key}. Reason: {reason}"
+            f"Failed to award course certificate for user {username} for course {course_run_key}. Reason: {reason}"
         )
         return self.retry(
             exc=exception,


### PR DESCRIPTION
## Description

I copy/pasted logging text and didn't update it.

## Supporting information
N/A

## Testing instructions
N/A

## Deadline
N/A

## Other information
N/A
