### PR TITLE
style: django-not-configured is not a sensible lint amnesty value

### DIFF
--- a/cms/celery.py
+++ b/cms/celery.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Import celery, load its settings from the django settings
 and auto discover tasks in all installed django apps.
 

--- a/cms/djangoapps/api/__init__.py
+++ b/cms/djangoapps/api/__init__.py
@@ -1,2 +1,2 @@
-# lint-amnesty, pylint: disable=django-not-configured, missing-module-docstring
+# lint-amnesty, pylint: disable=missing-module-docstring
 default_app_config = 'cms.djangoapps.api.apps.ApiConfig'

--- a/cms/djangoapps/contentstore/views/import_export.py
+++ b/cms/djangoapps/contentstore/views/import_export.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 These views handle all actions in Studio related to import and exporting of
 courses
 """

--- a/common/djangoapps/database_fixups/__init__.py
+++ b/common/djangoapps/database_fixups/__init__.py
@@ -1,3 +1,3 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 This app exists solely to host unusual database migrations.
 """

--- a/common/djangoapps/edxmako/__init__.py
+++ b/common/djangoapps/edxmako/__init__.py
@@ -1,4 +1,4 @@
-#   Copyright (c) 2008 Mikeal Rogers  # lint-amnesty, pylint: disable=django-not-configured, missing-module-docstring
+#   Copyright (c) 2008 Mikeal Rogers  # lint-amnesty, pylint: disable=missing-module-docstring
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/common/djangoapps/entitlements/admin.py
+++ b/common/djangoapps/entitlements/admin.py
@@ -1,4 +1,4 @@
-"""Admin forms for Course Entitlements"""  # lint-amnesty, pylint: disable=django-not-configured
+"""Admin forms for Course Entitlements"""
 
 
 from django import forms

--- a/common/djangoapps/entitlements/api.py
+++ b/common/djangoapps/entitlements/api.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Python APIs exposed by the Entitlements app to other in-process apps.
 """
 

--- a/common/djangoapps/entitlements/apps.py
+++ b/common/djangoapps/entitlements/apps.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Entitlements Application Configuration
 
 Signal handlers are connected here.

--- a/common/djangoapps/entitlements/management/commands/tests/test_expire_old_entitlements.py
+++ b/common/djangoapps/entitlements/management/commands/tests/test_expire_old_entitlements.py
@@ -1,4 +1,4 @@
-"""Test Entitlements models"""  # lint-amnesty, pylint: disable=django-not-configured
+"""Test Entitlements models"""
 
 
 from unittest import mock

--- a/common/djangoapps/entitlements/models.py
+++ b/common/djangoapps/entitlements/models.py
@@ -1,4 +1,4 @@
-"""Entitlement Models"""  # lint-amnesty, pylint: disable=django-not-configured
+"""Entitlement Models"""
 
 
 import logging

--- a/common/djangoapps/entitlements/rest_api/v1/tests/test_serializers.py
+++ b/common/djangoapps/entitlements/rest_api/v1/tests/test_serializers.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Tests for the API Serializers.
 """
 

--- a/common/djangoapps/entitlements/signals.py
+++ b/common/djangoapps/entitlements/signals.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Entitlements related signal handlers.
 """
 

--- a/common/djangoapps/entitlements/tasks.py
+++ b/common/djangoapps/entitlements/tasks.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 This file contains celery tasks for entitlements-related functionality.
 """
 

--- a/common/djangoapps/entitlements/utils.py
+++ b/common/djangoapps/entitlements/utils.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Utility methods for the entitlement application.
 """
 

--- a/common/djangoapps/pipeline_mako/__init__.py
+++ b/common/djangoapps/pipeline_mako/__init__.py
@@ -1,4 +1,4 @@
-# lint-amnesty, pylint: disable=django-not-configured, missing-module-docstring
+# lint-amnesty, pylint: disable=missing-module-docstring
 
 from django.conf import settings as django_settings
 from django.contrib.staticfiles.storage import staticfiles_storage

--- a/common/djangoapps/static_replace/__init__.py
+++ b/common/djangoapps/static_replace/__init__.py
@@ -1,4 +1,4 @@
-# lint-amnesty, pylint: disable=django-not-configured, missing-module-docstring
+# lint-amnesty, pylint: disable=missing-module-docstring
 
 import logging
 import re

--- a/common/djangoapps/student/__init__.py
+++ b/common/djangoapps/student/__init__.py
@@ -1,3 +1,3 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Student app helpers and settings
 """

