### PR TITLE
MICROBA-1024 | Move checks to certificates app

### DIFF
--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1204,7 +1204,7 @@ def _missing_required_verification(student, enrollment_mode):
 
 
 def _certificate_message(student, course, enrollment_mode):  # lint-amnesty, pylint: disable=missing-function-docstring
-    if certs_api.is_certificate_invalid(student, course.id):
+    if certs_api.is_certificate_invalidated(student, course.id):
         return INVALID_CERT_DATA
 
     cert_downloadable_status = certs_api.certificate_downloadable_status(student, course.id)

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -57,8 +57,6 @@ from lms.djangoapps.bulk_email.models import BulkEmailFlag, CourseEmail, CourseE
 from lms.djangoapps.certificates.api import generate_user_certificates
 from lms.djangoapps.certificates.models import CertificateStatuses
 from lms.djangoapps.certificates.tests.factories import (
-    CertificateInvalidationFactory,
-    CertificateWhitelistFactory,
     GeneratedCertificateFactory
 )
 from lms.djangoapps.courseware.models import StudentModule
@@ -72,8 +70,6 @@ from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from lms.djangoapps.experiments.testutils import override_experiment_waffle_flag
 from lms.djangoapps.instructor.tests.utils import FakeContentTask, FakeEmail, FakeEmailInfo
 from lms.djangoapps.instructor.views.api import (
-    _check_if_learner_on_allowlist,
-    _check_if_learner_on_blocklist,
     _get_certificate_for_user,
     _get_student_from_request_data,
     _split_input_list,
@@ -4440,10 +4436,7 @@ class TestInstructorCertificateExceptions(SharedModuleStoreTestCase):
         )
 
         retrieved_certificate = _get_certificate_for_user(self.course.id, self.user)
-
         assert retrieved_certificate.id == generated_certificate.id
-        assert retrieved_certificate.user == self.user
-        assert retrieved_certificate.course_id == self.course.id
 
     def test_get_certificate_for_user_no_certificate(self):
         """
@@ -4457,89 +4450,3 @@ class TestInstructorCertificateExceptions(SharedModuleStoreTestCase):
             f"The student {self.user} does not have certificate for the course {self.course.id.course}. Kindly "
             "verify student username/email and the selected course are correct and try again."
         )
-
-    def test_check_if_learner_on_allowlist(self):
-        """
-        Test to verify that no learner is returned if the learner does not have an active entry on the allowlist.
-        """
-        result = _check_if_learner_on_allowlist(self.course.id, self.user)
-
-        assert not result
-
-    def test_check_if_learner_on_allowlist_allowlist_entry_exists(self):
-        """
-        Test that verifies the correct result is returned if a learner has an active entry on the allowlist.
-        """
-        CertificateWhitelistFactory.create(
-            course_id=self.course.id,
-            user=self.user
-        )
-
-        result = _check_if_learner_on_allowlist(self.course.id, self.user)
-
-        assert result
-
-    def test_check_if_learner_on_blocklist_no_cert(self):
-        """
-        Test to verify that the correct result is returned if a learner does not currently have a certificate in a
-        course-run.
-        """
-        result = _check_if_learner_on_blocklist(self.course.id, self.user)
-
-        assert not result
-
-    def test_check_if_learner_on_blocklist_with_cert(self):
-        """
-        Test to verify that the correct result is returned if a learner has a certificate but does not have an active
-        entry on the blocklist.
-        """
-        GeneratedCertificateFactory.create(
-            user=self.user,
-            course_id=self.course.id,
-            mode='verified',
-            status=CertificateStatuses.downloadable,
-        )
-
-        result = _check_if_learner_on_blocklist(self.course.id, self.user)
-        assert not result
-
-    def test_check_if_learner_on_blocklist_blocklist_entry_exists(self):
-        """
-        Test to verify that the correct result is returned if a learner has a Certificate and an active entry on
-        the blocklist.
-        """
-        generated_certificate = GeneratedCertificateFactory.create(
-            user=self.user,
-            course_id=self.course.id,
-            mode='verified',
-            status=CertificateStatuses.downloadable,
-        )
-
-        CertificateInvalidationFactory.create(
-            generated_certificate=generated_certificate,
-            invalidated_by=self.global_staff,
-            active=True
-        )
-
-        result = _check_if_learner_on_blocklist(self.course.id, self.user)
-        assert result
-
-    def test_check_if_learner_on_blocklist_inactive_blocklist_entry_exists(self):
-        """
-        Test to verify that the correct result is returned if a learner has an inactive entry on the blocklist.
-        """
-        generated_certificate = GeneratedCertificateFactory.create(
-            user=self.user,
-            course_id=self.course.id,
-            mode='verified',
-            status=CertificateStatuses.downloadable,
-        )
-
-        CertificateInvalidationFactory.create(
-            generated_certificate=generated_certificate,
-            invalidated_by=self.global_staff,
-            active=False
-        )
-
-        result = _check_if_learner_on_blocklist(self.course.id, self.user)
-        assert not result


### PR DESCRIPTION
## Description
[MICROBA-1024]
- Move some of the recently added logic from the instructor app to the certificates app
- Attempt to not use other certificate models directly in the code I am touching, moving this logic to certificates as well.

I **may** have been a little overzealous here. After I started updating the functions for the allowlist and blocklist checks... it seemed easy to move a few other pieces to certificate exceptions and certificate invalidations over to the certificates app as well.

Happy to reverse this if this isn't the time or place. I figured that I was already in there and I might try and make progress on reducing how many times the Certificates app models are used directly outside of the Certificates app.

[MICROBA-1024]: https://openedx.atlassian.net/browse/MICROBA-1024