### PR TITLE
MICROBA-923 Add method to generate V2 course certificates

### DIFF
--- a/lms/djangoapps/certificates/models.py
+++ b/lms/djangoapps/certificates/models.py
@@ -1,48 +1,5 @@
 """
-Certificates are created for a student and an offering of a course.
-
-When a certificate is generated, a unique ID is generated so that
-the certificate can be verified later. The ID is a UUID4, so that
-it can't be easily guessed and so that it is unique.
-
-Certificates are generated in batches by a cron job, when a
-certificate is available for download the GeneratedCertificate
-table is updated with information that will be displayed
-on the course overview page.
-
-
-State diagram:
-
-[deleted,error,unavailable] [error,downloadable]
-            +                +             +
-            |                |             |
-            |                |             |
-         add_cert       regen_cert     del_cert
-            |                |             |
-            v                v             v
-       [generating]    [regenerating]  [deleting]
-            +                +             +
-            |                |             |
-       certificate      certificate    certificate
-         created       removed,created   deleted
-            +----------------+-------------+------->[error]
-            |                |             |
-            |                |             |
-            v                v             v
-      [downloadable]   [downloadable]  [deleted]
-
-
-Eligibility:
-
-    Students are eligible for a certificate if they pass the course
-    with the following exceptions:
-
-       If the student has allow_certificate set to False in the student profile
-       he will never be issued a certificate.
-
-       If the user and course is present in the certificate whitelist table
-       then the student will be issued a certificate regardless of his grade,
-       unless he has allow_certificate set to False.
+Course certificates are created for a student and an offering of a course (a course run).
 """
 
 

--- a/lms/djangoapps/certificates/queue.py
+++ b/lms/djangoapps/certificates/queue.py
@@ -59,8 +59,7 @@ class XQueueCertInterface:
     Instantiating an object will create a new
     connection to the queue server.
 
-    See models.py for valid state transitions,
-    summary of methods:
+    Summary of methods:
 
        add_cert:   Add a new certificate.  Puts a single
                    request on the queue for the student/course.

--- a/lms/djangoapps/certificates/tasks.py
+++ b/lms/djangoapps/certificates/tasks.py
@@ -13,7 +13,7 @@ from opaque_keys.edx.keys import CourseKey
 from lms.djangoapps.certificates.generation import generate_allowlist_certificate, generate_user_certificates
 from lms.djangoapps.verify_student.services import IDVerificationService
 
-logger = getLogger(__name__)
+log = getLogger(__name__)
 User = get_user_model()
 CERTIFICATE_DELAY_SECONDS = 2
 
@@ -35,22 +35,29 @@ def generate_certificate(self, **kwargs):
             has not yet updated with the user's new verification status.
         - allowlist_certificate: A flag indicating whether to generate an allowlist certificate (which is V2 of
             whitelisted certificates)
+        - v2_certificate: A flag indicating whether to generate a v2 course certificate
     """
     original_kwargs = kwargs.copy()
     student = User.objects.get(id=kwargs.pop('student'))
     course_key = CourseKey.from_string(kwargs.pop('course_key'))
     expected_verification_status = kwargs.pop('expected_verification_status', None)
     allowlist_certificate = kwargs.pop('allowlist_certificate', False)
+    v2_certificate = kwargs.pop('v2_certificate', False)
 
     if allowlist_certificate:
         generate_allowlist_certificate(user=student, course_key=course_key)
+        return
+
+    if v2_certificate:
+        # TODO: will be implemented in MICROBA-923
+        log.warning(f'Ignoring v2 certificate task request for {student.id}: {course_key}')
         return
 
     if expected_verification_status:
         actual_verification_status = IDVerificationService.user_status(student)
         actual_verification_status = actual_verification_status['status']
         if expected_verification_status != actual_verification_status:
-            logger.warning(
+            log.warning(
                 'Expected verification status {expected} '
                 'differs from actual verification status {actual} '
                 'for user {user} in course {course}'.format(

--- a/lms/djangoapps/certificates/tests/test_generation_handler.py
+++ b/lms/djangoapps/certificates/tests/test_generation_handler.py
@@ -13,12 +13,17 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
-from lms.djangoapps.certificates.generation_handler import CERTIFICATES_USE_ALLOWLIST
+from lms.djangoapps.certificates.generation_handler import CERTIFICATES_USE_ALLOWLIST, CERTIFICATES_USE_UPDATED
 from lms.djangoapps.certificates.generation_handler import (
     _can_generate_allowlist_certificate_for_status,
     is_using_certificate_allowlist,
-    can_generate_allowlist_certificate,
+    _is_using_v2_course_certificates,
+    _can_generate_allowlist_certificate,
+    _can_generate_v2_certificate,
+    can_generate_certificate_task,
     generate_allowlist_certificate_task,
+    generate_certificate_task,
+    generate_regular_certificate_task,
     is_using_certificate_allowlist_and_is_on_allowlist
 )
 from lms.djangoapps.certificates.models import GeneratedCertificate, CertificateStatuses
@@ -147,29 +152,38 @@ class AllowlistTests(ModuleStoreTestCase):
         """
         Test handling of an invalid user/course run combo
         """
-        assert not can_generate_allowlist_certificate(self.user, self.course_run_key)
+        assert not _can_generate_allowlist_certificate(self.user, self.course_run_key)
         assert not generate_allowlist_certificate_task(self.user, self.course_run_key)
+        assert not can_generate_certificate_task(self.user, self.course_run_key)
+        assert not generate_certificate_task(self.user, self.course_run_key)
 
     def test_handle_valid(self):
         """
         Test handling of a valid user/course run combo
         """
-        assert can_generate_allowlist_certificate(self.user, self.course_run_key)
+        assert _can_generate_allowlist_certificate(self.user, self.course_run_key)
         assert generate_allowlist_certificate_task(self.user, self.course_run_key)
+
+    def test_handle_valid_general_methods(self):
+        """
+        Test handling of a valid user/course run combo for the general (non-allowlist) generation methods
+        """
+        assert can_generate_certificate_task(self.user, self.course_run_key)
+        assert generate_certificate_task(self.user, self.course_run_key)
 
     def test_can_generate_auto_disabled(self):
         """
         Test handling when automatic generation is disabled
         """
         with override_waffle_switch(AUTO_GENERATION_SWITCH, active=False):
-            assert not can_generate_allowlist_certificate(self.user, self.course_run_key)
+            assert not _can_generate_allowlist_certificate(self.user, self.course_run_key)
 
     def test_can_generate_not_verified(self):
         """
         Test handling when the user's id is not verified
         """
         with mock.patch(ID_VERIFIED_METHOD, return_value=False):
-            assert not can_generate_allowlist_certificate(self.user, self.course_run_key)
+            assert not _can_generate_allowlist_certificate(self.user, self.course_run_key)
 
     def test_can_generate_not_enrolled(self):
         """
