### PR TITLE
fix: updates get provider from pipeline wrong parameter

### DIFF
--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -586,20 +586,15 @@ def ensure_user_information(strategy, auth_entry, backend=None, user=None, socia
         return (current_provider and
                 (current_provider.skip_email_verification or current_provider.send_to_registration_first))
 
-    def is_provider_saml():
-        """ Verify that the third party provider uses SAML """
-        current_provider = provider.Registry.get_from_pipeline({'backend': current_partial.backend, 'kwargs': kwargs})
-        saml_providers_list = list(provider.Registry.get_enabled_by_backend_name('tpa-saml'))
-        return (current_provider and
-                current_provider.slug in [saml_provider.slug for saml_provider in saml_providers_list])
-
     if current_partial:
         strategy.session_set('partial_pipeline_token_', current_partial.token)
         strategy.storage.partial.store(current_partial)
 
     if not user:
         # Use only email for user existence check in case of saml provider
-        if is_provider_saml():
+        saml_provider, _ = is_saml_provider(current_partial.backend, kwargs)
+
+        if saml_provider:
             user_details = {'email': details.get('email')} if details else None
         else:
             user_details = details

--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -592,7 +592,7 @@ def ensure_user_information(strategy, auth_entry, backend=None, user=None, socia
 
     if not user:
         # Use only email for user existence check in case of saml provider
-        saml_provider, _ = is_saml_provider(current_partial.backend, kwargs)
+        saml_provider, _ = is_saml_provider(backend, kwargs)
 
         if saml_provider:
             user_details = {'email': details.get('email')} if details else None

--- a/common/djangoapps/third_party_auth/utils.py
+++ b/common/djangoapps/third_party_auth/utils.py
@@ -80,8 +80,10 @@ def validate_uuid4_string(uuid_string):
 
 def is_saml_provider(backend, kwargs):
     """ Verify that the third party provider uses SAML """
-    current_provider = provider.Registry.get_from_pipeline({'backend': backend, 'kwargs': kwargs})
-    saml_providers_list = list(provider.Registry.get_enabled_by_backend_name('tpa-saml'))
+    current_provider = None
+    if backend:
+        current_provider = provider.Registry.get_from_pipeline({'backend': backend.name, 'kwargs': kwargs})
+        saml_providers_list = list(provider.Registry.get_enabled_by_backend_name('tpa-saml'))
     return (current_provider and
             current_provider.slug in [saml_provider.slug for saml_provider in saml_providers_list]), current_provider
 


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Previously, the provider was being retrieved from the pipeline using `common.djangoapps.third_party_auth.provider.Registry.get_from_pipeline`.

After some investigation into how the method works, it turned out that it used `ProviderConfig.is_active_for_pipeline` to check if the backend is active in the pipeline.

That method, compares `ProviderConfig.backend_name` with `pipeline['backend']` which indicates that the pipeline's backend name should be passed and not the pipeline's backend class.

This pull request also removes duplicate code for saml provider check. A SAML provider check has already been added to third_party_auth utils in b99a64c. This change simply removes the old `is_provider_saml` method and replaces it with the new `is_saml_provider`.

## Supporting information

* **Related Pull Requests**: [ENT-3798 Multiple_SSO_Accounts_Association_to_SAML_User #26170](https://github.com/edx/edx-platform/pull/26170)
* **Jira Tickets**: ENT-3798, OSPR-5682

## Testing instructions

Not sure... The pull request that introduced that change has no description, so I have no idea how to test it. 
