### PR TITLE
replaced unittest assertions pytest assertions (30)

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/tests/test_image_helpers.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_image_helpers.py
@@ -39,27 +39,20 @@ class ProfileImageUrlTestCase(TestCase):
         """
         Verify correct url structure.
         """
-        self.assertEqual(
-            actual_url,
-            'http://example-storage.com/profile-images/{name}_{size}.jpg?v={version}'.format(
-                name=expected_name, size=expected_pixels, version=expected_version
-            )
-        )
+        assert actual_url == 'http://example-storage.com/profile-images/{name}_{size}.jpg?v={version}'\
+            .format(name=expected_name, size=expected_pixels, version=expected_version)
 
     def verify_default_url(self, actual_url, expected_pixels):
         """
         Verify correct url structure for a default profile image.
         """
-        self.assertEqual(
-            actual_url,
-            '/static/default_{size}.png'.format(size=expected_pixels)
-        )
+        assert actual_url == '/static/default_{size}.png'.format(size=expected_pixels)
 
     def verify_urls(self, actual_urls, expected_name, is_default=False):
         """
         Verify correct url dictionary structure.
         """
-        self.assertEqual(set(TEST_SIZES.keys()), set(actual_urls.keys()))
+        assert set(TEST_SIZES.keys()) == set(actual_urls.keys())
         for size_display_name, url in actual_urls.items():
             if is_default:
                 self.verify_default_url(url, TEST_SIZES[size_display_name])

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_permissions.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_permissions.py
@@ -20,7 +20,7 @@ class CanDeactivateUserTest(TestCase):
         self.request.user = SuperuserFactory()
 
         result = CanDeactivateUser().has_permission(self.request, None)
-        self.assertTrue(result)
+        assert result
 
     def test_api_permission_user_granted_permission(self):
         user = UserFactory()
@@ -34,12 +34,12 @@ class CanDeactivateUserTest(TestCase):
         self.request.user = user
 
         result = CanDeactivateUser().has_permission(self.request, None)
-        self.assertTrue(result)
+        assert result
 
     def test_api_permission_user_without_permission(self):
         self.request.user = UserFactory()
         result = CanDeactivateUser().has_permission(self.request, None)
-        self.assertFalse(result)
+        assert not result
 
 
 class CanRetireUserTest(TestCase):
@@ -53,7 +53,7 @@ class CanRetireUserTest(TestCase):
         self.request.user = SuperuserFactory()
 
         result = CanRetireUser().has_permission(self.request, None)
-        self.assertTrue(result)
+        assert result
 
     def test_api_permission_user_granted_permission(self):
         user = UserFactory()
@@ -61,9 +61,9 @@ class CanRetireUserTest(TestCase):
 
         with self.settings(RETIREMENT_SERVICE_WORKER_USERNAME=user.username):
             result = CanRetireUser().has_permission(self.request, None)
-            self.assertTrue(result)
+            assert result
 
     def test_api_permission_user_without_permission(self):
         self.request.user = UserFactory()
         result = CanRetireUser().has_permission(self.request, None)
-        self.assertFalse(result)
+        assert not result

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_serializers.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_serializers.py
@@ -36,9 +36,9 @@ class UserReadOnlySerializerTest(TestCase):  # lint-amnesty, pylint: disable=mis
         """
         UserProfile.objects.create(user=self.user, name='test name')
         data = UserReadOnlySerializer(self.user, configuration=self.config, context={'request': self.request}).data
-        self.assertEqual(data['username'], self.user.username)
-        self.assertEqual(data['name'], 'test name')
-        self.assertEqual(data['email'], self.user.email)
+        assert data['username'] == self.user.username
+        assert data['name'] == 'test name'
+        assert data['email'] == self.user.email
 
     def test_user_no_profile(self):
         """
@@ -50,5 +50,5 @@ class UserReadOnlySerializerTest(TestCase):  # lint-amnesty, pylint: disable=mis
                 (LOGGER_NAME, 'WARNING', 'user profile for the user [test_user] does not exist')
             )
 
