### PR TITLE
[BB-3171] Prevent race condition that can delete user input

### DIFF
--- a/lms/static/js/views/fields.js
+++ b/lms/static/js/views/fields.js
@@ -383,7 +383,16 @@
 
             updateValueInField: function() {
                 var value = (_.isUndefined(this.modelValue()) || _.isNull(this.modelValue())) ? '' : this.modelValue();
-                this.$('.u-field-value input').val(value);
+
+                var fieldHasFocus = (document.activeElement === this.$('.u-field-value input')[0]);
+                var fieldChanged = this.fieldValue() !== value;
+                if (fieldHasFocus && fieldChanged) {
+                    // Race conidtion between successive user-changed input
+                    // If user changed input after it was submitted before it was saved,
+                    // do nothing, it will be handled by normal finishEditing hooks.
+                } else {
+                    this.$('.u-field-value input').val(value);
+                }
             },
 
             saveValue: function() {
@@ -478,7 +487,16 @@
 
             updateValueInField: function() {
                 if (this.editable !== 'never') {
-                    this.$('.u-field-value select').val(this.modelValue() || '');
+                    var value = this.modelValue() || '';
+                    var fieldHasFocus = (document.activeElement === this.$('.u-field-value select')[0]);
+                    var fieldChanged = this.fieldValue() !== value;
+                    if (fieldHasFocus && fieldChanged) {
+                        // Race conidtion between successive user-changed input
+                        // If user changed input after it was submitted before it was saved,
+                        // do nothing, it will be handled by normal finishEditing hooks.
+                    } else {
+                        this.$('.u-field-value select').val(value);
+                    }
                 }
 
                 var value = this.displayValue(this.modelValue() || '');


### PR DESCRIPTION
This PR changes how Account fields are updated in the UI so that updating the fields in quick succession does not cause previous XHR requests to remove information.

**JIRA tickets**: BB-3171

**Merge deadline**: "None"

**Testing instructions**:

1. Check out this branch in your master devstack.
2. Log in to the LMS and go to your Account Settings.
3. Open the DevTools and Enable slow 3G throttling.
4. Update the Account information in quick succession, keeping an eye on the DevTools Network tab.
5. Make sure no previously entered information is lost.