### PR TITLE
exp: Add logging to course cert availability date

### DIFF
--- a/openedx/core/djangoapps/content/course_overviews/signals.py
+++ b/openedx/core/djangoapps/content/course_overviews/signals.py
@@ -88,5 +88,11 @@ def _check_for_pacing_changes(previous_course_overview, updated_course_overview)
 
 
 def _check_for_cert_availability_date_changes(previous_course_overview, updated_course_overview):
+    """ Checks if the cert available date has changed and if so, sends a COURSE_CERT_DATE_CHANGE signal"""
     if previous_course_overview.certificate_available_date != updated_course_overview.certificate_available_date:
+        LOG.info(
+            f"Certificate availability date for {str(updated_course_overview.id)} has changed from " +
+            f"{previous_course_overview.certificate_available_date} to " +
+            f"{updated_course_overview.certificate_available_date}. Sending COURSE_CERT_DATE_CHANGE signal."
+        )
         COURSE_CERT_DATE_CHANGE.send_robust(sender=None, course_key=updated_course_overview.id)

--- a/openedx/core/djangoapps/programs/tasks.py
+++ b/openedx/core/djangoapps/programs/tasks.py
@@ -372,6 +372,10 @@ def award_course_certificate(self, username, course_run_key):
             # This is a known limitation of this implementation and was chosen to reduce the amount of replication,
             # endpoints, celery tasks, and jenkins jobs that needed to be written for this functionality
             visible_date = available_date_for_certificate(course_overview, certificate)
+            LOGGER.info(
+                "Task award_course_certificate will award certificate for course "
+                f"{course_key} with a visible date of {visible_date}"
+            )
             post_course_certificate(credentials_client, username, certificate, visible_date)
 
             LOGGER.info(f"Awarded certificate for course {course_key} to user {username}")


### PR DESCRIPTION
## Description

I believe there to be a race condition here that only manifests in a non-devstack environment. Adding some logging to better diagnose.

## Supporting information

N/A

## Testing instructions

N/A

## Deadline

N/A

## Other information

N/A