### PR TITLE
Update expiration timeline on dashboard and specify ID verification

### DIFF
--- a/conf/locale/en/LC_MESSAGES/django.po
+++ b/conf/locale/en/LC_MESSAGES/django.po
@@ -15108,18 +15108,18 @@ msgid "View Consent"
 msgstr ""
 
 #: lms/templates/dashboard/_dashboard_status_verification.html
-msgid "Current Verification Status: Approved"
+msgid "Current ID Verification Status: Approved"
 msgstr ""
 
 #: lms/templates/dashboard/_dashboard_status_verification.html
 msgid ""
-"Your edX verification has been approved. Your verification is effective for "
-"one year after submission."
+"Your edX ID verification has been approved. Your ID verification is effective for "
+"two years after submission."
 msgstr ""
 
 #: lms/templates/dashboard/_dashboard_status_verification.html
 msgid ""
-"Your photo verification expires on {verification_expiry}. Please be aware "
+"Your photo ID verification expires on {verification_expiry}. Please be aware "
 "photo verification can take up to three days once initiated and you will not"
 " be able to earn a certificate or take a proctored exam until approved."
 msgstr ""
@@ -15129,37 +15129,37 @@ msgid "Resubmit Verification"
 msgstr ""
 
 #: lms/templates/dashboard/_dashboard_status_verification.html
-msgid "Current Verification Status: Pending"
+msgid "Current ID Verification Status: Pending"
 msgstr ""
 
 #: lms/templates/dashboard/_dashboard_status_verification.html
 msgid ""
-"Your edX ID verification is pending. Your verification information has been "
+"Your edX ID verification is pending. Your ID verification information has been "
 "submitted and will be reviewed shortly."
 msgstr ""
 
 #: lms/templates/dashboard/_dashboard_status_verification.html
-msgid "Current Verification Status: Denied"
+msgid "Current ID Verification Status: Denied"
 msgstr ""
 
 #: lms/templates/dashboard/_dashboard_status_verification.html
 msgid ""
-"Your verification submission was not accepted. To receive a verified "
+"Your ID verification submission was not accepted. To receive a verified "
 "certificate, you must submit a new photo of yourself and your government-"
 "issued photo ID before the verification deadline for your course."
 msgstr ""
 
 #: lms/templates/dashboard/_dashboard_status_verification.html
-msgid "Your verification was denied for the following reasons:"
+msgid "Your ID verification was denied for the following reasons:"
 msgstr ""
 
 #: lms/templates/dashboard/_dashboard_status_verification.html
-msgid "Current Verification Status: Expired"
+msgid "Current ID Verification Status: Expired"
 msgstr ""
 
 #: lms/templates/dashboard/_dashboard_status_verification.html
 msgid ""
-"Your verification has expired. To receive a verified certificate, you must "
+"Your ID verification has expired. To receive a verified certificate, you must "
 "submit a new photo of yourself and your government-issued photo ID before "
 "the verification deadline for your course."
 msgstr ""
@@ -15643,7 +15643,7 @@ msgstr ""
 
 #: lms/templates/emails/passed_verification_email.txt
 msgid ""
-"Your verification is effective for one year. It will expire on "
+"Your verification is effective for two years. It will expire on "
 "{expiration_datetime}"
 msgstr ""
 

--- a/conf/locale/eo/LC_MESSAGES/django.po
+++ b/conf/locale/eo/LC_MESSAGES/django.po
@@ -19348,26 +19348,26 @@ msgid "View Consent"
 msgstr "Vïéw Çönsént Ⱡ'σяєм ιρѕυм ∂σłσя ѕ#"
 
 #: lms/templates/dashboard/_dashboard_status_verification.html
-msgid "Current Verification Status: Approved"
+msgid "Current ID Verification Status: Approved"
 msgstr ""
