### PR TITLE
feat: bump edx-ace to 1.1.0

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -88,7 +88,7 @@ docopt==0.6.2             # via xmodule
 docutils==0.16            # via botocore
 drf-jwt==1.18.0           # via edx-drf-extensions
 drf-yasg==1.20.0          # via edx-api-doc-tools
-edx-ace==1.0.1            # via -r requirements/edx/base.in
+edx-ace==1.1.0            # via -r requirements/edx/base.in
 edx-analytics-data-api-client==0.17.0  # via -r requirements/edx/base.in
 edx-api-doc-tools==1.4.0  # via -r requirements/edx/base.in
 edx-bulk-grades==0.8.7    # via -r requirements/edx/base.in, staff-graded-xblock

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -99,7 +99,7 @@ docopt==0.6.2             # via -r requirements/edx/testing.txt, xmodule
 docutils==0.16            # via -r requirements/edx/testing.txt, botocore, m2r, sphinx
 drf-jwt==1.18.0           # via -r requirements/edx/testing.txt, edx-drf-extensions
 drf-yasg==1.20.0          # via -r requirements/edx/testing.txt, edx-api-doc-tools
-edx-ace==1.0.1            # via -r requirements/edx/testing.txt
+edx-ace==1.1.0            # via -r requirements/edx/testing.txt
 edx-analytics-data-api-client==0.17.0  # via -r requirements/edx/testing.txt
 edx-api-doc-tools==1.4.0  # via -r requirements/edx/testing.txt
 edx-bulk-grades==0.8.7    # via -r requirements/edx/testing.txt, staff-graded-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -96,7 +96,7 @@ docopt==0.6.2             # via -r requirements/edx/base.txt, xmodule
 docutils==0.16            # via -r requirements/edx/base.txt, botocore
 drf-jwt==1.18.0           # via -r requirements/edx/base.txt, edx-drf-extensions
 drf-yasg==1.20.0          # via -r requirements/edx/base.txt, edx-api-doc-tools
-edx-ace==1.0.1            # via -r requirements/edx/base.txt
+edx-ace==1.1.0            # via -r requirements/edx/base.txt
 edx-analytics-data-api-client==0.17.0  # via -r requirements/edx/base.txt
 edx-api-doc-tools==1.4.0  # via -r requirements/edx/base.txt
 edx-bulk-grades==0.8.7    # via -r requirements/edx/base.txt, staff-graded-xblock


### PR DESCRIPTION
This gives us the ability to set a Braze-specific from-address via configuration settings.