### PR TITLE
fix: add missing ORA hooks for some response areas

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -164,7 +164,7 @@ nodeenv==1.5.0            # via -r requirements/edx/base.in
 numpy==1.20.1             # via chem, openedx-calc, scipy
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
 openedx-calc==2.0.1       # via -r requirements/edx/base.in
-ora2==3.3.1               # via -r requirements/edx/base.in
+ora2==3.3.2               # via -r requirements/edx/base.in
 packaging==20.9           # via bleach, drf-yasg
 path.py==12.5.0           # via edx-enterprise, edx-i18n-tools, ora2, staff-graded-xblock, xmodule
 path==13.1.0              # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt, path.py

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -197,7 +197,7 @@ nodeenv==1.5.0            # via -r requirements/edx/testing.txt
 numpy==1.20.1             # via -r requirements/edx/testing.txt, chem, openedx-calc, scipy
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
 openedx-calc==2.0.1       # via -r requirements/edx/testing.txt
-ora2==3.3.1               # via -r requirements/edx/testing.txt
+ora2==3.3.2               # via -r requirements/edx/testing.txt
 packaging==20.9           # via -r requirements/edx/testing.txt, bleach, drf-yasg, pytest, sphinx, tox
 path.py==12.5.0           # via -r requirements/edx/testing.txt, edx-enterprise, edx-i18n-tools, ora2, staff-graded-xblock, xmodule
 path==13.1.0              # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, path.py

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -189,7 +189,7 @@ nodeenv==1.5.0            # via -r requirements/edx/base.txt
 numpy==1.20.1             # via -r requirements/edx/base.txt, chem, openedx-calc, scipy
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
 openedx-calc==2.0.1       # via -r requirements/edx/base.txt
-ora2==3.3.1               # via -r requirements/edx/base.txt
+ora2==3.3.2               # via -r requirements/edx/base.txt
 packaging==20.9           # via -r requirements/edx/base.txt, bleach, drf-yasg, pytest, tox
 path.py==12.5.0           # via -r requirements/edx/base.txt, edx-enterprise, edx-i18n-tools, ora2, staff-graded-xblock, xmodule
 path==13.1.0              # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, path.py


### PR DESCRIPTION
## Description

Bump ORA [from 3.3.1 to 3.3.2](https://github.com/edx/edx-ora2/compare/3.3.1...3.3.2) to add missing editor hooks, fixing styling for responses in the "Your Grade" and "Top Responses" sections of an ORA.

Useful information to include:
- Affects all learners / staff interacting with ORAs

Bug behavior (see unstyled `textarea`s):

![Screenshot 2021-03-05 at 13 19 12](https://user-images.githubusercontent.com/12944465/110139989-9fd9f480-7da1-11eb-9b51-e83c3b4abbdf.png)

Fixed behavior:

<img width="925" alt="Screen Shot 2021-03-05 at 11 02 08" src="https://user-images.githubusercontent.com/12944465/110140797-77062f00-7da2-11eb-9633-66eebeaf04f0.png">


## Supporting information

Related Tickets: [Original CR](https://openedx.atlassian.net/browse/CR-3321), [Clone ticket for OpenCraft collab](https://openedx.atlassian.net/browse/EDUCATOR-5615)

## Testing instructions

- Create a ORA with a Leaderboard (ORA > Edit > Top Responses = [any non-zero number]) and self-assessment only (for faster testing)
- As a learner, provide a response and assessment to enable the "Your Grade" and "Top Responses" sections.
- Verify that the responses in all those sections appear styled correctly.

## Deadline

ASAP, bug affecting prod.