### PR TITLE
Exposed 'Date' header so clients can compute accurate relative time

### DIFF
--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -439,8 +439,11 @@ class CoursewareInformation(RetrieveAPIView):
         """
         response = super().finalize_response(request, response, *args, **kwargs)
         # Adding this header should be moved somewhere global, not just this endpoint
-        response['Access-Control-Expose-Headers'] = 'Date'
+        exposedHeaders = response.get('Access-Control-Expose-Headers', '')
+        exposedHeaders += ', Date' if exposedHeaders else 'Date'
+        response['Access-Control-Expose-Headers'] = exposedHeaders
         return response
+
 
 class SequenceMetadata(DeveloperErrorViewMixin, APIView):
     """

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -433,6 +433,14 @@ class CoursewareInformation(RetrieveAPIView):
         context['requested_fields'] = self.request.GET.get('requested_fields', None)
         return context
 
+    def finalize_response(self, request, response, *args, **kwargs):
+        """
+        Return the final response, exposing the 'Date' header for computing relative time to the dates in the data.
+        """
+        response = super().finalize_response(request, response, *args, **kwargs)
+        # Adding this header should be moved somewhere global, not just this endpoint
+        response['Access-Control-Expose-Headers'] = 'Date'
+        return response
 
 class SequenceMetadata(DeveloperErrorViewMixin, APIView):
     """


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Exposed the `Date` header so clients can accurately compute times relative to the dates returned by the API; browser time is notoriously unreliable for this, especially for a Learner-facing countdown call-to-action based on the access expiration date.  ([REV-2126](https://openedx.atlassian.net/browse/REV-2126))

Using the `Date` header for this allows the client to make use of information that is already sent, does not require additional calls nor modifying the API, and could be generalized to more or all our APIs without modifying them.

## Testing instructions

The `Access-Control-Expose-Headers` header can be seen in requests to the `/api/courseware/course/{course_key}` endpoint

## Deadline

This will be needed for the [frontend-app-learning PR for the countdown](https://github.com/edx/frontend-app-learning/pull/377)
