### PR TITLE
Use registration field order when using a registration extension form

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -356,6 +356,11 @@ class RegistrationFormFactory:
             handler = getattr(self, f"_add_{field_name}_field")
             self.field_handlers[field_name] = handler
 
+        custom_form = get_registration_extension_form()
+        if custom_form:
+            custom_form_field_names = [field_name for field_name, field in custom_form.fields.items()]
+            valid_fields.extend(custom_form_field_names)
+
         field_order = configuration_helpers.get_value('REGISTRATION_FIELD_ORDER')
         if not field_order:
             field_order = settings.REGISTRATION_FIELD_ORDER or valid_fields
@@ -363,7 +368,8 @@ class RegistrationFormFactory:
         # if not append missing fields at end of field order
         if set(valid_fields) != set(field_order):
             difference = set(valid_fields).difference(set(field_order))
-            field_order.extend(difference)
+            # sort the additional fields so we have could have a deterministic result when presenting them
+            field_order.extend(sorted(difference))
 
         self.field_order = field_order
 
@@ -387,57 +393,57 @@ class RegistrationFormFactory:
 
         # Custom form fields can be added via the form set in settings.REGISTRATION_EXTENSION_FORM
         custom_form = get_registration_extension_form()
-
         if custom_form:
-            # Default fields are always required
-            for field_name in self.DEFAULT_FIELDS:
-                self.field_handlers[field_name](form_desc, required=True)
-
-            for field_name, field in custom_form.fields.items():
-                restrictions = {}
-                if getattr(field, 'max_length', None):
-                    restrictions['max_length'] = field.max_length
-                if getattr(field, 'min_length', None):
-                    restrictions['min_length'] = field.min_length
-                field_options = getattr(
-                    getattr(custom_form, 'Meta', None), 'serialization_options', {}
-                ).get(field_name, {})
-                field_type = field_options.get('field_type', FormDescription.FIELD_TYPE_MAP.get(field.__class__))
-                if not field_type:
-                    raise ImproperlyConfigured(
-                        "Field type '{}' not recognized for registration extension field '{}'.".format(
-                            field_type,
-                            field_name
-                        )
-                    )
-                form_desc.add_field(
-                    field_name, label=field.label,
-                    default=field_options.get('default'),
-                    field_type=field_options.get('field_type', FormDescription.FIELD_TYPE_MAP.get(field.__class__)),
-                    placeholder=field.initial, instructions=field.help_text, required=field.required,
-                    restrictions=restrictions,
-                    options=getattr(field, 'choices', None), error_messages=field.error_messages,
-                    include_default_option=field_options.get('include_default_option'),
-                )
-
-            # Extra fields configured in Django settings
-            # may be required, optional, or hidden
-            for field_name in self.EXTRA_FIELDS:
-                if self._is_field_visible(field_name):
-                    self.field_handlers[field_name](
-                        form_desc,
-                        required=self._is_field_required(field_name)
-                    )
+            custom_form_field_names = [field_name for field_name, field in custom_form.fields.items()]
         else:
-            # Go through the fields in the fields order and add them if they are required or visible
-            for field_name in self.field_order:
-                if field_name in self.DEFAULT_FIELDS:
-                    self.field_handlers[field_name](form_desc, required=True)
-                elif self._is_field_visible(field_name):
-                    self.field_handlers[field_name](
-                        form_desc,
-                        required=self._is_field_required(field_name)
-                    )
+            custom_form_field_names = []
+
+        # Go through the fields in the fields order and add them if they are required or visible
+        for field_name in self.field_order:
+            if field_name in self.DEFAULT_FIELDS:
+                self.field_handlers[field_name](form_desc, required=True)
+            elif self._is_field_visible(field_name) and self.field_handlers.get(field_name):
+                self.field_handlers[field_name](
+                    form_desc,
+                    required=self._is_field_required(field_name)
+                )
+            elif field_name in custom_form_field_names:
+                for custom_field_name, field in custom_form.fields.items():
+                    if field_name == custom_field_name:
+                        restrictions = {}
+                        if getattr(field, 'max_length', None):
+                            restrictions['max_length'] = field.max_length
+                        if getattr(field, 'min_length', None):
+                            restrictions['min_length'] = field.min_length
+                        field_options = getattr(
+                            getattr(custom_form, 'Meta', None), 'serialization_options', {}
+                        ).get(field_name, {})
+                        field_type = field_options.get(
+                            'field_type',
+                            FormDescription.FIELD_TYPE_MAP.get(field.__class__))
+                        if not field_type:
+                            raise ImproperlyConfigured(
+                                u"Field type '{}' not recognized for registration extension field '{}'.".format(
+                                    field_type,
+                                    field_name
+                                )
+                            )
+                        if self._is_field_visible(field_name) or field.required:
+                            form_desc.add_field(
+                                field_name,
+                                label=field.label,
+                                default=field_options.get('default'),
+                                field_type=field_options.get(
+                                    'field_type',
+                                    FormDescription.FIELD_TYPE_MAP.get(field.__class__)),
+                                placeholder=field.initial,
+                                instructions=field.help_text,
+                                required=(self._is_field_required(field_name) or field.required),
+                                restrictions=restrictions,
+                                options=getattr(field, 'choices', None), error_messages=field.error_messages,
+                                include_default_option=field_options.get('include_default_option'),
+                            )
+
         # remove confirm_email form v1 registration form
         if is_api_v1(request):
             for index, field in enumerate(form_desc.fields):

