### PR TITLE
refactor: centralize checks for canonical courseware experience & URL

### DIFF
--- a/common/djangoapps/student/tests/test_models.py
+++ b/common/djangoapps/student/tests/test_models.py
@@ -40,6 +40,7 @@ from common.djangoapps.student.models import (
     PendingNameChange,
 )
 from common.djangoapps.student.tests.factories import AccountRecoveryFactory, CourseEnrollmentFactory, UserFactory
+from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
@@ -258,7 +259,7 @@ class UserCelebrationTests(SharedModuleStoreTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.course = CourseFactory()
+        cls.course = CourseFactory(default_store=ModuleStoreEnum.Type.split)
         cls.course_key = cls.course.id  # pylint: disable=no-member
 
     def setUp(self):

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -258,7 +258,7 @@ class TestJumpTo(ModuleStoreTestCase):
         )
         expected_url += "?{}".format(urlencode({'activate_block_id': six.text_type(staff_only_vertical.location)}))
 
-        assert expected_url == get_legacy_courseware_url(course_key, usage_key, request)
+        assert expected_url == get_legacy_courseware_url(usage_key, request)
 
 
 @ddt.ddt
@@ -548,9 +548,9 @@ class ViewsTestCase(BaseViewsTestCase):
 
     def test_get_redirect_url(self):
         # test the course location
-        assert u'/courses/{course_key}/courseware?{activate_block_id}'.format(course_key=text_type(self.course_key), activate_block_id=urlencode({'activate_block_id': text_type(self.course.location)})) == get_legacy_courseware_url(self.course_key, self.course.location)  # pylint: disable=line-too-long
+        assert u'/courses/{course_key}/courseware?{activate_block_id}'.format(course_key=text_type(self.course_key), activate_block_id=urlencode({'activate_block_id': text_type(self.course.location)})) == get_legacy_courseware_url(self.course.location)  # pylint: disable=line-too-long
         # test a section location
-        assert u'/courses/{course_key}/courseware/Chapter_1/Sequential_1/?{activate_block_id}'.format(course_key=text_type(self.course_key), activate_block_id=urlencode({'activate_block_id': text_type(self.section.location)})) == get_legacy_courseware_url(self.course_key, self.section.location)  # pylint: disable=line-too-long
+        assert u'/courses/{course_key}/courseware/Chapter_1/Sequential_1/?{activate_block_id}'.format(course_key=text_type(self.course_key), activate_block_id=urlencode({'activate_block_id': text_type(self.section.location)})) == get_legacy_courseware_url(self.section.location)  # pylint: disable=line-too-long
 
     def test_invalid_course_id(self):
         response = self.client.get('/courses/MITx/3.091X/')
@@ -3282,8 +3282,9 @@ class TestShowCoursewareMFE(TestCase):
                 assert show_courseware_mfe_link(global_staff_user, False, new_course_key)
                 assert show_courseware_mfe_link(regular_user, True, new_course_key)
 
-                # Regular users don't see the link.
-                assert not show_courseware_mfe_link(regular_user, False, new_course_key)
+                # (Regular users would see the link, but they can't see the Legacy
+                #  experience, so it doesn't matter.)
+
             with override_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=False):
                 # (preview=on, redirect=off)
                 # Global and Course Staff can see the link.
@@ -3305,8 +3306,9 @@ class TestShowCoursewareMFE(TestCase):
                 # if preview=off.
                 assert show_courseware_mfe_link(regular_user, True, new_course_key)
 
-                # Regular users don't see the link.
-                assert not show_courseware_mfe_link(regular_user, False, new_course_key)
+                # (Regular users would see the link, but they can't see the Legacy
+                #  experience, so it doesn't matter.)
+
             with override_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=False):
                 # (preview=off, redirect=off)
                 # Global staff see the link anyway

--- a/lms/djangoapps/courseware/testutils.py
+++ b/lms/djangoapps/courseware/testutils.py
@@ -175,7 +175,7 @@ class RenderXBlockTestMixin(six.with_metaclass(ABCMeta, object)):
             self.setup_user(admin=True, enroll=True, login=True)
 
             with check_mongo_calls(mongo_calls):
-                url = get_legacy_courseware_url(self.course.id, self.block_to_be_tested.location)
+                url = get_legacy_courseware_url(self.block_to_be_tested.location)
                 response = self.client.get(url)
                 expected_elements = self.block_specific_chrome_html_elements + self.COURSEWARE_CHROME_HTML_ELEMENTS
                 for chrome_element in expected_elements:

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -65,7 +65,7 @@ from ..masquerade import check_content_start_date_for_masquerade_user, setup_mas
 from ..model_data import FieldDataCache
 from ..module_render import get_module_for_descriptor, toc_for_course
 from ..permissions import MASQUERADE_AS_STUDENT
