### PR TITLE
fix: AA-724: Updating the HiddenContentTransformer

### DIFF
--- a/lms/djangoapps/course_blocks/transformers/hidden_content.py
+++ b/lms/djangoapps/course_blocks/transformers/hidden_content.py
@@ -7,10 +7,7 @@ from datetime import datetime
 
 from pytz import utc
 
-from openedx.core.djangoapps.content.block_structure.transformer import (
-    BlockStructureTransformer,
-    FilteringTransformerMixin
-)
+from openedx.core.djangoapps.content.block_structure.transformer import BlockStructureTransformer
 from xmodule.seq_module import SequenceBlock
 
 from .utils import collect_merged_boolean_field, collect_merged_date_field
@@ -18,21 +15,24 @@ from .utils import collect_merged_boolean_field, collect_merged_date_field
 MAXIMUM_DATE = utc.localize(datetime.max)
 
 
-class HiddenContentTransformer(FilteringTransformerMixin, BlockStructureTransformer):
+class HiddenContentTransformer(BlockStructureTransformer):
     """
     A transformer that enforces the hide_after_due field on
     blocks by removing children blocks from the block structure for
-    which the user does not have access. The due and hide_after_due
-    fields on a block is percolated down to its descendants, so that
+    which the user does not have access. The hide_after_due
+    field on a block is percolated down to its descendants, so that
     all blocks enforce the hidden content settings from their ancestors.
 
     For a block with multiple parents, access is denied only if
     access is denied from all its parents.
 
     Staff users are exempted from hidden content rules.
+
+    IMPORTANT: Must be run _after_ the DateOverrideTransformer from edx-when
+    in case the 'due' date on a block has been shifted for a user.
     """
     WRITE_VERSION = 3
-    READ_VERSION = 2
+    READ_VERSION = 3
     MERGED_DUE_DATE = 'merged_due_date'
     MERGED_HIDE_AFTER_DUE = 'merged_hide_after_due'
 
@@ -53,16 +53,6 @@ class HiddenContentTransformer(FilteringTransformerMixin, BlockStructureTransfor
         """
         return block_structure.get_transformer_block_field(
             block_key, cls, cls.MERGED_HIDE_AFTER_DUE, False
-        )
-
-    @classmethod
-    def _get_merged_due_date(cls, block_structure, block_key):
-        """
-        Returns the merged value for the start date for the block with
-        the given block_key in the given block_structure.
-        """
-        return block_structure.get_transformer_block_field(
-            block_key, cls, cls.MERGED_DUE_DATE, False
         )
 
     @classmethod
@@ -90,16 +80,12 @@ class HiddenContentTransformer(FilteringTransformerMixin, BlockStructureTransfor
 
         block_structure.request_xblock_fields('self_paced', 'end', 'due')
 
-    def transform_block_filters(self, usage_info, block_structure):
+    def transform(self, usage_info, block_structure):
         # Users with staff access bypass the Visibility check.
         if usage_info.has_staff_access:
             return [block_structure.create_universal_filter()]
 
-        return [
-            block_structure.create_removal_filter(
-                lambda block_key: self._is_block_hidden(block_structure, block_key),
-            ),
-        ]
+        block_structure.remove_block_traversal(lambda block_key: self._is_block_hidden(block_structure, block_key))
 
     def _is_block_hidden(self, block_structure, block_key):
         """
@@ -111,5 +97,9 @@ class HiddenContentTransformer(FilteringTransformerMixin, BlockStructureTransfor
         if self_paced:
             hidden_date = block_structure[block_structure.root_block_usage_key].end
         else:
-            hidden_date = self._get_merged_due_date(block_structure, block_key)
+            # Important Note:
+            # A small subtlety of grabbing the due date here is that this transformer relies on the
+            # DateOverrideTransformer (located in edx-when repo) to first set any overrides (one
+            # example is a user receiving an extension on an assignment).
+            hidden_date = block_structure.get_xblock_field(block_key, 'due', None) or MAXIMUM_DATE
         return not SequenceBlock.verify_current_content_visibility(hidden_date, hide_after_due)


### PR DESCRIPTION
We heard about a bug where learners granted extensions would still
lose access to content if it was marked as "hidden after due date".
This was caused by the HiddenContentTransformer using the due date
from collection time (publish time) rather than the user date returned
from the edx-when DateOverrideTransformer.

A small subtletly of these PRs is that Transformers with the
FilteringTransformerMixin are executed before those without it so
part of the fix was to make the HiddenContentTransformer not use the
FilteringTransformerMixin to ensure the DateOverrideTransformer had
run first.

Part 2/3 - Updating transform method + updating Read version

See also https://github.com/edx/edx-platform/pull/27152 and https://github.com/edx/edx-platform/pull/27154