### PR TITLE
[AA-461] Add temporary debugging logs to determine why the highlights export is not working

### DIFF
--- a/cms/djangoapps/export_course_metadata/signals.py
+++ b/cms/djangoapps/export_course_metadata/signals.py
@@ -3,7 +3,9 @@ This file exports metadata about the course.
 """
 
 import json
+import logging
 
+from django.conf import settings
 from django.core.files.base import ContentFile
 from django.dispatch import receiver
 from openedx.core.djangoapps.schedules.content_highlights import get_all_course_highlights
@@ -11,6 +13,8 @@ from xmodule.modulestore.django import SignalHandler
 
 from .storage import course_metadata_export_storage
 from .toggles import EXPORT_COURSE_METADATA_FLAG
+
+log = logging.getLogger(__name__)
 
 
 @receiver(SignalHandler.course_published)
@@ -27,6 +31,13 @@ def export_course_metadata(sender, course_key, **kwargs):  # pylint: disable=unu
     section highlights in emails, but may be used for other things in the future.
     """
     if EXPORT_COURSE_METADATA_FLAG.is_enabled():
+        log.info('exportdebugginglog flag is enabled')
         highlights = get_all_course_highlights(course_key)
+        log.info('exportdebugginglog highlights {}'.format(str(highlights)))
         highlights_content = ContentFile(json.dumps({'highlights': highlights}))
+        log.info('exportdebugginglog highlights_content {}'.format(str(highlights_content)))
+        log.info('exportdebugginglog path course_metadata_export/{}.json'.format(course_key))
+        log.info('exportdebugginglog bucket {} storage {}'.format(
+            settings.COURSE_METADATA_EXPORT_BUCKET, settings.COURSE_METADATA_EXPORT_STORAGE
+        ))
         course_metadata_export_storage.save('course_metadata_export/{}.json'.format(course_key), highlights_content)

--- a/cms/djangoapps/export_course_metadata/test_signals.py
+++ b/cms/djangoapps/export_course_metadata/test_signals.py
@@ -52,5 +52,5 @@ class TestExportCourseMetadata(SharedModuleStoreTestCase):
             '{"highlights": [["week1highlight1", "week1highlight2"], ["week1highlight1", "week1highlight2"], [], []]}'
         )
         patched_storage.save.assert_called_once_with(
-            'course_metadata_export/course-v1:org.0+course_0+Run_0.json', patched_content.return_value
+            'course_metadata_export/{}.json'.format(self.course_key), patched_content.return_value
         )


### PR DESCRIPTION
I published a couple of courses on stage but the bucket didn't get populated, so adding some temporary debugging logs to help determine the issue (which can be reverted afterwards)
