### PR TITLE
LEARNER-8158 - Fixed completion param issue

### DIFF
--- a/lms/djangoapps/course_api/blocks/tests/test_views.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_views.py
@@ -454,3 +454,14 @@ class TestBlocksInCourseView(TestBlocksView, CompletionWaffleTestMixin):  # pyli
         for block in response.data:
             if block['block_id'] in self.non_orphaned_block_usage_keys:
                 assert block.get('completion')
+
+    def test_completion_all_course_with_requested_fields_as_string(self):
+        for block in self.non_orphaned_raw_block_usage_keys:
+            submit_completions_for_testing(self.user, [block])
+
+        response = self.verify_response(params={
+            'depth': 'all',
+            'requested_fields': 'completion,children',
+        })
+        for block_id in self.non_orphaned_block_usage_keys:
+            assert response.data['blocks'][block_id].get('completion')

--- a/lms/djangoapps/course_api/blocks/views.py
+++ b/lms/djangoapps/course_api/blocks/views.py
@@ -305,7 +305,9 @@ class BlocksInCourseView(BlocksView):
         response = super().list(request, course_usage_key,
                                 hide_access_denials=hide_access_denials)  # lint-amnesty, pylint: disable=super-with-arguments
 
-        if 'completion' not in request.query_params.getlist('requested_fields', ''):
+        calculate_completion = any('completion' in param
+                                   for param in request.query_params.getlist('requested_fields', []))
+        if not calculate_completion:
             return response
 
         course_blocks = {}


### PR DESCRIPTION
Fixed completion param issue

LEARNER-8158
- There is a case where we are sending requested_fields in params as comma separated list
e.g. requested_fields=children,show_gated_sections,graded,special_exam_info,completion
- We didn't test for this case in first place and test cases were sending requested_fields as list
- Now we can also handle this comma separated completion field which was getting ignored before