### PR TITLE
Badgr integration updates

### DIFF
--- a/lms/djangoapps/badges/backends/tests/test_badgr_backend.py
+++ b/lms/djangoapps/badges/backends/tests/test_badgr_backend.py
@@ -2,15 +2,17 @@
 Tests for BadgrBackend
 """
 
-
-from datetime import datetime
+import datetime
 from unittest.mock import Mock, call, patch
 
+import json
 import ddt
+import httpretty
 from django.db.models.fields.files import ImageFieldFile
 from django.test.utils import override_settings
 from lazy.lazy import lazy  # lint-amnesty, pylint: disable=no-name-in-module
 
+from edx_django_utils.cache import TieredCache
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
 from common.djangoapps.track.tests import EventTrackingTestCase
 from lms.djangoapps.badges.backends.badgr import BadgrBackend
@@ -21,9 +23,11 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
 BADGR_SETTINGS = {
-    'BADGR_API_TOKEN': '12345',
     'BADGR_BASE_URL': 'https://example.com',
     'BADGR_ISSUER_SLUG': 'test-issuer',
+    'BADGR_USERNAME': 'example@example.com',
+    'BADGR_PASSWORD': 'password',
+    'BADGR_TOKENS_CACHE_KEY': 'badgr-test-cache-key'
 }
 
 # Should be the hashed result of test_slug as the slug, and test_component as the component
@@ -34,6 +38,7 @@ BADGR_SERVER_SLUG = 'test_badgr_server_slug'
 # pylint: disable=protected-access
 @ddt.ddt
 @override_settings(**BADGR_SETTINGS)
+@httpretty.activate
 class BadgrBackendTestCase(ModuleStoreTestCase, EventTrackingTestCase):
     """
     Tests the BadgeHandler object
@@ -47,8 +52,8 @@ class BadgrBackendTestCase(ModuleStoreTestCase, EventTrackingTestCase):
         # Need key to be deterministic to test slugs.
         self.course = CourseFactory.create(
             org='edX', course='course_test', run='test_run', display_name='Badged',
-            start=datetime(year=2015, month=5, day=19),
-            end=datetime(year=2015, month=5, day=20)
+            start=datetime.datetime(year=2015, month=5, day=19),
+            end=datetime.datetime(year=2015, month=5, day=20)
         )
         self.user = UserFactory.create(email='example@example.com')
         CourseEnrollmentFactory.create(user=self.user, course_id=self.course.location.course_key, mode='honor')
@@ -59,6 +64,8 @@ class BadgrBackendTestCase(ModuleStoreTestCase, EventTrackingTestCase):
             course_id=self.course.location.course_key, issuing_component=''
         )
         self.no_course_badge_class = BadgeClassFactory.create()
+        TieredCache.dangerous_clear_all_tiers()
+        httpretty.httpretty.reset()
 
     @lazy
     def handler(self):
@@ -67,6 +74,14 @@ class BadgrBackendTestCase(ModuleStoreTestCase, EventTrackingTestCase):
         overrides aren't in place.
         """
         return BadgrBackend()
+
+    def _mock_badgr_tokens_api(self, result):
+        assert httpretty.is_enabled()
+        responses = [httpretty.Response(body=json.dumps(result),
+                                        content_type='application/json')]
+        httpretty.register_uri(httpretty.POST,
+                               'https://example.com/o/token',
+                               responses=responses)
 
     def test_urls(self):
         """
@@ -85,12 +100,13 @@ class BadgrBackendTestCase(ModuleStoreTestCase, EventTrackingTestCase):
         """
         Verify the a headers dict from a requests call matches the proper auth info.
         """
-        assert headers == {'Authorization': 'Token 12345'}
+        assert headers == {'Authorization': 'Bearer 12345'}
 
     def test_get_headers(self):
         """
         Check to make sure the handler generates appropriate HTTP headers.
         """
+        self.handler._get_access_token = Mock(return_value='12345')
         self.check_headers(self.handler._get_headers())  # lint-amnesty, pylint: disable=no-member
 
     @patch('requests.post')
@@ -98,6 +114,7 @@ class BadgrBackendTestCase(ModuleStoreTestCase, EventTrackingTestCase):
         """
         Verify badge spec creation works.
         """
