### PR TITLE
fix: assign $$course_id in <head> to fix course-team-authored JS

### DIFF
--- a/lms/templates/courseware/courseware-chromeless.html
+++ b/lms/templates/courseware/courseware-chromeless.html
@@ -51,6 +51,14 @@ ${static.get_page_title_breadcrumbs(course_name())}
   ## in this iframe to navigate the parent window.
   <base target="_parent">
 %endif
+
+## Expose the $$course_id variable for course-team-authored JS.
+## We assign it in the <head> so that it will definitely be
+## assigned before any in-XBlock JS is run.
+<script type="text/javascript">
+  var $$course_id = "${course.id | n, js_escaped_string}";
+</script>
+
 </%block>
 
 <%block name="js_extra">
@@ -65,10 +73,6 @@ ${static.get_page_title_breadcrumbs(course_name())}
   % if staff_access:
   	<%include file="xqa_interface.html"/>
   % endif
-
-  <script type="text/javascript">
-    var $$course_id = "${course.id | n, js_escaped_string}";
-  </script>
 
 ${HTML(fragment.foot_html())}
 


### PR DESCRIPTION
## Description
Course-team-authored JS expects $$course_id to be defined
in the global scope. This has worked fine in Legacy courseware,
but due to some differences in page loading that I don't
understand between Legacy and Chromeless (ie New/MFE) XBlock
rendering templates, $$course_id wasn't being assigned before
course team JS was run, causing the scripts to break
on the undefined variable.

The fix here is to assign $$course_id in the head,
guaranteeing that the variable is assigned before
any other JS is run.

(I purposefully didn't touch the legacy view because, well... it works, and I don't want to break it).

## Supporting information

https://openedx.atlassian.net/browse/TNL-7993

## Testing instructions

* Export https://studio.edx.org/export/course-v1:HKPolyUx+HTM533x+1T2021
* `make dev.up.frontend-app-learning+studio`
* Import into your local Studio
* Go to end-of-course survey: http://localhost:18000/courses/course-v1:HKPolyUx+HTML533x+1T2021/courseware/83df9cdd3c03456c87d1d3d8f1478a0f/be3652f5a8d44d9a8499e364e1e15a49/
* Expect: To see a survey below: "How would you rank this course?" etc.
* View in the New Experience
* Expect: Survey to replaced with a blank white div.
* Check out my branch, `make lms-restart`, hard-refresh.
* Expect: Survey is now visible in New Experience.

## Deadline

By tonight or we'll have to exempt the course from the MFE.
