### PR TITLE
added iframe mfe overrides

### DIFF
--- a/lms/static/sass/lms-course-rtl.scss
+++ b/lms/static/sass/lms-course-rtl.scss
@@ -1,3 +1,6 @@
 @import 'bourbon/bourbon';
 @import 'vendor/bi-app/bi-app-rtl'; // set the layout for right to left languages
 @import 'build-course'; // shared app style assets/rendering
+
+// Extra theme-specific rules for mfe iframe
+@import 'lms/theme/extras-mfe';

--- a/lms/static/sass/lms-course-rtl.scss
+++ b/lms/static/sass/lms-course-rtl.scss
@@ -1,6 +1,3 @@
 @import 'bourbon/bourbon';
 @import 'vendor/bi-app/bi-app-rtl'; // set the layout for right to left languages
 @import 'build-course'; // shared app style assets/rendering
-
-// Extra theme-specific rules for mfe iframe
-@import 'lms/theme/extras-mfe';

--- a/lms/static/sass/lms-course.scss
+++ b/lms/static/sass/lms-course.scss
@@ -24,3 +24,6 @@
         }
     }
 }
+
+// Extra theme-specific rules for mfe iframe
+@import 'lms/theme/extras-mfe';

--- a/lms/static/sass/lms-course.scss
+++ b/lms/static/sass/lms-course.scss
@@ -25,5 +25,14 @@
     }
 }
 
-// Extra theme-specific rules for mfe iframe
-@import 'lms/theme/extras-mfe';
+.xmodule_display.xmodule_ProblemBlock div.problem {
+  .choicegroup {
+    label {
+      padding-left: $baseline*2.3;
+    }
+
+    input[type="radio"], input[type="checkbox"] {
+      top: 0.35em;
+    }
+  }
+}

--- a/lms/static/sass/lms-course.scss
+++ b/lms/static/sass/lms-course.scss
@@ -25,6 +25,8 @@
     }
 }
 
+// Extra mfe theme-specific rules.
+// Move this to a separate file in case more mfe specific rules need to be a added
 .xmodule_display.xmodule_ProblemBlock div.problem {
   .choicegroup {
     label {


### PR DESCRIPTION
[TNL-7976](https://openedx.atlassian.net/browse/TNL-7976)

Imported a new _extras-mfe.scss from the edx-themes inside the lms-course to overrides styles in an iframe inside an MFE. Styles override in the legacy code are imported in the edx-footer file but that file is not loaded in case of an iframe MFE so the overrides are not applied. This new file can be used to apply overrides inside the iframe of an MFE