### PR TITLE
draft: fix: course outlines should include problemsets & videosequences

### DIFF
--- a/openedx/core/djangoapps/content/block_structure/management/commands/generate_course_blocks.py
+++ b/openedx/core/djangoapps/content/block_structure/management/commands/generate_course_blocks.py
@@ -27,7 +27,7 @@ class Command(BaseCommand):
     """
     Example usage:
         $ ./manage.py lms generate_course_blocks --all_courses --settings=devstack
-        $ ./manage.py lms generate_course_blocks 'edX/DemoX/Demo_Course' --settings=devstack
+        $ ./manage.py lms generate_course_blocks --courses 'edX/DemoX/Demo_Course' --settings=devstack
     """
     args = u'<course_id course_id ...>'
     help = u'Generates and stores course blocks for one or more courses.'

--- a/openedx/core/lib/graph_traversals.py
+++ b/openedx/core/lib/graph_traversals.py
@@ -339,8 +339,11 @@ def leaf_filter(block):
     """
     Filter for traversals to find leaf blocks
     """
+    NON_LEAF_BLOCK_TYPES = {
+        'chapter', 'sequential', 'problemset', 'videosequence', 'vertical'
+    }
     return (
-        block.location.block_type not in ('chapter', 'sequential', 'vertical') and
+        block.location.block_type not in NON_LEAF_BLOCK_TYPES and
         len(block.get_children()) == 0
     )
 

--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -187,6 +187,8 @@ def get_course_outline_block_tree(request, course_id, user=None, allow_start_dat
         'course',
         'chapter',
         'sequential',
+        'problemset',  # Semantic alias to 'sequential'; functionally equivalent.
+        'videosequence',  # Semantic alias to 'sequential'; functionally equivalent.
         'vertical',
         'html',
         'problem',

--- a/openedx/features/effort_estimation/block_transformers.py
+++ b/openedx/features/effort_estimation/block_transformers.py
@@ -132,6 +132,8 @@ class EffortEstimationTransformer(BlockStructureTransformer):
             'course': self._estimate_children_effort,
             'html': self._estimate_html_effort,
             'sequential': self._estimate_children_effort,
+            'problemset': self._estimate_children_effort,
+            'videosequence': self._estimate_children_effort,
             'vertical': self._estimate_vertical_effort,
             'video': self._estimate_video_effort,
         }


### PR DESCRIPTION
This commit fixes a utility function that is used in several
places (including the new courseware experience and both
the new and legacy course homes) to include problemsets
and videosets in its query to the block transformers cache.

problemset and videoset are both aliases to
sequential (e.g. Subsection). They are purely semantic;
they aren't supposed to affect functionality at all
currently.

TNL-7978

<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
