### PR TITLE
replaced unittest assertions pytest assertions (33)

### DIFF
--- a/openedx/core/djangolib/testing/tests/test_utils.py
+++ b/openedx/core/djangolib/testing/tests/test_utils.py
@@ -24,13 +24,13 @@ class TestGetMockRequest(TestCase):
 
     def test_mock_request_is_request(self):
         request = get_mock_request(USER_MODEL())
-        self.assertIsInstance(request, HttpRequest)
+        assert isinstance(request, HttpRequest)
 
     def test_user_is_attached_to_mock_request(self):
         user = USER_MODEL()
         request = get_mock_request(user)
-        self.assertIs(request.user, user)
+        assert request.user is user
 
     def test_mock_request_without_user(self):
         request = get_mock_request()
-        self.assertIsInstance(request.user, AnonymousUser)
+        assert isinstance(request.user, AnonymousUser)

--- a/openedx/core/djangolib/testing/utils.py
+++ b/openedx/core/djangolib/testing/utils.py
@@ -190,13 +190,10 @@ class _AssertNumQueriesContext(CaptureQueriesContext):
             return
         filtered_queries = [query for query in self.captured_queries if is_unfiltered_query(query)]
         executed = len(filtered_queries)
-        self.test_case.assertEqual(
-            executed, self.num,
-            u"%d queries executed, %d expected\nCaptured queries were:\n%s" % (
-                executed, self.num,
-                '\n'.join(
-                    query['sql'] for query in filtered_queries
-                )
+
+        assert executed == self.num, (
+            u'%d queries executed, %d expected\nCaptured queries were:\n%s' % (
+                executed, self.num, '\n'.join((query['sql'] for query in filtered_queries))
             )
         )
 

--- a/openedx/core/djangolib/tests/test_blockstore_cache.py
+++ b/openedx/core/djangolib/tests/test_blockstore_cache.py
@@ -44,8 +44,8 @@ class BundleCacheTest(TestWithBundleMixin, unittest.TestCase):
         cache.set(key1, value1)
         value2 = {"this is": "a dict", "for": "key2"}
         cache.set(key2, value2)
-        self.assertEqual(cache.get(key1), value1)
-        self.assertEqual(cache.get(key2), value2)
+        assert cache.get(key1) == value1
+        assert cache.get(key2) == value2
 
         # Now publish a new version of the bundle:
         api.write_draft_file(self.draft.uuid, "test.txt", "we need a changed file in order to publish a new version")
@@ -53,8 +53,8 @@ class BundleCacheTest(TestWithBundleMixin, unittest.TestCase):
 
         # Now the cache should be invalidated
         # (immediately since we set MAX_BLOCKSTORE_CACHE_DELAY to 0)
-        self.assertEqual(cache.get(key1), None)
-        self.assertEqual(cache.get(key2), None)
+        assert cache.get(key1) is None
+        assert cache.get(key2) is None
 
     def test_bundle_draft_cache(self):
         """
@@ -69,16 +69,16 @@ class BundleCacheTest(TestWithBundleMixin, unittest.TestCase):
         cache.set(key1, value1)
         value2 = {"this is": "a dict", "for": "key2"}
         cache.set(key2, value2)
-        self.assertEqual(cache.get(key1), value1)
-        self.assertEqual(cache.get(key2), value2)
+        assert cache.get(key1) == value1
+        assert cache.get(key2) == value2
 
         # Now make a change to the draft (doesn't matter if we commit it or not)
         api.write_draft_file(self.draft.uuid, "test.txt", "we need a changed file in order to publish a new version")
 
         # Now the cache should be invalidated
         # (immediately since we set MAX_BLOCKSTORE_CACHE_DELAY to 0)
-        self.assertEqual(cache.get(key1), None)
-        self.assertEqual(cache.get(key2), None)
+        assert cache.get(key1) is None
+        assert cache.get(key2) is None
 
 
 @unittest.skipUnless(settings.RUN_BLOCKSTORE_TESTS, "Requires a running Blockstore server")
@@ -99,7 +99,7 @@ class BundleCacheClearTest(TestWithBundleMixin, unittest.TestCase):
         key1 = ("some", "key", "1")
         value1 = "value1"
         cache.set(key1, value1)
-        self.assertEqual(cache.get(key1), value1)
+        assert cache.get(key1) == value1
 
         # Now publish a new version of the bundle:
         api.write_draft_file(self.draft.uuid, "test.txt", "we need a changed file in order to publish a new version")
@@ -108,7 +108,7 @@ class BundleCacheClearTest(TestWithBundleMixin, unittest.TestCase):
         # Now the cache will not be immediately invalidated; it takes up to MAX_BLOCKSTORE_CACHE_DELAY seconds.
         # Since this is a new bundle and we _just_ accessed the cache for the first time, we can be confident
         # it won't yet be automatically invalidated.
-        self.assertEqual(cache.get(key1), value1)
+        assert cache.get(key1) == value1
         # Now "clear" the cache, forcing the check of the new version:
         cache.clear()
-        self.assertEqual(cache.get(key1), None)
+        assert cache.get(key1) is None

--- a/openedx/core/djangolib/tests/test_js_utils.py
+++ b/openedx/core/djangolib/tests/test_js_utils.py
@@ -46,7 +46,7 @@ class TestJSUtils(TestCase):
         )
 
         escaped_json = dump_js_escaped_json(malicious_dict)
-        self.assertEqual(expected_escaped_json, escaped_json)
+        assert expected_escaped_json == escaped_json
 
     def test_dump_js_escaped_json_with_custom_encoder_escapes_unsafe_html(self):
         """
@@ -66,7 +66,7 @@ class TestJSUtils(TestCase):
         )
 
         escaped_json = dump_js_escaped_json(malicious_dict, cls=self.SampleJSONEncoder)
-        self.assertEqual(expected_custom_escaped_json, escaped_json)
+        assert expected_custom_escaped_json == escaped_json
 
     def test_js_escaped_string_escapes_unsafe_html(self):
         """
@@ -78,14 +78,14 @@ class TestJSUtils(TestCase):
             r"\u003C/script\u003E\u003Cscript\u003Ealert(\u0027hello, \u0027)\u003B\u003C/script\u003E"
         )
         escaped_string_for_js = js_escaped_string(malicious_js_string)
-        self.assertEqual(expected_escaped_string_for_js, escaped_string_for_js)
+        assert expected_escaped_string_for_js == escaped_string_for_js
 
     def test_js_escaped_string_with_none(self):
         """
         Test js_escaped_string returns empty string for None
         """
         escaped_string_for_js = js_escaped_string(None)
-        self.assertEqual(u"", escaped_string_for_js)
+        assert u'' == escaped_string_for_js
 
     def test_mako(self):
         """
@@ -142,32 +142,32 @@ class TestJSUtils(TestCase):
             r"&#34;test-=&amp;\\;&#39;\&#34;&lt;&gt;\u2603&#34;}"
         )
         self._validate_expectation_of_json_for_html(test_dict, expected_json_for_html)
