### PR TITLE
docs: update CLA links to point to Docusign form.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,6 +1,6 @@
-############################
+########################
 Contributing to Open edX
-############################
+########################
 
 Contributions to Open edX are very welcome, and strongly encouraged! We've
 put together `some documentation that describes our contribution process`_,
@@ -99,19 +99,24 @@ to ask clarifying questions on the ticket as needed, too, if anything is unclear
 Step 1: Sign a Contribution Agreement
 =====================================
 
-Before edX can accept any code contributions from you, you'll need to sign
-the `individual contributor agreement`_ and send it in. This confirms
-that you have the authority to contribute the code in the pull request and
-ensures that edX can relicense it.
+Before edX can accept any code contributions from you, you'll need to sign the
+`individual contributor agreement`_. This confirms that you have the authority
+to contribute the code in the pull request and ensures that edX can re-license
+it.
 
-You should print out the agreement and sign it. Then scan (or photograph) the
-signed agreement and email it to the email address indicated on the agreement.
-Alternatively, you're also free to physically mail the agreement to the street
-address on the agreement. Once we have your agreement in hand, we can begin
-reviewing and merging your work.
+.. _individual contributor agreement: https://openedx.org/cla
+
+If you will be contributing code on behalf of your employer or another
+institution you are affiliated with, please reach out by email to legal@edx.org
+to request the Entity Contributor Agreement.
+
+Once we have received and processed your agreement, we will reach out to you by
+email to confirm. (Please make sure to indicate your email correctly in the
+agreement.) After that we can begin reviewing and merging your work.
 
 Step 2: Fork, Commit, and Pull Request
 ======================================
+
 GitHub has some great documentation on `how to fork a git repository`_. Once
 you've done that, make your changes and `send us a pull request`_! Be sure to
 include a detailed description for your pull request, so that a community
@@ -214,5 +219,3 @@ Expectations You Have of Us
 
 3. Once we have determined through visual review that your code is not
    malicious, we will run a Jenkins build on your branch.
-
-.. _individual contributor agreement: https://open.edx.org/wp-content/uploads/2019/01/individual-contributor-agreement.pdf

--- a/README.rst
+++ b/README.rst
@@ -86,5 +86,5 @@ Reporting Security Issues
 Please do not report security issues in public. Please email
 security@edx.org.
 
-.. _individual contributor agreement: https://openedx.org/wp-content/uploads/2019/01/individual-contributor-agreement.pdf
+.. _individual contributor agreement: https://openedx.org/cla
 .. _CONTRIBUTING: https://github.com/edx/edx-platform/blob/master/CONTRIBUTING.rst


### PR DESCRIPTION
The openedx.org/cla link is a redirection to Docusign.  If the form has
to change in the future, we can update the redirect at openedx.org.

There are other changes to make to CONTRIBUTING.rst, but those will have
to wait.
