### PR TITLE
replaced unittest assertions pytest assertions (36)

### DIFF
--- a/openedx/tests/completion_integration/test_handlers.py
+++ b/openedx/tests/completion_integration/test_handlers.py
@@ -2,10 +2,10 @@
 Test signal handlers for completion.
 """
 
-
 from datetime import datetime
 
 import ddt
+import pytest
 import six
 from completion import handlers
 from completion.models import BlockCompletion
@@ -85,7 +85,7 @@ class ScorableCompletionHandlerTestCase(CompletionSetUpMixin, TestCase):
             context_key=self.context_key,
             block_key=self.block_key,
         )
-        self.assertEqual(completion.completion, expected_completion)
+        assert completion.completion == expected_completion
 
     @XBlock.register_temp_plugin(CustomScorableBlock, 'custom_scorable')
     def test_handler_skips_custom_block(self):
@@ -96,7 +96,7 @@ class ScorableCompletionHandlerTestCase(CompletionSetUpMixin, TestCase):
             context_key=self.context_key,
             block_key=custom_block_key,
         )
-        self.assertFalse(completion.exists())
+        assert not completion.exists()
 
     @XBlock.register_temp_plugin(ExcludedScorableBlock, 'excluded_scorable')
     def test_handler_skips_excluded_block(self):
@@ -107,7 +107,7 @@ class ScorableCompletionHandlerTestCase(CompletionSetUpMixin, TestCase):
             context_key=self.context_key,
             block_key=excluded_block_key,
         )
-        self.assertFalse(completion.exists())
+        assert not completion.exists()
 
     def test_handler_skips_discussion_block(self):
         discussion_block_key = self.context_key.make_usage_key(block_type='discussion', block_id='blue')
@@ -117,7 +117,7 @@ class ScorableCompletionHandlerTestCase(CompletionSetUpMixin, TestCase):
             context_key=self.context_key,
             block_key=discussion_block_key,
         )
-        self.assertFalse(completion.exists())
+        assert not completion.exists()
 
     def test_signal_calls_handler(self):
         with patch('completion.handlers.BlockCompletion.objects.submit_completion') as mock_handler:
@@ -157,7 +157,7 @@ class DisabledCompletionHandlerTestCase(CompletionSetUpMixin, TestCase):
             modified=datetime.utcnow().replace(tzinfo=utc),
             score_db_table='submissions',
         )
-        with self.assertRaises(BlockCompletion.DoesNotExist):
+        with pytest.raises(BlockCompletion.DoesNotExist):
             BlockCompletion.objects.get(
                 user=self.user,
                 context_key=self.context_key,

--- a/openedx/tests/completion_integration/test_models.py
+++ b/openedx/tests/completion_integration/test_models.py
@@ -2,7 +2,7 @@
 Test models, managers, and validators.
 """
 
-
+import pytest
 import six
 from completion import models
 from completion.test_utils import CompletionWaffleTestMixin, submit_completions_for_testing
@@ -13,8 +13,8 @@ from edx_toggles.toggles.testutils import override_waffle_switch
 from opaque_keys.edx.keys import CourseKey, UsageKey
 from six.moves import range, zip
 
-from openedx.core.djangolib.testing.utils import skip_unless_lms
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 SELECT = 1
 UPDATE = 1
@@ -72,9 +72,9 @@ class SubmitCompletionTestCase(CompletionSetUpMixin, TestCase):
                 completion=0.9,
             )
         completion.refresh_from_db()
-        self.assertEqual(completion.completion, 0.9)
-        self.assertFalse(isnew)
-        self.assertEqual(models.BlockCompletion.objects.count(), 1)
+        assert completion.completion == 0.9
+        assert not isnew
+        assert models.BlockCompletion.objects.count() == 1
 
     def test_unchanged_value(self):
         with self.assertNumQueries(SELECT + 2 * SAVEPOINT):
@@ -84,9 +84,9 @@ class SubmitCompletionTestCase(CompletionSetUpMixin, TestCase):
                 completion=0.5,
             )
         completion.refresh_from_db()
