### PR TITLE
Learner 7858 - Fixed main content readability issue with Talkback

### DIFF
--- a/lms/templates/courseware/courseware-chromeless.html
+++ b/lms/templates/courseware/courseware-chromeless.html
@@ -87,7 +87,7 @@ ${HTML(fragment.foot_html())}
     % endif
     style="display: block; width: auto; margin: 0;"
   >
-      <main id="main" tabindex="-1" aria-label="Content">
+      <main id="main" aria-label="Content">
         ${HTML(fragment.body_html())}
       </main>
   </section>


### PR DESCRIPTION
Learner 7858
Fixed main content readability issue with Talkback

## Description

Removed tabindex="-1"  from main
We had a strange issue where TalkBack wasn’t reading content in some xBlocks but was reading some others. I figured out that if you remove tabindex=-1 from <main>, TalkBack works as expected again. Tangentially, this breaks the old method of implementing SkipNav links. Further tangentially, the SkipNav links were already broken (or in this case redundant on mobile). @wittjeff  will file two separate issues after this one PR is merged — one  for a better way to implement SkipNav links for  Learning MFE, and one for a better / functional way to implement SkipNav links for Mobile.


## How to reproduce
Go to [this unit](https://courses.edx.org/xblock/block-v1:W3Cx+WAI0.1x+3T2019+type@html+block@2eb3c86c479f44ba964f88ff0bfd9211) on mobile and turn on TalkBack. It will skip main content. For further information on testing go to [Jira Ticket](https://openedx.atlassian.net/browse/LEARNER-7858)
