### PR TITLE
refactor: use q objects when fetching user using an identifier

### DIFF
--- a/lms/djangoapps/discussion/management/commands/assign_role.py
+++ b/lms/djangoapps/discussion/management/commands/assign_role.py
@@ -1,6 +1,7 @@
 # lint-amnesty, pylint: disable=imported-auth-user, missing-module-docstring
 from django.contrib.auth.models import User
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
+from django.db.models import Q
 
 from openedx.core.djangoapps.django_comment_common.models import Role
 
@@ -26,10 +27,9 @@ class Command(BaseCommand):  # lint-amnesty, pylint: disable=missing-class-docst
 
         role = Role.objects.get(name=role, course_id=course_id)
 
-        if '@' in name_or_email:
-            user = User.objects.get(email=name_or_email)
-        else:
-            user = User.objects.get(username=name_or_email)
+        user = User.objects.filter(Q(email=name_or_email) | Q(username=name_or_email)).first()
+        if not user:
+            raise CommandError(f"User {name_or_email} does not exist.")
 
         if options['remove']:
             user.roles.remove(role)


### PR DESCRIPTION
A backend change to improve code quality and should not change any existing flow or behavior. There are many places in our code which use `if/else` to fetch users from the database which can be improved using the [Q objects](https://docs.djangoproject.com/en/3.1/topics/db/queries/). Q objects can be combined using the `&` and `|` operators. When an operator is used on two Q objects, it yields a new Q object.