### PR TITLE
fix: use github version of py2neo

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -119,7 +119,6 @@ openedx-calc                        # Library supporting mathematical calculatio
 ora2
 piexif                              # Exif image metadata manipulation, used in the profile_images app
 Pillow                              # Image manipulation library; used for course assets, profile images, invoice PDFs, etc.
-py2neo<4.0.0                        # Used to communicate with Neo4j, which is used internally for modulestore inspection
 PyContracts
 pycountry
 pycryptodomex

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -11,6 +11,7 @@
 -e git+https://github.com/edx/DoneXBlock.git@2.0.3#egg=done-xblock  # via -r requirements/edx/github.in
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme  # via -r requirements/edx/github.in
 -e .  # via -r requirements/edx/local.in
+-e git+https://github.com/technige/py2neo.git@py2neo-3.1.2#egg=py2neo==3.1.2  # via -r requirements/edx/github.in
 -e git+https://github.com/edx/RateXBlock.git@2.0.1#egg=rate-xblock  # via -r requirements/edx/github.in
 -e common/lib/safe_lxml  # via -r requirements/edx/local.in
 -e common/lib/sandbox-packages  # via -r requirements/edx/local.in
@@ -86,7 +87,7 @@ djangorestframework-xml==2.0.0  # via edx-enterprise
 djangorestframework==3.12.4  # via -r requirements/edx/base.in, django-config-models, django-user-tasks, drf-jwt, drf-yasg, edx-api-doc-tools, edx-completion, edx-drf-extensions, edx-enterprise, edx-organizations, edx-proctoring, edx-submissions, ora2, rest-condition, super-csv
 docopt==0.6.2             # via xmodule
 docutils==0.16            # via botocore
-drf-jwt==1.18.0           # via edx-drf-extensions
+drf-jwt==1.19.0           # via edx-drf-extensions
 drf-yasg==1.20.0          # via edx-api-doc-tools
 edx-ace==1.1.0            # via -r requirements/edx/base.in
 edx-analytics-data-api-client==0.17.0  # via -r requirements/edx/base.in
@@ -174,7 +175,6 @@ piexif==1.1.3             # via -r requirements/edx/base.in
 pillow==8.1.2             # via -r requirements/edx/base.in, edx-enterprise, edx-organizations
 polib==1.1.1              # via edx-i18n-tools
 psutil==5.8.0             # via -r requirements/edx/paver.txt, edx-django-utils
-py2neo==3.1.2             # via -r requirements/edx/base.in
 pycontracts==1.8.12       # via -r requirements/edx/base.in, edx-user-state-client
 pycountry==20.7.3         # via -r requirements/edx/base.in
 pycparser==2.20           # via -r requirements/edx/../edx-sandbox/shared.txt, cffi
@@ -204,7 +204,7 @@ requests-oauthlib==1.3.0  # via -r requirements/edx/base.in, social-auth-core
 requests==2.25.1          # via -r requirements/edx/paver.txt, analytics-python, coreapi, django-oauth-toolkit, edx-analytics-data-api-client, edx-bulk-grades, edx-drf-extensions, edx-enterprise, edx-event-routing-backends, edx-rest-api-client, geoip2, mailsnake, pyjwkest, python-swiftclient, requests-oauthlib, sailthru-client, slumber, social-auth-core, tableauserverclient
 rest-condition==1.0.3     # via -r requirements/edx/base.in, edx-drf-extensions
 ruamel.yaml.clib==0.2.2   # via ruamel.yaml
-ruamel.yaml==0.17.0       # via drf-yasg
+ruamel.yaml==0.17.2       # via drf-yasg
 rules==2.2                # via -r requirements/edx/base.in, edx-enterprise, edx-proctoring
 s3transfer==0.1.13        # via boto3
 sailthru-client==2.2.3    # via -r requirements/edx/base.in, edx-ace

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -11,6 +11,7 @@
 -e git+https://github.com/edx/DoneXBlock.git@2.0.3#egg=done-xblock  # via -r requirements/edx/testing.txt
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme  # via -r requirements/edx/testing.txt
 -e .  # via -r requirements/edx/testing.txt
+-e git+https://github.com/technige/py2neo.git@py2neo-3.1.2#egg=py2neo==3.1.2  # via -r requirements/edx/testing.txt
 -e git+https://github.com/edx/RateXBlock.git@2.0.1#egg=rate-xblock  # via -r requirements/edx/testing.txt
 -e common/lib/safe_lxml  # via -r requirements/edx/testing.txt
 -e common/lib/sandbox-packages  # via -r requirements/edx/testing.txt
