### PR TITLE
replaced unittest assertions pytest assertions (15)

### DIFF
--- a/lms/djangoapps/certificates/apis/v0/tests/test_views.py
+++ b/lms/djangoapps/certificates/apis/v0/tests/test_views.py
@@ -79,19 +79,15 @@ class CertificatesDetailRestApiTest(AuthAndScopesTestMixin, SharedModuleStoreTes
 
     def assert_success_response_for_student(self, response):
         """ This method is required by AuthAndScopesTestMixin. """
-        self.assertEqual(
-            response.data,
-            {
-                'username': self.student.username,
+        assert response.data ==\
+               {'username': self.student.username,
                 'status': CertificateStatuses.downloadable,
                 'is_passing': True,
                 'grade': '0.88',
                 'download_url': 'www.google.com',
                 'certificate_type': CourseMode.VERIFIED,
                 'course_id': six.text_type(self.course.id),
-                'created_date': self.now,
-            }
-        )
+                'created_date': self.now}
 
     def test_no_certificate(self):
         student_no_cert = UserFactory.create(password=self.user_password)
@@ -100,12 +96,9 @@ class CertificatesDetailRestApiTest(AuthAndScopesTestMixin, SharedModuleStoreTes
             requesting_user=student_no_cert,
             requested_user=student_no_cert,
         )
-        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
-        self.assertIn('error_code', resp.data)
-        self.assertEqual(
-            resp.data['error_code'],
-            'no_certificate_for_user',
-        )
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+        assert 'error_code' in resp.data
+        assert resp.data['error_code'] == 'no_certificate_for_user'
 
     def test_no_certificate_configuration(self):
         """
@@ -119,12 +112,9 @@ class CertificatesDetailRestApiTest(AuthAndScopesTestMixin, SharedModuleStoreTes
             requesting_user=self.student,
             requested_user=self.student,
         )
-        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
-        self.assertIn('error_code', resp.data)
-        self.assertEqual(
-            resp.data['error_code'],
-            'no_certificate_configuration_for_course',
-        )
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+        assert 'error_code' in resp.data
+        assert resp.data['error_code'] == 'no_certificate_configuration_for_course'
 
 
 @ddt.ddt
@@ -182,22 +172,17 @@ class CertificatesListRestApiTest(AuthAndScopesTestMixin, SharedModuleStoreTestC
 
     def assert_success_response_for_student(self, response, download_url='www.google.com'):
         """ This method is required by AuthAndScopesTestMixin. """
-        self.assertEqual(
-            response.data,
-            [{
-                'username': self.student.username,
-                'course_id': six.text_type(self.course.id),
-                'course_display_name': self.course.display_name,
-                'course_organization': self.course.org,
-                'certificate_type': CourseMode.VERIFIED,
-                'created_date': self.now,
-                'modified_date': self.now,
-                'status': CertificateStatuses.downloadable,
-                'is_passing': True,
-                'download_url': download_url,
-                'grade': '0.88',
-            }]
-        )
+        assert response.data ==\
+               [{'username': self.student.username,
+                 'course_id': six.text_type(self.course.id),
+                 'course_display_name': self.course.display_name,
+                 'course_organization': self.course.org,
+                 'certificate_type': CourseMode.VERIFIED,
+                 'created_date': self.now,
+                 'modified_date': self.now,
+                 'status': CertificateStatuses.downloadable,
+                 'is_passing': True,
+                 'download_url': download_url, 'grade': '0.88'}]
 
     @patch('edx_rest_framework_extensions.permissions.log')
     @ddt.data(*list(AuthType))
@@ -206,7 +191,7 @@ class CertificatesListRestApiTest(AuthAndScopesTestMixin, SharedModuleStoreTestC
         Returns 403 response for non-staff user on all auth types.
         """
         resp = self.get_response(auth_type, requesting_user=self.other_student)
-        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+        assert resp.status_code == status.HTTP_403_FORBIDDEN
 
     @ddt.data(*list(AuthType))
     def test_another_user_with_certs_shared_public(self, auth_type):
@@ -224,8 +209,8 @@ class CertificatesListRestApiTest(AuthAndScopesTestMixin, SharedModuleStoreTestC
 
         resp = self.get_response(auth_type, requesting_user=self.global_staff)
 
-        self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(resp.data), 1)
+        assert resp.status_code == status.HTTP_200_OK
+        assert len(resp.data) == 1
 
     def test_owner_can_access_its_certs(self):
         """
@@ -240,11 +225,11 @@ class CertificatesListRestApiTest(AuthAndScopesTestMixin, SharedModuleStoreTestC
         ).save()
 
         resp = self.get_response(AuthType.session, requesting_user=self.student)
-        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        assert resp.status_code == status.HTTP_200_OK
 
         # verifies that other than owner cert list api is not accessible
         resp = self.get_response(AuthType.session, requesting_user=self.other_student)
-        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+        assert resp.status_code == status.HTTP_403_FORBIDDEN
 
     def test_public_profile_certs_is_accessible(self):
         """
@@ -259,13 +244,13 @@ class CertificatesListRestApiTest(AuthAndScopesTestMixin, SharedModuleStoreTestC
         ).save()
 
         resp = self.get_response(AuthType.session, requesting_user=self.student)
-        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        assert resp.status_code == status.HTTP_200_OK
 
         resp = self.get_response(AuthType.session, requesting_user=self.other_student)
-        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        assert resp.status_code == status.HTTP_200_OK
 
         resp = self.get_response(AuthType.session, requesting_user=self.global_staff)
-        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        assert resp.status_code == status.HTTP_200_OK
 
     @ddt.data(*list(AuthType))
     def test_another_user_with_certs_shared_custom(self, auth_type):
@@ -288,8 +273,8 @@ class CertificatesListRestApiTest(AuthAndScopesTestMixin, SharedModuleStoreTestC
 
         resp = self.get_response(auth_type, requesting_user=self.global_staff)
 
-        self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(resp.data), 1)
+        assert resp.status_code == status.HTTP_200_OK
+        assert len(resp.data) == 1
 
     @patch('edx_rest_framework_extensions.permissions.log')
     @ddt.data(*JWT_AUTH_TYPES)
@@ -299,16 +284,16 @@ class CertificatesListRestApiTest(AuthAndScopesTestMixin, SharedModuleStoreTestC
         resp = self.get_response(AuthType.jwt, token=jwt_token)
 
         if auth_type == AuthType.jwt_restricted:
-            self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+            assert resp.status_code == status.HTTP_403_FORBIDDEN
             self._assert_in_log("JwtHasUserFilterForRequestedUser", mock_log.warning)
         else:
-            self.assertEqual(resp.status_code, status.HTTP_200_OK)
-            self.assertEqual(len(resp.data), 1)
+            assert resp.status_code == status.HTTP_200_OK
+            assert len(resp.data) == 1
 
     @patch('edx_rest_framework_extensions.permissions.log')
     @ddt.data(*JWT_AUTH_TYPES)
     def test_jwt_no_filter(self, auth_type, mock_log):
-        self.assertTrue(True)  # pylint: disable=redundant-unittest-assert
+        assert True  # pylint: disable=redundant-unittest-assert
 
     def test_no_certificate(self):
         student_no_cert = UserFactory.create(password=self.user_password)
@@ -317,8 +302,8 @@ class CertificatesListRestApiTest(AuthAndScopesTestMixin, SharedModuleStoreTestC
             requesting_user=self.global_staff,
             requested_user=student_no_cert,
         )
-        self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        self.assertEqual(resp.data, [])
+        assert resp.status_code == status.HTTP_200_OK
+        assert resp.data == []
 
     def test_query_counts(self):
         # Test student with no certificates
@@ -329,8 +314,8 @@ class CertificatesListRestApiTest(AuthAndScopesTestMixin, SharedModuleStoreTestC
                 requesting_user=self.global_staff,
                 requested_user=student_no_cert,
             )
-            self.assertEqual(resp.status_code, status.HTTP_200_OK)
-            self.assertEqual(len(resp.data), 0)
+            assert resp.status_code == status.HTTP_200_OK
+            assert len(resp.data) == 0
 
         # Test student with 1 certificate
         with self.assertNumQueries(10):
@@ -339,8 +324,8 @@ class CertificatesListRestApiTest(AuthAndScopesTestMixin, SharedModuleStoreTestC
                 requesting_user=self.global_staff,
                 requested_user=self.student,
             )
-            self.assertEqual(resp.status_code, status.HTTP_200_OK)
-            self.assertEqual(len(resp.data), 1)
+            assert resp.status_code == status.HTTP_200_OK
+            assert len(resp.data) == 1
 
         # Test student with 2 certificates
         student_2_certs = UserFactory.create(password=self.user_password)
@@ -379,8 +364,8 @@ class CertificatesListRestApiTest(AuthAndScopesTestMixin, SharedModuleStoreTestC
                 requesting_user=self.global_staff,
                 requested_user=student_2_certs,
             )
-            self.assertEqual(resp.status_code, status.HTTP_200_OK)
-            self.assertEqual(len(resp.data), 2)
+            assert resp.status_code == status.HTTP_200_OK
+            assert len(resp.data) == 2
 
     @patch.dict(settings.FEATURES, {'CERTIFICATES_HTML_VIEW': True})
     def test_with_no_certificate_configuration(self):
@@ -396,8 +381,8 @@ class CertificatesListRestApiTest(AuthAndScopesTestMixin, SharedModuleStoreTestC
             requesting_user=self.global_staff,
             requested_user=self.student,
         )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data, [])
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == []
 
         self.course_overview.has_any_active_web_certificate = True
         self.course_overview.save()
@@ -433,6 +418,6 @@ class CertificatesListRestApiTest(AuthAndScopesTestMixin, SharedModuleStoreTestC
             requesting_user=self.global_staff,
             requested_user=self.student,
         )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK
         self.assertContains(response, cert_for_deleted_course.download_url)
         self.assertContains(response, expected_course_name)

--- a/lms/djangoapps/certificates/tests/test_api.py
+++ b/lms/djangoapps/certificates/tests/test_api.py
@@ -125,16 +125,12 @@ class CertificateDownloadableStatusTests(WebCertificateTestMixin, ModuleStoreTes
             status=CertificateStatuses.generating,
             mode='verified'
         )
-        self.assertEqual(
-            certificate_downloadable_status(self.student, self.course.id),
-            {
-                'is_downloadable': False,
+        assert certificate_downloadable_status(self.student, self.course.id) ==\
+               {'is_downloadable': False,
                 'is_generating': True,
                 'is_unverified': False,
                 'download_url': None,
-                'uuid': None,
-            }
-        )
+                'uuid': None}
 
     def test_cert_status_with_error(self):
         GeneratedCertificateFactory.create(
@@ -144,28 +140,20 @@ class CertificateDownloadableStatusTests(WebCertificateTestMixin, ModuleStoreTes
             mode='verified'
         )
 
-        self.assertEqual(
-            certificate_downloadable_status(self.student, self.course.id),
-            {
-                'is_downloadable': False,
+        assert certificate_downloadable_status(self.student, self.course.id) ==\
+               {'is_downloadable': False,
                 'is_generating': True,
                 'is_unverified': False,
                 'download_url': None,
-                'uuid': None
-            }
-        )
+                'uuid': None}
 
     def test_without_cert(self):
-        self.assertEqual(
-            certificate_downloadable_status(self.student_no_cert, self.course.id),
-            {
-                'is_downloadable': False,
+        assert certificate_downloadable_status(self.student_no_cert, self.course.id) ==\
+               {'is_downloadable': False,
                 'is_generating': False,
                 'is_unverified': False,
                 'download_url': None,
-                'uuid': None,
-            }
-        )
+                'uuid': None}
 
     def verify_downloadable_pdf_cert(self):
         """
@@ -180,17 +168,13 @@ class CertificateDownloadableStatusTests(WebCertificateTestMixin, ModuleStoreTes
             download_url='www.google.com',
         )
 
-        self.assertEqual(
-            certificate_downloadable_status(self.student, self.course.id),
-            {
-                'is_downloadable': True,
+        assert certificate_downloadable_status(self.student, self.course.id) ==\
+               {'is_downloadable': True,
                 'is_generating': False,
                 'is_unverified': False,
                 'download_url': 'www.google.com',
                 'is_pdf_certificate': True,
-                'uuid': cert.verify_uuid
-            }
-        )
+                'uuid': cert.verify_uuid}
 
     @patch.dict(settings.FEATURES, {'CERTIFICATES_HTML_VIEW': True})
     def test_pdf_cert_with_html_enabled(self):
@@ -207,17 +191,13 @@ class CertificateDownloadableStatusTests(WebCertificateTestMixin, ModuleStoreTes
             generate_user_certificates(self.student, self.course.id)
 
         cert_status = certificate_status_for_student(self.student, self.course.id)
-        self.assertEqual(
-            certificate_downloadable_status(self.student, self.course.id),
-            {
-                'is_downloadable': True,
+        assert certificate_downloadable_status(self.student, self.course.id) ==\
+               {'is_downloadable': True,
                 'is_generating': False,
                 'is_unverified': False,
-                'download_url': '/certificates/{uuid}'.format(uuid=cert_status['uuid']),
+                'download_url': f'/certificates/{cert_status["uuid"]}',
                 'is_pdf_certificate': False,
-                'uuid': cert_status['uuid']
-            }
-        )
+                'uuid': cert_status['uuid']}
 
     @ddt.data(
         (False, timedelta(days=2), False, True),
@@ -241,8 +221,8 @@ class CertificateDownloadableStatusTests(WebCertificateTestMixin, ModuleStoreTes
             generate_user_certificates(self.student, self.course.id)
 
         downloadable_status = certificate_downloadable_status(self.student, self.course.id)
-        self.assertEqual(downloadable_status['is_downloadable'], cert_downloadable_status)
-        self.assertEqual(downloadable_status.get('earned_but_not_available'), earned_but_not_available)
+        assert downloadable_status['is_downloadable'] == cert_downloadable_status
+        assert downloadable_status.get('earned_but_not_available') == earned_but_not_available
 
 
 @ddt.ddt
@@ -270,9 +250,7 @@ class CertificateIsInvalid(WebCertificateTestMixin, ModuleStoreTestCase):
         )
         # Also check query count for 'is_certificate_invalid' method.
         with self.assertNumQueries(1):
-            self.assertFalse(
-                is_certificate_invalid(self.student, course.id)
-            )
+            assert not is_certificate_invalid(self.student, course.id)
 
     @ddt.data(
         CertificateStatuses.generating,
@@ -288,9 +266,7 @@ class CertificateIsInvalid(WebCertificateTestMixin, ModuleStoreTestCase):
         True. """
         generated_cert = self._generate_cert(status)
         self._invalidate_certificate(generated_cert, True)
-        self.assertTrue(
-            is_certificate_invalid(self.student, self.course.id)
-        )
+        assert is_certificate_invalid(self.student, self.course.id)
 
     @ddt.data(
         CertificateStatuses.generating,
@@ -306,9 +282,7 @@ class CertificateIsInvalid(WebCertificateTestMixin, ModuleStoreTestCase):
         false than method will return false. """
         generated_cert = self._generate_cert(status)
         self._invalidate_certificate(generated_cert, False)
-        self.assertFalse(
-            is_certificate_invalid(self.student, self.course.id)
-        )
+        assert not is_certificate_invalid(self.student, self.course.id)
 
     @ddt.data(
         CertificateStatuses.generating,
@@ -331,9 +305,7 @@ class CertificateIsInvalid(WebCertificateTestMixin, ModuleStoreTestCase):
         )
         # Also check query count for 'is_certificate_invalid' method.
         with self.assertNumQueries(2):
-            self.assertTrue(
-                is_certificate_invalid(self.student, self.course.id)
-            )
+            assert is_certificate_invalid(self.student, self.course.id)
 
     def _invalidate_certificate(self, certificate, active):
         """ Dry method to mark certificate as invalid. """
@@ -344,7 +316,7 @@ class CertificateIsInvalid(WebCertificateTestMixin, ModuleStoreTestCase):
         )
         # Invalidate user certificate
         certificate.invalidate()
-        self.assertFalse(certificate.is_valid())
+        assert not certificate.is_valid()
 
     def _generate_cert(self, status):
         """ Dry method to generate certificate. """
@@ -425,37 +397,37 @@ class CertificateGetTests(SharedModuleStoreTestCase):
         """
         cert = get_certificate_for_user(self.student.username, self.web_cert_course.id)
 
-        self.assertEqual(cert['username'], self.student.username)
-        self.assertEqual(cert['course_key'], self.web_cert_course.id)
-        self.assertEqual(cert['created'], self.now)
-        self.assertEqual(cert['type'], CourseMode.VERIFIED)
-        self.assertEqual(cert['status'], CertificateStatuses.downloadable)
-        self.assertEqual(cert['grade'], "0.88")
-        self.assertEqual(cert['is_passing'], True)
-        self.assertEqual(cert['download_url'], 'www.google.com')
+        assert cert['username'] == self.student.username
+        assert cert['course_key'] == self.web_cert_course.id
+        assert cert['created'] == self.now
+        assert cert['type'] == CourseMode.VERIFIED
+        assert cert['status'] == CertificateStatuses.downloadable
+        assert cert['grade'] == '0.88'
+        assert cert['is_passing'] is True
+        assert cert['download_url'] == 'www.google.com'
 
     def test_get_certificates_for_user(self):
         """
         Test to get all the certificates for a user
         """
         certs = get_certificates_for_user(self.student.username)
-        self.assertEqual(len(certs), 2)
-        self.assertEqual(certs[0]['username'], self.student.username)
-        self.assertEqual(certs[1]['username'], self.student.username)
-        self.assertEqual(certs[0]['course_key'], self.web_cert_course.id)
-        self.assertEqual(certs[1]['course_key'], self.pdf_cert_course.id)
-        self.assertEqual(certs[0]['created'], self.now)
-        self.assertEqual(certs[1]['created'], self.now)
-        self.assertEqual(certs[0]['type'], CourseMode.VERIFIED)
-        self.assertEqual(certs[1]['type'], CourseMode.HONOR)
-        self.assertEqual(certs[0]['status'], CertificateStatuses.downloadable)
-        self.assertEqual(certs[1]['status'], CertificateStatuses.downloadable)
-        self.assertEqual(certs[0]['is_passing'], True)
-        self.assertEqual(certs[1]['is_passing'], True)
-        self.assertEqual(certs[0]['grade'], '0.88')
-        self.assertEqual(certs[1]['grade'], '0.99')
-        self.assertEqual(certs[0]['download_url'], 'www.google.com')
-        self.assertEqual(certs[1]['download_url'], 'www.gmail.com')
+        assert len(certs) == 2
+        assert certs[0]['username'] == self.student.username
+        assert certs[1]['username'] == self.student.username
+        assert certs[0]['course_key'] == self.web_cert_course.id
+        assert certs[1]['course_key'] == self.pdf_cert_course.id
+        assert certs[0]['created'] == self.now
+        assert certs[1]['created'] == self.now
+        assert certs[0]['type'] == CourseMode.VERIFIED
+        assert certs[1]['type'] == CourseMode.HONOR
+        assert certs[0]['status'] == CertificateStatuses.downloadable
+        assert certs[1]['status'] == CertificateStatuses.downloadable
+        assert certs[0]['is_passing'] is True
+        assert certs[1]['is_passing'] is True
+        assert certs[0]['grade'] == '0.88'
+        assert certs[1]['grade'] == '0.99'
+        assert certs[0]['download_url'] == 'www.google.com'
+        assert certs[1]['download_url'] == 'www.gmail.com'
 
     def test_get_certificates_for_user_by_course_keys(self):
         """
@@ -468,26 +440,21 @@ class CertificateGetTests(SharedModuleStoreTestCase):
         )
         assert set(certs.keys()) == {self.web_cert_course.id}
         cert = certs[self.web_cert_course.id]
-        self.assertEqual(cert['username'], self.student.username)
-        self.assertEqual(cert['course_key'], self.web_cert_course.id)
-        self.assertEqual(cert['download_url'], 'www.google.com')
+        assert cert['username'] == self.student.username
+        assert cert['course_key'] == self.web_cert_course.id
+        assert cert['download_url'] == 'www.google.com'
 
     def test_no_certificate_for_user(self):
         """
         Test the case when there is no certificate for a user for a specific course.
         """
-        self.assertIsNone(
-            get_certificate_for_user(self.student_no_cert.username, self.web_cert_course.id)
-        )
+        assert get_certificate_for_user(self.student_no_cert.username, self.web_cert_course.id) is None
 
     def test_no_certificates_for_user(self):
         """
         Test the case when there are no certificates for a user.
         """
-        self.assertEqual(
-            get_certificates_for_user(self.student_no_cert.username),
-            []
-        )
+        assert get_certificates_for_user(self.student_no_cert.username) == []
 
     @patch.dict(settings.FEATURES, {'CERTIFICATES_HTML_VIEW': True})
     def test_get_web_certificate_url(self):
@@ -503,7 +470,7 @@ class CertificateGetTests(SharedModuleStoreTestCase):
             course_id=self.web_cert_course.id,
             uuid=self.uuid
         )
-        self.assertEqual(expected_url, cert_url)
+        assert expected_url == cert_url
 
         expected_url = reverse(
             'certificates:render_cert_by_uuid',
@@ -515,7 +482,7 @@ class CertificateGetTests(SharedModuleStoreTestCase):
             course_id=self.web_cert_course.id,
             uuid=self.uuid
         )
-        self.assertEqual(expected_url, cert_url)
+        assert expected_url == cert_url
 
     @patch.dict(settings.FEATURES, {'CERTIFICATES_HTML_VIEW': True})
     def test_get_pdf_certificate_url(self):
@@ -527,18 +494,13 @@ class CertificateGetTests(SharedModuleStoreTestCase):
             course_id=self.pdf_cert_course.id,
             uuid=self.uuid
         )
-        self.assertEqual('www.gmail.com', cert_url)
+        assert 'www.gmail.com' == cert_url
 
     def test_get_certificate_with_deleted_course(self):
         """
         Test the case when there is a certificate but the course was deleted.
         """
-        self.assertIsNone(
-            get_certificate_for_user(
-                self.student.username,
-                self.nonexistent_course_id
-            )
-        )
+        assert get_certificate_for_user(self.student.username, self.nonexistent_course_id) is None
 
 
 @override_settings(CERT_QUEUE='certificates')
@@ -573,7 +535,7 @@ class GenerateUserCertificatesTest(EventTestMixin, WebCertificateTestMixin, Modu
 
         # Verify that the certificate has status 'generating'
         cert = GeneratedCertificate.eligible_certificates.get(user=self.student, course_id=self.course.id)
-        self.assertEqual(cert.status, CertificateStatuses.generating)
+        assert cert.status == CertificateStatuses.generating
         self.assert_event_emitted(
             'edx.certificate.created',
             user_id=self.student.id,
@@ -591,8 +553,8 @@ class GenerateUserCertificatesTest(EventTestMixin, WebCertificateTestMixin, Modu
 
         # Verify that the certificate has been marked with status error
         cert = GeneratedCertificate.eligible_certificates.get(user=self.student, course_id=self.course.id)
-        self.assertEqual(cert.status, 'error')
-        self.assertIn(self.ERROR_REASON, cert.error_reason)
+        assert cert.status == 'error'
+        assert self.ERROR_REASON in cert.error_reason
 
     def test_generate_user_certificates_with_unverified_cert_status(self):
         """
@@ -612,7 +574,7 @@ class GenerateUserCertificatesTest(EventTestMixin, WebCertificateTestMixin, Modu
         with mock_passing_grade():
             with self._mock_queue():
                 status = generate_user_certificates(self.student, self.course.id)
-                self.assertEqual(status, 'generating')
+                assert status == 'generating'
 
     @patch.dict(settings.FEATURES, {'CERTIFICATES_HTML_VIEW': True})
     def test_new_cert_requests_returns_generating_for_html_certificate(self):
@@ -625,7 +587,7 @@ class GenerateUserCertificatesTest(EventTestMixin, WebCertificateTestMixin, Modu
 
         # Verify that the certificate has status 'downloadable'
         cert = GeneratedCertificate.eligible_certificates.get(user=self.student, course_id=self.course.id)
-        self.assertEqual(cert.status, CertificateStatuses.downloadable)
+        assert cert.status == CertificateStatuses.downloadable
 
     @patch.dict(settings.FEATURES, {'CERTIFICATES_HTML_VIEW': False})
     def test_cert_url_empty_with_invalid_certificate(self):
@@ -633,7 +595,7 @@ class GenerateUserCertificatesTest(EventTestMixin, WebCertificateTestMixin, Modu
         Test certificate url is empty if html view is not enabled and certificate is not yet generated
         """
         url = get_certificate_url(self.student.id, self.course.id)
-        self.assertEqual(url, "")
+        assert url == ''
 
 
 @ddt.ddt
@@ -700,7 +662,7 @@ class CertificateGenerationEnabledTest(EventTestMixin, TestCase):
     def _assert_enabled_for_course(self, course_key, expect_enabled):
         """Check that self-generated certificates are enabled or disabled for the course. """
         actual_enabled = cert_generation_enabled(course_key)
-        self.assertEqual(expect_enabled, actual_enabled)
+        assert expect_enabled == actual_enabled
 
 
 class GenerateExampleCertificatesTest(ModuleStoreTestCase):
@@ -756,14 +718,14 @@ class GenerateExampleCertificatesTest(ModuleStoreTestCase):
     def _assert_certs_in_queue(self, mock_queue, expected_num):
         """Check that the certificate generation task was added to the queue. """
         certs_in_queue = [call_args[0] for (call_args, __) in mock_queue.call_args_list]
-        self.assertEqual(len(certs_in_queue), expected_num)
+        assert len(certs_in_queue) == expected_num
         for cert in certs_in_queue:
-            self.assertTrue(isinstance(cert, ExampleCertificate))
+            assert isinstance(cert, ExampleCertificate)
 
     def _assert_cert_status(self, *expected_statuses):
         """Check the example certificate status. """
         actual_status = example_certificates_status(self.COURSE_KEY)
-        self.assertEqual(list(expected_statuses), actual_status)
+        assert list(expected_statuses) == actual_status
 
 
 @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
@@ -797,15 +759,9 @@ class CertificatesBrandingTest(ModuleStoreTestCase):
             list(data.keys()),
             ['logo_src', 'logo_url']
         )
-        self.assertIn(
-            self.configuration['logo_image_url'],
-            data['logo_src']
-        )
+        assert self.configuration['logo_image_url'] in data['logo_src']
 
-        self.assertIn(
-            self.configuration['SITE_NAME'],
-            data['logo_url']
-        )
+        assert self.configuration['SITE_NAME'] in data['logo_url']
 
     @with_site_configuration(configuration=configuration)
     def test_certificate_footer_data(self):
@@ -823,15 +779,6 @@ class CertificatesBrandingTest(ModuleStoreTestCase):
             list(data.keys()),
             ['company_about_url', 'company_privacy_url', 'company_tos_url']
         )
-        self.assertIn(
-            self.configuration['urls']['ABOUT'],
-            data['company_about_url']
-        )
-        self.assertIn(
-            self.configuration['urls']['PRIVACY'],
-            data['company_privacy_url']
-        )
-        self.assertIn(
-            self.configuration['urls']['TOS_AND_HONOR'],
-            data['company_tos_url']
-        )
+        assert self.configuration['urls']['ABOUT'] in data['company_about_url']
+        assert self.configuration['urls']['PRIVACY'] in data['company_privacy_url']
+        assert self.configuration['urls']['TOS_AND_HONOR'] in data['company_tos_url']

--- a/lms/djangoapps/certificates/tests/test_cert_management.py
+++ b/lms/djangoapps/certificates/tests/test_cert_management.py
@@ -60,7 +60,7 @@ class CertificateManagementTest(ModuleStoreTestCase):
     def _assert_cert_status(self, course_key, user, expected_status):
         """Check the status of a certificate. """
         cert = GeneratedCertificate.eligible_certificates.get(user=user, course_id=course_key)
-        self.assertEqual(cert.status, expected_status)
+        assert cert.status == expected_status
 
 
 @ddt.ddt
@@ -179,7 +179,7 @@ class RegenerateCertificatesTest(CertificateManagementTest):
         self._create_cert(key, self.user, CertificateStatuses.downloadable)
         badge_class = get_completion_badge(key, self.user)
         BadgeAssertionFactory(badge_class=badge_class, user=self.user)
-        self.assertTrue(BadgeAssertion.objects.filter(user=self.user, badge_class=badge_class))
+        assert BadgeAssertion.objects.filter(user=self.user, badge_class=badge_class)
         self.course.issue_badges = issue_badges
         self.store.update_item(self.course, None)
 
@@ -194,9 +194,7 @@ class RegenerateCertificatesTest(CertificateManagementTest):
             template_file=None,
             generate_pdf=True
         )
-        self.assertEqual(
-            bool(BadgeAssertion.objects.filter(user=self.user, badge_class=badge_class)), not issue_badges
-        )
+        assert bool(BadgeAssertion.objects.filter(user=self.user, badge_class=badge_class)) == (not issue_badges)
 
     @override_settings(CERT_QUEUE='test-queue')
     @patch('capa.xqueue_interface.XQueueInterface.send_to_queue', spec=True)
@@ -216,8 +214,8 @@ class RegenerateCertificatesTest(CertificateManagementTest):
             user=self.user,
             course_id=key
         )
-        self.assertEqual(certificate.status, CertificateStatuses.notpassing)
-        self.assertFalse(mock_send_to_queue.called)
+        assert certificate.status == CertificateStatuses.notpassing
+        assert not mock_send_to_queue.called
 
 
 class UngenerateCertificatesTest(CertificateManagementTest):
@@ -249,9 +247,9 @@ class UngenerateCertificatesTest(CertificateManagementTest):
             args = u'-c {} --insecure'.format(text_type(key))
             call_command(self.command, *args.split(' '))
 
-        self.assertTrue(mock_send_to_queue.called)
+        assert mock_send_to_queue.called
         certificate = GeneratedCertificate.eligible_certificates.get(
             user=self.user,
             course_id=key
         )
-        self.assertEqual(certificate.status, CertificateStatuses.generating)
+        assert certificate.status == CertificateStatuses.generating

--- a/lms/djangoapps/certificates/tests/test_create_fake_cert.py
+++ b/lms/djangoapps/certificates/tests/test_create_fake_cert.py
@@ -30,11 +30,11 @@ class CreateFakeCertTest(TestCase):
             grade='0.89'
         )
         cert = GeneratedCertificate.eligible_certificates.get(user=self.user, course_id=self.COURSE_KEY)
-        self.assertEqual(cert.status, 'downloadable')
-        self.assertEqual(cert.mode, 'verified')
-        self.assertEqual(cert.grade, '0.89')
-        self.assertEqual(cert.download_uuid, 'test')
-        self.assertEqual(cert.download_url, 'http://www.example.com')
+        assert cert.status == 'downloadable'
+        assert cert.mode == 'verified'
+        assert cert.grade == '0.89'
+        assert cert.download_uuid == 'test'
+        assert cert.download_url == 'http://www.example.com'
 
         # Cert already exists; modify it
         self._run_command(
@@ -43,7 +43,7 @@ class CreateFakeCertTest(TestCase):
             cert_mode='honor'
         )
         cert = GeneratedCertificate.eligible_certificates.get(user=self.user, course_id=self.COURSE_KEY)
-        self.assertEqual(cert.mode, 'honor')
+        assert cert.mode == 'honor'
 
     def test_too_few_args(self):
         if six.PY2:

--- a/lms/djangoapps/certificates/tests/test_generation.py
+++ b/lms/djangoapps/certificates/tests/test_generation.py
@@ -46,13 +46,13 @@ class AllowlistTests(EventTestMixin, ModuleStoreTestCase):
         )
 
         certs = GeneratedCertificate.objects.filter(user=u, course_id=key)
-        self.assertEqual(len(certs), 0)
+        assert len(certs) == 0
 
         generated_cert = generate_allowlist_certificate(u, key)
-        self.assertTrue(generated_cert.status, CertificateStatuses.downloadable)
+        assert generated_cert.status, CertificateStatuses.downloadable
 
         certs = GeneratedCertificate.objects.filter(user=u, course_id=key)
-        self.assertEqual(len(certs), 1)
+        assert len(certs) == 1
 
         self.assert_event_emitted(
             'edx.certificate.created',

--- a/lms/djangoapps/certificates/tests/test_generation_handler.py
+++ b/lms/djangoapps/certificates/tests/test_generation_handler.py
@@ -68,27 +68,27 @@ class AllowlistTests(ModuleStoreTestCase):
         """
         Test the allowlist flag
         """
-        self.assertTrue(_is_using_certificate_allowlist(self.course_run_key))
+        assert _is_using_certificate_allowlist(self.course_run_key)
 
     @override_waffle_flag(CERTIFICATES_USE_ALLOWLIST, active=False)
     def test_is_using_allowlist_false(self):
         """
         Test the allowlist flag without the override
         """
-        self.assertFalse(_is_using_certificate_allowlist(self.course_run_key))
+        assert not _is_using_certificate_allowlist(self.course_run_key)
 
     def test_is_using_allowlist_and_is_on_list(self):
         """
         Test the allowlist flag and the presence of the user on the list
         """
-        self.assertTrue(is_using_certificate_allowlist_and_is_on_allowlist(self.user, self.course_run_key))
+        assert is_using_certificate_allowlist_and_is_on_allowlist(self.user, self.course_run_key)
 
     @override_waffle_flag(CERTIFICATES_USE_ALLOWLIST, active=False)
     def test_is_using_allowlist_and_is_on_list_with_flag_off(self):
         """
         Test the allowlist flag and the presence of the user on the list when the flag is off
         """
-        self.assertFalse(is_using_certificate_allowlist_and_is_on_allowlist(self.user, self.course_run_key))
+        assert not is_using_certificate_allowlist_and_is_on_allowlist(self.user, self.course_run_key)
 
     def test_is_using_allowlist_and_is_on_list_true(self):
         """
@@ -102,7 +102,7 @@ class AllowlistTests(ModuleStoreTestCase):
             mode="verified",
         )
         CertificateWhitelistFactory.create(course_id=self.course_run_key, user=u, whitelist=False)
-        self.assertFalse(is_using_certificate_allowlist_and_is_on_allowlist(u, self.course_run_key))
+        assert not is_using_certificate_allowlist_and_is_on_allowlist(u, self.course_run_key)
 
     @ddt.data(
         (CertificateStatuses.deleted, True),
@@ -134,42 +134,42 @@ class AllowlistTests(ModuleStoreTestCase):
             status=status,
         )
 
-        self.assertEqual(_can_generate_allowlist_certificate_for_status(cert), expected_response)
+        assert _can_generate_allowlist_certificate_for_status(cert) == expected_response
 
     def test_generation_status_for_none(self):
         """
         Test handling of certificate statuses for a non-existent cert
         """
-        self.assertEqual(_can_generate_allowlist_certificate_for_status(None), True)
+        assert _can_generate_allowlist_certificate_for_status(None) is True
 
     @override_waffle_flag(CERTIFICATES_USE_ALLOWLIST, active=False)
     def test_handle_invalid(self):
         """
         Test handling of an invalid user/course run combo
         """
-        self.assertFalse(can_generate_allowlist_certificate(self.user, self.course_run_key))
-        self.assertFalse(generate_allowlist_certificate_task(self.user, self.course_run_key))
+        assert not can_generate_allowlist_certificate(self.user, self.course_run_key)
+        assert not generate_allowlist_certificate_task(self.user, self.course_run_key)
 
     def test_handle_valid(self):
         """
         Test handling of a valid user/course run combo
         """
-        self.assertTrue(can_generate_allowlist_certificate(self.user, self.course_run_key))
-        self.assertTrue(generate_allowlist_certificate_task(self.user, self.course_run_key))
+        assert can_generate_allowlist_certificate(self.user, self.course_run_key)
+        assert generate_allowlist_certificate_task(self.user, self.course_run_key)
 
     def test_can_generate_auto_disabled(self):
         """
         Test handling when automatic generation is disabled
         """
         with override_waffle_switch(AUTO_GENERATION_SWITCH, active=False):
-            self.assertFalse(can_generate_allowlist_certificate(self.user, self.course_run_key))
+            assert not can_generate_allowlist_certificate(self.user, self.course_run_key)
 
     def test_can_generate_not_verified(self):
         """
         Test handling when the user's id is not verified
         """
         with mock.patch(ID_VERIFIED_METHOD, return_value=False):
-            self.assertFalse(can_generate_allowlist_certificate(self.user, self.course_run_key))
+            assert not can_generate_allowlist_certificate(self.user, self.course_run_key)
 
     def test_can_generate_not_enrolled(self):
         """
@@ -179,7 +179,7 @@ class AllowlistTests(ModuleStoreTestCase):
         cr = CourseFactory()
         key = cr.id  # pylint: disable=no-member
         CertificateWhitelistFactory.create(course_id=key, user=u)
-        self.assertFalse(can_generate_allowlist_certificate(u, key))
+        assert not can_generate_allowlist_certificate(u, key)
 
     def test_can_generate_not_whitelisted(self):
         """
@@ -194,7 +194,7 @@ class AllowlistTests(ModuleStoreTestCase):
             is_active=True,
             mode="verified",
         )
-        self.assertFalse(can_generate_allowlist_certificate(u, key))
+        assert not can_generate_allowlist_certificate(u, key)
 
     def test_can_generate_invalidated(self):
         """
@@ -222,4 +222,4 @@ class AllowlistTests(ModuleStoreTestCase):
             active=True
         )
 
-        self.assertFalse(can_generate_allowlist_certificate(u, key))
+        assert not can_generate_allowlist_certificate(u, key)

--- a/lms/djangoapps/certificates/tests/test_queue.py
+++ b/lms/djangoapps/certificates/tests/test_queue.py
@@ -66,10 +66,10 @@ class XQueueCertInterfaceAddCertificateTest(ModuleStoreTestCase):
                 self.xqueue.add_cert(self.user, self.course.id)
 
         # Verify that the task was sent to the queue with the correct callback URL
-        self.assertTrue(mock_send.called)
+        assert mock_send.called
         __, kwargs = mock_send.call_args_list[0]
         actual_header = json.loads(kwargs['header'])
-        self.assertIn('https://edx.org/update_certificate?key=', actual_header['lms_callback_url'])
+        assert 'https://edx.org/update_certificate?key=' in actual_header['lms_callback_url']
 
     def test_no_create_action_in_queue_for_html_view_certs(self):
         """
@@ -80,10 +80,10 @@ class XQueueCertInterfaceAddCertificateTest(ModuleStoreTestCase):
                 self.xqueue.add_cert(self.user, self.course.id, generate_pdf=False)
 
         # Verify that add_cert method does not add message to queue
-        self.assertFalse(mock_send.called)
+        assert not mock_send.called
         certificate = GeneratedCertificate.eligible_certificates.get(user=self.user, course_id=self.course.id)
-        self.assertEqual(certificate.status, CertificateStatuses.downloadable)
-        self.assertIsNotNone(certificate.verify_uuid)
+        assert certificate.status == CertificateStatuses.downloadable
+        assert certificate.verify_uuid is not None
 
     @ddt.data('honor', 'audit')
     @override_settings(AUDIT_CERT_CUTOFF_DATE=datetime.now(pytz.UTC) - timedelta(days=1))
@@ -136,9 +136,9 @@ class XQueueCertInterfaceAddCertificateTest(ModuleStoreTestCase):
                 self.xqueue.add_cert(self.user_2, self.course.id)
 
         certificate = GeneratedCertificate.certificate_for_student(self.user_2, self.course.id)
-        self.assertIsNotNone(certificate)
-        self.assertEqual(certificate.mode, 'audit')
-        self.assertEqual(certificate.status, status)
+        assert certificate is not None
+        assert certificate.mode == 'audit'
+        assert certificate.status == status
 
     def add_cert_to_queue(self, mode):
         """
@@ -165,17 +165,17 @@ class XQueueCertInterfaceAddCertificateTest(ModuleStoreTestCase):
         template type.
         """
         # Verify that the task was sent to the queue with the correct callback URL
-        self.assertTrue(mock_send.called)
+        assert mock_send.called
         __, kwargs = mock_send.call_args_list[0]
 
         actual_header = json.loads(kwargs['header'])
-        self.assertIn('https://edx.org/update_certificate?key=', actual_header['lms_callback_url'])
+        assert 'https://edx.org/update_certificate?key=' in actual_header['lms_callback_url']
 
         body = json.loads(kwargs['body'])
-        self.assertIn(expected_template_name, body['template_pdf'])
+        assert expected_template_name in body['template_pdf']
 
         certificate = GeneratedCertificate.eligible_certificates.get(user=self.user_2, course_id=self.course.id)
-        self.assertEqual(certificate.mode, expected_mode)
+        assert certificate.mode == expected_mode
 
     def assert_ineligible_certificate_generated(self, mock_send, expected_mode):
         """
@@ -183,15 +183,15 @@ class XQueueCertInterfaceAddCertificateTest(ModuleStoreTestCase):
         correct mode.
         """
         # Ensure the certificate was not generated
-        self.assertFalse(mock_send.called)
+        assert not mock_send.called
 
         certificate = GeneratedCertificate.objects.get(
             user=self.user_2,
             course_id=self.course.id
         )
 
-        self.assertIn(certificate.status, (CertificateStatuses.audit_passing, CertificateStatuses.audit_notpassing))
-        self.assertEqual(certificate.mode, expected_mode)
+        assert certificate.status in (CertificateStatuses.audit_passing, CertificateStatuses.audit_notpassing)
+        assert certificate.mode == expected_mode
 
     @ddt.data(
         (CertificateStatuses.restricted, False),
@@ -216,9 +216,9 @@ class XQueueCertInterfaceAddCertificateTest(ModuleStoreTestCase):
         ):
             mock_send = self.add_cert_to_queue('verified')
             if should_generate:
-                self.assertTrue(mock_send.called)
+                assert mock_send.called
             else:
-                self.assertFalse(mock_send.called)
+                assert not mock_send.called
 
     @ddt.data(
         # Eligible and should stay that way
@@ -287,10 +287,7 @@ class XQueueCertInterfaceAddCertificateTest(ModuleStoreTestCase):
                 mock_send.return_value = (0, None)
                 self.xqueue.add_cert(self.user_2, self.course.id)
 
-        self.assertEqual(
-            GeneratedCertificate.objects.get(user=self.user_2, course_id=self.course.id).status,
-            expected_status
-        )
+        assert GeneratedCertificate.objects.get(user=self.user_2, course_id=self.course.id).status == expected_status
 
     def test_regen_cert_with_pdf_certificate(self):
         """
@@ -390,7 +387,7 @@ class XQueueCertInterfaceExampleCertificateTest(TestCase):
         self._assert_queue_task(mock_send, cert)
 
         # Verify the certificate status
-        self.assertEqual(cert.status, ExampleCertificate.STATUS_STARTED)
+        assert cert.status == ExampleCertificate.STATUS_STARTED
 
     def test_add_example_cert_error(self):
         cert = self._create_example_cert()
@@ -398,8 +395,8 @@ class XQueueCertInterfaceExampleCertificateTest(TestCase):
             self.xqueue.add_example_cert(cert)
 
         # Verify the error status of the certificate
-        self.assertEqual(cert.status, ExampleCertificate.STATUS_ERROR)
-        self.assertIn(self.ERROR_MSG, cert.error_reason)
+        assert cert.status == ExampleCertificate.STATUS_ERROR
+        assert self.ERROR_MSG in cert.error_reason
 
     def _create_example_cert(self):
         """Create an example certificate. """
@@ -434,11 +431,11 @@ class XQueueCertInterfaceExampleCertificateTest(TestCase):
             'example_certificate': True
         }
 
-        self.assertTrue(mock_send.called)
+        assert mock_send.called
 
         __, kwargs = mock_send.call_args_list[0]
         actual_header = json.loads(kwargs['header'])
         actual_body = json.loads(kwargs['body'])
 
-        self.assertEqual(expected_header, actual_header)
-        self.assertEqual(expected_body, actual_body)
+        assert expected_header == actual_header
+        assert expected_body == actual_body

--- a/lms/djangoapps/certificates/tests/test_services.py
+++ b/lms/djangoapps/certificates/tests/test_services.py
@@ -50,7 +50,7 @@ class CertificateServiceTests(ModuleStoreTestCase):
         Verify that CertificateService invalidates the user certificate
         """
         success = self.service.invalidate_certificate(self.user_id, self.course_id)
-        self.assertTrue(success)
+        assert success
 
         invalid_generated_certificate = GeneratedCertificate.objects.get(
             user=self.user_id,
@@ -86,7 +86,7 @@ class CertificateServiceTests(ModuleStoreTestCase):
             course_id=course_key
         )
         success = self.service.invalidate_certificate(u.id, course_key)
-        self.assertFalse(success)
+        assert not success
 
         cert = GeneratedCertificate.objects.get(user=u.id, course_id=course_key)
-        self.assertEqual(cert.status, CertificateStatuses.downloadable)
+        assert cert.status == CertificateStatuses.downloadable

--- a/lms/djangoapps/certificates/tests/test_signals.py
+++ b/lms/djangoapps/certificates/tests/test_signals.py
@@ -49,15 +49,15 @@ class SelfGeneratedCertsSignalTest(ModuleStoreTestCase):
         according to course-pacing.
         """
         course = CourseFactory.create(self_paced=False, emit_signals=True)
-        self.assertFalse(cert_generation_enabled(course.id))
+        assert not cert_generation_enabled(course.id)
 
         course.self_paced = True
         self.store.update_item(course, self.user.id)
-        self.assertTrue(cert_generation_enabled(course.id))
+        assert cert_generation_enabled(course.id)
 
         course.self_paced = False
         self.store.update_item(course, self.user.id)
-        self.assertFalse(cert_generation_enabled(course.id))
+        assert not cert_generation_enabled(course.id)
 
 
 class WhitelistGeneratedCertificatesTest(ModuleStoreTestCase):
@@ -371,7 +371,7 @@ class FailingGradeCertsTest(ModuleStoreTestCase):
         )
         CourseGradeFactory().update(self.user, self.course)
         cert = GeneratedCertificate.certificate_for_student(self.user, self.course.id)
-        self.assertEqual(cert.status, expected_status)
+        assert cert.status == expected_status
 
     @override_waffle_flag(CERTIFICATES_USE_ALLOWLIST, active=True)
     def test_failing_grade_allowlist(self):
@@ -383,7 +383,7 @@ class FailingGradeCertsTest(ModuleStoreTestCase):
         )
         CourseGradeFactory().update(self.user, self.course)
         cert = GeneratedCertificate.certificate_for_student(self.user, self.course.id)
-        self.assertEqual(cert.status, CertificateStatuses.notpassing)
+        assert cert.status == CertificateStatuses.notpassing
 
         # User who is on the allowlist
         u = UserFactory.create()
@@ -400,7 +400,7 @@ class FailingGradeCertsTest(ModuleStoreTestCase):
         )
         CourseGradeFactory().update(u, c)
         cert = GeneratedCertificate.certificate_for_student(u, course_key)
-        self.assertEqual(cert.status, CertificateStatuses.downloadable)
+        assert cert.status == CertificateStatuses.downloadable
 
 
 class LearnerTrackChangeCertsTest(ModuleStoreTestCase):
@@ -554,4 +554,4 @@ class CertificateGenerationTaskTest(ModuleStoreTestCase):
             with override_waffle_switch(AUTO_CERTIFICATE_GENERATION_SWITCH, active=True):
                 _fire_ungenerated_certificate_task(self.user, self.course.id)
                 task_created = mock_generate_certificate_apply_async.called
-                self.assertEqual(task_created, should_create)
+                assert task_created == should_create

--- a/lms/djangoapps/certificates/tests/test_support_views.py
+++ b/lms/djangoapps/certificates/tests/test_support_views.py
@@ -91,7 +91,7 @@ class CertificateSupportTestCase(ModuleStoreTestCase):
 
         # Login as support staff
         success = self.client.login(username=self.SUPPORT_USERNAME, password=self.SUPPORT_PASSWORD)
-        self.assertTrue(success, msg="Couldn't log in as support staff")
+        assert success, "Couldn't log in as support staff"
 
 
 @ddt.ddt
@@ -144,7 +144,7 @@ class CertificateSearchTests(CertificateSupportTestCase):
         # Create a user and log in
         user = UserFactory(username="foo", password="foo")
         success = self.client.login(username="foo", password="foo")
-        self.assertTrue(success, msg="Could not log in")
+        assert success, 'Could not log in'
 
         # Assign the user to the role
         if role is not None:
@@ -156,7 +156,7 @@ class CertificateSearchTests(CertificateSupportTestCase):
         if has_access:
             self.assertContains(response, json.dumps([]))
         else:
-            self.assertEqual(response.status_code, 403)
+            assert response.status_code == 403
 
     @ddt.data(
         (CertificateSupportTestCase.STUDENT_USERNAME, True),
@@ -174,11 +174,11 @@ class CertificateSearchTests(CertificateSupportTestCase):
     def test_search(self, user_filter, expect_result, course_filter=None):
         response = self._search(user_filter, course_filter)
         if expect_result:
-            self.assertEqual(response.status_code, 200)
+            assert response.status_code == 200
             results = json.loads(response.content.decode('utf-8'))
-            self.assertEqual(len(results), 1)
+            assert len(results) == 1
         else:
-            self.assertEqual(response.status_code, 400)
+            assert response.status_code == 400
 
     def test_search_with_plus_sign(self):
         """
@@ -188,30 +188,30 @@ class CertificateSearchTests(CertificateSupportTestCase):
         self.student.save()
 
         response = self._search(self.student.email)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         results = json.loads(response.content.decode('utf-8'))
 
-        self.assertEqual(len(results), 1)
+        assert len(results) == 1
         retrieved_data = results[0]
-        self.assertEqual(retrieved_data["username"], self.STUDENT_USERNAME)
+        assert retrieved_data['username'] == self.STUDENT_USERNAME
 
     def test_results(self):
         response = self._search(self.STUDENT_USERNAME)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         results = json.loads(response.content.decode('utf-8'))
 
-        self.assertEqual(len(results), 1)
+        assert len(results) == 1
         retrieved_cert = results[0]
 
-        self.assertEqual(retrieved_cert["username"], self.STUDENT_USERNAME)
-        self.assertEqual(retrieved_cert["course_key"], six.text_type(self.CERT_COURSE_KEY))
-        self.assertEqual(retrieved_cert["created"], self.cert.created_date.isoformat())
-        self.assertEqual(retrieved_cert["modified"], self.cert.modified_date.isoformat())
-        self.assertEqual(retrieved_cert["grade"], six.text_type(self.CERT_GRADE))
-        self.assertEqual(retrieved_cert["status"], self.CERT_STATUS)
-        self.assertEqual(retrieved_cert["type"], self.CERT_MODE)
-        self.assertEqual(retrieved_cert["download_url"], self.CERT_DOWNLOAD_URL)
-        self.assertFalse(retrieved_cert["regenerate"])
+        assert retrieved_cert['username'] == self.STUDENT_USERNAME
+        assert retrieved_cert['course_key'] == six.text_type(self.CERT_COURSE_KEY)
+        assert retrieved_cert['created'] == self.cert.created_date.isoformat()
+        assert retrieved_cert['modified'] == self.cert.modified_date.isoformat()
+        assert retrieved_cert['grade'] == six.text_type(self.CERT_GRADE)
+        assert retrieved_cert['status'] == self.CERT_STATUS
+        assert retrieved_cert['type'] == self.CERT_MODE
+        assert retrieved_cert['download_url'] == self.CERT_DOWNLOAD_URL
+        assert not retrieved_cert['regenerate']
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
     def test_download_link(self):
@@ -220,20 +220,16 @@ class CertificateSearchTests(CertificateSupportTestCase):
         self.cert.save()
 
         response = self._search(self.STUDENT_USERNAME)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         results = json.loads(response.content.decode('utf-8'))
 
-        self.assertEqual(len(results), 1)
+        assert len(results) == 1
         retrieved_cert = results[0]
 
-        self.assertEqual(
-            retrieved_cert["download_url"],
-            reverse(
-                'certificates:render_cert_by_uuid',
-                kwargs={"certificate_uuid": self.cert.verify_uuid}
-            )
-        )
-        self.assertTrue(retrieved_cert["regenerate"])
+        assert retrieved_cert['download_url'] ==\
+               reverse('certificates:render_cert_by_uuid',
+                       kwargs={'certificate_uuid': self.cert.verify_uuid})
+        assert retrieved_cert['regenerate']
 
     def _search(self, user_filter, course_filter=None):
         """Execute a search and return the response. """
@@ -272,7 +268,7 @@ class CertificateRegenerateTests(CertificateSupportTestCase):
         # Create a user and log in
         user = UserFactory(username="foo", password="foo")
         success = self.client.login(username="foo", password="foo")
-        self.assertTrue(success, msg="Could not log in")
+        assert success, 'Could not log in'
 
         # Assign the user to the role
         if role is not None:
@@ -284,9 +280,9 @@ class CertificateRegenerateTests(CertificateSupportTestCase):
         response = self._regenerate()
 
         if has_access:
-            self.assertEqual(response.status_code, 400)
+            assert response.status_code == 400
         else:
-            self.assertEqual(response.status_code, 403)
+            assert response.status_code == 403
 
     def test_regenerate_certificate(self):
         """Test web certificate regeneration."""
@@ -297,13 +293,13 @@ class CertificateRegenerateTests(CertificateSupportTestCase):
             course_key=self.course_key,
             username=self.STUDENT_USERNAME,
         )
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
         # Check that the user's certificate was updated
         # Since the student hasn't actually passed the course,
         # we'd expect that the certificate status will be "notpassing"
         cert = GeneratedCertificate.eligible_certificates.get(user=self.student)
-        self.assertEqual(cert.status, CertificateStatuses.notpassing)
+        assert cert.status == CertificateStatuses.notpassing
 
     @patch('lms.djangoapps.certificates.queue.XQueueCertInterface._generate_cert')
     def test_regenerate_certificate_for_honor_mode(self, mock_generate_cert):
@@ -325,25 +321,25 @@ class CertificateRegenerateTests(CertificateSupportTestCase):
     def test_regenerate_certificate_missing_params(self):
         # Missing username
         response = self._regenerate(course_key=self.CERT_COURSE_KEY)
-        self.assertEqual(response.status_code, 400)
+        assert response.status_code == 400
 
         # Missing course key
         response = self._regenerate(username=self.STUDENT_USERNAME)
-        self.assertEqual(response.status_code, 400)
+        assert response.status_code == 400
 
     def test_regenerate_no_such_user(self):
         response = self._regenerate(
             course_key=six.text_type(self.CERT_COURSE_KEY),
             username="invalid_username",
         )
-        self.assertEqual(response.status_code, 400)
+        assert response.status_code == 400
 
     def test_regenerate_no_such_course(self):
         response = self._regenerate(
             course_key=CourseKey.from_string("edx/invalid/course"),
             username=self.STUDENT_USERNAME
         )
-        self.assertEqual(response.status_code, 400)
+        assert response.status_code == 400
 
     def test_regenerate_user_is_not_enrolled(self):
         # Unenroll the user
@@ -354,7 +350,7 @@ class CertificateRegenerateTests(CertificateSupportTestCase):
             course_key=self.CERT_COURSE_KEY,
             username=self.STUDENT_USERNAME
         )
-        self.assertEqual(response.status_code, 400)
+        assert response.status_code == 400
 
     def test_regenerate_user_has_no_certificate(self):
         # Delete the user's certificate
@@ -365,11 +361,11 @@ class CertificateRegenerateTests(CertificateSupportTestCase):
             course_key=self.CERT_COURSE_KEY,
             username=self.STUDENT_USERNAME
         )
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
         # A new certificate is created
         num_certs = GeneratedCertificate.eligible_certificates.filter(user=self.student).count()
-        self.assertEqual(num_certs, 1)
+        assert num_certs == 1
 
     def test_regenerate_cert_with_invalidated_record(self):
         """ If the certificate is marked as invalid, regenerate the certificate. """
@@ -387,7 +383,7 @@ class CertificateRegenerateTests(CertificateSupportTestCase):
             course_key=self.CERT_COURSE_KEY,
             username=self.STUDENT_USERNAME
         )
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         self.assertInvalidatedCertExists()
 
         # Check that the user's certificate was updated
@@ -419,31 +415,20 @@ class CertificateRegenerateTests(CertificateSupportTestCase):
         )
         # Invalidate user certificate
         certificate.invalidate()