--- a/openedx/core/djangoapps/user_authn/views/tests/test_register.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_register.py
@@ -657,15 +657,15 @@ class RegistrationViewTestV1(
             }
         )
 
-        self._assert_reg_field(
+        self._assert_reg_absent_field(
             no_extra_fields_setting,
             {
-                "name": "favorite_editor",
-                "type": "select",
+                "name": u"favorite_editor",
+                "type": u"select",
                 "required": False,
-                "label": "Favorite Editor",
-                "placeholder": "cat",
-                "defaultValue": "vim",
+                "label": u"Favorite Editor",
+                "placeholder": u"cat",
+                "defaultValue": u"vim",
                 "errorMessages": {
                     'required': 'This field is required.',
                     'invalid_choice': 'Select a valid choice. %(value)s is not one of the available choices.',
@@ -1259,6 +1259,7 @@ class RegistrationViewTestV1(
             "honor_code": "required",
             "confirm_email": "required",
         },
+        REGISTRATION_FIELD_ORDER=None,
         REGISTRATION_EXTENSION_FORM='openedx.core.djangoapps.user_api.tests.test_helpers.TestCaseForm',
     )
     def test_field_order(self):
@@ -1268,9 +1269,22 @@ class RegistrationViewTestV1(
         # Verify that all fields render in the correct order
         form_desc = json.loads(response.content.decode('utf-8'))
         field_names = [field["name"] for field in form_desc["fields"]]
-        assert field_names == ['email', 'name', 'username', 'password', 'favorite_movie', 'favorite_editor',
-                               'city', 'state', 'country', 'gender', 'year_of_birth', 'level_of_education',
-                               'mailing_address', 'goals', 'honor_code']
+        assert field_names == [
+            "email",
+            "name",
+            "username",
+            "password",
+            "city",
+            "state",
+            "country",
+            "gender",
+            "year_of_birth",
+            "level_of_education",
+            "mailing_address",
+            "goals",
+            "honor_code",
+            "favorite_movie",
+        ]
 
     @override_settings(
         REGISTRATION_EXTRA_FIELDS={
@@ -1358,9 +1372,23 @@ class RegistrationViewTestV1(
         # Verify that all fields render in the correct order
         form_desc = json.loads(response.content.decode('utf-8'))
         field_names = [field["name"] for field in form_desc["fields"]]
-        assert field_names == ['email', 'name', 'username', 'password', 'favorite_movie', 'favorite_editor', 'city',
-                               'state', 'country', 'gender', 'year_of_birth', 'level_of_education',
-                               'mailing_address', 'goals', 'honor_code']
+
+        assert field_names == [
+            "name",
+            "password",
+            "gender",
+            "year_of_birth",
+            "level_of_education",
+            "mailing_address",
+            "goals",
+            "honor_code",
+            "city",
+            "country",
+            "email",
+            "favorite_movie",
+            "state",
+            "username",
+        ]
 
     def test_register(self):
         # Create a new registration
@@ -1821,6 +1849,31 @@ class RegistrationViewTestV1(
 
         self._assert_fields_match(actual_field, expected_field)
 
+    def _assert_reg_absent_field(self, extra_fields_setting, expected_absent_field: str):
+        """
+        Retrieve the registration form description from the server and
+        verify that it not contains the expected absent field.
+
+        Args:
+            extra_fields_setting (dict): Override the Django setting controlling
+                which extra fields are displayed in the form.
+            expected_absent_field (str): The field name we expect to be absent in the form.
+
+        Raises:
+            AssertionError
+        """
+        # Retrieve the registration form description
+        with override_settings(REGISTRATION_EXTRA_FIELDS=extra_fields_setting):
+            response = self.client.get(self.url)
+            self.assertHttpOK(response)
+
+        # Verify that the form description matches what we'd expect
+        form_desc = json.loads(response.content.decode('utf-8'))
+
+        current_present_field_names = [field["name"] for field in form_desc["fields"]]
+        assert expected_absent_field not in current_present_field_names, \
+            "Expected absent field {expected}".format(expected=expected_absent_field)
+
     def _assert_password_field_hidden(self, field_settings):
         self._assert_reg_field(field_settings, {
             "name": "password",
@@ -1900,9 +1953,23 @@ class RegistrationViewTestV2(RegistrationViewTestV1):
         form_desc = json.loads(response.content.decode('utf-8'))
         field_names = [field["name"] for field in form_desc["fields"]]
 
-        assert field_names == ['email', 'name', 'username', 'password', 'favorite_movie', 'favorite_editor',
-                               'confirm_email', 'city', 'state', 'country', 'gender', 'year_of_birth',
-                               'level_of_education', 'mailing_address', 'goals', 'honor_code']
+        assert field_names == [
+            "name",
+            "confirm_email",
+            "password",
+            "gender",
+            "year_of_birth",
+            "level_of_education",
+            "mailing_address",
+            "goals",
+            "honor_code",
+            "city",
+            "country",
+            "email",
+            "favorite_movie",
+            "state",
+            "username",
+        ]
 
     @override_settings(
         REGISTRATION_EXTRA_FIELDS={
@@ -1967,6 +2034,7 @@ class RegistrationViewTestV2(RegistrationViewTestV1):
             "honor_code": "required",
             "confirm_email": "required",
         },
+        REGISTRATION_FIELD_ORDER=None,
         REGISTRATION_EXTENSION_FORM='openedx.core.djangoapps.user_api.tests.test_helpers.TestCaseForm',
     )
     def test_field_order(self):
@@ -1976,10 +2044,23 @@ class RegistrationViewTestV2(RegistrationViewTestV1):
         # Verify that all fields render in the correct order
         form_desc = json.loads(response.content.decode('utf-8'))
         field_names = [field["name"] for field in form_desc["fields"]]
-        assert field_names ==\
-               ['email', 'name', 'username', 'password', 'favorite_movie', 'favorite_editor', 'confirm_email',
-                'city', 'state', 'country', 'gender', 'year_of_birth', 'level_of_education', 'mailing_address',
-                'goals', 'honor_code']
+        assert field_names == [
+            "email",
+            "name",
+            "username",
+            "password",
+            "confirm_email",
+            "city",
+            "state",
+            "country",
+            "gender",
+            "year_of_birth",
+            "level_of_education",
+            "mailing_address",
+            "goals",
+            "honor_code",
+            "favorite_movie",
+        ]
 
     def test_registration_form_confirm_email(self):
         self._assert_reg_field(


### PR DESCRIPTION
## Description

On registration screen, make it possible to change the `REGISTRATION_FIELD_ORDER` when using a custom `REGISTRATION_EXTENSION_FORM`.

If you are managing an open edx installation probably you need to ask more information about your users on the registration form. For that you use a registration extension form. But when you configure that extension form you no longer can change the ordering of presentation of each field on the registration form. This pull request tries to fix that specific thing.

This change has impact for Developers and Operators that manage a custom open edx installation.

Example, with this configuration, we can
```
REGISTRATION_EXTRA_FIELDS:
    city: required
    confirm_email: hidden
    country: required
    gender: optional
    goals: optional
    honor_code: required
    level_of_education: optional
    mailing_address: hidden
    year_of_birth: optional
    terms_of_service: hidden
    data_authorization: required # custom registration field
    employment_situation: optional # custom registration field
    allow_newsletter: optional # custom registration field

REGISTRATION_FIELD_ORDER:
- email
- name
- username
- password
- data_authorization # custom registration field
- honor_code
- city
- country
- allow_newsletter # custom registration field
- gender
- year_of_birth
- level_of_education
- employment_situation # custom registration field
- goals
```

**Required fields**:
![image](https://user-images.githubusercontent.com/67018/108524563-13223780-72c7-11eb-8afe-4e85a7c7c6bf.png)
**Optional fields**:
![image](https://user-images.githubusercontent.com/67018/108524630-246b4400-72c7-11eb-9157-ca7b510d0fee.png)
