### PR TITLE
replaced unittest assertions pytest assertions (9)

### DIFF
--- a/common/djangoapps/course_action_state/tests/test_managers.py
+++ b/common/djangoapps/course_action_state/tests/test_managers.py
@@ -5,6 +5,7 @@ Tests for basic common operations related to Course Action State managers
 
 from collections import namedtuple
 
+import pytest
 from ddt import data, ddt
 from django.test import TestCase
 from opaque_keys.edx.locations import CourseLocator
@@ -33,21 +34,19 @@ class TestCourseActionStateManager(TestCourseActionStateManagerBase):
     """
     @data(*COURSE_ACTION_STATES)
     def test_update_state_allow_not_found_is_false(self, action_class):
-        with self.assertRaises(CourseActionStateItemNotFoundError):
+        with pytest.raises(CourseActionStateItemNotFoundError):
             action_class.objects.update_state(self.course_key, "fake_state", allow_not_found=False)
 
     @data(*COURSE_ACTION_STATES)
     def test_update_state_allow_not_found(self, action_class):
         action_class.objects.update_state(self.course_key, "initial_state", allow_not_found=True)
-        self.assertIsNotNone(
-            action_class.objects.find_first(course_key=self.course_key)
-        )
+        assert action_class.objects.find_first(course_key=self.course_key) is not None
 
     @data(*COURSE_ACTION_STATES)
     def test_delete(self, action_class):
         obj = action_class.objects.update_state(self.course_key, "initial_state", allow_not_found=True)
         action_class.objects.delete(obj.id)
-        with self.assertRaises(CourseActionStateItemNotFoundError):
+        with pytest.raises(CourseActionStateItemNotFoundError):
             action_class.objects.find_first(course_key=self.course_key)
 
 
@@ -160,4 +159,4 @@ class TestCourseActionUIStateManager(TestCourseActionStateManagerBase):
             source_course_key=source_course_key,
         )
         found_action_state = CourseRerunState.objects.find_first(course_key=destination_course_key)
-        self.assertEqual(source_course_key, found_action_state.source_course_key)
+        assert source_course_key == found_action_state.source_course_key

--- a/common/djangoapps/course_action_state/tests/test_rerun_manager.py
+++ b/common/djangoapps/course_action_state/tests/test_rerun_manager.py
@@ -105,7 +105,7 @@ class TestCourseRerunStateManager(TestCase):
         )
         self.expected_rerun_state.pop('message')
         rerun = self.verify_rerun_state()
-        self.assertIn(text_type(exception), rerun.message)
+        assert text_type(exception) in rerun.message
 
         # dismiss ui and verify
         self.dismiss_ui_and_verify(rerun)

--- a/common/djangoapps/course_modes/tests/test_admin.py
+++ b/common/djangoapps/course_modes/tests/test_admin.py
@@ -74,7 +74,7 @@ class AdminCourseModePageTest(ModuleStoreTestCase):
         # Verify that the expiration datetime is the same as what we set
         # (hasn't changed because of a timezone translation).
         course_mode = CourseMode.objects.get(pk=1)
-        self.assertEqual(course_mode.expiration_datetime.replace(tzinfo=None), expiration.replace(tzinfo=None))
+        assert course_mode.expiration_datetime.replace(tzinfo=None) == expiration.replace(tzinfo=None)
 
 
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
@@ -116,12 +116,9 @@ class AdminCourseModeFormTest(ModuleStoreTestCase):
         # but ONLY for verified modes.
         loaded_deadline = form.initial.get("verification_deadline")
         if expect_deadline:
-            self.assertEqual(
-                loaded_deadline.replace(tzinfo=None),
-                self.VERIFICATION_DEADLINE.replace(tzinfo=None)
-            )
+            assert loaded_deadline.replace(tzinfo=None) == self.VERIFICATION_DEADLINE.replace(tzinfo=None)
         else:
-            self.assertIs(loaded_deadline, None)
+            assert loaded_deadline is None
 
     @ddt.data("verified", "professional")
     def test_set_verification_deadline(self, course_mode):
@@ -140,7 +137,7 @@ class AdminCourseModeFormTest(ModuleStoreTestCase):
 
         # Check that the deadline was updated
         updated_deadline = VerificationDeadline.deadline_for_course(self.course.id)
-        self.assertEqual(updated_deadline, new_deadline)
+        assert updated_deadline == new_deadline
 
     def test_disable_verification_deadline(self):
         # Configure a verification deadline for the course
@@ -154,7 +151,7 @@ class AdminCourseModeFormTest(ModuleStoreTestCase):
         form.save()
 
         # Check that the deadline was disabled
-        self.assertIs(VerificationDeadline.deadline_for_course(self.course.id), None)
+        assert VerificationDeadline.deadline_for_course(self.course.id) is None
 
     @ddt.data("honor", "professional", "no-id-professional", "credit")
     def test_validate_upgrade_deadline_only_for_verified(self, course_mode):
@@ -221,4 +218,4 @@ class AdminCourseModeFormTest(ModuleStoreTestCase):
     def _assert_form_has_error(self, form, error):
         """Check that a form has a validation error. """
         validation_errors = form.errors.get("__all__", [])
-        self.assertIn(error, validation_errors)
+        assert error in validation_errors

--- a/common/djangoapps/course_modes/tests/test_models.py
+++ b/common/djangoapps/course_modes/tests/test_models.py
@@ -71,11 +71,11 @@ class CourseModeModelTest(TestCase):
     def test_save(self):
         """ Verify currency is always lowercase. """
         cm, __ = self.create_mode('honor', 'honor', 0, '', 'USD')
-        self.assertEqual(cm.currency, 'usd')
+        assert cm.currency == 'usd'
 
         cm.currency = 'GHS'
         cm.save()
-        self.assertEqual(cm.currency, 'ghs')
+        assert cm.currency == 'ghs'
 
     def test_modes_for_course_empty(self):
         """
@@ -83,7 +83,7 @@ class CourseModeModelTest(TestCase):
         """
         # shouldn't be able to find a corresponding course
         modes = CourseMode.modes_for_course(self.course_key)
-        self.assertEqual([CourseMode.DEFAULT_MODE], modes)
+        assert [CourseMode.DEFAULT_MODE] == modes
 
     def test_nodes_for_course_single(self):
         """
