### PR TITLE
ARCHBOM-1667: fix: remove authentication from auth exchange

### DIFF
--- a/common/djangoapps/third_party_auth/tests/utils.py
+++ b/common/djangoapps/third_party_auth/tests/utils.py
@@ -36,7 +36,7 @@ class ThirdPartyOAuthTestMixin(ThirdPartyAuthTestMixin):
     def setUp(self):  # lint-amnesty, pylint: disable=arguments-differ
         super(ThirdPartyOAuthTestMixin, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         if self.CREATE_USER:
-            self.user = UserFactory()
+            self.user = UserFactory.create(password='secret')
             UserSocialAuth.objects.create(user=self.user, provider=self.BACKEND, uid=self.social_uid)
         self.oauth_client = self._create_client()
         if self.BACKEND == 'google-oauth2':

--- a/openedx/core/djangoapps/auth_exchange/tests/mixins.py
+++ b/openedx/core/djangoapps/auth_exchange/tests/mixins.py
@@ -2,16 +2,8 @@
 Mixins to facilitate testing OAuth connections to Django-OAuth-Toolkit or
 Django-OAuth2-Provider.
 """
-
-
-from unittest import expectedFailure
-
-from django.test.client import RequestFactory
-
 from openedx.core.djangoapps.oauth_dispatch import adapters
 from openedx.core.djangoapps.oauth_dispatch.tests.constants import DUMMY_REDIRECT_URL
-
-from ..views import DOTAccessTokenExchangeView
 
 
 class DOTAdapterMixin(object):

--- a/openedx/core/djangoapps/auth_exchange/tests/mixins.py
+++ b/openedx/core/djangoapps/auth_exchange/tests/mixins.py
@@ -52,17 +52,3 @@ class DOTAdapterMixin(object):
         Return the set of keys provided when requesting an access token
         """
         return {'access_token', 'refresh_token', 'token_type', 'expires_in', 'scope'}
-
-    def test_get_method(self):
-        # Dispatch routes all get methods to DOP, so we test this on the view
-        request_factory = RequestFactory()
-        request = request_factory.get('/oauth2/exchange_access_token/')
-        request.session = {}
-        view = DOTAccessTokenExchangeView.as_view()
-        response = view(request, backend='facebook')
-        assert response.status_code == 400
-
-    @expectedFailure
-    def test_single_access_token(self):
-        # TODO: Single access tokens not supported yet for DOT (See MA-2122)
-        super(DOTAdapterMixin, self).test_single_access_token()  # lint-amnesty, pylint: disable=super-with-arguments

--- a/openedx/core/djangoapps/auth_exchange/tests/test_forms.py
+++ b/openedx/core/djangoapps/auth_exchange/tests/test_forms.py
@@ -41,7 +41,7 @@ class AccessTokenExchangeFormTest(AccessTokenExchangeTestMixin):
         form = AccessTokenExchangeForm(request=self.request, oauth2_adapter=self.oauth2_adapter, data=data)
         assert form.errors == {'error': expected_error, 'error_description': expected_error_description}
 
-    def _assert_success(self, data, expected_scopes):
+    def _assert_success(self, data, expected_scopes, expected_logged_in_user=None):
         form = AccessTokenExchangeForm(request=self.request, oauth2_adapter=self.oauth2_adapter, data=data)
         assert form.is_valid()
         assert form.cleaned_data['user'] == self.user

--- a/openedx/core/djangoapps/auth_exchange/tests/test_views.py
+++ b/openedx/core/djangoapps/auth_exchange/tests/test_views.py
@@ -60,7 +60,7 @@ class AccessTokenExchangeViewTest(AccessTokenExchangeTestMixin):
     def _assert_success(self, data, expected_scopes, expected_logged_in_user=None):
         response = self.csrf_client.post(self.url, data)
         if expected_logged_in_user:
-            # Ensure that safe sessions isn't blocking an intentional login
+            # Ensure that safe sessions isn't preventing an expected login
             assert expected_logged_in_user == response.wsgi_request.user
         assert response.status_code == 200
         assert response['Content-Type'] == 'application/json'

--- a/openedx/core/djangoapps/auth_exchange/tests/test_views.py
+++ b/openedx/core/djangoapps/auth_exchange/tests/test_views.py
@@ -78,31 +78,6 @@ class AccessTokenExchangeViewTest(AccessTokenExchangeTestMixin):
         assert self.oauth2_adapter.get_client_for_token(token) == self.oauth_client
         assert set(self.oauth2_adapter.get_token_scope_names(token)) == set(expected_scopes)
 
-    def test_single_access_token(self):
-        """
-        WARNING: This functionality and test doesn't work for DOT and is left over
-            from DOP. It is confusing what tests are run where, and this
-            complexity/confusion isn't needed now that we just have DOT.
-            See https://github.com/edx/edx-platform/blob/277d52982c49e5d50d7582acb874cd5050ae27f7/openedx/core/djangoapps/auth_exchange/tests/mixins.py#L65-L67
-        """
-        def extract_token(response):
-            """
-            Returns the access token from the response payload.
-            """
-            return json.loads(response.content.decode('utf-8'))["access_token"]
-
-        self._setup_provider_response(success=True)
-        for single_access_token in [True, False]:
-            with mock.patch(
-                "openedx.core.djangoapps.auth_exchange.views.constants.SINGLE_ACCESS_TOKEN",
-                single_access_token,
-            ):
-                first_response = self.client.post(self.url, self.data)
-                second_response = self.client.post(self.url, self.data)
-            assert first_response.status_code == 200
-            assert second_response.status_code == 200
-            assert (extract_token(first_response) == extract_token(second_response)) == single_access_token
-
     def test_get_method(self):
         response = self.client.get(self.url, self.data)
         assert response.status_code == 400

--- a/openedx/core/djangoapps/auth_exchange/tests/test_views.py
+++ b/openedx/core/djangoapps/auth_exchange/tests/test_views.py
@@ -75,6 +75,7 @@ class AccessTokenExchangeViewTest(AccessTokenExchangeTestMixin):
             actual_scopes = []
         assert set(actual_scopes) == set(expected_scopes)
         token = self.oauth2_adapter.get_access_token(token_string=content["access_token"])
+        assert token.user == self.user
         assert self.oauth2_adapter.get_client_for_token(token) == self.oauth_client
         assert set(self.oauth2_adapter.get_token_scope_names(token)) == set(expected_scopes)
 

--- a/openedx/core/djangoapps/auth_exchange/tests/utils.py
+++ b/openedx/core/djangoapps/auth_exchange/tests/utils.py
@@ -35,7 +35,7 @@ class AccessTokenExchangeTestMixin(ThirdPartyOAuthTestMixin):
         """
         raise NotImplementedError()
 
-    def _assert_success(self, data, expected_scopes):
+    def _assert_success(self, data, expected_scopes, expected_logged_in_user=None):
         """
         Given request data, execute a test and check that the expected scopes
         were returned (along with any other appropriate assertions).

--- a/openedx/core/djangoapps/auth_exchange/views.py
+++ b/openedx/core/djangoapps/auth_exchange/views.py
@@ -43,9 +43,9 @@ class AccessTokenExchangeBase(APIView):
     Note: This base class was originally created to support multiple libraries,
         but we currently only support django-oauth-toolkit (DOT).
     """
-    # No CSRF protection is required because this requires the token to be
-    #  exchanged. However, we include session authntication to ensure that if
-    #  the user is logged in, the user matches the one in the token.
+    # No CSRF protection is required because the provided 3rd party OAuth access
+    #  token is sufficient. However, we include session authentication to ensure
+    #  the session user and token user match, if there is a logged in user.
     authentication_classes = [CsrfExemptSessionAuthentication]
     allowed_methods = ['POST']
 

--- a/openedx/core/djangoapps/auth_exchange/views.py
+++ b/openedx/core/djangoapps/auth_exchange/views.py
@@ -35,6 +35,12 @@ class AccessTokenExchangeBase(APIView):
     View for token exchange from 3rd party OAuth access token to 1st party
     OAuth access token.
     """
+    # Do not attempt to authenticate for the access token exchange.
+    # The request payload should have all that it needs, and
+    # SessionAuthentication can cause issues by doing a CSRF check and
+    # by setting the session cookie.
+    authentication_classes = []
+
     @method_decorator(csrf_exempt)
     @method_decorator(social_utils.psa("social:complete"))
     def dispatch(self, *args, **kwargs):  # pylint: disable=arguments-differ

--- a/openedx/core/djangoapps/auth_exchange/views.py
+++ b/openedx/core/djangoapps/auth_exchange/views.py
@@ -6,8 +6,6 @@ The following are currently implemented:
     2. LoginWithAccessTokenView:
        1st party (open-edx) OAuth 2.0 access token -> session cookie
 """
-import logging
-
 import django.contrib.auth as auth
 import social_django.utils as social_utils
 from django.conf import settings
@@ -27,30 +25,28 @@ from openedx.core.djangoapps.oauth_dispatch import adapters
 from openedx.core.djangoapps.oauth_dispatch.api import create_dot_access_token
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 
-log = logging.getLogger(__name__)
-
 
 class AccessTokenExchangeBase(APIView):
     """
     View for token exchange from 3rd party OAuth access token to 1st party
     OAuth access token.
-    """
-    # Do not attempt to authenticate for the access token exchange.
-    # The request payload should have all that it needs, and
-    # SessionAuthentication can cause issues by doing a CSRF check and
-    # by setting the session cookie.
-    authentication_classes = []
 
-    @method_decorator(csrf_exempt)
+    Note: This base class was originally created to support multiple libraries,
+        but we currently only support django-oauth-toolkit (DOT).
+    """
+    # No authentication is required, because the request payload has all it needs.
+    authentication_classes = []
+    allowed_methods = ['POST']
+
     @method_decorator(social_utils.psa("social:complete"))
     def dispatch(self, *args, **kwargs):  # pylint: disable=arguments-differ
         return super(AccessTokenExchangeBase, self).dispatch(*args, **kwargs)  # lint-amnesty, pylint: disable=super-with-arguments
 
     def get(self, request, _backend):
-        """
-        Pass through GET requests without the _backend
-        """
-        return super(AccessTokenExchangeBase, self).get(request)  # lint-amnesty, pylint: disable=no-member, super-with-arguments
+        return Response(status=400, data={
+            'error': 'invalid_request',
+            'error_description': 'Only POST requests allowed.',
+        })
 
     def post(self, request, _backend):
         """
@@ -59,13 +55,6 @@ class AccessTokenExchangeBase(APIView):
         form = AccessTokenExchangeForm(request=request, oauth2_adapter=self.oauth2_adapter, data=request.POST)  # lint-amnesty, pylint: disable=no-member
         if not form.is_valid():
             error_response = self.error_response(form.errors)  # pylint: disable=no-member
-            if error_response.status_code == 403:
-                log.info('message=login_filed_1, status="%d", user="%s" ,agent="%s", error_response"%s"',
-                         error_response.status_code,
-                         request.user,
-                         request.META.get('HTTP_USER_AGENT', ''),
-                         error_response.data
-                         )
             return error_response
 
         user = form.cleaned_data["user"]
@@ -78,7 +67,6 @@ class AccessTokenExchangeBase(APIView):
         Exchange third party credentials for an edx access token, and return a
         serialized access token response.
         """
-
         edx_access_token = self.create_access_token(request, user, scope, client)
         return self.access_token_response(edx_access_token)  # lint-amnesty, pylint: disable=no-member
 
@@ -91,12 +79,6 @@ class DOTAccessTokenExchangeView(AccessTokenExchangeBase, DOTAccessTokenView):
     """
 
     oauth2_adapter = adapters.DOTAdapter()
-
-    def get(self, request, _backend):
-        return Response(status=400, data={
-            'error': 'invalid_request',
-            'error_description': 'Only POST requests allowed.',
-        })
 
     def create_access_token(self, request, user, scopes, client):
         """


### PR DESCRIPTION
## Description

* Fix CSRF exemption by no longer using SessionAuthentication.
* Made several changes to make it more clear that only POST is supported.
* Removed the temporary 403 error logging that wasn't working.
* Test cleanup to remove test methods that were no longer being executed:
  * Remove the more complex overridden `test_get_method` to enable the original `test_get_method` to be
    executed.
  * Remove test_single_access_token which was written for DOP, but doesn't work with DOT. See [MA-2122](https://openedx.atlassian.net/browse/MA-2122) for a ticket about implementing this for DOT, although it doesn't seem to be a priority. NOTE: A comment was added to the ticket explaining that this test was removed.
* GET now returns default error for methods not allowed.

## Supporting information

[ARCHBOM-1667](https://openedx.atlassian.net/browse/MA-2122): This is the original ticket about the iOS mobile app getting unexpected 403s, which turned out to be CSRF permission failures when there was already a session cookie.