### PR TITLE
MB-849: Add command to generate credentials config

### DIFF
--- a/openedx/core/djangoapps/credentials/management/commands/create_credentials_api_configuration.py
+++ b/openedx/core/djangoapps/credentials/management/commands/create_credentials_api_configuration.py
@@ -1,0 +1,21 @@
+""" Command to create a credentials api configuration """
+from django.core.management.base import BaseCommand, CommandError
+from openedx.core.djangoapps.credentials.models import CredentialsApiConfig
+
+
+class Command(BaseCommand):
+    """
+    Creates a api configuration between LMS <--> Credentials service.
+    This command is meant to be used in combination with other commands to
+    create a fully connected path to awarding program certificates in devstack.
+    """
+
+    # pylint: disable=unused-argument
+    def handle(self, *args, **kwargs):
+        try:
+            CredentialsApiConfig.objects.create(
+                enabled=True,
+                enable_learner_issuance=True,
+            )
+        except Exception as e:
+            raise CommandError from e

--- a/openedx/core/djangoapps/credentials/management/commands/tests/test_create_credentials_api_configuration.py
+++ b/openedx/core/djangoapps/credentials/management/commands/tests/test_create_credentials_api_configuration.py
@@ -1,0 +1,30 @@
+"""
+Tests for the create_credentials_api_configuration command
+"""
+
+from unittest import TestCase
+
+import mock
+import pytest
+from django.core.management import call_command
+
+from openedx.core.djangoapps.credentials.models import CredentialsApiConfig
+from openedx.core.djangolib.testing.utils import skip_unless_lms
+
+from ..create_credentials_api_configuration import Command
+
+COMMAND_MODULE = "openedx.core.djangoapps.credentials.management.commands.create_credentials_api_configuration"
+
+
+@skip_unless_lms
+@pytest.mark.django_db
+class CertAllowlistGenerationTests(TestCase):
+    """
+    Tests for the create_credentials_api_configuration management command
+    """
+
+    @mock.patch(COMMAND_MODULE)
+    # pylint: disable=unused-argument
+    def test_successful_generation(self, mock_command):
+        call_command(Command())
+        assert len(CredentialsApiConfig.objects.all()) > 0


### PR DESCRIPTION
feat: Adds a command to create an API connection to credentials for testing
program certificates on devstack. This command is not meant to be ran
manually, and will be included in a provisioning type script that will
be added later.
