### PR TITLE
[BB-3825] Fix:  Hide new post indicator on thread open

### DIFF
--- a/common/static/common/js/discussion/views/discussion_inline_view.js
+++ b/common/static/common/js/discussion/views/discussion_inline_view.js
@@ -154,6 +154,7 @@
             });
             this.threadView.render();
             this.listenTo(this.threadView.showView, 'thread:_delete', this.navigateToAllPosts);
+            this.$(".forum-nav-thread[data-id='" + threadId + "']").removeClass('never-read');
             this.threadListView.$el.addClass('is-hidden');
             this.$('.inline-thread').removeClass('is-hidden');
         },

--- a/common/static/common/js/spec/discussion/view/discussion_inline_view_spec.js
+++ b/common/static/common/js/spec/discussion/view/discussion_inline_view_spec.js
@@ -35,6 +35,7 @@
         });
 
         createTestView = function(test) {
+            var testView;
             var courseSettings = DiscussionSpecHelper.createTestCourseSettings({
                 groups: [
                     {
@@ -62,7 +63,7 @@
                     children: []
                 }
             });
-            var testView = new DiscussionInlineView({
+            testView = new DiscussionInlineView({
                 el: $('.discussion-module')
             });
             testView.render();
@@ -233,6 +234,22 @@
 
                 // Verify that the individual thread is no longer shown
                 expect(testView.$('.group-visibility-label').length).toBe(0);
+            });
+
+            it('marks a thread as read once it is opened', function() {
+                var testView = createTestView(this);
+                var thread;
+                showDiscussion(this, testView);
+                thread = testView.$('.forum-nav-thread');
+
+                // The thread is marked as unread.
+                expect(thread).toHaveClass('never-read');
+
+                // Navigate to the thread.
+                thread.find('.forum-nav-thread-link').click();
+
+                // The thread is no longer marked as unread.
+                expect(thread).not.toHaveClass('never-read');
             });
         });
     });


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description
Fixes the removal of the new post indication in unit discussion once a thread has been opened.

When an unread thread is clicked, the user expects the blue margin highlight to be removed. However, it is not removed even after opening the thread a number of times. This behaviour is different from that shown in the Discussion tab where the margin highlight is removed. See below

![simplescreenrecorder-2021-03-05 (2)](https://user-images.githubusercontent.com/13065283/110171132-507cde00-7e0c-11eb-9a0c-e61816aad33a.gif)

## Testing Instructions
* Login to the LMS with account A
* Open a unit with a discussion block. Make a few contributions to the discussion by posting a few comments
* Logout and then login with a different account (account B) that is enrolled to the same course.
* Visit the same unit. You should be able to see the posts made by account A highlighted with a blue left border.
* Click on one post to open the thread. This should open a view of the thread.
* Click on All Posts to go back to the list of posts. Confirm that the highlight on this thread has been removed.
* Open other threads to confirm this fix.
