### PR TITLE
replaced unittest assertions pytest assertions (8)

### DIFF
--- a/pavelib/paver_tests/test_assets.py
+++ b/pavelib/paver_tests/test_assets.py
@@ -77,7 +77,7 @@ class TestPaverAssetTasks(PaverTestCase):
                 'rtlcss cms/static/css/bootstrap/studio-main.css cms/static/css/bootstrap/studio-main-rtl.css'
             )
 
-        self.assertCountEqual(self.task_messages, expected_messages)
+        assert len(self.task_messages) == len(expected_messages)
 
 
 @ddt.ddt
@@ -194,7 +194,7 @@ class TestPaverThemeAssetTasks(PaverTestCase):
                 'rtlcss cms/static/css/bootstrap/studio-main.css cms/static/css/bootstrap/studio-main-rtl.css'
             )
 
-        self.assertCountEqual(self.task_messages, expected_messages)
+        assert len(self.task_messages) == len(expected_messages)
 
 
 class TestPaverWatchAssetTasks(TestCase):
@@ -236,14 +236,14 @@ class TestPaverWatchAssetTasks(TestCase):
                         'pavelib.assets.watch_assets',
                         options={"background": True},
                     )
-                    self.assertEqual(mock_register.call_count, 2)
-                    self.assertEqual(mock_webpack.call_count, 1)
+                    assert mock_register.call_count == 2
+                    assert mock_webpack.call_count == 1
 
                     sass_watcher_args = mock_register.call_args_list[0][0]
 
-                    self.assertIsInstance(sass_watcher_args[0], Observer)
-                    self.assertIsInstance(sass_watcher_args[1], list)
-                    self.assertCountEqual(sass_watcher_args[1], self.expected_sass_directories)
+                    assert isinstance(sass_watcher_args[0], Observer)
+                    assert isinstance(sass_watcher_args[1], list)
+                    assert len(sass_watcher_args[1]) == len(self.expected_sass_directories)
 
     def test_watch_theme_assets(self):
         """
@@ -268,13 +268,13 @@ class TestPaverWatchAssetTasks(TestCase):
                             "themes": [TEST_THEME_DIR.basename()]
                         },
                     )
-                    self.assertEqual(mock_register.call_count, 2)
-                    self.assertEqual(mock_webpack.call_count, 1)
+                    assert mock_register.call_count == 2
+                    assert mock_webpack.call_count == 1
 
                     sass_watcher_args = mock_register.call_args_list[0][0]
-                    self.assertIsInstance(sass_watcher_args[0], Observer)
-                    self.assertIsInstance(sass_watcher_args[1], list)
-                    self.assertCountEqual(sass_watcher_args[1], self.expected_sass_directories)
+                    assert isinstance(sass_watcher_args[0], Observer)
+                    assert isinstance(sass_watcher_args[1], list)
+                    assert len(sass_watcher_args[1]) == len(self.expected_sass_directories)
 
 
 @ddt.ddt
@@ -346,10 +346,10 @@ class TestCollectAssets(PaverTestCase):
         """
         for i, sys in enumerate(systems):
             msg = self.task_messages[i]
-            self.assertTrue(msg.startswith('python manage.py {}'.format(sys)))
-            self.assertIn(' collectstatic ', msg)
-            self.assertIn('--settings={}'.format(Env.DEVSTACK_SETTINGS), msg)
-            self.assertTrue(msg.endswith(' {}'.format(log_location)))
+            assert msg.startswith('python manage.py {}'.format(sys))
+            assert ' collectstatic ' in msg
+            assert '--settings={}'.format(Env.DEVSTACK_SETTINGS) in msg
+            assert msg.endswith(' {}'.format(log_location))
 
 
 @ddt.ddt

--- a/pavelib/paver_tests/test_database.py
+++ b/pavelib/paver_tests/test_database.py
@@ -92,7 +92,7 @@ class TestPaverDatabaseTasks(PaverTestCase):
         with patch.object(db_utils, 'get_file_from_s3', wraps=db_utils.get_file_from_s3) as _mock_get_file:
             database.update_local_bokchoy_db_from_s3()  # pylint: disable=no-value-for-parameter
             # Make sure that the local cache files are used - NOT downloaded from s3
