### PR TITLE
feat: mark forum response notifications transactional

### DIFF
--- a/lms/djangoapps/discussion/tasks.py
+++ b/lms/djangoapps/discussion/tasks.py
@@ -57,7 +57,9 @@ def update_discussions_map(context):
 
 
 class ResponseNotification(BaseMessageType):
-    pass
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.options['transactional'] = True
 
 
 @shared_task(base=LoggedTask)


### PR DESCRIPTION
The user opts into them when making a post / through the forums UI. They are not truly a marketing email or similar.

These emails are sent if the forum poster is subscribed and the post gets its first reply. That kind of notification shouldn't be subject to any sort of campaign caps that an external email service like sailthru or braze might have - these are just transactional emails that the user asked for.

![Screenshot from 2021-03-16 08-52-25](https://user-images.githubusercontent.com/1196901/111311752-f6aebc00-8634-11eb-8b38-2f651f921c96.png)