-        self.assertEqual(data['username'], self.user.username)
-        self.assertEqual(data['name'], None)
+        assert data['username'] == self.user.username
+        assert data['name'] is None

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_settings_views.py
@@ -84,34 +84,30 @@ class AccountSettingsViewTest(ThirdPartyAuthTestMixin, SiteMixin, ProgramsApiCon
             context = account_settings_context(self.request)
 
             user_accounts_api_url = reverse("accounts_api", kwargs={'username': self.user.username})
-            self.assertEqual(context['user_accounts_api_url'], user_accounts_api_url)
+            assert context['user_accounts_api_url'] == user_accounts_api_url
 
             user_preferences_api_url = reverse('preferences_api', kwargs={'username': self.user.username})
-            self.assertEqual(context['user_preferences_api_url'], user_preferences_api_url)
+            assert context['user_preferences_api_url'] == user_preferences_api_url
 
             for attribute in self.FIELDS:
-                self.assertIn(attribute, context['fields'])
+                assert attribute in context['fields']
 
-            self.assertEqual(
-                context['user_accounts_api_url'], reverse("accounts_api", kwargs={'username': self.user.username})
-            )
-            self.assertEqual(
-                context['user_preferences_api_url'], reverse('preferences_api', kwargs={'username': self.user.username})
-            )
+            assert context['user_accounts_api_url'] == reverse('accounts_api', kwargs={'username': self.user.username})
+            assert context['user_preferences_api_url'] ==\
+                   reverse('preferences_api', kwargs={'username': self.user.username})
 
-            self.assertEqual(context['duplicate_provider'], 'facebook')
-            self.assertEqual(context['auth']['providers'][0]['name'], 'Facebook')
-            self.assertEqual(context['auth']['providers'][1]['name'], 'Google')
+            assert context['duplicate_provider'] == 'facebook'
+            assert context['auth']['providers'][0]['name'] == 'Facebook'
+            assert context['auth']['providers'][1]['name'] == 'Google'
 
-            self.assertEqual(context['sync_learner_profile_data'], False)
-            self.assertEqual(context['edx_support_url'], settings.SUPPORT_SITE_LINK)
-            self.assertEqual(context['enterprise_name'], None)
-            self.assertEqual(
-                context['enterprise_readonly_account_fields'],
-                {'fields': list(get_enterprise_readonly_account_fields(self.user))}
-            )
+            assert context['sync_learner_profile_data'] is False
+            assert context['edx_support_url'] == settings.SUPPORT_SITE_LINK
+            assert context['enterprise_name'] is None
+            assert context['enterprise_readonly_account_fields'] ==\
+                   {'fields': list(get_enterprise_readonly_account_fields(self.user))}
+
             expected_beta_language = {'code': 'lt-lt', 'name': settings.LANGUAGE_DICT.get('lt-lt')}
-            self.assertEqual(context['beta_language'], expected_beta_language)
+            assert context['beta_language'] == expected_beta_language
 
     @mock.patch('openedx.core.djangoapps.user_api.accounts.settings_views.enterprise_customer_for_request')
     @mock.patch('openedx.features.enterprise_support.utils.third_party_auth.provider.Registry.get')
@@ -129,34 +125,27 @@ class AccountSettingsViewTest(ThirdPartyAuthTestMixin, SiteMixin, ProgramsApiCon
         context = account_settings_context(self.request)
 
         user_accounts_api_url = reverse("accounts_api", kwargs={'username': self.user.username})
-        self.assertEqual(context['user_accounts_api_url'], user_accounts_api_url)
+        assert context['user_accounts_api_url'] == user_accounts_api_url
 
         user_preferences_api_url = reverse('preferences_api', kwargs={'username': self.user.username})
-        self.assertEqual(context['user_preferences_api_url'], user_preferences_api_url)
+        assert context['user_preferences_api_url'] == user_preferences_api_url
 
         for attribute in self.FIELDS:
-            self.assertIn(attribute, context['fields'])
+            assert attribute in context['fields']
 
-        self.assertEqual(
-            context['user_accounts_api_url'], reverse("accounts_api", kwargs={'username': self.user.username})
-        )
-        self.assertEqual(
-            context['user_preferences_api_url'], reverse('preferences_api', kwargs={'username': self.user.username})
-        )
+        assert context['user_accounts_api_url'] == reverse('accounts_api', kwargs={'username': self.user.username})
+        assert context['user_preferences_api_url'] ==\
+               reverse('preferences_api', kwargs={'username': self.user.username})
 
-        self.assertEqual(context['duplicate_provider'], 'facebook')
-        self.assertEqual(context['auth']['providers'][0]['name'], 'Facebook')
-        self.assertEqual(context['auth']['providers'][1]['name'], 'Google')
+        assert context['duplicate_provider'] == 'facebook'
+        assert context['auth']['providers'][0]['name'] == 'Facebook'
+        assert context['auth']['providers'][1]['name'] == 'Google'
 
-        self.assertEqual(
-            context['sync_learner_profile_data'], mock_get_auth_provider.return_value.sync_learner_profile_data
-        )
-        self.assertEqual(context['edx_support_url'], settings.SUPPORT_SITE_LINK)
-        self.assertEqual(context['enterprise_name'], dummy_enterprise_customer['name'])
-        self.assertEqual(
-            context['enterprise_readonly_account_fields'],
-            {'fields': list(get_enterprise_readonly_account_fields(self.user))}
-        )
+        assert context['sync_learner_profile_data'] == mock_get_auth_provider.return_value.sync_learner_profile_data
+        assert context['edx_support_url'] == settings.SUPPORT_SITE_LINK
+        assert context['enterprise_name'] == dummy_enterprise_customer['name']
+        assert context['enterprise_readonly_account_fields'] ==\
+               {'fields': list(get_enterprise_readonly_account_fields(self.user))}
 
     def test_view(self):
         """
@@ -203,13 +192,13 @@ class AccountSettingsViewTest(ThirdPartyAuthTestMixin, SiteMixin, ProgramsApiCon
                 'receipt_url': '/checkout/receipt/?order_number=' + order['number'],
                 'lines': order['lines'],
             }
-            self.assertEqual(order_detail[i], expected)
+            assert order_detail[i] == expected
 
     def test_commerce_order_detail_exception(self):
         with mock_get_orders(exception=exceptions.HttpNotFoundError):
             order_detail = get_user_orders(self.user)
 
-        self.assertEqual(order_detail, [])
+        assert order_detail == []
 
     def test_incomplete_order_detail(self):
         response = {
@@ -227,7 +216,7 @@ class AccountSettingsViewTest(ThirdPartyAuthTestMixin, SiteMixin, ProgramsApiCon
         with mock_get_orders(response=response):
             order_detail = get_user_orders(self.user)
 
-        self.assertEqual(order_detail, [])
+        assert order_detail == []
 
     def test_order_history_with_no_product(self):
         response = {
@@ -250,7 +239,7 @@ class AccountSettingsViewTest(ThirdPartyAuthTestMixin, SiteMixin, ProgramsApiCon
         with mock_get_orders(response=response):
             order_detail = get_user_orders(self.user)
 
-        self.assertEqual(len(order_detail), 1)
+        assert len(order_detail) == 1
 
     def test_redirect_view(self):
         with override_waffle_flag(REDIRECT_TO_ACCOUNT_MICROFRONTEND, active=True):

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_utils.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_utils.py
@@ -57,9 +57,9 @@ class UserAccountSettingsTest(TestCase):
         """
         Verify that social links are correctly validated and formatted.
         """
-        self.assertEqual(is_valid_expected, self.validate_social_link(platform_name, link_input))
+        assert is_valid_expected == self.validate_social_link(platform_name, link_input)
 
-        self.assertEqual(formatted_link_expected, format_social_link(platform_name, link_input))
+        assert formatted_link_expected == format_social_link(platform_name, link_input)
 
 
 @ddt.ddt
@@ -121,13 +121,12 @@ class CompletionUtilsTestCase(SharedModuleStoreTestCase, CompletionWaffleTestMix
         empty_block_url = retrieve_last_sitewide_block_completed(
             self.cruft_user
         )
-        self.assertEqual(
-            block_url,
-            u'test_url:9999/courses/{org}/{course}/{run}/jump_to/i4x://{org}/{course}/vertical/{vertical_id}'.format(
-                org=self.course.location.course_key.org,
-                course=self.course.location.course_key.course,
-                run=self.course.location.course_key.run,
-                vertical_id=self.vertical2.location.block_id,
-            )
-        )
-        self.assertEqual(empty_block_url, None)
+        assert block_url ==\
+               u'test_url:9999/courses/{org}/{course}/{run}/jump_to/i4x://{org}/{course}/vertical/{vertical_id}'.format(
+                   org=self.course.location.course_key.org,
+                   course=self.course.location.course_key.course,
+                   run=self.course.location.course_key.run,
+                   vertical_id=self.vertical2.location.block_id
+               )
+
+        assert empty_block_url is None

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
@@ -70,7 +70,7 @@ class UserAPITestCase(APITestCase):
         """
         # pylint: disable=no-member
         response = client.patch(self.url, data=json.dumps(json_data), content_type=content_type)
-        self.assertEqual(expected_status, response.status_code)
+        assert expected_status == response.status_code
         return response
 
     def send_get(self, client, query_parameters=None, expected_status=200):
@@ -79,7 +79,7 @@ class UserAPITestCase(APITestCase):
         """
         url = self.url + '?' + query_parameters if query_parameters else self.url    # pylint: disable=no-member
         response = client.get(url)
-        self.assertEqual(expected_status, response.status_code)
+        assert expected_status == response.status_code
         return response
 
     # pylint: disable=no-member
@@ -88,7 +88,7 @@ class UserAPITestCase(APITestCase):
         Helper method for sending a PUT to the server. Verifies the expected status and returns the response.
         """
         response = client.put(self.url, data=json.dumps(json_data), content_type=content_type)
-        self.assertEqual(expected_status, response.status_code)
+        assert expected_status == response.status_code
         return response
 
     # pylint: disable=no-member
@@ -97,7 +97,7 @@ class UserAPITestCase(APITestCase):
         Helper method for sending a DELETE to the server. Verifies the expected status and returns the response.
         """
         response = client.delete(self.url)
-        self.assertEqual(expected_status, response.status_code)
+        assert expected_status == response.status_code
         return response
 
     def create_mock_profile(self, user):
@@ -136,14 +136,9 @@ class UserAPITestCase(APITestCase):
             filename = 'default'
             file_extension = 'png'
         template = template.format(root=url_root, filename=filename, extension=file_extension)
-        self.assertEqual(
-            data['profile_image'],
-            {
-                'has_image': has_profile_image,
-                'image_url_full': template.format(size=50),
-                'image_url_small': template.format(size=10),
-            }
-        )
+        assert data['profile_image'] == {'has_image': has_profile_image,
+                                         'image_url_full': template.format(size=50),
+                                         'image_url_small': template.format(size=10)}
 
 
 @ddt.ddt
@@ -168,8 +163,8 @@ class TestOwnUsernameAPI(CacheIsolationTestCase, UserAPITestCase):
             response = self.send_get(self.client, expected_status=expected_status)
         if expected_status == 200:
             data = response.data
-            self.assertEqual(1, len(data))
-            self.assertEqual(self.user.username, data["username"])
+            assert 1 == len(data)
+            assert self.user.username == data['username']
 
     def test_get_username(self):
         """
@@ -235,73 +230,73 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
         Verify that the shareable fields from the account are returned
         """
         data = response.data
-        self.assertEqual(12, len(data))
+        assert 12 == len(data)
 
         # public fields (3)
-        self.assertEqual(account_privacy, data["account_privacy"])
+        assert account_privacy == data['account_privacy']
         self._verify_profile_image_data(data, True)
-        self.assertEqual(self.user.username, data["username"])
+        assert self.user.username == data['username']
 
         # additional shareable fields (8)
-        self.assertEqual(TEST_BIO_VALUE, data["bio"])
-        self.assertEqual("US", data["country"])
-        self.assertIsNotNone(data["date_joined"])
-        self.assertEqual([{"code": TEST_LANGUAGE_PROFICIENCY_CODE}], data["language_proficiencies"])
-        self.assertEqual("m", data["level_of_education"])
-        self.assertIsNotNone(data["social_links"])
-        self.assertIsNone(data["time_zone"])
-        self.assertEqual(badges_enabled, data['accomplishments_shared'])
+        assert TEST_BIO_VALUE == data['bio']
+        assert 'US' == data['country']
+        assert data['date_joined'] is not None
+        assert [{'code': TEST_LANGUAGE_PROFICIENCY_CODE}] == data['language_proficiencies']
+        assert 'm' == data['level_of_education']
+        assert data['social_links'] is not None
+        assert data['time_zone'] is None
+        assert badges_enabled == data['accomplishments_shared']
 
     def _verify_private_account_response(self, response, requires_parental_consent=False):
         """
         Verify that only the public fields are returned if a user does not want to share account fields
         """
         data = response.data
-        self.assertEqual(3, len(data))
-        self.assertEqual(PRIVATE_VISIBILITY, data["account_privacy"])
+        assert 3 == len(data)
+        assert PRIVATE_VISIBILITY == data['account_privacy']
         self._verify_profile_image_data(data, not requires_parental_consent)
-        self.assertEqual(self.user.username, data["username"])
+        assert self.user.username == data['username']
 
     def _verify_full_account_response(self, response, requires_parental_consent=False, year_of_birth=2000):
         """
         Verify that all account fields are returned (even those that are not shareable).
         """
         data = response.data
-        self.assertEqual(26, len(data))
+        assert 26 == len(data)
 
         # public fields (3)
         expected_account_privacy = (
             PRIVATE_VISIBILITY if requires_parental_consent else
             UserPreference.get_value(self.user, 'account_privacy')
         )
-        self.assertEqual(expected_account_privacy, data["account_privacy"])
+        assert expected_account_privacy == data['account_privacy']
         self._verify_profile_image_data(data, not requires_parental_consent)
-        self.assertEqual(self.user.username, data["username"])
+        assert self.user.username == data['username']
 
         # additional shareable fields (8)
-        self.assertEqual(TEST_BIO_VALUE, data["bio"])
-        self.assertEqual("US", data["country"])
-        self.assertIsNotNone(data["date_joined"])
-        self.assertIsNotNone(data["last_login"])
-        self.assertEqual([{"code": TEST_LANGUAGE_PROFICIENCY_CODE}], data["language_proficiencies"])
-        self.assertEqual("m", data["level_of_education"])
-        self.assertIsNotNone(data["social_links"])
-        self.assertEqual(UserPreference.get_value(self.user, 'time_zone'), data["time_zone"])
-        self.assertIsNotNone(data["accomplishments_shared"])
-        self.assertEqual(self.user.first_name + " " + self.user.last_name, data["name"])
+        assert TEST_BIO_VALUE == data['bio']
+        assert 'US' == data['country']
+        assert data['date_joined'] is not None
+        assert data['last_login'] is not None
+        assert [{'code': TEST_LANGUAGE_PROFICIENCY_CODE}] == data['language_proficiencies']
+        assert 'm' == data['level_of_education']
+        assert data['social_links'] is not None
+        assert UserPreference.get_value(self.user, 'time_zone') == data['time_zone']
+        assert data['accomplishments_shared'] is not None
+        assert ((self.user.first_name + ' ') + self.user.last_name) == data['name']
 
         # additional admin fields (10)
-        self.assertEqual(self.user.email, data["email"])
-        self.assertIsNotNone(data["extended_profile"])
-        self.assertEqual("MA", data["state"])
-        self.assertEqual("f", data["gender"])
-        self.assertEqual("world peace", data["goals"])
-        self.assertTrue(data["is_active"])
-        self.assertEqual("Park Ave", data['mailing_address'])
-        self.assertEqual(requires_parental_consent, data["requires_parental_consent"])
-        self.assertIsNone(data["secondary_email"])
-        self.assertIsNone(data["secondary_email_enabled"])
-        self.assertEqual(year_of_birth, data["year_of_birth"])
+        assert self.user.email == data['email']
+        assert data['extended_profile'] is not None
+        assert 'MA' == data['state']
+        assert 'f' == data['gender']
+        assert 'world peace' == data['goals']
+        assert data['is_active']
+        assert 'Park Ave' == data['mailing_address']
+        assert requires_parental_consent == data['requires_parental_consent']
+        assert data['secondary_email'] is None
+        assert data['secondary_email_enabled'] is None
+        assert year_of_birth == data['year_of_birth']
 
     def test_anonymous_access(self):
         """
@@ -315,9 +310,9 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
         Test that DELETE, POST, and PUT are not supported.
         """
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
-        self.assertEqual(405, self.client.put(self.url).status_code)
-        self.assertEqual(405, self.client.post(self.url).status_code)
-        self.assertEqual(405, self.client.delete(self.url).status_code)
+        assert 405 == self.client.put(self.url).status_code
+        assert 405 == self.client.post(self.url).status_code
+        assert 405 == self.client.delete(self.url).status_code
 
     @ddt.data(
         ("client", "user"),
@@ -330,7 +325,7 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
         """
         client = self.login_client(api_client, user)
         response = client.get(reverse("accounts_api", kwargs={'username': "does_not_exist"}))
-        self.assertEqual(404, response.status_code)
+        assert 404 == response.status_code
 
     @ddt.data(
         ("client", "user"),
@@ -441,17 +436,17 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
         # verify response
         if requesting_username == "different_user":
             data = response.data
-            self.assertEqual(6, len(data))
+            assert 6 == len(data)
 
             # public fields
-            self.assertEqual(self.user.username, data["username"])
-            self.assertEqual(UserPreference.get_value(self.user, 'account_privacy'), data["account_privacy"])
+            assert self.user.username == data['username']
+            assert UserPreference.get_value(self.user, 'account_privacy') == data['account_privacy']
             self._verify_profile_image_data(data, has_profile_image=True)
 
             # custom shared fields
-            self.assertEqual(TEST_BIO_VALUE, data["bio"])
-            self.assertEqual([{"code": TEST_LANGUAGE_PROFICIENCY_CODE}], data["language_proficiencies"])
-            self.assertEqual(self.user.first_name + " " + self.user.last_name, data["name"])
+            assert TEST_BIO_VALUE == data['bio']
+            assert [{'code': TEST_LANGUAGE_PROFICIENCY_CODE}] == data['language_proficiencies']
+            assert ((self.user.first_name + ' ') + self.user.last_name) == data['name']
         else:
             self._verify_full_account_response(response)
 
@@ -498,26 +493,26 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
             with self.assertNumQueries(queries):
                 response = self.send_get(self.client)
             data = response.data
-            self.assertEqual(26, len(data))
-            self.assertEqual(self.user.username, data["username"])
-            self.assertEqual(self.user.first_name + " " + self.user.last_name, data["name"])
+            assert 26 == len(data)
+            assert self.user.username == data['username']
+            assert ((self.user.first_name + ' ') + self.user.last_name) == data['name']
             for empty_field in ("year_of_birth", "level_of_education", "mailing_address", "bio"):
-                self.assertIsNone(data[empty_field])
-            self.assertIsNone(data["country"])
-            self.assertIsNone(data["state"])
-            self.assertEqual("m", data["gender"])
-            self.assertEqual("Learn a lot", data["goals"])
-            self.assertEqual(self.user.email, data["email"])
-            self.assertIsNotNone(data["date_joined"])
-            self.assertIsNotNone(data["last_login"])
-            self.assertEqual(self.user.is_active, data["is_active"])
+                assert data[empty_field] is None
+            assert data['country'] is None
+            assert data['state'] is None
+            assert 'm' == data['gender']
+            assert 'Learn a lot' == data['goals']
+            assert self.user.email == data['email']
+            assert data['date_joined'] is not None
+            assert data['last_login'] is not None
+            assert self.user.is_active == data['is_active']
             self._verify_profile_image_data(data, False)
-            self.assertTrue(data["requires_parental_consent"])
-            self.assertEqual([], data["language_proficiencies"])
-            self.assertEqual(PRIVATE_VISIBILITY, data["account_privacy"])
-            self.assertIsNone(data["time_zone"])
+            assert data['requires_parental_consent']
+            assert [] == data['language_proficiencies']
+            assert PRIVATE_VISIBILITY == data['account_privacy']
+            assert data['time_zone'] is None
             # Badges aren't on by default, so should not be present.
-            self.assertEqual(False, data["accomplishments_shared"])
+            assert data['accomplishments_shared'] is False
 
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
         verify_get_own_information(22)
@@ -543,7 +538,7 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
         with self.assertNumQueries(22):
             response = self.send_get(self.client)
         for empty_field in ("level_of_education", "gender", "country", "state", "bio",):
-            self.assertIsNone(response.data[empty_field])
+            assert response.data[empty_field] is None
 
     @ddt.data(
         ("different_client", "different_user"),
@@ -572,7 +567,7 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
             reverse("accounts_api", kwargs={'username': "does_not_exist"}),
             data=json.dumps({}), content_type="application/merge-patch+json"
         )
-        self.assertEqual(403, response.status_code)
+        assert 403 == response.status_code
 
     @ddt.data(
         ("gender", "f", "not a gender", u'"not a gender" is not a valid choice.'),
@@ -609,7 +604,7 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
             legacy_profile.save()
 
         response = self.send_patch(client, {field: value})
-        self.assertEqual(value, response.data[field])
+        assert value == response.data[field]
 
         if fails_validation_value:
             error_response = self.send_patch(client, {field: fails_validation_value}, expected_status=400)
@@ -617,22 +612,19 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
             if field == 'bio':
                 expected_user_message = u"The about me field must be at most 300 characters long."
 
-            self.assertEqual(
-                expected_user_message,
-                error_response.data["field_errors"][field]["user_message"]
-            )
+            assert expected_user_message == error_response.data['field_errors'][field]['user_message']
 
-            self.assertEqual(
-                u"Value '{value}' is not valid for field '{field}': {messages}".format(
-                    value=fails_validation_value, field=field, messages=[developer_validation_message]
-                ),
-                error_response.data["field_errors"][field]["developer_message"]
-            )
+            assert u"Value '{value}' is not valid for field '{field}': {messages}"\
+                .format(value=fails_validation_value,
+                        field=field,
+                        messages=[developer_validation_message]) ==\
+                   error_response.data['field_errors'][field]['developer_message']
+
         elif field != "account_privacy":
             # If there are no values that would fail validation, then empty string should be supported;
             # except for account_privacy, which cannot be an empty string.
             response = self.send_patch(client, {field: ""})
-            self.assertEqual("", response.data[field])
+            assert '' == response.data[field]
 
     def test_patch_inactive_user(self):
         """ Verify that a user can patch her own account, even if inactive. """
@@ -640,7 +632,7 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
         self.user.is_active = False
         self.user.save()
         response = self.send_patch(self.client, {"goals": "to not activate account"})
-        self.assertEqual("to not activate account", response.data["goals"])
+        assert 'to not activate account' == response.data['goals']
 
     @ddt.unpack
     def test_patch_account_noneditable(self):
@@ -653,13 +645,9 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
             """
             Internal helper to check the error messages returned
             """
-            self.assertEqual(
-                "This field is not editable via this API", data["field_errors"][field_name]["developer_message"]
-            )
-            self.assertEqual(
-                u"The '{0}' field cannot be edited.".format(field_name),
-                data["field_errors"][field_name]["user_message"]
-            )
+            assert 'This field is not editable via this API' == data['field_errors'][field_name]['developer_message']
+            assert u"The '{0}' field cannot be edited."\
+                .format(field_name) == data['field_errors'][field_name]['user_message']
 
         for field_name in ["username", "date_joined", "is_active", "profile_image", "requires_parental_consent"]:
             response = self.send_patch(client, {field_name: "will_error", "gender": "o"}, expected_status=400)
@@ -667,11 +655,11 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
 
         # Make sure that gender did not change.
         response = self.send_get(client)
-        self.assertEqual("m", response.data["gender"])
+        assert 'm' == response.data['gender']
 
         # Test error message with multiple read-only items
         response = self.send_patch(client, {"username": "will_error", "date_joined": "xx"}, expected_status=400)
-        self.assertEqual(2, len(response.data["field_errors"]))
+        assert 2 == len(response.data['field_errors'])
         verify_error_response("username", response.data)
         verify_error_response("date_joined", response.data)
 
@@ -693,11 +681,11 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
             response = self.send_patch(self.client, {field_name: ""})
             # Although throwing a 400 might be reasonable, the default DRF behavior with ModelSerializer
             # is to convert to None, which also seems acceptable (and is difficult to override).
-            self.assertIsNone(response.data[field_name])
+            assert response.data[field_name] is None
 
             # Verify that the behavior is the same for sending None.
             response = self.send_patch(self.client, {field_name: ""})
-            self.assertIsNone(response.data[field_name])
+            assert response.data[field_name] is None
 
     def test_patch_name_metadata(self):
         """
@@ -709,24 +697,24 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
             """
             legacy_profile = UserProfile.objects.get(id=self.user.id)
             name_change_info = legacy_profile.get_meta()["old_names"]
-            self.assertEqual(expected_entries, len(name_change_info))
+            assert expected_entries == len(name_change_info)
             return name_change_info
 
         def verify_change_info(change_info, old_name, requester, new_name):
             """
             Internal method to validate name changes
             """
-            self.assertEqual(3, len(change_info))
-            self.assertEqual(old_name, change_info[0])
-            self.assertEqual(u"Name change requested through account API by {}".format(requester), change_info[1])
-            self.assertIsNotNone(change_info[2])
+            assert 3 == len(change_info)
+            assert old_name == change_info[0]
+            assert u'Name change requested through account API by {}'.format(requester) == change_info[1]
+            assert change_info[2] is not None
             # Verify the new name was also stored.
             get_response = self.send_get(self.client)
-            self.assertEqual(new_name, get_response.data["name"])
+            assert new_name == get_response.data['name']
 
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
         legacy_profile = UserProfile.objects.get(id=self.user.id)
-        self.assertEqual({}, legacy_profile.get_meta())
+        assert {} == legacy_profile.get_meta()
         old_name = legacy_profile.name
 
         # First change the name as the user and verify meta information.
@@ -757,21 +745,21 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
         response = self.send_patch(client, {"email": new_email, "goals": "change my email"})
 
         # Since request is multi-step, the email won't change on GET immediately (though goals will update).
-        self.assertEqual(old_email, response.data["email"])
-        self.assertEqual("change my email", response.data["goals"])
+        assert old_email == response.data['email']
+        assert 'change my email' == response.data['goals']
 
         # Now call the method that will be invoked with the user clicks the activation key in the received email.
         # First we must get the activation key that was sent.
         pending_change = PendingEmailChange.objects.filter(user=self.user)
-        self.assertEqual(1, len(pending_change))
+        assert 1 == len(pending_change)
         activation_key = pending_change[0].activation_key
         confirm_change_url = reverse(
             "confirm_email_change", kwargs={'key': activation_key}
         )
         response = self.client.post(confirm_change_url)
-        self.assertEqual(200, response.status_code)
+        assert 200 == response.status_code
         get_response = self.send_get(client)
-        self.assertEqual(new_email, get_response.data["email"])
+        assert new_email == get_response.data['email']
 
     @ddt.data(
         ("not_an_email",),
@@ -788,11 +776,9 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
         # Try changing to an invalid email to make sure error messages are appropriately returned.
         error_response = self.send_patch(client, {"email": bad_email}, expected_status=400)
         field_errors = error_response.data["field_errors"]
-        self.assertEqual(
-            "Error thrown from validate_new_email: 'Valid e-mail address required.'",
-            field_errors["email"]["developer_message"]
-        )
-        self.assertEqual("Valid e-mail address required.", field_errors["email"]["user_message"])
+        assert "Error thrown from validate_new_email: 'Valid e-mail address required.'" ==\
+               field_errors['email']['developer_message']
+        assert 'Valid e-mail address required.' == field_errors['email']['user_message']
 
     @mock.patch('common.djangoapps.student.views.management.do_email_change_request')
     def test_patch_duplicate_email(self, do_email_change_request):
@@ -806,10 +792,10 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
 
         # Try changing to an existing email to make sure no error messages returned.
         response = self.send_patch(client, {"email": existing_email})
-        self.assertEqual(200, response.status_code)
+        assert 200 == response.status_code
 
         # Verify that no actual request made for email change
-        self.assertFalse(do_email_change_request.called)
+        assert not do_email_change_request.called
 
     def test_patch_language_proficiencies(self):
         """
@@ -859,13 +845,8 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
 
         client = self.login_client("client", "user")
         response = self.send_patch(client, {"language_proficiencies": patch_value}, expected_status=400)
-        self.assertEqual(
-            response.data["field_errors"]["language_proficiencies"]["developer_message"],
-            u"Value '{patch_value}' is not valid for field 'language_proficiencies': {error_message}".format(
-                patch_value=patch_value,
-                error_message=expected_error_message
-            )
-        )
+        assert response.data['field_errors']['language_proficiencies']['developer_message'] == \
+               f"Value '{patch_value}' is not valid for field 'language_proficiencies': {expected_error_message}"
 
     @mock.patch('openedx.core.djangoapps.user_api.accounts.serializers.AccountUserSerializer.save')
     def test_patch_serializer_save_fails(self, serializer_save):
@@ -875,11 +856,8 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
         serializer_save.side_effect = [Exception("bummer"), None]
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
         error_response = self.send_patch(self.client, {"goals": "save an account field"}, expected_status=400)
-        self.assertEqual(
-            "Error thrown when saving account updates: 'bummer'",
-            error_response.data["developer_message"]
-        )
-        self.assertIsNone(error_response.data["user_message"])
+        assert "Error thrown when saving account updates: 'bummer'" == error_response.data['developer_message']
+        assert error_response.data['user_message'] is None
 
     @override_settings(PROFILE_IMAGE_BACKEND=TEST_PROFILE_IMAGE_BACKEND)
     def test_convert_relative_profile_url(self):
@@ -890,14 +868,10 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
         """
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
         response = self.send_get(self.client)
-        self.assertEqual(
-            response.data["profile_image"],
-            {
-                "has_image": False,
-                "image_url_full": "http://testserver/static/default_50.png",
-                "image_url_small": "http://testserver/static/default_10.png"
-            }
-        )
+        assert response.data['profile_image'] ==\
+               {'has_image': False,
+                'image_url_full': 'http://testserver/static/default_50.png',
+                'image_url_small': 'http://testserver/static/default_10.png'}
 
     @ddt.data(
         ("client", "user", True),
@@ -918,21 +892,21 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
         response = self.send_get(client)
         if has_full_access:
             data = response.data
-            self.assertEqual(26, len(data))
-            self.assertEqual(self.user.username, data["username"])
-            self.assertEqual(self.user.first_name + " " + self.user.last_name, data["name"])
-            self.assertEqual(self.user.email, data["email"])
-            self.assertEqual(year_of_birth, data["year_of_birth"])
+            assert 26 == len(data)
+            assert self.user.username == data['username']
+            assert ((self.user.first_name + ' ') + self.user.last_name) == data['name']
+            assert self.user.email == data['email']
+            assert year_of_birth == data['year_of_birth']
             for empty_field in ("country", "level_of_education", "mailing_address", "bio", "state",):
-                self.assertIsNone(data[empty_field])
-            self.assertEqual("m", data["gender"])
-            self.assertEqual("Learn a lot", data["goals"])
-            self.assertTrue(data["is_active"])
-            self.assertIsNotNone(data["date_joined"])
-            self.assertIsNotNone(data["last_login"])
+                assert data[empty_field] is None
+            assert 'm' == data['gender']
+            assert 'Learn a lot' == data['goals']
+            assert data['is_active']
+            assert data['date_joined'] is not None
+            assert data['last_login'] is not None
             self._verify_profile_image_data(data, False)
-            self.assertTrue(data["requires_parental_consent"])
-            self.assertEqual(PRIVATE_VISIBILITY, data["account_privacy"])
+            assert data['requires_parental_consent']
+            assert PRIVATE_VISIBILITY == data['account_privacy']
         else:
             self._verify_private_account_response(response, requires_parental_consent=True)
 
@@ -967,13 +941,13 @@ class TestAccountAPITransactions(TransactionTestCase):
 
         json_data = {"email": "foo@bar.com", "gender": "o"}
         response = self.client.patch(self.url, data=json.dumps(json_data), content_type="application/merge-patch+json")
-        self.assertEqual(400, response.status_code)
+        assert 400 == response.status_code
 
         # Verify that GET returns the original preferences
         response = self.client.get(self.url)
         data = response.data
-        self.assertEqual(old_email, data["email"])
-        self.assertEqual(u"m", data["gender"])
+        assert old_email == data['email']
+        assert u'm' == data['gender']
 
 
 @ddt.ddt
@@ -1012,16 +986,16 @@ class UsernameReplacementViewTests(APITestCase):
 
         # Test unauthenticated
         response = self.client.post(self.url)
-        self.assertEqual(response.status_code, 401)
+        assert response.status_code == 401
 
         # Test non-service worker
         random_user = UserFactory()
         response = self.call_api(random_user, data)
-        self.assertEqual(response.status_code, 403)
+        assert response.status_code == 403
 
         # Test service worker
         response = self.call_api(self.service_user, data)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
     @ddt.data(
         [{}, {}],
@@ -1034,7 +1008,7 @@ class UsernameReplacementViewTests(APITestCase):
             "username_mappings": mapping_data
         }
         response = self.call_api(self.service_user, data)
-        self.assertEqual(response.status_code, 400)
+        assert response.status_code == 400
 
     def test_existing_and_non_existing_users(self):
         """ Tests a mix of existing and non existing users """
@@ -1050,5 +1024,5 @@ class UsernameReplacementViewTests(APITestCase):
             'successful_replacements': existing_users + non_existing_users
         }
         response = self.call_api(self.service_user, data)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data, expected_response)
+        assert response.status_code == 200
+        assert response.data == expected_response

--- a/openedx/core/djangoapps/user_api/course_tag/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/course_tag/tests/test_api.py
@@ -24,16 +24,16 @@ class TestCourseTagAPI(TestCase):
     def test_get_set_course_tag(self):
         # get a tag that doesn't exist
         tag = course_tag_api.get_course_tag(self.user, self.course_id, self.test_key)
-        self.assertIsNone(tag)
+        assert tag is None
 
         # test setting a new key
         test_value = 'value'
         course_tag_api.set_course_tag(self.user, self.course_id, self.test_key, test_value)
         tag = course_tag_api.get_course_tag(self.user, self.course_id, self.test_key)
-        self.assertEqual(tag, test_value)
+        assert tag == test_value
 
         #test overwriting an existing key
         test_value = 'value2'
         course_tag_api.set_course_tag(self.user, self.course_id, self.test_key, test_value)
         tag = course_tag_api.get_course_tag(self.user, self.course_id, self.test_key)
-        self.assertEqual(tag, test_value)
+        assert tag == test_value

--- a/openedx/core/djangoapps/user_api/management/tests/test_email_opt_in_list.py
+++ b/openedx/core/djangoapps/user_api/management/tests/test_email_opt_in_list.py
@@ -243,7 +243,7 @@ class EmailOptInListTest(ModuleStoreTestCase):
         # Expect that every enrollment shows up in the report
         output_emails = [row["email"] for row in output]
         for email in output_emails:
-            self.assertIn(email, output_emails)
+            assert email in output_emails
 
     def test_org_capitalization(self):
         # Lowercase some of the org names in the course IDs
@@ -302,12 +302,12 @@ class EmailOptInListTest(ModuleStoreTestCase):
         self._set_opt_in_pref(self.user, self.TEST_ORG, True)
 
         # Remove the user profile, and re-fetch user
-        self.assertTrue(hasattr(self.user, 'profile'))
+        assert hasattr(self.user, 'profile')
         self.user.profile.delete()
         user = User.objects.get(id=self.user.id)
 
         # Test that user do not have profile
-        self.assertFalse(hasattr(user, 'profile'))
+        assert not hasattr(user, 'profile')
 
         output = self._run_command(self.TEST_ORG)
         self._assert_output(output, (user, self.courses[0].id, True))
@@ -437,31 +437,19 @@ class EmailOptInListTest(ModuleStoreTestCase):
             AssertionError
 
         """
-        self.assertEqual(len(output), len(args) + 1)
+        assert len(output) == (len(args) + 1)
 
         # Check the header row
-        self.assertEqual({
-            "user_id": "user_id",
-            "username": "username",
-            "email": "email",
-            "full_name": "full_name",
-            "course_id": "course_id",
-            "is_opted_in_for_email": "is_opted_in_for_email",
-            "preference_set_datetime": "preference_set_datetime"
-        }, output[0])
+        assert {'user_id': 'user_id', 'username': 'username', 'email': 'email', 'full_name': 'full_name',
+                'course_id': 'course_id', 'is_opted_in_for_email': 'is_opted_in_for_email',
+                'preference_set_datetime': 'preference_set_datetime'} == output[0]
 
         # Check data rows
         for user, course_id, opt_in_pref in args:
-            self.assertIn({
-                "user_id": str(user.id),
-                "username": user.username,
-                "email": user.email if six.PY3 else user.email.encode('utf-8'),
-                "full_name": ((user.profile.name if six.PY3 else user.profile.name.encode('utf-8')) if
-                              hasattr(user, 'profile') else ''),
-                "course_id": text_type(course_id) if six.PY3 else text_type(course_id).encode('utf-8'),
-                "is_opted_in_for_email": text_type(opt_in_pref) if six.PY3 else text_type(opt_in_pref).encode('utf-8'),
-                "preference_set_datetime": (
-                    self._latest_pref_set_datetime(self.user)
-                    if kwargs.get("expect_pref_datetime", True)
-                    else self.DEFAULT_DATETIME_STR)
-            }, output[1:])
+            assert {'user_id': str(user.id), 'username': user.username, 'email': user.email,
+                    'full_name': (user.profile.name if hasattr(user, 'profile') else ''),
+                    'course_id': text_type(course_id),
+                    'is_opted_in_for_email': text_type(opt_in_pref),
+                    'preference_set_datetime':
+                        (self._latest_pref_set_datetime(self.user) if kwargs.get('expect_pref_datetime', True) else
+                         self.DEFAULT_DATETIME_STR)} in output[1:]

--- a/openedx/core/djangoapps/user_api/management/tests/test_sync_hubspot_contacts.py
+++ b/openedx/core/djangoapps/user_api/management/tests/test_sync_hubspot_contacts.py
@@ -69,7 +69,7 @@ class TestHubspotSyncCommand(TestCase):
         sync_site = patch.object(sync_command, '_sync_site')
         mock_sync_site = sync_site.start()
         call_command('sync_hubspot_contacts')
-        self.assertFalse(mock_sync_site.called, "_sync_site should not be called")
+        assert not mock_sync_site.called, '_sync_site should not be called'
         sync_site.stop()
         # put values back
         self.hubspot_site_config.site_values = orig_values
@@ -84,8 +84,9 @@ class TestHubspotSyncCommand(TestCase):
         out = StringIO()
         call_command('sync_hubspot_contacts', '--initial-sync-days=7', '--batch-size=2', stdout=out)
         output = out.getvalue()
-        self.assertIn('Successfully synced users', output)
-        self.assertEqual(mock_sync_with_hubspot.call_count, 4)  # 4 requests of batch (2, 2, 2, 1), total 7 contacts
+        assert 'Successfully synced users' in output
+        assert mock_sync_with_hubspot.call_count == 4
+        # 4 requests of batch (2, 2, 2, 1), total 7 contacts
         sync_with_hubspot.stop()
 
     def test_command_without_initial_sync_days(self):
@@ -97,6 +98,6 @@ class TestHubspotSyncCommand(TestCase):
         out = StringIO()
         call_command('sync_hubspot_contacts', '--batch-size=3', stdout=out)
         output = out.getvalue()
-        self.assertIn('Successfully synced users', output)
-        self.assertEqual(mock_sync_with_hubspot.call_count, 1)
+        assert 'Successfully synced users' in output
+        assert mock_sync_with_hubspot.call_count == 1
         sync_with_hubspot.stop()

--- a/openedx/core/djangoapps/user_api/preferences/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/preferences/tests/test_api.py
@@ -5,7 +5,7 @@ Unit tests for preference APIs.
 
 
 import datetime
-
+import pytest
 import ddt
 from dateutil.parser import parse as parse_datetime
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
@@ -63,26 +63,21 @@ class TestPreferenceAPI(CacheIsolationTestCase):
         """
         Verifies the basic behavior of get_user_preference.
         """
-        self.assertEqual(
-            get_user_preference(self.user, self.test_preference_key),
-            self.test_preference_value
-        )
-        self.assertEqual(
-            get_user_preference(self.staff_user, self.test_preference_key, username=self.user.username),
-            self.test_preference_value
-        )
+        assert get_user_preference(self.user, self.test_preference_key) == self.test_preference_value
+        assert get_user_preference(self.staff_user, self.test_preference_key, username=self.user.username) == \
+               self.test_preference_value
 
     def test_get_user_preference_errors(self):
         """
         Verifies that get_user_preference returns appropriate errors.
         """
-        with self.assertRaises(UserNotAuthorized):
+        with pytest.raises(UserNotAuthorized):
             get_user_preference(self.user, self.test_preference_key, username="no_such_user")
 
-        with self.assertRaises(UserNotFound):
+        with pytest.raises(UserNotFound):
             get_user_preference(self.no_such_user, self.test_preference_key)
 
-        with self.assertRaises(UserNotAuthorized):
+        with pytest.raises(UserNotAuthorized):
             get_user_preference(self.different_user, self.test_preference_key, username=self.user.username)
 
     def test_get_user_preferences(self):
@@ -92,20 +87,20 @@ class TestPreferenceAPI(CacheIsolationTestCase):
         expected_user_preferences = {
             self.test_preference_key: self.test_preference_value,
         }
-        self.assertEqual(get_user_preferences(self.user), expected_user_preferences)
-        self.assertEqual(get_user_preferences(self.staff_user, username=self.user.username), expected_user_preferences)
+        assert get_user_preferences(self.user) == expected_user_preferences
+        assert get_user_preferences(self.staff_user, username=self.user.username) == expected_user_preferences
 
     def test_get_user_preferences_errors(self):
         """
         Verifies that get_user_preferences returns appropriate errors.
         """
-        with self.assertRaises(UserNotAuthorized):
+        with pytest.raises(UserNotAuthorized):
             get_user_preferences(self.user, username="no_such_user")
 
-        with self.assertRaises(UserNotFound):
+        with pytest.raises(UserNotFound):
             get_user_preferences(self.no_such_user)
 
-        with self.assertRaises(UserNotAuthorized):
+        with pytest.raises(UserNotAuthorized):
             get_user_preferences(self.different_user, username=self.user.username)
 
     def test_set_user_preference(self):
@@ -115,79 +110,61 @@ class TestPreferenceAPI(CacheIsolationTestCase):
         test_key = u'ⓟⓡⓔⓕⓔⓡⓔⓝⓒⓔ_ⓚⓔⓨ'
         test_value = u'ǝnןɐʌ_ǝɔuǝɹǝɟǝɹd'
         set_user_preference(self.user, test_key, test_value)
-        self.assertEqual(get_user_preference(self.user, test_key), test_value)
+        assert get_user_preference(self.user, test_key) == test_value
         set_user_preference(self.user, test_key, "new_value", username=self.user.username)
-        self.assertEqual(get_user_preference(self.user, test_key), "new_value")
+        assert get_user_preference(self.user, test_key) == 'new_value'
 
     @patch('openedx.core.djangoapps.user_api.models.UserPreference.save')
     def test_set_user_preference_errors(self, user_preference_save):
         """
         Verifies that set_user_preference returns appropriate errors.
         """
-        with self.assertRaises(UserNotAuthorized):
+        with pytest.raises(UserNotAuthorized):
             set_user_preference(self.user, self.test_preference_key, "new_value", username="no_such_user")
 
-        with self.assertRaises(UserNotFound):
+        with pytest.raises(UserNotFound):
             set_user_preference(self.no_such_user, self.test_preference_key, "new_value")
 
-        with self.assertRaises(UserNotAuthorized):
+        with pytest.raises(UserNotAuthorized):
             set_user_preference(self.staff_user, self.test_preference_key, "new_value", username=self.user.username)
 
-        with self.assertRaises(UserNotAuthorized):
+        with pytest.raises(UserNotAuthorized):
             set_user_preference(self.different_user, self.test_preference_key, "new_value", username=self.user.username)
 
         too_long_key = "x" * 256
-        with self.assertRaises(PreferenceValidationError) as context_manager:
+        with pytest.raises(PreferenceValidationError) as context_manager:
             set_user_preference(self.user, too_long_key, "new_value")
-        errors = context_manager.exception.preference_errors
-        self.assertEqual(len(list(errors.keys())), 1)
-        self.assertEqual(
-            errors[too_long_key],
-            {
-                "developer_message": get_expected_validation_developer_message(too_long_key, "new_value"),
-                "user_message": get_expected_key_error_user_message(too_long_key, "new_value"),
-            }
-        )
+        errors = context_manager.value.preference_errors
+        assert len(list(errors.keys())) == 1
+        assert errors[too_long_key] ==\
+               {'developer_message': get_expected_validation_developer_message(too_long_key, 'new_value'),
+                'user_message': get_expected_key_error_user_message(too_long_key, 'new_value')}
 
         for empty_value in (None, "", "   "):
-            with self.assertRaises(PreferenceValidationError) as context_manager:
+            with pytest.raises(PreferenceValidationError) as context_manager:
                 set_user_preference(self.user, self.test_preference_key, empty_value)
-            errors = context_manager.exception.preference_errors
-            self.assertEqual(len(list(errors.keys())), 1)
-            self.assertEqual(
-                errors[self.test_preference_key],
-                {
-                    "developer_message": get_empty_preference_message(self.test_preference_key),
-                    "user_message": get_empty_preference_message(self.test_preference_key),
-                }
-            )
+            errors = context_manager.value.preference_errors
+            assert len(list(errors.keys())) == 1
+            assert errors[self.test_preference_key] ==\
+                   {'developer_message': get_empty_preference_message(self.test_preference_key),
+                    'user_message': get_empty_preference_message(self.test_preference_key)}
 
         user_preference_save.side_effect = [Exception, None]
-        with self.assertRaises(PreferenceUpdateError) as context_manager:
+        with pytest.raises(PreferenceUpdateError) as context_manager:
             set_user_preference(self.user, u"new_key_ȻħȺɍłɇs", u"new_value_ȻħȺɍłɇs")
-        self.assertEqual(
-            context_manager.exception.developer_message,
-            u"Save failed for user preference 'new_key_ȻħȺɍłɇs' with value 'new_value_ȻħȺɍłɇs': "
-        )
-        self.assertEqual(
-            context_manager.exception.user_message,
-            u"Save failed for user preference 'new_key_ȻħȺɍłɇs' with value 'new_value_ȻħȺɍłɇs'."
-        )
+        assert context_manager.value.developer_message ==\
+               u"Save failed for user preference 'new_key_ȻħȺɍłɇs' with value 'new_value_ȻħȺɍłɇs': "
+        assert context_manager.value.user_message ==\
+               u"Save failed for user preference 'new_key_ȻħȺɍłɇs' with value 'new_value_ȻħȺɍłɇs'."
 
     def test_update_user_preferences(self):
         """
         Verifies the basic behavior of update_user_preferences.
         """
         set_user_preference(self.user, self.test_preference_key, "new_value")
-        self.assertEqual(
-            get_user_preference(self.user, self.test_preference_key),
-            "new_value"
-        )
+        assert get_user_preference(self.user, self.test_preference_key) == 'new_value'
         set_user_preference(self.user, self.test_preference_key, "new_value", username=self.user.username)
-        self.assertEqual(
-            get_user_preference(self.user, self.test_preference_key),
-            "new_value"
-        )
+        assert get_user_preference(self.user, self.test_preference_key) == 'new_value'
 
     def test_update_user_preferences_with_username(self):
         """
@@ -198,10 +175,7 @@ class TestPreferenceAPI(CacheIsolationTestCase):
             self.test_preference_key: "new_value"
         }
         update_user_preferences(self.user, update_data, user=self.user.username)
-        self.assertEqual(
-            get_user_preference(self.user, self.test_preference_key),
-            "new_value"
-        )
+        assert get_user_preference(self.user, self.test_preference_key) == 'new_value'
 
     def test_update_user_preferences_with_user(self):
         """
@@ -212,10 +186,7 @@ class TestPreferenceAPI(CacheIsolationTestCase):
             self.test_preference_key: "new_value"
         }
         update_user_preferences(self.user, update_data, user=self.user)
-        self.assertEqual(
-            get_user_preference(self.user, self.test_preference_key),
-            "new_value"
-        )
+        assert get_user_preference(self.user, self.test_preference_key) == 'new_value'
 
     @patch('openedx.core.djangoapps.user_api.models.UserPreference.delete')
     @patch('openedx.core.djangoapps.user_api.models.UserPreference.save')
@@ -226,105 +197,81 @@ class TestPreferenceAPI(CacheIsolationTestCase):
         update_data = {
             self.test_preference_key: "new_value"
         }
-        with self.assertRaises(UserNotAuthorized):
+        with pytest.raises(UserNotAuthorized):
             update_user_preferences(self.user, update_data, user="no_such_user")
 
-        with self.assertRaises(UserNotFound):
+        with pytest.raises(UserNotFound):
             update_user_preferences(self.no_such_user, update_data)
 
-        with self.assertRaises(UserNotAuthorized):
+        with pytest.raises(UserNotAuthorized):
             update_user_preferences(self.staff_user, update_data, user=self.user.username)
 
-        with self.assertRaises(UserNotAuthorized):
+        with pytest.raises(UserNotAuthorized):
             update_user_preferences(self.different_user, update_data, user=self.user.username)
 
         too_long_key = "x" * 256
-        with self.assertRaises(PreferenceValidationError) as context_manager:
+        with pytest.raises(PreferenceValidationError) as context_manager:
             update_user_preferences(self.user, {too_long_key: "new_value"})
-        errors = context_manager.exception.preference_errors
-        self.assertEqual(len(list(errors.keys())), 1)
-        self.assertEqual(
-            errors[too_long_key],
-            {
-                "developer_message": get_expected_validation_developer_message(too_long_key, "new_value"),
-                "user_message": get_expected_key_error_user_message(too_long_key, "new_value"),
-            }
-        )
+        errors = context_manager.value.preference_errors
+        assert len(list(errors.keys())) == 1
+        assert errors[too_long_key] ==\
+               {'developer_message': get_expected_validation_developer_message(too_long_key, 'new_value'),
+                'user_message': get_expected_key_error_user_message(too_long_key, 'new_value')}
 
         for empty_value in ("", "   "):
-            with self.assertRaises(PreferenceValidationError) as context_manager:
+            with pytest.raises(PreferenceValidationError) as context_manager:
                 update_user_preferences(self.user, {self.test_preference_key: empty_value})
-            errors = context_manager.exception.preference_errors
-            self.assertEqual(len(list(errors.keys())), 1)
-            self.assertEqual(
-                errors[self.test_preference_key],
-                {
-                    "developer_message": get_empty_preference_message(self.test_preference_key),
-                    "user_message": get_empty_preference_message(self.test_preference_key),
-                }
-            )
+            errors = context_manager.value.preference_errors
+            assert len(list(errors.keys())) == 1
+            assert errors[self.test_preference_key] ==\
+                   {'developer_message': get_empty_preference_message(self.test_preference_key),
+                    'user_message': get_empty_preference_message(self.test_preference_key)}
 
         user_preference_save.side_effect = [Exception, None]
-        with self.assertRaises(PreferenceUpdateError) as context_manager:
+        with pytest.raises(PreferenceUpdateError) as context_manager:
             update_user_preferences(self.user, {self.test_preference_key: "new_value"})
-        self.assertEqual(
-            context_manager.exception.developer_message,
-            u"Save failed for user preference 'test_key' with value 'new_value': "
-        )
-        self.assertEqual(
-            context_manager.exception.user_message,
-            u"Save failed for user preference 'test_key' with value 'new_value'."
-        )
+        assert context_manager.value.developer_message ==\
+               u"Save failed for user preference 'test_key' with value 'new_value': "
+        assert context_manager.value.user_message ==\
+               u"Save failed for user preference 'test_key' with value 'new_value'."
 
         user_preference_delete.side_effect = [Exception, None]
-        with self.assertRaises(PreferenceUpdateError) as context_manager:
+        with pytest.raises(PreferenceUpdateError) as context_manager:
             update_user_preferences(self.user, {self.test_preference_key: None})
-        self.assertEqual(
-            context_manager.exception.developer_message,
-            u"Delete failed for user preference 'test_key': "
-        )
-        self.assertEqual(
-            context_manager.exception.user_message,
-            u"Delete failed for user preference 'test_key'."
-        )
+        assert context_manager.value.developer_message == u"Delete failed for user preference 'test_key': "
+        assert context_manager.value.user_message == u"Delete failed for user preference 'test_key'."
 
     def test_delete_user_preference(self):
         """
         Verifies the basic behavior of delete_user_preference.
         """
-        self.assertTrue(delete_user_preference(self.user, self.test_preference_key))
+        assert delete_user_preference(self.user, self.test_preference_key)
         set_user_preference(self.user, self.test_preference_key, self.test_preference_value)
-        self.assertTrue(delete_user_preference(self.user, self.test_preference_key, username=self.user.username))
-        self.assertFalse(delete_user_preference(self.user, "no_such_key"))
+        assert delete_user_preference(self.user, self.test_preference_key, username=self.user.username)
+        assert not delete_user_preference(self.user, 'no_such_key')
 
     @patch('openedx.core.djangoapps.user_api.models.UserPreference.delete')
     def test_delete_user_preference_errors(self, user_preference_delete):
         """
         Verifies that delete_user_preference returns appropriate errors.
         """
-        with self.assertRaises(UserNotAuthorized):
+        with pytest.raises(UserNotAuthorized):
             delete_user_preference(self.user, self.test_preference_key, username="no_such_user")
 
-        with self.assertRaises(UserNotFound):
+        with pytest.raises(UserNotFound):
             delete_user_preference(self.no_such_user, self.test_preference_key)
 
-        with self.assertRaises(UserNotAuthorized):
+        with pytest.raises(UserNotAuthorized):
             delete_user_preference(self.staff_user, self.test_preference_key, username=self.user.username)
 
-        with self.assertRaises(UserNotAuthorized):
+        with pytest.raises(UserNotAuthorized):
             delete_user_preference(self.different_user, self.test_preference_key, username=self.user.username)
 
         user_preference_delete.side_effect = [Exception, None]
-        with self.assertRaises(PreferenceUpdateError) as context_manager:
+        with pytest.raises(PreferenceUpdateError) as context_manager:
             delete_user_preference(self.user, self.test_preference_key)
-        self.assertEqual(
-            context_manager.exception.developer_message,
-            u"Delete failed for user preference 'test_key': "
-        )
-        self.assertEqual(
-            context_manager.exception.user_message,
-            u"Delete failed for user preference 'test_key'."
-        )
+        assert context_manager.value.developer_message == u"Delete failed for user preference 'test_key': "
+        assert context_manager.value.user_message == u"Delete failed for user preference 'test_key'."
 
 
 @ddt.ddt
@@ -346,7 +293,7 @@ class UpdateEmailOptInTests(ModuleStoreTestCase):
             'name': username,
             'honor_code': 'true',
         })
-        self.assertEqual(resp.status_code, 200)
+        assert resp.status_code == 200
 
     @ddt.data(
         # Check that a 27 year old can opt-in
@@ -380,7 +327,7 @@ class UpdateEmailOptInTests(ModuleStoreTestCase):
 
         update_email_opt_in(user, course.id.org, option)
         result_obj = UserOrgTag.objects.get(user=user, org=course.id.org, key='email-optin')
-        self.assertEqual(result_obj.value, expected_result)
+        assert result_obj.value == expected_result
 
     def test_update_email_optin_no_age_set(self):
         # Test that the API still works if no age is specified.
@@ -392,13 +339,13 @@ class UpdateEmailOptInTests(ModuleStoreTestCase):
 
         update_email_opt_in(user, course.id.org, True)
         result_obj = UserOrgTag.objects.get(user=user, org=course.id.org, key='email-optin')
-        self.assertEqual(result_obj.value, u"True")
+        assert result_obj.value == u'True'
 
     def test_update_email_optin_anonymous_user(self):
         """Verify that the API raises an exception for a user with no profile."""
         course = CourseFactory.create()
         no_profile_user, __ = User.objects.get_or_create(username="no_profile_user", password=self.PASSWORD)
-        with self.assertRaises(UserNotFound):
+        with pytest.raises(UserNotFound):
             update_email_opt_in(no_profile_user, course.id.org, True)
 
     @ddt.data(
@@ -432,7 +379,7 @@ class UpdateEmailOptInTests(ModuleStoreTestCase):
         update_email_opt_in(user, course.id.org, second_option)
 
         result_obj = UserOrgTag.objects.get(user=user, org=course.id.org, key='email-optin')
-        self.assertEqual(result_obj.value, expected_result)
+        assert result_obj.value == expected_result
 
     def _assert_is_datetime(self, timestamp):
         """
@@ -471,7 +418,7 @@ class CountryTimeZoneTest(CacheIsolationTestCase):
             for time_zone in expected_time_zones
         ]
         country_time_zones_dicts = get_country_time_zones(country_code)[:10]
-        self.assertEqual(country_time_zones_dicts, expected_dict)
+        assert country_time_zones_dicts == expected_dict
 
 
 def get_expected_validation_developer_message(preference_key, preference_value):

--- a/openedx/core/djangoapps/user_api/preferences/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/preferences/tests/test_views.py
@@ -46,9 +46,9 @@ class TestPreferencesAPI(UserAPITestCase):
         Test that DELETE, POST, and PUT are not supported.
         """
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
-        self.assertEqual(405, self.client.put(self.url).status_code)
-        self.assertEqual(405, self.client.post(self.url).status_code)
-        self.assertEqual(405, self.client.delete(self.url).status_code)
+        assert 405 == self.client.put(self.url).status_code
+        assert 405 == self.client.post(self.url).status_code
+        assert 405 == self.client.delete(self.url).status_code
 
     def test_get_different_user(self):
         """
@@ -68,7 +68,7 @@ class TestPreferencesAPI(UserAPITestCase):
         """
         client = self.login_client(api_client, username)
         response = client.get(reverse(self.url_endpoint_name, kwargs={'username': "does_not_exist"}))
-        self.assertEqual(404 if username == "staff_user" else 403, response.status_code)
+        assert (404 if (username == 'staff_user') else 403) == response.status_code
 
     def test_get_preferences_default(self):
         """
@@ -77,7 +77,7 @@ class TestPreferencesAPI(UserAPITestCase):
         """
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
         response = self.send_get(self.client)
-        self.assertEqual({}, response.data)
+        assert {} == response.data
 
     @ddt.data(
         ("client", "user"),
@@ -96,8 +96,7 @@ class TestPreferencesAPI(UserAPITestCase):
         # Log in the client and do the GET.
         client = self.login_client(api_client, user)
         response = self.send_get(client)
-        self.assertEqual({"dict_pref": "{'int_key': 10}", "string_pref": "value", "time_zone": "Asia/Tokyo"},  # lint-amnesty, pylint: disable=bad-option-value, unicode-format-string
-                         response.data)
+        assert {'dict_pref': "{'int_key': 10}", 'string_pref': 'value', 'time_zone': 'Asia/Tokyo'} == response.data
 
     @ddt.data(
         ("client", "user"),
@@ -113,7 +112,7 @@ class TestPreferencesAPI(UserAPITestCase):
             reverse(self.url_endpoint_name, kwargs={'username': "does_not_exist"}),
             data=json.dumps({"string_pref": "value"}), content_type="application/merge-patch+json"
         )
-        self.assertEqual(403, response.status_code)
+        assert 403 == response.status_code
 
     def test_patch_bad_content_type(self):
         """
@@ -157,7 +156,7 @@ class TestPreferencesAPI(UserAPITestCase):
         else:
             # lint-amnesty, pylint: disable=bad-option-value, unicode-format-string
             pref_dict = {"dict_pref": "{'int_key': 10}", "string_pref": "value"}
-        self.assertEqual(pref_dict, response.data)
+        assert pref_dict == response.data
 
     @ddt.data(
         ("different_client", "different_user"),
@@ -209,7 +208,7 @@ class TestPreferencesAPI(UserAPITestCase):
             "new_pref": "new_value",
             "time_zone": "Europe/London",
         }
-        self.assertEqual(expected_preferences, response.data)
+        assert expected_preferences == response.data
 
     def test_update_preferences_bad_data(self):
         """
@@ -234,30 +233,9 @@ class TestPreferencesAPI(UserAPITestCase):
             },
             expected_status=400
         )
-        self.assertTrue(response.data.get("field_errors", None))
+        assert response.data.get('field_errors', None)
         field_errors = response.data["field_errors"]
-        self.assertEqual(
-            field_errors,
-            {
-                TOO_LONG_PREFERENCE_KEY: {
-                    "developer_message": get_expected_validation_developer_message(
-                        TOO_LONG_PREFERENCE_KEY, "new_value"
-                    ),
-                    "user_message": get_expected_key_error_user_message(
-                        TOO_LONG_PREFERENCE_KEY, "new_value"
-                    ),
-                },
-                u"empty_pref_ȻħȺɍłɇs": {
-                    "developer_message": u"Preference 'empty_pref_ȻħȺɍłɇs' cannot be set to an empty value.",
-                    "user_message": u"Preference 'empty_pref_ȻħȺɍłɇs' cannot be set to an empty value.",
-                },
-                "time_zone": {
-                    "developer_message": u"Value 'Asia/Africa' not valid for preference 'time_zone': Not in "
-                                         u"timezone set.",
-                    "user_message": u"Value 'Asia/Africa' is not a valid time zone selection."
-                },
-            }
-        )
+        assert field_errors == {TOO_LONG_PREFERENCE_KEY: {'developer_message': get_expected_validation_developer_message(TOO_LONG_PREFERENCE_KEY, 'new_value'), 'user_message': get_expected_key_error_user_message(TOO_LONG_PREFERENCE_KEY, 'new_value')}, u'empty_pref_ȻħȺɍłɇs': {'developer_message': u"Preference 'empty_pref_ȻħȺɍłɇs' cannot be set to an empty value.", 'user_message': u"Preference 'empty_pref_ȻħȺɍłɇs' cannot be set to an empty value."}, 'time_zone': {'developer_message': u"Value 'Asia/Africa' not valid for preference 'time_zone': Not in timezone set.", 'user_message': u"Value 'Asia/Africa' is not a valid time zone selection."}}  # pylint: disable=line-too-long
 
         # Verify that GET returns the original preferences
         response = self.send_get(self.client)
@@ -267,7 +245,7 @@ class TestPreferencesAPI(UserAPITestCase):
             "extra_pref": u"extra_value",
             "time_zone": u"Pacific/Midway",
         }
-        self.assertEqual(expected_preferences, response.data)
+        assert expected_preferences == response.data
 
     def test_update_preferences_bad_request(self):
         """
@@ -277,23 +255,15 @@ class TestPreferencesAPI(UserAPITestCase):
 
         # Verify a non-dict request
         response = self.send_patch(self.client, "non_dict_request", expected_status=400)
-        self.assertEqual(
-            response.data,
-            {
-                "developer_message": u"No data provided for user preference update",
-                "user_message": u"No data provided for user preference update"
-            }
-        )
+        assert response.data ==\
+               {'developer_message': u'No data provided for user preference update',
+                'user_message': u'No data provided for user preference update'}
 
         # Verify an empty dict request
         response = self.send_patch(self.client, {}, expected_status=400)
-        self.assertEqual(
-            response.data,
-            {
-                "developer_message": u"No data provided for user preference update",
-                "user_message": u"No data provided for user preference update"
-            }
-        )
+        assert response.data ==\
+               {'developer_message': u'No data provided for user preference update',
+                'user_message': u'No data provided for user preference update'}
 
     @ddt.data(
         ("different_client", "different_user"),
@@ -356,7 +326,7 @@ class TestPreferencesAPITransactions(TransactionTestCase):
             "c": "1",
         }
         response = self.client.patch(self.url, data=json.dumps(json_data), content_type="application/merge-patch+json")
-        self.assertEqual(400, response.status_code)
+        assert 400 == response.status_code
 
         # Verify that GET returns the original preferences
         response = self.client.get(self.url)
@@ -365,7 +335,7 @@ class TestPreferencesAPITransactions(TransactionTestCase):
             "b": "2",
             "c": "3",
         }
-        self.assertEqual(expected_preferences, response.data)
+        assert expected_preferences == response.data
 
 
 @ddt.ddt
@@ -404,8 +374,8 @@ class TestPreferencesDetailAPI(UserAPITestCase):
         Test that POST and PATCH are not supported.
         """
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
-        self.assertEqual(405, self.client.post(self.url).status_code)
-        self.assertEqual(405, self.client.patch(self.url).status_code)
+        assert 405 == self.client.post(self.url).status_code
+        assert 405 == self.client.patch(self.url).status_code
 
     def test_different_user_access(self):
         """
@@ -429,7 +399,7 @@ class TestPreferencesDetailAPI(UserAPITestCase):
         response = client.get(
             reverse(self.url_endpoint_name, kwargs={'username': "does_not_exist", 'preference_key': self.test_pref_key})
         )
-        self.assertEqual(404 if username == "staff_user" else 403, response.status_code)
+        assert (404 if (username == 'staff_user') else 403) == response.status_code
 
     def test_get_preference_does_not_exist(self):
         """
@@ -438,7 +408,7 @@ class TestPreferencesDetailAPI(UserAPITestCase):
         self._set_url("does_not_exist")
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
         response = self.send_get(self.client, expected_status=404)
-        self.assertIsNone(response.data)
+        assert response.data is None
 
     @ddt.data(
         ("client", "user"),
@@ -452,13 +422,13 @@ class TestPreferencesDetailAPI(UserAPITestCase):
         """
         client = self.login_client(api_client, user)
         response = self.send_get(client)
-        self.assertEqual(self.test_pref_value, response.data)
+        assert self.test_pref_value == response.data
 
         # Test a different value.
         set_user_preference(self.user, "dict_pref", {"int_key": 10})
         self._set_url("dict_pref")
         response = self.send_get(client)
-        self.assertEqual(u"{'int_key': 10}", response.data)
+        assert u"{'int_key': 10}" == response.data
 
     def test_create_preference(self):
         """
@@ -484,7 +454,7 @@ class TestPreferencesDetailAPI(UserAPITestCase):
         new_value = "new value"
         self.send_put(self.client, new_value)
         response = self.send_get(self.client)
-        self.assertEqual(new_value, response.data)
+        assert new_value == response.data
 
     @ddt.data(
         (None,),
@@ -499,13 +469,9 @@ class TestPreferencesDetailAPI(UserAPITestCase):
         self._set_url("new_key")
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
         response = self.send_put(self.client, preference_value, expected_status=400)
-        self.assertEqual(
-            response.data,
-            {
-                "developer_message": u"Preference 'new_key' cannot be set to an empty value.",
-                "user_message": u"Preference 'new_key' cannot be set to an empty value."
-            }
-        )
+        assert response.data ==\
+               {'developer_message': u"Preference 'new_key' cannot be set to an empty value.",
+                'user_message': u"Preference 'new_key' cannot be set to an empty value."}
         self.send_get(self.client, expected_status=404)
 
     def test_create_preference_too_long_key(self):
@@ -518,13 +484,9 @@ class TestPreferencesDetailAPI(UserAPITestCase):
         new_value = "new value"
         self._set_url(too_long_preference_key)
         response = self.send_put(self.client, new_value, expected_status=400)
-        self.assertEqual(
-            response.data,
-            {
-                "developer_message": get_expected_validation_developer_message(too_long_preference_key, new_value),
-                "user_message": get_expected_key_error_user_message(too_long_preference_key, new_value),
-            }
-        )
+        assert response.data ==\
+               {'developer_message': get_expected_validation_developer_message(too_long_preference_key, new_value),
+                'user_message': get_expected_key_error_user_message(too_long_preference_key, new_value)}
 
     @ddt.data(
         ("different_client", "different_user"),
@@ -554,7 +516,7 @@ class TestPreferencesDetailAPI(UserAPITestCase):
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
         self.send_put(self.client, preference_value)
         response = self.send_get(self.client)
-        self.assertEqual(six.text_type(preference_value), response.data)
+        assert six.text_type(preference_value) == response.data
 
     @ddt.data(
         ("different_client", "different_user"),
@@ -581,15 +543,10 @@ class TestPreferencesDetailAPI(UserAPITestCase):
         """
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
         response = self.send_put(self.client, preference_value, expected_status=400)
-        self.assertEqual(
-            response.data,
-            {
-                "developer_message": u"Preference 'test_key' cannot be set to an empty value.",
-                "user_message": u"Preference 'test_key' cannot be set to an empty value."
-            }
-        )
+        assert response.data == {'developer_message': u"Preference 'test_key' cannot be set to an empty value.",
+                                 'user_message': u"Preference 'test_key' cannot be set to an empty value."}
         response = self.send_get(self.client)
-        self.assertEqual(self.test_pref_value, response.data)
+        assert self.test_pref_value == response.data
 
     def test_delete_preference(self):
         """

--- a/openedx/core/djangoapps/user_api/tests/test_helpers.py
+++ b/openedx/core/djangoapps/user_api/tests/test_helpers.py
@@ -68,21 +68,21 @@ class InterceptErrorsTest(TestCase):
             intercepted_function(raise_error=FakeInputException)
         except FakeOutputException as ex:
             actual_message = re.sub(r'line \d+', 'line XXX', text_type(ex), flags=re.MULTILINE)
-            self.assertEqual(actual_message, expected_log_msg)
+            assert actual_message == expected_log_msg
 
         # Verify that the error logger is called
         # This will include the stack trace for the original exception
         # because it's called with log level "ERROR"
         calls = mock_logger.exception.mock_calls
-        self.assertEqual(len(calls), 1)
+        assert len(calls) == 1
         name, args, kwargs = calls[0]
 
-        self.assertEqual(name, '')
-        self.assertEqual(len(args), 1)
-        self.assertEqual(kwargs, {})
+        assert name == ''
+        assert len(args) == 1
+        assert kwargs == {}
 
         actual_message = re.sub(r'line \d+', 'line XXX', args[0], flags=re.MULTILINE)
-        self.assertEqual(actual_message, expected_log_msg)
+        assert actual_message == expected_log_msg
 
 
 class FormDescriptionTest(TestCase):
@@ -108,45 +108,29 @@ class FormDescriptionTest(TestCase):
             supplementalText="",
         )
 
-        self.assertEqual(desc.to_json(), json.dumps({
-            "method": "post",
-            "submit_url": "/submit",
-            "fields": [
-                {
-                    "name": "name",
-                    "label": "label",
-                    "type": "text",
-                    "defaultValue": "default",
-                    "placeholder": "placeholder",
-                    "instructions": "instructions",
-                    "required": True,
-                    "restrictions": {
-                        "min_length": 2,
-                        "max_length": 10,
-                    },
-                    "errorMessages": {
-                        "required": "You must provide a value!"
-                    },
-                    "supplementalLink": "",
-                    "supplementalText": "",
-                    "loginIssueSupportLink": "https://support.example.com/login-issue-help.html",
-                }
-            ]
-        }))
+        assert desc.to_json() ==\
+               json.dumps({'method': 'post',
+                           'submit_url': '/submit',
+                           'fields': [{'name': 'name', 'label': 'label', 'type': 'text', 'defaultValue': 'default',
+                                       'placeholder': 'placeholder', 'instructions': 'instructions', 'required': True,
+                                       'restrictions': {'min_length': 2, 'max_length': 10},
+                                       'errorMessages': {'required': 'You must provide a value!'},
+                                       'supplementalLink': '', 'supplementalText': '',
+                                       'loginIssueSupportLink': 'https://support.example.com/login-issue-help.html'}]})
 
     def test_invalid_field_type(self):
         desc = FormDescription("post", "/submit")
-        with self.assertRaises(InvalidFieldError):
+        with pytest.raises(InvalidFieldError):
             desc.add_field("invalid", field_type="invalid")
 
     def test_missing_options(self):
         desc = FormDescription("post", "/submit")
-        with self.assertRaises(InvalidFieldError):
+        with pytest.raises(InvalidFieldError):
             desc.add_field("name", field_type="select")
 
     def test_invalid_restriction(self):
         desc = FormDescription("post", "/submit")
-        with self.assertRaises(InvalidFieldError):
+        with pytest.raises(InvalidFieldError):
             desc.add_field("name", field_type="text", restrictions={"invalid": 0})
 
     def test_option_overrides(self):
@@ -170,22 +154,9 @@ class FormDescriptionTest(TestCase):
             default="PK"
         )
         desc.add_field(**field)
-        self.assertEqual(
-            desc.fields[0]["options"],
-            [
-                {
-                    'default': False,
-                    'name': 'United States of America',
-                    'value': 'US'
-                },
-                {
-                    'default': True,
-                    'name': 'Pakistan',
-                    'value': 'PK'
-                }
-
-            ]
-        )
+        assert desc.fields[0]['options'] ==\
+               [{'default': False, 'name': 'United States of America', 'value': 'US'},
+                {'default': True, 'name': 'Pakistan', 'value': 'PK'}]
 
 
 class DummyRegistrationExtensionModel(object):

--- a/openedx/core/djangoapps/user_api/tests/test_middleware.py
+++ b/openedx/core/djangoapps/user_api/tests/test_middleware.py
@@ -42,7 +42,7 @@ class TagsMiddlewareTest(TestCase):
         so that the request continues.
         """
         # Middleware should pass request through
-        self.assertEqual(self.middleware.process_request(self.request), None)
+        assert self.middleware.process_request(self.request) is None
 
     def assertContextSetTo(self, context):
         """Asserts UserTagsEventContextMiddleware.CONTEXT_NAME matches ``context``"""
@@ -114,16 +114,10 @@ class TagsMiddlewareTest(TestCase):
         exit_context = get_tracker.return_value.exit_context
 
         # The middleware should clean up the context when the request is done
-        self.assertEqual(
-            self.middleware.process_response(self.request, self.response),
-            self.response
-        )
+        assert self.middleware.process_response(self.request, self.response) == self.response
         exit_context.assert_called_with(UserTagsEventContextMiddleware.CONTEXT_NAME)
         exit_context.reset_mock()
 
         # Even if the tracker blows up, the middleware should still return the response
         get_tracker.side_effect = Exception
-        self.assertEqual(
-            self.middleware.process_response(self.request, self.response),
-            self.response
-        )
+        assert self.middleware.process_response(self.request, self.response) == self.response

--- a/openedx/core/djangoapps/user_api/tests/test_partition_schemes.py
+++ b/openedx/core/djangoapps/user_api/tests/test_partition_schemes.py
@@ -69,7 +69,7 @@ class TestRandomUserPartitionScheme(PartitionTestCase):
                 self.user,
                 self.user_partition
             )
