### PR TITLE
add email to segment traits

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1495,6 +1495,10 @@ class CourseEnrollment(models.Model):
             segment_traits = dict(segment_properties)
             # Add course_title to the traits, as it is used by Hubspot filters
             segment_traits['course_title'] = self.course_overview.display_name if self.course_overview else None
+            # Hubspot requires all incoming events have an email address to link it
+            # to a Contact object.
+            segment_traits['email'] = self.user.email
+
             if event_name == EVENT_NAME_ENROLLMENT_ACTIVATED:
                 segment_properties['email'] = self.user.email
                 # This next property is for an experiment, see method's comments for more information

--- a/common/djangoapps/student/tests/test_enrollment.py
+++ b/common/djangoapps/student/tests/test_enrollment.py
@@ -174,6 +174,7 @@ class EnrollmentTest(UrlResetMixin, SharedModuleStoreTestCase):
         traits = mock_segment.track.call_args[1]['traits']
         assert traits['course_title'] == self.course.display_name
         assert traits['mode'] == 'audit'
+        assert traits['email'] == self.EMAIL
 
         with patch('common.djangoapps.student.models.segment') as mock_segment:
             enrollment.update_enrollment(mode='verified')
@@ -182,6 +183,7 @@ class EnrollmentTest(UrlResetMixin, SharedModuleStoreTestCase):
         traits = mock_segment.track.call_args[1]['traits']
         assert traits['course_title'] == self.course.display_name
         assert traits['mode'] == 'verified'
+        assert traits['email'] == self.EMAIL
 
     @patch.dict(settings.FEATURES, {'ENABLE_MKTG_EMAIL_OPT_IN': True})
     @patch('openedx.core.djangoapps.user_api.preferences.api.update_email_opt_in')


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Hubspot is rejecting some of the enrollment events, and it is because the user email address is missing from some of the payloads. User `email`  is only added to the segment properties for `activation` events, not for `mode_change` and `deactivation` events. Rather than change all of the events to include an email field, I have just added `email` directly to the traits.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
