### PR TITLE
AA-682: Update the pseudo session fallback session

### DIFF
--- a/openedx/core/djangoapps/catalog/utils.py
+++ b/openedx/core/djangoapps/catalog/utils.py
@@ -526,7 +526,8 @@ def get_pseudo_session_for_entitlement(entitlement):
     This function is used to pass pseudo-data to the front end, returning a single session, regardless of whether that
     session is currently available.
 
-    First tries to return the first available session, followed by the first session regardless of availability.
+    First tries to return the first available session. If there are no available sessions, will try
+    to return the most recent session regardless of availability.
     Returns None if there are no sessions for that course.
     """
     sessions_for_course = get_course_runs_for_course(entitlement.course_uuid)
@@ -534,7 +535,7 @@ def get_pseudo_session_for_entitlement(entitlement):
     if available_sessions:
         return available_sessions[0]
     if sessions_for_course:
-        return sessions_for_course[0]
+        return sessions_for_course[-1]
     return None
 
 


### PR DESCRIPTION
There was a bug where the earliest course returned for a pseudo session
(when there were no available sessions) might not exist in modulestore and
would cause a 500 error. The data problem is another issue that will need to
be fixed, but by switching to the most recent session in this scenario, we believe
we will reduce the likelihood of this error occurring. We also believe the most
recent session is a better return value than the first ever session.

https://openedx.atlassian.net/browse/AA-682
