### PR TITLE
[AA-461] Change course metadata export to be a celery task

### DIFF
--- a/cms/djangoapps/export_course_metadata/signals.py
+++ b/cms/djangoapps/export_course_metadata/signals.py
@@ -1,43 +1,18 @@
 """
-This file exports metadata about the course.
+This file calls the task that exports metadata about the course
 """
 
-import json
-import logging
-
-from django.conf import settings
-from django.core.files.base import ContentFile
 from django.dispatch import receiver
-from openedx.core.djangoapps.schedules.content_highlights import get_all_course_highlights
 from xmodule.modulestore.django import SignalHandler
 
-from .storage import course_metadata_export_storage
+from .tasks import export_course_metadata_task
 from .toggles import EXPORT_COURSE_METADATA_FLAG
-
-log = logging.getLogger(__name__)
 
 
 @receiver(SignalHandler.course_published)
 def export_course_metadata(sender, course_key, **kwargs):  # pylint: disable=unused-argument
     """
     Export course metadata on course publish.
-
-    File format
-    '{"highlights": [["week1highlight1", "week1highlight2"], ["week1highlight1", "week1highlight2"], [], []]}'
-    To retrieve highlights for week1, you would need to do
-    course_metadata['highlights'][0]
-
-    This data is initially being used by Braze Connected Content to include
-    section highlights in emails, but may be used for other things in the future.
     """
     if EXPORT_COURSE_METADATA_FLAG.is_enabled():
-        log.info('exportdebugginglog flag is enabled')
-        highlights = get_all_course_highlights(course_key)
-        log.info('exportdebugginglog highlights {}'.format(str(highlights)))
-        highlights_content = ContentFile(json.dumps({'highlights': highlights}))
-        log.info('exportdebugginglog highlights_content {}'.format(str(highlights_content)))
-        log.info('exportdebugginglog path course_metadata_export/{}.json'.format(course_key))
-        log.info('exportdebugginglog bucket {} storage {}'.format(
-            settings.COURSE_METADATA_EXPORT_BUCKET, settings.COURSE_METADATA_EXPORT_STORAGE
-        ))
-        course_metadata_export_storage.save('course_metadata_export/{}.json'.format(course_key), highlights_content)
+        export_course_metadata_task.delay(str(course_key))

--- a/cms/djangoapps/export_course_metadata/tasks.py
+++ b/cms/djangoapps/export_course_metadata/tasks.py
@@ -1,0 +1,31 @@
+"""
+This file exports metadata about the course
+"""
+
+import json
+
+from celery import shared_task
+from django.core.files.base import ContentFile
+from opaque_keys.edx.keys import CourseKey
+from openedx.core.djangoapps.schedules.content_highlights import get_all_course_highlights
+
+from .storage import course_metadata_export_storage
+
+
+@shared_task(bind=True)
+def export_course_metadata_task(self, course_key_string):  # pylint: disable=unused-argument
+    """
+    Export course metadata
+
+    File format
+    '{"highlights": [["week1highlight1", "week1highlight2"], ["week1highlight1", "week1highlight2"], [], []]}'
+    To retrieve highlights for week1, you would need to do
+    course_metadata['highlights'][0]
+
+    This data is initially being used by Braze Connected Content to include
+    section highlights in emails, but may be used for other things in the future.
+    """
+    course_key = CourseKey.from_string(course_key_string)
+    highlights = get_all_course_highlights(course_key)
+    highlights_content = ContentFile(json.dumps({'highlights': highlights}))
+    course_metadata_export_storage.save('course_metadata_export/{}.json'.format(course_key), highlights_content)

--- a/cms/djangoapps/export_course_metadata/test_signals.py
+++ b/cms/djangoapps/export_course_metadata/test_signals.py
@@ -38,8 +38,8 @@ class TestExportCourseMetadata(SharedModuleStoreTestCase):
             **kwargs
         )
 
-    @patch('cms.djangoapps.export_course_metadata.signals.course_metadata_export_storage')
-    @patch('cms.djangoapps.export_course_metadata.signals.ContentFile')
+    @patch('cms.djangoapps.export_course_metadata.tasks.course_metadata_export_storage')
+    @patch('cms.djangoapps.export_course_metadata.tasks.ContentFile')
     def test_happy_path(self, patched_content, patched_storage):
         """ Ensure we call the storage class with the correct parameters and course metadata """
         all_highlights = [["week1highlight1", "week1highlight2"], ["week1highlight1", "week1highlight2"], [], []]


### PR DESCRIPTION
Previously the export wasn't working because the terraform policy is attached to the worker role.
Devops suggested making this a celery task rather than attaching the policy to the studio role
I haven't written celery tasks before but I think this is all that is necessary?