-        self.assertFalse(certificate.is_valid())
+        assert not certificate.is_valid()
 
     def assertInvalidatedCertExists(self):
         """ Dry method to check certificate invalidated entry exists. """
-        self.assertTrue(
-            CertificateInvalidation.objects.filter(
-                generated_certificate__user=self.student, active=True
-            ).exists()
-        )
+        assert CertificateInvalidation.objects.filter(generated_certificate__user=self.student, active=True).exists()
 
     def assertInvalidatedCertDoesNotExist(self):
         """ Dry method to check certificate invalidated entry does not exists. """
-        self.assertFalse(
-            CertificateInvalidation.objects.filter(
-                generated_certificate__user=self.student, active=True
-            ).exists()
-        )
+        assert not CertificateInvalidation.objects\
+            .filter(generated_certificate__user=self.student, active=True).exists()
 
     def assertGeneratedCertExists(self, user, status):
         """ Dry method to check if certificate exists. """
-        self.assertTrue(
-            GeneratedCertificate.objects.filter(
-                user=user, status=status
-            ).exists()
-        )
+        assert GeneratedCertificate.objects.filter(user=user, status=status).exists()
 
 
 @ddt.ddt
@@ -475,7 +460,7 @@ class CertificateGenerateTests(CertificateSupportTestCase):
         # Create a user and log in
         user = UserFactory(username="foo", password="foo")
         success = self.client.login(username="foo", password="foo")