@@ -93,12 +93,11 @@ class CourseModeModelTest(TestCase):
         self.create_mode('verified', 'Verified Certificate', 10)
         modes = CourseMode.modes_for_course(self.course_key)
         mode = Mode(u'verified', u'Verified Certificate', 10, '', 'usd', None, None, None, None)
-        self.assertEqual([mode], modes)
+        assert [mode] == modes
 
         modes_dict = CourseMode.modes_for_course_dict(self.course_key)
-        self.assertEqual(modes_dict['verified'], mode)
-        self.assertEqual(CourseMode.mode_for_course(self.course_key, 'verified'),
-                         mode)
+        assert modes_dict['verified'] == mode
+        assert CourseMode.mode_for_course(self.course_key, 'verified') == mode
 
     def test_modes_for_course_multiple(self):
         """
@@ -111,17 +110,17 @@ class CourseModeModelTest(TestCase):
             self.create_mode(mode.slug, mode.name, mode.min_price, mode.suggested_prices)
 
         modes = CourseMode.modes_for_course(self.course_key)
-        self.assertEqual(modes, set_modes)
-        self.assertEqual(mode1, CourseMode.mode_for_course(self.course_key, u'honor'))
-        self.assertEqual(mode2, CourseMode.mode_for_course(self.course_key, u'verified'))
-        self.assertIsNone(CourseMode.mode_for_course(self.course_key, 'DNE'))
+        assert modes == set_modes
+        assert mode1 == CourseMode.mode_for_course(self.course_key, u'honor')
+        assert mode2 == CourseMode.mode_for_course(self.course_key, u'verified')
+        assert CourseMode.mode_for_course(self.course_key, 'DNE') is None
 
     def test_min_course_price_for_currency(self):
         """
         Get the min course price for a course according to currency
         """
         # no modes, should get 0
-        self.assertEqual(0, CourseMode.min_course_price_for_currency(self.course_key, 'usd'))
+        assert 0 == CourseMode.min_course_price_for_currency(self.course_key, 'usd')
 
         # create some modes
         mode1 = Mode(u'honor', u'Honor Code Certificate', 10, '', 'usd', None, None, None, None)
@@ -131,20 +130,20 @@ class CourseModeModelTest(TestCase):
         for mode in set_modes:
             self.create_mode(mode.slug, mode.name, mode.min_price, mode.suggested_prices, mode.currency)
 
-        self.assertEqual(10, CourseMode.min_course_price_for_currency(self.course_key, 'usd'))
-        self.assertEqual(80, CourseMode.min_course_price_for_currency(self.course_key, 'cny'))
+        assert 10 == CourseMode.min_course_price_for_currency(self.course_key, 'usd')
+        assert 80 == CourseMode.min_course_price_for_currency(self.course_key, 'cny')
 
     def test_modes_for_course_expired(self):
         expired_mode, _status = self.create_mode('verified', 'Verified Certificate', 10)
         expired_mode.expiration_datetime = now() + timedelta(days=-1)
         expired_mode.save()
         modes = CourseMode.modes_for_course(self.course_key)
-        self.assertEqual([CourseMode.DEFAULT_MODE], modes)
+        assert [CourseMode.DEFAULT_MODE] == modes
 
         mode1 = Mode(u'honor', u'Honor Code Certificate', 0, '', 'usd', None, None, None, None)
         self.create_mode(mode1.slug, mode1.name, mode1.min_price, mode1.suggested_prices)
         modes = CourseMode.modes_for_course(self.course_key)
-        self.assertEqual([mode1], modes)
+        assert [mode1] == modes
 
         expiration_datetime = now() + timedelta(days=1)
         expired_mode.expiration_datetime = expiration_datetime
@@ -161,47 +160,47 @@ class CourseModeModelTest(TestCase):
             None
         )
         modes = CourseMode.modes_for_course(self.course_key)
-        self.assertEqual([expired_mode_value, mode1], modes)
+        assert [expired_mode_value, mode1] == modes
 
         modes = CourseMode.modes_for_course(CourseLocator('TestOrg', 'TestCourse', 'TestRun'))
-        self.assertEqual([CourseMode.DEFAULT_MODE], modes)
+        assert [CourseMode.DEFAULT_MODE] == modes
 
     def test_verified_mode_for_course(self):
         self.create_mode('verified', 'Verified Certificate', 10)
 
         mode = CourseMode.verified_mode_for_course(self.course_key)
 
-        self.assertEqual(mode.slug, 'verified')
+        assert mode.slug == 'verified'
 
         # verify that the professional mode is preferred
         self.create_mode('professional', 'Professional Education Verified Certificate', 10)
 
         mode = CourseMode.verified_mode_for_course(self.course_key)
 
-        self.assertEqual(mode.slug, 'professional')
+        assert mode.slug == 'professional'
 
     def test_course_has_payment_options(self):
         # Has no payment options.
         honor, _ = self.create_mode('honor', 'Honor')
-        self.assertFalse(CourseMode.has_payment_options(self.course_key))
+        assert not CourseMode.has_payment_options(self.course_key)
 
         # Now we do have a payment option.
         verified, _ = self.create_mode('verified', 'Verified', min_price=5)
-        self.assertTrue(CourseMode.has_payment_options(self.course_key))
+        assert CourseMode.has_payment_options(self.course_key)
 
         # Remove the verified option.
         verified.delete()
-        self.assertFalse(CourseMode.has_payment_options(self.course_key))
+        assert not CourseMode.has_payment_options(self.course_key)
 
         # Finally, give the honor mode payment options
         honor.suggested_prices = '5, 10, 15'
         honor.save()
-        self.assertTrue(CourseMode.has_payment_options(self.course_key))
+        assert CourseMode.has_payment_options(self.course_key)
 
     def test_course_has_payment_options_with_no_id_professional(self):
         # Has payment options.
         self.create_mode('no-id-professional', 'no-id-professional', min_price=5)
-        self.assertTrue(CourseMode.has_payment_options(self.course_key))
+        assert CourseMode.has_payment_options(self.course_key)
 
     @ddt.data(
         ([], True),
@@ -217,7 +216,7 @@ class CourseModeModelTest(TestCase):
             self.create_mode(mode_slug, mode_slug.capitalize(), min_price=min_price)
 
         # Verify that we can or cannot auto enroll
-        self.assertEqual(CourseMode.can_auto_enroll(self.course_key), can_auto_enroll)
+        assert CourseMode.can_auto_enroll(self.course_key) == can_auto_enroll
 
     @ddt.data(
         ([], None),
@@ -232,7 +231,7 @@ class CourseModeModelTest(TestCase):
     @ddt.unpack
     def test_auto_enroll_mode(self, modes, result):
         # Verify that the proper auto enroll mode is returned
-        self.assertEqual(CourseMode.auto_enroll_mode(self.course_key, modes), result)
+        assert CourseMode.auto_enroll_mode(self.course_key, modes) == result
 
     def test_all_modes_for_courses(self):
         now_dt = now()
@@ -267,14 +266,14 @@ class CourseModeModelTest(TestCase):
         # including ones that have expired.
         other_course_key = CourseLocator(org="not", course="a", run="course")
         all_modes = CourseMode.all_modes_for_courses([self.course_key, other_course_key])
-        self.assertEqual(len(all_modes[self.course_key]), 3)
-        self.assertEqual(all_modes[self.course_key][0].name, "Honor No Expiration")
-        self.assertEqual(all_modes[self.course_key][1].name, "Honor Not Expired")
-        self.assertEqual(all_modes[self.course_key][2].name, "Verified Expired")
+        assert len(all_modes[self.course_key]) == 3
+        assert all_modes[self.course_key][0].name == 'Honor No Expiration'
+        assert all_modes[self.course_key][1].name == 'Honor Not Expired'
+        assert all_modes[self.course_key][2].name == 'Verified Expired'
 
         # Check that we get a default mode for when no course mode is available
-        self.assertEqual(len(all_modes[other_course_key]), 1)
-        self.assertEqual(all_modes[other_course_key][0], CourseMode.DEFAULT_MODE)
+        assert len(all_modes[other_course_key]) == 1
+        assert all_modes[other_course_key][0] == CourseMode.DEFAULT_MODE
 
     @ddt.data('', 'no-id-professional', 'professional', 'verified')
     def test_course_has_professional_mode(self, mode):
@@ -284,9 +283,9 @@ class CourseModeModelTest(TestCase):
         modes_dict = CourseMode.modes_for_course_dict(self.course_key)
 
         if mode in ['professional', 'no-id-professional']:
-            self.assertTrue(CourseMode.has_professional_mode(modes_dict))
+            assert CourseMode.has_professional_mode(modes_dict)
         else:
-            self.assertFalse(CourseMode.has_professional_mode(modes_dict))
+            assert not CourseMode.has_professional_mode(modes_dict)
 
     @ddt.data('no-id-professional', 'professional', 'verified')
     def test_course_is_professional_mode(self, mode):
@@ -294,13 +293,13 @@ class CourseModeModelTest(TestCase):
 
         course_mode, __ = self.create_mode(mode, 'course mode', 10)
         if mode in ['professional', 'no-id-professional']:
-            self.assertTrue(CourseMode.is_professional_mode(course_mode.to_tuple()))
+            assert CourseMode.is_professional_mode(course_mode.to_tuple())
         else:
-            self.assertFalse(CourseMode.is_professional_mode(course_mode.to_tuple()))
+            assert not CourseMode.is_professional_mode(course_mode.to_tuple())
 
     def test_course_is_professional_mode_with_invalid_tuple(self):
         # check that tuple has professional mode with None
-        self.assertFalse(CourseMode.is_professional_mode(None))
+        assert not CourseMode.is_professional_mode(None)
 
     @ddt.data(
         ('no-id-professional', False),
@@ -313,9 +312,9 @@ class CourseModeModelTest(TestCase):
     def test_is_verified_slug(self, mode_slug, is_verified):
         # check that mode slug is verified or not
         if is_verified:
-            self.assertTrue(CourseMode.is_verified_slug(mode_slug))
+            assert CourseMode.is_verified_slug(mode_slug)
         else:
-            self.assertFalse(CourseMode.is_verified_slug(mode_slug))
+            assert not CourseMode.is_verified_slug(mode_slug)
 
     @ddt.data(*itertools.product(
         (
@@ -333,13 +332,10 @@ class CourseModeModelTest(TestCase):
         is_error_expected = CourseMode.is_professional_slug(mode_slug) and exp_dt is not None
         try:
             self.create_mode(mode_slug=mode_slug, mode_name=mode_slug.title(), expiration_datetime=exp_dt, min_price=10)
-            self.assertFalse(is_error_expected, "Expected a ValidationError to be thrown.")
+            assert not is_error_expected, 'Expected a ValidationError to be thrown.'
         except ValidationError as exc:
-            self.assertTrue(is_error_expected, "Did not expect a ValidationError to be thrown.")
-            self.assertEqual(
-                exc.messages,
-                [u"Professional education modes are not allowed to have expiration_datetime set."],
-            )
+            assert is_error_expected, 'Did not expect a ValidationError to be thrown.'
+            assert exc.messages == [u'Professional education modes are not allowed to have expiration_datetime set.']
 
     @ddt.data(
         ("verified", "verify_need_to_verify"),
@@ -357,33 +353,21 @@ class CourseModeModelTest(TestCase):
     @ddt.unpack
     def test_enrollment_mode_display(self, mode, verification_status):
         if mode == "verified":
-            self.assertEqual(
-                enrollment_mode_display(mode, verification_status, self.course_key),
-                self._enrollment_display_modes_dicts(verification_status)
-            )
-            self.assertEqual(
-                enrollment_mode_display(mode, verification_status, self.course_key),
-                self._enrollment_display_modes_dicts(verification_status)
-            )
-            self.assertEqual(
-                enrollment_mode_display(mode, verification_status, self.course_key),
-                self._enrollment_display_modes_dicts(verification_status)
-            )
+            assert enrollment_mode_display(mode, verification_status, self.course_key) ==\
+                   self._enrollment_display_modes_dicts(verification_status)
+            assert enrollment_mode_display(mode, verification_status, self.course_key) ==\
+                   self._enrollment_display_modes_dicts(verification_status)
+            assert enrollment_mode_display(mode, verification_status, self.course_key) ==\
+                   self._enrollment_display_modes_dicts(verification_status)
         elif mode == "honor":
-            self.assertEqual(
-                enrollment_mode_display(mode, verification_status, self.course_key),
-                self._enrollment_display_modes_dicts(mode)
-            )
+            assert enrollment_mode_display(mode, verification_status, self.course_key) ==\
+                   self._enrollment_display_modes_dicts(mode)
         elif mode == "audit":
-            self.assertEqual(
-                enrollment_mode_display(mode, verification_status, self.course_key),
-                self._enrollment_display_modes_dicts(mode)
-            )
+            assert enrollment_mode_display(mode, verification_status, self.course_key) ==\
+                   self._enrollment_display_modes_dicts(mode)
         elif mode == "professional":
-            self.assertEqual(
-                enrollment_mode_display(mode, verification_status, self.course_key),
-                self._enrollment_display_modes_dicts(mode)
-            )
+            assert enrollment_mode_display(mode, verification_status, self.course_key) ==\
+                   self._enrollment_display_modes_dicts(mode)
 
     @ddt.data(
         (['honor', 'verified', 'credit'], ['honor', 'verified']),
@@ -436,8 +420,8 @@ class CourseModeModelTest(TestCase):
         now_dt = now()
         verified_mode.expiration_datetime = now_dt
 
-        self.assertTrue(verified_mode.expiration_datetime_is_explicit)
-        self.assertEqual(verified_mode.expiration_datetime, now_dt)
+        assert verified_mode.expiration_datetime_is_explicit
+        assert verified_mode.expiration_datetime == now_dt
 
     def test_expiration_datetime_not_explicitly_set(self):
         """ Verify that setting the _expiration_date property does not set the explicit flag. """
@@ -445,17 +429,17 @@ class CourseModeModelTest(TestCase):
         now_dt = now()
         verified_mode._expiration_datetime = now_dt  # pylint: disable=protected-access
 
-        self.assertFalse(verified_mode.expiration_datetime_is_explicit)
-        self.assertEqual(verified_mode.expiration_datetime, now_dt)
+        assert not verified_mode.expiration_datetime_is_explicit
+        assert verified_mode.expiration_datetime == now_dt
 
     def test_expiration_datetime_explicitly_set_to_none(self):
         """ Verify that setting the _expiration_date property does not set the explicit flag. """
         verified_mode, __ = self.create_mode('verified', 'Verified Certificate', 10)
-        self.assertFalse(verified_mode.expiration_datetime_is_explicit)
+        assert not verified_mode.expiration_datetime_is_explicit
 
         verified_mode.expiration_datetime = None
-        self.assertFalse(verified_mode.expiration_datetime_is_explicit)
-        self.assertIsNone(verified_mode.expiration_datetime)
+        assert not verified_mode.expiration_datetime_is_explicit
+        assert verified_mode.expiration_datetime is None
 
     @ddt.data(
         (False, CourseMode.AUDIT, False),
@@ -475,7 +459,7 @@ class CourseModeModelTest(TestCase):
     def test_eligible_for_cert(self, disable_honor_cert, mode_slug, expected_eligibility):
         """Verify that non-audit modes are eligible for a cert."""
         with override_settings(FEATURES={'DISABLE_HONOR_CERTIFICATES': disable_honor_cert}):
-            self.assertEqual(CourseMode.is_eligible_for_certificate(mode_slug), expected_eligibility)
+            assert CourseMode.is_eligible_for_certificate(mode_slug) == expected_eligibility
 
     @ddt.data(
         (CourseMode.AUDIT, False),
@@ -492,9 +476,9 @@ class CourseModeModelTest(TestCase):
         try:
             self.create_mode(mode_slug=mode_slug, mode_name=mode_slug.title(), min_price=0)
         except ValidationError:
-            self.assertTrue(is_error_expected, "Did not expect a ValidationError to be thrown.")
+            assert is_error_expected, 'Did not expect a ValidationError to be thrown.'
         else:
-            self.assertFalse(is_error_expected, "Expected a ValidationError to be thrown.")
+            assert not is_error_expected, 'Expected a ValidationError to be thrown.'
 
     @ddt.data(
         ([], False),
@@ -508,7 +492,7 @@ class CourseModeModelTest(TestCase):
             self.create_mode(mode, mode, 10)
 
         modes = CourseMode.modes_for_course_dict(self.course_key)
-        self.assertEqual(CourseMode.contains_masters_mode(modes), expected_contains_masters_mode)
+        assert CourseMode.contains_masters_mode(modes) == expected_contains_masters_mode
 
     @ddt.data(
         ([], False),
@@ -521,7 +505,7 @@ class CourseModeModelTest(TestCase):
         for mode in available_modes:
             self.create_mode(mode, mode, 10)
 
-        self.assertEqual(CourseMode.is_masters_only(self.course_key), expected_is_masters_only)
+        assert CourseMode.is_masters_only(self.course_key) == expected_is_masters_only
 
 
 class TestCourseOverviewIntegration(ModuleStoreTestCase):  # lint-amnesty, pylint: disable=missing-class-docstring
@@ -551,7 +535,7 @@ class TestDisplayPrices(ModuleStoreTestCase):  # lint-amnesty, pylint: disable=m
                 return_value=registration_price,
         ):
             # Since registration_price is set, it overrides the cosmetic_display_price and should be returned
-            self.assertEqual(get_cosmetic_display_price(course), "$99")
+            assert get_cosmetic_display_price(course) == '$99'
 
         registration_price = 0
         with patch(
@@ -559,8 +543,8 @@ class TestDisplayPrices(ModuleStoreTestCase):  # lint-amnesty, pylint: disable=m
                 return_value=registration_price,
         ):
             # Since registration_price is not set, cosmetic_display_price should be returned
-            self.assertEqual(get_cosmetic_display_price(course), "$10")
+            assert get_cosmetic_display_price(course) == '$10'
 
         course.cosmetic_display_price = 0
         # Since both prices are not set, there is no price, thus "Free"
-        self.assertEqual(get_cosmetic_display_price(course), "Free")
+        assert get_cosmetic_display_price(course) == 'Free'

--- a/common/djangoapps/course_modes/tests/test_signals.py
+++ b/common/djangoapps/course_modes/tests/test_signals.py
@@ -59,13 +59,13 @@ class CourseModeSignalTest(ModuleStoreTestCase):
         _listen_for_course_publish('store', self.course.id)
         course_mode.refresh_from_db()
 
-        self.assertIsNone(course_mode.expiration_datetime)
+        assert course_mode.expiration_datetime is None
 
     @ddt.data(1, 14, 30)
     def test_verified_mode(self, verification_window):
         """ Verify signal updates expiration to configured time period before course end for verified mode. """
         course_mode, __ = self.create_mode('verified', 'verified', 10)
-        self.assertIsNone(course_mode.expiration_datetime)
+        assert course_mode.expiration_datetime is None
 
         with patch('common.djangoapps.course_modes.models.CourseModeExpirationConfig.current') as config:
             instance = config.return_value
@@ -74,14 +74,14 @@ class CourseModeSignalTest(ModuleStoreTestCase):
             _listen_for_course_publish('store', self.course.id)
             course_mode.refresh_from_db()
 
-            self.assertEqual(course_mode.expiration_datetime, self.end - timedelta(days=verification_window))
+            assert course_mode.expiration_datetime == (self.end - timedelta(days=verification_window))
 
     @ddt.data(1, 14, 30)
     def test_verified_mode_explicitly_set(self, verification_window):
         """ Verify signal does not update expiration for verified mode with explicitly set expiration. """
         course_mode, __ = self.create_mode('verified', 'verified', 10)
         course_mode.expiration_datetime_is_explicit = True
-        self.assertIsNone(course_mode.expiration_datetime)
+        assert course_mode.expiration_datetime is None
 
         with patch('common.djangoapps.course_modes.models.CourseModeExpirationConfig.current') as config:
             instance = config.return_value
@@ -90,7 +90,7 @@ class CourseModeSignalTest(ModuleStoreTestCase):
             _listen_for_course_publish('store', self.course.id)
             course_mode.refresh_from_db()
 
-            self.assertEqual(course_mode.expiration_datetime, self.end - timedelta(days=verification_window))
+            assert course_mode.expiration_datetime == (self.end - timedelta(days=verification_window))
 
     def test_masters_mode(self):
         # create an xblock with verified group access

--- a/common/djangoapps/course_modes/tests/test_views.py
+++ b/common/djangoapps/course_modes/tests/test_views.py
@@ -100,7 +100,7 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
             else:
                 self.assertRedirects(response, reverse('dashboard'))
         else:
-            self.assertEqual(response.status_code, 200)
+            assert response.status_code == 200
 
     def test_no_id_redirect(self):
         # Create the course modes
@@ -174,7 +174,7 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
             follow=False,
         )
 
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         # TODO: Fix it so that response.templates works w/ mako templates, and then assert
         # that the right template rendered
 
@@ -326,8 +326,8 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
 
         # Assert learner is not enrolled in Audit track pre-POST
         mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
-        self.assertIsNone(mode)
-        self.assertIsNone(is_active)
+        assert mode is None
+        assert is_active is None
 
         # Choose the audit mode (POST request)
         choose_track_url = reverse('course_modes_choose', args=[six.text_type(self.course.id)])
@@ -335,22 +335,22 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
 
         # Assert learner is enrolled in Audit track post-POST
         mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
-        self.assertEqual(mode, audit_mode)
-        self.assertTrue(is_active)
+        assert mode == audit_mode
+        assert is_active
 
         # Unenroll learner from Audit track and confirm the enrollment record is now 'inactive'
         CourseEnrollment.unenroll(self.user, self.course.id)
         mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
-        self.assertEqual(mode, audit_mode)
-        self.assertFalse(is_active)
+        assert mode == audit_mode
+        assert not is_active
 
         # Choose the audit mode again
         self.client.post(choose_track_url, self.POST_PARAMS_FOR_COURSE_MODE[audit_mode])
 
         # Assert learner is again enrolled in Audit track post-POST-POST
         mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
-        self.assertEqual(mode, audit_mode)
-        self.assertTrue(is_active)
+        assert mode == audit_mode
+        assert is_active
 
     def test_remember_donation_for_course(self):
         # Create the course modes
@@ -362,12 +362,12 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
         self.client.post(choose_track_url, self.POST_PARAMS_FOR_COURSE_MODE['verified'])
 
         # Expect that the contribution amount is stored in the user's session
-        self.assertIn('donation_for_course', self.client.session)
-        self.assertIn(six.text_type(self.course.id), self.client.session['donation_for_course'])
+        assert 'donation_for_course' in self.client.session
+        assert six.text_type(self.course.id) in self.client.session['donation_for_course']
 
         actual_amount = self.client.session['donation_for_course'][six.text_type(self.course.id)]
         expected_amount = decimal.Decimal(self.POST_PARAMS_FOR_COURSE_MODE['verified']['contribution'])
-        self.assertEqual(actual_amount, expected_amount)
+        assert actual_amount == expected_amount
 
     def test_successful_default_enrollment(self):
         # Create the course modes
@@ -388,8 +388,8 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
 
         # Verify that the user's enrollment remains unchanged
         mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
-        self.assertEqual(mode, CourseMode.DEFAULT_MODE_SLUG)
-        self.assertEqual(is_active, True)
+        assert mode == CourseMode.DEFAULT_MODE_SLUG
+        assert is_active is True
 
     def test_unsupported_enrollment_mode_failure(self):
         # Create the supported course modes
@@ -400,7 +400,7 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
         choose_track_url = reverse('course_modes_choose', args=[six.text_type(self.course.id)])
         response = self.client.post(choose_track_url, self.POST_PARAMS_FOR_COURSE_MODE['unsupported'])
 
-        self.assertEqual(400, response.status_code)
+        assert 400 == response.status_code
 
     @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
     def test_default_mode_creation(self):
@@ -408,12 +408,12 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
         url = reverse('create_mode', args=[six.text_type(self.course.id)])
         response = self.client.get(url)
 
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
         expected_mode = [Mode(u'honor', u'Honor Code Certificate', 0, '', 'usd', None, None, None, None)]
         course_mode = CourseMode.modes_for_course(self.course.id)
 
-        self.assertEqual(course_mode, expected_mode)
+        assert course_mode == expected_mode
 
     @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
     @ddt.data(
@@ -432,7 +432,7 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
         url = reverse('create_mode', args=[six.text_type(self.course.id)])
         response = self.client.get(url, parameters)
 
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
         expected_mode = [
             Mode(
@@ -449,7 +449,7 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
         ]
         course_mode = CourseMode.modes_for_course(self.course.id)
 
-        self.assertEqual(course_mode, expected_mode)
+        assert course_mode == expected_mode
 
     @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
     def test_multiple_mode_creation(self):
@@ -474,7 +474,7 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
         expected_modes = [honor_mode, verified_mode]
         course_modes = CourseMode.modes_for_course(self.course.id)
 
-        self.assertEqual(course_modes, expected_modes)
+        assert course_modes == expected_modes
 
     @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
     @with_comprehensive_theme("edx.org")
@@ -540,4 +540,4 @@ class TrackSelectionEmbargoTest(UrlResetMixin, ModuleStoreTestCase):
     @httpretty.activate
     def test_embargo_allow(self):
         response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200

--- a/common/djangoapps/edxmako/tests.py
+++ b/common/djangoapps/edxmako/tests.py
@@ -37,38 +37,38 @@ class ShortcutsTests(UrlResetMixin, TestCase):
             with patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': True}):
                 expected_link = 'https://dummy-root/about-us'
                 link = marketing_link('ABOUT')
-                self.assertEqual(link, expected_link)
+                assert link == expected_link
             # test marketing site off
             with patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': False}):
                 expected_link = reverse(self._get_test_url_name())
                 link = marketing_link('ABOUT')
-                self.assertEqual(link, expected_link)
+                assert link == expected_link
 
     @override_settings(MKTG_URLS={'ROOT': 'https://dummy-root', 'ABOUT': '/about-us'})
     def test_is_marketing_link_set(self):
         with override_settings(MKTG_URL_LINK_MAP={'ABOUT': self._get_test_url_name()}):
             # test marketing site on
             with patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': True}):
-                self.assertTrue(is_marketing_link_set('ABOUT'))
-                self.assertFalse(is_marketing_link_set('NOT_CONFIGURED'))
+                assert is_marketing_link_set('ABOUT')
+                assert not is_marketing_link_set('NOT_CONFIGURED')
             # test marketing site off
             with patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': False}):
-                self.assertTrue(is_marketing_link_set('ABOUT'))
-                self.assertFalse(is_marketing_link_set('NOT_CONFIGURED'))
+                assert is_marketing_link_set('ABOUT')
+                assert not is_marketing_link_set('NOT_CONFIGURED')
 
     @override_settings(MKTG_URLS={'ROOT': 'https://dummy-root', 'ABOUT': '/about-us'})
     def test_is_any_marketing_link_set(self):
         with override_settings(MKTG_URL_LINK_MAP={'ABOUT': self._get_test_url_name()}):
             # test marketing site on
             with patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': True}):
-                self.assertTrue(is_any_marketing_link_set(['ABOUT']))
-                self.assertTrue(is_any_marketing_link_set(['ABOUT', 'NOT_CONFIGURED']))
-                self.assertFalse(is_any_marketing_link_set(['NOT_CONFIGURED']))
+                assert is_any_marketing_link_set(['ABOUT'])
+                assert is_any_marketing_link_set(['ABOUT', 'NOT_CONFIGURED'])
+                assert not is_any_marketing_link_set(['NOT_CONFIGURED'])
             # test marketing site off
             with patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': False}):
-                self.assertTrue(is_any_marketing_link_set(['ABOUT']))
-                self.assertTrue(is_any_marketing_link_set(['ABOUT', 'NOT_CONFIGURED']))
-                self.assertFalse(is_any_marketing_link_set(['NOT_CONFIGURED']))
+                assert is_any_marketing_link_set(['ABOUT'])
+                assert is_any_marketing_link_set(['ABOUT', 'NOT_CONFIGURED'])
+                assert not is_any_marketing_link_set(['NOT_CONFIGURED'])
 
     def _get_test_url_name(self):  # lint-amnesty, pylint: disable=missing-function-docstring
         if settings.ROOT_URLCONF == 'lms.urls':
@@ -85,11 +85,11 @@ class ShortcutsTests(UrlResetMixin, TestCase):
         # test marketing site on
         with patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': True}):
             link = marketing_link('TOS')
-            self.assertEqual(link, expected_link)
+            assert link == expected_link
         # test marketing site off
         with patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': False}):
             link = marketing_link('TOS')
-            self.assertEqual(link, expected_link)
+            assert link == expected_link
 
     @override_settings(MKTG_URLS={'ROOT': 'https://dummy-root', 'TOS': '/tos'})
     @override_settings(MKTG_URL_OVERRIDES={'TOS': '123456'})
@@ -98,11 +98,11 @@ class ShortcutsTests(UrlResetMixin, TestCase):
         # test marketing site on
         with patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': True}):
             link = marketing_link('TOS')
-            self.assertEqual(link, expected_link)
+            assert link == expected_link
         # test marketing site off
         with patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': False}):
             link = marketing_link('TOS')
-            self.assertEqual(link, expected_link)
+            assert link == expected_link
 
     @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
     def test_link_map_url_reverse(self):
@@ -129,8 +129,8 @@ class AddLookupTests(TestCase):
     def test_with_package(self):
         add_lookup('test', 'management', __name__)
         dirs = LOOKUP['test'].directories
-        self.assertEqual(len(dirs), 1)
-        self.assertTrue(dirs[0].endswith('management'))
+        assert len(dirs) == 1
+        assert dirs[0].endswith('management')
 
 
 class MakoRequestContextTest(TestCase):
@@ -156,7 +156,7 @@ class MakoRequestContextTest(TestCase):
 
         with patch('common.djangoapps.edxmako.request_context.get_current_request', return_value=self.request):
             # requestcontext should not be None.
-            self.assertIsNotNone(get_template_request_context())
+            assert get_template_request_context() is not None
 
     def test_without_current_request(self):
         """
