### PR TITLE
Check course outline and course date toggles in addition to courseware toggle for streak

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -76,7 +76,7 @@ from lms.djangoapps.courseware.models import (
     OrgDynamicUpgradeDeadlineConfiguration,
 )
 from lms.djangoapps.courseware.toggles import (
-    courseware_mfe_streak_celebration_is_active,
+    streak_celebration_is_active,
     COURSEWARE_PROCTORING_IMPROVEMENTS,
 )
 from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
@@ -3210,9 +3210,8 @@ class UserCelebration(TimeStampedModel):
     def _get_celebration(cls, user, course_key):
         """ Retrieve (or create) the celebration for the provided user and course_key """
         try:
-            # The UI for celebrations is only supported on the MFE right now, so don't turn on
-            # celebrations unless this enrollment's course is MFE-enabled and has milestones enabled.
-            if not courseware_mfe_streak_celebration_is_active(course_key):
+            # Only enable the streak if milestones and the streak are enabled for this course
+            if not streak_celebration_is_active(course_key):
                 return None
             return user.celebration
         except (cls.DoesNotExist, User.celebration.RelatedObjectDoesNotExist):  # pylint: disable=no-member

--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -162,9 +162,8 @@ def courseware_mfe_first_section_celebration_is_active(course_key):
     )
 
 
-def courseware_mfe_streak_celebration_is_active(course_key):
+def streak_celebration_is_active(course_key):
     return (
-        REDIRECT_TO_COURSEWARE_MICROFRONTEND.is_enabled(course_key) and
         COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES.is_enabled(course_key) and
         COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES_STREAK_CELEBRATION.is_enabled(course_key)
     )


### PR DESCRIPTION
I was previously only checking if the courseware mfe is enabled, but the streak celebration can display anywhere on the learning MFE.  
This is fixing a use case where courses have the learning mfe enabled for course home but disabled for the courseware.

I'm updating the check to not check if the MFE is enabled for the course since these APIs are only called from the MFE