### PR TITLE
replaced unittest assertions pytest assertions (29)

### DIFF
--- a/openedx/core/djangoapps/schedules/management/commands/tests/test_send_course_update.py
+++ b/openedx/core/djangoapps/schedules/management/commands/tests/test_send_course_update.py
@@ -72,7 +72,7 @@ class TestSendCourseUpdate(ScheduleUpsellTestMixin, ScheduleSendEmailTestMixin, 
             ItemFactory.create(parent=course, category='chapter', highlights=[u'highlights'])
 
         enrollment = CourseEnrollmentFactory(course_id=course.id, user=self.user, mode=u'audit')
-        self.assertEqual(enrollment.schedule.get_experience_type(), ScheduleExperience.EXPERIENCES.course_updates)
+        assert enrollment.schedule.get_experience_type() == ScheduleExperience.EXPERIENCES.course_updates
 
         _, offset, target_day, _ = self._get_dates(offset=self.expected_offsets[0])
         enrollment.schedule.start_date = target_day
@@ -109,7 +109,7 @@ class TestSendCourseUpdate(ScheduleUpsellTestMixin, ScheduleSendEmailTestMixin, 
                 bin_num=self._calculate_bin_for_user(enrollment.user),
             ))
 
-            self.assertTrue(mock_ace.send.called)
+            assert mock_ace.send.called
 
     @override_waffle_flag(COURSE_UPDATE_WAFFLE_FLAG, True)
     @patch('openedx.core.djangoapps.schedules.signals.get_current_site')
@@ -126,4 +126,4 @@ class TestSendCourseUpdate(ScheduleUpsellTestMixin, ScheduleSendEmailTestMixin, 
             day_offset=offset,
             bin_num=self._calculate_bin_for_user(enrollment.user),
         ))
-        self.assertEqual(u'{} Weekly Update'.format(enrollment.course.display_name), mail.outbox[0].subject)
+        assert u'{} Weekly Update'.format(enrollment.course.display_name) == mail.outbox[0].subject

--- a/openedx/core/djangoapps/schedules/management/commands/tests/test_send_email_base_command.py
+++ b/openedx/core/djangoapps/schedules/management/commands/tests/test_send_email_base_command.py
@@ -39,7 +39,7 @@ class TestSendEmailBaseCommand(CacheIsolationTestCase):  # lint-amnesty, pylint:
     def test_weeks_option(self):
         with patch.object(self.command, 'enqueue') as enqueue:
             self.command.handle(site_domain_name=self.site.domain, date='2017-09-29', weeks=12)
-            self.assertEqual(enqueue.call_count, 12)
+            assert enqueue.call_count == 12
 
     def test_send_emails(self):
         with patch.multiple(
@@ -50,8 +50,8 @@ class TestSendEmailBaseCommand(CacheIsolationTestCase):  # lint-amnesty, pylint:
             arg = Mock(name='arg')
             kwarg = Mock(name='kwarg')
             self.command.send_emails(arg, kwarg=kwarg)
-            self.assertFalse(arg.called)
-            self.assertFalse(kwarg.called)
+            assert not arg.called
+            assert not kwarg.called
 
             for offset in self.command.offsets:
                 self.command.enqueue.assert_any_call(offset, arg, kwarg=kwarg)  # lint-amnesty, pylint: disable=no-member

--- a/openedx/core/djangoapps/schedules/management/commands/tests/test_send_upgrade_reminder.py
+++ b/openedx/core/djangoapps/schedules/management/commands/tests/test_send_upgrade_reminder.py
@@ -60,7 +60,7 @@ class TestUpgradeReminder(ScheduleSendEmailTestMixin, CacheIsolationTestCase):  
             bin_num=self._calculate_bin_for_user(schedule.enrollment.user),
         ))
 
-        self.assertEqual(mock_ace.send.called, not is_verified)
+        assert mock_ace.send.called == (not is_verified)
 
     def test_filter_out_verified_schedules(self):
         current_day, offset, target_day, upgrade_deadline = self._get_dates()  # lint-amnesty, pylint: disable=unused-variable
@@ -85,7 +85,7 @@ class TestUpgradeReminder(ScheduleSendEmailTestMixin, CacheIsolationTestCase):  
             ))
 
             messages = [Message.from_string(m) for m in sent_messages]
-            self.assertEqual(len(messages), 1)
+            assert len(messages) == 1
             message = messages[0]
             six.assertCountEqual(
                 self,
@@ -103,7 +103,7 @@ class TestUpgradeReminder(ScheduleSendEmailTestMixin, CacheIsolationTestCase):  
             site_id=self.site_config.site.id, target_day_str=serialize(target_day), day_offset=offset,
             bin_num=self._calculate_bin_for_user(schedule.enrollment.user),
         ))
-        self.assertEqual(mock_ace.send.called, False)
+        assert mock_ace.send.called is False
 
     @ddt.data(
         ExperienceTest(experience=ScheduleExperience.EXPERIENCES.default, offset=expected_offsets[0], email_sent=True),

--- a/openedx/core/djangoapps/schedules/management/commands/tests/upsell_base.py
+++ b/openedx/core/djangoapps/schedules/management/commands/tests/upsell_base.py
@@ -49,7 +49,7 @@ class ScheduleUpsellTestMixin(object):  # lint-amnesty, pylint: disable=missing-
                 site_id=self.site_config.site.id, target_day_str=serialize(target_day), day_offset=offset,
                 bin_num=self._calculate_bin_for_user(schedule.enrollment.user),
             ))
-        self.assertEqual(len(sent_messages), 1)
+        assert len(sent_messages) == 1
         return Message.from_string(sent_messages[0])
 
     def _contains_upsell(self, message):
@@ -83,7 +83,7 @@ class ScheduleUpsellTestMixin(object):  # lint-amnesty, pylint: disable=missing-
 
         found_upsell = self._contains_upsell(message)
         expect_upsell = enable_config and testcase.expect_upsell
-        self.assertEqual(found_upsell, expect_upsell)
+        assert found_upsell == expect_upsell
 
     @ddt.data('es', 'es-es', 'es-419')
     def test_upsell_translated(self, course_language):
@@ -96,7 +96,4 @@ class ScheduleUpsellTestMixin(object):  # lint-amnesty, pylint: disable=missing-
             mock_course_language.return_value = course_language
             message = self._send_message_task(schedule, offset, target_day)
 
-        self.assertEqual(
-            message.context['user_schedule_upgrade_deadline_time'],
-            u'8 de agosto de 2017',
-        )
+        assert message.context['user_schedule_upgrade_deadline_time'] == u'8 de agosto de 2017'

--- a/openedx/core/djangoapps/schedules/tests/test_resolvers.py
+++ b/openedx/core/djangoapps/schedules/tests/test_resolvers.py
@@ -65,7 +65,7 @@ class TestBinnedSchedulesBaseResolver(SchedulesResolverTestMixin, TestCase):
         self.site_config.save()
         mock_query = Mock()
         result = self.resolver.filter_by_org(mock_query)
-        self.assertEqual(result, mock_query.filter.return_value)
+        assert result == mock_query.filter.return_value
         mock_query.filter.assert_called_once_with(enrollment__course__org=course_org_filter)
 
     @ddt.unpack
@@ -77,7 +77,7 @@ class TestBinnedSchedulesBaseResolver(SchedulesResolverTestMixin, TestCase):
         self.site_config.save()
         mock_query = Mock()
         result = self.resolver.filter_by_org(mock_query)
-        self.assertEqual(result, mock_query.filter.return_value)
+        assert result == mock_query.filter.return_value
         mock_query.filter.assert_called_once_with(enrollment__course__org__in=expected_org_list)
 
     @ddt.unpack
@@ -93,7 +93,7 @@ class TestBinnedSchedulesBaseResolver(SchedulesResolverTestMixin, TestCase):
         mock_query = Mock()
         result = self.resolver.filter_by_org(mock_query)
         mock_query.exclude.assert_called_once_with(enrollment__course__org__in=expected_org_list)
-        self.assertEqual(result, mock_query.exclude.return_value)
+        assert result == mock_query.exclude.return_value
 
 
 @skip_unless_lms
@@ -147,14 +147,14 @@ class TestCourseUpdateResolver(SchedulesResolverTestMixin, ModuleStoreTestCase):
             'week_highlights': ['good stuff'],
             'week_num': 1,
         }
-        self.assertEqual(schedules, [(self.user, None, expected_context)])
+        assert schedules == [(self.user, None, expected_context)]
 
     @override_waffle_flag(COURSE_UPDATE_WAFFLE_FLAG, True)
     @override_switch('schedules.course_update_show_unsubscribe', True)
     def test_schedule_context_show_unsubscribe(self):
         resolver = self.create_resolver()
         schedules = list(resolver.schedules_for_bin())