-"Çürrént Vérïfïçätïön Stätüs: Àpprövéd Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, "
+"Çürrént ÌD Vérïfïçätïön Stätüs: Àpprövéd Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, "
 "¢σηѕє¢тєтυ#"
 
 #: lms/templates/dashboard/_dashboard_status_verification.html
 msgid ""
-"Your edX verification has been approved. Your verification is effective for "
-"one year after submission."
+"Your edX ID verification has been approved. Your ID verification is effective for "
+"two years after submission."
 msgstr ""
-"Ýöür édX vérïfïçätïön häs ßéén äpprövéd. Ýöür vérïfïçätïön ïs éfféçtïvé för "
-"öné ýéär äftér süßmïssïön. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αм#"
+"Ýöür édX ÌD vérïfïçätïön häs ßéén äpprövéd. Ýöür ÌD vérïfïçätïön ïs éfféçtïvé för "
+"twö ýéärs äftér süßmïssïön. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αм#"
 
 #: lms/templates/dashboard/_dashboard_status_verification.html
 msgid ""
-"Your photo verification expires on {verification_expiry}. Please be aware "
+"Your photo ID verification expires on {verification_expiry}. Please be aware "
 "photo verification can take up to three days once initiated and you will not"
 " be able to earn a certificate or take a proctored exam until approved."
 msgstr ""
-"Ýöür phötö vérïfïçätïön éxpïrés ön {verification_expiry}. Pléäsé ßé äwäré "
+"Ýöür phötö ÌD vérïfïçätïön éxpïrés ön {verification_expiry}. Pléäsé ßé äwäré "
 "phötö vérïfïçätïön çän täké üp tö thréé däýs önçé ïnïtïätéd änd ýöü wïll nöt"
 " ßé äßlé tö éärn ä çértïfïçäté ör täké ä pröçtöréd éxäm üntïl äpprövéd. "
 "Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя α∂ιριѕι¢ιηg єłιт, ѕє∂ ∂σ єιυѕмσ∂ "
@@ -19381,31 +19381,31 @@ msgid "Resubmit Verification"
 msgstr "Résüßmït Vérïfïçätïön Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, #"
 
 #: lms/templates/dashboard/_dashboard_status_verification.html
-msgid "Current Verification Status: Pending"
+msgid "Current ID Verification Status: Pending"
 msgstr ""
-"Çürrént Vérïfïçätïön Stätüs: Péndïng Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, "
+"Çürrént ÌD Vérïfïçätïön Stätüs: Péndïng Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, "
 "¢σηѕє¢тєтυ#"
 
 #: lms/templates/dashboard/_dashboard_status_verification.html
 msgid ""
-"Your edX ID verification is pending. Your verification information has been "
+"Your edX ID verification is pending. Your ID verification information has been "
 "submitted and will be reviewed shortly."
 msgstr ""
-"Ýöür édX ÌD vérïfïçätïön ïs péndïng. Ýöür vérïfïçätïön ïnförmätïön häs ßéén "
+"Ýöür édX ÌD vérïfïçätïön ïs péndïng. Ýöür ÌD vérïfïçätïön ïnförmätïön häs ßéén "
 "süßmïttéd änd wïll ßé révïéwéd shörtlý. Ⱡ'σяєм ιρѕυм ∂σł#"
 
 #: lms/templates/dashboard/_dashboard_status_verification.html
-msgid "Current Verification Status: Denied"
+msgid "Current ID Verification Status: Denied"
 msgstr ""
-"Çürrént Vérïfïçätïön Stätüs: Dénïéd Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєт#"
+"Çürrént ÌD Vérïfïçätïön Stätüs: Dénïéd Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєт#"
 
 #: lms/templates/dashboard/_dashboard_status_verification.html
 msgid ""
-"Your verification submission was not accepted. To receive a verified "
+"Your ID verification submission was not accepted. To receive a verified "
 "certificate, you must submit a new photo of yourself and your government-"
 "issued photo ID before the verification deadline for your course."
 msgstr ""
