### PR TITLE
Allow `get_proctoring_escalation_email` to use a course key object

### DIFF
--- a/lms/djangoapps/instructor/tests/test_services.py
+++ b/lms/djangoapps/instructor/tests/test_services.py
@@ -175,9 +175,16 @@ class InstructorServiceTests(SharedModuleStoreTestCase):
         expected_body = body.format(**args)
         mock_create_zendesk_ticket.assert_called_with(requester_name, email, subject, expected_body, tags)
 
-    def test_get_proctoring_escalation_email(self):
+    def test_get_proctoring_escalation_email_from_course_key(self):
         """
-        Test that it returns the correct proctoring escalation email
+        Test that it returns the correct proctoring escalation email from a course key object
+        """
+        email = self.service.get_proctoring_escalation_email(self.course.id)
+        assert email == self.email
+
+    def test_get_proctoring_escalation_email_from_course_id(self):
+        """
+        Test that it returns the correct proctoring escalation email from a course id string
         """
         email = self.service.get_proctoring_escalation_email(str(self.course.id))
         assert email == self.email


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

- In `get_proctoring_escalation_email`, change parameter name to better describe what should be passed in (course_id, not course_key)
- If a course key object is still passed in, use it instead of raising an exception.