-from ..toggles import COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW, REDIRECT_TO_COURSEWARE_MICROFRONTEND
+from ..toggles import courseware_legacy_is_visible, courseware_mfe_is_visible
 from .views import CourseTabView
 
 log = logging.getLogger("edx.courseware.views.index")
@@ -170,21 +170,24 @@ class CoursewareIndex(View):
 
     def _redirect_to_learning_mfe(self):
         """
-        Redirect to the new courseware micro frontend,
-        unless this is a time limited exam.
+        Can the user access this sequence in Legacy courseware? If not, redirect to MFE.
+
+        We specifically allow users to stay in the Legacy frontend for special
+        (ie timed/proctored) exams since they're not yet supported by the MFE.
         """
-        # DENY: staff access
-        if self.is_staff:
+        # STAY: if the course run as a whole is visible in the Legacy experience.
+        if courseware_legacy_is_visible(
+                course_key=self.course_key,
+                is_global_staff=self.request.user.is_staff,
+                is_course_staff=self.is_staff,
+        ):
             return
-        # DENY: Old Mongo courses, until removed from platform
-        if self.course_key.deprecated:
-            return
-        # DENY: Timed Exams, until supported
+        # STAY: if we are in a special (ie proctored/timed) exam, which isn't yet
+        #       supported on the MFE.
         if getattr(self.section, 'is_time_limited', False):
             return
-        # ALLOW: when flag set for course
-        if REDIRECT_TO_COURSEWARE_MICROFRONTEND.is_enabled(self.course_key):
-            raise Redirect(self.microfrontend_url)
+        # REDIRECT otherwise.
+        raise Redirect(self.microfrontend_url)
 
     @property
     def microfrontend_url(self):
@@ -622,24 +625,8 @@ def show_courseware_mfe_link(user, staff_access, course_key):
     """
     Return whether to display the button to switch to the Courseware MFE.
     """
-    # MFE does not work for Old Mongo courses.
-    if course_key.deprecated:
-        return False
-
-    # Global staff members always get to see the courseware MFE button if the
-    # platform and course are capable, regardless of rollout waffle flags.
-    if user.is_staff:
-        return True
-
-    # If you have course staff access, you can see this link if...
-    if staff_access:
-        # (a) we've turned on the redirect for your students, or...
-        mfe_enabled_for_course = REDIRECT_TO_COURSEWARE_MICROFRONTEND.is_enabled(course_key)
-        if mfe_enabled_for_course:
-            return True
-        # (b) we've enabled the course team preview.
-        mfe_enabled_for_course_team = COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW.is_enabled(course_key)
-        if mfe_enabled_for_course_team:
-            return True
-
-    return False
+    return courseware_mfe_is_visible(
+        course_key=course_key,
+        is_global_staff=user.is_staff,
+        is_course_staff=staff_access,
+    )

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -396,7 +396,7 @@ def jump_to(_request, course_id, location):
     except InvalidKeyError:
         raise Http404(u"Invalid course_key or usage_key")  # lint-amnesty, pylint: disable=raise-missing-from
     try:
-        redirect_url = get_legacy_courseware_url(course_key, usage_key, _request)
+        redirect_url = get_legacy_courseware_url(usage_key, _request)
     except ItemNotFoundError:
         raise Http404(u"No data at this location: {0}".format(usage_key))  # lint-amnesty, pylint: disable=raise-missing-from
     except NoPathToItem:

