### PR TITLE
Track total time it takes users to register

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -351,6 +351,7 @@ def _track_user_registration(user, profile, params, third_party_provider):
             'is_year_of_birth_selected': bool(profile.year_of_birth),
             'is_education_selected': bool(profile.level_of_education_display),
             'is_goal_set': bool(profile.goals),
+            'total_registration_time': round(float(params.get('totalRegistrationTime', '0'))),
         }
         # DENG-803: For segment events forwarded along to Hubspot, duplicate the `properties` section of
         # the event payload into the `traits` section so that they can be received. This is a temporary


### PR DESCRIPTION
## Description

Added a new property in `edx.bi.user.account.registered` event to track total time it took the user to register.

## Supporting information

Ticket: https://openedx.atlassian.net/browse/VAN-413

## Other information

Related to changes made in: https://github.com/edx/frontend-app-authn/pull/205
