### PR TITLE
fix: AA-724: Updating the HiddenContentTransformer

### DIFF
--- a/lms/djangoapps/course_blocks/transformers/hidden_content.py
+++ b/lms/djangoapps/course_blocks/transformers/hidden_content.py
@@ -10,7 +10,7 @@ from pytz import utc
 from openedx.core.djangoapps.content.block_structure.transformer import BlockStructureTransformer
 from xmodule.seq_module import SequenceBlock
 
-from .utils import collect_merged_boolean_field, collect_merged_date_field
+from .utils import collect_merged_boolean_field
 
 MAXIMUM_DATE = utc.localize(datetime.max)
 
@@ -33,7 +33,6 @@ class HiddenContentTransformer(BlockStructureTransformer):
     """
     WRITE_VERSION = 3
     READ_VERSION = 3
-    MERGED_DUE_DATE = 'merged_due_date'
     MERGED_HIDE_AFTER_DUE = 'merged_hide_after_due'
 
     @classmethod
@@ -66,16 +65,6 @@ class HiddenContentTransformer(BlockStructureTransformer):
             transformer=cls,
             xblock_field_name='hide_after_due',
             merged_field_name=cls.MERGED_HIDE_AFTER_DUE,
-        )
-
-        collect_merged_date_field(
-            block_structure,
-            transformer=cls,
-            xblock_field_name='due',
-            merged_field_name=cls.MERGED_DUE_DATE,
-            default_date=MAXIMUM_DATE,
-            func_merge_parents=max,
-            func_merge_ancestors=min,
         )
 
         block_structure.request_xblock_fields('self_paced', 'end', 'due')


### PR DESCRIPTION
We heard about a bug where learners granted extensions would still
lose access to content if it was marked as "hidden after due date".
This was caused by the HiddenContentTransformer using the due date
from collection time (publish time) rather than the user date returned
from the edx-when DateOverrideTransformer.

A small subtletly of these PRs is that Transformers with the
FilteringTransformerMixin are executed before those without it so
part of the fix was to make the HiddenContentTransformer not use the
FilteringTransformerMixin to ensure the DateOverrideTransformer had
run first.

Part 3/3 - Removing old collect code with merged due date

See also https://github.com/edx/edx-platform/pull/27152 and https://github.com/edx/edx-platform/pull/27153