-        self.assertIn('optout', schedules[0][2]['unsubscribe_url'])
+        assert 'optout' in schedules[0][2]['unsubscribe_url']
 
     @override_waffle_flag(COURSE_UPDATE_WAFFLE_FLAG, True)
     def test_get_schedules_with_target_date_by_bin_and_orgs_filter_inactive_users(self):
@@ -162,11 +162,11 @@ class TestCourseUpdateResolver(SchedulesResolverTestMixin, ModuleStoreTestCase):
         resolver = self.create_resolver()
         schedules = resolver.get_schedules_with_target_date_by_bin_and_orgs()
 
-        self.assertEqual(schedules.count(), 1)
+        assert schedules.count() == 1
         self.user.is_active = False
         self.user.save()
         schedules = resolver.get_schedules_with_target_date_by_bin_and_orgs()
-        self.assertEqual(schedules.count(), 0)
+        assert schedules.count() == 0
 
 
 @skip_unless_lms
@@ -240,14 +240,14 @@ class TestCourseNextSectionUpdateResolver(SchedulesResolverTestMixin, ModuleStor
             'week_highlights': ['good stuff 2'],
             'week_num': 2,
         }
-        self.assertEqual(schedules, [(self.user, None, expected_context)])
+        assert schedules == [(self.user, None, expected_context)]
 
     @override_waffle_flag(COURSE_UPDATE_WAFFLE_FLAG, True)
     @override_switch('schedules.course_update_show_unsubscribe', True)
     def test_schedule_context_show_unsubscribe(self):
         resolver = self.create_resolver()
         schedules = list(resolver.get_schedules())
-        self.assertIn('optout', schedules[0][2]['unsubscribe_url'])
+        assert 'optout' in schedules[0][2]['unsubscribe_url']
 
     @override_waffle_flag(COURSE_UPDATE_WAFFLE_FLAG, True)
     def test_schedule_context_error(self):

--- a/openedx/core/djangoapps/schedules/tests/test_signals.py
+++ b/openedx/core/djangoapps/schedules/tests/test_signals.py
@@ -255,7 +255,8 @@ class ResetScheduleTests(SharedModuleStoreTestCase):  # lint-amnesty, pylint: di
         CourseEnrollment.enroll(self.user, self.course.id, mode=CourseMode.VERIFIED)
 
         self.schedule.refresh_from_db()
-        self.assertGreater(self.schedule.start_date, original_start)  # should have been reset to current time
+        assert self.schedule.start_date > original_start
+        # should have been reset to current time
 
     def test_schedule_is_reset_to_availability_date(self):
         """ Test that a switch to audit enrollment resets to the availability date, not current time. """
@@ -264,14 +265,14 @@ class ResetScheduleTests(SharedModuleStoreTestCase):  # lint-amnesty, pylint: di
         # Switch to verified, confirm we change start date
         CourseEnrollment.enroll(self.user, self.course.id, mode=CourseMode.VERIFIED)
         self.schedule.refresh_from_db()
-        self.assertNotEqual(self.schedule.start_date, original_start)
+        assert self.schedule.start_date != original_start
 
         CourseEnrollment.unenroll(self.user, self.course.id)
 
         # Switch back to audit, confirm we change back to original availability date
         CourseEnrollment.enroll(self.user, self.course.id, mode=CourseMode.AUDIT)
         self.schedule.refresh_from_db()
-        self.assertEqual(self.schedule.start_date, original_start)
+        assert self.schedule.start_date == original_start
 
 
 def _create_course_run(self_paced=True, start_day_offset=-1):

--- a/openedx/core/djangoapps/schedules/tests/test_utils.py
+++ b/openedx/core/djangoapps/schedules/tests/test_utils.py
@@ -52,7 +52,7 @@ class ResetSelfPacedScheduleTests(SharedModuleStoreTestCase):  # lint-amnesty, p
             reset_self_paced_schedule(self.user, self.course.id, use_availability_date=False)
 
         self.schedule.refresh_from_db()
