### PR TITLE
Remove numpy & scipy constraints

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -106,12 +106,6 @@ zipp==1.0.0
 # Matplotlib 3.1 requires Python 3.6
 matplotlib<3.1
 
-# numpy 1.19 requires Python 3.6
-numpy<1.19
-
-# scipy 1.5 requires Python 3.6
-scipy<1.5
-
 # geoip2 requires Python 3.6
 geoip2<4.0.1
 

--- a/requirements/edx-sandbox/py35.txt
+++ b/requirements/edx-sandbox/py35.txt
@@ -20,7 +20,7 @@ matplotlib==2.2.4         # via -c requirements/edx-sandbox/../constraints.txt, 
 mpmath==1.2.1             # via sympy
 networkx==2.2             # via -r requirements/edx-sandbox/py35.in
 nltk==3.5                 # via -r requirements/edx-sandbox/shared.txt, chem
-numpy==1.16.5             # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/py35.in, chem, matplotlib, openedx-calc, scipy
+numpy==1.16.5             # via -r requirements/edx-sandbox/py35.in, chem, matplotlib, openedx-calc
 openedx-calc==1.0.9       # via -r requirements/edx-sandbox/py35.in
 pycparser==2.20           # via -r requirements/edx-sandbox/shared.txt, cffi
 pyparsing==2.2.0          # via -r requirements/edx-sandbox/py35.in, chem, matplotlib, openedx-calc
@@ -28,7 +28,7 @@ python-dateutil==2.4.0    # via -c requirements/edx-sandbox/../constraints.txt, 
 pytz==2021.1              # via matplotlib
 random2==1.0.1            # via -r requirements/edx-sandbox/py35.in
 regex==2020.11.13         # via -r requirements/edx-sandbox/shared.txt, nltk
-scipy==1.2.1              # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/py35.in, chem, openedx-calc
+scipy==1.2.1              # via -r requirements/edx-sandbox/py35.in, chem, openedx-calc
 six==1.15.0               # via -r requirements/edx-sandbox/shared.txt, chem, cryptography, cycler, matplotlib, openedx-calc, python-dateutil
 sympy==1.6.2              # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/py35.in, symmath
 tqdm==4.57.0              # via -r requirements/edx-sandbox/shared.txt, nltk

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -161,7 +161,7 @@ mysqlclient==2.0.3        # via -r requirements/edx/base.in
 newrelic==6.0.1.155       # via -r requirements/edx/base.in, edx-django-utils
 nltk==3.5                 # via -r requirements/edx/../edx-sandbox/shared.txt, chem
 nodeenv==1.5.0            # via -r requirements/edx/base.in
-numpy==1.18.5             # via -c requirements/edx/../constraints.txt, chem, openedx-calc, scipy
+numpy==1.20.1             # via chem, openedx-calc, scipy
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
 openedx-calc==2.0.0       # via -r requirements/edx/base.in
 ora2==3.1.3               # via -r requirements/edx/base.in
@@ -208,7 +208,7 @@ ruamel.yaml==0.16.12      # via drf-yasg
 rules==2.2                # via -r requirements/edx/base.in, edx-enterprise, edx-proctoring
 s3transfer==0.1.13        # via boto3
 sailthru-client==2.2.3    # via -r requirements/edx/base.in, edx-ace
-scipy==1.4.1              # via -c requirements/edx/../constraints.txt, chem, openedx-calc
+scipy==1.6.0              # via chem, openedx-calc
 semantic-version==2.8.5   # via edx-drf-extensions
 shapely==1.7.1            # via -r requirements/edx/base.in
 simplejson==3.17.2        # via -r requirements/edx/base.in, sailthru-client, super-csv, xblock-utils

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -194,7 +194,7 @@ mysqlclient==2.0.3        # via -r requirements/edx/testing.txt
 newrelic==6.0.1.155       # via -r requirements/edx/testing.txt, edx-django-utils
 nltk==3.5                 # via -r requirements/edx/testing.txt, chem
 nodeenv==1.5.0            # via -r requirements/edx/testing.txt
-numpy==1.18.5             # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, chem, openedx-calc, scipy
+numpy==1.20.1             # via -r requirements/edx/testing.txt, chem, openedx-calc, scipy
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
 openedx-calc==2.0.0       # via -r requirements/edx/testing.txt
 ora2==3.1.3               # via -r requirements/edx/testing.txt
@@ -261,7 +261,7 @@ ruamel.yaml==0.16.12      # via -r requirements/edx/testing.txt, drf-yasg
 rules==2.2                # via -r requirements/edx/testing.txt, edx-enterprise, edx-proctoring
 s3transfer==0.1.13        # via -r requirements/edx/testing.txt, boto3
 sailthru-client==2.2.3    # via -r requirements/edx/testing.txt, edx-ace
-scipy==1.4.1              # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, chem, openedx-calc
+scipy==1.6.0              # via -r requirements/edx/testing.txt, chem, openedx-calc
 selenium==3.141.0         # via -r requirements/edx/testing.txt, bok-choy
 semantic-version==2.8.5   # via -r requirements/edx/testing.txt, edx-drf-extensions
 shapely==1.7.1            # via -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -186,7 +186,7 @@ mysqlclient==2.0.3        # via -r requirements/edx/base.txt
 newrelic==6.0.1.155       # via -r requirements/edx/base.txt, edx-django-utils
 nltk==3.5                 # via -r requirements/edx/base.txt, chem
 nodeenv==1.5.0            # via -r requirements/edx/base.txt
-numpy==1.18.5             # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, chem, openedx-calc, scipy
+numpy==1.20.1             # via -r requirements/edx/base.txt, chem, openedx-calc, scipy
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
 openedx-calc==2.0.0       # via -r requirements/edx/base.txt
 ora2==3.1.3               # via -r requirements/edx/base.txt
@@ -250,7 +250,7 @@ ruamel.yaml==0.16.12      # via -r requirements/edx/base.txt, drf-yasg
 rules==2.2                # via -r requirements/edx/base.txt, edx-enterprise, edx-proctoring
 s3transfer==0.1.13        # via -r requirements/edx/base.txt, boto3
 sailthru-client==2.2.3    # via -r requirements/edx/base.txt, edx-ace
-scipy==1.4.1              # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, chem, openedx-calc
+scipy==1.6.0              # via -r requirements/edx/base.txt, chem, openedx-calc
 selenium==3.141.0         # via -r requirements/edx/testing.in, bok-choy
 semantic-version==2.8.5   # via -r requirements/edx/base.txt, edx-drf-extensions
 shapely==1.7.1            # via -r requirements/edx/base.txt


### PR DESCRIPTION
**Issue:** [BOM-2244](https://openedx.atlassian.net/browse/BOM-2244)

### Description
- Removed `numpy` and `scipy` constraints.
- Sandbox https://numpyscipyconstraint.sandbox.edx.org/ successfully created to test this change.