### PR TITLE
Add retirement methods for configuration models

### DIFF
--- a/lms/djangoapps/certificates/management/commands/cert_allowlist_generation.py
+++ b/lms/djangoapps/certificates/management/commands/cert_allowlist_generation.py
@@ -23,6 +23,9 @@ class Command(BaseCommand):
 
     Example usage:
     ./manage.py lms cert_allowlist_generation -u edx verified -c course-v1:edX+DemoX+Demo_Course
+
+    NOTE: If adding any additional PII fields, please update the retire_user method on the model to filter on this new
+    additional field.
     """
 
     help = """

--- a/openedx/core/djangoapps/credentials/apps.py
+++ b/openedx/core/djangoapps/credentials/apps.py
@@ -37,6 +37,10 @@ class CredentialsConfig(AppConfig):
                         PluginSignals.RECEIVER_FUNC_NAME: u'handle_cert_change',
                         PluginSignals.SIGNAL_PATH: u'openedx.core.djangoapps.signals.signals.COURSE_CERT_CHANGED',
                     },
+                    {
+                        PluginSignals.RECEIVER_FUNC_NAME: "listen_for_lms_retire",
+                        PluginSignals.SIGNAL_PATH: "openedx.core.djangoapps.user_api.accounts.signals.USER_RETIRE_LMS_MISC",
+                    }
                 ],
             },
         },

--- a/openedx/core/djangoapps/credentials/management/commands/notify_credentials.py
+++ b/openedx/core/djangoapps/credentials/management/commands/notify_credentials.py
@@ -97,6 +97,9 @@ class Command(BaseCommand):
             course-v1:edX+RecordsSelfPaced+1 for user 14
             course-v1:edX+RecordsSelfPaced+1 for user 17
             course-v1:edX+RecordsSelfPaced+1 for user 18
+
+    NOTE: If adding any additional PII fields, please update the retire_user
+    method on the model to filter on this new additional field.
     """
     help = (
         u"Simulate certificate/grade changes without actually modifying database "

--- a/openedx/core/djangoapps/credentials/models.py
+++ b/openedx/core/djangoapps/credentials/models.py
@@ -122,7 +122,9 @@ class NotifyCredentialsConfig(ConfigurationModel):
     """
     Manages configuration for a run of the notify_credentials management command.
 
-    .. no_pii:
+    .. pii: the arguments field may contains username of learners
+    .. pii_types: username
+    .. pii_retirement: local_api
     """
 
     class Meta(object):
@@ -137,3 +139,10 @@ class NotifyCredentialsConfig(ConfigurationModel):
 
     def __str__(self):
         return six.text_type(self.arguments)
+
+    @classmethod
+    def retire_user(cls, username):
+        """
+        Blanks out any arguments list that includes the username of a retiring user.
+        """
+        cls.objects.filter(arguments__includes=username).update(arguments="<Redacted for user retirement>")

--- a/openedx/core/djangoapps/credentials/signals.py
+++ b/openedx/core/djangoapps/credentials/signals.py
@@ -11,7 +11,7 @@ from common.djangoapps.course_modes.models import CourseMode
 from lms.djangoapps.certificates.models import CertificateStatuses, GeneratedCertificate
 from lms.djangoapps.grades.api import CourseGradeFactory
 from openedx.core.djangoapps.catalog.utils import get_programs
-from openedx.core.djangoapps.credentials.models import CredentialsApiConfig
+from openedx.core.djangoapps.credentials.models import CredentialsApiConfig, NotifyCredentialsConfig
 
 from .helpers import is_learner_records_enabled, is_learner_records_enabled_for_org  # lint-amnesty, pylint: disable=unused-import
 from .tasks.v1.tasks import send_grade_to_credentials
@@ -160,3 +160,11 @@ def handle_cert_change(user, course_key, mode, status, **kwargs):
     Notifies the Credentials IDA about certain grades it needs for its records, when a cert changes.
     """
     send_grade_if_interesting(user, course_key, mode, status, None, None, verbose=kwargs.get('verbose', False))
+
+
+def listen_for_lms_retire(sender, **kwargs):  # pylint: disable=unused-argument
+    """
+    Listener for the USER_RETIRE_LMS_MISC signal, does user retirement
+    """
+    user = kwargs.get('user')
+    NotifyCredentialsConfig.retire_user(user.username)


### PR DESCRIPTION


<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description
We have two management command argument configuration models that may store usernames or emails. This replaces those configurations when a user in the list has been retired.

## Supporting information

N/A

## Testing instructions

N/A

## Deadline

N/A
## Other information