### PR TITLE
fix: streak celebration feature should require progress milestones

### DIFF
--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -205,6 +205,6 @@ def courseware_mfe_progress_milestones_are_active(course_key):
 
 def streak_celebration_is_active(course_key):
     return (
-        courseware_mfe_is_active(course_key) and
+        courseware_mfe_progress_milestones_are_active(course_key) and
         COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES_STREAK_CELEBRATION.is_enabled(course_key)
     )


### PR DESCRIPTION
## Description

In commit 9b37e7d0, the logic of
`streak_celebration_is_active` was accidentally
changed such that it no longer checks the
Progress Milestones waffle flag.
This commit fixes that.

Note: This also adds in a transitive check to
`courseware_mfe_is_active`,
which makes sense for Streak Celebration
and should not have any functional impact.

## Supporting information

Here is where the logic was inadvertently chaged : https://github.com/edx/edx-platform/pull/26815/files#diff-320af990a0401f44fffa1c9eb36dbc3a1b14e5e171891c200ca19be18bfce0e7L146-L150

## Deadline

Soon is good.
