### PR TITLE
Update exam attempt table css and edx-proctoring version

### DIFF
--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -2599,6 +2599,15 @@ input[name="subject"] {
       border-bottom: 1px solid #f3f3f3;
     }
 
+    tbody.even {
+      background-color: $gray-l6;
+      border-bottom: 1px solid #f3f3f3;
+    }
+
+    tbody.accordion-trigger {
+      cursor: pointer;
+    }
+
     .allowance-headings,
     .exam-attempt-headings,
     .onboarding-status-headings {
@@ -2626,10 +2635,12 @@ input[name="subject"] {
 
         &.attempt-type {
           width: 90px;
+          text-align: center;
         }
 
         &.attempt-started-at {
           width: 170px;
+          text-align: center;
         }
 
         &.attempt-completed-at {
@@ -2646,13 +2657,15 @@ input[name="subject"] {
           width: 150px;
         }
 
+        &.more {
+          width: 30px;
+        }
+
         &.username {
           width: 140px;
         }
 
         &.email {
-          @include text-align(center);
-
           width: ($baseline*8);
           word-wrap: break-word;
         }
@@ -2688,7 +2701,7 @@ input[name="subject"] {
         @include padding-left($baseline);
       }
 
-      td:nth-child(2) {
+      td:nth-child(3) {
         line-height: 22px;
 
         @include padding-right(0);
@@ -2696,20 +2709,20 @@ input[name="subject"] {
         word-wrap: break-word;
       }
 
+      td:nth-child(6),
       td:nth-child(5),
-      td:nth-child(4),
-      td:nth-child(6) {
+      td:nth-child(7) {
         @include padding-left(0);
 
         text-align: center;
       }
 
-      td:nth-child(3) {
+      td:nth-child(4) {
         word-wrap: break-word;
         text-align: center;
       }
 
-      td:nth-child(7) {
+      td:nth-child(8) {
         word-wrap: break-word;
         text-align: center;
       }

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -106,7 +106,7 @@ edx-milestones==0.3.0     # via -r requirements/edx/base.in
 edx-opaque-keys[django]==2.2.0  # via -r requirements/edx/paver.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, lti-consumer-xblock, xmodule
 edx-organizations==6.9.0  # via -r requirements/edx/base.in
 edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/base.in
-edx-proctoring==3.7.0     # via -r requirements/edx/base.in, edx-proctoring-proctortrack
+edx-proctoring==3.7.1     # via -r requirements/edx/base.in, edx-proctoring-proctortrack
 edx-rbac==1.4.1           # via edx-enterprise
 edx-rest-api-client==5.3.0  # via -r requirements/edx/base.in, edx-enterprise, edx-proctoring
 edx-search==3.0.0         # via -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -118,7 +118,7 @@ edx-milestones==0.3.0     # via -r requirements/edx/testing.txt
 edx-opaque-keys[django]==2.2.0  # via -r requirements/edx/testing.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, lti-consumer-xblock, xmodule
 edx-organizations==6.9.0  # via -r requirements/edx/testing.txt
 edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/testing.txt
-edx-proctoring==3.7.0     # via -r requirements/edx/testing.txt, edx-proctoring-proctortrack
+edx-proctoring==3.7.1     # via -r requirements/edx/testing.txt, edx-proctoring-proctortrack
 edx-rbac==1.4.1           # via -r requirements/edx/testing.txt, edx-enterprise
 edx-rest-api-client==5.3.0  # via -r requirements/edx/testing.txt, edx-enterprise, edx-proctoring
 edx-search==3.0.0         # via -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -115,7 +115,7 @@ edx-milestones==0.3.0     # via -r requirements/edx/base.txt
 edx-opaque-keys[django]==2.2.0  # via -r requirements/edx/base.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, lti-consumer-xblock, xmodule
 edx-organizations==6.9.0  # via -r requirements/edx/base.txt
 edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/base.txt
-edx-proctoring==3.7.0     # via -r requirements/edx/base.txt, edx-proctoring-proctortrack
+edx-proctoring==3.7.1     # via -r requirements/edx/base.txt, edx-proctoring-proctortrack
 edx-rbac==1.4.1           # via -r requirements/edx/base.txt, edx-enterprise
 edx-rest-api-client==5.3.0  # via -r requirements/edx/base.txt, edx-enterprise, edx-proctoring
 edx-search==3.0.0         # via -r requirements/edx/base.txt


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description
The newest version of edx-proctoring contains updates to the exam attempt table (see PR here: https://github.com/edx/edx-proctoring/pull/802). So in addition to the version update, the CSS for that table also needs to be updated here.

The new table looks like this:

<img width="1281" alt="Screen Shot 2021-03-02 at 8 28 44 AM" src="https://user-images.githubusercontent.com/46360176/109664411-188b4780-7b3b-11eb-80cb-cee6e3cddeab.png">

<img width="1277" alt="Screen Shot 2021-03-02 at 8 28 52 AM" src="https://user-images.githubusercontent.com/46360176/109664425-1cb76500-7b3b-11eb-9054-fc8f41b29bb2.png">
