### PR TITLE
Update edX-hosted video player to use 2x playback speed

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/video/html5_video_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/html5_video_spec.js
@@ -3,7 +3,7 @@
         var STATUS = window.STATUS;
         var state,
             oldOTBD,
-            playbackRates = [0.75, 1.0, 1.25, 1.5],
+            playbackRates = [0.75, 1.0, 1.25, 1.5, 2.0],
             describeInfo,
             POSTER_URL = '/media/video-images/poster.png';
 

--- a/common/lib/xmodule/xmodule/js/src/video/02_html5_video.js
+++ b/common/lib/xmodule/xmodule/js/src/video/02_html5_video.js
@@ -192,7 +192,7 @@ function(_) {
         };
 
         Player.prototype.getAvailablePlaybackRates = function() {
-            return [0.75, 1.0, 1.25, 1.5];
+            return [0.75, 1.0, 1.25, 1.5, 2.0];
         };
 
         // eslint-disable-next-line no-underscore-dangle


### PR DESCRIPTION
## Description

Some learners would prefer to watch course videos at 2x playback speed.  Currently the edX-hosted  video players limits playback speed to 1.5x.  The YouTube-hosted video player allows 2x playback.  Chrome seems to support 2x playback natively.

Useful information to include:
- Which edX user roles will this change impact?
Learner

- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
TBD - Devstack is not cooperating 

## Supporting information

https://openedx.atlassian.net/browse/LEARNER-8247

## Testing instructions

Visit an edX-hosted video player and note it supports 2x playback

To be done: Test on Firefox, Chrome, Edge

## Deadline

None

## Other information

None