-            self.assertEqual(group1_id, group2_id)
+            assert group1_id == group2_id
 
     def test_get_group_for_user_with_assign(self):
         """
@@ -82,12 +82,12 @@ class TestRandomUserPartitionScheme(PartitionTestCase):
             self.MOCK_COURSE_ID, self.user, self.user_partition, assign=False
         )
 
-        self.assertIsNone(group)
+        assert group is None
 
         # We should get a group automatically assigned to user
         group = RandomUserPartitionScheme.get_group_for_user(self.MOCK_COURSE_ID, self.user, self.user_partition)
 
-        self.assertIsNotNone(group)
+        assert group is not None
 
     def test_empty_partition(self):
         empty_partition = UserPartition(
@@ -104,7 +104,7 @@ class TestRandomUserPartitionScheme(PartitionTestCase):
     def test_user_in_deleted_group(self):
         # get a group assigned to the user - should be group 0 or 1
         old_group = RandomUserPartitionScheme.get_group_for_user(self.MOCK_COURSE_ID, self.user, self.user_partition)
-        self.assertIn(old_group.id, [0, 1])
+        assert old_group.id in [0, 1]
 
         # Change the group definitions! No more group 0 or 1
         groups = [Group(3, 'Group 3'), Group(4, 'Group 4')]
@@ -112,17 +112,17 @@ class TestRandomUserPartitionScheme(PartitionTestCase):
 
         # Now, get a new group using the same call - should be 3 or 4
         new_group = RandomUserPartitionScheme.get_group_for_user(self.MOCK_COURSE_ID, self.user, user_partition)
-        self.assertIn(new_group.id, [3, 4])
+        assert new_group.id in [3, 4]
 
         # We should get the same group over multiple calls
         new_group_2 = RandomUserPartitionScheme.get_group_for_user(self.MOCK_COURSE_ID, self.user, user_partition)
-        self.assertEqual(new_group, new_group_2)
+        assert new_group == new_group_2
 
     def test_change_group_name(self):
         # Changing the name of the group shouldn't affect anything
         # get a group assigned to the user - should be group 0 or 1
         old_group = RandomUserPartitionScheme.get_group_for_user(self.MOCK_COURSE_ID, self.user, self.user_partition)
-        self.assertIn(old_group.id, [0, 1])
+        assert old_group.id in [0, 1]
 
         # Change the group names
         groups = [Group(0, 'Group 0'), Group(1, 'Group 1')]
@@ -136,7 +136,7 @@ class TestRandomUserPartitionScheme(PartitionTestCase):
 
         # Now, get a new group using the same call
         new_group = RandomUserPartitionScheme.get_group_for_user(self.MOCK_COURSE_ID, self.user, user_partition)
-        self.assertEqual(old_group.id, new_group.id)
+        assert old_group.id == new_group.id
 
 
 class TestExtension(TestCase):
@@ -146,6 +146,6 @@ class TestExtension(TestCase):
     """
 
     def test_get_scheme(self):