-            self.assertFalse(_mock_get_file.called)
+            assert not _mock_get_file.called
         calls = [
             call('{}/scripts/reset-test-db.sh --calculate_migrations'.format(Env.REPO_ROOT)),
             call('{}/scripts/reset-test-db.sh --use-existing-db'.format(Env.REPO_ROOT))
@@ -191,4 +191,4 @@ class TestPaverDatabaseTasks(PaverTestCase):
             fingerprint_file.write(local_fingerprint)
 
         database.update_local_bokchoy_db_from_s3()  # pylint: disable=no-value-for-parameter
-        self.assertTrue(self.bucket.get_key(self.fingerprint_filename))
+        assert self.bucket.get_key(self.fingerprint_filename)

--- a/pavelib/paver_tests/test_eslint.py
+++ b/pavelib/paver_tests/test_eslint.py
@@ -4,6 +4,7 @@ Tests for Paver's Stylelint tasks.
 
 
 import unittest
+import pytest
 
 from mock import patch
 from paver.easy import BuildFailure, call_task
@@ -39,7 +40,7 @@ class TestPaverESLint(unittest.TestCase):
         run_eslint encounters an error parsing the eslint output log
         """
         mock_count.return_value = None
-        with self.assertRaises(BuildFailure):
+        with pytest.raises(BuildFailure):
             call_task('pavelib.quality.run_eslint', args=[''])
 
     @patch.object(pavelib.quality, '_write_metric')

--- a/pavelib/paver_tests/test_extract_and_generate.py
+++ b/pavelib/paver_tests/test_extract_and_generate.py
@@ -66,7 +66,7 @@ class TestGenerate(TestCase):
         """
         filename = os.path.join(self.configuration.source_messages_dir, random_name())
         generate.merge(self.configuration, self.configuration.source_locale, target=filename)
-        self.assertTrue(os.path.exists(filename))
+        assert os.path.exists(filename)
         os.remove(filename)
 
     def test_main(self):
@@ -86,12 +86,9 @@ class TestGenerate(TestCase):
                 mofile = filename + '.mo'
                 path = os.path.join(self.configuration.get_messages_dir(locale), mofile)
                 exists = os.path.exists(path)
-                self.assertTrue(exists, msg='Missing file in locale %s: %s' % (locale, mofile))
-                self.assertGreaterEqual(
-                    datetime.fromtimestamp(os.path.getmtime(path), UTC),
-                    self.start_time,
-                    msg='File not recently modified: %s' % path
-                )
+                assert exists, ('Missing file in locale %s: %s' % (locale, mofile))
+                assert datetime.fromtimestamp(os.path.getmtime(path), UTC) >= \
+                       self.start_time, ('File not recently modified: %s' % path)
             # Segmenting means that the merge headers don't work they way they
             # used to, so don't make this check for now. I'm not sure if we'll
             # get the merge header back eventually, or delete this code eventually.
@@ -112,11 +109,7 @@ class TestGenerate(TestCase):
         pof = pofile(path)
         pattern = re.compile('^#-#-#-#-#', re.M)
         match = pattern.findall(pof.header)
-        self.assertEqual(
-            len(match),
-            3,
-            msg="Found %s (should be 3) merge comments in the header for %s" % (len(match), path)
-        )
+        assert len(match) == 3, ('Found %s (should be 3) merge comments in the header for %s' % (len(match), path))
 
 
 def random_name(size=6):

--- a/pavelib/paver_tests/test_i18n.py
+++ b/pavelib/paver_tests/test_i18n.py
@@ -6,6 +6,7 @@ Tests for pavelib/i18n.py.
 import os
 import textwrap
 import unittest
+import pytest
 
 from mock import mock_open, patch
 from paver.easy import call_task, task
@@ -93,10 +94,8 @@ class FindReleaseResourcesTest(unittest.TestCase):
 
     @mocked_i18n_open(TX_CONFIG_RELEASE)
     def test_good_resources(self):
-        self.assertEqual(
-            pavelib.i18n.find_release_resources(),
-            ['edx-platform.release-zebrawood', 'edx-platform.release-zebrawood-js'],
-        )
+        assert pavelib.i18n.find_release_resources() ==\
+               ['edx-platform.release-zebrawood', 'edx-platform.release-zebrawood-js']
 
 
 class ReleasePushPullTest(PaverTestCase):
@@ -106,17 +105,17 @@ class ReleasePushPullTest(PaverTestCase):
     @mocked_i18n_open(TX_CONFIG_SIMPLE)
     @patch.object(pavelib.i18n, 'i18n_generate', new=do_nothing)
     def test_cant_push_nothing(self):
-        with self.assertRaises(SystemExit) as sysex:
+        with pytest.raises(SystemExit) as sysex:
             pavelib.i18n.i18n_release_push()
         # Check that we exited with a failure status code.
-        self.assertEqual(sysex.exception.args, (1,))
+        assert sysex.value.args == (1,)
 
     @mocked_i18n_open(TX_CONFIG_SIMPLE)
     def test_cant_pull_nothing(self):
-        with self.assertRaises(SystemExit) as sysex:
+        with pytest.raises(SystemExit) as sysex:
             pavelib.i18n.i18n_release_pull()
         # Check that we exited with a failure status code.
-        self.assertEqual(sysex.exception.args, (1,))
+        assert sysex.value.args == (1,)
 
     @mocked_i18n_open(TX_CONFIG_RELEASE)
     @patch.object(pavelib.i18n, 'i18n_generate', new=do_nothing)
@@ -157,14 +156,7 @@ class TestI18nDummy(PaverTestCase):
         self.reset_task_messages()
         os.environ['NO_PREREQ_INSTALL'] = "true"
         call_task('pavelib.i18n.i18n_dummy')
-        self.assertEqual(
-            self.task_messages,
-            [
-                'i18n_tool extract',
-                'i18n_tool dummy',
-                'i18n_tool generate',
-            ]
-        )
+        assert self.task_messages == ['i18n_tool extract', 'i18n_tool dummy', 'i18n_tool generate']
 
 
 class TestI18nCompileJS(PaverTestCase):
@@ -190,10 +182,5 @@ class TestI18nCompileJS(PaverTestCase):
         self.reset_task_messages()
         os.environ['NO_PREREQ_INSTALL'] = "true"
         call_task('pavelib.i18n.i18n_compilejs', options={"settings": Env.TEST_SETTINGS})
-        self.assertEqual(
-            self.task_messages,
-            [
-                'python manage.py lms --settings={} compilejsi18n'.format(Env.TEST_SETTINGS),
-                'python manage.py cms --settings={} compilejsi18n'.format(Env.TEST_SETTINGS),
-            ]
-        )
+        assert self.task_messages == ['python manage.py lms --settings={} compilejsi18n'.format(Env.TEST_SETTINGS),
+                                      'python manage.py cms --settings={} compilejsi18n'.format(Env.TEST_SETTINGS)]

--- a/pavelib/paver_tests/test_js_test.py
+++ b/pavelib/paver_tests/test_js_test.py
@@ -147,4 +147,4 @@ class TestPaverJavaScriptTestTasks(PaverTestCase):
 
             expected_messages.append(expected_test_tool_command)
 
-        self.assertEqual(self.task_messages, expected_messages)
+        assert self.task_messages == expected_messages

--- a/pavelib/paver_tests/test_paver_bok_choy_cmds.py
+++ b/pavelib/paver_tests/test_paver_bok_choy_cmds.py
@@ -56,67 +56,58 @@ class TestPaverBokChoyCmd(unittest.TestCase):
     def test_default(self):
         suite = BokChoyTestSuite('')
         name = 'tests'
-        self.assertEqual(suite.cmd, self._expected_command(name=name))
+        assert suite.cmd == self._expected_command(name=name)
 
     def test_suite_spec(self):
         spec = 'test_foo.py'
         suite = BokChoyTestSuite('', test_spec=spec)
         name = 'tests/{}'.format(spec)
-        self.assertEqual(suite.cmd, self._expected_command(name=name))
+        assert suite.cmd == self._expected_command(name=name)
 
     def test_class_spec(self):
         spec = 'test_foo.py:FooTest'
         suite = BokChoyTestSuite('', test_spec=spec)
         name = 'tests/{}'.format(spec)
-        self.assertEqual(suite.cmd, self._expected_command(name=name))
+        assert suite.cmd == self._expected_command(name=name)
 
     def test_testcase_spec(self):
         spec = 'test_foo.py:FooTest.test_bar'
         suite = BokChoyTestSuite('', test_spec=spec)
         name = 'tests/{}'.format(spec)
-        self.assertEqual(suite.cmd, self._expected_command(name=name))
+        assert suite.cmd == self._expected_command(name=name)
 
     def test_spec_with_draft_default_store(self):
         spec = 'test_foo.py'
         suite = BokChoyTestSuite('', test_spec=spec, default_store='draft')
         name = 'tests/{}'.format(spec)
-        self.assertEqual(
-            suite.cmd,
-            self._expected_command(name=name, store='draft')
-        )
+        assert suite.cmd == self._expected_command(name=name, store='draft')
 
     def test_invalid_default_store(self):
         # the cmd will dumbly compose whatever we pass in for the default_store
         suite = BokChoyTestSuite('', default_store='invalid')
         name = 'tests'
-        self.assertEqual(
-            suite.cmd,
-            self._expected_command(name=name, store='invalid')
-        )
+        assert suite.cmd == self._expected_command(name=name, store='invalid')
 
     def test_serversonly(self):
         suite = BokChoyTestSuite('', serversonly=True)
-        self.assertEqual(suite.cmd, None)
+        assert suite.cmd is None
 
     def test_verify_xss(self):
         suite = BokChoyTestSuite('', verify_xss=True)
         name = 'tests'
-        self.assertEqual(suite.cmd, self._expected_command(name=name, verify_xss=True))
+        assert suite.cmd == self._expected_command(name=name, verify_xss=True)
 
     def test_verify_xss_env_var(self):
         self.env_var_override.set('VERIFY_XSS', 'False')
         with self.env_var_override:
             suite = BokChoyTestSuite('')
             name = 'tests'
-            self.assertEqual(suite.cmd, self._expected_command(name=name, verify_xss=False))
+            assert suite.cmd == self._expected_command(name=name, verify_xss=False)
 
     def test_test_dir(self):
         test_dir = 'foo'
         suite = BokChoyTestSuite('', test_dir=test_dir)
-        self.assertEqual(
-            suite.cmd,
-            self._expected_command(name=test_dir)
-        )
+        assert suite.cmd == self._expected_command(name=test_dir)
 
     def test_verbosity_settings_1_process(self):
         """
@@ -130,7 +121,7 @@ class TestPaverBokChoyCmd(unittest.TestCase):
             "--verbose",
         ]
         suite = BokChoyTestSuite('', num_processes=1)
-        self.assertEqual(suite.verbosity_processes_command, expected_verbosity_command)
+        assert suite.verbosity_processes_command == expected_verbosity_command
 
     def test_verbosity_settings_2_processes(self):
         """
@@ -148,7 +139,7 @@ class TestPaverBokChoyCmd(unittest.TestCase):
             "--verbose",
         ]
         suite = BokChoyTestSuite('', num_processes=process_count)