-"Ýöür vérïfïçätïön süßmïssïön wäs nöt äççéptéd. Tö réçéïvé ä vérïfïéd "
+"Ýöür ÌD vérïfïçätïön süßmïssïön wäs nöt äççéptéd. Tö réçéïvé ä vérïfïéd "
 "çértïfïçäté, ýöü müst süßmït ä néw phötö öf ýöürsélf änd ýöür gövérnmént-"
 "ïssüéd phötö ÌD ßéföré thé vérïfïçätïön déädlïné för ýöür çöürsé. Ⱡ'σяєм "
 "ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя α∂ιριѕι¢ιηg єłιт, ѕє∂ ∂σ єιυѕмσ∂ тємρσя "
@@ -19415,15 +19415,15 @@ msgstr ""
 "¢ιłłυм ∂σłσяє єυ ƒυgιαт ηυłłα ραяιαтυя. єχ¢єρтєυя ѕι#"
 
 #: lms/templates/dashboard/_dashboard_status_verification.html
-msgid "Your verification was denied for the following reasons:"
+msgid "Your ID verification was denied for the following reasons:"
 msgstr ""
-"Ýöür vérïfïçätïön wäs dénïéd för thé föllöwïng réäsöns: Ⱡ'σяєм ιρѕυм ∂σłσя "
+"Ýöür ÌD vérïfïçätïön wäs dénïéd för thé föllöwïng réäsöns: Ⱡ'σяєм ιρѕυм ∂σłσя "
 "ѕιт αмєт, ¢σηѕє¢тєтυя α#"
 
 #: lms/templates/dashboard/_dashboard_status_verification.html
-msgid "Current Verification Status: Expired"
+msgid "Current ID Verification Status: Expired"
 msgstr ""
-"Çürrént Vérïfïçätïön Stätüs: Éxpïréd Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, "
+"Çürrént ÌD Vérïfïçätïön Stätüs: Éxpïréd Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, "
 "¢σηѕє¢тєтυ#"
 
 #: lms/templates/dashboard/_dashboard_status_verification.html
@@ -20013,10 +20013,10 @@ msgstr ""
 
 #: lms/templates/emails/passed_verification_email.txt
 msgid ""
-"Your verification is effective for one year. It will expire on "
+"Your verification is effective for two years. It will expire on "
 "{expiration_datetime}"
 msgstr ""
-"Ýöür vérïfïçätïön ïs éfféçtïvé för öné ýéär. Ìt wïll éxpïré ön "
+"Ýöür vérïfïçätïön ïs éfféçtïvé för twö ýéärs. Ìt wïll éxpïré ön "
 "{expiration_datetime} Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя #"
 
 #: lms/templates/emails/photo_submission_confirmation.txt

--- a/lms/templates/dashboard/_dashboard_status_verification.html
+++ b/lms/templates/dashboard/_dashboard_status_verification.html
@@ -9,10 +9,10 @@ from lms.djangoapps.verify_student.services import IDVerificationService
 %if verification_display:
     %if verification_status == 'approved':
         <li class="status status-verification is-accepted">
-            <span class="title status-title">${_("Current Verification Status: Approved")}</span>
-            <p class="status-note">${_("Your edX verification has been approved. Your verification is effective for one year after submission.")}</p>
+            <span class="title status-title">${_("Current ID Verification Status: Approved")}</span>
+            <p class="status-note">${_("Your edX ID verification has been approved. Your ID verification is effective for two years after submission.")}</p>
             %if verification_expiry:
-                <p class="status-note"><span><b>${_("Warning")}: </b></span><i>${_("Your photo verification expires on {verification_expiry}. Please be aware photo verification can take up to three days once initiated and you will not be able to earn a certificate or take a proctored exam until approved.").format(verification_expiry=verification_expiry)}</i></p>
+                <p class="status-note"><span><b>${_("Warning")}: </b></span><i>${_("Your photo ID verification expires on {verification_expiry}. Please be aware photo verification can take up to three days once initiated and you will not be able to earn a certificate or take a proctored exam until approved.").format(verification_expiry=verification_expiry)}</i></p>
                 <div class="btn-reverify">
                     <a href="${IDVerificationService.get_verify_location()}" class="action action-reverify">${_("Resubmit Verification")}</a>
                 </div>