@@ -165,7 +165,7 @@ class MakoRequestContextTest(TestCase):
         """
         with patch('common.djangoapps.edxmako.request_context.get_current_request', return_value=None):
             # requestcontext should be None.
-            self.assertIsNone(get_template_request_context())
+            assert get_template_request_context() is None
 
     def test_request_context_caching(self):
         """
@@ -173,17 +173,17 @@ class MakoRequestContextTest(TestCase):
         """
         with patch('common.djangoapps.edxmako.request_context.get_current_request', return_value=None):
             # requestcontext should be None, because the cache isn't filled
-            self.assertIsNone(get_template_request_context())
+            assert get_template_request_context() is None
 
         with patch('common.djangoapps.edxmako.request_context.get_current_request', return_value=self.request):
             # requestcontext should not be None, and should fill the cache
-            self.assertIsNotNone(get_template_request_context())
+            assert get_template_request_context() is not None
 
         mock_get_current_request = Mock()
         with patch('common.djangoapps.edxmako.request_context.get_current_request'):
             with patch('common.djangoapps.edxmako.request_context.RequestContext.__init__') as mock_context_init:
                 # requestcontext should not be None, because the cache is filled
-                self.assertIsNotNone(get_template_request_context())
+                assert get_template_request_context() is not None
                 mock_context_init.assert_not_called()
         mock_get_current_request.assert_not_called()
 
@@ -191,7 +191,7 @@ class MakoRequestContextTest(TestCase):
 
         with patch('common.djangoapps.edxmako.request_context.get_current_request', return_value=None):
             # requestcontext should be None, because the cache isn't filled
-            self.assertIsNone(get_template_request_context())
+            assert get_template_request_context() is None
 
     @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
     def test_render_to_string_when_no_global_context_lms(self):
@@ -199,7 +199,7 @@ class MakoRequestContextTest(TestCase):
         Test render_to_string() when makomiddleware has not initialized
         the threadlocal REQUEST_CONTEXT.context. This is meant to run in LMS.
         """