-        self.assertIn("&#34;test_tuple&#34;: [1, 2, 3]", out)
-        self.assertIn("&#34;test_number&#34;: 3.5", out)
-        self.assertIn("&#34;test_bool&#34;: false", out)
-        self.assertIn("&#34;test_string&#34;: &#34;test-=&amp;\\\\;&#39;\\&#34;&lt;&gt;\\u2603&#34", out)
-        self.assertIn(u"data-test-string='test-=&amp;\\;&#39;&#34;&lt;&gt;☃'", out)
-        self.assertIn("data-test-tuple='[1, 2, 3]'", out)
-        self.assertIn("data-test-number='3.5'", out)
-        self.assertIn("data-test-bool='false'", out)
+        assert '&#34;test_tuple&#34;: [1, 2, 3]' in out
+        assert '&#34;test_number&#34;: 3.5' in out
+        assert '&#34;test_bool&#34;: false' in out
+        assert '&#34;test_string&#34;: &#34;test-=&amp;\\\\;&#39;\\&#34;&lt;&gt;\\u2603&#34' in out
+        assert u"data-test-string='test-=&amp;\\;&#39;&#34;&lt;&gt;☃'" in out
+        assert "data-test-tuple='[1, 2, 3]'" in out
+        assert "data-test-number='3.5'" in out
+        assert "data-test-bool='false'" in out
 
         expected_string_for_js_in_dict = r'''test-=\u0026\\;'\"\u003c\u003e\u2603'''
         self._validate_expectation_of_string_for_js(test_dict['test_string'], expected_string_for_js_in_dict)
         location_of_dict_in_out = re.search("var test_dict.*}", out)
         var_dict_in_out = out[location_of_dict_in_out.span()[0]:location_of_dict_in_out.span()[1]]
-        self.assertIn('"test_number": 3.5', var_dict_in_out)
-        self.assertIn('"test_string": "test-=\\u0026\\\\;\'\\"\\u003c\\u003e\\u2603"', var_dict_in_out)
-        self.assertIn('"test_tuple": [1, 2, 3]', var_dict_in_out)
-        self.assertIn('"test_bool": false', var_dict_in_out)
+        assert '"test_number": 3.5' in var_dict_in_out
+        assert '"test_string": "test-=\\u0026\\\\;\'\\"\\u003c\\u003e\\u2603"' in var_dict_in_out
+        assert '"test_tuple": [1, 2, 3]' in var_dict_in_out
+        assert '"test_bool": false' in var_dict_in_out
 
         expected_string_for_js = u"test\\u002D\\u003D\\u0026\\u005C\\u003B\\u0027\\u0022\\u003C\\u003E☃"
         self._validate_expectation_of_string_for_js(test_dict['test_string'], expected_string_for_js)
