### PR TITLE
DENG-803: add traits to segment context for enrollment activated events

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1492,7 +1492,7 @@ class CourseEnrollment(models.Model):
                                                                                                        self.course_id)
             with tracker.get_tracker().context(event_name, context):
                 tracker.emit(event_name, data)
-                segment.track(self.user_id, event_name, segment_properties)
+                segment.track(self.user_id, event_name, segment_properties, traits=segment_properties)
 
         except Exception:  # pylint: disable=broad-except
             if event_name and self.course_id:

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1485,6 +1485,8 @@ class CourseEnrollment(models.Model):
                 'run': self.course_id.run,
                 'mode': self.mode,
             }
+            segment_traits = dict(segment_properties)
+            segment_traits['course_title'] = self.course_overview.display_name if self.course_overview else None
             if event_name == EVENT_NAME_ENROLLMENT_ACTIVATED:
                 segment_properties['email'] = self.user.email
                 # This next property is for an experiment, see method's comments for more information
@@ -1492,7 +1494,7 @@ class CourseEnrollment(models.Model):
                                                                                                        self.course_id)
             with tracker.get_tracker().context(event_name, context):
                 tracker.emit(event_name, data)
-                segment.track(self.user_id, event_name, segment_properties, traits=segment_properties)
+                segment.track(self.user_id, event_name, segment_properties, traits=segment_traits)
 
         except Exception:  # pylint: disable=broad-except
             if event_name and self.course_id:

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1490,6 +1490,7 @@ class CourseEnrollment(models.Model):
                 # This next property is for an experiment, see method's comments for more information
                 segment_properties['external_course_updates'] = set_up_external_updates_for_enrollment(self.user,
                                                                                                        self.course_id)
+            segment_traits = dict(segment_properties)
             with tracker.get_tracker().context(event_name, context):
                 tracker.emit(event_name, data)
                 segment.track(self.user_id, event_name, segment_properties, traits=segment_properties)

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1485,7 +1485,12 @@ class CourseEnrollment(models.Model):
                 'run': self.course_id.run,
                 'mode': self.mode,
             }
+            # DENG-803: For segment events forwarded along to Hubspot, duplicate the `properties`
+            # section of the event payload into the `traits` section so that they can be received.
+            # This is a temporary fix until we implement this behavior outside of the LMS.
+            # TODO: DENG-804: remove the properties duplication in the event traits.
             segment_traits = dict(segment_properties)
+            # Add course_title to the traits, as it is used by Hubspot filters
             segment_traits['course_title'] = self.course_overview.display_name if self.course_overview else None
             if event_name == EVENT_NAME_ENROLLMENT_ACTIVATED:
                 segment_properties['email'] = self.user.email

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1490,7 +1490,6 @@ class CourseEnrollment(models.Model):
                 # This next property is for an experiment, see method's comments for more information
                 segment_properties['external_course_updates'] = set_up_external_updates_for_enrollment(self.user,
                                                                                                        self.course_id)
-            segment_traits = dict(segment_properties)
             with tracker.get_tracker().context(event_name, context):
                 tracker.emit(event_name, data)
                 segment.track(self.user_id, event_name, segment_properties, traits=segment_properties)

--- a/common/djangoapps/student/tests/test_enrollment.py
+++ b/common/djangoapps/student/tests/test_enrollment.py
@@ -172,7 +172,7 @@ class EnrollmentTest(UrlResetMixin, SharedModuleStoreTestCase):
         assert mock_segment.track.call_count == 1
         assert mock_segment.track.call_args[0][1] == 'edx.course.enrollment.activated'
         traits = mock_segment.track.call_args[1]['traits']
-        assert traits['course_title'] == 'Run 0'
+        assert traits['course_title'] == self.course.display_name
         assert traits['mode'] == 'audit'
 
         with patch('common.djangoapps.student.models.segment') as mock_segment:
@@ -180,7 +180,7 @@ class EnrollmentTest(UrlResetMixin, SharedModuleStoreTestCase):
         assert mock_segment.track.call_count == 1
         assert mock_segment.track.call_args[0][1] == 'edx.course.enrollment.mode_changed'
         traits = mock_segment.track.call_args[1]['traits']
