### PR TITLE
Throw an error message if the assertion fails

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/xml_importer.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml_importer.py
@@ -267,7 +267,7 @@ class ImportManager:
         # If we're going to remap the ID, then we can only do that with
         # a single target
         if self.target_id:
-            assert len(self.xml_module_store.modules) == 1
+            assert len(self.xml_module_store.modules) == 1, 'Store unable to load course correctly.'
 
     def import_static(self, data_path, dest_id):
         """


### PR DESCRIPTION
Adding an explicit message when the assertion fails. This message is needed so that it can be recorded in `UserTaskArtifact` table. 

```
>>> assert len([]) == 1
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AssertionError
>>> assert len([]) == 1, 'expected number of items not found'
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AssertionError: expected number of items not found.
```