### PR TITLE
MST-682 Add external_user_key to the student profile CSV

### DIFF
--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -2618,13 +2618,16 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
 
         assert ('team' in res_json['feature_names']) == has_teams
 
-    def test_get_students_features_external_user_key(self):
+    @ddt.data(True, False)
+    def test_get_students_features_external_user_key(self, has_program_enrollments):
         external_key_dict = {}
-        for i in range(len(self.students)):
-            student = self.students[i]
-            external_key = "{}_{}".format(student.username, i)
-            ProgramEnrollmentFactory.create(user=student, external_user_key=external_key)
-            external_key_dict[student.username] = external_key
+        if has_program_enrollments:
+            for i in range(len(self.students)):
+                student = self.students[i]
+                external_key = "{}_{}".format(student.username, i)
+                ProgramEnrollmentFactory.create(user=student, external_user_key=external_key)
+                external_key_dict[student.username] = external_key
+
         url = reverse('get_students_features', kwargs={'course_id': str(self.course.id)})
 
         response = self.client.post(url, {})
@@ -2636,7 +2639,10 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
                 if x['username'] == student.username
             ][0]
             assert student_json['username'] == student.username
-            assert student_json['external_user_key'] == external_key_dict[student.username]
+            if has_program_enrollments:
+                assert student_json['external_user_key'] == external_key_dict[student.username]
+            else:
+                assert student_json['external_user_key'] == ''
 
     def test_get_students_who_may_enroll(self):
         """

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1141,7 +1141,7 @@ def get_students_features(request, course_id, csv=False):  # pylint: disable=red
             'id', 'username', 'name', 'email', 'language', 'location',
             'year_of_birth', 'gender', 'level_of_education', 'mailing_address',
             'goals', 'enrollment_mode', 'verification_status',
-            'last_login', 'date_joined',
+            'last_login', 'date_joined', 'external_user_key'
         ]
 
     # Provide human-friendly and translatable names for these features. These names
@@ -1163,6 +1163,7 @@ def get_students_features(request, course_id, csv=False):  # pylint: disable=red
         'verification_status': _('Verification Status'),
         'last_login': _('Last Login'),
         'date_joined': _('Date Joined'),
+        'external_user_key': _('External User Key'),
     }
 
     if is_course_cohorted(course.id):

--- a/lms/djangoapps/instructor_analytics/tests/test_basic.py
+++ b/lms/djangoapps/instructor_analytics/tests/test_basic.py
@@ -248,7 +248,6 @@ class TestAnalyticsBasic(ModuleStoreTestCase):
             else:
                 assert '' == report['external_user_key']
 
-
     def test_available_features(self):
         assert len(AVAILABLE_FEATURES) == len((STUDENT_FEATURES + PROFILE_FEATURES + PROGRAM_ENROLLMENT_FEATURES))
         assert set(AVAILABLE_FEATURES) == set((STUDENT_FEATURES + PROFILE_FEATURES + PROGRAM_ENROLLMENT_FEATURES))

--- a/lms/djangoapps/program_enrollments/api/__init__.py
+++ b/lms/djangoapps/program_enrollments/api/__init__.py
@@ -21,6 +21,7 @@ from .reading import (
     fetch_program_course_enrollments_by_students,
     fetch_program_enrollments,
     fetch_program_enrollments_by_student,
+    fetch_program_enrollments_by_students,
     get_external_key_by_user_and_course,
     get_org_key_for_program,
     get_program_course_enrollment,

--- a/lms/djangoapps/program_enrollments/api/reading.py
+++ b/lms/djangoapps/program_enrollments/api/reading.py
@@ -291,7 +291,7 @@ def fetch_program_enrollments_by_students(
         * waiting_only (bool)
 
     Optional arguments are used as filtersets if they are not None.
-    
+
     Returns: queryset[ProgramEnrollment]
     """
     if not (users or external_user_keys):
