### PR TITLE
MST-686 Update the IDV approval email with the newest changes

### DIFF
--- a/conf/locale/en/LC_MESSAGES/django.po
+++ b/conf/locale/en/LC_MESSAGES/django.po
@@ -7935,7 +7935,7 @@ msgstr ""
 #: lms/templates/verify_student/edx_ace/verificationapproved/email/body.txt
 #, python-format
 msgid ""
-"Your approval status remains valid for one year, and it will expire "
+"Your approval status remains valid for two years, and it will expire "
 "%(expiration_datetime)s."
 msgstr ""
 
@@ -8035,7 +8035,7 @@ msgstr ""
 #: lms/templates/verify_student/edx_ace/verificationsubmitted/email/body.html
 #: lms/templates/verify_student/edx_ace/verificationsubmitted/email/body.txt
 msgid ""
-"We have received your photos and they will be reviewed within 5-7 days."
+"We have received your photos and they will be reviewed within 3-5 days."
 msgstr ""
 
 #: lms/templates/verify_student/edx_ace/verificationsubmitted/email/body.html

--- a/conf/locale/eo/LC_MESSAGES/django.po
+++ b/conf/locale/eo/LC_MESSAGES/django.po
@@ -10220,10 +10220,10 @@ msgstr ""
 #: lms/templates/verify_student/edx_ace/verificationapproved/email/body.txt
 #, python-format
 msgid ""
-"Your approval status remains valid for one year, and it will expire "
+"Your approval status remains valid for two years, and it will expire "
 "%(expiration_datetime)s."
 msgstr ""
-"Ýöür äppröväl stätüs rémäïns välïd för öné ýéär, änd ït wïll éxpïré "
+"Ýöür äppröväl stätüs rémäïns välïd för twö ýéärs, änd ït wïll éxpïré "
 "%(expiration_datetime)s. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя#"
 
 #: lms/templates/verify_student/edx_ace/verificationapproved/email/body.html
@@ -10340,9 +10340,9 @@ msgstr ""
 #: lms/templates/verify_student/edx_ace/verificationsubmitted/email/body.html
 #: lms/templates/verify_student/edx_ace/verificationsubmitted/email/body.txt
 msgid ""
-"We have received your photos and they will be reviewed within 5-7 days."
+"We have received your photos and they will be reviewed within 3-5 days."
 msgstr ""
-"Wé hävé réçéïvéd ýöür phötös änd théý wïll ßé révïéwéd wïthïn 5-7 däýs. "
+"Wé hävé réçéïvéd ýöür phötös änd théý wïll ßé révïéwéd wïthïn 3-5 däýs. "
 "Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя#"
 
 #: lms/templates/verify_student/edx_ace/verificationsubmitted/email/body.html

--- a/lms/templates/verify_student/edx_ace/verificationapproved/email/body.html
+++ b/lms/templates/verify_student/edx_ace/verificationapproved/email/body.html
@@ -20,7 +20,7 @@
         {% endfilter %}
 
         {% filter force_escape %}
-          {% blocktrans %}Your approval status remains valid for one year, and it will expire {{ expiration_datetime }}.{% endblocktrans %}
+          {% blocktrans %}Your approval status remains valid for two years, and it will expire {{ expiration_datetime }}.{% endblocktrans %}
         {% endfilter %}
         <br/>
       </p>

--- a/lms/templates/verify_student/edx_ace/verificationapproved/email/body.txt
+++ b/lms/templates/verify_student/edx_ace/verificationapproved/email/body.txt
@@ -1,7 +1,7 @@
 {% load i18n %}{% autoescape off %}
 {% blocktrans %}Hello {{full_name}}, {% endblocktrans %}
 {% blocktrans %}Your {{ platform_name }} ID verification photos have been approved.{% endblocktrans %}
-{% blocktrans %}Your approval status remains valid for one year, and it will expire {{ expiration_datetime }}.{% endblocktrans %}
+{% blocktrans %}Your approval status remains valid for two years, and it will expire {{ expiration_datetime }}.{% endblocktrans %}
 
 {% trans "Enjoy your studies," %}
 {% blocktrans %}The {{ platform_name }} Team {% endblocktrans %}

--- a/lms/templates/verify_student/edx_ace/verificationsubmitted/email/body.html
+++ b/lms/templates/verify_student/edx_ace/verificationsubmitted/email/body.html
@@ -21,7 +21,7 @@
       </p>
 
       <p style="color: rgba(0,0,0,.75);">
-        {% trans "We have received your photos and they will be reviewed within 5-7 days." as tmsg %}{{ tmsg | force_escape }}
+        {% trans "We have received your photos and they will be reviewed within 3-5 days." as tmsg %}{{ tmsg | force_escape }}
 
       {% filter force_escape %}
         {% blocktrans %}You may check the status on your dashboard: {{ dashboard_link }} {% endblocktrans %}

--- a/lms/templates/verify_student/edx_ace/verificationsubmitted/email/body.txt
+++ b/lms/templates/verify_student/edx_ace/verificationsubmitted/email/body.txt
@@ -1,7 +1,7 @@
 {% load i18n %}{% autoescape off %}
 {% blocktrans %}Hello {{full_name}}, {% endblocktrans %}
 {% blocktrans %}Thank you for submitting your photos for identity verification with {{ platform_name }}. {% endblocktrans %}
-{% trans "We have received your photos and they will be reviewed within 5-7 days." %}
+{% trans "We have received your photos and they will be reviewed within 3-5 days." %}
 {% blocktrans %}You may check the status on your dashboard: {{ dashboard_link }} {% endblocktrans %}
 
 {% trans "Best regards," %}


### PR DESCRIPTION
## Description
This change will impact all learners who got their IDV approved.
This PR updates the language in the IDV approval email to let them know the IDV approval is valid for 2 years instead of 1. The change is also lower the number of days we advertise to learner about the approval waiting period. Changing it from 5-7 days back to 3-5 days.


## Supporting information

[MST-686](https://openedx.atlassian.net/browse/MST-686)

## Testing instructions

Go through the IDV flow at account.edx.org/id-verification and submit
See in the email that edX sent an submit confirmation email. Verify in the email we say 3-5 days of wait for approval or denial.
Wait for the approval of the IDV attempt.
Check the email telling you are approved for IDV and ensure the language says about 2 years of validity.

