### PR TITLE
Add toggle to redirect user to the login page on unauthenticated enrollement

### DIFF
--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -41,9 +41,8 @@ from six import string_types
           location.href = xhr.responseText;
         }
       } else if (xhr.status == 403) {
-        $('#register_error').text(
-            (xhr.responseText ? xhr.responseText : "${_("An error has occurred. Please ensure that you are logged in to enroll.") | n, js_escaped_string}")
-        ).css("display", "block");
+        // redirect unauthenticated user to the login page
+        location.replace("${reverse('signin_user') | n, js_escaped_string}?next=" + encodeURIComponent("${request.path | n, js_escaped_string}"));
       } else {
         $('#register_error').text(
             (xhr.responseText ? xhr.responseText : "${_("An error occurred. Please try again later.") | n, js_escaped_string}")


### PR DESCRIPTION
## Description
Adds toggle REDIRECT_UNAUTHENTICATED_USER_TO_LOGIN_ON_ENROLL for enrollment behaviour for unauthenticated user. If true, the user will be redirected to 'signin_user' route with `next` query parameter set to current page.


## Testing instructions

1. Get the master devstack running and checkout to this branch.
2. Attach to lms shell using make lms-shell.
3. Edit `/edx/etc/lms.yml` and add `REDIRECT_UNAUTHENTICATED_USER_TO_LOGIN_ON_ENROLL: true`
4. Restart lms using `make lms-restart`
5. Visit about page for Demo course on LMS
6. Make sure you are unauthenticated.
7. Click 'Enroll Now' button
8. Verify that the page redirects to login page.
9. Login with audit user.
10. Verify that the user is redirected to Demo course about page.

## Deadline

"None"