-        self.assertTrue(success, msg="Could not log in")
+        assert success, 'Could not log in'
 
         # Assign the user to the role
         if role is not None:
@@ -487,39 +472,39 @@ class CertificateGenerateTests(CertificateSupportTestCase):
         response = self._generate()
 
         if has_access:
-            self.assertEqual(response.status_code, 400)
+            assert response.status_code == 400
         else:
-            self.assertEqual(response.status_code, 403)
+            assert response.status_code == 403
 
     def test_generate_certificate(self):
         response = self._generate(
             course_key=self.course_key,
             username=self.STUDENT_USERNAME,
         )
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
     def test_generate_certificate_missing_params(self):
         # Missing username
         response = self._generate(course_key=self.EXISTED_COURSE_KEY_2)
-        self.assertEqual(response.status_code, 400)
+        assert response.status_code == 400
 
         # Missing course key
         response = self._generate(username=self.STUDENT_USERNAME)
-        self.assertEqual(response.status_code, 400)
+        assert response.status_code == 400
 
     def test_generate_no_such_user(self):
         response = self._generate(
             course_key=six.text_type(self.EXISTED_COURSE_KEY_2),
             username="invalid_username",
         )
-        self.assertEqual(response.status_code, 400)
+        assert response.status_code == 400
 
     def test_generate_no_such_course(self):
         response = self._generate(
             course_key=CourseKey.from_string("edx/invalid/course"),
             username=self.STUDENT_USERNAME
         )
