### PR TITLE
[AA-461] Call celery task directly from management command instead of calling the signal

### DIFF
--- a/cms/djangoapps/export_course_metadata/management/commands/export_course_metadata_for_all_courses.py
+++ b/cms/djangoapps/export_course_metadata/management/commands/export_course_metadata_for_all_courses.py
@@ -7,6 +7,7 @@ from django.core.management.base import BaseCommand
 from xmodule.modulestore.django import modulestore
 
 from cms.djangoapps.export_course_metadata.signals import export_course_metadata
+from cms.djangoapps.export_course_metadata.tasks import export_course_metadata_task
 
 
 class Command(BaseCommand):
@@ -28,6 +29,5 @@ def export_course_metadata_for_all_courses():
     """
     module_store = modulestore()
     courses = module_store.get_courses()
-
     for course in courses:
-        export_course_metadata(None, course.id)
+        export_course_metadata_task.delay(str(course.id))


### PR DESCRIPTION
The management command was taking too long to run so this may fix it