### PR TITLE
fix: render_xblock was denying access to staff masquerading as learners

### DIFF
--- a/lms/djangoapps/courseware/testutils.py
+++ b/lms/djangoapps/courseware/testutils.py
@@ -10,7 +10,6 @@ from urllib.parse import urlencode
 
 import ddt
 
-from lms.djangoapps.courseware.field_overrides import OverrideModulestoreFieldData
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.features.course_experience.url_helpers import get_legacy_courseware_url
 from common.djangoapps.student.tests.factories import AdminFactory, CourseEnrollmentFactory, UserFactory
@@ -18,9 +17,12 @@ from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, check_mongo_calls
 
+from .field_overrides import OverrideModulestoreFieldData
+from .tests.helpers import MasqueradeMixin
+
 
 @ddt.ddt
-class RenderXBlockTestMixin(metaclass=ABCMeta):
+class RenderXBlockTestMixin(MasqueradeMixin, metaclass=ABCMeta):
     """
     Mixin for testing the courseware.render_xblock function.
     It can be used for testing any higher-level endpoint that calls this method.
@@ -218,6 +220,12 @@ class RenderXBlockTestMixin(metaclass=ABCMeta):
     def test_success_unenrolled_staff(self):
         self.setup_course()
         self.setup_user(admin=True, enroll=False, login=True)
+        self.verify_response()
+
+    def test_success_unenrolled_staff_masquerading_as_student(self):
+        self.setup_course()
+        self.setup_user(admin=True, enroll=False, login=True)
+        self.update_masquerade(role='student')
         self.verify_response()
 
     def test_success_enrolled_student(self):


### PR DESCRIPTION
## Description

The render_xblock view, which powers the Learning
MFE (among other things) returned a 404 when un-
enrolled course staff users tried to load it while
masquerading as learners. This was because we
checked course access *after* enabling the
masquerading context, which triggered a redirect-
to-enrollment exception.

The fix is simply to enable the masquerading
context *after* checking course access.
Content-level behavior and access is still
calculated within the masquerading context,
as intended.

## Supporting information

https://openedx.atlassian.net/browse/TNL-7989

## Test instructions

On master:
* Using an admin account, in the instructor dashboard, add someone to a course as Course Staff.
* (make sure the Course Staff member is not actually enrolled; otherwise, you will not observe the bug)
* As the Course Staff member, navigate to the courseware MFE (you may need to hit "View in New Experience" within a course)
* "View As" at the top should show "Staff"
* Change "View As" to "Audit".
* The bug: the unit renderer should show an infinite spinner

On my branch:
* Navigate back to the Courseware MFE, as a Course Staff member, viewing as "Staff".
* Change "View As" to "Audit"
* You should be able to view the unit.

## Deadline

Today or tomorrow would be ideal.

## Other information

This fix is very similar to my fix from Friday: https://github.com/edx/edx-platform/pull/26975 -- in fact, both these issues were reported on the same CR. 