-        self.assertEqual(response.status_code, 400)
+        assert response.status_code == 400
 
     def test_generate_user_is_not_enrolled(self):
         # Unenroll the user
@@ -530,7 +515,7 @@ class CertificateGenerateTests(CertificateSupportTestCase):
             course_key=self.EXISTED_COURSE_KEY_2,
             username=self.STUDENT_USERNAME
         )
-        self.assertEqual(response.status_code, 400)
+        assert response.status_code == 400
 
     def test_generate_user_has_no_certificate(self):
         # Delete the user's certificate
@@ -541,11 +526,11 @@ class CertificateGenerateTests(CertificateSupportTestCase):
             course_key=self.EXISTED_COURSE_KEY_2,
             username=self.STUDENT_USERNAME
         )
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
         # A new certificate is created
         num_certs = GeneratedCertificate.eligible_certificates.filter(user=self.student).count()
-        self.assertEqual(num_certs, 1)
+        assert num_certs == 1
 
     def _generate(self, course_key=None, username=None):
         """Call the generation end-point and return the response. """

--- a/lms/djangoapps/certificates/tests/test_views.py
+++ b/lms/djangoapps/certificates/tests/test_views.py
@@ -72,8 +72,8 @@ class UpdateExampleCertificateViewTest(CacheIsolationTestCase):
         self._assert_response(response)
 
         self.cert = ExampleCertificate.objects.get()
-        self.assertEqual(self.cert.status, ExampleCertificate.STATUS_SUCCESS)
-        self.assertEqual(self.cert.download_url, self.DOWNLOAD_URL)
+        assert self.cert.status == ExampleCertificate.STATUS_SUCCESS
+        assert self.cert.download_url == self.DOWNLOAD_URL
 
     def test_update_example_certificate_invalid_key(self):
         payload = {
@@ -86,15 +86,15 @@ class UpdateExampleCertificateViewTest(CacheIsolationTestCase):
             })
         }
         response = self.client.post(self.url, data=payload)
-        self.assertEqual(response.status_code, 404)
+        assert response.status_code == 404
 
     def test_update_example_certificate_error(self):
         response = self._post_to_view(self.cert, error_reason=self.ERROR_REASON)
         self._assert_response(response)
 
         self.cert = ExampleCertificate.objects.get()
-        self.assertEqual(self.cert.status, ExampleCertificate.STATUS_ERROR)
-        self.assertEqual(self.cert.error_reason, self.ERROR_REASON)
+        assert self.cert.status == ExampleCertificate.STATUS_ERROR
+        assert self.cert.error_reason == self.ERROR_REASON
 
     @ddt.data('xqueue_header', 'xqueue_body')
     def test_update_example_certificate_invalid_params(self, missing_param):
@@ -110,7 +110,7 @@ class UpdateExampleCertificateViewTest(CacheIsolationTestCase):
         del payload[missing_param]
 
         response = self.client.post(self.url, data=payload)
-        self.assertEqual(response.status_code, 400)
+        assert response.status_code == 400
 
     def test_update_example_certificate_missing_download_url(self):
         payload = {
@@ -122,7 +122,7 @@ class UpdateExampleCertificateViewTest(CacheIsolationTestCase):
             })
         }
         response = self.client.post(self.url, data=payload)
-        self.assertEqual(response.status_code, 400)
+        assert response.status_code == 400
 
     def test_update_example_certificate_non_json_param(self):
         payload = {
@@ -130,11 +130,11 @@ class UpdateExampleCertificateViewTest(CacheIsolationTestCase):
             'xqueue_body': '{/invalid'
         }
         response = self.client.post(self.url, data=payload)
-        self.assertEqual(response.status_code, 400)
+        assert response.status_code == 400
 
     def test_unsupported_http_method(self):
         response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 405)
