### PR TITLE
fix: Allow capa_problem optioninput option with empty text

### DIFF
--- a/common/lib/capa/capa/capa_problem.py
+++ b/common/lib/capa/capa/capa_problem.py
@@ -285,7 +285,8 @@ class LoncapaProblem(object):
             correct_option = None
             child_options = []
             for option_element in optioninput.findall('./option'):
-                option_name = option_element.text.strip()
+                text = option_element.text
+                option_name = text.strip()
                 if option_element.get('correct').upper() == 'TRUE':
                     correct_option = option_name
                 child_options.append("'" + option_name + "'")

--- a/common/lib/capa/capa/capa_problem.py
+++ b/common/lib/capa/capa/capa_problem.py
@@ -286,6 +286,7 @@ class LoncapaProblem(object):
             child_options = []
             for option_element in optioninput.findall('./option'):
                 text = option_element.text
+                text = text or ''
                 option_name = text.strip()
                 if option_element.get('correct').upper() == 'TRUE':
                     correct_option = option_name

--- a/common/lib/capa/capa/tests/test_capa_problem.py
+++ b/common/lib/capa/capa/tests/test_capa_problem.py
@@ -397,6 +397,26 @@ class CAPAProblemTest(unittest.TestCase):
         problem = new_loncapa_problem(xml.format(correctness=False))
         assert problem is not None
 
+    def test_optionresponse_option_with_empty_text(self):
+        """
+        Verify successful instantiation of an optionresponse problem
+        with an option with empty text
+        """
+        xml = """
+        <problem>
+            <optionresponse>
+                <label>Select True or False</label>
+                <optioninput>
+                    <option correct="False">True <optionhint>Not this one</optionhint></option>
+                    <option correct="True">False</option>
+                    <option correct="False"><optionhint>Not this empty one either</optionhint></option>
+                </optioninput>
+            </optionresponse>
+        </problem>
+        """
+        problem = new_loncapa_problem(xml)
+        assert problem is not None
+
 
 @ddt.ddt
 class CAPAMultiInputProblemTest(unittest.TestCase):


### PR DESCRIPTION
This fixes TNL-7973 [1].

Background
----------

> An alert was sent out because a malformed capa problem caused block
> transformers to fail to run.

> This specific error/alert was triggered when an optionresponse problem
> lacked text. The authoring-based fix is to edit the offending
> option-response problem to remove the empty option.

> Expected behavior: We should be able to keep the error local to the
> ProblemBlock and not blow up the whole course publish block
> transformer collection process.

> This is a really easy error for authors to make, and the consequences
> to them (one problem doesn’t work) are disproportionate to the
> consequences [...] (alerting triggered).

Testing
-------

```xml
<problem>
<optionresponse>
  <label>Select True or False</label>
<optioninput>
    <option correct="False">True <optionhint>Not this one</optionhint>
</option>
    <option correct="True">False</option>
    <option correct="False"> <optionhint>Not this one either</optionhint>
</option>
  </optioninput>
</optionresponse>
</problem>
```

Extra
-----

This PR also contains a minor refactoring commit.

- [1] https://openedx.atlassian.net/browse/TNL-7973