### PR TITLE
allow inactive users to submit support tickets

### DIFF
--- a/openedx/core/djangoapps/zendesk_proxy/tests/test_v1_views.py
+++ b/openedx/core/djangoapps/zendesk_proxy/tests/test_v1_views.py
@@ -47,7 +47,16 @@ class ZendeskProxyTestCase(ApiTestCase):
         }
         return super(ZendeskProxyTestCase, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
 
-    def test_post(self):
+    @ddt.data(
+        True, False
+    )
+    def test_post(self, user_activation_status):
+        """
+        Test both active and inactive users can request Zendesk Proxy for the
+        submission of support tickets.
+        """
+        self.user.is_active = user_activation_status
+        self.user.save()
         with patch('requests.post', return_value=MagicMock(status_code=201)) as mock_post:
             response = self.request_without_auth(
                 'post',

--- a/openedx/core/djangoapps/zendesk_proxy/v1/views.py
+++ b/openedx/core/djangoapps/zendesk_proxy/v1/views.py
@@ -3,6 +3,8 @@ Define request handlers used by the zendesk_proxy djangoapp
 """
 import logging
 
+from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
+from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
 from rest_framework import status
 from rest_framework.parsers import JSONParser
 from rest_framework.response import Response
@@ -10,6 +12,7 @@ from rest_framework.throttling import UserRateThrottle
 from rest_framework.views import APIView
 
 from openedx.core.djangoapps.zendesk_proxy.utils import create_zendesk_ticket
+from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 
 logger = logging.getLogger(__name__)
 REQUESTS_PER_HOUR = 50
@@ -32,6 +35,11 @@ class ZendeskPassthroughView(APIView):
     """
     throttle_classes = (ZendeskProxyThrottle,)
     parser_classes = (JSONParser,)
+    authentication_classes = (
+        JwtAuthentication,
+        BearerAuthenticationAllowInactiveUser,
+        SessionAuthenticationAllowInactiveUser,
+    )
 
     def post(self, request):
         """


### PR DESCRIPTION
### [PROD-2282](https://openedx.atlassian.net/browse/PROD-2282)

### Description
Allow inactive users to submit support tickets from support/contact_us page. This change was removed unintentionally in https://github.com/edx/edx-platform/pull/24418 as part of a security fix. 
