### PR TITLE
Use pip-compile `--no-emit-index` instead of deprecated `--no-index`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,8 +97,8 @@ compile-requirements: ## Re-compile *.in requirements to *.txt
 	for f in $(REQ_FILES); do \
 		echo ; \
 		echo "== $$f ===============================" ; \
-		echo "pip-compile -v --no-emit-trusted-host --no-index $$REBUILD ${COMPILE_OPTS} -o $$f.txt $$f.in"; \
-		pip-compile -v --no-emit-trusted-host --no-index $$REBUILD ${COMPILE_OPTS} -o $$f.txt $$f.in || exit 1; \
+		echo "pip-compile -v --no-emit-trusted-host --no-emit-index $$REBUILD ${COMPILE_OPTS} -o $$f.txt $$f.in"; \
+		pip-compile -v --no-emit-trusted-host --no-emit-index $$REBUILD ${COMPILE_OPTS} -o $$f.txt $$f.in || exit 1; \
 		export REBUILD=''; \
 	done
 	# Post process all of the files generated above to work around open pip-tools issues


### PR DESCRIPTION
Option `--no-index` is deprecated since [5.2.0](https://github.com/jazzband/pip-tools/releases/tag/5.2.0).

