### PR TITLE
 fix: Align answer submission notification to bottom of viewport if out of view

### DIFF
--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -112,6 +112,48 @@ from openedx.features.course_experience import course_home_page_title, DISABLE_C
       </script>
   % endif
 
+  <script type="text/javascript">
+    /* Helper function isInViewport checks whether
+    the given element is in viewport vertically or not */
+    function isInViewport(el) {
+      const scroll = window.scrollY || window.pageYOffset
+      const elementTop = el.getBoundingClientRect().top + scroll
+      const viewport = {
+        top: scroll,
+        bottom: scroll + window.innerHeight,
+      }
+      const elementMid = elementTop + el.clientHeight/2
+      // Returns true if the middle of the element is in the viewport.
+      return elementMid >= viewport.top && elementMid <= viewport.bottom
+    }
+
+    /* Add a jQuery plugin to override the focus behavior.
+    When focused, if the element in not in the viewport then
+    the element will be scrolled to the bottom of the viewport.
+    */
+    (function ($) {
+      $.fn.extend({
+        focus: (function(orig) {
+          return function(delay, fn) {
+            orig.apply(this, arguments);
+            this.each(function(){
+              var elem = this;
+              // Scroll only when the element is not in the viewport and it contains the notification-btn.
+              if (elem.classList.contains('notification-btn') && !isInViewport(elem)) {
+                this.scrollIntoView({
+                  behaviour: 'auto',
+                  block: 'end',
+                })
+              }
+            })
+            return this;
+          }
+        })($.fn.focus),
+
+      })
+    })(jQuery)
+  </script>
+
 ${HTML(fragment.foot_html())}
 
 </%block>


### PR DESCRIPTION
## Description

This PR changes the alignment of answer submission notification. Currently the notification is aligned vertically centred if not in viewport. This behaviour was observed in Chrome browser (87+). The alignment was correct when tested on Mozilla Firefox (86.0)

**JIRA Tickets**: [BB-3828](https://tasks.opencraft.com/browse/BB-3828)

**Sandbox URL**: TBD

**Screenshots**

Before
![before-pr](https://user-images.githubusercontent.com/18226212/111296207-3b0c7d00-8672-11eb-8b5b-a29ae76c4ae8.gif)

After:
![after](https://user-images.githubusercontent.com/18226212/111296238-465fa880-8672-11eb-833d-24264b4d4673.gif)


## Testing instructions
1. Get the master devstack running
2. Sign in to LMS
3. Open Exam section of Demo Course.
4. Answer questions and click on Submit button.
5. Verify that the notification is scrolled to the **centre** of the viewport when not in viewport.
6. With notification in centre of viewport, submit another answer.
7. Verify that page does not scroll.
8. Now checkout to this branch and perform the same tests after restarting the LMS server
    a. Verify that the notification is scrolled to the **bottom** of the viewport when not in viewport.
    b. With notification in viewport, submit another answer
    c. Verify that the page does not scroll.

## Deadline
None

## Reviewers
- [ ] @viadanna 
- [ ] @Agrendalath
- [ ] edx-reviewer
