### PR TITLE
feat(jsinput): Allow JSInput problems to create downloads

### DIFF
--- a/common/lib/capa/capa/inputtypes.py
+++ b/common/lib/capa/capa/inputtypes.py
@@ -587,6 +587,7 @@ class JSInput(InputTypeBase):
         - allow-popups
         - allow-forms
         - allow-pointer-lock
+        - allow-downloads
 
     This in turn means that the iframe cannot directly access the top-level
     window elements.

--- a/common/lib/capa/capa/templates/jsinput.html
+++ b/common/lib/capa/capa/templates/jsinput.html
@@ -28,7 +28,7 @@
 
   <iframe name="iframe_${id}"
       id="iframe_${id}"
-      sandbox="allow-scripts allow-popups allow-same-origin allow-forms allow-pointer-lock"
+      sandbox="allow-scripts allow-popups allow-same-origin allow-forms allow-pointer-lock allow-downloads"
       seamless="seamless"
       frameborder="0"
       src="${html_file}"

--- a/common/static/js/capa/fixtures/jsinput.html
+++ b/common/static/js/capa/fixtures/jsinput.html
@@ -16,7 +16,8 @@
         allow-popups
         allow-same-origin
         allow-forms
-        allow-pointer-lock"
+        allow-pointer-lock
+        allow-downloads"
       height="500"
       width="500"
       src="https://studio.edx.org/c4x/edX/DemoX/asset/webGLDemo.html">
@@ -50,4 +51,3 @@
   </div>
 </section>
 </div>
-


### PR DESCRIPTION
## Description

A small fix for a small issue. 

As of fairly recently, browser security settings prevent sandboxed iframes from creating downloads in certain browsers - downloads are still acceptable in Safari, but not Chrome and Firefox. We have a small number of [jsinput problems](https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/custom_javascript.html) that are affected by this, including in a course that just went live ([Early Childhood Development](https://www.edx.org/course/early-childhood-development-global-strategies-for-implementation) on edx.org). This slipped through testing because, well, "fairly recently."

We're getting around the limitation right now by having everyone right-click, open in new tab, and then download the resulting PDF, but it would be nice to not deal with this limitation in the future.

## Deadline

None. 

## Other information

Given that the pages iframed into JSInput problems are always controlled by partners, typically hosted in Files & Uploads, and have access only to the current user's data, the additional security risk from adding "allow-downloads" to the sandbox list feels minimal.

Sandbox attributes are not passed from the `<jsinput>` tag to the iframe, so the change can't be made on a problem-by-problem basis.