### PR TITLE
fix: Add ‘ENABLE_HELP_LINK’ to Studio settings

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -447,6 +447,16 @@ FEATURES = {
     # .. toggle_tickets: None
     # .. toggle_warnings: Another toggle DISABLE_LIBRARY_CREATION overrides DISABLE_COURSE_CREATION, if present.
     'DISABLE_COURSE_CREATION': False,
+
+    # Can be turned off to disable the help link in the navbar
+    # .. toggle_name: FEATURES['ENABLE_HELP_LINK']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: True
+    # .. toggle_description: When True, a help link is displayed on the main navbar. Set False to hide it.
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2021-03-05
+    # .. toggle_tickets: https://github.com/edx/edx-platform/pull/26106
+    'ENABLE_HELP_LINK': True,
 }
 
 ENABLE_JASMINE = False

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -279,7 +279,6 @@ FEATURES = {
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/26106
     'ENABLE_HELP_LINK': True,
 
-
     # .. toggle_name: FEATURES['HIDE_DASHBOARD_COURSES_UNTIL_ACTIVATED']
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False


### PR DESCRIPTION
Fixes an issue where the button that linked to edX documentation for
course teams in Studio that displayed beside the logged-in user's username/
drop-down menu is gone. Regression from PR #26106

Ref: TNL-8138