-        self.assertEqual(UserPartition.get_scheme('random'), RandomUserPartitionScheme)
+        assert UserPartition.get_scheme('random') == RandomUserPartitionScheme
         with self.assertRaisesRegex(UserPartitionError, 'Unrecognized scheme'):
             UserPartition.get_scheme('other')

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -3,7 +3,7 @@
 
 import json  # lint-amnesty, pylint: disable=unused-import
 from unittest import skipUnless  # lint-amnesty, pylint: disable=unused-import
-
+import pytest
 import ddt
 import httpretty  # lint-amnesty, pylint: disable=unused-import
 import mock  # lint-amnesty, pylint: disable=unused-import
@@ -114,10 +114,10 @@ class EmptyUserTestCase(UserAPITestCase):
     """
     def test_get_list_empty(self):
         result = self.get_json(self.LIST_URI)
-        self.assertEqual(result["count"], 0)
-        self.assertIsNone(result["next"])
-        self.assertIsNone(result["previous"])
-        self.assertEqual(result["results"], [])
+        assert result['count'] == 0
+        assert result['next'] is None
+        assert result['previous'] is None
+        assert result['results'] == []
 
 
 @skip_unless_lms
@@ -129,10 +129,10 @@ class EmptyRoleTestCase(UserAPITestCase):
     def test_get_list_empty(self):
         """Test that the endpoint properly returns empty result sets"""
         result = self.get_json(self.LIST_URI)
-        self.assertEqual(result["count"], 0)
-        self.assertIsNone(result["next"])
-        self.assertIsNone(result["previous"])
-        self.assertEqual(result["results"], [])
+        assert result['count'] == 0
+        assert result['next'] is None
+        assert result['previous'] is None
+        assert result['results'] == []
 
 
 class UserApiTestCase(UserAPITestCase):
@@ -208,10 +208,10 @@ class RoleTestCase(UserApiTestCase):
     def test_get_list_nonempty(self):
         result = self.get_json(self.LIST_URI)
         users = result["results"]
-        self.assertEqual(result["count"], len(self.users))
-        self.assertEqual(len(users), len(self.users))
-        self.assertIsNone(result["next"])
-        self.assertIsNone(result["previous"])
+        assert result['count'] == len(self.users)
+        assert len(users) == len(self.users)
+        assert result['next'] is None
+        assert result['previous'] is None
         for user in users:
             self.assertUserIsValid(user)
 
@@ -224,25 +224,25 @@ class RoleTestCase(UserApiTestCase):
             "page_size": 3,
             "course_id": text_type(self.course_id),
         })
-        self.assertEqual(first_page["count"], 5)
+        assert first_page['count'] == 5
         first_page_next_uri = first_page["next"]
-        self.assertIsNone(first_page["previous"])
+        assert first_page['previous'] is None
         first_page_users = first_page["results"]
-        self.assertEqual(len(first_page_users), 3)
+        assert len(first_page_users) == 3
 
         second_page = self.get_json(first_page_next_uri)
-        self.assertEqual(second_page["count"], 5)
-        self.assertIsNone(second_page["next"])
+        assert second_page['count'] == 5
+        assert second_page['next'] is None
         second_page_prev_uri = second_page["previous"]
         second_page_users = second_page["results"]
-        self.assertEqual(len(second_page_users), 2)
+        assert len(second_page_users) == 2
 
-        self.assertEqual(self.get_json(second_page_prev_uri), first_page)
+        assert self.get_json(second_page_prev_uri) == first_page
 
         for user in first_page_users + second_page_users:
             self.assertUserIsValid(user)
         all_user_uris = [user["url"] for user in first_page_users + second_page_users]
-        self.assertEqual(len(set(all_user_uris)), 5)
+        assert len(set(all_user_uris)) == 5
 
 
 @skip_unless_lms
@@ -293,35 +293,35 @@ class UserViewSetTest(UserApiTestCase):
 
     def test_get_list_nonempty(self):
         result = self.get_json(self.LIST_URI)
-        self.assertEqual(result["count"], 5)
-        self.assertIsNone(result["next"])
-        self.assertIsNone(result["previous"])
+        assert result['count'] == 5
+        assert result['next'] is None
+        assert result['previous'] is None
         users = result["results"]
-        self.assertEqual(len(users), 5)
+        assert len(users) == 5
         for user in users:
             self.assertUserIsValid(user)
 
     def test_get_list_pagination(self):
         first_page = self.get_json(self.LIST_URI, data={"page_size": 3})
-        self.assertEqual(first_page["count"], 5)
+        assert first_page['count'] == 5
         first_page_next_uri = first_page["next"]
-        self.assertIsNone(first_page["previous"])
+        assert first_page['previous'] is None
         first_page_users = first_page["results"]
-        self.assertEqual(len(first_page_users), 3)
+        assert len(first_page_users) == 3
 
         second_page = self.get_json(first_page_next_uri)
-        self.assertEqual(second_page["count"], 5)
-        self.assertIsNone(second_page["next"])
+        assert second_page['count'] == 5
+        assert second_page['next'] is None
         second_page_prev_uri = second_page["previous"]
         second_page_users = second_page["results"]
-        self.assertEqual(len(second_page_users), 2)
+        assert len(second_page_users) == 2
 
-        self.assertEqual(self.get_json(second_page_prev_uri), first_page)
+        assert self.get_json(second_page_prev_uri) == first_page
 
         for user in first_page_users + second_page_users:
             self.assertUserIsValid(user)
         all_user_uris = [user["url"] for user in first_page_users + second_page_users]
-        self.assertEqual(len(set(all_user_uris)), 5)
+        assert len(set(all_user_uris)) == 5
 
     # Detail view tests
 
@@ -346,21 +346,10 @@ class UserViewSetTest(UserApiTestCase):
     def test_get_detail(self):
         user = self.users[1]
         uri = self.get_uri_for_user(user)
-        self.assertEqual(
-            self.get_json(uri),
-            {
-                "email": user.email,
-                "id": user.id,
-                "name": user.profile.name,
-                "username": user.username,
-                "preferences": dict([  # lint-amnesty, pylint: disable=consider-using-dict-comprehension
-                    (user_pref.key, user_pref.value)
-                    for user_pref in self.prefs
-                    if user_pref.user == user
-                ]),
-                "url": uri
-            }
-        )
+        assert self.get_json(uri) ==\
+               {'email': user.email, 'id': user.id, 'name': user.profile.name, 'username': user.username,
+                'preferences': {user_pref.key: user_pref.value for user_pref in self.prefs if user_pref.user == user},
+                'url': uri}
 
 
 @skip_unless_lms
@@ -400,33 +389,33 @@ class UserPreferenceViewSetTest(CacheIsolationTestCase, UserApiTestCase):
 
     def test_get_list_nonempty(self):
         result = self.get_json(self.LIST_URI)
-        self.assertEqual(result["count"], 3)
-        self.assertIsNone(result["next"])
-        self.assertIsNone(result["previous"])
+        assert result['count'] == 3
+        assert result['next'] is None
+        assert result['previous'] is None
         prefs = result["results"]
-        self.assertEqual(len(prefs), 3)
+        assert len(prefs) == 3
         for pref in prefs:
             self.assertPrefIsValid(pref)
 
     def test_get_list_filter_key_empty(self):
         result = self.get_json(self.LIST_URI, data={"key": "non-existent"})
-        self.assertEqual(result["count"], 0)
-        self.assertEqual(result["results"], [])
+        assert result['count'] == 0
+        assert result['results'] == []
 
     def test_get_list_filter_key_nonempty(self):
         result = self.get_json(self.LIST_URI, data={"key": "key0"})
-        self.assertEqual(result["count"], 2)
+        assert result['count'] == 2
         prefs = result["results"]
-        self.assertEqual(len(prefs), 2)
+        assert len(prefs) == 2
         for pref in prefs:
             self.assertPrefIsValid(pref)
-            self.assertEqual(pref["key"], "key0")
+            assert pref['key'] == 'key0'
 
     def test_get_list_filter_user_empty(self):
         def test_id(user_id):
             result = self.get_json(self.LIST_URI, data={"user": user_id})
-            self.assertEqual(result["count"], 0)
-            self.assertEqual(result["results"], [])
+            assert result['count'] == 0
+            assert result['results'] == []
         test_id(self.users[2].id)
         # TODO: If the given id does not match a user, then the filter is a no-op
         # test_id(42)
@@ -435,34 +424,34 @@ class UserPreferenceViewSetTest(CacheIsolationTestCase, UserApiTestCase):
     def test_get_list_filter_user_nonempty(self):
         user_id = self.users[0].id
         result = self.get_json(self.LIST_URI, data={"user": user_id})
-        self.assertEqual(result["count"], 2)
+        assert result['count'] == 2
         prefs = result["results"]
-        self.assertEqual(len(prefs), 2)
+        assert len(prefs) == 2
         for pref in prefs:
             self.assertPrefIsValid(pref)
-            self.assertEqual(pref["user"]["id"], user_id)
+            assert pref['user']['id'] == user_id
 
     def test_get_list_pagination(self):
         first_page = self.get_json(self.LIST_URI, data={"page_size": 2})
-        self.assertEqual(first_page["count"], 3)
+        assert first_page['count'] == 3
         first_page_next_uri = first_page["next"]
-        self.assertIsNone(first_page["previous"])
+        assert first_page['previous'] is None
         first_page_prefs = first_page["results"]
-        self.assertEqual(len(first_page_prefs), 2)
+        assert len(first_page_prefs) == 2
 
         second_page = self.get_json(first_page_next_uri)
-        self.assertEqual(second_page["count"], 3)
-        self.assertIsNone(second_page["next"])
+        assert second_page['count'] == 3
+        assert second_page['next'] is None
         second_page_prev_uri = second_page["previous"]
         second_page_prefs = second_page["results"]
-        self.assertEqual(len(second_page_prefs), 1)
+        assert len(second_page_prefs) == 1
 
-        self.assertEqual(self.get_json(second_page_prev_uri), first_page)
+        assert self.get_json(second_page_prev_uri) == first_page
 
         for pref in first_page_prefs + second_page_prefs:
             self.assertPrefIsValid(pref)
         all_pref_uris = [pref["url"] for pref in first_page_prefs + second_page_prefs]
-        self.assertEqual(len(set(all_pref_uris)), 3)
+        assert len(set(all_pref_uris)) == 3
 
     # Detail view tests
 
@@ -487,26 +476,12 @@ class UserPreferenceViewSetTest(CacheIsolationTestCase, UserApiTestCase):
     def test_get_detail(self):
         pref = self.prefs[1]
         uri = self.get_uri_for_pref(pref)
-        self.assertEqual(
-            self.get_json(uri),
-            {
-                "user": {
-                    "email": pref.user.email,
-                    "id": pref.user.id,
-                    "name": pref.user.profile.name,
-                    "username": pref.user.username,
-                    "preferences": dict([  # lint-amnesty, pylint: disable=consider-using-dict-comprehension
-                        (user_pref.key, user_pref.value)
-                        for user_pref in self.prefs
-                        if user_pref.user == pref.user
-                    ]),
-                    "url": self.get_uri_for_user(pref.user),
-                },
-                "key": pref.key,
-                "value": pref.value,
-                "url": uri,
-            }
-        )
+        assert self.get_json(uri) ==\
+               {'user': {'email': pref.user.email, 'id': pref.user.id, 'name': pref.user.profile.name,
+                         'username': pref.user.username,
+                         'preferences': {user_pref.key: user_pref.value for user_pref in self.prefs if
+                                         user_pref.user == pref.user}, 'url': self.get_uri_for_user(pref.user)},
+                'key': pref.key, 'value': pref.value, 'url': uri}
 
 
 @skip_unless_lms
@@ -538,35 +513,35 @@ class PreferenceUsersListViewTest(UserApiTestCase):
 
     def test_get_basic(self):
         result = self.get_json(self.LIST_URI)
-        self.assertEqual(result["count"], 2)
-        self.assertIsNone(result["next"])
-        self.assertIsNone(result["previous"])
+        assert result['count'] == 2
+        assert result['next'] is None
+        assert result['previous'] is None
         users = result["results"]
-        self.assertEqual(len(users), 2)
+        assert len(users) == 2
         for user in users:
             self.assertUserIsValid(user)
 
     def test_get_pagination(self):
         first_page = self.get_json(self.LIST_URI, data={"page_size": 1})
-        self.assertEqual(first_page["count"], 2)
+        assert first_page['count'] == 2
         first_page_next_uri = first_page["next"]
-        self.assertIsNone(first_page["previous"])
+        assert first_page['previous'] is None
         first_page_users = first_page["results"]
-        self.assertEqual(len(first_page_users), 1)
+        assert len(first_page_users) == 1
 
         second_page = self.get_json(first_page_next_uri)
-        self.assertEqual(second_page["count"], 2)
-        self.assertIsNone(second_page["next"])
+        assert second_page['count'] == 2
+        assert second_page['next'] is None
         second_page_prev_uri = second_page["previous"]
         second_page_users = second_page["results"]
-        self.assertEqual(len(second_page_users), 1)
+        assert len(second_page_users) == 1
 
-        self.assertEqual(self.get_json(second_page_prev_uri), first_page)
+        assert self.get_json(second_page_prev_uri) == first_page
 
         for user in first_page_users + second_page_users:
             self.assertUserIsValid(user)
         all_user_uris = [user["url"] for user in first_page_users + second_page_users]
-        self.assertEqual(len(set(all_user_uris)), 2)
+        assert len(set(all_user_uris)) == 2
 
 
 @ddt.ddt
@@ -610,7 +585,7 @@ class UpdateEmailOptInTestCase(UserAPITestCase, SharedModuleStoreTestCase):
         preference = UserOrgTag.objects.get(
             user=self.user, org=self.course.id.org, key="email-optin"
         )
-        self.assertEqual(preference.value, result)
+        assert preference.value == result
 
     @ddt.data(
         (True, False),
@@ -642,7 +617,7 @@ class UpdateEmailOptInTestCase(UserAPITestCase, SharedModuleStoreTestCase):
         preference = UserOrgTag.objects.get(
             user=self.user, org=self.course.id.org, key="email-optin"
         )
-        self.assertEqual(preference.value, u"True")
+        assert preference.value == u'True'
 
     def test_update_email_opt_in_anonymous_user(self):
         """
