### PR TITLE
replaced unittest assertions pytest assertions (24)

### DIFF
--- a/lms/lib/courseware_search/test/test_lms_filter_generator.py
+++ b/lms/lib/courseware_search/test/test_lms_filter_generator.py
@@ -65,9 +65,9 @@ class LmsSearchFilterGeneratorTestCase(ModuleStoreTestCase):
         """
         field_dictionary, filter_dictionary, _ = LmsSearchFilterGenerator.generate_field_filters(user=self.user)
 
-        self.assertIn('start_date', filter_dictionary)
-        self.assertIn(six.text_type(self.courses[0].id), field_dictionary['course'])
-        self.assertIn(six.text_type(self.courses[1].id), field_dictionary['course'])
+        assert 'start_date' in filter_dictionary
+        assert six.text_type(self.courses[0].id) in field_dictionary['course']
+        assert six.text_type(self.courses[1].id) in field_dictionary['course']
 
     def test_course_id_provided(self):
         """
@@ -78,8 +78,8 @@ class LmsSearchFilterGeneratorTestCase(ModuleStoreTestCase):
             course_id=six.text_type(self.courses[0].id)
         )
 
-        self.assertIn('start_date', filter_dictionary)
-        self.assertEqual(six.text_type(self.courses[0].id), field_dictionary['course'])
+        assert 'start_date' in filter_dictionary
+        assert six.text_type(self.courses[0].id) == field_dictionary['course']
 
     def test_user_not_provided(self):
         """
@@ -87,8 +87,8 @@ class LmsSearchFilterGeneratorTestCase(ModuleStoreTestCase):
         """
         field_dictionary, filter_dictionary, _ = LmsSearchFilterGenerator.generate_field_filters()
 
