### PR TITLE
Update FIELD_TYPE_MAP in helpers.py 

### DIFF
--- a/openedx/core/djangoapps/user_api/helpers.py
+++ b/openedx/core/djangoapps/user_api/helpers.py
@@ -113,6 +113,7 @@ class FormDescription(object):
         forms.Textarea: "textarea",
         forms.BooleanField: "checkbox",
         forms.EmailField: "email",
+        forms.models.ModelMultipleChoiceField: "select",
     }
 
     OVERRIDE_FIELD_PROPERTIES = [


### PR DESCRIPTION
When adding values such as custom register form, values requiring checkbox are added, under registration_form.py, 
`field_type = field_options.get ('field_type', FormDescription.FIELD_TYPE_MAP.get (field .__ class __))` line returns None and receives that error `Field type 'None' not recognized for registration extension field 'choices'.` 

So I wanted to add this value. I also share the relevant address with the justification:
https://discuss.openedx.org/t/field-type-none-not-recognized-for-registration-extension-field-company/3715

<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
