### PR TITLE
Fixing dates serialization in course import

### DIFF
--- a/common/lib/xmodule/xmodule/tests/test_xml_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_xml_module.py
@@ -4,6 +4,7 @@
 
 import unittest
 from unittest.mock import Mock
+import dateutil.parser
 
 from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator
 from xblock.field_data import DictFieldData
@@ -386,6 +387,7 @@ class TestSerialize(unittest.TestCase):
         assert serialize_field(['foo', 'bar']) == '["foo", "bar"]'
         assert serialize_field("2012-12-31T23:59:59Z") == '2012-12-31T23:59:59Z'
         assert serialize_field("1 day 12 hours 59 minutes 59 seconds") == '1 day 12 hours 59 minutes 59 seconds'
+        assert serialize_field(dateutil.parser.parse('2012-12-31T23:59:59Z')) == '2012-12-31T23:59:59+00:00'
 
 
 class TestDeserialize(unittest.TestCase):

--- a/common/lib/xmodule/xmodule/xml_module.py
+++ b/common/lib/xmodule/xmodule/xml_module.py
@@ -1,4 +1,5 @@
 # lint-amnesty, pylint: disable=missing-module-docstring
+import datetime
 
 import copy
 import json
@@ -65,6 +66,10 @@ def serialize_field(value):
     """
     if isinstance(value, str):
         return value
+    elif isinstance(value, datetime.datetime):
+        if value.tzinfo is not None and value.utcoffset() is None:
+            return value.isoformat() + 'Z'
+        return value.isoformat()
 
     return json.dumps(value, cls=EdxJSONEncoder)
 


### PR DESCRIPTION
During the course Export, course `start` and `end` dates are dumped twice. e.g.`'"2020-01-01"'` and also in the screenshot below. 

<img width="1172" alt="Screen Shot 2021-03-25 at 6 02 19 PM" src="https://user-images.githubusercontent.com/4252738/112477128-77d42480-8d94-11eb-847a-0daaf941849f.png">

While running the `olxcleaner` on the exported course, it gave an error that the dates are not parseable. 
```
The tag <course url_name=\'T22021\' display_name=\'E2E Test Course\'> has an invalid date setting for end: \'"2028-12-31T00:00:00+00:00"\'.
```

[TNL-8153](https://openedx.atlassian.net/browse/TNL-8153)