### PR TITLE
Log error when failing to award program certificate

### DIFF
--- a/openedx/core/djangoapps/programs/tasks.py
+++ b/openedx/core/djangoapps/programs/tasks.py
@@ -255,9 +255,9 @@ def award_program_certificates(self, username):  # lint-amnesty, pylint: disable
                         f"Unable to award certificate to user {username} for program {program_uuid}. "
                         "The program might not be configured."
                     )
-            except Exception:  # pylint: disable=broad-except
+            except Exception as exc:  # pylint: disable=broad-except
                 # keep trying to award other certs, but retry the whole task to fix any missing entries
-                LOGGER.warning(f"Failed to award certificate for program {program_uuid} to user {username}.")
+                LOGGER.exception(f"Failed to award certificate for program {program_uuid} to user {username}.")
                 failed_program_certificate_award_attempts.append(program_uuid)
 
         if failed_program_certificate_award_attempts:

--- a/openedx/core/djangoapps/programs/tests/test_tasks.py
+++ b/openedx/core/djangoapps/programs/tests/test_tasks.py
@@ -343,7 +343,7 @@ class AwardProgramCertificatesTestCase(CatalogIntegrationMixin, CredentialsApiCo
         mock_award_program_certificate.side_effect = self._make_side_effect([Exception('boom'), None])
 
         with mock.patch(TASKS_MODULE + '.LOGGER.info') as mock_info, \
-                mock.patch(TASKS_MODULE + '.LOGGER.warning') as mock_warning:
+                mock.patch(TASKS_MODULE + '.LOGGER.exception') as mock_warning:
             tasks.award_program_certificates.delay(self.student.username).get()
 
         assert mock_award_program_certificate.call_count == 3


### PR DESCRIPTION
## Description

We are currently swallowing an exception that can occur when attempting to reward program certificates to learners. Logging the error may help us triage problems that are encountered when this task runs.

## Deadline

None
