### PR TITLE
build: begin linting imports

### DIFF
--- a/.github/workflows/lint-imports.yml
+++ b/.github/workflows/lint-imports.yml
@@ -1,0 +1,54 @@
+name: Lint Python Imports
+
+on: pull_request
+
+jobs:
+
+  lint-imports:
+    name: Lint Python Imports
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Check out branch
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+
+      - name: Install system requirements
+        run: sudo apt update && sudo apt install -y libxmlsec1-dev
+
+      - name: Install pip
+        run: python -m pip install -r requirements/pip.txt
+
+      - name: Get pip cache dir
+        id: pip-cache-dir
+        run: echo "::set-output name=dir::$(pip cache dir)"
+
+      - name: Cache pip dependencies
+        id: cache-dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements/edx/development.txt') }}
+          restore-keys: ${{ runner.os }}-pip-
+
+      - name: Install python dependencies
+        run: pip install -r requirements/edx/development.txt
+
+      # As long there are sub-projects[1] in edx-platform, we analyze each
+      # project separately here, in order to make import-linting errors easier
+      # to pinpoint.
+      #
+      #  [1] https://openedx.atlassian.net/browse/BOM-2579
+
+      - name: Analyze imports (repo root)
+        run: make lint-imports-root
+
+      - name: Analyze imports (common/lib/xmodule)
+        run: make lint-imports-xmodule
+
+      - name: Analyze imports (common/lib/capa)
+        run: make lint-imports-capa

--- a/Makefile
+++ b/Makefile
@@ -153,3 +153,14 @@ docker_push: docker_tag docker_auth ## push to docker hub
 	docker push "openedx/cms:${GITHUB_SHA}"
 	docker push "openedx/cms-dev:latest"
 	docker push "openedx/cms-dev:${GITHUB_SHA}"
+
+lint-imports: lint-imports-root lint-imports-xmodule lint-imports-capa
+
+lint-imports-root:
+	lint-imports
+
+lint-imports-xmodule:
+	cd common/lib/xmodule && lint-imports
+
+lint-imports-capa:
+	cd common/lib/capa && lint-imports

--- a/common/lib/capa/setup.cfg
+++ b/common/lib/capa/setup.cfg
@@ -1,0 +1,42 @@
+# The CAPA subsystem is the backend ProblemBlock. Its implementation is mostly
+# independent from the rest of edx-platform. We would like to keep it that way.
+
+[importlinter]
+root_packages =
+    capa
+include_external_packages = True
+
+[importlinter:contract:capa_should_not_depend_on_cms]
+name = capa should not depend on cms
+type = forbidden
+source_modules =
+    capa
+forbidden_modules =
+    cms
+
+[importlinter:contract:capa_should_not_depend_on_common]
+name = capa should not depend on common
+type = forbidden
+source_modules =
+    capa
+forbidden_modules =
+    common
+
+[importlinter:contract:capa_should_not_depend_on_lms]
+name = capa should not depend on lms
+type = forbidden
+source_modules =
+    capa
+forbidden_modules =
+    lms
+
+# Aspirational!
+# This would be easy to make true by extracting or duplicating
+# the `HTML` and `Text` helper functions from ./openedx/.
+# [importlinter:contract:capa_should_not_depend_on_openedx]
+# name = capa should not depend on openedx
+# type = forbidden
+# source_modules =
+#     capa
+# forbidden_modules =
+#     openedx

--- a/common/lib/xmodule/setup.cfg
+++ b/common/lib/xmodule/setup.cfg
@@ -1,0 +1,17 @@
+# The XModule subsystem contains various legacy (yet mission-critical) features
+# such as ModuleStore, the LMS & CMS XBlock runtimes, and several common block types.
+# It is semi-intertwined with the `openedx`, `common`, and `lms` packages. However,
+# it is mostly independent from the CMS, which is something we'd like to preserve.
+
+[importlinter]
+root_packages =
+    xmodule
+include_external_packages = True
+
+[importlinter:contract:xmodule_should_not_depend_on_cms]
+name = xmodule should not depend on cms
+type = forbidden
+source_modules =
+    xmodule
+forbidden_modules =
+    cms

--- a/requirements/edx-sandbox/py38.txt
+++ b/requirements/edx-sandbox/py38.txt
@@ -24,7 +24,7 @@ joblib==1.1.0
     # via nltk
 kiwisolver==1.4.2
     # via matplotlib
