### PR TITLE
Skip workflow steps with secrets, if unavailable

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,3 +20,4 @@ jobs:
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
         run : make docker_push
+        if: env.DOCKERHUB_USERNAME != null && env.DOCKERHUB_PASSWORD != null

--- a/.github/workflows/mysqldbdump.yml
+++ b/.github/workflows/mysqldbdump.yml
@@ -21,3 +21,4 @@ jobs:
         run: ./.github/workflows/mysqldbdump_pr.sh
         env:
           GH_ACCESS_TOKEN: ${{ secrets.EDX_DEPLOYMENT_GH_TOKEN }}
+        if: env.GH_ACCESS_TOKEN != null

--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -56,3 +56,4 @@ jobs:
           --commit-message="chore: Updating Python Requirements" --pr-title="Python Requirements Update" \
           --pr-body="Python requirements update.Please review the [changelogs](https://openedx.atlassian.net/wiki/spaces/TE/pages/1001521320/Python+Package+Changelogs) for the upgraded packages." \
           --user-reviewers="" --team-reviewers="arbi-bom" --delete-old-pull-requests
+        if: env.GITHUB_TOKEN != null && env.GITHUB_USER_EMAIL != null


### PR DESCRIPTION
otherwise the jobs fail for every non-edx repo, by default.
    
This was an issue on my personal fork, leading to daily email spam about failed builds.
