### PR TITLE
BOM-2453

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_proctoring.py
+++ b/cms/djangoapps/contentstore/tests/test_proctoring.py
@@ -12,6 +12,8 @@ from edx_proctoring.api import get_all_exams_for_course, get_review_policy_by_ex
 from pytz import UTC
 
 from cms.djangoapps.contentstore.signals.handlers import listen_for_course_publish
+from common.djangoapps.student.tests.factories import UserFactory
+from common.lib.xmodule.xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
@@ -36,6 +38,9 @@ class TestProctoredExams(ModuleStoreTestCase):
             enable_proctored_exams=True,
             proctoring_provider=settings.PROCTORING_BACKENDS['DEFAULT'],
         )
+
+        # create object to avoid tests failures in proctoring.
+        UserFactory(id=ModuleStoreEnum.UserID.test)
 
     def _verify_exam_data(self, sequence, expected_active):
         """

--- a/cms/djangoapps/contentstore/tests/test_tasks.py
+++ b/cms/djangoapps/contentstore/tests/test_tasks.py
@@ -73,6 +73,15 @@ class ExportCourseTestCase(CourseTestCase):
         result = export_olx.delay(user.id, key, 'en')
         self._assert_failed(result, f'Unknown User ID: {user.id}')
 
+    def test_non_course_author(self):
+        """
+        Verify that users who aren't authors of the course are unable to export it
+        """
+        _, nonstaff_user = self.create_non_staff_authed_user_client()
+        key = str(self.course.location.course_key)
+        result = export_olx.delay(nonstaff_user.id, key, 'en')
+        self._assert_failed(result, 'Permission denied')
+
     def _assert_failed(self, task_result, error_message):
         """
         Verify that a task failed with the specified error message

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
@@ -1594,7 +1594,7 @@ class TestLMSAccountRetirementPost(RetirementTestCase, ModuleStoreTestCase):
             plugin=rp,
             user=self.test_user,
         )
-        article = Article.objects.create()
+        article = Article.objects.create(id=rp.article_id)
         ArticleRevision.objects.create(ip_address="ipaddresss", user=self.test_user, article=article)
 
         # ManualEnrollmentAudit setup


### PR DESCRIPTION
Tests are failing locally in 3 different apps with ubunut20. But on jenkins with ubuntu16 they are passing.

On jenkins sqlite3 version == **'3.14.1'** and ubuntu20 == **'3.31.1'**

Reasons:
User ID is setting [here](https://github.com/edx/edx-platform/blob/bebcbef3dd3604321321bf4488be12f3f317ff60/common/lib/xmodule/xmodule/modulestore/__init__.py#L108) as -3
 
It throws error [here](https://github.com/edx/edx-proctoring/blob/8566363dcdf914e8715399948252f62b939fc2e5/edx_proctoring/api.py#L152)  in  edx_proctoring/api.py -->create_exam_review_policy as it did't find any related object in auth-user table.

```
django.db.utils.IntegrityError: 
The row in table 'proctoring_proctoredexamreviewpolicy' with primary key '1' 
has an invalid foreign key: proctoring_proctoredexamreviewpolicy.set_by_
user_id contains a value '-3' that does not have a corresponding value 
in auth_user.id.
```


In other fix article id was mis-match.