### PR TITLE
fix: don't duplicate text in forum notification email

### DIFF
--- a/lms/djangoapps/discussion/templates/discussion/edx_ace/responsenotification/email/body.html
+++ b/lms/djangoapps/discussion/templates/discussion/edx_ace/responsenotification/email/body.html
@@ -20,7 +20,9 @@
                 {{ comment_body }}
             </div>
 
-            {% trans "View discussion" as course_cta_text %}{{course_cta_text|force_escape}}
+            {% filter force_escape %}
+                {% blocktrans asvar course_cta_text %}View discussion{% endblocktrans %}
+            {% endfilter %}
             {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=post_link%}
 
             {% block google_analytics_pixel %}


### PR DESCRIPTION
While testing some ACE work, I noticed that our forum response notification email has some duplicated text. You can see it below in the screenshot.

![Screenshot from 2021-03-15 14-46-22](https://user-images.githubusercontent.com/1196901/111205491-ab959a00-859d-11eb-8a04-16131d97001d.png)

That text is not clickable or anything. I think it's just a mistaken inclusion in the template.

This looks like it was introduced when trying to fix https://openedx.atlassian.net/browse/PROD-2123 with https://github.com/edx/edx-platform/commit/9ca5df866650e46206eabb4ea1483ae01d28e475