### PR TITLE
fix: don't duplicate text in forum notification email

### DIFF
--- a/lms/djangoapps/discussion/templates/discussion/edx_ace/responsenotification/email/body.html
+++ b/lms/djangoapps/discussion/templates/discussion/edx_ace/responsenotification/email/body.html
@@ -20,7 +20,9 @@
                 {{ comment_body }}
             </div>
 
-            {% trans "View discussion" as course_cta_text %}{{course_cta_text|force_escape}}
+            {% filter force_escape %}
+                {% blocktrans asvar course_cta_text %}View discussion{% endblocktrans %}
+            {% endfilter %}
             {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=post_link%}
 
             {% block google_analytics_pixel %}


### PR DESCRIPTION
Corresponds to #27014 