### PR TITLE
Revert "ARCHBOM-1667: feat: 403 logging for exchange_access_token"

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3076,7 +3076,6 @@ REST_FRAMEWORK = {
     'DEFAULT_RENDERER_CLASSES': (
         'rest_framework.renderers.JSONRenderer',
     ),
-    'EXCEPTION_HANDLER': 'openedx.core.lib.request_utils.custom_exception_handler',
     'PAGE_SIZE': 10,
     'URL_FORMAT_OVERRIDE': None,
     'DEFAULT_THROTTLE_RATES': {


### PR DESCRIPTION
Reverts edx/edx-platform#26511

This was masking a LabXchange error by blowing up with: "Stack trace builtins:AttributeError: 'NoneType' object has no attribute 'status_code'"