--- a/common/djangoapps/third_party_auth/__init__.py
+++ b/common/djangoapps/third_party_auth/__init__.py
@@ -1,4 +1,4 @@
-"""Third party authentication. """  # lint-amnesty, pylint: disable=django-not-configured
+"""Third party authentication. """
 
 
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers

--- a/common/lib/capa/setup.py
+++ b/common/lib/capa/setup.py
@@ -1,4 +1,4 @@
-# lint-amnesty, pylint: disable=django-not-configured, missing-module-docstring
+# lint-amnesty, pylint: disable=missing-module-docstring
 
 from setuptools import find_packages, setup
 

--- a/common/lib/conftest.py
+++ b/common/lib/conftest.py
@@ -1,4 +1,4 @@
-"""Code run by pylint before running any tests."""  # lint-amnesty, pylint: disable=django-not-configured
+"""Code run by pylint before running any tests."""
 
 # Patch the xml libs before anything else.
 

--- a/common/lib/safe_lxml/safe_lxml/__init__.py
+++ b/common/lib/safe_lxml/safe_lxml/__init__.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Defuse vulnerabilities in XML packages.
 """
 

--- a/common/lib/safe_lxml/setup.py
+++ b/common/lib/safe_lxml/setup.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Setup.py for safe_lxml.
 """
 

--- a/common/lib/sandbox-packages/eia.py
+++ b/common/lib/sandbox-packages/eia.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Standard resistor values.
 
 Commonly used for verifying electronic components in circuit classes are

--- a/common/lib/sandbox-packages/loncapa/__init__.py
+++ b/common/lib/sandbox-packages/loncapa/__init__.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python  # lint-amnesty, pylint: disable=django-not-configured, missing-module-docstring
+#!/usr/bin/python  # lint-amnesty, pylint: disable=missing-module-docstring
 
 from .loncapa_check import *  # lint-amnesty, pylint: disable=redefined-builtin