+        assert response.status_code == 405
 
     def test_bad_request_rate_limiting(self):
         payload = {
@@ -156,7 +156,7 @@ class UpdateExampleCertificateViewTest(CacheIsolationTestCase):
 
         # The final status code should indicate that the rate
         # limit was exceeded.
-        self.assertEqual(response.status_code, 403)
+        assert response.status_code == 403
 
     def _post_to_view(self, cert, download_url=None, error_reason=None):
         """Simulate a callback from the XQueue to the example certificate end-point. """
@@ -179,8 +179,8 @@ class UpdateExampleCertificateViewTest(CacheIsolationTestCase):
     def _assert_response(self, response):
         """Check the response from the callback end-point. """
         content = json.loads(response.content.decode('utf-8'))
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(content['return_code'], 0)
+        assert response.status_code == 200
+        assert content['return_code'] == 0
 
 
 class CertificatesViewsSiteTests(ModuleStoreTestCase):

--- a/lms/djangoapps/certificates/tests/test_webview_views.py
+++ b/lms/djangoapps/certificates/tests/test_webview_views.py
@@ -263,7 +263,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self._add_course_certificates(count=1, signatory_count=1, is_active=True)
         test_url = get_certificate_url(course_id=self.course.id, uuid=self.cert.verify_uuid)
         response = self.client.get(test_url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         params = {
             'name': '{platform_name} Honor Code Certificate for {course_name}'.format(
                 platform_name=settings.PLATFORM_NAME, course_name=self.course.display_name,
@@ -293,7 +293,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self._add_course_certificates(count=1, signatory_count=1, is_active=True)
         test_url = get_certificate_url(course_id=self.cert.course_id, uuid=self.cert.verify_uuid)
         response = self.client.get(test_url, HTTP_HOST='test.localhost')
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         # the linkedIn share URL with appropriate parameters should be present
         params = {
             'name': 'My Platform Site Honor Code Certificate for {course_name}'.format(
@@ -353,10 +353,10 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             },
         ):
             response = self.client.get(test_url, HTTP_HOST='test.localhost')
-            self.assertEqual(response.status_code, 200)
-            self.assertEqual("Post on Facebook" in response.content.decode('utf-8'), facebook_sharing)
-            self.assertEqual("Share on Twitter" in response.content.decode('utf-8'), twitter_sharing)
-            self.assertEqual("Add to LinkedIn Profile" in response.content.decode('utf-8'), linkedin_sharing)
+            assert response.status_code == 200
+            assert ('Post on Facebook' in response.content.decode('utf-8')) == facebook_sharing
+            assert ('Share on Twitter' in response.content.decode('utf-8')) == twitter_sharing
+            assert ('Add to LinkedIn Profile' in response.content.decode('utf-8')) == linkedin_sharing
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
     def test_facebook_default_text_site(self):
@@ -445,7 +445,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             test_url = get_certificate_url(user_id=self.user.id, course_id=self.cert.course_id,
                                            uuid=self.cert.verify_uuid)
             response = self.client.get(test_url)
-            self.assertEqual(response.status_code, 200)
+            assert response.status_code == 200
 
         if issue_badges:
             mock_get_completion_badge.assert_called()
@@ -574,7 +574,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.cert.status = CertificateStatuses.generating
         self.cert.save()
         response = self.client.get(test_url)
-        self.assertEqual(response.status_code, 404)
+        assert response.status_code == 404
 
     @ddt.data(
         (CertificateStatuses.downloadable, True),
@@ -603,7 +603,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         if eligible_for_certificate:
             self.assertContains(response, str(self.cert.verify_uuid))
         else:
-            self.assertEqual(response.status_code, 404)
+            assert response.status_code == 404
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
     def test_html_view_returns_404_for_invalid_certificate(self):
@@ -625,7 +625,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         # invalidate certificate and verify that "Cannot Find Certificate" is returned
         self.cert.invalidate()
         response = self.client.get(test_url)
-        self.assertEqual(response.status_code, 404)
+        assert response.status_code == 404
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
     def test_html_lang_attribute_is_dynamic_for_certificate_html_view(self):
@@ -818,7 +818,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             course_id=six.text_type(self.course.id),
             uuid=self.cert.verify_uuid
         )
-        self.assertIn(str(self.cert.download_url), test_url)
+        assert str(self.cert.download_url) in test_url
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
     def test_render_html_view_invalid_course(self):
@@ -841,7 +841,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertListEqual(list(GeneratedCertificate.eligible_certificates.all()), [])
 
         response = self.client.get(test_url)
-        self.assertEqual(response.status_code, 404)
+        assert response.status_code == 404
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED, PLATFORM_NAME=u'Űńíćődé Űńívéŕśítӳ')
     def test_render_html_view_with_unicode_platform_name(self):
@@ -853,7 +853,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             uuid=self.cert.verify_uuid
         )
         response = self.client.get(test_url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
     def test_user_id_cert_url_not_supported(self):
@@ -968,9 +968,9 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.cert.save()
         request_certificate_url = reverse('request_certificate')
         response = self.client.post(request_certificate_url, {'course_id': six.text_type(self.course.id)})
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         response_json = json.loads(response.content.decode('utf-8'))
-        self.assertEqual(CertificateStatuses.notpassing, response_json['add_status'])
+        assert CertificateStatuses.notpassing == response_json['add_status']
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_DISABLED)
     @override_settings(CERT_QUEUE='test-queue')
@@ -982,9 +982,9 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             mock_queue.return_value = (0, "Successfully queued")
             with mock_passing_grade():
                 response = self.client.post(request_certificate_url, {'course_id': six.text_type(self.course.id)})
-                self.assertEqual(response.status_code, 200)
+                assert response.status_code == 200
                 response_json = json.loads(response.content.decode('utf-8'))
-                self.assertEqual(CertificateStatuses.generating, response_json['add_status'])
+                assert CertificateStatuses.generating == response_json['add_status']
 
     # TEMPLATES WITHOUT LANGUAGE TESTS
     @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
@@ -1013,12 +1013,12 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         with patch('lms.djangoapps.certificates.api.get_course_organization_id') as mock_get_org_id:
             mock_get_org_id.side_effect = [1, 2]
             response = self.client.get(test_url)
-            self.assertEqual(response.status_code, 200)
+            assert response.status_code == 200
             self.assertContains(response, 'lang: fr')
             self.assertContains(response, 'course name: test_template_1_course')
             # test with second organization template
             response = self.client.get(test_url)
-            self.assertEqual(response.status_code, 200)
+            assert response.status_code == 200
             self.assertContains(response, 'lang: fr')
             self.assertContains(response, 'course name: test_template_3_course')
 
@@ -1054,7 +1054,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         with patch('lms.djangoapps.certificates.api.get_course_organization_id') as mock_get_org_id:
             mock_get_org_id.side_effect = [1]
             response = self.client.get(test_url)
-            self.assertEqual(response.status_code, 200)
+            assert response.status_code == 200
             self.assertContains(response, 'course name: test_template_1_course')
 
     @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
@@ -1078,7 +1078,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         with patch('lms.djangoapps.certificates.api.get_course_organization_id') as mock_get_org_id:
             mock_get_org_id.side_effect = [1]
             response = self.client.get(test_url)
-            self.assertEqual(response.status_code, 200)
+            assert response.status_code == 200
             self.assertContains(response, 'course name: test_template_1_course')
 
     @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
@@ -1103,7 +1103,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         with patch('lms.djangoapps.certificates.api.get_course_organization_id') as mock_get_org_id:
             mock_get_org_id.return_value = None
             response = self.client.get(test_url)
-            self.assertEqual(response.status_code, 200)
+            assert response.status_code == 200
             self.assertContains(response, u'mode: {}'.format(mode))
             self.assertContains(response, 'course name: test_template_1_course')
 
@@ -1151,7 +1151,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         )
         # Verify return template lang = null
         response = self.client.get(test_url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         self.assertContains(response, 'course name: test_null_lang_template')
 
         # Create an org_mode_and_coursekey template language=wrong_language
@@ -1164,7 +1164,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         )
         # Verify returns null lang template
         response = self.client.get(test_url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         self.assertContains(response, 'course name: test_null_lang_template')
 
         # Create an org_mode_and_coursekey template language=''
@@ -1177,7 +1177,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         )
         # Verify returns null lang template
         response = self.client.get(test_url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         self.assertContains(response, 'course name: test_all_languages_template')
 
         # Create a org_mode_and_coursekey template language=lang
@@ -1190,7 +1190,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         )
         # verify return right_language template
         response = self.client.get(test_url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         self.assertContains(response, 'course name: test_right_lang_template')
 
     # 2
@@ -1229,28 +1229,28 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self._create_custom_named_template('test_null_lang_template', org_id=1, mode='honor', language=None)
         # Verify return template lang = null
         response = self.client.get(test_url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         self.assertContains(response, 'course name: test_null_lang_template')
 
         # Create a org and mode template language=wrong_language
         self._create_custom_named_template('test_wrong_lang_template', org_id=1, mode='honor', language=wrong_language)
         # Verify returns null lang template
         response = self.client.get(test_url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         self.assertContains(response, 'course name: test_null_lang_template')
 
         # Create an org and mode template language=''
         self._create_custom_named_template('test_all_languages_template', org_id=1, mode='honor', language='')
         # Verify returns All Languages template
         response = self.client.get(test_url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         self.assertContains(response, 'course name: test_all_languages_template')
 
         # Create a org and mode template language=lang
         self._create_custom_named_template('test_right_lang_template', org_id=1, mode='honor', language=right_language)
         # Verify return right_language template
         response = self.client.get(test_url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         self.assertContains(response, 'course name: test_right_lang_template')
 
     # 3
@@ -1287,28 +1287,28 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self._create_custom_named_template('test_null_lang_template', org_id=1, language=None)
         # Verify return template lang = null
         response = self.client.get(test_url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         self.assertContains(response, 'course name: test_null_lang_template')
 
         # Create a org template language=wrong_language
         self._create_custom_named_template('test_wrong_lang_template', org_id=1, language=wrong_language)
         # Verify returns null lang template
         response = self.client.get(test_url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         self.assertContains(response, 'course name: test_null_lang_template')
 
         # Create an org template language=''
         self._create_custom_named_template('test_all_languages_template', org_id=1, language='')
         # Verify returns All Languages template
         response = self.client.get(test_url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         self.assertContains(response, 'course name: test_all_languages_template')
 
         # Create a org template language=lang
         self._create_custom_named_template('test_right_lang_template', org_id=1, language=right_language)
         # Verify return right_language template
         response = self.client.get(test_url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         self.assertContains(response, 'course name: test_right_lang_template')
 
     # 4
@@ -1346,28 +1346,28 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self._create_custom_named_template('test_null_lang_template', mode='honor', language=None)
         # Verify return template with lang = null
         response = self.client.get(test_url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         self.assertContains(response, 'course name: test_null_lang_template')
 
         # Create a mode template language=wrong_language
         self._create_custom_named_template('test_wrong_lang_template', mode='honor', language=wrong_language)
         # Verify returns null lang template
         response = self.client.get(test_url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         self.assertContains(response, 'course name: test_null_lang_template')
 
         # Create a mode template language=''
         self._create_custom_named_template('test_all_languages_template', mode='honor', language='')
         # Verify returns All Languages template
         response = self.client.get(test_url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         self.assertContains(response, 'course name: test_all_languages_template')
 
         # Create a mode template language=lang
         self._create_custom_named_template('test_right_lang_template', mode='honor', language=right_language)
         # Verify return right_language template
         response = self.client.get(test_url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         self.assertContains(response, 'course name: test_right_lang_template')
 
     @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
@@ -1408,28 +1408,28 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self._create_custom_named_template('test_null_lang_template', org_id=1, mode='honor', language=None)
         # Verify return template with lang = null
         response = self.client.get(test_url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         self.assertContains(response, 'course name: test_null_lang_template')
 
         # Create a mode template language=wrong_language
         self._create_custom_named_template('test_wrong_lang_template', org_id=1, mode='honor', language=wrong_language)
         # Verify returns null lang template
         response = self.client.get(test_url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         self.assertContains(response, 'course name: test_null_lang_template')
 
         # Create a mode template language=''
         self._create_custom_named_template('test_all_languages_template', org_id=1, mode='honor', language='')
         # Verify returns All Languages template
         response = self.client.get(test_url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         self.assertContains(response, 'course name: test_all_languages_template')
 
         # Create a mode template language=lang
         self._create_custom_named_template('test_right_lang_template', org_id=1, mode='honor', language=right_language)
         # verify return right_language template
         response = self.client.get(test_url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         self.assertContains(response, 'course name: test_right_lang_template')
 
     @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
@@ -1462,7 +1462,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             uuid=self.cert.verify_uuid
         )
         response = self.client.get(test_url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         if include_effort:
             self.assertContains(response, 'hours of effort: 40')
         else:
@@ -1496,7 +1496,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
                     with patch('lms.djangoapps.certificates.api.get_course_organization_id') as mock_get_org_id:
                         mock_get_org_id.return_value = None
                         response = self.client.get(test_url)
-                        self.assertEqual(response.status_code, 200)
+                        assert response.status_code == 200
                         if custom_certs_enabled:
                             self.assertContains(response, u'mode: {}'.format(mode))
                         else:
@@ -1558,7 +1558,7 @@ class CertificateEventTests(CommonCertificatesTestCase, EventTrackingTestCase):
             uuid=self.cert.verify_uuid
         )
         response = self.client.get(test_url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
         # There are two events being emitted in this flow.
         # One for page hit (due to the tracker in the middleware) and
@@ -1566,7 +1566,7 @@ class CertificateEventTests(CommonCertificatesTestCase, EventTrackingTestCase):
         # We are interested in the second one.
         actual_event = self.get_event(1)
 
-        self.assertEqual(actual_event['name'], 'edx.certificate.evidence_visited')
+        assert actual_event['name'] == 'edx.certificate.evidence_visited'
         assert_event_matches(
             {
                 'user_id': self.user.id,
@@ -1608,7 +1608,7 @@ class CertificateEventTests(CommonCertificatesTestCase, EventTrackingTestCase):
         # We are interested in the second one.
         actual_event = self.get_event(1)
 
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         assert_event_matches(
             {
                 'name': 'edx.badge.assertion.evidence_visited',

--- a/lms/djangoapps/certificates/tests/tests.py
+++ b/lms/djangoapps/certificates/tests/tests.py
@@ -54,8 +54,8 @@ class CertificatesModelTest(ModuleStoreTestCase, MilestonesTestCaseMixin):
         course = CourseFactory.create(org='edx', number='verified', display_name='Verified Course')
 
         certificate_status = certificate_status_for_student(student, course.id)
-        self.assertEqual(certificate_status['status'], CertificateStatuses.unavailable)
-        self.assertEqual(certificate_status['mode'], GeneratedCertificate.MODES.honor)
+        assert certificate_status['status'] == CertificateStatuses.unavailable
+        assert certificate_status['mode'] == GeneratedCertificate.MODES.honor
 
     @unpack
     @data(
@@ -78,14 +78,14 @@ class CertificatesModelTest(ModuleStoreTestCase, MilestonesTestCaseMixin):
             student, self.instructor_paced_course.id, grade,
             whitelisted, user_certificate=None
         )
-        self.assertEqual(certificate_info, output)
+        assert certificate_info == output
 
         # for self paced course
         certificate_info = certificate_info_for_user(
             student, self.self_paced_course.id, grade,
             whitelisted, user_certificate=None
         )
-        self.assertEqual(certificate_info, output)
+        assert certificate_info == output
 
     @unpack
     @data(
@@ -127,14 +127,14 @@ class CertificatesModelTest(ModuleStoreTestCase, MilestonesTestCaseMixin):
             student, self.instructor_paced_course.id, grade,
             whitelisted, certificate1
         )
-        self.assertEqual(certificate_info, output)
+        assert certificate_info == output
 
         # for self paced course
         certificate_info = certificate_info_for_user(
             student, self.self_paced_course.id, grade,
             whitelisted, certificate2
         )
-        self.assertEqual(certificate_info, output)
+        assert certificate_info == output
 
     @unpack
     @data(
@@ -154,7 +154,7 @@ class CertificatesModelTest(ModuleStoreTestCase, MilestonesTestCaseMixin):
             user, self.instructor_paced_course.id, grade,
             whitelisted, user_certificate=None
         )
-        self.assertEqual(certificate_info, output)
+        assert certificate_info == output
 
     def test_course_ids_with_certs_for_user(self):
         # Create one user with certs and one without
@@ -201,7 +201,7 @@ class CertificatesModelTest(ModuleStoreTestCase, MilestonesTestCaseMixin):
         set_prerequisite_courses(course.id, [six.text_type(pre_requisite_course.id)])
         # get milestones collected by user before completing the pre-requisite course
         completed_milestones = milestones_achieved_by_user(student, six.text_type(pre_requisite_course.id))
-        self.assertEqual(len(completed_milestones), 0)
+        assert len(completed_milestones) == 0
 
         GeneratedCertificateFactory.create(
             user=student,
@@ -211,8 +211,8 @@ class CertificatesModelTest(ModuleStoreTestCase, MilestonesTestCaseMixin):
         )
         # get milestones collected by user after user has completed the pre-requisite course
         completed_milestones = milestones_achieved_by_user(student, six.text_type(pre_requisite_course.id))
-        self.assertEqual(len(completed_milestones), 1)
-        self.assertEqual(completed_milestones[0]['namespace'], six.text_type(pre_requisite_course.id))
+        assert len(completed_milestones) == 1
+        assert completed_milestones[0]['namespace'] == six.text_type(pre_requisite_course.id)
 
     @patch.dict(settings.FEATURES, {'ENABLE_OPENBADGES': True})
     @patch('lms.djangoapps.badges.backends.badgr.BadgrBackend', spec=True)
@@ -229,4 +229,4 @@ class CertificatesModelTest(ModuleStoreTestCase, MilestonesTestCaseMixin):
         )
         cert.status = CertificateStatuses.downloadable
         cert.save()
-        self.assertTrue(handler.return_value.award.called)
+        assert handler.return_value.award.called

--- a/lms/djangoapps/commerce/api/v0/tests/test_views.py
+++ b/lms/djangoapps/commerce/api/v0/tests/test_views.py
@@ -66,7 +66,7 @@ class BasketsViewTests(EnrollmentEventTestMixin, UserMixin, ModuleStoreTestCase)
     def assertResponseMessage(self, response, expected_msg):
         """ Asserts the detail field in the response's JSON body equals the expected message. """
         actual = json.loads(response.content.decode('utf-8'))['detail']
-        self.assertEqual(actual, expected_msg)
+        assert actual == expected_msg
 
     def setUp(self):
         super(BasketsViewTests, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
@@ -97,16 +97,16 @@ class BasketsViewTests(EnrollmentEventTestMixin, UserMixin, ModuleStoreTestCase)
         """
         with restrict_course(self.course.id) as redirect_url:
             response = self._post_to_view()
-            self.assertEqual(403, response.status_code)
+            assert 403 == response.status_code
             body = json.loads(response.content.decode('utf-8'))
-            self.assertEqual(get_absolute_url(redirect_url), body['user_message_url'])
+            assert get_absolute_url(redirect_url) == body['user_message_url']
 
     def test_login_required(self):
         """
         The view should return HTTP 401 status if the user is not logged in.
         """
         self.client.logout()
-        self.assertEqual(401, self._post_to_view().status_code)
+        assert 401 == self._post_to_view().status_code
 
     @ddt.data('delete', 'get', 'put')
     def test_post_required(self, method):
@@ -114,21 +114,21 @@ class BasketsViewTests(EnrollmentEventTestMixin, UserMixin, ModuleStoreTestCase)
         Verify that the view only responds to POST operations.
         """
         response = getattr(self.client, method)(self.url)
-        self.assertEqual(405, response.status_code)
+        assert 405 == response.status_code
 
     def test_invalid_course(self):
         """
         If the course does not exist, the view should return HTTP 406.
         """
         # TODO Test inactive courses, and those not open for enrollment.
-        self.assertEqual(406, self._post_to_view('aaa/bbb/ccc').status_code)
+        assert 406 == self._post_to_view('aaa/bbb/ccc').status_code
 
     def test_invalid_request_data(self):
         """
         If invalid data is supplied with the request, the view should return HTTP 406.
         """
-        self.assertEqual(406, self.client.post(self.url, {}).status_code)
-        self.assertEqual(406, self.client.post(self.url, {'not_course_id': ''}).status_code)
+        assert 406 == self.client.post(self.url, {}).status_code
+        assert 406 == self.client.post(self.url, {'not_course_id': ''}).status_code
 
     @ddt.data(True, False)
     def test_course_for_active_and_inactive_user(self, user_is_active):
@@ -141,7 +141,7 @@ class BasketsViewTests(EnrollmentEventTestMixin, UserMixin, ModuleStoreTestCase)
         response = self._post_to_view()
 
         # Validate the response content
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         msg = Messages.ENROLL_DIRECTLY.format(
             course_id=self.course.id,
             username=self.user.username
@@ -155,7 +155,7 @@ class BasketsViewTests(EnrollmentEventTestMixin, UserMixin, ModuleStoreTestCase)
         response = self._post_to_view()
 
         # Validate the response content
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         msg = Messages.NO_SKU_ENROLLED.format(
             enrollment_mode=enrollment_mode,
             course_id=self.course.id,
@@ -206,7 +206,7 @@ class BasketsViewTests(EnrollmentEventTestMixin, UserMixin, ModuleStoreTestCase)
         response = self._post_to_view()
 
         # The view should return an error status code
-        self.assertEqual(response.status_code, 406)
+        assert response.status_code == 406
         msg = Messages.NO_DEFAULT_ENROLLMENT_MODE.format(course_id=self.course.id)
         self.assertResponseMessage(response, msg)
 
@@ -236,10 +236,10 @@ class BasketsViewTests(EnrollmentEventTestMixin, UserMixin, ModuleStoreTestCase)
 
         # Enroll user in the course
         CourseEnrollment.enroll(self.user, self.course.id)
-        self.assertTrue(CourseEnrollment.is_enrolled(self.user, self.course.id))
+        assert CourseEnrollment.is_enrolled(self.user, self.course.id)
 
         response = self._post_to_view()
-        self.assertEqual(response.status_code, 409)
+        assert response.status_code == 409
         msg = Messages.ENROLLMENT_EXISTS.format(username=self.user.username, course_id=self.course.id)
         self.assertResponseMessage(response, msg)
 
@@ -251,8 +251,8 @@ class BasketsViewTests(EnrollmentEventTestMixin, UserMixin, ModuleStoreTestCase)
         # Create an inactive enrollment
         CourseEnrollment.enroll(self.user, self.course.id)
         CourseEnrollment.unenroll(self.user, self.course.id, True)
-        self.assertFalse(CourseEnrollment.is_enrolled(self.user, self.course.id))
-        self.assertIsNotNone(get_enrollment(self.user.username, six.text_type(self.course.id)))
+        assert not CourseEnrollment.is_enrolled(self.user, self.course.id)
+        assert get_enrollment(self.user.username, six.text_type(self.course.id)) is not None
 
     @mock.patch('lms.djangoapps.commerce.api.v0.views.update_email_opt_in')
     @ddt.data(*itertools.product((False, True), (False, True), (False, True)))
@@ -271,8 +271,8 @@ class BasketsViewTests(EnrollmentEventTestMixin, UserMixin, ModuleStoreTestCase)
             mock_update.side_effect = Exception("boink")
 
         response = self._post_to_view(marketing_email_opt_in=is_opt_in)
-        self.assertEqual(mock_update.called, is_opt_in)
-        self.assertEqual(response.status_code, 200)
+        assert mock_update.called == is_opt_in
+        assert response.status_code == 200
 
     def test_closed_course(self):
         """
@@ -280,7 +280,7 @@ class BasketsViewTests(EnrollmentEventTestMixin, UserMixin, ModuleStoreTestCase)
         """
         self.course.enrollment_end = datetime.now(pytz.UTC) - timedelta(days=1)
         modulestore().update_item(self.course, self.user.id)
-        self.assertEqual(self._post_to_view().status_code, 406)
+        assert self._post_to_view().status_code == 406
 
 
 class BasketOrderViewTests(UserMixin, TestCase):
@@ -299,18 +299,18 @@ class BasketOrderViewTests(UserMixin, TestCase):
         with mock_basket_order(basket_id=1, response=self.MOCK_ORDER):
             response = self.client.get(self.path)
 
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         actual = json.loads(response.content.decode('utf-8'))
-        self.assertEqual(actual, self.MOCK_ORDER)
+        assert actual == self.MOCK_ORDER
 
     def test_order_not_found(self):
         """ If the order is not found, the view should return a 404. """
         with mock_basket_order(basket_id=1, status=404):
             response = self.client.get(self.path)
-        self.assertEqual(response.status_code, 404)
+        assert response.status_code == 404
 
     def test_login_required(self):
         """ The view should return 403 if the user is not logged in. """
         self.client.logout()
         response = self.client.get(self.path)
-        self.assertEqual(response.status_code, 403)
+        assert response.status_code == 403

--- a/lms/djangoapps/commerce/api/v1/tests/test_models.py
+++ b/lms/djangoapps/commerce/api/v1/tests/test_models.py
@@ -29,9 +29,9 @@ class CourseTests(TestCase):
     def test_get_mode_display_name(self, slug, expected_display_name):
         """ Verify the method properly maps mode slugs to display names. """
         mode = CourseMode(mode_slug=slug)
-        self.assertEqual(self.course.get_mode_display_name(mode), expected_display_name)
+        assert self.course.get_mode_display_name(mode) == expected_display_name
 
     def test_get_mode_display_name_unknown_slug(self):
         """ Verify the method returns the slug if it has no known mapping. """
         mode = CourseMode(mode_slug='Blah!')
-        self.assertEqual(self.course.get_mode_display_name(mode), mode.mode_slug)
+        assert self.course.get_mode_display_name(mode) == mode.mode_slug

--- a/lms/djangoapps/commerce/management/commands/tests/test_configure_commerce.py
+++ b/lms/djangoapps/commerce/management/commands/tests/test_configure_commerce.py
@@ -25,10 +25,10 @@ class TestCommerceConfigurationCommand(TestCase):
         # Verify commerce configuration is enabled with appropriate values
         commerce_configuration = CommerceConfiguration.current()
 
-        self.assertTrue(commerce_configuration.enabled)
-        self.assertTrue(commerce_configuration.checkout_on_ecommerce_service)
-        self.assertEqual(commerce_configuration.basket_checkout_page, "/basket/add/")
-        self.assertEqual(commerce_configuration.cache_ttl, 0)
+        assert commerce_configuration.enabled
+        assert commerce_configuration.checkout_on_ecommerce_service
+        assert commerce_configuration.basket_checkout_page == '/basket/add/'
+        assert commerce_configuration.cache_ttl == 0
 
         # Verify commerce configuration can be disabled from command
         call_command(
@@ -37,7 +37,7 @@ class TestCommerceConfigurationCommand(TestCase):
         )
 
         commerce_configuration = CommerceConfiguration.current()
-        self.assertFalse(commerce_configuration.enabled)
+        assert not commerce_configuration.enabled
 
         # Verify commerce configuration can be disabled from command
         call_command(
@@ -46,7 +46,7 @@ class TestCommerceConfigurationCommand(TestCase):
         )
 
         commerce_configuration = CommerceConfiguration.current()
-        self.assertFalse(commerce_configuration.checkout_on_ecommerce_service)
+        assert not commerce_configuration.checkout_on_ecommerce_service
 
     def test_site_associated_commerce_configuration(self):
         """
@@ -55,7 +55,5 @@ class TestCommerceConfigurationCommand(TestCase):
         This is done to make sure that this command gets updated once site_id field is added to
         CommerceConfiguration model.
         """
-        self.assertFalse(
-            hasattr(CommerceConfiguration, "site"),
-            "Update configure_commerce command to account for site specific configurations.",
-        )
+        assert not hasattr(CommerceConfiguration, 'site'),\
+            'Update configure_commerce command to account for site specific configurations.'

--- a/lms/djangoapps/commerce/management/commands/tests/test_create_orders_for_old_enterprise_course_enrollmnet.py
+++ b/lms/djangoapps/commerce/management/commands/tests/test_create_orders_for_old_enterprise_course_enrollmnet.py
@@ -66,17 +66,14 @@ class TestEnterpriseCourseEnrollmentCreateOldOrder(TestCase):
         out = StringIO()
         call_command('create_orders_for_old_enterprise_course_enrollment', '--batch-size=10', stdout=out)
         output = out.getvalue()
-        self.assertIn("Total Enrollments count to process: 32", output)  # 30 + 1 + 1
-        self.assertTrue(
-            re.search(
-                r'\[Final Summary\] Enrollments Success: \d+, New: \d+, Failed: 0, Invalid: 1 , Non-Paid: 1',
-                output
-            )
-        )
+        assert 'Total Enrollments count to process: 32' in output
+        # 30 + 1 + 1
+        assert re.search(r'\[Final Summary\] Enrollments Success: \d+, New: \d+, Failed: 0, Invalid: 1 , Non-Paid: 1',
+                         output)
         # There are total 32 enrollments so there would be 4 batches (i.e: [10, 10, 10, 2])
         # as there are 2 enrollments in last batch and that 2 enrollments are not valid enrollment to process,
         # so _create_manual_enrollment_orders will not be called for last batch.
-        self.assertEqual(mock_create_manual_enrollment_orders.call_count, 3)
+        assert mock_create_manual_enrollment_orders.call_count == 3
 
     @patch('lms.djangoapps.commerce.management.commands.create_orders_for_old_enterprise_course_enrollment'
            '.Command._create_manual_enrollment_orders')
@@ -95,6 +92,7 @@ class TestEnterpriseCourseEnrollmentCreateOldOrder(TestCase):
             stdout=out
         )
         output = out.getvalue()
-        self.assertIn("Total Enrollments count to process: 15", output)
-        self.assertIn('[Final Summary] Enrollments Success: ', output)
-        self.assertEqual(mock_create_manual_enrollment_orders.call_count, 2)  # batch of 2 (10, 5)
+        assert 'Total Enrollments count to process: 15' in output
+        assert '[Final Summary] Enrollments Success: ' in output
+        assert mock_create_manual_enrollment_orders.call_count == 2
+        # batch of 2 (10, 5)

--- a/lms/djangoapps/commerce/tests/__init__.py
+++ b/lms/djangoapps/commerce/tests/__init__.py
@@ -68,7 +68,7 @@ class EdxRestApiClientTest(TestCase):
             }
             expected_jwt = create_jwt_for_user(self.user, additional_claims=claims, scopes=self.SCOPES)
             expected_header = u'JWT {}'.format(expected_jwt)
-            self.assertEqual(actual_header, expected_header)
+            assert actual_header == expected_header
 
     @httpretty.activate
     def test_client_unicode(self):
@@ -86,4 +86,4 @@ class EdxRestApiClientTest(TestCase):
             adding_headers={'Content-Type': JSON},
         )
         actual_object = ecommerce_api_client(self.user).baskets(1).order.get()
-        self.assertEqual(actual_object, {u"result": u"Préparatoire"})
+        assert actual_object == {u'result': u'Préparatoire'}

--- a/lms/djangoapps/commerce/tests/test_utils.py
+++ b/lms/djangoapps/commerce/tests/test_utils.py
@@ -49,7 +49,7 @@ class AuditLogTests(TestCase):
         # Verify that the logged message contains comma-separated
         # key-value pairs ordered alphabetically by key.
         message = 'foo: bar="baz", qux="quux"'
-        self.assertTrue(mock_log.info.called_with(message))
+        assert mock_log.info.called_with(message)
 
 
 @ddt.ddt
@@ -66,13 +66,13 @@ class EcommerceServiceTests(TestCase):
     def test_is_enabled(self):
         """Verify that is_enabled() returns True when ecomm checkout is enabled. """
         is_enabled = EcommerceService().is_enabled(self.user)
-        self.assertTrue(is_enabled)
+        assert is_enabled
 
         config = CommerceConfiguration.current()
         config.checkout_on_ecommerce_service = False
         config.save()
         is_not_enabled = EcommerceService().is_enabled(self.user)
-        self.assertFalse(is_not_enabled)
+        assert not is_not_enabled
 
     @override_switch(settings.DISABLE_ACCOUNT_ACTIVATION_REQUIREMENT_SWITCH, active=True)
     def test_is_enabled_activation_requirement_disabled(self):
@@ -80,25 +80,25 @@ class EcommerceServiceTests(TestCase):
         self.user.is_active = False
         self.user.save()
         is_enabled = EcommerceService().is_enabled(self.user)
-        self.assertTrue(is_enabled)
+        assert is_enabled
 
     @patch('openedx.core.djangoapps.theming.helpers.is_request_in_themed_site')
     def test_is_enabled_for_sites(self, is_site):
         """Verify that is_enabled() returns True if used for a site."""
         is_site.return_value = True
         is_enabled = EcommerceService().is_enabled(self.user)
-        self.assertTrue(is_enabled)
+        assert is_enabled
 
     @override_settings(ECOMMERCE_PUBLIC_URL_ROOT='http://ecommerce_url')
     def test_ecommerce_url_root(self):
         """Verify that the proper root URL is returned."""
-        self.assertEqual(EcommerceService().ecommerce_url_root, 'http://ecommerce_url')
+        assert EcommerceService().ecommerce_url_root == 'http://ecommerce_url'
 
     @override_settings(ECOMMERCE_PUBLIC_URL_ROOT='http://ecommerce_url')
     def test_get_absolute_ecommerce_url(self):
         """Verify that the proper URL is returned."""
         url = EcommerceService().get_absolute_ecommerce_url('/test_basket/')
-        self.assertEqual(url, 'http://ecommerce_url/test_basket/')
+        assert url == 'http://ecommerce_url/test_basket/'
 
     @override_settings(ECOMMERCE_PUBLIC_URL_ROOT='http://ecommerce_url')
     def test_get_receipt_page_url(self):
@@ -106,14 +106,14 @@ class EcommerceServiceTests(TestCase):
         order_number = 'ORDER1'
         url = EcommerceService().get_receipt_page_url(order_number)
         expected_url = 'http://ecommerce_url/checkout/receipt/?order_number={}'.format(order_number)
-        self.assertEqual(url, expected_url)
+        assert url == expected_url
 
     @override_settings(ECOMMERCE_PUBLIC_URL_ROOT='http://ecommerce_url')
     def test_get_order_dashboard_url(self):
         """Verify that the proper order dashboard url is returned."""
         url = EcommerceService().get_order_dashboard_url()
         expected_url = 'http://ecommerce_url/dashboard/orders/'
-        self.assertEqual(url, expected_url)
+        assert url == expected_url
 
     @override_settings(ECOMMERCE_PUBLIC_URL_ROOT='http://ecommerce_url')
     @ddt.data(
@@ -146,7 +146,7 @@ class EcommerceServiceTests(TestCase):
                 expected_url=expected_url,
                 program_uuid=program_uuid
             )
-        self.assertEqual(url, expected_url)
+        assert url == expected_url
 
     @override_settings(ECOMMERCE_PUBLIC_URL_ROOT='http://ecommerce_url')
     @ddt.data(
@@ -178,7 +178,7 @@ class EcommerceServiceTests(TestCase):
             skus=urlencode(query, doseq=True),
         )
 
-        self.assertEqual(url, expected_url)
+        assert url == expected_url
 
 
 @ddt.ddt
@@ -375,4 +375,4 @@ class RefundUtilMethodTests(ModuleStoreTestCase):
         enrollment = CourseEnrollment.get_or_create_enrollment(self.user, course_id)
 
         assert refund_success
-        self.assertEqual(enrollment.mode, new_mode)
+        assert enrollment.mode == new_mode

--- a/lms/djangoapps/course_api/blocks/tests/test_api.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_api.py
@@ -46,15 +46,15 @@ class TestGetBlocks(SharedModuleStoreTestCase):
 
     def test_basic(self):
         blocks = get_blocks(self.request, self.course.location, self.user)
-        self.assertEqual(blocks['root'], six.text_type(self.course.location))
+        assert blocks['root'] == six.text_type(self.course.location)
 
         # subtract for (1) the orphaned course About block and (2) the hidden Html block
-        self.assertEqual(len(blocks['blocks']), len(self.store.get_items(self.course.id)) - 2)
-        self.assertNotIn(six.text_type(self.html_block.location), blocks['blocks'])
+        assert len(blocks['blocks']) == (len(self.store.get_items(self.course.id)) - 2)
+        assert six.text_type(self.html_block.location) not in blocks['blocks']
 
     def test_no_user(self):
         blocks = get_blocks(self.request, self.course.location)
-        self.assertIn(six.text_type(self.html_block.location), blocks['blocks'])
+        assert six.text_type(self.html_block.location) in blocks['blocks']
 
     def test_access_before_api_transformer_order(self):
         """
@@ -67,15 +67,15 @@ class TestGetBlocks(SharedModuleStoreTestCase):
 
         vertical_descendants = blocks['blocks'][six.text_type(vertical_block.location)]['descendants']
 
-        self.assertIn(six.text_type(problem_block.location), vertical_descendants)
-        self.assertNotIn(six.text_type(self.html_block.location), vertical_descendants)
+        assert six.text_type(problem_block.location) in vertical_descendants
+        assert six.text_type(self.html_block.location) not in vertical_descendants
 
     def test_sub_structure(self):
         sequential_block = self.store.get_item(self.course.id.make_usage_key('sequential', 'sequential_y1'))
 
         blocks = get_blocks(self.request, sequential_block.location, self.user)
-        self.assertEqual(blocks['root'], six.text_type(sequential_block.location))
-        self.assertEqual(len(blocks['blocks']), 5)
+        assert blocks['root'] == six.text_type(sequential_block.location)
+        assert len(blocks['blocks']) == 5
 
         for block_type, block_name, is_inside_of_structure in (
                 ('vertical', 'vertical_y1a', True),
@@ -85,28 +85,28 @@ class TestGetBlocks(SharedModuleStoreTestCase):
         ):
             block = self.store.get_item(self.course.id.make_usage_key(block_type, block_name))
             if is_inside_of_structure:
-                self.assertIn(six.text_type(block.location), blocks['blocks'])
+                assert six.text_type(block.location) in blocks['blocks']
             else:
-                self.assertNotIn(six.text_type(block.location), blocks['blocks'])
+                assert six.text_type(block.location) not in blocks['blocks']
 
     def test_filtering_by_block_types(self):
         sequential_block = self.store.get_item(self.course.id.make_usage_key('sequential', 'sequential_y1'))
 
         # not filtered blocks
         blocks = get_blocks(self.request, sequential_block.location, self.user, requested_fields=['type'])
-        self.assertEqual(len(blocks['blocks']), 5)
+        assert len(blocks['blocks']) == 5
         found_not_problem = False
         for block in six.itervalues(blocks['blocks']):
             if block['type'] != 'problem':
                 found_not_problem = True
-        self.assertTrue(found_not_problem)
+        assert found_not_problem
 
         # filtered blocks
         blocks = get_blocks(self.request, sequential_block.location, self.user,
                             block_types_filter=['problem'], requested_fields=['type'])
-        self.assertEqual(len(blocks['blocks']), 3)
+        assert len(blocks['blocks']) == 3
         for block in six.itervalues(blocks['blocks']):
-            self.assertEqual(block['type'], 'problem')
+            assert block['type'] == 'problem'
 
 
 # TODO: Remove this class after REVE-52 lands and old-mobile-app traffic falls to < 5% of mobile traffic
@@ -152,7 +152,7 @@ class TestGetBlocksMobileHack(SharedModuleStoreTestCase):
         with patch('lms.djangoapps.course_api.blocks.api.is_request_from_mobile_app', return_value=is_mobile):
             blocks = get_blocks(self.request, self.course.location)
         full_container_key = self.course.id.make_usage_key(container_type, 'full_{}'.format(container_type))
-        self.assertIn(str(full_container_key), blocks['blocks'])
+        assert str(full_container_key) in blocks['blocks']
         empty_container_key = self.course.id.make_usage_key(container_type, 'empty_{}'.format(container_type))
         assert_containment = self.assertNotIn if is_mobile else self.assertIn
         assert_containment(str(empty_container_key), blocks['blocks'])
@@ -181,7 +181,7 @@ class TestGetBlocksMobileHack(SharedModuleStoreTestCase):
         video_block_key = str(self.course.id.make_usage_key('video', 'sample_video'))
         video_block_data = blocks['blocks'][video_block_key]
         for video_data in six.itervalues(video_block_data['student_view_data']['encoded_videos']):
-            self.assertNotIn('cloudfront', video_data['url'])
+            assert 'cloudfront' not in video_data['url']
 
 
 @ddt.ddt

--- a/lms/djangoapps/course_api/blocks/tests/test_forms.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_forms.py
@@ -4,6 +4,7 @@ Tests for Course Blocks forms
 
 
 import ddt
+import pytest
 import six
 from six.moves.urllib.parse import urlencode
 from django.http import Http404, QueryDict
@@ -70,14 +71,14 @@ class TestBlockListGetForm(FormTestMixin, SharedModuleStoreTestCase):
         """
         Fail unless permission is denied to the form
         """
-        with self.assertRaises(PermissionDenied):
+        with pytest.raises(PermissionDenied):
             self.get_form(expected_valid=False)
 
     def assert_raises_not_found(self):
         """
         Fail unless a 404 occurs
         """
-        with self.assertRaises(Http404):
+        with pytest.raises(Http404):
             self.get_form(expected_valid=False)
 
     def assert_equals_cleaned_data(self):

--- a/lms/djangoapps/course_api/blocks/tests/test_serializers.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_serializers.py
@@ -64,14 +64,8 @@ class TestBlockSerializerBase(SharedModuleStoreTestCase):
         Verifies the given serialized_block when basic fields are requested.
         """
         block_key = deserialize_usage_key(block_key_string, self.course.id)
-        self.assertEqual(
-            self.block_structure.get_xblock_field(block_key, 'category'),
-            serialized_block['type'],
-        )
-        self.assertEqual(
-            set(six.iterkeys(serialized_block)),
-            {'id', 'block_id', 'type', 'lms_web_url', 'student_view_url'},
-        )
+        assert self.block_structure.get_xblock_field(block_key, 'category') == serialized_block['type']
+        assert set(six.iterkeys(serialized_block)) == {'id', 'block_id', 'type', 'lms_web_url', 'student_view_url'}
 
     def add_additional_requested_fields(self, context=None):
         """
@@ -95,32 +89,24 @@ class TestBlockSerializerBase(SharedModuleStoreTestCase):
         """
         Verifies the given serialized_block when additional fields are requested.
         """
-        self.assertLessEqual(
-            {
-                'id', 'type', 'lms_web_url', 'student_view_url',
-                'display_name', 'graded',
-                'student_view_multi_device',
-                'lti_url',
-                'visible_to_staff_only',
-            },
-            set(six.iterkeys(serialized_block)),
-        )
+        assert {'id', 'type', 'lms_web_url', 'student_view_url', 'display_name', 'graded', 'student_view_multi_device',
+                'lti_url', 'visible_to_staff_only'} <= set(six.iterkeys(serialized_block))
 
         # video blocks should have student_view_data
         if serialized_block['type'] == 'video':
-            self.assertIn('student_view_data', serialized_block)
+            assert 'student_view_data' in serialized_block
 
         # html blocks should have student_view_multi_device set to True
         if serialized_block['type'] == 'html':
-            self.assertIn('student_view_multi_device', serialized_block)
-            self.assertTrue(serialized_block['student_view_multi_device'])
+            assert 'student_view_multi_device' in serialized_block
+            assert serialized_block['student_view_multi_device']
 
         # chapters with video should have block_counts
         if serialized_block['type'] == 'chapter':
             if serialized_block['display_name'] not in ('poll_test', 'handout_container'):
-                self.assertIn('block_counts', serialized_block)
+                assert 'block_counts' in serialized_block
             else:
-                self.assertNotIn('block_counts', serialized_block)
+                assert 'block_counts' not in serialized_block
 
     def create_staff_context(self):
         """
@@ -146,9 +132,9 @@ class TestBlockSerializerBase(SharedModuleStoreTestCase):
         Test fields accessed by a staff user
         """
         if serialized_block['id'] == six.text_type(self.html_block.location):
-            self.assertTrue(serialized_block['visible_to_staff_only'])
+            assert serialized_block['visible_to_staff_only']
         else:
-            self.assertFalse(serialized_block['visible_to_staff_only'])
+            assert not serialized_block['visible_to_staff_only']
 
 
 class TestBlockSerializer(TestBlockSerializerBase):
@@ -170,14 +156,14 @@ class TestBlockSerializer(TestBlockSerializerBase):
         serializer = self.create_serializer()
         for serialized_block in serializer.data:
             self.assert_basic_block(serialized_block['id'], serialized_block)
-        self.assertEqual(len(serializer.data), 28)
+        assert len(serializer.data) == 28
 
     def test_additional_requested_fields(self):
         self.add_additional_requested_fields()
         serializer = self.create_serializer()
         for serialized_block in serializer.data:
             self.assert_extended_block(serialized_block)
-        self.assertEqual(len(serializer.data), 28)
+        assert len(serializer.data) == 28
 
     def test_staff_fields(self):
         """
@@ -189,7 +175,7 @@ class TestBlockSerializer(TestBlockSerializerBase):
         for serialized_block in serializer.data:
             self.assert_extended_block(serialized_block)
             self.assert_staff_fields(serialized_block)
-        self.assertEqual(len(serializer.data), 29)
+        assert len(serializer.data) == 29
 
 
 class TestBlockDictSerializer(TestBlockSerializerBase):
@@ -211,20 +197,20 @@ class TestBlockDictSerializer(TestBlockSerializerBase):
         serializer = self.create_serializer()
 
         # verify root
-        self.assertEqual(serializer.data['root'], six.text_type(self.block_structure.root_block_usage_key))
+        assert serializer.data['root'] == six.text_type(self.block_structure.root_block_usage_key)
 
         # verify blocks
         for block_key_string, serialized_block in six.iteritems(serializer.data['blocks']):
-            self.assertEqual(serialized_block['id'], block_key_string)
+            assert serialized_block['id'] == block_key_string
             self.assert_basic_block(block_key_string, serialized_block)
-        self.assertEqual(len(serializer.data['blocks']), 28)
+        assert len(serializer.data['blocks']) == 28
 
     def test_additional_requested_fields(self):
         self.add_additional_requested_fields()
         serializer = self.create_serializer()
         for serialized_block in six.itervalues(serializer.data['blocks']):
             self.assert_extended_block(serialized_block)
-        self.assertEqual(len(serializer.data['blocks']), 28)
+        assert len(serializer.data['blocks']) == 28
 
     def test_staff_fields(self):
         """
@@ -236,4 +222,4 @@ class TestBlockDictSerializer(TestBlockSerializerBase):
         for serialized_block in six.itervalues(serializer.data['blocks']):
             self.assert_extended_block(serialized_block)
             self.assert_staff_fields(serialized_block)
-        self.assertEqual(len(serializer.data['blocks']), 29)
+        assert len(serializer.data['blocks']) == 29

--- a/lms/djangoapps/course_api/blocks/tests/test_views.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_views.py
@@ -81,7 +81,7 @@ class TestBlocksView(SharedModuleStoreTestCase):
         if params:
             self.query_params.update(params)
         response = self.client.get(url or self.url, self.query_params)
-        self.assertEqual(response.status_code, expected_status_code, str(response.content))
+        assert response.status_code == expected_status_code, str(response.content)
         if cacheable:
             assert response.get('Cache-Control', None) == 'max-age={}'.format(
                 settings.CACHE_MIDDLEWARE_SECONDS
@@ -122,7 +122,7 @@ class TestBlocksView(SharedModuleStoreTestCase):
             self.assert_in_iff('format', block_data, xblock.format is not None)
             self.assert_in_iff('due', block_data, xblock.due is not None)
             self.assert_true_iff(block_data['student_view_multi_device'], block_data['type'] == 'html')
-            self.assertNotIn('not_a_field', block_data)
+            assert 'not_a_field' not in block_data
 
             if xblock.has_children:
                 self.assertSetEqual(
@@ -140,9 +140,9 @@ class TestBlocksView(SharedModuleStoreTestCase):
             predicate - an expression, tested for truthiness
         """
         if predicate:
-            self.assertIn(member, container)
+            assert member in container
         else:
-            self.assertNotIn(member, container)
+            assert member not in container
 
     def assert_true_iff(self, expression, predicate):
         """
@@ -154,9 +154,9 @@ class TestBlocksView(SharedModuleStoreTestCase):
         """
 
         if predicate:
-            self.assertTrue(expression)
+            assert expression
         else:
-            self.assertFalse(expression)
+            assert not expression
 
     def test_not_authenticated_non_public_course_with_other_username(self):
         """
@@ -269,13 +269,13 @@ class TestBlocksView(SharedModuleStoreTestCase):
 
     def test_basic(self):
         response = self.verify_response()
-        self.assertEqual(response.data['root'], str(self.course_usage_key))
+        assert response.data['root'] == str(self.course_usage_key)
         self.verify_response_block_dict(response)
         for block_key_string, block_data in response.data['blocks'].items():
             block_key = deserialize_usage_key(block_key_string, self.course_key)
-            self.assertEqual(block_data['id'], block_key_string)
-            self.assertEqual(block_data['type'], block_key.block_type)
-            self.assertEqual(block_data['display_name'], self.store.get_item(block_key).display_name or '')
+            assert block_data['id'] == block_key_string
+            assert block_data['type'] == block_key.block_type
+            assert block_data['display_name'] == (self.store.get_item(block_key).display_name or '')
 
     def test_return_type_param(self):
         response = self.verify_response(params={'return_type': 'list'})
@@ -285,18 +285,9 @@ class TestBlocksView(SharedModuleStoreTestCase):
         response = self.verify_response(params={'block_counts': ['course', 'chapter']})
         self.verify_response_block_dict(response)
         for block_data in response.data['blocks'].values():
-            self.assertEqual(
-                block_data['block_counts']['course'],
-                1 if block_data['type'] == 'course' else 0,
-            )
-            self.assertEqual(
-                block_data['block_counts']['chapter'],
-                (
-                    1 if block_data['type'] == 'chapter' else
-                    5 if block_data['type'] == 'course' else
-                    0
-                )
-            )
+            assert block_data['block_counts']['course'] == (1 if (block_data['type'] == 'course') else 0)
+            assert block_data['block_counts']['chapter'] == (1 if (block_data['type'] == 'chapter') else
+                                                             (5 if (block_data['type'] == 'course') else 0))
 
     def test_student_view_data_param(self):
         response = self.verify_response(params={
@@ -360,10 +351,7 @@ class TestBlocksView(SharedModuleStoreTestCase):
         })
         self.verify_response_block_dict(response)
         for block_data in response.data['blocks'].values():
-            self.assertNotIn(
-                'other_course_settings',
-                block_data
-            )
+            assert 'other_course_settings' not in block_data
 
             self.assert_in_iff(
                 'course_visibility',
@@ -375,7 +363,7 @@ class TestBlocksView(SharedModuleStoreTestCase):
         response = self.verify_response(params={'nav_depth': 10})
         self.verify_response_block_dict(response)
         for block_data in response.data['blocks'].values():
-            self.assertIn('descendants', block_data)
+            assert 'descendants' in block_data
 
     def test_requested_fields_param(self):
         response = self.verify_response(
@@ -441,7 +429,7 @@ class TestBlocksInCourseView(TestBlocksView, CompletionWaffleTestMixin):  # pyli
         })
 
         completion = response.data['blocks'][str(block_usage_key)].get('completion')
-        self.assertTrue(completion)
+        assert completion
 
     def test_completion_all_course(self):
         for block in self.non_orphaned_raw_block_usage_keys:
@@ -452,7 +440,7 @@ class TestBlocksInCourseView(TestBlocksView, CompletionWaffleTestMixin):  # pyli
             'requested_fields': ['completion', 'children'],
         })
         for block_id in self.non_orphaned_block_usage_keys:
-            self.assertTrue(response.data['blocks'][block_id].get('completion'))
+            assert response.data['blocks'][block_id].get('completion')
 
     def test_completion_all_course_with_list_return_type(self):
         for block in self.non_orphaned_raw_block_usage_keys:
@@ -465,4 +453,4 @@ class TestBlocksInCourseView(TestBlocksView, CompletionWaffleTestMixin):  # pyli
         })
         for block in response.data:
             if block['block_id'] in self.non_orphaned_block_usage_keys:
-                self.assertTrue(block.get('completion'))
+                assert block.get('completion')

--- a/lms/djangoapps/course_api/blocks/transformers/tests/test_block_completion.py
+++ b/lms/djangoapps/course_api/blocks/transformers/tests/test_block_completion.py
@@ -115,4 +115,4 @@ class BlockCompletionTransformerTestCase(TransformerRegistryTestMixin, Completio
         )
         completion_value = block_data.fields['completion']
 
-        self.assertEqual(completion_value, expected_value)
+        assert completion_value == expected_value

--- a/lms/djangoapps/course_api/blocks/transformers/tests/test_block_counts.py
+++ b/lms/djangoapps/course_api/blocks/transformers/tests/test_block_counts.py
@@ -41,13 +41,13 @@ class TestBlockCountsTransformer(ModuleStoreTestCase):
         )
 
         # verify count of chapters
-        self.assertEqual(block_counts_for_course.chapter, 2)
+        assert block_counts_for_course.chapter == 2
 
         # verify count of problems
-        self.assertEqual(block_counts_for_course.problem, 6)
-        self.assertEqual(block_counts_for_chapter_x.problem, 3)
+        assert block_counts_for_course.problem == 6
+        assert block_counts_for_chapter_x.problem == 3
 
         # verify other block types are not counted
         for block_type in ['course', 'html', 'video']:
-            self.assertFalse(hasattr(block_counts_for_course, block_type))
-            self.assertFalse(hasattr(block_counts_for_chapter_x, block_type))
+            assert not hasattr(block_counts_for_course, block_type)
+            assert not hasattr(block_counts_for_chapter_x, block_type)

--- a/lms/djangoapps/course_api/blocks/transformers/tests/test_extra_fields.py
+++ b/lms/djangoapps/course_api/blocks/transformers/tests/test_extra_fields.py
@@ -55,7 +55,4 @@ class TestExtraFieldsTransformer(ModuleStoreTestCase):
             self.course_usage_key, ExtraFieldsTransformer,
         )
 
-        self.assertEqual(
-            block_data.other_course_settings,
-            self.OTHER_COURSE_SETTINGS_DEFAULT
-        )
+        assert block_data.other_course_settings == self.OTHER_COURSE_SETTINGS_DEFAULT

--- a/lms/djangoapps/course_api/blocks/transformers/tests/test_milestones.py
+++ b/lms/djangoapps/course_api/blocks/transformers/tests/test_milestones.py
@@ -222,7 +222,4 @@ class MilestonesTransformerTestCase(CourseStructureTestCase, MilestonesTestCaseM
             self.course.location,
             self.transformers,
         )
-        self.assertEqual(
-            set(block_structure.get_block_keys()),
-            set(self.get_block_key_set(self.blocks, *expected_blocks)),
-        )
+        assert set(block_structure.get_block_keys()) == set(self.get_block_key_set(self.blocks, *expected_blocks))

--- a/lms/djangoapps/course_api/blocks/transformers/tests/test_navigation.py
+++ b/lms/djangoapps/course_api/blocks/transformers/tests/test_navigation.py
@@ -92,14 +92,14 @@ class BlockNavigationTransformerCourseTestCase(ModuleStoreTestCase):
         BlockNavigationTransformer.collect(block_structure)
         block_structure._collect_requested_xblock_fields()
 
-        self.assertIn(chapter_x_key, block_structure)
+        assert chapter_x_key in block_structure
 
         # transform phase
         BlockDepthTransformer().transform(usage_info=None, block_structure=block_structure)
         BlockNavigationTransformer(0).transform(usage_info=None, block_structure=block_structure)
         block_structure._prune_unreachable()
 
-        self.assertIn(chapter_x_key, block_structure)
+        assert chapter_x_key in block_structure
 
         course_descendants = block_structure.get_transformer_block_field(
             course_usage_key,
@@ -114,7 +114,7 @@ class BlockNavigationTransformerCourseTestCase(ModuleStoreTestCase):
                 course_key.make_usage_key('vertical', 'vertical_y1a'),
                 course_key.make_usage_key('problem', 'problem_y1a_1'),
         ]:
-            self.assertIn(six.text_type(block_key), course_descendants)
+            assert six.text_type(block_key) in course_descendants
 
         # chapter_x and its descendants should not be included
         for block_key in [
@@ -123,4 +123,4 @@ class BlockNavigationTransformerCourseTestCase(ModuleStoreTestCase):
                 course_key.make_usage_key('vertical', 'vertical_x1a'),
                 course_key.make_usage_key('problem', 'problem_x1a_1'),
         ]:
-            self.assertNotIn(six.text_type(block_key), course_descendants)
+            assert six.text_type(block_key) not in course_descendants

--- a/lms/djangoapps/course_api/blocks/transformers/tests/test_student_view.py
+++ b/lms/djangoapps/course_api/blocks/transformers/tests/test_student_view.py
@@ -41,28 +41,23 @@ class TestStudentViewTransformer(ModuleStoreTestCase):
 
         # verify video data returned iff requested
         video_block_key = self.course_key.make_usage_key('video', 'sample_video')
-        self.assertEqual(
-            self.block_structure.get_transformer_block_field(
-                video_block_key, StudentViewTransformer, StudentViewTransformer.STUDENT_VIEW_DATA,
-            ) is not None,
-            'video' in requested_student_view_data
-        )
-        self.assertFalse(
-            self.block_structure.get_transformer_block_field(
-                video_block_key, StudentViewTransformer, StudentViewTransformer.STUDENT_VIEW_MULTI_DEVICE,
-            )
-        )
+        assert (self.block_structure
+                .get_transformer_block_field(video_block_key,
+                                             StudentViewTransformer,
+                                             StudentViewTransformer.STUDENT_VIEW_DATA) is not None) == \
+               ('video' in requested_student_view_data)
+
+        assert not self.block_structure\
+            .get_transformer_block_field(video_block_key, StudentViewTransformer,
+                                         StudentViewTransformer.STUDENT_VIEW_MULTI_DEVICE)
 
         # verify html data returned iff requested
         html_block_key = self.course_key.make_usage_key('html', 'toyhtml')
-        self.assertEqual(
-            self.block_structure.get_transformer_block_field(
-                html_block_key, StudentViewTransformer, StudentViewTransformer.STUDENT_VIEW_DATA,
-            ) is not None,
-            'html' in requested_student_view_data
-        )
-        self.assertTrue(
-            self.block_structure.get_transformer_block_field(
-                html_block_key, StudentViewTransformer, StudentViewTransformer.STUDENT_VIEW_MULTI_DEVICE,
-            )
-        )
+        assert (self.block_structure
+                .get_transformer_block_field(html_block_key, StudentViewTransformer,
+                                             StudentViewTransformer.STUDENT_VIEW_DATA) is not None) ==\
+               ('html' in requested_student_view_data)
+
+        assert self.block_structure\
+            .get_transformer_block_field(html_block_key, StudentViewTransformer,
+                                         StudentViewTransformer.STUDENT_VIEW_MULTI_DEVICE)

--- a/lms/djangoapps/course_api/blocks/transformers/tests/test_video_urls.py
+++ b/lms/djangoapps/course_api/blocks/transformers/tests/test_video_urls.py
@@ -92,7 +92,7 @@ class TestVideoBlockURLTransformer(ModuleStoreTestCase):
         post_transform_data = self.change_encoded_videos_presentation(post_transform_data['encoded_videos'])
 
         for video_format, video_url in six.iteritems(post_transform_data):
-            self.assertNotEqual(pre_transform_data[video_format], video_url)
+            assert pre_transform_data[video_format] != video_url
 
     @mock.patch('xmodule.video_module.VideoBlock.student_view_data')
     def test_no_rewrite_for_third_party_vendor(self, mock_video_data):
@@ -122,7 +122,7 @@ class TestVideoBlockURLTransformer(ModuleStoreTestCase):
         post_transform_data = self.change_encoded_videos_presentation(post_transform_data['encoded_videos'])
 
         for video_format, video_url in six.iteritems(post_transform_data):
-            self.assertEqual(pre_transform_data[video_format], video_url)
+            assert pre_transform_data[video_format] == video_url
 
     @mock.patch('xmodule.video_module.VideoBlock.student_view_data')
     def test_no_rewrite_for_web_only_videos(self, mock_video_data):

--- a/lms/djangoapps/course_api/tests/test_permissions.py
+++ b/lms/djangoapps/course_api/tests/test_permissions.py
@@ -2,7 +2,7 @@
 Test authorization functions
 """
 
-
+import pytest
 from django.contrib.auth.models import AnonymousUser
 from django.test import TestCase
 
@@ -26,23 +26,23 @@ class ViewCoursesForUsernameTestCase(CourseApiFactoryMixin, TestCase):
         cls.anonymous_user = AnonymousUser()
 
     def test_for_staff(self):
-        self.assertTrue(can_view_courses_for_username(self.staff_user, self.staff_user.username))
+        assert can_view_courses_for_username(self.staff_user, self.staff_user.username)
 
     def test_for_honor(self):
-        self.assertTrue(can_view_courses_for_username(self.honor_user, self.honor_user.username))
+        assert can_view_courses_for_username(self.honor_user, self.honor_user.username)
 
     def test_for_staff_as_honor(self):
-        self.assertTrue(can_view_courses_for_username(self.staff_user, self.honor_user.username))
+        assert can_view_courses_for_username(self.staff_user, self.honor_user.username)
 
     def test_for_honor_as_staff(self):
-        self.assertFalse(can_view_courses_for_username(self.honor_user, self.staff_user.username))
+        assert not can_view_courses_for_username(self.honor_user, self.staff_user.username)
 
     def test_for_none_as_staff(self):
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             can_view_courses_for_username(self.staff_user, None)
 
     def test_for_anonymous(self):
-        self.assertTrue(can_view_courses_for_username(self.anonymous_user, self.anonymous_user.username))
+        assert can_view_courses_for_username(self.anonymous_user, self.anonymous_user.username)
 
     def test_for_anonymous_as_honor(self):
-        self.assertFalse(can_view_courses_for_username(self.anonymous_user, self.honor_user.username))
+        assert not can_view_courses_for_username(self.anonymous_user, self.honor_user.username)

--- a/lms/djangoapps/course_api/tests/test_serializers.py
+++ b/lms/djangoapps/course_api/tests/test_serializers.py
@@ -115,7 +115,7 @@ class TestCourseSerializer(CourseApiFactoryMixin, ModuleStoreTestCase):
             catalog_visibility=u'none'
         )
         result = self._get_result(course)
-        self.assertEqual(result['hidden'], True)
+        assert result['hidden'] is True
 
     def test_advertised_start(self):
         course = self.create_course(
@@ -124,16 +124,16 @@ class TestCourseSerializer(CourseApiFactoryMixin, ModuleStoreTestCase):
             advertised_start=u'The Ides of March'
         )
         result = self._get_result(course)
-        self.assertEqual(result['course_id'], u'edX/custom/2012_Fall')
-        self.assertEqual(result['start_type'], u'string')
-        self.assertEqual(result['start_display'], u'The Ides of March')
+        assert result['course_id'] == u'edX/custom/2012_Fall'
+        assert result['start_type'] == u'string'
+        assert result['start_display'] == u'The Ides of March'
 
     def test_empty_start(self):
         course = self.create_course(start=DEFAULT_START_DATE, course=u'custom')
         result = self._get_result(course)
-        self.assertEqual(result['course_id'], u'edX/custom/2012_Fall')
-        self.assertEqual(result['start_type'], u'empty')
-        self.assertIsNone(result['start_display'])
+        assert result['course_id'] == u'edX/custom/2012_Fall'
+        assert result['start_type'] == u'empty'
+        assert result['start_display'] is None
 
     @ddt.unpack
     @ddt.data(
@@ -143,7 +143,7 @@ class TestCourseSerializer(CourseApiFactoryMixin, ModuleStoreTestCase):
     def test_pacing(self, self_paced, expected_pacing):
         course = self.create_course(self_paced=self_paced)
         result = self._get_result(course)
-        self.assertEqual(result['pacing'], expected_pacing)
+        assert result['pacing'] == expected_pacing
 
 
 class TestCourseDetailSerializer(TestCourseSerializer):  # lint-amnesty, pylint: disable=test-inherits-tests
@@ -171,4 +171,4 @@ class TestCourseKeySerializer(TestCase):  # lint-amnesty, pylint: disable=missin
     def test_course_key_serializer(self):
         course_key = CourseLocator(org='org', course='course', run='2020_Q3')
         serializer = CourseKeySerializer(course_key)
-        self.assertEqual(serializer.data, str(course_key))
+        assert serializer.data == str(course_key)


### PR DESCRIPTION
## Description
This PR is using `codemod-unittest-to-pytest-asserts` to automatically replace `unittest` assertions with `pytest` 
for following apps in `lms/djangoapps`
```
certificates, class_dashboard, commerce, course_api
```
Relevant JIRA issue here: https://openedx.atlassian.net/browse/BOM-2386