### PR TITLE
VAN-367: Track optional and goals field usage

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -343,12 +343,10 @@ def _track_user_registration(user, profile, params, third_party_provider):
                 'email': user.email,
                 'label': params.get('course_id'),
                 'provider': third_party_provider.name if third_party_provider else None,
-                'optional_fields': bool(
-                    profile.goals
-                    or profile.level_of_education_display
-                    or profile.gender_display
-                    or profile.year_of_birth
-                )
+                'is_gender_selected': bool(profile.gender_display),
+                'is_year_of_birth_selected': bool(profile.year_of_birth),
+                'is_education_selected': bool(profile.level_of_education_display),
+                'is_goal_set': bool(profile.goals),
             },
         )
 


### PR DESCRIPTION
We need to track registration event  on NR in the following manner:

1. Number of users successfully registered.
2. Number of users filling out any of the **three optional fields** (gender, year of birth, level of education)
3. Number of users filling out **goals**. 

[VAN-367](https://openedx.atlassian.net/browse/VAN-367)