@@ -654,7 +629,7 @@ class UpdateEmailOptInTestCase(UserAPITestCase, SharedModuleStoreTestCase):
             "course_id": six.text_type(self.course.id),
             "email_opt_in": u"True"
         })
-        self.assertEqual(response.status_code, 403)
+        assert response.status_code == 403
 
     def test_update_email_opt_with_invalid_course_key(self):
         """
@@ -666,7 +641,7 @@ class UpdateEmailOptInTestCase(UserAPITestCase, SharedModuleStoreTestCase):
             "email_opt_in": u"True"
         })
         self.assertHttpBadRequest(response)
-        with self.assertRaises(UserOrgTag.DoesNotExist):
+        with pytest.raises(UserOrgTag.DoesNotExist):
             UserOrgTag.objects.get(user=self.user, org=self.course.id.org, key="email-optin")
 
 
@@ -694,8 +669,8 @@ class CountryTimeZoneListViewTest(UserApiTestCase):
     def _assert_time_zone_is_valid(self, time_zone_info):
         """ Asserts that the time zone is a valid pytz time zone """
         time_zone_name = time_zone_info['time_zone']
-        self.assertIn(time_zone_name, common_timezones_set)
-        self.assertEqual(time_zone_info['description'], get_display_time_zone(time_zone_name))
+        assert time_zone_name in common_timezones_set
+        assert time_zone_info['description'] == get_display_time_zone(time_zone_name)
 
     # The time zones count may need to change each time we upgrade pytz
     @ddt.data((ALL_TIME_ZONES_URI, 439),
@@ -704,6 +679,6 @@ class CountryTimeZoneListViewTest(UserApiTestCase):
     def test_get_basic(self, country_uri, expected_count):
         """ Verify that correct time zone info is returned """
         results = self.get_json(country_uri)
-        self.assertEqual(len(results), expected_count)
+        assert len(results) == expected_count
         for time_zone_info in results:
             self._assert_time_zone_is_valid(time_zone_info)

--- a/openedx/core/djangoapps/user_api/verification_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/verification_api/tests/test_views.py
@@ -38,7 +38,7 @@ class VerificationStatusViewTestsMixin:
     def assert_path_not_found(self, path):
         """ Assert the path returns HTTP 404. """
         response = self.client.get(path)
-        self.assertEqual(response.status_code, 404)
+        assert response.status_code == 404
 
     def get_expected_response(self, *args, **kwargs):
         raise NotImplementedError
@@ -46,17 +46,17 @@ class VerificationStatusViewTestsMixin:
     def assert_verification_returned(self, verified=False):
         """ Assert the path returns HTTP 200 and returns appropriately-serialized data. """
         response = self.client.get(self.path)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         expected_expires = self.CREATED_AT + datetime.timedelta(settings.VERIFY_STUDENT['DAYS_GOOD_FOR'])
 
         expected = self.get_expected_response(verified=verified, expected_expires=expected_expires)
-        self.assertEqual(json.loads(response.content.decode('utf-8')), expected)
+        assert json.loads(response.content.decode('utf-8')) == expected
 
     def test_authentication_required(self):
         """ The endpoint should return HTTP 403 if the user is not authenticated. """
         self.client.logout()
         response = self.client.get(self.path)
-        self.assertEqual(response.status_code, 401)
+        assert response.status_code == 401
 
     def test_no_verifications(self):
         """ The endpoint should return HTTP 404 if the user has no verifications. """
@@ -81,7 +81,7 @@ class VerificationStatusViewTestsMixin:
         user = UserFactory()
         self.client.login(username=user.username, password=self.PASSWORD)
         response = self.client.get(self.path)
-        self.assertEqual(response.status_code, 403)
+        assert response.status_code == 403
 
     def test_non_existent_user(self):
         """ The endpoint should return HTTP 404 if the user does not exist. """
@@ -148,7 +148,7 @@ class VerificationsDetailsViewTests(VerificationStatusViewTestsMixin, TestCase):
         self.photo_verification.status = 'denied'
         self.photo_verification.save()
         response = self.client.get(self.path)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         expected_expires = self.CREATED_AT + datetime.timedelta(settings.VERIFY_STUDENT['DAYS_GOOD_FOR'])
 
         expected = [
@@ -177,7 +177,7 @@ class VerificationsDetailsViewTests(VerificationStatusViewTestsMixin, TestCase):
                 'receipt_id': None,
             },
         ]
-        self.assertEqual(json.loads(response.content.decode('utf-8')), expected)
+        assert json.loads(response.content.decode('utf-8')) == expected
 
     def test_multiple_verification_instances(self):
         self.sso_verification = SSOVerificationFactory(user=self.user, status='approved')  # lint-amnesty, pylint: disable=attribute-defined-outside-init
@@ -188,7 +188,7 @@ class VerificationsDetailsViewTests(VerificationStatusViewTestsMixin, TestCase):
             error_code='plain_code'
         )
         response = self.client.get(self.path)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         expected_expires = self.CREATED_AT + datetime.timedelta(settings.VERIFY_STUDENT['DAYS_GOOD_FOR'])
 
         expected = [
@@ -217,4 +217,4 @@ class VerificationsDetailsViewTests(VerificationStatusViewTestsMixin, TestCase):
                 'receipt_id': None,
             },
         ]
-        self.assertEqual(json.loads(response.content.decode('utf-8')), expected)
+        assert json.loads(response.content.decode('utf-8')) == expected


### PR DESCRIPTION
## Description
This PR is using `codemod-unittest-to-pytest-asserts` to automatically replace `unittest` assertions with `pytest` 
for following apps  in `openedx/core/djangoapps/` 
```
user_api
```
Relevant JIRA issue here: https://openedx.atlassian.net/browse/BOM-2401