### PR TITLE
MICROBA-1038 | Don't check enrollment status when removing allowlist entries

### DIFF
--- a/common/djangoapps/student/api.py
+++ b/common/djangoapps/student/api.py
@@ -7,6 +7,7 @@ Python APIs exposed by the student app to other in-process apps.
 from django.contrib.auth import get_user_model
 from django.conf import settings
 
+from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.models_api import create_manual_enrollment_audit as _create_manual_enrollment_audit
 from common.djangoapps.student.models_api import get_course_access_role
 from common.djangoapps.student.models_api import get_course_enrollment as _get_course_enrollment
@@ -101,3 +102,10 @@ def get_access_role_by_role_name(role_name):
         role_name: the name of the role
     """
     return _REGISTERED_ACCESS_ROLES.get(role_name, None)
+
+
+def is_user_enrolled_in_course(student, course_key):
+    """
+    Determines if a learner is enrolled in a given course-run.
+    """
+    return CourseEnrollment.is_enrolled(student, course_key)

--- a/common/djangoapps/student/tests/test_api.py
+++ b/common/djangoapps/student/tests/test_api.py
@@ -1,0 +1,57 @@
+"""
+Test Student api.py
+"""
+
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
+
+from common.djangoapps.student.api import is_user_enrolled_in_course
+from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
+
+
+class TestStudentApi(SharedModuleStoreTestCase):
+    """
+    Tests for functionality in the api.py file of the Student django app.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.course = CourseFactory.create()
+
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory.create()
+        self.course_run_key = self.course.id
+
+    def test_is_user_enrolled_in_course(self):
+        """
+        Verify the correct value is returned when a learner is actively enrolled in a course-run.
+        """
+        CourseEnrollmentFactory.create(
+            user_id=self.user.id,
+            course_id=self.course.id
+        )
+
+        result = is_user_enrolled_in_course(self.user, self.course_run_key)
+        assert result
+
+    def test_is_user_enrolled_in_course_not_active(self):
+        """
+        Verify the correct value is returned when a learner is not actively enrolled in a course-run.
+        """
+        CourseEnrollmentFactory.create(
+            user_id=self.user.id,
+            course_id=self.course.id,
+            is_active=False
+        )
+
+        result = is_user_enrolled_in_course(self.user, self.course_run_key)
+        assert not result
+
+    def test_is_user_enrolled_in_course_no_enrollment(self):
+        """
+        Verify the correct value is returned when a learner is not enrolled in a course-run.
+        """
+        result = is_user_enrolled_in_course(self.user, self.course_run_key)
+        assert not result

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -4383,7 +4383,7 @@ class TestInstructorCertificateExceptions(SharedModuleStoreTestCase):
         """
         Test ability to retrieve a learner record using their username and course id
         """
-        student = _get_student_from_request_data({"user": self.user.username}, self.course.id)
+        student = _get_student_from_request_data({"user": self.user.username})
 
         assert student.username == self.user.username
 
@@ -4392,7 +4392,7 @@ class TestInstructorCertificateExceptions(SharedModuleStoreTestCase):
         Test that we receive an expected error when no learner's username or email is entered
         """
         with pytest.raises(ValueError) as error:
-            _get_student_from_request_data({"user": ""}, self.course.id)
+            _get_student_from_request_data({"user": ""})
 
         assert str(error.value) == (
             'Student username/email field is required and can not be empty. Kindly fill in username/email and then '
@@ -4405,23 +4405,9 @@ class TestInstructorCertificateExceptions(SharedModuleStoreTestCase):
         in the LMS.
         """
         with pytest.raises(ValueError) as error:
-            _get_student_from_request_data({"user": "Neo"}, self.course.id)
+            _get_student_from_request_data({"user": "Neo"})
 
         assert str(error.value) == "Neo does not exist in the LMS. Please check your spelling and retry."
-
-    def test_get_student_from_request_data_user_not_enrolled(self):
-        """
-        Test to verify an expected error message is returned when attempting to retrieve a learner that is not enrolled
-        in a course-run.
-        """
-        new_course = CourseFactory.create()
-
-        with pytest.raises(ValueError) as error:
-            _get_student_from_request_data({"user": self.user.username}, new_course.id)
-
-        assert str(error.value) == (
-            f"{self.user.username} is not enrolled in this course. Please check your spelling and retry."
-        )
 
     def test_get_certificate_for_user(self):
         """

--- a/lms/djangoapps/instructor/tests/test_certificates.py
+++ b/lms/djangoapps/instructor/tests/test_certificates.py
@@ -667,8 +667,9 @@ class CertificateExceptionViewInstructorApiTest(SharedModuleStoreTestCase):
         assert not res_json['success']
 
         # Assert Error Message
-        assert res_json['message'] == '{user} is not enrolled in this course. Please check your spelling and retry.'\
-            .format(user=self.certificate_exception['user_name'])
+        assert res_json['message'] == (
+            f"Student {self.user.username} is not enrolled in this course. Please check your spelling and retry."
+        )
 
     def test_certificate_exception_removed_successfully(self):
         """
@@ -1196,26 +1197,6 @@ class CertificateInvalidationViewTests(SharedModuleStoreTestCase):
 
         # Assert Error Message
         assert res_json['message'] == f'{invalid_user} does not exist in the LMS. Please check your spelling and retry.'
-
-    def test_user_not_enrolled_error(self):
-        """
-        Test error message if user is not enrolled in the course.
-        """
-        self.certificate_invalidation_data.update({"user": self.not_enrolled_student.username})
-
-        response = self.client.post(
-            self.url,
-            data=json.dumps(self.certificate_invalidation_data),
-            content_type='application/json',
-        )
-
-        # Assert 400 status code in response
-        assert response.status_code == 400
-        res_json = json.loads(response.content.decode('utf-8'))
-
-        # Assert Error Message
-        assert res_json['message'] == '{user} is not enrolled in this course. Please check your spelling and retry.'\
-            .format(user=self.not_enrolled_student.username)
 
     def test_no_generated_certificate_error(self):
         """


### PR DESCRIPTION
## Description
[MICROBA-1038]

- Today, we check if a learner is actively enrolled in a course-run before we add or remove them from the Instructor Dashboard allow list. We ran into an issue where we couldn't remove an entry from the list because the learner is no longer actively enrolled in the course-run. Update instructor dashboard logic to only check enrollment status when _adding_ a learner to the allow list.

Previously, we also performed the active enrollment check before invalidating/revalidating a certificate on the Instructor Dashboard. This will no longer happen with these changes.

[MICROBA-1038]: https://openedx.atlassian.net/browse/MICROBA-1038