### PR TITLE
replaced unittest assertions pytest assertions (13)

### DIFF
--- a/common/test/acceptance/pages/studio/utils.py
+++ b/common/test/acceptance/pages/studio/utils.py
@@ -69,14 +69,15 @@ def verify_ordering(test_class, page, expected_orderings):
                 blocks_checked.add(parent)
                 children = xblock.children
                 expected_length = len(expected_ordering.get(parent))
-                test_class.assertEqual(
-                    expected_length, len(children),
-                    u"Number of children incorrect for group {0}. Expected {1} but got {2}.".format(parent, expected_length, len(children)))  # lint-amnesty, pylint: disable=line-too-long
+                assert expected_length == \
+                       len(children), f'Number of children incorrect for group {parent}.' \
+                                      f' Expected {expected_length} but got {len(children)}.'
+
                 for idx, expected in enumerate(expected_ordering.get(parent)):
-                    test_class.assertEqual(expected, children[idx].name)
+                    assert expected == children[idx].name
                     blocks_checked.add(expected)
                 break
-    test_class.assertEqual(len(blocks_checked), len(xblocks))
+    assert len(blocks_checked) == len(xblocks)
 
 
 class HelpMixin(object):

--- a/common/test/acceptance/tests/discussion/helpers.py
+++ b/common/test/acceptance/tests/discussion/helpers.py
@@ -39,7 +39,7 @@ class BaseDiscussionMixin(object):
             self.thread_ids.append(thread_id)
         thread_fixture = MultipleThreadFixture(threads)
         response = thread_fixture.push()
-        self.assertTrue(response.ok, "Failed to push discussion content")
+        assert response.ok, 'Failed to push discussion content'
 
 
 class CohortTestMixin(object):
@@ -68,7 +68,7 @@ class CohortTestMixin(object):
         url = LMS_BASE_URL + "/courses/" + course_fixture._course_key + '/cohorts/'  # lint-amnesty, pylint: disable=protected-access
         data = json.dumps({"name": cohort_name, 'assignment_type': 'manual'})
         response = course_fixture.session.post(url, data=data, headers=course_fixture.headers)
-        self.assertTrue(response.ok, "Failed to create cohort")
+        assert response.ok, 'Failed to create cohort'
         return response.json()['id']
 
     def add_user_to_cohort(self, course_fixture, username, cohort_id):
@@ -79,7 +79,7 @@ class CohortTestMixin(object):
         data = {"users": username}
         course_fixture.headers['Content-type'] = 'application/x-www-form-urlencoded'
         response = course_fixture.session.post(url, data=data, headers=course_fixture.headers)
-        self.assertTrue(response.ok, "Failed to add user to cohort")
+        assert response.ok, 'Failed to add user to cohort'
 
 
 class BaseDiscussionTestCase(UniqueCourseTest, ForumsConfigMixin):

--- a/common/test/acceptance/tests/lms/test_learner_profile.py
+++ b/common/test/acceptance/tests/lms/test_learner_profile.py
@@ -66,9 +66,9 @@ class LearnerProfileTestMixin(EventsTestMixin):
 
             # Verify the current setting is as expected
             if privacy == self.PRIVACY_PUBLIC:
-                self.assertEqual(profile_page.privacy, 'all_users')
+                assert profile_page.privacy == 'all_users'
             else:
-                self.assertEqual(profile_page.privacy, 'private')
+                assert profile_page.privacy == 'private'
 
             if privacy == self.PRIVACY_PUBLIC:
                 self.set_public_profile_fields_data(profile_page)

--- a/common/test/acceptance/tests/lms/test_lms_dashboard.py
+++ b/common/test/acceptance/tests/lms/test_lms_dashboard.py
@@ -135,5 +135,5 @@ class LmsDashboardA11yTest(BaseLmsDashboardTestMultiple):
             ]
         })
         course_listings = self.dashboard_page.get_courses()
-        self.assertEqual(len(course_listings), 3)
+        assert len(course_listings) == 3
         self.dashboard_page.a11y_audit.check_for_accessibility_errors()

