### PR TITLE
Fix finish auth url for MFE

### DIFF
--- a/openedx/core/djangoapps/user_authn/api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_authn/api/tests/test_views.py
@@ -27,7 +27,7 @@ class TPAContextViewTest(ThirdPartyAuthTestMixin, APITestCase):
         super(TPAContextViewTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
 
         self.url = reverse('third_party_auth_context')
-        self.query_params = {'redirect_to': '/dashboard'}
+        self.query_params = {'next': '/dashboard'}
 
         # Several third party auth providers are created for these tests:
         self.configure_google_provider(enabled=True, visible=True)
@@ -87,15 +87,6 @@ class TPAContextViewTest(ThirdPartyAuthTestMixin, APITestCase):
             'pipeline_user_details': {'email': 'test@test.com'} if add_user_details else {}
         }
 
-    def test_missing_arguments(self):
-        """
-        Test that if required arguments are missing, proper status code and message
-        is returned.
-        """
-        response = self.client.get(self.url)
-        assert response.status_code == 400
-        assert response.data == {'message': 'Request missing required parameter: redirect_to'}
-
     @patch.dict(settings.FEATURES, {'ENABLE_THIRD_PARTY_AUTH': False})
     def test_no_third_party_auth_providers(self):
         """
@@ -112,7 +103,7 @@ class TPAContextViewTest(ThirdPartyAuthTestMixin, APITestCase):
         """
         response = self.client.get(self.url, self.query_params)
         params = {
-            'next': self.query_params['redirect_to']
+            'next': self.query_params['next']
         }
 
         assert response.status_code == 200
@@ -131,7 +122,7 @@ class TPAContextViewTest(ThirdPartyAuthTestMixin, APITestCase):
         """
         email = 'test@test.com' if add_user_details else None
         params = {
-            'next': self.query_params['redirect_to']
+            'next': self.query_params['next']
         }
 
         # Simulate a running pipeline
@@ -148,7 +139,7 @@ class TPAContextViewTest(ThirdPartyAuthTestMixin, APITestCase):
         even if it is not visible on the login page
         """
         params = {
-            'next': self.query_params['redirect_to']
+            'next': self.query_params['next']
         }
         tpa_hint = self.hidden_enabled_provider.provider_id
         self.query_params.update({'tpa_hint': tpa_hint})

--- a/openedx/core/djangoapps/user_authn/api/views.py
+++ b/openedx/core/djangoapps/user_authn/api/views.py
@@ -8,9 +8,8 @@ from rest_framework.response import Response
 from rest_framework.throttling import AnonRateThrottle
 from rest_framework.views import APIView
 
+from common.djangoapps.student.helpers import get_next_url_for_login_page
 from openedx.core.djangoapps.user_authn.views.utils import third_party_auth_context
-
-REDIRECT_KEY = 'redirect_to'
 
 
 class ThirdPartyAuthContextThrottle(AnonRateThrottle):
@@ -33,20 +32,11 @@ class TPAContextView(APIView):
         Arguments:
             request (HttpRequest): The request, used to determine if a pipeline
                 is currently running.
-            redirect_to: The URL to send the user to following successful
-                authentication.
             tpa_hint (string): An override flag that will return a matching provider
                 as long as its configuration has been enabled
         """
         request_params = request.GET
-
-        if REDIRECT_KEY not in request_params:
-            return Response(
-                status=status.HTTP_400_BAD_REQUEST,
-                data={'message': 'Request missing required parameter: {}'.format(REDIRECT_KEY)}
-            )
-
-        redirect_to = request_params.get(REDIRECT_KEY)
+        redirect_to = get_next_url_for_login_page(request)
         third_party_auth_hint = request_params.get('tpa_hint')
 
         context = third_party_auth_context(request, redirect_to, third_party_auth_hint)


### PR DESCRIPTION
## Description

Currently, extra query params are not being handled in getting TPAContextView,
Fixed using already available `get_next_url_for_login_page()`.

`next` query param is already being handled in `get_next_url_for_login_page()`,  no need to send it explicitly in another query param `redirect_to`.

## Supporting information

[VAN-415](https://openedx.atlassian.net/browse/VAN-415)

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
