### PR TITLE
temp: remove false positives on safe sessions middleware

### DIFF
--- a/openedx/core/djangoapps/safe_sessions/middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/middleware.py
@@ -368,6 +368,8 @@ class SafeSessionMiddleware(SessionMiddleware, MiddlewareMixin):
         given userid_in_session.
         """
         if hasattr(request, 'safe_cookie_verified_user_id'):
+            if hasattr(request.user, 'real_user'):  # User is a masqueraded user.
+                request.user = request.user.real_user
             if request.safe_cookie_verified_user_id != request.user.id:
                 # The user at response time is expected to be None when the user
                 # is logging out. To prevent extra noise in the logs,

--- a/openedx/core/djangoapps/safe_sessions/middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/middleware.py
@@ -368,7 +368,9 @@ class SafeSessionMiddleware(SessionMiddleware, MiddlewareMixin):
         given userid_in_session.
         """
         if hasattr(request, 'safe_cookie_verified_user_id'):
-            if hasattr(request.user, 'real_user'):  # User is a masqueraded user.
+            if hasattr(request.user, 'real_user'):
+                # If a view overrode the request.user with a masqueraded user, this will
+                #   revert/clean-up that change during response processing.
                 request.user = request.user.real_user
             if request.safe_cookie_verified_user_id != request.user.id:
                 # The user at response time is expected to be None when the user


### PR DESCRIPTION
## Description
This is a temporary fix to deal with false positives in the system due
to the masquerading feature.  Long term we may not want to rely on
knowing about how masquerding works in the safe sessions middleware and
instead manage masquerding of the requset user in some other way.

## Supporting information
Jira: ARCHBOM-1718