--- a/common/test/acceptance/tests/lms/test_lms_user_preview.py
+++ b/common/test/acceptance/tests/lms/test_lms_user_preview.py
@@ -49,7 +49,7 @@ class StaffViewTest(UniqueCourseTest):
         """
         self.courseware_page.visit()
         staff_page = StaffCoursewarePage(self.browser, self.course_id)
-        self.assertEqual(staff_page.staff_view_mode, 'Staff')
+        assert staff_page.staff_view_mode == 'Staff'
         return staff_page
 
 

--- a/common/test/acceptance/tests/lms/test_programs.py
+++ b/common/test/acceptance/tests/lms/test_programs.py
@@ -99,8 +99,8 @@ class ProgramListingPageA11yTest(ProgramPageBase):
 
         self.listing_page.visit()
 
-        self.assertTrue(self.listing_page.is_sidebar_present)
-        self.assertFalse(self.listing_page.are_cards_present)
+        assert self.listing_page.is_sidebar_present
+        assert not self.listing_page.are_cards_present
         self.listing_page.a11y_audit.check_for_accessibility_errors()
 
     def test_cards_a11y(self):
@@ -118,8 +118,8 @@ class ProgramListingPageA11yTest(ProgramPageBase):
 
         self.listing_page.visit()
 
-        self.assertTrue(self.listing_page.is_sidebar_present)
-        self.assertTrue(self.listing_page.are_cards_present)
+        assert self.listing_page.is_sidebar_present
+        assert self.listing_page.are_cards_present
         self.listing_page.a11y_audit.check_for_accessibility_errors()
 
 

--- a/common/test/acceptance/tests/lms/test_progress_page.py
+++ b/common/test/acceptance/tests/lms/test_progress_page.py
@@ -148,16 +148,16 @@ class SubsectionGradingPolicyBase(ProgressPageBaseTest):
         Asserts that the given problem and section scores, and text,
         appear on the progress page.
         """
-        self.assertEqual(self._get_problem_scores(), problem_scores)
-        self.assertEqual(self._get_section_score(), section_score)
-        self.assertTrue(self.progress_page.text_on_page(text))  # lint-amnesty, pylint: disable=no-member
+        assert self._get_problem_scores() == problem_scores
+        assert self._get_section_score() == section_score
+        assert self.progress_page.text_on_page(text)  # lint-amnesty, pylint: disable=no-member
 
     def _check_tick_text(self, index, sr_text, label, label_hidden=True):
         """
         Check the label and sr text for a horizontal (X-axis) tick.
         """
-        self.assertEqual(sr_text, self.progress_page.x_tick_sr_text(index))
-        self.assertEqual([label, 'true' if label_hidden else None], self.progress_page.x_tick_label(index))
+        assert sr_text == self.progress_page.x_tick_sr_text(index)
+        assert [label, ('true' if label_hidden else None)] == self.progress_page.x_tick_label(index)
 
 
 class SubsectionGradingPolicyA11yTest(SubsectionGradingPolicyBase):
@@ -190,9 +190,9 @@ class SubsectionGradingPolicyA11yTest(SubsectionGradingPolicyBase):
             self.progress_page.a11y_audit.check_for_accessibility_errors()
 
             # Verify that y-Axis labels are aria-hidden
-            self.assertEqual(['100%', 'true'], self.progress_page.y_tick_label(0))
-            self.assertEqual(['0%', 'true'], self.progress_page.y_tick_label(1))
-            self.assertEqual(['Pass 50%', 'true'], self.progress_page.y_tick_label(2))
+            assert ['100%', 'true'] == self.progress_page.y_tick_label(0)
+            assert ['0%', 'true'] == self.progress_page.y_tick_label(1)
+            assert ['Pass 50%', 'true'] == self.progress_page.y_tick_label(2)
             # Verify x-Axis labels and sr-text
             self._check_tick_text(0, [u'Homework 1 - Test Subsection 1 - 50% (1/2)'], u'HW 01')
 
@@ -253,7 +253,7 @@ class SubsectionGradingPolicyA11yTest(SubsectionGradingPolicyBase):
 
             # Verify the overall score. The first element in the array is the sr-only text, and the
             # second is the total text (including the sr-only text).
-            self.assertEqual(['Overall Score', 'Overall Score\n2%'], self.progress_page.graph_overall_score())
+            assert ['Overall Score', 'Overall Score\n2%'] == self.progress_page.graph_overall_score()
 
 
 class ProgressPageA11yTest(ProgressPageBaseTest):

--- a/common/test/utils.py
+++ b/common/test/utils.py
@@ -92,15 +92,15 @@ class MockSignalHandlerMixin(object):
             mock_handler = Mock(spec=handler)
             mock_signal.connect(mock_handler)
             yield
-            self.assertTrue(mock_handler.called)
+            assert mock_handler.called
             mock_args, mock_kwargs = mock_handler.call_args
             if 'exclude_args' in kwargs:
                 for key in kwargs['exclude_args']:
-                    self.assertIn(key, mock_kwargs)
+                    assert key in mock_kwargs
                     del mock_kwargs[key]
                 del kwargs['exclude_args']
-            self.assertEqual(mock_args, args)
-            self.assertEqual(mock_kwargs, dict(kwargs, signal=mock_signal))
+            assert mock_args == args
+            assert mock_kwargs == dict(kwargs, signal=mock_signal)
 
 
 @contextmanager


### PR DESCRIPTION
## Description
This PR is using `codemod-unittest-to-pytest-asserts` to automatically replace `unittest` assertions with `pytest` 
for following modules:
```
common/test/
```
Relevant JIRA issue here: https://openedx.atlassian.net/browse/BOM-2384