-        self.assertEqual(completion.completion, 0.5)
-        self.assertFalse(isnew)
-        self.assertEqual(models.BlockCompletion.objects.count(), 1)
+        assert completion.completion == 0.5
+        assert not isnew
+        assert models.BlockCompletion.objects.count() == 1
 
     def test_new_user(self):
         newuser = UserFactory()
@@ -96,8 +96,8 @@ class SubmitCompletionTestCase(CompletionSetUpMixin, TestCase):
                 block_key=self.block_key,
                 completion=0.0,
             )
-        self.assertTrue(isnew)
-        self.assertEqual(models.BlockCompletion.objects.count(), 2)
+        assert isnew
+        assert models.BlockCompletion.objects.count() == 2
 
     def test_new_block(self):
         newblock = UsageKey.from_string(u'block-v1:edx+test+run+type@video+block@puppers')
@@ -107,19 +107,19 @@ class SubmitCompletionTestCase(CompletionSetUpMixin, TestCase):
                 block_key=newblock,
                 completion=1.0,
             )
-        self.assertTrue(isnew)
-        self.assertEqual(models.BlockCompletion.objects.count(), 2)
+        assert isnew
+        assert models.BlockCompletion.objects.count() == 2
 
     def test_invalid_completion(self):
-        with self.assertRaises(ValidationError):
+        with pytest.raises(ValidationError):
             models.BlockCompletion.objects.submit_completion(
                 user=self.user,
                 block_key=self.block_key,
                 completion=1.2
             )
         completion = models.BlockCompletion.objects.get(user=self.user, block_key=self.block_key)
-        self.assertEqual(completion.completion, 0.5)
-        self.assertEqual(models.BlockCompletion.objects.count(), 1)
+        assert completion.completion == 0.5
+        assert models.BlockCompletion.objects.count() == 1
 
 
 @skip_unless_lms
@@ -135,14 +135,14 @@ class CompletionDisabledTestCase(CompletionSetUpMixin, TestCase):
         self.override_waffle_switch(False)
 
     def test_cannot_call_submit_completion(self):
-        self.assertEqual(models.BlockCompletion.objects.count(), 1)
-        with self.assertRaises(RuntimeError):
+        assert models.BlockCompletion.objects.count() == 1
+        with pytest.raises(RuntimeError):
             models.BlockCompletion.objects.submit_completion(
                 user=self.user,
                 block_key=self.block_key,
                 completion=0.9,
             )
-        self.assertEqual(models.BlockCompletion.objects.count(), 1)
+        assert models.BlockCompletion.objects.count() == 1
 
 
 @skip_unless_lms
@@ -163,29 +163,29 @@ class SubmitBatchCompletionTestCase(CompletionWaffleTestMixin, TestCase):
     def test_submit_batch_completion(self):
         blocks = [(self.block_key, 1.0)]
         models.BlockCompletion.objects.submit_batch_completion(self.user, blocks)
-        self.assertEqual(models.BlockCompletion.objects.count(), 1)
-        self.assertEqual(models.BlockCompletion.objects.last().completion, 1.0)
+        assert models.BlockCompletion.objects.count() == 1
+        assert models.BlockCompletion.objects.last().completion == 1.0
 
     def test_submit_batch_completion_without_waffle(self):
         with override_waffle_switch(ENABLE_COMPLETION_TRACKING_SWITCH, False):
-            with self.assertRaises(RuntimeError):
+            with pytest.raises(RuntimeError):
                 blocks = [(self.block_key, 1.0)]
                 models.BlockCompletion.objects.submit_batch_completion(self.user, blocks)
 
     def test_submit_batch_completion_with_same_block_new_completion_value(self):
         blocks = [(self.block_key, 0.0)]
-        self.assertEqual(models.BlockCompletion.objects.count(), 0)
+        assert models.BlockCompletion.objects.count() == 0
         models.BlockCompletion.objects.submit_batch_completion(self.user, blocks)