-lxml==4.8.0
+lxml==4.9.0
     # via
     #   -r requirements/edx-sandbox/py38.in
     #   openedx-calc

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -639,9 +639,9 @@ libsass==0.10.0
     #   ora2
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==4.1.0
+lti-consumer-xblock==4.1.1
     # via -r requirements/edx/base.in
-lxml==4.8.0
+lxml==4.9.0
     # via
     #   -r requirements/edx/base.in
     #   edxval
@@ -897,7 +897,7 @@ random2==1.0.1
     # via -r requirements/edx/base.in
 recommender-xblock==2.0.1
     # via -r requirements/edx/base.in
-redis==4.3.1
+redis==4.3.3
     # via -r requirements/edx/base.in
 regex==2022.4.24
     # via nltk

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -6,7 +6,7 @@
 #
 chardet==4.0.0
     # via diff-cover
-coverage==6.4
+coverage==6.4.1
     # via -r requirements/edx/coverage.in
 diff-cover==6.5.0
     # via -r requirements/edx/coverage.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -174,6 +174,7 @@ click==8.1.3
     #   code-annotations
     #   edx-django-utils
     #   edx-lint
+    #   import-linter
     #   nltk
     #   pact-python
     #   pip-tools
@@ -214,7 +215,7 @@ coreschema==0.0.4
     #   -r requirements/edx/testing.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==6.4
+coverage[toml]==6.4.1
     # via
     #   -r requirements/edx/testing.txt
     #   pytest-cov
@@ -241,6 +242,10 @@ ddt==1.5.0
     #   -r requirements/edx/testing.txt
     #   xblock-drag-and-drop-v2
     #   xblock-poll
+decorator==4.4.2
+    # via
+    #   -r requirements/edx/testing.txt
+    #   networkx
 defusedxml==0.7.1
     # via
     #   -r requirements/edx/testing.txt
@@ -693,7 +698,7 @@ fastavro==1.4.12
     # via
     #   -r requirements/edx/testing.txt
     #   openedx-events
-filelock==3.7.0
+filelock==3.7.1
     # via
     #   -r requirements/edx/testing.txt
     #   tox
@@ -726,6 +731,10 @@ geoip2==4.5.0
     # via -r requirements/edx/testing.txt
 glob2==0.7
     # via -r requirements/edx/testing.txt
+grimp==1.2.3
+    # via
+    #   -r requirements/edx/testing.txt
+    #   import-linter
 gunicorn==20.1.0
     # via -r requirements/edx/testing.txt
 h11==0.13.0
@@ -750,6 +759,8 @@ idna==3.3
     #   yarl
 imagesize==1.3.0
     # via sphinx
+import-linter==1.2.7
+    # via -r requirements/edx/testing.txt
 importlib-metadata==4.11.4
     # via
     #   -r requirements/edx/testing.txt
@@ -813,7 +824,7 @@ jsonfield==3.1.0
     #   edx-submissions
     #   lti-consumer-xblock
     #   ora2
-jsonschema==4.5.1
+jsonschema==4.6.0
     # via sphinxcontrib-openapi
 jwcrypto==1.3.1
     # via
@@ -844,9 +855,9 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/testing.txt
     #   ora2
-lti-consumer-xblock==4.1.0
+lti-consumer-xblock==4.1.1
     # via -r requirements/edx/testing.txt
-lxml==4.8.0
+lxml==4.9.0
     # via
     #   -r requirements/edx/testing.txt
     #   edxval
@@ -929,6 +940,11 @@ mysqlclient==2.1.0
     # via
     #   -r requirements/edx/testing.txt
     #   blockstore
+networkx==2.5.1
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   -r requirements/edx/testing.txt
+    #   grimp
 newrelic==7.10.0.175
     # via
     #   -r requirements/edx/testing.txt
@@ -1091,7 +1107,7 @@ pylatexenc==2.10
     # via
     #   -r requirements/edx/testing.txt
     #   olxcleaner
-pylint==2.13.9
+pylint==2.14.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-lint
@@ -1248,7 +1264,7 @@ random2==1.0.1
     # via -r requirements/edx/testing.txt
 recommender-xblock==2.0.1
     # via -r requirements/edx/testing.txt
-redis==4.3.1
+redis==4.3.3
     # via -r requirements/edx/testing.txt
 regex==2022.4.24
     # via
@@ -1395,7 +1411,7 @@ soupsieve==2.3.2.post1
     # via
     #   -r requirements/edx/testing.txt
     #   beautifulsoup4
-sphinx==5.0.0
+sphinx==5.0.1
     # via
     #   edx-sphinx-theme
     #   sphinxcontrib-httpdomain
