### PR TITLE
replaced unittest assertions pytest assertions (16)

### DIFF
--- a/lms/djangoapps/course_blocks/transformers/tests/helpers.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/helpers.py
@@ -324,33 +324,21 @@ class BlockParentsMapTestCase(TransformerRegistryTestMixin, ModuleStoreTestCase)
             block_structure_result = xblock_key in block_structure
 
             # compare with expected value
-            self.assertEqual(
-                block_structure_result,
-                i in expected_accessible_blocks,
-                u"block_structure return value {0} not equal to expected value for block {1} for user {2}".format(
-                    block_structure_result, i, user.username
-                )
-            )
+            assert block_structure_result == (i in expected_accessible_blocks), \
+                f'block_structure return value {block_structure_result} not equal to expected value for block' \
+                f' {i} for user {user.username}'
 
             if blocks_with_differing_access:
                 # compare with has_access_result
                 has_access_result = bool(has_access(user, 'load', self.get_block(i), course_key=self.course.id))
                 if i in blocks_with_differing_access:
-                    self.assertNotEqual(
-                        block_structure_result,
-                        has_access_result,
-                        u"block structure ({0}) & has_access ({1}) results are equal for block {2} for user {3}".format(
-                            block_structure_result, has_access_result, i, user.username
-                        )
-                    )
+                    assert block_structure_result != has_access_result, \
+                        f'block structure ({block_structure_result}) & has_access ({has_access_result})' \
+                        f' results are equal for block {i} for user {user.username}'
                 else:
-                    self.assertEqual(
-                        block_structure_result,
-                        has_access_result,
-                        u"block structure ({0}) & has_access ({1}) results not equal for block {2} for user {3}".format(
-                            block_structure_result, has_access_result, i, user.username
-                        )
-                    )
+                    assert block_structure_result == has_access_result, \
+                        f'block structure ({block_structure_result}) & has_access ({has_access_result})' \
+                        f' results not equal for block {i} for user {user.username}'
 
         self.client.logout()
 

--- a/lms/djangoapps/course_blocks/transformers/tests/test_library_content.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_library_content.py
@@ -122,7 +122,7 @@ class ContentLibraryTransformerTestCase(CourseStructureTestCase):
             self.course.location,
             transformers=BlockStructureTransformers(),
         )
-        self.assertEqual(len(list(raw_block_structure.get_block_keys())), len(self.blocks))
+        assert len(list(raw_block_structure.get_block_keys())) == len(self.blocks)
 
         clear_course_from_cache(self.course.id)
         trans_block_structure = get_course_blocks(
@@ -137,12 +137,13 @@ class ContentLibraryTransformerTestCase(CourseStructureTestCase):
             self.blocks, 'course', 'chapter1', 'lesson1', 'vertical1', 'library_content1'
         )
         for key in block_key_set:
-            self.assertIn(key, trans_keys)
+            assert key in trans_keys
 
         vertical2_selected = self.get_block_key_set(self.blocks, 'vertical2').pop() in trans_keys
         vertical3_selected = self.get_block_key_set(self.blocks, 'vertical3').pop() in trans_keys
 
-        self.assertNotEqual(vertical2_selected, vertical3_selected)  # only one of them should be selected
+        assert vertical2_selected != vertical3_selected
+        # only one of them should be selected
         selected_vertical = 'vertical2' if vertical2_selected else 'vertical3'
         selected_child = 'html1' if vertical2_selected else 'html2'
 
@@ -154,20 +155,7 @@ class ContentLibraryTransformerTestCase(CourseStructureTestCase):
                 self.course.location,
                 self.transformers,
             )
-            self.assertEqual(
-                set(trans_block_structure.get_block_keys()),
-                self.get_block_key_set(
-                    self.blocks,
-                    'course',
-                    'chapter1',
-                    'lesson1',
-                    'vertical1',
-                    'library_content1',
-                    selected_vertical,
-                    selected_child,
-                ),
-                u"Expected 'selected' equality failed in iteration {}.".format(i)
-            )
+            assert set(trans_block_structure.get_block_keys()) == self.get_block_key_set(self.blocks, 'course', 'chapter1', 'lesson1', 'vertical1', 'library_content1', selected_vertical, selected_child), f"Expected 'selected' equality failed in iteration {i}."  # pylint: disable=line-too-long
 
 
 class ContentLibraryOrderTransformerTestCase(CourseStructureTestCase):
@@ -290,11 +278,8 @@ class ContentLibraryOrderTransformerTestCase(CourseStructureTestCase):
                     break
 
             expected_children = ['vertical_vertical3', 'vertical_vertical2', 'vertical_vertical4']
-            self.assertEqual(
-                expected_children,
-                [child.block_id for child in children],
-                u"Expected 'selected' equality failed in iteration {}.".format(i)
-            )
+            assert expected_children == [child.block_id for child in children], \
+                f"Expected 'selected' equality failed in iteration {i}."
 
     @mock.patch('lms.djangoapps.course_blocks.transformers.library_content.get_student_module_as_dict')
     def test_content_library_randomize_selected_blocks_mismatch(self, mocked):
@@ -344,7 +329,4 @@ class ContentLibraryOrderTransformerTestCase(CourseStructureTestCase):
                     children = trans_block_structure.get_children(block_key)
                     break
 