-        self.assertEqual(models.BlockCompletion.objects.count(), 1)
+        assert models.BlockCompletion.objects.count() == 1
         model = models.BlockCompletion.objects.first()
-        self.assertEqual(model.completion, 0.0)
+        assert model.completion == 0.0
         blocks = [
             (UsageKey.from_string('block-v1:edx+test+run+type@video+block@doggos'), 1.0),
         ]
         models.BlockCompletion.objects.submit_batch_completion(self.user, blocks)
-        self.assertEqual(models.BlockCompletion.objects.count(), 1)
+        assert models.BlockCompletion.objects.count() == 1
         model = models.BlockCompletion.objects.first()
-        self.assertEqual(model.completion, 1.0)
+        assert model.completion == 1.0
 
 
 @skip_unless_lms
@@ -216,19 +216,14 @@ class BatchCompletionMethodTests(CompletionWaffleTestMixin, TestCase):
         actual_completions = models.BlockCompletion.get_learning_context_completions(self.user, self.course_key)
         expected_block_keys = self.block_keys_with_runs[:3]
         expected_completions = dict(list(zip(expected_block_keys, [1.0, 0.8, 0.6])))
-        self.assertEqual(expected_completions, actual_completions)
+        assert expected_completions == actual_completions
 
     def test_get_learning_context_completions_empty_result_set(self):
-        self.assertEqual(
-            models.BlockCompletion.get_learning_context_completions(self.other_user, self.other_course_key),
-            {}
-        )
+        assert models.BlockCompletion.get_learning_context_completions(self.other_user, self.other_course_key) == {}
 
     def test_get_latest_block_completed(self):
-        self.assertEqual(
-            models.BlockCompletion.get_latest_block_completed(self.user, self.course_key).block_key,
-            self.block_keys[2]
-        )
+        assert models.BlockCompletion.get_latest_block_completed(self.user, self.course_key).block_key == \
+               self.block_keys[2]
 
     def test_get_latest_completed_none_exist(self):
-        self.assertIsNone(models.BlockCompletion.get_latest_block_completed(self.other_user, self.other_course_key))
+        assert models.BlockCompletion.get_latest_block_completed(self.other_user, self.other_course_key) is None

--- a/openedx/tests/completion_integration/test_views.py
+++ b/openedx/tests/completion_integration/test_views.py
@@ -49,21 +49,21 @@ class CompletionBatchTestCase(CompletionWaffleTestMixin, ModuleStoreTestCase):
             org='TestX', number='101', display_name='Test',
             default_store=ModuleStoreEnum.Type.split,
         )
-        self.assertEqual(six.text_type(self.course.id), self.COURSE_KEY)
+        assert six.text_type(self.course.id) == self.COURSE_KEY
         self.problem = ItemFactory.create(
             parent=self.course, category="problem", display_name="Test Problem", publish_item=False,
         )
-        self.assertEqual(six.text_type(self.problem.location), self.BLOCK_KEY)
+        assert six.text_type(self.problem.location) == self.BLOCK_KEY
         # And an old mongo course:
         self.course_deprecated = CourseFactory.create(
             org='TestX', number='201', display_name='Test',
             default_store=ModuleStoreEnum.Type.mongo,
         )
-        self.assertEqual(six.text_type(self.course_deprecated.id), self.COURSE_KEY_DEPRECATED)
+        assert six.text_type(self.course_deprecated.id) == self.COURSE_KEY_DEPRECATED
         self.problem_deprecated = ItemFactory.create(
             parent=self.course_deprecated, category="problem", display_name="Test Problem",
         )
-        self.assertEqual(six.text_type(self.problem_deprecated.location), self.BLOCK_KEY_DEPRECATED)
+        assert six.text_type(self.problem_deprecated.location) == self.BLOCK_KEY_DEPRECATED
 
         # Create users
         self.staff_user = UserFactory(is_staff=True)