-        self.assertIn("this module is temporarily unavailable", render_to_string("courseware/error-message.html", None))
+        assert 'this module is temporarily unavailable' in render_to_string('courseware/error-message.html', None)
 
     @unittest.skipUnless(settings.ROOT_URLCONF == 'cms.urls', 'Test only valid in cms')
     def test_render_to_string_when_no_global_context_cms(self):
@@ -207,4 +207,4 @@ class MakoRequestContextTest(TestCase):
         Test render_to_string() when makomiddleware has not initialized
         the threadlocal REQUEST_CONTEXT.context. This is meant to run in CMS.
         """
-        self.assertIn("We're having trouble rendering your component", render_to_string("html_error.html", None))
+        assert "We're having trouble rendering your component" in render_to_string('html_error.html', None)

--- a/common/djangoapps/entitlements/management/commands/tests/test_expire_old_entitlements.py
+++ b/common/djangoapps/entitlements/management/commands/tests/test_expire_old_entitlements.py
@@ -24,22 +24,22 @@ class TestExpireOldEntitlementsCommand(TestCase):
         CourseEntitlementFactory.create()
 
         call_command('expire_old_entitlements')
-        self.assertEqual(mock_task.call_count, 0)
+        assert mock_task.call_count == 0
 
         call_command('expire_old_entitlements', commit=True)
-        self.assertEqual(mock_task.call_count, 1)
+        assert mock_task.call_count == 1
 
     def test_no_tasks_if_no_work(self, mock_task):
         """
         Verify that we never try to spin off a task if there are no database rows.
         """
         call_command('expire_old_entitlements', commit=True)
-        self.assertEqual(mock_task.call_count, 0)
+        assert mock_task.call_count == 0
 
         # Now confirm that the above test wasn't a fluke and we will create a task if there is work
         CourseEntitlementFactory.create()
         call_command('expire_old_entitlements', commit=True)
-        self.assertEqual(mock_task.call_count, 1)
+        assert mock_task.call_count == 1
 
     def test_pagination(self, mock_task):
         """
