### PR TITLE
ARCHBOM-1708: fix: move ignored error message custom attribute

### DIFF
--- a/openedx/core/lib/docs/how_tos/logging-and-monitoring-expected-errors.rst
+++ b/openedx/core/lib/docs/how_tos/logging-and-monitoring-expected-errors.rst
@@ -21,7 +21,8 @@ At a minimum, it is recommended that you add monitoring for any expected errors,
 By default, this will provide an ``error_expected`` custom attribute for every expected error. This custom attribute can be used in the following ways:
 
 * Alert conditions can exclude or include expected errors as necessary.
-* The value of the custom attribute includes the error name and message, which may help in diagnosing an unexpected scenario.
+* The value of the custom attribute includes the error module and class name.
+* The message of the expected error can be found in the ``error_expected_message`` custom attribute, which may also help in diagnosing an unexpected scenario.
 
 Additionally, a subset of these errors will also have an ``error_ignored`` custom attribute if the error is configured as ignored.
 

--- a/openedx/core/lib/docs/how_tos/logging-and-monitoring-expected-errors.rst
+++ b/openedx/core/lib/docs/how_tos/logging-and-monitoring-expected-errors.rst
@@ -18,13 +18,15 @@ Monitoring expected errors
 
 At a minimum, it is recommended that you add monitoring for any expected errors, including ignored errors. You do this by using the ``EXPECTED_ERRORS`` setting. For details on configuring, see the documentation for `EXPECTED_ERRORS settings and toggles on Readthedocs`_.
 
-By default, this will provide an ``error_expected`` custom attribute for every expected error. This custom attribute can be used in the following ways:
+This will provide an ``error_expected`` custom attribute for every expected error. This custom attribute can be used in the following ways.
 
-* Alert conditions can exclude or include expected errors as necessary.
-* The value of the custom attribute includes the error module and class name.
-* The message of the expected error can be found in the ``error_expected_message`` custom attribute, which may also help in diagnosing an unexpected scenario.
+* Use ``WHERE error_expected IS NULL`` to filter out expected errors from most alert conditions.
+* Set up special alerts for an overabundance of expected errors using ``WHERE error_expected IS NOT NULL``.
 
-Additionally, a subset of these errors will also have an ``error_ignored`` custom attribute if the error is configured as ignored.
+Additionally, a subset of expected errors that are configured as ignored will also get ``error_ignored_class`` and ``error_ignored_message`` custom attributes.
+
+* Using New Relic terminology, this extra error class and message data will live on the Transaction and not the TransactionError, because ignored errors won't have a TransactionError.
+* Use these additional custom attributes to help diagnose unexpected issues with ignored errors.
 
 .. _EXPECTED_ERRORS settings and toggles on Readthedocs: https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/search.html?q=EXPECTED_ERRORS&check_keywords=yes&area=default
 

--- a/openedx/core/lib/tests/test_request_utils.py
+++ b/openedx/core/lib/tests/test_request_utils.py
@@ -399,9 +399,9 @@ class TestExpectedErrorMiddleware(unittest.TestCase):
         mock_set_custom_attribute.assert_has_calls(
             [
                 call('checked_error_expected_from', 'middleware'),
-                call('error_expected', 'openedx.core.lib.tests.test_request_utils.CustomError1'),
-                call('error_expected_message', 'Test failure'),
-                call('error_ignored', True)
+                call('error_expected', True),
+                call('error_ignored_class', 'openedx.core.lib.tests.test_request_utils.CustomError1'),
+                call('error_ignored_message', 'Test failure'),
             ],
             any_order=True
         )
@@ -427,9 +427,9 @@ class TestExpectedErrorMiddleware(unittest.TestCase):
 
         expected_calls = [
             call('checked_error_expected_from', 'middleware'),
-            call('error_expected', 'openedx.core.lib.tests.test_request_utils.CustomError1'),
-            call('error_expected_message', 'Test failure'),
-            call('error_ignored', True),
+            call('error_expected', True),
+            call('error_ignored_class', 'openedx.core.lib.tests.test_request_utils.CustomError1'),
+            call('error_ignored_message', 'Test failure'),
             call('checked_error_expected_from', 'middleware'),
         ]
         if use_same_exception:
@@ -451,8 +451,9 @@ class TestExpectedErrorMiddleware(unittest.TestCase):
         ExpectedErrorMiddleware('mock-response').process_exception(self.mock_request, mock_exception)
 
         mock_set_custom_attribute.assert_has_calls([
-            call('error_expected', "Exception"),
-            call('error_expected_message', 'Oops'),
+            call('error_expected', True),
+            call('error_ignored_class', 'Exception'),
+            call('error_ignored_message', 'Oops'),
         ])
 
     @patch('openedx.core.lib.request_utils.set_custom_attribute')
@@ -488,8 +489,7 @@ class TestExpectedErrorMiddleware(unittest.TestCase):
         mock_set_custom_attribute.assert_has_calls(
             [
                 call('checked_error_expected_from', 'middleware'),
-                call('error_expected', expected_class),
-                call('error_expected_message', expected_message),
+                call('error_expected', True),
             ],
             any_order=True
         )
@@ -540,9 +540,9 @@ class TestExpectedErrorExceptionHandler(unittest.TestCase):
         mock_set_custom_attribute.assert_has_calls(
             [
                 call('checked_error_expected_from', 'drf'),
-                call('error_expected', expected_class),
-                call('error_expected_message', expected_message),
-                call('error_ignored', True)
+                call('error_expected', True),
+                call('error_ignored_class', expected_class),
+                call('error_ignored_message', expected_message),
             ],
             any_order=True
         )


### PR DESCRIPTION
## Description

The `error_expected` custom attribute used to contain
both the class name and the error message. This had
the following issues:

* Combining data in the same custom attribute limits
the ability to query.
* The additional error class and message data is only
needed for ignored errors, since this data isn't
available elsewhere.

The following changes were made:
* `error_expected` will always have the value True
if present.
* `error_ignored` no longer exists.
* `error_ignored_class` will contain the error module
and class for ignored errors.
* `error_ignored_message` will contain the error message
for ignored errors.

## Supporting information

Note: The following ticket has no additional data about this PR, but is just for tracking purposes.

ARCHBOM-1708

## Testing instructions

Unit tests have been updated.  Also, here is a sample updated log message, which is nearly unchanged:
```
2021-03-17 21:57:42,669 INFO 2372 [openedx.core.lib.request_utils] [user None] [ip 172.18.0.1] request_utils.py:483 - Expected error rest_framework.exceptions.NotAuthenticated: Authentication credentials were not provided.: seen for path /api/toggles/v0/state/
```