### PR TITLE
fix: lower bundle cache timeout from 47hrs to 50mins

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2275,8 +2275,15 @@ BLOCKSTORE_API_URL = 'http://localhost:18250/api/v1/'
 # in the blockstore-based XBlock runtime
 XBLOCK_RUNTIME_V2_EPHEMERAL_DATA_CACHE = 'default'
 
-# Blockstore data could contain S3 links, so this should be lower than Blockstore's AWS_QUERYSTRING_EXPIRE
-BLOCKSTORE_BUNDLE_CACHE_TIMEOUT = 169200
+# .. setting_name: BLOCKSTORE_BUNDLE_CACHE_TIMEOUT
+# .. setting_default: 3000
+# .. setting_description: Maximum time-to-live of cached Bundles fetched from
+#     Blockstore, in seconds. When the values returned from Blockstore have
+#     TTLs of their own (such as signed S3 URLs), the maximum TTL of this cache
+#     must be lower than the minimum TTL of those values.
+#     We use a default of 3000s (50mins) because temporary URLs are often
+#     configured to expire after one hour.
+BLOCKSTORE_BUNDLE_CACHE_TIMEOUT = 3000
 
 ###################### LEARNER PORTAL ################################
 LEARNER_PORTAL_URL_ROOT = 'https://learner-portal-localhost:18000'

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -4612,8 +4612,15 @@ BLOCKSTORE_API_URL = 'http://localhost:18250/api/v1/'
 # .. setting_description: The django cache key of the cache to use for storing anonymous user state for XBlocks.
 XBLOCK_RUNTIME_V2_EPHEMERAL_DATA_CACHE = 'default'
 
-# Blockstore data could contain S3 links, so this should be lower than Blockstore's AWS_QUERYSTRING_EXPIRE
-BLOCKSTORE_BUNDLE_CACHE_TIMEOUT = 169200
+# .. setting_name: BLOCKSTORE_BUNDLE_CACHE_TIMEOUT
+# .. setting_default: 3000
+# .. setting_description: Maximum time-to-live of cached Bundles fetched from
+#     Blockstore, in seconds. When the values returned from Blockstore have
+#     TTLs of their own (such as signed S3 URLs), the maximum TTL of this cache
+#     must be lower than the minimum TTL of those values.
+#     We use a default of 3000s (50mins) because temporary URLs are often
+#     configured to expire after one hour.
+BLOCKSTORE_BUNDLE_CACHE_TIMEOUT = 3000
 
 ######################### MICROSITE ###############################
 MICROSITE_ROOT_DIR = '/edx/app/edxapp/edx-microsite'


### PR DESCRIPTION
## Description

_S3 URLs served by Blockstore have a max TTL of 1hr, since the temporary credentials the Blockstore uses to sign the URLs themselves have a TTL of 1hr. Thus, we must cache Blockstore bundles for less than 1hr._

@bradenmacdonald @symbolist @eLRuLL I've been looking into increasing the `max_session_duration` of Blockstore's IAM role to 12hrs, the maximum. It would be out-of-the-ordinary for us (the vast majority of our services use the 1hr default; only one of them bumps it up to 2hrs), and thus will be subject to scrutiny by our SRE team.

While I work on that, what are your thoughts on just lowering the LMS bundle cache timeout to 50 minutes?

I get the importance of minimizing backend-to-backend blocking API calls, but it is not clear to me that caching the results of these calls for hours is necessary. My guess is that _any_ amount of caching will significantly reduce Edxapp->Blockstore API calls, although I don't understand the system as well as you folks.

## Supporting information

[TNL-7771](https://openedx.atlassian.net/browse/TNL-7771)


## Deadline

Active causing issues for LabXChange; sooner is better

## Other information

The best possible outcome is that it eliminates the BundleStorageErrors entirely with no noticable performance impact; the worst outcome is that the increased number of requests to Blockstore overwhelms the service the service and causes LX disruption.

Here's a precautionary revert (via overridng the setting in remote config) which we can push out in <10mins if we need to): https://github.com/edx/edx-internal/pull/4615