-        self.assertGreater(self.schedule.start_date, original_start)
+        assert self.schedule.start_date > original_start
 
     @ddt.data(
         (-1, 0),  # enrolled before course started (will reset to start date)
@@ -67,7 +67,7 @@ class ResetSelfPacedScheduleTests(SharedModuleStoreTestCase):  # lint-amnesty, p
             reset_self_paced_schedule(self.user, self.course.id, use_availability_date=True)
 
         self.schedule.refresh_from_db()
-        self.assertEqual(self.schedule.start_date.replace(microsecond=0), expected_start.replace(microsecond=0))
+        assert self.schedule.start_date.replace(microsecond=0) == expected_start.replace(microsecond=0)
 
     def test_safe_without_schedule(self):
         """ Just ensure that we don't raise exceptions or create any schedules """
@@ -77,4 +77,4 @@ class ResetSelfPacedScheduleTests(SharedModuleStoreTestCase):  # lint-amnesty, p
         reset_self_paced_schedule(self.user, self.course.id, use_availability_date=False)
         reset_self_paced_schedule(self.user, self.course.id, use_availability_date=True)
 
-        self.assertEqual(Schedule.objects.count(), 0)
+        assert Schedule.objects.count() == 0

--- a/openedx/core/djangoapps/service_status/test.py
+++ b/openedx/core/djangoapps/service_status/test.py
@@ -33,20 +33,20 @@ class CeleryConfigTest(unittest.TestCase):
         response = self.client.get(self.ping_url)
 
         # HTTP response should be successful
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
         # Expect to get a JSON-serialized dict with
         # task and time information
         result_dict = json.loads(response.content.decode('utf-8'))
 
         # Was it successful?
-        self.assertTrue(result_dict['success'])
+        assert result_dict['success']
 
         # We should get a "pong" message back
-        self.assertEqual(result_dict['value'], "pong")
+        assert result_dict['value'] == 'pong'
 
         # We don't know the other dict values exactly,
         # but we can assert that they take the right form
-        self.assertIsInstance(result_dict['task_id'], six.text_type)
-        self.assertIsInstance(result_dict['time'], float)
-        self.assertGreater(result_dict['time'], 0.0)
+        assert isinstance(result_dict['task_id'], six.text_type)
+        assert isinstance(result_dict['time'], float)
+        assert result_dict['time'] > 0.0

--- a/openedx/core/djangoapps/site_configuration/management/commands/tests/test_create_or_update_site_configuration.py
+++ b/openedx/core/djangoapps/site_configuration/management/commands/tests/test_create_or_update_site_configuration.py
@@ -4,7 +4,7 @@ Tests for the create_or_update_site_configuration management command.
 
 import codecs
 import json
-
+import pytest
 import ddt
 from django.contrib.sites.models import Site
 from django.core.management import call_command, CommandError
@@ -43,7 +43,7 @@ class CreateOrUpdateSiteConfigurationTest(TestCase):
         """
         Assert that the site configuration for the fixture site does not exist.
         """
-        with self.assertRaises(SiteConfiguration.DoesNotExist):
+        with pytest.raises(SiteConfiguration.DoesNotExist):
             SiteConfiguration.objects.get(site=self.site)
 
     def get_site_configuration(self):
@@ -62,16 +62,16 @@ class CreateOrUpdateSiteConfigurationTest(TestCase):
         """
         Verify the error on the command with no arguments.
         """
-        with self.assertRaises(CommandError) as error:
+        with pytest.raises(CommandError) as error:
             call_command(self.command)
-        self.assertIn('Error: one of the arguments --site-id domain is required', str(error.exception))
+        assert 'Error: one of the arguments --site-id domain is required' in str(error.value)
 
     def test_site_created_when_site_id_non_existent(self):
         """
         Verify that a new site is created  when given a site ID that doesn't exist.
         """
         non_existent_site_id = 999
-        with self.assertRaises(Site.DoesNotExist):
+        with pytest.raises(Site.DoesNotExist):
             Site.objects.get(id=non_existent_site_id)
 
         call_command(self.command, '--site-id', non_existent_site_id)
@@ -82,7 +82,7 @@ class CreateOrUpdateSiteConfigurationTest(TestCase):
         Verify that a new site is created when given a domain name that does not have an existing site..
         """
         domain = 'nonexistent.com'
-        with self.assertRaises(Site.DoesNotExist):
+        with pytest.raises(Site.DoesNotExist):
             Site.objects.get(domain=domain)
         call_command(self.command, domain)
         Site.objects.get(domain=domain)
@@ -91,10 +91,10 @@ class CreateOrUpdateSiteConfigurationTest(TestCase):
         """
         Verify that an error is thrown when both site_id and the domain name are provided.
         """
-        with self.assertRaises(CommandError) as error:
+        with pytest.raises(CommandError) as error:
             call_command(self.command, 'domain.com', '--site-id', '1')
 
-        self.assertIn('not allowed with argument', str(error.exception))
+        assert 'not allowed with argument' in str(error.value)
 
     def test_site_configuration_created_when_non_existent(self):
         """
@@ -104,16 +104,16 @@ class CreateOrUpdateSiteConfigurationTest(TestCase):
 
         call_command(self.command, *self.site_id_arg)
         site_configuration = SiteConfiguration.objects.get(site=self.site)
-        self.assertFalse(site_configuration.site_values)
-        self.assertFalse(site_configuration.enabled)
+        assert not site_configuration.site_values
+        assert not site_configuration.enabled
 
     def test_both_enabled_disabled_flags(self):
         """
         Verify the error on providing both the --enabled and --disabled flags.
         """
-        with self.assertRaises(CommandError) as error:
+        with pytest.raises(CommandError) as error:
             call_command(self.command, '--enabled', '--disabled', *self.site_id_arg)
-        self.assertIn('argument --disabled: not allowed with argument --enabled', str(error.exception))
+        assert 'argument --disabled: not allowed with argument --enabled' in str(error.value)
 
     @ddt.data(('enabled', True),
               ('disabled', False))
@@ -125,8 +125,8 @@ class CreateOrUpdateSiteConfigurationTest(TestCase):
         self.assert_site_configuration_does_not_exist()
         call_command(self.command, '--{}'.format(flag), *self.site_id_arg)
         site_configuration = SiteConfiguration.objects.get(site=self.site)
-        self.assertFalse(site_configuration.site_values)
-        self.assertEqual(enabled, site_configuration.enabled)
+        assert not site_configuration.site_values
+        assert enabled == site_configuration.enabled
 
     def test_site_configuration_created_with_parameters(self):
         """
@@ -144,7 +144,7 @@ class CreateOrUpdateSiteConfigurationTest(TestCase):
         self.assert_site_configuration_does_not_exist()
         call_command(self.command, '-f', str(self.json_file_path.abspath()), *self.site_id_arg)
         site_configuration = self.get_site_configuration()
-        self.assertEqual(site_configuration.site_values, {'ABC': 123, 'XYZ': '789'})
+        assert site_configuration.site_values == {'ABC': 123, 'XYZ': '789'}
 
     @ddt.data(True, False)
     def test_site_configuration_updated_with_parameters(self, enabled):
@@ -154,11 +154,9 @@ class CreateOrUpdateSiteConfigurationTest(TestCase):
         self.create_fixture_site_configuration(enabled)
         call_command(self.command, '--configuration', json.dumps(self.input_configuration), *self.site_id_arg)
         site_configuration = self.get_site_configuration()
-        self.assertEqual(
-            site_configuration.site_values,
-            {'ABC': 123, 'B': 'b', 'FEATURE_FLAG': True, 'SERVICE_URL': 'https://foo.bar'}
-        )
-        self.assertEqual(site_configuration.enabled, enabled)
+        assert site_configuration.site_values ==\
+               {'ABC': 123, 'B': 'b', 'FEATURE_FLAG': True, 'SERVICE_URL': 'https://foo.bar'}
+        assert site_configuration.enabled == enabled
 
     @ddt.data(True, False)
     def test_site_configuration_updated_from_json_file(self, enabled):
@@ -171,5 +169,5 @@ class CreateOrUpdateSiteConfigurationTest(TestCase):
         expected_site_configuration = {'ABC': 'abc', 'B': 'b'}
         with codecs.open(self.json_file_path, encoding='utf-8') as f:
             expected_site_configuration.update(json.load(f))
-        self.assertEqual(site_configuration.site_values, expected_site_configuration)
-        self.assertEqual(site_configuration.enabled, enabled)
+        assert site_configuration.site_values == expected_site_configuration
+        assert site_configuration.enabled == enabled

--- a/openedx/core/djangoapps/site_configuration/tests/test_context_processors.py
+++ b/openedx/core/djangoapps/site_configuration/tests/test_context_processors.py
@@ -27,7 +27,7 @@ class ContextProcessorTests(TestCase):
         request = RequestFactory().get('/')
         context = configuration_context(request)
 
-        self.assertEqual(context['platform_name'], PLATFORM_NAME)
+        assert context['platform_name'] == PLATFORM_NAME
 
     @with_site_configuration(configuration={"platform_name": "Testing Configuration Platform Name"})
     def test_configuration_platform_name(self):
@@ -36,4 +36,4 @@ class ContextProcessorTests(TestCase):
         """
         request = RequestFactory().get('/')
         context = configuration_context(request)
-        self.assertEqual(context['platform_name'], "Testing Configuration Platform Name")
+        assert context['platform_name'] == 'Testing Configuration Platform Name'

--- a/openedx/core/djangoapps/site_configuration/tests/test_helpers.py
+++ b/openedx/core/djangoapps/site_configuration/tests/test_helpers.py
@@ -54,27 +54,19 @@ class TestHelpers(TestCase):
         Test that get_value returns correct value for any given key.
         """
         # Make sure entry is saved and retrieved correctly
-        self.assertEqual(configuration_helpers.get_value("university"), test_config['university'])
-        self.assertEqual(configuration_helpers.get_value("platform_name"), test_config['platform_name'])
-        self.assertEqual(configuration_helpers.get_value("SITE_NAME"), test_config['SITE_NAME'])
-        self.assertEqual(configuration_helpers.get_value("course_org_filter"), test_config['course_org_filter'])
-        self.assertEqual(configuration_helpers.get_value("css_overrides_file"), test_config['css_overrides_file'])
-        self.assertEqual(configuration_helpers.get_value("ENABLE_MKTG_SITE"), test_config['ENABLE_MKTG_SITE'])
-        self.assertEqual(configuration_helpers.get_value("favicon_path"), test_config['favicon_path'])
-        self.assertEqual(
-            configuration_helpers.get_value("ENABLE_THIRD_PARTY_AUTH"),
-            test_config['ENABLE_THIRD_PARTY_AUTH'],
-        )
-        self.assertEqual(
-            configuration_helpers.get_value("course_about_show_social_links"),
-            test_config['course_about_show_social_links'],
-        )
+        assert configuration_helpers.get_value('university') == test_config['university']
+        assert configuration_helpers.get_value('platform_name') == test_config['platform_name']
+        assert configuration_helpers.get_value('SITE_NAME') == test_config['SITE_NAME']
+        assert configuration_helpers.get_value('course_org_filter') == test_config['course_org_filter']
+        assert configuration_helpers.get_value('css_overrides_file') == test_config['css_overrides_file']
+        assert configuration_helpers.get_value('ENABLE_MKTG_SITE') == test_config['ENABLE_MKTG_SITE']
+        assert configuration_helpers.get_value('favicon_path') == test_config['favicon_path']
+        assert configuration_helpers.get_value('ENABLE_THIRD_PARTY_AUTH') == test_config['ENABLE_THIRD_PARTY_AUTH']
+        assert configuration_helpers.get_value('course_about_show_social_links') ==\
+               test_config['course_about_show_social_links']
 
         # Test that the default value is returned if the value for the given key is not found in the configuration
-        self.assertEqual(
-            configuration_helpers.get_value("non_existent_name", "dummy-default-value"),
-            "dummy-default-value",
-        )
+        assert configuration_helpers.get_value('non_existent_name', 'dummy-default-value') == 'dummy-default-value'
 
     @with_site_configuration(configuration=test_config)
     def test_get_dict(self):
@@ -105,22 +97,22 @@ class TestHelpers(TestCase):
         Test that has_override_value returns correct value for any given key.
         """
 
-        self.assertTrue(configuration_helpers.has_override_value("university"))
-        self.assertTrue(configuration_helpers.has_override_value("platform_name"))
-        self.assertTrue(configuration_helpers.has_override_value("ENABLE_MKTG_SITE"))
-        self.assertTrue(configuration_helpers.has_override_value("REGISTRATION_EXTRA_FIELDS"))
+        assert configuration_helpers.has_override_value('university')
+        assert configuration_helpers.has_override_value('platform_name')
+        assert configuration_helpers.has_override_value('ENABLE_MKTG_SITE')
+        assert configuration_helpers.has_override_value('REGISTRATION_EXTRA_FIELDS')
 
-        self.assertFalse(configuration_helpers.has_override_value("non_existent_key"))
+        assert not configuration_helpers.has_override_value('non_existent_key')
 
     def test_is_site_configuration_enabled(self):
         """
         Test that is_site_configuration_enabled returns True when configuration is enabled.
         """
         with with_site_configuration_context(configuration=test_config):
-            self.assertTrue(configuration_helpers.is_site_configuration_enabled())
+            assert configuration_helpers.is_site_configuration_enabled()
 
         # Test without a Site Configuration
-        self.assertFalse(configuration_helpers.is_site_configuration_enabled())
+        assert not configuration_helpers.is_site_configuration_enabled()
 
     def test_get_value_for_org(self):
         """
@@ -128,14 +120,9 @@ class TestHelpers(TestCase):
         """
         test_org = test_config['course_org_filter']
         with with_site_configuration_context(configuration=test_config):
-            self.assertEqual(
-                configuration_helpers.get_value_for_org(test_org, "university"),
-                test_config['university']
-            )
-            self.assertEqual(
-                configuration_helpers.get_value_for_org(test_org, "css_overrides_file"),
-                test_config['css_overrides_file']
-            )
+            assert configuration_helpers.get_value_for_org(test_org, 'university') == test_config['university']
+            assert configuration_helpers.get_value_for_org(test_org, 'css_overrides_file') ==\
+                   test_config['css_overrides_file']
 
             six.assertCountEqual(
                 self,
@@ -144,18 +131,11 @@ class TestHelpers(TestCase):
             )
 
             # Test default value of key is not present in configuration
-            self.assertEqual(
-                configuration_helpers.get_value_for_org(test_org, "non_existent_key"),
-                None
-            )
-            self.assertEqual(
-                configuration_helpers.get_value_for_org(test_org, "non_existent_key", "default for non existent"),
-                "default for non existent"
-            )
-            self.assertEqual(
-                configuration_helpers.get_value_for_org("missing_org", "university", "default for non existent"),
-                "default for non existent"
-            )
+            assert configuration_helpers.get_value_for_org(test_org, 'non_existent_key') is None
+            assert configuration_helpers.get_value_for_org(test_org, 'non_existent_key', 'default for non existent') ==\
+                   'default for non existent'
+            assert configuration_helpers.get_value_for_org('missing_org', 'university', 'default for non existent') ==\
+                   'default for non existent'
 
     def test_get_value_for_org_2(self):
         """
@@ -165,15 +145,9 @@ class TestHelpers(TestCase):
         with with_site_configuration_context(configuration=test_config):
 
             # Make sure if ORG is not present in site configuration then default is used instead
-            self.assertEqual(
-                configuration_helpers.get_value_for_org("TestSiteX", "email_from_address"),
-                None
-            )
+            assert configuration_helpers.get_value_for_org('TestSiteX', 'email_from_address') is None
             # Make sure 'default' is returned if org is present but key is not
-            self.assertEqual(
-                configuration_helpers.get_value_for_org(test_org, "email_from_address"),
-                None
-            )
+            assert configuration_helpers.get_value_for_org(test_org, 'email_from_address') is None
 
     def test_get_all_orgs(self):
         """

--- a/openedx/core/djangoapps/site_configuration/tests/test_middleware.py
+++ b/openedx/core/djangoapps/site_configuration/tests/test_middleware.py
@@ -48,8 +48,8 @@ class SessionCookieDomainTests(TestCase):
         Test sessionid cookie when no override is set
         """
         response = self.client.get('/')
-        self.assertNotIn('test_site.localhost', str(response.cookies['sessionid']))
-        self.assertNotIn('Domain', str(response.cookies['sessionid']))
+        assert 'test_site.localhost' not in str(response.cookies['sessionid'])
+        assert 'Domain' not in str(response.cookies['sessionid'])
 
 
 # NOTE: We set SESSION_SAVE_EVERY_REQUEST to True in order to make sure
@@ -85,4 +85,4 @@ class SessionCookieDomainSiteConfigurationOverrideTests(TestCase):
         Makes sure that the cookie being set is for the overridden domain
         """
         response = self.client.get('/', HTTP_HOST=self.site.domain)
-        self.assertIn(self.site.domain, str(response.cookies['sessionid']))
+        assert self.site.domain in str(response.cookies['sessionid'])

--- a/openedx/core/djangoapps/site_configuration/tests/test_models.py
+++ b/openedx/core/djangoapps/site_configuration/tests/test_models.py
@@ -2,7 +2,7 @@
 Tests for site configuration's django models.
 """
 import six
-
+import pytest
 from django.contrib.sites.models import Site
 from django.db import IntegrityError, transaction
 from django.test import TestCase
@@ -71,7 +71,7 @@ class SiteConfigurationTests(TestCase):
         ).all()
 
         # Make sure an entry (and only one entry) is saved for SiteConfiguration
-        self.assertEqual(len(site_configuration_history), 1)
+        assert len(site_configuration_history) == 1
 
     def test_site_configuration_post_update_receiver(self):
         """
@@ -92,7 +92,7 @@ class SiteConfigurationTests(TestCase):
         ).all()
 
         # Make sure two entries (one for create and one for update) are saved for SiteConfiguration
