### PR TITLE
[Support Tool] Update the Enrollments to take Entitlements into account

### DIFF
--- a/lms/djangoapps/support/tests/test_views.py
+++ b/lms/djangoapps/support/tests/test_views.py
@@ -21,6 +21,7 @@ from social_django.models import UserSocialAuth
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
+from common.djangoapps.entitlements.tests.factories import CourseEntitlementFactory
 from common.djangoapps.student.models import (
     ENROLLED_TO_ENROLLED,
     CourseEnrollment,
@@ -318,6 +319,39 @@ class SupportViewEnrollmentsTests(SharedModuleStoreTestCase, SupportViewTestCase
         })
         assert response.status_code == 200
         assert ManualEnrollmentAudit.get_manual_enrollment_by_email(self.student.email) is not None
+        self.assert_enrollment(CourseMode.VERIFIED)
+
+    @disable_signal(signals, 'post_save')
+    @ddt.data('username', 'email')
+    @patch("common.djangoapps.entitlements.models.get_course_uuid_for_course")
+    def test_change_enrollment_mode_fullfills_entitlement(self, search_string_type, mock_get_course_uuid):
+        """
+        Assert that changing student's enrollment fulfills it's respective entitlement if it exists.
+        """
+        assert ManualEnrollmentAudit.get_manual_enrollment_by_email(self.student.email) is None
+        enrollment = CourseEnrollment.get_enrollment(self.student, self.course.id)
+        entitlement = CourseEntitlementFactory.create(
+            user=self.user,
+            mode=CourseMode.VERIFIED,
+            enrollment_course_run=enrollment
+        )
+        mock_get_course_uuid.return_value = entitlement.course_uuid
+
+        url = reverse(
+            'support:enrollment_list',
+            kwargs={'username_or_email': getattr(self.student, search_string_type)}
+        )
+        response = self.client.post(url, data={
+            'course_id': str(self.course.id),
+            'old_mode': CourseMode.AUDIT,
+            'new_mode': CourseMode.VERIFIED,
+            'reason': 'Financial Assistance'
+        })
+        entitlement.refresh_from_db()
+        assert response.status_code == 200
+        assert ManualEnrollmentAudit.get_manual_enrollment_by_email(self.student.email) is not None
+        assert entitlement.enrollment_course_run is not None
+        assert entitlement.is_entitlement_redeemable() is False
         self.assert_enrollment(CourseMode.VERIFIED)
 
     @ddt.data(


### PR DESCRIPTION
[PROD-1136](https://openedx.atlassian.net/browse/PROD-1136)

Changing the enrollment mode in an `enrollment` from support tools will take `entitlement` into account. Given a fulfillable entitlement for a course_run, if the new mode matches with the mode in the entitlement, the corresponding entitlement shall be fulfilled and the enrollment will be set for that particular entitlement.