### PR TITLE
VAN-367: Capture optional fields usage

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -342,7 +342,13 @@ def _track_user_registration(user, profile, params, third_party_provider):
                 # ..pii: Learner email is sent to Segment in following line and will be associated with analytics data.
                 'email': user.email,
                 'label': params.get('course_id'),
-                'provider': third_party_provider.name if third_party_provider else None
+                'provider': third_party_provider.name if third_party_provider else None,
+                'optional_fields': bool(
+                    profile.goals
+                    or profile.level_of_education_display
+                    or profile.gender_display
+                    or profile.year_of_birth
+                )
             },
         )
 


### PR DESCRIPTION
The goal is to know how many users are adding data to optional fields during account creation.We have a FE event of checkbox click `Support education research by providing additional information`; the event name is `edx.bi.user.register.optional_fields_selected`. This event only tells us if a user has expanded the optional field component but does not give us the surety that they also contributed to providing the optional data.

### Notes:
Add a new property in the existing registration event `edx.bi.user.account.registered` at the backend to track optional field data.