-        self.assertEqual(len(site_configuration_history), 2)
+        assert len(site_configuration_history) == 2
 
     def test_site_configuration_post_update_receiver_with_skip(self):
         """
@@ -109,14 +109,14 @@ class SiteConfigurationTests(TestCase):
         save_siteconfig_without_historical_record(site_configuration)  # Instead of .save().
 
         # Verify that the SiteConfiguration has been updated.
-        self.assertEqual(site_configuration.get_value("test"), "test")
+        assert site_configuration.get_value('test') == 'test'
 
         # Verify an entry to SiteConfigurationHistory was NOT added.
         # Make sure one entry (one for create and NONE for update) is saved for SiteConfiguration.
         site_configuration_history = SiteConfigurationHistory.objects.filter(
             site=site_configuration.site,
         ).all()
-        self.assertEqual(len(site_configuration_history), 1)
+        assert len(site_configuration_history) == 1
 
     def test_no_entry_is_saved_for_errors(self):
         """
@@ -134,10 +134,10 @@ class SiteConfigurationTests(TestCase):
         ).all()
 
         # Make sure entry is saved if there is no error
-        self.assertEqual(len(site_configuration_history), 1)
+        assert len(site_configuration_history) == 1
 
         with transaction.atomic():
-            with self.assertRaises(IntegrityError):
+            with pytest.raises(IntegrityError):
                 # try to add a duplicate entry
                 site_configuration = SiteConfigurationFactory.create(
                     site=self.site,
@@ -147,7 +147,7 @@ class SiteConfigurationTests(TestCase):
         ).all()
 
         # Make sure no entry is saved if there an error
-        self.assertEqual(len(site_configuration_history), 1)
+        assert len(site_configuration_history) == 1
 
     def test_get_value(self):
         """
@@ -160,38 +160,27 @@ class SiteConfigurationTests(TestCase):
         )
 
         # Make sure entry is saved and retrieved correctly
-        self.assertEqual(site_configuration.get_value("university"), self.test_config1['university'])
-        self.assertEqual(site_configuration.get_value("platform_name"), self.test_config1['platform_name'])
-        self.assertEqual(site_configuration.get_value("SITE_NAME"), self.test_config1['SITE_NAME'])
-        self.assertEqual(site_configuration.get_value("course_org_filter"), self.test_config1['course_org_filter'])
-        self.assertEqual(site_configuration.get_value("css_overrides_file"), self.test_config1['css_overrides_file'])
-        self.assertEqual(site_configuration.get_value("ENABLE_MKTG_SITE"), self.test_config1['ENABLE_MKTG_SITE'])
-        self.assertEqual(site_configuration.get_value("favicon_path"), self.test_config1['favicon_path'])
-        self.assertEqual(
-            site_configuration.get_value("ENABLE_THIRD_PARTY_AUTH"),
-            self.test_config1['ENABLE_THIRD_PARTY_AUTH'],
-        )
-        self.assertEqual(
-            site_configuration.get_value("course_about_show_social_links"),
-            self.test_config1['course_about_show_social_links'],
-        )
+        assert site_configuration.get_value('university') == self.test_config1['university']
+        assert site_configuration.get_value('platform_name') == self.test_config1['platform_name']
+        assert site_configuration.get_value('SITE_NAME') == self.test_config1['SITE_NAME']
+        assert site_configuration.get_value('course_org_filter') == self.test_config1['course_org_filter']
+        assert site_configuration.get_value('css_overrides_file') == self.test_config1['css_overrides_file']
+        assert site_configuration.get_value('ENABLE_MKTG_SITE') == self.test_config1['ENABLE_MKTG_SITE']
+        assert site_configuration.get_value('favicon_path') == self.test_config1['favicon_path']
+        assert site_configuration.get_value('ENABLE_THIRD_PARTY_AUTH') == self.test_config1['ENABLE_THIRD_PARTY_AUTH']
+        assert site_configuration.get_value('course_about_show_social_links') == \
+               self.test_config1['course_about_show_social_links']
 
         # Test that the default value is returned if the value for the given key is not found in the configuration
-        self.assertEqual(
-            site_configuration.get_value("non_existent_name", "dummy-default-value"),
-            "dummy-default-value",
-        )
+        assert site_configuration.get_value('non_existent_name', 'dummy-default-value') == 'dummy-default-value'
 
         # Test that the default value is returned if Site configuration is not enabled
         site_configuration.enabled = False
         site_configuration.save()
 
-        self.assertEqual(site_configuration.get_value("university"), None)
-        self.assertEqual(
-            site_configuration.get_value("platform_name", "Default Platform Name"),
-            "Default Platform Name",
-        )
-        self.assertEqual(site_configuration.get_value("SITE_NAME", "Default Site Name"), "Default Site Name")
+        assert site_configuration.get_value('university') is None
+        assert site_configuration.get_value('platform_name', 'Default Platform Name') == 'Default Platform Name'
+        assert site_configuration.get_value('SITE_NAME', 'Default Site Name') == 'Default Site Name'
 
     def test_invalid_data_error_on_get_value(self):
         """
