### PR TITLE
fix: Standardize the name of the education field in Segment

### DIFF
--- a/lms/djangoapps/email_marketing/signals.py
+++ b/lms/djangoapps/email_marketing/signals.py
@@ -257,7 +257,7 @@ def email_marketing_user_fields_changed(
         if 'country' in fields:
             fields['country'] = str(fields['country'])
         if 'level_of_education' in fields and fields['level_of_education']:
-            fields['level_of_education'] = dict(UserProfile.LEVEL_OF_EDUCATION_CHOICES)[fields['level_of_education']]
+            fields['education'] = dict(UserProfile.LEVEL_OF_EDUCATION_CHOICES)[fields['level_of_education']]
         if 'year_of_birth' in fields:
             fields['yearOfBirth'] = fields.pop('year_of_birth')
         if 'mailing_address' in fields:


### PR DESCRIPTION
## Description

The UserProfile fields level_of_education is named education in the identify call we send to segment on registration. This fixes it so that that same field name is used when we send identify events when user profiles change.

## Supporting Information
JIRA Ticket: https://openedx.atlassian.net/browse/AA-626
