### PR TITLE
Revert Revert of #26885

### DIFF
--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -294,10 +294,10 @@ def _studio_wrap_xblock(xblock, view, frag, context, display_name_only=False):
             'is_root': is_root,
             'is_reorderable': is_reorderable,
             'can_edit': context.get('can_edit', True),
-            'can_edit_visibility': context.get('can_edit_visibility', True),
+            'can_edit_visibility': context.get('can_edit_visibility', xblock.course_id.is_course),
             'selected_groups_label': selected_groups_label,
             'can_add': context.get('can_add', True),
-            'can_move': context.get('can_move', True),
+            'can_move': context.get('can_move', xblock.course_id.is_course),
             'language': getattr(course, 'language', None)
         }
 

--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -294,10 +294,10 @@ def _studio_wrap_xblock(xblock, view, frag, context, display_name_only=False):
             'is_root': is_root,
             'is_reorderable': is_reorderable,
             'can_edit': context.get('can_edit', True),
-            'can_edit_visibility': context.get('can_edit_visibility', xblock.course_id.is_course),
+            'can_edit_visibility': context.get('can_edit_visibility', xblock.scope_ids.usage_id.context_key.is_course),
             'selected_groups_label': selected_groups_label,
             'can_add': context.get('can_add', True),
-            'can_move': context.get('can_move', xblock.course_id.is_course),
+            'can_move': context.get('can_move', xblock.scope_ids.usage_id.context_key.is_course),
             'language': getattr(course, 'language', None)
         }
 


### PR DESCRIPTION
## Description

In #27113 I reverted #26885

This PR is reintroduces the changes from  #26885, in such a way that they don't cause any issues with open response assessments. 
Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

https://github.com/edx/edx-platform/pull/27113#issuecomment-805100987

![Screen Shot 2021-03-23 at 5 01 09 PM](https://user-images.githubusercontent.com/1639231/112217909-73bfcf80-8bf9-11eb-8c25-fd4d0353daaf.png)

Background and testing instructions are the same as in #26885, but also check that we can create ORAs. 


https://studio-jansenk.sandbox.edx.org/container/block-v1:edX+Test101+course+type@vertical+block@d61ce075223648da8346752bc5a46e95