### PR TITLE
fix: Allow Discussions Configuration creation

### DIFF
--- a/openedx/core/djangoapps/discussions/admin.py
+++ b/openedx/core/djangoapps/discussions/admin.py
@@ -3,6 +3,7 @@ Customize the django admin experience
 """
 from django.contrib import admin
 from django.contrib.admin import SimpleListFilter
+from lti_consumer.models import LtiConfiguration
 from simple_history.admin import SimpleHistoryAdmin
 
 from openedx.core.djangoapps.config_model_utils.admin import StackedConfigModelAdmin
@@ -25,6 +26,11 @@ class DiscussionsConfigurationAdmin(SimpleHistoryAdmin):
         'enabled',
         'provider_type',
     )
+
+    def formfield_for_foreignkey(self, db_field, request, **kwargs):
+        if db_field.name == 'lti_configuration':
+            kwargs['queryset'] = LtiConfiguration.objects.filter(config_id__isnull=False)
+        return super().formfield_for_foreignkey(db_field, request, **kwargs)
 
 
 class AllowListFilter(SimpleListFilter):


### PR DESCRIPTION
## Description

There is currently an error on the /add page, due to a database
inconsistency when an null column exists where the schema says it
should not...

This appears to be blowing up the rendering of the LtiConfiguration
widget within the Discussions Configurations creation page, causing it,
too, to break.

Hopefully, by excluding invalid entries from the admin dropdown, we can
circumvent this issue (inside the LTI XBlock).

## Testing instructions

- Visit `/admin/discussions/discussionsconfiguration/add/`
- Page should not error.
- User should be able to add an entry.

## Deadline

This blocks BD03 rollout.

## Other information

Note: This does not fix the underlying data inconsistency, but hopefully shields us from it in-app.

Confirmed working locally, but frankly, so did the migration :shrug:
It's also faster/easier to deploy/test from w/in `edx-platform`, instead of the XBlock's repo.