-        self.assertEqual(suite.verbosity_processes_command, expected_verbosity_command)
+        assert suite.verbosity_processes_command == expected_verbosity_command
 
     def test_verbosity_settings_3_processes(self):
         """
@@ -165,4 +156,4 @@ class TestPaverBokChoyCmd(unittest.TestCase):
             "--verbose",
         ]
         suite = BokChoyTestSuite('', num_processes=process_count)
-        self.assertEqual(suite.verbosity_processes_command, expected_verbosity_command)
+        assert suite.verbosity_processes_command == expected_verbosity_command

--- a/pavelib/paver_tests/test_paver_get_quality_reports.py
+++ b/pavelib/paver_tests/test_paver_get_quality_reports.py
@@ -23,7 +23,7 @@ class TestGetReportFiles(unittest.TestCase):
             ('/bar', ('/baz',), ('pylint.report',))
         ])
         reports = pavelib.quality.get_violations_reports("pylint")
-        self.assertEqual(len(reports), 2)
+        assert len(reports) == 2
 
     @patch('os.walk')
     def test_get_pep8_reports(self, my_mock):
@@ -32,7 +32,7 @@ class TestGetReportFiles(unittest.TestCase):
             ('/bar', ('/baz',), ('pep8.report',))
         ])
         reports = pavelib.quality.get_violations_reports("pep8")
-        self.assertEqual(len(reports), 2)
+        assert len(reports) == 2
 
     @patch('os.walk')
     def test_get_pep8_reports_noisy(self, my_mock):
@@ -45,4 +45,4 @@ class TestGetReportFiles(unittest.TestCase):
             ('/bar', ('/baz',), ('pep8.report',))
         ])
         reports = pavelib.quality.get_violations_reports("pep8")
-        self.assertEqual(len(reports), 2)
+        assert len(reports) == 2

--- a/pavelib/paver_tests/test_paver_quality.py
+++ b/pavelib/paver_tests/test_paver_quality.py
@@ -8,6 +8,7 @@ import shutil
 import tempfile
 import textwrap
 import unittest
+import pytest
 
 from ddt import data, ddt, file_data, unpack
 from mock import MagicMock, mock_open, patch
@@ -35,14 +36,14 @@ class TestPaverQualityViolations(unittest.TestCase):
         with open(self.f.name, 'w') as f:
             f.write("hello")
         num = pavelib.quality._count_pylint_violations(f.name)  # pylint: disable=protected-access
-        self.assertEqual(num, 0)
+        assert num == 0
 
     def test_pylint_parser_pep8(self):
         # Pep8 violations should be ignored.
         with open(self.f.name, 'w') as f:
             f.write("foo/hello/test.py:304:15: E203 whitespace before ':'")
         num = pavelib.quality._count_pylint_violations(f.name)  # pylint: disable=protected-access
-        self.assertEqual(num, 0)
+        assert num == 0
 
     @file_data('pylint_test_list.json')
     def test_pylint_parser_count_violations(self, value):
@@ -54,13 +55,13 @@ class TestPaverQualityViolations(unittest.TestCase):
         with open(self.f.name, 'w') as f:
             f.write(value)
         num = pavelib.quality._count_pylint_violations(f.name)  # pylint: disable=protected-access
-        self.assertEqual(num, 1)
+        assert num == 1
 
     def test_pep8_parser(self):
         with open(self.f.name, 'w') as f:
             f.write("hello\nhithere")
         num = len(pavelib.quality._pep8_violations(f.name))  # pylint: disable=protected-access
-        self.assertEqual(num, 2)
+        assert num == 2
 
 
 @ddt
@@ -88,7 +89,7 @@ class TestPaverQualityOptions(unittest.TestCase):
                 self.__dict__ = d
         paver_options = PaverOptions(options)
         returned_values = pavelib.quality._parse_pylint_options(paver_options)  # pylint: disable=protected-access
-        self.assertEqual(returned_values, expected_values)
+        assert returned_values == expected_values
 
 
 class TestPaverReportViolationsCounts(unittest.TestCase):
@@ -111,13 +112,13 @@ class TestPaverReportViolationsCounts(unittest.TestCase):
         with open(self.f.name, 'w') as f:
             f.write("3000 violations found")
         actual_count = pavelib.quality._get_count_from_last_line(self.f.name, "eslint")  # pylint: disable=protected-access
-        self.assertEqual(actual_count, 3000)
+        assert actual_count == 3000
 
     def test_get_eslint_violations_no_number_found(self):
         with open(self.f.name, 'w') as f:
             f.write("Not expected string regex")
         actual_count = pavelib.quality._get_count_from_last_line(self.f.name, "eslint")  # pylint: disable=protected-access
-        self.assertEqual(actual_count, None)
+        assert actual_count is None
 
     def test_get_eslint_violations_count_truncated_report(self):
         """
