### PR TITLE
Fixed Html escaping in course name in API

### DIFF
--- a/common/lib/xmodule/xmodule/block_metadata_utils.py
+++ b/common/lib/xmodule/xmodule/block_metadata_utils.py
@@ -6,7 +6,7 @@ allows us to share code between the XModuleMixin and CourseOverview and
 BlockStructure.
 """
 
-from markupsafe import escape
+from markupsafe import Markup
 
 
 def url_name_for_block(block):
@@ -77,6 +77,6 @@ def display_name_with_default_escaped(block):
             Block that is being accessed
     """
     # This escaping is incomplete.  However, rather than switching this to use
-    # markupsafe.escape() and fixing issues, better to put that energy toward
+    # markupsafe.striptags() and fixing issues, better to put that energy toward
     # migrating away from this method altogether.
-    return escape(display_name_with_default(block)).replace('&amp;', '&')
+    return Markup(display_name_with_default(block)).striptags()

--- a/common/lib/xmodule/xmodule/tests/test_course_metadata_utils.py
+++ b/common/lib/xmodule/xmodule/tests/test_course_metadata_utils.py
@@ -70,7 +70,7 @@ class CourseMetadataUtilsTestCase(TestCase):
                     user_id=-3,  # -3 refers to a "testing user"
                     fields={
                         "start": _NEXT_WEEK,
-                        "display_name": "Intro to <html>"
+                        "display_name": "Intro to <div>html</div>"
                     }
                 )
 
@@ -136,13 +136,13 @@ class CourseMetadataUtilsTestCase(TestCase):
                 # Test course with no display name.
                 TestScenario((self.demo_course,), "Empty"),
                 # Test course with a display name that contains characters that need escaping.
-                TestScenario((self.html_course,), "Intro to &lt;html&gt;"),
+                TestScenario((self.html_course,), "Intro to html"),
             ]),
             FunctionTest(display_name_with_default, [
                 # Test course with no display name.
                 TestScenario((self.demo_course,), "Empty"),
                 # Test course with a display name that contains characters that need escaping.
-                TestScenario((self.html_course,), "Intro to <html>"),
+                TestScenario((self.html_course,), "Intro to <div>html</div>"),
             ]),
             FunctionTest(number_for_course_location, [
                 TestScenario((self.demo_course.location,), "DemoX.1"),


### PR DESCRIPTION

https://openedx.atlassian.net/browse/TNL-7999

& Showing up instead of & in course API which is impacting Insights.Fixed Html escaping in course name in API