@@ -179,7 +193,7 @@ class AllowlistTests(ModuleStoreTestCase):
         cr = CourseFactory()
         key = cr.id  # pylint: disable=no-member
         CertificateWhitelistFactory.create(course_id=key, user=u)
-        assert not can_generate_allowlist_certificate(u, key)
+        assert not _can_generate_allowlist_certificate(u, key)
 
     def test_can_generate_not_whitelisted(self):
         """
@@ -194,7 +208,7 @@ class AllowlistTests(ModuleStoreTestCase):
             is_active=True,
             mode="verified",
         )
-        assert not can_generate_allowlist_certificate(u, key)
+        assert not _can_generate_allowlist_certificate(u, key)
 
     def test_can_generate_invalidated(self):
         """
@@ -222,4 +236,61 @@ class AllowlistTests(ModuleStoreTestCase):
             active=True
         )
 
-        assert not can_generate_allowlist_certificate(u, key)
+        assert not _can_generate_allowlist_certificate(u, key)
+
+
+@override_switch(AUTO_GENERATION_SWITCH_NAME, active=True)
+@override_waffle_flag(CERTIFICATES_USE_UPDATED, active=True)
+@mock.patch(ID_VERIFIED_METHOD, mock.Mock(return_value=True))
+class CertificateTests(ModuleStoreTestCase):
+    """
+    Tests for handling course certificates
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        # Create user, a course run, and an enrollment
+        self.user = UserFactory()
+        self.course_run = CourseFactory()
+        self.course_run_key = self.course_run.id  # pylint: disable=no-member
+        self.enrollment = CourseEnrollmentFactory(
+            user=self.user,
+            course_id=self.course_run_key,
+            is_active=True,
+            mode="verified",
+        )
+
+    def test_handle_valid(self):
+        """
+        Test handling of a valid user/course run combo.
+
+        Note: these assertions are placeholders for now. They will be updated as the implementation is added.
+        """
+        assert not _can_generate_v2_certificate(self.user, self.course_run_key)
+        assert can_generate_certificate_task(self.user, self.course_run_key)
+        assert not generate_certificate_task(self.user, self.course_run_key)
+        assert not generate_regular_certificate_task(self.user, self.course_run_key)
+
+    @override_waffle_flag(CERTIFICATES_USE_UPDATED, active=False)
+    def test_handle_invalid(self):
+        """
+        Test handling of an invalid user/course run combo
+        """
+        assert not _can_generate_v2_certificate(self.user, self.course_run_key)
+        assert not can_generate_certificate_task(self.user, self.course_run_key)
+        assert not generate_certificate_task(self.user, self.course_run_key)
+        assert not generate_regular_certificate_task(self.user, self.course_run_key)
+
+    def test_is_using_updated_true(self):
+        """
+        Test the updated flag
+        """
+        assert _is_using_v2_course_certificates(self.course_run_key)
+
+    @override_waffle_flag(CERTIFICATES_USE_UPDATED, active=False)
+    def test_is_using_updated_false(self):
+        """
+        Test the updated flag without the override
+        """
+        assert not _is_using_v2_course_certificates(self.course_run_key)

--- a/lms/djangoapps/certificates/views/xqueue.py
+++ b/lms/djangoapps/certificates/views/xqueue.py
@@ -69,8 +69,6 @@ def update_certificate(request):
     Will update GeneratedCertificate for a new certificate or
     modify an existing certificate entry.
 
-    See models.py for a state diagram of certificate states
-
     This view should only ever be accessed by the xqueue server
     """
 


### PR DESCRIPTION
Initial PR to begin work on V2 course certificates, including:

- Add a new CourseWaffleFlag to gate V2 regular (non-allowlist) course certificate behavior
- Add new, unused methods for V2 regular course certificate generation. In later PRs we'll:
-- Add implementation for these methods
-- Start to call these methods
- Mark some methods as private
- Minor formatting of existing log messages
- Remove some outdated doc on the various states of course certificates. In later PRs we'll replace this with updated doc.