### PR TITLE
[BB-3710] Stop rendering Visibility button on libraries

### DIFF
--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -294,10 +294,10 @@ def _studio_wrap_xblock(xblock, view, frag, context, display_name_only=False):
             'is_root': is_root,
             'is_reorderable': is_reorderable,
             'can_edit': context.get('can_edit', True),
-            'can_edit_visibility': context.get('can_edit_visibility', True),
+            'can_edit_visibility': context.get('can_edit_visibility', xblock.course_id.is_course),
             'selected_groups_label': selected_groups_label,
             'can_add': context.get('can_add', True),
-            'can_move': context.get('can_move', True),
+            'can_move': context.get('can_move', xblock.course_id.is_course),
             'language': getattr(course, 'language', None)
         }
 


### PR DESCRIPTION
_The original PR for this bugfix is https://github.com/open-craft/edx-platform/pull/323_
### Description

We're fixing an error that appears when you click the "edit access" button on an XBlock in the library page. 

### Supporting information

Libraries in the "Add library" page shouldn't have the accessibility config icon. Access settings for libraries are changed at the top, on Settings > User Access.
When clicking the access-button (the cog) on a Library, an error appears.

This is know to happen on koa.master and open-release/juniper.3.

More on "Other information"

### Testing instructions:
([Sandbox link](https://manage.opencraft.com/instance/25060/))
1. Create a new library
2. Add a component
3. Click the cogwheel button
4. You should see this error (group configurations don't apply to Libraries because they're a particular type of XBlock that can be reused throughout its course org)
![image](https://user-images.githubusercontent.com/33784039/109730599-1e5f4800-7b90-11eb-8567-16fd2afbd7ba.png)
5. **This fix removes the access button**. You can pull this branch to your local devstack or use the sandbox link provided. the buttons shouldn't appear in the library page.

This happens due to the way XBlocks are rendered; as they get rendered initially, the previews are unaware of whether they're part of a library. We can confirm this by refreshing the page, this makes the button disappear.
![image](https://user-images.githubusercontent.com/33784039/109730782-6c744b80-7b90-11eb-8b29-8edb115b0777.png)

This fix removes the cogwheel when the XBlock is part of a library. This doesn't affect the XBlocks imported to courses because those are rendered on a Randomized Content XBlock, which does have its access options.
 
![image](https://user-images.githubusercontent.com/33784039/109733448-7ba9c800-7b95-11eb-943c-420538e5a9b3.png)

### Other information:
From [library docs](https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/course_components/libraries.html#give-other-users-access-to-your-library)

> You can give other Studio users access to your library. Depending on the level of access that you give them in the library, additional library users can view and use library content in courses, edit library content, or add and manage other library users. All users to whom you give library access must be registered with Studio and have an active account.
> 
>     Ensure that the new library member has an active Studio account.
>     On the Studio home page, select the Libraries tab and locate the library to which you are adding this user.
>     From the Settings menu select User Access.
>     On the User Access page, select Add a New User.
>     Enter the new user’s email address, then select ADD USER.
>     The new user is added to the list of library members with the User level of access.

From [randomized content XBlock docs](https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/randomized_content_blocks.html#use-components-from-libraries-in-a-course)

> To create randomized assignments that make use of components from content libraries, you must have at least User level access to the libraries that you want to use. If you do not have access to a library, members of your course team who have Admin access to that library can grant you access.
> 
> The libraries that you create or have access to are listed on the Libraries tab on the Studio Home page. For details about content libraries, see Working with Content Libraries.

On the error image, we see that this has to do with groups. Groups are handled by course runs, so the Edit Access button has no place in a library (which is different from the Randomized XBlock that uses the library, which does support changing its access settings)

### Deadline: 
None