### PR TITLE
feat: Implement generation of regular V2 course certificates

### DIFF
--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -222,15 +222,21 @@ def can_generate_certificate_task(user, course_key):
     return _can_generate_certificate_task(user, course_key)
 
 
-def generate_certificate_task(user, course_key):
+def generate_certificate_task(user, course_key, generation_mode=None):
     """
     Create a task to generate a certificate for this user in this course run, if the user is eligible and a certificate
     can be generated.
 
     If the allowlist is enabled for this course run and the user is on the allowlist, the allowlist logic will be used.
     Otherwise, the regular course certificate generation logic will be used.
+
+    Args:
+        user: user for whom to generate a certificate
+        course_key: course run key for which to generate a certificate
+        generation_mode: Used when emitting an events. Options are "self" (implying the user generated the cert
+            themself) and "batch" for everything else.
     """
-    return _generate_certificate_task(user, course_key)
+    return _generate_certificate_task(user, course_key, generation_mode)
 
 
 def certificate_downloadable_status(student, course_key):

--- a/lms/djangoapps/certificates/generation.py
+++ b/lms/djangoapps/certificates/generation.py
@@ -25,54 +25,55 @@ from xmodule.modulestore.django import modulestore
 log = logging.getLogger(__name__)
 
 
-def generate_allowlist_certificate(user, course_key):
+def generate_course_certificate(user, course_key, generation_mode):
     """
-    Generate an allowlist certificate for this user, in this course run. This method should be called from a task.
+    Generate a course certificate for this user, in this course run. If the certificate has a passing status, also emit
+    a certificate event.
+
+    Note that the certificate could be either an allowlist certificate or a "regular" course certificate; the content
+    will be the same either way.
+
+    Args:
+        user: user for whom to generate a certificate
+        course_key: course run key for which to generate a certificate
+        generation_mode: Used when emitting an events. Options are "self" (implying the user generated the cert
+            themself) and "batch" for everything else.
     """
     cert = _generate_certificate(user, course_key)
 
     if CertificateStatuses.is_passing_status(cert.status):
-        # Emit a certificate event. Note that the two options for generation_mode are "self" (implying the user
-        # generated the cert themself) and "batch" for everything else.
+        # Emit a certificate event
         event_data = {
             'user_id': user.id,
             'course_id': str(course_key),
             'certificate_id': cert.verify_uuid,
             'enrollment_mode': cert.mode,
-            'generation_mode': 'batch'
+            'generation_mode': generation_mode
         }
         emit_certificate_event(event_name='created', user=user, course_id=course_key, event_data=event_data)
 
     return cert
 
 
-def generate_course_certificate(user, course_key):
-    """
-    Generate a regular certificate for this user, in this course run. This method should be called from a task.
-    """
-    # TODO: Implementation will be added in MICROBA-1039
-    log.warning(f'Ignoring course certificate generation for {user.id}: {course_key}')
-
-
-def _generate_certificate(user, course_id):
+def _generate_certificate(user, course_key):
     """
     Generate a certificate for this user, in this course run.
     """
     profile = UserProfile.objects.get(user=user)
     profile_name = profile.name
 
-    course = modulestore().get_course(course_id, depth=0)
+    course = modulestore().get_course(course_key, depth=0)
     course_grade = CourseGradeFactory().read(user, course)