@@ -84,11 +84,12 @@ class CompletionBatchTestCase(CompletionWaffleTestMixin, ModuleStoreTestCase):
         """
         with override_waffle_switch(ENABLE_COMPLETION_TRACKING_SWITCH, False):
             response = self.client.post(self.url, {'username': self.ENROLLED_USERNAME}, format='json')
-        self.assertEqual(response.data, {
-            "detail":
-                "BlockCompletion.objects.submit_batch_completion should not be called when the feature is disabled."
-        })
-        self.assertEqual(response.status_code, 400)
+        assert response.data == \
+               {
+                   'detail': 'BlockCompletion.objects.submit_batch_completion'
+                             ' should not be called when the feature is disabled.'
+               }
+        assert response.status_code == 400
 
     @ddt.data(
         # Valid submission
@@ -208,8 +209,8 @@ class CompletionBatchTestCase(CompletionWaffleTestMixin, ModuleStoreTestCase):
         Test the batch submission response for student users.
         """
         response = self.client.post(self.url, payload, format='json')
-        self.assertEqual(response.data, expected_data)
-        self.assertEqual(response.status_code, expected_status)
+        assert response.data == expected_data
+        assert response.status_code == expected_status
 
     @ddt.data(
         # Staff can submit completion on behalf of other users
@@ -269,5 +270,5 @@ class CompletionBatchTestCase(CompletionWaffleTestMixin, ModuleStoreTestCase):
         """
         self.client.force_authenticate(user=self.staff_user)
         response = self.client.post(self.url, payload, format='json')
-        self.assertEqual(response.data, expected_data)
-        self.assertEqual(response.status_code, expected_status)
+        assert response.data == expected_data
+        assert response.status_code == expected_status

--- a/openedx/tests/xblock_integration/test_crowdsource_hinter.py
+++ b/openedx/tests/xblock_integration/test_crowdsource_hinter.py
@@ -132,7 +132,7 @@ class TestCrowdsourceHinter(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         if xblock_name is None:
             xblock_name = TestCrowdsourceHinter.XBLOCK_NAMES[0]
         resp = self.call_event(handler, resource, xblock_name)
-        self.assertEqual(resp[resp_key], resp_val)
+        assert resp[resp_key] == resp_val
         self.assert_request_status_code(200, self.course_url)
 
 
@@ -150,7 +150,7 @@ class TestHinterFunctions(TestCrowdsourceHinter):
         result = self.call_event('get_hint', {'submittedanswer': 'ans=incorrect+answer+1'}, 'crowdsourcehinter')
         expected = {'BestHint': 'Sorry, there are no hints for this answer.', 'StudentAnswer': 'incorrect answer 1',
                     'HintCategory': False}
-        self.assertEqual(json.loads(result.content), expected)
+        assert json.loads(result.content) == expected
 
     def test_add_new_hint(self):
         """
@@ -162,7 +162,7 @@ class TestHinterFunctions(TestCrowdsourceHinter):
         result = self.call_event('add_new_hint', data)
         expected = {'success': True,
                     'result': 'Hint added'}
-        self.assertEqual(json.loads(result.content), expected)
+        assert json.loads(result.content) == expected
 
     def test_get_hint(self):
         """
@@ -175,7 +175,7 @@ class TestHinterFunctions(TestCrowdsourceHinter):
         result = self.call_event('get_hint', {'submittedanswer': 'ans=incorrect+answer+1'})
         expected = {'BestHint': 'new hint for answer 1', 'StudentAnswer': 'incorrect answer 1',
                     'HintCategory': 'ErrorResponse'}
-        self.assertEqual(json.loads(result.content), expected)
+        assert json.loads(result.content) == expected
 
     def test_rate_hint_upvote(self):
         """
@@ -192,7 +192,7 @@ class TestHinterFunctions(TestCrowdsourceHinter):
         }
         expected = {'success': True}
         result = self.call_event('rate_hint', data)