--- a/openedx/features/course_experience/tests/test_url_helpers.py
+++ b/openedx/features/course_experience/tests/test_url_helpers.py
@@ -1,0 +1,248 @@
+"""
+Test some of the functions in url_helpers
+"""
+from unittest import mock
+
+import ddt
+
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+
+from .. import url_helpers
+
+
+def _patch_courseware_mfe_is_active(ret_val):
+    return mock.patch.object(
+        url_helpers,
+        'courseware_mfe_is_active',
+        return_value=ret_val,
+    )
+
+
+@ddt.ddt
+class GetCoursewareUrlTests(SharedModuleStoreTestCase):
+    """
+    Test get_courseware_url.
+
+    Mock out `courseware_mfe_is_active`; that is tested elseware.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Set up data used across test functions.
+        """
+        # pylint: disable=super-method-not-called
+        with super().setUpClassAndTestData():
+            cls.items = cls.create_test_courses()
+
+    @classmethod
+    def create_test_courses(cls):
+        """
+        We build two simple course structures (one using Split, the other Old Mongo).
+        Each course structure is a non-branching tree from the root Course block down
+        to the Component-level problem block; that is, we make one item for each course
+        hierarchy level.
+
+        For easy access in the test functions, we return them in a dict like this:
+        {
+            "split": {
+                "course_run": <course block for Split Mongo course>,
+                "section": <chapter block in course run>
+                "subsection": <sequence block in section>
+                "unit": <vertical block in subsection>
+                "component": <problem block in unit>
+            },
+            "mongo": {
+                "course_run": <course block for (deprecated) Old Mongo course>,
+                ... etc ...
+            }
+        }
+        """
+
+        # Make Split Mongo course.
+        with cls.store.default_store(ModuleStoreEnum.Type.split):
+            course_run = CourseFactory.create(
+                org='TestX',
+                number='UrlHelpers',
+                run='split',
+                display_name='URL Helpers Test Course',
+            )
+            with cls.store.bulk_operations(course_run.id):
+                section = ItemFactory.create(
+                    parent_location=course_run.location,
+                    category='chapter',
+                    display_name="Generated Section",
+                )
+                subsection = ItemFactory.create(
+                    parent_location=section.location,
+                    category='sequential',
+                    display_name="Generated Subsection",
+                )
+                unit = ItemFactory.create(
+                    parent_location=subsection.location,
+                    category='vertical',
+                    display_name="Generated Unit",
+                )
+                component = ItemFactory.create(
+                    parent_location=unit.location,
+                    category='problem',
+                    display_name="Generated Problem Component",
+                )
+
+        # Make (deprecated) Old Mongo course.
+        with cls.store.default_store(ModuleStoreEnum.Type.mongo):
+            deprecated_course_run = CourseFactory.create(
+                org='TestX',
+                number='UrlHelpers',
+                run='mongo',
+                display_name='URL Helpers Test Course (Deprecated)',
+            )
+            with cls.store.bulk_operations(deprecated_course_run.id):
+                deprecated_section = ItemFactory.create(
+                    parent_location=deprecated_course_run.location,
+                    category='chapter',
+                    display_name="Generated Section",
+                )
+                deprecated_subsection = ItemFactory.create(
+                    parent_location=deprecated_section.location,
+                    category='sequential',
+                    display_name="Generated Subsection",
+                )
+                deprecated_unit = ItemFactory.create(
+                    parent_location=deprecated_subsection.location,
+                    category='vertical',
+                    display_name="Generated Unit",
+                )
+                deprecated_component = ItemFactory.create(
+                    parent_location=deprecated_unit.location,
+                    category='problem',
+                    display_name="Generated Problem Component",
+                )
+
+        return {
+            ModuleStoreEnum.Type.split: {
+                'course_run': course_run,
+                'section': section,
+                'subsection': subsection,
+                'unit': unit,
+                'component': component,
+            },
+            ModuleStoreEnum.Type.mongo: {
+                'course_run': deprecated_course_run,
+                'section': deprecated_section,
+                'subsection': deprecated_subsection,
+                'unit': deprecated_unit,
+                'component': deprecated_component,
+            }
+        }
+
+    @ddt.data(
+        (
+            ModuleStoreEnum.Type.split,
+            'mfe',
+            'course_run',
+            'http://learning-mfe/course/course-v1:TestX+UrlHelpers+split'
+        ),
+        (
+            ModuleStoreEnum.Type.split,
+            'mfe',
+            'subsection',
+            (
+                'http://learning-mfe/course/course-v1:TestX+UrlHelpers+split' +
+                '/block-v1:TestX+UrlHelpers+split+type@sequential+block@Generated_Subsection'
+            ),
+        ),
+        (
+            ModuleStoreEnum.Type.split,
+            'mfe',
+            'unit',
+            (
+                'http://learning-mfe/course/course-v1:TestX+UrlHelpers+split' +
+                '/block-v1:TestX+UrlHelpers+split+type@sequential+block@Generated_Subsection' +
+                '/block-v1:TestX+UrlHelpers+split+type@vertical+block@Generated_Unit'
+            ),
+        ),
+        (
+            ModuleStoreEnum.Type.split,
+            'mfe',
+            'component',
+            (
+                'http://learning-mfe/course/course-v1:TestX+UrlHelpers+split' +
+                '/block-v1:TestX+UrlHelpers+split+type@sequential+block@Generated_Subsection' +
+                '/block-v1:TestX+UrlHelpers+split+type@vertical+block@Generated_Unit'
+            ),
+        ),
+        (
+            ModuleStoreEnum.Type.split,
+            'legacy',
+            'course_run',
+            '/courses/course-v1:TestX+UrlHelpers+split/courseware',
+        ),
+        (
+            ModuleStoreEnum.Type.split,
+            'legacy',
+            'subsection',
+            '/courses/course-v1:TestX+UrlHelpers+split/courseware/Generated_Section/Generated_Subsection/',
+        ),
+        (
+            ModuleStoreEnum.Type.split,
+            'legacy',
+            'unit',
+            '/courses/course-v1:TestX+UrlHelpers+split/courseware/Generated_Section/Generated_Subsection/1',
+        ),
+        (
+            ModuleStoreEnum.Type.split,
+            'legacy',
+            'component',
+            '/courses/course-v1:TestX+UrlHelpers+split/courseware/Generated_Section/Generated_Subsection/1',
+        ),
+        (
+            ModuleStoreEnum.Type.mongo,
+            'legacy',
+            'course_run',
+            '/courses/TestX/UrlHelpers/mongo/courseware',
+        ),
+        (
+            ModuleStoreEnum.Type.mongo,
+            'legacy',
+            'subsection',
+            '/courses/TestX/UrlHelpers/mongo/courseware/Generated_Section/Generated_Subsection/',
+        ),
+        (
+            ModuleStoreEnum.Type.mongo,
+            'legacy',
+            'unit',
+            '/courses/TestX/UrlHelpers/mongo/courseware/Generated_Section/Generated_Subsection/1',
+        ),
+        (
+            ModuleStoreEnum.Type.mongo,
+            'legacy',
+            'component',
+            '/courses/TestX/UrlHelpers/mongo/courseware/Generated_Section/Generated_Subsection/1',
+        ),
+    )
+    @ddt.unpack
+    def test_get_courseware_url(
+        self,
+        store_type,
+        active_experience,
+        structure_level,
+        expected_path,
+    ):
+        """
+        Given:
+        * a `store_type` ('split' or [old] 'mongo'),
+        * an `active_experience` ('mfe' or 'legacy'),
+        * and a `structure_level` ('course_run', 'section', 'subsection', 'unit', or 'component'),
+
+        check that the expected path (URL without querystring) is returned by `get_courseware_url`.
+        """
+        block = self.items[store_type][structure_level]
+        with _patch_courseware_mfe_is_active(active_experience == 'mfe') as mock_mfe_is_active:
+            url = url_helpers.get_courseware_url(block.location)
+        path = url.split('?')[0]
+        assert path == expected_path
+        course_run = self.items[store_type]['course_run']
+        mock_mfe_is_active.assert_called_once_with(course_run.id)