@@ -97,7 +98,7 @@ djangorestframework-xml==2.0.0  # via -r requirements/edx/testing.txt, edx-enter
 djangorestframework==3.12.4  # via -r requirements/edx/testing.txt, django-config-models, django-user-tasks, drf-jwt, drf-yasg, edx-api-doc-tools, edx-completion, edx-drf-extensions, edx-enterprise, edx-organizations, edx-proctoring, edx-submissions, ora2, rest-condition, super-csv
 docopt==0.6.2             # via -r requirements/edx/testing.txt, xmodule
 docutils==0.16            # via -r requirements/edx/testing.txt, botocore, m2r, sphinx
-drf-jwt==1.18.0           # via -r requirements/edx/testing.txt, edx-drf-extensions
+drf-jwt==1.19.0           # via -r requirements/edx/testing.txt, edx-drf-extensions
 drf-yasg==1.20.0          # via -r requirements/edx/testing.txt, edx-api-doc-tools
 edx-ace==1.1.0            # via -r requirements/edx/testing.txt
 edx-analytics-data-api-client==0.17.0  # via -r requirements/edx/testing.txt
@@ -136,7 +137,7 @@ enmerkar==0.7.1           # via -r requirements/edx/testing.txt, enmerkar-unders
 event-tracking==1.0.4     # via -r requirements/edx/testing.txt, edx-event-routing-backends, edx-proctoring, edx-search
 execnet==1.8.0            # via -r requirements/edx/testing.txt, pytest-xdist
 factory-boy==2.8.1        # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
-faker==6.6.3              # via -r requirements/edx/testing.txt, factory-boy
+faker==7.0.0              # via -r requirements/edx/testing.txt, factory-boy
 filelock==3.0.12          # via -r requirements/edx/testing.txt, tox, virtualenv
 freezegun==0.3.12         # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
 fs-s3fs==0.1.8            # via -r requirements/edx/testing.txt, django-pyfs
@@ -209,7 +210,6 @@ pip-tools==5.3.1          # via -c requirements/edx/../constraints.txt, -r requi
 pluggy==0.13.1            # via -r requirements/edx/testing.txt, diff-cover, pytest, tox
 polib==1.1.1              # via -r requirements/edx/testing.txt, edx-i18n-tools
 psutil==5.8.0             # via -r requirements/edx/testing.txt, edx-django-utils, pytest-xdist
-py2neo==3.1.2             # via -r requirements/edx/testing.txt
 py==1.10.0                # via -r requirements/edx/testing.txt, pytest, pytest-forked, tox
 pycodestyle==2.7.0        # via -r requirements/edx/testing.txt
 pycontracts==1.8.12       # via -r requirements/edx/testing.txt, edx-user-state-client
@@ -257,7 +257,7 @@ requests-oauthlib==1.3.0  # via -r requirements/edx/testing.txt, social-auth-cor
 requests==2.25.1          # via -r requirements/edx/testing.txt, analytics-python, coreapi, django-oauth-toolkit, edx-analytics-data-api-client, edx-bulk-grades, edx-drf-extensions, edx-enterprise, edx-event-routing-backends, edx-rest-api-client, geoip2, mailsnake, pyjwkest, python-swiftclient, requests-oauthlib, sailthru-client, slumber, social-auth-core, sphinx, tableauserverclient, transifex-client
 rest-condition==1.0.3     # via -r requirements/edx/testing.txt, edx-drf-extensions
 ruamel.yaml.clib==0.2.2   # via -r requirements/edx/testing.txt, ruamel.yaml
-ruamel.yaml==0.17.0       # via -r requirements/edx/testing.txt, drf-yasg
+ruamel.yaml==0.17.2       # via -r requirements/edx/testing.txt, drf-yasg
 rules==2.2                # via -r requirements/edx/testing.txt, edx-enterprise, edx-proctoring
 s3transfer==0.1.13        # via -r requirements/edx/testing.txt, boto3
 sailthru-client==2.2.3    # via -r requirements/edx/testing.txt, edx-ace

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -57,6 +57,7 @@
 -e git+https://github.com/edx/django-wiki.git@1.0.0#egg=django-wiki
 git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
+-e git+https://github.com/technige/py2neo.git@py2neo-3.1.2#egg=py2neo==3.1.2
 
 # This is a temporary fork until https://github.com/brutasse/django-ratelimit-backend/pull/50 is merged
 # back into the upstream code.

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -11,6 +11,7 @@
 -e git+https://github.com/edx/DoneXBlock.git@2.0.3#egg=done-xblock  # via -r requirements/edx/base.txt
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme  # via -r requirements/edx/base.txt
 -e .  # via -r requirements/edx/base.txt
