### PR TITLE
WIP: example fix for toggle state report

### DIFF
--- a/openedx/core/djangoapps/waffle_utils/views.py
+++ b/openedx/core/djangoapps/waffle_utils/views.py
@@ -63,7 +63,12 @@ class ToggleStateView(views.APIView):
         Expose toggle state report dict as a view.
         """
         report = CourseOverrideToggleStateReport().as_dict()
-        _add_waffle_flag_course_override_state(report["waffle_flags"])
+        flags_list = report["waffle_flags"]
+        flags_dict = {flag['name']:flag for flag in flags_list}
+        _add_waffle_flag_course_override_state(flags_dict)
+        # sorted_values_by_name should be exposed from edx_toggles.toggles.state
+        from edx_toggles.toggles.state.internal.report import sorted_values_by_name
+        report["waffle_flags"] = sorted_values_by_name(flags_dict)
         return Response(report)
 
 


### PR DESCRIPTION
## Description

Example fix for toggle state report.

Needs:
* Update in edx-toggles to expose sorted_values_by_name
* Unit test that breaks without this change and works with this change.

@regis: I'm using this PR simply to communicate the problem. The endpoint is currently broken for edx.org until we get a fix in.