### PR TITLE
replaced unittest assertions pytest assertions (27)

### DIFF
--- a/openedx/core/djangoapps/credit/tests/test_models.py
+++ b/openedx/core/djangoapps/credit/tests/test_models.py
@@ -48,9 +48,9 @@ class CreditEligibilityModelTests(TestCase):
     def test_is_credit_course(self, is_credit):
         CreditCourse(course_key=self.course_key, enabled=is_credit).save()
         if is_credit:
-            self.assertTrue(CreditCourse.is_credit_course(self.course_key))
+            assert CreditCourse.is_credit_course(self.course_key)
         else:
-            self.assertFalse(CreditCourse.is_credit_course(self.course_key))
+            assert not CreditCourse.is_credit_course(self.course_key)
 
     def test_get_course_requirements(self):
         credit_course = add_credit_course(self.course_key)
@@ -63,10 +63,10 @@ class CreditEligibilityModelTests(TestCase):
             },
         }
         credit_req, created = CreditRequirement.add_or_update_course_requirement(credit_course, requirement, 0)
-        self.assertEqual(credit_course, credit_req.course)
-        self.assertEqual(created, True)
+        assert credit_course == credit_req.course
+        assert created is True
         requirements = CreditRequirement.get_course_requirements(self.course_key)
-        self.assertEqual(len(requirements), 1)
+        assert len(requirements) == 1
 
     def test_add_course_requirement_namespace(self):
         credit_course = add_credit_course(self.course_key)
@@ -79,8 +79,8 @@ class CreditEligibilityModelTests(TestCase):
             },
         }
         credit_req, created = CreditRequirement.add_or_update_course_requirement(credit_course, requirement, 0)
-        self.assertEqual(credit_course, credit_req.course)
-        self.assertEqual(created, True)
+        assert credit_course == credit_req.course
+        assert created is True
 
         requirement = {
             "namespace": "new_grade",
@@ -89,14 +89,14 @@ class CreditEligibilityModelTests(TestCase):
             "criteria": {},
         }
         credit_req, created = CreditRequirement.add_or_update_course_requirement(credit_course, requirement, 1)
-        self.assertEqual(credit_course, credit_req.course)
-        self.assertEqual(created, True)
+        assert credit_course == credit_req.course
+        assert created is True
 
         requirements = CreditRequirement.get_course_requirements(self.course_key)
-        self.assertEqual(len(requirements), 2)
+        assert len(requirements) == 2
 
         requirements = CreditRequirement.get_course_requirements(self.course_key, namespace="grade")
-        self.assertEqual(len(requirements), 1)
+        assert len(requirements) == 1
 
 
 class CreditRequirementStatusTests(RetirementTestCase):
@@ -154,21 +154,21 @@ class CreditRequirementStatusTests(RetirementTestCase):
         self.add_course_requirements()
 
         retirement_succeeded = CreditRequirementStatus.retire_user(self.retirement)
-        self.assertTrue(retirement_succeeded)
+        assert retirement_succeeded
 
         old_username_records_exist = CreditRequirementStatus.objects.filter(
             username=self.old_username
         ).exists()
-        self.assertFalse(old_username_records_exist)
+        assert not old_username_records_exist
 
         new_username_records_exist = CreditRequirementStatus.objects.filter(
             username=self.retirement.retired_username
         ).exists()
-        self.assertTrue(new_username_records_exist)
+        assert new_username_records_exist
 
     def test_retire_user_without_data(self):
         retirement_succeeded = CreditRequirementStatus.retire_user(self.retirement)
-        self.assertFalse(retirement_succeeded)
+        assert not retirement_succeeded
 
 
 class CreditRequestTest(RetirementTestCase):
@@ -196,7 +196,7 @@ class CreditRequestTest(RetirementTestCase):
             username=self.user.username
         )[0]
 
-        self.assertEqual(credit_request_before_retire.parameters, test_parameters)
+        assert credit_request_before_retire.parameters == test_parameters
 
         user_was_retired = CreditRequest.retire_user(self.retirement)
         credit_request_before_retire.refresh_from_db()
@@ -204,9 +204,9 @@ class CreditRequestTest(RetirementTestCase):
             username=self.retirement.original_username
         )
 
-        self.assertTrue(user_was_retired)
-        self.assertEqual(credit_request_before_retire.parameters, {})
-        self.assertFalse(credit_requests_after_retire.exists())
+        assert user_was_retired
+        assert credit_request_before_retire.parameters == {}
+        assert not credit_requests_after_retire.exists()
 
     def test_cannot_retire_nonexistent_user(self):
         test_parameters = {'hi': 'there'}
@@ -226,5 +226,5 @@ class CreditRequestTest(RetirementTestCase):
         was_retired = CreditRequest.retire_user(another_retirement)
         credit_request_before_retire.refresh_from_db()
 
-        self.assertFalse(was_retired)
-        self.assertEqual(credit_request_before_retire.parameters, test_parameters)
+        assert not was_retired
+        assert credit_request_before_retire.parameters == test_parameters

--- a/openedx/core/djangoapps/credit/tests/test_serializers.py
+++ b/openedx/core/djangoapps/credit/tests/test_serializers.py
@@ -1,6 +1,6 @@
 """ Tests for Credit API serializers. """
 
-
+import pytest
 import six
 from django.test import TestCase
 from django.test.utils import override_settings  # lint-amnesty, pylint: disable=unused-import
@@ -57,7 +57,7 @@ class CreditProviderCallbackSerializerTests(TestCase):
         provider_id = 'asu'
 
         serializer = serializers.CreditProviderCallbackSerializer()
-        with self.assertRaises(PermissionDenied):
+        with pytest.raises(PermissionDenied):
             serializer._check_keys_exist_for_provider(secret_key, provider_id)  # lint-amnesty, pylint: disable=protected-access
 
     def test_check_keys_exist_for_provider_list_no_keys(self):
@@ -71,7 +71,7 @@ class CreditProviderCallbackSerializerTests(TestCase):
         provider_id = 'asu'
 
         serializer = serializers.CreditProviderCallbackSerializer()
-        with self.assertRaises(PermissionDenied):
+        with pytest.raises(PermissionDenied):
             serializer._check_keys_exist_for_provider(secret_key, provider_id)  # lint-amnesty, pylint: disable=protected-access
 
     def test_check_keys_exist_for_provider_list_with_key_present(self):
@@ -101,7 +101,7 @@ class CreditProviderCallbackSerializerTests(TestCase):
         serializer = serializers.CreditProviderCallbackSerializer(
             data={'signature': sig}
         )
-        with self.assertRaises(PermissionDenied):
+        with pytest.raises(PermissionDenied):
             # The first arg here is key we have (that doesn't match the sig)
             serializer._compare_signatures('abcd1234', provider.provider_id)  # lint-amnesty, pylint: disable=protected-access
 
@@ -120,7 +120,7 @@ class CreditProviderCallbackSerializerTests(TestCase):
             data={'signature': sig}
         )
 
