### PR TITLE
AA-664: add JwtAuthentication to course home api

### DIFF
--- a/lms/djangoapps/course_home_api/course_metadata/v1/views.py
+++ b/lms/djangoapps/course_home_api/course_metadata/v1/views.py
@@ -7,6 +7,10 @@ from rest_framework.response import Response
 
 from opaque_keys.edx.keys import CourseKey
 
+from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
+from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
+
 from common.djangoapps.student.models import CourseEnrollment
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.masquerade import setup_masquerade
@@ -49,6 +53,12 @@ class CourseHomeMetadataView(RetrieveAPIView):
         * 200 on success with above fields.
         * 404 if the course is not available or cannot be seen.
     """
+
+    authentication_classes = (
+        JwtAuthentication,
+        BearerAuthenticationAllowInactiveUser,
+        SessionAuthenticationAllowInactiveUser,
+    )
 
     serializer_class = CourseHomeMetadataSerializer
 

--- a/lms/djangoapps/course_home_api/outline/v1/views.py
+++ b/lms/djangoapps/course_home_api/outline/v1/views.py
@@ -30,6 +30,7 @@ from lms.djangoapps.courseware.courses import get_course_date_blocks, get_course
 from lms.djangoapps.courseware.date_summary import TodaysDate
 from lms.djangoapps.courseware.masquerade import setup_masquerade
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from openedx.features.course_duration_limits.access import get_access_expiration_data
 from openedx.features.course_experience import COURSE_ENABLE_UNENROLLED_ACCESS_FLAG
 from openedx.features.course_experience.course_tools import CourseToolsPluginManager
@@ -137,6 +138,12 @@ class OutlineTabView(RetrieveAPIView):
         * 404 if the course is not available or cannot be seen.
 
     """
+
+    authentication_classes = (
+        JwtAuthentication,
+        BearerAuthenticationAllowInactiveUser,
+        SessionAuthenticationAllowInactiveUser,
+    )
 
     serializer_class = OutlineTabSerializer
 


### PR DESCRIPTION
## Description

[Similar PR](https://github.com/edx/edx-platform/pull/23901/)

"Allows users who are logged in but have not activated their accounts to be considered authenticated for the purpose of the courseware api.

This fixes what in effect is a bug: users who create an account were not able to access the learning mfe until they click the activate button in the email sent to them."