@@ -51,7 +51,7 @@ class TestExpireOldEntitlementsCommand(TestCase):
         call_command('expire_old_entitlements', commit=True, batch_size=2)
 
         args_list = mock_task.call_args_list
-        self.assertEqual(len(args_list), 3)
-        self.assertEqual(args_list[0][0], (1, 3))
-        self.assertEqual(args_list[1][0], (3, 5))
-        self.assertEqual(args_list[2][0], (5, 6))
+        assert len(args_list) == 3
+        assert args_list[0][0] == (1, 3)
+        assert args_list[1][0] == (3, 5)
+        assert args_list[2][0] == (5, 6)

--- a/common/djangoapps/entitlements/rest_api/v1/tests/test_views.py
+++ b/common/djangoapps/entitlements/rest_api/v1/tests/test_views.py
@@ -387,7 +387,7 @@ class EntitlementViewSetTest(ModuleStoreTestCase):
         assert response.status_code == 201
 
         result_obj = UserOrgTag.objects.get(user=self.user, org=org, key='email-optin')
-        self.assertEqual(result_obj.value, u"True")
+        assert result_obj.value == u'True'
 
     @patch("common.djangoapps.entitlements.rest_api.v1.views.get_owners_for_course")
     def test_email_opt_in_multiple_orgs(self, mock_get_owners):