@@ -1473,6 +1489,10 @@ tomli==2.0.1
     #   pep517
     #   pylint
     #   pytest
+tomlkit==0.11.0
+    # via
+    #   -r requirements/edx/testing.txt
+    #   pylint
 tox==3.25.0
     # via
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -62,7 +62,7 @@ smmap==5.0.0
     # via gitdb
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==5.0.0
+sphinx==5.0.1
     # via
     #   -r requirements/edx/doc.in
     #   edx-sphinx-theme

--- a/requirements/edx/testing.in
+++ b/requirements/edx/testing.in
@@ -28,6 +28,7 @@ factory-boy               # Library for creating test fixtures, used in many tes
 # Pinning the freezegun version because 0.3.13 is causing failures which have also been reported on the git repo by public.
 freezegun                 # Allows tests to mock the output of assorted datetime module functions
 httpretty                 # Library for mocking HTTP requests, used in many tests
+import-linter             # Tool for making assertions about which modules can import which others
 isort                     # For checking and fixing the order of imports
 pycodestyle               # Checker for compliance with the Python style guide (PEP 8)
 polib                     # Library for manipulating gettext translation files, used to test paver i18n commands

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -168,6 +168,7 @@ click==8.1.3
     #   code-annotations
     #   edx-django-utils
     #   edx-lint
+    #   import-linter
     #   nltk
     #   pact-python
     #   user-util
@@ -206,7 +207,7 @@ coreschema==0.0.4
     #   -r requirements/edx/base.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==6.4
+coverage[toml]==6.4.1
     # via
     #   -r requirements/edx/coverage.txt
     #   pytest-cov
@@ -234,6 +235,8 @@ ddt==1.5.0
     #   -r requirements/edx/testing.in
     #   xblock-drag-and-drop-v2
     #   xblock-poll
+decorator==4.4.2
+    # via networkx
 defusedxml==0.7.1
     # via
     #   -r requirements/edx/base.txt
@@ -669,7 +672,7 @@ fastavro==1.4.12
     # via
     #   -r requirements/edx/base.txt
     #   openedx-events
-filelock==3.7.0
+filelock==3.7.1
     # via
     #   tox
     #   virtualenv
@@ -701,6 +704,8 @@ geoip2==4.5.0
     # via -r requirements/edx/base.txt
 glob2==0.7
     # via -r requirements/edx/base.txt
+grimp==1.2.3
+    # via import-linter
 gunicorn==20.1.0
     # via -r requirements/edx/base.txt
 h11==0.13.0
@@ -721,6 +726,8 @@ idna==3.3
     #   anyio
     #   requests
     #   yarl
+import-linter==1.2.7
+    # via -r requirements/edx/testing.in
 importlib-metadata==4.11.4
     # via
     #   -r requirements/edx/base.txt
@@ -806,9 +813,9 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==4.1.0
+lti-consumer-xblock==4.1.1
     # via -r requirements/edx/base.txt
-lxml==4.8.0
+lxml==4.9.0
     # via
     #   -r requirements/edx/base.txt
     #   edxval
@@ -880,6 +887,10 @@ mysqlclient==2.1.0
     # via
     #   -r requirements/edx/base.txt
     #   blockstore
+networkx==2.5.1
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   grimp
 newrelic==7.10.0.175
     # via
     #   -r requirements/edx/base.txt
@@ -1032,7 +1043,7 @@ pylatexenc==2.10
     # via
     #   -r requirements/edx/base.txt
     #   olxcleaner
-pylint==2.13.9
+pylint==2.14.0
     # via
     #   edx-lint
     #   pylint-celery
@@ -1176,7 +1187,7 @@ random2==1.0.1
     # via -r requirements/edx/base.txt
 recommender-xblock==2.0.1
     # via -r requirements/edx/base.txt
-redis==4.3.1
+redis==4.3.3
     # via -r requirements/edx/base.txt
 regex==2022.4.24
     # via
@@ -1365,6 +1376,8 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
+tomlkit==0.11.0
+    # via pylint
 tox==3.25.0
     # via
     #   -r requirements/edx/testing.in

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,3 +47,69 @@ multi_line_output=3
 skip=
     envs
     migrations
