### PR TITLE
FAL-1496: Catch xblock parsing exceptions on reading blocks

### DIFF
--- a/openedx/core/djangoapps/content_libraries/api.py
+++ b/openedx/core/djangoapps/content_libraries/api.py
@@ -109,6 +109,7 @@ from openedx.core.lib.blockstore_api import (
     set_draft_link,
     commit_draft,
     delete_draft,
+    BundleNotFound,
 )
 from openedx.core.djangolib import blockstore_cache
 from openedx.core.djangolib.blockstore_cache import BundleCache
@@ -1001,12 +1002,16 @@ def get_bundle_links(library_key):
             opaque_key = libraries_linked[link_data.bundle_uuid].library_key
         except KeyError:
             opaque_key = None
-        # Append the link information:
+        try:
+            latest_version = blockstore_cache.get_bundle_version_number(link_data.bundle_uuid)
+        except BundleNotFound:
+            # if the bundle doesn't exist, it's a broken link, so ignore it
+            continue
         results.append(LibraryBundleLink(
             id=link_name,
             bundle_uuid=link_data.bundle_uuid,
             version=link_data.version,
-            latest_version=blockstore_cache.get_bundle_version_number(link_data.bundle_uuid),
+            latest_version=latest_version,
             opaque_key=opaque_key,
         ))
     return results


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->
## Description

This MR is about rising a special `xblock.exceptions.XBlockParseException` on failed blocks parsing. It will allow avoiding impact on parent Block if child block caused issues while parsed. 

Example: [labxchange-xblocks/pull/17/files](https://github.com/open-craft/labxchange-xblocks/pull/17/files#diff-cb15436eafd5444eb607d5c13803643614714c84fb796ad9eabe8510e87e4cf9R56-R59)

**Note:** unit tests fails because the xblock library wasn't yet bumped.

## Supporting information

FAL-1496 OLX parsing should not impact parent XBlocks

## Testing instructions

1. Install xblock from master into LMS/studio:
```
$ pip install Xblock==1.4.2
```
2. Restart both studio/LMS
3. Update labxchange-xblock version 
4. Run tests, changes shouldn't affect anything

Raise exception at AssignmentBlock.student_view_blcok 

## Deadline

None?

## Other information

This change depends on this PR https://github.com/edx/XBlock/pull/516 (I will update the library version for edx-platform as soon as it will be bumped) 

