### PR TITLE
Update edX-hosted video player to use 2x playback speed

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/helper.js
+++ b/common/lib/xmodule/xmodule/js/spec/helper.js
@@ -123,7 +123,7 @@
         }
     };
 
-    jasmine.stubbedHtml5Speeds = ['0.75', '1.0', '1.25', '1.50'];
+    jasmine.stubbedHtml5Speeds = ['0.75', '1.0', '1.25', '1.50', '2.0'];
 
     jasmine.stubRequests = function() {
         var spy = $.ajax;

--- a/common/lib/xmodule/xmodule/js/spec/video/html5_video_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/html5_video_spec.js
@@ -3,7 +3,7 @@
         var STATUS = window.STATUS;
         var state,
             oldOTBD,
-            playbackRates = [0.75, 1.0, 1.25, 1.5],
+            playbackRates = [0.75, 1.0, 1.25, 1.5, 2.0],
             describeInfo,
             POSTER_URL = '/media/video-images/poster.png';
 
@@ -280,8 +280,14 @@
                 });
 
                 describe('setPlaybackRate', function() {
-                    it('set a correct value', function() {
-                        playbackRate = 1.5;
+                    it('set a slow value', function() {
+                        playbackRate = 0.75;
+                        state.videoPlayer.player.setPlaybackRate(playbackRate);
+                        expect(state.videoPlayer.player.video.playbackRate).toBe(playbackRate);
+                    });
+
+                    it('set a fast value', function() {
+                        playbackRate = 2.0;
                         state.videoPlayer.player.setPlaybackRate(playbackRate);
                         expect(state.videoPlayer.player.video.playbackRate).toBe(playbackRate);
                     });

--- a/common/lib/xmodule/xmodule/js/spec/video/initialize_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/initialize_spec.js
@@ -194,12 +194,12 @@ function(Initialize) {
             describe('HTML5', function() {
                 beforeEach(function() {
                     state = {
-                        speeds: ['0.75', '1.0', '1.25', '1.50'],
+                        speeds: ['0.75', '1.0', '1.25', '1.50', '2.0'],
                         storage: jasmine.createSpyObj('storage', ['setItem'])
                     };
                 });
 
-                describe('when new speed is available', function() {
+                describe('when 0.75 speed is available', function() {
                     beforeEach(function() {
                         Initialize.prototype.setSpeed.call(state, '0.75');
                     });
@@ -208,6 +208,17 @@ function(Initialize) {
                         expect(state.speed).toEqual(0.75);
                     });
                 });
+
+                describe('when 2.0 speed is available', function() {
+                    beforeEach(function() {
+                        Initialize.prototype.setSpeed.call(state, '2.0');
+                    });
+
+                    it('set new speed', function() {
+                        expect(state.speed).toEqual(2.0);
+                    });
+                });
+
 
                 describe('when new speed is not available', function() {
                     beforeEach(function() {
@@ -222,8 +233,7 @@ function(Initialize) {
                 it('check mapping', function() {
                     var map = {
                         0.25: '0.75',
-                        '0.50': '0.75',
-                        '2.0': '1.50'
+                        '0.50': '0.75'
                     };
 
                     $.each(map, function(key, expected) {

--- a/common/lib/xmodule/xmodule/js/spec/video/video_speed_control_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_speed_control_spec.js
@@ -143,36 +143,36 @@
                     expect($speedButton).toBeFocused();
                 });
 
-                it('ENTER keydown on speed entry selects speed and closes menu',
+                it('ENTER keydown on speed entry selects 2.0x speed and closes menu',
                    function() {
                     // First open menu.
                        $speedControl.trigger(keyPressEvent(KEY.UP));
-                    // Focus on 1.50x speed
+                    // Focus on 2.0x speed
                        speedEntries.eq(0).focus();
                        speedEntries.eq(0).trigger(keyPressEvent(KEY.ENTER));
 
                     // Menu is closed, focus has been returned to speed
-                    // control and video speed is 1.50x.
+                    // control and video speed is 2.0x.
                        expect($speedButton).toBeFocused();
-                       expect($('.video-speeds li[data-speed="1.50"]'))
+                       expect($('.video-speeds li[data-speed="2.0"]'))
                         .toHaveClass('is-active');
-                       expect($('.speeds .value')).toHaveHtml('1.50x');
+                       expect($('.speeds .value')).toHaveHtml('2.0x');
                    });
 
-                it('SPACE keydown on speed entry selects speed and closes menu',
+                it('SPACE keydown on speed entry selects 0.75x speed and closes menu',
                    function() {
                     // First open menu.
                        $speedControl.trigger(keyPressEvent(KEY.UP));
-                    // Focus on 1.50x speed
-                       speedEntries.eq(0).focus();
-                       speedEntries.eq(0).trigger(keyPressEvent(KEY.SPACE));
+                    // Focus on 0.75x speed
+                       speedEntries.eq(4).focus();
+                       speedEntries.eq(4).trigger(keyPressEvent(KEY.SPACE));
 
                     // Menu is closed, focus has been returned to speed
-                    // control and video speed is 1.50x.
+                    // control and video speed is 0.75x.
                        expect($speedButton).toBeFocused();
-                       expect($('.video-speeds li[data-speed="1.50"]'))
+                       expect($('.video-speeds li[data-speed="0.75"]'))
                         .toHaveClass('is-active');
-                       expect($('.speeds .value')).toHaveHtml('1.50x');
+                       expect($('.speeds .value')).toHaveHtml('0.75x');
                    });
             });
         });

--- a/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
+++ b/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
@@ -269,7 +269,7 @@ function(VideoPlayer, i18n, moment, _) {
     // The function prepare HTML5 video, parse HTML5
     // video sources etc.
     function _prepareHTML5Video(state) {
-        state.speeds = ['0.75', '1.0', '1.25', '1.50'];
+        state.speeds = ['0.75', '1.0', '1.25', '1.50', '2.0'];
         // If none of the supported video formats can be played and there is no
         // short-hand video links, than hide the spinner and show error message.
         if (!state.config.sources.length) {
@@ -669,7 +669,7 @@ function(VideoPlayer, i18n, moment, _) {
 
     function setSpeed(newSpeed) {
         // Possible speeds for each player type.
-        // HTML5 =          [0.75, 1, 1.25, 1.5]
+        // HTML5 =          [0.75, 1, 1.25, 1.5, 2]
         // Youtube Flash =  [0.75, 1, 1.25, 1.5]
         // Youtube HTML5 =  [0.25, 0.5, 1, 1.5, 2]
         var map = {
@@ -677,7 +677,7 @@ function(VideoPlayer, i18n, moment, _) {
             '0.50': '0.75', // Youtube HTML5 -> HTML5 or Youtube Flash
             0.75: '0.50', // HTML5 or Youtube Flash -> Youtube HTML5
             1.25: '1.50', // HTML5 or Youtube Flash -> Youtube HTML5
-            '2.0': '1.50'   // Youtube HTML5 -> HTML5 or Youtube Flash
+            2.0: '1.50'   // HTML5 or Youtube HTML5 -> Youtube Flash
         };
 
         if (_.contains(this.speeds, newSpeed)) {

--- a/common/lib/xmodule/xmodule/js/src/video/02_html5_video.js
+++ b/common/lib/xmodule/xmodule/js/src/video/02_html5_video.js
@@ -192,7 +192,7 @@ function(_) {
         };
 
         Player.prototype.getAvailablePlaybackRates = function() {
-            return [0.75, 1.0, 1.25, 1.5];
+            return [0.75, 1.0, 1.25, 1.5, 2.0];
         };
 
         // eslint-disable-next-line no-underscore-dangle


### PR DESCRIPTION
## Description

Some learners would prefer to watch course videos at 2x playback speed.  Currently the edX-hosted  video players limits playback speed to 1.5x.  The YouTube-hosted video player allows 2x playback.  Chrome seems to support 2x playback natively.

Useful information to include:
- Which edX user roles will this change impact?
Learner

- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
Before (Chrome):
![image](https://user-images.githubusercontent.com/1985317/109862281-41d8d000-7c2e-11eb-83a8-66b9bee685de.png)


After (Chrome):
![image](https://user-images.githubusercontent.com/1985317/109861197-07226800-7c2d-11eb-85cb-d8bd985c1fb7.png)


## Supporting information

https://openedx.atlassian.net/browse/LEARNER-8247

## Testing instructions

Visit an edX-hosted video player and note it supports 2x playback

To be done: Test on Firefox, Edge

Done: test on Chrome

## Deadline

None

## Other information

None

Reviewers:
@wittjeff 
@davidjoy - I'm not entirely sure the scope of impact this might have, so is there anything I should be testing here? I think I found that we don't test 2.0 speed for YT videos (despite supporting that) soooo