### PR TITLE
fix: Update logging

### DIFF
--- a/lms/djangoapps/certificates/docs/decisions/001-allowlist-requirements.rst
+++ b/lms/djangoapps/certificates/docs/decisions/001-allowlist-requirements.rst
@@ -8,10 +8,10 @@ Accepted
 Background
 ----------
 Users can earn a course certificate in a particular course run (the certificate
-is stored in the GeneratedCertificate model). If a user has not earned a certificate
+is stored in the *GeneratedCertificate* model). If a user has not earned a certificate
 but the course staff would like them to have a certificate anyway, the user can
 be added to the certificate allowlist for the course run. The allowlist is currently
-stored in the CertificateWhitelist model, and was previously referred to as the
+stored in the *CertificateWhitelist* model, and was previously referred to as the
 certificate whitelist.
 
 Requirements

--- a/lms/djangoapps/certificates/services.py
+++ b/lms/djangoapps/certificates/services.py
@@ -37,11 +37,6 @@ class CertificateService:
                 course_id=course_key
             )
             generated_certificate.invalidate()
-            log.info(
-                'Certificate invalidated for user %d in course %s',
-                user_id,
-                course_key
-            )
         except ObjectDoesNotExist:
             log.warning(
                 'Invalidation failed because a certificate for user %d in course %s does not exist.',

--- a/lms/djangoapps/certificates/tests/test_generation_handler.py
+++ b/lms/djangoapps/certificates/tests/test_generation_handler.py
@@ -132,20 +132,20 @@ class AllowlistTests(ModuleStoreTestCase):
         u = UserFactory()
         cr = CourseFactory()
         key = cr.id  # pylint: disable=no-member
-        cert = GeneratedCertificateFactory(
+        GeneratedCertificateFactory(
             user=u,
             course_id=key,
             mode=GeneratedCertificate.MODES.verified,
             status=status,
         )
 
-        assert _can_generate_allowlist_certificate_for_status(cert) == expected_response
+        assert _can_generate_allowlist_certificate_for_status(u, key) == expected_response
 
     def test_generation_status_for_none(self):
         """
         Test handling of certificate statuses for a non-existent cert
         """
-        assert _can_generate_allowlist_certificate_for_status(None) is True
+        assert _can_generate_allowlist_certificate_for_status(None, None)
 
     @override_waffle_flag(CERTIFICATES_USE_ALLOWLIST, active=False)
     def test_handle_invalid(self):


### PR DESCRIPTION
MICROBA-923

* Update existing logging messages to refer to allowlist certificates, since we'll soon have logging for "regular" certificates as well
* Remove duplicate log message from the service (essentially the same thing is already logged by the invalidate method)
* Italics added to the decision doc
