### PR TITLE
upgrade factory-boy

### DIFF
--- a/lms/djangoapps/badges/tests/factories.py
+++ b/lms/djangoapps/badges/tests/factories.py
@@ -30,7 +30,7 @@ def generate_dummy_image(_unused):
     )
 
 
-class CourseCompleteImageConfigurationFactory(DjangoModelFactory):
+class CourseCompleteImageConfigurationFactory(factory.django.DjangoModelFactory):
     """
     Factory for BadgeImageConfigurations
     """
@@ -41,7 +41,7 @@ class CourseCompleteImageConfigurationFactory(DjangoModelFactory):
     icon = factory.LazyAttribute(generate_dummy_image)
 
 
-class BadgeClassFactory(DjangoModelFactory):
+class BadgeClassFactory(factory.django.DjangoModelFactory):
     """
     Factory for BadgeClass
     """
@@ -64,7 +64,7 @@ class RandomBadgeClassFactory(BadgeClassFactory):
     slug = factory.lazy_attribute(lambda _: 'test_slug_' + str(random()).replace('.', '_'))
 
 
-class BadgeAssertionFactory(DjangoModelFactory):
+class BadgeAssertionFactory(factory.django.DjangoModelFactory):
     """
     Factory for BadgeAssertions
     """
@@ -78,7 +78,7 @@ class BadgeAssertionFactory(DjangoModelFactory):
     image_url = 'http://example.com/image.png'
 
 
-class CourseEventBadgesConfigurationFactory(DjangoModelFactory):
+class CourseEventBadgesConfigurationFactory(factory.django.DjangoModelFactory):
     """
     Factory for CourseEventsBadgesConfiguration
     """

--- a/lms/djangoapps/badges/tests/factories.py
+++ b/lms/djangoapps/badges/tests/factories.py
@@ -7,7 +7,6 @@ from random import random
 
 import factory
 from django.core.files.base import ContentFile
-from factory import DjangoModelFactory
 from factory.django import ImageField
 
 from common.djangoapps.student.tests.factories import UserFactory

--- a/lms/djangoapps/courseware/tests/test_date_summary.py
+++ b/lms/djangoapps/courseware/tests/test_date_summary.py
@@ -40,6 +40,7 @@ from lms.djangoapps.verify_student.models import VerificationDeadline
 from lms.djangoapps.verify_student.services import IDVerificationService
 from lms.djangoapps.verify_student.tests.factories import SoftwareSecurePhotoVerificationFactory
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory  # pylint: disable=unused-import
 from openedx.core.djangoapps.user_api.preferences.api import set_user_preference
@@ -1016,7 +1017,8 @@ class TestScheduleOverrides(SharedModuleStoreTestCase):
         course = create_self_paced_course_run(days_till_start=-1, org_id='TestOrg')
         DynamicUpgradeDeadlineConfiguration.objects.create(enabled=True)
         if enroll_first:
-            enrollment = CourseEnrollmentFactory(course_id=course.id, mode=CourseMode.AUDIT, course__self_paced=True)
+            course_overview = CourseOverviewFactory.create(self_paced=True)
+            enrollment = CourseEnrollmentFactory(course_id=course.id, mode=CourseMode.AUDIT, course=course_overview)
         OrgDynamicUpgradeDeadlineConfiguration.objects.create(
             enabled=org_config_enabled, opt_out=org_config_opt_out, org_id=course.id.org
         )
@@ -1024,7 +1026,8 @@ class TestScheduleOverrides(SharedModuleStoreTestCase):
             enabled=course_config_enabled, opt_out=course_config_opt_out, course_id=course.id
         )
         if not enroll_first:
-            enrollment = CourseEnrollmentFactory(course_id=course.id, mode=CourseMode.AUDIT, course__self_paced=True)
+            course_overview = CourseOverviewFactory.create(self_paced=True)
+            enrollment = CourseEnrollmentFactory(course_id=course.id, mode=CourseMode.AUDIT, course=course_overview)
 
         # The enrollment has a schedule, and the upgrade_deadline is set when expected_dynamic_deadline is True
         if not enroll_first:

--- a/lms/djangoapps/experiments/factories.py
+++ b/lms/djangoapps/experiments/factories.py
@@ -10,7 +10,7 @@ from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.experiments.models import ExperimentData, ExperimentKeyValue
 
 
-class ExperimentDataFactory(factory.DjangoModelFactory):  # lint-amnesty, pylint: disable=missing-class-docstring
+class ExperimentDataFactory(factory.django.DjangoModelFactory):  # lint-amnesty, pylint: disable=missing-class-docstring
     class Meta:
         model = ExperimentData
 
@@ -20,7 +20,7 @@ class ExperimentDataFactory(factory.DjangoModelFactory):  # lint-amnesty, pylint
     value = factory.Faker('word')
 
 
-class ExperimentKeyValueFactory(factory.DjangoModelFactory):  # lint-amnesty, pylint: disable=missing-class-docstring
+class ExperimentKeyValueFactory(factory.django.DjangoModelFactory):  # lint-amnesty, pylint: disable=missing-class-docstring
     class Meta:
         model = ExperimentKeyValue
 

--- a/lms/djangoapps/survey/tests/factories.py
+++ b/lms/djangoapps/survey/tests/factories.py
@@ -5,7 +5,7 @@ from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.survey.models import SurveyAnswer, SurveyForm
 
 
-class SurveyFormFactory(factory.DjangoModelFactory):  # lint-amnesty, pylint: disable=missing-class-docstring
+class SurveyFormFactory(factory.django.DjangoModelFactory):  # lint-amnesty, pylint: disable=missing-class-docstring
     class Meta:
         model = SurveyForm
 
@@ -13,7 +13,7 @@ class SurveyFormFactory(factory.DjangoModelFactory):  # lint-amnesty, pylint: di
     form = '<form>First name:<input type="text" name="firstname"/></form>'
 
 
-class SurveyAnswerFactory(factory.DjangoModelFactory):  # lint-amnesty, pylint: disable=missing-class-docstring
+class SurveyAnswerFactory(factory.django.DjangoModelFactory):  # lint-amnesty, pylint: disable=missing-class-docstring
     class Meta:
         model = SurveyAnswer
 

--- a/openedx/core/djangoapps/credit/tests/factories.py
+++ b/openedx/core/djangoapps/credit/tests/factories.py
@@ -21,7 +21,7 @@ from openedx.core.djangoapps.credit.models import (
 from common.djangoapps.util.date_utils import to_timestamp
 
 
-class CreditCourseFactory(factory.DjangoModelFactory):
+class CreditCourseFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = CreditCourse
 
@@ -29,14 +29,14 @@ class CreditCourseFactory(factory.DjangoModelFactory):
     enabled = True
 
 
-class CreditRequirementFactory(factory.DjangoModelFactory):
+class CreditRequirementFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = CreditRequirement
 
     course = factory.SubFactory(CreditCourseFactory)
 
 
-class CreditRequirementStatusFactory(factory.DjangoModelFactory):
+class CreditRequirementStatusFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = CreditRequirementStatus
 
@@ -44,7 +44,7 @@ class CreditRequirementStatusFactory(factory.DjangoModelFactory):
     status = CreditRequirementStatus.REQUIREMENT_STATUS_CHOICES[0][0]
 
 
-class CreditProviderFactory(factory.DjangoModelFactory):
+class CreditProviderFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = CreditProvider
 
@@ -52,14 +52,14 @@ class CreditProviderFactory(factory.DjangoModelFactory):
     provider_url = FuzzyText(prefix='http://')
 
 
-class CreditEligibilityFactory(factory.DjangoModelFactory):
+class CreditEligibilityFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = CreditEligibility
 
     course = factory.SubFactory(CreditCourseFactory)
 
 
-class CreditRequestFactory(factory.DjangoModelFactory):
+class CreditRequestFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = CreditRequest
 

--- a/openedx/core/djangoapps/credit/tests/factories.py
+++ b/openedx/core/djangoapps/credit/tests/factories.py
@@ -93,3 +93,4 @@ class CreditRequestFactory(factory.DjangoModelFactory):
             })
 
         obj.save()
