### PR TITLE
Add a waffle flag to show/hide a link to the pages and resources view [TNL-7791] [BD-38] [BB-3872]

### DIFF
--- a/cms/djangoapps/contentstore/config/waffle.py
+++ b/cms/djangoapps/contentstore/config/waffle.py
@@ -67,3 +67,19 @@ REDIRECT_TO_LIBRARY_AUTHORING_MICROFRONTEND = LegacyWaffleFlag(
     flag_name='library_authoring_mfe',
     module_name=__name__,
 )
+
+
+# .. toggle_name: studio.pages_and_resources_mfe
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Waffle flag to link existing studio views to the new Pages and Resources experience.
+# .. toggle_use_cases: temporary, open_edx
+# .. toggle_creation_date: 2021-05-24
+# .. toggle_target_removal_date: 2021-12-31
+# .. toggle_warnings: Also set settings.COURSE_AUTHORING_MICROFRONTEND_URL.
+# .. toggle_tickets: None
+ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND = CourseWaffleFlag(
+    waffle_namespace=waffle_flags(),
+    flag_name='pages_and_resources_mfe',
+    module_name=__name__,
+)

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -15,6 +15,7 @@ from opaque_keys.edx.keys import CourseKey, UsageKey
 from opaque_keys.edx.locator import LibraryLocator
 from pytz import UTC
 
+from cms.djangoapps.contentstore.config.waffle import ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND
 from common.djangoapps.student import auth
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole
@@ -156,18 +157,36 @@ def get_lms_link_for_certificate_web_view(course_key, mode):
     )
 
 
+def get_course_authoring_url(course_module):
+    """
+    Gets course authoring microfrontend URL
+    """
+    return configuration_helpers.get_value_for_org(
+        course_module.location.org,
+        'COURSE_AUTHORING_MICROFRONTEND_URL',
+        settings.COURSE_AUTHORING_MICROFRONTEND_URL
+    )
+
+
+def get_pages_and_resources_url(course_module):
+    """
+    Gets course authoring microfrontend URL for Pages and Resources view.
+    """
+    pages_and_resources_url = None
+    if ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND.is_enabled(course_module.id):
+        mfe_base_url = get_course_authoring_url(course_module)
+        if mfe_base_url:
+            pages_and_resources_url = f'{mfe_base_url}/course/{course_module.id}/pages-and-resources'
+    return pages_and_resources_url
+
+
 def get_proctored_exam_settings_url(course_module):
     """
     Gets course authoring microfrontend URL for links to proctored exam settings page
     """
     course_authoring_microfrontend_url = ''
-
     if settings.FEATURES.get('ENABLE_EXAM_SETTINGS_HTML_VIEW'):
-        course_authoring_microfrontend_url = configuration_helpers.get_value_for_org(
-            course_module.location.org,
-            'COURSE_AUTHORING_MICROFRONTEND_URL',
-            settings.COURSE_AUTHORING_MICROFRONTEND_URL
-        )
+        course_authoring_microfrontend_url = get_course_authoring_url(course_module)
     return course_authoring_microfrontend_url
 
 

--- a/cms/djangoapps/contentstore/views/tabs.py
+++ b/cms/djangoapps/contentstore/views/tabs.py
@@ -15,8 +15,7 @@ from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 from xmodule.tabs import CourseTab, CourseTabList, InvalidTabsException, StaticTab
 
-from ..utils import get_lms_link_for_item
-
+from ..utils import get_lms_link_for_item, get_pages_and_resources_url
 __all__ = ['tabs_handler']
 
 
@@ -72,6 +71,7 @@ def tabs_handler(request, course_key_string):
             'context_course': course_item,
             'tabs_to_render': tabs_to_render,
             'lms_link': get_lms_link_for_item(course_item.location),
+            'pages_and_resources_mfe_link': get_pages_and_resources_url(course_item),
         })
     else:
         return HttpResponseNotFound()

--- a/cms/djangoapps/contentstore/views/tests/test_tabs.py
+++ b/cms/djangoapps/contentstore/views/tests/test_tabs.py
@@ -2,7 +2,10 @@
 
 
 import json
+import ddt
+from edx_toggles.toggles.testutils import override_waffle_flag
 
+from cms.djangoapps.contentstore.config.waffle import ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
 from cms.djangoapps.contentstore.utils import reverse_course_url
 from cms.djangoapps.contentstore.views import tabs
@@ -13,6 +16,7 @@ from xmodule.tabs import CourseTabList
 from xmodule.x_module import STUDENT_VIEW
 
 
+@ddt.ddt
 class TabsPageTests(CourseTestCase):
     """Test cases for Tabs (a.k.a Pages) page"""
 
@@ -70,6 +74,18 @@ class TabsPageTests(CourseTestCase):
 
         resp = self.client.get_html(self.url)
         self.assertContains(resp, 'course-nav-list')
+
+    @ddt.data(
+        # toggle active, assert count
+        (True, 1),
+        (False, 0),
+    )
+    @ddt.unpack
+    def test_pages_and_resources_toggle(self, toggle_active, assert_count):
+        """Basic check that the Pages page responds correctly"""
+        with override_waffle_flag(ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND, active=toggle_active):
+            resp = self.client.get_html(self.url)
+            self.assertContains(resp, 'View new Pages and Resources Experience', count=assert_count)
 
     def test_reorder_tabs(self):
         """Test re-ordering of tabs"""

--- a/cms/templates/edit-tabs.html
+++ b/cms/templates/edit-tabs.html
@@ -43,6 +43,11 @@
         <li class="nav-item">
           <a href="${lms_link}" rel="external" class="button view-button view-live-button">${_("View Live")}</a>
         </li>
+        % if pages_and_resources_mfe_link:
+        <li class="nav-item">
+          <a href="${pages_and_resources_mfe_link}" rel="external" class="button"><span class="icon fa fa-link" aria-hidden="true"></span>${_("View new Pages and Resources Experience")}</a>
+        </li>
+        % endif
       </ul>
     </nav>
   </header>


### PR DESCRIPTION
Adds a waffle flag to enable disable a link to the course-authoring MFE's Pages and Resources view. This will be used to 

**JIRA tickets**: TNL-7791

**Dependencies**: None

**Screenshots**: 
![Screenshot](https://user-images.githubusercontent.com/118837/110794641-dc0fc800-826d-11eb-8f16-47fd32f9a245.png)


**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: "None"

**Testing instructions**:

1. Configure and set up the course authoring MFE 
2. Enable the pages and resources view for a course by adding a waffle flag called "studio.pages_and_resources_mfe" either globally or for a particular course. 
3. Visit the "Pages" view in studio for the above course (http://localhost:18010/tabs/<course_id>)
4. A link to the new Pages and Resources experience should show up.

**Reviewers**
- [ ] @farhaanbukhsh 
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
```

flag:
`studio.pages_and_resources_mfe`