### PR TITLE
 ENT4134 Add the support for multiple IDPs

### DIFF
--- a/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
@@ -162,8 +162,10 @@ class TestShibIntegrationTest(SamlIntegrationTestUtilities, IntegrationTestMixin
 
     @patch('openedx.features.enterprise_support.api.enterprise_customer_for_request')
     @patch('openedx.core.djangoapps.user_api.accounts.settings_views.enterprise_customer_for_request')
+    @patch('openedx.features.enterprise_support.utils.third_party_auth.provider.Registry.get')
     def test_full_pipeline_succeeds_for_unlinking_testshib_account(
         self,
+        mock_auth_provider,
         mock_enterprise_customer_for_request_settings_view,
         mock_enterprise_customer_for_request,
     ):
@@ -196,7 +198,13 @@ class TestShibIntegrationTest(SamlIntegrationTestUtilities, IntegrationTestMixin
             'uuid': enterprise_customer.uuid,
             'name': enterprise_customer.name,
             'identity_provider': 'saml-default',
+            'identity_providers': [
+                {
+                    "provider_id": "saml-default",
+                }
+            ],
         }
+        mock_auth_provider.return_value.backend_name = 'tpa-saml'
         mock_enterprise_customer_for_request.return_value = enterprise_customer_data
         mock_enterprise_customer_for_request_settings_view.return_value = enterprise_customer_data
 

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
@@ -274,7 +274,12 @@ class TestAccountApi(UserSettingsEventTestMixin, EmailTemplateTagMixin, CreateAc
             mock_customer.return_value.update({
                 'uuid': 'real-ent-uuid',
                 'name': 'Dummy Enterprise',
-                'identity_provider': 'saml-ubc'
+                'identity_provider': 'saml-ubc',
+                'identity_providers': [
+                    {
+                        "provider_id": "saml-ubc",
+                    }
+                ],
             })
         mock_auth_provider.return_value.sync_learner_profile_data = is_synch_learner_profile_data
         mock_auth_provider.return_value.backend_name = idp_backend_name

--- a/openedx/features/enterprise_support/tests/test_utils.py
+++ b/openedx/features/enterprise_support/tests/test_utils.py
@@ -254,7 +254,7 @@ class TestEnterpriseUtils(TestCase):
     @mock.patch('openedx.features.enterprise_support.utils.get_current_request')
     @mock.patch('openedx.features.enterprise_support.api.enterprise_customer_for_request')
     def test_get_enterprise_readonly_account_fields_no_sync_learner_profile_data(
-            self, mock_customer_for_request, mock_get_current_request
+            self, mock_customer_for_request, mock_get_current_request,
     ):
         mock_get_current_request.return_value = mock.Mock(
             GET={'enterprise_customer': 'some-uuid'},
@@ -262,6 +262,7 @@ class TestEnterpriseUtils(TestCase):
         mock_customer_for_request.return_value = {
             'uuid': 'some-uuid',
             'identity_provider': None,
+            'identity_providers': [],
         }
         user = mock.Mock()
 
@@ -283,6 +284,11 @@ class TestEnterpriseUtils(TestCase):
         mock_customer_for_request.return_value = {
             'uuid': 'some-uuid',
             'identity_provider': 'mock-idp',
+            'identity_providers': [
+                {
+                    "provider_id": "mock-idp",
+                },
+            ]
         }
         mock_idp = mock.MagicMock(
             backend_name='mock-backend',
@@ -299,11 +305,10 @@ class TestEnterpriseUtils(TestCase):
         mock_get_current_request.assert_called_once_with()
 
         mock_tpa.provider.Registry.get.assert_called_with(provider_id='mock-idp')
-
         mock_select_related = mock_user_social_auth.objects.select_related
         mock_select_related.assert_called_once_with('user')
         mock_select_related.return_value.filter.assert_called_once_with(
-            provider=mock_idp.backend_name,
+            provider__in=[mock_idp.backend_name],
             user=user
         )
 

--- a/openedx/features/enterprise_support/utils.py
+++ b/openedx/features/enterprise_support/utils.py
@@ -279,13 +279,14 @@ def _user_has_social_auth_record(user, enterprise_customer):
     Return True if a `UserSocialAuth` record exists for `user` False otherwise.
     """
     provider_backend_names = []
-    if enterprise_customer:
-        for idp in enterprise_customer.identity_providers:
+    if enterprise_customer and enterprise_customer['identity_providers']:
+        for idp in enterprise_customer['identity_providers']:
             identity_provider = third_party_auth.provider.Registry.get(
-                provider_id=idp.provider_id,
+                provider_id=idp['provider_id']
             )
             provider_backend_names.append(identity_provider.backend_name)
-        return UserSocialAuth.objects.filter(provider__in=provider_backend_names, user=user).exists()
+        return UserSocialAuth.objects.select_related('user').\
+            filter(provider__in=provider_backend_names, user=user).exists()
     return False
 
 

--- a/openedx/features/enterprise_support/utils.py
+++ b/openedx/features/enterprise_support/utils.py
@@ -278,16 +278,14 @@ def _user_has_social_auth_record(user, enterprise_customer):
     """
     Return True if a `UserSocialAuth` record exists for `user` False otherwise.
     """
+    provider_backend_names = []
     if enterprise_customer:
-        identity_provider = third_party_auth.provider.Registry.get(
-            provider_id=enterprise_customer['identity_provider'],
-        )
-        if identity_provider:
-            return UserSocialAuth.objects.select_related('user').filter(
-                provider=identity_provider.backend_name,
-                user=user
-            ).exists()
-
+        for idp in enterprise_customer.identity_providers:
+            identity_provider = third_party_auth.provider.Registry.get(
+                provider_id=idp.provider_id,
+            )
+            provider_backend_names.append(identity_provider.backend_name)
+        return UserSocialAuth.objects.filter(provider__in=provider_backend_names, user=user).exists()
     return False
 
 


### PR DESCRIPTION
[ENT-4134](https://openedx.atlassian.net/browse/ENT-4134): With this PR we are checking the User's `UserSocialAuth` record from all the IDPs attached with users `EnterpriseCustomer` which was previously checked from only the` first IDP` attached with that `EnterpriseCustomer`.
The impact of adding this change is on Enterprise Customers users to allow them to edit or not their `Full Name` on the basis of their already exists record.

P.S: If the user has no `UserSocialAuth` record then allow to edit `full name
    # whether the `sync_learner_profile_data` is enabled or disabled