-        with self.assertRaises(PermissionDenied):
+        with pytest.raises(PermissionDenied):
             # The first arg here is the list of keys he have (that dont matcht the sig)
             serializer._compare_signatures(  # lint-amnesty, pylint: disable=protected-access
                 ['abcd1234', 'xyz789'],

--- a/openedx/core/djangoapps/credit/tests/test_services.py
+++ b/openedx/core/djangoapps/credit/tests/test_services.py
@@ -43,7 +43,7 @@ class CreditServiceTests(ModuleStoreTestCase):
         Makes sure that get_credit_state returns None if user_id cannot be found
         """
 
-        self.assertIsNone(self.service.get_credit_state(0, self.course.id))
+        assert self.service.get_credit_state(0, self.course.id) is None
 
     def test_user_not_enrolled(self):
         """
@@ -51,7 +51,7 @@ class CreditServiceTests(ModuleStoreTestCase):
         in the test course
         """
 
-        self.assertIsNone(self.service.get_credit_state(self.user.id, self.course.id))
+        assert self.service.get_credit_state(self.user.id, self.course.id) is None
 
     def test_inactive_enrollment(self):
         """
@@ -63,7 +63,7 @@ class CreditServiceTests(ModuleStoreTestCase):
         enrollment.is_active = False
         enrollment.save()
 
-        self.assertIsNone(self.service.get_credit_state(self.user.id, self.course.id))
+        assert self.service.get_credit_state(self.user.id, self.course.id) is None
 
     def test_not_credit_course(self):
         """
@@ -77,8 +77,8 @@ class CreditServiceTests(ModuleStoreTestCase):
         self.credit_course.save()
 
         credit_state = self.service.get_credit_state(self.user.id, self.course.id)
-        self.assertIsNotNone(credit_state)
-        self.assertFalse(credit_state['is_credit_course'])
+        assert credit_state is not None
+        assert not credit_state['is_credit_course']
 
     def test_no_profile_name(self):
         """
@@ -90,14 +90,14 @@ class CreditServiceTests(ModuleStoreTestCase):
         profile = UserProfile.objects.get(user_id=self.user.id)
         profile.delete()
 
-        self.assertIsNone(self.service.get_credit_state(self.user.id, self.course.id))
+        assert self.service.get_credit_state(self.user.id, self.course.id) is None
 
     def test_get_and_set_credit_state(self):
         """
         Happy path through the service
         """
 
-        self.assertTrue(self.service.is_credit_course(self.course.id))
+        assert self.service.is_credit_course(self.course.id)
 
         self.enroll()
 
@@ -126,19 +126,19 @@ class CreditServiceTests(ModuleStoreTestCase):
 
         credit_state = self.service.get_credit_state(self.user.id, self.course.id)
 
-        self.assertIsNotNone(credit_state)
-        self.assertTrue(credit_state['is_credit_course'])
-        self.assertEqual(credit_state['enrollment_mode'], 'verified')
-        self.assertEqual(credit_state['profile_fullname'], 'Foo Bar')
-        self.assertEqual(len(credit_state['credit_requirement_status']), 1)
-        self.assertEqual(credit_state['credit_requirement_status'][0]['name'], 'grade')
-        self.assertEqual(credit_state['credit_requirement_status'][0]['status'], 'satisfied')
+        assert credit_state is not None
+        assert credit_state['is_credit_course']
+        assert credit_state['enrollment_mode'] == 'verified'
+        assert credit_state['profile_fullname'] == 'Foo Bar'
+        assert len(credit_state['credit_requirement_status']) == 1
+        assert credit_state['credit_requirement_status'][0]['name'] == 'grade'
+        assert credit_state['credit_requirement_status'][0]['status'] == 'satisfied'
 
     def test_remove_credit_requirement_status(self):
         """
         Happy path when deleting the requirement status.
         """
-        self.assertTrue(self.service.is_credit_course(self.course.id))
+        assert self.service.is_credit_course(self.course.id)
 
         self.enroll()
 
@@ -167,7 +167,7 @@ class CreditServiceTests(ModuleStoreTestCase):
 
         # now the status should be "satisfied" when looking at the credit_requirement_status list
         credit_state = self.service.get_credit_state(self.user.id, self.course.id)
-        self.assertEqual(credit_state['credit_requirement_status'][0]['status'], "satisfied")
+        assert credit_state['credit_requirement_status'][0]['status'] == 'satisfied'
 
         # remove the requirement status.
         self.service.remove_credit_requirement_status(
@@ -179,7 +179,7 @@ class CreditServiceTests(ModuleStoreTestCase):
 
         # now the status should be None when looking at the credit_requirement_status list
         credit_state = self.service.get_credit_state(self.user.id, self.course.id)
-        self.assertEqual(credit_state['credit_requirement_status'][0]['status'], None)
+        assert credit_state['credit_requirement_status'][0]['status'] is None
 
     def test_invalid_user(self):
         """
@@ -208,7 +208,7 @@ class CreditServiceTests(ModuleStoreTestCase):
             'grade',
             'grade'
         )
-        self.assertIsNone(retval)
+        assert retval is None
 
         # remove the requirement status with the invalid user id
         retval = self.service.remove_credit_requirement_status(  # lint-amnesty, pylint: disable=assignment-from-none
@@ -217,7 +217,7 @@ class CreditServiceTests(ModuleStoreTestCase):
             'grade',
             'grade'
         )
-        self.assertIsNone(retval)
+        assert retval is None
 
     def test_remove_status_non_credit(self):
         """
@@ -227,7 +227,7 @@ class CreditServiceTests(ModuleStoreTestCase):
 
         no_credit_course = CourseFactory.create(org='NoCredit', number='NoCredit', display_name='Demo_Course')
 
-        self.assertFalse(self.service.is_credit_course(no_credit_course.id))
+        assert not self.service.is_credit_course(no_credit_course.id)
 
         self.enroll(no_credit_course.id)
 
@@ -241,9 +241,9 @@ class CreditServiceTests(ModuleStoreTestCase):
 
         credit_state = self.service.get_credit_state(self.user.id, no_credit_course.id)
 
-        self.assertIsNotNone(credit_state)
-        self.assertFalse(credit_state['is_credit_course'])
-        self.assertEqual(len(credit_state['credit_requirement_status']), 0)
+        assert credit_state is not None
+        assert not credit_state['is_credit_course']
+        assert len(credit_state['credit_requirement_status']) == 0
 
     def test_course_name(self):
         """
@@ -254,12 +254,12 @@ class CreditServiceTests(ModuleStoreTestCase):
 
         # make sure it is not returned by default
         credit_state = self.service.get_credit_state(self.user.id, self.course.id)
-        self.assertNotIn('course_name', credit_state)
+        assert 'course_name' not in credit_state
 
         # now make sure it is in there when we pass in the flag
         credit_state = self.service.get_credit_state(self.user.id, self.course.id, return_course_info=True)
-        self.assertIn('course_name', credit_state)
-        self.assertEqual(credit_state['course_name'], self.course.display_name)
+        assert 'course_name' in credit_state
+        assert credit_state['course_name'] == self.course.display_name
 
     def test_set_status_non_credit(self):
         """
@@ -269,7 +269,7 @@ class CreditServiceTests(ModuleStoreTestCase):
 
         no_credit_course = CourseFactory.create(org='NoCredit', number='NoCredit', display_name='Demo_Course')
 
-        self.assertFalse(self.service.is_credit_course(no_credit_course.id))
+        assert not self.service.is_credit_course(no_credit_course.id)
 
         self.enroll(no_credit_course.id)
 
@@ -283,9 +283,9 @@ class CreditServiceTests(ModuleStoreTestCase):
 
         credit_state = self.service.get_credit_state(self.user.id, no_credit_course.id)
 
-        self.assertIsNotNone(credit_state)
-        self.assertFalse(credit_state['is_credit_course'])
-        self.assertEqual(len(credit_state['credit_requirement_status']), 0)
+        assert credit_state is not None
+        assert not credit_state['is_credit_course']
+        assert len(credit_state['credit_requirement_status']) == 0
 
     @ddt.data(
         CourseMode.AUDIT,
@@ -323,11 +323,11 @@ class CreditServiceTests(ModuleStoreTestCase):
         )
         # Verify credit requirement status for user in the course should be None.
         credit_state = self.service.get_credit_state(self.user.id, self.course.id)
-        self.assertIsNotNone(credit_state)
-        self.assertEqual(credit_state['enrollment_mode'], mode)
-        self.assertEqual(len(credit_state['credit_requirement_status']), 1)
-        self.assertIsNone(credit_state['credit_requirement_status'][0]['status'])
-        self.assertIsNone(credit_state['credit_requirement_status'][0]['status_date'])
+        assert credit_state is not None
+        assert credit_state['enrollment_mode'] == mode
+        assert len(credit_state['credit_requirement_status']) == 1
+        assert credit_state['credit_requirement_status'][0]['status'] is None
+        assert credit_state['credit_requirement_status'][0]['status_date'] is None
 
     def test_bad_user(self):
         """
@@ -356,7 +356,7 @@ class CreditServiceTests(ModuleStoreTestCase):
             'grade',
             'grade'
         )
-        self.assertIsNone(retval)
+        assert retval is None
 
     def test_course_id_string(self):
         """
@@ -390,9 +390,9 @@ class CreditServiceTests(ModuleStoreTestCase):
 
         credit_state = self.service.get_credit_state(self.user.id, six.text_type(self.course.id))
 
-        self.assertIsNotNone(credit_state)
-        self.assertEqual(credit_state['enrollment_mode'], 'verified')
-        self.assertEqual(credit_state['profile_fullname'], 'Foo Bar')
-        self.assertEqual(len(credit_state['credit_requirement_status']), 1)
-        self.assertEqual(credit_state['credit_requirement_status'][0]['name'], 'grade')
-        self.assertEqual(credit_state['credit_requirement_status'][0]['status'], 'satisfied')
+        assert credit_state is not None
+        assert credit_state['enrollment_mode'] == 'verified'
+        assert credit_state['profile_fullname'] == 'Foo Bar'
+        assert len(credit_state['credit_requirement_status']) == 1
+        assert credit_state['credit_requirement_status'][0]['name'] == 'grade'
+        assert credit_state['credit_requirement_status'][0]['status'] == 'satisfied'

--- a/openedx/core/djangoapps/credit/tests/test_signals.py
+++ b/openedx/core/djangoapps/credit/tests/test_signals.py
@@ -81,11 +81,11 @@ class TestMinGradedRequirementStatus(ModuleStoreTestCase):
         listen_for_grade_calculation(None, self.user, course_grade, self.course.id, due_date)
         req_status = get_credit_requirement_status(self.course.id, self.request.user.username, 'grade', 'grade')
 
-        self.assertEqual(req_status[0]['status'], expected_status)
+        assert req_status[0]['status'] == expected_status
 
         if expected_status == 'satisfied':
             expected_reason = {'final_grade': grade}
-            self.assertEqual(req_status[0]['reason'], expected_reason)
+            assert req_status[0]['reason'] == expected_reason
 
     @ddt.data(
         (0.6, 'valid'),

--- a/openedx/core/djangoapps/credit/tests/test_signature.py
+++ b/openedx/core/djangoapps/credit/tests/test_signature.py
@@ -24,7 +24,7 @@ class SignatureTest(TestCase):
         # When retrieving the shared secret, the type should be converted to `str`
         key = signature.get_shared_secret_key("asu")
         sig = signature.signature({}, key)
-        self.assertEqual(sig, "7d70a26b834d9881cc14466eceac8d39188fc5ef5ffad9ab281a8327c2c0d093")
+        assert sig == '7d70a26b834d9881cc14466eceac8d39188fc5ef5ffad9ab281a8327c2c0d093'
 
     @override_settings(CREDIT_PROVIDER_SECRET_KEYS={
         "asu": u'\u4567'
@@ -35,13 +35,13 @@ class SignatureTest(TestCase):
         # is then responsible for logging the appropriate errors
         # so we can fix the misconfiguration.
         key = signature.get_shared_secret_key("asu")
-        self.assertIs(key, None)
+        assert key is None
 
     def test_unicode_data(self):
         """ Verify the signature generation method supports Unicode data. """
         key = signature.get_shared_secret_key("asu")
         sig = signature.signature({'name': u'Ed Xavíer'}, key)
-        self.assertEqual(sig, "76b6c9a657000829253d7c23977b35b34ad750c5681b524d7fdfb25cd5273cec")
+        assert sig == '76b6c9a657000829253d7c23977b35b34ad750c5681b524d7fdfb25cd5273cec'
 
     @override_settings(CREDIT_PROVIDER_SECRET_KEYS={
         "asu": 'abcd1234',
@@ -52,7 +52,7 @@ class SignatureTest(TestCase):
         secret is stored as a single key.
         """
         key = signature.get_shared_secret_key("asu")
-        self.assertEqual(key, 'abcd1234')
+        assert key == 'abcd1234'
 
     @override_settings(CREDIT_PROVIDER_SECRET_KEYS={
         "asu": ['abcd1234', 'zyxw9876']
@@ -63,7 +63,7 @@ class SignatureTest(TestCase):
         secret is stored as a list for multiple key support.
         """
         key = signature.get_shared_secret_key("asu")
-        self.assertEqual(key, ['abcd1234', 'zyxw9876'])
+        assert key == ['abcd1234', 'zyxw9876']
 
     @override_settings(CREDIT_PROVIDER_SECRET_KEYS={
         "asu": [u'\u4567', u'zyxw9876']
@@ -75,4 +75,4 @@ class SignatureTest(TestCase):
         for unencodable strings.
         """
         key = signature.get_shared_secret_key("asu")
-        self.assertEqual(key, [None, 'zyxw9876'])
+        assert key == [None, 'zyxw9876']

--- a/openedx/core/djangoapps/credit/tests/test_tasks.py
+++ b/openedx/core/djangoapps/credit/tests/test_tasks.py
@@ -45,11 +45,11 @@ class TestTaskExecution(ModuleStoreTestCase):
         Test that credit requirements cannot be added for non credit course.
         """
         requirements = get_credit_requirements(self.course.id)
-        self.assertEqual(len(requirements), 0)
+        assert len(requirements) == 0
         on_course_publish(self.course.id)
 
         requirements = get_credit_requirements(self.course.id)
-        self.assertEqual(len(requirements), 0)
+        assert len(requirements) == 0
 
     def test_task_adding_requirements(self):
         """Test that credit requirements are added properly for credit course.
@@ -59,11 +59,11 @@ class TestTaskExecution(ModuleStoreTestCase):
         """
         self.add_credit_course(self.course.id)
         requirements = get_credit_requirements(self.course.id)
-        self.assertEqual(len(requirements), 0)
+        assert len(requirements) == 0
         on_course_publish(self.course.id)
 
         requirements = get_credit_requirements(self.course.id)
-        self.assertEqual(len(requirements), 1)
+        assert len(requirements) == 1
 
     def test_proctored_exam_requirements(self):
         """
@@ -82,16 +82,16 @@ class TestTaskExecution(ModuleStoreTestCase):
         )
 
         requirements = get_credit_requirements(self.course.id)
-        self.assertEqual(len(requirements), 0)
+        assert len(requirements) == 0
 
         on_course_publish(self.course.id)
 
         requirements = get_credit_requirements(self.course.id)
-        self.assertEqual(len(requirements), 2)
-        self.assertEqual(requirements[1]['namespace'], 'proctored_exam')
-        self.assertEqual(requirements[1]['name'], six.text_type(self.subsection.location))
-        self.assertEqual(requirements[1]['display_name'], 'A Proctored Exam')
-        self.assertEqual(requirements[1]['criteria'], {})
+        assert len(requirements) == 2
+        assert requirements[1]['namespace'] == 'proctored_exam'
+        assert requirements[1]['name'] == six.text_type(self.subsection.location)
+        assert requirements[1]['display_name'] == 'A Proctored Exam'
+        assert requirements[1]['criteria'] == {}
 
     def test_proctored_exam_filtering(self):
         """
@@ -110,19 +110,15 @@ class TestTaskExecution(ModuleStoreTestCase):
         )
 
         requirements = get_credit_requirements(self.course.id)
-        self.assertEqual(len(requirements), 0)
+        assert len(requirements) == 0
 
         on_course_publish(self.course.id)
 
         requirements = get_credit_requirements(self.course.id)
-        self.assertEqual(len(requirements), 1)
+        assert len(requirements) == 1
 
         # make sure we don't have a proctoring requirement
-        self.assertFalse([
-            requirement
-            for requirement in requirements
-            if requirement['namespace'] == 'proctored_exam'
-        ])
+        assert not [requirement for requirement in requirements if requirement['namespace'] == 'proctored_exam']
 
         create_exam(
             course_id=six.text_type(self.course.id),
@@ -136,14 +132,10 @@ class TestTaskExecution(ModuleStoreTestCase):
         on_course_publish(self.course.id)
 
         requirements = get_credit_requirements(self.course.id)
-        self.assertEqual(len(requirements), 1)
+        assert len(requirements) == 1
 
         # make sure we don't have a proctoring requirement
-        self.assertFalse([
-            requirement
-            for requirement in requirements
-            if requirement['namespace'] == 'proctored_exam'
-        ])
+        assert not [requirement for requirement in requirements if requirement['namespace'] == 'proctored_exam']
 
         # practice proctored exams aren't requirements
         create_exam(
@@ -159,14 +151,10 @@ class TestTaskExecution(ModuleStoreTestCase):
         on_course_publish(self.course.id)
 
         requirements = get_credit_requirements(self.course.id)
-        self.assertEqual(len(requirements), 1)
+        assert len(requirements) == 1
 
         # make sure we don't have a proctoring requirement
-        self.assertFalse([
-            requirement
-            for requirement in requirements
-            if requirement['namespace'] == 'proctored_exam'
-        ])
+        assert not [requirement for requirement in requirements if requirement['namespace'] == 'proctored_exam']
 
     @mock.patch(
         'openedx.core.djangoapps.credit.tasks.set_credit_requirements',
@@ -183,11 +171,11 @@ class TestTaskExecution(ModuleStoreTestCase):
         """
         self.add_credit_course(self.course.id)
         requirements = get_credit_requirements(self.course.id)
-        self.assertEqual(len(requirements), 0)
+        assert len(requirements) == 0
         on_course_publish(self.course.id)
 
         requirements = get_credit_requirements(self.course.id)
-        self.assertEqual(len(requirements), 0)
+        assert len(requirements) == 0
 
     def test_credit_requirement_blocks_ordering(self):
         """
@@ -206,25 +194,25 @@ class TestTaskExecution(ModuleStoreTestCase):
         )
 
         requirements = get_credit_requirements(self.course.id)
-        self.assertEqual(len(requirements), 0)
+        assert len(requirements) == 0
         on_course_publish(self.course.id)
 
         requirements = get_credit_requirements(self.course.id)
-        self.assertEqual(len(requirements), 2)
-        self.assertEqual(requirements[1]['namespace'], 'proctored_exam')
-        self.assertEqual(requirements[1]['name'], six.text_type(subsection.location))
-        self.assertEqual(requirements[1]['display_name'], 'A Proctored Exam')
-        self.assertEqual(requirements[1]['criteria'], {})
+        assert len(requirements) == 2
+        assert requirements[1]['namespace'] == 'proctored_exam'
+        assert requirements[1]['name'] == six.text_type(subsection.location)
+        assert requirements[1]['display_name'] == 'A Proctored Exam'
+        assert requirements[1]['criteria'] == {}
 
         # Primary sort is based on start date
         on_course_publish(self.course.id)
         requirements = get_credit_requirements(self.course.id)
         # grade requirement is added on publish of the requirements
-        self.assertEqual(len(requirements), 2)
+        assert len(requirements) == 2
         # check requirements are added in the desired order
         # 1st Minimum grade then the blocks with start date than other blocks
-        self.assertEqual(requirements[0]["display_name"], "Minimum Grade")
-        self.assertEqual(requirements[1]["display_name"], "A Proctored Exam")
+        assert requirements[0]['display_name'] == 'Minimum Grade'
+        assert requirements[1]['display_name'] == 'A Proctored Exam'
 
     def add_credit_course(self, course_key):
         """Add the course as a credit.

--- a/openedx/core/djangoapps/dark_lang/tests.py
+++ b/openedx/core/djangoapps/dark_lang/tests.py
@@ -69,7 +69,7 @@ class DarkLangMiddlewareTests(CacheIsolationTestCase):
         )
 
         # Process it through the Middleware to ensure the language is available as expected.
-        self.assertIsNone(DarkLangMiddleware().process_request(request))
+        assert DarkLangMiddleware().process_request(request) is None
         return request
 
     def assertAcceptEquals(self, value, request):
@@ -77,10 +77,7 @@ class DarkLangMiddlewareTests(CacheIsolationTestCase):
         Assert that the HTML_ACCEPT_LANGUAGE header in request
         is equal to value
         """
-        self.assertEqual(
-            value,
-            request.META.get('HTTP_ACCEPT_LANGUAGE', UNSET)
-        )
+        assert value == request.META.get('HTTP_ACCEPT_LANGUAGE', UNSET)
 
     def test_empty_accept(self):
         self.assertAcceptEquals(UNSET, self.process_middleware_request())
@@ -237,10 +234,7 @@ class DarkLangMiddlewareTests(CacheIsolationTestCase):
         """
         Assert that the LANGUAGE_SESSION_KEY set in session is equal to value
         """
-        self.assertEqual(
-            value,
-            session.get(LANGUAGE_SESSION_KEY, UNSET)
-        )
+        assert value == session.get(LANGUAGE_SESSION_KEY, UNSET)
 
     def _post_set_preview_lang(self, preview_language):
         """

--- a/openedx/core/djangoapps/demographics/tests/test_status.py
+++ b/openedx/core/djangoapps/demographics/tests/test_status.py
@@ -52,7 +52,7 @@ class TestShowDemographics(SharedModuleStoreTestCase):  # lint-amnesty, pylint: 
     def test_user_enterprise(self, mock_get_programs_by_type):
         mock_get_programs_by_type.return_value = [self.program]
         EnterpriseCustomerUserFactory.create(user_id=self.user.id)
-        self.assertFalse(show_user_demographics(user=self.user))
+        assert not show_user_demographics(user=self.user)
 
 
 @skip_unless_lms
@@ -63,16 +63,16 @@ class TestShowCallToAction(TestCase):  # lint-amnesty, pylint: disable=missing-c
         self.user = UserFactory()
 
     def test_new_user(self):
-        self.assertTrue(show_call_to_action_for_user(self.user))
+        assert show_call_to_action_for_user(self.user)
 
     def test_existing_user_no_dismiss(self):
         user_demographics = UserDemographicsFactory.create(user=self.user)
-        self.assertTrue(user_demographics.show_call_to_action)
-        self.assertTrue(show_call_to_action_for_user(self.user))
+        assert user_demographics.show_call_to_action
+        assert show_call_to_action_for_user(self.user)
 
     def test_existing_user_dismissed(self):
         user_demographics = UserDemographicsFactory.create(user=self.user)
         user_demographics.show_call_to_action = False
         user_demographics.save()
-        self.assertFalse(user_demographics.show_call_to_action)
-        self.assertFalse(show_call_to_action_for_user(self.user))
+        assert not user_demographics.show_call_to_action
+        assert not show_call_to_action_for_user(self.user)

--- a/openedx/core/djangoapps/discussions/tests/test_models.py
+++ b/openedx/core/djangoapps/discussions/tests/test_models.py
@@ -1,7 +1,9 @@
 """
 Perform basic validation of the models
 """
+
 from unittest.mock import patch
+import pytest
 
 from django.test import TestCase
 from opaque_keys.edx.keys import CourseKey
@@ -146,7 +148,7 @@ class DiscussionsConfigurationModelTest(TestCase):
         """
         Assert we can not fetch a non-existent record
         """
-        with self.assertRaises(DiscussionsConfiguration.DoesNotExist):
+        with pytest.raises(DiscussionsConfiguration.DoesNotExist):
             DiscussionsConfiguration.objects.get(
                 context_key=self.course_key_without_config,
             )

--- a/openedx/core/djangoapps/django_comment_common/tests.py
+++ b/openedx/core/djangoapps/django_comment_common/tests.py
@@ -2,6 +2,7 @@
 
 
 import six
+import pytest
 from contracts import new_contract
 from django.test import TestCase
 from opaque_keys.edx.locator import CourseLocator
@@ -51,8 +52,8 @@ class RoleAssignmentTest(TestCase):
             name="Student"
         )
 
-        self.assertEqual([student_role], list(self.staff_user.roles.all()))
-        self.assertEqual([student_role], list(self.student_user.roles.all()))
+        assert [student_role] == list(self.staff_user.roles.all())
+        assert [student_role] == list(self.student_user.roles.all())
 
     # The following was written on the assumption that unenrolling from a course
     # should remove all forum Roles for that student for that course. This is
@@ -82,9 +83,9 @@ class CourseDiscussionSettingsTest(ModuleStoreTestCase):
 
     def test_get_course_discussion_settings(self):
         discussion_settings = get_course_discussion_settings(self.course.id)
-        self.assertEqual(CourseDiscussionSettings.NONE, discussion_settings.division_scheme)
-        self.assertEqual([], discussion_settings.divided_discussions)
-        self.assertFalse(discussion_settings.always_divide_inline_discussions)
+        assert CourseDiscussionSettings.NONE == discussion_settings.division_scheme
+        assert [] == discussion_settings.divided_discussions
+        assert not discussion_settings.always_divide_inline_discussions
 
     def test_get_course_discussion_settings_legacy_settings(self):
         self.course.cohort_config = {
@@ -94,9 +95,9 @@ class CourseDiscussionSettingsTest(ModuleStoreTestCase):
         }
         modulestore().update_item(self.course, ModuleStoreEnum.UserID.system)
         discussion_settings = get_course_discussion_settings(self.course.id)
-        self.assertEqual(CourseDiscussionSettings.COHORT, discussion_settings.division_scheme)
-        self.assertEqual(['foo'], discussion_settings.divided_discussions)
-        self.assertTrue(discussion_settings.always_divide_inline_discussions)
+        assert CourseDiscussionSettings.COHORT == discussion_settings.division_scheme
+        assert ['foo'] == discussion_settings.divided_discussions
+        assert discussion_settings.always_divide_inline_discussions
 
     def test_get_course_discussion_settings_cohort_settings(self):
         CourseCohortsSettings.objects.get_or_create(
@@ -108,9 +109,9 @@ class CourseDiscussionSettingsTest(ModuleStoreTestCase):
             }
         )
         discussion_settings = get_course_discussion_settings(self.course.id)
-        self.assertEqual(CourseDiscussionSettings.COHORT, discussion_settings.division_scheme)
-        self.assertEqual(['foo', 'bar'], discussion_settings.divided_discussions)
-        self.assertTrue(discussion_settings.always_divide_inline_discussions)
+        assert CourseDiscussionSettings.COHORT == discussion_settings.division_scheme
+        assert ['foo', 'bar'] == discussion_settings.divided_discussions
+        assert discussion_settings.always_divide_inline_discussions
 
     def test_set_course_discussion_settings(self):
         set_course_discussion_settings(
@@ -120,9 +121,9 @@ class CourseDiscussionSettingsTest(ModuleStoreTestCase):
             always_divide_inline_discussions=True,
         )
         discussion_settings = get_course_discussion_settings(self.course.id)
-        self.assertEqual(CourseDiscussionSettings.ENROLLMENT_TRACK, discussion_settings.division_scheme)
-        self.assertEqual(['cohorted_topic'], discussion_settings.divided_discussions)
-        self.assertTrue(discussion_settings.always_divide_inline_discussions)
+        assert CourseDiscussionSettings.ENROLLMENT_TRACK == discussion_settings.division_scheme
+        assert ['cohorted_topic'] == discussion_settings.divided_discussions
+        assert discussion_settings.always_divide_inline_discussions
 
     def test_invalid_data_types(self):
         exception_msg_template = "Incorrect field type for `{}`. Type must be `{}`"
@@ -134,10 +135,7 @@ class CourseDiscussionSettingsTest(ModuleStoreTestCase):
         invalid_value = 3.14
 
         for field in fields:
-            with self.assertRaises(ValueError) as value_error:
+            with pytest.raises(ValueError) as value_error:
                 set_course_discussion_settings(self.course.id, **{field['name']: invalid_value})
 
-            self.assertEqual(
-                text_type(value_error.exception),
-                exception_msg_template.format(field['name'], field['type'].__name__)
-            )
+            assert text_type(value_error.value) == exception_msg_template.format(field['name'], field['type'].__name__)

--- a/openedx/core/djangoapps/embargo/tests/test_api.py
+++ b/openedx/core/djangoapps/embargo/tests/test_api.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 import geoip2.database
 import maxminddb
 import ddt
-
+import pytest
 import mock
 from mock import patch, MagicMock
 
@@ -99,7 +99,7 @@ class EmbargoCheckAccessApiTests(ModuleStoreTestCase):
             result = embargo_api.check_course_access(self.course.id, user=self.user, ip_address='0.0.0.0')
 
         # Verify that the access rules were applied correctly
-        self.assertEqual(result, allow_access)
+        assert result == allow_access
 
     def test_no_user_has_access(self):
         CountryAccessRule.objects.create(
@@ -111,7 +111,7 @@ class EmbargoCheckAccessApiTests(ModuleStoreTestCase):
         # The user is set to None, because the user has not been authenticated.
         with self._mock_geoip(""):
             result = embargo_api.check_course_access(self.course.id, ip_address='0.0.0.0')
-        self.assertTrue(result)
+        assert result
 
     def test_no_user_blocked(self):
         CountryAccessRule.objects.create(
@@ -123,7 +123,7 @@ class EmbargoCheckAccessApiTests(ModuleStoreTestCase):
         with self._mock_geoip('US'):
             # The user is set to None, because the user has not been authenticated.
             result = embargo_api.check_course_access(self.course.id, ip_address='0.0.0.0')
-            self.assertFalse(result)
+            assert not result
 
     def test_course_not_restricted(self):
         # No restricted course model for this course key,
@@ -142,7 +142,7 @@ class EmbargoCheckAccessApiTests(ModuleStoreTestCase):
         with self._mock_geoip('US'):
             result = embargo_api.check_course_access(self.course.id, user=self.user,
                                                      ip_address='FE80::0202:B3FF:FE1E:8329')
-        self.assertTrue(result)
+        assert result
 
     def test_country_access_fallback_to_continent_code(self):
         # Simulate Geolite2 falling back to a continent code
@@ -150,7 +150,7 @@ class EmbargoCheckAccessApiTests(ModuleStoreTestCase):
         # allow the user access.
         with self._mock_geoip('EU'):
             result = embargo_api.check_course_access(self.course.id, user=self.user, ip_address='0.0.0.0')
-            self.assertTrue(result)
+            assert result
 
     @mock.patch.dict(settings.FEATURES, {'EMBARGO': True})
     def test_profile_country_db_null(self):
@@ -168,7 +168,7 @@ class EmbargoCheckAccessApiTests(ModuleStoreTestCase):
         # Verify that we can check the user's access without error
         with self._mock_geoip('US'):
             result = embargo_api.check_course_access(self.course.id, user=self.user, ip_address='0.0.0.0')
-        self.assertTrue(result)
+        assert result
 
     def test_caching(self):
         with self._mock_geoip('US'):
@@ -212,7 +212,7 @@ class EmbargoCheckAccessApiTests(ModuleStoreTestCase):
             result = embargo_api.check_course_access(self.course.id, user=self.user, ip_address='0.0.0.0')
 
         # Expect that the user is blocked, because the user isn't staff
-        self.assertFalse(result, msg="User should not have access because the user isn't staff.")
+        assert not result, "User should not have access because the user isn't staff."
 
         # Instantiate the role, configuring it for this course or org
         if issubclass(staff_role_cls, CourseRole):
@@ -229,7 +229,7 @@ class EmbargoCheckAccessApiTests(ModuleStoreTestCase):
         with self._mock_geoip('US'):
             result = embargo_api.check_course_access(self.course.id, user=self.user, ip_address='0.0.0.0')
 
-        self.assertTrue(result, msg="User should have access because the user is staff.")
+        assert result, 'User should have access because the user is staff.'
 
     @contextmanager
     def _mock_geoip(self, country_code):
@@ -283,7 +283,7 @@ class EmbargoMessageUrlApiTests(UrlResetMixin, ModuleStoreTestCase):
 
         # Retrieve the URL to the blocked message page
         url_path = embargo_api.message_url_path(self.course.id, access_point)
-        self.assertEqual(url_path, expected_url_path)
+        assert url_path == expected_url_path
 
     def test_message_url_path_caching(self):
         self._restrict_course(self.course.id)
@@ -303,10 +303,10 @@ class EmbargoMessageUrlApiTests(UrlResetMixin, ModuleStoreTestCase):
         url_path = embargo_api.message_url_path(self.course.id, access_point)
 
         # Use a default path
-        self.assertEqual(url_path, '/embargo/blocked-message/courseware/default/')
+        assert url_path == '/embargo/blocked-message/courseware/default/'
 
     def test_invalid_access_point(self):
-        with self.assertRaises(InvalidAccessPoint):
+        with pytest.raises(InvalidAccessPoint):
             embargo_api.message_url_path(self.course.id, "invalid")
 
     def test_message_url_stale_cache(self):
@@ -327,7 +327,7 @@ class EmbargoMessageUrlApiTests(UrlResetMixin, ModuleStoreTestCase):
         # Try again.  Even though the cache results are stale,
         # we should still get a valid URL.
         url_path = embargo_api.message_url_path(self.course.id, 'courseware')
-        self.assertEqual(url_path, '/embargo/blocked-message/courseware/default/')
+        assert url_path == '/embargo/blocked-message/courseware/default/'
 
     def _restrict_course(self, course_key):
         """Restrict the user from accessing the course. """

--- a/openedx/core/djangoapps/embargo/tests/test_forms.py
+++ b/openedx/core/djangoapps/embargo/tests/test_forms.py
@@ -28,7 +28,7 @@ class RestrictedCourseFormTest(ModuleStoreTestCase):
             'access_msg_key': 'default'
         }
         form = RestrictedCourseForm(data=data)
-        self.assertTrue(form.is_valid())
+        assert form.is_valid()
 
     def test_invalid_course_key(self):
         # Invalid format for the course key
@@ -44,10 +44,10 @@ class RestrictedCourseFormTest(ModuleStoreTestCase):
         """
         Validation shouldn't work.
         """
-        self.assertFalse(form.is_valid())
+        assert not form.is_valid()
 
         msg = 'COURSE NOT FOUND'
-        self.assertIn(msg, form._errors['course_key'][0])  # pylint: disable=protected-access
+        assert msg in form._errors['course_key'][0]  # pylint: disable=protected-access
 
         with self.assertRaisesRegex(
             ValueError, "The RestrictedCourse could not be created because the data didn't validate."
@@ -73,28 +73,28 @@ class IPFilterFormTest(TestCase):
             'blacklist': u'  18.244.1.5  ,  2002:c0a8:101::42, 18.36.22.1, 1.0.0.0/16'
         }
         form = IPFilterForm(data=form_data)
-        self.assertTrue(form.is_valid())
+        assert form.is_valid()
         form.save()
         whitelist = IPFilter.current().whitelist_ips
         blacklist = IPFilter.current().blacklist_ips
         for addr in u'127.0.0.1, 2003:dead:beef:4dad:23:46:bb:101'.split(','):
-            self.assertIn(addr.strip(), whitelist)
+            assert addr.strip() in whitelist
         for addr in u'18.244.1.5, 2002:c0a8:101::42, 18.36.22.1'.split(','):
-            self.assertIn(addr.strip(), blacklist)
+            assert addr.strip() in blacklist
 
         # Network tests
         # ips not in whitelist network
         for addr in [u'1.1.0.2', u'1.0.1.0']:
-            self.assertNotIn(addr.strip(), whitelist)
+            assert addr.strip() not in whitelist
         # ips in whitelist network
         for addr in [u'1.1.0.1', u'1.0.0.100']:
-            self.assertIn(addr.strip(), whitelist)
+            assert addr.strip() in whitelist
         # ips not in blacklist network
         for addr in [u'2.0.0.0', u'1.1.0.0']:
-            self.assertNotIn(addr.strip(), blacklist)
+            assert addr.strip() not in blacklist
         # ips in blacklist network
         for addr in [u'1.0.100.0', u'1.0.0.10']:
-            self.assertIn(addr.strip(), blacklist)
+            assert addr.strip() in blacklist
 
         # Test clearing by adding an empty list is OK too
         form_data = {
@@ -102,10 +102,10 @@ class IPFilterFormTest(TestCase):
             'blacklist': ''
         }
         form = IPFilterForm(data=form_data)
-        self.assertTrue(form.is_valid())
+        assert form.is_valid()
         form.save()
-        self.assertEqual(len(IPFilter.current().whitelist), 0)
-        self.assertEqual(len(IPFilter.current().blacklist), 0)
+        assert len(IPFilter.current().whitelist) == 0
+        assert len(IPFilter.current().blacklist) == 0
 
     def test_add_invalid_ips(self):
         # test adding invalid ip addresses
@@ -114,7 +114,7 @@ class IPFilterFormTest(TestCase):
             'blacklist': u'  18.244.*  ,  999999:c0a8:101::42, 1.0.0.0/'
         }
         form = IPFilterForm(data=form_data)
-        self.assertFalse(form.is_valid())
+        assert not form.is_valid()
 
         if six.PY2:
             wmsg = "Invalid IP Address(es): [u'.0.0.1', u':dead:beef:::', u'1.0.0.0/55']" \
@@ -122,7 +122,7 @@ class IPFilterFormTest(TestCase):
         else:
             wmsg = "Invalid IP Address(es): ['.0.0.1', ':dead:beef:::', '1.0.0.0/55']" \
                    " Please fix the error(s) and try again."
-        self.assertEqual(wmsg, form._errors['whitelist'][0])  # pylint: disable=protected-access
+        assert wmsg == form._errors['whitelist'][0]  # pylint: disable=protected-access
 
         if six.PY2:
             bmsg = "Invalid IP Address(es): [u'18.244.*', u'999999:c0a8:101::42', u'1.0.0.0/']" \
@@ -130,7 +130,7 @@ class IPFilterFormTest(TestCase):
         else:
             bmsg = "Invalid IP Address(es): ['18.244.*', '999999:c0a8:101::42', '1.0.0.0/']" \
                    " Please fix the error(s) and try again."
-        self.assertEqual(bmsg, form._errors['blacklist'][0])  # pylint: disable=protected-access
+        assert bmsg == form._errors['blacklist'][0]  # pylint: disable=protected-access
 
         with self.assertRaisesRegex(ValueError, "The IPFilter could not be created because the data didn't validate."):
             form.save()

--- a/openedx/core/djangoapps/embargo/tests/test_middleware.py
+++ b/openedx/core/djangoapps/embargo/tests/test_middleware.py
@@ -59,7 +59,7 @@ class EmbargoMiddlewareAccessTests(UrlResetMixin, ModuleStoreTestCase):
         with restrict_course(self.course.id, access_point='courseware', disable_access_check=disable_access_check) as redirect_url:  # pylint: disable=line-too-long
             response = self.client.get(self.courseware_url)
             if disable_access_check:
-                self.assertEqual(response.status_code, 200)
+                assert response.status_code == 200
             else:
                 self.assertRedirects(response, redirect_url)
 
@@ -71,13 +71,13 @@ class EmbargoMiddlewareAccessTests(UrlResetMixin, ModuleStoreTestCase):
 
         # Expect that we can access courseware
         response = self.client.get(self.courseware_url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
     @patch.dict(settings.FEATURES, {'EMBARGO': True})
     def test_non_courseware_url(self):
         with restrict_course(self.course.id):
             response = self.client.get(self.non_courseware_url)
-            self.assertEqual(response.status_code, 200)
+            assert response.status_code == 200
 
     @patch.dict(settings.FEATURES, {'EMBARGO': True})
     @ddt.data(
@@ -111,7 +111,7 @@ class EmbargoMiddlewareAccessTests(UrlResetMixin, ModuleStoreTestCase):
         )
 
         if allow_access:
-            self.assertEqual(response.status_code, 200)
+            assert response.status_code == 200
         else:
             redirect_url = reverse(
                 'embargo:blocked_message',
@@ -149,7 +149,7 @@ class EmbargoMiddlewareAccessTests(UrlResetMixin, ModuleStoreTestCase):
             HTTP_X_FORWARDED_FOR="192.168.10.20",
             REMOTE_ADDR="192.168.10.20"
         )
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
     @patch.dict(settings.FEATURES, {'EMBARGO': True})
     def test_whitelist_ip_skips_country_access_checks(self):
@@ -172,4 +172,4 @@ class EmbargoMiddlewareAccessTests(UrlResetMixin, ModuleStoreTestCase):
         # Expect that we were still able to access the page,
         # even though we would have been blocked by country
         # access rules.
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200

--- a/openedx/core/djangoapps/embargo/tests/test_models.py
+++ b/openedx/core/djangoapps/embargo/tests/test_models.py
@@ -2,7 +2,7 @@
 
 
 import json
-
+import pytest
 import six
 from django.db.utils import IntegrityError
 from django.test import TestCase
@@ -29,28 +29,22 @@ class EmbargoModelsTest(CacheIsolationTestCase):
     def test_course_embargo(self):
         course_id = CourseLocator('abc', '123', 'doremi')
         # Test that course is not authorized by default
-        self.assertFalse(EmbargoedCourse.is_embargoed(course_id))
+        assert not EmbargoedCourse.is_embargoed(course_id)
 
         # Authorize
         cauth = EmbargoedCourse(course_id=course_id, embargoed=True)
         cauth.save()
 
         # Now, course should be embargoed
-        self.assertTrue(EmbargoedCourse.is_embargoed(course_id))
-        self.assertEqual(
-            six.text_type(cauth),
-            u"Course '{course_id}' is Embargoed".format(course_id=course_id)
-        )
+        assert EmbargoedCourse.is_embargoed(course_id)
+        assert six.text_type(cauth) == u"Course '{course_id}' is Embargoed".format(course_id=course_id)
 
         # Unauthorize by explicitly setting email_enabled to False
         cauth.embargoed = False
         cauth.save()
         # Test that course is now unauthorized
-        self.assertFalse(EmbargoedCourse.is_embargoed(course_id))
-        self.assertEqual(
-            six.text_type(cauth),
-            u"Course '{course_id}' is Not Embargoed".format(course_id=course_id)
-        )
+        assert not EmbargoedCourse.is_embargoed(course_id)
+        assert six.text_type(cauth) == u"Course '{course_id}' is Not Embargoed".format(course_id=course_id)
 
     def test_state_embargo(self):
         # Azerbaijan and France should not be blocked
@@ -60,7 +54,7 @@ class EmbargoModelsTest(CacheIsolationTestCase):
         currently_blocked = EmbargoedState.current().embargoed_countries_list
 
         for state in blocked_states + good_states:
-            self.assertNotIn(state, currently_blocked)
+            assert state not in currently_blocked
 
         # Block
         cauth = EmbargoedState(embargoed_countries='US, AQ')
@@ -68,9 +62,9 @@ class EmbargoModelsTest(CacheIsolationTestCase):
         currently_blocked = EmbargoedState.current().embargoed_countries_list
 
         for state in good_states:
-            self.assertNotIn(state, currently_blocked)
+            assert state not in currently_blocked
         for state in blocked_states:
-            self.assertIn(state, currently_blocked)
+            assert state in currently_blocked
 
         # Change embargo - block Isle of Man too
         blocked_states.append('IM')
@@ -79,25 +73,25 @@ class EmbargoModelsTest(CacheIsolationTestCase):
         currently_blocked = EmbargoedState.current().embargoed_countries_list
 
         for state in good_states:
-            self.assertNotIn(state, currently_blocked)
+            assert state not in currently_blocked
         for state in blocked_states:
-            self.assertIn(state, currently_blocked)
+            assert state in currently_blocked
 
     def test_ip_blocking(self):
         whitelist = u'127.0.0.1'
         blacklist = u'18.244.51.3'
 
         cwhitelist = IPFilter.current().whitelist_ips
-        self.assertNotIn(whitelist, cwhitelist)
+        assert whitelist not in cwhitelist
         cblacklist = IPFilter.current().blacklist_ips
-        self.assertNotIn(blacklist, cblacklist)
+        assert blacklist not in cblacklist
 
         IPFilter(whitelist=whitelist, blacklist=blacklist).save()
 
         cwhitelist = IPFilter.current().whitelist_ips
-        self.assertIn(whitelist, cwhitelist)
+        assert whitelist in cwhitelist
         cblacklist = IPFilter.current().blacklist_ips
-        self.assertIn(blacklist, cblacklist)
+        assert blacklist in cblacklist
 
     def test_ip_network_blocking(self):
         whitelist = u'1.0.0.0/24'
@@ -106,14 +100,14 @@ class EmbargoModelsTest(CacheIsolationTestCase):
         IPFilter(whitelist=whitelist, blacklist=blacklist).save()
 
         cwhitelist = IPFilter.current().whitelist_ips
-        self.assertIn(u'1.0.0.100', cwhitelist)
-        self.assertIn(u'1.0.0.10', cwhitelist)
-        self.assertNotIn(u'1.0.1.0', cwhitelist)
+        assert u'1.0.0.100' in cwhitelist
+        assert u'1.0.0.10' in cwhitelist
+        assert u'1.0.1.0' not in cwhitelist
         cblacklist = IPFilter.current().blacklist_ips
-        self.assertIn(u'1.1.0.0', cblacklist)
-        self.assertIn(u'1.1.0.1', cblacklist)
-        self.assertIn(u'1.1.1.0', cblacklist)
-        self.assertNotIn(u'1.2.0.0', cblacklist)
+        assert u'1.1.0.0' in cblacklist
+        assert u'1.1.0.1' in cblacklist
+        assert u'1.1.1.0' in cblacklist
+        assert u'1.2.0.0' not in cblacklist
 
 
 class RestrictedCourseTest(CacheIsolationTestCase):
@@ -124,10 +118,7 @@ class RestrictedCourseTest(CacheIsolationTestCase):
     def test_unicode_values(self):
         course_id = CourseLocator('abc', '123', 'doremi')
         restricted_course = RestrictedCourse.objects.create(course_key=course_id)
-        self.assertEqual(
-            six.text_type(restricted_course),
-            six.text_type(course_id)
-        )
+        assert six.text_type(restricted_course) == six.text_type(course_id)
 
     def test_restricted_course_cache_with_save_delete(self):
         course_id = CourseLocator('abc', '123', 'doremi')
@@ -143,7 +134,7 @@ class RestrictedCourseTest(CacheIsolationTestCase):
             RestrictedCourse.is_restricted_course(course_id)
             RestrictedCourse.is_disabled_access_check(course_id)
 
-        self.assertFalse(RestrictedCourse.is_disabled_access_check(course_id))
+        assert not RestrictedCourse.is_disabled_access_check(course_id)
 
         # add new the course so the cache must get delete and again hit the db
         new_course_id = CourseLocator('def', '123', 'doremi')
@@ -157,7 +148,7 @@ class RestrictedCourseTest(CacheIsolationTestCase):
             RestrictedCourse.is_restricted_course(new_course_id)
             RestrictedCourse.is_disabled_access_check(new_course_id)
 
-        self.assertTrue(RestrictedCourse.is_disabled_access_check(new_course_id))
+        assert RestrictedCourse.is_disabled_access_check(new_course_id)
 
         # deleting an object will delete cache also.and hit db on
         # get the is_restricted course
@@ -176,7 +167,7 @@ class CountryTest(TestCase):
 
     def test_unicode_values(self):
         country = Country.objects.create(country='NZ')
-        self.assertEqual(six.text_type(country), "New Zealand (NZ)")
+        assert six.text_type(country) == 'New Zealand (NZ)'
 
 
 class CountryAccessRuleTest(CacheIsolationTestCase):
@@ -193,10 +184,7 @@ class CountryAccessRuleTest(CacheIsolationTestCase):
             country=country
         )
 
-        self.assertEqual(
-            six.text_type(access_rule),
-            u"Whitelist New Zealand (NZ) for {course_key}".format(course_key=course_id)
-        )
+        assert six.text_type(access_rule) == u'Whitelist New Zealand (NZ) for {course_key}'.format(course_key=course_id)
 
         course_id = CourseLocator('def', '123', 'doremi')
         restricted_course1 = RestrictedCourse.objects.create(course_key=course_id)
@@ -206,10 +194,7 @@ class CountryAccessRuleTest(CacheIsolationTestCase):
             country=country
         )
 
-        self.assertEqual(
-            six.text_type(access_rule),
-            u"Blacklist New Zealand (NZ) for {course_key}".format(course_key=course_id)
-        )
+        assert six.text_type(access_rule) == u'Blacklist New Zealand (NZ) for {course_key}'.format(course_key=course_id)
 
     def test_unique_together_constraint(self):
         """
@@ -226,7 +211,7 @@ class CountryAccessRuleTest(CacheIsolationTestCase):
             country=country
         )
 
-        with self.assertRaises(IntegrityError):
+        with pytest.raises(IntegrityError):
             CountryAccessRule.objects.create(
                 restricted_course=restricted_course1,
                 rule_type=CountryAccessRule.BLACKLIST_RULE,
@@ -341,26 +326,20 @@ class CourseAccessRuleHistoryTest(TestCase):
         record = CourseAccessRuleHistory.objects.latest()
 
         # Check that the record is for the correct course
-        self.assertEqual(record.course_key, self.course_key)
+        assert record.course_key == self.course_key
 
         # Load the history entry and verify the message keys
         snapshot = json.loads(record.snapshot)
-        self.assertEqual(snapshot['enroll_msg'], enroll_msg)
-        self.assertEqual(snapshot['access_msg'], access_msg)
+        assert snapshot['enroll_msg'] == enroll_msg
+        assert snapshot['access_msg'] == access_msg
 
         # For each rule, check that there is an entry
         # in the history record.
         for (country, rule_type) in country_rules:
-            self.assertIn(
-                {
-                    'country': country,
-                    'rule_type': rule_type
-                },
-                snapshot['country_rules']
-            )
+            assert {'country': country, 'rule_type': rule_type} in snapshot['country_rules']
 
         # Check that there are no duplicate entries
-        self.assertEqual(len(snapshot['country_rules']), len(country_rules))
+        assert len(snapshot['country_rules']) == len(country_rules)
 
     def _assert_history_deleted(self):
         """Check the latest history entry for a 'DELETED' placeholder.
@@ -370,5 +349,5 @@ class CourseAccessRuleHistoryTest(TestCase):
 
         """
         record = CourseAccessRuleHistory.objects.latest()
-        self.assertEqual(record.course_key, self.course_key)
-        self.assertEqual(record.snapshot, "DELETED")
+        assert record.course_key == self.course_key
+        assert record.snapshot == 'DELETED'

--- a/openedx/core/djangoapps/embargo/tests/test_views.py
+++ b/openedx/core/djangoapps/embargo/tests/test_views.py
@@ -83,17 +83,9 @@ class CourseAccessMessageViewTest(CacheIsolationTestCase, UrlResetMixin):
             'message_key': message_key
         })
         response = self.client.get(url)
-        self.assertEqual(
-            response.status_code, expected_status,
-            msg=(
-                u"Unexpected status code when loading '{url}': "
-                u"expected {expected} but got {actual}"
-            ).format(
-                url=url,
-                expected=expected_status,
-                actual=response.status_code
-            )
-        )
+        assert response.status_code ==\
+               expected_status, f"Unexpected status code when loading '{url}': expected {expected_status}" \
+                                f" but got {response.status_code}"
 
 
 @skip_unless_lms
@@ -116,8 +108,8 @@ class CheckCourseAccessViewTest(CourseApiFactoryMixin, ModuleStoreTestCase):
     def test_course_access_endpoint_with_unrestricted_course(self):
         response = self.client.get(self.url, data=self.request_data)
         expected_response = {'access': True}
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data, expected_response)
+        assert response.status_code == 200
+        assert response.data == expected_response
 
     def test_course_access_endpoint_with_restricted_course(self):
         CountryAccessRuleFactory(restricted_course=RestrictedCourseFactory(course_key=self.course_id))
@@ -149,26 +141,26 @@ class CheckCourseAccessViewTest(CourseApiFactoryMixin, ModuleStoreTestCase):
         response = self.client.get(self.url, data=self.request_data)
 
         expected_response = {'access': False}
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data, expected_response)
+        assert response.status_code == 200
+        assert response.data == expected_response
 
     def test_course_access_endpoint_with_logged_out_user(self):
         self.client.logout()
         response = self.client.get(self.url, data=self.request_data)
-        self.assertEqual(response.status_code, 403)
+        assert response.status_code == 403
 
     def test_course_access_endpoint_with_non_staff_user(self):
         user = UserFactory(is_staff=False)
         self.client.login(username=user.username, password=UserFactory._DEFAULT_PASSWORD)  # lint-amnesty, pylint: disable=protected-access
 
         response = self.client.get(self.url, data=self.request_data)
-        self.assertEqual(response.status_code, 403)
+        assert response.status_code == 403
 
     def test_course_access_endpoint_with_invalid_data(self):
         response = self.client.get(self.url, data=None)
-        self.assertEqual(response.status_code, 400)
+        assert response.status_code == 400
 
     def test_invalid_course_id(self):
         self.request_data['course_ids'] = ['foo']
         response = self.client.get(self.url, data=self.request_data)
-        self.assertEqual(response.status_code, 400)
+        assert response.status_code == 400

--- a/openedx/core/djangoapps/enrollments/management/tests/test_enroll_user_in_course.py
+++ b/openedx/core/djangoapps/enrollments/management/tests/test_enroll_user_in_course.py
@@ -4,7 +4,7 @@
 import unittest
 from uuid import uuid4
 import ddt
-
+import pytest
 from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import CommandError
@@ -51,7 +51,7 @@ class EnrollManagementCommandTest(SharedModuleStoreTestCase):
         )
 
         user_enroll = get_enrollment(self.username, self.course_id)
-        self.assertTrue(user_enroll['is_active'])
+        assert user_enroll['is_active']
 
     def test_enroll_user_twice(self):
         """
@@ -72,7 +72,7 @@ class EnrollManagementCommandTest(SharedModuleStoreTestCase):
         # Second run does not impact the first run (i.e., the
         # user is still enrolled, no exception was raised, etc)
         user_enroll = get_enrollment(self.username, self.course_id)
-        self.assertTrue(user_enroll['is_active'])
+        assert user_enroll['is_active']
 
     @ddt.data(['--email', 'foo'], ['--course', 'bar'], ['--bad-param', 'baz'])
     def test_not_enough_args(self, arg):
@@ -83,7 +83,7 @@ class EnrollManagementCommandTest(SharedModuleStoreTestCase):
 
         command_args = arg
 
-        with self.assertRaises(CommandError):
+        with pytest.raises(CommandError):
             call_command(
                 'enroll_user_in_course',
                 *command_args

--- a/openedx/core/djangoapps/enrollments/tests/test_api.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_api.py
@@ -56,13 +56,13 @@ class EnrollmentTest(CacheIsolationTestCase):
         fake_data_api.add_course(self.COURSE_ID, course_modes=course_modes)
         # Enroll in the course and verify the URL we get sent to
         result = api.add_enrollment(self.USERNAME, self.COURSE_ID, mode=mode)
-        self.assertIsNotNone(result)
-        self.assertEqual(result['student'], self.USERNAME)
-        self.assertEqual(result['course']['course_id'], self.COURSE_ID)
-        self.assertEqual(result['mode'], mode)
+        assert result is not None
+        assert result['student'] == self.USERNAME
+        assert result['course']['course_id'] == self.COURSE_ID
+        assert result['mode'] == mode
 
         get_result = api.get_enrollment(self.USERNAME, self.COURSE_ID)
-        self.assertEqual(result, get_result)
+        assert result == get_result
 
     @ddt.data(
         ([CourseMode.DEFAULT_MODE_SLUG, 'verified', 'credit'], CourseMode.DEFAULT_MODE_SLUG),
@@ -78,10 +78,10 @@ class EnrollmentTest(CacheIsolationTestCase):
             mock_modes_for_course.return_value = mock_course_modes
             # Enroll in the course and verify the URL we get sent to
             result = api.add_enrollment(self.USERNAME, self.COURSE_ID)
-            self.assertIsNotNone(result)
-            self.assertEqual(result['student'], self.USERNAME)
-            self.assertEqual(result['course']['course_id'], self.COURSE_ID)
-            self.assertEqual(result['mode'], expected_mode)
+            assert result is not None
+            assert result['student'] == self.USERNAME
+            assert result['course']['course_id'] == self.COURSE_ID
+            assert result['mode'] == expected_mode
 
     @ddt.data(
         ['professional'],
@@ -122,18 +122,18 @@ class EnrollmentTest(CacheIsolationTestCase):
         fake_data_api.add_course(self.COURSE_ID, course_modes=course_modes)
         # Enroll in the course and verify the URL we get sent to
         result = api.add_enrollment(self.USERNAME, self.COURSE_ID, mode=mode)
-        self.assertIsNotNone(result)
-        self.assertEqual(result['student'], self.USERNAME)
-        self.assertEqual(result['course']['course_id'], self.COURSE_ID)
-        self.assertEqual(result['mode'], mode)
-        self.assertTrue(result['is_active'])
+        assert result is not None
+        assert result['student'] == self.USERNAME
+        assert result['course']['course_id'] == self.COURSE_ID
+        assert result['mode'] == mode
+        assert result['is_active']
 
         result = api.update_enrollment(self.USERNAME, self.COURSE_ID, mode=mode, is_active=False)
-        self.assertIsNotNone(result)
-        self.assertEqual(result['student'], self.USERNAME)
-        self.assertEqual(result['course']['course_id'], self.COURSE_ID)
-        self.assertEqual(result['mode'], mode)
-        self.assertFalse(result['is_active'])
+        assert result is not None
+        assert result['student'] == self.USERNAME
+        assert result['course']['course_id'] == self.COURSE_ID
+        assert result['mode'] == mode
+        assert not result['is_active']
 
     def test_unenroll_not_enrolled_in_course(self):
         # Add a fake course enrollment information to the fake data API
@@ -161,12 +161,9 @@ class EnrollmentTest(CacheIsolationTestCase):
             fake_data_api.add_course(enrollment['course_id'], course_modes=enrollment['course_modes'])
             api.add_enrollment(self.USERNAME, enrollment['course_id'], enrollment['mode'])
         result = api.get_enrollments(self.USERNAME)
-        self.assertEqual(len(enrollments), len(result))
+        assert len(enrollments) == len(result)
         for result_enrollment in result:
-            self.assertIn(
-                result_enrollment['course']['course_id'],
-                [enrollment['course_id'] for enrollment in enrollments]
-            )
+            assert result_enrollment['course']['course_id'] in [enrollment['course_id'] for enrollment in enrollments]
 
     def test_update_enrollment(self):
         # Add fake course enrollment information to the fake data API
@@ -174,13 +171,13 @@ class EnrollmentTest(CacheIsolationTestCase):
         # Enroll in the course and verify the URL we get sent to
         result = api.add_enrollment(self.USERNAME, self.COURSE_ID, mode='audit')
         get_result = api.get_enrollment(self.USERNAME, self.COURSE_ID)
-        self.assertEqual(result, get_result)
+        assert result == get_result
 
         result = api.update_enrollment(self.USERNAME, self.COURSE_ID, mode='honor')
-        self.assertEqual('honor', result['mode'])
+        assert 'honor' == result['mode']
 
         result = api.update_enrollment(self.USERNAME, self.COURSE_ID, mode='verified')
-        self.assertEqual('verified', result['mode'])
+        assert 'verified' == result['mode']
 
     def test_update_enrollment_attributes(self):
         # Add fake course enrollment information to the fake data API
@@ -188,7 +185,7 @@ class EnrollmentTest(CacheIsolationTestCase):
         # Enroll in the course and verify the URL we get sent to
         result = api.add_enrollment(self.USERNAME, self.COURSE_ID, mode='audit')
         get_result = api.get_enrollment(self.USERNAME, self.COURSE_ID)
-        self.assertEqual(result, get_result)
+        assert result == get_result
 
         enrollment_attributes = [
             {
@@ -201,16 +198,16 @@ class EnrollmentTest(CacheIsolationTestCase):
         result = api.update_enrollment(
             self.USERNAME, self.COURSE_ID, mode='credit', enrollment_attributes=enrollment_attributes
         )
-        self.assertEqual('credit', result['mode'])
+        assert 'credit' == result['mode']
         attributes = api.get_enrollment_attributes(self.USERNAME, self.COURSE_ID)
-        self.assertEqual(enrollment_attributes[0], attributes[0])
+        assert enrollment_attributes[0] == attributes[0]
 
     def test_get_course_details(self):
         # Add a fake course enrollment information to the fake data API
         fake_data_api.add_course(self.COURSE_ID, course_modes=['honor', 'verified', 'audit'])
         result = api.get_course_enrollment_details(self.COURSE_ID)
-        self.assertEqual(result['course_id'], self.COURSE_ID)
-        self.assertEqual(3, len(result['course_modes']))
+        assert result['course_id'] == self.COURSE_ID
+        assert 3 == len(result['course_modes'])
 
     @override_settings(ENROLLMENT_DATA_API='foo.bar.biz.baz')
     def test_data_api_config_error(self):
@@ -230,15 +227,15 @@ class EnrollmentTest(CacheIsolationTestCase):
         cached_details = api.get_course_enrollment_details(self.COURSE_ID)
 
         # The data matches
-        self.assertEqual(len(details['course_modes']), 3)
-        self.assertEqual(details, cached_details)
+        assert len(details['course_modes']) == 3
+        assert details == cached_details
 
     def test_update_enrollment_expired_mode_with_error(self):
         """ Verify that if verified mode is expired and include expire flag is
         false then enrollment cannot be updated. """
         self.assert_add_modes_with_enrollment('audit')
         # On updating enrollment mode to verified it should the raise the error.
-        with self.assertRaises(CourseModeNotFoundError):
+        with pytest.raises(CourseModeNotFoundError):
             self.assert_update_enrollment(mode='verified', include_expired=False)
 
     def test_update_enrollment_with_expired_mode(self):
@@ -261,7 +258,7 @@ class EnrollmentTest(CacheIsolationTestCase):
         fake_data_api.add_course(self.COURSE_ID, course_modes=['honor', 'verified', 'audit'])
         result = api.add_enrollment(self.USERNAME, self.COURSE_ID, mode=enrollment_mode)
         get_result = api.get_enrollment(self.USERNAME, self.COURSE_ID)
-        self.assertEqual(result, get_result)
+        assert result == get_result
         # set the course verify mode as expire.
         fake_data_api.set_expired_mode(self.COURSE_ID)
 
@@ -271,13 +268,13 @@ class EnrollmentTest(CacheIsolationTestCase):
         result = api.update_enrollment(
             self.USERNAME, self.COURSE_ID, mode=mode, is_active=is_active, include_expired=include_expired
         )
-        self.assertEqual(mode, result['mode'])
-        self.assertIsNotNone(result)
-        self.assertEqual(result['student'], self.USERNAME)
-        self.assertEqual(result['course']['course_id'], self.COURSE_ID)
-        self.assertEqual(result['mode'], mode)
+        assert mode == result['mode']
+        assert result is not None
+        assert result['student'] == self.USERNAME
+        assert result['course']['course_id'] == self.COURSE_ID
+        assert result['mode'] == mode
 
         if is_active:
-            self.assertTrue(result['is_active'])
+            assert result['is_active']
         else:
-            self.assertFalse(result['is_active'])
+            assert not result['is_active']

--- a/openedx/core/djangoapps/enrollments/tests/test_data.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_data.py
@@ -71,15 +71,15 @@ class EnrollmentDataTest(ModuleStoreTestCase):
             True
         )
 
-        self.assertTrue(CourseEnrollment.is_enrolled(self.user, self.course.id))
+        assert CourseEnrollment.is_enrolled(self.user, self.course.id)
         course_mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
-        self.assertTrue(is_active)
-        self.assertEqual(course_mode, enrollment_mode)
+        assert is_active
+        assert course_mode == enrollment_mode
 
         # Confirm the returned enrollment and the data match up.
-        self.assertEqual(course_mode, enrollment['mode'])
-        self.assertEqual(is_active, enrollment['is_active'])
-        self.assertEqual(self.course.display_name_with_default, enrollment['course_details']['course_name'])
+        assert course_mode == enrollment['mode']
+        assert is_active == enrollment['is_active']
+        assert self.course.display_name_with_default == enrollment['course_details']['course_name']
 
     def test_unenroll(self):
         # Enroll the user in the course
@@ -92,10 +92,10 @@ class EnrollmentDataTest(ModuleStoreTestCase):
         )
 
         # Determine that the returned enrollment is inactive.
-        self.assertFalse(enrollment['is_active'])
+        assert not enrollment['is_active']
 
         # Expect that we're no longer enrolled
-        self.assertFalse(CourseEnrollment.is_enrolled(self.user, self.course.id))
+        assert not CourseEnrollment.is_enrolled(self.user, self.course.id)
 
     @ddt.data(
         # No course modes, no course enrollments.
@@ -109,7 +109,7 @@ class EnrollmentDataTest(ModuleStoreTestCase):
         result_course = data.get_course_enrollment_info(six.text_type(self.course.id))
         result_slugs = [mode['slug'] for mode in result_course['course_modes']]
         for course_mode in course_modes:
-            self.assertIn(course_mode, result_slugs)
+            assert course_mode in result_slugs
 
     @ddt.data(
         # No course modes, no course enrollments.
@@ -139,7 +139,7 @@ class EnrollmentDataTest(ModuleStoreTestCase):
         # Compare the created enrollments with the results
         # from the get enrollments request.
         results = data.get_course_enrollments(self.user.username)
-        self.assertEqual(results, created_enrollments)
+        assert results == created_enrollments
 
         # Now create a course enrollment with some invalid course (does
         # not exist in database) for the user and check that the method
@@ -155,7 +155,7 @@ class EnrollmentDataTest(ModuleStoreTestCase):
         enrollement.course.delete()
 
         updated_results = data.get_course_enrollments(self.user.username)
-        self.assertEqual(results, updated_results)
+        assert results == updated_results
 
     def test_get_enrollments_including_inactive(self):
         """ Verify that if 'include_inactive' is True, all enrollments
@@ -187,11 +187,11 @@ class EnrollmentDataTest(ModuleStoreTestCase):
 
         # by default in-active enrollment will be excluded.
         results = data.get_course_enrollments(self.user.username)
-        self.assertNotEqual(len(results), len(created_enrollments))
+        assert len(results) != len(created_enrollments)
 
         # we can get all enrollments including inactive by passing "include_inactive"
         results = data.get_course_enrollments(self.user.username, include_inactive=True)
-        self.assertEqual(len(results), len(created_enrollments))
+        assert len(results) == len(created_enrollments)
 
     @ddt.data(
         # Default (no course modes in the database)
@@ -209,7 +209,7 @@ class EnrollmentDataTest(ModuleStoreTestCase):
 
         # Try to get an enrollment before it exists.
         result = data.get_course_enrollment(self.user.username, six.text_type(self.course.id))
-        self.assertIsNone(result)
+        assert result is None
 
         # Create the original enrollment.
         enrollment = data.create_course_enrollment(
@@ -220,8 +220,8 @@ class EnrollmentDataTest(ModuleStoreTestCase):
         )
         # Get the enrollment and compare it to the original.
         result = data.get_course_enrollment(self.user.username, six.text_type(self.course.id))
-        self.assertEqual(self.user.username, result['user'])
-        self.assertEqual(enrollment, result)
+        assert self.user.username == result['user']
+        assert enrollment == result
 
     @ddt.data(
         # Default (no course modes in the database)
@@ -239,7 +239,7 @@ class EnrollmentDataTest(ModuleStoreTestCase):
 
         # Try to get enrollments before they exist.
         result = data.get_user_enrollments(self.course.id)
-        self.assertFalse(result.exists())
+        assert not result.exists()
 
         # Create 10 test users to enroll in the course
         users = []
@@ -265,8 +265,8 @@ class EnrollmentDataTest(ModuleStoreTestCase):
         results = data.get_user_enrollments(
             self.course.id
         )
-        self.assertTrue(result.exists())
-        self.assertEqual(CourseEnrollmentSerializer(results, many=True).data, created_enrollments)
+        assert result.exists()
+        assert CourseEnrollmentSerializer(results, many=True).data == created_enrollments
 
     @ddt.data(
         # Default (no course modes in the database)
@@ -293,7 +293,7 @@ class EnrollmentDataTest(ModuleStoreTestCase):
 
         data.add_or_update_enrollment_attr(self.user.username, six.text_type(self.course.id), enrollment_attributes)
         enrollment_attr = data.get_enrollment_attributes(self.user.username, six.text_type(self.course.id))
-        self.assertEqual(enrollment_attr[0], enrollment_attributes[0])
+        assert enrollment_attr[0] == enrollment_attributes[0]
 
         enrollment_attributes = [
             {
@@ -305,7 +305,7 @@ class EnrollmentDataTest(ModuleStoreTestCase):
 
         data.add_or_update_enrollment_attr(self.user.username, six.text_type(self.course.id), enrollment_attributes)
         enrollment_attr = data.get_enrollment_attributes(self.user.username, six.text_type(self.course.id))
-        self.assertEqual(enrollment_attr[0], enrollment_attributes[0])
+        assert enrollment_attr[0] == enrollment_attributes[0]
 
     def test_non_existent_course(self):
         with pytest.raises(CourseNotFoundError):
@@ -353,7 +353,7 @@ class EnrollmentDataTest(ModuleStoreTestCase):
 
     def test_update_for_non_existent_course(self):
         enrollment = data.update_course_enrollment(self.user.username, "some/fake/course", is_active=False)
-        self.assertIsNone(enrollment)
+        assert enrollment is None
 
     def test_get_course_with_expired_mode_included(self):
         """Verify that method returns expired modes if include_expired
@@ -381,10 +381,10 @@ class EnrollmentDataTest(ModuleStoreTestCase):
         result_course = data.get_course_enrollment_info(six.text_type(self.course.id), include_expired=include_expired)
         result_slugs = [mode['slug'] for mode in result_course['course_modes']]
         for course_mode in expected_modes:
-            self.assertIn(course_mode, result_slugs)
+            assert course_mode in result_slugs
 
         if not include_expired:
-            self.assertNotIn('verified', result_slugs)
+            assert 'verified' not in result_slugs
 
     def test_get_roles(self):
         """Create a role for a user, then get it"""
@@ -392,12 +392,12 @@ class EnrollmentDataTest(ModuleStoreTestCase):
             course_id=self.course.id, user=self.user, role="SuperCoolTestRole",
         )
         roles = data.get_user_roles(self.user.username)
-        self.assertEqual(roles, {expected_role})
+        assert roles == {expected_role}
 
     def test_get_roles_no_roles(self):
         """Get roles for a user who has no roles"""
         roles = data.get_user_roles(self.user.username)
-        self.assertEqual(roles, set())
+        assert roles == set()
 
     def test_get_roles_invalid_user(self):
         """Get roles for a user that doesn't exist"""

--- a/openedx/core/djangoapps/enrollments/tests/test_services.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_services.py
@@ -31,11 +31,11 @@ class EnrollmentsServiceTests(ModuleStoreTestCase):
         Test that it returns a list of active enrollments
         """
         enrollments = self.service.get_active_enrollments_by_course(self.course.id)
-        self.assertEqual(len(enrollments), 3)
+        assert len(enrollments) == 3
         # At minimum, the function should return the user and mode tied to each enrollment
         for x in range(3):
-            self.assertEqual(enrollments[x].user.username, 'user{}'.format(x))
-            self.assertEqual(enrollments[x].mode, self.course_modes[x])
+            assert enrollments[x].user.username == 'user{}'.format(x)
+            assert enrollments[x].mode == self.course_modes[x]
 
     def test_get_active_enrollments_by_course_ignore_inactive(self):
         """
@@ -45,7 +45,7 @@ class EnrollmentsServiceTests(ModuleStoreTestCase):
         inactive_enrollment.is_active = False
         inactive_enrollment.save()
         enrollments = self.service.get_active_enrollments_by_course(self.course.id)
-        self.assertEqual(len(enrollments), 2)
+        assert len(enrollments) == 2
 
     def test_get_active_enrollments_no_enrollments(self):
         """
@@ -53,4 +53,4 @@ class EnrollmentsServiceTests(ModuleStoreTestCase):
         """
         new_course = CourseFactory()
         enrollments = self.service.get_active_enrollments_by_course(new_course.id)  # pylint: disable=no-member
-        self.assertEqual(len(enrollments), 0)
+        assert len(enrollments) == 0

--- a/openedx/core/djangoapps/enrollments/tests/test_views.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_views.py
@@ -8,7 +8,7 @@ import datetime
 import itertools
 import json
 import unittest
-
+import pytest
 import ddt
 import httpretty
 import pytz
@@ -109,23 +109,23 @@ class EnrollmentTestMixin(object):
             with patch('openedx.core.djangoapps.enrollments.views.audit_log') as mock_audit_log:
                 url = reverse('courseenrollments')
                 response = self.client.post(url, json.dumps(data), content_type='application/json', **extra)
-                self.assertEqual(response.status_code, expected_status)
+                assert response.status_code == expected_status
 
                 if expected_status == status.HTTP_200_OK:
                     data = json.loads(response.content.decode('utf-8'))
-                    self.assertEqual(course_id, data['course_details']['course_id'])
+                    assert course_id == data['course_details']['course_id']
 
                     if mode is not None:
-                        self.assertEqual(mode, data['mode'])
+                        assert mode == data['mode']
 
                     if is_active is not None:
-                        self.assertEqual(is_active, data['is_active'])
+                        assert is_active == data['is_active']
                     else:
-                        self.assertTrue(data['is_active'])
+                        assert data['is_active']
 
                     if as_server:
                         # Verify that an audit message was logged.
-                        self.assertTrue(mock_audit_log.called)
+                        assert mock_audit_log.called
 
                         # If multiple enrollment calls are made in the scope of a
                         # single test, we want to validate that audit messages are
@@ -143,8 +143,8 @@ class EnrollmentTestMixin(object):
             expected_status=status.HTTP_200_OK
         )
         actual_mode, actual_activation = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
-        self.assertEqual(actual_activation, expected_activation)
-        self.assertEqual(actual_mode, expected_mode)
+        assert actual_activation == expected_activation
+        assert actual_mode == expected_mode
 
     def _get_enrollments(self):
         """Retrieve the enrollment list for the current user. """
@@ -221,13 +221,13 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
 
         # Verify that the response contains the correct course_name
         data = json.loads(resp.content.decode('utf-8'))
-        self.assertEqual(self.course.display_name_with_default, data['course_details']['course_name'])
+        assert self.course.display_name_with_default == data['course_details']['course_name']
 
         # Verify that the enrollment was created correctly
-        self.assertTrue(CourseEnrollment.is_enrolled(self.user, self.course.id))
+        assert CourseEnrollment.is_enrolled(self.user, self.course.id)
         course_mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
-        self.assertTrue(is_active)
-        self.assertEqual(course_mode, enrollment_mode)
+        assert is_active
+        assert course_mode == enrollment_mode
 
     def test_check_enrollment(self):
         CourseModeFactory.create(
@@ -243,12 +243,12 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
                 kwargs={'username': self.user.username, "course_id": six.text_type(self.course.id)},
             )
         )
-        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        assert resp.status_code == status.HTTP_200_OK
         data = json.loads(resp.content.decode('utf-8'))
-        self.assertEqual(six.text_type(self.course.id), data['course_details']['course_id'])
-        self.assertEqual(self.course.display_name_with_default, data['course_details']['course_name'])
-        self.assertEqual(CourseMode.DEFAULT_MODE_SLUG, data['mode'])
-        self.assertTrue(data['is_active'])
+        assert six.text_type(self.course.id) == data['course_details']['course_id']
+        assert self.course.display_name_with_default == data['course_details']['course_name']
+        assert CourseMode.DEFAULT_MODE_SLUG == data['mode']
+        assert data['is_active']
 
     @ddt.data(
         (True, u"True"),
@@ -264,7 +264,7 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
 
         def _assert_no_opt_in_set():
             """ Check the tag doesn't exit"""
-            with self.assertRaises(UserOrgTag.DoesNotExist):
+            with pytest.raises(UserOrgTag.DoesNotExist):
                 UserOrgTag.objects.get(user=self.user, org=self.course.id.org, key="email-optin")
 
         _assert_no_opt_in_set()
@@ -273,7 +273,7 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
             _assert_no_opt_in_set()
         else:
             preference = UserOrgTag.objects.get(user=self.user, org=self.course.id.org, key="email-optin")
-            self.assertEqual(preference.value, pref_value)
+            assert preference.value == pref_value
 
     def test_enroll_prof_ed(self):
         # Create the prod ed mode.
@@ -289,9 +289,9 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         # While the enrollment wrong is invalid, the response content should have
         # all the valid enrollment modes.
         data = json.loads(resp.content.decode('utf-8'))
-        self.assertEqual(six.text_type(self.course.id), data['course_details']['course_id'])
-        self.assertEqual(1, len(data['course_details']['course_modes']))
-        self.assertEqual('professional', data['course_details']['course_modes'][0]['slug'])
+        assert six.text_type(self.course.id) == data['course_details']['course_id']
+        assert 1 == len(data['course_details']['course_modes'])
+        assert 'professional' == data['course_details']['course_modes'][0]['slug']
 
     def test_user_not_specified(self):
         CourseModeFactory.create(
@@ -304,11 +304,11 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         resp = self.client.get(
             reverse('courseenrollment', kwargs={"course_id": six.text_type(self.course.id)})
         )
-        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        assert resp.status_code == status.HTTP_200_OK
         data = json.loads(resp.content.decode('utf-8'))
-        self.assertEqual(six.text_type(self.course.id), data['course_details']['course_id'])
-        self.assertEqual(CourseMode.DEFAULT_MODE_SLUG, data['mode'])
-        self.assertTrue(data['is_active'])
+        assert six.text_type(self.course.id) == data['course_details']['course_id']
+        assert CourseMode.DEFAULT_MODE_SLUG == data['mode']
+        assert data['is_active']
 
     def test_user_not_authenticated(self):
         # Log out, so we're no longer authenticated
@@ -361,7 +361,7 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         if use_server_key:
             kwargs.update(HTTP_X_EDX_API_KEY=self.API_KEY)
         response = self.client.get(reverse('courseenrollments'), {'user': self.user.username}, **kwargs)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK
         data = json.loads(response.content.decode('utf-8'))
         six.assertCountEqual(
             self,
@@ -419,18 +419,18 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
                       kwargs={'username': self.other_user.username, "course_id": six.text_type(self.course.id)})
 
         response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
 
         # Verify that the server still has access to this endpoint.
         self.client.logout()
         response = self.client.get(url, **{'HTTP_X_EDX_API_KEY': self.API_KEY})
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK
 
         # Verify staff have access to this endpoint
         staff_user = UserFactory.create(password=self.PASSWORD, is_staff=True)
         self.client.login(username=staff_user.username, password=self.PASSWORD)
         response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK
 
     def test_get_course_details(self):
         CourseModeFactory.create(
@@ -443,16 +443,16 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         resp = self.client.get(
             reverse('courseenrollmentdetails', kwargs={"course_id": six.text_type(self.course.id)})
         )
-        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        assert resp.status_code == status.HTTP_200_OK
 
         data = json.loads(resp.content.decode('utf-8'))
-        self.assertEqual(six.text_type(self.course.id), data['course_id'])
-        self.assertEqual(self.course.display_name_with_default, data['course_name'])
+        assert six.text_type(self.course.id) == data['course_id']
+        assert self.course.display_name_with_default == data['course_name']
         mode = data['course_modes'][0]
-        self.assertEqual(mode['slug'], CourseMode.HONOR)
-        self.assertEqual(mode['sku'], '123')
-        self.assertEqual(mode['bulk_sku'], 'BULK123')
-        self.assertEqual(mode['name'], CourseMode.HONOR)
+        assert mode['slug'] == CourseMode.HONOR
+        assert mode['sku'] == '123'
+        assert mode['bulk_sku'] == 'BULK123'
+        assert mode['name'] == CourseMode.HONOR
 
     def test_get_course_details_with_credit_course(self):
         CourseModeFactory.create(
@@ -463,13 +463,13 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         resp = self.client.get(
             reverse('courseenrollmentdetails', kwargs={"course_id": six.text_type(self.course.id)})
         )
-        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        assert resp.status_code == status.HTTP_200_OK
 
         data = json.loads(resp.content.decode('utf-8'))
-        self.assertEqual(six.text_type(self.course.id), data['course_id'])
+        assert six.text_type(self.course.id) == data['course_id']
         mode = data['course_modes'][0]
-        self.assertEqual(mode['slug'], CourseMode.CREDIT_MODE)
-        self.assertEqual(mode['name'], CourseMode.CREDIT_MODE)
+        assert mode['slug'] == CourseMode.CREDIT_MODE
+        assert mode['name'] == CourseMode.CREDIT_MODE
 
     @ddt.data(
         # NOTE: Studio requires a start date, but this is not
@@ -497,28 +497,28 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         # Check course details
         url = reverse('courseenrollmentdetails', kwargs={"course_id": six.text_type(course.id)})
         resp = self.client.get(url)
-        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        assert resp.status_code == status.HTTP_200_OK
 
         data = json.loads(resp.content.decode('utf-8'))
-        self.assertEqual(data['course_start'], expected_start)
-        self.assertEqual(data['course_end'], expected_end)
+        assert data['course_start'] == expected_start
+        assert data['course_end'] == expected_end
 
         # Check enrollment course details
         url = reverse('courseenrollment', kwargs={"course_id": six.text_type(course.id)})
         resp = self.client.get(url)
-        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        assert resp.status_code == status.HTTP_200_OK
 
         data = json.loads(resp.content.decode('utf-8'))
-        self.assertEqual(data['course_details']['course_start'], expected_start)
-        self.assertEqual(data['course_details']['course_end'], expected_end)
+        assert data['course_details']['course_start'] == expected_start
+        assert data['course_details']['course_end'] == expected_end
 
         # Check enrollment list course details
         resp = self.client.get(reverse('courseenrollments'))
-        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        assert resp.status_code == status.HTTP_200_OK
 
         data = json.loads(resp.content.decode('utf-8'))
-        self.assertEqual(data[0]['course_details']['course_start'], expected_start)
-        self.assertEqual(data[0]['course_details']['course_end'], expected_end)
+        assert data[0]['course_details']['course_start'] == expected_start
+        assert data[0]['course_details']['course_end'] == expected_end
 
     def test_with_invalid_course_id(self):
         self.assert_enrollment_status(
@@ -532,7 +532,7 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         resp = self.client.get(
             reverse('courseenrollmentdetails', kwargs={"course_id": "some/fake/course"})
         )
-        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
 
     @patch.object(api, "get_enrollment")
     def test_get_enrollment_internal_error(self, mock_get_enrollment):
@@ -543,7 +543,7 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
                 kwargs={'username': self.user.username, "course_id": six.text_type(self.course.id)},
             )
         )
-        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_enrollment_already_enrolled(self):
         response = self.assert_enrollment_status()
@@ -552,7 +552,7 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         repeat_response = self.assert_enrollment_status(expected_status=status.HTTP_200_OK)
         repeat_json = json.loads(repeat_response.content.decode('utf-8'))
 
-        self.assertEqual(response_json, repeat_json)
+        assert response_json == repeat_json
 
     def test_get_enrollment_with_invalid_key(self):
         resp = self.client.post(
@@ -603,10 +603,10 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         # Create an enrollment
 
         self.assert_enrollment_status(cohort=cohort_name)
-        self.assertTrue(CourseEnrollment.is_enrolled(self.user, self.course.id))
+        assert CourseEnrollment.is_enrolled(self.user, self.course.id)
         _, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
-        self.assertTrue(is_active)
-        self.assertEqual(cohorts.get_cohort(self.user, self.course.id, assign=False).name, cohort_name)
+        assert is_active
+        assert cohorts.get_cohort(self.user, self.course.id, assign=False).name == cohort_name
 
     def test_create_enrollment_with_wrong_cohort(self):
         """Enroll in the course, and also add to a cohort."""
@@ -628,10 +628,10 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         # Create an enrollment
         self.assert_enrollment_status(as_server=True, mode='professional')
 
-        self.assertTrue(CourseEnrollment.is_enrolled(self.user, self.course.id))
+        assert CourseEnrollment.is_enrolled(self.user, self.course.id)
         course_mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
-        self.assertTrue(is_active)
-        self.assertEqual(course_mode, 'professional')
+        assert is_active
+        assert course_mode == 'professional'
 
     def test_enrollment_includes_expired_verified(self):
         """With the right API key, request that expired course verifications are still returned. """
@@ -661,7 +661,7 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         v_data = json.loads(v_response.content.decode('utf-8'))
 
         # Ensure that both course modes are returned
-        self.assertEqual(len(v_data['course_modes']), 2)
+        assert len(v_data['course_modes']) == 2
 
         # Omits the include_expired parameter from the API call
         h_response = self.client.get(
@@ -670,8 +670,8 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         h_data = json.loads(h_response.content.decode('utf-8'))
 
         # Ensure that only one course mode is returned and that it is honor
-        self.assertEqual(len(h_data['course_modes']), 1)
-        self.assertEqual(h_data['course_modes'][0]['slug'], CourseMode.HONOR)
+        assert len(h_data['course_modes']) == 1
+        assert h_data['course_modes'][0]['slug'] == CourseMode.HONOR
 
     def test_update_enrollment_with_mode(self):
         """With the right API key, update an existing enrollment with a new mode. """
@@ -687,16 +687,16 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         self.assert_enrollment_status(as_server=True)
 
         # Check that the enrollment is default.
-        self.assertTrue(CourseEnrollment.is_enrolled(self.user, self.course.id))
+        assert CourseEnrollment.is_enrolled(self.user, self.course.id)
         course_mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
-        self.assertTrue(is_active)
-        self.assertEqual(course_mode, CourseMode.DEFAULT_MODE_SLUG)
+        assert is_active
+        assert course_mode == CourseMode.DEFAULT_MODE_SLUG
 
         # Check that the enrollment upgraded to verified.
         self.assert_enrollment_status(as_server=True, mode=CourseMode.VERIFIED, expected_status=status.HTTP_200_OK)
         course_mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
-        self.assertTrue(is_active)
-        self.assertEqual(course_mode, CourseMode.VERIFIED)
+        assert is_active
+        assert course_mode == CourseMode.VERIFIED
 
     def test_enrollment_with_credit_mode(self):
         """With the right API key, update an existing enrollment with credit
@@ -713,10 +713,10 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         self.assert_enrollment_status(as_server=True)
 
         # Check that the enrollment is the default.
-        self.assertTrue(CourseEnrollment.is_enrolled(self.user, self.course.id))
+        assert CourseEnrollment.is_enrolled(self.user, self.course.id)
         course_mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
-        self.assertTrue(is_active)
-        self.assertEqual(course_mode, CourseMode.DEFAULT_MODE_SLUG)
+        assert is_active
+        assert course_mode == CourseMode.DEFAULT_MODE_SLUG
 
         # Check that the enrollment upgraded to credit.
         enrollment_attributes = [{
@@ -731,8 +731,8 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
             enrollment_attributes=enrollment_attributes
         )
         course_mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
-        self.assertTrue(is_active)
-        self.assertEqual(course_mode, CourseMode.CREDIT_MODE)
+        assert is_active
+        assert course_mode == CourseMode.CREDIT_MODE
 
     def test_enrollment_with_invalid_attr(self):
         """Check response status is bad request when invalid enrollment
@@ -749,10 +749,10 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         self.assert_enrollment_status(as_server=True)
 
         # Check that the enrollment is the default.
-        self.assertTrue(CourseEnrollment.is_enrolled(self.user, self.course.id))
+        assert CourseEnrollment.is_enrolled(self.user, self.course.id)
         course_mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
-        self.assertTrue(is_active)
-        self.assertEqual(course_mode, CourseMode.DEFAULT_MODE_SLUG)
+        assert is_active
+        assert course_mode == CourseMode.DEFAULT_MODE_SLUG
 
         # Check that the enrollment upgraded to credit.
         enrollment_attributes = [{
@@ -767,8 +767,8 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
             enrollment_attributes=enrollment_attributes
         )
         course_mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
-        self.assertTrue(is_active)
-        self.assertEqual(course_mode, CourseMode.DEFAULT_MODE_SLUG)
+        assert is_active
+        assert course_mode == CourseMode.DEFAULT_MODE_SLUG
 
     def test_downgrade_enrollment_with_mode(self):
         """With the right API key, downgrade an existing enrollment with a new mode. """
@@ -784,10 +784,10 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         self.assert_enrollment_status(as_server=True, mode=CourseMode.VERIFIED)
 
         # Check that the enrollment is verified.
-        self.assertTrue(CourseEnrollment.is_enrolled(self.user, self.course.id))
+        assert CourseEnrollment.is_enrolled(self.user, self.course.id)
         course_mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
-        self.assertTrue(is_active)
-        self.assertEqual(course_mode, CourseMode.VERIFIED)
+        assert is_active
+        assert course_mode == CourseMode.VERIFIED
 
         # Check that the enrollment was downgraded to the default mode.
         self.assert_enrollment_status(
@@ -796,8 +796,8 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
             expected_status=status.HTTP_200_OK
         )
         course_mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
-        self.assertTrue(is_active)
-        self.assertEqual(course_mode, CourseMode.DEFAULT_MODE_SLUG)
+        assert is_active
+        assert course_mode == CourseMode.DEFAULT_MODE_SLUG
 
     @ddt.data(
         ((CourseMode.DEFAULT_MODE_SLUG, ), CourseMode.DEFAULT_MODE_SLUG),
@@ -823,10 +823,10 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         self.assert_enrollment_status(as_server=True, mode=selected_mode)
 
         # Check that the enrollment has the correct mode and is active.
-        self.assertTrue(CourseEnrollment.is_enrolled(self.user, self.course.id))
+        assert CourseEnrollment.is_enrolled(self.user, self.course.id)
         course_mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
-        self.assertTrue(is_active)
-        self.assertEqual(course_mode, selected_mode)
+        assert is_active
+        assert course_mode == selected_mode
 
         # Verify that a non-Boolean enrollment status is treated as invalid.
         self.assert_enrollment_status(
@@ -869,10 +869,10 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         self.assert_enrollment_status(as_server=True, mode=mode)
 
         # Check that the enrollment has the correct mode and is active.
-        self.assertTrue(CourseEnrollment.is_enrolled(self.user, self.course.id))
+        assert CourseEnrollment.is_enrolled(self.user, self.course.id)
         course_mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
-        self.assertTrue(is_active)
-        self.assertEqual(course_mode, mode)
+        assert is_active
+        assert course_mode == mode
 
         username = 'global_staff'
         AdminFactory(username=username, email='global_staff@example.com', password=self.PASSWORD)
@@ -916,16 +916,16 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         self.assert_enrollment_status()
 
         # Check that the enrollment is honor.
-        self.assertTrue(CourseEnrollment.is_enrolled(self.user, self.course.id))
+        assert CourseEnrollment.is_enrolled(self.user, self.course.id)
         course_mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
-        self.assertTrue(is_active)
-        self.assertEqual(course_mode, CourseMode.DEFAULT_MODE_SLUG)
+        assert is_active
+        assert course_mode == CourseMode.DEFAULT_MODE_SLUG
 
         # Get a 403 response when trying to upgrade yourself.
         self.assert_enrollment_status(mode=CourseMode.VERIFIED, expected_status=status.HTTP_403_FORBIDDEN)
         course_mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
-        self.assertTrue(is_active)
-        self.assertEqual(course_mode, CourseMode.DEFAULT_MODE_SLUG)
+        assert is_active
+        assert course_mode == CourseMode.DEFAULT_MODE_SLUG
 
     @ddt.data(*itertools.product(
         (CourseMode.HONOR, CourseMode.VERIFIED),
@@ -950,8 +950,8 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         # Set up the initial enrollment
         self.assert_enrollment_status(as_server=True, mode=old_mode, is_active=old_is_active)
         course_mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
-        self.assertEqual(is_active, old_is_active)
-        self.assertEqual(course_mode, old_mode)
+        assert is_active == old_is_active
+        assert course_mode == old_mode
 
         expected_status = status.HTTP_400_BAD_REQUEST if (
             old_mode != new_mode and
@@ -970,8 +970,8 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         course_mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
         if expected_status == status.HTTP_400_BAD_REQUEST:
             # nothing should have changed
-            self.assertEqual(is_active, old_is_active)
-            self.assertEqual(course_mode, old_mode)
+            assert is_active == old_is_active
+            assert course_mode == old_mode
             # error message should contain specific text.  Otto checks for this text in the message.
             self.assertRegex(
                 json.loads(response.content.decode('utf-8'))['message'],
@@ -979,8 +979,8 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
             )
         else:
             # call should have succeeded
-            self.assertEqual(is_active, new_is_active)
-            self.assertEqual(course_mode, new_mode)
+            assert is_active == new_is_active
+            assert course_mode == new_mode
 
     def test_change_mode_invalid_user(self):
         """
@@ -1009,10 +1009,10 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         self.assert_enrollment_status(as_server=True)
 
         # Check that the enrollment is the default.
-        self.assertTrue(CourseEnrollment.is_enrolled(self.user, self.course.id))
+        assert CourseEnrollment.is_enrolled(self.user, self.course.id)
         course_mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
-        self.assertTrue(is_active)
-        self.assertEqual(course_mode, CourseMode.DEFAULT_MODE_SLUG)
+        assert is_active
+        assert course_mode == CourseMode.DEFAULT_MODE_SLUG
 
         # Change verified mode expiration.
         mode = CourseMode.objects.get(course_id=self.course.id, mode_slug=CourseMode.VERIFIED)
@@ -1024,8 +1024,8 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
             expected_status=status.HTTP_200_OK if using_api_key else status.HTTP_403_FORBIDDEN
         )
         course_mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
-        self.assertTrue(is_active)
-        self.assertEqual(course_mode, updated_mode)
+        assert is_active
+        assert course_mode == updated_mode
 
     @ddt.data(
         (True, status.HTTP_200_OK),
@@ -1057,8 +1057,8 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
 
         if using_global_staff_user:
             course_mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
-            self.assertTrue(is_active)
-            self.assertEqual(course_mode, CourseMode.VERIFIED)
+            assert is_active
+            assert course_mode == CourseMode.VERIFIED
         self.client.logout()
 
     @httpretty.activate
@@ -1092,14 +1092,8 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
             username='enterprise_worker',
             linked_enterprise_customer='this-is-a-real-uuid',
         )
-        self.assertEqual(
-            httpretty.last_request().path,  # lint-amnesty, pylint: disable=no-member
-            '/consent/api/v1/data_sharing_consent',
-        )
-        self.assertEqual(
-            httpretty.last_request().method,
-            httpretty.POST
-        )
+        assert httpretty.last_request().path == '/consent/api/v1/data_sharing_consent'    # pylint: disable=no-member
+        assert httpretty.last_request().method == httpretty.POST
 
     def test_enrollment_attributes_always_written(self):
         """ Enrollment attributes should always be written, regardless of whether
@@ -1128,9 +1122,9 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
             enrollment_attributes=enrollment_attributes
         )
         enrollment = CourseEnrollment.objects.get(user=self.user, course_id=course_key)
-        self.assertTrue(enrollment.is_active)
-        self.assertEqual(enrollment.mode, CourseMode.VERIFIED)
-        self.assertEqual(enrollment.attributes.get(namespace='order', name='order_number').value, order_number)
+        assert enrollment.is_active
+        assert enrollment.mode == CourseMode.VERIFIED
+        assert enrollment.attributes.get(namespace='order', name='order_number').value == order_number
 
         # Updating an enrollment should update attributes
         order_number = 'EDX-2000'
@@ -1146,9 +1140,9 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
             enrollment_attributes=enrollment_attributes
         )
         enrollment.refresh_from_db()
-        self.assertTrue(enrollment.is_active)
-        self.assertEqual(enrollment.mode, mode)
-        self.assertEqual(enrollment.attributes.get(namespace='order', name='order_number').value, order_number)
+        assert enrollment.is_active
+        assert enrollment.mode == mode
+        assert enrollment.attributes.get(namespace='order', name='order_number').value == order_number
 
 
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
@@ -1191,15 +1185,15 @@ class EnrollmentEmbargoTest(EnrollmentTestMixin, UrlResetMixin, ModuleStoreTestC
         response = self.client.post(self.url, data, content_type='application/json')
 
         # Expect an error response
-        self.assertEqual(response.status_code, 403)
+        assert response.status_code == 403
 
         # Expect that the redirect URL is included in the response
         resp_data = json.loads(response.content.decode('utf-8'))
         user_message_url = get_absolute_url(user_message_path)
-        self.assertEqual(resp_data['user_message_url'], user_message_url)
+        assert resp_data['user_message_url'] == user_message_url
 
         # Verify that we were not enrolled
-        self.assertEqual(self._get_enrollments(), [])
+        assert self._get_enrollments() == []
 
     @patch.dict(settings.FEATURES, {'EMBARGO': True})
     def test_embargo_change_enrollment_restrict_geoip(self):
@@ -1260,7 +1254,7 @@ class EnrollmentEmbargoTest(EnrollmentTestMixin, UrlResetMixin, ModuleStoreTestC
         self.assert_enrollment_status()
 
         # Verify that we were enrolled
-        self.assertEqual(len(self._get_enrollments()), 1)
+        assert len(self._get_enrollments()) == 1
 
 
 def cross_domain_config(func):
@@ -1308,12 +1302,12 @@ class EnrollmentCrossDomainTest(ModuleStoreTestCase):
 
         # Expect that the request gets through successfully,
         # passing the CSRF checks (including the referer check).
-        self.assertEqual(resp.status_code, 200)
+        assert resp.status_code == 200
 
     @cross_domain_config
     def test_cross_domain_missing_csrf(self, *args):  # pylint: disable=unused-argument
         resp = self._cross_domain_post('invalid_csrf_token')
-        self.assertEqual(resp.status_code, 403)
+        assert resp.status_code == 403
 
     def _get_csrf_cookie(self):
         """Retrieve the cross-domain CSRF cookie. """
@@ -1321,8 +1315,8 @@ class EnrollmentCrossDomainTest(ModuleStoreTestCase):
             'course_id': six.text_type(self.course.id)
         })
         resp = self.client.get(url, HTTP_REFERER=self.REFERER)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIn('prod-edx-csrftoken', resp.cookies)
+        assert resp.status_code == 200
+        assert 'prod-edx-csrftoken' in resp.cookies
         return resp.cookies['prod-edx-csrftoken'].value
 
     def _cross_domain_post(self, csrf_cookie):
@@ -1415,65 +1409,65 @@ class UnenrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase):
         self._assert_active()
         self._create_test_retirement(self.user)
         response = self._submit_unenroll(self.superuser, self.user.username)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK
         data = json.loads(response.content.decode('utf-8'))
         # order doesn't matter so compare sets
-        self.assertEqual(set(data), self.orgs)
+        assert set(data) == self.orgs
         self._assert_inactive()
 
     def test_deactivate_enrollments_no_retirement_status(self):
         self._assert_active()
         response = self._submit_unenroll(self.superuser, self.user.username)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
 
     def test_deactivate_enrollments_unauthorized(self):
         self._assert_active()
         response = self._submit_unenroll(self.user, self.user.username)
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
         self._assert_active()
 
     def test_deactivate_enrollments_no_username(self):
         self._assert_active()
         response = self._submit_unenroll(self.superuser, None)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
         data = json.loads(response.content.decode('utf-8'))
-        self.assertEqual(data, u"Username not specified.")
+        assert data == u'Username not specified.'
         self._assert_active()
 
     def test_deactivate_enrollments_empty_username(self):
         self._assert_active()
         self._create_test_retirement(self.user)
         response = self._submit_unenroll(self.superuser, "")
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
         self._assert_active()
 
     def test_deactivate_enrollments_invalid_username(self):
         self._assert_active()
         self._create_test_retirement(self.user)
         response = self._submit_unenroll(self.superuser, "a made up username")
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
         self._assert_active()
 
     def test_deactivate_enrollments_called_twice(self):
         self._assert_active()
         self._create_test_retirement(self.user)
         response = self._submit_unenroll(self.superuser, self.user.username)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK
         response = self._submit_unenroll(self.superuser, self.user.username)
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
-        self.assertEqual(response.content.decode('utf-8'), "")
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert response.content.decode('utf-8') == ''
         self._assert_inactive()
 
     def _assert_active(self):
         for course in self.courses:
-            self.assertTrue(CourseEnrollment.is_enrolled(self.user, course.id))
+            assert CourseEnrollment.is_enrolled(self.user, course.id)
             _, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, course.id)
-            self.assertTrue(is_active)
+            assert is_active
 
     def _assert_inactive(self):
         for course in self.courses:
             _, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, course.id)
-            self.assertFalse(is_active)
+            assert not is_active
 
     def _submit_unenroll(self, submitting_user, unenrolling_username):
         data = {}
@@ -1531,13 +1525,13 @@ class UserRoleTest(ModuleStoreTestCase):
             response = self.client.get(reverse('roles'), {'course_id': course_id})
         else:
             response = self.client.get(reverse('roles'))
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK
         response_data = json.loads(response.content.decode('utf-8'))
         sort_by_role_id = lambda r: r['course_id']
         response_data['roles'] = sorted(response_data['roles'], key=sort_by_role_id)
         expected_roles = sorted(expected_roles, key=sort_by_role_id)
         expected = {'roles': expected_roles, 'is_staff': is_staff}
-        self.assertEqual(response_data, expected)
+        assert response_data == expected
 
     def _login(self, is_staff):
         """ If is_staff is true, logs in the staff user. Otherwise, logs in the non-staff user """
@@ -1548,7 +1542,7 @@ class UserRoleTest(ModuleStoreTestCase):
     def test_not_logged_in(self):
         self.client.logout()
         response = self.client.get(reverse('roles'))
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     @ddt.data(True, False)
     def test_roles_no_roles(self, is_staff):
@@ -1583,14 +1577,14 @@ class UserRoleTest(ModuleStoreTestCase):
         with patch('openedx.core.djangoapps.enrollments.api.get_user_roles') as mock_get_user_roles:
             mock_get_user_roles.side_effect = Exception()
             response = self.client.get(reverse('roles'))
-            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            assert response.status_code == status.HTTP_400_BAD_REQUEST
             expected_response = {
                 "message": (
                     u"An error occurred while retrieving roles for user '{username}"
                 ).format(username=self.user.username)
             }
             response_data = json.loads(response.content.decode('utf-8'))
-            self.assertEqual(response_data, expected_response)
+            assert response_data == expected_response
 
 
 @ddt.ddt
@@ -1689,23 +1683,23 @@ class CourseEnrollmentsApiListTest(APITestCase, ModuleStoreTestCase):
         using the optional parameters 'query_params', 'expected_status' and 'error_fields'.
         """
         response = self._make_request(query_params)
-        self.assertEqual(response.status_code, expected_status)
+        assert response.status_code == expected_status
         content = json.loads(response.content.decode('utf-8'))
         if error_fields is not None:
-            self.assertIn('field_errors', content)
+            assert 'field_errors' in content
             for error_field in error_fields:
-                self.assertIn(error_field, content['field_errors'])
+                assert error_field in content['field_errors']
         return content
 
     def test_user_not_authenticated(self):
         self.client.logout()
         response = self.client.get(self.url, {'course_id': str(self.course.id)})
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_user_not_authorized(self):
         self.client.login(username=self.student1.username, password='edx')
         response = self.client.get(self.url, {'course_id': str(self.course.id)})
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
 
     @ddt.data(
         ({'course_id': '1'}, ['course_id', ]),
@@ -1736,7 +1730,7 @@ class CourseEnrollmentsApiListTest(APITestCase, ModuleStoreTestCase):
     def test_non_existent_course_user(self, query_params):
         self._login_as_staff()
         content = self._assert_list_of_enrollments(query_params, status.HTTP_200_OK)
-        self.assertEqual(len(content['results']), 0)
+        assert len(content['results']) == 0
 
     @ddt.file_data('fixtures/course-enrollments-api-list-valid-data.json')
     @ddt.unpack


### PR DESCRIPTION
## Description
This PR is using `codemod-unittest-to-pytest-asserts` to automatically replace `unittest` assertions with `pytest` 
for following apps  in `openedx/core/djangoapps/` 
```
credit, dark_lang, debug, demographics, discussions, django_comment_common, embargo, enrollments
```
Relevant JIRA issue here: https://openedx.atlassian.net/browse/BOM-2398