### PR TITLE
refactor!: drop redundant ENABLE_COURSEWARE_MICROFRONTEND toggle

### DIFF
--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -16,8 +16,7 @@ WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name='courseware')
 # .. toggle_use_cases: temporary, open_edx
 # .. toggle_creation_date: 2020-01-29
 # .. toggle_target_removal_date: 2020-12-31
-# .. toggle_warnings: Also set settings.LEARNING_MICROFRONTEND_URL and
-#   ENABLE_COURSEWARE_MICROFRONTEND.
+# .. toggle_warnings: Also set settings.LEARNING_MICROFRONTEND_URL.
 # .. toggle_tickets: DEPR-109
 REDIRECT_TO_COURSEWARE_MICROFRONTEND = CourseWaffleFlag(
     WAFFLE_FLAG_NAMESPACE, 'courseware_mfe', __name__
@@ -32,8 +31,7 @@ REDIRECT_TO_COURSEWARE_MICROFRONTEND = CourseWaffleFlag(
 # .. toggle_use_cases: temporary, open_edx
 # .. toggle_creation_date: 2020-03-09
 # .. toggle_target_removal_date: 2020-12-31
-# .. toggle_warnings: Also set settings.LEARNING_MICROFRONTEND_URL and
-#   ENABLE_COURSEWARE_MICROFRONTEND.
+# .. toggle_warnings: Also set settings.LEARNING_MICROFRONTEND_URL.
 # .. toggle_tickets: DEPR-109
 COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW = CourseWaffleFlag(
     WAFFLE_FLAG_NAMESPACE, 'microfrontend_course_team_preview', __name__
@@ -49,7 +47,7 @@ COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW = CourseWaffleFlag(
 # .. toggle_use_cases: open_edx, temporary
 # .. toggle_creation_date: 2020-10-02
 # .. toggle_target_removal_date: None
-# .. toggle_warnings: Also set settings.LEARNING_MICROFRONTEND_URL and ENABLE_COURSEWARE_MICROFRONTEND.
+# .. toggle_warnings: Also set settings.LEARNING_MICROFRONTEND_URL.
 # .. toggle_tickets: AA-188
 COURSEWARE_MICROFRONTEND_COURSE_EXIT_PAGE = CourseWaffleFlag(
     WAFFLE_FLAG_NAMESPACE, 'microfrontend_course_exit_page', __name__
@@ -63,7 +61,7 @@ COURSEWARE_MICROFRONTEND_COURSE_EXIT_PAGE = CourseWaffleFlag(
 # .. toggle_use_cases: temporary, open_edx
 # .. toggle_creation_date: 2020-10-07
 # .. toggle_target_removal_date: none
-# .. toggle_warnings: Also set settings.LEARNING_MICROFRONTEND_URL and ENABLE_COURSEWARE_MICROFRONTEND.
+# .. toggle_warnings: Also set settings.LEARNING_MICROFRONTEND_URL.
 # .. toggle_tickets: AA-371
 COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES = CourseWaffleFlag(
     WAFFLE_FLAG_NAMESPACE, 'mfe_progress_milestones', __name__
@@ -78,7 +76,7 @@ COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES = CourseWaffleFlag(
 # .. toggle_use_cases: temporary, open_edx
 # .. toggle_creation_date: 2020-10-07
 # .. toggle_target_removal_date: None
-# .. toggle_warnings: Also set settings.LEARNING_MICROFRONTEND_URL and ENABLE_COURSEWARE_MICROFRONTEND and
+# .. toggle_warnings: Also set settings.LEARNING_MICROFRONTEND_URL and
 #   COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES.
 # .. toggle_tickets: AA-371
 COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES_FIRST_SECTION_CELEBRATION = CourseWaffleFlag(
@@ -94,7 +92,7 @@ COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES_FIRST_SECTION_CELEBRATION = CourseW
 # .. toggle_use_cases: temporary, open_edx
 # .. toggle_creation_date: 2021-02-16
 # .. toggle_target_removal_date: None
-# .. toggle_warnings: Also set settings.LEARNING_MICROFRONTEND_URL and ENABLE_COURSEWARE_MICROFRONTEND and
+# .. toggle_warnings: Also set settings.LEARNING_MICROFRONTEND_URL and
 #   COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES.
 # .. toggle_tickets: AA-304
 COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES_STREAK_CELEBRATION = CourseWaffleFlag(

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -173,9 +173,6 @@ class CoursewareIndex(View):
         Redirect to the new courseware micro frontend,
         unless this is a time limited exam.
         """
-        # DENY: feature disabled globally
-        if not settings.FEATURES.get('ENABLE_COURSEWARE_MICROFRONTEND'):
-            return
         # DENY: staff access
         if self.is_staff:
             return
@@ -625,10 +622,6 @@ def show_courseware_mfe_link(user, staff_access, course_key):
     """
     Return whether to display the button to switch to the Courseware MFE.
     """
-    # The MFE isn't enabled at all, so don't show the button.
-    if not settings.FEATURES.get('ENABLE_COURSEWARE_MICROFRONTEND'):
-        return False
-
     # MFE does not work for Old Mongo courses.
     if course_key.deprecated:
         return False

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -837,19 +837,6 @@ FEATURES = {
     # .. toggle_tickets: 'https://github.com/edx/edx-platform/pull/21616'
     'ENABLE_CHANGE_USER_PASSWORD_ADMIN': False,
 
-    # .. toggle_name: FEATURES['ENABLE_COURSEWARE_MICROFRONTEND']
-    # .. toggle_implementation: DjangoSetting
-    # .. toggle_default: False
-    # .. toggle_description: Set to True to enable the Courseware MFE at the platform level for global staff (see
-    #   REDIRECT_TO_COURSEWARE_MICROFRONTEND for course rollout)
-    # .. toggle_use_cases: open_edx
-    # .. toggle_creation_date: 2020-03-05
-    # .. toggle_target_removal_date: None
-    # .. toggle_tickets: DEPR-109
-    # .. toggle_warnings: Also set settings.LEARNING_MICROFRONTEND_URL and see REDIRECT_TO_COURSEWARE_MICROFRONTEND for
-    #   rollout.
-    'ENABLE_COURSEWARE_MICROFRONTEND': False,
-
     # .. toggle_name: FEATURES['ENABLE_AUTHN_MICROFRONTEND']
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
@@ -4530,8 +4517,7 @@ PROGRAM_CONSOLE_MICROFRONTEND_URL = None
 # .. setting_name: LEARNING_MICROFRONTEND_URL
 # .. setting_default: None
 # .. setting_description: Base URL of the micro-frontend-based courseware page.
-# .. setting_warning: Also set site's ENABLE_COURSEWARE_MICROFRONTEND or
-#     FEATURES['ENABLE_COURSEWARE_MICROFRONTEND'] and courseware.courseware_mfe waffle flag
+# .. setting_warning: Also set site's courseware.courseware_mfe waffle flag.
 LEARNING_MICROFRONTEND_URL = None
 
 ############### Settings for the ace_common plugin #################

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -215,9 +215,6 @@ FEATURES['ENABLE_COSMETIC_DISPLAY_PRICE'] = True
 ######################### Program Enrollments #####################
 FEATURES['ENABLE_ENROLLMENT_RESET'] = True
 
-######################### New Courseware MFE #####################
-FEATURES['ENABLE_COURSEWARE_MICROFRONTEND'] = True
-
 ########################## Third Party Auth #######################
 
 if FEATURES.get('ENABLE_THIRD_PARTY_AUTH') and (

--- a/lms/envs/devstack_decentralized.py
+++ b/lms/envs/devstack_decentralized.py
@@ -180,9 +180,6 @@ FEATURES['ENABLE_COSMETIC_DISPLAY_PRICE'] = True
 ######################### Program Enrollments #####################
 FEATURES['ENABLE_ENROLLMENT_RESET'] = True
 
-######################### New Courseware MFE #####################
-FEATURES['ENABLE_COURSEWARE_MICROFRONTEND'] = True
-
 ########################## Third Party Auth #######################
 
 if FEATURES.get('ENABLE_THIRD_PARTY_AUTH') and (

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -89,20 +89,14 @@ class CoursewareMeta:
         This method is the "opposite" of _redirect_to_learning_mfe in
         lms/djangoapps/courseware/views/index.py. But not exactly...
 
-        1. It needs to respect the global
-           ENABLE_COURSEWARE_MICROFRONTEND feature flag and redirect users
-           out of the MFE experience if it's turned off.
-        2. It needs to redirect for old Mongo courses.
-        3. It does NOT need to worry about exams - the MFE will handle
+        1. It needs to redirect for old Mongo courses.
+        2. It does NOT need to worry about exams - the MFE will handle
            those on its own. As of this writing, it will redirect back to
            the LMS experience, but that may change soon.
-        4. Finally, it needs to redirect users who are bucketed out of
+        3. Finally, it needs to redirect users who are bucketed out of
            the MFE experience, but who aren't staff. Staff are allowed to
            stay.
         """
-        # REDIRECT: feature disabled globally
-        if not settings.FEATURES.get('ENABLE_COURSEWARE_MICROFRONTEND'):
-            return False
         # REDIRECT: Old Mongo courses, until removed from platform
         if self.course_key.deprecated:
             return False


### PR DESCRIPTION
## Description

The Django setting
FEATURES['ENABLE_COURSEWARE_MICROFRONTEND']
has been an additional gate to activating
usage of the Learning MFE for an Open edX
instance.
    
The toggle is redundant with the
`courseware.courseware_mfe`
Waffle flag. By removing it, we simplify our config
and simplify our path towards making the Learning MFE
the default courseware experience.

## Supporting information

http://openedx.atlassian.net/browse/TNL-7796

## Testing instructions

* Devstack: `make frontend-app-learning-up`
* Log in to localhost:18000 as audit@edx.org, pwd 'edx'
  * Enroll in the demo course
  * Start course
  * You should be in the old experience
* In another browser or Incognito, log in to localhost:18000/admin as edx, pwd 'edx'
  * Add a row to the Waffle Flag table: name=`courseware.courseware_mfe`, everyone=`Yes`
* Go back to first browser with audit@edx.org
   * Refresh the courseware page
   * You should be in the new experience.

## Deadline

Today or tomorrow is good; there are more PRs coming behind this one

## Other information

Since everything that was gated by `ENABLE_COURSEWARE_MICROFRONTEND` is _also_ gated by the `courseware.courseware_mfe` Waffle flag, which defaults to False, this change will not result in the MFE being enabled on any environments where the Waffle flag isn't enabled. I checked Edge; nothing will change there.

Follow-up:
* Remove the overrides of this flag from edx-internal (https://github.com/edx/edx-internal/pull/4585)
* Update the [rollout wiki page](https://openedx.atlassian.net/wiki/spaces/AT/pages/1630306418/Courseware+MFE+Rollout)
