### PR TITLE
AA-517: fix duplicate IDs in MessageBannerView

### DIFF
--- a/lms/static/js/views/message_banner.js
+++ b/lms/static/js/views/message_banner.js
@@ -11,7 +11,7 @@
         var MessageBannerView = Backbone.View.extend({
 
             events: {
-                'click #close': 'closeBanner'
+                'click .close-btn': 'closeBanner'
             },
 
             closeBanner: function(event) {

--- a/lms/static/sass/elements/_system-feedback.scss
+++ b/lms/static/sass/elements/_system-feedback.scss
@@ -116,7 +116,7 @@
 
   &.recovery-email-alert,
   &.learner-portal-enabled-alert {
-    &#banner-msg {
+    &.banner-msg {
       position: relative;
       top: -10px;
       padding: 20px 40px;
@@ -138,7 +138,7 @@
   }
 
   &.learner-portal-enabled-alert {
-    &#banner-msg {
+    &.banner-msg {
       margin-bottom: 10px;
     }
   }

--- a/lms/templates/fields/message_banner.underscore
+++ b/lms/templates/fields/message_banner.underscore
@@ -1,5 +1,5 @@
-<div id="banner-msg" class="wrapper-msg urgency-<%- urgency %> <%- type %> <% if (isRecoveryEmailMsg == true) { %> recovery-email-alert <% } %> <% if (isLearnerPortalEnabled == true) { %> learner-portal-enabled-alert <% } %>" role="alert">
-  <i <% if (hideCloseBtn == true) { %> hidden <% } %> id="close" class="fa fa-close close-icon"></i>
+<div class="banner-msg wrapper-msg urgency-<%- urgency %> <%- type %> <% if (isRecoveryEmailMsg == true) { %> recovery-email-alert <% } %> <% if (isLearnerPortalEnabled == true) { %> learner-portal-enabled-alert <% } %>" role="alert">
+  <i <% if (hideCloseBtn == true) { %> hidden <% } %> class="fa fa-close close-icon close-btn"></i>
     <div class="msg">
         <div class="msg-content">
             <div class="copy">


### PR DESCRIPTION
## Description

The learner dashboard can render multiple MessageBannerViews at once, all with the same DOM IDs (id=“banner-msg” and id=“close”). Generally, we should never have duplicate DOM IDs.

This ticket switches the IDs to class names, and updates the css and backbone selector to match.