-        self.assertEqual(json.loads(result.content), expected)
+        assert json.loads(result.content) == expected
 
     def test_rate_hint_downvote(self):
         """
@@ -209,7 +209,7 @@ class TestHinterFunctions(TestCrowdsourceHinter):
         }
         expected = {'success': True}
         result = self.call_event('rate_hint', data)
-        self.assertEqual(json.loads(result.content), expected)
+        assert json.loads(result.content) == expected
 
     def test_report_hint(self):
         """
@@ -226,7 +226,7 @@ class TestHinterFunctions(TestCrowdsourceHinter):
         }
         expected = {'rating': 'reported', 'hint': 'new hint for answer 1'}
         result = self.call_event('rate_hint', data)
-        self.assertEqual(json.loads(result.content), expected)
+        assert json.loads(result.content) == expected
 
     def test_dont_show_reported_hint(self):
         """
@@ -245,7 +245,7 @@ class TestHinterFunctions(TestCrowdsourceHinter):
         result = self.call_event('get_hint', {'submittedanswer': 'ans=incorrect+answer+1'})
         expected = {'BestHint': 'Sorry, there are no hints for this answer.', 'StudentAnswer': 'incorrect answer 1',
                     'HintCategory': False}
-        self.assertEqual(json.loads(result.content), expected)
+        assert json.loads(result.content) == expected
 
     def test_get_used_hint_answer_data(self):
         """
@@ -260,7 +260,7 @@ class TestHinterFunctions(TestCrowdsourceHinter):
         self.call_event('get_hint', {'submittedanswer': 'ans=incorrect+answer+1'})
         result = self.call_event('get_used_hint_answer_data', "")
         expected = {'new hint for answer 1': 'incorrect answer 1'}
-        self.assertEqual(json.loads(result.content), expected)
+        assert json.loads(result.content) == expected
 
     def test_show_best_hint(self):
         """
@@ -288,4 +288,4 @@ class TestHinterFunctions(TestCrowdsourceHinter):
         result = self.call_event('get_hint', {'submittedanswer': 'ans=incorrect+answer+1'})
         expected = {'BestHint': 'new hint for answer 1', 'StudentAnswer': 'incorrect answer 1',
                     'HintCategory': 'ErrorResponse'}
-        self.assertEqual(json.loads(result.content), expected)
+        assert json.loads(result.content) == expected

--- a/openedx/tests/xblock_integration/test_done.py
+++ b/openedx/tests/xblock_integration/test_done.py
@@ -54,8 +54,8 @@ class TestDone(XBlockTestCase):
         desired.
         """
         resp = self.ajax('toggle_button', block, data)
-        self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp.data, {"state": desired_state})
+        assert resp.status_code == 200  # pylint: disable=comparison-with-callable
+        assert resp.data == {'state': desired_state}  # pylint: disable=comparison-with-callable
 
     # pylint: disable=unused-argument
     def check_response(self, block_urlname, rendering):