-        self.assertIn('start_date', filter_dictionary)
-        self.assertEqual(0, len(field_dictionary['course']))
+        assert 'start_date' in filter_dictionary
+        assert 0 == len(field_dictionary['course'])
 
     @patch(
         'openedx.core.djangoapps.site_configuration.helpers.get_all_orgs',
@@ -99,24 +99,24 @@ class LmsSearchFilterGeneratorTestCase(ModuleStoreTestCase):
         By default site orgs not belonging to current site org should be excluded.
         """
         _, _, exclude_dictionary = LmsSearchFilterGenerator.generate_field_filters(user=self.user)
-        self.assertIn('org', exclude_dictionary)
+        assert 'org' in exclude_dictionary
         exclude_orgs = exclude_dictionary['org']
-        self.assertEqual(2, len(exclude_orgs))
-        self.assertEqual('LogistrationX', exclude_orgs[0])
-        self.assertEqual('TestSiteX', exclude_orgs[1])
+        assert 2 == len(exclude_orgs)
+        assert 'LogistrationX' == exclude_orgs[0]
+        assert 'TestSiteX' == exclude_orgs[1]
 
     @patch('openedx.core.djangoapps.site_configuration.helpers.get_all_orgs', Mock(return_value=set()))
     def test_no_excludes_with_no_orgs(self):
         """ Test when no org is present - nothing to exclude """
         _, _, exclude_dictionary = LmsSearchFilterGenerator.generate_field_filters(user=self.user)
-        self.assertNotIn('org', exclude_dictionary)
+        assert 'org' not in exclude_dictionary
 
     @patch('openedx.core.djangoapps.site_configuration.helpers.get_value', Mock(return_value='TestSiteX'))
     def test_excludes_org_within(self):
         field_dictionary, _, exclude_dictionary = LmsSearchFilterGenerator.generate_field_filters(user=self.user)
-        self.assertNotIn('org', exclude_dictionary)
-        self.assertIn('org', field_dictionary)
-        self.assertEqual(['TestSiteX'], field_dictionary['org'])
+        assert 'org' not in exclude_dictionary
+        assert 'org' in field_dictionary
+        assert ['TestSiteX'] == field_dictionary['org']
 
     @patch(
         'openedx.core.djangoapps.site_configuration.helpers.get_all_orgs',
@@ -124,13 +124,13 @@ class LmsSearchFilterGeneratorTestCase(ModuleStoreTestCase):
     )
     def test_excludes_multi_orgs(self):
         _, _, exclude_dictionary = LmsSearchFilterGenerator.generate_field_filters(user=self.user)
-        self.assertIn('org', exclude_dictionary)
+        assert 'org' in exclude_dictionary
         exclude_orgs = exclude_dictionary['org']
-        self.assertEqual(4, len(exclude_orgs))
-        self.assertIn('TestSite1', exclude_orgs)
-        self.assertIn('TestSite2', exclude_orgs)
-        self.assertIn('TestSite3', exclude_orgs)
-        self.assertIn('TestSite4', exclude_orgs)
+        assert 4 == len(exclude_orgs)
+        assert 'TestSite1' in exclude_orgs
+        assert 'TestSite2' in exclude_orgs
+        assert 'TestSite3' in exclude_orgs
+        assert 'TestSite4' in exclude_orgs
 
     @patch(
         'openedx.core.djangoapps.site_configuration.helpers.get_all_orgs',
@@ -139,6 +139,6 @@ class LmsSearchFilterGeneratorTestCase(ModuleStoreTestCase):
     @patch('openedx.core.djangoapps.site_configuration.helpers.get_value', Mock(return_value='TestSite3'))
     def test_excludes_multi_orgs_within(self):
         field_dictionary, _, exclude_dictionary = LmsSearchFilterGenerator.generate_field_filters(user=self.user)
-        self.assertNotIn('org', exclude_dictionary)
-        self.assertIn('org', field_dictionary)
-        self.assertEqual(['TestSite3'], field_dictionary['org'])
+        assert 'org' not in exclude_dictionary
+        assert 'org' in field_dictionary
+        assert ['TestSite3'] == field_dictionary['org']

--- a/lms/lib/courseware_search/test/test_lms_result_processor.py
+++ b/lms/lib/courseware_search/test/test_lms_result_processor.py
@@ -4,6 +4,7 @@ Tests for the lms_result_processor
 
 
 import six
+import pytest
 
 from lms.djangoapps.courseware.tests.factories import UserFactory
 from lms.lib.courseware_search.lms_result_processor import LmsSearchResultProcessor
@@ -69,9 +70,9 @@ class LmsSearchResultProcessorTestCase(ModuleStoreTestCase):
     def test_url_parameter(self):
         fake_url = ""
         srp = LmsSearchResultProcessor({}, "test")
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             fake_url = srp.url
-        self.assertEqual(fake_url, "")
+        assert fake_url == ''
 
         srp = LmsSearchResultProcessor(
             {
@@ -82,11 +83,8 @@ class LmsSearchResultProcessorTestCase(ModuleStoreTestCase):
             "test"
         )
 
-        self.assertEqual(
-            srp.url, "/courses/{}/jump_to/{}".format(
-                six.text_type(self.course.id),
-                six.text_type(self.html.scope_ids.usage_id))
-        )
+        assert srp.url == '/courses/{}/jump_to/{}'.format(six.text_type(self.course.id),
+                                                          six.text_type(self.html.scope_ids.usage_id))
 
     def test_should_remove(self):
         """
@@ -101,4 +99,4 @@ class LmsSearchResultProcessorTestCase(ModuleStoreTestCase):
             "test"
         )
 
-        self.assertEqual(srp.should_remove(self.global_staff), False)
+        assert srp.should_remove(self.global_staff) is False

