### PR TITLE
Remove unused imports-II

### DIFF
--- a/common/djangoapps/course_modes/admin.py
+++ b/common/djangoapps/course_modes/admin.py
@@ -1,7 +1,6 @@
 """Django admin for course_modes"""
 
 
-import six
 from django import forms
 from django.conf import settings
 from django.contrib import admin

--- a/common/djangoapps/course_modes/helpers.py
+++ b/common/djangoapps/course_modes/helpers.py
@@ -2,7 +2,6 @@
 
 
 import logging
-import six
 from django.utils.translation import ugettext_lazy as _
 
 from requests.exceptions import ConnectionError, Timeout  # pylint: disable=redefined-builtin

--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -6,7 +6,6 @@ Add and create new modes for running courses on this particular LMS
 from collections import defaultdict, namedtuple
 from datetime import timedelta
 import logging
-import six
 from config_models.models import ConfigurationModel
 from django.conf import settings
 from django.core.exceptions import ValidationError

--- a/common/djangoapps/course_modes/rest_api/v1/tests/test_views.py
+++ b/common/djangoapps/course_modes/rest_api/v1/tests/test_views.py
@@ -12,7 +12,6 @@ from django.urls import reverse
 from opaque_keys.edx.keys import CourseKey
 from rest_framework import status
 from rest_framework.test import APITestCase
-from six import text_type
 
 from common.djangoapps.course_modes.rest_api.v1.views import CourseModesView
 from common.djangoapps.course_modes.models import CourseMode

--- a/common/djangoapps/course_modes/tests/factories.py
+++ b/common/djangoapps/course_modes/tests/factories.py
@@ -4,7 +4,6 @@ Factories for course mode models.
 
 
 import random
-import six
 
 from factory import lazy_attribute
 from factory.django import DjangoModelFactory

--- a/common/djangoapps/course_modes/tests/test_admin.py
+++ b/common/djangoapps/course_modes/tests/test_admin.py
@@ -7,7 +7,6 @@ import unittest
 from datetime import datetime, timedelta
 
 import ddt
-import six
 from django.conf import settings
 from django.urls import reverse
 from pytz import UTC, timezone

--- a/common/djangoapps/course_modes/tests/test_models.py
+++ b/common/djangoapps/course_modes/tests/test_models.py
@@ -17,7 +17,7 @@ from django.utils.timezone import now
 from opaque_keys.edx.locator import CourseLocator
 
 from common.djangoapps.course_modes.helpers import enrollment_mode_display
