### PR TITLE
Reduce top padding by half for emails

### DIFF
--- a/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_body.html
+++ b/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_body.html
@@ -77,7 +77,7 @@
         <tr>
             <!-- MAIN -->
             <td class="main" bgcolor="#ffffff" style="
-                padding: 30px 20px;
+                padding: 15px 20px 30px 20px;
                 box-shadow: 0 1px 5px rgba(0,0,0,0.25);
             ">
                 {% block content %}{% endblock %}


### PR DESCRIPTION
Before:
![Screen Shot 2021-03-03 at 11 59 42 AM](https://user-images.githubusercontent.com/373677/109964843-04e50a00-7d10-11eb-88b3-428dfcbf5ebb.png)

After:
<img width="645" alt="Screen Shot 2021-03-04 at 5 26 01 PM" src="https://user-images.githubusercontent.com/373677/109964866-0b738180-7d10-11eb-84a9-fce848536247.png">


VAN-177
