### PR TITLE
refactor: Convert discussions to pluggable app

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2867,7 +2867,6 @@ INSTALLED_APPS = [
 
     # Discussion forums
     'openedx.core.djangoapps.django_comment_common',
-    'openedx.core.djangoapps.discussions',
 
     # Notes
     'lms.djangoapps.edxnotes',

--- a/openedx/core/djangoapps/discussions/apps.py
+++ b/openedx/core/djangoapps/discussions/apps.py
@@ -2,6 +2,8 @@
 Configure the django app
 """
 from django.apps import AppConfig
+from edx_django_utils.plugins import PluginSettings
+from edx_django_utils.plugins import PluginURLs
 
 
 class DiscussionsConfig(AppConfig):
@@ -9,3 +11,9 @@ class DiscussionsConfig(AppConfig):
     Configure the discussions django app
     """
     name = 'openedx.core.djangoapps.discussions'
+    plugin_app = {
+        PluginURLs.CONFIG: {
+        },
+        PluginSettings.CONFIG: {
+        },
+    }

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ setup(
             "credentials = openedx.core.djangoapps.credentials.apps:CredentialsConfig",
             "content_libraries = openedx.core.djangoapps.content_libraries.apps:ContentLibrariesConfig",
             "discussion = lms.djangoapps.discussion.apps:DiscussionConfig",
+            "discussions = openedx.core.djangoapps.discussions.apps:DiscussionsConfig",
             "grades = lms.djangoapps.grades.apps:GradesConfig",
             "plugins = openedx.core.djangoapps.plugins.apps:PluginsConfig",
             "theming = openedx.core.djangoapps.theming.apps:ThemingConfig",


### PR DESCRIPTION
## Description

This minimizes our footprint outside of the djangoapp, now and moving
forward. Not only can we drop the `lms/envs/common.py` change, but we
can also avoid touching `lms/urls.py` when we add the API. Everything
can stay contained within `openedx/core/djangoapps/discussions`.


## Testing instructions

This should be a no-op.

## Deadline

none