@@ -209,14 +198,14 @@ class SiteConfigurationTests(TestCase):
 
         # make sure get_value logs an error for invalid json data
         with patch.object(logger, "exception") as mock_logger:
-            self.assertEqual(site_configuration.get_value("university"), None)
-            self.assertTrue(mock_logger.called)
+            assert site_configuration.get_value('university') is None
+            assert mock_logger.called
 
         # make sure get_value returns default_value for invalid json data
         with patch.object(logger, "exception") as mock_logger:
             value = site_configuration.get_value("platform_name", "Default Platform Name")
-            self.assertTrue(mock_logger.called)
-            self.assertEqual(value, "Default Platform Name")
+            assert mock_logger.called
+            assert value == 'Default Platform Name'
 
     def test_get_value_for_org(self):
         """
@@ -233,75 +222,48 @@ class SiteConfigurationTests(TestCase):
         )
 
         # Make sure entry is saved and retrieved correctly
-        self.assertEqual(
-            SiteConfiguration.get_value_for_org(self.test_config1['course_org_filter'], "university"),
-            self.test_config1['university'],
-        )
-        self.assertEqual(
-            SiteConfiguration.get_value_for_org(self.test_config1['course_org_filter'], "platform_name"),
-            self.test_config1['platform_name'],
-        )
-        self.assertEqual(
-            SiteConfiguration.get_value_for_org(self.test_config1['course_org_filter'], "SITE_NAME"),
-            self.test_config1['SITE_NAME'],
-        )
-        self.assertEqual(
-            SiteConfiguration.get_value_for_org(self.test_config1['course_org_filter'], "css_overrides_file"),
-            self.test_config1['css_overrides_file'],
-        )
-        self.assertEqual(
-            SiteConfiguration.get_value_for_org(self.test_config1['course_org_filter'], "ENABLE_MKTG_SITE"),
-            self.test_config1['ENABLE_MKTG_SITE'],
-        )
+        assert SiteConfiguration.get_value_for_org(self.test_config1['course_org_filter'], 'university') ==\
+               self.test_config1['university']
+        assert SiteConfiguration.get_value_for_org(self.test_config1['course_org_filter'], 'platform_name') ==\
+               self.test_config1['platform_name']
+        assert SiteConfiguration.get_value_for_org(self.test_config1['course_org_filter'], 'SITE_NAME') ==\
+               self.test_config1['SITE_NAME']
+        assert SiteConfiguration.get_value_for_org(self.test_config1['course_org_filter'], 'css_overrides_file') ==\
+               self.test_config1['css_overrides_file']
+        assert SiteConfiguration.get_value_for_org(self.test_config1['course_org_filter'], 'ENABLE_MKTG_SITE') ==\
+               self.test_config1['ENABLE_MKTG_SITE']
 
         # Make sure entry is saved and retrieved correctly
-        self.assertEqual(
-            SiteConfiguration.get_value_for_org(self.test_config2['course_org_filter'], "university"),
-            self.test_config2['university'],
-        )
-        self.assertEqual(
-            SiteConfiguration.get_value_for_org(self.test_config2['course_org_filter'], "platform_name"),
-            self.test_config2['platform_name'],
-        )
-        self.assertEqual(
-            SiteConfiguration.get_value_for_org(self.test_config2['course_org_filter'], "SITE_NAME"),
-            self.test_config2['SITE_NAME'],
-        )
-        self.assertEqual(
-            SiteConfiguration.get_value_for_org(self.test_config2['course_org_filter'], "css_overrides_file"),
-            self.test_config2['css_overrides_file'],
-        )
-        self.assertEqual(
-            SiteConfiguration.get_value_for_org(self.test_config2['course_org_filter'], "ENABLE_MKTG_SITE"),
-            self.test_config2['ENABLE_MKTG_SITE'],
-        )
+        assert SiteConfiguration.get_value_for_org(self.test_config2['course_org_filter'], 'university') ==\
+               self.test_config2['university']
+
+        assert SiteConfiguration.get_value_for_org(self.test_config2['course_org_filter'], 'platform_name') ==\
+               self.test_config2['platform_name']
+        assert SiteConfiguration\
+            .get_value_for_org(self.test_config2['course_org_filter'], 'SITE_NAME') == \
+               self.test_config2['SITE_NAME']
+
+        assert SiteConfiguration\
+            .get_value_for_org(self.test_config2['course_org_filter'],
+                               'css_overrides_file') == self.test_config2['css_overrides_file']
+
+        assert SiteConfiguration\
+            .get_value_for_org(self.test_config2['course_org_filter'],
+                               'ENABLE_MKTG_SITE') == self.test_config2['ENABLE_MKTG_SITE']
 
         # Test that the default value is returned if the value for the given key is not found in the configuration
-        self.assertEqual(
-            SiteConfiguration.get_value_for_org(
-                self.test_config1['course_org_filter'],
-                "non-existent",
-                "dummy-default-value"),
-            "dummy-default-value",
-        )
+        assert SiteConfiguration\
+            .get_value_for_org(self.test_config1['course_org_filter'],
+                               'non-existent', 'dummy-default-value') == 'dummy-default-value'
 
         # Test that the default value is returned if the value for the given key is not found in the configuration
-        self.assertEqual(
-            SiteConfiguration.get_value_for_org(
-                self.test_config2['course_org_filter'],
-                "non-existent",
-                "dummy-default-value"),
-            "dummy-default-value",
-        )
+        assert SiteConfiguration\
+            .get_value_for_org(self.test_config2['course_org_filter'],
+                               'non-existent', 'dummy-default-value') == 'dummy-default-value'
 
         # Test that the default value is returned if org is not found in the configuration
-        self.assertEqual(
-            SiteConfiguration.get_value_for_org(
-                "non-existent-org",
-                "platform_name",
-                "dummy-default-value"),
-            "dummy-default-value",
-        )
+        assert SiteConfiguration.get_value_for_org('non-existent-org', 'platform_name', 'dummy-default-value') ==\
+               'dummy-default-value'
 
     def test_get_site_for_org(self):
         """
@@ -318,18 +280,9 @@ class SiteConfigurationTests(TestCase):
         )
 
         # Make sure entry is saved and retrieved correctly
-        self.assertEqual(
-            SiteConfiguration.get_configuration_for_org(self.test_config1['course_org_filter']),
-            config1,
-        )
-        self.assertEqual(
-            SiteConfiguration.get_configuration_for_org(self.test_config2['course_org_filter']),
-            config2,
-        )
-        self.assertEqual(
-            SiteConfiguration.get_configuration_for_org('something else'),
-            None,
-        )
+        assert SiteConfiguration.get_configuration_for_org(self.test_config1['course_org_filter']) == config1
+        assert SiteConfiguration.get_configuration_for_org(self.test_config2['course_org_filter']) == config2
+        assert SiteConfiguration.get_configuration_for_org('something else') is None
 
     def test_get_all_orgs(self):
         """

--- a/openedx/core/djangoapps/system_wide_roles/tests/test_models.py
+++ b/openedx/core/djangoapps/system_wide_roles/tests/test_models.py
@@ -17,10 +17,10 @@ class SystemWideRoleTests(TestCase):
         self.role = SystemWideRole.objects.create(name='TestRole')
 
     def test_str(self):
-        self.assertEqual(str(self.role), '<SystemWideRole TestRole>')
+        assert str(self.role) == '<SystemWideRole TestRole>'
 
     def test_repr(self):
-        self.assertEqual(repr(self.role), '<SystemWideRole TestRole>')
+        assert repr(self.role) == '<SystemWideRole TestRole>'
 
 
 class SystemWideRoleAssignmentTests(TestCase):
@@ -33,18 +33,10 @@ class SystemWideRoleAssignmentTests(TestCase):
 
     def test_str(self):
         role_assignment = SystemWideRoleAssignment.objects.create(role=self.role, user=self.user)
-        self.assertEqual(
-            str(role_assignment),
-            '<SystemWideRoleAssignment for User {user} assigned to role {role}>'.format(
-                user=self.user.id, role=self.role.name
-            )
-        )
+        assert str(role_assignment) == \
+               f'<SystemWideRoleAssignment for User {self.user.id} assigned to role {self.role.name}>'
 
     def test_repr(self):
         role_assignment = SystemWideRoleAssignment.objects.create(role=self.role, user=self.user)
-        self.assertEqual(
-            repr(role_assignment),
-            '<SystemWideRoleAssignment for User {user} assigned to role {role}>'.format(
-                user=self.user.id, role=self.role.name
-            )
-        )
+        assert repr(role_assignment) == \
+               f'<SystemWideRoleAssignment for User {self.user.id} assigned to role {self.role.name}>'

--- a/openedx/core/djangoapps/theming/management/commands/tests/test_create_sites_and_configurations.py
+++ b/openedx/core/djangoapps/theming/management/commands/tests/test_create_sites_and_configurations.py
@@ -2,7 +2,7 @@
 Test cases for create_sites_and_configurations command.
 """
 
