### PR TITLE
Revert "fix: Stop rendering Visibility and Move buttons on libraries #26885)"

### DIFF
--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -294,10 +294,10 @@ def _studio_wrap_xblock(xblock, view, frag, context, display_name_only=False):
             'is_root': is_root,
             'is_reorderable': is_reorderable,
             'can_edit': context.get('can_edit', True),
-            'can_edit_visibility': context.get('can_edit_visibility', xblock.course_id.is_course),
+            'can_edit_visibility': context.get('can_edit_visibility', True),
             'selected_groups_label': selected_groups_label,
             'can_add': context.get('can_add', True),
-            'can_move': context.get('can_move', xblock.course_id.is_course),
+            'can_move': context.get('can_move', True),
             'language': getattr(course, 'language', None)
         }
 


### PR DESCRIPTION
This reverts commit 777bb633c5b2e1c54eb61d9bcd2bdf13436aaef4.

Unfortunately this breaks ORAs in studio. There's no problem with this change but we will need to make some changes to ORA.

https://openedx.atlassian.net/browse/EDUCATOR-5641
https://openedx.atlassian.net/browse/EDUCATOR-5643
