### PR TITLE
wip: write GetCoursewareUrlTests

### DIFF
--- a/openedx/features/course_experience/tests/test_url_helpers.py
+++ b/openedx/features/course_experience/tests/test_url_helpers.py
@@ -1,0 +1,220 @@
+"""
+Test some of the functions in url_helpers
+"""
+from unittest import mock
+
+import ddt
+
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+
+from .. import url_helpers
+
+
+def _patch_courseware_mfe_is_active(ret_val):
+    return mock.patch.object(
+        url_helpers,
+        'courseware_mfe_is_active',
+        return_value=ret_val,
+    )
+
+
+@ddt.ddt
+class GetCoursewareUrlTests(SharedModuleStoreTestCase):
+    """
+    Test get_courseware_url.
+
+    Mock out `courseware_mfe_is_active`; that is tested elseware.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Set up data used across test functions.
+
+        We build two simple course structures (one using Split, the other Old Mongo).
+        Each course structure is a non-branching tree from the root Course block down
+        to the Component-level problem block; that is, we make one item for each course
+        hierarchy level.
+
+        For easy access in the test functions, we expose them in `self.items`
+        in a dict like this:
+        {
+            "split": {
+                "course_run": <course block for Split Mongo course>,
+                "section": <chapter block in course run>
+                "subsection": <sequence block in section>
+                "unit": <vertical block in subsection>
+                "component": <problem block in unit>
+            },
+            "mongo": {
+                "course_run": <course block for (deprecated) Old Mongo course>,
+                ... etc ...
+            }
+        }
+        """
+        super().setUpClass()
+
+        with super().setUpClassAndTestData():
+
+            # Make Split Mongo course.
+            course_run = CourseFactory.create(
+                org='TestX',
+                number='UrlHelpers',
+                run='split',
+                display_name='URL Helpers Test Course',
+                default_store=ModuleStoreEnum.Type.split,
+            )
+            with cls.store.bulk_operations(course_run.id):
+                section = ItemFactory.create(
+                    parent_location=course_run.location,
+                    category='chapter',
+                    display_name="Generated Section",
+                    publish_item=False,
+                )
+                subsection = ItemFactory.create(
+                    parent_location=section.location,
+                    category='sequential',
+                    display_name="Generated Subsection",
+                    publish_item=False,
+                )
+                unit = ItemFactory.create(
+                    parent_location=subsection.location,
+                    category='vertical',
+                    display_name="Generated Unit",
+                    publish_item=False,
+                )
+                component = ItemFactory.create(
+                    parent_location=unit.location,
+                    category='problem',
+                    display_name="Generated Problem Component",
+                    publish_item=False,
+                )
+                cls.store.publish(course_run.location, None)
+
+            # Make (deprecated) Old Mongo course.
+            deprecated_course_run = CourseFactory.create(
+                org='TestX',
+                number='UrlHelpers',
+                run='mongo',
+                display_name='URL Helpers Test Course (Deprecated)',
+                default_store=ModuleStoreEnum.Type.mongo,
+            )
+            with cls.store.bulk_operations(deprecated_course_run.id):
+                deprecated_section = ItemFactory.create(
+                    parent_location=deprecated_course_run.location,
+                    category='chapter',
+                )
+                deprecated_subsection = ItemFactory.create(
+                    parent_location=deprecated_section.location,
+                    category='sequential',
+                    display_name="Generated Subsection",
+                )
+                deprecated_unit = ItemFactory.create(
+                    parent_location=deprecated_subsection.location,
+                    category='vertical',
+                    display_name="Generated Unit",
+                )
+                deprecated_component = ItemFactory.create(
+                    parent_location=deprecated_unit.location,
+                    category='problem',
+                    display_name="Generated Problem Component",
+                )
+
+        cls.items = {
+            ModuleStoreEnum.Type.split: {
+                'course_run': course_run,
+                'section': section,
+                'subsection': subsection,
+                'unit': unit,
+                'component': component,
+            },
+            ModuleStoreEnum.Type.mongo: {
+                'course_run': deprecated_course_run,
+                'section': deprecated_section,
+                'subsection': deprecated_subsection,
+                'unit': deprecated_unit,
+                'component': deprecated_component,
+            }
+        }
+
+    @ddt.data(
+        (
+            ModuleStoreEnum.Type.split,
+            'mfe',
+            'course_run',
+            'http://learning-mfe/course/course-v1:TestX+UrlHelpers+split'
+        ),
+        (
+            ModuleStoreEnum.Type.split,
+            'mfe',
+            'subsection',
+            'http://learning-mfe/course/course-v1:TestX+UrlHelpers+split/TODO'
+        ),
+        (
+            ModuleStoreEnum.Type.split,
+            'mfe',
+            'component',
+            'http://learning-mfe/course/course-v1:TestX+UrlHelpers+split/TODO/TODO'
+        ),
+        (
+            ModuleStoreEnum.Type.split,
+            'legacy',
+            'course_run',
+            '/courses/course-v1:TestX+UrlHelpers+split/courseware',
+        ),
+        (
+            ModuleStoreEnum.Type.split,
+            'legacy',
+            'subsection',
+            '/courses/course-v1:TestX+UrlHelpers+split/courseware/chapter_6/Generated_Subsection/',
+        ),
+        (
+            ModuleStoreEnum.Type.split,
+            'legacy',
+            'component',
+            '/courses/course-v1:TestX+UrlHelpers+split/courseware/chapter_6/Generated_Subsection/1',
+        ),
+        (
+            ModuleStoreEnum.Type.mongo,
+            'legacy',
+            'course_run',
+            '/courses/TestX/UrlHelpers/mongo/courseware',
+        ),
+        (
+            ModuleStoreEnum.Type.mongo,
+            'legacy',
+            'subsection',
+            '/courses/TestX/UrlHelpers/mongo/courseware/chapter_6/Generated_Subsection/',
+        ),
+        (
+            ModuleStoreEnum.Type.mongo,
+            'legacy',
+            'component',
+            '/courses/TestX/UrlHelpers/mongo/courseware/chapter_6/Generated_Subsection/1',
+        ),
+    )
+    @ddt.unpack
+    def test_get_courseware_url(
+        self,
+        store_type,
+        active_experience,
+        structure_level,
+        expected_path,
+    ):
+        """
+        Given:
+        * a `store_type` ('split' or [old] 'mongo'),
+        * an `active_experience` ('mfe' or 'legacy'),
+        * and a `structure_level` ('course_run', 'section', 'subsection', 'unit', or 'component'),
+
+        check that the expected path (URL without querystring) is returned by `get_courseware_url`.
+        """
+        block = self.items[store_type][structure_level]
+        with _patch_courseware_mfe_is_active(active_experience == 'mfe') as mock_mfe_is_active:
+            url = url_helpers.get_courseware_url(block.location)
+        path = url.split('?')[0]
+        assert path == expected_path
+        course_run = self.items[store_type]['course_run']
+        mock_mfe_is_active.assert_called_once_with(course_run.id)