-        assert traits['course_title'] == 'Run 0'
+        assert traits['course_title'] == self.course.display_name
         assert traits['mode'] == 'verified'
 
     @patch.dict(settings.FEATURES, {'ENABLE_MKTG_EMAIL_OPT_IN': True})

--- a/common/djangoapps/track/segment.py
+++ b/common/djangoapps/track/segment.py
@@ -16,7 +16,7 @@ from eventtracking import tracker
 from six.moves.urllib.parse import urlunsplit
 
 
-def track(user_id, event_name, properties=None, context=None):
+def track(user_id, event_name, properties=None, context=None, traits=None):
     """
     Wrapper for emitting Segment track event, including augmenting context information from middleware.
     """
@@ -58,6 +58,9 @@ def track(user_id, event_name, properties=None, context=None):
                 segment_context['page']['referrer'] = referer
             if page is not None and 'url' not in segment_context['page']:
                 segment_context['page']['url'] = page
+
+        if traits:
+            segment_context['traits'] = traits
 
         analytics.track(user_id, event_name, properties, segment_context)
 

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -334,20 +334,22 @@ def _track_user_registration(user, profile, params, third_party_provider):
         # .. pii_types: email_address, username, name, birth_date, location, gender
         # .. pii_retirement: third_party
         segment.identify(*identity_args)
+        properties = {
+            'category': 'conversion',
+            # ..pii: Learner email is sent to Segment in following line and will be associated with analytics data.
+            'email': user.email,
+            'label': params.get('course_id'),
+            'provider': third_party_provider.name if third_party_provider else None,
+            'is_gender_selected': bool(profile.gender_display),
+            'is_year_of_birth_selected': bool(profile.year_of_birth),
+            'is_education_selected': bool(profile.level_of_education_display),
+            'is_goal_set': bool(profile.goals),
+        }
         segment.track(
             user.id,
             "edx.bi.user.account.registered",
-            {
-                'category': 'conversion',
-                # ..pii: Learner email is sent to Segment in following line and will be associated with analytics data.
-                'email': user.email,
-                'label': params.get('course_id'),
-                'provider': third_party_provider.name if third_party_provider else None,
-                'is_gender_selected': bool(profile.gender_display),
-                'is_year_of_birth_selected': bool(profile.year_of_birth),
-                'is_education_selected': bool(profile.level_of_education_display),
-                'is_goal_set': bool(profile.goals),
-            },
+            properties=properties,
+            traits=properties,
         )
 
 

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -345,11 +345,18 @@ def _track_user_registration(user, profile, params, third_party_provider):
             'is_education_selected': bool(profile.level_of_education_display),
             'is_goal_set': bool(profile.goals),
         }
+        # DENG-803: For segment events forwarded along to Hubspot, duplicate the `properties` section of
+        # the event payload into the `traits` section so that they can be received. This is a temporary
+        # fix until we implement this behavior outside of the LMS.
+        # TODO: DENG-805: remove the properties duplication in the event traits.
+        segment_traits = dict(properties)
+        segment_traits['user_id'] = user.id
+        segment_traits['joined_date'] = user.date_joined.strftime("%Y-%m-%d")
         segment.track(
             user.id,
             "edx.bi.user.account.registered",
             properties=properties,
-            traits=properties,
+            traits=segment_traits,
         )
 
 


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

We currently use Sailthru to send certain event data along to Hubspot for marketing purposes. This pull request will replace the Sailthru component by forwarding existing Segment events along to Hubspot. The events in question are:
* edx.course.enrollment.activated
* edx.course.enrollment.deactivated
* edx.course.enrollment.mode_changed
* edx.bi.user.account.registered

In order to do so, I needed to duplicate the event `properties` into the `context.traits` section, so that Hubspot can see them (see: https://segment.com/docs/connections/destinations/catalog/hubspot/#setting-contact-properties-on-track). As per Justin Miller's request, I have added a couple of extra fields into the `traits` section of the event payload.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
