### PR TITLE
feat!: Remove SemanticSectionDescriptor (DEPR-124)

### DIFF
--- a/common/lib/xmodule/setup.py
+++ b/common/lib/xmodule/setup.py
@@ -8,7 +8,6 @@ XMODULES = [
     "discuss = xmodule.backcompat_module:TranslateCustomTagDescriptor",
     "image = xmodule.backcompat_module:TranslateCustomTagDescriptor",
     "poll_question = xmodule.poll_module:PollDescriptor",
-    "section = xmodule.backcompat_module:SemanticSectionDescriptor",
     "slides = xmodule.backcompat_module:TranslateCustomTagDescriptor",
     "videodev = xmodule.backcompat_module:TranslateCustomTagDescriptor",
     "custom_tag_template = xmodule.raw_module:RawDescriptor",

--- a/common/lib/xmodule/xmodule/backcompat_module.py
+++ b/common/lib/xmodule/xmodule/backcompat_module.py
@@ -1,92 +1,11 @@
 """
 These modules exist to translate old format XML into newer, semantic forms
 """
-
-
-import logging
-import traceback
-from functools import wraps
-
 from lxml import etree
 
 from openedx.core.djangolib.markup import Text
 
 from .x_module import XModuleDescriptor
-
-log = logging.getLogger(__name__)
-
-
-def process_includes(fn):
-    """
-    Wraps a XModuleDescriptor.from_xml method, and modifies xml_data to replace
-    any immediate child <include> items with the contents of the file that they
-    are supposed to include
-    """
-    @wraps(fn)
-    def from_xml(cls, xml_data, system, id_generator):
-        xml_object = etree.fromstring(xml_data)
-        next_include = xml_object.find('include')
-        while next_include is not None:
-            system.error_tracker("WARNING: the <include> tag is deprecated, and will go away.")
-            file = next_include.get('file').decode('utf-8')
-            parent = next_include.getparent()
-
-            if file is None:
-                continue
-
-            try:
-                ifp = system.resources_fs.open(file)
-                # read in and convert to XML
-                incxml = etree.XML(ifp.read())
-
-                # insert  new XML into tree in place of include
-                parent.insert(parent.index(next_include), incxml)
-            except Exception:  # lint-amnesty, pylint: disable=broad-except
-                # Log error
-                msg = "Error in problem xml include: %s" % (
-                    etree.tostring(next_include, pretty_print=True))
-                # tell the tracker
-                system.error_tracker(msg)
-
-                # work around
-                parent = next_include.getparent()
-                errorxml = etree.Element('error')
-                messagexml = etree.SubElement(errorxml, 'message')
-                messagexml.text = msg
-                stackxml = etree.SubElement(errorxml, 'stacktrace')
-                stackxml.text = traceback.format_exc()
-                # insert error XML in place of include
-                parent.insert(parent.index(next_include), errorxml)
-
-            parent.remove(next_include)
-
-            next_include = xml_object.find('include')
-        return fn(cls, etree.tostring(xml_object), system, id_generator)
-    return from_xml
-
-
-class SemanticSectionDescriptor(XModuleDescriptor):  # lint-amnesty, pylint: disable=abstract-method, missing-class-docstring
-    resources_dir = None
-
-    @classmethod
-    @process_includes
-    def from_xml(cls, xml_data, system, id_generator):
-        """
-        Removes sections with single child elements in favor of just embedding
-        the child element
-        """
-        xml_object = etree.fromstring(xml_data)
-        system.error_tracker(Text("WARNING: the <{tag}> tag is deprecated.  Please do not use in new content.")
-                             .format(tag=xml_object.tag))
-
-        if len(xml_object) == 1:
-            for (key, val) in xml_object.items():
-                xml_object[0].set(key, val)
-
-            return system.process_xml(etree.tostring(xml_object[0]))
-        else:
-            xml_object.tag = 'sequential'
-            return system.process_xml(etree.tostring(xml_object))
 
 
 class TranslateCustomTagDescriptor(XModuleDescriptor):  # lint-amnesty, pylint: disable=abstract-method, missing-class-docstring


### PR DESCRIPTION
## Description

```
A "section" tag in an OLX upload used to map to the
SemanticSectionDescriptor, which translated it into a Sequence
("sequential" tag). This is both obscure and confusing, since it uses
language that predates Studio. Back in the LMS prototype days,
"section" was inconsistently used to be interchangeable with "sequence"
and "sequential", and what Studio today calls a "section" was called a
"chapter". Bits of this legacy terminology are still around in the
courseware rendering code.

The upshot is that if you make an OLX tag "section" before this commit,
it would not map to what we call a "Section" in all our documentation,
but to a "Subsection". The fact that you can make a "section" OLX tag
at all is nowhere in our documentation because courses haven't been
written that way since late 2011 or early 2012.

SemanticSectionDescriptor came up as part of the ongoing XModule ->
XBlock conversion efforts, as a legacy XModule that isn't worth
converting.

This commit also removes the process_includes decorator, which was only
used for "section" tags. This does NOT delete the ProblemBlock-specific
<include> tag, which is still supported (if obscure).

There is a chance that through tribal knowledge or copy-paste, some
section tags survive in the wild of old edX courses. It's difficult for
us to assess because by its nature, this tag doesn't just say
"section", but instead actually does the mutation on import so it's
stored as "sequential" in the modulestore–therefore things like
CourseGraph can't detect it. The fix for any such XML-authored courses
is to change all instances of "section" tags in the OLX to be
"sequential" tags instead. Note that "<section>" is a valid HTML tag
type and so may show up in any component that can contain HTML and is
unrelated to the course structure OLX tag alias "<section>" that this
commit removes.
 ```

## Supporting information

* DEPR Ticket: https://openedx.atlassian.net/browse/DEPR-124
* Announcement post: https://discuss.openedx.org/t/deprecation-removal-semanticsectiondescriptor-depr-124/4308
