### PR TITLE
ARCHBOM-1708: feat: monitor and log expected errors

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1990,10 +1990,13 @@ MIDDLEWARE = [
 
     # A newer and safer request cache.
     'edx_django_utils.cache.middleware.RequestCacheMiddleware',
-    'edx_django_utils.monitoring.CachedCustomMonitoringMiddleware',
 
     # Generate code ownership attributes. Keep this immediately after RequestCacheMiddleware.
     'edx_django_utils.monitoring.CodeOwnerMonitoringMiddleware',
+
+    # Monitoring and logging middleware
+    'openedx.core.lib.request_utils.ExpectedErrorMiddleware',
+    'edx_django_utils.monitoring.CachedCustomMonitoringMiddleware',
 
     # Cookie monitoring
     'openedx.core.lib.request_utils.CookieMonitoringMiddleware',
@@ -3107,6 +3110,7 @@ REST_FRAMEWORK = {
     'DEFAULT_RENDERER_CLASSES': (
         'rest_framework.renderers.JSONRenderer',
     ),
+    'EXCEPTION_HANDLER': 'openedx.core.lib.request_utils.expected_error_exception_handler',
     'PAGE_SIZE': 10,
     'URL_FORMAT_OVERRIDE': None,
     'DEFAULT_THROTTLE_RATES': {

--- a/openedx/core/lib/docs/decisions/0001-logging-and-monitoring-ignored-errors.rst
+++ b/openedx/core/lib/docs/decisions/0001-logging-and-monitoring-ignored-errors.rst
@@ -28,4 +28,3 @@ The new feature adds the ability to mark errors as expected, temporarily or perm
 For help configuring and using the new logging and monitoring features, see the `EXPECTED_ERRORS settings and toggles on Readthedocs`_.
 
 .. _EXPECTED_ERRORS settings and toggles on Readthedocs: https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/search.html?q=EXPECTED_ERRORS&check_keywords=yes&area=default
-https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html

--- a/openedx/core/lib/docs/decisions/0001-logging-and-monitoring-ignored-errors.rst
+++ b/openedx/core/lib/docs/decisions/0001-logging-and-monitoring-ignored-errors.rst
@@ -14,7 +14,7 @@ We had two recent Production issues that took longer than necessary to diagnose 
 Decision
 ________
 
-Add a capability for logging and monitoring ignored errors. The feature will be configurable, the monitoring will be available by default, and the logging will be opt-in as needed.
+Add a capability for logging and monitoring ignored errors and expected errors. The feature will be configurable, the monitoring will be available by default, and the logging will be opt-in as needed.
 
 Note: This feature is being added to edx-platform to start, but could be moved to edx-django-utils monitoring for use in other IDAs.
 
@@ -25,6 +25,4 @@ The new capabilities have been built in edx-platform, although they could be mov
 
 The new feature adds the ability to mark errors as expected, temporarily or permanently, even without "ignoring" them everywhere. For example, the errors and stacktraces would still appear, but it would be possible for alert conditions to ignore expected errors.
 
-For help configuring and using the new logging and monitoring features, see the `EXPECTED_ERRORS settings and toggles on Readthedocs`_.
-
-.. _EXPECTED_ERRORS settings and toggles on Readthedocs: https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/search.html?q=EXPECTED_ERRORS&check_keywords=yes&area=default
+See how_tos/logging-and-monitoring-expected-errors.rst for more information.

--- a/openedx/core/lib/docs/decisions/0001-logging-and-monitoring-ignored-errors.rst
+++ b/openedx/core/lib/docs/decisions/0001-logging-and-monitoring-ignored-errors.rst
@@ -1,0 +1,31 @@
+Logging and monitoring ignored errors
+=====================================
+
+Status
+------
+
+Accepted
+
+Context
+-------
+
+We had two recent Production issues that took longer than necessary to diagnose because they involved errors that are currently ignored by our Production monitoring configuration. One case took over 2 months to properly diagnose, and required temporary custom logging.
+
+Decision
+________
+
+Add a capability for logging and monitoring ignored errors. The feature will be configurable, the monitoring will be available by default, and the logging will be opt-in as needed.
+
+Note: This feature is being added to edx-platform to start, but could be moved to edx-django-utils monitoring for use in other IDAs.
+
+Consequence
+-----------
+
+The new capabilities have been built in edx-platform, although they could be moved to edx-django-utils monitoring in the future for use in other IDAs.
+
+The new feature adds the ability to mark errors as expected, temporarily or permanently, even without "ignoring" them everywhere. For example, the errors and stacktraces would still appear, but it would be possible for alert conditions to ignore expected errors.
+
+For help configuring and using the new logging and monitoring features, see the `EXPECTED_ERRORS settings and toggles on Readthedocs`_.
+
+.. _EXPECTED_ERRORS settings and toggles on Readthedocs: https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/search.html?q=EXPECTED_ERRORS&check_keywords=yes&area=default
+https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html

--- a/openedx/core/lib/docs/how_tos/logging-and-monitoring-expected-errors.rst
+++ b/openedx/core/lib/docs/how_tos/logging-and-monitoring-expected-errors.rst
@@ -1,0 +1,38 @@
+How to log and monitor expected errors
+======================================
+
+What are expected and ignored errors?
+-------------------------------------
+
+Errors might be "expected" for various reasons. Some examples:
+
+* Errors like ``PermissionDenied``, or ``Ratelimited``, where users or bots are prevented from doing something that is not allowed.
+* Errors that we have already diagnosed, but may either not be worth fixing, or we are unable to fix for some time.
+
+In some cases, a bug could introduce a large number errors where an "expected" error becomes an "unexpected" error. Or, there might be certain request paths for which the same error may be expected or unexpected.
+
+A subset of "expected" errors are "ignored" errors. edX uses New Relic, which can be configured to ignore errors. These errors get suppressed and leave no (stack) trace, and won't trigger error alerts.
+
+Monitoring expected errors
+--------------------------
+
+At a minimum, it is recommended that you add monitoring for any expected errors, including ignored errors. You do this by using the ``EXPECTED_ERRORS`` setting. For details on configuring, see the documentation for `EXPECTED_ERRORS settings and toggles on Readthedocs`_.
+
+By default, this will provide an ``error_expected`` custom attribute for every expected error. This custom attribute can be used in the following ways:
+
+* Alert conditions can exclude or include expected errors as necessary.
+* The value of the custom attribute includes the error name and message, which may help in diagnosing an unexpected scenario.
+
+Additionally, a subset of these errors will also have an ``error_ignored`` custom attribute if the error is configured as ignored.
+
+.. _EXPECTED_ERRORS settings and toggles on Readthedocs: https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/search.html?q=EXPECTED_ERRORS&check_keywords=yes&area=default
+
+Logging expected errors
+-----------------------
+
+Following the same documentation as for monitoring, you can also enable logging with or without a stack trace. This additional information may be useful for tracking down the source of a mysterious appearance of an otherwise expected error.
+
+More targeted scoping of errors
+-------------------------------
+
+The initial implementation only enables this functionality by error ``module.Class``. If you need to scope the monitoring/logging for a more limited subset, like for certain requests, the expectation would be to enhance and document these new capabilities.

--- a/openedx/core/lib/request_utils.py
+++ b/openedx/core/lib/request_utils.py
@@ -455,7 +455,7 @@ def _log_and_monitor_expected_errors(request, exception, caller):
             return
 
         # Currently, it seems unexpected that middleware and drf will both handle different uncaught exceptions.
-        # However, since it is possible, we will add an additional attribute and log message and then continue.
+        # We will monitor for this and adjust accordingly if it turns out this is a common case.
         set_custom_attribute('unexpected_multiple_exceptions', cached_module_and_class)
         log.warning(
             "Unexpected scenario where different exceptions are handled by _log_and_monitor_expected_errors. "

--- a/openedx/core/lib/request_utils.py
+++ b/openedx/core/lib/request_utils.py
@@ -458,8 +458,10 @@ def _log_and_monitor_expected_errors(request, exception, caller):
         set_custom_attribute('unexpected_multiple_exceptions', cached_module_and_class)
         log.warning(
             "Unexpected scenario where different exceptions are handled by _log_and_monitor_expected_errors. "
-            "See 'unexpected_multiple_exceptions' custom attribute."
+            "See 'unexpected_multiple_exceptions' custom attribute. Skipping exception for %s.",
+            module_and_class,
         )
+        return
     request_cache.set('handled_exception', module_and_class)
 
     if module_and_class not in expected_error_settings_dict:

--- a/openedx/core/lib/request_utils.py
+++ b/openedx/core/lib/request_utils.py
@@ -291,6 +291,7 @@ class ExpectedErrorMiddleware:
 # .. toggle_description: If True, adds a custom attribute ``error_ignored`` if the error is configured to be ignored
 #      from monitoring. For example, for ignoring errors in New Relic, see:
 #      https://docs.newrelic.com/docs/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected/#ignore  pylint: disable=line-too-long,useless-suppression
+#      Ignored errors would be errors where ``error_ignored IS NOT NULL``.
 #      Note: This is defaulted to True because it will be easier for us to detect if True is not the correct value, by
 #      seeing that these errors aren't actually ignored.
 # .. toggle_warning: At this time, this toggle does not actually configure the error to be ignored. It is meant to match

--- a/openedx/core/lib/request_utils.py
+++ b/openedx/core/lib/request_utils.py
@@ -291,6 +291,8 @@ class ExpectedErrorMiddleware:
 # .. toggle_description: If True, adds a custom attribute ``error_ignored`` if the error is configured to be ignored
 #      from monitoring. For example, for ignoring errors in New Relic, see:
 #      https://docs.newrelic.com/docs/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected/#ignore  pylint: disable=line-too-long,useless-suppression
+#      Note: This is defaulted to True because it will be easier for us to detect if True is not the correct value, by
+#      seeing that these errors aren't actually ignored.
 # .. toggle_warning: At this time, this toggle does not actually configure the error to be ignored. It is meant to match
 #     the ignored error configuration found elsewhere. When monitoring, no errors should ever have the attribute
 #     ``error_ignored``. If it is found, it means we are stating an error should be ignored when it is not actually

--- a/openedx/core/lib/request_utils.py
+++ b/openedx/core/lib/request_utils.py
@@ -7,12 +7,14 @@ import crum
 from django.conf import settings
 from django.test.client import RequestFactory
 from django.utils.deprecation import MiddlewareMixin
+from edx_django_utils.cache import RequestCache
 from edx_django_utils.monitoring import set_custom_attribute
+from edx_toggles.toggles import WaffleFlag
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
+from rest_framework.views import exception_handler
 from six.moves.urllib.parse import urlparse
 
-from edx_toggles.toggles import WaffleFlag
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 # accommodates course api urls, excluding any course api routes that do not fall under v*/courses, such as v1/blocks.
@@ -227,3 +229,235 @@ class CookieMonitoringMiddleware(MiddlewareMixin):
             set_custom_attribute(name_attribute, name)
             set_custom_attribute(size_attribute, size)
             log.debug('%s = %d', name, size)
+
+
+def expected_error_exception_handler(exc, context):
+    """
+    Replacement for DRF's default exception handler to enable observing expected errors.
+
+    In addition to the default behaviour, add logging and monitoring for expected errors.
+    """
+    # Call REST framework's default exception handler first to get the standard error response.
+    response = exception_handler(exc, context)
+
+    try:
+        request = context['request']
+    except TypeError:
+        request = None
+
+    _log_and_monitor_expected_errors(request, exc, 'drf')
+    return response
+
+
+class ExpectedErrorMiddleware:
+    """
+    Middleware to add logging and monitoring for expected errors.
+    """
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        return response
+
+    def process_exception(self, request, exception):
+        """
+        Add logging and monitoring of expected errors.
+        """
+        _log_and_monitor_expected_errors(request, exception, 'middleware')
+
+
+# .. setting_name: EXPECTED_ERRORS
+# .. setting_default: []
+# .. setting_description: Used to configured logging and monitoring for expected errors.
+#     This setting is configured of a list of dicts. See setting and toggle annotations for
+#     ``EXPECTED_ERRORS[N]['XXX']`` for details of each item in the dict.
+#     If this setting is configured, all uncaught errors processed will get a ``checked_error_expected_from`` attribute,
+#     whether they are expected or not. This can be used to ensure that all uncaught errors are actually processed.
+#     Those errors that are processed and match a 'MODULE_AND_CLASS' (documented elsewhere), will get an
+#     ``error_expected`` custom attribute. The value of the custom attribute will include the error class module, name
+#     and message. Unexpected errors would be errors with ``error_expected IS NULL``.
+# .. setting_warning: We use Django Middleware and a DRF custom error handler to find uncaught errors. It is still
+#     possible that some errors could slip by these mechanisms.
+
+# .. setting_name: EXPECTED_ERRORS[N]['MODULE_AND_CLASS']
+# .. setting_default: None
+# .. setting_description: Required error module and class name that is expected. The two names should be separated by a
+#    `:`. For example, ``rest_framework.exceptions:PermissionDenied``. This format is to simplify copying/pasting from
+#    New Relic.
+
+# .. toggle_name: EXPECTED_ERRORS[N]['IS_IGNORED']
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: True
+# .. toggle_description: If True, adds a custom attribute ``error_ignored`` if the error is configured to be ignored
+#      from monitoring. For example, for ignoring errors in New Relic, see:
+#      https://docs.newrelic.com/docs/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected/#ignore  pylint: disable=line-too-long,useless-suppression
+# .. toggle_warning: At this time, this toggle does not actually configure the error to be ignored. It is meant to match
+#     the ignored error configuration found elsewhere. When monitoring, no errors should ever have the attribute
+#     ``error_ignored``. If it is found, it means we are stating an error should be ignored when it is not actually
+#     configured as such, or the configuration is not working.
+# .. toggle_use_cases: opt_out
+# .. toggle_creation_date: 2021-03-11
+
+# .. toggle_name: EXPECTED_ERRORS[N]['LOG_ERROR']
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: If True, the error will be logged with a message like: "Expected error ...".
+# .. toggle_use_cases: opt_in
+# .. toggle_creation_date: 2021-03-11
+
+# .. toggle_name: EXPECTED_ERRORS[N]['LOG_STACK_TRACE']
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: If True, the stacktrace will be included with the logging message. Also, if True, the
+#     ``LOG_ERROR`` toggle value will be ignored, even if disabled.
+# .. toggle_use_cases: opt_in
+# .. toggle_creation_date: 2021-03-11
+
+# .. setting_name: EXPECTED_ERRORS[N]['REASON_EXPECTED']
+# .. setting_default: None
+# .. setting_description: Required string explaining why the error is expected and/or ignored for documentation
+#     purposes.error module and class name that is expected.
+
+
+# Warning: do not access this directly, but instead use get_expected_errors.
+# EXPECTED ERRORS Django setting is processed and stored as a dict keyed by ERROR_MODULE_AND_CLASS.
+_EXPECTED_ERROR_SETTINGS_DICT = None
+
+
+def _get_expected_error_settings_dict():
+    """
+    Returns a dict of dicts of expected error settings used for logging and monitoring.
+
+    The contents of the EXPECTED_ERRORS Django Setting list is processed for efficient lookup by module:class.
+
+    Returns:
+         (dict): dict of dicts, mapping module-and-class name to settings for proper handling of expected errors.
+           Keys of the inner dicts use the lowercase version of the related Django Setting (e.g. ''REASON_EXPECTED' =>
+           'reason_expected').
+
+    Example return value::
+
+        {
+            'rest_framework.exceptions:PermissionDenied': {
+                'is_ignored': True,
+                'log_error': True,
+                'log_stack_trace': True,
+                'reason_expected': 'In most cases, signifies a user was trying to do something they couldn't.' /
+                   'It is possible that there could be a bug, so this case should still be monitored at some level.'
+            }
+            ...
+        }
+
+    """
+    global _EXPECTED_ERROR_SETTINGS_DICT
+
+    # Return cached processed mappings if already processed
+    if _EXPECTED_ERROR_SETTINGS_DICT is not None:
+        return _EXPECTED_ERROR_SETTINGS_DICT
+
+    expected_errors = getattr(settings, 'EXPECTED_ERRORS', None)
+    if expected_errors is None:
+        return None
+
+    # Use temporary variable to build mappings to avoid multi-threading issue with a partially
+    # processed map.  Worst case, it is processed more than once at start-up.
+    expected_error_settings_dict = {}
+
+    try:
+        for index, expected_error in enumerate(expected_errors):
+            module_and_class = expected_error.get('MODULE_AND_CLASS')
+            processed_expected_error = {
+                'is_ignored': expected_error.get('IS_IGNORED', True),
+                'log_error': expected_error.get('LOG_ERROR', False),
+                'log_stack_trace': expected_error.get('LOG_STACK_TRACE', False),
+                'reason_expected': expected_error.get('REASON_EXPECTED'),
+            }
+
+            # validate configuration
+            if not isinstance(module_and_class, str) or ':' not in module_and_class:
+                log.error(
+                    "Skipping EXPECTED_ERRORS[%d] setting. 'MODULE_AND_CLASS' set to [%s] and should be module:class, "
+                    "like 'rest_framework.exceptions:PermissionDenied'.",
+                    index, module_and_class
+                )
+                continue
+            if not processed_expected_error['reason_expected']:
+                log.error(
+                    "Skipping EXPECTED_ERRORS[%d] setting. 'REASON_EXPECTED' is required to document why %s is an "
+                    "expected error.",
+                    index, module_and_class
+                )
+                continue
+
+            expected_error_settings_dict[module_and_class] = processed_expected_error
+    except Exception as e:  # pylint: disable=broad-except
+        set_custom_attribute('expected_errors_setting_misconfigured', repr(e))
+        log.exception(f'Error processing setting EXPECTED_ERRORS. {repr(e)}')
+
+    _EXPECTED_ERROR_SETTINGS_DICT = expected_error_settings_dict
+    return _EXPECTED_ERROR_SETTINGS_DICT
+
+
+def clear_cached_expected_error_settings():
+    """
+    Clears the cached expected error settings. Useful for testing.
+    """
+    global _EXPECTED_ERROR_SETTINGS_DICT
+    _EXPECTED_ERROR_SETTINGS_DICT = None
+
+
+def _log_and_monitor_expected_errors(request, exception, caller):
+    """
+    Adds logging and monitoring for expected errors as needed.
+
+    Arguments:
+        request: The request
+        exception: The exception
+        caller: Either 'middleware' or 'drf`
+    """
+    expected_error_settings_dict = _get_expected_error_settings_dict()
+    if not expected_error_settings_dict:
+        return
+
+    # 'module:class', for example, 'django.core.exceptions:PermissionDenied'
+    # Note: `Exception` itself doesn't have a module.
+    exception_module = exception.__module__ if hasattr(exception, '__module__') else ''
+    module_and_class = f'{exception_module}:{exception.__class__.__name__}'
+
+    # Set checked_error_expected_from custom attribute to potentially help find issues where errors are never processed.
+    set_custom_attribute('checked_error_expected_from', caller)
+
+    # check if we already added logging/monitoring from a different caller
+    request_cache = RequestCache('openedx.core.lib.request_utils')
+    cached_handled_exception = request_cache.get_cached_response('handled_exception')
+    if cached_handled_exception.is_found:
+        cached_module_and_class = cached_handled_exception.value
+        # exception was already processed by a different caller
+        if cached_handled_exception.value == module_and_class:
+            set_custom_attribute('checked_error_expected_from', 'multiple')
+            return
+
+        # Currently, it seems unexpected that middleware and drf will both handle different uncaught exceptions.
+        # However, since it is possible, we will add an additional attribute and log message and then continue.
+        set_custom_attribute('unexpected_multiple_exceptions', cached_module_and_class)
+        log.warning(
+            "Unexpected scenario where different exceptions are handled by _log_and_monitor_expected_errors. "
+            "See 'unexpected_multiple_exceptions' custom attribute."
+        )
+    request_cache.set('handled_exception', module_and_class)
+
+    if module_and_class not in expected_error_settings_dict:
+        return
+
+    module_and_class_with_message = f'{exception_module}:{repr(exception)}'
+    set_custom_attribute('error_expected', module_and_class_with_message)
+
+    expected_error_settings = expected_error_settings_dict[module_and_class]
+    if expected_error_settings['is_ignored']:
+        set_custom_attribute('error_ignored', True)
+
+    if expected_error_settings['log_error'] or expected_error_settings['log_stack_trace']:
+        print_stack = expected_error_settings['log_stack_trace']
+        request_path = request.path if hasattr(request, 'path') else 'request-path-unknown'
+        log.info('Expected error seen for %s', request_path, exc_info=exception, stack_info=print_stack)

--- a/openedx/core/lib/tests/test_request_utils.py
+++ b/openedx/core/lib/tests/test_request_utils.py
@@ -1,17 +1,25 @@
 """Tests for request_utils module."""
+
 import unittest
 from unittest.mock import Mock, call, patch
 
+import ddt
 import pytest
 from django.conf import settings
 from django.core.exceptions import SuspiciousOperation
 from django.test.client import RequestFactory
+from django.test.utils import override_settings
+from edx_django_utils.cache import RequestCache
 
 from openedx.core.lib.request_utils import (
     CookieMonitoringMiddleware,
+    ExpectedErrorMiddleware,
+    _get_expected_error_settings_dict,
+    clear_cached_expected_error_settings,
     course_id_from_url,
+    expected_error_exception_handler,
     get_request_or_stub,
-    safe_get_host
+    safe_get_host,
 )
 
 
@@ -202,3 +210,287 @@ class RequestUtilTestCase(unittest.TestCase):
             call('cookies.2.size', 10),
             call('cookies_total_size', 25),
         ], any_order=True)
+
+
+class TestGetExpectedErrorSettingsDict(unittest.TestCase):
+    """
+    Tests for processing issues in _get_expected_error_settings_dict()
+
+    Note: Although this is a private method, we have broken out the testing of
+      special cases so they don't have to be tested with the middleware and drf
+      custom error handler.
+    """
+    def setUp(self):
+        super().setUp()
+        clear_cached_expected_error_settings()
+
+    def test_get_with_no_setting(self):
+        expected_error_settings_dict = _get_expected_error_settings_dict()
+        assert expected_error_settings_dict is None
+
+    @override_settings(EXPECTED_ERRORS=[])
+    def test_get_with_empty_list_setting(self):
+        expected_error_settings_dict = _get_expected_error_settings_dict()
+        assert expected_error_settings_dict == {}
+
+    MODULE_AND_CLASS_MESSAGE = "Skipping EXPECTED_ERRORS[%d] setting. 'MODULE_AND_CLASS' set to [%s] and should " \
+                               "be module:class, like 'rest_framework.exceptions:PermissionDenied'."
+
+    @patch('openedx.core.lib.request_utils.log')
+    @override_settings(EXPECTED_ERRORS=[{}])
+    def test_get_with_missing_module_and_class(self, mock_logger):
+        expected_error_settings_dict = _get_expected_error_settings_dict()
+        mock_logger.error.assert_called_once_with(self.MODULE_AND_CLASS_MESSAGE, 0, None)
+        assert expected_error_settings_dict == {}
+
+    @patch('openedx.core.lib.request_utils.log')
+    @override_settings(EXPECTED_ERRORS=[{'MODULE_AND_CLASS': 'invalid.module.and.class'}])
+    def test_get_with_invalid_class_and_module(self, mock_logger):
+        expected_error_settings_dict = _get_expected_error_settings_dict()
+        mock_logger.error.assert_called_once_with(self.MODULE_AND_CLASS_MESSAGE, 0, 'invalid.module.and.class')
+        assert expected_error_settings_dict == {}
+
+    @patch('openedx.core.lib.request_utils.log')
+    @override_settings(EXPECTED_ERRORS=[{'MODULE_AND_CLASS': 'valid.module.and.class:ButMissingReason'}])
+    def test_get_with_missing_reason(self, mock_logger):
+        expected_error_settings_dict = _get_expected_error_settings_dict()
+        mock_logger.error.assert_called_once_with(
+            "Skipping EXPECTED_ERRORS[%d] setting. 'REASON_EXPECTED' is required to document why %s is an expected "
+            "error.",
+            0, 'valid.module.and.class:ButMissingReason'
+        )
+        assert expected_error_settings_dict == {}
+
+    @patch('openedx.core.lib.request_utils.log')
+    @override_settings(EXPECTED_ERRORS=['not-a-dict'])
+    def test_get_with_invalid_dict(self, mock_logger):
+        expected_error_settings_dict = _get_expected_error_settings_dict()
+        mock_logger.exception.assert_called_once_with(
+            'Error processing setting EXPECTED_ERRORS. AttributeError("\'str\' object has no attribute \'get\'")'
+        )
+        assert expected_error_settings_dict == {}
+
+    @override_settings(EXPECTED_ERRORS=[{
+        'MODULE_AND_CLASS': 'test.module:TestClass',
+        'REASON_EXPECTED': 'Because'
+    }])
+    def test_get_with_defaults(self):
+        expected_error_settings_dict = _get_expected_error_settings_dict()
+        assert expected_error_settings_dict == {
+            'test.module:TestClass': {
+                'is_ignored': True,
+                'log_error': False,
+                'log_stack_trace': False,
+                'reason_expected': 'Because'
+            }
+        }
+
+
+class CustomError1(Exception):
+    pass
+
+
+class CustomError2(Exception):
+    pass
+
+
+@ddt.ddt
+class TestExpectedErrorMiddleware(unittest.TestCase):
+    """
+    Tests for ExpectedErrorMiddleware
+    """
+    def setUp(self):
+        super().setUp()
+        RequestCache.clear_all_namespaces()
+        clear_cached_expected_error_settings()
+        self.mock_request = RequestFactory().get('/test')
+        self.mock_exception = CustomError1('Test failure')
+
+    def test_get_response(self):
+        expected_response = Mock()
+
+        middleware = ExpectedErrorMiddleware(lambda _: expected_response)
+        response = middleware(self.mock_request)
+
+        assert response == expected_response
+
+    @patch('openedx.core.lib.request_utils.set_custom_attribute')
+    @patch('openedx.core.lib.request_utils.log')
+    def test_process_exception_no_expected_errors(self, mock_logger, mock_set_custom_attribute):
+        ExpectedErrorMiddleware('mock-response').process_exception(self.mock_request, self.mock_exception)
+
+        mock_logger.info.assert_not_called()
+        mock_set_custom_attribute.assert_not_called()
+
+    @patch('openedx.core.lib.request_utils.set_custom_attribute')
+    @patch('openedx.core.lib.request_utils.log')
+    @ddt.data(None, [])
+    def test_process_exception_with_empty_expected_errors(
+        self, expected_errors_setting, mock_logger, mock_set_custom_attribute,
+    ):
+        with override_settings(EXPECTED_ERRORS=expected_errors_setting):
+            ExpectedErrorMiddleware('mock-response').process_exception(self.mock_request, self.mock_exception)
+
+        mock_logger.info.assert_not_called()
+        mock_set_custom_attribute.assert_not_called()
+
+    @override_settings(EXPECTED_ERRORS=[{
+        'MODULE_AND_CLASS': 'test.module:TestException',
+        'REASON_EXPECTED': 'Because',
+    }])
+    @patch('openedx.core.lib.request_utils.set_custom_attribute')
+    @patch('openedx.core.lib.request_utils.log')
+    def test_process_exception_not_matching_expected_errors(self, mock_logger, mock_set_custom_attribute):
+        ExpectedErrorMiddleware('mock-response').process_exception(self.mock_request, self.mock_exception)
+
+        mock_logger.info.assert_not_called()
+        mock_set_custom_attribute.assert_called_once_with('checked_error_expected_from', 'middleware')
+
+    @override_settings(EXPECTED_ERRORS=[
+        {
+            'MODULE_AND_CLASS': 'test.module:TestException',
+            'REASON_EXPECTED': 'Because',
+        },
+        {
+            'MODULE_AND_CLASS': 'openedx.core.lib.tests.test_request_utils:CustomError1',
+            'REASON_EXPECTED': 'Because',
+        }
+    ])
+    @patch('openedx.core.lib.request_utils.set_custom_attribute')
+    @patch('openedx.core.lib.request_utils.log')
+    def test_process_exception_expected_error_with_defaults(self, mock_logger, mock_set_custom_attribute):
+        ExpectedErrorMiddleware('mock-response').process_exception(self.mock_request, self.mock_exception)
+
+        mock_logger.info.assert_not_called()
+        mock_set_custom_attribute.assert_has_calls(
+            [
+                call('checked_error_expected_from', 'middleware'),
+                call('error_expected', "openedx.core.lib.tests.test_request_utils:CustomError1('Test failure')"),
+                call('error_ignored', True)
+            ],
+            any_order=True
+        )
+
+    @override_settings(EXPECTED_ERRORS=[
+        {
+            'MODULE_AND_CLASS': 'openedx.core.lib.tests.test_request_utils:CustomError1',
+            'REASON_EXPECTED': 'Because',
+        },
+        {
+            'MODULE_AND_CLASS': 'openedx.core.lib.tests.test_request_utils:CustomError2',
+            'REASON_EXPECTED': 'Because',
+        }
+    ])
+    @patch('openedx.core.lib.request_utils.set_custom_attribute')
+    @ddt.data(True, False)
+    def test_process_exception_called_multiple_times(self, use_same_exception, mock_set_custom_attribute):
+        mock_first_exception = self.mock_exception
+        mock_second_exception = mock_first_exception if use_same_exception else CustomError2("Oops")
+
+        ExpectedErrorMiddleware('mock-response').process_exception(self.mock_request, mock_first_exception)
+        ExpectedErrorMiddleware('mock-response').process_exception(self.mock_request, mock_second_exception)
+
+        expected_calls = [
+            call('checked_error_expected_from', 'middleware'),
+            call('error_expected', "openedx.core.lib.tests.test_request_utils:CustomError1('Test failure')"),
+            call('error_ignored', True),
+            call('checked_error_expected_from', 'middleware'),
+        ]
+        if use_same_exception:
+            expected_calls += [call('checked_error_expected_from', 'multiple')]
+        else:
+            expected_calls += [
+                call('unexpected_multiple_exceptions', 'openedx.core.lib.tests.test_request_utils:CustomError1'),
+                call('error_expected', "openedx.core.lib.tests.test_request_utils:CustomError2('Oops')"),
+                call('error_ignored', True),
+            ]
+        mock_set_custom_attribute.assert_has_calls(expected_calls)
+        assert mock_set_custom_attribute.call_count == len(expected_calls)
+
+    @override_settings(EXPECTED_ERRORS=[{
+        'MODULE_AND_CLASS': ':Exception',
+        'REASON_EXPECTED': 'Because',
+    }])
+    @patch('openedx.core.lib.request_utils.set_custom_attribute')
+    def test_process_exception_with_plain_exception(self, mock_set_custom_attribute):
+        mock_exception = Exception("Oops")
+        ExpectedErrorMiddleware('mock-response').process_exception(self.mock_request, mock_exception)
+
+        mock_set_custom_attribute.assert_has_calls([call('error_expected', ":Exception('Oops')")])
+
+    @patch('openedx.core.lib.request_utils.set_custom_attribute')
+    @patch('openedx.core.lib.request_utils.log')
+    @ddt.data(
+        (True, False),  # log without stacktrace
+        (True, True),   # log with stacktrace
+        (False, True),  # log with stacktrace overrides disabled logging
+    )
+    @ddt.unpack
+    def test_process_exception_expected_error_with_overrides(
+        self, log_error, log_stack_trace, mock_logger, mock_set_custom_attribute,
+    ):
+        with override_settings(EXPECTED_ERRORS=[{
+            'MODULE_AND_CLASS': 'openedx.core.lib.tests.test_request_utils:CustomError1',
+            'IS_IGNORED': False,
+            'LOG_ERROR': log_error,
+            'LOG_STACK_TRACE': log_stack_trace,
+            'REASON_EXPECTED': 'Because',
+        }]):
+            ExpectedErrorMiddleware('mock-response').process_exception(self.mock_request, self.mock_exception)
+
+        mock_logger.info.assert_called_once_with(
+            'Expected error seen for %s', '/test', exc_info=self.mock_exception, stack_info=log_stack_trace
+        )
+        mock_set_custom_attribute.assert_has_calls(
+            [
+                call('checked_error_expected_from', 'middleware'),
+                call('error_expected', "openedx.core.lib.tests.test_request_utils:CustomError1('Test failure')"),
+            ],
+            any_order=True
+        )
+
+
+@ddt.ddt
+class TestExpectedErrorExceptionHandler(unittest.TestCase):
+    """
+    Tests for expected_error_exception_handler.
+
+    Note: Only smoke tests the handler to not duplicate all testing in TestExpectedErrorMiddleware.
+    """
+    def setUp(self):
+        super().setUp()
+        RequestCache.clear_all_namespaces()
+        clear_cached_expected_error_settings()
+        self.mock_request = RequestFactory().get('/test')
+        self.mock_exception = CustomError1('Test failure')
+
+    @override_settings(EXPECTED_ERRORS=[{
+        'MODULE_AND_CLASS': 'openedx.core.lib.tests.test_request_utils:CustomError1',
+        'LOG_ERROR': True,
+        'REASON_EXPECTED': 'Because',
+    }])
+    @patch('openedx.core.lib.request_utils.set_custom_attribute')
+    @patch('openedx.core.lib.request_utils.log')
+    @ddt.data(True, False)
+    def test_handler_with_expected_error(
+        self, use_valid_context, mock_logger, mock_set_custom_attribute
+    ):
+        if use_valid_context:
+            mock_context = {'request': self.mock_request}
+            expected_request_path = '/test'
+        else:
+            mock_context = None
+            expected_request_path = 'request-path-unknown'
+        expected_error_exception_handler(self.mock_exception, mock_context)
+
+        mock_logger.info.assert_called_once_with(
+            'Expected error seen for %s', expected_request_path, exc_info=self.mock_exception, stack_info=False
+        )
+        mock_set_custom_attribute.assert_has_calls(
+            [
+                call('checked_error_expected_from', 'drf'),
+                call('error_expected', "openedx.core.lib.tests.test_request_utils:CustomError1('Test failure')"),
+                call('error_ignored', True)
+            ],
+            any_order=True
+        )

--- a/openedx/core/lib/tests/test_request_utils.py
+++ b/openedx/core/lib/tests/test_request_utils.py
@@ -435,8 +435,6 @@ class TestExpectedErrorMiddleware(unittest.TestCase):
         else:
             expected_calls += [
                 call('unexpected_multiple_exceptions', 'openedx.core.lib.tests.test_request_utils.CustomError1'),
-                call('error_expected', "openedx.core.lib.tests.test_request_utils.CustomError2('Oops')"),
-                call('error_ignored', True),
             ]
         mock_set_custom_attribute.assert_has_calls(expected_calls)
         assert mock_set_custom_attribute.call_count == len(expected_calls)


### PR DESCRIPTION
## Description

Adds logging and monitoring capabilities for expected errors. See the annotation documentation for the EXPECTED_ERRORS setting for help with configuring and using the new features.

This change is for developers and operators, to assist in diagnosing issues in Production.

This logging and monitoring effort is related to two recent RCAs:
* In one case, we were missing logging information for New Relic ignore errors that possibly added 2+ months to the investigation. Also, there was hesitation to change the error to no longer be ignored, because it might have set off alerts.
* In another case, New Relic's ignored errors feature stopped working correctly, and a proper alert for this could have saved a bunch of time diagnosing.

I hypothesize that this would reduce MTTR for diagnosing any issues related to our ignored errors, which are errors that mostly are expected, but sometimes are unexpected. However, we won’t know this for sure unless people report that they used the additional logging/monitoring for diagnosis, or if an alert goes off to let us know that New Relic ignored errors is broken.

## Supporting information

https://openedx.atlassian.net/browse/ARCHBOM-1708

## Testing instructions

There is currently unit test coverage. I tested logging locally and added a comment with an example.  I don't plan on sandbox testing unless that is requested.

## Sample Log Output

Here is some sample output of the logging code.

### Without stack trace
```
2021-03-15 22:04:00,967 INFO 5078 [openedx.core.lib.request_utils] [user None] [ip 172.18.0.1] request_utils.py:481 - Expected error rest_framework.exceptions.NotAuthenticated('Authentication credentials were not provided.') seen for path /api/toggles/v0/state/
```

### With stack trace
```
2021-03-15 22:01:17,931 INFO 4952 [openedx.core.lib.request_utils] [user None] [ip 172.18.0.1] request_utils.py:481 - Expected error rest_framework.exceptions.NotAuthenticated('Authentication credentials were not provided.') seen for path /api/toggles/v0/state/
Traceback (most recent call last):
  File "/edx/src/django-rest-framework/rest_framework/views.py", line 497, in dispatch
    self.initial(request, *args, **kwargs)
  File "/edx/src/django-rest-framework/rest_framework/views.py", line 415, in initial
    self.check_permissions(request)
  File "/edx/src/django-rest-framework/rest_framework/views.py", line 333, in check_permissions
    self.permission_denied(
  File "/edx/src/django-rest-framework/rest_framework/views.py", line 174, in permission_denied
    raise exceptions.NotAuthenticated()
rest_framework.exceptions.NotAuthenticated: Authentication credentials were not provided.
```

## Deadline

It is unclear if this would be useful now for tuning Rate Limits, which are currently ignored errors in New Relic.