### PR TITLE
EDUCATOR-5571: filter gradebook api by course staff role

### DIFF
--- a/lms/djangoapps/grades/rest_api/v1/gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/gradebook_views.py
@@ -618,6 +618,17 @@ class GradebookView(GradeViewMixin, PaginatedAPIView):
                 q_object |= Q(course_grade_in_range=True)
 
                 q_objects.append(q_object)
+            if request.GET.get('excluded_course_roles'):
+                excluded_course_roles = request.GET.getlist('excluded_course_roles')
+                if 'all' in excluded_course_roles:
+                    q_objects.append(~Q(user__courseaccessrole__course_id=course_key))
+                else:
+                    q_objects.append(
+                        ~Q(
+                            user__courseaccessrole__course_id=course_key,
+                            user__courseaccessrole__role__in=excluded_course_roles
+                        )
+                    )
 
             entries = []
             related_models = ['user']

--- a/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
@@ -1321,7 +1321,8 @@ class GradebookViewTest(GradebookViewTestBase):
             self.program_student.username,
             self.program_masters_student.username
         ]
-        self._assert_usernames(response,
+        self._assert_usernames(
+            response,
             course_students + [staff_user.username]
         )
 
@@ -1422,6 +1423,7 @@ class GradebookViewTest(GradebookViewTestBase):
                 self.program_masters_student.username,
             ]
         )
+
 
 @ddt.ddt
 class GradebookBulkUpdateViewTest(GradebookViewTestBase):

--- a/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
@@ -1315,13 +1315,15 @@ class GradebookViewTest(GradebookViewTestBase):
         with override_waffle_flag(self.waffle_flag, active=True):
             with self._mock_all_course_grade_reads():
                 response = self.client.get(self.get_url(course_key=self.course.id))
-        self._assert_usernames(response, [
+        course_students = [
             self.student.username,
             self.other_student.username,
             self.program_student.username,
-            self.program_masters_student.username,
-            staff_user.username,
-        ])
+            self.program_masters_student.username
+        ]
+        self._assert_usernames(response,
+            course_students + [staff_user.username]
+        )
 
     @ddt.data(
         None,


### PR DESCRIPTION
## Description

-Add an optional parameter, `excluded_course_roles`, to the GradebookView.
- This parameter will exclude from results users with course roles, in order to enable a new feature in gradebook that will filter out course staff from results.

## Supporting information

[EDUCATOR-5571](https://openedx.atlassian.net/browse/EDUCATOR-5571)

## Testing instructions

Unfortunately without the gradebook change this is slightly more difficult to test.
- Log in to LMS
- Navigate to a  course with users enrolled (the managements command `create_test_users` may be useful here)
- Under the Instructor Dashboard -> Membership -> Course Team Management, add enrolled learners to the following roles(see below*):
        + Staff
        + Admin
        + Beta Tester
        + Course Data Researcher
- Make a request to <lms>/api/grades/v1/gradebook/<course_id>
- You should see a result for every enrolled user in the course, whether or not they have a course role.
- now, make a request to <previous_url>/?excluded_course_roles=all
- You should see only those without the above specified roles.
- You can also exclude specific roles:
        + Staff: <previous_url>/?excluded_course_roles=staff
        + Admin: <previous_url>/?excluded_course_roles=instructor
        + Beta Tester: <previous_url>/?excluded_course_roles=beta_testers
        + Course Data Researcher: <previous_url>/?excluded_course_roles=data_researcher
- These should result in all but the specified role.

## Deadline

None

## Other information

- This enables [the gradebook pr](https://github.com/edx/frontend-app-gradebook/pull/168)
- @edx/masters-devs-gta 
