### PR TITLE
temp: removing pylint_django_plugin from load-plugins

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -72,7 +72,7 @@
 [MASTER]
 ignore = ,.git,.tox,migrations,node_modules,.pycharm_helpers
 persistent = yes
-load-plugins = edx_lint.pylint,pylint_django_settings,pylint_django,pylint_celery
+load-plugins = edx_lint.pylint,pylint_django,pylint_celery
 
 [MESSAGES CONTROL]
 enable =


### PR DESCRIPTION
removing pylint_django_plugin from load-plugins to test ubuntu 20 in jenkins workers

<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

removing pylint_django_plugin from load-plugins to test ubuntu 20 in jenkins workers