@@ -407,9 +407,9 @@ class EntitlementViewSetTest(ModuleStoreTestCase):
         assert response.status_code == 201
 
         result_obj = UserOrgTag.objects.get(user=self.user, org=org_1, key='email-optin')
-        self.assertEqual(result_obj.value, u"True")
+        assert result_obj.value == u'True'
         result_obj = UserOrgTag.objects.get(user=self.user, org=org_2, key='email-optin')
-        self.assertEqual(result_obj.value, u"True")
+        assert result_obj.value == u'True'
 
     def test_add_entitlement_with_support_detail(self):
         """

--- a/common/djangoapps/entitlements/tests/test_tasks.py
+++ b/common/djangoapps/entitlements/tests/test_tasks.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 
 import mock
 import pytz
+import pytest
 from django.test import TestCase
 
 from common.djangoapps.entitlements import tasks
@@ -45,7 +46,7 @@ class TestExpireOldEntitlementsTask(TestCase):
         ) as mock_datetime:
             tasks.expire_old_entitlements.delay(1, 3).get()
 
-        self.assertEqual(mock_datetime.call_count, 2)
+        assert mock_datetime.call_count == 2
 
     def test_only_unexpired(self):
         """
@@ -62,7 +63,7 @@ class TestExpireOldEntitlementsTask(TestCase):
             tasks.expire_old_entitlements.delay(1, 3).get()
 
         # Make sure only the unexpired one gets used
