### PR TITLE
Fix edxloggedin cookie not present issue.

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/login_form.py
+++ b/openedx/core/djangoapps/user_authn/views/login_form.py
@@ -187,6 +187,14 @@ def login_and_registration_form(request, initial_mode="login"):
     enterprise_customer = enterprise_customer_for_request(request)
     # Redirect to authn MFE if it is enabled
     if should_redirect_to_authn_microfrontend() and not enterprise_customer:
+
+        # This is to handle a case where a logged-in cookie is not present but the user is authenticated.
+        # Note: If we don't handle this learner is redirected to authn MFE and then back to dashboard
+        # instead of the desired redirect URL (e.g. finish_auth) resulting in learners not enrolling
+        # into the courses.
+        if request.user.is_authenticated and redirect_to:
+            return redirect(redirect_to)
+
         query_params = request.GET.urlencode()
         url_path = '/{}{}'.format(
             initial_mode,


### PR DESCRIPTION
## Description

If `edxloggedin` cookie is not present but the user is authenticated; the user is redirected to authn MFE and then back to dashboard instead of the desired redirect URL (e.g. finish_auth) resulting in learners not enrolling into the courses.

VAN-415