@@ -126,7 +127,7 @@ class TestPaverReportViolationsCounts(unittest.TestCase):
         with open(self.f.name, 'w') as f:
             f.write("foo/bar/js/fizzbuzz.js: line 45, col 59, Missing semicolon.")
         actual_count = pavelib.quality._get_count_from_last_line(self.f.name, "eslint")  # pylint: disable=protected-access
-        self.assertEqual(actual_count, None)
+        assert actual_count is None
 
     def test_generic_value(self):
         """
@@ -135,7 +136,7 @@ class TestPaverReportViolationsCounts(unittest.TestCase):
         with open(self.f.name, 'w') as f:
             f.write("5.777 good to see you")
         actual_count = pavelib.quality._get_count_from_last_line(self.f.name, "foo")  # pylint: disable=protected-access
-        self.assertEqual(actual_count, 5)
+        assert actual_count == 5
 
     def test_generic_value_none_found(self):
         """
@@ -144,7 +145,7 @@ class TestPaverReportViolationsCounts(unittest.TestCase):
         with open(self.f.name, 'w') as f:
             f.write("hello 5.777 good to see you")
         actual_count = pavelib.quality._get_count_from_last_line(self.f.name, "foo")  # pylint: disable=protected-access
-        self.assertEqual(actual_count, None)
+        assert actual_count is None
 
     def test_get_xsslint_counts_happy(self):
         """
@@ -202,7 +203,7 @@ class TestPaverReportViolationsCounts(unittest.TestCase):
             f.write(report)
         count = pavelib.quality._get_xsscommitlint_count(self.f.name)  # pylint: disable=protected-access
 
-        self.assertEqual(count, 5)
+        assert count == 5
 
     def test_get_xsscommitlint_count_bad_counts(self):
         """
@@ -215,7 +216,7 @@ class TestPaverReportViolationsCounts(unittest.TestCase):
             f.write(report)
         count = pavelib.quality._get_xsscommitlint_count(self.f.name)  # pylint: disable=protected-access
 
