### PR TITLE
MICROBA-918 Unify course cert invalidation

### DIFF
--- a/lms/djangoapps/certificates/models.py
+++ b/lms/djangoapps/certificates/models.py
@@ -407,6 +407,13 @@ class GeneratedCertificate(models.Model):
         self.grade = grade
         self.status = CertificateStatuses.notpassing
         self.save()
+        COURSE_CERT_REVOKED.send_robust(
+            sender=self.__class__,
+            user=self.user,
+            course_key=self.course_id,
+            mode=self.mode,
+            status=self.status,
+        )
 
     def is_valid(self):
         """

--- a/lms/djangoapps/instructor_task/tasks_helper/certs.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/certs.py
@@ -155,18 +155,12 @@ def _invalidate_generated_certificates(course_id, enrolled_students, certificate
 
     allowlisted_users = get_allowlisted_users(course_id)
 
-    # Mark generated certificates as 'unavailable' and update download_url, download_uui, verify_uuid and
-    # grade with empty string for each cert that is not allowlisted. We loop over the certs and save each individually
-    # in order to save a history of the change.
+    # Invalidate each cert that is not allowlisted. We loop over the certs and invalidate each individually in order to
+    # save a history of the change.
     for c in certificates:
         if c.user in allowlisted_users:
             log.info(f'Certificate for user {c.user.id} will not be invalidated because they are on the allowlist for '
                      f'course {course_id}')
         else:
             log.info(f'About to invalidate certificate for user {c.user.id} in course {course_id}')
-            c.status = CertificateStatuses.unavailable
-            c.verify_uuid = ''
-            c.download_uuid = ''
-            c.download_url = ''
-            c.grade = ''
-            c.save()
+            c.invalidate()


### PR DESCRIPTION
* Send COURSE_CERT_REVOKED signal when marking a cert as "not passing"
* Update the instructor task to use the existing invalidate method, in order to send the COURSE_CERT_REVOKED signal.