@@ -65,7 +65,7 @@ class TestDone(XBlockTestCase):
         In the future, visual diff test the response.
         """
         response = self.render_block(block_urlname)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200  # pylint: disable=comparison-with-callable
         # To do: Below method needs to be implemented
         #self.assertXBlockScreenshot(block_urlname, rendering)
 

--- a/openedx/tests/xblock_integration/test_recommender.py
+++ b/openedx/tests/xblock_integration/test_recommender.py
@@ -184,7 +184,7 @@ class TestRecommender(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         if xblock_name is None:
             xblock_name = TestRecommender.XBLOCK_NAMES[0]
         resp = json.loads(self.call_event(handler, resource, xblock_name).content)
-        self.assertEqual(resp[resp_key], resp_val)
+        assert resp[resp_key] == resp_val
         self.assert_request_status_code(200, self.course_url)
 
     def check_event_response_by_http_status(self, handler, resource, http_status_code, xblock_name=None):
@@ -195,7 +195,7 @@ class TestRecommender(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         if xblock_name is None:
             xblock_name = TestRecommender.XBLOCK_NAMES[0]
         resp = self.call_event(handler, resource, xblock_name)
-        self.assertEqual(resp.status_code, http_status_code)
+        assert resp.status_code == http_status_code
         self.assert_request_status_code(200, self.course_url)
 
 
@@ -377,8 +377,8 @@ class TestRecommenderWithResources(TestRecommenderResourceBase):
         # Test
         resource['reason'] = 'reason 1'
         resp = json.loads(self.call_event('flag_resource', resource).content)
-        self.assertEqual(resp['oldReason'], 'reason 0')
-        self.assertEqual(resp['reason'], 'reason 1')
+        assert resp['oldReason'] == 'reason 0'
+        assert resp['reason'] == 'reason 1'
         self.assert_request_status_code(200, self.course_url)
 
     def test_flag_resources_in_different_xblocks(self):
@@ -401,8 +401,8 @@ class TestRecommenderWithResources(TestRecommenderResourceBase):
         # Test
         resp = json.loads(self.call_event('flag_resource', resource).content)
         # The second user won't see the reason provided by the first user
-        self.assertNotIn('oldReason', resp)
-        self.assertEqual(resp['reason'], 'reason 0')
+        assert 'oldReason' not in resp
+        assert resp['reason'] == 'reason 0'
         self.assert_request_status_code(200, self.course_url)
 
     def test_export_resources(self):
@@ -414,10 +414,10 @@ class TestRecommenderWithResources(TestRecommenderResourceBase):
         # Test
         resp = json.loads(self.call_event('export_resources', {}).content)
 
-        self.assertIn(self.resource_id_second, resp['export']['recommendations'])
-        self.assertNotIn(self.resource_id, resp['export']['recommendations'])
-        self.assertIn(self.resource_id_second, resp['export']['endorsed_recommendation_ids'])
-        self.assertIn(self.resource_id, resp['export']['removed_recommendations'])
+        assert self.resource_id_second in resp['export']['recommendations']
+        assert self.resource_id not in resp['export']['recommendations']
+        assert self.resource_id_second in resp['export']['endorsed_recommendation_ids']
+        assert self.resource_id in resp['export']['removed_recommendations']
         self.assert_request_status_code(200, self.course_url)
 
 
@@ -661,7 +661,7 @@ class TestRecommenderFileUploading(TestRecommender):
         f_handler.name = 'file' + test_case['suffixes']
         url = self.get_handler_url(event_name)
         resp = self.client.post(url, {'file': f_handler})
-        self.assertEqual(resp.status_code, test_case['status'])
+        assert resp.status_code == test_case['status']
 
     @data(
         {

--- a/openedx/tests/xblock_integration/xblock_testcase.py
+++ b/openedx/tests/xblock_integration/xblock_testcase.py
@@ -136,7 +136,7 @@ class XBlockEventTestMixin(object):
 
         """
         for event in self.events:
-            self.assertNotEqual(event['event_type'], event_type)
+            assert event['event_type'] != event_type
 
     def assert_event_published(self, event_type, event_fields=None):
         """
@@ -157,9 +157,7 @@ class XBlockEventTestMixin(object):
                         found = False
                 if found:
                     return
-        self.assertIn({'event_type': event_type,
-                       'event': event_fields},
-                      self.events)
+        assert {'event_type': event_type, 'event': event_fields} in self.events
 
     def reset_published_events(self):
         """
@@ -217,7 +215,7 @@ class GradePublishTestMixin(object):
 
         HACK: In the future, this should take a user ID and a block url_name.
         '''
-        self.assertEqual(grade, self.scores[-1]['score'])
+        assert grade == self.scores[(- 1)]['score']
 
 
 class XBlockScenarioTestCaseMixin(object):


### PR DESCRIPTION
## Description
This PR is using `codemod-unittest-to-pytest-asserts` to automatically replace `unittest` assertions with `pytest` 
for following modules
```
openedx/tests
```
Relevant JIRA issue here: https://openedx.atlassian.net/browse/BOM-2407