-
+import pytest
 import mock
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.contrib.sites.models import Site
@@ -64,15 +64,12 @@ class TestCreateSiteAndConfiguration(TestCase):
         Checks that data of all sites is valid
         """
         sites = Site.objects.filter(domain__contains=self.dns_name)
-        self.assertEqual(len(sites), len(SITES))
+        assert len(sites) == len(SITES)
         for site in sites:
             if site.name in SITES:
                 site_theme = SiteTheme.objects.get(site=site)
 
-                self.assertEqual(
-                    site_theme.theme_dir_name,
-                    "{}_dir_name".format(site.name)
-                )
+                assert site_theme.theme_dir_name == '{}_dir_name'.format(site.name)
 
                 self.assertDictEqual(
                     dict(site.configuration.values),
@@ -81,13 +78,13 @@ class TestCreateSiteAndConfiguration(TestCase):
 
     def _assert_service_user_is_valid(self, username):  # lint-amnesty, pylint: disable=missing-function-docstring
         service_user = User.objects.filter(username=username)
-        self.assertEqual(len(service_user), 1)
-        self.assertTrue(service_user[0].is_active)
-        self.assertTrue(service_user[0].is_staff)
-        self.assertTrue(service_user[0].is_superuser)
+        assert len(service_user) == 1
+        assert service_user[0].is_active
+        assert service_user[0].is_staff
+        assert service_user[0].is_superuser
 
         user_profile = UserProfile.objects.filter(user=service_user[0])
-        self.assertEqual(len(user_profile), 1)
+        assert len(user_profile) == 1
         return service_user
 
     def _assert_ecommerce_clients_are_valid(self, devstack=False):
@@ -98,7 +95,7 @@ class TestCreateSiteAndConfiguration(TestCase):
 
         clients = Application.objects.filter(user=service_user[0])
 
-        self.assertEqual(len(clients), len(SITES))
+        assert len(clients) == len(SITES)
 
         if devstack:
             ecommerce_url_fmt = u"http://ecommerce-{site_name}-{dns_name}.e2e.devstack:18130/"
@@ -106,25 +103,16 @@ class TestCreateSiteAndConfiguration(TestCase):
             ecommerce_url_fmt = u"https://ecommerce-{site_name}-{dns_name}.sandbox.edx.org/"
 
         for client in clients:
-            self.assertEqual(client.user.username, service_user[0].username)
+            assert client.user.username == service_user[0].username
             site_name = [name for name in SITES if name in client.name][0]
             ecommerce_url = ecommerce_url_fmt.format(
                 site_name=site_name,
                 dns_name=self.dns_name
             )
-            self.assertEqual(
-                client.redirect_uris,
-                "{ecommerce_url}complete/edx-oauth2/".format(ecommerce_url=ecommerce_url)
-            )
-            self.assertEqual(
-                client.client_id,
-                "ecommerce-key-{site_name}".format(site_name=site_name)
-            )
+            assert client.redirect_uris == '{ecommerce_url}complete/edx-oauth2/'.format(ecommerce_url=ecommerce_url)
+            assert client.client_id == 'ecommerce-key-{site_name}'.format(site_name=site_name)
             access = ApplicationAccess.objects.filter(application_id=client.id).first()
-            self.assertEqual(
-                access.scopes,
-                ["user_id"]
-            )
+            assert access.scopes == ['user_id']
 
     def _assert_discovery_clients_are_valid(self, devstack=False):
         """
@@ -134,7 +122,7 @@ class TestCreateSiteAndConfiguration(TestCase):
 
         clients = Application.objects.filter(user=service_user[0])
 
-        self.assertEqual(len(clients), len(SITES))
+        assert len(clients) == len(SITES)
 
         if devstack:
             discovery_url_fmt = u"http://discovery-{site_name}-{dns_name}.e2e.devstack:18381/"
@@ -142,30 +130,21 @@ class TestCreateSiteAndConfiguration(TestCase):
             discovery_url_fmt = u"https://discovery-{site_name}-{dns_name}.sandbox.edx.org/"
 
         for client in clients:
-            self.assertEqual(client.user.username, service_user[0].username)
+            assert client.user.username == service_user[0].username
             site_name = [name for name in SITES if name in client.name][0]
             discovery_url = discovery_url_fmt.format(
                 site_name=site_name,
                 dns_name=self.dns_name
             )
 
-            self.assertEqual(
-                client.redirect_uris,
-                "{discovery_url}complete/edx-oauth2/".format(discovery_url=discovery_url)
-            )
-            self.assertEqual(
-                client.client_id,
-                "discovery-key-{site_name}".format(site_name=site_name)
-            )
+            assert client.redirect_uris == '{discovery_url}complete/edx-oauth2/'.format(discovery_url=discovery_url)
+            assert client.client_id == 'discovery-key-{site_name}'.format(site_name=site_name)
             access = ApplicationAccess.objects.filter(application_id=client.id).first()
-            self.assertEqual(
-                access.scopes,
-                ["user_id"]
-            )
+            assert access.scopes == ['user_id']
 
     def test_without_dns(self):
         """ Test the command without dns_name """
-        with self.assertRaises(CommandError):
+        with pytest.raises(CommandError):
             call_command(
                 "create_sites_and_configurations"
             )

--- a/openedx/core/djangoapps/theming/tests/test_commands.py
+++ b/openedx/core/djangoapps/theming/tests/test_commands.py
@@ -2,7 +2,7 @@
 Tests for Management commands of comprehensive theming.
 """
 
-
+import pytest
 import six
 from django.core.management import CommandError, call_command
 from django.test import TestCase
@@ -24,19 +24,19 @@ class TestUpdateAssets(TestCase):
         Test update_asset command.
         """
         # make sure error is raised for invalid theme list
-        with self.assertRaises(CommandError):
+        with pytest.raises(CommandError):
             call_command("compile_sass", themes=["all", "test-theme"])
 
         # make sure error is raised for invalid theme list
-        with self.assertRaises(CommandError):
+        with pytest.raises(CommandError):
             call_command("compile_sass", themes=["no", "test-theme"])
 
         # make sure error is raised for invalid theme list
-        with self.assertRaises(CommandError):
+        with pytest.raises(CommandError):
             call_command("compile_sass", themes=["all", "no"])
 
         # make sure error is raised for invalid theme list
-        with self.assertRaises(CommandError):
+        with pytest.raises(CommandError):
             call_command("compile_sass", themes=["test-theme", "non-existing-theme"])
 
     def test_parse_arguments(self):

--- a/openedx/core/djangoapps/theming/tests/test_finders.py
+++ b/openedx/core/djangoapps/theming/tests/test_finders.py
@@ -28,7 +28,7 @@ class TestThemeFinders(TestCase):
         asset = "test-theme/images/logo.png"
         match = self.finder.find(asset)
 
-        self.assertEqual(match, themes_dir / "test-theme" / "lms" / "static" / "images" / "logo.png")
+        assert match == (((((themes_dir / 'test-theme') / 'lms') / 'static') / 'images') / 'logo.png')
 
     def test_find_all_themed_asset(self):
         """
@@ -40,9 +40,9 @@ class TestThemeFinders(TestCase):
         matches = self.finder.find(asset, all=True)
 
         # Make sure only first match was returned
-        self.assertEqual(1, len(matches))
+        assert 1 == len(matches)
 
-        self.assertEqual(matches[0], themes_dir / "test-theme" / "lms" / "static" / "images" / "logo.png")
+        assert matches[0] == (((((themes_dir / 'test-theme') / 'lms') / 'static') / 'images') / 'logo.png')
 
     def test_find_in_theme(self):
         """
@@ -53,4 +53,4 @@ class TestThemeFinders(TestCase):
         asset = "images/logo.png"
         match = self.finder.find_in_theme("test-theme", asset)
 
-        self.assertEqual(match, themes_dir / "test-theme" / "lms" / "static" / "images" / "logo.png")
+        assert match == (((((themes_dir / 'test-theme') / 'lms') / 'static') / 'images') / 'logo.png')

--- a/openedx/core/djangoapps/theming/tests/test_helpers.py
+++ b/openedx/core/djangoapps/theming/tests/test_helpers.py
@@ -62,7 +62,7 @@ class TestHelpers(TestCase):
             override_value = 'testing'
             mock_get_value.return_value = {override_key: override_value}
             jwt_auth = configuration_helpers.get_value('JWT_AUTH')
