### PR TITLE
MST-624: Bug fix for IDV approved verification email

### DIFF
--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -1479,12 +1479,13 @@ class TestPhotoVerificationResultsCallback(ModuleStoreTestCase, TestVerification
         """
         return True
 
-    def _assert_verification_approved_email(self):
+    def _assert_verification_approved_email(self, expiration_date):
         """Check that a verification approved email was sent."""
         self.assertEqual(len(mail.outbox), 1)
         email = mail.outbox[0]
         self.assertEqual(email.subject, 'Your édX ID verification was approved!')
         self.assertIn('Your édX ID verification photos have been approved', email.body)
+        self.assertIn(expiration_date.strftime("%m/%d/%Y"), email.body)
 
     def _assert_verification_denied_email(self):
         """Check that a verification approved email was sent."""
@@ -1607,7 +1608,7 @@ class TestPhotoVerificationResultsCallback(ModuleStoreTestCase, TestVerification
         self.assertEqual(attempt.expiration_datetime.date(), expiration_datetime.date())
         self.assertIsNone(old_verification.expiry_email_date)
         self.assertEqual(response.content.decode('utf-8'), 'OK!')
-        self._assert_verification_approved_email()
+        self._assert_verification_approved_email(expiration_datetime.date())
 
     @patch(
         'lms.djangoapps.verify_student.ssencrypt.has_valid_signature',
@@ -1641,7 +1642,7 @@ class TestPhotoVerificationResultsCallback(ModuleStoreTestCase, TestVerification
         self.assertEqual(attempt.status, u'approved')
         self.assertEqual(attempt.expiration_datetime.date(), expiration_datetime.date())
         self.assertEqual(response.content.decode('utf-8'), 'OK!')
-        self._assert_verification_approved_email()
+        self._assert_verification_approved_email(expiration_datetime.date())
 
     @patch(
         'lms.djangoapps.verify_student.ssencrypt.has_valid_signature',

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -1118,8 +1118,8 @@ def results_callback(request):  # lint-amnesty, pylint: disable=too-many-stateme
         log.debug(u'Approving verification for {}'.format(receipt_id))
         attempt.approve()
 
-        expiry_date = datetime.date.today() + datetime.timedelta(days=settings.VERIFY_STUDENT["DAYS_GOOD_FOR"])
-        email_context = {'user': user, 'expiry_date': expiry_date.strftime("%m/%d/%Y")}
+        expiration_datetime = attempt.expiration_datetime.date()
+        email_context = {'user': user, 'expiration_datetime': expiration_datetime.strftime("%m/%d/%Y")}
         send_verification_approved_email(context=email_context)
 
     elif result == "FAIL":


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## [MST-624](https://openedx.atlassian.net/browse/MST-624)

The template for the IDV approved verification email was expecting a variable called `expiration_datetime`, but no such key was available in the context being used to fill out the template. I updated the variable name for the context and also updated the supplied value to come directly from the verification model. 
