### PR TITLE
[MST-614] bump version of edx-proctoring to 3.6.0

### DIFF
--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -1225,27 +1225,6 @@ class TestProctoringRendering(SharedModuleStoreTestCase):
 
     @ddt.data(
         (
-            CourseMode.DEFAULT_MODE_SLUG,
-            True,
-            None,
-            'Try a proctored exam',
-            True
-        ),
-        (
-            CourseMode.DEFAULT_MODE_SLUG,
-            True,
-            'submitted',
-            'You have submitted this practice proctored exam',
-            False
-        ),
-        (
-            CourseMode.DEFAULT_MODE_SLUG,
-            True,
-            'error',
-            'There was a problem with your practice proctoring session',
-            True
-        ),
-        (
             CourseMode.VERIFIED,
             False,
             None,

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -106,7 +106,7 @@ edx-milestones==0.3.0     # via -r requirements/edx/base.in
 edx-opaque-keys[django]==2.2.0  # via -r requirements/edx/paver.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, lti-consumer-xblock, xmodule
 edx-organizations==6.9.0  # via -r requirements/edx/base.in
 edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/base.in
-edx-proctoring==3.5.0     # via -r requirements/edx/base.in, edx-proctoring-proctortrack
+edx-proctoring==3.6.0     # via -r requirements/edx/base.in, edx-proctoring-proctortrack
 edx-rbac==1.4.1           # via edx-enterprise
 edx-rest-api-client==5.3.0  # via -r requirements/edx/base.in, edx-enterprise, edx-proctoring
 edx-search==3.0.0         # via -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -118,7 +118,7 @@ edx-milestones==0.3.0     # via -r requirements/edx/testing.txt
 edx-opaque-keys[django]==2.2.0  # via -r requirements/edx/testing.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, lti-consumer-xblock, xmodule
 edx-organizations==6.9.0  # via -r requirements/edx/testing.txt
 edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/testing.txt
-edx-proctoring==3.5.0     # via -r requirements/edx/testing.txt, edx-proctoring-proctortrack
+edx-proctoring==3.6.0     # via -r requirements/edx/testing.txt, edx-proctoring-proctortrack
 edx-rbac==1.4.1           # via -r requirements/edx/testing.txt, edx-enterprise
 edx-rest-api-client==5.3.0  # via -r requirements/edx/testing.txt, edx-enterprise, edx-proctoring
 edx-search==3.0.0         # via -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -115,7 +115,7 @@ edx-milestones==0.3.0     # via -r requirements/edx/base.txt
 edx-opaque-keys[django]==2.2.0  # via -r requirements/edx/base.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, lti-consumer-xblock, xmodule
 edx-organizations==6.9.0  # via -r requirements/edx/base.txt
 edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/base.txt
-edx-proctoring==3.5.0     # via -r requirements/edx/base.txt, edx-proctoring-proctortrack
+edx-proctoring==3.6.0     # via -r requirements/edx/base.txt, edx-proctoring-proctortrack
 edx-rbac==1.4.1           # via -r requirements/edx/base.txt, edx-enterprise
 edx-rest-api-client==5.3.0  # via -r requirements/edx/base.txt, edx-enterprise, edx-proctoring
 edx-search==3.0.0         # via -r requirements/edx/base.txt


### PR DESCRIPTION
## Description

This release adds a new permission check when rendering the practice proctored exam view. If a learner is not in a paid enrollment track, the learner will no longer be able to use proctoring software in a practice proctored exam. As with other proctored exams, learners not in a paid enrollment track will see the exam content. This uses the 'can_take_proctored_exam' permission.

## Supporting information

JIRA: https://openedx.atlassian.net/browse/MST-614
edx-proctoring PR: https://github.com/edx/edx-proctoring/pull/787

## Testing instructions

View a practice proctored exam as a learner in a not paid enrollment track (.e.g verified). The learner should see the exam content and should not see proctoring related content.
