### PR TITLE
doc: Correctly annotate the setting name.

### DIFF
--- a/openedx/core/lib/request_utils.py
+++ b/openedx/core/lib/request_utils.py
@@ -142,13 +142,13 @@ class CookieMonitoringMiddleware(MiddlewareMixin):
         if not CAPTURE_COOKIE_SIZES.is_enabled():
             return
 
-        # ..setting_name: TOP_N_COOKIES_CAPTURED
+        # .. setting_name: TOP_N_COOKIES_CAPTURED
         # .. setting_default: 5
         # .. setting_description: The number of the largest cookies to capture when monitoring. Capture fewer cookies
         #       if you need to save on monitoring resources.
         # .. setting_warning: Depends on the `request_utils.capture_cookie_sizes` toggle being enabled.
         top_n_cookies_captured = getattr(settings, "TOP_N_COOKIES_CAPTURED", 5)
-        # ..setting_name: TOP_N_COOKIE_GROUPS_CAPTURED
+        # .. setting_name: TOP_N_COOKIE_GROUPS_CAPTURED
         # .. setting_default: 5
         # .. setting_description: The number of the largest cookie groups to capture when monitoring. Capture
         #       fewer cookies if you need to save on monitoring resources.


### PR DESCRIPTION
## Description

The `setting_name` annotation needed a space before it so that it's
picked up properly by the toggle annotations tooling.

## Supporting information

The linting errors:
```
openedx@f4e9272f720f:~/edx-platform$ pylint --rcfile=pylintrc --django-settings-module=lms.envs.test openedx/core/lib/request_utils.py
************* Module openedx.core.lib.request_utils
openedx/core/lib/request_utils.py:145:0: E7655: missing non-optional annotation: '.. setting_name:' (annotation-missing-token)
openedx/core/lib/request_utils.py:145:0: E7655: missing non-optional annotation: '.. setting_name:' (annotation-missing-token)
openedx/core/lib/request_utils.py:151:0: E7655: missing non-optional annotation: '.. setting_name:' (annotation-missing-token)
```

## Deadline

None