### PR TITLE
fix: AA-724: Updating the HiddenContentTransformer

### DIFF
--- a/lms/djangoapps/course_blocks/transformers/hidden_content.py
+++ b/lms/djangoapps/course_blocks/transformers/hidden_content.py
@@ -31,7 +31,7 @@ class HiddenContentTransformer(FilteringTransformerMixin, BlockStructureTransfor
 
     Staff users are exempted from hidden content rules.
     """
-    WRITE_VERSION = 2
+    WRITE_VERSION = 3
     READ_VERSION = 2
     MERGED_DUE_DATE = 'merged_due_date'
     MERGED_HIDE_AFTER_DUE = 'merged_hide_after_due'
@@ -88,7 +88,7 @@ class HiddenContentTransformer(FilteringTransformerMixin, BlockStructureTransfor
             func_merge_ancestors=min,
         )
 
-        block_structure.request_xblock_fields('self_paced', 'end')
+        block_structure.request_xblock_fields('self_paced', 'end', 'due')
 
     def transform_block_filters(self, usage_info, block_structure):
         # Users with staff access bypass the Visibility check.


### PR DESCRIPTION
We heard about a bug where learners granted extensions would still
lose access to content if it was marked as "hidden after due date".
This was caused by the HiddenContentTransformer using the due date
from collection time (publish time) rather than the user date returned
from the edx-when DateOverrideTransformer.

A small subtletly of these PRs is that Transformers with the
FilteringTransformerMixin are executed before those without it so
part of the fix was to make the HiddenContentTransformer not use the
FilteringTransformerMixin to ensure the DateOverrideTransformer had
run first.

Part 1/3 - Updating collect method + updating Write version

See also https://github.com/edx/edx-platform/pull/27153 and https://github.com/edx/edx-platform/pull/27154