### PR TITLE
 feat: Add more detailed request user change logging.

### DIFF
--- a/common/djangoapps/util/tests/test_date_utils.py
+++ b/common/djangoapps/util/tests/test_date_utils.py
@@ -6,10 +6,13 @@ import unittest
 from datetime import datetime, timedelta, tzinfo
 from unittest.mock import patch
 
+import crum
 import ddt
 import pytest
 from markupsafe import Markup
 from pytz import utc
+
+from django.test.client import RequestFactory
 
 from common.djangoapps.util.date_utils import (
     almost_same_datetime, get_default_time_display, get_time_display, strftime_localized, strftime_localized_html
@@ -217,6 +220,12 @@ class StrftimeLocalizedHtmlTest(unittest.TestCase):
     """
     Tests for strftime_localized_html.
     """
+    def setUp(self):
+        super().setUp()
+        request = RequestFactory().request()
+        self.addCleanup(crum.set_current_request, None)
+        crum.set_current_request(request)
+
     @ddt.data(
         None,
         'Africa/Casablanca',

--- a/lms/djangoapps/course_api/tests/test_views.py
+++ b/lms/djangoapps/course_api/tests/test_views.py
@@ -387,7 +387,7 @@ class CourseListSearchViewTest(CourseApiTestViewMixin, ModuleStoreTestCase, Sear
         self.setup_user(self.audit_user)
 
         # These query counts were found empirically
-        query_counts = [54, 46, 46, 46, 46, 46, 46, 46, 46, 46, 16]
+        query_counts = [55, 46, 46, 46, 46, 46, 46, 46, 46, 46, 16]
         ordered_course_ids = sorted([str(cid) for cid in (course_ids + [c.id for c in self.courses])])
 
         self.clear_caches()

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
@@ -171,7 +171,7 @@ class TestOwnUsernameAPI(CacheIsolationTestCase, UserAPITestCase):
         Test that a client (logged in) can get her own username.
         """
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
-        self._verify_get_own_username(17)
+        self._verify_get_own_username(18)
 
     def test_get_username_inactive(self):
         """
@@ -181,7 +181,7 @@ class TestOwnUsernameAPI(CacheIsolationTestCase, UserAPITestCase):
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
         self.user.is_active = False
         self.user.save()
-        self._verify_get_own_username(17)
+        self._verify_get_own_username(18)
 
     def test_get_username_not_logged_in(self):
         """
@@ -355,7 +355,7 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
         """
         self.different_client.login(username=self.different_user.username, password=TEST_PASSWORD)
         self.create_mock_profile(self.user)
-        with self.assertNumQueries(24):
+        with self.assertNumQueries(25):
             response = self.send_get(self.different_client)
         self._verify_full_shareable_account_response(response, account_privacy=ALL_USERS_VISIBILITY)
 
@@ -370,7 +370,7 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
         """
         self.different_client.login(username=self.different_user.username, password=TEST_PASSWORD)
         self.create_mock_profile(self.user)
-        with self.assertNumQueries(24):
+        with self.assertNumQueries(25):
             response = self.send_get(self.different_client)
         self._verify_private_account_response(response)
 
@@ -517,7 +517,7 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
             assert data['accomplishments_shared'] is False
 
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
-        verify_get_own_information(22)
+        verify_get_own_information(23)
 
         # Now make sure that the user can get the same information, even if not active
         self.user.is_active = False
@@ -537,7 +537,7 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
         legacy_profile.save()
 
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
-        with self.assertNumQueries(22):
+        with self.assertNumQueries(23):
             response = self.send_get(self.client)
         for empty_field in ("level_of_education", "gender", "country", "state", "bio",):
             assert response.data[empty_field] is None


### PR DESCRIPTION
## Description
The change is behind a WafleFlag and can be turned on to log every time
the `user` attribute of an instrumented request changes.  This will
significantly increase log volume so it shouldn't be left on all the
time but can be turned on to quickly debug issues related to sessions.

Ticket: https://openedx.atlassian.net/browse/ARCHBOM-1718

This change will be relevant to Developers and Operators of Open edX. See the toggle annotation for more
details.

## Deadline

None
