### PR TITLE
feat: Allow optionally passing PII in course LTI tab [BD-38] [BB-3899] [TNL-8104]

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -20,7 +20,7 @@ from edx_proctoring.api import (
 )
 from edx_proctoring.exceptions import ProctoredExamNotFoundException
 from help_tokens.core import HelpUrlExpert
-from lti_consumer.models import CourseEditLTIFieldsEnabledFlag
+from lti_consumer.models import CourseAllowPIISharingInLTIFlag
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import LibraryUsageLocator
 from pytz import UTC
@@ -311,7 +311,7 @@ class StudioEditModuleRuntime:
             if service_name == "settings":
                 return SettingsService()
             if service_name == "lti-configuration":
-                return ConfigurationService(CourseEditLTIFieldsEnabledFlag)
+                return ConfigurationService(CourseAllowPIISharingInLTIFlag)
             if service_name == "teams_configuration":
                 return TeamsConfigurationService()
             if service_name == "library_tools":

--- a/openedx/features/lti_course_tab/tab.py
+++ b/openedx/features/lti_course_tab/tab.py
@@ -8,6 +8,7 @@ from django.contrib.auth.models import AbstractBaseUser
 from django.contrib.sites.shortcuts import get_current_site
 from django.http import HttpRequest
 from django.utils.translation import get_language, to_locale, ugettext_lazy
+from lti_consumer.api import get_lti_pii_sharing_state_for_course
 from lti_consumer.lti_1p1.contrib.django import lti_embed
 from lti_consumer.models import LtiConfiguration
 from opaque_keys.edx.keys import CourseKey
@@ -34,7 +35,43 @@ class LtiCourseLaunchMixin:
     }
     DEFAULT_ROLE = 'Student'
 
+    def _get_pii_lti_parameters(self, course: CourseBlock, request: HttpRequest) -> Dict[str, str]:
+        """
+        Get LTI parameters that contain PII.
+
+        Args:
+            course (CourseBlock): CourseBlock object.
+            request (HttpRequest): Request object for view in which LTI will be embedded.
+
+        Returns:
+            Dictionary with LTI parameters containing PII.
+        """
+        pii_sharing_allowed = get_lti_pii_sharing_state_for_course(course.id)
+        if not pii_sharing_allowed:
+            return {}
+        lti_config = self._get_lti_config(course)
+        # Currently only LTI 1.1 is supported by the tab
+        if lti_config.version != lti_config.LTI_1P1:
+            return {}
+
+        pii_config = {}
+        if lti_config.pii_share_username:
+            pii_config['person_sourcedid'] = request.user.username
+        if lti_config.pii_share_email:
+            pii_config['person_contact_email_primary'] = request.user.email
+        return pii_config
+
     def _get_additional_lti_parameters(self, course: CourseBlock, request: HttpRequest) -> Dict[str, str]:
+        """
+        Get additional misc LTI parameters.
+
+        Args:
+            course (CourseBlock): CourseBlock object.
+            request (HttpRequest): Request object for view in which LTI will be embedded.
+
+        Returns:
+            Dictionary with additional LTI parameters.
+        """
         lti_config = self._get_lti_config(course)
         additional_config = lti_config.lti_config.get('additional_parameters', {})
         return additional_config
@@ -98,6 +135,7 @@ class LtiCourseLaunchMixin:
         context_title = self._get_context_title(course)
         result_sourcedid = quote(self._get_result_sourcedid(context_id, resource_link_id, user_id))
         additional_params = self._get_additional_lti_parameters(course, request)
+        pii_params = self._get_pii_lti_parameters(course, request)
         locale = to_locale(get_language())
 
         return lti_embed(
@@ -111,6 +149,7 @@ class LtiCourseLaunchMixin:
             context_label=context_id,
             result_sourcedid=result_sourcedid,
             launch_presentation_locale=locale,
+            **pii_params,
             **additional_params,
         )
 

--- a/openedx/features/lti_course_tab/tests.py
+++ b/openedx/features/lti_course_tab/tests.py
@@ -1,39 +1,76 @@
 """
 Tests for LTI Course tabs.
 """
+import itertools
 from unittest.mock import Mock, patch
 
+import ddt
+from django.test import RequestFactory
+from lti_consumer.models import CourseAllowPIISharingInLTIFlag, LtiConfiguration
+
 from lms.djangoapps.courseware.tests.test_tabs import TabTestCase
+from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration
 from openedx.features.lti_course_tab.tab import DiscussionLtiCourseTab
 
 
+@ddt.ddt
 class DiscussionLtiCourseTabTestCase(TabTestCase):
     """Test cases for LTI Discussion Tab."""
