### PR TITLE
FAL-249: fixes the blockstore runtime to set the correct translator

### DIFF
--- a/openedx/core/djangoapps/content_libraries/tests/test_runtime.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_runtime.py
@@ -2,6 +2,7 @@
 Test the Blockstore-based XBlock runtime and content libraries together.
 """
 import json
+from gettext import GNUTranslations
 
 from completion.test_utils import CompletionWaffleTestMixin
 from django.db import connections
@@ -100,6 +101,13 @@ class ContentLibraryRuntimeTest(ContentLibraryContentTestMixin, TestCase):
         unit_block2 = xblock_api.load_block(unit_block2_key, self.student_a)
         assert library_api.get_library_block_olx(unit_block_key) == library_api.get_library_block_olx(unit_block2_key)
         assert unit_block.children != unit_block2.children
+
+    def test_dndv2_sets_translator(self):
+        dnd_block_key = library_api.create_library_block(self.library.key, "drag-and-drop-v2", "dnd1").usage_key
+        library_api.publish_changes(self.library.key)
+        dnd_block = xblock_api.load_block(dnd_block_key, self.student_a)
+        i18n_service = dnd_block.runtime.service(dnd_block, 'i18n')
+        assert isinstance(i18n_service.translator, GNUTranslations)
 
     def test_has_score(self):
         """

--- a/openedx/core/djangoapps/xblock/runtime/runtime.py
+++ b/openedx/core/djangoapps/xblock/runtime/runtime.py
@@ -78,9 +78,6 @@ class XBlockRuntime(RuntimeShim, Runtime):
                 LmsBlockMixin,  # Adds Non-deprecated LMS/Studio functionality
                 XBlockShim,  # Adds deprecated LMS/Studio functionality / backwards compatibility
             ),
-            services={
-                "i18n": ModuleI18nService(),
-            },
             default_class=None,
             select=None,
             id_generator=system.id_generator,
@@ -229,6 +226,8 @@ class XBlockRuntime(RuntimeShim, Runtime):
         elif service_name == "completion":
             context_key = block.scope_ids.usage_id.context_key
             return CompletionService(user=self.user, context_key=context_key)
+        elif service_name == "i18n":
+            return ModuleI18nService(block=block)
         # Check if the XBlockRuntimeSystem wants to handle this:
         service = self.system.get_service(block, service_name)
         # Otherwise, fall back to the base implementation which loads services


### PR DESCRIPTION
## Description

This PR fixes the translator  assignment for blockstore runtime (to be used from the `xblock_handler` endpoint)

## Testing Instructions

This was tested in devstack, confirming this keeps working on normal course units and also when requesting this from the `xblock_handler` view (like from LabXchange)

**from the LMS/Studio**
- Create a new course and add a new DnDv2 problem
- Edit the DnDv2 problem to use the Assessment mode
- Change the user's language going to `/update_lang/` (lms), choose one supported by this xblock (check "LANGUAGES" inside this repository settings file)
- Go back to the problem and confirm the problem is being translated correctly (even interpolated and pluralized strings)

**from LX**
- Go to a Drag and Drop asset in LX (http://localhost:4556/library?t=Language%3Aen&t=ItemType%3Aactivity&page=1&size=24&order=relevance)
- Install this package latest version and restart the LMS

      make lms-shell
      cd /edx/src
      git clone https://github.com/open-craft/xblock-drag-and-drop-v2.git
      git checkout raul/fal-249-django-translations
      cd xblock-drag-and-drop-v2/
      pip install -e .
      exit
      make dev.restart-container.lms

- If DarkLang is enabled in the LMS (should be by default), make sure you include the LX languages as released_languages:

      source /edx/app/edxapp/edxapp_env && echo \"from openedx.core.djangoapps.dark_lang.models import DarkLangConfig; DarkLangConfig.objects.create(released_languages='en,ar,zh,nl,fr,de,it,ja,ko,pt,es,tr', enabled=True); \" | python /edx/app/edxapp/edx-platform/manage.py lms shell --settings=devstack_docker

- Visit the LX asset and reload
- Change the user language in LX and make sure interpolated and pluralized strings work

## Reviewers
- [ ] @pomegranited 
- [ ] edx reviewer