### PR TITLE
VAN-392: suppress PII from logistration error messages

### DIFF
--- a/common/static/common/js/utils/edx.utils.validate.js
+++ b/common/static/common/js/utils/edx.utils.validate.js
@@ -21,7 +21,7 @@
                 var _fn = {
                     validate: {
 
-                        template: _.template('<li><%- content %></li>'),
+                        template: _.template('<li <%- suppressAttr %>><%- content %></li>'),
 
                         msg: {
                             email: gettext("The email address you've provided isn't formatted correctly."),
@@ -133,7 +133,8 @@
                                 context,
                                 content,
                                 customMsg,
-                                liveValidationMsg;
+                                liveValidationMsg,
+                                suppressAttr;
 
                             _.each(tests, function(value, key) {
                                 if (!value) {
@@ -159,8 +160,14 @@
                                         content = _.sprintf(_fn.validate.msg[key], context);
                                     }
 
+                                    suppressAttr = '';
+                                    if (['username', 'email'].indexOf($el.attr('name')) > -1) {
+                                        suppressAttr = 'data-hj-suppress';
+                                    }
+
                                     txt.push(_fn.validate.template({
-                                        content: content
+                                        content: content,
+                                        suppressAttr: suppressAttr
                                     }));
                                 }
                             });

--- a/lms/static/js/student_account/views/RegisterView.js
+++ b/lms/static/js/student_account/views/RegisterView.js
@@ -423,6 +423,9 @@
                     $label.addClass(indicator);
                     $req.addClass(indicator);
                     $icon.addClass(indicator + ' ' + icon);
+                    if (['username', 'email'].indexOf($el.attr('name')) > -1) {
+                        $tip.addClass(' data-hj-suppress');
+                    }
                     $tip.text(msg);
                 },
 


### PR DESCRIPTION
On register page, when user enters a username and/or email that already exists in the platform. the error is generated on
- field focus out
- submit "Create Account" 

and error is displayed below the form field and on top of the page in alert box saying that this username/email already exists.This is being captured in hotjar recordings of this page.

### Note:
Suppressed username and email validation errors to avoid sending PII to hotjar