### PR TITLE
fixes contentstore next section navigation

### DIFF
--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -587,7 +587,7 @@ def get_sibling_urls(subsection):
             ))
         else:
             try:
-                next_section = sections[sections.index(next(s for s in sections if s.location == section.location)) - 1]
+                next_section = sections[sections.index(next(s for s in sections if s.location == section.location)) + 1]
                 next_loc = next_section.get_children()[0].get_children()[0].location
             except IndexError:
                 pass


### PR DESCRIPTION
## Description
fixes bug introduced by #25965 pointed out in this conversation https://github.com/edx/edx-platform/commit/dd96a2#r48570091

Bug: https://openedx.atlassian.net/browse/CR-3413: Next button redirect in Studio is not allowing instructors to move through the course sequentially