-            self.assertEqual(jwt_auth[override_key], override_value)
+            assert jwt_auth[override_key] == override_value
 
     def test_is_comprehensive_theming_enabled(self):
         """
@@ -83,14 +83,14 @@ class TestHelpers(TestCase):
             "openedx.core.djangoapps.theming.helpers.current_request_has_associated_site_theme",
             Mock(return_value=True),
         ):
-            self.assertTrue(theming_helpers.is_comprehensive_theming_enabled())
+            assert theming_helpers.is_comprehensive_theming_enabled()
 
         # Theming is enabled, there is not a SiteTheme record
         with patch(
             "openedx.core.djangoapps.theming.helpers.current_request_has_associated_site_theme",
             Mock(return_value=False),
         ):
-            self.assertTrue(theming_helpers.is_comprehensive_theming_enabled())
+            assert theming_helpers.is_comprehensive_theming_enabled()
 
         with override_settings(ENABLE_COMPREHENSIVE_THEMING=False):
             # Theming is disabled, there is a SiteTheme record
@@ -98,14 +98,14 @@ class TestHelpers(TestCase):
                 "openedx.core.djangoapps.theming.helpers.current_request_has_associated_site_theme",
                 Mock(return_value=True),
             ):
-                self.assertFalse(theming_helpers.is_comprehensive_theming_enabled())
+                assert not theming_helpers.is_comprehensive_theming_enabled()
 
             # Theming is disabled, there is no SiteTheme record
             with patch(
                 "openedx.core.djangoapps.theming.helpers.current_request_has_associated_site_theme",
                 Mock(return_value=False),
             ):
-                self.assertFalse(theming_helpers.is_comprehensive_theming_enabled())
+                assert not theming_helpers.is_comprehensive_theming_enabled()
 
 
 @skip_unless_lms
@@ -118,7 +118,7 @@ class TestHelpersLMS(TestCase):
         Tests template paths are returned from enabled theme.
         """
         template_path = get_template_path_with_theme('header.html')
-        self.assertEqual(template_path, 'red-theme/lms/templates/header.html')
+        assert template_path == 'red-theme/lms/templates/header.html'
 
     @with_comprehensive_theme('red-theme')
     def test_get_template_path_with_theme_for_missing_template(self):
@@ -126,14 +126,14 @@ class TestHelpersLMS(TestCase):
         Tests default template paths are returned if template is not found in the theme.
         """
         template_path = get_template_path_with_theme('course.html')
-        self.assertEqual(template_path, 'course.html')
+        assert template_path == 'course.html'
 
     def test_get_template_path_with_theme_disabled(self):
         """
         Tests default template paths are returned when theme is non theme is enabled.
         """
         template_path = get_template_path_with_theme('header.html')
-        self.assertEqual(template_path, 'header.html')
+        assert template_path == 'header.html'
 
     @with_comprehensive_theme('red-theme')
     def test_strip_site_theme_templates_path_theme_enabled(self):
@@ -141,14 +141,14 @@ class TestHelpersLMS(TestCase):
         Tests site theme templates path is stripped from the given template path.
         """
         template_path = strip_site_theme_templates_path('/red-theme/lms/templates/header.html')
-        self.assertEqual(template_path, 'header.html')
+        assert template_path == 'header.html'
 
     def test_strip_site_theme_templates_path_theme_disabled(self):
         """
         Tests site theme templates path returned unchanged if no theme is applied.
         """
         template_path = strip_site_theme_templates_path('/red-theme/lms/templates/header.html')
-        self.assertEqual(template_path, '/red-theme/lms/templates/header.html')
+        assert template_path == '/red-theme/lms/templates/header.html'
 
 
 @skip_unless_cms
@@ -165,14 +165,14 @@ class TestHelpersCMS(TestCase):
         Tests default template paths are returned if template is not found in the theme.
         """
         template_path = get_template_path_with_theme('certificates.html')
-        self.assertEqual(template_path, 'certificates.html')
+        assert template_path == 'certificates.html'
 
     def test_get_template_path_with_theme_disabled(self):
         """
         Tests default template paths are returned when theme is non theme is enabled.
         """
         template_path = get_template_path_with_theme('login.html')
-        self.assertEqual(template_path, 'login.html')
+        assert template_path == 'login.html'
 
     @with_comprehensive_theme('red-theme')
     def test_strip_site_theme_templates_path_theme_enabled(self):
@@ -180,11 +180,11 @@ class TestHelpersCMS(TestCase):
         Tests site theme templates path is stripped from the given template path.
         """
         template_path = strip_site_theme_templates_path('/red-theme/cms/templates/login.html')
-        self.assertEqual(template_path, 'login.html')
+        assert template_path == 'login.html'
 
     def test_strip_site_theme_templates_path_theme_disabled(self):
         """
         Tests site theme templates path returned unchanged if no theme is applied.
         """
         template_path = strip_site_theme_templates_path('/red-theme/cms/templates/login.html')
-        self.assertEqual(template_path, '/red-theme/cms/templates/login.html')
+        assert template_path == '/red-theme/cms/templates/login.html'

--- a/openedx/core/djangoapps/theming/tests/test_middleware.py
+++ b/openedx/core/djangoapps/theming/tests/test_middleware.py
@@ -58,9 +58,9 @@ class TestCurrentSiteThemeMiddleware(TestCase):
         when there is no theme associated with the current site.
         """
         request = self.create_mock_get_request()
-        self.assertEqual(self.site_theme_middleware.process_request(request), None)
-        self.assertIsNotNone(request.site_theme)  # lint-amnesty, pylint: disable=no-member
-        self.assertEqual(request.site_theme.theme_dir_name, TEST_THEME_NAME)  # lint-amnesty, pylint: disable=no-member
+        assert self.site_theme_middleware.process_request(request) is None
+        assert request.site_theme is not None  # lint-amnesty, pylint: disable=no-member
+        assert request.site_theme.theme_dir_name == TEST_THEME_NAME  # lint-amnesty, pylint: disable=no-member
 
     @override_settings(DEFAULT_SITE_THEME=None)
     def test_default_site_theme_2(self):
@@ -69,8 +69,8 @@ class TestCurrentSiteThemeMiddleware(TestCase):
         the current site and DEFAULT_SITE_THEME is also None.
         """
         request = self.create_mock_get_request()
-        self.assertEqual(self.site_theme_middleware.process_request(request), None)
-        self.assertIsNone(request.site_theme)  # lint-amnesty, pylint: disable=no-member
+        assert self.site_theme_middleware.process_request(request) is None
+        assert request.site_theme is None  # lint-amnesty, pylint: disable=no-member
 
     def test_preview_theme(self):
         """
@@ -83,8 +83,8 @@ class TestCurrentSiteThemeMiddleware(TestCase):
 
         # Next request a page and verify that the theme is returned
         get_request = self.create_mock_get_request()
-        self.assertEqual(self.site_theme_middleware.process_request(get_request), None)
-        self.assertEqual(get_request.site_theme.theme_dir_name, TEST_THEME_NAME)  # lint-amnesty, pylint: disable=no-member
+        assert self.site_theme_middleware.process_request(get_request) is None
+        assert get_request.site_theme.theme_dir_name == TEST_THEME_NAME  # lint-amnesty, pylint: disable=no-member
 
         # Request to reset the theme
         post_request = RequestFactory().post('/test')
@@ -93,10 +93,10 @@ class TestCurrentSiteThemeMiddleware(TestCase):
 
         # Verify that no theme is returned now
         get_request = self.create_mock_get_request()
-        self.assertEqual(self.site_theme_middleware.process_request(get_request), None)
-        self.assertIsNone(get_request.site_theme)  # lint-amnesty, pylint: disable=no-member
+        assert self.site_theme_middleware.process_request(get_request) is None
+        assert get_request.site_theme is None  # lint-amnesty, pylint: disable=no-member
 
         # Verify that we can still force the theme with a querystring arg
         get_request = self.create_mock_get_request(qs_theme=TEST_THEME_NAME)
-        self.assertEqual(self.site_theme_middleware.process_request(get_request), None)
-        self.assertEqual(get_request.site_theme.theme_dir_name, TEST_THEME_NAME)  # lint-amnesty, pylint: disable=no-member
+        assert self.site_theme_middleware.process_request(get_request) is None
+        assert get_request.site_theme.theme_dir_name == TEST_THEME_NAME  # lint-amnesty, pylint: disable=no-member

--- a/openedx/core/djangoapps/theming/tests/test_storage.py
+++ b/openedx/core/djangoapps/theming/tests/test_storage.py
@@ -40,7 +40,7 @@ class TestStorageLMS(TestCase):
         """
         Verify storage returns True on themed assets
         """
-        self.assertEqual(is_themed, self.storage.themed(asset, self.enabled_theme))
+        assert is_themed == self.storage.themed(asset, self.enabled_theme)
 
     @override_settings(DEBUG=True)
     @ddt.data(
@@ -61,7 +61,7 @@ class TestStorageLMS(TestCase):
             asset_url = re.sub(r"(\.\w+)(\.png|\.ico)$", r"\g<2>", asset_url)
             expected_url = self.storage.base_url + self.enabled_theme + "/" + asset
 
-            self.assertEqual(asset_url, expected_url)
+            assert asset_url == expected_url
 
     @override_settings(DEBUG=True)
     @ddt.data(
@@ -80,4 +80,4 @@ class TestStorageLMS(TestCase):
             returned_path = self.storage.path(asset)
             expected_path = self.themes_dir / self.enabled_theme / "lms/static/" / asset
 
-            self.assertEqual(expected_path, returned_path)
+            assert expected_path == returned_path

--- a/openedx/core/djangoapps/theming/tests/test_theme_locales.py
+++ b/openedx/core/djangoapps/theming/tests/test_theme_locales.py
@@ -20,10 +20,10 @@ class TestComprehensiveThemeLocale(TestCase):
         """
         test comprehensive theming paths in settings.
         """
-        self.assertIn(settings.REPO_ROOT / 'themes/conf/locale', settings.LOCALE_PATHS)
+        assert settings.REPO_ROOT / 'themes/conf/locale' in settings.LOCALE_PATHS
 
     def test_theme_locale_path_exist(self):
         """
         test comprehensive theming directory path exist.
         """
-        self.assertTrue(os.path.exists(settings.REPO_ROOT / "themes/conf/locale"))
+        assert os.path.exists((settings.REPO_ROOT / 'themes/conf/locale'))

--- a/openedx/core/djangoapps/theming/tests/test_theme_style_overrides.py
+++ b/openedx/core/djangoapps/theming/tests/test_theme_style_overrides.py
@@ -39,7 +39,7 @@ class TestComprehensiveThemeLMS(TestCase):
         Test that theme footer is used instead of default footer.
         """
         resp = self.client.get('/')