+

--- a/openedx/core/djangoapps/credit/tests/factories.py
+++ b/openedx/core/djangoapps/credit/tests/factories.py
@@ -93,4 +93,3 @@ class CreditRequestFactory(factory.django.DjangoModelFactory):
             })
 
         obj.save()
-

--- a/openedx/core/djangoapps/schedules/tests/factories.py
+++ b/openedx/core/djangoapps/schedules/tests/factories.py
@@ -11,14 +11,14 @@ from openedx.core.djangoapps.site_configuration.tests.factories import SiteFacto
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory
 
 
-class ScheduleExperienceFactory(factory.DjangoModelFactory):
+class ScheduleExperienceFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.ScheduleExperience
 
     experience_type = models.ScheduleExperience.EXPERIENCES.default
 
 
-class ScheduleFactory(factory.DjangoModelFactory):  # lint-amnesty, pylint: disable=missing-class-docstring
+class ScheduleFactory(factory.django.DjangoModelFactory):  # lint-amnesty, pylint: disable=missing-class-docstring
     class Meta:
         model = models.Schedule
 
@@ -28,7 +28,7 @@ class ScheduleFactory(factory.DjangoModelFactory):  # lint-amnesty, pylint: disa
     experience = factory.RelatedFactory(ScheduleExperienceFactory, 'schedule')
 
 
-class ScheduleConfigFactory(factory.DjangoModelFactory):  # lint-amnesty, pylint: disable=missing-class-docstring
+class ScheduleConfigFactory(factory.django.DjangoModelFactory):  # lint-amnesty, pylint: disable=missing-class-docstring
     class Meta:
         model = models.ScheduleConfig
 

--- a/openedx/features/course_duration_limits/tests/test_access.py
+++ b/openedx/features/course_duration_limits/tests/test_access.py
@@ -14,6 +14,7 @@ from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
 from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.courseware.models import DynamicUpgradeDeadlineConfiguration
+from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from openedx.core.djangoapps.schedules.models import Schedule
 from openedx.core.djangoapps.user_api.preferences.api import set_user_preference
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
@@ -36,6 +37,7 @@ class TestAccess(CacheIsolationTestCase):
 
         CourseDurationLimitConfig.objects.create(enabled=True, enabled_as_of=datetime(2018, 1, 1, tzinfo=UTC))
         DynamicUpgradeDeadlineConfiguration.objects.create(enabled=True)
+        self.course = CourseOverviewFactory.create(start=datetime(2018, 1, 1, tzinfo=UTC), self_paced=True)
 
     def assertDateInMessage(self, date, message):  # lint-amnesty, pylint: disable=missing-function-docstring
         # First, check that the formatted version is in there
@@ -100,10 +102,7 @@ class TestAccess(CacheIsolationTestCase):
         else:
             course_upgrade_deadline = None
 
