### PR TITLE
Remove unused imports-I

### DIFF
--- a/cms/djangoapps/export_course_metadata/management/commands/export_course_metadata_for_all_courses.py
+++ b/cms/djangoapps/export_course_metadata/management/commands/export_course_metadata_for_all_courses.py
@@ -6,7 +6,7 @@ from django.core.management.base import BaseCommand
 
 from xmodule.modulestore.django import modulestore
 
-from cms.djangoapps.export_course_metadata.signals import export_course_metadata
+from cms.djangoapps.export_course_metadata.signals import export_course_metadata  # pylint: disable=unused-import
 from cms.djangoapps.export_course_metadata.tasks import export_course_metadata_task
 
 

--- a/lms/djangoapps/dashboard/management/commands/tests/test_git_add_course.py
+++ b/lms/djangoapps/dashboard/management/commands/tests/test_git_add_course.py
@@ -9,7 +9,6 @@ import unittest
 from uuid import uuid4
 
 import pytest
-import six
 from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import CommandError

--- a/lms/djangoapps/edxnotes/tests.py
+++ b/lms/djangoapps/edxnotes/tests.py
@@ -11,7 +11,6 @@ from unittest.mock import MagicMock, patch
 import ddt
 import jwt
 import pytest
-import six
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ImproperlyConfigured

--- a/lms/djangoapps/survey/tests/test_models.py
+++ b/lms/djangoapps/survey/tests/test_models.py
@@ -7,7 +7,6 @@ from collections import OrderedDict
 
 import ddt
 import pytest
-import six
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.core.exceptions import ValidationError
 from django.test import TestCase

--- a/lms/djangoapps/survey/tests/test_views.py
+++ b/lms/djangoapps/survey/tests/test_views.py
@@ -6,7 +6,6 @@ Python tests for the Survey views
 import json
 from collections import OrderedDict
 
-import six
 from django.test.client import Client
 from django.urls import reverse
 

--- a/lms/djangoapps/teams/serializers.py
+++ b/lms/djangoapps/teams/serializers.py
@@ -5,7 +5,6 @@ Defines serializers used by the Team API.
 
 from copy import deepcopy
 
-import six
 from django.conf import settings
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django_countries import countries

--- a/lms/djangoapps/teams/views.py
+++ b/lms/djangoapps/teams/views.py
@@ -6,7 +6,6 @@ HTTP endpoints for the Teams API.
 import logging
 from collections import Counter
 
-import six
 from django.conf import settings
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.core.exceptions import PermissionDenied

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -2,7 +2,6 @@
 Views for the verification flow
 """
 
-import datetime
 import decimal
 import json
 import logging

--- a/openedx/core/djangoapps/discussions/models.py
+++ b/openedx/core/djangoapps/discussions/models.py
@@ -3,7 +3,6 @@ Provide django models to back the discussions app
 """
 from __future__ import annotations
 import logging
-from typing import List
 
 from django.core.exceptions import ValidationError
 from django.db import models

--- a/openedx/features/content_type_gating/partitions.py
+++ b/openedx/features/content_type_gating/partitions.py
@@ -11,7 +11,6 @@ import logging
 
 import crum
 import pytz
-import six
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext_lazy as _
 from web_fragments.fragment import Fragment

--- a/openedx/features/content_type_gating/tests/test_access.py
+++ b/openedx/features/content_type_gating/tests/test_access.py
@@ -3,12 +3,10 @@ Test audit user's access to various content based on content-gating features.
 """
 
 
-import json
 import os
 from datetime import datetime, timedelta
 
 import ddt
-import six
 from django.conf import settings
 from django.test.client import RequestFactory, Client
 from django.test.utils import override_settings

--- a/openedx/features/course_bookmarks/templates/course_bookmarks/course_bookmarks_js.template
+++ b/openedx/features/course_bookmarks/templates/course_bookmarks/course_bookmarks_js.template
@@ -1,7 +1,6 @@
 ## mako
 
 <%!
-import six
 from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string
 %>
 
@@ -9,7 +8,7 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
     require(['course_bookmarks/js/course_bookmarks_factory'], function (CourseBookmarksFactory) {
         CourseBookmarksFactory({
             $el: $(".course-bookmarks"),
-            courseId: '${six.text_type(course.id) | n, js_escaped_string}',
+            courseId: '${str(course.id) | n, js_escaped_string}',
             bookmarksApiUrl: '${bookmarks_api_url | n, js_escaped_string}',
         });
     });

--- a/openedx/features/course_bookmarks/views/course_bookmarks.py
+++ b/openedx/features/course_bookmarks/views/course_bookmarks.py
@@ -3,7 +3,6 @@ Views to show a course's bookmarks.
 """
 
 
-import six
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import render_to_response
 from django.template.context_processors import csrf

--- a/openedx/features/course_duration_limits/tests/test_course_expiration.py
+++ b/openedx/features/course_duration_limits/tests/test_course_expiration.py
@@ -6,7 +6,6 @@ from datetime import timedelta
 from unittest import mock
 
 import ddt
-import six
 from django.conf import settings
 from django.urls import reverse
 from django.utils.timezone import now

--- a/openedx/features/course_experience/tests/views/test_course_outline.py
+++ b/openedx/features/course_experience/tests/views/test_course_outline.py
@@ -34,7 +34,7 @@ from lms.djangoapps.experiments.testutils import override_experiment_waffle_flag
 from lms.urls import RESET_COURSE_DEADLINES_NAME
 from openedx.core.djangoapps.course_date_signals.models import SelfPacedRelativeDatesConfig
 from openedx.core.djangoapps.schedules.models import Schedule
-from openedx.core.djangoapps.schedules.tests.factories import ScheduleFactory
+from openedx.core.djangoapps.schedules.tests.factories import ScheduleFactory  # pylint: disable=unused-import
 from openedx.core.lib.gating import api as gating_api
 from openedx.features.content_type_gating.models import ContentTypeGatingConfig
 from openedx.features.course_experience import RELATIVE_DATES_FLAG

--- a/openedx/features/course_search/views/course_search.py
+++ b/openedx/features/course_search/views/course_search.py
@@ -3,7 +3,6 @@ Views for the course search page.
 """
 
 
-import six
 from django.contrib.auth.decorators import login_required
 from django.template.context_processors import csrf
 from django.template.loader import render_to_string

--- a/openedx/features/discounts/utils.py
+++ b/openedx/features/discounts/utils.py
@@ -5,7 +5,6 @@ Utility functions for working with discounts and discounted pricing.
 from datetime import datetime
 
 import pytz
-import six
 from django.utils.translation import get_language
 from django.utils.translation import ugettext as _
 from edx_django_utils.cache import RequestCache

--- a/openedx/features/enterprise_support/signals.py
+++ b/openedx/features/enterprise_support/signals.py
@@ -5,7 +5,6 @@ This module contains signals related to enterprise.
 
 import logging
 
-import six
 from django.conf import settings
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.db.models.signals import post_save, pre_save


### PR DESCRIPTION
Remove unused imports caused by pyugprade PRs to fix the pylint warnings.
This PR fixes `16 unused-import` warnings and drops the count to `33 unused-import` and total `112 pylint` [warnings](https://build.testeng.edx.org/job/edx-platform-quality-pipeline-pr/26273/).

