### PR TITLE
For Lilac: always raise on old imports; update import_shims docs; fix docs build.

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2393,17 +2393,3 @@ LOGO_URL_PNG = None
 LOGO_TRADEMARK_URL = None
 FAVICON_URL = None
 DEFAULT_EMAIL_LOGO_URL = 'https://edx-cdn.org/v3/default/logo.png'
-
-# .. toggle_name: ERROR_ON_DEPRECATED_EDX_PLATFORM_IMPORTS
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_use_cases: temporary
-# .. toggle_creation_date: 2021-01-20
-# .. toggle_target_removal_date: 2021-01-27
-# .. toggle_tickets: https://github.com/edx/edx-platform/pull/25932
-# .. toggle_description: Whether to raise an exception where,
-#   normally, a DeprecatedEdxPlatformImportWarning would be raised.
-#   This will allow us to test dropping support for the deprecated
-#   import paths without yet removing all of the import_shims
-#   machinery.
-ERROR_ON_DEPRECATED_EDX_PLATFORM_IMPORTS = False

--- a/docs/decisions/0007-sys-path-modification-removal.rst
+++ b/docs/decisions/0007-sys-path-modification-removal.rst
@@ -5,10 +5,12 @@ It used to be acceptable to import code from "lms.djangoapps.something" with `im
 
 Soon the old import style will stop working.
 
+
 Status
 ======
 
-In Progress
+Complete (as of the Lilac Open edX release)
+
 
 Context
 =======
@@ -32,7 +34,7 @@ This deprecation will take place in the following steps:
 
 4. Fix all instances where the ``sys.path``-based modules were ``patch``-ed in unit tests, as those patches no longer work.
 
-5. Once all instances of the ``sys.path``-based imports have been migrated in the ``edx-platform`` codebase, officially deprecate that import pattern for the next open-source release (as per the standard deprecation process).
+5. Once all instances of the ``sys.path``-based imports have been migrated in the ``edx-platform`` codebase, officially deprecate that import pattern for the next open-source release.
 
 6. Monitor logs to address continued use of the ``sys.path`` based import patterns.
 
@@ -40,3 +42,182 @@ Goals
 =====
 
 Eliminate modifications to ``sys.path`` to enable easier tool use in edx-platform.
+
+
+Timeline
+========
+
+In the Koa release, usages of the old import style raised instances of
+``DeprecatedEdxPlatformImportWarning``, but still worked.
+
+In the Lilac release, usages of old import paths will raise instances of
+``DeprecatedEdxPlatformImportError``, breaking any code that was not updated.
+This error class is intentionally *not* a subclass of ``ImportError``;
+to understand why, consider the following common pattern used in packages outside
+of the edx-platform repo itself::
+  try:
+      from student.models import CourseEnrollment
+  except ImportError:
+      CourseEnrollment = None
+This pattern is (unfortunately) widely used to so packages can import
+objects from edx-platform modules in developer or production environments,
+whilst falling back to ``None`` when unit tests are run.
+Now, if the the above old-style import statement raised a subclass of
+``ImportError``, then it would be silently caught by the ``except`` clause!
+By instead raising from a disjoint error class in the Lilac release,
+we make it more likely that operators can quickly notice and fix
+any lingering old-style import paths as they migrate from Koa.
+
+In Maple and beyond, old import paths will simply raise ``ImportError``,
+allowing us to remove the ``import_shims`` directory tree.
+
+
+Upgrade Guide
+=============
+
+Where to look for old import paths:
+
+* Forks of ``edx-platform`` itself.
+* Packages that import edx-platform code (``edx-completion``, ``edx-enterprise``, et al).
+* Repositories/files that override Ansible variables or ``edx-platform`` Django settings.
+
+What forms old import paths may take:
+
+* Direct imports (e.g. ``import courseware.views``)
+* Direct "from" imports (e.g. ``from contentstore.models import VideoUploadConfig``)
+* String references to modules (e.g. ``@patch('edxmako.LOOKUP', {})``)
+* YAML references to modules (e.g. ``KEY_FUNCTION: util.memcache.safe_key``)
+
+What the old imports are, and their replacements:
+
++-------------------------------+----------------------------------------------+
++ **Old prefix**                | **New prefix**                               |
++-------------------------------+----------------------------------------------+
+| ``badges``                    | ``lms.djangoapps.badges``                    |
++-------------------------------+----------------------------------------------+
+| ``branding``                  | ``lms.djangoapps.branding``                  |
++-------------------------------+----------------------------------------------+
+| ``bulk_email``                | ``lms.djangoapps.bulk_email``                |
++-------------------------------+----------------------------------------------+
+| ``bulk_enroll``               | ``lms.djangoapps.bulk_enroll``               |
++-------------------------------+----------------------------------------------+
+| ``ccx``                       | ``lms.djangoapps.ccx``                       |
++-------------------------------+----------------------------------------------+
+| ``certificates``              | ``lms.djangoapps.certificates``              |
++-------------------------------+----------------------------------------------+
+| ``commerce``                  | ``lms.djangoapps.commerce``                  |
++-------------------------------+----------------------------------------------+
+| ``course_api``                | ``lms.djangoapps.course_api``                |
++-------------------------------+----------------------------------------------+
+| ``course_blocks``             | ``lms.djangoapps.course_blocks``             |
++-------------------------------+----------------------------------------------+
+| ``course_goals``              | ``lms.djangoapps.course_goals``              |
++-------------------------------+----------------------------------------------+
+| ``course_home_api``           | ``lms.djangoapps.course_home_api``           |
++-------------------------------+----------------------------------------------+
+| ``courseware``                | ``lms.djangoapps.courseware``                |
++-------------------------------+----------------------------------------------+
+| ``coursewarehistoryextended`` | ``lms.djangoapps.coursewarehistoryextended`` |
++-------------------------------+----------------------------------------------+
+| ``course_wiki``               | ``lms.djangoapps.course_wiki``               |
++-------------------------------+----------------------------------------------+
+| ``dashboard``                 | ``lms.djangoapps.dashboard``                 |
++-------------------------------+----------------------------------------------+
+| ``debug``                     | ``lms.djangoapps.debug``                     |
++-------------------------------+----------------------------------------------+
+| ``discussion``                | ``lms.djangoapps.discussion``                |
++-------------------------------+----------------------------------------------+
+| ``edxnotes``                  | ``lms.djangoapps.edxnotes``                  |
++-------------------------------+----------------------------------------------+
+| ``email_marketing``           | ``lms.djangoapps.email_marketing``           |
++-------------------------------+----------------------------------------------+
+| ``experiments``               | ``lms.djangoapps.experiments``               |
++-------------------------------+----------------------------------------------+
+| ``gating``                    | ``lms.djangoapps.gating``                    |
++-------------------------------+----------------------------------------------+
+| ``grades``                    | ``lms.djangoapps.grades``                    |
++-------------------------------+----------------------------------------------+
+| ``instructor``                | ``lms.djangoapps.instructor``                |
++-------------------------------+----------------------------------------------+
+| ``instructor_analytics``      | ``lms.djangoapps.instructor_analytics``      |
++-------------------------------+----------------------------------------------+
+| ``instructor_task``           | ``lms.djangoapps.instructor_task``           |
++-------------------------------+----------------------------------------------+
+| ``learner_dashboard``         | ``lms.djangoapps.learner_dashboard``         |
++-------------------------------+----------------------------------------------+
+| ``lms_initialization``        | ``lms.djangoapps.lms_initialization``        |
++-------------------------------+----------------------------------------------+
+| ``lms_xblock``                | ``lms.djangoapps.lms_xblock``                |
++-------------------------------+----------------------------------------------+
+| ``lti_provider``              | ``lms.djangoapps.lti_provider``              |
++-------------------------------+----------------------------------------------+
+| ``mailing``                   | ``lms.djangoapps.mailing``                   |
++-------------------------------+----------------------------------------------+
+| ``mobile_api``                | ``lms.djangoapps.mobile_api``                |
++-------------------------------+----------------------------------------------+
+| ``monitoring``                | ``lms.djangoapps.monitoring``                |
++-------------------------------+----------------------------------------------+
+| ``program_enrollments``       | ``lms.djangoapps.program_enrollments``       |
++-------------------------------+----------------------------------------------+
+| ``rss_proxy``                 | ``lms.djangoapps.rss_proxy``                 |
++-------------------------------+----------------------------------------------+
+| ``shoppingcart``              | ``lms.djangoapps.shoppingcart``              |
++-------------------------------+----------------------------------------------+
+| ``staticbook``                | ``lms.djangoapps.staticbook``                |
++-------------------------------+----------------------------------------------+
+| ``static_template_view``      | ``lms.djangoapps.static_template_view``      |
++-------------------------------+----------------------------------------------+
+| ``support``                   | ``lms.djangoapps.support``                   |
++-------------------------------+----------------------------------------------+
+| ``survey``                    | ``lms.djangoapps.survey``                    |
++-------------------------------+----------------------------------------------+
+| ``teams``                     | ``lms.djangoapps.teams``                     |
++-------------------------------+----------------------------------------------+
+| ``tests``                     | ``lms.djangoapps.tests``                     |
++-------------------------------+----------------------------------------------+
+| ``verify_student``            | ``lms.djangoapps.verify_student``            |
++-------------------------------+----------------------------------------------+
+| ``course_action_state``       | ``common.djangoapps.course_action_state``    |
++-------------------------------+----------------------------------------------+
+| ``course_modes``              | ``common.djangoapps.course_modes``           |
++-------------------------------+----------------------------------------------+
+| ``database_fixups``           | ``common.djangoapps.database_fixups``        |
++-------------------------------+----------------------------------------------+
+| ``edxmako``                   | ``common.djangoapps.edxmako``                |
++-------------------------------+----------------------------------------------+
+| ``entitlements``              | ``common.djangoapps.entitlements``           |
++-------------------------------+----------------------------------------------+
+| ``pipeline_mako``             | ``common.djangoapps.pipeline_mako``          |
++-------------------------------+----------------------------------------------+
+| ``static_replace``            | ``common.djangoapps.static_replace``         |
++-------------------------------+----------------------------------------------+
+| ``status``                    | ``common.djangoapps.status``                 |
++-------------------------------+----------------------------------------------+
+| ``student``                   | ``common.djangoapps.student``                |
++-------------------------------+----------------------------------------------+
+| ``terrain``                   | ``common.djangoapps.terrain``                |
++-------------------------------+----------------------------------------------+
+| ``third_party_auth``          | ``common.djangoapps.third_party_auth``       |
++-------------------------------+----------------------------------------------+
+| ``track``                     | ``common.djangoapps.track``                  |
++-------------------------------+----------------------------------------------+
+| ``util``                      | ``common.djangoapps.util``                   |
++-------------------------------+----------------------------------------------+
+| ``xblock_django``             | ``common.djangoapps.xblock_django``          |
++-------------------------------+----------------------------------------------+
+| ``api``                       | ``cms.djangoapps.api``                       |
++-------------------------------+----------------------------------------------+
+| ``cms_user_tasks``            | ``cms.djangoapps.cms_user_tasks``            |
++-------------------------------+----------------------------------------------+
+| ``contentstore``              | ``cms.djangoapps.contentstore``              |
++-------------------------------+----------------------------------------------+
+| ``course_creators``           | ``cms.djangoapps.course_creators``           |
++-------------------------------+----------------------------------------------+
+| ``maintenance``               | ``cms.djangoapps.maintenance``               |
++-------------------------------+----------------------------------------------+
+| ``models``                    | ``cms.djangoapps.models``                    |
++-------------------------------+----------------------------------------------+
+| ``pipeline_js``               | ``cms.djangoapps.pipeline_js``               |
++-------------------------------+----------------------------------------------+
+| ``xblock_config``             | ``cms.djangoapps.xblock_config``             |
++-------------------------------+----------------------------------------------+

--- a/docs/docs_settings.py
+++ b/docs/docs_settings.py
@@ -7,26 +7,17 @@ import all the Studio code.
 
 import os
 
-if os.environ['EDX_PLATFORM_SETTINGS'] == 'devstack_docker':
-    from lms.envs.devstack_docker import *  # lint-amnesty, pylint: disable=wildcard-import
-    from cms.envs.devstack_docker import (  # lint-amnesty, pylint: disable=unused-import
-        ADVANCED_PROBLEM_TYPES,
-        COURSE_IMPORT_EXPORT_STORAGE,
-        LIBRARY_AUTHORING_MICROFRONTEND_URL,
-        SCRAPE_YOUTUBE_THUMBNAILS_JOB_QUEUE,
-        VIDEO_TRANSCRIPT_MIGRATIONS_JOB_QUEUE,
-        UPDATE_SEARCH_INDEX_JOB_QUEUE,
-    )
-else:
-    from lms.envs.devstack import *  # lint-amnesty, pylint: disable=wildcard-import
-    from cms.envs.devstack import (
-        ADVANCED_PROBLEM_TYPES,
-        COURSE_IMPORT_EXPORT_STORAGE,
-        LIBRARY_AUTHORING_MICROFRONTEND_URL,
-        SCRAPE_YOUTUBE_THUMBNAILS_JOB_QUEUE,
-        VIDEO_TRANSCRIPT_MIGRATIONS_JOB_QUEUE,
-        UPDATE_SEARCH_INDEX_JOB_QUEUE,
-    )
+from lms.envs.devstack import *  # lint-amnesty, pylint: disable=wildcard-import
+from cms.envs.devstack import (  # lint-amnesty, pylint: disable=unused-import
+    ADVANCED_PROBLEM_TYPES,
+    COURSE_IMPORT_EXPORT_STORAGE,
+    GIT_EXPORT_DEFAULT_IDENT,
+    LIBRARY_AUTHORING_MICROFRONTEND_URL,
+    SCRAPE_YOUTUBE_THUMBNAILS_JOB_QUEUE,
+    VIDEO_TRANSCRIPT_MIGRATIONS_JOB_QUEUE,
+    UPDATE_SEARCH_INDEX_JOB_QUEUE,
+)
+
 
 # Turn on all the boolean feature flags, so that conditionally included
 # API endpoints will be found.
@@ -38,9 +29,9 @@ for key, value in FEATURES.items():
 FEATURES['RUN_AS_ANALYTICS_SERVER_ENABLED'] = False
 
 INSTALLED_APPS.extend([
-    'contentstore.apps.ContentstoreConfig',
+    'cms.djangoapps.contentstore.apps.ContentstoreConfig',
     'cms.djangoapps.course_creators',
-    'xblock_config.apps.XBlockConfig',
+    'cms.djangoapps.xblock_config.apps.XBlockConfig',
     'lms.djangoapps.lti_provider'
 ])
 

--- a/docs/guides/conf.py
+++ b/docs/guides/conf.py
@@ -21,16 +21,10 @@ root = Path('../..').abspath()
 # can be successfully imported
 sys.path.insert(0, root)
 sys.path.append(root / "docs/guides")
-sys.path.append(root / "cms/djangoapps")
-sys.path.append(root / "common/djangoapps")
 sys.path.append(root / "common/lib/capa")
 sys.path.append(root / "common/lib/safe_lxml")
 sys.path.append(root / "common/lib/symmath")
 sys.path.append(root / "common/lib/xmodule")
-sys.path.append(root / "lms/djangoapps")
-sys.path.append(root / "lms/envs")
-sys.path.append(root / "openedx/core/djangoapps")
-sys.path.append(root / "openedx/features")
 
 # Use a settings module that allows all LMS and Studio code to be imported
 # without errors.  If running sphinx-apidoc, we already set a different
@@ -239,30 +233,6 @@ modules = {
     'openedx': 'openedx',
 }
 
-# These Django apps under cms don't import correctly with the "cms.djangapps" prefix
-# Others don't import correctly without it...INSTALLED_APPS entries are inconsistent
-cms_djangoapps = ['contentstore', 'course_creators', 'xblock_config']
-for app in cms_djangoapps:
-    path = os.path.join('cms', 'djangoapps', app)
-    modules[path] = path
-
-# The Django apps under common must be imported directly, not under their path
-for app in os.listdir(str(root / 'common' / 'djangoapps')):
-    path = os.path.join('common', 'djangoapps', app)
-    if os.path.isdir(str(root / path)) and app != 'terrain':
-        modules[path] = path
-
-
-# These Django apps under lms don't import correctly with the "lms.djangapps" prefix
-# Others don't import correctly without it...INSTALLED_APPS entries are inconsistent
-lms_djangoapps = ['badges', 'branding', 'bulk_email', 'courseware',
-                  'coursewarehistoryextended', 'email_marketing', 'experiments', 'lti_provider',
-                  'mobile_api', 'notes', 'rss_proxy', 'shoppingcart', 'survey']
-for app in lms_djangoapps:
-    path = os.path.join('lms', 'djangoapps', app)
-    if app not in ['notes']:
-        modules[path] = path
-
 
 def update_settings_module(service='lms'):
     """
@@ -290,8 +260,6 @@ def on_init(app):  # lint-amnesty, pylint: disable=redefined-outer-name, unused-
         bin_path = os.path.abspath(os.path.join(sys.prefix, 'bin'))
         apidoc_path = os.path.join(bin_path, apidoc_path)
     exclude_dirs = ['envs', 'migrations', 'test', 'tests']
-    exclude_dirs.extend(cms_djangoapps)
-    exclude_dirs.extend(lms_djangoapps)
 
     exclude_files = ['admin.py', 'test.py', 'testing.py', 'tests.py', 'testutils.py', 'wsgi.py']
     for module in modules:

--- a/import_shims/warn.py
+++ b/import_shims/warn.py
@@ -1,41 +1,9 @@
-"""  # lint-amnesty, pylint: disable=django-not-configured
+"""
 Utilities for warning about deprecated imports temporarily supported by
 the import_shim/ system.
 
 See /docs/decisions/0007-sys-path-modification-removal.rst for details.
 """
-
-import warnings
-
-from django.conf import settings
-from edx_django_utils.monitoring import set_custom_attribute
-
-
-class DeprecatedEdxPlatformImportWarning(DeprecationWarning):
-    """
-    A warning that a module is being imported from an unsupported location.
-
-    Example use case:
-        edx-platform modules should be imported from the root of the repository.
-
-        For example, `from lms.djangoapps.course_wiki import views` is good.
-
-        However, we historically modify `sys.path` to allow importing relative to
-        certain subdirectories. For example, `from course_wiki ipmort views` currently
-        works.
-
-        We want to stardize on the prefixed version for a few different reasons.
-    """
-
-    def __init__(self, old_import, new_import):
-        super().__init__()
-        self.old_import = old_import
-        self.new_import = new_import
-
-    def __str__(self):
-        return (
-            "Importing {self.old_import} instead of {self.new_import} is deprecated"
-        ).format(self=self)
 
 
 class DeprecatedEdxPlatformImportError(Exception):
@@ -58,12 +26,12 @@ class DeprecatedEdxPlatformImportError(Exception):
 
 def warn_deprecated_import(old_import, new_import):
     """
-    Warn that a module is being imported from its old location.
+    Raise an error that a module is being imported from an unsupported location.
+
+    The function is named "warn_deprecated_import" because importing
+    from these locations used to raise warnings instead of errors,
+    but updating all references to the old function name did not seem
+    worth it, especially since this function will be removed soon after
+    the Lilac release is cut.
     """
-    if settings.ERROR_ON_DEPRECATED_EDX_PLATFORM_IMPORTS:
-        raise DeprecatedEdxPlatformImportError(old_import, new_import)
-    set_custom_attribute("deprecated_edx_platform_import", old_import)
-    warnings.warn(
-        DeprecatedEdxPlatformImportWarning(old_import, new_import),
-        stacklevel=3,  # Should surface the line that is doing the importing.
-    )
+    raise DeprecatedEdxPlatformImportError(old_import, new_import)

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -4662,17 +4662,3 @@ LOGO_URL_PNG = None
 LOGO_TRADEMARK_URL = None
 FAVICON_URL = None
 DEFAULT_EMAIL_LOGO_URL = 'https://edx-cdn.org/v3/default/logo.png'
-
-# .. toggle_name: ERROR_ON_DEPRECATED_EDX_PLATFORM_IMPORTS
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_use_cases: rollout
-# .. toggle_creation_date: 2021-01-20
-# .. toggle_target_removal_date: 2021-01-27
-# .. toggle_tickets: https://github.com/edx/edx-platform/pull/25932
-# .. toggle_description: Whether to raise an exception where,
-#  normally, a DeprecatedEdxPlatformImportWarning would be raised.
-#  This will allow us to test dropping support for the deprecated
-#  import paths without yet removing all of the import_shims
-#  machinery.
-ERROR_ON_DEPRECATED_EDX_PLATFORM_IMPORTS = False


### PR DESCRIPTION
## Description

### refactor!: deprecated import paths now always raise

Previously, deprecated [lms|cms|common]/djangoapps
import paths would only raise errors if the
ERROR_ON_DEPRECATED_EDX_PLATFORM_IMPORTS
flag, which defaulted to False (but is overriden
to True for Devstack and *.edx.org), was enabled.

This change removes that setting and always raises
on use those deprecated import paths.

### docs: update sys.path hacks ADR & add upgrade guide

The timeline of the import_shims removal has evolved
over time; notably, we are keeping the import_shims
in Lilac in order to make any lingering old-style
import paths obvious to operators.

Update the ADR to reflect this. Also, add a table
mapping old import paths to new ones.

### build: fix+simplify docs config now that sys.paths hacks are gone

The docs configuration files previously had to account
for the fact that lms/djangoapps, cms/djangoapps, and
common/djangoapps were hacked into sys.path. As of ~Lilac,
this is no longer the case.

Unrelated cleanup: devstack_docker and devstack
are now aliases, so we can simplify a conditional import
in docs_settings.py


## Supporting information

See my ["hub" PR for the removal of import_shims](https://github.com/edx/edx-platform/pull/25932).

There is also this [forum post about the import changes](https://discuss.openedx.org/t/koa-will-change-how-edx-platform-code-is-imported/3610), which provides helpful context.

## Deadline

Before Lilac cut (4/9). Sooner is better, though.

## Other information

This will have no impact on edx.org, stage.edx.org, edge.edx.org, or Devstack, since all of those environments already enabled ERROR_ON_DEPRECATED_EDX_PLATFORM_IMPORTS.