--- a/openedx/features/course_experience/tests/test_url_helpers.py
+++ b/openedx/features/course_experience/tests/test_url_helpers.py
@@ -148,6 +148,15 @@ class GetCoursewareUrlTests(SharedModuleStoreTestCase):
         (
             ModuleStoreEnum.Type.split,
             'mfe',
+            'section',
+            (
+                'http://learning-mfe/course/course-v1:TestX+UrlHelpers+split' +
+                '/block-v1:TestX+UrlHelpers+split+type@chapter+block@Generated_Section'
+            ),
+        ),
+        (
+            ModuleStoreEnum.Type.split,
+            'mfe',
             'subsection',
             (
                 'http://learning-mfe/course/course-v1:TestX+UrlHelpers+split' +


### PR DESCRIPTION
## Description

Centralize the logic for choosing between
MFE and Legacy-frontend courseware within
three new functions:
* courseware_mfe_is_active
* courseware_mfe_is_visible
* courseware_legacy_is_visible

This allows us to create another new function:
* get_courseware_url

which can be called anywhere in LMS/Studio
to get the canonical URL to courseware
content (whether it be MFE or Legacy).

In future commits we we begin using
get_courseware_url throughout the platform.

## Supporting information

https://openedx.atlassian.net/browse/TNL-7796

## Deadline

None, but there are more PRs coming after this one.

## Other information

Before we use the new `get_courseware_url` function, a fix needs to be merged to the MFE so that this doesn't happen:

![image](https://user-images.githubusercontent.com/3628148/110031637-2ab8e180-7d05-11eb-82f8-1f4ef3983c8e.png)

(What you're looking at: The Learning MFE rendering the _Section_ as the learning sequence, with its _Subsection_ as the iframed content. That's what currently happens if you give the MFE a Section instead of a Subsection as the sequence. The MFE should be fixed to redirect users to the first Subsection in the Section.)