-        self.assertEqual(resp.status_code, 200)
+        assert resp.status_code == 200
         # This string comes from header.html of test-theme
         self.assertContains(resp, "This is a footer for test-theme.")
 
@@ -64,7 +64,7 @@ class TestComprehensiveThemeLMS(TestCase):
         Test that theme logo is used instead of default logo.
         """
         result = staticfiles.finders.find('test-theme/images/logo.png')
-        self.assertEqual(result, settings.TEST_THEME / 'lms/static/images/logo.png')
+        assert result == (settings.TEST_THEME / 'lms/static/images/logo.png')
 
     @with_comprehensive_theme("test-theme")
     def test_override_block_in_parent(self):
@@ -74,7 +74,7 @@ class TestComprehensiveThemeLMS(TestCase):
         self._login()
         dashboard_url = reverse('dashboard')
         resp = self.client.get(dashboard_url)
-        self.assertEqual(resp.status_code, 200)
+        assert resp.status_code == 200
         # This string comes from the 'pagetitle' block of the overriding theme.
         self.assertContains(resp, "Overridden Title!")
 
@@ -86,7 +86,7 @@ class TestComprehensiveThemeLMS(TestCase):
         self._login()
         dashboard_url = reverse('dashboard')
         resp = self.client.get(dashboard_url)
-        self.assertEqual(resp.status_code, 200)
+        assert resp.status_code == 200
         # This string comes from the 'bodyextra' block of the overriding theme.
         self.assertContains(resp, "Overriden Body Extra!")
 
@@ -98,7 +98,7 @@ class TestComprehensiveThemeLMS(TestCase):
         self._login()
         dashboard_url = reverse('dashboard')
         resp = self.client.get(dashboard_url)
-        self.assertEqual(resp.status_code, 200)
+        assert resp.status_code == 200
         # This string comes from the default dashboard.html template.
         self.assertContains(resp, "Explore courses")
 
@@ -110,7 +110,7 @@ class TestComprehensiveThemeLMS(TestCase):
         self._login()
         courses_url = reverse('courses')
         resp = self.client.get(courses_url)
-        self.assertEqual(resp.status_code, 200)
+        assert resp.status_code == 200
         # The courses.html template includes the error-message.html template.
         # Verify that the error message is included in the output.
         self.assertContains(resp, "this module is temporarily unavailable")
@@ -123,7 +123,7 @@ class TestComprehensiveThemeLMS(TestCase):
         self._login()
         courses_url = reverse('courses')
         resp = self.client.get(courses_url)
-        self.assertEqual(resp.status_code, 200)
+        assert resp.status_code == 200
         # The courses.html template includes the info.html file, which is overriden in the theme.
         self.assertContains(resp, "This overrides the courseware/info.html template.")
 
@@ -136,7 +136,7 @@ class TestComprehensiveThemeLMS(TestCase):
         self._login()
         courses_url = reverse('courses')
         resp = self.client.get(courses_url)
-        self.assertEqual(resp.status_code, 200)
+        assert resp.status_code == 200
         # The courses.html template includes the test-theme.custom.html file.
         # Verify its contents are present in the output.
         self.assertContains(resp, "This is a custom template.")
@@ -162,7 +162,7 @@ class TestComprehensiveThemeDisabledLMS(TestCase):
         Test that default logo is picked in case of no comprehensive theme.
         """
         result = staticfiles.finders.find('images/logo.png')
-        self.assertEqual(result, settings.REPO_ROOT / 'lms/static/images/logo.png')
+        assert result == (settings.REPO_ROOT / 'lms/static/images/logo.png')
 
 
 @skip_unless_lms
@@ -188,7 +188,7 @@ class TestStanfordTheme(TestCase):
         Test stanford theme footer.
         """
         resp = self.client.get('/')
-        self.assertEqual(resp.status_code, 200)
+        assert resp.status_code == 200
         # This string comes from header.html of test-theme
         self.assertContains(resp, "footer overrides for stanford theme go here")
 
@@ -198,7 +198,7 @@ class TestStanfordTheme(TestCase):
         Test custom logo.
         """
         result = staticfiles.finders.find('stanford-style/images/logo.png')
-        self.assertEqual(result, settings.REPO_ROOT / 'themes/stanford-style/lms/static/images/logo.png')
+        assert result == (settings.REPO_ROOT / 'themes/stanford-style/lms/static/images/logo.png')
 
     @with_comprehensive_theme("stanford-style")
     def test_favicon_image(self):
@@ -206,7 +206,7 @@ class TestStanfordTheme(TestCase):
         Test correct favicon for custom theme.
         """
         result = staticfiles.finders.find('stanford-style/images/favicon.ico')
-        self.assertEqual(result, settings.REPO_ROOT / 'themes/stanford-style/lms/static/images/favicon.ico')
+        assert result == (settings.REPO_ROOT / 'themes/stanford-style/lms/static/images/favicon.ico')
 
     @with_comprehensive_theme("stanford-style")
     def test_index_page(self):
@@ -214,6 +214,6 @@ class TestStanfordTheme(TestCase):
         Test custom theme overrides for index page.
         """
         resp = self.client.get('/')
-        self.assertEqual(resp.status_code, 200)
+        assert resp.status_code == 200
         # This string comes from header.html of test-theme
         self.assertContains(resp, "Free courses from <strong>Stanford</strong>")

--- a/openedx/core/djangoapps/theming/tests/test_views.py
+++ b/openedx/core/djangoapps/theming/tests/test_views.py
@@ -59,13 +59,13 @@ class TestThemingViews(TestCase):
         # Logged in non-global staff get a 404
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
         response = self.client.get(THEMING_ADMIN_URL)
-        self.assertEqual(response.status_code, 404)
+        assert response.status_code == 404
 
         # Global staff can access the page
         global_staff = GlobalStaffFactory()
         self.client.login(username=global_staff.username, password=TEST_PASSWORD)
         response = self.client.get(THEMING_ADMIN_URL)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
     def test_preview_theme(self):
         """
@@ -86,7 +86,7 @@ class TestThemingViews(TestCase):
 
         # Next request a page and verify that the correct theme has been chosen
         response = self.client.get(THEMING_ADMIN_URL)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         self.assertContains(
             response,
             u'<option value="{theme_name}" selected=selected>'.format(theme_name=TEST_THEME_NAME)
@@ -103,7 +103,7 @@ class TestThemingViews(TestCase):
 
         # Finally verify that the test theme is no longer selected
         response = self.client.get(THEMING_ADMIN_URL)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         self.assertContains(
             response,
             u'<option value="{theme_name}">'.format(theme_name=TEST_THEME_NAME)


### PR DESCRIPTION
## Description
This PR is using `codemod-unittest-to-pytest-asserts` to automatically replace `unittest` assertions with `pytest` 
for following apps  in `openedx/core/djangoapps/` 
```
schedules, self_paced, servis_status, session_inactivity_timeout, signals, site_configuration, system_wide_roles, theming
```
Relevant JIRA issue here: https://openedx.atlassian.net/browse/BOM-2400