### PR TITLE
Add NewRelic Course Import Logs

### DIFF
--- a/cms/djangoapps/contentstore/views/import_export.py
+++ b/cms/djangoapps/contentstore/views/import_export.py
@@ -22,6 +22,7 @@ from django.http import Http404, HttpResponse, HttpResponseNotFound, StreamingHt
 from django.utils.translation import ugettext as _
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_GET, require_http_methods
+from edx_django_utils.monitoring import set_custom_attribute, set_custom_attributes_for_course_key
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import LibraryLocator
 from path import Path as path
@@ -33,6 +34,7 @@ from user_tasks.models import UserTaskArtifact, UserTaskStatus
 from common.djangoapps.edxmako.shortcuts import render_to_response
 from common.djangoapps.student.auth import has_course_author_access
 from common.djangoapps.util.json_request import JsonResponse
+from common.djangoapps.util.monitoring import monitor_import_failure
 from common.djangoapps.util.views import ensure_valid_course_key
 from xmodule.modulestore.django import modulestore
 
@@ -121,11 +123,11 @@ def _write_chunk(request, courselike_key):
     subdir = base64.urlsafe_b64encode(repr(courselike_key).encode('utf-8')).decode('utf-8')
     course_dir = data_root / subdir
     filename = request.FILES['course-data'].name
+    set_custom_attributes_for_course_key(courselike_key)
+    current_step = 'Uploading'
 
     def error_response(message, status):
-        """
-        Returns Json error response
-        """
+        """Returns Json error response"""
         return JsonResponse({'ErrMsg': message, 'Stage': -1}, status=status)
 
     courselike_string = str(courselike_key) + filename
@@ -135,8 +137,10 @@ def _write_chunk(request, courselike_key):
         _save_request_status(request, courselike_string, 0)
 
         if not filename.endswith('.tar.gz'):
+            error_message = _('We only support uploading a .tar.gz file.')
             _save_request_status(request, courselike_string, -1)
-            return error_response(_('We only support uploading a .tar.gz file.'), 415)
+            monitor_import_failure(courselike_key, current_step, message=error_message)
+            return error_response(error_message, 415)
 
         temp_filepath = course_dir / filename
         if not course_dir.isdir():
@@ -154,25 +158,30 @@ def _write_chunk(request, courselike_key):
             content_range = {'start': 0, 'stop': 1, 'end': 2}
 
         # stream out the uploaded files in chunks to disk
-        if int(content_range['start']) == 0:
+        is_initial_import_request = int(content_range['start']) == 0
+        if is_initial_import_request:
             mode = "wb+"
+            set_custom_attribute('course_import_init', True)
         else:
             mode = "ab+"
+            # Appending to fail would fail if the file doesn't exist.
             if not temp_filepath.exists():
+                error_message = _('Some chunks missed during file upload. Please try again')
                 _save_request_status(request, courselike_string, -1)
-                log.error(f'Course Import: {courselike_key} Chunks missed during upload.')
-                return error_response(_('Some chunks missed during file upload. Please try again'), 409)
+                log.error(f'Course Import {courselike_key}: {error_message}')
+                monitor_import_failure(courselike_key, current_step, message=error_message)
+                return error_response(error_message, status=409)
 
             size = os.path.getsize(temp_filepath)
             # Check to make sure we haven't missed a chunk
             # This shouldn't happen, even if different instances are handling
             # the same session, but it's always better to catch errors earlier.
             if size < int(content_range['start']):
+                error_message = _('File upload corrupted. Please try again')
                 _save_request_status(request, courselike_string, -1)
-                log.error(
-                    f'Course import {courselike_key}: A chunk has been missed'
-                )
-                return error_response(_('File upload corrupted. Please try again'), 409)
+                log.error(f'Course import {courselike_key}: A chunk has been missed')
+                monitor_import_failure(courselike_key, current_step, message=error_message)
+                return error_response(error_message, status=409)
 
             # The last request sometimes comes twice. This happens because
             # nginx sends a 499 error code when the response takes too long.