-            self.assertNotEqual(
-                expected_children_without_hiding_or_gating,
-                [child.block_id for child in children],
-            )
+            assert expected_children_without_hiding_or_gating != [child.block_id for child in children]

--- a/lms/djangoapps/course_blocks/transformers/tests/test_split_test.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_split_test.py
@@ -197,17 +197,14 @@ class SplitTestTransformerTestCase(CourseStructureTestCase):
             self.course.location,
             self.transformers,
         )
-        self.assertEqual(
-            set(block_structure1.get_block_keys()),
-            set(self.get_block_key_set(self.blocks, *expected_blocks)),
-        )
+        assert set(block_structure1.get_block_keys()) == set(self.get_block_key_set(self.blocks, *expected_blocks))
 
     def test_user_randomly_assigned(self):
         # user was randomly assigned to one of the groups
         user_groups = get_user_partition_groups(
             self.course.id, [self.split_test_user_partition], self.user, 'id'
         )
-        self.assertEqual(len(user_groups), 1)
+        assert len(user_groups) == 1
 
         # calling twice should result in the same block set
         block_structure1 = get_course_blocks(
@@ -221,7 +218,4 @@ class SplitTestTransformerTestCase(CourseStructureTestCase):
                 self.course.location,
                 self.transformers,
             )
-        self.assertEqual(
-            set(block_structure1.get_block_keys()),
-            set(block_structure2.get_block_keys()),
-        )
+        assert set(block_structure1.get_block_keys()) == set(block_structure2.get_block_keys())

--- a/lms/djangoapps/course_blocks/transformers/tests/test_user_partitions.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_user_partitions.py
@@ -475,10 +475,7 @@ class MergedGroupAccessTestData(UserPartitionTestMixin, CourseStructureTestCase)
         for partition_id, group_id in six.iteritems(user_partition_groups):
             user_partition_groups[partition_id] = self.groups[group_id - 1]
 
-        self.assertEqual(
-            merged_group_access.check_group_access(user_partition_groups),
-            expected_access,
-        )
+        assert merged_group_access.check_group_access(user_partition_groups) == expected_access
 
     @ddt.data(
         ([None], None),
@@ -493,7 +490,4 @@ class MergedGroupAccessTestData(UserPartitionTestMixin, CourseStructureTestCase)
     )
     @ddt.unpack
     def test_intersection_method(self, input_value, expected_result):
-        self.assertEqual(
-            _MergedGroupAccess._intersection(*input_value),
-            expected_result,
-        )
+        assert _MergedGroupAccess._intersection(*input_value) == expected_result

--- a/lms/djangoapps/course_goals/tests/test_api.py
+++ b/lms/djangoapps/course_goals/tests/test_api.py
@@ -44,25 +44,25 @@ class TestCourseGoalsAPI(EventTrackingTestCase, SharedModuleStoreTestCase):
     def test_add_valid_goal(self, ga_call):
         """ Ensures a correctly formatted post succeeds."""
         response = self.post_course_goal(valid=True, goal_key='certify')
-        self.assertEqual(self.get_event(-1)['name'], EVENT_NAME_ADDED)
+        assert self.get_event((- 1))['name'] == EVENT_NAME_ADDED
         ga_call.assert_called_with(self.user.id, EVENT_NAME_ADDED)
-        self.assertEqual(response.status_code, 201)
+        assert response.status_code == 201
 
         current_goals = CourseGoal.objects.filter(user=self.user, course_key=self.course.id)
-        self.assertEqual(len(current_goals), 1)
-        self.assertEqual(current_goals[0].goal_key, 'certify')
+        assert len(current_goals) == 1
+        assert current_goals[0].goal_key == 'certify'
 
     def test_add_invalid_goal(self):
         """ Ensures an incorrectly formatted post does not succeed. """
         response = self.post_course_goal(valid=False)
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(len(CourseGoal.objects.filter(user=self.user, course_key=self.course.id)), 0)
+        assert response.status_code == 400
+        assert len(CourseGoal.objects.filter(user=self.user, course_key=self.course.id)) == 0
 
     def test_add_without_goal_key(self):
         """ Ensures if no goal key provided, post does not succeed. """
 
         response = self.post_course_goal(goal_key=None)
