### PR TITLE
fix: Text comparison should be done with `==` not via is.

### DIFF
--- a/lms/templates/problem_notifications.html
+++ b/lms/templates/problem_notifications.html
@@ -9,7 +9,7 @@
     <span class="notification-message" aria-describedby="${ short_id }-problem-title">${notification_message}
     </span>
     <div class="notification-btn-wrapper">
-        % if notification_name is 'hint':
+        % if notification_name == 'hint':
         <button type="button" class="btn btn-default btn-small notification-btn hint-button">
           ${_('Next Hint')}
         </button>


### PR DESCRIPTION
## Description

`is` will check if two objects are the same whereas `==` will check if
their values are the same which is what we want here.


This PR fixes a syntax warning we're getting, there shouldn't be an impact other than a reduction in warnings.

## Deadline

None