### PR TITLE
[AA-727] Ensure that course staff can see course outline content when masquerading as a learner

### DIFF
--- a/lms/djangoapps/course_home_api/outline/v1/views.py
+++ b/lms/djangoapps/course_home_api/outline/v1/views.py
@@ -35,7 +35,7 @@ from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.context_processor import user_timezone_locale_prefs
 from lms.djangoapps.courseware.courses import get_course_date_blocks, get_course_info_section, get_course_with_access
 from lms.djangoapps.courseware.date_summary import TodaysDate
-from lms.djangoapps.courseware.masquerade import setup_masquerade
+from lms.djangoapps.courseware.masquerade import is_masquerading, setup_masquerade
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from openedx.features.course_duration_limits.access import get_access_expiration_data
@@ -170,12 +170,14 @@ class OutlineTabView(RetrieveAPIView):
 
         course = get_course_with_access(request.user, 'load', course_key, check_if_enrolled=False)
 
-        _masquerade, request.user = setup_masquerade(
+        masquerade_object, request.user = setup_masquerade(
             request,
             course_key,
             staff_access=has_access(request.user, 'staff', course_key),
             reset_masquerade_data=True,
         )
+
+        user_is_masquerading = is_masquerading(request.user, course_key, course_masquerade=masquerade_object)
 
         course_overview = CourseOverview.get_from_id(course_key)
         enrollment = CourseEnrollment.get_enrollment(request.user, course_key)
@@ -259,9 +261,9 @@ class OutlineTabView(RetrieveAPIView):
                 start_block = get_start_block(course_blocks)
                 resume_course['url'] = start_block['lms_web_url']
 
-        elif allow_public_outline or allow_public:
+        elif allow_public_outline or allow_public or user_is_masquerading:
             course_blocks = get_course_outline_block_tree(request, course_key_string, None)
-            if allow_public:
+            if allow_public or user_is_masquerading:
                 handouts_html = get_course_info_section(request, request.user, course, 'handouts')
 
         if not show_enrolled:


### PR DESCRIPTION
before
<img width="1428" alt="Screen Shot 2021-03-31 at 12 31 50 PM" src="https://user-images.githubusercontent.com/5958221/113179273-72a42900-921d-11eb-9599-4a0d266eaf25.png">
after
<img width="1437" alt="Screen Shot 2021-04-01 at 10 01 42 AM" src="https://user-images.githubusercontent.com/5958221/113309515-39c78b00-92d5-11eb-80c8-726968807915.png">

The ticket mentions the PR that fixed a similar issue in the courseware which fixed it by moving when the access checks happened relative to the masquerade.
https://github.com/edx/edx-platform/pull/26975/files#diff-e1221a569c1c5f896d2be047b50d17c09c967785c90a7fbc2a68f0c8d9543129R71
I tried to replicate a similar approach to fix the issue on the course home page