### PR TITLE
replaced unittest assertions pytest assertions (22)

### DIFF
--- a/lms/djangoapps/program_enrollments/api/tests/test_linking.py
+++ b/lms/djangoapps/program_enrollments/api/tests/test_linking.py
@@ -80,7 +80,7 @@ class TestLinkProgramEnrollmentsMixin(object):
         """
         if refresh:
             program_enrollment.refresh_from_db()
-        self.assertIsNone(program_enrollment.user)
+        assert program_enrollment.user is None
 
     def _assert_no_program_enrollment(self, user, program_uuid, refresh=True):
         """
@@ -88,7 +88,7 @@ class TestLinkProgramEnrollmentsMixin(object):
         """
         if refresh:
             user.refresh_from_db()
-        self.assertFalse(user.programenrollment_set.filter(program_uuid=program_uuid).exists())
+        assert not user.programenrollment_set.filter(program_uuid=program_uuid).exists()
 
     def _assert_program_enrollment(self, user, program_uuid, external_user_key, refresh=True):
         """
@@ -100,7 +100,7 @@ class TestLinkProgramEnrollmentsMixin(object):
         enrollment = user.programenrollment_set.get(
             program_uuid=program_uuid, external_user_key=external_user_key
         )
-        self.assertIsNotNone(enrollment)
+        assert enrollment is not None
 
     def _assert_user_enrolled_in_program_courses(self, user, program_uuid, *course_keys):
         """
@@ -121,9 +121,7 @@ class TestLinkProgramEnrollmentsMixin(object):
             program_course_enrollment.course_enrollment
             for program_course_enrollment in program_course_enrollments
         ]
-        self.assertTrue(
-            all(course_enrollment.is_active for course_enrollment in course_enrollments)
-        )
+        assert all((course_enrollment.is_active for course_enrollment in course_enrollments))
         self.assertCountEqual(
             course_keys,
             [course_enrollment.course.id for course_enrollment in course_enrollments]
@@ -177,14 +175,14 @@ class TestLinkProgramEnrollments(TestLinkProgramEnrollmentsMixin, TestCase):
         self._assert_program_enrollment(self.user_1, self.program, '0001')
 
         active_enrollment.refresh_from_db()
-        self.assertIsNotNone(active_enrollment.course_enrollment)
-        self.assertEqual(active_enrollment.course_enrollment.course.id, self.fruit_course)
-        self.assertTrue(active_enrollment.course_enrollment.is_active)
+        assert active_enrollment.course_enrollment is not None
+        assert active_enrollment.course_enrollment.course.id == self.fruit_course
+        assert active_enrollment.course_enrollment.is_active
 
         inactive_enrollment.refresh_from_db()
-        self.assertIsNotNone(inactive_enrollment.course_enrollment)
-        self.assertEqual(inactive_enrollment.course_enrollment.course.id, self.animal_course)
-        self.assertFalse(inactive_enrollment.course_enrollment.is_active)
+        assert inactive_enrollment.course_enrollment is not None
+        assert inactive_enrollment.course_enrollment.course.id == self.animal_course
+        assert not inactive_enrollment.course_enrollment.is_active
 
     def test_realize_course_access_roles(self):
         program_enrollment = self._create_waiting_enrollment(self.program, '0001')
@@ -440,13 +438,13 @@ class TestLinkProgramEnrollmentsErrors(TestLinkProgramEnrollmentsMixin, TestCase
                 '0002': self.user_2.username
             }
         )
-        self.assertIn(errors['0001'], 'NonExistentCourseError: ')
+        assert errors['0001'] in 'NonExistentCourseError: '
         self._assert_no_program_enrollment(self.user_1, self.program)
         self._assert_no_user(program_enrollment_1)
         course_enrollment_1.refresh_from_db()
-        self.assertIsNone(course_enrollment_1.course_enrollment)
+        assert course_enrollment_1.course_enrollment is None
         course_enrollment_2.refresh_from_db()
-        self.assertIsNone(course_enrollment_2.course_enrollment)
+        assert course_enrollment_2.course_enrollment is None
 
         self._assert_user_enrolled_in_program_courses(
             self.user_2, self.program, self.animal_course, self.fruit_course
@@ -468,7 +466,7 @@ class TestLinkProgramEnrollmentsErrors(TestLinkProgramEnrollmentsMixin, TestCase
             }
         )
 
-        self.assertEqual(len(errors), 1)
-        self.assertIn('UNIQUE constraint failed', errors['0001'])
+        assert len(errors) == 1
+        assert 'UNIQUE constraint failed' in errors['0001']
         self._assert_no_user(program_enrollment_1)
         self._assert_program_enrollment(self.user_2, self.program, '0002')

--- a/lms/djangoapps/program_enrollments/api/tests/test_reading.py
+++ b/lms/djangoapps/program_enrollments/api/tests/test_reading.py
@@ -4,7 +4,7 @@ Tests for program enrollment reading Python API.
 
 
 from uuid import UUID
-
+import pytest
 import ddt
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
@@ -557,7 +557,7 @@ class GetUsersByExternalKeysTests(CacheIsolationTestCase):
         not include the requested program uuid.
         """
         fake_program_uuid = UUID('80cc59e5-003e-4664-a582-48da44bc7e12')
-        with self.assertRaises(ProgramDoesNotExistException):
+        with pytest.raises(ProgramDoesNotExistException):
             get_users_by_external_keys(fake_program_uuid, [])
 
     def test_catalog_program_missing_org(self):
@@ -570,7 +570,7 @@ class GetUsersByExternalKeysTests(CacheIsolationTestCase):
             authoring_organizations=[]
         )
         cache.set(PROGRAM_CACHE_KEY_TPL.format(uuid=self.program_uuid), program, None)
-        with self.assertRaises(OrganizationDoesNotExistException):
+        with pytest.raises(OrganizationDoesNotExistException):
             get_users_by_external_keys(self.program_uuid, [])
 
     def test_lms_organization_not_found(self):
@@ -580,7 +580,7 @@ class GetUsersByExternalKeysTests(CacheIsolationTestCase):
         """
         organization = OrganizationFactory.create(short_name='some_other_org')
         SAMLProviderConfigFactory.create(organization=organization)
-        with self.assertRaises(OrganizationDoesNotExistException):
+        with pytest.raises(OrganizationDoesNotExistException):
             get_users_by_external_keys(self.program_uuid, [])
 
     def test_saml_provider_not_found(self):
@@ -589,7 +589,7 @@ class GetUsersByExternalKeysTests(CacheIsolationTestCase):
         program's organization.
         """
         OrganizationFactory.create(short_name=self.organization_key)
-        with self.assertRaises(ProviderDoesNotExistException):
+        with pytest.raises(ProviderDoesNotExistException):
             get_users_by_external_keys(self.program_uuid, [])
 
     def test_extra_saml_provider_disabled(self):
@@ -616,7 +616,7 @@ class GetUsersByExternalKeysTests(CacheIsolationTestCase):
         SAMLProviderConfigFactory.create(
             organization=organization, slug='foox', enabled=True
         )
-        with self.assertRaises(ProviderConfigurationException):
+        with pytest.raises(ProviderConfigurationException):
             get_users_by_external_keys(self.program_uuid, [])
 
 

--- a/lms/djangoapps/program_enrollments/api/tests/test_writing.py
+++ b/lms/djangoapps/program_enrollments/api/tests/test_writing.py
@@ -169,16 +169,16 @@ class WriteProgramCourseEnrollmentTest(EnrollmentTestMixin):
             program_enrollment__external_user_key=external_user_key,
             program_enrollment__program_uuid=self.program_uuid
         )
-        self.assertEqual(expected_status, enrollment.status)
-        self.assertEqual(self.course_id, enrollment.course_key)
+        assert expected_status == enrollment.status
+        assert self.course_id == enrollment.course_key
         course_enrollment = enrollment.course_enrollment
         if has_user:
-            self.assertIsNotNone(course_enrollment)
-            self.assertEqual(expected_status == 'active', course_enrollment.is_active)
-            self.assertEqual(self.course_id, course_enrollment.course_id)
-            self.assertEqual(mode, course_enrollment.mode)
+            assert course_enrollment is not None
+            assert (expected_status == 'active') == course_enrollment.is_active
+            assert self.course_id == course_enrollment.course_id
+            assert mode == course_enrollment.mode
         else:
-            self.assertIsNone(course_enrollment)
+            assert course_enrollment is None
 
     def setup_change_test_data(self, initial_statuses):
         """

--- a/lms/djangoapps/program_enrollments/management/commands/tests/test_expire_waiting_enrollments.py
+++ b/lms/djangoapps/program_enrollments/management/commands/tests/test_expire_waiting_enrollments.py
@@ -2,7 +2,7 @@
 Tests for the expire_waiting_enrollments management command.
 """
 
-
+import pytest
 import ddt
 from django.core.management import call_command
 from django.test import TestCase
@@ -37,5 +37,5 @@ class TestExpireWaitingEnrollments(TestCase):
     @patch('lms.djangoapps.program_enrollments.tasks.expire_waiting_enrollments', autospec=True)
     def test_task_failure_fails_command(self, mock_task):
         mock_task.side_effect = Exception('BOOM!')
-        with self.assertRaises(Exception):
+        with pytest.raises(Exception):
             call_command('expire_waiting_enrollments')

--- a/lms/djangoapps/program_enrollments/management/commands/tests/test_reset_enrollment_data.py
+++ b/lms/djangoapps/program_enrollments/management/commands/tests/test_reset_enrollment_data.py
@@ -6,7 +6,7 @@ Tests for the reset_enrollment_data management command.
 import sys
 from contextlib import contextmanager
 from uuid import uuid4
-
+import pytest
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import TestCase
@@ -48,9 +48,9 @@ class TestResetEnrollmentData(TestCase):
         return program_enrollment
 
     def _validate_enrollments_count(self, n):
-        self.assertEqual(len(CourseEnrollment.objects.all()), n)
-        self.assertEqual(len(ProgramCourseEnrollment.objects.all()), n)
-        self.assertEqual(len(ProgramEnrollment.objects.all()), n)
+        assert len(CourseEnrollment.objects.all()) == n
+        assert len(ProgramCourseEnrollment.objects.all()) == n
+        assert len(ProgramEnrollment.objects.all()) == n
 
     def test_reset(self):
         """ Validate enrollments with a user and waiting enrollments without a user are removed """
@@ -74,7 +74,7 @@ class TestResetEnrollmentData(TestCase):
         """ Failing to confirm reset will result in no modifications """
         self._create_program_and_course_enrollment(self.program_uuid, self.user)
 
-        with self.assertRaises(CommandError):
+        with pytest.raises(CommandError):
             with self._replace_stdin('no'):
                 call_command(self.command, self.program_uuid)
 
@@ -94,7 +94,7 @@ class TestResetEnrollmentData(TestCase):
         program_enrollment = ProgramEnrollment.objects.get(program_uuid=alt_program_uuid)
         program_course_enrollment = ProgramCourseEnrollment.objects.get(program_enrollment=program_enrollment)
         course_enrollment = program_course_enrollment.course_enrollment
-        self.assertIsNotNone(course_enrollment)
+        assert course_enrollment is not None
 
         # other enrollments have been deleted
         self._validate_enrollments_count(1)

--- a/lms/djangoapps/program_enrollments/rest_api/v1/tests/test_views.py
+++ b/lms/djangoapps/program_enrollments/rest_api/v1/tests/test_views.py
@@ -375,12 +375,12 @@ class ProgramEnrollmentsWriteMixin(EnrollmentsDataMixin):
         self.client.logout()
         request_data = [self.student_enrollment('enrolled')]
         response = self.request(self.get_url(), json.dumps(request_data), content_type='application/json')
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_enrollment_payload_limit(self):
         request_data = [self.student_enrollment('enrolled') for _ in range(MAX_ENROLLMENT_RECORDS + 1)]
         response = self.request(self.get_url(), json.dumps(request_data), content_type='application/json')