-        self.assertIsNone(count)
+        assert count is None
 
     def test_get_xsscommitlint_count_no_files(self):
         """
@@ -229,7 +230,7 @@ class TestPaverReportViolationsCounts(unittest.TestCase):
             f.write(report)
         count = pavelib.quality._get_xsscommitlint_count(self.f.name)  # pylint: disable=protected-access
 
-        self.assertEqual(count, 0)
+        assert count == 0
 
 
 class TestPrepareReportDir(unittest.TestCase):
@@ -244,14 +245,14 @@ class TestPrepareReportDir(unittest.TestCase):
         self.addCleanup(os.removedirs, self.test_dir)
 
     def test_report_dir_with_files(self):
-        self.assertTrue(os.path.exists(self.test_file.name))
+        assert os.path.exists(self.test_file.name)
         pavelib.quality._prepare_report_dir(path(self.test_dir))  # pylint: disable=protected-access
-        self.assertFalse(os.path.exists(self.test_file.name))
+        assert not os.path.exists(self.test_file.name)
 
     def test_report_dir_without_files(self):
         os.remove(self.test_file.name)
         pavelib.quality._prepare_report_dir(path(self.test_dir))  # pylint: disable=protected-access
-        self.assertEqual(os.listdir(path(self.test_dir)), [])
+        assert os.listdir(path(self.test_dir)) == []
 
 
 class TestPaverRunQuality(PaverTestCase):
@@ -284,15 +285,15 @@ class TestPaverRunQuality(PaverTestCase):
         _mock_pylint_violations = MagicMock(return_value=(10000, ['some error']))
         with patch('pavelib.quality._get_pylint_violations', _mock_pylint_violations):
             with patch('pavelib.quality._parse_pylint_options', return_value=(0, 1000, 0, 0)):
-                with self.assertRaises(SystemExit):
+                with pytest.raises(SystemExit):
                     pavelib.quality.run_quality("")
 
         # Assert that _get_pylint_violations (which calls "pylint") is called once
-        self.assertEqual(_mock_pylint_violations.call_count, 1)
+        assert _mock_pylint_violations.call_count == 1
         # Assert that sh was called twice- once for diff quality with pylint
         # and once for diff quality with eslint. This means that in the event
         # of a diff-quality pylint failure, eslint is still called.
-        self.assertEqual(self._mock_paver_sh.call_count, 2)
+        assert self._mock_paver_sh.call_count == 2
 
     @patch(OPEN_BUILTIN, mock_open())
     def test_failure_on_diffquality_eslint(self):
@@ -303,7 +304,7 @@ class TestPaverRunQuality(PaverTestCase):
         self._mock_paver_sh.side_effect = fail_on_eslint
         _mock_pylint_violations = MagicMock(return_value=(0, []))
         with patch('pavelib.quality._get_pylint_violations', _mock_pylint_violations):
-            with self.assertRaises(SystemExit):
+            with pytest.raises(SystemExit):
                 pavelib.quality.run_quality("")
         print(self._mock_paver_sh.mock_calls)
 
@@ -312,7 +313,7 @@ class TestPaverRunQuality(PaverTestCase):
         # Assert that sh was called four times - once to get the comparison commit hash,
         # once to get the current commit hash, once for diff quality with pylint,
         # and once for diff quality with eslint
-        self.assertEqual(self._mock_paver_sh.call_count, 4)
+        assert self._mock_paver_sh.call_count == 4
 
     @patch(OPEN_BUILTIN, mock_open())
     def test_other_exception(self):
@@ -321,10 +322,10 @@ class TestPaverRunQuality(PaverTestCase):
         pylint should not be run
         """
         self._mock_paver_sh.side_effect = [Exception('unrecognized failure!'), 0]
-        with self.assertRaises(SystemExit):
+        with pytest.raises(SystemExit):
             pavelib.quality.run_quality("")
         # Test that pylint is NOT called by counting calls
-        self.assertEqual(self._mock_paver_sh.call_count, 1)
+        assert self._mock_paver_sh.call_count == 1
 
     @patch(OPEN_BUILTIN, mock_open())
     def test_no_diff_quality_failures(self):
@@ -334,7 +335,7 @@ class TestPaverRunQuality(PaverTestCase):
         # 6 for pylint on each of the system directories
         # 1 for diff_quality for pylint
         # 1 for diff_quality for eslint
-        self.assertEqual(self._mock_paver_sh.call_count, 8)
+        assert self._mock_paver_sh.call_count == 8
 
 
 class TestPaverRunDiffQuality(PaverTestCase):
@@ -359,7 +360,7 @@ class TestPaverRunDiffQuality(PaverTestCase):
         This bubbles up to paver with a subprocess return code error and should return False.
         """
         self._mock_paver_sh.side_effect = [BuildFailure('Subprocess return code: 1')]
-        self.assertEqual(pavelib.quality.run_diff_quality(""), False)
+        assert pavelib.quality.run_diff_quality('') is False
 
     @patch(OPEN_BUILTIN, mock_open())
     def test_other_failures(self):

--- a/pavelib/paver_tests/test_pii_check.py
+++ b/pavelib/paver_tests/test_pii_check.py
@@ -5,6 +5,7 @@ Tests for Paver's PII checker task.
 import shutil
 import tempfile
 import unittest
+import pytest
 
 from mock import patch
 from path import Path as path
@@ -61,7 +62,7 @@ class TestPaverPIICheck(unittest.TestCase):
         ])
 
         mock_needs.return_value = 0
-        with self.assertRaises(SystemExit):
+        with pytest.raises(SystemExit):
             call_task('pavelib.quality.run_pii_check', options={"report_dir": str(self.report_dir)})
             self.assertRaises(BuildFailure)
         mock_calls = [str(call) for call in mock_paver_sh.mock_calls]

--- a/pavelib/paver_tests/test_prereqs.py
+++ b/pavelib/paver_tests/test_prereqs.py
@@ -5,6 +5,7 @@ Tests covering the Open edX Paver prequisites installation workflow
 
 import os
 import unittest
+import pytest
 
 import mock
 from mock import patch
@@ -29,12 +30,8 @@ class TestPaverPrereqInstall(unittest.TestCase):
         """
         _orig_environ = dict(os.environ)
         os.environ['NO_PREREQ_INSTALL'] = set_val
