### PR TITLE
fix: Upsize LTI Discussions iframe, 400px -> 800px

### DIFF
--- a/openedx/features/lti_course_tab/tab.py
+++ b/openedx/features/lti_course_tab/tab.py
@@ -143,7 +143,7 @@ class LtiCourseLaunchMixin:
             """
             #lti-tab-embed {
                 width: 100%;
-                min-height: 400px;
+                min-height: 800px;
                 border: none;
             }
             """


### PR DESCRIPTION
## Description

Otherwise, there's too much scrolling.


## Supporting information

Fixes: https://openedx.atlassian.net/browse/TNL-7996


## Testing instructions

- Configure an LTI-based discussion provider for a course
- View the discussions tab
- Confirm larger height.
 

## Deadline

BD-03 v1.1