### PR TITLE
feat: default staff to courseware MFE if active (via jump_to)

### DIFF
--- a/lms/djangoapps/course_api/blocks/serializers.py
+++ b/lms/djangoapps/course_api/blocks/serializers.py
@@ -95,6 +95,7 @@ FIELDS_ALLOWED_IN_AUTH_DENIED_CONTENT = [
     "student_view_url",
     "student_view_multi_device",
     "lms_web_url",
+    "legacy_web_url",
     "type",
     "id",
     "block_counts",
@@ -137,14 +138,20 @@ class BlockSerializer(serializers.Serializer):  # pylint: disable=abstract-metho
         authorization_denial_reason = block_structure.get_xblock_field(block_key, 'authorization_denial_reason')
         authorization_denial_message = block_structure.get_xblock_field(block_key, 'authorization_denial_message')
 
+        jump_to_courseware_url = reverse(
+            'jump_to',
+            kwargs={
+                'course_id': str(block_key.course_key),
+                'location': str(block_key),
+            },
+            request=self.context['request'],
+        )
+
         data = {
             'id': str(block_key),
             'block_id': str(block_key.block_id),
-            'lms_web_url': reverse(
-                'jump_to',
-                kwargs={'course_id': str(block_key.course_key), 'location': str(block_key)},
-                request=self.context['request'],
-            ),
+            'lms_web_url': jump_to_courseware_url,
+            'legacy_web_url': jump_to_courseware_url + '?experience=legacy',
             'student_view_url': reverse(
                 'render_xblock',
                 kwargs={'usage_key_string': str(block_key)},

--- a/lms/djangoapps/course_api/blocks/tests/test_serializers.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_serializers.py
@@ -64,7 +64,9 @@ class TestBlockSerializerBase(SharedModuleStoreTestCase):
         """
         block_key = deserialize_usage_key(block_key_string, self.course.id)
         assert self.block_structure.get_xblock_field(block_key, 'category') == serialized_block['type']
-        assert set(serialized_block.keys()) == {'id', 'block_id', 'type', 'lms_web_url', 'student_view_url'}
+        assert set(serialized_block.keys()) == {
+            'id', 'block_id', 'type', 'lms_web_url', 'legacy_web_url', 'student_view_url'
+        }
 
     def add_additional_requested_fields(self, context=None):
         """
@@ -88,8 +90,18 @@ class TestBlockSerializerBase(SharedModuleStoreTestCase):
         """
         Verifies the given serialized_block when additional fields are requested.
         """
-        assert {'id', 'type', 'lms_web_url', 'student_view_url', 'display_name', 'graded', 'student_view_multi_device',
-                'lti_url', 'visible_to_staff_only'} <= set(serialized_block.keys())
+        assert {
+            'id',
+            'type',
+            'lms_web_url',
+            'legacy_web_url',
+            'student_view_url',
+            'display_name',
+            'graded',
+            'student_view_multi_device',
+            'lti_url',
+            'visible_to_staff_only'
+        } <= set(serialized_block.keys())
 
         # video blocks should have student_view_data
         if serialized_block['type'] == 'video':

--- a/lms/djangoapps/course_api/blocks/views.py
+++ b/lms/djangoapps/course_api/blocks/views.py
@@ -178,9 +178,15 @@ class BlocksView(DeveloperErrorViewMixin, ListAPIView):
             parameter.
 
           * lms_web_url: (string) The URL to the navigational container of the
-            xBlock on the web LMS.  This URL can be used as a further fallback
+            xBlock on the web. This URL can be used as a further fallback
             if the student_view_url and the student_view_data fields are not
-            supported.
+            supported. Will direct to either the "New" (micro-frontend) or
+            "Legacy" (Django-template-rendered) frontend experience depending
+            on which experience is active.
+
+          * legacy_web_url: (string) Like `lms_web_url`, but always directs to
+            the "Legacy" frontend experience. Should only be used for
+            transitional purposes; will be removed as part of DEPR-109.
 
           * lti_url: The block URL for an LTI consumer. Returned only if the
             "ENABLE_LTI_PROVIDER" Django settign is set to "True".

--- a/lms/djangoapps/course_home_api/outline/v1/serializers.py
+++ b/lms/djangoapps/course_home_api/outline/v1/serializers.py
@@ -50,6 +50,7 @@ class CourseBlockSerializer(serializers.Serializer):
                 'icon': icon,
                 'id': block_key,
                 'lms_web_url': block['lms_web_url'] if enable_links else None,
+                'legacy_web_url': block['legacy_web_url'] if enable_links else None,
                 'resume_block': block.get('resume_block', False),
                 'type': block_type,
             },

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -144,20 +144,20 @@ class TestJumpTo(ModuleStoreTestCase):
         response = self.client.get(jumpto_url)
         assert response.status_code == 404
 
-    def test_jumpto_from_section(self):
+    def test_jumpto_from_sequence(self):
         course = CourseFactory.create()
         chapter = ItemFactory.create(category='chapter', parent_location=course.location)
-        section = ItemFactory.create(category='sequential', parent_location=chapter.location)
-        expected = '/courses/{course_id}/courseware/{chapter_id}/{section_id}/?{activate_block_id}'.format(
+        sequence = ItemFactory.create(category='sequential', parent_location=chapter.location)
+        expected = '/courses/{course_id}/courseware/{chapter_id}/{sequence_id}/?{activate_block_id}'.format(
             course_id=str(course.id),
             chapter_id=chapter.url_name,
-            section_id=section.url_name,
-            activate_block_id=urlencode({'activate_block_id': str(section.location)})
+            sequence_id=sequence.url_name,
+            activate_block_id=urlencode({'activate_block_id': str(sequence.location)})
         )
         jumpto_url = '{}/{}/jump_to/{}'.format(
             '/courses',
             str(course.id),
-            str(section.location),
+            str(sequence.location),
         )
         response = self.client.get(jumpto_url)
         self.assertRedirects(response, expected, status_code=302, target_status_code=302)
@@ -165,16 +165,16 @@ class TestJumpTo(ModuleStoreTestCase):
     def test_jumpto_from_module(self):
         course = CourseFactory.create()
         chapter = ItemFactory.create(category='chapter', parent_location=course.location)
-        section = ItemFactory.create(category='sequential', parent_location=chapter.location)
-        vertical1 = ItemFactory.create(category='vertical', parent_location=section.location)
-        vertical2 = ItemFactory.create(category='vertical', parent_location=section.location)
+        sequence = ItemFactory.create(category='sequential', parent_location=chapter.location)
+        vertical1 = ItemFactory.create(category='vertical', parent_location=sequence.location)
+        vertical2 = ItemFactory.create(category='vertical', parent_location=sequence.location)
         module1 = ItemFactory.create(category='html', parent_location=vertical1.location)
         module2 = ItemFactory.create(category='html', parent_location=vertical2.location)
 
-        expected = '/courses/{course_id}/courseware/{chapter_id}/{section_id}/1?{activate_block_id}'.format(
+        expected = '/courses/{course_id}/courseware/{chapter_id}/{sequence_id}/1?{activate_block_id}'.format(
             course_id=str(course.id),
             chapter_id=chapter.url_name,
-            section_id=section.url_name,
+            sequence_id=sequence.url_name,
             activate_block_id=urlencode({'activate_block_id': str(module1.location)})
         )
         jumpto_url = '{}/{}/jump_to/{}'.format(
@@ -185,10 +185,10 @@ class TestJumpTo(ModuleStoreTestCase):
         response = self.client.get(jumpto_url)
         self.assertRedirects(response, expected, status_code=302, target_status_code=302)
 
-        expected = '/courses/{course_id}/courseware/{chapter_id}/{section_id}/2?{activate_block_id}'.format(
+        expected = '/courses/{course_id}/courseware/{chapter_id}/{sequence_id}/2?{activate_block_id}'.format(
             course_id=str(course.id),
             chapter_id=chapter.url_name,
-            section_id=section.url_name,
+            sequence_id=sequence.url_name,
             activate_block_id=urlencode({'activate_block_id': str(module2.location)})
         )
         jumpto_url = '{}/{}/jump_to/{}'.format(
@@ -202,20 +202,20 @@ class TestJumpTo(ModuleStoreTestCase):
     def test_jumpto_from_nested_module(self):
         course = CourseFactory.create()
         chapter = ItemFactory.create(category='chapter', parent_location=course.location)
-        section = ItemFactory.create(category='sequential', parent_location=chapter.location)
-        vertical = ItemFactory.create(category='vertical', parent_location=section.location)
-        nested_section = ItemFactory.create(category='sequential', parent_location=vertical.location)
-        nested_vertical1 = ItemFactory.create(category='vertical', parent_location=nested_section.location)
+        sequence = ItemFactory.create(category='sequential', parent_location=chapter.location)
+        vertical = ItemFactory.create(category='vertical', parent_location=sequence.location)
+        nested_sequence = ItemFactory.create(category='sequential', parent_location=vertical.location)
+        nested_vertical1 = ItemFactory.create(category='vertical', parent_location=nested_sequence.location)
         # put a module into nested_vertical1 for completeness
         ItemFactory.create(category='html', parent_location=nested_vertical1.location)
-        nested_vertical2 = ItemFactory.create(category='vertical', parent_location=nested_section.location)
+        nested_vertical2 = ItemFactory.create(category='vertical', parent_location=nested_sequence.location)
         module2 = ItemFactory.create(category='html', parent_location=nested_vertical2.location)
 
         # internal position of module2 will be 1_2 (2nd item withing 1st item)
-        expected = '/courses/{course_id}/courseware/{chapter_id}/{section_id}/1?{activate_block_id}'.format(
+        expected = '/courses/{course_id}/courseware/{chapter_id}/{sequence_id}/1?{activate_block_id}'.format(
             course_id=str(course.id),
             chapter_id=chapter.url_name,
-            section_id=section.url_name,
+            sequence_id=sequence.url_name,
             activate_block_id=urlencode({'activate_block_id': str(module2.location)})
         )
         jumpto_url = '{}/{}/jump_to/{}'.format(
@@ -248,11 +248,11 @@ class TestJumpTo(ModuleStoreTestCase):
         request.session = {}
         course_key = CourseKey.from_string(str(course.id))
         chapter = ItemFactory.create(category='chapter', parent_location=course.location)
-        section = ItemFactory.create(category='sequential', parent_location=chapter.location)
-        __ = ItemFactory.create(category='vertical', parent_location=section.location)
-        staff_only_vertical = ItemFactory.create(category='vertical', parent_location=section.location,
+        sequence = ItemFactory.create(category='sequential', parent_location=chapter.location)
+        __ = ItemFactory.create(category='vertical', parent_location=sequence.location)
+        staff_only_vertical = ItemFactory.create(category='vertical', parent_location=sequence.location,
                                                  metadata=dict(visible_to_staff_only=True))
-        __ = ItemFactory.create(category='vertical', parent_location=section.location)
+        __ = ItemFactory.create(category='vertical', parent_location=sequence.location)
 
         usage_key = UsageKey.from_string(str(staff_only_vertical.location)).replace(course_key=course_key)
         expected_url = reverse(
@@ -260,7 +260,7 @@ class TestJumpTo(ModuleStoreTestCase):
             kwargs={
                 'course_id': str(course.id),
                 'chapter': chapter.url_name,
-                'section': section.url_name,
+                'section': sequence.url_name,
                 'position': position,
             }
         )
@@ -3269,7 +3269,7 @@ class TestShowCoursewareMFE(TestCase):
 
         # Old style course keys are never supported and should always return false...
         old_mongo_combos = itertools.product(
-            [regular_user, global_staff_user],  # User (is global staf`f)
+            [regular_user, global_staff_user],  # User (is global staff)
             [True, False],  # is_course_staff
             [True, False],  # preview_active (COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW)
             [True, False],  # redirect_active (REDIRECT_TO_COURSEWARE_MICROFRONTEND)

--- a/lms/djangoapps/courseware/testutils.py
+++ b/lms/djangoapps/courseware/testutils.py
@@ -11,7 +11,7 @@ from urllib.parse import urlencode
 import ddt
 
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
-from openedx.features.course_experience.url_helpers import get_legacy_courseware_url
+from openedx.features.course_experience.url_helpers import get_courseware_url, ExperienceOption
 from common.djangoapps.student.tests.factories import AdminFactory, CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
@@ -176,7 +176,10 @@ class RenderXBlockTestMixin(MasqueradeMixin, metaclass=ABCMeta):
             self.setup_user(admin=True, enroll=True, login=True)
 
             with check_mongo_calls(mongo_calls):
-                url = get_legacy_courseware_url(self.block_to_be_tested.location)
+                url = get_courseware_url(
+                    self.block_to_be_tested.location,
+                    experience=ExperienceOption.LEGACY,
+                )
                 response = self.client.get(url)
                 expected_elements = self.block_specific_chrome_html_elements + self.COURSEWARE_CHROME_HTML_ELEMENTS
                 for chrome_element in expected_elements:

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -43,7 +43,7 @@ from openedx.features.course_experience import (
     default_course_url_name
 )
 from openedx.features.course_experience.views.course_sock import CourseSockFragmentView
-from openedx.features.course_experience.url_helpers import get_learning_mfe_courseware_url
+from openedx.features.course_experience.url_helpers import make_learning_mfe_courseware_url
 from openedx.features.enterprise_support.api import data_sharing_consent_required
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.util.views import ensure_valid_course_key
@@ -202,7 +202,7 @@ class CoursewareIndex(View):
                 unit_key = None
         except InvalidKeyError:
             unit_key = None
-        url = get_learning_mfe_courseware_url(
+        url = make_learning_mfe_courseware_url(
             self.course_key,
             self.section.location if self.section else None,
             unit_key

--- a/openedx/features/course_experience/url_helpers.py
+++ b/openedx/features/course_experience/url_helpers.py
@@ -1,7 +1,7 @@
 """
 Helper functions for logic related to learning (courseare & course home) URLs.
 
-Centralizdd in openedx/features/course_experience instead of lms/djangoapps/courseware
+Centralized in openedx/features/course_experience instead of lms/djangoapps/courseware
 because the Studio course outline may need these utilities.
 """
 from enum import Enum
@@ -48,9 +48,9 @@ def get_courseware_url(
     course that the block is in, the requesting user, and the state of
     the 'courseware' waffle flags.
 
-    If you know the specific Sequence or Sequence/Unit you need to redirect to,
-    and you know that you want a Learning MFE URL regardless of configuration,
-    then it is more performant to call `make_learning_mfe_courseware_url` directly.
+    If redirecting to a specific Sequence or Sequence/Unit in a Learning MFE
+    regardless of configuration, call make_learning_mfe_courseware_url directly
+    for better performance.
 
     Raises:
         * ItemNotFoundError if no data at the `usage_key`.
@@ -114,9 +114,6 @@ def _get_new_courseware_url(
 ) -> str:
     """
     Return the URL to the "new" (Learning Micro-Frontend) experience for a given block.
-
-    If you know the specific Sequence or Sequence/Unit you need to redirect to,
-    then it is more performant to call `make_learning_mfe_courseware_url` directly.
 
     Raises:
         * ItemNotFoundError if no data at the `usage_key`.


### PR DESCRIPTION
Reviewers: I broke out two minor refactors into their own commits.

## Description

The /jump_to/ LMS endpoint is used in a number of places
to direct users to courseware. It currently only redirects to
Legacy courseware URLs, which then conditionally may
redirect to the Learning MFE.

Two issues with this:
1. Performance Impact: In most cases, going to Legacy first
   is just an extra redirect.
2. Confusion for Privileged Users: Neither course nor global
   staff are auto-redirected from the Legacy experience to the
   MFE. Thus, these priviliged users confusingly never see the
   MFE by default; they must always manually click into it.

This commit makes it so that /jump_to/ directs
users to whatever the default courseware experience is
for them. For staff of courses active in the new experience,
this will impact (at a minimum) the "View Live"
links in Studio, all links on the old and new LMS
course outline, and the "Resume" links on the course
dashboard. Learners should see no difference other than
a performance improvement when following courseware links
from the LMS.

This also adds an optional 'experience=[legacy|new]'
query param to /jump_to/, allowing us to specifically
generate Legacy courseware URLs for the
"View in Legacy Experience" tool.


## Supporting information

https://openedx.atlassian.net/browse/TNL-7796

## Testing instructions

### Setup

1. If testing on Devstack, `make dev.up.studio+lms+frontend-app-learning`
2. Have two courses; we'll call them CourseNew and CourseLegacy.
   * Both should be Split Mongo (`course-v1:`) courses.
   * Ideally both should have multiple sections, subsections, and units.
   * Specific content is unimportant.
3. In LMS Django Admin, add two Waffle flag overrides:
   * force new course into MFE
      * Waffle flag: `courseware.courseware_mfe`
      * Course id: id of CourseNew
      * Override choice: Force On
      * Enabled: checked
   * force legacy course 
      * Waffle flag: `courseware.courseware_mfe`
      * Course id: id of CourseLegacy
      * Override choice: Force Off
      * Enabled: checked
4. Have two users; we'll call them Staff and Learner
   * Staff should be course staff in both CourseNew and CourseLegacy
   * Learner should be staff in neither, but enrolled in both.

### Test

* Log in as Staff
  * Go to your course dashboard and click on CourseNew, which should bring you to the Legacy outline.
    * Click on Resume or any link in the outline.
    * You should be directed to the corresponding location in the MFE!
    * Click "View in Studio", which should bring you to the unit in Studio.
    * Click "View Live Version", which should bring you to the unit in the MFE.
    * Click "View in Legacy Experience", which should bring you to Legacy courseware.
    * Click around Legacy courseware a bit, confirming that you are able to use it without being forced into the MFE.
    * (While you're here, copy a Legacy courseware link for CourseNew and keep it somewhere; you will need this for the Learner portion)
    * Click "View in the New Experience", which should bring you back to the MFE.
    * Return to your course dashboard.
    * Click "Resume" on CourseNew, which should bring you to the MFE.
  * Go to your course dashboard and click on CourseLegacy, which should bring you to the legacy outline.
    * Click on Resume or any link in the outline.
    * You should be directed to the corresponding location in the Legacy experience.
    * Click "View in Studio", which should bring you to the unit in Studio.
    * Click "View Live Version", which should bring you to the unit in the Legacy experience.
    * Click "View in New Experience", which should bring you to the unit in the MFE.
    * Click around MFE courseware a bit, confirming that you are able to use it without being kicked back to Legacy.
    * (While you're here, copy an MFE courseware link for CourseLegacy and keep it somewhere; you will need this for the Learner portion)
    * Click "View in the Legacy Experience", which should bring you back to Legacy.
    * Return to your course dashboard.
    * Click "Resume" on CourseLegacy, which should drop you where you left off in Legacy courseware.
* Log in as Learner.
  * Go to your course dashboard and click on CourseNew, which should bring you to the legacy outline.
    * Click on Resume or any link in the outline.
    * You should be directed to the corresponding location in the MFE!
    * Click around a bit to confirm that you stay in the MFE.
    * Return to your course dashboard.
    * Click "Resume" on CourseNew, which should bring you to the MFE again.
    * Paste a Legacy courseware link for CourseNew into the URL bar. You should be immediately kicked back into the MFE.
  * Go to your course dashboard and click on CourseLegacy, which should bring you to the legacy outline.
    * Click on Resume or any link in the outline.
    * You should be directed to the corresponding location in the Legacy experience.
    * Click around a bit to confirm that you stay in Legacy.
    * Return to your course dashboard.
    * Click "Resume" on CourseLegacy, which should bring you to Legacy again.
    * Paste an MFE courseware link for CourseLegacy into the URL bar. You should be immediately kicked back into the Legacy experience.
   
## Deadline

Goal is to merge Monday.

## Other information

Prereqs:
- [x] https://github.com/edx/frontend-app-learning/pull/395
- [ ] https://github.com/edx/frontend-app-learning/pull/404

