### PR TITLE
[AA-461] Change how we get course ids to avoid memory issues

### DIFF
--- a/cms/djangoapps/export_course_metadata/management/commands/export_course_metadata_for_all_courses.py
+++ b/cms/djangoapps/export_course_metadata/management/commands/export_course_metadata_for_all_courses.py
@@ -27,7 +27,6 @@ def export_course_metadata_for_all_courses():
     """
     Export course metadata for all courses
     """
-    module_store = modulestore()
-    courses = module_store.get_courses()
+    courses = modulestore().get_course_summaries()
     for course in courses:
         export_course_metadata_task.delay(str(course.id))


### PR DESCRIPTION
It seems like module_store.get_courses() causes memory issues so using get_course_summaries instead