-from common.djangoapps.course_modes.models import (  # lint-amnesty, pylint: disable=line-too-long
+from common.djangoapps.course_modes.models import (
     CourseMode,
     Mode,
     get_cosmetic_display_price,

--- a/common/djangoapps/course_modes/tests/test_views.py
+++ b/common/djangoapps/course_modes/tests/test_views.py
@@ -12,7 +12,6 @@ import ddt
 import freezegun
 import httpretty
 import pytz
-import six
 from django.conf import settings
 from django.urls import reverse
 

--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -23,7 +23,6 @@ from django.views.generic.base import View
 from edx_django_utils.monitoring.utils import increment
 from ipware.ip import get_client_ip
 from opaque_keys.edx.keys import CourseKey
-from six import text_type
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.helpers import get_course_final_price

--- a/common/djangoapps/student/management/commands/anonymized_id_mapping.py
+++ b/common/djangoapps/student/management/commands/anonymized_id_mapping.py
@@ -13,7 +13,6 @@ import csv
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.core.management.base import BaseCommand, CommandError
 from opaque_keys.edx.keys import CourseKey
-from six import text_type
 
 from common.djangoapps.student.models import anonymous_id_for_user
 

--- a/common/djangoapps/student/management/commands/bulk_change_enrollment.py
+++ b/common/djangoapps/student/management/commands/bulk_change_enrollment.py
@@ -7,7 +7,6 @@ from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
-from six import text_type
 
 from common.djangoapps.course_modes.models import CourseMode
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview

--- a/common/djangoapps/student/management/commands/change_enrollment.py
+++ b/common/djangoapps/student/management/commands/change_enrollment.py
@@ -7,7 +7,6 @@ from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
-from six import text_type
 
 from openedx.core.djangoapps.credit.email_utils import get_credit_provider_attribute_values
 from common.djangoapps.student.models import CourseEnrollment, CourseEnrollmentAttribute, User

--- a/common/djangoapps/student/management/commands/set_staff.py
+++ b/common/djangoapps/student/management/commands/set_staff.py
@@ -4,7 +4,6 @@ import re
 
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.core.management.base import BaseCommand
-from six import text_type
 
 
 class Command(BaseCommand):  # lint-amnesty, pylint: disable=missing-class-docstring

--- a/common/djangoapps/student/management/commands/set_superuser.py
+++ b/common/djangoapps/student/management/commands/set_superuser.py
@@ -3,7 +3,6 @@
 
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.core.management.base import BaseCommand
-from six import text_type
 
 
 class Command(BaseCommand):

--- a/common/djangoapps/student/management/commands/transfer_students.py
+++ b/common/djangoapps/student/management/commands/transfer_students.py
@@ -8,7 +8,6 @@ from textwrap import dedent
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.db import transaction
 from opaque_keys.edx.keys import CourseKey
-from six import text_type
 
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.track.management.tracked_command import TrackedCommand

--- a/common/djangoapps/student/management/tests/test_create_random_users.py
+++ b/common/djangoapps/student/management/tests/test_create_random_users.py
@@ -7,7 +7,6 @@ import pytest
 from django.contrib.auth import get_user_model
 from django.core.management import call_command
 from opaque_keys import InvalidKeyError
-from six import text_type
 
 from common.djangoapps.student.models import CourseEnrollment
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase

--- a/common/djangoapps/student/management/tests/test_create_test_users.py
+++ b/common/djangoapps/student/management/tests/test_create_test_users.py
@@ -9,7 +9,6 @@ from django.core.exceptions import ValidationError
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from opaque_keys import InvalidKeyError
-from six import text_type
 
 from common.djangoapps.student.helpers import AccountValidationError
 from common.djangoapps.student.models import CourseAccessRole, CourseEnrollment

--- a/common/djangoapps/student/tests/test_models.py
+++ b/common/djangoapps/student/tests/test_models.py
@@ -8,7 +8,7 @@ import pytz
 from crum import set_current_request
 from django.contrib.auth.models import AnonymousUser, User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.core.cache import cache
-from django.db.models import signals
+from django.db.models import signals  # pylint: disable=unused-import
 from django.db.models.functions import Lower
 from django.test import TestCase
 from edx_toggles.toggles.testutils import override_waffle_flag

--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -19,7 +19,6 @@ from edx_django_utils.plugins import get_plugins_view_context
 from edx_toggles.toggles import LegacyWaffleFlag, LegacyWaffleFlagNamespace
 from opaque_keys.edx.keys import CourseKey
 from pytz import UTC
-from six import iteritems, text_type
 
 from lms.djangoapps.bulk_email.api import is_bulk_email_feature_enabled
 from lms.djangoapps.bulk_email.models import Optout

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -8,7 +8,6 @@ import logging
 import uuid
 from collections import namedtuple
 
-import six
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
@@ -34,7 +33,6 @@ from ipware.ip import get_client_ip
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from pytz import UTC
-from six import text_type
 
 from common.djangoapps.track import views as track_views
 from lms.djangoapps.bulk_email.models import Optout

--- a/common/djangoapps/third_party_auth/lti.py
+++ b/common/djangoapps/third_party_auth/lti.py
@@ -7,7 +7,6 @@ import calendar
 import logging
 import time
 
-import six
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from oauthlib.common import Request
 from oauthlib.oauth1.rfc5849.signature import (
@@ -17,7 +16,6 @@ from oauthlib.oauth1.rfc5849.signature import (
     normalize_parameters,
     sign_hmac_sha1
 )
-from six import text_type
 from social_core.backends.base import BaseAuth
 from social_core.exceptions import AuthFailed
 from social_core.utils import sanitize_redirect

--- a/common/djangoapps/third_party_auth/saml.py
+++ b/common/djangoapps/third_party_auth/saml.py
@@ -12,7 +12,6 @@ from django.http import Http404
 from django.utils.functional import cached_property
 from django_countries import countries
 from onelogin.saml2.settings import OneLogin_Saml2_Settings
-from six import text_type
 from social_core.backends.saml import OID_EDU_PERSON_ENTITLEMENT, SAMLAuth, SAMLIdentityProvider
 from social_core.exceptions import AuthForbidden
 

--- a/common/djangoapps/third_party_auth/tasks.py
+++ b/common/djangoapps/third_party_auth/tasks.py
@@ -15,7 +15,6 @@ from edx_django_utils.monitoring import set_code_owner_attribute
 from lxml import etree
 from onelogin.saml2.utils import OneLogin_Saml2_Utils
 from requests import exceptions
-from six import text_type
 
 from openedx.core.djangolib.markup import Text
 from common.djangoapps.third_party_auth.models import SAMLConfiguration, SAMLProviderConfig, SAMLProviderData

--- a/common/djangoapps/third_party_auth/tests/testutil.py
+++ b/common/djangoapps/third_party_auth/tests/testutil.py
@@ -10,7 +10,6 @@ from contextlib import contextmanager
 from unittest import mock
 
 import django.test
-import six
 from django.conf import settings
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.contrib.sites.models import Site

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
@@ -22,7 +22,7 @@ import pytest
 # TODO remove this import and the configuration -- xmodule should not depend on django!
 from django.conf import settings
 from opaque_keys.edx.keys import CourseKey
-from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator, LibraryLocator
+from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator, LibraryLocator  # pylint: disable=unused-import
 from pytz import UTC
 from web_fragments.fragment import Fragment
 from xblock.core import XBlockAside

--- a/common/lib/xmodule/xmodule/modulestore/tests/utils.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/utils.py
@@ -3,7 +3,6 @@ Helper classes and methods for running modulestore tests without Django.
 """
 
 
-import io
 import os
 from contextlib import contextmanager
 from importlib import import_module

--- a/common/lib/xmodule/xmodule/modulestore/xml.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml.py
@@ -2,7 +2,6 @@
 
 import glob
 import hashlib
-import io
 import itertools
 import json
 import logging

--- a/common/lib/xmodule/xmodule/modulestore/xml_importer.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml_importer.py
@@ -23,7 +23,6 @@ Modulestore virtual   |          XML physical (draft, published)
 
 
 import json
-import io
 import logging
 import mimetypes
 import os

--- a/common/lib/xmodule/xmodule/raw_module.py
+++ b/common/lib/xmodule/xmodule/raw_module.py
@@ -4,8 +4,8 @@ import re
 
 from lxml import etree
 from xblock.fields import Scope, String
-from xmodule.editing_module import XMLEditingDescriptor
-from xmodule.xml_module import XmlDescriptor
+from xmodule.editing_module import XMLEditingDescriptor  # pylint: disable=unused-import
+from xmodule.xml_module import XmlDescriptor  # pylint: disable=unused-import
 
 from .exceptions import SerializationError
 

--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -38,7 +38,7 @@ from .exceptions import NotFoundError
 from .fields import Date
 from .mako_module import MakoTemplateBlockBase
 from .progress import Progress
-from .x_module import AUTHOR_VIEW, PUBLIC_VIEW, STUDENT_VIEW, XModule
+from .x_module import AUTHOR_VIEW, PUBLIC_VIEW, STUDENT_VIEW, XModule  # pylint: disable=unused-import
 from .xml_module import XmlMixin
 
 


### PR DESCRIPTION
Remove unused imports caused by pyupgrade PRs to fix pylint warnings.
This PR fixes the remaining `33 unused-import` warnings and along with the PR https://github.com/edx/edx-platform/pull/27083, it reduces the `unused-import` warnings to 0 & [total pylint violations to 91](https://build.testeng.edx.org/job/edx-platform-quality-pipeline-pr/26274/)