### PR TITLE
[TSD] add annotations for ENABLE_DISCUSSION_HOME_PANEL feature flag

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -143,8 +143,15 @@ FEATURES = {
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/3064
     'ENABLE_TEXTBOOK': True,
 
-    # discussion home panel, which includes a subscription on/off setting for discussion digest emails.
-    # this should remain off in production until digest notifications are online.
+    # .. toggle_name: FEATURES['ENABLE_DISCUSSION_HOME_PANEL']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: True
+    # .. toggle_description: Hides or displays a welcome panel under the Discussion tab, which includes a subscription
+    #   on/off setting for discussion digest emails.
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2013-07-30
+    # .. toggle_warnings: This should remain off in production until digest notifications are online.
+    # .. toggle_tickets: https://github.com/edx/edx-platform/pull/520
     'ENABLE_DISCUSSION_HOME_PANEL': False,
 
     # .. toggle_name: FEATURES['ENABLE_DISCUSSION_EMAIL_DIGEST']


### PR DESCRIPTION
## Description

This PR adds annotaions for `ENABLE_DISCUSSION_HOME_PANEL` feature flag.

## Supporting information

https://github.com/edx/edx-platform/pull/520

This feature flag is `False` in `lms/envs/common.py` but from the [ansible config](https://github.com/edx/configuration/blob/1327b57a5a94fba1114c622497309f1d618b5210/playbooks/roles/edxapp/defaults/main.yml#L183) its value is `True` by default, that's why I have added `toggle_default` as `True`.