### PR TITLE
docs: Update references to Django MIDDLEWARE_CLASSES

### DIFF
--- a/openedx/core/djangoapps/cache_toolbox/middleware.py
+++ b/openedx/core/djangoapps/cache_toolbox/middleware.py
@@ -55,9 +55,9 @@ However, this has two main disadvantages:
 Usage
 ~~~~~
 
-To use, find ``MIDDLEWARE_CLASSES`` in your ``settings.py`` and replace::
+To use, find ``MIDDLEWARE`` in your ``settings.py`` and replace::
 
-    MIDDLEWARE_CLASSES = [
+    MIDDLEWARE = [
         ...
         'django.contrib.auth.middleware.AuthenticationMiddleware',
         ...
@@ -65,7 +65,7 @@ To use, find ``MIDDLEWARE_CLASSES`` in your ``settings.py`` and replace::
 
 with::
 
-    MIDDLEWARE_CLASSES = [
+    MIDDLEWARE = [
         ...
         'openedx.core.djangoapps.cache_toolbox.middleware.CacheBackedAuthenticationMiddleware',
         ...

--- a/openedx/core/djangoapps/dark_lang/__init__.py
+++ b/openedx/core/djangoapps/dark_lang/__init__.py
@@ -9,7 +9,7 @@ are only accessible through the use of a specific query parameter
 Installation
 ------------
 
-Add the ``DarkLangMiddleware`` to your list of ``MIDDLEWARE_CLASSES``.
+Add the ``DarkLangMiddleware`` to your list of ``MIDDLEWARE``.
 It must come after the ``SessionMiddleware``, and before the ``LocaleMiddleware``.
 
 Run migrations to install the configuration table.


### PR DESCRIPTION
As code was already updated (~1 year ago) in #23070.
A first attempt was made in #18342, which can now be closed.

References: https://github.com/edx/edx-platform/pull/23070
References: https://github.com/edx/edx-platform/pull/18342