+
+[importlinter]
+root_packages =
+    cms
+    common
+    lms
+    openedx
+    pavelib
+include_external_packages = True
+
+# To aid in the decoupling of LMS and CMS, ensure that LMS-specific code and shared
+# code cannot import CMS/Studio-specific code.
+# Please note that the exceptions here ought to be fixed. They are not examples
+# to be followed. Please do not add to the list of exceptions.
+[importlinter:contract:lms_should_not_depend_on_cms]
+name = neither common/djangoapps, openedx, nor lms should depend on lms
+type = forbidden
+source_modules =
+    common.djangoapps
+    lms
+    openedx
+forbidden_modules =
+    cms
+ignore_imports =
+    lms.djangoapps.courseware.plugins -> cms.djangoapps.contentstore.utils
+    lms.djangoapps.course_home_api.tests.utils -> cms.djangoapps.contentstore.outlines
+    lms.djangoapps.course_home_api.outline.tests.test_view -> cms.djangoapps.contentstore.outlines
+    openedx.core.djangoapps.course_date_signals.handlers -> cms.djangoapps.contentstore.config.waffle
+    openedx.core.djangoapps.course_date_signals.tests -> cms.djangoapps.contentstore.config.waffle
+    openedx.core.djangoapps.content_libraries.api -> cms.djangoapps.contentstore.views.helpers
+    openedx.core.djangoapps.content_libraries.management.commands.reindex_content_library -> cms.djangoapps.contentstore.management.commands.prompt
+
+# To ensure that production code remains independent from our tooling infrastructure,
+# disallow imports of anything into the Paver tools library.
+[importlinter:contract:paver_and_pavelib_forbidden]
+name = application code should not reference pavelib nor paver
+type = forbidden
+source_modules =
+    lms
+    common
+    cms
+    openedx
+forbidden_modules =
+    pavelib
+    paver
+ignore_imports =
+    openedx.core.djangoapps.theming.management.commands.compile_sass -> pavelib.assets
+    openedx.core.djangoapps.theming.management.commands.compile_sass -> paver
+    openedx.testing.coverage_context_listener.pytest_plugin -> pavelib.utils.envs
+
+# safe_lxml is one example of an edx-platform app that is completely independent of any
+# other platform code. Let's try to keep it that way.
+# We would like to say "openedx.core.lib" is a forbidden module, but import-linter doesn't like
+# that, so we just disallow as much of the "openedx" package as we can.
+[importlinter:contract:safe_lxml_independent]
+name = openedx/core/lib/safe_lxml should not depend on any other application code
+type = forbidden
+source_modules =
+    openedx.core.lib.safe_lxml
+forbidden_modules =
+    openedx.features
+    openedx.core.djangoapps
+    openedx.core.djangolib
+    common
+    lms
+    cms


### PR DESCRIPTION
## Blockers

1. https://github.com/edx/edx-platform/pull/27875 : ensure every python source dir has an `__init__.py`
2. https://github.com/edx/edx-platform/pull/27874 : remove dependency of xmodule on cms
3. https://github.com/openedx/edx-platform/pull/30533 : normalize capa and xmodule imports
4. https://github.com/openedx/edx-platform/pull/30791
5. Need to write an ADR to accompany this

## Description

This PR installs and configures `import-linter`. We start with a fairly light set of constraints; for example, we declare that `lms_should_not_depend_on_cms`, with a few existing exceptions. Over time, we could make these constraints stricter. The linter is run as a GitHub Action on PR builds and the master branch.

### Rationale

In order to empower refactoring, restructuring, and extraction of edx-platform code, we would like to be able to analyze and make assertions about what code depends on what. One way to do this is by computing the digraph of Python import statements in our codebase, and failing PR builds if unwanted imports exist in the graph. This is exactly what the tool import-linter will allow us to do.

### Example

LMS-specific code belongs in ./lms, and CMS-specific code belongs in ./cms. Since we want to decouple LMS and CMS, we don’t want code in one of these folders to import code in the other.

Using import-linter , we can fail any PR that adds a cms import to a module within lms. We can add exceptions for existing imports.

## Supporting information

See [BOM-2576](https://openedx.atlassian.net/browse/BOM-2576) for context and details.

## Testing instructions

Run `make lint-imports` locally within `lms-shell` and `studio-shell`. Make sure the check passes.

Add an illegal import (for example, `from cms.djangoapps.contentstore import views` within any `lms` module). Make sure the check fails, and make sure the output is comprehensible.

## Deadline

None.

## Other information
* Upon merging, we'll want to communicate this new check in the forums and Slack, so that developers now how to resolve any
`import-linter` failures that they see on their PRs. We'll want to educate folks on the importance of these checks so that they don't get frustrated and/or just add their forbidden imports to the "ignore" list.
* I had a more ambitious version of this [over here](https://github.com/edx/edx-platform/pull/25836). I closed that and decided to stick with rules that don't have so many exceptions.