### PR TITLE
MICROBA-918 Update allowlist check to handle more signals

### DIFF
--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -19,6 +19,7 @@ from organizations.api import get_course_organization_id
 from lms.djangoapps.branding import api as branding_api
 from lms.djangoapps.certificates.generation_handler import (
     is_using_certificate_allowlist_and_is_on_allowlist as _is_using_certificate_allowlist_and_is_on_allowlist,
+    generate_allowlist_certificate_task as _generate_allowlist_certificate_task,
     generate_user_certificates as _generate_user_certificates,
     regenerate_user_certificates as _regenerate_user_certificates
 )
@@ -189,6 +190,10 @@ def generate_user_certificates(student, course_key, course=None, insecure=False,
 def regenerate_user_certificates(student, course_key, course=None,
                                  forced_grade=None, template_file=None, insecure=False):
     return _regenerate_user_certificates(student, course_key, course, forced_grade, template_file, insecure)
+
+
+def generate_allowlist_certificate_task(user, course_key):
+    return _generate_allowlist_certificate_task(user, course_key)
 
 
 def certificate_downloadable_status(student, course_key):

--- a/lms/djangoapps/certificates/management/commands/ungenerated_certs.py
+++ b/lms/djangoapps/certificates/management/commands/ungenerated_certs.py
@@ -131,24 +131,15 @@ class Command(BaseCommand):
 
                     if not options['noop']:
                         # Add the certificate request to the queue
-                        ret = generate_user_certificates(
+                        generate_user_certificates(
                             student,
                             course_key,
                             course=course,
                             insecure=options['insecure']
                         )
 
-                        if ret == 'generating':
-                            LOGGER.info(
-                                (
-                                    u"Added a certificate generation task to the XQueue "
-                                    u"for student %s in course '%s'. "
-                                    u"The new certificate status is '%s'."
-                                ),
-                                student.id,
-                                text_type(course_key),
-                                ret
-                            )
+                        LOGGER.info(f"Added a certificate generation task to the XQueue for student {student.id} in "
+                                    f"course {course_key}.")
 
                     else:
                         LOGGER.info(

--- a/lms/djangoapps/certificates/signals.py
+++ b/lms/djangoapps/certificates/signals.py
@@ -54,10 +54,15 @@ def _listen_for_certificate_whitelist_append(sender, instance, **kwargs):  # pyl
     """
     Listen for a user being added to or modified on the whitelist (allowlist)
     """
+    if is_using_certificate_allowlist_and_is_on_allowlist(instance.user, instance.course_id):
+        log.info(f'{instance.course_id} is using allowlist certificates, and the user {instance.user.id} is now on '
+                 f'its allowlist. Attempt will be made to generate an allowlist certificate.')
+        return generate_allowlist_certificate_task(instance.user, instance.course_id)
+
     if not auto_certificate_generation_enabled():
         return
 
-    if fire_ungenerated_certificate_task(instance.user, instance.course_id):
+    if _fire_ungenerated_certificate_task(instance.user, instance.course_id):
         log.info(u'Certificate generation task initiated for {user} : {course} via whitelist'.format(
             user=instance.user.id,
             course=instance.course_id
@@ -70,10 +75,15 @@ def listen_for_passing_grade(sender, user, course_id, **kwargs):  # pylint: disa
     Listen for a learner passing a course, send cert generation task,
     downstream signal from COURSE_GRADE_CHANGED
     """
+    if is_using_certificate_allowlist_and_is_on_allowlist(user, course_id):
+        log.info(f'{course_id} is using allowlist certificates, and the user {user.id} is on its allowlist. Attempt '
+                 f'will be made to generate an allowlist certificate as a passing grade was received.')
+        return generate_allowlist_certificate_task(user, course_id)
+
     if not auto_certificate_generation_enabled():
         return
 
-    if fire_ungenerated_certificate_task(user, course_id):
+    if _fire_ungenerated_certificate_task(user, course_id):
         log.info(u'Certificate generation task initiated for {user} : {course} via passing grade'.format(
             user=user.id,
             course=course_id
@@ -107,7 +117,7 @@ def _listen_for_failing_grade(sender, user, course_id, grade, **kwargs):  # pyli
 def _listen_for_id_verification_status_changed(sender, user, **kwargs):  # pylint: disable=unused-argument
     """
     Catches a track change signal, determines user status,
-    calls fire_ungenerated_certificate_task for passing grades
+    calls _fire_ungenerated_certificate_task for passing grades
     """
     if not auto_certificate_generation_enabled():
         return
@@ -118,8 +128,13 @@ def _listen_for_id_verification_status_changed(sender, user, **kwargs):  # pylin
     expected_verification_status = IDVerificationService.user_status(user)
     expected_verification_status = expected_verification_status['status']
     for enrollment in user_enrollments:
-        if grade_factory.read(user=user, course=enrollment.course_overview).passed:
-            if fire_ungenerated_certificate_task(user, enrollment.course_id, expected_verification_status):
+        if is_using_certificate_allowlist_and_is_on_allowlist(user, enrollment.course_id):
+            log.info(f'{enrollment.course_id} is using allowlist certificates, and the user {user.id} is on its '
+                     f'allowlist. Attempt will be made to generate an allowlist certificate. Id verification status '
+                     f'is {expected_verification_status}')
+            generate_allowlist_certificate_task(user, enrollment.course_id)
+        elif grade_factory.read(user=user, course=enrollment.course_overview).passed:
+            if _fire_ungenerated_certificate_task(user, enrollment.course_id, expected_verification_status):
                 message = (
                     u'Certificate generation task initiated for {user} : {course} via track change ' +
                     u'with verification status of {status}'
@@ -131,7 +146,7 @@ def _listen_for_id_verification_status_changed(sender, user, **kwargs):  # pylin
                 ))
 
 
-def fire_ungenerated_certificate_task(user, course_key, expected_verification_status=None):
+def _fire_ungenerated_certificate_task(user, course_key, expected_verification_status=None):
     """
     Helper function to fire certificate generation task.
     Auto-generation of certificates is available for following course modes:
@@ -155,14 +170,6 @@ def fire_ungenerated_certificate_task(user, course_key, expected_verification_st
 
     message = u'Entered into Ungenerated Certificate task for {user} : {course}'
     log.info(message.format(user=user.id, course=course_key))
-
-    if is_using_certificate_allowlist_and_is_on_allowlist(user, course_key):
-        log.info('{course} is using allowlist certificates, and the user {user} is on its allowlist. Attempt will be '
-                 'made to generate an allowlist certificate.'.format(course=course_key, user=user.id))
-        return generate_allowlist_certificate_task(user, course_key)
-
-    log.info('{course} is not using allowlist certificates (or user {user} is not on its allowlist). The normal '
-             'generation logic will be followed.'.format(course=course_key, user=user.id))
 
     allowed_enrollment_modes_list = [
         CourseMode.VERIFIED,

--- a/lms/djangoapps/grades/tests/test_course_grade_factory.py
+++ b/lms/djangoapps/grades/tests/test_course_grade_factory.py
@@ -100,7 +100,7 @@ class TestCourseGradeFactory(GradeTestBase):
         with self.assertNumQueries(3), mock_get_score(1, 2):
             _assert_read(expected_pass=False, expected_percent=0)  # start off with grade of 0
 
-        num_queries = 42
+        num_queries = 44
         with self.assertNumQueries(num_queries), mock_get_score(1, 2):
             grade_factory.update(self.request.user, self.course, force_update_subsections=True)
 
@@ -121,7 +121,7 @@ class TestCourseGradeFactory(GradeTestBase):
         with self.assertNumQueries(3):
             _assert_read(expected_pass=True, expected_percent=1.0)  # updated to grade of 1.0
 
-        num_queries = 30
+        num_queries = 28
         with self.assertNumQueries(num_queries), mock_get_score(0, 0):  # the subsection now is worth zero
             grade_factory.update(self.request.user, self.course, force_update_subsections=True)
 


### PR DESCRIPTION
* Move the allowlist check earlier in the signals code, to allow the allowlist checks to take precedence over non-allowlist business rules
* Add new generate_allowlist_certificate_task() API in preparation for a future PR
* Ignore the returned status in a management command, since this will eventually be going away