### PR TITLE
Fix running tests in common/lib.

### DIFF
--- a/common/lib/capa/capa/safe_exec/tests/test_safe_exec.py
+++ b/common/lib/capa/capa/safe_exec/tests/test_safe_exec.py
@@ -77,7 +77,7 @@ class TestSafeExec(unittest.TestCase):  # lint-amnesty, pylint: disable=missing-
         g = {}
         with pytest.raises(SafeExecException) as cm:
             safe_exec("1/0", g)
-        assert 'ZeroDivisionError' in text_type(cm.exception)
+        assert 'ZeroDivisionError' in text_type(cm.value)
 
 
 class TestSafeOrNot(unittest.TestCase):  # lint-amnesty, pylint: disable=missing-class-docstring

--- a/common/lib/capa/capa/tests/test_responsetypes.py
+++ b/common/lib/capa/capa/tests/test_responsetypes.py
@@ -798,7 +798,7 @@ class StringResponseTest(ResponseTest):  # pylint: disable=missing-class-docstri
         problem = self.build_problem(answer="a2", case_sensitive=False, regexp=True, additional_answers=['?\\d?'])
         with pytest.raises(Exception) as cm:
             self.assert_grade(problem, "a3", "correct")
-        exception_message = text_type(cm.exception)
+        exception_message = text_type(cm.value)
         assert 'nothing to repeat' in exception_message
 
     def test_hints(self):

--- a/common/lib/pytest.ini
+++ b/common/lib/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = openedx.tests.settings
-addopts = --nomigrations --reuse-db --durations=20 --json-report --json-report-omit keywords streams collectors log traceback tests --json-report-file=none  # lint-amnesty, pylint: disable=syntax-error
+addopts = --nomigrations --reuse-db --durations=20 --json-report --json-report-omit keywords streams collectors log traceback tests --json-report-file=none
 # Enable default handling for all warnings, including those that are ignored by default;
 # but hide rate-limit warnings (because we deliberately don't throttle test user logins)
 # and field_data deprecation warnings (because fixing them requires a major low-priority refactoring)

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -1642,26 +1642,16 @@ class ProblemBlockTest(unittest.TestCase):  # lint-amnesty, pylint: disable=miss
         assert not result['should_enable_next_hint']
 
     def test_demand_hint_logging(self):
-        def mock_location_text(self):  # lint-amnesty, pylint: disable=unused-argument
-            """
-            Mock implementation of __unicode__ or __str__ for the module's location.
-            """
-            return u'i4x://edX/capa_test/problem/meh'
-
+        """
+        Test calling get_demand_hunt() results in an event being published.
+        """
         module = CapaFactory.create(xml=self.demand_xml)
