### PR TITLE
chore: Unpin pillow and upgrade Python requirements

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -76,9 +76,6 @@ django-oauth-toolkit<=1.3.2
 # path 13.2.0 drops support for Python 3.5
 path<13.2.0
 
-# pillow 8.0.0 drops support for Python 3.5
-pillow<8.0.0
-
 # ARCHBOM-1141: pip-tools upgrade requires pip upgrade
 pip-tools<5.4
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -99,7 +99,7 @@ edx-django-release-util==1.0.0  # via -r requirements/edx/base.in
 edx-django-sites-extensions==3.0.0  # via -r requirements/edx/base.in
 edx-django-utils==3.15.0  # via -r requirements/edx/base.in, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-toggles, edx-when, ora2, super-csv
 edx-drf-extensions==6.5.0  # via -r requirements/edx/base.in, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
-edx-enterprise==3.19.0   # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
+edx-enterprise==3.19.0    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
 edx-event-routing-backends==4.0.1  # via -r requirements/edx/base.in
 edx-i18n-tools==0.5.3     # via ora2
 edx-milestones==0.3.0     # via -r requirements/edx/base.in
@@ -171,7 +171,7 @@ path==13.1.0              # via -c requirements/edx/../constraints.txt, -r requi
 paver==1.3.4              # via -r requirements/edx/paver.txt
 pbr==5.5.1                # via -r requirements/edx/paver.txt, stevedore
 piexif==1.1.3             # via -r requirements/edx/base.in
-pillow==7.2.0             # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, edx-enterprise, edx-organizations
+pillow==8.1.2             # via -r requirements/edx/base.in, edx-enterprise, edx-organizations
 polib==1.1.0              # via edx-i18n-tools
 psutil==5.8.0             # via -r requirements/edx/paver.txt, edx-django-utils
 py2neo==3.1.2             # via -r requirements/edx/base.in
@@ -218,7 +218,7 @@ social-auth-app-django==4.0.0  # via -r requirements/edx/base.in
 social-auth-core==4.0.2   # via -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt, -r requirements/edx/base.in, social-auth-app-django
 sorl-thumbnail==12.7.0    # via -r requirements/edx/base.in, django-wiki
 sortedcontainers==2.3.0   # via -r requirements/edx/base.in
-soupsieve==2.2            # via beautifulsoup4
+soupsieve==2.2.1          # via beautifulsoup4
 sqlparse==0.4.1           # via -r requirements/edx/base.in, django
 staff-graded-xblock==1.5  # via -r requirements/edx/base.in
 stevedore==1.32.0         # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, -r requirements/edx/paver.txt, code-annotations, edx-ace, edx-django-utils, edx-enterprise, edx-opaque-keys

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -204,7 +204,7 @@ path==13.1.0              # via -c requirements/edx/../constraints.txt, -r requi
 paver==1.3.4              # via -r requirements/edx/testing.txt
 pbr==5.5.1                # via -r requirements/edx/testing.txt, stevedore
 piexif==1.1.3             # via -r requirements/edx/testing.txt
-pillow==7.2.0             # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, edx-enterprise, edx-organizations
+pillow==8.1.2             # via -r requirements/edx/testing.txt, edx-enterprise, edx-organizations
 pip-tools==5.3.1          # via -c requirements/edx/../constraints.txt, -r requirements/edx/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/edx/testing.txt, diff-cover, pytest, tox
 polib==1.1.0              # via -r requirements/edx/testing.txt, edx-i18n-tools
@@ -275,7 +275,7 @@ social-auth-app-django==4.0.0  # via -r requirements/edx/testing.txt
 social-auth-core==4.0.2   # via -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt, -r requirements/edx/testing.txt, social-auth-app-django
 sorl-thumbnail==12.7.0    # via -r requirements/edx/testing.txt, django-wiki
 sortedcontainers==2.3.0   # via -r requirements/edx/testing.txt
-soupsieve==2.2            # via -r requirements/edx/testing.txt, beautifulsoup4
+soupsieve==2.2.1          # via -r requirements/edx/testing.txt, beautifulsoup4
 sphinx==3.3.0             # via -c requirements/edx/../constraints.txt, edx-sphinx-theme, sphinxcontrib-httpdomain
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -107,7 +107,7 @@ edx-django-release-util==1.0.0  # via -r requirements/edx/base.txt
 edx-django-sites-extensions==3.0.0  # via -r requirements/edx/base.txt
 edx-django-utils==3.15.0  # via -r requirements/edx/base.txt, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-toggles, edx-when, ora2, super-csv
 edx-drf-extensions==6.5.0  # via -r requirements/edx/base.txt, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
-edx-enterprise==3.19.0   # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt
+edx-enterprise==3.19.0    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt
 edx-event-routing-backends==4.0.1  # via -r requirements/edx/base.txt
 edx-i18n-tools==0.5.3     # via -r requirements/edx/base.txt, -r requirements/edx/testing.in, ora2
 edx-lint==4.1.1           # via -r requirements/edx/testing.in
@@ -196,7 +196,7 @@ path==13.1.0              # via -c requirements/edx/../constraints.txt, -r requi
 paver==1.3.4              # via -r requirements/edx/base.txt
 pbr==5.5.1                # via -r requirements/edx/base.txt, stevedore
 piexif==1.1.3             # via -r requirements/edx/base.txt
-pillow==7.2.0             # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, edx-enterprise, edx-organizations
+pillow==8.1.2             # via -r requirements/edx/base.txt, edx-enterprise, edx-organizations
 pluggy==0.13.1            # via -r requirements/edx/coverage.txt, diff-cover, pytest, tox
 polib==1.1.0              # via -r requirements/edx/base.txt, -r requirements/edx/testing.in, edx-i18n-tools
 psutil==5.8.0             # via -r requirements/edx/base.txt, edx-django-utils, pytest-xdist
@@ -263,7 +263,7 @@ social-auth-app-django==4.0.0  # via -r requirements/edx/base.txt
 social-auth-core==4.0.2   # via -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt, -r requirements/edx/base.txt, social-auth-app-django
 sorl-thumbnail==12.7.0    # via -r requirements/edx/base.txt, django-wiki
 sortedcontainers==2.3.0   # via -r requirements/edx/base.txt
-soupsieve==2.2            # via -r requirements/edx/base.txt, beautifulsoup4
+soupsieve==2.2.1          # via -r requirements/edx/base.txt, beautifulsoup4
 sqlparse==0.4.1           # via -r requirements/edx/base.txt, django
 staff-graded-xblock==1.5  # via -r requirements/edx/base.txt
 stevedore==1.32.0         # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, code-annotations, edx-ace, edx-django-utils, edx-enterprise, edx-opaque-keys


### PR DESCRIPTION
## Description

Pillow was pinned for Python 3.5 support, which we no longer need.

## Supporting information

- https://github.com/python-pillow/Pillow/blob/master/CHANGES.rst
- https://facelessuser.github.io/soupsieve/about/changelog/

## Deadline

ASAP, latest pillow has important fixes.