@@ -20,18 +20,18 @@ from lms.djangoapps.verify_student.services import IDVerificationService
         </li>
     %elif verification_status == 'pending':
         <li class="status status-verification is-pending">
-            <span class="title status-title">${_("Current Verification Status: Pending")}</span>
-            <p class="status-note">${_("Your edX ID verification is pending. Your verification information has been submitted and will be reviewed shortly.")}</p>
+            <span class="title status-title">${_("Current ID Verification Status: Pending")}</span>
+            <p class="status-note">${_("Your edX ID verification is pending. Your ID verification information has been submitted and will be reviewed shortly.")}</p>
         </li>
     %elif verification_status in ['denied','must_reverify', 'must_retry']:
         <li class="status status-verification is-denied">
-            <span class="title status-title">${_("Current Verification Status: Denied")}</span>
+            <span class="title status-title">${_("Current ID Verification Status: Denied")}</span>
             <p class="status-note">
-        ${_("Your verification submission was not accepted. To receive a verified certificate, you must submit a new photo of yourself and your government-issued photo ID before the verification deadline for your course.")}
+        ${_("Your ID verification submission was not accepted. To receive a verified certificate, you must submit a new photo of yourself and your government-issued photo ID before the verification deadline for your course.")}
 
             %if verification_errors:
                 <br><br>
-                ${_("Your verification was denied for the following reasons:")}<br>
+                ${_("Your ID verification was denied for the following reasons:")}<br>
                 <ul>
                 %for error in verification_errors:
                     <li>${error}</li>
@@ -45,8 +45,8 @@ from lms.djangoapps.verify_student.services import IDVerificationService
         </li>
     %elif verification_status == 'expired':
         <li class="status status-verification is-denied">
-            <span class="title status-title">${_("Current Verification Status: Expired")}</span>
-            <p class="status-note">${_("Your verification has expired. To receive a verified certificate, you must submit a new photo of yourself and your government-issued photo ID before the verification deadline for your course.")}</p>
+            <span class="title status-title">${_("Current ID Verification Status: Expired")}</span>
+            <p class="status-note">${_("Your ID verification has expired. To receive a verified certificate, you must submit a new photo of yourself and your government-issued photo ID before the verification deadline for your course.")}</p>
             <p class="status-note"><span><b>${_("Warning")}: </b></span>${_(" Please be aware photo verification can take up to three days once initiated and you will not be able to earn a certificate or take a proctored exam until approved.")}</p>
             <div class="btn-reverify">
                 <a href="${IDVerificationService.get_verify_location()}" class="action action-reverify">${_("Resubmit Verification")}</a>

--- a/lms/templates/emails/passed_verification_email.txt
+++ b/lms/templates/emails/passed_verification_email.txt
@@ -4,7 +4,7 @@
 ${_("Hi {full_name}").format(full_name=full_name)}
 
 ${_("Congratulations! Your ID verification process was successful.")}
-${_("Your verification is effective for one year. It will expire on {expiration_datetime}").format(expiration_date=expiration_datetime)}
+${_("Your verification is effective for two years. It will expire on {expiration_datetime}").format(expiration_date=expiration_datetime)}
 
 ${_("Thank you,")}
 ${_("The {platform_name} team").format(platform_name=platform_name)}


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## [MST-706](https://openedx.atlassian.net/browse/MST-706)
An ID verification is now valid for two years, so the text in the dashboard status has been updated to reflect that. The more generic term `verification` has also been changed to `ID Verification` as to minimize confusion between what it means to be enrolled in a verified track and the process of ID Verification.