@@ -212,6 +221,7 @@ def _write_chunk(request, courselike_key):
             shutil.rmtree(course_dir)
             log.info("Course import %s: Temp data cleared", courselike_key)
 
+        monitor_import_failure(courselike_key, current_step, exception=exception)
         log.exception(f'Course import {courselike_key}: error importing course.')
         return error_response(str(exception), 400)
 

--- a/common/djangoapps/util/monitoring.py
+++ b/common/djangoapps/util/monitoring.py
@@ -1,0 +1,26 @@
+"""Helper methods for monitoring of events."""
+from edx_django_utils.monitoring import set_custom_attribute, set_custom_attributes_for_course_key
+
+
+def monitor_import_failure(course_key, import_step, message=None, exception=None):
+    """
+    Helper method to add custom parameters to for import failures.
+    Arguments:
+        course_key: CourseKey object
+        import_step (str): current step in course import
+        message (str): any particular message to add
+        exception: Exception object
+    """
+    exception_module = getattr(exception, '__module__', '')
+    separator = '.' if exception_module else ''
+    module_and_class = f'{exception_module}{separator}{exception.__class__.__name__}'
+    exc_message = str(exception)
+
+    set_custom_attribute('course_import_failure', import_step)
+    set_custom_attributes_for_course_key(course_key)
+    if message:
+        set_custom_attribute('course_import_failure_message', message)
+
+    if exception is not None:
+        set_custom_attribute('course_import_failure_error_class', module_and_class)
+        set_custom_attribute('course_import_failure_error_message', exc_message)

--- a/common/lib/xmodule/xmodule/modulestore/xml.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml.py
@@ -14,7 +14,6 @@ from contextlib import contextmanager
 from importlib import import_module
 
 from django.utils.encoding import python_2_unicode_compatible
-from edx_django_utils.monitoring import set_custom_attribute
 from fs.osfs import OSFS
 from lazy import lazy
 from lxml import etree
@@ -25,6 +24,7 @@ from xblock.field_data import DictFieldData
 from xblock.fields import ScopeIds
 from xblock.runtime import DictKeyValueStore
 
+from common.djangoapps.util.monitoring import monitor_import_failure
 from xmodule.error_module import ErrorBlock
 from xmodule.errortracker import exc_info_to_str, make_error_tracker
 from xmodule.mako_module import MakoDescriptorSystem
@@ -378,10 +378,10 @@ class XMLModuleStore(ModuleStoreReadBase):
             course_descriptor = self.load_course(course_dir, course_ids, errorlog.tracker, target_course_id)
         except Exception as exc:  # pylint: disable=broad-except
             msg = f'Course import {target_course_id}: ERROR: Failed to load courselike "{course_dir}": {str(exc)}'
-            set_custom_attribute('course_import_failure', f"Courselike load failure: {msg}")
             log.exception(msg)
             errorlog.tracker(msg)
             self.errored_courses[course_dir] = errorlog
+            monitor_import_failure(target_course_id, 'Updating', exception=exc)
 
         if course_descriptor is None:
             pass


### PR DESCRIPTION
Adds NR tracking logs for course import. The reason to add these logs is to monitor the following. 

* Total Course Imports
* Total Successful Course Imports
* Total Course Imports Failures 

NR custom parameters introduced: 
* `course_import_init` (bool) => How much courses used the import feature?
* `course_import_completed` (bool) => How many of imports were successful?
* `course_import_failure` (str) => How many of imports were failed & what kind of error? & How often course import failed on certain steps.
* `course_import_failure_message` (str) => helpful to diagnose unique errors. This message is not an exception message but user provided message. 
* `course_import_failure_error_class` (str) => Helpful to diagnose unique error classes
* `course_import_failure_error_message` (str) => This would also helpful to diagnose unique errors but this is exception message. 

Another graph which we should target is the number of import failures group by course Ids. 


[TNL-8100](https://openedx.atlassian.net/browse/TNL-8100)

FYI: [@saadyousafarbi @AhtishamShahid ]