-        self.assertEqual(
-            pavelib.prereqs.no_prereq_install(),
-            expected_val,
-            'NO_PREREQ_INSTALL is set to {}, but we read it as {}'.format(
-                set_val, expected_val),
-        )
+        assert pavelib.prereqs.no_prereq_install() == expected_val,\
+            'NO_PREREQ_INSTALL is set to {}, but we read it as {}'.format(set_val, expected_val)
 
         # Reset Environment back to original state
         os.environ.clear()
@@ -97,11 +94,11 @@ class TestPaverNodeInstall(PaverTestCase):
             attrs = {'wait': fail_on_npm_install}
             _mock_subprocess.configure_mock(**attrs)
             _mock_popen.return_value = _mock_subprocess
-            with self.assertRaises(Exception):
+            with pytest.raises(Exception):
                 pavelib.prereqs.node_prereqs_installation()
 
         # npm install will be called twice
-        self.assertEqual(_mock_popen.call_count, 2)
+        assert _mock_popen.call_count == 2
 
     def test_npm_install_called_once_when_successful(self):
         """
@@ -110,7 +107,7 @@ class TestPaverNodeInstall(PaverTestCase):
         with patch('subprocess.Popen') as _mock_popen:
             pavelib.prereqs.node_prereqs_installation()
         # when there's no failure, npm install is only called once
-        self.assertEqual(_mock_popen.call_count, 1)
+        assert _mock_popen.call_count == 1
 
     def test_npm_install_with_unexpected_subprocess_error(self):
         """
@@ -118,6 +115,6 @@ class TestPaverNodeInstall(PaverTestCase):
         """
         with patch('subprocess.Popen') as _mock_popen:
             _mock_popen.side_effect = unexpected_fail_on_npm_install
-            with self.assertRaises(BuildFailure):
+            with pytest.raises(BuildFailure):
                 pavelib.prereqs.node_prereqs_installation()
-        self.assertEqual(_mock_popen.call_count, 1)
+        assert _mock_popen.call_count == 1

--- a/pavelib/paver_tests/test_servers.py
+++ b/pavelib/paver_tests/test_servers.py
@@ -1,6 +1,5 @@
 """Unit tests for the Paver server tasks."""
 
-
 import json
 
 import ddt
@@ -62,6 +61,7 @@ class TestPaverServerTasks(PaverTestCase):
     """
     Test the Paver server tasks.
     """
+
     @ddt.data(
         [{}],
         [{"settings": "aws"}],
@@ -158,7 +158,7 @@ class TestPaverServerTasks(PaverTestCase):
         """
         settings = options.get("settings", "devstack_with_worker")
         call_task("pavelib.servers.celery", options=options)
