### PR TITLE
Trigger regrade on visibility change

### DIFF
--- a/cms/djangoapps/contentstore/signals/signals.py
+++ b/cms/djangoapps/contentstore/signals/signals.py
@@ -14,3 +14,10 @@ GRADING_POLICY_CHANGED = Signal(
         'course_key',  # Unicode string representing the course
     ]
 )
+
+COURSE_BLOCK_VISIBILTY_CHANGED = Signal(
+    providing_args=[
+        'user_id',  # Integer User ID
+        'course_key',  # Unicode string representing the course
+    ]
+)


### PR DESCRIPTION
## Description

Add a signal that is sent when a block's `visible_to_staff_only` is changed.  Add a handler for this signal that enqueues a `compute_all_grades_for_course` task for the given course.

## Background

If a course has a graded subsection that has learner grades associated with it, and course staff hides the subsection, section, or a unit in the subsection, persistent grades become stale. Course staff expect to be able to hide a subsection and have that reflected in the grade report, but it is not.

## Supporting information

[EDUCATOR-5526](https://openedx.atlassian.net/browse/EDUCATOR-5526)

## Testing instructions

- Navigate to studio for a course with some graded subsections and persistent grades.
- Click the gear icon next to a section, subsection, or unit and go to the 'Visibility' tab.
- For section or unit, check the box for 'Hide from learners'. For a subsection, select "Hide entire subsection"
- Save
- Navigate to the instructor dashboard -> data download, and click "generate grade report" 
- The grade report should reflect the hidden component. Unhiding the component should be reflected as well.
Note: Sometimes the grade report doesn't work on devstack. You can also just inspect the persistent grades models in the local db.

## Potential future optimization

- Don't send the signal if we are also changing the grading type, since that will also enqueue a grading task
- Logic to determine if the inherited visibility status has changed, for example if we have a hidden section, and we're hiding a subsection within that section, well, ultimately nothing is changing.
- Logic to consider if this is part of a graded subsection, or contains a graded subsection. If we're hiding a unit that does not effect grading, regrading accomplishes nothing.

@edx/masters-devs-gta 