### PR TITLE
temp: Apply pylint amnesy ( Type annotation-invalid-choice )

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -949,7 +949,7 @@ FEATURES = {
     # .. toggle_warnings: None.
     'ENABLE_COURSE_ASSESSMENT_GRADE_CHANGE_SIGNAL': False,
 
-    # .. toggle_name: FEATURES['ALLOW_ADMIN_ENTERPRISE_COURSE_ENROLLMENT_DELETION']
+    # .. toggle_name: FEATURES['ALLOW_ADMIN_ENTERPRISE_COURSE_ENROLLMENT_DELETION']  # lint-amnesty, pylint: disable=annotation-invalid-choice
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
     # .. toggle_description: If true, allows for the deletion of EnterpriseCourseEnrollment records via Django Admin.


### PR DESCRIPTION
On ubuntu20 quality was failing. 
Tried to fix one of the quality issue related with Type annotation-invalid-choice.

Old Jenkins [build](https://build.testeng.edx.org/job/edx-platform-quality-pipeline-pr/26122/pylint/folder.537484803/type.368910485/source.43e2b828-573e-48ed-ae5e-37dcc7247742/#942)

On devstack I got this. 
```
root@lms:/edx/app/edxapp/edx-platform# pylint lms/envs/common.py
************* Module lms.envs.common
lms/envs/common.py:952:0: E7650: "enterprise" is not a valid choice for 
".. toggle_use_cases:". Expected one of ['temporary', 'circuit_breaker', 'vip', 'opt_out', 'opt_in', 'open_edx']. 
(annotation-invalid-choice)
```