+-e git+https://github.com/technige/py2neo.git@py2neo-3.1.2#egg=py2neo==3.1.2  # via -r requirements/edx/base.txt
 -e git+https://github.com/edx/RateXBlock.git@2.0.1#egg=rate-xblock  # via -r requirements/edx/base.txt
 -e common/lib/safe_lxml  # via -r requirements/edx/base.txt
 -e common/lib/sandbox-packages  # via -r requirements/edx/base.txt
@@ -94,7 +95,7 @@ djangorestframework-xml==2.0.0  # via -r requirements/edx/base.txt, edx-enterpri
 djangorestframework==3.12.4  # via -r requirements/edx/base.txt, django-config-models, django-user-tasks, drf-jwt, drf-yasg, edx-api-doc-tools, edx-completion, edx-drf-extensions, edx-enterprise, edx-organizations, edx-proctoring, edx-submissions, ora2, rest-condition, super-csv
 docopt==0.6.2             # via -r requirements/edx/base.txt, xmodule
 docutils==0.16            # via -r requirements/edx/base.txt, botocore
-drf-jwt==1.18.0           # via -r requirements/edx/base.txt, edx-drf-extensions
+drf-jwt==1.19.0           # via -r requirements/edx/base.txt, edx-drf-extensions
 drf-yasg==1.20.0          # via -r requirements/edx/base.txt, edx-api-doc-tools
 edx-ace==1.1.0            # via -r requirements/edx/base.txt
 edx-analytics-data-api-client==0.17.0  # via -r requirements/edx/base.txt
@@ -132,7 +133,7 @@ enmerkar==0.7.1           # via -r requirements/edx/base.txt, enmerkar-underscor
 event-tracking==1.0.4     # via -r requirements/edx/base.txt, edx-event-routing-backends, edx-proctoring, edx-search
 execnet==1.8.0            # via pytest-xdist
 factory-boy==2.8.1        # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.in
-faker==6.6.3              # via factory-boy
+faker==7.0.0              # via factory-boy
 filelock==3.0.12          # via tox, virtualenv
 freezegun==0.3.12         # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.in
 fs-s3fs==0.1.8            # via -r requirements/edx/base.txt, django-pyfs
@@ -200,7 +201,6 @@ pillow==8.1.2             # via -r requirements/edx/base.txt, edx-enterprise, ed
 pluggy==0.13.1            # via -r requirements/edx/coverage.txt, diff-cover, pytest, tox
 polib==1.1.1              # via -r requirements/edx/base.txt, -r requirements/edx/testing.in, edx-i18n-tools
 psutil==5.8.0             # via -r requirements/edx/base.txt, edx-django-utils, pytest-xdist
-py2neo==3.1.2             # via -r requirements/edx/base.txt
 py==1.10.0                # via pytest, pytest-forked, tox
 pycodestyle==2.7.0        # via -r requirements/edx/testing.in
 pycontracts==1.8.12       # via -r requirements/edx/base.txt, edx-user-state-client
@@ -246,7 +246,7 @@ requests-oauthlib==1.3.0  # via -r requirements/edx/base.txt, social-auth-core
 requests==2.25.1          # via -r requirements/edx/base.txt, analytics-python, coreapi, django-oauth-toolkit, edx-analytics-data-api-client, edx-bulk-grades, edx-drf-extensions, edx-enterprise, edx-event-routing-backends, edx-rest-api-client, geoip2, mailsnake, pyjwkest, python-swiftclient, requests-oauthlib, sailthru-client, slumber, social-auth-core, tableauserverclient, transifex-client
 rest-condition==1.0.3     # via -r requirements/edx/base.txt, edx-drf-extensions
 ruamel.yaml.clib==0.2.2   # via -r requirements/edx/base.txt, ruamel.yaml
-ruamel.yaml==0.17.0       # via -r requirements/edx/base.txt, drf-yasg
+ruamel.yaml==0.17.2       # via -r requirements/edx/base.txt, drf-yasg
 rules==2.2                # via -r requirements/edx/base.txt, edx-enterprise, edx-proctoring
 s3transfer==0.1.13        # via -r requirements/edx/base.txt, boto3
 sailthru-client==2.2.3    # via -r requirements/edx/base.txt, edx-ace


### PR DESCRIPTION
All py2neo releases prior to 4.0 were just removed from PyPI, but we haven't upgraded to 4.0 yet.

A followup ticket to upgrade py2neo to a newer release has been created at https://openedx.atlassian.net/browse/BOM-2466 .