--- a/common/lib/symmath/setup.py
+++ b/common/lib/symmath/setup.py
@@ -1,4 +1,4 @@
-# lint-amnesty, pylint: disable=django-not-configured, missing-module-docstring
+# lint-amnesty, pylint: disable=missing-module-docstring
 from setuptools import setup
 
 setup(

--- a/common/lib/symmath/symmath/__init__.py
+++ b/common/lib/symmath/symmath/__init__.py
@@ -1,3 +1,3 @@
-# lint-amnesty, pylint: disable=django-not-configured, missing-module-docstring
+# lint-amnesty, pylint: disable=missing-module-docstring
 from .formula import *
 from .symmath_check import *

--- a/common/lib/xmodule/setup.py
+++ b/common/lib/xmodule/setup.py
@@ -1,4 +1,4 @@
-# lint-amnesty, pylint: disable=django-not-configured, missing-module-docstring
+# lint-amnesty, pylint: disable=missing-module-docstring
 
 from setuptools import find_packages, setup
 

--- a/lms/__init__.py
+++ b/lms/__init__.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Celery needs to be loaded when the cms modules are so that task
 registration and discovery can work correctly.
 """

--- a/lms/celery.py
+++ b/lms/celery.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Import celery, load its settings from the django settings
 and auto discover tasks in all installed django apps.
 

--- a/lms/djangoapps/branding/__init__.py
+++ b/lms/djangoapps/branding/__init__.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 EdX Branding package.
 
 Provides a way to retrieve "branded" parts of the site.

--- a/lms/djangoapps/course_api/__init__.py
+++ b/lms/djangoapps/course_api/__init__.py
@@ -1,4 +1,4 @@
-""" Course API """  # lint-amnesty, pylint: disable=django-not-configured
+""" Course API """
 
 
 from edx_toggles.toggles import LegacyWaffleSwitch, LegacyWaffleSwitchNamespace

--- a/lms/djangoapps/course_blocks/__init__.py
+++ b/lms/djangoapps/course_blocks/__init__.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 The Course Blocks app, built upon the Block Cache framework in
 openedx.core.djangoapps.content.block_structure, is a higher layer django app in LMS that
 provides additional context of Courses and Users (via usage_info.py) with

--- a/lms/djangoapps/courseware/__init__.py
+++ b/lms/djangoapps/courseware/__init__.py
@@ -1,4 +1,4 @@
-# lint-amnesty, pylint: disable=django-not-configured, missing-module-docstring
+# lint-amnesty, pylint: disable=missing-module-docstring
 import warnings
 
 if __name__ == 'courseware':

--- a/lms/djangoapps/instructor/views/__init__.py
+++ b/lms/djangoapps/instructor/views/__init__.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 This is the UserPreference key for the user's recipient invoice copy
 """
 INVOICE_KEY = 'pref-invoice-copy'

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Instructor Dashboard Views
 """
 

--- a/lms/djangoapps/instructor_task/__init__.py
+++ b/lms/djangoapps/instructor_task/__init__.py
@@ -1,2 +1,2 @@
-# lint-amnesty, pylint: disable=django-not-configured, missing-module-docstring
+# lint-amnesty, pylint: disable=missing-module-docstring
 default_app_config = 'lms.djangoapps.instructor_task.apps.InstructorTaskConfig'

--- a/lms/djangoapps/lti_provider/__init__.py
+++ b/lms/djangoapps/lti_provider/__init__.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 The LTI Provider app gives a way to launch edX content via a campus LMS
 platform. LTI is a standard protocol for connecting educational tools, defined
 by IMS:

--- a/lms/djangoapps/teams/__init__.py
+++ b/lms/djangoapps/teams/__init__.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Defines common methods shared by Teams classes
 """
 

--- a/lms/djangoapps/verify_student/__init__.py
+++ b/lms/djangoapps/verify_student/__init__.py
@@ -1,3 +1,3 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Student Identity Verification App
 """

--- a/lms/docker_lms_gunicorn.py
+++ b/lms/docker_lms_gunicorn.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 gunicorn configuration file: http://docs.gunicorn.org/en/stable/configure.html
 """
 

--- a/lms/startup.py
+++ b/lms/startup.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Module for code that should run during LMS startup (deprecated)
 """
 

--- a/lms/tests.py
+++ b/lms/tests.py
@@ -1,4 +1,4 @@
-"""Tests for the lms module itself."""  # lint-amnesty, pylint: disable=django-not-configured
+"""Tests for the lms module itself."""
 
 
 import logging

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 URLs for LMS
 """
 

--- a/lms/wsgi.py
+++ b/lms/wsgi.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 WSGI config for LMS.
 
 This module contains the WSGI application used by Django's development server

--- a/lms/wsgi_apache_lms.py
+++ b/lms/wsgi_apache_lms.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Apache WSGI file for LMS
 
 This module contains the WSGI application used for Apache deployment.

--- a/openedx/__init__.py
+++ b/openedx/__init__.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 This is the root package for Open edX. The intent is that all importable code
 from Open edX will eventually live here, including the code in the lms, cms,
 and common directories.

--- a/openedx/core/apidocs.py
+++ b/openedx/core/apidocs.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Open API support.
 """
 

--- a/openedx/core/constants.py
+++ b/openedx/core/constants.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Constants that are relevant to all of Open edX
 """
 # These are standard regexes for pulling out info like course_ids, usage_ids, etc.

--- a/openedx/core/djangoapps/bookmarks/__init__.py
+++ b/openedx/core/djangoapps/bookmarks/__init__.py
@@ -1,6 +1,6 @@
 """
 # lint-amnesty, pylint: disable=django-not-configured
-# lint-amnesty, pylint: disable=django-not-configured  # lint-amnesty, pylint: disable=django-not-configured
+# lint-amnesty, pylint: disable=django-not-configured
 Bookmarks module.
 """
 

--- a/openedx/core/djangoapps/cache_toolbox/__init__.py
+++ b/openedx/core/djangoapps/cache_toolbox/__init__.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 :mod:`cache_toolbox` --- Non-magical object caching tools for Django
 ====================================================================
 

--- a/openedx/core/djangoapps/catalog/__init__.py
+++ b/openedx/core/djangoapps/catalog/__init__.py
@@ -1,2 +1,2 @@
-# lint-amnesty, pylint: disable=django-not-configured, missing-module-docstring
+# lint-amnesty, pylint: disable=missing-module-docstring
 default_app_config = 'openedx.core.djangoapps.catalog.apps.CatalogConfig'

--- a/openedx/core/djangoapps/ccxcon/__init__.py
+++ b/openedx/core/djangoapps/ccxcon/__init__.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 The ccxcon app contains the models and the APIs to  interact
 with the `CCX Connector`, an application external to openedx
 that is used to interact with the CCX and their master courses.

--- a/openedx/core/djangoapps/commerce/__init__.py
+++ b/openedx/core/djangoapps/commerce/__init__.py
@@ -1,1 +1,1 @@
-""" Thin Client for the Ecommerce API Service """  # lint-amnesty, pylint: disable=django-not-configured
+""" Thin Client for the Ecommerce API Service """

--- a/openedx/core/djangoapps/contentserver/__init__.py
+++ b/openedx/core/djangoapps/contentserver/__init__.py
@@ -1,3 +1,3 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Serves course assets to end users.
 """

--- a/openedx/core/djangoapps/course_date_signals/__init__.py
+++ b/openedx/core/djangoapps/course_date_signals/__init__.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Django app to manage course content dates, and ingesting them into edx-when for later use by the LMS.
 """
 

--- a/openedx/core/djangoapps/credentials/__init__.py
+++ b/openedx/core/djangoapps/credentials/__init__.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 edX Platform support for credentials.
 
 This package will be used as a wrapper for interacting with the credentials

--- a/openedx/core/djangoapps/dark_lang/__init__.py
+++ b/openedx/core/djangoapps/dark_lang/__init__.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Language Translation Dark Launching
 ===================================
 

--- a/openedx/core/djangoapps/discussions/__init__.py
+++ b/openedx/core/djangoapps/discussions/__init__.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Handle discussions integrations
 """
 default_app_config = 'openedx.core.djangoapps.discussions.apps.DiscussionsConfig'

--- a/openedx/core/djangoapps/enrollments/__init__.py
+++ b/openedx/core/djangoapps/enrollments/__init__.py
@@ -1,3 +1,3 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Enrollment API helpers and settings
 """

--- a/openedx/core/djangoapps/external_user_ids/__init__.py
+++ b/openedx/core/djangoapps/external_user_ids/__init__.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 edX Platform support for external user IDs.
 
 This package will be used to support generating external User IDs to be shared

--- a/openedx/core/djangoapps/header_control/__init__.py
+++ b/openedx/core/djangoapps/header_control/__init__.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 This middleware is used for adjusting the headers in a response before it is sent to the end user.
 
 This middleware is intended to sit as close as possible to the top of the middleare list as possible,

--- a/openedx/core/djangoapps/lang_pref/__init__.py
+++ b/openedx/core/djangoapps/lang_pref/__init__.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Useful information for setting the language preference
 """
 

--- a/openedx/core/djangoapps/monkey_patch/__init__.py
+++ b/openedx/core/djangoapps/monkey_patch/__init__.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Monkey-patch the edX platform
 
 Here be dragons (and simians!)

--- a/openedx/core/djangoapps/programs/__init__.py
+++ b/openedx/core/djangoapps/programs/__init__.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Platform support for Programs.
 
 This package is a thin wrapper around interactions with the Programs service,

--- a/openedx/core/djangoapps/schedules/__init__.py
+++ b/openedx/core/djangoapps/schedules/__init__.py
@@ -1,2 +1,2 @@
-# lint-amnesty, pylint: disable=django-not-configured, missing-module-docstring
+# lint-amnesty, pylint: disable=missing-module-docstring
 default_app_config = 'openedx.core.djangoapps.schedules.apps.SchedulesConfig'

--- a/openedx/core/djangoapps/schedules/config.py
+++ b/openedx/core/djangoapps/schedules/config.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Contains configuration for schedules app
 """
 

--- a/openedx/core/djangoapps/schedules/content_highlights.py
+++ b/openedx/core/djangoapps/schedules/content_highlights.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Contains methods for accessing course highlights. Course highlights is a
 schedule experience built on the Schedules app.
 """

--- a/openedx/core/djangoapps/schedules/resolvers.py
+++ b/openedx/core/djangoapps/schedules/resolvers.py
@@ -1,4 +1,4 @@
-# lint-amnesty, pylint: disable=django-not-configured, missing-module-docstring
+# lint-amnesty, pylint: disable=missing-module-docstring
 
 import datetime
 import logging

--- a/openedx/core/djangoapps/schedules/signals.py
+++ b/openedx/core/djangoapps/schedules/signals.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 CourseEnrollment related signal handlers.
 """
 

--- a/openedx/core/djangoapps/schedules/tasks.py
+++ b/openedx/core/djangoapps/schedules/tasks.py
@@ -1,4 +1,4 @@
-# lint-amnesty, pylint: disable=django-not-configured, missing-module-docstring
+# lint-amnesty, pylint: disable=missing-module-docstring
 
 import datetime
 import logging

--- a/openedx/core/djangoapps/schedules/utils.py
+++ b/openedx/core/djangoapps/schedules/utils.py
@@ -1,4 +1,4 @@
-# lint-amnesty, pylint: disable=django-not-configured, missing-module-docstring
+# lint-amnesty, pylint: disable=missing-module-docstring
 
 import datetime
 import logging

--- a/openedx/core/djangoapps/self_paced/admin.py
+++ b/openedx/core/djangoapps/self_paced/admin.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Admin site bindings for self-paced courses.
 """
 

--- a/openedx/core/djangoapps/service_status/__init__.py
+++ b/openedx/core/djangoapps/service_status/__init__.py
@@ -1,3 +1,3 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Stub for a Django app to report the status of various services
 """

--- a/openedx/core/djangoapps/site_configuration/__init__.py
+++ b/openedx/core/djangoapps/site_configuration/__init__.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 This app is used for creating/updating site's configuration. This app encapsulate configuration related logic for sites
 and provides a way for sites to override default/system behavioural or presentation logic.
 

--- a/openedx/core/djangoapps/site_configuration/helpers.py
+++ b/openedx/core/djangoapps/site_configuration/helpers.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Helpers methods for site configuration.
 """
 

--- a/openedx/core/djangoapps/video_config/__init__.py
+++ b/openedx/core/djangoapps/video_config/__init__.py
@@ -1,1 +1,1 @@
-# TODO Move this Application to video codebase when Video XModule becomes an XBlock. Reference: TNL-6867.  # lint-amnesty, pylint: disable=django-not-configured
+# TODO Move this Application to video codebase when Video XModule becomes an XBlock. Reference: TNL-6867.

--- a/openedx/core/djangoapps/waffle_utils/__init__.py
+++ b/openedx/core/djangoapps/waffle_utils/__init__.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Extra utilities for waffle: most classes are defined in edx_toggles.toggles (https://edx-toggles.readthedocs.io/), but
 we keep here some extra classes for usage within edx-platform. These classes cover course override use cases.
 """

--- a/openedx/core/djangoapps/xblock/__init__.py
+++ b/openedx/core/djangoapps/xblock/__init__.py
@@ -1,3 +1,3 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 The new XBlock runtime and related code.
 """

--- a/openedx/core/djangolib/blockstore_cache.py
+++ b/openedx/core/djangolib/blockstore_cache.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 An API for caching data related to Blockstore bundles
 
 The whole point of this is to make the hard problem of cache invalidation

--- a/openedx/core/djangolib/fields.py
+++ b/openedx/core/djangolib/fields.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Custom Django fields.
 """
 

--- a/openedx/core/djangolib/js_utils.py
+++ b/openedx/core/djangolib/js_utils.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Utilities for dealing with Javascript and JSON.
 """
 

--- a/openedx/core/djangolib/markup.py
+++ b/openedx/core/djangolib/markup.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Utilities for use in Mako markup.
 """
 

--- a/openedx/core/djangolib/model_mixins.py
+++ b/openedx/core/djangolib/model_mixins.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Custom Django Model mixins.
 """
 

--- a/openedx/core/djangolib/oauth2_retirement_utils.py
+++ b/openedx/core/djangolib/oauth2_retirement_utils.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Removes user PII from OAuth2 models.
 """
 

--- a/openedx/core/djangolib/testing/tests/test_utils.py
+++ b/openedx/core/djangolib/testing/tests/test_utils.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Test that testing utils do what they say.
 """
 

--- a/openedx/core/djangolib/testing/utils.py
+++ b/openedx/core/djangolib/testing/utils.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Utility classes for testing django applications.
 
 :py:class:`CacheIsolationMixin`

--- a/openedx/core/djangolib/tests/test_blockstore_cache.py
+++ b/openedx/core/djangolib/tests/test_blockstore_cache.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-  # lint-amnesty, pylint: disable=django-not-configured
+# -*- coding: utf-8 -*-
 """
 Tests for BundleCache
 """

--- a/openedx/core/djangolib/tests/test_js_utils.py
+++ b/openedx/core/djangolib/tests/test_js_utils.py
@@ -1,4 +1,4 @@
-# lint-amnesty, pylint: disable=bad-option-value, unicode-format-string  # lint-amnesty, pylint: disable=django-not-configured
+# lint-amnesty, pylint: disable=bad-option-value, unicode-format-string
 # -*- coding: utf-8 -*-
 """
 Tests for js_utils.py

--- a/openedx/core/djangolib/tests/test_markup.py
+++ b/openedx/core/djangolib/tests/test_markup.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-  # lint-amnesty, pylint: disable=django-not-configured
+# -*- coding: utf-8 -*-
 """
 Tests for openedx.core.djangolib.markup
 """

--- a/openedx/core/djangolib/tests/test_oauth2_retirement_utils.py
+++ b/openedx/core/djangolib/tests/test_oauth2_retirement_utils.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Contains tests for OAuth2 model-retirement methods.
 """
 

--- a/openedx/core/djangolib/tests/test_translation_utils.py
+++ b/openedx/core/djangolib/tests/test_translation_utils.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-  # lint-amnesty, pylint: disable=django-not-configured
+# -*- coding: utf-8 -*-
 """
 Tests for openedx.core.djangolib.translation_utils
 """

--- a/openedx/core/djangolib/translation_utils.py
+++ b/openedx/core/djangolib/translation_utils.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 i18n utility functions
 """
 

--- a/openedx/core/pytest_hooks.py
+++ b/openedx/core/pytest_hooks.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Module to put all pytest hooks that modify pytest behaviour
 """
 import os

--- a/openedx/core/release.py
+++ b/openedx/core/release.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Information about the release line of this Open edX code.
 """
 

--- a/openedx/core/storage.py
+++ b/openedx/core/storage.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Django storage backends for Open edX.
 """
 

--- a/openedx/core/tests/test_admin_view.py
+++ b/openedx/core/tests/test_admin_view.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Tests that verify that the admin view loads.
 
 This is not inside a django app because it is a global property of the system.

--- a/openedx/core/toggles.py
+++ b/openedx/core/toggles.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Feature toggles used across the platform. Toggles should only be added to this module if we don't have a better place
 for them. Generally speaking, they should be added to the most appropriate app or repo.
 """

--- a/openedx/core/write_to_html.py
+++ b/openedx/core/write_to_html.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Class used to write pytest warning data  into html format
 """
 import textwrap

--- a/openedx/features/calendar_sync/__init__.py
+++ b/openedx/features/calendar_sync/__init__.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Calendar syncing Course dates with a User.
 """
 default_app_config = 'openedx.features.calendar_sync.apps.UserCalendarSyncConfig'

--- a/openedx/features/course_experience/__init__.py
+++ b/openedx/features/course_experience/__init__.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Unified course experience settings and helper methods.
 """
 import crum

--- a/openedx/features/discounts/__init__.py
+++ b/openedx/features/discounts/__init__.py
@@ -1,4 +1,4 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Discounts are determined by a combination of user and course, and have a one to one relationship with the enrollment
 (if already enrolled) or a join table of user and course. They are determined in LMS, because all of the data for
 the business rules exists here. Discount rules are meant to be permanent.


### PR DESCRIPTION
## Description

django-not-configured is an error raised by pylint (with
the pylint-django plugin) when it's not correctly configured.

We should not be applying lint amnesty for such a violation.
