### PR TITLE
[TSD] Added annotations for DISABLE_COURSE_CREATION feature flag

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -430,6 +430,20 @@ FEATURES = {
     # .. toggle_warnings: Also set settings.LIBRARY_AUTHORING_MICROFRONTEND_URL and see
     #   REDIRECT_TO_LIBRARY_AUTHORING_MICROFRONTEND for rollout.
     'ENABLE_LIBRARY_AUTHORING_MICROFRONTEND': False,
+
+    # .. toggle_name: FEATURES['DISABLE_COURSE_CREATION']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: If set to True, it disables the course creation functionality and hides the "New Course"
+    #   button in studio.
+    #   It is important to note that the value of this flag only affects if the user doesn't have a staff role,
+    #   otherwise the course creation functionality will work as it should.
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2013-12-02
+    # .. toggle_target_removal_date: None
+    # .. toggle_tickets: None
+    # .. toggle_warnings: Another toggle DISABLE_LIBRARY_CREATION overrides DISABLE_COURSE_CREATION, if present.
+    'DISABLE_COURSE_CREATION': False,
 }
 
 ENABLE_JASMINE = False


### PR DESCRIPTION
## Related ticket:
https://github.com/mitodl/edx-platform/issues/244

## Description
Adds annotations for `DISABLE_COURSE_CREATION` feature flag.


## Other information
There are a few points of explanation for this PR,
- Since this flag was never added into `cms/envs/common.py` and it was only used with a get call with default value as `False`, so for the sake of consistency I've added it to `cms/envs/common.py`.
- The value I've used for the `toggle_creation_date` is based on the earliest usage of this flag I could find in the codebase.
- The value(None) used for `toggle_tickets` is because there was no specific ticket that would add this flag specifically, there are multiple PR that just have the usage of this.
