### PR TITLE
Prevent errors for escalation email if proctoring is disabled

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_exam_settings_view.py
+++ b/cms/djangoapps/contentstore/views/tests/test_exam_settings_view.py
@@ -97,6 +97,7 @@ class TestExamSettingsView(CourseTestCase, UrlResetMixin):
         # create an error by setting proctortrack as the provider and not setting
         # the (required) escalation contact
         self.course.proctoring_provider = 'proctortrack'
+        self.course.enable_proctored_exams = True
         self.save_course()
 
         url = reverse_course_url(page_handler, self.course.id)
@@ -131,6 +132,7 @@ class TestExamSettingsView(CourseTestCase, UrlResetMixin):
         # create an error by setting proctortrack as the provider and not setting
         # the (required) escalation contact
         self.course.proctoring_provider = 'proctortrack'
+        self.course.enable_proctored_exams = True
         self.save_course()
 
         url = reverse_course_url(page_handler, self.course.id)

--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -399,34 +399,41 @@ class CourseMetadata:
             ).format(support_email=settings.PARTNER_SUPPORT_EMAIL or 'support')
             errors.append({'key': 'proctoring_provider', 'message': message, 'model': proctoring_provider_model})
 
-        # Require a valid escalation email if Proctortrack is chosen as the proctoring provider
-        escalation_email_model = settings_dict.get('proctoring_escalation_email')
-        if escalation_email_model:
-            escalation_email = escalation_email_model.get('value')
+        enable_proctoring_model = settings_dict.get('enable_proctored_exams')
+        if enable_proctoring_model:
+            enable_proctoring = enable_proctoring_model.get('value')
         else:
-            escalation_email = descriptor.proctoring_escalation_email
+            enable_proctoring = descriptor.enable_proctored_exams
 
-        missing_escalation_email_msg = 'Provider \'{provider}\' requires an exam escalation contact.'
-        if proctoring_provider_model and proctoring_provider_model.get('value') == 'proctortrack':
-            if not escalation_email:
-                message = missing_escalation_email_msg.format(provider=proctoring_provider_model.get('value'))
-                errors.append({
-                    'key': 'proctoring_provider',
-                    'message': message,
-                    'model': proctoring_provider_model
-                })
+        if enable_proctoring:
+            # Require a valid escalation email if Proctortrack is chosen as the proctoring provider
+            escalation_email_model = settings_dict.get('proctoring_escalation_email')
+            if escalation_email_model:
+                escalation_email = escalation_email_model.get('value')
+            else:
+                escalation_email = descriptor.proctoring_escalation_email
 
-        if (
-            escalation_email_model and not proctoring_provider_model and
-            descriptor.proctoring_provider == 'proctortrack'
-        ):
-            if not escalation_email:
-                message = missing_escalation_email_msg.format(provider=descriptor.proctoring_provider)
-                errors.append({
-                    'key': 'proctoring_escalation_email',
-                    'message': message,
-                    'model': escalation_email_model
-                })
+            missing_escalation_email_msg = 'Provider \'{provider}\' requires an exam escalation contact.'
+            if proctoring_provider_model and proctoring_provider_model.get('value') == 'proctortrack':
+                if not escalation_email:
+                    message = missing_escalation_email_msg.format(provider=proctoring_provider_model.get('value'))
+                    errors.append({
+                        'key': 'proctoring_provider',
+                        'message': message,
+                        'model': proctoring_provider_model
+                    })
+
+            if (
+                escalation_email_model and not proctoring_provider_model and
+                descriptor.proctoring_provider == 'proctortrack'
+            ):
+                if not escalation_email:
+                    message = missing_escalation_email_msg.format(provider=descriptor.proctoring_provider)
+                    errors.append({
+                        'key': 'proctoring_escalation_email',
+                        'message': message,
+                        'model': escalation_email_model
+                    })
 
         return errors
 


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

[MST-643](https://openedx.atlassian.net/browse/MST-643) - Allow proctoring settings to be validated if the proctoring escalation email is missing but proctoring is disabled. 

This PR is also related to a [PR on frontend-app-course-authoring](https://github.com/edx/frontend-app-course-authoring/pull/61), which removes validation on the frontend for this specific case.