-        self.assertIn("var test_string = '" + expected_string_for_js + "'", out)
-        self.assertIn("var test_none_string = ''", out)
-        self.assertIn("var test_tuple = [1, 2, 3]", out)
-        self.assertIn("var test_number = 3.5", out)
-        self.assertIn("var test_bool = false", out)
-        self.assertIn("var test_none_json = null", out)
+        assert ("var test_string = '" + expected_string_for_js) + "'" in out
+        assert "var test_none_string = ''" in out
+        assert 'var test_tuple = [1, 2, 3]' in out
+        assert 'var test_number = 3.5' in out
+        assert 'var test_bool = false' in out
+        assert 'var test_none_json = null' in out
 
     def _validate_expectation_of_json_for_html(self, test_dict, expected_json_for_html_string):
         """
@@ -191,10 +191,10 @@ class TestJSUtils(TestCase):
         # tuples become arrays in json, so it is parsed to a list that is
         # switched back to a tuple before comparing
         parsed_expected_dict['test_tuple'] = tuple(parsed_expected_dict['test_tuple'])
-        self.assertEqual(test_dict['test_string'], parsed_expected_dict['test_string'])
-        self.assertEqual(test_dict['test_tuple'], parsed_expected_dict['test_tuple'])
-        self.assertEqual(test_dict['test_number'], parsed_expected_dict['test_number'])
-        self.assertEqual(test_dict['test_bool'], parsed_expected_dict['test_bool'])
+        assert test_dict['test_string'] == parsed_expected_dict['test_string']
+        assert test_dict['test_tuple'] == parsed_expected_dict['test_tuple']
+        assert test_dict['test_number'] == parsed_expected_dict['test_number']
+        assert test_dict['test_bool'] == parsed_expected_dict['test_bool']
 
     def _validate_expectation_of_string_for_js(self, test_string, expected_string_for_js):
         """
@@ -212,4 +212,4 @@ class TestJSUtils(TestCase):
 
         """
         parsed_expected_string = json.loads('"' + expected_string_for_js + '"')
-        self.assertEqual(test_string, parsed_expected_string)
+        assert test_string == parsed_expected_string

--- a/openedx/core/djangolib/tests/test_markup.py
+++ b/openedx/core/djangolib/tests/test_markup.py
@@ -30,8 +30,8 @@ class FormatHtmlTest(unittest.TestCase):
     )
     def test_simple(self, before_after):
         (before, after) = before_after
-        self.assertEqual(six.text_type(Text(_(before))), after)  # pylint: disable=translation-of-non-string
-        self.assertEqual(six.text_type(Text(before)), after)
+        assert six.text_type(Text(_(before))) == after  # pylint: disable=translation-of-non-string
+        assert six.text_type(Text(before)) == after
 
     def test_formatting(self):
         # The whole point of this function is to make sure this works:
@@ -39,10 +39,7 @@ class FormatHtmlTest(unittest.TestCase):
             start=HTML("<a href='http://edx.org'>"),
             end=HTML("</a>"),
         )
-        self.assertEqual(
-            six.text_type(out),
-            u"Point &amp; click <a href='http://edx.org'>here</a>!",
-        )
+        assert six.text_type(out) == u"Point &amp; click <a href='http://edx.org'>here</a>!"
 
     def test_nested_formatting(self):
         # Sometimes, you have plain text, with html inserted, and the html has
@@ -51,10 +48,7 @@ class FormatHtmlTest(unittest.TestCase):
             start=HTML(u"<a href='mailto:{email}'>").format(email="A&B"),
             end=HTML("</a>"),
         )
-        self.assertEqual(
-            six.text_type(out),
-            u"Send <a href='mailto:A&amp;B'>email</a>",
-        )
+        assert six.text_type(out) == u"Send <a href='mailto:A&amp;B'>email</a>"
 
     def test_mako(self):
         # The default_filters used here have to match the ones in edxmako.
@@ -70,12 +64,12 @@ class FormatHtmlTest(unittest.TestCase):
             default_filters=['decode.utf8', 'h'],
         )
         out = template.render()
-        self.assertEqual(out.strip(), u"A &amp; B & C")
+        assert out.strip() == u'A &amp; B & C'
 
     def test_ungettext(self):
         for i in [1, 2]:
             out = Text(ungettext(u"1 & {}", u"2 & {}", i)).format(HTML(u"<>"))
-            self.assertEqual(out, u"{} &amp; <>".format(i))
+            assert out == u'{} &amp; <>'.format(i)
 
     def test_strip_all_tags_but_br_filter(self):
         """ Verify filter removes every tags except br """
@@ -90,8 +84,8 @@ class FormatHtmlTest(unittest.TestCase):
         )
         rendered_template = template.render()
 
-        self.assertIn('<br>', rendered_template)
-        self.assertNotIn('<script>', rendered_template)
+        assert '<br>' in rendered_template
+        assert '<script>' not in rendered_template
 
     def test_strip_all_tags_but_br_returns_html(self):
         """
