### PR TITLE
[BD-21] fix: TypeError in toggle state report view

### DIFF
--- a/openedx/core/djangoapps/waffle_utils/tests/test_views.py
+++ b/openedx/core/djangoapps/waffle_utils/tests/test_views.py
@@ -37,6 +37,16 @@ class ToggleStateViewTests(TestCase):  # lint-amnesty, pylint: disable=missing-c
             "class": "SettingDictToggle",
         } in response.data["django_settings"]
 
+    def test_response_with_course_override(self):
+        models.WaffleFlagCourseOverrideModel.objects.create(waffle_flag="my.flag", enabled=True)
+        response = get_toggle_state_response()
+        assert response.data["waffle_flags"]
+        assert "my.flag" == response.data["waffle_flags"][0]["name"]
+        assert response.data["waffle_flags"][0]["course_overrides"]
+        assert "None" == response.data["waffle_flags"][0]["course_overrides"][0]["course_id"]
+        assert "on" == response.data["waffle_flags"][0]["course_overrides"][0]["force"]
+        assert "both" == response.data["waffle_flags"][0]["computed_status"]
+
     def test_course_overrides(self):
         models.WaffleFlagCourseOverrideModel.objects.create(waffle_flag="my.flag", enabled=True)
         course_overrides = {}

--- a/openedx/core/djangoapps/waffle_utils/views.py
+++ b/openedx/core/djangoapps/waffle_utils/views.py
@@ -63,7 +63,6 @@ class ToggleStateView(views.APIView):
         Expose toggle state report dict as a view.
         """
         report = CourseOverrideToggleStateReport().as_dict()
-        _add_waffle_flag_course_override_state(report["waffle_flags"])
         return Response(report)
 
 


### PR DESCRIPTION
## Description

We were attempting to add course overrides twice to objects returned in
the toggle state report view. This was causing a TypeError (and thus a
500 error) because the second time, we were attempting to add entries to
an incorrect object.

This issue was not caught by unit tests because we were not testing the
view with WaffleFlagCourseOverride objects. This commit adds a unit test
to prevent future errors.

## Supporting information

This is another fix for PR #27108.

This is ready for review @robrap.