-        self.assertEqual(mock_datetime.call_count, 1)
+        assert mock_datetime.call_count == 1
 
     def test_retry(self):
         """
@@ -78,8 +79,8 @@ class TestExpireOldEntitlementsTask(TestCase):
         ) as mock_datetime:
             task = tasks.expire_old_entitlements.delay(1, 2)
 
-        self.assertRaises(Exception, task.get)
-        self.assertEqual(mock_datetime.call_count, tasks.MAX_RETRIES + 1)
+        pytest.raises(Exception, task.get)
+        assert mock_datetime.call_count == (tasks.MAX_RETRIES + 1)
 
 
 @skip_unless_lms
@@ -95,10 +96,10 @@ class TestExpireOldEntitlementsTaskIntegration(TestCase):
         entitlement = make_entitlement()
 
         # Sanity check
-        self.assertIsNone(entitlement.expired_at)
+        assert entitlement.expired_at is None
 
         # Run enforcement
         tasks.expire_old_entitlements.delay(1, 2).get()
         entitlement.refresh_from_db()
 
-        self.assertIsNotNone(entitlement.expired_at)
+        assert entitlement.expired_at is not None

--- a/common/djangoapps/pipeline_mako/tests/test_render.py
+++ b/common/djangoapps/pipeline_mako/tests/test_render.py
@@ -65,11 +65,11 @@ class PipelineRenderTest(TestCase):
         with self.settings(PIPELINE=pipeline):
             # Verify the default behavior
             css_include = compressed_css('style-main-v1')
-            self.assertIn(u'lms-main-v1.css', css_include)
+            assert u'lms-main-v1.css' in css_include
 
             # Verify that raw keyword causes raw URLs to be emitted
             css_include = compressed_css('style-main-v1', raw=True)
-            self.assertIn(u'lms-main-v1.css?raw', css_include)
+            assert u'lms-main-v1.css?raw' in css_include
 
     @patch('django.contrib.staticfiles.storage.staticfiles_storage.exists', return_value=True)
     @patch('common.djangoapps.static_replace.try_staticfiles_lookup', side_effect=mock_staticfiles_lookup)
@@ -83,10 +83,10 @@ class PipelineRenderTest(TestCase):
         pipeline['PIPELINE_ENABLED'] = True
         with self.settings(PIPELINE=pipeline):
             js_include = compressed_js('base_application')
-            self.assertIn(u'lms-base-application.js', js_include)
+            assert u'lms-base-application.js' in js_include
 
         # Verify that multiple JS files are rendered with the pipeline disabled
         pipeline['PIPELINE_ENABLED'] = False
         with self.settings(PIPELINE=pipeline):
             js_include = compressed_js('base_application')
-            self.assertIn(u'/static/js/src/logger.js', js_include)
+            assert u'/static/js/src/logger.js' in js_include

--- a/common/djangoapps/pipeline_mako/tests/test_static_content.py
+++ b/common/djangoapps/pipeline_mako/tests/test_static_content.py
@@ -13,5 +13,5 @@ class TestStaticContent(unittest.TestCase):
 
     def test_optional_include_mako(self):
         out = render_to_string("test_optional_include_mako.html", {})
-        self.assertIn("Welcome to test_optional_include_mako.html", out)
-        self.assertIn("This is test_exists.html", out)
+        assert 'Welcome to test_optional_include_mako.html' in out
+        assert 'This is test_exists.html' in out

--- a/common/djangoapps/static_replace/test/test_static_replace.py
+++ b/common/djangoapps/static_replace/test/test_static_replace.py
@@ -588,7 +588,7 @@ class CanonicalContentTest(SharedModuleStoreTestCase):
 
         with check_mongo_calls(mongo_calls):
             asset_path = StaticContent.get_canonicalized_asset_path(self.courses[prefix].id, start, base_url, exts)
-            self.assertIsNotNone(re.match(expected, asset_path))
+            assert re.match(expected, asset_path) is not None
 
     @ddt.data(
         # No leading slash.
@@ -784,4 +784,4 @@ class CanonicalContentTest(SharedModuleStoreTestCase):
 
         with check_mongo_calls(mongo_calls):
             asset_path = StaticContent.get_canonicalized_asset_path(self.courses[prefix].id, start, base_url, exts)
-            self.assertIsNotNone(re.match(expected, asset_path))
+            assert re.match(expected, asset_path) is not None

--- a/common/djangoapps/status/tests.py
+++ b/common/djangoapps/status/tests.py
@@ -38,25 +38,22 @@ class TestStatus(TestCase):
         """Test status messages in a variety of situations."""
 
         # When we don't have any data set.
-        self.assertEqual(get_site_status_msg(None), None)
-        self.assertEqual(get_site_status_msg(self.course_key), None)
+        assert get_site_status_msg(None) is None
+        assert get_site_status_msg(self.course_key) is None
 
         msg = GlobalStatusMessage.objects.create(message=test_global_message, enabled=True)
         msg.save()
 
-        self.assertEqual(get_site_status_msg(None), test_global_message)
+        assert get_site_status_msg(None) == test_global_message
 
         course_msg = CourseMessage.objects.create(
             global_message=msg, message=test_course_message, course_key=self.course_key
         )
         course_msg.save()
-        self.assertEqual(
-            get_site_status_msg(self.course_key),
-            u"{} <br /> {}".format(test_global_message, test_course_message)
-        )
+        assert get_site_status_msg(self.course_key) == u'{} <br /> {}'.format(test_global_message, test_course_message)
 
         msg = GlobalStatusMessage.objects.create(message="", enabled=False)
         msg.save()
 
-        self.assertEqual(get_site_status_msg(None), None)
-        self.assertEqual(get_site_status_msg(self.course_key), None)
+        assert get_site_status_msg(None) is None
+        assert get_site_status_msg(self.course_key) is None


### PR DESCRIPTION
## Description
This PR is using `codemod-unittest-to-pytest-asserts` to automatically replace `unittest` assertions with `pytest` 
for following apps under `common/djangoapps`
```
course_action_state, course_modes, database_fixups, edxmako, entitlements, pipeline_mako, static_replace, status
```
Relevant JIRA issue here: https://openedx.atlassian.net/browse/BOM-2380