@@ -100,7 +94,7 @@ class FormatHtmlTest(unittest.TestCase):
 
         html = strip_all_tags_but_br('{name}<br><script>')
         html = html.format(name='Rock & Roll')
-        self.assertEqual(six.text_type(html), u'Rock &amp; Roll<br>')
+        assert six.text_type(html) == u'Rock &amp; Roll<br>'
 
     def test_clean_dengers_html_filter(self):
         """ Verify filter removes expected tags """
@@ -149,19 +143,19 @@ class FormatHtmlTest(unittest.TestCase):
         rendered_template = template.render()
         html_soup = BeautifulSoup(rendered_template, 'html.parser')
 
-        self.assertTrue(html_soup.find('a'))
-        self.assertTrue(html_soup.find('div'))
-        self.assertTrue(html_soup.find('div', attrs={'style': 'display: none'}))
-        self.assertTrue(html_soup.find('p'))
-        self.assertTrue(html_soup.find('img'))
+        assert html_soup.find('a')
+        assert html_soup.find('div')
+        assert html_soup.find('div', attrs={'style': 'display: none'})
+        assert html_soup.find('p')
+        assert html_soup.find('img')
 
-        self.assertFalse(html_soup.find('a', attrs={'onclick': 'evil_function()'}))
-        self.assertFalse(html_soup.find('html'))
-        self.assertFalse(html_soup.find('head'))
-        self.assertFalse(html_soup.find('script'))
-        self.assertFalse(html_soup.find('style'))
-        self.assertFalse(html_soup.find('link'))
-        self.assertFalse(html_soup.find('iframe'))
-        self.assertFalse(html_soup.find('form'))
-        self.assertFalse(html_soup.find('blink'))
-        self.assertFalse(html_soup.find('object'))
+        assert not html_soup.find('a', attrs={'onclick': 'evil_function()'})
+        assert not html_soup.find('html')
+        assert not html_soup.find('head')
+        assert not html_soup.find('script')
+        assert not html_soup.find('style')
+        assert not html_soup.find('link')
+        assert not html_soup.find('iframe')
+        assert not html_soup.find('form')
+        assert not html_soup.find('blink')
+        assert not html_soup.find('object')

--- a/openedx/core/djangolib/tests/test_oauth2_retirement_utils.py
+++ b/openedx/core/djangolib/tests/test_oauth2_retirement_utils.py
@@ -47,4 +47,4 @@ class RetireDOTModelsTest(TestCase):  # lint-amnesty, pylint: disable=missing-cl
         query_sets = [applications, access_tokens, refresh_tokens, grants]
 
         for query_set in query_sets:
-            self.assertFalse(query_set.exists())
+            assert not query_set.exists()

--- a/openedx/core/djangolib/tests/test_translation_utils.py
+++ b/openedx/core/djangolib/tests/test_translation_utils.py
@@ -36,7 +36,7 @@ class TranslateDateTest(unittest.TestCase):
         Tests that date is correctly translating in spanish language
         """
         date_in_spanish = translate_date(date_to_translate, 'es')
-        self.assertEqual(date_in_spanish, expected_translated_date)
+        assert date_in_spanish == expected_translated_date
 
     @ddt.data(
         (datetime.datetime(2018, 1, 21), u'Jan. 21, 2018'),
@@ -58,4 +58,4 @@ class TranslateDateTest(unittest.TestCase):
         Tests that date is correctly translating to default when language is not specified.
         """
         date_in_spanish = translate_date(date_to_translate, language=None)
-        self.assertEqual(date_in_spanish, expected_translated_date)
+        assert date_in_spanish == expected_translated_date


### PR DESCRIPTION
## Description
This PR is using `codemod-unittest-to-pytest-asserts` to automatically replace `unittest` assertions with `pytest` 
for following modules
```
openedx/core/djangolib/
```
Relevant JIRA issue here: https://openedx.atlassian.net/browse/BOM-2404