### PR TITLE
fix: changed setting to fix login through studio

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -47,6 +47,9 @@ LMS_BASE = 'localhost:18000'
 LMS_ROOT_URL = 'http://{}'.format(LMS_BASE)
 FEATURES['PREVIEW_LMS_BASE'] = "preview." + LMS_BASE
 
+FRONTEND_LOGIN_URL = LMS_ROOT_URL + '/login'
+FRONTEND_LOGOUT_URL = LMS_ROOT_URL + '/logout'
+FRONTEND_REGISTER_URL = LMS_ROOT_URL + '/register'
 ########################### PIPELINE #################################
 
 # Skip packaging and optimization in development


### PR DESCRIPTION
Login redirect was using wrong url, thus making it impossible to login from studio in devstack. This settings change should fix that.


https://openedx.atlassian.net/browse/ARCHBOM-1687

## Testing instructions

Bring up devstack studio and press sign in. If it redirects you correctly to lms login page, this works!

