### PR TITLE
replaced unittest assertions pytest assertions (32)

### DIFF
--- a/openedx/core/djangoapps/video_config/tests/test_models.py
+++ b/openedx/core/djangoapps/video_config/tests/test_models.py
@@ -59,12 +59,10 @@ class FeatureFlagTestMixin(object):
             course_id=self.course_id_1,
             enabled_for_course=enabled_for_course_1
         ):
-            self.assertEqual(
-                all_courses_model_class.feature_enabled(self.course_id_1),
+            assert all_courses_model_class.feature_enabled(self.course_id_1) == (
                 global_flag and (enabled_for_all_courses or enabled_for_course_1)
             )
-            self.assertEqual(
-                all_courses_model_class.feature_enabled(self.course_id_2),
+            assert all_courses_model_class.feature_enabled(self.course_id_2) == (
                 global_flag and enabled_for_all_courses
             )
 
@@ -80,7 +78,7 @@ class FeatureFlagTestMixin(object):
             course_id=self.course_id_1,
             enabled_for_course=True
         ):
-            self.assertTrue(all_courses_model_class.feature_enabled(self.course_id_1))
+            assert all_courses_model_class.feature_enabled(self.course_id_1)
             with video_feature_flags(
                 all_courses_model_class=all_courses_model_class,
                 course_specific_model_class=course_specific_model_class,
@@ -89,7 +87,7 @@ class FeatureFlagTestMixin(object):
                 course_id=self.course_id_1,
                 enabled_for_course=False
             ):
-                self.assertFalse(all_courses_model_class.feature_enabled(self.course_id_1))
+                assert not all_courses_model_class.feature_enabled(self.course_id_1)
 
     def verify_enable_disable_globally(self, all_courses_model_class, course_specific_model_class):
         """
@@ -101,23 +99,23 @@ class FeatureFlagTestMixin(object):
             global_flag=True,
             enabled_for_all_courses=True,
         ):
-            self.assertTrue(all_courses_model_class.feature_enabled(self.course_id_1))
-            self.assertTrue(all_courses_model_class.feature_enabled(self.course_id_2))
+            assert all_courses_model_class.feature_enabled(self.course_id_1)
+            assert all_courses_model_class.feature_enabled(self.course_id_2)
             with video_feature_flags(
                 all_courses_model_class=all_courses_model_class,
                 course_specific_model_class=course_specific_model_class,
                 global_flag=True,
                 enabled_for_all_courses=False,
             ):
-                self.assertFalse(all_courses_model_class.feature_enabled(self.course_id_1))
-                self.assertFalse(all_courses_model_class.feature_enabled(self.course_id_2))
+                assert not all_courses_model_class.feature_enabled(self.course_id_1)
+                assert not all_courses_model_class.feature_enabled(self.course_id_2)
                 with video_feature_flags(
                     all_courses_model_class=all_courses_model_class,
                     course_specific_model_class=course_specific_model_class,
                     global_flag=False,
                 ):
-                    self.assertFalse(all_courses_model_class.feature_enabled(self.course_id_1))
-                    self.assertFalse(all_courses_model_class.feature_enabled(self.course_id_2))
+                    assert not all_courses_model_class.feature_enabled(self.course_id_1)
+                    assert not all_courses_model_class.feature_enabled(self.course_id_2)
 
 
 @ddt.ddt

--- a/openedx/core/djangoapps/video_pipeline/tests/test_api.py
+++ b/openedx/core/djangoapps/video_pipeline/tests/test_api.py
@@ -42,7 +42,7 @@ class TestAPIUtils(VideoPipelineMixin, TestCase):
         self.vem_pipeline_integration.save()
 
         __, is_updated = update_3rd_party_transcription_service_credentials()
-        self.assertFalse(is_updated)
+        assert not is_updated
 
     @ddt.data(
         {
@@ -67,8 +67,8 @@ class TestAPIUtils(VideoPipelineMixin, TestCase):
 
         # Making sure log.exception is not called.
         self.assertDictEqual(error_response, {})
-        self.assertFalse(mock_logger.exception.called)
-        self.assertTrue(is_updated)
+        assert not mock_logger.exception.called
+        assert is_updated
 
         mock_logger.info.assert_any_call('Sending transcript credentials to VEM for org: {} and provider: {}'.format(
             credentials_payload.get('org'), credentials_payload.get('provider')
@@ -93,7 +93,7 @@ class TestAPIUtils(VideoPipelineMixin, TestCase):
         error_response, is_updated = update_3rd_party_transcription_service_credentials(**credentials_payload)
 
         # Assert the results.
-        self.assertFalse(is_updated)
+        assert not is_updated
         self.assertDictEqual(error_response, json.loads(error_content))
         mock_logger.exception.assert_called_with(
             'Unable to update transcript credentials -- org={}, provider={}, response={}'.format(

--- a/openedx/core/djangoapps/zendesk_proxy/tests/test_utils.py
+++ b/openedx/core/djangoapps/zendesk_proxy/tests/test_utils.py
@@ -42,7 +42,7 @@ class TestUtils(ApiTestCase):  # lint-amnesty, pylint: disable=missing-class-doc
             body=self.request_data['body'],
         )
 
-        self.assertEqual(status_code, 503)
+        assert status_code == 503
 
     @ddt.data(201, 400, 401, 403, 404, 500)
     def test_zendesk_status_codes(self, mock_code):
@@ -54,7 +54,7 @@ class TestUtils(ApiTestCase):  # lint-amnesty, pylint: disable=missing-class-doc
                 body=self.request_data['body'],
             )
 
-            self.assertEqual(status_code, mock_code)
+            assert status_code == mock_code
 
     def test_unexpected_error_pinging_zendesk(self):
         with patch('requests.post', side_effect=Exception("WHAMMY")):
@@ -64,7 +64,7 @@ class TestUtils(ApiTestCase):  # lint-amnesty, pylint: disable=missing-class-doc
                 subject=self.request_data['subject'],
                 body=self.request_data['body'],
             )
-            self.assertEqual(status_code, 500)
+            assert status_code == 500
 
     def test_financial_assistant_ticket(self):
         """ Test Financial Assistent request ticket. """
@@ -93,4 +93,4 @@ class TestUtils(ApiTestCase):  # lint-amnesty, pylint: disable=missing-class-doc
                         )
                     ),
                 )
-                self.assertEqual(status_code, 200)
+                assert status_code == 200

--- a/openedx/core/djangoapps/zendesk_proxy/tests/test_v0_views.py
+++ b/openedx/core/djangoapps/zendesk_proxy/tests/test_v0_views.py
@@ -46,33 +46,23 @@ class ZendeskProxyTestCase(ApiTestCase):
             )
             self.assertHttpCreated(response)
             (mock_args, mock_kwargs) = mock_post.call_args
-            self.assertEqual(mock_args, ('https://www.superrealurlsthataredefinitelynotfake.com/api/v2/tickets.json',))
+            assert mock_args == ('https://www.superrealurlsthataredefinitelynotfake.com/api/v2/tickets.json',)
             six.assertCountEqual(self, mock_kwargs.keys(), ['headers', 'data'])
-            self.assertEqual(
-                mock_kwargs['headers'],
-                {
-                    'content-type': 'application/json',
-                    'Authorization': 'Bearer abcdefghijklmnopqrstuvwxyz1234567890'
-                }
-            )
-            self.assertEqual(
-                json.loads(mock_kwargs['data']),
-                {
-                    'ticket': {
-                        'comment': {
-                            'body': "Help! I'm trapped in a unit test factory and I can't get out!",
-                            'uploads': None,
-                        },
-                        'custom_fields': None,
-                        'requester': {
-                            'email': 'JohnQStudent@example.com',
-                            'name': 'John Q. Student',
-                        },
+            assert mock_kwargs['headers'] == {
+                'content-type': 'application/json', 'Authorization': 'Bearer abcdefghijklmnopqrstuvwxyz1234567890'
+            }
+            assert json.loads(mock_kwargs['data']) == {
+                'ticket':
+                    {
+                        'comment':
+                            {
+                                'body': "Help! I'm trapped in a unit test factory and I can't get out!", 'uploads': None
+                            }, 'custom_fields': None,
+                        'requester': {'email': 'JohnQStudent@example.com', 'name': 'John Q. Student'},
                         'subject': 'Python Unit Test Help Request',
-                        'tags': ['python_unit_test'],
-                    },
-                }
-            )
+                        'tags': ['python_unit_test']
+                    }
+            }
 
     @ddt.data('name', 'tags', 'email')
     def test_bad_request(self, key_to_delete):
@@ -103,4 +93,4 @@ class ZendeskProxyTestCase(ApiTestCase):
         for _ in range(ZENDESK_REQUESTS_PER_HOUR):
             self.request_without_auth('post', self.url)
         response = self.request_without_auth('post', self.url)
-        self.assertEqual(response.status_code, 429)
+        assert response.status_code == 429

--- a/openedx/core/djangoapps/zendesk_proxy/tests/test_v1_views.py
+++ b/openedx/core/djangoapps/zendesk_proxy/tests/test_v1_views.py
@@ -57,33 +57,21 @@ class ZendeskProxyTestCase(ApiTestCase):
             )
             self.assertHttpCreated(response)
             (mock_args, mock_kwargs) = mock_post.call_args
-            self.assertEqual(mock_args, ('https://www.superrealurlsthataredefinitelynotfake.com/api/v2/tickets.json',))
+            assert mock_args == ('https://www.superrealurlsthataredefinitelynotfake.com/api/v2/tickets.json',)
             six.assertCountEqual(self, mock_kwargs.keys(), ['headers', 'data'])
-            self.assertEqual(
-                mock_kwargs['headers'],
-                {
-                    'content-type': 'application/json',
-                    'Authorization': 'Bearer abcdefghijklmnopqrstuvwxyz1234567890'
-                }
-            )
-            self.assertEqual(
-                json.loads(mock_kwargs['data']),
-                {
-                    'ticket': {
-                        'comment': {
-                            'body': "Help! I'm trapped in a unit test factory and I can't get out!",
-                            'uploads': None,
-                        },
-                        'custom_fields': [{'id': '001', 'value': 'demo-course'}],
-                        'requester': {
-                            'email': self.user.email,
-                            'name': self.user.username
-                        },
-                        'subject': 'Python Unit Test Help Request',
-                        'tags': ['python_unit_test'],
+            assert mock_kwargs['headers'] == {
+                'content-type': 'application/json', 'Authorization': 'Bearer abcdefghijklmnopqrstuvwxyz1234567890'
+            }
+            assert json.loads(mock_kwargs['data']) == {
+                'ticket': {
+                    'comment': {
+                        'body': "Help! I'm trapped in a unit test factory and I can't get out!", 'uploads': None
                     },
+                    'custom_fields': [{'id': '001', 'value': 'demo-course'}],
+                    'requester': {'email': self.user.email, 'name': self.user.username},
+                    'subject': 'Python Unit Test Help Request', 'tags': ['python_unit_test']
                 }
-            )
+            }
 
     @ddt.data('subject', 'tags')
     def test_bad_request(self, key_to_delete):
@@ -115,4 +103,4 @@ class ZendeskProxyTestCase(ApiTestCase):
         for _ in range(ZendeskProxyThrottle().num_requests):
             self.request_without_auth('post', self.url)
         response = self.request_without_auth('post', self.url)
-        self.assertEqual(response.status_code, 429)
+        assert response.status_code == 429


### PR DESCRIPTION
## Description
This PR is using `codemod-unittest-to-pytest-asserts` to automatically replace `unittest` assertions with `pytest` 
for following apps  in `openedx/core/djangoapps/` 
```
video_config, video_pipeline, waffle_utils, xblock, xmodule_django, zendesk_proxy
```
Relevant JIRA issue here: https://openedx.atlassian.net/browse/BOM-2403