### PR TITLE
feat: redirect course staff to learning MFE when enabled

### DIFF
--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -3394,17 +3394,19 @@ class MFERedirectTests(BaseViewsTestCase):  # lint-amnesty, pylint: disable=miss
         with override_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=True):
             assert self.client.get(lms_url).url == mfe_url
 
-    def test_staff_no_redirect(self):
-        lms_url, mfe_url = self._get_urls()  # lint-amnesty, pylint: disable=unused-variable
+    def test_course_staff_redirect(self):
+        lms_url, mfe_url = self._get_urls()
 
         # course staff will not redirect
         course_staff = UserFactory.create(is_staff=False)
         CourseStaffRole(self.course_key).add_users(course_staff)
         self.client.login(username=course_staff.username, password='test')
 
-        assert self.client.get(lms_url).status_code == 200
         with override_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=True):
-            assert self.client.get(lms_url).status_code == 200
+            assert self.client.get(lms_url).url == mfe_url
+
+    def test_global_staff_no_redirect(self):
+        lms_url, _mfe_url = self._get_urls()
 
         # global staff will never be redirected
         self._create_global_staff_user()
@@ -3418,7 +3420,7 @@ class MFERedirectTests(BaseViewsTestCase):  # lint-amnesty, pylint: disable=miss
         self.section2.is_time_limited = True
         self.store.update_item(self.section2, self.user.id)
 
-        lms_url, mfe_url = self._get_urls()  # lint-amnesty, pylint: disable=unused-variable
+        lms_url, _mfe_url = self._get_urls()
 
         with override_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=True):
             assert self.client.get(lms_url).status_code == 200

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -176,8 +176,9 @@ class CoursewareIndex(View):
         # DENY: feature disabled globally
         if not settings.FEATURES.get('ENABLE_COURSEWARE_MICROFRONTEND'):
             return
-        # DENY: staff access
-        if self.is_staff:
+        # DENY: global staff are not automatically redirected,
+        #       allowing them to debug/develop in both experiences.
+        if self.request.user.is_staff:
             return
         # DENY: Old Mongo courses, until removed from platform
         if self.course_key.deprecated:


### PR DESCRIPTION
Previously, learners were automatically redirected
to the micro-frontend (MFE) courseware experience
when the correct flags are enabled,
whereas global staff and course staff were allowed
to view the legacy experience without being redirected.

With this change, learners AND course staff will
be automatically redirected. Global staff will not,
as before.

TNL-7796

<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