--- a/openedx/features/course_experience/tests/test_url_helpers.py
+++ b/openedx/features/course_experience/tests/test_url_helpers.py
@@ -150,13 +150,20 @@ class GetCoursewareUrlTests(SharedModuleStoreTestCase):
             ModuleStoreEnum.Type.split,
             'mfe',
             'subsection',
-            'http://learning-mfe/course/course-v1:TestX+UrlHelpers+split/TODO'
+            (
+                'http://learning-mfe/course/course-v1:TestX+UrlHelpers+split' +
+                '/block-v1:TestX+UrlHelpers+split+type@sequential+block@Generated_Subsection'
+            ),
         ),
         (
             ModuleStoreEnum.Type.split,
             'mfe',
             'component',
-            'http://learning-mfe/course/course-v1:TestX+UrlHelpers+split/TODO/TODO'
+            (
+                'http://learning-mfe/course/course-v1:TestX+UrlHelpers+split' +
+                '/block-v1:TestX+UrlHelpers+split+type@sequential+block@Generated_Subsection' +
+                '/block-v1:TestX+UrlHelpers+split+type@problem+block@1'
+            ),
         ),
         (
             ModuleStoreEnum.Type.split,


### PR DESCRIPTION
This is a PR into another feature branch (https://github.com/edx/edx-platform/pull/26815). I am trying to add tests to the new `get_courseware_url` function.

I am testing that URLs can be generated for a subset of cases that are the product of:
```
* STORE_TYPE (split/mongo)
* EXPERIENCE (mfe/legacy)
* STRUCTURE_LEVEL (course-run/section/subsection/unit/component)
```

Of the six cases in the Split store type, only two cases are passing: the ones requesting course-run-level URLs.
The four other, deeper-URL test cases are all failing with:
```
xmodule.modulestore.exceptions.ItemNotFoundError: block-v1:TestX+UrlHelpers+split+type@<sequential|problem>+...
```

I think I'm doing something wrong in `setUpClass`, but I'm not sure what.