--- a/lms/lib/tests/test_utils.py
+++ b/lms/lib/tests/test_utils.py
@@ -50,21 +50,21 @@ class LmsUtilsTest(ModuleStoreTestCase):
         Tests `get_parent_unit` method for the successful result.
         """
         parent = utils.get_parent_unit(self.html_module_1)
-        self.assertEqual(parent.location, self.vertical.location)
+        assert parent.location == self.vertical.location
 
         parent = utils.get_parent_unit(self.child_html_module)
-        self.assertEqual(parent.location, self.vertical_with_container.location)
+        assert parent.location == self.vertical_with_container.location
 
-        self.assertIsNone(utils.get_parent_unit(None))
-        self.assertIsNone(utils.get_parent_unit(self.vertical))
-        self.assertIsNone(utils.get_parent_unit(self.course))
-        self.assertIsNone(utils.get_parent_unit(self.chapter))
-        self.assertIsNone(utils.get_parent_unit(self.sequential))
+        assert utils.get_parent_unit(None) is None
+        assert utils.get_parent_unit(self.vertical) is None
+        assert utils.get_parent_unit(self.course) is None
+        assert utils.get_parent_unit(self.chapter) is None
+        assert utils.get_parent_unit(self.sequential) is None
 
     def test_is_unit(self):
         """
         Tests `is_unit` method for the successful result.
         """
-        self.assertFalse(utils.is_unit(self.html_module_1))
-        self.assertFalse(utils.is_unit(self.child_vertical))
-        self.assertTrue(utils.is_unit(self.vertical))
+        assert not utils.is_unit(self.html_module_1)
+        assert not utils.is_unit(self.child_vertical)
+        assert utils.is_unit(self.vertical)

--- a/lms/lib/xblock/test/test_mixin.py
+++ b/lms/lib/xblock/test/test_mixin.py
@@ -77,15 +77,15 @@ class XBlockValidationTest(LmsXBlockMixinTestCase):
         """
         Verify that the validation message has the expected validation message and type.
         """
-        self.assertEqual(message.text, expected_message)
-        self.assertEqual(message.type, expected_message_type)
+        assert message.text == expected_message
+        assert message.type == expected_message_type
 
     def test_validate_full_group_access(self):
         """
         Test the validation messages produced for an xblock with full group access.
         """
         validation = self.store.get_item(self.video_location).validate()
-        self.assertEqual(len(validation.messages), 0)
+        assert len(validation.messages) == 0
 
     def test_validate_restricted_group_access(self):
         """
@@ -93,7 +93,7 @@ class XBlockValidationTest(LmsXBlockMixinTestCase):
         """
         self.set_group_access(self.video_location, {self.user_partition.id: [self.group1.id, self.group2.id]})
         validation = self.store.get_item(self.video_location).validate()
-        self.assertEqual(len(validation.messages), 0)
+        assert len(validation.messages) == 0
 
     def test_validate_invalid_user_partitions(self):
         """
@@ -101,7 +101,7 @@ class XBlockValidationTest(LmsXBlockMixinTestCase):
         """
         self.set_group_access(self.video_location, {999: [self.group1.id]})
         validation = self.store.get_item(self.video_location).validate()
-        self.assertEqual(len(validation.messages), 1)
+        assert len(validation.messages) == 1
         self.verify_validation_message(
             validation.messages[0],
             INVALID_USER_PARTITION_VALIDATION_COMPONENT,
@@ -113,7 +113,7 @@ class XBlockValidationTest(LmsXBlockMixinTestCase):
         # only a single error message will be returned.
         self.set_group_access(self.video_location, {998: [self.group2.id]})
         validation = self.store.get_item(self.video_location).validate()
-        self.assertEqual(len(validation.messages), 1)
+        assert len(validation.messages) == 1
         self.verify_validation_message(
             validation.messages[0],
             INVALID_USER_PARTITION_VALIDATION_COMPONENT,
@@ -126,7 +126,7 @@ class XBlockValidationTest(LmsXBlockMixinTestCase):
         """
         self.set_group_access(self.vertical_location, {999: [self.group1.id]})
         validation = self.store.get_item(self.vertical_location).validate()
