### PR TITLE
TNL-7771: reverts back the bundle_draft_files cache key

### DIFF
--- a/openedx/core/djangolib/blockstore_cache.py
+++ b/openedx/core/djangolib/blockstore_cache.py
@@ -147,7 +147,7 @@ def get_bundle_version_number(bundle_uuid, draft_name=None):
             # Cache the draft files using the version.  This saves an API call when the draft is first retrieved.
             draft_files = list(draft_metadata.files.values())
             draft_files_cache_key = _construct_versioned_cache_key(
-                bundle_uuid, version, ('bundle_draft_files_v2', ), draft_name)
+                bundle_uuid, version, ('bundle_draft_files', ), draft_name)
             cache.set(draft_files_cache_key, draft_files)
     # If we're not using a draft or the draft does not exist [anymore], fall
     # back to the bundle version, if any versions have been published:
@@ -183,8 +183,7 @@ def get_bundle_draft_files_cached(bundle_uuid, draft_name):
     """
     bundle_cache = BundleCache(bundle_uuid, draft_name)
 
-    # This key is `_v2` to avoid reading invalid values cached by a past version of this code with no timeout.
-    cache_key = ('bundle_draft_files_v2', )
+    cache_key = ('bundle_draft_files', )
     result = bundle_cache.get(cache_key)
     if result is None:
         result = list(blockstore_api.get_bundle_files(bundle_uuid, use_draft=draft_name))


### PR DESCRIPTION
## Description
This PR reverts back the changes of https://github.com/edx/edx-platform/pull/25881 to setup a new cache key for draft bundle information coming from Blockstore

**ticket**: [TNL-7771](https://openedx.atlassian.net/browse/TNL-7771)

## Reviewers

- [ ] @kdmccormick 
- [ ] @symbolist 