-        self.assertEqual(self.task_messages, [EXPECTED_CELERY_COMMAND.format(settings=settings)])
+        assert self.task_messages == [EXPECTED_CELERY_COMMAND.format(settings=settings)]
 
     @ddt.data(
         [{}],
@@ -173,13 +173,8 @@ class TestPaverServerTasks(PaverTestCase):
         call_task("pavelib.servers.update_db", options=options)
         # pylint: disable=line-too-long
         db_command = "NO_EDXAPP_SUDO=1 EDX_PLATFORM_SETTINGS_OVERRIDE={settings} /edx/bin/edxapp-migrate-{server} --traceback --pythonpath=. "
-        self.assertEqual(
-            self.task_messages,
-            [
-                db_command.format(server="lms", settings=settings),
-                db_command.format(server="cms", settings=settings),
-            ]
-        )
+        assert self.task_messages == [db_command.format(server='lms', settings=settings),
+                                      db_command.format(server='cms', settings=settings)]
 
     @ddt.data(
         ["lms", {}],
@@ -194,15 +189,9 @@ class TestPaverServerTasks(PaverTestCase):
         """
         settings = options.get("settings", Env.DEVSTACK_SETTINGS)
         call_task("pavelib.servers.check_settings", args=[system, settings])
-        self.assertEqual(
-            self.task_messages,
-            [
-                "echo 'import {system}.envs.{settings}' "
-                "| python manage.py {system} --settings={settings} shell --plain --pythonpath=.".format(
-                    system=system, settings=settings
-                ),
-            ]
-        )
+        assert self.task_messages ==\
+               ["echo 'import {system}.envs.{settings}' | python manage.py {system} "
+                "--settings={settings} shell --plain --pythonpath=.".format(system=system, settings=settings)]
 
     def verify_server_task(self, task_name, options, contracts_default=False):
         """
@@ -271,7 +260,7 @@ class TestPaverServerTasks(PaverTestCase):
         if not no_contracts:
             expected_run_server_command += " --contracts"
         expected_messages.append(expected_run_server_command)
-        self.assertEqual(self.task_messages, expected_messages)
+        assert self.task_messages == expected_messages
 
     def verify_run_all_servers_task(self, options):
         """
@@ -328,7 +317,7 @@ class TestPaverServerTasks(PaverTestCase):
             )
         )
         expected_messages.append(EXPECTED_CELERY_COMMAND.format(settings="devstack_with_worker"))
-        self.assertEqual(self.task_messages, expected_messages)
+        assert self.task_messages == expected_messages
 
     def expected_sass_commands(self, system=None, asset_settings="test_static_optimized"):
         """

--- a/pavelib/paver_tests/test_stylelint.py
+++ b/pavelib/paver_tests/test_stylelint.py
@@ -2,7 +2,7 @@
 Tests for Paver's Stylelint tasks.
 """
 
-
+import pytest
 import ddt
 from mock import MagicMock, patch
 from paver.easy import call_task
@@ -30,5 +30,5 @@ class TestPaverStylelint(PaverTestCase):
             if should_pass:
                 call_task('pavelib.quality.run_stylelint', options={"limit": violations_limit})
             else:
-                with self.assertRaises(SystemExit):
+                with pytest.raises(SystemExit):
                     call_task('pavelib.quality.run_stylelint', options={"limit": violations_limit})

--- a/pavelib/paver_tests/test_timer.py
+++ b/pavelib/paver_tests/test_timer.py
@@ -75,48 +75,48 @@ class TimedDecoratorTests(TestCase):
         self.mock_datetime.utcnow.side_effect = [start, end]
 
         messages = self.get_log_messages()
-        self.assertEqual(len(messages), 1)
+        assert len(messages) == 1
 
         # I'm not using assertDictContainsSubset because it is
         # removed in python 3.2 (because the arguments were backwards)
         # and it wasn't ever replaced by anything *headdesk*
-        self.assertIn('duration', messages[0])
-        self.assertEqual(35.6, messages[0]['duration'])
+        assert 'duration' in messages[0]
+        assert 35.6 == messages[0]['duration']
 
-        self.assertIn('started_at', messages[0])
-        self.assertEqual(start.isoformat(' '), messages[0]['started_at'])
+        assert 'started_at' in messages[0]
+        assert start.isoformat(' ') == messages[0]['started_at']
 
-        self.assertIn('ended_at', messages[0])
-        self.assertEqual(end.isoformat(' '), messages[0]['ended_at'])
+        assert 'ended_at' in messages[0]
+        assert end.isoformat(' ') == messages[0]['ended_at']
 
     @patch.object(timer, 'PAVER_TIMER_LOG', None)
     def test_no_logs(self):
         messages = self.get_log_messages()
-        self.assertEqual(len(messages), 0)
+        assert len(messages) == 0
 
     @patch.object(timer, 'PAVER_TIMER_LOG', '/tmp/some-log')
     def test_arguments(self):
         messages = self.get_log_messages(args=(1, 'foo'), kwargs=dict(bar='baz'))
-        self.assertEqual(len(messages), 1)
+        assert len(messages) == 1
 
         # I'm not using assertDictContainsSubset because it is
         # removed in python 3.2 (because the arguments were backwards)
         # and it wasn't ever replaced by anything *headdesk*
-        self.assertIn('args', messages[0])
-        self.assertEqual([repr(1), repr('foo')], messages[0]['args'])
-        self.assertIn('kwargs', messages[0])
-        self.assertEqual({'bar': repr('baz')}, messages[0]['kwargs'])
+        assert 'args' in messages[0]
+        assert [repr(1), repr('foo')] == messages[0]['args']
+        assert 'kwargs' in messages[0]
+        assert {'bar': repr('baz')} == messages[0]['kwargs']
 
     @patch.object(timer, 'PAVER_TIMER_LOG', '/tmp/some-log')
     def test_task_name(self):
         messages = self.get_log_messages()
-        self.assertEqual(len(messages), 1)
+        assert len(messages) == 1
 
         # I'm not using assertDictContainsSubset because it is
         # removed in python 3.2 (because the arguments were backwards)
         # and it wasn't ever replaced by anything *headdesk*
-        self.assertIn('task', messages[0])
-        self.assertEqual('pavelib.paver_tests.test_timer.identity', messages[0]['task'])
+        assert 'task' in messages[0]
+        assert 'pavelib.paver_tests.test_timer.identity' == messages[0]['task']
 
     @patch.object(timer, 'PAVER_TIMER_LOG', '/tmp/some-log')
     def test_exceptions(self):
@@ -129,13 +129,13 @@ class TimedDecoratorTests(TestCase):
             raise Exception('The Message!')
 
         messages = self.get_log_messages(task=raises, raises=Exception)
-        self.assertEqual(len(messages), 1)
+        assert len(messages) == 1
 
         # I'm not using assertDictContainsSubset because it is
         # removed in python 3.2 (because the arguments were backwards)
         # and it wasn't ever replaced by anything *headdesk*
-        self.assertIn('exception', messages[0])
-        self.assertEqual("Exception: The Message!", messages[0]['exception'])
+        assert 'exception' in messages[0]
+        assert 'Exception: The Message!' == messages[0]['exception']
 
     @patch.object(timer, 'PAVER_TIMER_LOG', '/tmp/some-log-%Y-%m-%d-%H-%M-%S.log')
     def test_date_formatting(self):
@@ -145,7 +145,7 @@ class TimedDecoratorTests(TestCase):
         self.mock_datetime.utcnow.side_effect = [start, end]
 
         messages = self.get_log_messages()
-        self.assertEqual(len(messages), 1)
+        assert len(messages) == 1
 
         MOCK_OPEN.assert_called_once_with('/tmp/some-log-2016-07-20-10-56-19.log', 'a')
 
@@ -167,24 +167,24 @@ class TimedDecoratorTests(TestCase):
         self.mock_datetime.utcnow.side_effect = [parent_start, child_start, child_end, parent_end]
 
         messages = self.get_log_messages(task=parent)
-        self.assertEqual(len(messages), 2)
+        assert len(messages) == 2
 
         # Child messages first
-        self.assertIn('duration', messages[0])
-        self.assertEqual(40, messages[0]['duration'])
+        assert 'duration' in messages[0]
+        assert 40 == messages[0]['duration']
 
-        self.assertIn('started_at', messages[0])
-        self.assertEqual(child_start.isoformat(' '), messages[0]['started_at'])
+        assert 'started_at' in messages[0]
+        assert child_start.isoformat(' ') == messages[0]['started_at']
 
-        self.assertIn('ended_at', messages[0])
-        self.assertEqual(child_end.isoformat(' '), messages[0]['ended_at'])
+        assert 'ended_at' in messages[0]
+        assert child_end.isoformat(' ') == messages[0]['ended_at']
 
         # Parent messages after
-        self.assertIn('duration', messages[1])
-        self.assertEqual(60, messages[1]['duration'])
+        assert 'duration' in messages[1]
+        assert 60 == messages[1]['duration']
 
-        self.assertIn('started_at', messages[1])
-        self.assertEqual(parent_start.isoformat(' '), messages[1]['started_at'])
+        assert 'started_at' in messages[1]
+        assert parent_start.isoformat(' ') == messages[1]['started_at']
 
-        self.assertIn('ended_at', messages[1])
-        self.assertEqual(parent_end.isoformat(' '), messages[1]['ended_at'])
+        assert 'ended_at' in messages[1]
+        assert parent_end.isoformat(' ') == messages[1]['ended_at']

--- a/pavelib/paver_tests/test_utils.py
+++ b/pavelib/paver_tests/test_utils.py
@@ -4,6 +4,7 @@ Tests for pavelib/utils/test/utils
 
 
 import unittest
+import pytest
 
 from mock import patch
 
@@ -32,17 +33,17 @@ class TestUtils(unittest.TestCase):
         _mock_subprocesss.return_value = "Mozilla Firefox {version}".format(
             version=test_version
         )
-        with self.assertRaises(Exception):
+        with pytest.raises(Exception):
             check_firefox_version()
 
     @patch('subprocess.check_output')
     def test_firefox_version_not_detected(self, _mock_subprocesss):
         _mock_subprocesss.return_value = "Mozilla Firefox"
-        with self.assertRaises(Exception):
+        with pytest.raises(Exception):
             check_firefox_version()
 
     @patch('subprocess.check_output')
     def test_firefox_version_bad(self, _mock_subprocesss):
         _mock_subprocesss.return_value = "garbage"
-        with self.assertRaises(Exception):
+        with pytest.raises(Exception):
             check_firefox_version()

--- a/pavelib/paver_tests/test_xsscommitlint.py
+++ b/pavelib/paver_tests/test_xsscommitlint.py
@@ -2,7 +2,7 @@
 Tests for paver xsscommitlint quality tasks
 """
 
-
+import pytest
 from mock import patch
 from paver.easy import call_task
 
@@ -32,7 +32,7 @@ class PaverXSSCommitLintTest(PaverTestCase):
 
         """
         _mock_count.return_value = None
-        with self.assertRaises(SystemExit):
+        with pytest.raises(SystemExit):
             call_task('pavelib.quality.run_xsscommitlint')
 
     @patch.object(pavelib.quality, '_write_metric')

--- a/pavelib/paver_tests/test_xsslint.py
+++ b/pavelib/paver_tests/test_xsslint.py
@@ -2,7 +2,7 @@
 Tests for paver xsslint quality tasks
 """
 
-
+import pytest
 from mock import patch
 from paver.easy import call_task
 
@@ -28,7 +28,7 @@ class PaverXSSLintTest(PaverTestCase):
         run_xsslint encounters an error parsing the xsslint output log
         """
         _mock_counts.return_value = {}
-        with self.assertRaises(SystemExit):
+        with pytest.raises(SystemExit):
             call_task('pavelib.quality.run_xsslint')
 
     @patch.object(pavelib.quality, '_write_metric')
@@ -49,7 +49,7 @@ class PaverXSSLintTest(PaverTestCase):
         run_xsslint fails when thresholds option is poorly formatted
         """
         _mock_counts.return_value = {'total': 0}
-        with self.assertRaises(SystemExit):
+        with pytest.raises(SystemExit):
             call_task('pavelib.quality.run_xsslint', options={"thresholds": "invalid"})
 
     @patch.object(pavelib.quality, '_write_metric')
@@ -60,7 +60,7 @@ class PaverXSSLintTest(PaverTestCase):
         run_xsslint fails when thresholds option is poorly formatted
         """
         _mock_counts.return_value = {'total': 0}
-        with self.assertRaises(SystemExit):
+        with pytest.raises(SystemExit):
             call_task('pavelib.quality.run_xsslint', options={"thresholds": '{"invalid": 3}'})
 
     @patch.object(pavelib.quality, '_write_metric')
@@ -71,7 +71,7 @@ class PaverXSSLintTest(PaverTestCase):
         run_xsslint finds more violations than are allowed
         """
         _mock_counts.return_value = {'total': 4}
-        with self.assertRaises(SystemExit):
+        with pytest.raises(SystemExit):
             call_task('pavelib.quality.run_xsslint', options={"thresholds": '{"total": 3}'})
 
     @patch.object(pavelib.quality, '_write_metric')
@@ -94,7 +94,7 @@ class PaverXSSLintTest(PaverTestCase):
         given rule threshold that was set.
         """
         _mock_counts.return_value = {'total': 4}
-        with self.assertRaises(SystemExit):
+        with pytest.raises(SystemExit):
             call_task('pavelib.quality.run_xsslint', options={"thresholds": '{"rules": {"javascript-escape": 3}}'})
 
     @patch.object(pavelib.quality, '_write_metric')
@@ -105,7 +105,7 @@ class PaverXSSLintTest(PaverTestCase):
         run_xsslint finds more rule violations than are allowed
         """
         _mock_counts.return_value = {'total': 4, 'rules': {'javascript-escape': 4}}
-        with self.assertRaises(SystemExit):
+        with pytest.raises(SystemExit):
             call_task('pavelib.quality.run_xsslint', options={"thresholds": '{"rules": {"javascript-escape": 3}}'})
 
     @patch.object(pavelib.quality, '_write_metric')


### PR DESCRIPTION
## Description
This PR is using `codemod-unittest-to-pytest-asserts` to automatically replace `unittest` assertions with `pytest` 
for following modules:
```
pavelib/
```
Relevant JIRA issue here: https://openedx.atlassian.net/browse/BOM-2379