+
+    def setUp(self):
+        super().setUp()
+        self.discussion_config = DiscussionsConfiguration.objects.create(context_key=self.course.id, enabled=False)
+        self.discussion_config.lti_configuration = LtiConfiguration.objects.create(
+            config_store=LtiConfiguration.CONFIG_ON_DB,
+            lti_1p1_launch_url='http://test.url',
+            lti_1p1_client_key='test_client_key',
+            lti_1p1_client_secret='test_client_secret',
+        )
+        self.discussion_config.save()
+        self.url = self.reverse('course_tab_view', args=[str(self.course.id), DiscussionLtiCourseTab.type])
 
     def check_discussion_tab(self):
         """Helper function for verifying the LTI discussion tab."""
         return self.check_tab(
             tab_class=DiscussionLtiCourseTab,
             dict_tab={'type': DiscussionLtiCourseTab.type, 'name': 'same'},
-            expected_link=self.reverse('course_tab_view', args=[str(self.course.id), DiscussionLtiCourseTab.type]),
+            expected_link=self.url,
             expected_tab_id=DiscussionLtiCourseTab.type,
             invalid_dict_tab=None,
         )
 
-    @patch('openedx.features.lti_course_tab.tab.DiscussionsConfiguration.get')
-    @patch('common.djangoapps.student.models.CourseEnrollment.is_enrolled')
-    def test_discussion_lti_tab(self, is_enrolled, discussion_config_get):
-        is_enrolled.return_value = True
-        mock_config = Mock()
-        mock_config.lti_configuration = {}
-        mock_config.enabled = False
-        discussion_config_get.return_value = mock_config
+    @ddt.data(True, False)
+    @patch('common.djangoapps.student.models.CourseEnrollment.is_enrolled', Mock(return_value=True))
+    def test_pii_params_on_discussion_lti_tab(self, discussion_config_enabled):
+        self.discussion_config.enabled = discussion_config_enabled
+        self.discussion_config.save()
         tab = self.check_discussion_tab()
         self.check_can_display_results(
-            tab, for_staff_only=True, for_enrolled_users_only=True, expected_value=False
+            tab,
+            for_staff_only=True,
+            for_enrolled_users_only=True,
+            expected_value=discussion_config_enabled,
         )
-        mock_config.enabled = True
-        self.check_discussion_tab()
-        self.check_can_display_results(
-            tab, for_staff_only=True, for_enrolled_users_only=True
-        )
+
+    @ddt.data(*itertools.product((True, False), repeat=3))
+    @ddt.unpack
+    def test_discussion_lti_tab_pii(self, enable_sending_pii, share_username, share_email):
+        CourseAllowPIISharingInLTIFlag.objects.create(course_id=self.course.id, enabled=enable_sending_pii)
+        self.discussion_config.lti_configuration.lti_config = {
+            "pii_share_username": share_username,
+            "pii_share_email": share_email,
+        }
+        self.discussion_config.lti_configuration.save()
+        tab = self.check_discussion_tab()
+        request = RequestFactory().get(self.url)
+        user = self.create_mock_user(is_enrolled=True)
+        request.user = user
+        embed_code = tab._get_lti_embed_code(self.course, request)  # pylint: disable=protected-access
+        if enable_sending_pii and share_username:
+            assert user.username in embed_code
+        else:
+            assert user.username not in embed_code
+        if enable_sending_pii and share_email:
+            assert user.email in embed_code
+        else:
+            assert user.email not in embed_code

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -596,7 +596,7 @@ libsass==0.10.0
     #   ora2
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==2.11.0
+lti-consumer-xblock==3.0.0
     # via -r requirements/edx/base.in
 lxml==4.5.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -776,7 +776,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/testing.txt
     #   ora2
-lti-consumer-xblock==2.11.0
+lti-consumer-xblock==3.0.0
     # via -r requirements/edx/testing.txt
 lxml==4.5.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -741,7 +741,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==2.11.0
+lti-consumer-xblock==3.0.0
     # via -r requirements/edx/base.txt
 lxml==4.5.0
     # via


### PR DESCRIPTION
Adds the ability to pass PII to an LTI provider in the LTI course tab if the LtiConfiguration associated with that tab is configured to allow that. 

**Jira task**: https://openedx.atlassian.net/browse/TNL-8104

**Dependencies**: None

**Sandbox URL**: 

    LMS: https://pr26982.sandbox.opencraft.hosting/
    Studio: https://studio.pr26982.sandbox.opencraft.hosting/



**Merge deadline**: "None"

**Testing instructions**:

1. Set up a new course with an LTI-based discussion provider.
2. In the `LtiConfiguration` for this provider set the `lti_config` to: 
    ```{"ask_to_send_username":true,"ask_to_send_email":true}```
3. Check and see if it's passing the data to the LTI provider. 

**Reviewers**
- [ ] (OpenCraft internal reviewer's GitHub username goes here)
- [ ] edX reviewer[s] TBD

