### PR TITLE
build: requirements/edx/private.txt files weren't handled properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,9 @@ pre-requirements: ## install Python requirements for running pip-tools
 	pip install -qr requirements/edx/pip-tools.txt
 
 requirements: pre-requirements ## install development environment requirements
-	pip-sync -q requirements/edx/development.txt requirements/edx/private.*
+	# The "$(wildcard..)" is to include private.txt if it exists, and make no mention
+	# of it if it does not.  Shell wildcarding can't do that with default options.
+	pip-sync -q requirements/edx/development.txt $(wildcard requirements/edx/private.txt)
 
 shell: ## launch a bash shell in a Docker container with all edx-platform dependencies installed
 	docker run -it -e "NO_PYTHON_UNINSTALL=1" -e "PIP_INDEX_URL=https://pypi.python.org/simple" -e TERM \
@@ -130,4 +132,3 @@ docker_push: docker_tag docker_auth ## push to docker hub
 	docker push "openedx/edx-platform:${GITHUB_SHA}-newrelic"
 	docker push 'openedx/edx-platform:latest-devstack'
 	docker push "openedx/edx-platform:${GITHUB_SHA}-devstack"
-

--- a/pavelib/prereqs.py
+++ b/pavelib/prereqs.py
@@ -30,7 +30,7 @@ else:
 
 # Developers can have private requirements, for local copies of github repos,
 # or favorite debugging tools, etc.
-PRIVATE_REQS = 'requirements/private.txt'
+PRIVATE_REQS = 'requirements/edx/private.txt'
 if os.path.exists(PRIVATE_REQS):
     PYTHON_REQ_FILES.append(PRIVATE_REQS)
 


### PR DESCRIPTION
The requirements/edx/private.txt file is for dev's own private package
needs.  There are two installation mechanisms in edx-platform, and
neither handled the file properly:

- `paver install_prereqs` had the wrong file name.  The file was moved
  almost three years ago, and paver wasn't kept up.

- `make requirements` used `private.*` which included private.in, which
  pip-sync balks at.


Now the requirements/edx/private.txt files can be installed correctly.  Developers will be happier.