@@ -303,7 +303,7 @@ def fetch_program_enrollments_by_students(
     filters = {
         "user__in": users,
         "external_user_key__in": external_user_keys,
-        "program_enrollment__status__in": program_enrollment_statuses,
+        "status__in": program_enrollment_statuses,
     }
     if realized_only:
         filters["user__isnull"] = False

--- a/lms/djangoapps/program_enrollments/api/reading.py
+++ b/lms/djangoapps/program_enrollments/api/reading.py
@@ -271,6 +271,47 @@ def fetch_program_enrollments_by_student(
     return ProgramEnrollment.objects.filter(**_remove_none_values(filters))
 
 
+def fetch_program_enrollments_by_students(
+    users=None,
+    external_user_keys=None,
+    program_enrollment_statuses=None,
+    realized_only=False,
+    waiting_only=False,
+):
+    """
+    Fetch program enrollments for a specific list of students.
+
+    Required arguments (at least one must be provided):
+        * users (iterable[User])
+        * external_user_keys (iterable[str])
+
+    Optional arguments:
+        * program_enrollment_statuses (iterable[str])
+        * realized_only (bool)
+        * waiting_only (bool)
+
+    Optional arguments are used as filtersets if they are not None.
+    
+    Returns: queryset[ProgramEnrollment]
+    """
+    if not (users or external_user_keys):
+        raise ValueError(_STUDENT_LIST_ARG_ERROR_MESSAGE)
+    if realized_only and waiting_only:
+        raise ValueError(
+            _REALIZED_FILTER_ERROR_TEMPLATE.format("realized_only", "waiting_only")
+        )
+    filters = {
+        "user__in": users,
+        "external_user_key__in": external_user_keys,
+        "program_enrollment__status__in": program_enrollment_statuses,
+    }
+    if realized_only:
+        filters["user__isnull"] = False
+    if waiting_only:
+        filters["user__isnull"] = True
+    return ProgramEnrollment.objects.filter(**_remove_none_values(filters))
+
+
 def fetch_program_course_enrollments_by_students(
         users=None,
         external_user_keys=None,

--- a/lms/djangoapps/program_enrollments/api/tests/test_reading.py
+++ b/lms/djangoapps/program_enrollments/api/tests/test_reading.py
@@ -42,6 +42,7 @@ from ..reading import (
     fetch_program_course_enrollments_by_students,
     fetch_program_enrollments,
     fetch_program_enrollments_by_student,
+    fetch_program_enrollments_by_students,
     get_external_key_by_user_and_course,
     get_program_course_enrollment,
     get_program_enrollment,
@@ -368,6 +369,52 @@ class ProgramEnrollmentReadingTests(TestCase):
     def test_fetch_program_enrollments_by_student(self, kwargs, expected_enrollment_ids):
         kwargs = self._username_to_user(kwargs)
         actual_enrollments = fetch_program_enrollments_by_student(**kwargs)
+        actual_enrollment_ids = {enrollment.id for enrollment in actual_enrollments}
+        assert actual_enrollment_ids == expected_enrollment_ids
+
+
+    @ddt.data(
+
+        # User with no enrollments
+        (
+            {'usernames': [username_0]},
+            set(),
+        ),
+
+        # Filters
+        (
+            {
+                'usernames': [username_3],
+            },
+            {3, 7},
+        ),
+
+        # More filters
+        (
+            {
+                'usernames': [username_3],
+                'external_user_keys': [ext_3],
+                'program_enrollment_statuses': {PEStatuses.SUSPENDED, PEStatuses.CANCELED},
+            },
+            {7},
+        ),
+
+        # Realized-only filter
+        (
+            {'usernames': [username_4], 'realized_only': True},
+            {4},
+        ),
+
+        # Waiting-only filter
+        (
+            {'external_user_keys': [ext_4], 'waiting_only': True},
+            {8},
+        ),
+    )
+    @ddt.unpack
+    def test_fetch_program_enrollments_by_students(self, kwargs, expected_enrollment_ids):
+        kwargs = self._usernames_to_users(kwargs)
+        actual_enrollments = fetch_program_enrollments_by_students(**kwargs)
         actual_enrollment_ids = {enrollment.id for enrollment in actual_enrollments}
         assert actual_enrollment_ids == expected_enrollment_ids
 

--- a/lms/djangoapps/program_enrollments/api/tests/test_reading.py
+++ b/lms/djangoapps/program_enrollments/api/tests/test_reading.py
@@ -372,7 +372,6 @@ class ProgramEnrollmentReadingTests(TestCase):
         actual_enrollment_ids = {enrollment.id for enrollment in actual_enrollments}
         assert actual_enrollment_ids == expected_enrollment_ids
 
-
     @ddt.data(
 
         # User with no enrollments


### PR DESCRIPTION

## Description

This is a request from some Masters school partners. They would like to download the student enrolled list with the Masters external_user_key data referenced. This way, the schools can properly match the students enrolled in the course with the students enrolled through Masters enrollment system

The edX role impacted by this change is the course team members and edX staff members who have access to instructors dashboard data download tab. They are able to download students enrolled list and see extra external_user_key field.

## Testing Instructions
* As a course team member, not an edX staff, go to "Instructors Dashboard" "Data Download" tab.
* Initiate the download of "Profile information as CSV"
* See the downloaded list and make sure the field "external_user_key" is within the CSV
* Make sure the value of the data is what's stored in edX database
