### PR TITLE
 fix: staff debug actions depended on legacy courseware URL

### DIFF
--- a/lms/static/js/spec/staff_debug_actions_spec.js
+++ b/lms/static/js/spec/staff_debug_actions_spec.js
@@ -9,6 +9,7 @@ define([
         var StaffDebug = window.StaffDebug;
 
         describe('StaffDebugActions', function() {
+            var courseId = 'edX/Open_DemoX/edx_demo_course';
             var location = 'i4x://edX/Open_DemoX/edx_demo_course/problem/test_loc';
             var locationName = 'test_loc';
             var usernameFixtureID = 'sd_fu_' + locationName;
@@ -24,19 +25,15 @@ define([
 
             describe('getURL ', function() {
                 it('defines url to courseware ajax entry point', function() {
-                    spyOn(StaffDebug, 'getCurrentUrl')
-                      .and.returnValue('/courses/edX/Open_DemoX/edx_demo_course/courseware/stuff');
-                    expect(StaffDebug.getURL('rescore_problem'))
-                      .toBe('/courses/edX/Open_DemoX/edx_demo_course/instructor/api/rescore_problem');
+                    expect(StaffDebug.getURL('course-v1:edX+Open_DemoX:edx_demo_course', 'rescore_problem'))
+                      .toBe('/courses/course-v1:edX+Open_DemoX:edx_demo_course/instructor/api/rescore_problem');
                 });
             });
 
             describe('getURL ', function() {
-                it('defines that getCurrentUrl works on instructor page as expected', function() {
-                    spyOn(StaffDebug, 'getCurrentUrl')
-                      .and.returnValue('/courses/edx_demo_course/instructor#view-open_response_assessment');
-                    expect(StaffDebug.getURL('rescore_problem'))
-                      .toBe('/courses/edx_demo_course/instructor/api/rescore_problem');
+                it('defines url to courseware ajax entry point for deprecated courses', function() {
+                    expect(StaffDebug.getURL(courseId, 'rescore_problem'))
+                      .toBe('/courses/edX/Open_DemoX/edx_demo_course/instructor/api/rescore_problem');
                 });
             });
 
@@ -87,6 +84,7 @@ define([
                     $('body').append($escapableResultArea);
                     var requests = AjaxHelpers.requests(this);
                     var action = {
+                        courseId: courseId,
                         locationName: esclocationName,
                         success_msg: 'Successfully reset the attempts for user userman'
                     };
@@ -101,6 +99,7 @@ define([
                     $('body').append($escapableResultArea);
                     var requests = AjaxHelpers.requests(this);
                     var action = {
+                        courseId: courseId,
                         locationName: esclocationName,
                         error_msg: 'Failed to reset attempts for user.'
                     };
@@ -115,7 +114,7 @@ define([
                     $('body').append($usernameFixture);
 
                     spyOn($, 'ajax');
-                    StaffDebug.reset(locationName, location);
+                    StaffDebug.reset(courseId, locationName, location);
 
                     expect($.ajax.calls.mostRecent().args[0].type).toEqual('POST');
                     expect($.ajax.calls.mostRecent().args[0].data).toEqual({
@@ -136,7 +135,7 @@ define([
                     $('body').append($usernameFixture);
 
                     spyOn($, 'ajax');
-                    StaffDebug.deleteStudentState(locationName, location);
+                    StaffDebug.deleteStudentState(courseId, locationName, location);
 
                     expect($.ajax.calls.mostRecent().args[0].type).toEqual('POST');
                     expect($.ajax.calls.mostRecent().args[0].data).toEqual({
@@ -158,7 +157,7 @@ define([
                     $('body').append($usernameFixture);
 
                     spyOn($, 'ajax');
-                    StaffDebug.rescore(locationName, location);
+                    StaffDebug.rescore(courseId, locationName, location);
 
                     expect($.ajax.calls.mostRecent().args[0].type).toEqual('POST');
                     expect($.ajax.calls.mostRecent().args[0].data).toEqual({
@@ -179,7 +178,7 @@ define([
                     $('body').append($usernameFixture);
 
                     spyOn($, 'ajax');
-                    StaffDebug.rescoreIfHigher(locationName, location);
+                    StaffDebug.rescoreIfHigher(courseId, locationName, location);
 
                     expect($.ajax.calls.mostRecent().args[0].type).toEqual('POST');
                     expect($.ajax.calls.mostRecent().args[0].data).toEqual({
@@ -201,7 +200,7 @@ define([
                     $('body').append($scoreFixture);
                     $('#' + scoreFixtureID).val('1');
                     spyOn($, 'ajax');
-                    StaffDebug.overrideScore(locationName, location);
+                    StaffDebug.overrideScore(courseId, locationName, location);
 
                     expect($.ajax.calls.mostRecent().args[0].type).toEqual('POST');
                     expect($.ajax.calls.mostRecent().args[0].data).toEqual({

--- a/lms/static/js/spec/staff_debug_actions_spec.js
+++ b/lms/static/js/spec/staff_debug_actions_spec.js
@@ -6,12 +6,12 @@ define([
 ],
     function(Backbone, $, tmp, AjaxHelpers) {
         'use strict';
-        var courseId = 'edX/Open_DemoX/edx_demo_course';
-        var locationName = 'test_loc';
-        var location = 'i4x://edX/Open_DemoX/edx_demo_course/problem/test_loc';
-        var staffDebugActions = window.StaffDebugActions(courseId, locationName, location);
+        var StaffDebug = window.StaffDebug;
 
         describe('StaffDebugActions', function() {
+            var courseId = 'edX/Open_DemoX/edx_demo_course';
+            var location = 'i4x://edX/Open_DemoX/edx_demo_course/problem/test_loc';
+            var locationName = 'test_loc';
             var usernameFixtureID = 'sd_fu_' + locationName;
             var $usernameFixture = $('<input>', {id: usernameFixtureID, placeholder: 'userman'});
             var scoreFixtureID = 'sd_fs_' + locationName;
@@ -25,14 +25,21 @@ define([
 
             describe('getURL ', function() {
                 it('defines url to courseware ajax entry point', function() {
-                    expect(staffDebugActions.getURL('rescore_problem'))
+                    expect(StaffDebug.getURL('course-v1:edX+Open_DemoX:edx_demo_course', 'rescore_problem'))
+                      .toBe('/courses/course-v1:edX+Open_DemoX:edx_demo_course/instructor/api/rescore_problem');
+                });
+            });
+
+            describe('getURL ', function() {
+                it('defines url to courseware ajax entry point for deprecated courses', function() {
+                    expect(StaffDebug.getURL(courseId, 'rescore_problem'))
                       .toBe('/courses/edX/Open_DemoX/edx_demo_course/instructor/api/rescore_problem');
                 });
             });
 
             describe('sanitizeString', function() {
                 it('escapes escapable characters in a string', function() {
-                    expect(staffDebugActions.sanitizeString('.*+?^:${}()|]['))
+                    expect(StaffDebug.sanitizeString('.*+?^:${}()|]['))
                       .toBe('\\.\\*\\+\\?\\^\\:\\$\\{\\}\\(\\)\\|\\]\\[');
                 });
             });
@@ -40,33 +47,33 @@ define([
             describe('getUser', function() {
                 it('gets the placeholder username if input field is empty', function() {
                     $('body').append($usernameFixture);
-                    expect(staffDebugActions.getUser()).toBe('userman');
+                    expect(StaffDebug.getUser(locationName)).toBe('userman');
                     $('#' + usernameFixtureID).remove();
                 });
                 it('gets a filled in name if there is one', function() {
                     $('body').append($usernameFixture);
                     $('#' + usernameFixtureID).val('notuserman');
-                    expect(staffDebugActions.getUser()).toBe('notuserman');
+                    expect(StaffDebug.getUser(locationName)).toBe('notuserman');
 
                     $('#' + usernameFixtureID).val('');
                     $('#' + usernameFixtureID).remove();
                 });
                 it('gets the placeholder name if the id has escapable characters', function() {
                     $('body').append($escapableFixture);
-                    expect(staffDebugActions.getUser('test.*+?^:${}()|][loc')).toBe('userman');
+                    expect(StaffDebug.getUser('test.*+?^:${}()|][loc')).toBe('userman');
                     $("input[id^='sd_fu_']").remove();
                 });
             });
             describe('getScore', function() {
                 it('gets the placeholder score if input field is empty', function() {
                     $('body').append($scoreFixture);
-                    expect(staffDebugActions.getScore()).toBe('0');
+                    expect(StaffDebug.getScore(locationName)).toBe('0');
                     $('#' + scoreFixtureID).remove();
                 });
                 it('gets a filled in score if there is one', function() {
                     $('body').append($scoreFixture);
                     $('#' + scoreFixtureID).val('1');
-                    expect(staffDebugActions.getScore()).toBe('1');
+                    expect(StaffDebug.getScore(locationName)).toBe('1');
 
                     $('#' + scoreFixtureID).val('');
                     $('#' + scoreFixtureID).remove();
@@ -77,9 +84,11 @@ define([
                     $('body').append($escapableResultArea);
                     var requests = AjaxHelpers.requests(this);
                     var action = {
+                        courseId: courseId,
+                        locationName: esclocationName,
                         success_msg: 'Successfully reset the attempts for user userman'
                     };
-                    staffDebugActions.doInstructorDashAction(action);
+                    StaffDebug.doInstructorDashAction(action);
                     AjaxHelpers.respondWithJson(requests, action);
                     expect($('#idash_msg').text()).toBe('Successfully reset the attempts for user userman');
                     $('#result_' + locationName).remove();
@@ -90,9 +99,11 @@ define([
                     $('body').append($escapableResultArea);
                     var requests = AjaxHelpers.requests(this);
                     var action = {
+                        courseId: courseId,
+                        locationName: esclocationName,
                         error_msg: 'Failed to reset attempts for user.'
                     };
-                    staffDebugActions.doInstructorDashAction(action);
+                    StaffDebug.doInstructorDashAction(action);
                     AjaxHelpers.respondWithTextError(requests);
                     expect($('#idash_msg').text()).toBe('Failed to reset attempts for user. Unknown Error Occurred.');
                     $('#result_' + locationName).remove();
@@ -103,7 +114,7 @@ define([
                     $('body').append($usernameFixture);
 
                     spyOn($, 'ajax');
-                    staffDebugActions.reset();
+                    StaffDebug.reset(courseId, locationName, location);
 
                     expect($.ajax.calls.mostRecent().args[0].type).toEqual('POST');
                     expect($.ajax.calls.mostRecent().args[0].data).toEqual({
@@ -124,7 +135,7 @@ define([
                     $('body').append($usernameFixture);
 
                     spyOn($, 'ajax');
-                    staffDebugActions.deleteStudentState();
+                    StaffDebug.deleteStudentState(courseId, locationName, location);
 
                     expect($.ajax.calls.mostRecent().args[0].type).toEqual('POST');
                     expect($.ajax.calls.mostRecent().args[0].data).toEqual({
@@ -146,7 +157,7 @@ define([
                     $('body').append($usernameFixture);
 
                     spyOn($, 'ajax');
-                    staffDebugActions.rescore();
+                    StaffDebug.rescore(courseId, locationName, location);
 
                     expect($.ajax.calls.mostRecent().args[0].type).toEqual('POST');
                     expect($.ajax.calls.mostRecent().args[0].data).toEqual({
@@ -167,7 +178,7 @@ define([
                     $('body').append($usernameFixture);
 
                     spyOn($, 'ajax');
-                    staffDebugActions.rescoreIfHigher();
+                    StaffDebug.rescoreIfHigher(courseId, locationName, location);
 
                     expect($.ajax.calls.mostRecent().args[0].type).toEqual('POST');
                     expect($.ajax.calls.mostRecent().args[0].data).toEqual({
@@ -189,7 +200,7 @@ define([
                     $('body').append($scoreFixture);
                     $('#' + scoreFixtureID).val('1');
                     spyOn($, 'ajax');
-                    staffDebugActions.overrideScore();
+                    StaffDebug.overrideScore(courseId, locationName, location);
 
                     expect($.ajax.calls.mostRecent().args[0].type).toEqual('POST');
                     expect($.ajax.calls.mostRecent().args[0].data).toEqual({

--- a/lms/static/js/spec/staff_debug_actions_spec.js
+++ b/lms/static/js/spec/staff_debug_actions_spec.js
@@ -6,12 +6,12 @@ define([
 ],
     function(Backbone, $, tmp, AjaxHelpers) {
         'use strict';
-        var StaffDebug = window.StaffDebug;
+        var courseId = 'edX/Open_DemoX/edx_demo_course';
+        var locationName = 'test_loc';
+        var location = 'i4x://edX/Open_DemoX/edx_demo_course/problem/test_loc';
+        var staffDebugActions = window.StaffDebugActions(courseId, locationName, location);
 
         describe('StaffDebugActions', function() {
-            var courseId = 'edX/Open_DemoX/edx_demo_course';
-            var location = 'i4x://edX/Open_DemoX/edx_demo_course/problem/test_loc';
-            var locationName = 'test_loc';
             var usernameFixtureID = 'sd_fu_' + locationName;
             var $usernameFixture = $('<input>', {id: usernameFixtureID, placeholder: 'userman'});
             var scoreFixtureID = 'sd_fs_' + locationName;
@@ -25,21 +25,14 @@ define([
 
             describe('getURL ', function() {
                 it('defines url to courseware ajax entry point', function() {
-                    expect(StaffDebug.getURL('course-v1:edX+Open_DemoX:edx_demo_course', 'rescore_problem'))
-                      .toBe('/courses/course-v1:edX+Open_DemoX:edx_demo_course/instructor/api/rescore_problem');
-                });
-            });
-
-            describe('getURL ', function() {
-                it('defines url to courseware ajax entry point for deprecated courses', function() {
-                    expect(StaffDebug.getURL(courseId, 'rescore_problem'))
+                    expect(staffDebugActions.getURL('rescore_problem'))
                       .toBe('/courses/edX/Open_DemoX/edx_demo_course/instructor/api/rescore_problem');
                 });
             });
 
             describe('sanitizeString', function() {
                 it('escapes escapable characters in a string', function() {
-                    expect(StaffDebug.sanitizeString('.*+?^:${}()|]['))
+                    expect(staffDebugActions.sanitizeString('.*+?^:${}()|]['))
                       .toBe('\\.\\*\\+\\?\\^\\:\\$\\{\\}\\(\\)\\|\\]\\[');
                 });
             });
@@ -47,33 +40,33 @@ define([
             describe('getUser', function() {
                 it('gets the placeholder username if input field is empty', function() {
                     $('body').append($usernameFixture);
-                    expect(StaffDebug.getUser(locationName)).toBe('userman');
+                    expect(staffDebugActions.getUser()).toBe('userman');
                     $('#' + usernameFixtureID).remove();
                 });
                 it('gets a filled in name if there is one', function() {
                     $('body').append($usernameFixture);
                     $('#' + usernameFixtureID).val('notuserman');
-                    expect(StaffDebug.getUser(locationName)).toBe('notuserman');
+                    expect(staffDebugActions.getUser()).toBe('notuserman');
 
                     $('#' + usernameFixtureID).val('');
                     $('#' + usernameFixtureID).remove();
                 });
                 it('gets the placeholder name if the id has escapable characters', function() {
                     $('body').append($escapableFixture);
-                    expect(StaffDebug.getUser('test.*+?^:${}()|][loc')).toBe('userman');
+                    expect(staffDebugActions.getUser('test.*+?^:${}()|][loc')).toBe('userman');
                     $("input[id^='sd_fu_']").remove();
                 });
             });
             describe('getScore', function() {
                 it('gets the placeholder score if input field is empty', function() {
                     $('body').append($scoreFixture);
-                    expect(StaffDebug.getScore(locationName)).toBe('0');
+                    expect(staffDebugActions.getScore()).toBe('0');
                     $('#' + scoreFixtureID).remove();
                 });
                 it('gets a filled in score if there is one', function() {
                     $('body').append($scoreFixture);
                     $('#' + scoreFixtureID).val('1');
-                    expect(StaffDebug.getScore(locationName)).toBe('1');
+                    expect(staffDebugActions.getScore()).toBe('1');
 
                     $('#' + scoreFixtureID).val('');
                     $('#' + scoreFixtureID).remove();
@@ -84,11 +77,9 @@ define([
                     $('body').append($escapableResultArea);
                     var requests = AjaxHelpers.requests(this);
                     var action = {
-                        courseId: courseId,
-                        locationName: esclocationName,
                         success_msg: 'Successfully reset the attempts for user userman'
                     };
-                    StaffDebug.doInstructorDashAction(action);
+                    staffDebugActions.doInstructorDashAction(action);
                     AjaxHelpers.respondWithJson(requests, action);
                     expect($('#idash_msg').text()).toBe('Successfully reset the attempts for user userman');
                     $('#result_' + locationName).remove();
@@ -99,11 +90,9 @@ define([
                     $('body').append($escapableResultArea);
                     var requests = AjaxHelpers.requests(this);
                     var action = {
-                        courseId: courseId,
-                        locationName: esclocationName,
                         error_msg: 'Failed to reset attempts for user.'
                     };
-                    StaffDebug.doInstructorDashAction(action);
+                    staffDebugActions.doInstructorDashAction(action);
                     AjaxHelpers.respondWithTextError(requests);
                     expect($('#idash_msg').text()).toBe('Failed to reset attempts for user. Unknown Error Occurred.');
                     $('#result_' + locationName).remove();
@@ -114,7 +103,7 @@ define([
                     $('body').append($usernameFixture);
 
                     spyOn($, 'ajax');
-                    StaffDebug.reset(courseId, locationName, location);
+                    staffDebugActions.reset();
 
                     expect($.ajax.calls.mostRecent().args[0].type).toEqual('POST');
                     expect($.ajax.calls.mostRecent().args[0].data).toEqual({
@@ -135,7 +124,7 @@ define([
                     $('body').append($usernameFixture);
 
                     spyOn($, 'ajax');
-                    StaffDebug.deleteStudentState(courseId, locationName, location);
+                    staffDebugActions.deleteStudentState();
 
                     expect($.ajax.calls.mostRecent().args[0].type).toEqual('POST');
                     expect($.ajax.calls.mostRecent().args[0].data).toEqual({
@@ -157,7 +146,7 @@ define([
                     $('body').append($usernameFixture);
 
                     spyOn($, 'ajax');
-                    StaffDebug.rescore(courseId, locationName, location);
+                    staffDebugActions.rescore();
 
                     expect($.ajax.calls.mostRecent().args[0].type).toEqual('POST');
                     expect($.ajax.calls.mostRecent().args[0].data).toEqual({
@@ -178,7 +167,7 @@ define([
                     $('body').append($usernameFixture);
 
                     spyOn($, 'ajax');
-                    StaffDebug.rescoreIfHigher(courseId, locationName, location);
+                    staffDebugActions.rescoreIfHigher();
 
                     expect($.ajax.calls.mostRecent().args[0].type).toEqual('POST');
                     expect($.ajax.calls.mostRecent().args[0].data).toEqual({
@@ -200,7 +189,7 @@ define([
                     $('body').append($scoreFixture);
                     $('#' + scoreFixtureID).val('1');
                     spyOn($, 'ajax');
-                    StaffDebug.overrideScore(courseId, locationName, location);
+                    staffDebugActions.overrideScore();
 
                     expect($.ajax.calls.mostRecent().args[0].type).toEqual('POST');
                     expect($.ajax.calls.mostRecent().args[0].data).toEqual({

--- a/lms/static/js/spec/staff_debug_actions_spec.js
+++ b/lms/static/js/spec/staff_debug_actions_spec.js
@@ -9,8 +9,8 @@ define([
         var StaffDebug = window.StaffDebug;
 
         describe('StaffDebugActions', function() {
-            var courseId = 'edX/Open_DemoX/edx_demo_course';
-            var location = 'i4x://edX/Open_DemoX/edx_demo_course/problem/test_loc';
+            var courseId = 'course-v1:edX+DemoX+1';
+            var location = 'block-v1:edX+DemoX+1+type@problem+block@9518dd51055b40cd82feb01502644c89';
             var locationName = 'test_loc';
             var usernameFixtureID = 'sd_fu_' + locationName;
             var $usernameFixture = $('<input>', {id: usernameFixtureID, placeholder: 'userman'});
@@ -25,15 +25,15 @@ define([
 
             describe('getURL ', function() {
                 it('defines url to courseware ajax entry point', function() {
-                    expect(StaffDebug.getURL('course-v1:edX+Open_DemoX:edx_demo_course', 'rescore_problem'))
-                      .toBe('/courses/course-v1:edX+Open_DemoX:edx_demo_course/instructor/api/rescore_problem');
+                    expect(StaffDebug.getURL(courseId, 'rescore_problem'))
+                      .toBe('/courses/course-v1:edX+DemoX+1/instructor/api/rescore_problem');
                 });
             });
 
             describe('getURL ', function() {
                 it('defines url to courseware ajax entry point for deprecated courses', function() {
-                    expect(StaffDebug.getURL(courseId, 'rescore_problem'))
-                      .toBe('/courses/edX/Open_DemoX/edx_demo_course/instructor/api/rescore_problem');
+                    expect(StaffDebug.getURL('edX/DemoX/1', 'rescore_problem'))
+                      .toBe('/courses/edX/DemoX/1/instructor/api/rescore_problem');
                 });
             });
 
@@ -125,7 +125,7 @@ define([
                         score: undefined
                     });
                     expect($.ajax.calls.mostRecent().args[0].url).toEqual(
-                        '/instructor/api/reset_student_attempts'
+                        '/courses/course-v1:edX+DemoX+1/instructor/api/reset_student_attempts'
                     );
                     $('#' + usernameFixtureID).remove();
                 });
@@ -146,7 +146,7 @@ define([
                         score: undefined
                     });
                     expect($.ajax.calls.mostRecent().args[0].url).toEqual(
-                        '/instructor/api/reset_student_attempts'
+                        '/courses/course-v1:edX+DemoX+1/instructor/api/reset_student_attempts'
                     );
 
                     $('#' + usernameFixtureID).remove();
@@ -168,7 +168,7 @@ define([
                         score: undefined
                     });
                     expect($.ajax.calls.mostRecent().args[0].url).toEqual(
-                        '/instructor/api/rescore_problem'
+                        '/courses/course-v1:edX+DemoX+1/instructor/api/rescore_problem'
                     );
                     $('#' + usernameFixtureID).remove();
                 });
@@ -189,7 +189,7 @@ define([
                         score: undefined
                     });
                     expect($.ajax.calls.mostRecent().args[0].url).toEqual(
-                        '/instructor/api/rescore_problem'
+                        '/courses/course-v1:edX+DemoX+1/instructor/api/rescore_problem'
                     );
                     $('#' + usernameFixtureID).remove();
                 });
@@ -211,7 +211,7 @@ define([
                         score: '1'
                     });
                     expect($.ajax.calls.mostRecent().args[0].url).toEqual(
-                        '/instructor/api/override_problem_score'
+                        '/courses/course-v1:edX+DemoX+1/instructor/api/override_problem_score'
                     );
                     $('#' + usernameFixtureID).remove();
                 });

--- a/lms/static/js/staff_debug_actions.js
+++ b/lms/static/js/staff_debug_actions.js
@@ -1,15 +1,20 @@
-/* globals _ */
-// Build StaffDebug object
-var StaffDebug = (function() {
-    var getURL = function(courseId, action) {
-        return '/courses/' + courseId + '/instructor/api/' + action;
+'use strict';
+/**
+ * A functional class to encapsulate staff actions within the context of a given course
+ * and block.
+ *
+ * Stateless; please do not add inner variables.
+ */
+function StaffDebugActions(courseId, locationName, location) {
+    var getURL = function(action) {
+        return 'courses/' + courseId + '/instructor/api/' + action;
     };
 
     var sanitizeString = function(string) {
         return string.replace(/[.*+?^:${}()|[\]\\]/g, '\\$&');
     };
 
-    var getUser = function(locationName) {
+    var getUser = function() {
         var sanitizedLocationName = sanitizeString(locationName);
         var uname = $('#sd_fu_' + sanitizedLocationName).val();
         if (uname === '') {
@@ -18,7 +23,7 @@ var StaffDebug = (function() {
         return uname;
     };
 
-    var getScore = function(locationName) {
+    var getScore = function() {
         var sanitizedLocationName = sanitizeString(locationName);
         var score = $('#sd_fs_' + sanitizedLocationName).val();
         if (score === '') {
@@ -29,15 +34,15 @@ var StaffDebug = (function() {
 
     var doInstructorDashAction = function(action) {
         var pdata = {
-            problem_to_reset: action.location,
-            unique_student_identifier: getUser(action.locationName),
+            problem_to_reset: location,
+            unique_student_identifier: getUser(locationName),
             delete_module: action.delete_module,
             only_if_higher: action.only_if_higher,
             score: action.score
         };
         $.ajax({
             type: 'POST',
-            url: getURL(action.courseId, action.method),
+            url: getURL(action.method),
             data: pdata,
             success: function(data) {
                 var text = _.template(action.success_msg, {interpolate: /\{(.+?)\}/g})(
@@ -47,7 +52,7 @@ var StaffDebug = (function() {
                 {text: text}
             );
                 edx.HtmlUtils.setHtml(
-                  $('#result_' + sanitizeString(action.locationName)),
+                  $('#result_' + sanitizeString(locationName)),
                   edx.HtmlUtils.HTML(html)
                 );
             },
@@ -68,7 +73,7 @@ var StaffDebug = (function() {
                 {text: text}
             );
                 edx.HtmlUtils.setHtml(
-                  $('#result_' + sanitizeString(action.locationName)),
+                  $('#result_' + sanitizeString(locationName)),
                   edx.HtmlUtils.HTML(html)
                 );
             },
@@ -76,11 +81,8 @@ var StaffDebug = (function() {
         });
     };
 
-    var reset = function(courseId, locname, location) {
+    var reset = function() {
         this.doInstructorDashAction({
-            courseId: courseId,
-            locationName: locname,
-            location: location,
             method: 'reset_student_attempts',
             success_msg: gettext('Successfully reset the attempts for user {user}'),
             error_msg: gettext('Failed to reset attempts for user.'),
@@ -88,11 +90,8 @@ var StaffDebug = (function() {
         });
     };
 
-    var deleteStudentState = function(courseId, locname, location) {
+    var deleteStudentState = function() {
         this.doInstructorDashAction({
-            courseId: courseId,
-            locationName: locname,
-            location: location,
             method: 'reset_student_attempts',
             success_msg: gettext('Successfully deleted student state for user {user}'),
             error_msg: gettext('Failed to delete student state for user.'),
@@ -100,11 +99,8 @@ var StaffDebug = (function() {
         });
     };
 
-    var rescore = function(courseId, locname, location) {
+    var rescore = function() {
         this.doInstructorDashAction({
-            courseId: courseId,
-            locationName: locname,
-            location: location,
             method: 'rescore_problem',
             success_msg: gettext('Successfully rescored problem for user {user}'),
             error_msg: gettext('Failed to rescore problem for user.'),
@@ -112,11 +108,8 @@ var StaffDebug = (function() {
         });
     };
 
-    var rescoreIfHigher = function(courseId, locname, location) {
+    var rescoreIfHigher = function() {
         this.doInstructorDashAction({
-            courseId: courseId,
-            locationName: locname,
-            location: location,
             method: 'rescore_problem',
             success_msg: gettext('Successfully rescored problem to improve score for user {user}'),
             error_msg: gettext('Failed to rescore problem to improve score for user.'),
@@ -124,11 +117,8 @@ var StaffDebug = (function() {
         });
     };
 
-    var overrideScore = function(courseId, locname, location) {
+    var overrideScore = function() {
         this.doInstructorDashAction({
-            courseId: courseId,
-            locationName: locname,
-            location: location,
             method: 'override_problem_score',
             success_msg: gettext('Successfully overrode problem score for {user}'),
             error_msg: gettext('Could not override problem score for {user}.'),
@@ -150,31 +140,42 @@ var StaffDebug = (function() {
         getScore: getScore,
         sanitizeString: sanitizeString
     };
-}());
+};
 
 // Register click handlers
 $(document).ready(function() {
-
     var $mainContainer = $('#main');
-    $mainContainer.on('click', '.staff-debug-reset', function() {
-        StaffDebug.reset($(this).parent().data('course-id'), $(this).parent().data('location-name'), $(this).parent().data('location'));
-        return false;
-    });
-    $mainContainer.on('click', '.staff-debug-sdelete', function() {
-        StaffDebug.deleteStudentState($(this).parent().data('course-id'), $(this).parent().data('location-name'), $(this).parent().data('location'));
-        return false;
-    });
-    $mainContainer.on('click', '.staff-debug-rescore', function() {
-        StaffDebug.rescore($(this).parent().data('course-id'), $(this).parent().data('location-name'), $(this).parent().data('location'));
-        return false;
-    });
-    $mainContainer.on('click', '.staff-debug-rescore-if-higher', function() {
-        StaffDebug.rescoreIfHigher($(this).parent().data('course-id'), $(this).parent().data('location-name'), $(this).parent().data('location'));
-        return false;
-    });
 
-    $mainContainer.on('click', '.staff-debug-override-score', function() {
-        StaffDebug.overrideScore($(this).parent().data('course-id'), $(this).parent().data('location-name'), $(this).parent().data('location'));
-        return false;
-    });
-});
+    function staffActionOnClick(elementClass, handlerMethodName) {
+        $mainContainer.on('click', elementClass, function() {
+            var debugActionsDiv = $(this).parent();
+            var staffActions = StaffDebugActions(
+                debugActionsDiv.data('course-id'),
+                debugActionsDiv.data('location-name'),
+                debugActionsDiv.data('location')
+            );
+            staffActions[handlerMethodName]();
+            return false;
+        });
+    }
+    staffActionOnClick(
+        '.staff-debug-reset',
+        'reset'
+    );
+    staffActionOnClick(
+        '.staff-debug-sdelete',
+        'deleteStudentState'
+    );
+    staffActionOnClick(
+        '.staff-debug-rescore',
+        'rescore'
+    );
+    staffActionOnClick(
+        '.staff-debug-rescore-if-higher',
+        'rescoreIfHigher'
+    );
+    staffActionOnClick(
+        '.staff-debug-override-score',
+        'overrideScore'
+    );
+};

--- a/lms/static/js/staff_debug_actions.js
+++ b/lms/static/js/staff_debug_actions.js
@@ -1,14 +1,8 @@
 /* globals _ */
 // Build StaffDebug object
 var StaffDebug = (function() {
-    /* global getCurrentUrl:true */
-    var getURL = function(action) {
-        var pathname = this.getCurrentUrl();
-        var index = pathname.indexOf('/courseware');
-        if (index <= 0) {
-            index = pathname.indexOf('/', '/courses/'.length);
-        }
-        return pathname.substr(0, index) + '/instructor/api/' + action;
+    var getURL = function(courseId, action) {
+        return '/courses/' + courseId + '/instructor/api/' + action;
     };
 
     var sanitizeString = function(string) {
@@ -43,7 +37,7 @@ var StaffDebug = (function() {
         };
         $.ajax({
             type: 'POST',
-            url: getURL(action.method),
+            url: getURL(action.courseId, action.method),
             data: pdata,
             success: function(data) {
                 var text = _.template(action.success_msg, {interpolate: /\{(.+?)\}/g})(
@@ -82,8 +76,9 @@ var StaffDebug = (function() {
         });
     };
 
-    var reset = function(locname, location) {
+    var reset = function(courseId, locname, location) {
         this.doInstructorDashAction({
+            courseId: courseId,
             locationName: locname,
             location: location,
             method: 'reset_student_attempts',
@@ -93,8 +88,9 @@ var StaffDebug = (function() {
         });
     };
 
-    var deleteStudentState = function(locname, location) {
+    var deleteStudentState = function(courseId, locname, location) {
         this.doInstructorDashAction({
+            courseId: courseId,
             locationName: locname,
             location: location,
             method: 'reset_student_attempts',
@@ -104,8 +100,9 @@ var StaffDebug = (function() {
         });
     };
 
-    var rescore = function(locname, location) {
+    var rescore = function(courseId, locname, location) {
         this.doInstructorDashAction({
+            courseId: courseId,
             locationName: locname,
             location: location,
             method: 'rescore_problem',
@@ -115,8 +112,9 @@ var StaffDebug = (function() {
         });
     };
 
-    var rescoreIfHigher = function(locname, location) {
+    var rescoreIfHigher = function(courseId, locname, location) {
         this.doInstructorDashAction({
+            courseId: courseId,
             locationName: locname,
             location: location,
             method: 'rescore_problem',
@@ -126,8 +124,9 @@ var StaffDebug = (function() {
         });
     };
 
-    var overrideScore = function(locname, location) {
+    var overrideScore = function(courseId, locname, location) {
         this.doInstructorDashAction({
+            courseId: courseId,
             locationName: locname,
             location: location,
             method: 'override_problem_score',
@@ -135,10 +134,6 @@ var StaffDebug = (function() {
             error_msg: gettext('Could not override problem score for {user}.'),
             score: getScore(locname)
         });
-    };
-
-    getCurrentUrl = function() {
-        return window.location.pathname;
     };
 
     return {
@@ -150,7 +145,6 @@ var StaffDebug = (function() {
 
         // export for testing
         doInstructorDashAction: doInstructorDashAction,
-        getCurrentUrl: getCurrentUrl,
         getURL: getURL,
         getUser: getUser,
         getScore: getScore,
@@ -160,26 +154,27 @@ var StaffDebug = (function() {
 
 // Register click handlers
 $(document).ready(function() {
+
     var $mainContainer = $('#main');
     $mainContainer.on('click', '.staff-debug-reset', function() {
-        StaffDebug.reset($(this).parent().data('location-name'), $(this).parent().data('location'));
+        StaffDebug.reset($(this).parent().data('course-id'), $(this).parent().data('location-name'), $(this).parent().data('location'));
         return false;
     });
     $mainContainer.on('click', '.staff-debug-sdelete', function() {
-        StaffDebug.deleteStudentState($(this).parent().data('location-name'), $(this).parent().data('location'));
+        StaffDebug.deleteStudentState($(this).parent().data('course-id'), $(this).parent().data('location-name'), $(this).parent().data('location'));
         return false;
     });
     $mainContainer.on('click', '.staff-debug-rescore', function() {
-        StaffDebug.rescore($(this).parent().data('location-name'), $(this).parent().data('location'));
+        StaffDebug.rescore($(this).parent().data('course-id'), $(this).parent().data('location-name'), $(this).parent().data('location'));
         return false;
     });
     $mainContainer.on('click', '.staff-debug-rescore-if-higher', function() {
-        StaffDebug.rescoreIfHigher($(this).parent().data('location-name'), $(this).parent().data('location'));
+        StaffDebug.rescoreIfHigher($(this).parent().data('course-id'), $(this).parent().data('location-name'), $(this).parent().data('location'));
         return false;
     });
 
     $mainContainer.on('click', '.staff-debug-override-score', function() {
-        StaffDebug.overrideScore($(this).parent().data('location-name'), $(this).parent().data('location'));
+        StaffDebug.overrideScore($(this).parent().data('course-id'), $(this).parent().data('location-name'), $(this).parent().data('location'));
         return false;
     });
 });

--- a/lms/static/js/staff_debug_actions.js
+++ b/lms/static/js/staff_debug_actions.js
@@ -157,24 +157,44 @@ $(document).ready(function() {
 
     var $mainContainer = $('#main');
     $mainContainer.on('click', '.staff-debug-reset', function() {
-        StaffDebug.reset($(this).parent().data('course-id'), $(this).parent().data('location-name'), $(this).parent().data('location'));
+        StaffDebug.reset(
+            $(this).parent().data('course-id'),
+            $(this).parent().data('location-name'),
+            $(this).parent().data('location')
+        );
         return false;
     });
     $mainContainer.on('click', '.staff-debug-sdelete', function() {
-        StaffDebug.deleteStudentState($(this).parent().data('course-id'), $(this).parent().data('location-name'), $(this).parent().data('location'));
+        StaffDebug.deleteStudentState(
+            $(this).parent().data('course-id'),
+            $(this).parent().data('location-name'),
+            $(this).parent().data('location')
+        );
         return false;
     });
     $mainContainer.on('click', '.staff-debug-rescore', function() {
-        StaffDebug.rescore($(this).parent().data('course-id'), $(this).parent().data('location-name'), $(this).parent().data('location'));
+        StaffDebug.rescore(
+            $(this).parent().data('course-id'),
+            $(this).parent().data('location-name'),
+            $(this).parent().data('location')
+        );
         return false;
     });
     $mainContainer.on('click', '.staff-debug-rescore-if-higher', function() {
-        StaffDebug.rescoreIfHigher($(this).parent().data('course-id'), $(this).parent().data('location-name'), $(this).parent().data('location'));
+        StaffDebug.rescoreIfHigher(
+            $(this).parent().data('course-id'),
+            $(this).parent().data('location-name'),
+            $(this).parent().data('location')
+        );
         return false;
     });
 
     $mainContainer.on('click', '.staff-debug-override-score', function() {
-        StaffDebug.overrideScore($(this).parent().data('course-id'), $(this).parent().data('location-name'), $(this).parent().data('location'));
+        StaffDebug.overrideScore(
+            $(this).parent().data('course-id'),
+            $(this).parent().data('location-name'),
+            $(this).parent().data('location')
+        );
         return false;
     });
 });

--- a/lms/templates/staff_problem_info.html
+++ b/lms/templates/staff_problem_info.html
@@ -76,7 +76,7 @@ ${block_content | n, decode.utf8}
         <label for="sd_fs_${location.block_id}"> / ${max_problem_score}</label>
       </div>
       % endif
-      <div data-location="${location}" data-location-name="${location.block_id}">
+      <div data-location="${location}" data-location-name="${location.block_id}" data-course-id="${location.course_key}">
         [
         % if can_reset_attempts:
         <button type="button" class="btn-link staff-debug-reset">${_('Reset Learner\'s Attempts to Zero')}</button>


### PR DESCRIPTION

## Description

The Staff Debug Actions didn't work in the Learning MFE
because the underlying JS depended on the URL being
formatted as /courses/<course_key>/... in order to
parse out the course key. This worked in the legacy
experience, but breaks in the chromeless xblock view,
which is rendered under the URL /xblock/<usage_key>/...

The fix is to explicitly pass the course key into the
templated courseware HTML as a data attribute.

## Commits

I'll squash these together before merging, so I recommend reviewing using the full diff. But if you're interested:

1. `fix: ...` : The bugfix itself.
2. `refactor: ...`: I started refactoring the StaffDebug class to de-dupe the parameters, but I decided it wasn't worth it. You can ignore this.
3. `revert: ...`: Reverts refactor commit. You can ignore this.
4. `style: ...`: Breaks some long lines.
5. `squahsme: ...`: Fixes JS tests affected by first commit.

## Supporting information

https://openedx.atlassian.net/browse/TNL-7955

## Testing instructions

Reproducing the bug:
* In devstack: `make frontend-app-learning-up`
* In Legacy Experience, nagivate to a block in a course that you have staff access to.
* Hit "Staff Debug Info". Override your score. Confirm that there is no error message. In your browser's network log, note the URL that was POSTed to when you tried overriding the score.
* Do the same thing in New Experience. You should see a red error message. In your browser's networok log, note that the POSTed URL is missing the `/courses/<course_key>` part.

Confirming the fix:
* Checkout this branch
* Devstack: `make lms-restart lms-shell`
* Within the :LMS shell: `NO_PREREQ_INSTALL=1 paver update_assets lms`
* Get some coffee...
* Navigate to the New Experience and try to override your score again. There should be no error message, and the POSTed URL should the same as what you saw for the Legacy Experience.

## Deadline

CAT-3 ; sooner is better