+        self.handler._get_access_token = Mock(return_value='12345')
         self.handler._create_badge(self.badge_class)
         args, kwargs = post.call_args
         assert args[0] == 'https://example.com/v1/issuer/issuers/test-issuer/badges'
@@ -136,6 +153,7 @@ class BadgrBackendTestCase(ModuleStoreTestCase, EventTrackingTestCase):
         response.status_code = 200
         get.return_value = response
         assert 'test_componenttest_slug' not in BadgrBackend.badges
+        self.handler._get_access_token = Mock(return_value='12345')
         self.handler._create_badge = Mock()
         self.handler._ensure_badge_created(self.badge_class)  # lint-amnesty, pylint: disable=no-member
         assert get.called
@@ -153,6 +171,7 @@ class BadgrBackendTestCase(ModuleStoreTestCase, EventTrackingTestCase):
         response.status_code = 404
         get.return_value = response
         assert BADGR_SERVER_SLUG not in BadgrBackend.badges
+        self.handler._get_access_token = Mock(return_value='12345')
         self.handler._create_badge = Mock()
         self.handler._ensure_badge_created(self.badge_class)  # lint-amnesty, pylint: disable=no-member
         assert self.handler._create_badge.called
@@ -171,6 +190,7 @@ class BadgrBackendTestCase(ModuleStoreTestCase, EventTrackingTestCase):
         response.json.return_value = result
         post.return_value = response
         self.recreate_tracker()