-        # Re-mock the module_id to a fixed string, so we can check the logging
-        module.location = Mock(module.location)
-        if six.PY2:
-            module.location.__unicode__ = mock_location_text
-        else:
-            module.location.__str__ = mock_location_text
-
         with patch.object(module.runtime, 'publish') as mock_track_function:
             module.get_problem_html()
             module.get_demand_hint(0)
             mock_track_function.assert_called_with(
                 module, 'edx.problem.hint.demandhint_displayed',
-                {'hint_index': 0, 'module_id': u'i4x://edX/capa_test/problem/meh',
+                {'hint_index': 0, 'module_id': str(module.location),
                  'hint_text': 'Demand 1', 'hint_len': 2}
             )
 

--- a/common/lib/xmodule/xmodule/tests/test_course_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_course_module.py
@@ -451,7 +451,7 @@ class ProctoringProviderTestCase(unittest.TestCase):
 
         with pytest.raises(ValueError) as context_manager:
             self.proctoring_provider.from_json(provider)
-        assert context_manager.exception.args[0] ==\
+        assert context_manager.value.args[0] ==\
                [f'The selected proctoring provider, {provider},'
                 f' is not a valid provider. Please select from one of {allowed_proctoring_providers}.']
 

--- a/common/lib/xmodule/xmodule/tests/test_graders.py
+++ b/common/lib/xmodule/xmodule/tests/test_graders.py
@@ -43,14 +43,14 @@ class GradesheetTest(unittest.TestCase):
         agg_fields['first_attempted'] = now
         scores.append(ProblemScore(weighted_earned=3, weighted_possible=5, graded=True, **prob_fields))
         all_total, graded_total = aggregate_scores(scores)
-        assert round(all_total - AggregatedScore(tw_earned=3, tw_possible=10, graded=False, **agg_fields), 7) >= 0
-        assert round(graded_total - AggregatedScore(tw_earned=3, tw_possible=5, graded=True, **agg_fields), 7) >= 0
+        assert all_total == AggregatedScore(tw_earned=3, tw_possible=10, graded=False, **agg_fields)
+        assert graded_total == AggregatedScore(tw_earned=3, tw_possible=5, graded=True, **agg_fields)
 
         # (0/5 non-graded) + (3/5 graded) + (2/5 graded) = 5/15 total, 5/10 graded
         scores.append(ProblemScore(weighted_earned=2, weighted_possible=5, graded=True, **prob_fields))
         all_total, graded_total = aggregate_scores(scores)
-        assert round(all_total - AggregatedScore(tw_earned=5, tw_possible=15, graded=False, **agg_fields), 7) >= 0
-        assert round(graded_total - AggregatedScore(tw_earned=5, tw_possible=10, graded=True, **agg_fields), 7) >= 0
+        assert all_total == AggregatedScore(tw_earned=5, tw_possible=15, graded=False, **agg_fields)
+        assert graded_total == AggregatedScore(tw_earned=5, tw_possible=10, graded=True, **agg_fields)
 
 
 @ddt.ddt

--- a/common/lib/xmodule/xmodule/tests/test_graders.py
+++ b/common/lib/xmodule/xmodule/tests/test_graders.py
@@ -337,7 +337,7 @@ class GraderTest(unittest.TestCase):
     def test_grader_with_invalid_conf(self, invalid_conf, expected_error_message):
         with pytest.raises(ValueError) as error:
             graders.grader_from_conf([invalid_conf])
-        assert expected_error_message in text_type(error.exception)
+        assert expected_error_message in text_type(error.value)
 
 
 @ddt.ddt

--- a/pavelib/utils/envs.py
+++ b/pavelib/utils/envs.py
@@ -211,7 +211,7 @@ class Env:
     JS_REPORT_DIR = REPORT_DIR / 'javascript'
 
     # Directories used for common/lib/tests
-    IGNORED_TEST_DIRS = ('__pycache__', '.cache')
+    IGNORED_TEST_DIRS = ('__pycache__', '.cache', '.pytest_cache')
     LIB_TEST_DIRS = []
     for item in (REPO_ROOT / "common/lib").listdir():
         dir_name = (REPO_ROOT / 'common/lib' / item)


### PR DESCRIPTION
## Description

A pylint ignore message got added to `common/lib/pytest.ini` as part of running pylint amnesty in https://github.com/edx/edx-platform/pull/26326. This is preventing the tests in `common/lib/` from running. This PR fixes the issue by removing the pylint ignore message.

https://github.com/edx/edx-platform/pull/26530 updated the tests to use pytest assertions instead of unittest assertions. But there is some difference in behavior which is causing some of the tests to fail. For now we revert to the unittest assertions in these cases.

- Which edX user roles will this change impact?
"Developer"

## Testing instructions

Before checking out this fix:
* Try running `paver test_lib`.  It should result in `collected 0 items` and `ERROR: file or directory not found: #` for the directories in `common/lib`.
* Try running a single test file like `pytest common/lib/xmodule/xmodule/tests/test_vertical.py`. It should result in the same error.
* In the Jenkins logs for the python tests, search for a test name from `common/lib/xmodule` and check that there is message indicating it passed. e.g. `[gw2] PASSED common/lib/xmodule/xmodule/tests/test_capa_module.py::ProblemBlockTest::test_random_seed_with_reset_6_onreset`. 

After checking out this PR, the tests should run correctly.