### PR TITLE
AA-513: Ensure user id exists before trying to send event

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -2558,7 +2558,8 @@ def log_successful_logout(sender, request, user, **kwargs):  # lint-amnesty, pyl
             AUDIT_LOG.info('Logout - user.id: {0}'.format(request.user.id))  # pylint: disable=logging-format-interpolation
         else:
             AUDIT_LOG.info('Logout - {0}'.format(request.user))  # pylint: disable=logging-format-interpolation
-        segment.track(request.user.id, 'edx.bi.user.account.logout')
+        if request.user.id:
+            segment.track(request.user.id, 'edx.bi.user.account.logout')
 
 
 @receiver(user_logged_in)


### PR DESCRIPTION
request.user.id could be None which ends up raising an error in
the analytics package we use.