+        self.handler._get_access_token = Mock(return_value='12345')
         self.handler._create_assertion(self.badge_class, self.user, 'https://example.com/irrefutable_proof')  # lint-amnesty, pylint: disable=no-member
         args, kwargs = post.call_args
         assert args[0] == ((
@@ -182,7 +202,8 @@ class BadgrBackendTestCase(ModuleStoreTestCase, EventTrackingTestCase):
         assert assertion.data == result
         assert assertion.image_url == 'http://www.example.com/example.png'
         assert assertion.assertion_url == 'http://www.example.com/example'
-        assert kwargs['data'] == {'email': 'example@example.com', 'evidence': 'https://example.com/irrefutable_proof'}
+        assert kwargs['json'] == {"recipient": {"identity": 'example@example.com', "type": "email"},
+                                  "evidence": [{"url": 'https://example.com/irrefutable_proof'}]}
         assert_event_matches({
             'name': 'edx.badge.assertion.created',
             'data': {
@@ -199,3 +220,80 @@ class BadgrBackendTestCase(ModuleStoreTestCase, EventTrackingTestCase):
                 'issuer': 'https://example.com/v1/issuer/issuers/test-issuer',
             }
         }, self.get_event())
+
+    def test_get_new_tokens(self):
+        result = {
+            'access_token': '12345',
+            'refresh_token': '67890',
+            'expires_in': 86400,
+        }
+        self._mock_badgr_tokens_api(result)
+        self.handler._get_and_cache_oauth_tokens()
+        assert 'o/token' in httpretty.httpretty.last_request.path
+        assert httpretty.httpretty.last_request.parsed_body == {
+            'username': ['example@example.com'],
+            'password': ['password']}
+
+    def test_renew_tokens(self):
+        result = {
+            'access_token': '12345',
+            'refresh_token': '67890',
+            'expires_in': 86400,
+        }
+        self._mock_badgr_tokens_api(result)
+        self.handler._get_and_cache_oauth_tokens(refresh_token='67890')
+        assert 'o/token' in httpretty.httpretty.last_request.path
+        assert httpretty.httpretty.last_request.parsed_body == {
+            'grant_type': ['refresh_token'],
+            'refresh_token': ['67890']}
+
+    def test_get_access_token_from_cache_valid(self):
+        encrypted_access_token = self.handler._encrypt_token('12345')
+        encrypted_refresh_token = self.handler._encrypt_token('67890')
+        tokens = {
+            'access_token': encrypted_access_token,
+            'refresh_token': encrypted_refresh_token,
+            'expires_at': datetime.datetime.utcnow() + datetime.timedelta(seconds=20)
+        }
+        TieredCache.set_all_tiers('badgr-test-cache-key', tokens, None)
+
+        access_token = self.handler._get_access_token()
+        assert access_token == self.handler._decrypt_token(
+            tokens.get('access_token'))
+
+    def test_get_access_token_from_cache_expired(self):
+        encrypted_access_token = self.handler._encrypt_token('12345')
+        encrypted_refresh_token = self.handler._encrypt_token('67890')
+        tokens = {
+            'access_token': encrypted_access_token,
+            'refresh_token': encrypted_refresh_token,
+            'expires_at': datetime.datetime.utcnow()
+        }
+        TieredCache.set_all_tiers('badgr-test-cache-key', tokens, None)
+        result = {
+            'access_token': '12345',
+            'refresh_token': '67890',
+            'expires_in': 86400,
+        }
+        self._mock_badgr_tokens_api(result)
+        access_token = self.handler._get_access_token()
+        assert access_token == result.get('access_token')
+        assert 'o/token' in httpretty.httpretty.last_request.path
+        assert httpretty.httpretty.last_request.parsed_body == {
+            'grant_type': ['refresh_token'],
+            'refresh_token': [self.handler._decrypt_token(
+                tokens.get('refresh_token'))]}
+
+    def test_get_access_token_from_cache_none(self):
+        result = {
+            'access_token': '12345',
+            'refresh_token': '67890',
+            'expires_in': 86400,
+        }
+        self._mock_badgr_tokens_api(result)
+        access_token = self.handler._get_access_token()
+        assert access_token == result.get('access_token')
+        assert 'o/token' in httpretty.httpretty.last_request.path
+        assert httpretty.httpretty.last_request.parsed_body == {
+            'username': ['example@example.com'],
+            'password': ['password']}

--- a/lms/djangoapps/badges/migrations/0004_badgeclass_badgr_server_slug.py
+++ b/lms/djangoapps/badges/migrations/0004_badgeclass_badgr_server_slug.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('badges', '0003_schema__add_event_configuration'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='badgeclass',
+            name='badgr_server_slug',
+            field=models.SlugField(blank=True, default='', max_length=255),
+        ),
+    ]

--- a/lms/djangoapps/badges/models.py
+++ b/lms/djangoapps/badges/models.py
@@ -56,6 +56,7 @@ class BadgeClass(models.Model):
     .. no_pii:
     """
     slug = models.SlugField(max_length=255, validators=[validate_lowercase])
+    badgr_server_slug = models.SlugField(max_length=255, default='', blank=True)
     issuing_component = models.SlugField(max_length=50, default='', blank=True, validators=[validate_lowercase])
     display_name = models.CharField(max_length=255)
     course_id = CourseKeyField(max_length=255, blank=True, default=None)

--- a/lms/djangoapps/badges/tests/factories.py
+++ b/lms/djangoapps/badges/tests/factories.py
@@ -48,6 +48,7 @@ class BadgeClassFactory(factory.django.DjangoModelFactory):
         model = BadgeClass
 
     slug = 'test_slug'
+    badgr_server_slug = 'test_badgr_server_slug'
     issuing_component = 'test_component'
     display_name = 'Test Badge'
     description = "Yay! It's a test badge."

--- a/lms/djangoapps/badges/tests/test_models.py
+++ b/lms/djangoapps/badges/tests/test_models.py
@@ -209,7 +209,11 @@ class BadgeClassTest(ModuleStoreTestCase):
         assertion = BadgeAssertionFactory.create(badge_class=badge_class, user=user)
         assert list(badge_class.get_for_user(user)) == [assertion]
 
-    @override_settings(BADGING_BACKEND='lms.djangoapps.badges.backends.badgr.BadgrBackend', BADGR_API_TOKEN='test')
+    @override_settings(
+        BADGING_BACKEND='lms.djangoapps.badges.backends.badgr.BadgrBackend',
+        BADGR_USERNAME='example@example.com',
+        BADGR_PASSWORD='password',
+        BADGR_TOKENS_CACHE_KEY='badgr-test-cache-key')
     @patch('lms.djangoapps.badges.backends.badgr.BadgrBackend.award')
     def test_award(self, mock_award):
         """

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3403,13 +3403,6 @@ CERT_NAME_LONG = "Certificate of Achievement"
 # .. setting_warning: Review FEATURES['ENABLE_OPENBADGES'] for further context.
 BADGING_BACKEND = 'lms.djangoapps.badges.backends.badgr.BadgrBackend'
 
-# .. setting_name: BADGR_API_TOKEN
-# .. setting_default: None
-# .. setting_description: The API token string for Badgr. You should be able to create this via Badgr's settings. See
-#    https://github.com/concentricsky/badgr-server for details on setting up Badgr.
-# .. setting_warning: Review FEATURES['ENABLE_OPENBADGES'] for further context.
-BADGR_API_TOKEN = None
-
 # .. setting_name: BADGR_BASE_URL
 # .. setting_default: 'http://localhost:8005'
 # .. setting_description: The base URL for the Badgr server.
@@ -3423,6 +3416,29 @@ BADGR_BASE_URL = "http://localhost:8005"
 #    http://exampleserver.com/issuer/test-issuer, the issuer slug is "test-issuer".
 # .. setting_warning: Review FEATURES['ENABLE_OPENBADGES'] for further context.
 BADGR_ISSUER_SLUG = "example-issuer"
+
+# .. setting_name: BADGR_USERNAME
+# .. setting_default: None
+# .. setting_description: The username for Badgr. You should set up an issuer application with Badgr
+#    (https://badgr.org/app-developers/). The username and password will then be used to create or renew
+#    OAuth2 tokens.
+# .. setting_warning: Review FEATURES['ENABLE_OPENBADGES'] for further context.
+BADGR_USERNAME = None
+
+# .. setting_name: BADGR_PASSWORD
+# .. setting_default: None
+# .. setting_description: The password for Badgr. You should set up an issuer application with Badgr
+#    (https://badgr.org/app-developers/). The username and password will then be used to create or renew
+#    OAuth2 tokens.
+# .. setting_warning: Review FEATURES['ENABLE_OPENBADGES'] for further context.
+BADGR_PASSWORD = None
+
+# .. setting_name: BADGR_TOKENS_CACHE_KEY
+# .. setting_default: None
+# .. setting_description: The cache key for Badgr API tokens. Once created, the tokens will be stored in cache.
+#    Define the key here for setting and retrieveing the tokens.
+# .. setting_warning: Review FEATURES['ENABLE_OPENBADGES'] for further context.
+BADGR_TOKENS_CACHE_KEY = None
 
 # .. setting_name: BADGR_TIMEOUT
 # .. setting_default: 10


### PR DESCRIPTION
## Description

The Badgr integration at its current state is broken and it would be great if we could fix it. This PR holds commits for that purpose.

For a while now, it is not possible to create a badge on the Badgr side with a `slug` that we provide. Instead a `slug` (Badgr API v1) or an `entityId` (Badgr API v2) is created for each badge on the Badgr side and we will need to know about it in order to check if a certain badge exists or to create assertions for one.
A proposed fix for this is to cherry-pick a commit (from 3309aab2a2eb00d28c5ca3d3145c8dddb15e6159) to introduce a new field to the BadgeClass model: `badgr_server_slug` that will store this value for us.
However, I've modified that commit by making this field optional since Badgr is not the only backend that can be used for badging.

The long-lived access tokens are no longer supported by Badgr. Instead, we'll need to implement the flow of creating and refreshing the access tokens that are valid for 24h. This PR proposes the changes to implement this flow. With this change the necessary values for creating tokens should be configured in `lms.yml`. The tokens will be then created or refreshed on the go as needed and stored in cache.

The Badgr API v1 will likely reach end-of-life in Q4 2021 so we'd probably want to make the switch to API v2 as well.

## Testing instructions

Prerequisites:

An Issuer App is needed, either registered at https://badgr.org/app-developers/#issuer-apps or in your own instance of the Badgr Server.

Configuration examples:

in `studio.yml` and `lms.yml`:
```
FEATURES:
	ENABLE_OPENBADGES: true
```

in `lms.yml`:
```
BADGR_USERNAME = "example@example.com"
BADGR_PASSWORD = "password"
BADGR_TOKENS_CACHE_KEY = "secret-cache-key"
BADGR_BASE_URL = "http://localhost:8005"
BADGR_ISSUER_SLUG = "issuer-slug"
```

Make sure your Issuer App is configured properly, you can test creating and refreshing tokens as noted in https://api.badgr.io/docs/v2/ :

```
curl -X POST '$BADGR_BASE_URL/o/token' -d "username=$BADGR_USERNAME&password=$BADGR_PASSWORD"
```
```
curl -X POST '$BADGR_BASE_URL/o/token' -d "grant_type=refresh_token&refresh_token=<refresh_token>"
```

## Documentation

PR for updating the documentation to match these changes: https://github.com/edx/edx-documentation/pull/1927