### PR TITLE
Fix diff-cover with recent git versions on shallow repositories

### DIFF
--- a/pavelib/tests.py
+++ b/pavelib/tests.py
@@ -389,8 +389,9 @@ def diff_coverage(options):
         diff_html_path = os.path.join(Env.REPORT_DIR, 'diff_coverage_combined.html')
 
         # Generate the diff coverage reports (HTML and console)
+        # The --diff-range-notation parameter is a workaround for https://github.com/Bachmann1234/diff_cover/issues/153
         sh(
-            "diff-cover {xml_report_str} --compare-branch={compare_branch} "
+            "diff-cover {xml_report_str} --diff-range-notation '..' --compare-branch={compare_branch} "
             "--html-report {diff_html_path}".format(
                 xml_report_str=xml_report_str,
                 compare_branch=compare_branch,


### PR DESCRIPTION
## Description

When we tried upgrading Jenkins workers from Ubuntu 16.04 to 20.04, `diff-cover` started silently failing with a return code of `1`.  We suspect this is due to https://github.com/Bachmann1234/diff_cover/issues/153 , so we're adding the workaround described in that ticket.

## Deadline

Before we retry switching the Jenkins workers to Ubuntu 20.04.