-        self.assertEqual(len(CourseGoal.objects.filter(user=self.user, course_key=self.course.id)), 0)
+        assert len(CourseGoal.objects.filter(user=self.user, course_key=self.course.id)) == 0
         self.assertContains(
             response=response,
             text='Please provide a valid goal key from following options.',
@@ -76,12 +76,12 @@ class TestCourseGoalsAPI(EventTrackingTestCase, SharedModuleStoreTestCase):
         self.post_course_goal(valid=True, goal_key='explore')
         self.post_course_goal(valid=True, goal_key='certify')
         self.post_course_goal(valid=True, goal_key='unsure')
-        self.assertEqual(self.get_event(-1)['name'], EVENT_NAME_UPDATED)
+        assert self.get_event((- 1))['name'] == EVENT_NAME_UPDATED
 
         ga_call.assert_called_with(self.user.id, EVENT_NAME_UPDATED)
         current_goals = CourseGoal.objects.filter(user=self.user, course_key=self.course.id)
-        self.assertEqual(len(current_goals), 1)
-        self.assertEqual(current_goals[0].goal_key, 'unsure')
+        assert len(current_goals) == 1
+        assert current_goals[0].goal_key == 'unsure'
 
     def post_course_goal(self, valid=True, goal_key='certify'):
         """

--- a/lms/djangoapps/course_home_api/course_metadata/v1/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/course_metadata/v1/tests/test_views.py
@@ -25,10 +25,10 @@ class CourseHomeMetadataTests(BaseCourseHomeTests):
     def test_get_authenticated_user(self):
         CourseEnrollment.enroll(self.user, self.course.id, CourseMode.VERIFIED)
         response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 200)
-        self.assertFalse(response.data.get('is_staff'))
+        assert response.status_code == 200
+        assert not response.data.get('is_staff')
         # 'Course', 'Wiki', 'Progress' tabs
-        self.assertEqual(len(response.data.get('tabs', [])), 3)
+        assert len(response.data.get('tabs', [])) == 3
 
     def test_get_authenticated_staff_user(self):
         self.client.logout()
@@ -40,13 +40,13 @@ class CourseHomeMetadataTests(BaseCourseHomeTests):
         )
         self.client.login(username=staff_user.username, password='bar')
         response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(response.data['is_staff'])
+        assert response.status_code == 200
+        assert response.data['is_staff']
         # This differs for a staff user because they also receive the Instructor tab
         # 'Course', 'Wiki', 'Progress', and 'Instructor' tabs
-        self.assertEqual(len(response.data.get('tabs', [])), 4)
+        assert len(response.data.get('tabs', [])) == 4
 
     def test_get_unknown_course(self):
         url = reverse('course-home-course-metadata', args=['course-v1:unknown+course+2T2020'])
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 404)
+        assert response.status_code == 404

--- a/lms/djangoapps/course_home_api/dates/v1/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/dates/v1/tests/test_views.py
@@ -32,39 +32,39 @@ class DatesTabTestViews(BaseCourseHomeTests):
     def test_get_authenticated_enrolled_user(self, enrollment_mode):
         CourseEnrollment.enroll(self.user, self.course.id, enrollment_mode)
         response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
         # Pulling out the date blocks to check learner has access.
         date_blocks = response.data.get('course_date_blocks')
-        self.assertEqual(response.data.get('learner_is_full_access'), enrollment_mode == CourseMode.VERIFIED)
-        self.assertTrue(all(block.get('learner_has_access') for block in date_blocks))
+        assert response.data.get('learner_is_full_access') == (enrollment_mode == CourseMode.VERIFIED)
+        assert all((block.get('learner_has_access') for block in date_blocks))
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @override_waffle_flag(COURSE_HOME_MICROFRONTEND_DATES_TAB, active=True)
     def test_get_authenticated_user_not_enrolled(self):
         response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 200)
-        self.assertFalse(response.data.get('learner_is_full_access'))
+        assert response.status_code == 200
+        assert not response.data.get('learner_is_full_access')
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @override_waffle_flag(COURSE_HOME_MICROFRONTEND_DATES_TAB, active=True)
     def test_get_unauthenticated_user(self):
         self.client.logout()
         response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 401)
+        assert response.status_code == 401
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @override_waffle_flag(COURSE_HOME_MICROFRONTEND_DATES_TAB, active=True)
     def test_get_unknown_course(self):
         url = reverse('course-home-dates-tab', args=['course-v1:unknown+course+2T2020'])
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 404)
+        assert response.status_code == 404
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @override_waffle_flag(COURSE_HOME_MICROFRONTEND_DATES_TAB, active=True)
     def test_banner_data_is_returned(self):
         response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         self.assertContains(response, 'missed_deadlines')
         self.assertContains(response, 'missed_gated_content')
         self.assertContains(response, 'content_type_gating_enabled')
@@ -75,7 +75,7 @@ class DatesTabTestViews(BaseCourseHomeTests):
     def test_masquerade(self):
         self.switch_to_staff()
         CourseEnrollment.enroll(self.user, self.course.id, 'audit')
-        self.assertTrue(self.client.get(self.url).data.get('learner_is_full_access'))
+        assert self.client.get(self.url).data.get('learner_is_full_access')
 
         self.update_masquerade(role='student')
-        self.assertFalse(self.client.get(self.url).data.get('learner_is_full_access'))
+        assert not self.client.get(self.url).data.get('learner_is_full_access')

--- a/lms/djangoapps/course_home_api/outline/v1/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/outline/v1/tests/test_views.py
@@ -46,68 +46,68 @@ class OutlineTabTestViews(BaseCourseHomeTests):
     def test_get_authenticated_enrolled_user(self, enrollment_mode):
         CourseEnrollment.enroll(self.user, self.course.id, enrollment_mode)
         response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
         course_goals = response.data.get('course_goals')
         goal_options = course_goals['goal_options']
         if enrollment_mode == CourseMode.VERIFIED:
-            self.assertEqual(goal_options, [])
+            assert goal_options == []
         else:
-            self.assertGreater(len(goal_options), 0)
+            assert len(goal_options) > 0
 
             selected_goal = course_goals['selected_goal']
-            self.assertIsNone(selected_goal)
+            assert selected_goal is None
 
         course_tools = response.data.get('course_tools')
-        self.assertTrue(course_tools)
-        self.assertEqual(course_tools[0]['analytics_id'], 'edx.bookmarks')
+        assert course_tools
+        assert course_tools[0]['analytics_id'] == 'edx.bookmarks'
 
         dates_widget = response.data.get('dates_widget')
-        self.assertTrue(dates_widget)
+        assert dates_widget
         date_blocks = dates_widget.get('course_date_blocks')
-        self.assertTrue(all((block.get('title') != "") for block in date_blocks))
-        self.assertTrue(all(block.get('date') for block in date_blocks))
+        assert all(((block.get('title') != '') for block in date_blocks))
+        assert all((block.get('date') for block in date_blocks))
 
         resume_course = response.data.get('resume_course')
         resume_course_url = resume_course.get('url')
         if resume_course_url:
-            self.assertIn('http://', resume_course_url)
+            assert 'http://' in resume_course_url
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
     def test_get_authenticated_user_not_enrolled(self):
         response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
         course_goals = response.data.get('course_goals')
-        self.assertEqual(course_goals['goal_options'], [])
+        assert course_goals['goal_options'] == []
 
         course_tools = response.data.get('course_tools')
-        self.assertEqual(len(course_tools), 0)
+        assert len(course_tools) == 0
 
         dates_widget = response.data.get('dates_widget')
-        self.assertTrue(dates_widget)
+        assert dates_widget
         date_blocks = dates_widget.get('course_date_blocks')
-        self.assertTrue(all((block.get('title') != "") for block in date_blocks))
-        self.assertTrue(all(block.get('date') for block in date_blocks))
+        assert all(((block.get('title') != '') for block in date_blocks))
+        assert all((block.get('date') for block in date_blocks))
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
     def test_get_unauthenticated_user(self):
         self.client.logout()
         response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
         course_blocks = response.data.get('course_blocks')
-        self.assertEqual(course_blocks, None)
+        assert course_blocks is None
 
         course_tools = response.data.get('course_tools')
-        self.assertEqual(len(course_tools), 0)
+        assert len(course_tools) == 0
 
         dates_widget = response.data.get('dates_widget')
-        self.assertTrue(dates_widget)
+        assert dates_widget
         date_blocks = dates_widget.get('course_date_blocks')
-        self.assertEqual(len(date_blocks), 0)
+        assert len(date_blocks) == 0
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
@@ -119,11 +119,11 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         self.switch_to_staff()  # needed for masquerade
 
         # Sanity check on our normal user
-        self.assertEqual(self.client.get(self.url).data['dates_widget']['user_timezone'], None)
+        assert self.client.get(self.url).data['dates_widget']['user_timezone'] is None
 
         # Now switch users and confirm we get a different result
         self.update_masquerade(username=user.username)
-        self.assertEqual(self.client.get(self.url).data['dates_widget']['user_timezone'], 'Asia/Tokyo')
+        assert self.client.get(self.url).data['dates_widget']['user_timezone'] == 'Asia/Tokyo'
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
@@ -131,14 +131,14 @@ class OutlineTabTestViews(BaseCourseHomeTests):
     def test_handouts(self):
         CourseEnrollment.enroll(self.user, self.course.id)
         self.store.create_item(self.user.id, self.course.id, 'course_info', 'handouts', fields={'data': '<p>Hi</p>'})
-        self.assertEqual(self.client.get(self.url).data['handouts_html'], '<p>Hi</p>')
+        assert self.client.get(self.url).data['handouts_html'] == '<p>Hi</p>'
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
     def test_get_unknown_course(self):
         url = reverse('course-home-outline-tab', args=['course-v1:unknown+course+2T2020'])
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 404)
+        assert response.status_code == 404
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=False)
@@ -146,7 +146,7 @@ class OutlineTabTestViews(BaseCourseHomeTests):
     def test_waffle_flag_disabled(self, enrollment_mode):
         CourseEnrollment.enroll(self.user, self.course.id, enrollment_mode)
         response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 404)
+        assert response.status_code == 404
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
@@ -173,7 +173,7 @@ class OutlineTabTestViews(BaseCourseHomeTests):
             value=False if welcome_message_is_dismissed else True
         )
         welcome_message_html = self.client.get(self.url).data['welcome_message_html']
-        self.assertEqual(welcome_message_html, None if welcome_message_is_dismissed else '<p>Welcome</p>')
+        assert welcome_message_html == (None if welcome_message_is_dismissed else '<p>Welcome</p>')
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
@@ -181,13 +181,13 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         CourseEnrollment.enroll(self.user, self.course.id)
 
         response = self.client.get(self.url)
-        self.assertIsNone(response.data['offer'])
+        assert response.data['offer'] is None
 
         with override_waffle_flag(DISCOUNT_APPLICABILITY_FLAG, active=True):
             response = self.client.get(self.url)
 
             # Just a quick spot check that the dictionary looks like what we expect
-            self.assertEqual(response.data['offer']['code'], 'EDXWELCOME')
+            assert response.data['offer']['code'] == 'EDXWELCOME'
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
@@ -196,14 +196,14 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         CourseDurationLimitConfig.objects.create(enabled=True, enabled_as_of=datetime(2018, 1, 1))
 
         response = self.client.get(self.url)
-        self.assertIsNone(response.data['access_expiration'])
+        assert response.data['access_expiration'] is None
 
         enrollment.update_enrollment(CourseMode.AUDIT)
         response = self.client.get(self.url)
 
         # Just a quick spot check that the dictionary looks like what we expect
         deadline = enrollment.created + MIN_DURATION
-        self.assertEqual(response.data['access_expiration']['expiration_date'], deadline)
+        assert response.data['access_expiration']['expiration_date'] == deadline
 
     @override_waffle_flag(ENABLE_COURSE_GOALS, active=True)
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
@@ -216,15 +216,15 @@ class OutlineTabTestViews(BaseCourseHomeTests):
             'goal_key': 'certify'
         }
         post_course_goal_response = self.client.post(reverse('course-home-save-course-goal'), post_data)
-        self.assertEqual(post_course_goal_response.status_code, 200)
+        assert post_course_goal_response.status_code == 200
 
         response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
         course_goals = response.data.get('course_goals')
         selected_goal = course_goals['selected_goal']
-        self.assertIsNotNone(selected_goal)
-        self.assertEqual(selected_goal['key'], 'certify')
+        assert selected_goal is not None
+        assert selected_goal['key'] == 'certify'
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
@@ -261,14 +261,14 @@ class OutlineTabTestViews(BaseCourseHomeTests):
 
         CourseEnrollment.enroll(self.user, course.id)
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
         exam_data = response.data['course_blocks']['blocks'][str(sequence.location)]
-        self.assertFalse(exam_data['complete'])
-        self.assertEqual(exam_data['description'], 'My Exam')
-        self.assertEqual(exam_data['display_name'], 'Test Proctored Exam')
-        self.assertIsNotNone(exam_data['due'])
-        self.assertEqual(exam_data['icon'], 'fa-foo-bar')
+        assert not exam_data['complete']
+        assert exam_data['description'] == 'My Exam'
+        assert exam_data['display_name'] == 'Test Proctored Exam'
+        assert exam_data['due'] is not None
+        assert exam_data['icon'] == 'fa-foo-bar'
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
@@ -293,15 +293,15 @@ class OutlineTabTestViews(BaseCourseHomeTests):
 
         CourseEnrollment.enroll(self.user, course.id)
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
         exam_data = response.data['course_blocks']['blocks'][str(sequential.location)]
-        self.assertEqual(exam_data['display_name'], 'Test (2 Questions)')
-        self.assertEqual(exam_data['icon'], 'fa-pencil-square-o')
+        assert exam_data['display_name'] == 'Test (2 Questions)'
+        assert exam_data['icon'] == 'fa-pencil-square-o'
 
         ungraded_data = response.data['course_blocks']['blocks'][str(sequential2.location)]
-        self.assertEqual(ungraded_data['display_name'], 'Ungraded')
-        self.assertIsNone(ungraded_data['icon'])
+        assert ungraded_data['display_name'] == 'Ungraded'
+        assert ungraded_data['icon'] is None
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
@@ -336,11 +336,11 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         is_public_outline = course_visibility == COURSE_VISIBILITY_PUBLIC_OUTLINE
 
         data = self.client.get(self.url).data
-        self.assertEqual(data['course_blocks'] is not None, show_enrolled or is_public or is_public_outline)
-        self.assertEqual(data['handouts_html'] is not None, show_enrolled or is_public)
-        self.assertEqual(data['offer'] is not None, show_enrolled)
-        self.assertEqual(data['access_expiration'] is not None, show_enrolled)
-        self.assertEqual(data['resume_course']['url'] is not None, show_enrolled)
+        assert (data['course_blocks'] is not None) == (show_enrolled or is_public or is_public_outline)
+        assert (data['handouts_html'] is not None) == (show_enrolled or is_public)
+        assert (data['offer'] is not None) == show_enrolled
+        assert (data['access_expiration'] is not None) == show_enrolled
+        assert (data['resume_course']['url'] is not None) == show_enrolled
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
@@ -348,7 +348,7 @@ class OutlineTabTestViews(BaseCourseHomeTests):
     def test_can_show_upgrade_sock(self, sock_enabled):
         with override_waffle_flag(DISPLAY_COURSE_SOCK_FLAG, active=sock_enabled):
             response = self.client.get(self.url)
-            self.assertEqual(response.data['can_show_upgrade_sock'], sock_enabled)
+            assert response.data['can_show_upgrade_sock'] == sock_enabled
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
@@ -357,11 +357,4 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         CourseDurationLimitConfig.objects.create(enabled=True, enabled_as_of=datetime(2018, 1, 1))
 
         response = self.client.get(self.url)
-        self.assertEqual(response.data['verified_mode'], {
-            'access_expiration_date': enrollment.created + MIN_DURATION,
-            'currency': 'USD',
-            'currency_symbol': '$',
-            'price': 149,
-            'sku': 'ABCD1234',
-            'upgrade_url': '/dashboard',
-        })
+        assert response.data['verified_mode'] == {'access_expiration_date': (enrollment.created + MIN_DURATION), 'currency': 'USD', 'currency_symbol': '$', 'price': 149, 'sku': 'ABCD1234', 'upgrade_url': '/dashboard'}

--- a/lms/djangoapps/course_home_api/progress/v1/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/progress/v1/tests/test_views.py
@@ -31,38 +31,38 @@ class ProgressTabTestViews(BaseCourseHomeTests):
     def test_get_authenticated_enrolled_user(self, enrollment_mode):
         CourseEnrollment.enroll(self.user, self.course.id, enrollment_mode)
         response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
         # Pulling out the courseware summary to check that the learner is able to see this info
-        self.assertIsNotNone(response.data['courseware_summary'])
+        assert response.data['courseware_summary'] is not None
         for chapter in response.data['courseware_summary']:
-            self.assertIsNotNone(chapter)
-        self.assertIn('settings/grading/' + str(self.course.id), response.data['studio_url'])
-        self.assertEqual(response.data['credit_support_url'], CREDIT_SUPPORT_URL)
-        self.assertIsNotNone(response.data['verification_data'])
-        self.assertEqual(response.data['verification_data']['status'], 'none')
+            assert chapter is not None
+        assert ('settings/grading/' + str(self.course.id)) in response.data['studio_url']
+        assert response.data['credit_support_url'] == CREDIT_SUPPORT_URL
+        assert response.data['verification_data'] is not None
+        assert response.data['verification_data']['status'] == 'none'
         if enrollment_mode == CourseMode.VERIFIED:
             ManualVerification.objects.create(user=self.user, status='approved')
             response = self.client.get(self.url)
-            self.assertEqual(response.data['verification_data']['status'], 'approved')
-            self.assertIsNone(response.data['certificate_data'])
+            assert response.data['verification_data']['status'] == 'approved'
+            assert response.data['certificate_data'] is None
         elif enrollment_mode == CourseMode.AUDIT:
-            self.assertEqual(response.data['certificate_data']['cert_status'], 'audit_passing')
+            assert response.data['certificate_data']['cert_status'] == 'audit_passing'
 
     def test_get_authenticated_user_not_enrolled(self):
         response = self.client.get(self.url)
         # expecting a redirect
-        self.assertEqual(response.status_code, 302)
+        assert response.status_code == 302
 
     def test_get_unauthenticated_user(self):
         self.client.logout()
         response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 403)
+        assert response.status_code == 403
 
     def test_get_unknown_course(self):
         url = reverse('course-home-progress-tab', args=['course-v1:unknown+course+2T2020'])
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 404)
+        assert response.status_code == 404
 
     def test_masquerade(self):
         user = UserFactory()
@@ -72,8 +72,8 @@ class ProgressTabTestViews(BaseCourseHomeTests):
         self.switch_to_staff()  # needed for masquerade
 
         # Sanity check on our normal user
-        self.assertIsNone(self.client.get(self.url).data['user_timezone'])
+        assert self.client.get(self.url).data['user_timezone'] is None
 
         # Now switch users and confirm we get a different result
         self.update_masquerade(username=user.username)
-        self.assertEqual(self.client.get(self.url).data['user_timezone'], 'Asia/Tokyo')
+        assert self.client.get(self.url).data['user_timezone'] == 'Asia/Tokyo'

--- a/lms/djangoapps/course_wiki/tests/test_access.py
+++ b/lms/djangoapps/course_wiki/tests/test_access.py
@@ -67,48 +67,48 @@ class TestWikiAccess(TestWikiAccessBase):
     def test_no_one_is_root_wiki_staff(self):
         all_course_staff = self.course_math101_staff + self.course_310b_staff + self.course_310b2_staff
         for course_staff in all_course_staff:
-            self.assertFalse(user_is_article_course_staff(course_staff, self.wiki.article))
+            assert not user_is_article_course_staff(course_staff, self.wiki.article)
 
     def test_course_staff_is_course_wiki_staff(self):
         for page in self.wiki_math101_pages:
             for course_staff in self.course_math101_staff:
-                self.assertTrue(user_is_article_course_staff(course_staff, page.article))
+                assert user_is_article_course_staff(course_staff, page.article)
 
         for page in self.wiki_math101b_pages:
             for course_staff in self.course_math101b_staff:
-                self.assertTrue(user_is_article_course_staff(course_staff, page.article))
+                assert user_is_article_course_staff(course_staff, page.article)
 
     def test_settings(self):
         for page in self.wiki_math101_pages:
             for course_staff in self.course_math101_staff:
-                self.assertTrue(settings.CAN_DELETE(page.article, course_staff))
-                self.assertTrue(settings.CAN_MODERATE(page.article, course_staff))
-                self.assertTrue(settings.CAN_CHANGE_PERMISSIONS(page.article, course_staff))
-                self.assertTrue(settings.CAN_ASSIGN(page.article, course_staff))
-                self.assertTrue(settings.CAN_ASSIGN_OWNER(page.article, course_staff))
+                assert settings.CAN_DELETE(page.article, course_staff)
+                assert settings.CAN_MODERATE(page.article, course_staff)
+                assert settings.CAN_CHANGE_PERMISSIONS(page.article, course_staff)
+                assert settings.CAN_ASSIGN(page.article, course_staff)
+                assert settings.CAN_ASSIGN_OWNER(page.article, course_staff)
 
         for page in self.wiki_math101b_pages:
             for course_staff in self.course_math101b_staff:
-                self.assertTrue(settings.CAN_DELETE(page.article, course_staff))
-                self.assertTrue(settings.CAN_MODERATE(page.article, course_staff))
-                self.assertTrue(settings.CAN_CHANGE_PERMISSIONS(page.article, course_staff))
-                self.assertTrue(settings.CAN_ASSIGN(page.article, course_staff))
-                self.assertTrue(settings.CAN_ASSIGN_OWNER(page.article, course_staff))
+                assert settings.CAN_DELETE(page.article, course_staff)
+                assert settings.CAN_MODERATE(page.article, course_staff)
+                assert settings.CAN_CHANGE_PERMISSIONS(page.article, course_staff)
+                assert settings.CAN_ASSIGN(page.article, course_staff)
+                assert settings.CAN_ASSIGN_OWNER(page.article, course_staff)
 
     def test_other_course_staff_is_not_course_wiki_staff(self):
         for page in self.wiki_math101_pages:
             for course_staff in self.course_math101b_staff:
-                self.assertFalse(user_is_article_course_staff(course_staff, page.article))
+                assert not user_is_article_course_staff(course_staff, page.article)
 
         for page in self.wiki_math101_pages:
             for course_staff in self.course_310b_staff:
-                self.assertFalse(user_is_article_course_staff(course_staff, page.article))
+                assert not user_is_article_course_staff(course_staff, page.article)
 
         for course_staff in self.course_310b_staff:
-            self.assertFalse(user_is_article_course_staff(course_staff, self.wiki_310b2.article))
+            assert not user_is_article_course_staff(course_staff, self.wiki_310b2.article)
 
         for course_staff in self.course_310b2_staff:
-            self.assertFalse(user_is_article_course_staff(course_staff, self.wiki_310b.article))
+            assert not user_is_article_course_staff(course_staff, self.wiki_310b.article)
 
 
 class TestWikiAccessForStudent(TestWikiAccessBase):
@@ -119,11 +119,11 @@ class TestWikiAccessForStudent(TestWikiAccessBase):
         self.student = UserFactory.create()
 
     def test_student_is_not_root_wiki_staff(self):
-        self.assertFalse(user_is_article_course_staff(self.student, self.wiki.article))
+        assert not user_is_article_course_staff(self.student, self.wiki.article)
 
     def test_student_is_not_course_wiki_staff(self):
         for page in self.wiki_math101_pages:
-            self.assertFalse(user_is_article_course_staff(self.student, page.article))
+            assert not user_is_article_course_staff(self.student, page.article)
 
 
 class TestWikiAccessForNumericalCourseNumber(TestWikiAccessBase):
@@ -142,7 +142,7 @@ class TestWikiAccessForNumericalCourseNumber(TestWikiAccessBase):
     def test_course_staff_is_course_wiki_staff_for_numerical_course_number(self):
         for page in self.wiki_200_pages:
             for course_staff in self.course_200_staff:
-                self.assertTrue(user_is_article_course_staff(course_staff, page.article))
+                assert user_is_article_course_staff(course_staff, page.article)
 
 
 class TestWikiAccessForOldFormatCourseStaffGroups(TestWikiAccessBase):
@@ -162,4 +162,4 @@ class TestWikiAccessForOldFormatCourseStaffGroups(TestWikiAccessBase):
     def test_course_staff_is_course_wiki_staff(self):
         for page in self.wiki_math101c_pages:
             for course_staff in self.course_math101c_staff:
-                self.assertTrue(user_is_article_course_staff(course_staff, page.article))
+                assert user_is_article_course_staff(course_staff, page.article)

--- a/lms/djangoapps/course_wiki/tests/test_comprehensive_theming.py
+++ b/lms/djangoapps/course_wiki/tests/test_comprehensive_theming.py
@@ -41,6 +41,6 @@ class TestComprehensiveTheming(ModuleStoreTestCase):
         footer when comprehensive theme is enabled.
         """
         response = self.client.get('/courses/edx/math101/2014/wiki/math101/')
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         # This string comes from themes/red-theme/lms/templates/footer.html
         self.assertContains(response, "super-ugly")

--- a/lms/djangoapps/course_wiki/tests/test_tab.py
+++ b/lms/djangoapps/course_wiki/tests/test_tab.py
@@ -35,7 +35,7 @@ class WikiTabTestCase(ModuleStoreTestCase):
         """
         settings.WIKI_ENABLED = True
         self.course.allow_public_wiki_access = True
-        self.assertIsNotNone(self.get_wiki_tab(self.user, self.course))
+        assert self.get_wiki_tab(self.user, self.course) is not None
 
     def test_wiki_enabled_and_not_public(self):
         """
@@ -43,23 +43,23 @@ class WikiTabTestCase(ModuleStoreTestCase):
         """
         settings.WIKI_ENABLED = True
         self.course.allow_public_wiki_access = False
-        self.assertIsNone(self.get_wiki_tab(self.user, self.course))
-        self.assertIsNotNone(self.get_wiki_tab(self.instructor, self.course))
+        assert self.get_wiki_tab(self.user, self.course) is None
+        assert self.get_wiki_tab(self.instructor, self.course) is not None
 
     def test_wiki_enabled_false(self):
         """Test wiki tab when Enabled setting is False"""
         settings.WIKI_ENABLED = False
-        self.assertIsNone(self.get_wiki_tab(self.user, self.course))
-        self.assertIsNone(self.get_wiki_tab(self.instructor, self.course))
+        assert self.get_wiki_tab(self.user, self.course) is None
+        assert self.get_wiki_tab(self.instructor, self.course) is None
 
     def test_wiki_visibility(self):
         """Test toggling of visibility of wiki tab"""
         settings.WIKI_ENABLED = True
         self.course.allow_public_wiki_access = True
         wiki_tab = self.get_wiki_tab(self.user, self.course)
-        self.assertIsNotNone(wiki_tab)
-        self.assertTrue(wiki_tab.is_hideable)
+        assert wiki_tab is not None
+        assert wiki_tab.is_hideable
         wiki_tab.is_hidden = True
-        self.assertTrue(wiki_tab['is_hidden'])
+        assert wiki_tab['is_hidden']
         wiki_tab['is_hidden'] = False
-        self.assertFalse(wiki_tab.is_hidden)
+        assert not wiki_tab.is_hidden

--- a/lms/djangoapps/course_wiki/tests/tests.py
+++ b/lms/djangoapps/course_wiki/tests/tests.py
@@ -55,9 +55,9 @@ class WikiRedirectTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCas
         redirected_to = referer.replace("progress", "wiki/some/fake/wiki/page/")
 
         resp = self.client.get(destination, HTTP_REFERER=referer)
-        self.assertEqual(resp.status_code, 302)
+        assert resp.status_code == 302
 
-        self.assertEqual(resp['Location'], redirected_to)
+        assert resp['Location'] == redirected_to
 
         # Now we test that the student will be redirected away from that page if the course doesn't exist
         # We do this in the same test because we want to make sure the redirected_to is constructed correctly
@@ -65,8 +65,8 @@ class WikiRedirectTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCas
         bad_course_wiki_page = redirected_to.replace(self.toy.location.course, "bad_course")
 
         resp = self.client.get(bad_course_wiki_page, HTTP_REFERER=referer)
-        self.assertEqual(resp.status_code, 302)
-        self.assertEqual(resp['Location'], destination)
+        assert resp.status_code == 302
+        assert resp['Location'] == destination
 
     @patch.dict("django.conf.settings.FEATURES", {'ALLOW_WIKI_ROOT_ACCESS': False})
     def test_wiki_no_root_access(self):
@@ -82,7 +82,7 @@ class WikiRedirectTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCas
         destination = reverse("wiki:get", kwargs={'path': 'some/fake/wiki/page/'})
 
         resp = self.client.get(destination, HTTP_REFERER=referer)
-        self.assertEqual(resp.status_code, 403)
+        assert resp.status_code == 403
 
     def create_course_page(self, course):
         """
@@ -99,8 +99,8 @@ class WikiRedirectTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCas
 
         ending_location = resp.redirect_chain[-1][0]
 
-        self.assertEqual(ending_location, course_wiki_page)
-        self.assertEqual(resp.status_code, 200)
+        assert ending_location == course_wiki_page
+        assert resp.status_code == 200
 
         self.has_course_navigator(resp)
         self.assertContains(resp, u'<h3 class="entry-title">{}</h3>'.format(course.display_name_with_default))
@@ -147,14 +147,12 @@ class WikiRedirectTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCas
 
         # When not enrolled, we should get a 302
         resp = self.client.get(course_wiki_page, follow=False, HTTP_REFERER=referer)
-        self.assertEqual(resp.status_code, 302)
+        assert resp.status_code == 302
 
         # and end up at the course about page
         resp = self.client.get(course_wiki_page, follow=True, HTTP_REFERER=referer)
         target_url, __ = resp.redirect_chain[-1]
-        self.assertTrue(
-            target_url.endswith(reverse('about_course', args=[text_type(self.toy.id)]))
-        )
+        assert target_url.endswith(reverse('about_course', args=[text_type(self.toy.id)]))
 
     @patch.dict("django.conf.settings.FEATURES", {'ALLOW_WIKI_ROOT_ACCESS': True})
     def test_redirect_when_not_logged_in(self):
@@ -167,12 +165,12 @@ class WikiRedirectTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCas
 
         # When not logged in, we should get a 302
         resp = self.client.get(course_wiki_page, follow=False)
-        self.assertEqual(resp.status_code, 302)
+        assert resp.status_code == 302
 
         # and end up at the login page
         resp = self.client.get(course_wiki_page, follow=True)
         target_url, __ = resp.redirect_chain[-1]
-        self.assertIn(reverse('signin_user'), target_url)
+        assert reverse('signin_user') in target_url
 
     @patch.dict("django.conf.settings.FEATURES", {'ALLOW_WIKI_ROOT_ACCESS': True})
     def test_create_wiki_with_long_course_id(self):
@@ -189,7 +187,8 @@ class WikiRedirectTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCas
         # This is how wiki_slug is generated in cms/djangoapps/contentstore/views/course.py.
         wiki_slug = "{0}.{1}.{2}".format(org, course, display_name)
 
-        self.assertEqual(len(org + course + display_name), 65)  # sanity check
+        assert len(((org + course) + display_name)) == 65
+        # sanity check
 
         course = CourseFactory.create(org=org, course=course, display_name=display_name, wiki_slug=wiki_slug)
 
@@ -201,7 +200,7 @@ class WikiRedirectTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCas
         referer = reverse("courseware", kwargs={'course_id': text_type(course.id)})
 
         resp = self.client.get(course_wiki_page, follow=True, HTTP_REFERER=referer)
-        self.assertEqual(resp.status_code, 200)
+        assert resp.status_code == 200
 
     @patch.dict("django.conf.settings.FEATURES", {'ALLOW_WIKI_ROOT_ACCESS': True})
     @patch('openedx.features.enterprise_support.api.enterprise_customer_for_request')


### PR DESCRIPTION
## Description
This PR is using `codemod-unittest-to-pytest-asserts` to automatically replace `unittest` assertions with `pytest` 
for following apps in `lms/djangoapps`
```
course_blocks, course_goals, course_home_api, course_wiki
```
Relevant JIRA issue here: https://openedx.atlassian.net/browse/BOM-2387