### PR TITLE
feat!: remove old waffle classes

### DIFF
--- a/openedx/core/djangoapps/waffle_utils/__init__.py
+++ b/openedx/core/djangoapps/waffle_utils/__init__.py
@@ -18,119 +18,6 @@ from opaque_keys.edx.keys import CourseKey
 log = logging.getLogger(__name__)
 
 
-class WaffleSwitchNamespace(LegacyWaffleSwitchNamespace):
-    """
-    Deprecated class: instead, use edx_toggles.toggles.WaffleSwitchNamespace.
-    """
-
-    def __init__(self, name, log_prefix=None):
-        super().__init__(name, log_prefix=log_prefix)
-        warnings.warn(
-            (
-                "Importing WaffleSwitchNamespace from waffle_utils is deprecated. Instead, import from"
-                " edx_toggles.toggles."
-            ),
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        set_custom_attribute(
-            "deprecated_waffle_utils", "WaffleSwitchNamespace[{}]".format(name)
-        )
-
-    @contextmanager
-    def override(self, switch_name, active=True):
-        """
-        Deprecated method: instead, use edx_toggles.toggles.testutils.override_waffle_switch.
-        """
-        warnings.warn(
-            (
-                "WaffleSwitchNamespace.override is deprecated. Instead, use"
-                " edx_toggles.toggles.testutils.override_waffle_switch."
-            ),
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        set_custom_attribute(
-            "deprecated_waffle_utils", "WaffleSwitchNamespace.override"
-        )
-        from edx_toggles.toggles.testutils import override_waffle_switch
-
-        with override_waffle_switch(
-            LegacyWaffleSwitch(self, switch_name, module_name=__name__), active
-        ):
-            yield
-
-
-class WaffleSwitch(LegacyWaffleSwitch):
-    """
-    Deprecated class: instead, use edx_toggles.toggles.WaffleSwitch.
-    """
-
-    def __init__(self, waffle_namespace, switch_name, module_name=None):
-        super().__init__(waffle_namespace, switch_name, module_name=module_name)
-        warnings.warn(
-            "Importing WaffleSwitch from waffle_utils is deprecated. Instead, import from edx_toggles.toggles.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        set_custom_attribute(
-            "deprecated_waffle_utils", "WaffleSwitch[{}]".format(self.name)
-        )
-
-
-class WaffleFlagNamespace(LegacyWaffleFlagNamespace):
-    """
-    Deprecated class: instead, use edx_toggles.toggles.WaffleFlagNamespace.
-    """
-
-    def __init__(self, name, log_prefix=None):
-        super().__init__(name, log_prefix=log_prefix)
-        warnings.warn(
-            "Importing WaffleFlagNamespace from waffle_utils is deprecated. Instead, import from edx_toggles.toggles.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        set_custom_attribute(
-            "deprecated_waffle_utils", "WaffleFlagNamespace[{}]".format(name)
-        )
-
-
-class WaffleFlag(LegacyWaffleFlag):
-    """
-    Deprecated class: instead, use edx_toggles.toggles.WaffleFlag.
-    """
-
-    def __init__(self, waffle_namespace, flag_name, module_name=None):
-        super().__init__(waffle_namespace, flag_name, module_name=module_name)
-        warnings.warn(
-            "Importing WaffleFlag from waffle_utils is deprecated. Instead, import from edx_toggles.toggles.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        set_custom_attribute(
-            "deprecated_waffle_utils", "WaffleFlag[{}]".format(self.name)
-        )
-
-    @contextmanager
-    def override(self, active=True):
-        """
-        Deprecated method: instead, use edx_toggles.toggles.testutils.override_waffle_flag.
-        """
-        warnings.warn(
-            (
-                "WaffleFlag.override is deprecated. Instead, use"
-                " edx_toggles.toggles.testutils.override_waffle_flag."
-            ),
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        set_custom_attribute("deprecated_waffle_utils", "WaffleFlag.override")
-        from edx_toggles.toggles.testutils import override_waffle_flag
-
-        with override_waffle_flag(self, active):
-            yield
-
-
 class CourseWaffleFlag(LegacyWaffleFlag):
     """
     Represents a single waffle flag that can be forced on/off for a course. This class should be used instead of
@@ -140,7 +27,7 @@ class CourseWaffleFlag(LegacyWaffleFlag):
 
     Usage:
 
-       WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='my_namespace')
+       WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name='my_namespace')
        SOME_COURSE_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'some_course_feature', __name__)
 
     And then we can check this flag in code with::

--- a/openedx/core/djangoapps/waffle_utils/__init__.py
+++ b/openedx/core/djangoapps/waffle_utils/__init__.py
@@ -27,8 +27,7 @@ class CourseWaffleFlag(LegacyWaffleFlag):
 
     Usage:
 
-       WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name='my_namespace')
-       SOME_COURSE_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'some_course_feature', __name__)
+       SOME_COURSE_FLAG = CourseWaffleFlag('my_namespace', 'some_course_feature', __name__)
 
     And then we can check this flag in code with::
 

--- a/openedx/core/djangoapps/waffle_utils/tests/test_init.py
+++ b/openedx/core/djangoapps/waffle_utils/tests/test_init.py
@@ -11,10 +11,7 @@ from mock import patch
 from opaque_keys.edx.keys import CourseKey
 from waffle.testutils import override_flag
 
-from .. import (
-    CourseWaffleFlag,
-    WaffleSwitchNamespace,
-)
+from .. import CourseWaffleFlag
 from ..models import WaffleFlagCourseOverrideModel
 
 
@@ -125,14 +122,3 @@ class TestCourseWaffleFlag(TestCase):
         )
         with override_flag(self.NAMESPACED_FLAG_NAME, active=True):
             assert test_course_flag.is_enabled(self.TEST_COURSE_KEY) is True
-
-
-class DeprecatedWaffleFlagTests(TestCase):
-    """
-    Tests for the deprecated waffle methods, including override and import paths.
-    """
-
-    def test_waffle_switch_namespace_override(self):
-        namespace = WaffleSwitchNamespace("namespace")
-        with namespace.override("waffle_switch1", True):
-            assert namespace.is_enabled('waffle_switch1')

--- a/openedx/core/djangoapps/waffle_utils/tests/test_init.py
+++ b/openedx/core/djangoapps/waffle_utils/tests/test_init.py
@@ -1,6 +1,7 @@
 """
 Tests for waffle utils features.
 """
+# pylint: disable=toggle-missing-annotation
 
 import crum
 import ddt

--- a/openedx/core/djangoapps/waffle_utils/tests/test_views.py
+++ b/openedx/core/djangoapps/waffle_utils/tests/test_views.py
@@ -2,16 +2,21 @@
 Tests for waffle utils views.
 """
 from django.test import TestCase
+from edx_toggles.toggles import (
+    LegacyWaffleFlag,
+    LegacyWaffleFlagNamespace,
+    SettingDictToggle,
+    SettingToggle
+)
 from rest_framework.test import APIRequestFactory
 
 from common.djangoapps.student.tests.factories import UserFactory
 
-from .. import WaffleFlag, WaffleFlagNamespace
 from .. import models
 from .. import views as toggle_state_views
 
-TEST_WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace("test")
-TEST_WAFFLE_FLAG = WaffleFlag(TEST_WAFFLE_FLAG_NAMESPACE, "flag", __name__)
+TEST_WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace("test")
+TEST_WAFFLE_FLAG = LegacyWaffleFlag(TEST_WAFFLE_FLAG_NAMESPACE, "flag", __name__)
 
 
 class ToggleStateViewTests(TestCase):  # lint-amnesty, pylint: disable=missing-class-docstring

--- a/openedx/core/djangoapps/waffle_utils/tests/test_views.py
+++ b/openedx/core/djangoapps/waffle_utils/tests/test_views.py
@@ -3,19 +3,12 @@ Tests for waffle utils views.
 """
 # pylint: disable=toggle-missing-annotation
 from django.test import TestCase
-from edx_toggles.toggles import (
-    LegacyWaffleFlag,
-    LegacyWaffleFlagNamespace
-)
 from rest_framework.test import APIRequestFactory
 
 from common.djangoapps.student.tests.factories import UserFactory
 
 from .. import models
 from .. import views as toggle_state_views
-
-TEST_WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace("test")
-TEST_WAFFLE_FLAG = LegacyWaffleFlag(TEST_WAFFLE_FLAG_NAMESPACE, "flag", __name__)
 
 
 class ToggleStateViewTests(TestCase):  # lint-amnesty, pylint: disable=missing-class-docstring

--- a/openedx/core/djangoapps/waffle_utils/tests/test_views.py
+++ b/openedx/core/djangoapps/waffle_utils/tests/test_views.py
@@ -1,12 +1,11 @@
 """
 Tests for waffle utils views.
 """
+# pylint: disable=toggle-missing-annotation
 from django.test import TestCase
 from edx_toggles.toggles import (
     LegacyWaffleFlag,
-    LegacyWaffleFlagNamespace,
-    SettingDictToggle,
-    SettingToggle
+    LegacyWaffleFlagNamespace
 )
 from rest_framework.test import APIRequestFactory
 

--- a/openedx/core/djangoapps/waffle_utils/views.py
+++ b/openedx/core/djangoapps/waffle_utils/views.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from edx_rest_framework_extensions.permissions import IsStaff
 from edx_toggles.toggles.state import ToggleStateReport, get_or_create_toggle_response
-from rest_framework import permissions, views
+from rest_framework import views
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.response import Response
 


### PR DESCRIPTION
## Description

BREAKING CHANGE: Remove WaffleSwitchNamespace, WaffleSwitch, WaffleFlagNamespace,
and WaffleFlag from waffle_utils, in favor of the Legecy* classes
in edx-toggles. 

Although this is a breaking change, we have preemptively removed all known uses, so it shouldn't affect anyone. Monitoring for edX.org shows that these aren't used in Production.

## Supporting information

BD-21