-        self.assertEqual(len(validation.messages), 1)
+        assert len(validation.messages) == 1
         self.verify_validation_message(
             validation.messages[0],
             INVALID_USER_PARTITION_VALIDATION_UNIT,
@@ -138,7 +138,7 @@ class XBlockValidationTest(LmsXBlockMixinTestCase):
         # only a single error message will be returned.
         self.set_group_access(self.vertical_location, {998: [self.group2.id]})
         validation = self.store.get_item(self.vertical_location).validate()
-        self.assertEqual(len(validation.messages), 1)
+        assert len(validation.messages) == 1
         self.verify_validation_message(
             validation.messages[0],
             INVALID_USER_PARTITION_VALIDATION_UNIT,
@@ -151,7 +151,7 @@ class XBlockValidationTest(LmsXBlockMixinTestCase):
         """
         self.set_group_access(self.video_location, {self.user_partition.id: [self.group1.id, 999]})
         validation = self.store.get_item(self.video_location).validate()
-        self.assertEqual(len(validation.messages), 1)
+        assert len(validation.messages) == 1
         self.verify_validation_message(
             validation.messages[0],
             INVALID_USER_PARTITION_GROUP_VALIDATION_COMPONENT,
@@ -161,7 +161,7 @@ class XBlockValidationTest(LmsXBlockMixinTestCase):
         # Now try again with two invalid group ids
         self.set_group_access(self.video_location, {self.user_partition.id: [self.group1.id, 998, 999]})
         validation = self.store.get_item(self.video_location).validate()
-        self.assertEqual(len(validation.messages), 1)
+        assert len(validation.messages) == 1
         self.verify_validation_message(
             validation.messages[0],
             INVALID_USER_PARTITION_GROUP_VALIDATION_COMPONENT,
@@ -182,13 +182,13 @@ class XBlockValidationTest(LmsXBlockMixinTestCase):
         self.set_group_access(self.child_vertical_location, {self.user_partition.id: [self.group2.id]})
         self.set_group_access(self.child_html_module_location, {self.user_partition.id: [self.group2.id]})
         validation = self.store.get_item(self.child_html_module_location).validate()
-        self.assertEqual(len(validation.messages), 0)
+        assert len(validation.messages) == 0
 
         # Test that a validation message is displayed on split_test child when the child contradicts the parent,
         # even though the child agrees with the grandparent unit.
         self.set_group_access(self.child_html_module_location, {self.user_partition.id: [self.group1.id]})
         validation = self.store.get_item(self.child_html_module_location).validate()
-        self.assertEqual(len(validation.messages), 1)
+        assert len(validation.messages) == 1
         self.verify_validation_message(
             validation.messages[0],
             NONSENSICAL_ACCESS_RESTRICTION,
@@ -201,7 +201,7 @@ class XBlockValidationTest(LmsXBlockMixinTestCase):
         """
         self.set_group_access(self.vertical_location, {self.user_partition.id: [self.group1.id, 999]})
         validation = self.store.get_item(self.vertical_location).validate()
-        self.assertEqual(len(validation.messages), 1)
+        assert len(validation.messages) == 1
         self.verify_validation_message(
             validation.messages[0],
             INVALID_USER_PARTITION_GROUP_VALIDATION_UNIT,
@@ -217,13 +217,13 @@ class XBlockValidationTest(LmsXBlockMixinTestCase):
         self.set_group_access(self.vertical_location, {self.user_partition.id: [self.group1.id]})
         self.set_group_access(self.video_location, {self.user_partition.id: [self.group1.id]})
         validation = self.store.get_item(self.video_location).validate()
-        self.assertEqual(len(validation.messages), 0)
+        assert len(validation.messages) == 0
 
         # Now try again with opposing access restrictions
         self.set_group_access(self.vertical_location, {self.user_partition.id: [self.group1.id]})
         self.set_group_access(self.video_location, {self.user_partition.id: [self.group2.id]})
         validation = self.store.get_item(self.video_location).validate()
-        self.assertEqual(len(validation.messages), 1)
+        assert len(validation.messages) == 1
         self.verify_validation_message(
             validation.messages[0],
             NONSENSICAL_ACCESS_RESTRICTION,
@@ -234,7 +234,7 @@ class XBlockValidationTest(LmsXBlockMixinTestCase):
         self.set_group_access(self.vertical_location, {self.user_partition.id: [self.group1.id]})
         self.set_group_access(self.video_location, {self.user_partition.id: [self.group1.id, self.group2.id]})
         validation = self.store.get_item(self.video_location).validate()
-        self.assertEqual(len(validation.messages), 1)
+        assert len(validation.messages) == 1
         self.verify_validation_message(
             validation.messages[0],
             NONSENSICAL_ACCESS_RESTRICTION,
@@ -245,7 +245,7 @@ class XBlockValidationTest(LmsXBlockMixinTestCase):
         self.set_group_access(self.vertical_location, {self.user_partition.id: [self.group1.id]})
         self.set_group_access(self.video_location, {})
         validation = self.store.get_item(self.video_location).validate()
-        self.assertEqual(len(validation.messages), 1)
+        assert len(validation.messages) == 1
         self.verify_validation_message(
             validation.messages[0],
             NONSENSICAL_ACCESS_RESTRICTION,
@@ -261,7 +261,7 @@ class XBlockValidationTest(LmsXBlockMixinTestCase):
         self.set_group_access(self.vertical_location, {self.user_partition.id: [self.group1.id]})
         self.set_group_access(self.video_location, {self.user_partition.id: [self.group2.id, 999]})
         validation = self.store.get_item(self.video_location).validate()
-        self.assertEqual(len(validation.messages), 2)
+        assert len(validation.messages) == 2
         self.verify_validation_message(
             validation.messages[0],
             INVALID_USER_PARTITION_GROUP_VALIDATION_COMPONENT,
@@ -293,7 +293,7 @@ class OpenAssessmentBlockMixinTestCase(ModuleStoreTestCase):
         """
         Test has_score is true for ora2 problems.
         """
-        self.assertTrue(self.open_assessment.has_score)
+        assert self.open_assessment.has_score
 
 
 @ddt.ddt
@@ -313,7 +313,7 @@ class XBlockGetParentTest(LmsXBlockMixinTestCase):
 
             course_key = ToyCourseFactory.create().id
             course = self.store.get_course(course_key)
-            self.assertIsNone(course.get_parent())
+            assert course.get_parent() is None
 
             def recurse(parent):
                 """
@@ -322,13 +322,13 @@ class XBlockGetParentTest(LmsXBlockMixinTestCase):
                 """
                 visited = []
                 for child in parent.get_children():
-                    self.assertEqual(parent.location, child.get_parent().location)
+                    assert parent.location == child.get_parent().location
                     visited.append(child)
                     visited += recurse(child)
                 return visited
 
             visited = recurse(course)
-            self.assertEqual(len(visited), 28)
+            assert len(visited) == 28
 
     @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
     def test_parents_draft_content(self, modulestore_type):
@@ -342,7 +342,7 @@ class XBlockGetParentTest(LmsXBlockMixinTestCase):
             old_parent_location = self.vertical_location.for_branch(None)
 
             with self.store.branch_setting(ModuleStoreEnum.Branch.draft_preferred):
-                self.assertIsNone(self.course.get_parent())
+                assert self.course.get_parent() is None
 
                 with self.store.bulk_operations(self.course.id):
                     user_id = ModuleStoreEnum.UserID.test
@@ -358,17 +358,11 @@ class XBlockGetParentTest(LmsXBlockMixinTestCase):
                     # re-fetch video from draft store
                     video = self.store.get_item(child_to_move_location)
 
-                    self.assertEqual(
-                        new_parent_location,
-                        video.get_parent().location
-                    )
+                    assert new_parent_location == video.get_parent().location
             with self.store.branch_setting(ModuleStoreEnum.Branch.published_only):
                 # re-fetch video from published store
                 video = self.store.get_item(child_to_move_location)
-                self.assertEqual(
-                    old_parent_location,
-                    video.get_parent().location.for_branch(None)
-                )
+                assert old_parent_location == video.get_parent().location.for_branch(None)
 
 
 class RenamedTuple(tuple):
@@ -420,7 +414,7 @@ class XBlockMergedGroupAccessTest(LmsXBlockMixinTestCase):
         Verify the expected value for the block's group_access.
         """
         block = self.store.get_item(block_location)
-        self.assertEqual(block.merged_group_access, expected_dict)
+        assert block.merged_group_access == expected_dict
 
     @ddt.data(*PARENT_CHILD_PAIRS)
     @ddt.unpack

--- a/lms/tests.py
+++ b/lms/tests.py
@@ -19,11 +19,11 @@ class LmsModuleTests(TestCase):
         extensions = ['eot', 'otf', 'ttf', 'woff']
         for extension in extensions:
             mimetype, _ = mimetypes.guess_type('test.' + extension)
-            self.assertIsNotNone(mimetype)
+            assert mimetype is not None
 
     def test_api_docs(self):
         """
         Tests that requests to the `/api-docs/` endpoint do not raise an exception.
         """
         response = self.client.get('/api-docs/')
-        self.assertEqual(200, response.status_code)
+        assert response.status_code == 200


### PR DESCRIPTION
## Description
This PR is using `codemod-unittest-to-pytest-asserts` to automatically replace `unittest` assertions with `pytest` 
for following modules in `lms` 
```
 envs, lib, static, templates, tests.py
```
Relevant JIRA issue here: https://openedx.atlassian.net/browse/BOM-2395