-    enrollment_mode, __ = CourseEnrollment.enrollment_mode_for_user(user, course_id)
+    enrollment_mode, __ = CourseEnrollment.enrollment_mode_for_user(user, course_key)
     key = make_hashkey(random.random())
     uuid = uuid4().hex
 
     cert, created = GeneratedCertificate.objects.update_or_create(
         user=user,
-        course_id=course_id,
+        course_id=course_key,
         defaults={
             'user': user,
-            'course_id': course_id,
+            'course_id': course_key,
             'mode': enrollment_mode,
             'name': profile_name,
             'status': CertificateStatuses.downloadable,
@@ -87,13 +88,7 @@ def _generate_certificate(user, course_id):
         created_msg = 'Certificate was created.'
     else:
         created_msg = 'Certificate already existed and was updated.'
-    log.info(
-        'Generated certificate with status {status} for {user} : {course}. {created_msg}'.format(
-            status=cert.status,
-            user=cert.user.id,
-            course=cert.course_id,
-            created_msg=created_msg
-        ))
+    log.info(f'Generated certificate with status {cert.status} for {user.id} : {course_key}. {created_msg}')
     return cert
 
 

--- a/lms/djangoapps/certificates/tests/test_generation_handler.py
+++ b/lms/djangoapps/certificates/tests/test_generation_handler.py
@@ -302,6 +302,14 @@ class CertificateTests(ModuleStoreTestCase):
         assert _can_generate_v2_certificate(self.user, self.course_run_key)
         assert can_generate_certificate_task(self.user, self.course_run_key)
         assert generate_certificate_task(self.user, self.course_run_key)
+
+    def test_handle_valid_task(self):
+        """
+        Test handling of a valid user/course run combo.
+
+        We test generate_certificate_task() and generate_regular_certificate_task() separately since they both
+        generate a cert.
+        """
         assert generate_regular_certificate_task(self.user, self.course_run_key)
 
     @override_waffle_flag(CERTIFICATES_USE_UPDATED, active=False)

--- a/lms/djangoapps/certificates/tests/test_tasks.py
+++ b/lms/djangoapps/certificates/tests/test_tasks.py
@@ -1,8 +1,9 @@
 """
-Test module for user certificate generation.
+Tests for course certificate tasks.
 """
 
 
+from unittest import mock
 from unittest.mock import call, patch
 
 import ddt
@@ -17,8 +18,12 @@ from lms.djangoapps.verify_student.models import IDVerificationAttempt
 @ddt.ddt
 class GenerateUserCertificateTest(TestCase):
     """
-    Tests for course certificates
+    Tests for course certificate tasks
     """
+    def setUp(self):
+        super().setUp()
+
+        self.user = UserFactory()
 
     @patch('lms.djangoapps.certificates.tasks.generate_user_certificates')
     @patch('lms.djangoapps.certificates.tasks.User.objects.get')
@@ -78,3 +83,51 @@ class GenerateUserCertificateTest(TestCase):
             student=student,
             course_key=CourseKey.from_string(course_key)
         )
+
+    def test_generation(self):
+        """
+        Verify the task handles V2 certificate generation
+        """
+        course_key = 'course-v1:edX+DemoX+Demo_Course'
+
+        with mock.patch(
+            'lms.djangoapps.certificates.tasks.generate_course_certificate',
+            return_value=None
+        ) as mock_generate_cert:
+            kwargs = {
+                'student': self.user.id,
+                'course_key': course_key,
+                'v2_certificate': True
+            }
+
+            generate_certificate.apply_async(kwargs=kwargs)
+            mock_generate_cert.assert_called_with(
+                user=self.user,
+                course_key=CourseKey.from_string(course_key),
+                generation_mode='batch'
+            )
+
+    def test_generation_mode(self):
+        """
+        Verify the task handles V2 certificate generation with a generation mode
+        """
+        course_key = 'course-v1:edX+DemoX+Demo_Course'
+        gen_mode = 'self'
+
+        with mock.patch(
+            'lms.djangoapps.certificates.tasks.generate_course_certificate',
+            return_value=None
+        ) as mock_generate_cert:
+            kwargs = {
+                'student': self.user.id,
+                'course_key': course_key,
+                'v2_certificate': True,
+                'generation_mode': gen_mode
+            }
+
+            generate_certificate.apply_async(kwargs=kwargs)
+            mock_generate_cert.assert_called_with(
+                user=self.user,
+                course_key=CourseKey.from_string(course_key),
+                generation_mode=gen_mode
+            )

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1583,7 +1583,7 @@ def generate_user_cert(request, course_id):
     if certs_api.can_generate_certificate_task(student, course_key):
         log.info(f'{course_key} is using V2 certificates. Attempt will be made to generate a V2 certificate for '
                  f'user {student.id}.')
-        certs_api.generate_certificate_task(student, course_key)
+        certs_api.generate_certificate_task(student, course_key, 'self')
         return HttpResponse()
 
     if not is_course_passed(student, course):


### PR DESCRIPTION
* Implement generation of regular V2 course certificates.
* Combine generation of regular and allowlist certs, since the cert itself will be the same (it's the "_should this cert be generated?_" checks that differ).
* Correctly set the generation_mode in the emitted event when generation is initiated by an end user.

MICROBA-1039