-        enrollment = CourseEnrollmentFactory.create(
-            course__start=datetime(2018, 1, 1, tzinfo=UTC),
-            course__self_paced=True,
-        )
+        enrollment = CourseEnrollmentFactory.create(course=self.course)
         CourseModeFactory.create(
             course_id=enrollment.course.id,
             mode_slug=CourseMode.VERIFIED,
@@ -140,10 +139,7 @@ class TestAccess(CacheIsolationTestCase):
         enrollment date, content_availability_date is set to max of course start
         or enrollment date
         """
-        enrollment = CourseEnrollmentFactory.create(
-            course__start=datetime(2018, 1, 1, tzinfo=UTC),
-            course__self_paced=True,
-        )
+        enrollment = CourseEnrollmentFactory.create(course=self.course)
         CourseModeFactory.create(
             course_id=enrollment.course.id,
             mode_slug=CourseMode.VERIFIED,

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -33,9 +33,6 @@ django-storages<1.9
 # for them.
 edx-enterprise==3.22.4
 
-# Upgrading to 2.12.0 breaks several test classes due to API changes, need to update our code accordingly
-factory-boy==2.8.1
-
 # Newer versions need a more recent version of python-dateutil
 freezegun==0.3.12
 

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -138,7 +138,7 @@ enmerkar-underscore==2.0.0  # via -r requirements/edx/testing.txt
 enmerkar==0.7.1           # via -r requirements/edx/testing.txt, enmerkar-underscore
 event-tracking==1.0.4     # via -r requirements/edx/testing.txt, edx-event-routing-backends, edx-proctoring, edx-search
 execnet==1.8.0            # via -r requirements/edx/testing.txt, pytest-xdist
-factory-boy==2.8.1        # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
+factory-boy==3.2.0        # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
 faker==8.0.0              # via -r requirements/edx/testing.txt, factory-boy
 filelock==3.0.12          # via -r requirements/edx/testing.txt, tox, virtualenv
 freezegun==0.3.12         # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -134,7 +134,7 @@ enmerkar-underscore==2.0.0  # via -r requirements/edx/base.txt
 enmerkar==0.7.1           # via -r requirements/edx/base.txt, enmerkar-underscore
 event-tracking==1.0.4     # via -r requirements/edx/base.txt, edx-event-routing-backends, edx-proctoring, edx-search
 execnet==1.8.0            # via pytest-xdist
-factory-boy==2.8.1        # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.in
+factory-boy==3.2.0        # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.in
 faker==8.0.0              # via factory-boy
 filelock==3.0.12          # via tox, virtualenv
 freezegun==0.3.12         # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.in


### PR DESCRIPTION
upgrade factory-boy

Lots of tests were throwing following errors. 
````
 if not enroll_first:
>           enrollment = CourseEnrollmentFactory(course_id=course.id, mode=CourseMode.AUDIT, course__self_paced=True)

lms/djangoapps/courseware/tests/test_date_summary.py:1023:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../venvs/edxapp/lib/python3.8/site-packages/factory/base.py:40: in __call__
    return cls.create(**kwargs)
../venvs/edxapp/lib/python3.8/site-packages/factory/base.py:528: in create
    return cls._generate(enums.CREATE_STRATEGY, kwargs)
../venvs/edxapp/lib/python3.8/site-packages/factory/django.py:117: in _generate
    return super()._generate(strategy, params)
../venvs/edxapp/lib/python3.8/site-packages/factory/base.py:465: in _generate
    return step.build()
../venvs/edxapp/lib/python3.8/site-packages/factory/builder.py:240: in build
    pre, post = parse_declarations(
../venvs/edxapp/lib/python3.8/site-packages/factory/builder.py:174: in parse_declarations
    pre_declarations.update({
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <DeclarationSet: {'user': <factory.declarations.SubFactory object at 0x7f35e2b133a0>, 'course_id': CourseLocator('TestOrg', 'course_102', 'Run_102', None, None), 'mode': 'audit'}>
values = {'course__self_paced': True, 'course_id': CourseLocator('TestOrg', 'course_102', 'Run_102', None, None), 'mode': 'audit'}

    def update(self, values):
        """Add new declarations to this set/

        Args:
            values (dict(name, declaration)): the declarations to ingest.
        """
        for k, v in values.items():
            root, sub = self.split(k)
            if sub is None:
                self.declarations[root] = v
            else:
                self.contexts[root][sub] = v

        extra_context_keys = set(self.contexts) - set(self.declarations)
        if extra_context_keys:
>           raise errors.InvalidDeclarationError(
                "Received deep context for unknown fields: %r (known=%r)" % (
                    {
                        self.join(root, sub): v
                        for root in extra_context_keys
                        for sub, v in self.contexts[root].items()
                    },
                    sorted(self.declarations),
                )
            )
E           factory.errors.InvalidDeclarationError: Received deep context for unknown fields: {'course__self_paced': True} (known=['course_id', 'mode', 'user'])

../venvs/edxapp/lib/python3.8/site-packages/factory/builder.py:75: InvalidDeclarationError
```