-        self.assertEqual(response.status_code, status.HTTP_413_REQUEST_ENTITY_TOO_LARGE)
+        assert response.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
 
     def test_duplicate_enrollment(self):
         request_data = [
@@ -390,8 +390,8 @@ class ProgramEnrollmentsWriteMixin(EnrollmentsDataMixin):
 
         response = self.request(self.get_url(), json.dumps(request_data), content_type='application/json')
 
-        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
-        self.assertEqual(response.data, {'001': 'duplicated'})
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.data == {'001': 'duplicated'}
 
     def test_unprocessable_enrollment(self):
         response = self.request(
@@ -399,7 +399,7 @@ class ProgramEnrollmentsWriteMixin(EnrollmentsDataMixin):
             json.dumps([{'status': 'enrolled'}]),
             content_type='application/json'
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_program_unauthorized(self):
         student = UserFactory.create(password='password')
@@ -407,7 +407,7 @@ class ProgramEnrollmentsWriteMixin(EnrollmentsDataMixin):
 
         request_data = [self.student_enrollment('enrolled')]
         response = self.request(self.get_url(), json.dumps(request_data), content_type='application/json')
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_program_not_found(self):
         post_data = [self.student_enrollment('enrolled')]
@@ -417,7 +417,7 @@ class ProgramEnrollmentsWriteMixin(EnrollmentsDataMixin):
             json.dumps(post_data),
             content_type='application/json'
         )
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
 
     @ddt.data(
         [{'status': 'pending'}],
@@ -431,7 +431,7 @@ class ProgramEnrollmentsWriteMixin(EnrollmentsDataMixin):
 
         response = self.request(url, json.dumps(enrollments), content_type='application/json')
 
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_extra_field(self):
         self.student_enrollment('pending', 'learner-01', prepare_student=True)
@@ -441,7 +441,7 @@ class ProgramEnrollmentsWriteMixin(EnrollmentsDataMixin):
         with _patch_get_users:
             url = self.get_url()
             response = self.request(url, json.dumps(enrollments), content_type='application/json')
-        self.assertEqual(200, response.status_code)
+        assert 200 == response.status_code
         self.assertDictEqual(
             response.data,
             {'learner-01': 'enrolled'}
@@ -481,16 +481,16 @@ class ProgramEnrollmentsPostTests(ProgramEnrollmentsWriteMixin, APITestCase):
         with _patch_get_users:
             response = self.client.post(url, json.dumps(post_data), content_type='application/json')
 
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
         for i in range(4):
             enrollment = ProgramEnrollment.objects.get(external_user_key=external_user_keys[i])
 
-            self.assertEqual(enrollment.external_user_key, external_user_keys[i])
-            self.assertEqual(enrollment.program_uuid, self.program_uuid)
-            self.assertEqual(enrollment.status, statuses[i])
-            self.assertEqual(enrollment.curriculum_uuid, curriculum_uuids[i])
-            self.assertIsNone(enrollment.user)
+            assert enrollment.external_user_key == external_user_keys[i]
+            assert enrollment.program_uuid == self.program_uuid
+            assert enrollment.status == statuses[i]
+            assert enrollment.curriculum_uuid == curriculum_uuids[i]
+            assert enrollment.user is None
 
     def test_successful_program_enrollments_existing_user(self):
         post_data = [
@@ -510,13 +510,13 @@ class ProgramEnrollmentsPostTests(ProgramEnrollmentsWriteMixin, APITestCase):
             response = self.client.post(
                 url, json.dumps(post_data), content_type='application/json'
             )
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         enrollment = ProgramEnrollment.objects.get(external_user_key='abc1')
-        self.assertEqual(enrollment.external_user_key, 'abc1')
-        self.assertEqual(enrollment.program_uuid, self.program_uuid)
-        self.assertEqual(enrollment.status, 'enrolled')
-        self.assertEqual(enrollment.curriculum_uuid, self.curriculum_uuid)
-        self.assertEqual(enrollment.user, user)
+        assert enrollment.external_user_key == 'abc1'
+        assert enrollment.program_uuid == self.program_uuid
+        assert enrollment.status == 'enrolled'
+        assert enrollment.curriculum_uuid == self.curriculum_uuid
+        assert enrollment.user == user
 
     def test_program_enrollments_no_idp(self):
         post_data = [
@@ -535,15 +535,15 @@ class ProgramEnrollmentsPostTests(ProgramEnrollmentsWriteMixin, APITestCase):
         ):
             response = self.client.post(url, json.dumps(post_data), content_type='application/json')
 
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
         for i in range(3):
             enrollment = ProgramEnrollment.objects.get(external_user_key='abc{}'.format(i))
 
-            self.assertEqual(enrollment.program_uuid, self.program_uuid)
-            self.assertEqual(enrollment.status, 'enrolled')
-            self.assertEqual(enrollment.curriculum_uuid, self.curriculum_uuid)
-            self.assertIsNone(enrollment.user)
+            assert enrollment.program_uuid == self.program_uuid
+            assert enrollment.status == 'enrolled'
+            assert enrollment.curriculum_uuid == self.curriculum_uuid
+            assert enrollment.user is None
 
 
 @ddt.ddt
@@ -643,11 +643,8 @@ class ProgramEnrollmentsPatchTests(ProgramEnrollmentsWriteMixin, APITestCase):
         for user_key, enrollment in enrollments.items():
             assert expected_statuses[user_key] == enrollment.status
 
-        self.assertEqual(response.status_code, status.HTTP_207_MULTI_STATUS)
-        self.assertEqual(response.data, {
-            'user-1': 'duplicated',
-            'user-2': 'enrolled',
-        })
+        assert response.status_code == status.HTTP_207_MULTI_STATUS
+        assert response.data == {'user-1': 'duplicated', 'user-2': 'enrolled'}
 
     def test_partially_valid_enrollment_record_changed(self):
         enrollments = {}
@@ -683,12 +680,9 @@ class ProgramEnrollmentsPatchTests(ProgramEnrollmentsWriteMixin, APITestCase):
         for user_key, enrollment in enrollments.items():
             assert expected_statuses[user_key] == enrollment.status
 
-        self.assertEqual(response.status_code, status.HTTP_207_MULTI_STATUS)
-        self.assertEqual(response.data, {
-            'user-1': 'invalid-status',
-            'user-3': 'canceled',
-            'user-who-is-not-in-program': 'not-in-program',
-        })
+        assert response.status_code == status.HTTP_207_MULTI_STATUS
+        assert response.data ==\
+               {'user-1': 'invalid-status', 'user-3': 'canceled', 'user-who-is-not-in-program': 'not-in-program'}
 
 
 @ddt.ddt
@@ -731,10 +725,10 @@ class ProgramEnrollmentsPutTests(ProgramEnrollmentsWriteMixin, APITestCase):
             response = self.client.put(
                 url, json.dumps(request_data), content_type='application/json'
             )
-        self.assertEqual(200, response.status_code)
-        self.assertEqual(5, len(response.data))
+        assert 200 == response.status_code
+        assert 5 == len(response.data)
         for response_status in response.data.values():
-            self.assertEqual(response_status, ProgramStatuses.ENROLLED)
+            assert response_status == ProgramStatuses.ENROLLED
 
     def test_half_create_modify(self):
         request_data = [
@@ -759,10 +753,10 @@ class ProgramEnrollmentsPutTests(ProgramEnrollmentsWriteMixin, APITestCase):
             response = self.client.put(
                 url, json.dumps(request_data), content_type='application/json'
             )
-        self.assertEqual(200, response.status_code)
-        self.assertEqual(4, len(response.data))
+        assert 200 == response.status_code
+        assert 4 == len(response.data)
         for response_status in response.data.values():
-            self.assertEqual(response_status, ProgramStatuses.ENROLLED)
+            assert response_status == ProgramStatuses.ENROLLED
 
 
 @ddt.ddt
@@ -793,19 +787,19 @@ class ProgramCourseEnrollmentsMixin(EnrollmentsDataMixin):
         self.client.logout()
         request_data = [self.learner_enrollment("learner-1")]
         response = self.request(self.default_url, request_data)
-        self.assertEqual(401, response.status_code)
+        assert 401 == response.status_code
 
     def test_403_forbidden(self):
         self.client.logout()
         self.log_in_non_staff()
         request_data = [self.learner_enrollment("learner-1")]
         response = self.request(self.default_url, request_data)
-        self.assertEqual(403, response.status_code)
+        assert 403 == response.status_code
 
     def test_413_payload_too_large(self):
         request_data = [self.learner_enrollment(str(i)) for i in range(30)]
         response = self.request(self.default_url, request_data)
-        self.assertEqual(413, response.status_code)
+        assert 413 == response.status_code
 
     def test_404_not_found(self):
         nonexistant_course_key = CourseKey.from_string("course-v1:fake+fake+fake")
@@ -817,14 +811,14 @@ class ProgramCourseEnrollmentsMixin(EnrollmentsDataMixin):
         request_data = [self.learner_enrollment("learner-1")]
         for path_404 in paths:
             response = self.request(path_404, request_data)
-            self.assertEqual(404, response.status_code)
+            assert 404 == response.status_code
 
     def test_404_no_curriculum(self):
         with mock.patch.dict(self.program, curricula=[]):
             self.set_program_in_catalog_cache(self.program_uuid, self.program)
             request_data = [self.learner_enrollment("learner-1")]
             response = self.request(self.default_url, request_data)
-            self.assertEqual(404, response.status_code)
+            assert 404 == response.status_code
 
     @ddt.data(
         [{'status': 'active'}],
@@ -835,7 +829,7 @@ class ProgramCourseEnrollmentsMixin(EnrollmentsDataMixin):
     )
     def test_422_unprocessable_entity_bad_data(self, request_data):
         response = self.request(self.default_url, request_data)
-        self.assertEqual(response.status_code, 400)
+        assert response.status_code == 400
 
     @ddt.data(
         [{'status': 'pending'}],
@@ -846,7 +840,7 @@ class ProgramCourseEnrollmentsMixin(EnrollmentsDataMixin):
         request_data = [self.learner_enrollment('learner-1')]
         request_data.extend(bad_records)
         response = self.request(self.default_url, request_data)
-        self.assertEqual(response.status_code, 400)
+        assert response.status_code == 400
 
     def test_extra_field(self):
         enrollment = self.learner_enrollment('learner-1', 'inactive')
@@ -859,7 +853,7 @@ class ProgramCourseEnrollmentsMixin(EnrollmentsDataMixin):
             return_value=mock_write_response,
         ):
             response = self.request(self.default_url, request_data)
-            self.assertEqual(200, response.status_code)
+            assert 200 == response.status_code
             self.assertDictEqual(
                 mock_write_response,
                 response.data,
@@ -880,7 +874,7 @@ class ProgramCourseEnrollmentsMixin(EnrollmentsDataMixin):
             return_value=mock_write_response,
         ):
             response = self.request(self.default_url, request_data)
-            self.assertEqual(207, response.status_code)
+            assert 207 == response.status_code
             self.assertDictEqual(
                 {'learner-1': CourseStatuses.ACTIVE, 'learner-2': CourseStatuses.NOT_IN_PROGRAM},
                 response.data
@@ -1050,7 +1044,7 @@ class ProgramCourseEnrollmentsPostTests(ProgramCourseEnrollmentsMixin, APITestCa
             return_value=mock_write_response,
         ) as mock_write:
             response = self.request(self.default_url, post_data)
-            self.assertEqual(200, response.status_code)
+            assert 200 == response.status_code
             self.assertDictEqual(
                 mock_write_response,
                 response.data,
@@ -1078,7 +1072,7 @@ class ProgramCourseEnrollmentsPostTests(ProgramCourseEnrollmentsMixin, APITestCa
             return_value=mock_write_response,
         ):
             response = self.request(self.default_url, post_data)
-            self.assertEqual(422, response.status_code)
+            assert 422 == response.status_code
             self.assertDictEqual({'learner-1': CourseStatuses.CONFLICT}, response.data)
 
 
@@ -1095,7 +1089,7 @@ class ProgramCourseEnrollmentsModifyMixin(ProgramCourseEnrollmentsMixin):
             return_value=mock_write_response,
         ) as mock_write:
             response = self.request(self.default_url, request_data)
-            self.assertEqual(200, response.status_code)
+            assert 200 == response.status_code
             self.assertDictEqual(
                 mock_write_response,
                 response.data,
@@ -1232,28 +1226,28 @@ class MultiprogramEnrollmentsTest(EnrollmentsDataMixin, APITestCase):
         response = self.write_program_enrollment(
             'post', self.program_uuid, self.curriculum_uuid, 'enrolled', existing_user
         )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK
         response = self.write_program_course_enrollment(
             'post', self.program_uuid, self.course_id, 'active'
         )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK
 
         response = self.write_program_enrollment(
             'put', self.program_uuid, self.curriculum_uuid, 'canceled', existing_user
         )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK
         response = self.write_program_course_enrollment(
             'put', self.program_uuid, self.course_id, 'inactive'
         )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK
 
         response = self.write_program_enrollment(
             'post', self.another_program_uuid, self.another_curriculum_uuid, 'enrolled', existing_user
         )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK
         response = self.write_program_course_enrollment(
             'post', self.another_program_uuid, self.course_id, 'active')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK
 
         if not existing_user:
             self.link_user_social_auth()
@@ -1261,7 +1255,7 @@ class MultiprogramEnrollmentsTest(EnrollmentsDataMixin, APITestCase):
                 program_enrollment__external_user_key=self.external_user_key,
                 program_enrollment__program_uuid=self.another_program_uuid
             )
-            self.assertIsNotNone(program_course_enrollment.program_enrollment.user)
+            assert program_course_enrollment.program_enrollment.user is not None
 
     @ddt.data(True, False)
     @mock.patch('lms.djangoapps.program_enrollments.api.writing.logger')
@@ -1269,20 +1263,20 @@ class MultiprogramEnrollmentsTest(EnrollmentsDataMixin, APITestCase):
         response = self.write_program_enrollment(
             'post', self.program_uuid, self.curriculum_uuid, 'enrolled', existing_user
         )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK
         response = self.write_program_course_enrollment(
             'post', self.program_uuid, self.course_id, 'active'
         )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK
 
         response = self.write_program_enrollment(
             'post', self.another_program_uuid, self.another_curriculum_uuid, 'enrolled', existing_user
         )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK
         response = self.write_program_course_enrollment(
             'post', self.another_program_uuid, self.course_id, 'active'
         )
-        self.assertEqual(response.status_code, 422)
+        assert response.status_code == 422
         mock_log.error.assert_called_with(
             u'Detected conflicting active ProgramCourseEnrollment. This is happening on'
             u' The program_uuid [{}] with course_key [{}] for external_user_key [{}]'.format(
@@ -1304,28 +1298,28 @@ class ProgramCourseGradesGetTests(EnrollmentsDataMixin, APITestCase):
     def test_401_if_unauthenticated(self):
         url = self.get_url(course_id=self.course_id)
         response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_403_if_not_staff(self):
         self.log_in_non_staff()
         url = self.get_url(course_id=self.course_id)
         response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_404_not_found(self):
         fake_program_uuid = UUID(self.program_uuid_tmpl.format(99))
         self.log_in_staff()
         url = self.get_url(program_uuid=fake_program_uuid, course_id=self.course_id)
         response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
 
     def test_204_no_grades_to_return(self):
         self.log_in_staff()
         url = self.get_url(course_id=self.course_id)
         with self.patch_grades_with({}):
             response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
-        self.assertEqual(response.data['results'], [])
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert response.data['results'] == []
 
     def test_200_grades_with_no_exceptions(self):
         other_student = UserFactory.create(username='other_student')
@@ -1345,7 +1339,7 @@ class ProgramCourseGradesGetTests(EnrollmentsDataMixin, APITestCase):
         url = self.get_url(course_id=self.course_id)
         with self.patch_grades_with(mock_grades_by_user):
             response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK
         expected_results = [
             {
                 'student_key': 'student-key',
@@ -1360,7 +1354,7 @@ class ProgramCourseGradesGetTests(EnrollmentsDataMixin, APITestCase):
                 'letter_grade': 'F',
             },
         ]
-        self.assertEqual(response.data['results'], expected_results)
+        assert response.data['results'] == expected_results
 
     def test_207_grades_with_some_exceptions(self):
         other_student = UserFactory.create(username='other_student')
@@ -1377,7 +1371,7 @@ class ProgramCourseGradesGetTests(EnrollmentsDataMixin, APITestCase):
         url = self.get_url(course_id=self.course_id)
         with self.patch_grades_with(mock_grades_by_user):
             response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_207_MULTI_STATUS)
+        assert response.status_code == status.HTTP_207_MULTI_STATUS
         expected_results = [
             {
                 'student_key': 'student-key',
@@ -1390,7 +1384,7 @@ class ProgramCourseGradesGetTests(EnrollmentsDataMixin, APITestCase):
                 'letter_grade': 'F',
             },
         ]
-        self.assertEqual(response.data['results'], expected_results)
+        assert response.data['results'] == expected_results
 
     def test_422_grades_with_only_exceptions(self):
         other_student = UserFactory.create(username='other_student')
@@ -1404,7 +1398,7 @@ class ProgramCourseGradesGetTests(EnrollmentsDataMixin, APITestCase):
         url = self.get_url(course_id=self.course_id)
         with self.patch_grades_with(mock_grades_by_user):
             response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
         expected_results = [
             {
                 'student_key': 'student-key',
@@ -1415,7 +1409,7 @@ class ProgramCourseGradesGetTests(EnrollmentsDataMixin, APITestCase):
                 'error': 'Timeout',
             },
         ]
-        self.assertEqual(response.data['results'], expected_results)
+        assert response.data['results'] == expected_results
 
     @staticmethod
     def patch_grades_with(grades_by_user):
@@ -1819,20 +1813,20 @@ class ProgramCourseEnrollmentOverviewGetTests(
         self.log_in()
         response_status_code, response_course_runs = self.get_status_and_course_runs()
 
-        self.assertEqual(status.HTTP_200_OK, response_status_code)
+        assert status.HTTP_200_OK == response_status_code
         actual_course_run_ids = {run['course_run_id'] for run in response_course_runs}
         expected_course_run_ids = {text_type(self.course_id)}
         if other_enrollment_active:
             expected_course_run_ids.add(text_type(other_course_key))
-        self.assertEqual(expected_course_run_ids, actual_course_run_ids)
+        assert expected_course_run_ids == actual_course_run_ids
 
     @patch_resume_url
     def test_blank_resume_url_omitted(self, mock_get_resume_urls):
         self.log_in()
         mock_get_resume_urls.return_value = {self.course_id: ''}
         response_status_code, response_course_runs = self.get_status_and_course_runs()
-        self.assertEqual(status.HTTP_200_OK, response_status_code)
-        self.assertNotIn('resume_course_run_url', response_course_runs[0])
+        assert status.HTTP_200_OK == response_status_code
+        assert 'resume_course_run_url' not in response_course_runs[0]
 
     @patch_resume_url
     def test_relative_resume_url_becomes_absolute(self, mock_get_resume_urls):
@@ -1840,10 +1834,10 @@ class ProgramCourseEnrollmentOverviewGetTests(
         resume_url = '/resume-here'
         mock_get_resume_urls.return_value = {self.course_id: resume_url}
         response_status_code, response_course_runs = self.get_status_and_course_runs()
-        self.assertEqual(status.HTTP_200_OK, response_status_code)
+        assert status.HTTP_200_OK == response_status_code
         response_resume_url = response_course_runs[0]['resume_course_run_url']
-        self.assertTrue(response_resume_url.startswith("http://testserver"))
-        self.assertTrue(response_resume_url.endswith(resume_url))
+        assert response_resume_url.startswith('http://testserver')
+        assert response_resume_url.endswith(resume_url)
 
     @patch_resume_url
     def test_absolute_resume_url_stays_absolute(self, mock_get_resume_urls):
@@ -1851,15 +1845,15 @@ class ProgramCourseEnrollmentOverviewGetTests(
         resume_url = 'http://www.resume.com/'
         mock_get_resume_urls.return_value = {self.course_id: resume_url}
         response_status_code, response_course_runs = self.get_status_and_course_runs()
-        self.assertEqual(status.HTTP_200_OK, response_status_code)
+        assert status.HTTP_200_OK == response_status_code
         response_resume_url = response_course_runs[0]['resume_course_run_url']
-        self.assertEqual(response_resume_url, resume_url)
+        assert response_resume_url == resume_url
 
     def test_no_url_without_certificate(self):
         self.log_in()
         response_status_code, response_course_runs = self.get_status_and_course_runs()
-        self.assertEqual(status.HTTP_200_OK, response_status_code)
-        self.assertNotIn('certificate_download_url', response_course_runs[0])
+        assert status.HTTP_200_OK == response_status_code
+        assert 'certificate_download_url' not in response_course_runs[0]
 
     def test_relative_certificate_url_becomes_absolute(self):
         self.log_in()
@@ -1867,10 +1861,10 @@ class ProgramCourseEnrollmentOverviewGetTests(
             download_url=self.relative_certificate_download_url
         )
         response_status_code, response_course_runs = self.get_status_and_course_runs()
-        self.assertEqual(status.HTTP_200_OK, response_status_code)
+        assert status.HTTP_200_OK == response_status_code
         response_url = response_course_runs[0]['certificate_download_url']
-        self.assertTrue(response_url.startswith("http://testserver"))
-        self.assertTrue(response_url.endswith(self.relative_certificate_download_url))
+        assert response_url.startswith('http://testserver')
+        assert response_url.endswith(self.relative_certificate_download_url)
 
     def test_absolute_certificate_url_stays_absolute(self):
         self.log_in()
@@ -1878,15 +1872,15 @@ class ProgramCourseEnrollmentOverviewGetTests(
             download_url=self.absolute_certificate_download_url
         )
         response_status_code, response_course_runs = self.get_status_and_course_runs()
-        self.assertEqual(status.HTTP_200_OK, response_status_code)
+        assert status.HTTP_200_OK == response_status_code
         response_url = response_course_runs[0]['certificate_download_url']
-        self.assertEqual(response_url, self.absolute_certificate_download_url)
+        assert response_url == self.absolute_certificate_download_url
 
     def test_no_due_dates(self):
         self.log_in()
 
         response_status_code, response_course_runs = self.get_status_and_course_runs()
-        self.assertEqual(status.HTTP_200_OK, response_status_code)
+        assert status.HTTP_200_OK == response_status_code
         assert [] == response_course_runs[0]['due_dates']
 
     @ddt.data(
@@ -1943,7 +1937,7 @@ class ProgramCourseEnrollmentOverviewGetTests(
 
             self.log_in()
             response_status_code, response_course_runs = self.get_status_and_course_runs()
-            self.assertEqual(status.HTTP_200_OK, response_status_code)
+            assert status.HTTP_200_OK == response_status_code
 
             block_data = [
                 {
@@ -1975,7 +1969,7 @@ class ProgramCourseEnrollmentOverviewGetTests(
 
             if course_in_progress:
                 for block in block_data:
-                    self.assertIn(block, due_dates)
+                    assert block in due_dates
             else:
                 assert due_dates == []
 
@@ -1990,8 +1984,8 @@ class ProgramCourseEnrollmentOverviewGetTests(
         mock_has_ended.return_value = True
 
         response_status_code, response_course_runs = self.get_status_and_course_runs()
-        self.assertEqual(status.HTTP_200_OK, response_status_code)
-        self.assertEqual(CourseRunProgressStatuses.COMPLETED, response_course_runs[0]['course_run_status'])
+        assert status.HTTP_200_OK == response_status_code
+        assert CourseRunProgressStatuses.COMPLETED == response_course_runs[0]['course_run_status']
 
     @mock.patch.object(CourseOverview, 'has_ended')
     @mock.patch.object(CourseOverview, 'has_started')
@@ -2006,8 +2000,8 @@ class ProgramCourseEnrollmentOverviewGetTests(
         mock_has_ended.return_value = False
 
         response_status_code, response_course_runs = self.get_status_and_course_runs()
-        self.assertEqual(status.HTTP_200_OK, response_status_code)
-        self.assertEqual(CourseRunProgressStatuses.IN_PROGRESS, response_course_runs[0]['course_run_status'])
+        assert status.HTTP_200_OK == response_status_code
+        assert CourseRunProgressStatuses.IN_PROGRESS == response_course_runs[0]['course_run_status']
 
     @mock.patch.object(CourseOverview, 'has_ended')
     @mock.patch.object(CourseOverview, 'has_started')
@@ -2022,8 +2016,8 @@ class ProgramCourseEnrollmentOverviewGetTests(
         mock_has_ended.return_value = False
 
         response_status_code, response_course_runs = self.get_status_and_course_runs()
-        self.assertEqual(status.HTTP_200_OK, response_status_code)
-        self.assertEqual(CourseRunProgressStatuses.UPCOMING, response_course_runs[0]['course_run_status'])
+        assert status.HTTP_200_OK == response_status_code
+        assert CourseRunProgressStatuses.UPCOMING == response_course_runs[0]['course_run_status']
 
     @mock.patch.object(CourseOverview, 'has_ended')
     def test_course_run_status_self_paced_completed(self, mock_has_ended):
@@ -2037,8 +2031,8 @@ class ProgramCourseEnrollmentOverviewGetTests(
         mock_has_ended.return_value = True
 
         response_status_code, response_course_runs = self.get_status_and_course_runs()
-        self.assertEqual(status.HTTP_200_OK, response_status_code)
-        self.assertEqual(CourseRunProgressStatuses.COMPLETED, response_course_runs[0]['course_run_status'])
+        assert status.HTTP_200_OK == response_status_code
+        assert CourseRunProgressStatuses.COMPLETED == response_course_runs[0]['course_run_status']
 
         # course run has not ended and user has earned a passing certificate more than 30 days ago
         certificate = self.create_generated_certificate()
@@ -2047,15 +2041,15 @@ class ProgramCourseEnrollmentOverviewGetTests(
         mock_has_ended.return_value = False
 
         response_status_code, response_course_runs = self.get_status_and_course_runs()
-        self.assertEqual(status.HTTP_200_OK, response_status_code)
-        self.assertEqual(CourseRunProgressStatuses.COMPLETED, response_course_runs[0]['course_run_status'])
+        assert status.HTTP_200_OK == response_status_code
+        assert CourseRunProgressStatuses.COMPLETED == response_course_runs[0]['course_run_status']
 
         # course run has ended and user has earned a passing certificate
         mock_has_ended.return_value = True
 
         response_status_code, response_course_runs = self.get_status_and_course_runs()
-        self.assertEqual(status.HTTP_200_OK, response_status_code)
-        self.assertEqual(CourseRunProgressStatuses.COMPLETED, response_course_runs[0]['course_run_status'])
+        assert status.HTTP_200_OK == response_status_code
+        assert CourseRunProgressStatuses.COMPLETED == response_course_runs[0]['course_run_status']
 
     @mock.patch.object(CourseOverview, 'has_ended')
     @mock.patch.object(CourseOverview, 'has_started')
@@ -2071,8 +2065,8 @@ class ProgramCourseEnrollmentOverviewGetTests(
         mock_has_ended.return_value = False
 
         response_status_code, response_course_runs = self.get_status_and_course_runs()
-        self.assertEqual(status.HTTP_200_OK, response_status_code)
-        self.assertEqual(CourseRunProgressStatuses.IN_PROGRESS, response_course_runs[0]['course_run_status'])
+        assert status.HTTP_200_OK == response_status_code
+        assert CourseRunProgressStatuses.IN_PROGRESS == response_course_runs[0]['course_run_status']
 
         # course run has not ended and user has earned a passing certificate fewer than 30 days ago
         certificate = self.create_generated_certificate()
@@ -2080,8 +2074,8 @@ class ProgramCourseEnrollmentOverviewGetTests(
         certificate.save()
 
         response_status_code, response_course_runs = self.get_status_and_course_runs()
-        self.assertEqual(status.HTTP_200_OK, response_status_code)
-        self.assertEqual(CourseRunProgressStatuses.IN_PROGRESS, response_course_runs[0]['course_run_status'])
+        assert status.HTTP_200_OK == response_status_code
+        assert CourseRunProgressStatuses.IN_PROGRESS == response_course_runs[0]['course_run_status']
 
     @mock.patch.object(CourseOverview, 'has_ended')
     @mock.patch.object(CourseOverview, 'has_started')
@@ -2097,8 +2091,8 @@ class ProgramCourseEnrollmentOverviewGetTests(
         mock_has_ended.return_value = False
 
         response_status_code, response_course_runs = self.get_status_and_course_runs()
-        self.assertEqual(status.HTTP_200_OK, response_status_code)
-        self.assertEqual(CourseRunProgressStatuses.UPCOMING, response_course_runs[0]['course_run_status'])
+        assert status.HTTP_200_OK == response_status_code
+        assert CourseRunProgressStatuses.UPCOMING == response_course_runs[0]['course_run_status']
 
     def test_course_run_url(self):
         self.log_in()
@@ -2106,74 +2100,74 @@ class ProgramCourseEnrollmentOverviewGetTests(
         course_run_url = 'http://testserver/courses/{}/course/'.format(text_type(self.course_id))
 
         response_status_code, response_course_runs = self.get_status_and_course_runs()
-        self.assertEqual(status.HTTP_200_OK, response_status_code)
-        self.assertEqual(course_run_url, response_course_runs[0]['course_run_url'])
+        assert status.HTTP_200_OK == response_status_code
+        assert course_run_url == response_course_runs[0]['course_run_url']
 
     def test_course_run_dates(self):
         self.log_in()
 
         response_status_code, response_course_runs = self.get_status_and_course_runs()
-        self.assertEqual(status.HTTP_200_OK, response_status_code)
+        assert status.HTTP_200_OK == response_status_code
 
         course_run_overview = response_course_runs[0]
 
-        self.assertEqual(course_run_overview['start_date'], '2018-12-31T00:00:00Z')
-        self.assertEqual(course_run_overview['end_date'], '2019-01-02T00:00:00Z')
+        assert course_run_overview['start_date'] == '2018-12-31T00:00:00Z'
+        assert course_run_overview['end_date'] == '2019-01-02T00:00:00Z'
 
         # course run end date may not exist
         self.course_overview.end = None
         self.course_overview.save()
 
         response_status_code, response_course_runs = self.get_status_and_course_runs()
-        self.assertEqual(status.HTTP_200_OK, response_status_code)
-        self.assertEqual(response_course_runs[0]['end_date'], None)
+        assert status.HTTP_200_OK == response_status_code
+        assert response_course_runs[0]['end_date'] is None
 
     def test_course_run_id_and_display_name(self):
         self.log_in()
 
         response_status_code, response_course_runs = self.get_status_and_course_runs()
-        self.assertEqual(status.HTTP_200_OK, response_status_code)
+        assert status.HTTP_200_OK == response_status_code
 
         course_run_overview = response_course_runs[0]
 
-        self.assertEqual(course_run_overview['course_run_id'], text_type(self.course_id))
-        self.assertEqual(course_run_overview['display_name'], "{} Course".format(text_type(self.course_id)))
+        assert course_run_overview['course_run_id'] == text_type(self.course_id)
+        assert course_run_overview['display_name'] == '{} Course'.format(text_type(self.course_id))
 
     def test_emails_enabled(self):
         self.log_in()
 
         # by default, BulkEmailFlag is not enabled, so 'emails_enabled' won't be in the response
         response_status_code, response_course_runs = self.get_status_and_course_runs()
-        self.assertEqual(status.HTTP_200_OK, response_status_code)
-        self.assertNotIn('emails_enabled', response_course_runs[0])
+        assert status.HTTP_200_OK == response_status_code
+        assert 'emails_enabled' not in response_course_runs[0]
 
         with mock.patch.object(BulkEmailFlag, 'feature_enabled', return_value=True):
             response_status_code, response_course_runs = self.get_status_and_course_runs()
-            self.assertEqual(status.HTTP_200_OK, response_status_code)
-            self.assertTrue(response_course_runs[0]['emails_enabled'])
+            assert status.HTTP_200_OK == response_status_code
+            assert response_course_runs[0]['emails_enabled']
 
             Optout.objects.create(
                 user=self.student,
                 course_id=self.course_id
             )
             response_status_code, response_course_runs = self.get_status_and_course_runs()
-            self.assertEqual(status.HTTP_200_OK, response_status_code)
-            self.assertFalse(response_course_runs[0]['emails_enabled'])
+            assert status.HTTP_200_OK == response_status_code
+            assert not response_course_runs[0]['emails_enabled']
 
     def test_micromasters_title(self):
         self.log_in()
 
         response_status_code, response_course_runs = self.get_status_and_course_runs()
-        self.assertEqual(status.HTTP_200_OK, response_status_code)
-        self.assertNotIn('micromasters_title', response_course_runs[0])
+        assert status.HTTP_200_OK == response_status_code
+        assert 'micromasters_title' not in response_course_runs[0]
 
         self.program['type'] = 'MicroMasters'
         # update the program in the catalog cache
         self.set_program_in_catalog_cache(self.program_uuid, self.program)
 
         response_status_code, response_course_runs = self.get_status_and_course_runs()
-        self.assertEqual(status.HTTP_200_OK, response_status_code)
-        self.assertIn('micromasters_title', response_course_runs[0])
+        assert status.HTTP_200_OK == response_status_code
+        assert 'micromasters_title' in response_course_runs[0]
 
 
 @ddt.ddt
@@ -2394,7 +2388,7 @@ class EnrollmentDataResetViewTests(ProgramCacheMixin, APITestCase):
     @patch_call_command
     def test_feature_disabled_by_default(self, mock_call_command):
         response = self.request(self.organization.short_name)
-        self.assertEqual(response.status_code, status.HTTP_501_NOT_IMPLEMENTED)
+        assert response.status_code == status.HTTP_501_NOT_IMPLEMENTED
         mock_call_command.assert_has_calls([])
 
     @override_settings(FEATURES=FEATURES_WITH_ENABLED)
@@ -2403,7 +2397,7 @@ class EnrollmentDataResetViewTests(ProgramCacheMixin, APITestCase):
         student = UserFactory.create(username='student', password='password')
         self.client.login(username=student.username, password='password')
         response = self.request(self.organization.short_name)
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
         mock_call_command.assert_has_calls([])
 
     @override_settings(FEATURES=FEATURES_WITH_ENABLED)
@@ -2413,7 +2407,7 @@ class EnrollmentDataResetViewTests(ProgramCacheMixin, APITestCase):
         self.set_org_in_catalog_cache(self.organization, programs)
 
         response = self.request(self.organization.short_name)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK
         mock_call_command.assert_has_calls([
             mock.call(self.reset_users_cmd, self.provider.slug, force=True),
             mock.call(self.reset_enrollments_cmd, ','.join(programs), force=True),
@@ -2427,7 +2421,7 @@ class EnrollmentDataResetViewTests(ProgramCacheMixin, APITestCase):
         self.set_org_in_catalog_cache(organization, programs)
 
         response = self.request(organization.short_name)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK
         mock_call_command.assert_has_calls([
             mock.call(self.reset_enrollments_cmd, ','.join(programs), force=True),
         ])
@@ -2436,7 +2430,7 @@ class EnrollmentDataResetViewTests(ProgramCacheMixin, APITestCase):
     @patch_call_command
     def test_organization_not_found(self, mock_call_command):
         response = self.request('yyz')
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
         mock_call_command.assert_has_calls([])
 
     @override_settings(FEATURES=FEATURES_WITH_ENABLED)
@@ -2446,7 +2440,7 @@ class EnrollmentDataResetViewTests(ProgramCacheMixin, APITestCase):
         self.set_org_in_catalog_cache(self.organization, programs)
 
         response = self.request(self.organization.short_name)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK
         mock_call_command.assert_has_calls([
             mock.call(self.reset_users_cmd, self.provider.slug, force=True),
         ])
@@ -2458,5 +2452,5 @@ class EnrollmentDataResetViewTests(ProgramCacheMixin, APITestCase):
             reverse('programs_api:v1:reset_enrollment_data'),
             format='json',
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
         mock_call_command.assert_has_calls([])

--- a/lms/djangoapps/program_enrollments/tests/test_models.py
+++ b/lms/djangoapps/program_enrollments/tests/test_models.py
@@ -4,7 +4,7 @@ Unit tests for ProgramEnrollment models.
 
 
 from uuid import UUID
-
+import pytest
 import ddt
 from django.db.utils import IntegrityError
 from django.test import TestCase
@@ -57,7 +57,7 @@ class ProgramEnrollmentModelTests(TestCase):
         """
         A record with the same (external_user_key, program_uuid, curriculum_uuid) cannot be duplicated.
         """
-        with self.assertRaises(IntegrityError):
+        with pytest.raises(IntegrityError):
             _ = ProgramEnrollmentFactory(
                 user=None,
                 external_user_key='abc',
@@ -70,7 +70,7 @@ class ProgramEnrollmentModelTests(TestCase):
         """
         A record with the same (user, program_uuid, curriculum_uuid) cannot be duplicated.
         """
-        with self.assertRaises(IntegrityError):
+        with pytest.raises(IntegrityError):
             _ = ProgramEnrollmentFactory(
                 user=self.user,
                 external_user_key=None,
@@ -90,29 +90,21 @@ class ProgramEnrollmentModelTests(TestCase):
         self.enrollment.save()
 
         # Ensure that all the records had values for external_user_key
-        self.assertEqual(self.enrollment.external_user_key, 'abc')
+        assert self.enrollment.external_user_key == 'abc'
 
-        self.assertTrue(self.enrollment.historical_records.all())
+        assert self.enrollment.historical_records.all()
         for record in self.enrollment.historical_records.all():
-            self.assertEqual(record.external_user_key, 'abc')
+            assert record.external_user_key == 'abc'
 
         ProgramEnrollment.retire_user(self.user.id)
         self.enrollment.refresh_from_db()
 
         # Ensure those values are retired
-        self.assertTrue(
-            self.enrollment.external_user_key.startswith(
-                'retired_external_key'
-            )
-        )
+        assert self.enrollment.external_user_key.startswith('retired_external_key')
 
-        self.assertTrue(self.enrollment.historical_records.all())
+        assert self.enrollment.historical_records.all()
         for record in self.enrollment.historical_records.all():
-            self.assertTrue(
-                record.external_user_key.startswith(
-                    'retired_external_key'
-                )
-            )
+            assert record.external_user_key.startswith('retired_external_key')
 
 
 @ddt.ddt
@@ -178,7 +170,7 @@ class ProgramCourseEnrollmentModelTests(TestCase):
         cannot be created.
         """
         pce = self._create_waiting_program_course_enrollment()
-        with self.assertRaises(IntegrityError):
+        with pytest.raises(IntegrityError):
             ProgramCourseEnrollmentFactory(
                 program_enrollment=pce.program_enrollment,
                 course_key=pce.course_key,
@@ -242,7 +234,7 @@ class CourseAccessRoleAssignmentTests(TestCase):
         """
         Multiple records with the same enrollment and role cannot be created
         """
-        with self.assertRaises(IntegrityError):
+        with pytest.raises(IntegrityError):
             CourseAccessRoleAssignmentFactory(
                 enrollment=self.program_course_enrollment,
                 role=ProgramCourseEnrollmentRoles.COURSE_STAFF,

--- a/lms/djangoapps/program_enrollments/tests/test_signals.py
+++ b/lms/djangoapps/program_enrollments/tests/test_signals.py
@@ -52,11 +52,11 @@ class ProgramEnrollmentRetireSignalTests(ModuleStoreTestCase):
         Assert that for the enrollment and all histories, external key is None
         """
         enrollment.refresh_from_db()
-        self.assertIsNotNone(enrollment.external_user_key)
-        self.assertTrue(enrollment.external_user_key.startswith('retired_external_key'))
+        assert enrollment.external_user_key is not None
+        assert enrollment.external_user_key.startswith('retired_external_key')
         for history_record in enrollment.historical_records.all():
-            self.assertIsNotNone(history_record.external_user_key)
-            self.assertTrue(history_record.external_user_key.startswith('retired_external_key'))
+            assert history_record.external_user_key is not None
+            assert history_record.external_user_key.startswith('retired_external_key')
 
     def test_retire_enrollment(self):
         """
@@ -162,15 +162,15 @@ class SocialAuthEnrollmentCompletionSignalTest(CacheIsolationTestCase):
     def _assert_program_enrollment_user(self, program_enrollment, user):
         """ validate program enrollment has a user """
         program_enrollment.refresh_from_db()
-        self.assertEqual(program_enrollment.user, user)
+        assert program_enrollment.user == user
 
     def _assert_program_course_enrollment(self, program_course_enrollment, mode=CourseMode.MASTERS):
         """ validate program course enrollment has a valid course enrollment """
         program_course_enrollment.refresh_from_db()
         student_course_enrollment = program_course_enrollment.course_enrollment
-        self.assertEqual(student_course_enrollment.user, self.user)
-        self.assertEqual(student_course_enrollment.course.id, program_course_enrollment.course_key)
-        self.assertEqual(student_course_enrollment.mode, mode)
+        assert student_course_enrollment.user == self.user
+        assert student_course_enrollment.course.id == program_course_enrollment.course_key
+        assert student_course_enrollment.mode == mode
 
     def test_update_social_auth(self):
         """
@@ -186,7 +186,7 @@ class SocialAuthEnrollmentCompletionSignalTest(CacheIsolationTestCase):
 
         # Not yet a thing, didn't match
         program_enrollment.refresh_from_db()
-        self.assertIsNone(program_enrollment.user)
+        assert program_enrollment.user is None
 
         user_social_auth.uid = '{0}:{1}'.format(self.provider_slug, self.external_id)
         user_social_auth.save()
@@ -249,14 +249,14 @@ class SocialAuthEnrollmentCompletionSignalTest(CacheIsolationTestCase):
         # update will create a second record
         self.provider_config.organization = None
         self.provider_config.save()
-        self.assertEqual(len(SAMLProviderConfig.objects.all()), 2)
+        assert len(SAMLProviderConfig.objects.all()) == 2
 
         UserSocialAuth.objects.create(
             user=self.user,
             uid='{0}:{1}'.format(self.provider_slug, self.external_id)
         )
         program_enrollment.refresh_from_db()
-        self.assertIsNone(program_enrollment.user)
+        assert program_enrollment.user is None
 
     def test_learner_already_enrolled_in_course(self):
         course_key = self.course_keys[0]

--- a/lms/djangoapps/rss_proxy/tests/test_models.py
+++ b/lms/djangoapps/rss_proxy/tests/test_models.py
@@ -20,4 +20,4 @@ class WhitelistedRssUrlTests(TestCase):
         """
         Test the unicode function returns the url
         """
-        self.assertEqual(six.text_type(self.whitelisted_rss_url), self.whitelisted_rss_url.url)
+        assert six.text_type(self.whitelisted_rss_url) == self.whitelisted_rss_url.url

--- a/lms/djangoapps/rss_proxy/tests/test_views.py
+++ b/lms/djangoapps/rss_proxy/tests/test_views.py
@@ -46,9 +46,9 @@ class RssProxyViewTests(TestCase):
         """
         mock_requests_get.return_value = Mock(status_code=200, content=self.rss)
         resp = self.client.get('%s?url=%s' % (reverse('rss_proxy:proxy'), self.whitelisted_url1))
-        self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp['Content-Type'], 'application/xml')
-        self.assertEqual(resp.content.decode('utf-8'), self.rss)
+        assert resp.status_code == 200
+        assert resp['Content-Type'] == 'application/xml'
+        assert resp.content.decode('utf-8') == self.rss
 
     @patch('lms.djangoapps.rss_proxy.views.requests.get')
     def test_proxy_with_whitelisted_url_404(self, mock_requests_get):
@@ -60,13 +60,13 @@ class RssProxyViewTests(TestCase):
         print(resp.status_code)
         print(resp.content)
         print(resp['Content-Type'])
-        self.assertEqual(resp.status_code, 404)
-        self.assertEqual(resp['Content-Type'], 'application/xml')
-        self.assertEqual(resp.content.decode('utf-8'), '')
+        assert resp.status_code == 404
+        assert resp['Content-Type'] == 'application/xml'
+        assert resp.content.decode('utf-8') == ''
 
     def test_proxy_with_non_whitelisted_url(self):
         """
         Test the proxy view with a non-whitelisted URL
         """
         resp = self.client.get('%s?url=%s' % (reverse('rss_proxy:proxy'), self.non_whitelisted_url))
-        self.assertEqual(resp.status_code, 404)
+        assert resp.status_code == 404

--- a/lms/djangoapps/static_template_view/tests/test_views.py
+++ b/lms/djangoapps/static_template_view/tests/test_views.py
@@ -18,8 +18,8 @@ class MarketingSiteViewTests(TestCase):
         Gets a view and tests that it exists.
         """
         resp = self.client.get(reverse(view_name))
-        self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp['Content-Type'], mimetype)
+        assert resp.status_code == 200
+        assert resp['Content-Type'] == mimetype
 
     def test_sitemap(self):
         """
@@ -69,8 +69,8 @@ class MarketingSiteViewTests(TestCase):
         """
         url = reverse('static_template_view.views.render_404')
         resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp['Content-Type'], 'text/html')
+        assert resp.status_code == 200
+        assert resp['Content-Type'] == 'text/html'
 
     def test_500(self):
         """
@@ -78,8 +78,8 @@ class MarketingSiteViewTests(TestCase):
         """
         url = reverse('static_template_view.views.render_500')
         resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 500)
-        self.assertEqual(resp['Content-Type'], 'text/html; charset=utf-8')
+        assert resp.status_code == 500
+        assert resp['Content-Type'] == 'text/html; charset=utf-8'
 
         # check response with branding
         resp = self.client.get(url)

--- a/lms/djangoapps/staticbook/tests.py
+++ b/lms/djangoapps/staticbook/tests.py
@@ -4,7 +4,7 @@ Test the lms/staticbook views.
 
 
 import textwrap
-
+import pytest
 import mock
 import requests
 from django.urls import NoReverseMatch, reverse
@@ -102,19 +102,19 @@ class StaticImageBookTest(StaticBookTest):
     def test_bad_book_id(self):
         # A bad book id will be a 404.
         self.make_course(textbooks=[IMAGE_BOOK])
-        with self.assertRaises(NoReverseMatch):
+        with pytest.raises(NoReverseMatch):
             self.make_url('book', book_index='fooey')
 
     def test_out_of_range_book_id(self):
         self.make_course()
         url = self.make_url('book', book_index=0)
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 404)
+        assert response.status_code == 404
 
     def test_bad_page_id(self):
         # A bad page id will cause a 404.
         self.make_course(textbooks=[IMAGE_BOOK])
-        with self.assertRaises(NoReverseMatch):
+        with pytest.raises(NoReverseMatch):
             self.make_url('book', book_index=0, page='xyzzy')
 
 
@@ -162,7 +162,7 @@ class StaticPdfBookTest(StaticBookTest):
     def test_bad_book_id(self):
         # If the book id isn't an int, we'll get a 404.
         self.make_course(pdf_textbooks=[PDF_BOOK])
-        with self.assertRaises(NoReverseMatch):
+        with pytest.raises(NoReverseMatch):
             self.make_url('pdf_book', book_index='fooey', chapter=1)
 
     def test_out_of_range_book_id(self):
@@ -170,34 +170,34 @@ class StaticPdfBookTest(StaticBookTest):
         self.make_course(pdf_textbooks=[PDF_BOOK])
         url = self.make_url('pdf_book', book_index=1, chapter=1)
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 404)
+        assert response.status_code == 404
 
     def test_no_book(self):
         # If we have no books, asking for the first book will fail with a 404.
         self.make_course()
         url = self.make_url('pdf_book', book_index=0, chapter=1)
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 404)
+        assert response.status_code == 404
 
     def test_chapter_xss(self):
         # The chapter in the URL used to go right on the page.
         self.make_course(pdf_textbooks=[PDF_BOOK])
         # It's no longer possible to use a non-integer chapter.
-        with self.assertRaises(NoReverseMatch):
+        with pytest.raises(NoReverseMatch):
             self.make_url('pdf_book', book_index=0, chapter='xyzzy')
 
     def test_page_xss(self):
         # The page in the URL used to go right on the page.
         self.make_course(pdf_textbooks=[PDF_BOOK])
         # It's no longer possible to use a non-integer page.
-        with self.assertRaises(NoReverseMatch):
+        with pytest.raises(NoReverseMatch):
             self.make_url('pdf_book', book_index=0, page='xyzzy')
 
     def test_chapter_page_xss(self):
         # The page in the URL used to go right on the page.
         self.make_course(pdf_textbooks=[PDF_BOOK])
         # It's no longer possible to use a non-integer page and a non-integer chapter.
-        with self.assertRaises(NoReverseMatch):
+        with pytest.raises(NoReverseMatch):
             self.make_url('pdf_book', book_index=0, chapter='fooey', page='xyzzy')
 
     def test_static_url_map_contentstore(self):
@@ -235,7 +235,7 @@ class StaticPdfBookTest(StaticBookTest):
         invalid_chapter = len(PDF_BOOK['chapters']) + 1
         url = self.make_url('pdf_book', book_index=0, chapter=invalid_chapter)
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         self.assertContains(response, "Chapter 1 for PDF")
 
 
@@ -265,18 +265,18 @@ class StaticHtmlBookTest(StaticBookTest):
         self.make_course(html_textbooks=[HTML_BOOK])
         url = self.make_url('html_book', book_index=1, chapter=1)
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 404)
+        assert response.status_code == 404
 
     def test_no_book(self):
         # If we have no books, asking for the first book will fail with a 404.
         self.make_course()
         url = self.make_url('html_book', book_index=0, chapter=1)
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 404)
+        assert response.status_code == 404
 
     def test_chapter_xss(self):
         # The chapter in the URL used to go right on the page.
         self.make_course(pdf_textbooks=[HTML_BOOK])
         # It's no longer possible to use a non-integer chapter.
-        with self.assertRaises(NoReverseMatch):
+        with pytest.raises(NoReverseMatch):
             self.make_url('html_book', book_index=0, chapter='xyzzy')

--- a/lms/djangoapps/support/tests/test_views.py
+++ b/lms/djangoapps/support/tests/test_views.py
@@ -52,7 +52,7 @@ class SupportViewTestCase(ModuleStoreTestCase):
         self.user = UserFactory(username=self.USERNAME, email=self.EMAIL, password=self.PASSWORD)
         self.course = CourseFactory.create()
         success = self.client.login(username=self.USERNAME, password=self.PASSWORD)
-        self.assertTrue(success, msg="Could not log in")
+        assert success, 'Could not log in'
 
 
 class SupportViewManageUserTests(SupportViewTestCase):
@@ -71,7 +71,7 @@ class SupportViewManageUserTests(SupportViewTestCase):
         """
         url = reverse('support:contact_us')
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
     def test_get_password_assistance(self):
         """
@@ -79,7 +79,7 @@ class SupportViewManageUserTests(SupportViewTestCase):
         """
         url = '/password_assistance'
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
     def test_get_support_form(self):
         """
@@ -87,7 +87,7 @@ class SupportViewManageUserTests(SupportViewTestCase):
         """
         url = reverse('support:manage_user')
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
     def test_get_form_with_user_info(self):
         """
@@ -97,7 +97,7 @@ class SupportViewManageUserTests(SupportViewTestCase):
         url = reverse('support:manage_user_detail') + self.user.username
         response = self.client.get(url)
         data = json.loads(response.content.decode('utf-8'))
-        self.assertEqual(data['username'], self.user.username)
+        assert data['username'] == self.user.username
 
     def test_disable_user_account(self):
         """
@@ -112,9 +112,9 @@ class SupportViewManageUserTests(SupportViewTestCase):
             'comment': 'Test comment'
         })
         data = json.loads(response.content.decode('utf-8'))
-        self.assertEqual(data['success_msg'], 'User Disabled Successfully')
+        assert data['success_msg'] == 'User Disabled Successfully'
         test_user = User.objects.get(username=test_user.username, email=test_user.email)
-        self.assertEqual(test_user.has_usable_password(), False)
+        assert test_user.has_usable_password() is False
 
 
 @ddt.ddt
@@ -149,9 +149,9 @@ class SupportViewAccessTests(SupportViewTestCase):
         response = self.client.get(url)
 
         if has_access:
-            self.assertEqual(response.status_code, 200)
+            assert response.status_code == 200
         else:
-            self.assertEqual(response.status_code, 403)
+            assert response.status_code == 403
 
     @ddt.data(
         "support:index",
@@ -261,7 +261,7 @@ class SupportViewEnrollmentsTests(SharedModuleStoreTestCase, SupportViewTestCase
         Assert that the student's enrollment has the correct mode.
         """
         enrollment = CourseEnrollment.get_enrollment(self.student, self.course.id)
-        self.assertEqual(enrollment.mode, mode)
+        assert enrollment.mode == mode
 
     @ddt.data('username', 'email')
     def test_get_enrollments(self, search_string_type):
@@ -270,9 +270,9 @@ class SupportViewEnrollmentsTests(SharedModuleStoreTestCase, SupportViewTestCase
             kwargs={'username_or_email': getattr(self.student, search_string_type)}
         )
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         data = json.loads(response.content.decode('utf-8'))
-        self.assertEqual(len(data), 1)
+        assert len(data) == 1
         self.assertDictContainsSubset({
             'mode': CourseMode.AUDIT,
             'manual_enrollment': {},
@@ -281,12 +281,8 @@ class SupportViewEnrollmentsTests(SharedModuleStoreTestCase, SupportViewTestCase
             'is_active': True,
             'verified_upgrade_deadline': None,
         }, data[0])
-        self.assertEqual(
-            {CourseMode.VERIFIED, CourseMode.AUDIT, CourseMode.HONOR,
-             CourseMode.NO_ID_PROFESSIONAL_MODE, CourseMode.PROFESSIONAL,
-             CourseMode.CREDIT_MODE},
-            {mode['slug'] for mode in data[0]['course_modes']}
-        )
+        assert {CourseMode.VERIFIED, CourseMode.AUDIT, CourseMode.HONOR, CourseMode.NO_ID_PROFESSIONAL_MODE,
+                CourseMode.PROFESSIONAL, CourseMode.CREDIT_MODE} == {mode['slug'] for mode in data[0]['course_modes']}
 
     def test_get_manual_enrollment_history(self):
         ManualEnrollmentAudit.create_manual_enrollment_audit(
@@ -297,7 +293,7 @@ class SupportViewEnrollmentsTests(SharedModuleStoreTestCase, SupportViewTestCase
             CourseEnrollment.objects.get(course_id=self.course.id, user=self.student)
         )
         response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         self.assertDictContainsSubset({
             'enrolled_by': self.user.email,
             'reason': 'Financial Assistance',
@@ -306,7 +302,7 @@ class SupportViewEnrollmentsTests(SharedModuleStoreTestCase, SupportViewTestCase
     @disable_signal(signals, 'post_save')
     @ddt.data('username', 'email')
     def test_change_enrollment(self, search_string_type):
-        self.assertIsNone(ManualEnrollmentAudit.get_manual_enrollment_by_email(self.student.email))
+        assert ManualEnrollmentAudit.get_manual_enrollment_by_email(self.student.email) is None
         url = reverse(
             'support:enrollment_list',
             kwargs={'username_or_email': getattr(self.student, search_string_type)}
@@ -317,8 +313,8 @@ class SupportViewEnrollmentsTests(SharedModuleStoreTestCase, SupportViewTestCase
             'new_mode': CourseMode.VERIFIED,
             'reason': 'Financial Assistance'
         })
-        self.assertEqual(response.status_code, 200)
-        self.assertIsNotNone(ManualEnrollmentAudit.get_manual_enrollment_by_email(self.student.email))
+        assert response.status_code == 200
+        assert ManualEnrollmentAudit.get_manual_enrollment_by_email(self.student.email) is not None
         self.assert_enrollment(CourseMode.VERIFIED)
 
     @ddt.data(
@@ -351,12 +347,10 @@ class SupportViewEnrollmentsTests(SharedModuleStoreTestCase, SupportViewTestCase
             data['course_id'] = str(self.course.id)
         response = self.client.post(self.url, data)
 
-        self.assertEqual(response.status_code, 400)
-        self.assertIsNotNone(
-            re.match(error_message, response.content.decode('utf-8').replace("'", '').replace('"', ''))
-        )
+        assert response.status_code == 400
+        assert re.match(error_message, response.content.decode('utf-8').replace("'", '').replace('"', '')) is not None
         self.assert_enrollment(CourseMode.AUDIT)
-        self.assertIsNone(ManualEnrollmentAudit.get_manual_enrollment_by_email(self.student.email))
+        assert ManualEnrollmentAudit.get_manual_enrollment_by_email(self.student.email) is None
 
     @disable_signal(signals, 'post_save')
     @ddt.data('honor', 'audit', 'verified', 'professional', 'no-id-professional', 'credit')
@@ -387,7 +381,7 @@ class SupportViewEnrollmentsTests(SharedModuleStoreTestCase, SupportViewTestCase
     def test_update_enrollments_with_expired_mode(self, search_string_type):
         """ Verify that enrollment can be updated to verified mode. """
         self.set_course_end_date_and_expiry()
-        self.assertIsNone(ManualEnrollmentAudit.get_manual_enrollment_by_email(self.student.email))
+        assert ManualEnrollmentAudit.get_manual_enrollment_by_email(self.student.email) is None
         self.assert_update_enrollment(search_string_type, CourseMode.VERIFIED)
 
     def _assert_generated_modes(self, response):
@@ -408,24 +402,18 @@ class SupportViewEnrollmentsTests(SharedModuleStoreTestCase, SupportViewTestCase
                 'description': mode.description
             })
 
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         data = json.loads(response.content.decode('utf-8'))
-        self.assertEqual(len(data), 1)
+        assert len(data) == 1
 
-        self.assertEqual(
-            modes_data,
-            data[0]['course_modes']
-        )
+        assert modes_data == data[0]['course_modes']
 
-        self.assertEqual(
-            {CourseMode.VERIFIED, CourseMode.AUDIT, CourseMode.NO_ID_PROFESSIONAL_MODE,
-             CourseMode.PROFESSIONAL, CourseMode.HONOR, CourseMode.CREDIT_MODE},
-            {mode['slug'] for mode in data[0]['course_modes']}
-        )
+        assert {CourseMode.VERIFIED, CourseMode.AUDIT, CourseMode.NO_ID_PROFESSIONAL_MODE, CourseMode.PROFESSIONAL,
+                CourseMode.HONOR, CourseMode.CREDIT_MODE} == {mode['slug'] for mode in data[0]['course_modes']}
 
     def assert_update_enrollment(self, search_string_type, new_mode):
         """ Dry method to update the enrollment and assert response."""
-        self.assertIsNone(ManualEnrollmentAudit.get_manual_enrollment_by_email(self.student.email))
+        assert ManualEnrollmentAudit.get_manual_enrollment_by_email(self.student.email) is None
         url = reverse(
             'support:enrollment_list',
             kwargs={'username_or_email': getattr(self.student, search_string_type)}
@@ -443,12 +431,12 @@ class SupportViewEnrollmentsTests(SharedModuleStoreTestCase, SupportViewTestCase
                 'reason': 'Financial Assistance'
             })
 
-        self.assertEqual(response.status_code, 200)
-        self.assertIsNotNone(ManualEnrollmentAudit.get_manual_enrollment_by_email(self.student.email))
+        assert response.status_code == 200
+        assert ManualEnrollmentAudit.get_manual_enrollment_by_email(self.student.email) is not None
         self.assert_enrollment(new_mode)
         if new_mode == 'credit':
             enrollment_attr = CourseEnrollmentAttribute.objects.first()
-            self.assertEqual(enrollment_attr.value, six.text_type(credit_provider[0]))
+            assert enrollment_attr.value == six.text_type(credit_provider[0])
 
     def set_course_end_date_and_expiry(self):
         """ Set the course-end date and expire its verified mode."""
@@ -984,14 +972,14 @@ class SsoRecordsTests(SupportViewTestCase):  # lint-amnesty, pylint: disable=mis
     def test_empty_response(self):
         response = self.client.get(self.url)
         data = json.loads(response.content.decode('utf-8'))
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(data), 0)
+        assert response.status_code == 200
+        assert len(data) == 0
 
     def test_user_does_not_exist(self):
         response = self.client.get(reverse("support:sso_records", kwargs={'username_or_email': 'wrong_username'}))
         data = json.loads(response.content.decode('utf-8'))
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(data), 0)
+        assert response.status_code == 200
+        assert len(data) == 0
 
     def test_response(self):
         user_social_auth = UserSocialAuth.objects.create(  # lint-amnesty, pylint: disable=unused-variable
@@ -1001,6 +989,6 @@ class SsoRecordsTests(SupportViewTestCase):  # lint-amnesty, pylint: disable=mis
         )
         response = self.client.get(self.url)
         data = json.loads(response.content.decode('utf-8'))
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(data), 1)
+        assert response.status_code == 200
+        assert len(data) == 1
         self.assertContains(response, '"uid": "test@example.com"')

--- a/lms/djangoapps/survey/tests/test_models.py
+++ b/lms/djangoapps/survey/tests/test_models.py
@@ -4,7 +4,7 @@ Python tests for the Survey models
 
 
 from collections import OrderedDict
-
+import pytest
 import ddt
 import six
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
@@ -68,7 +68,7 @@ class SurveyModelsTests(TestCase):
         Asserts that when looking up a form that does not exist
         """
 
-        with self.assertRaises(SurveyFormNotFound):
+        with pytest.raises(SurveyFormNotFound):
             SurveyForm.get(self.test_survey_name)
 
     def test_form_not_found_none(self):
@@ -76,7 +76,7 @@ class SurveyModelsTests(TestCase):
         Asserts that when looking up a form that does not exist
         """
 
-        self.assertIsNone(SurveyForm.get(self.test_survey_name, throw_if_not_found=False))
+        assert SurveyForm.get(self.test_survey_name, throw_if_not_found=False) is None
 
     def test_create_new_form(self):
         """
@@ -84,26 +84,26 @@ class SurveyModelsTests(TestCase):
         """
 
         survey = self._create_test_survey()
-        self.assertIsNotNone(survey)
+        assert survey is not None
 
         new_survey = SurveyForm.get(self.test_survey_name)
-        self.assertIsNotNone(new_survey)
-        self.assertEqual(new_survey.form, self.test_form)
+        assert new_survey is not None
+        assert new_survey.form == self.test_form
 
     def test_unicode_rendering(self):
         """
         See if the survey form returns the expected unicode string
         """
         survey = self._create_test_survey()
-        self.assertIsNotNone(survey)
-        self.assertEqual(six.text_type(survey), self.test_survey_name)
+        assert survey is not None
+        assert six.text_type(survey) == self.test_survey_name
 
     def test_create_form_with_malformed_html(self):
         """
         Make sure that if a SurveyForm is saved with unparseable html
         an exception is thrown
         """
-        with self.assertRaises(ValidationError):
+        with pytest.raises(ValidationError):
             SurveyForm.create('badform', '<input name="oops" /><<<>')
 
     def test_create_form_with_no_fields(self):
@@ -111,10 +111,10 @@ class SurveyModelsTests(TestCase):
         Make sure that if a SurveyForm is saved without any named fields
         an exception is thrown
         """
-        with self.assertRaises(ValidationError):
+        with pytest.raises(ValidationError):
             SurveyForm.create('badform', '<p>no input fields here</p>')
 
-        with self.assertRaises(ValidationError):
+        with pytest.raises(ValidationError):
             SurveyForm.create('badform', '<input id="input_without_name" />')
 
     def test_create_form_already_exists(self):
@@ -123,7 +123,7 @@ class SurveyModelsTests(TestCase):
         """
 
         self._create_test_survey()
-        with self.assertRaises(SurveyFormNameAlreadyExists):
+        with pytest.raises(SurveyFormNameAlreadyExists):
             self._create_test_survey()
 
     def test_create_form_update_existing(self):
@@ -131,14 +131,14 @@ class SurveyModelsTests(TestCase):
         Make sure we can update an existing form
         """
         survey = self._create_test_survey()
-        self.assertIsNotNone(survey)
+        assert survey is not None
 
         survey = SurveyForm.create(self.test_survey_name, self.test_form_update, update_if_exists=True)
-        self.assertIsNotNone(survey)
+        assert survey is not None
 
         survey = SurveyForm.get(self.test_survey_name)
-        self.assertIsNotNone(survey)
-        self.assertEqual(survey.form, self.test_form_update)
+        assert survey is not None
+        assert survey.form == self.test_form_update
 
     def test_survey_has_no_answers(self):
         """
@@ -146,7 +146,7 @@ class SurveyModelsTests(TestCase):
         """
 
         survey = self._create_test_survey()
-        self.assertEqual(len(survey.get_answers()), 0)
+        assert len(survey.get_answers()) == 0
 
     def test_user_has_no_answers(self):
         """
@@ -154,8 +154,8 @@ class SurveyModelsTests(TestCase):
         """
 
         survey = self._create_test_survey()
-        self.assertFalse(survey.has_user_answered_survey(self.student))
-        self.assertEqual(len(survey.get_answers()), 0)
+        assert not survey.has_user_answered_survey(self.student)
+        assert len(survey.get_answers()) == 0
 
     @ddt.data(None, 'foo/bar/baz')
     def test_single_user_answers(self, course_id):
@@ -164,21 +164,21 @@ class SurveyModelsTests(TestCase):
         """
 
         survey = self._create_test_survey()
-        self.assertIsNotNone(survey)
+        assert survey is not None
 
         survey.save_user_answers(self.student, self.student_answers, course_id)
 
-        self.assertTrue(survey.has_user_answered_survey(self.student))
+        assert survey.has_user_answered_survey(self.student)
 
         all_answers = survey.get_answers()
-        self.assertEqual(len(list(all_answers.keys())), 1)
-        self.assertIn(self.student.id, all_answers)
-        self.assertEqual(all_answers[self.student.id], self.student_answers)
+        assert len(list(all_answers.keys())) == 1
+        assert self.student.id in all_answers
+        assert all_answers[self.student.id] == self.student_answers
 
         answers = survey.get_answers(self.student)
-        self.assertEqual(len(list(answers.keys())), 1)
-        self.assertIn(self.student.id, answers)
-        self.assertEqual(all_answers[self.student.id], self.student_answers)
+        assert len(list(answers.keys())) == 1
+        assert self.student.id in answers
+        assert all_answers[self.student.id] == self.student_answers
 
         # check that the course_id was set
 
@@ -189,9 +189,9 @@ class SurveyModelsTests(TestCase):
 
         for answer_obj in answer_objs:
             if course_id:
-                self.assertEqual(six.text_type(answer_obj.course_key), course_id)
+                assert six.text_type(answer_obj.course_key) == course_id
             else:
-                self.assertIsNone(answer_obj.course_key)
+                assert answer_obj.course_key is None
 
     def test_multiple_user_answers(self):
         """
@@ -199,29 +199,29 @@ class SurveyModelsTests(TestCase):
         """
 
         survey = self._create_test_survey()
-        self.assertIsNotNone(survey)
+        assert survey is not None
 
         survey.save_user_answers(self.student, self.student_answers, self.course_id)
         survey.save_user_answers(self.student2, self.student2_answers, self.course_id)
 
-        self.assertTrue(survey.has_user_answered_survey(self.student))
+        assert survey.has_user_answered_survey(self.student)
 
         all_answers = survey.get_answers()
-        self.assertEqual(len(list(all_answers.keys())), 2)
-        self.assertIn(self.student.id, all_answers)
-        self.assertIn(self.student2.id, all_answers)
-        self.assertEqual(all_answers[self.student.id], self.student_answers)
-        self.assertEqual(all_answers[self.student2.id], self.student2_answers)
+        assert len(list(all_answers.keys())) == 2
+        assert self.student.id in all_answers
+        assert self.student2.id in all_answers
+        assert all_answers[self.student.id] == self.student_answers
+        assert all_answers[self.student2.id] == self.student2_answers
 
         answers = survey.get_answers(self.student)
-        self.assertEqual(len(list(answers.keys())), 1)
-        self.assertIn(self.student.id, answers)
-        self.assertEqual(answers[self.student.id], self.student_answers)
+        assert len(list(answers.keys())) == 1
+        assert self.student.id in answers
+        assert answers[self.student.id] == self.student_answers
 
         answers = survey.get_answers(self.student2)
-        self.assertEqual(len(list(answers.keys())), 1)
-        self.assertIn(self.student2.id, answers)
-        self.assertEqual(answers[self.student2.id], self.student2_answers)
+        assert len(list(answers.keys())) == 1
+        assert self.student2.id in answers
+        assert answers[self.student2.id] == self.student2_answers
 
     def test_update_answers(self):
         """
@@ -229,30 +229,30 @@ class SurveyModelsTests(TestCase):
         """
 
         survey = self._create_test_survey()
-        self.assertIsNotNone(survey)
+        assert survey is not None
 
         survey.save_user_answers(self.student, self.student_answers, self.course_id)
 
         answers = survey.get_answers(self.student)
-        self.assertEqual(len(list(answers.keys())), 1)
-        self.assertIn(self.student.id, answers)
-        self.assertEqual(answers[self.student.id], self.student_answers)
+        assert len(list(answers.keys())) == 1
+        assert self.student.id in answers
+        assert answers[self.student.id] == self.student_answers
 
         # update
         survey.save_user_answers(self.student, self.student_answers_update, self.course_id)
 
         answers = survey.get_answers(self.student)
-        self.assertEqual(len(list(answers.keys())), 1)
-        self.assertIn(self.student.id, answers)
-        self.assertEqual(answers[self.student.id], self.student_answers_update)
+        assert len(list(answers.keys())) == 1
+        assert self.student.id in answers
+        assert answers[self.student.id] == self.student_answers_update
 
         # update with just a subset of the origin dataset
         survey.save_user_answers(self.student, self.student_answers_update2, self.course_id)
 
         answers = survey.get_answers(self.student)
-        self.assertEqual(len(list(answers.keys())), 1)
-        self.assertIn(self.student.id, answers)
-        self.assertEqual(answers[self.student.id], self.student_answers_update2)
+        assert len(list(answers.keys())) == 1
+        assert self.student.id in answers
+        assert answers[self.student.id] == self.student_answers_update2
 
     def test_limit_num_users(self):
         """
@@ -267,7 +267,7 @@ class SurveyModelsTests(TestCase):
         # even though we have 2 users submitted answers
         # limit the result set to just 1
         all_answers = survey.get_answers(limit_num_users=1)
-        self.assertEqual(len(list(all_answers.keys())), 1)
+        assert len(list(all_answers.keys())) == 1
 
     def test_get_field_names(self):
         """
@@ -275,36 +275,36 @@ class SurveyModelsTests(TestCase):
         """
 
         survey = self._create_test_survey()
-        self.assertIsNotNone(survey)
+        assert survey is not None
 
         survey.save_user_answers(self.student, self.student_answers, self.course_id)
         survey.save_user_answers(self.student2, self.student2_answers, self.course_id)
 
         names = survey.get_field_names()
 
-        self.assertEqual(sorted(names), ['ddl', 'field1', 'field2'])
+        assert sorted(names) == ['ddl', 'field1', 'field2']
 
     def test_retire_user_successful(self):
         survey = self._create_test_survey()
-        self.assertIsNotNone(survey)
+        assert survey is not None
 
         survey.save_user_answers(self.student, self.student_answers, self.course_id)
         survey.save_user_answers(self.student2, self.student2_answers, self.course_id)
 
         retire_result = SurveyAnswer.retire_user(self.student.id)
-        self.assertTrue(retire_result)
+        assert retire_result
         answers = survey.get_answers(self.student)
         blanked_out_student_answser = {key: '' for key in self.student_answers}
-        self.assertEqual(answers[self.student.id], blanked_out_student_answser)
-        self.assertEqual(survey.get_answers(self.student2)[self.student2.id], self.student2_answers)
+        assert answers[self.student.id] == blanked_out_student_answser
+        assert survey.get_answers(self.student2)[self.student2.id] == self.student2_answers
 
     def test_retire_user_not_exist(self):
         survey = self._create_test_survey()
-        self.assertIsNotNone(survey)
+        assert survey is not None
 
         survey.save_user_answers(self.student, self.student_answers, self.course_id)
 
         retire_result = SurveyAnswer.retire_user(self.student2.id)
-        self.assertFalse(retire_result)
+        assert not retire_result
         answers = survey.get_answers(self.student)
-        self.assertEqual(answers[self.student.id], self.student_answers)
+        assert answers[self.student.id] == self.student_answers

--- a/lms/djangoapps/survey/tests/test_signals.py
+++ b/lms/djangoapps/survey/tests/test_signals.py
@@ -25,7 +25,7 @@ class SurveyRetireSignalTests(ModuleStoreTestCase):
         _listen_for_lms_retire(sender=self.__class__, user=answer.user)
 
         # All values for this user should now be empty string
-        self.assertFalse(SurveyAnswer.objects.filter(user=answer.user).exclude(field_value='').exists())
+        assert not SurveyAnswer.objects.filter(user=answer.user).exclude(field_value='').exists()
 
     def test_success_no_answers(self):
         """
@@ -46,4 +46,4 @@ class SurveyRetireSignalTests(ModuleStoreTestCase):
         _listen_for_lms_retire(sender=self.__class__, user=answer.user)
 
         # All values for this user should still be here and just be an empty string
-        self.assertFalse(SurveyAnswer.objects.filter(user=answer.user).exclude(field_value='').exists())
+        assert not SurveyAnswer.objects.filter(user=answer.user).exclude(field_value='').exists()

--- a/lms/djangoapps/survey/tests/test_utils.py
+++ b/lms/djangoapps/survey/tests/test_utils.py
@@ -60,7 +60,7 @@ class SurveyModelsTests(ModuleStoreTestCase):
         Assert the a requried course survey is when both the flags is set and a survey name
         is set on the course descriptor
         """
-        self.assertTrue(is_survey_required_for_course(self.course))
+        assert is_survey_required_for_course(self.course)
 
     def test_is_survey_not_required_for_course(self):
         """
@@ -68,51 +68,51 @@ class SurveyModelsTests(ModuleStoreTestCase):
         then the survey is not considered required
         """
         course = CourseFactory.create()
-        self.assertFalse(is_survey_required_for_course(course))
+        assert not is_survey_required_for_course(course)
 
         course = CourseFactory.create(
             course_survey_required=False
         )
-        self.assertFalse(is_survey_required_for_course(course))
+        assert not is_survey_required_for_course(course)
 
         course = CourseFactory.create(
             course_survey_required=True,
             course_survey_name="NonExisting"
         )
-        self.assertFalse(is_survey_required_for_course(course))
+        assert not is_survey_required_for_course(course)
 
         course = CourseFactory.create(
             course_survey_required=False,
             course_survey_name=self.test_survey_name
         )
-        self.assertFalse(is_survey_required_for_course(course))
+        assert not is_survey_required_for_course(course)
 
     def test_user_not_yet_answered_required_survey(self):
         """
         Assert that a new course which has a required survey but user has not answered it yet
         """
-        self.assertFalse(check_survey_required_and_unanswered(self.student, self.course))
+        assert not check_survey_required_and_unanswered(self.student, self.course)
 
         temp_course = CourseFactory.create(
             course_survey_required=False
         )
-        self.assertTrue(check_survey_required_and_unanswered(self.student, temp_course))
+        assert check_survey_required_and_unanswered(self.student, temp_course)
 
         temp_course = CourseFactory.create(
             course_survey_required=True,
             course_survey_name="NonExisting"
         )
-        self.assertTrue(check_survey_required_and_unanswered(self.student, temp_course))
+        assert check_survey_required_and_unanswered(self.student, temp_course)
 
     def test_user_has_answered_required_survey(self):
         """
         Assert that a new course which has a required survey and user has answers for it
         """
         self.survey.save_user_answers(self.student, self.student_answers, None)
-        self.assertTrue(check_survey_required_and_unanswered(self.student, self.course))
+        assert check_survey_required_and_unanswered(self.student, self.course)
 
     def test_staff_must_answer_survey(self):
         """
         Assert that someone with staff level permissions does not have to answer the survey
         """
-        self.assertTrue(check_survey_required_and_unanswered(self.staff, self.course))
+        assert check_survey_required_and_unanswered(self.staff, self.course)

--- a/lms/djangoapps/survey/tests/test_views.py
+++ b/lms/djangoapps/survey/tests/test_views.py
@@ -66,14 +66,14 @@ class SurveyViewsTests(ModuleStoreTestCase):
         anon_user = Client()
 
         resp = anon_user.get(self.view_url)
-        self.assertEqual(resp.status_code, 302)
+        assert resp.status_code == 302
 
     def test_survey_not_found(self):
         """
         Asserts that if we ask for a Survey that does not exist, then we get a 302 redirect
         """
         resp = self.client.get(reverse('view_survey', args=['NonExisting']))
-        self.assertEqual(resp.status_code, 302)
+        assert resp.status_code == 302
 
     def test_authenticated_survey_view(self):
         """
@@ -93,7 +93,7 @@ class SurveyViewsTests(ModuleStoreTestCase):
             self.postback_url,
             self.student_answers
         )
-        self.assertEqual(resp.status_code, 302)
+        assert resp.status_code == 302
 
     def test_survey_postback_to_nonexisting_survey(self):
         """
@@ -103,7 +103,7 @@ class SurveyViewsTests(ModuleStoreTestCase):
             reverse('submit_answers', args=['NonExisting']),
             self.student_answers
         )
-        self.assertEqual(resp.status_code, 404)
+        assert resp.status_code == 404
 
     def test_survey_postback(self):
         """
@@ -114,12 +114,12 @@ class SurveyViewsTests(ModuleStoreTestCase):
             self.postback_url,
             self.student_answers
         )
-        self.assertEqual(resp.status_code, 200)
+        assert resp.status_code == 200
         data = json.loads(resp.content.decode('utf-8'))
-        self.assertIn('redirect_url', data)
+        assert 'redirect_url' in data
 
         answers = self.survey.get_answers(self.student)
-        self.assertEqual(answers[self.student.id], self.student_answers)
+        assert answers[self.student.id] == self.student_answers
 
     def test_strip_extra_fields(self):
         """
@@ -136,11 +136,11 @@ class SurveyViewsTests(ModuleStoreTestCase):
             self.postback_url,
             data
         )
-        self.assertEqual(resp.status_code, 200)
+        assert resp.status_code == 200
         answers = self.survey.get_answers(self.student)
-        self.assertNotIn('csrfmiddlewaretoken', answers[self.student.id])
-        self.assertNotIn('_redirect_url', answers[self.student.id])
-        self.assertNotIn('course_id', answers[self.student.id])
+        assert 'csrfmiddlewaretoken' not in answers[self.student.id]
+        assert '_redirect_url' not in answers[self.student.id]
+        assert 'course_id' not in answers[self.student.id]
 
         # however we want to make sure we persist the course_id
         answer_objs = SurveyAnswer.objects.filter(
@@ -149,7 +149,7 @@ class SurveyViewsTests(ModuleStoreTestCase):
         )
 
         for answer_obj in answer_objs:
-            self.assertEqual(six.text_type(answer_obj.course_key), data['course_id'])
+            assert six.text_type(answer_obj.course_key) == data['course_id']
 
     def test_encoding_answers(self):
         """
@@ -163,9 +163,7 @@ class SurveyViewsTests(ModuleStoreTestCase):
             self.postback_url,
             data
         )
-        self.assertEqual(resp.status_code, 200)
+        assert resp.status_code == 200
         answers = self.survey.get_answers(self.student)
-        self.assertEqual(
-            '&lt;script type=&quot;javascript&quot;&gt;alert(&quot;Deleting filesystem...&quot;)&lt;/script&gt;',
-            answers[self.student.id]['field1']
-        )
+        assert '&lt;script type=&quot;javascript&quot;&gt;alert(&quot;Deleting filesystem...&quot;)&lt;/script&gt;' ==\
+               answers[self.student.id]['field1']


### PR DESCRIPTION
## Description
This PR is using `codemod-unittest-to-pytest-asserts` to automatically replace `unittest` assertions with `pytest` 
for following apps in `lms/djangoapps`
```
 monitoring, oauth2_handler, program_enrollments, rss_proxy, shoppingcart, static_template_view,s taticbook, support, survey
```
Relevant JIRA issue here: https://openedx.atlassian.net/browse/BOM-2393