### PR TITLE
[MST-678] Remove proctored exam resume waffle flag

### DIFF
--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -101,21 +101,6 @@ COURSEWARE_PROCTORING_IMPROVEMENTS = CourseWaffleFlag(
     WAFFLE_FLAG_NAMESPACE, 'proctoring_improvements', __name__
 )
 
-# .. toggle_name: courseware.exam_resume_proctoring_improvements
-# .. toggle_implementation: CourseWaffleFlag
-# .. toggle_default: False
-# .. toggle_description: Waffle flag to toggle various exam resumption enhancements to the proctoring experience,
-#   including but not limited to the addition of a "Resume" action for exam attempts in the "error" state to the
-#   Student Special Exam Attempts panel of the Special Exams tab of the Instructor Dashboard, etc.
-# .. toggle_use_cases: temporary
-# .. toggle_creation_date: 2020-01-25
-# .. toggle_target_removal_date: None
-# .. toggle_warnings: None
-# .. toggle_tickets: MST-597
-EXAM_RESUME_PROCTORING_IMPROVEMENTS = CourseWaffleFlag(
-    WAFFLE_FLAG_NAMESPACE, 'exam_resume_proctoring_improvements', __name__
-)
-
 # .. toggle_name: courseware.optimized_render_xblock
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False

--- a/lms/djangoapps/instructor/tests/test_proctoring.py
+++ b/lms/djangoapps/instructor/tests/test_proctoring.py
@@ -14,7 +14,6 @@ from edx_toggles.toggles.testutils import override_waffle_flag
 
 from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole
 from common.djangoapps.student.tests.factories import AdminFactory
-from lms.djangoapps.courseware.toggles import EXAM_RESUME_PROCTORING_IMPROVEMENTS
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
@@ -178,32 +177,6 @@ class TestProctoringDashboardViews(SharedModuleStoreTestCase):
         self.instructor.is_staff = True
         self.instructor.save()
         self._assert_escalation_email_available(True)
-
-    @override_waffle_flag(EXAM_RESUME_PROCTORING_IMPROVEMENTS, True)
-    def test_exam_resume_proctoring_improvements_toggle_enabled(self):
-        """
-        The value of the feature toggle EXAM_RESUME_PROCTORING_IMPROVEMENTS should be included in the response
-        via the data-enable-exam-resume-proctoring-improvements data attribute when the toggle is enabled.
-        """
-        self.setup_course(True, True)
-        self.instructor.is_staff = True
-        self.instructor.save()
-
-        response = self.client.get(self.url)
-        assert 'data-enable-exam-resume-proctoring-improvements="True"' in response.content.decode('utf-8')
-
-    @override_waffle_flag(EXAM_RESUME_PROCTORING_IMPROVEMENTS, False)
-    def test_exam_resume_proctoring_improvements_toggle_disabled(self):
-        """
-        The value of the feature toggle EXAM_RESUME_PROCTORING_IMPROVEMENTS should be included in the response
-        via the data-enable-exam-resume-proctoring-improvements data attribute when the toggle is disabled.
-        """
-        self.setup_course(True, True)
-        self.instructor.is_staff = True
-        self.instructor.save()
-
-        response = self.client.get(self.url)
-        assert 'data-enable-exam-resume-proctoring-improvements="False"' in response.content.decode('utf-8')
 
     def test_review_dashboard(self):
         """

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -50,7 +50,6 @@ from lms.djangoapps.certificates.models import (
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.courses import get_course_by_id, get_studio_url
 from lms.djangoapps.courseware.module_render import get_module_by_usage_id
-from lms.djangoapps.courseware.toggles import EXAM_RESUME_PROCTORING_IMPROVEMENTS
 from lms.djangoapps.discussion.django_comment_client.utils import available_division_schemes, has_forum_access
 from lms.djangoapps.grades.api import is_writable_gradebook_enabled
 from openedx.core.djangoapps.course_groups.cohorts import DEFAULT_COHORT_NAME, get_course_cohorts, is_course_cohorted
@@ -278,7 +277,6 @@ def _section_special_exams(course, access):
         'escalation_email': escalation_email,
         'show_dashboard': is_backend_dashboard_available(course_key),
         'show_onboarding': does_backend_support_onboarding(course.proctoring_provider),
-        'enable_exam_resume_proctoring_improvements': EXAM_RESUME_PROCTORING_IMPROVEMENTS.is_enabled(course.id),
     }
     return section_data
 

--- a/lms/templates/instructor/instructor_dashboard_2/special_exams.html
+++ b/lms/templates/instructor/instructor_dashboard_2/special_exams.html
@@ -13,7 +13,7 @@ import pytz
       <h3 class="hd hd-3">${_('Allowance Section')}</h3>
       <div class="special-allowance-container" data-course-id="${ section_data['course_id'] }"></div>
     </div>
-    % if section_data['show_onboarding'] and section_data['enable_exam_resume_proctoring_improvements']:
+    % if section_data['show_onboarding']:
     <div class="wrap">
       <h3 class="hd hd-3">${_('Student Onboarding Status')}</h3>
       <div class="student-onboarding-status-container" data-course-id="${ section_data['course_id'] }"></div>
@@ -21,7 +21,7 @@ import pytz
     % endif
     <div class="wrap">
       <h3 class="hd hd-3">${_('Student Special Exam Attempts')}</h3>
-      <div class="student-proctored-exam-container" data-course-id="${ section_data['course_id'] }" data-enable-exam-resume-proctoring-improvements="${ section_data['enable_exam_resume_proctoring_improvements'] }"></div>
+      <div class="student-proctored-exam-container" data-course-id="${ section_data['course_id'] }"></div>
     </div>
     % if section_data['show_dashboard']:
     <div class="wrap">

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -107,7 +107,7 @@ edx-milestones==0.3.1     # via -r requirements/edx/base.in
 edx-opaque-keys[django]==2.2.0  # via -r requirements/edx/paver.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, lti-consumer-xblock, xmodule
 edx-organizations==6.9.0  # via -r requirements/edx/base.in
 edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/base.in
-edx-proctoring==3.7.16    # via -r requirements/edx/base.in, edx-proctoring-proctortrack
+edx-proctoring==3.8.0     # via -r requirements/edx/base.in, edx-proctoring-proctortrack
 edx-rbac==1.4.2           # via edx-enterprise
 edx-rest-api-client==5.3.0  # via -r requirements/edx/base.in, edx-enterprise, edx-proctoring
 edx-search==3.0.0         # via -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -119,7 +119,7 @@ edx-milestones==0.3.1     # via -r requirements/edx/testing.txt
 edx-opaque-keys[django]==2.2.0  # via -r requirements/edx/testing.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, lti-consumer-xblock, xmodule
 edx-organizations==6.9.0  # via -r requirements/edx/testing.txt
 edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/testing.txt
-edx-proctoring==3.7.16    # via -r requirements/edx/testing.txt, edx-proctoring-proctortrack
+edx-proctoring==3.8.0     # via -r requirements/edx/testing.txt, edx-proctoring-proctortrack
 edx-rbac==1.4.2           # via -r requirements/edx/testing.txt, edx-enterprise
 edx-rest-api-client==5.3.0  # via -r requirements/edx/testing.txt, edx-enterprise, edx-proctoring
 edx-search==3.0.0         # via -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -116,7 +116,7 @@ edx-milestones==0.3.1     # via -r requirements/edx/base.txt
 edx-opaque-keys[django]==2.2.0  # via -r requirements/edx/base.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, lti-consumer-xblock, xmodule
 edx-organizations==6.9.0  # via -r requirements/edx/base.txt
 edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/base.txt
-edx-proctoring==3.7.16    # via -r requirements/edx/base.txt, edx-proctoring-proctortrack
+edx-proctoring==3.8.0     # via -r requirements/edx/base.txt, edx-proctoring-proctortrack
 edx-rbac==1.4.2           # via -r requirements/edx/base.txt, edx-enterprise
 edx-rest-api-client==5.3.0  # via -r requirements/edx/base.txt, edx-enterprise, edx-proctoring
 edx-search==3.0.0         # via -r requirements/edx/base.txt


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This removes the `EXAM_RESUME_PROCTORING_IMPROVEMENTS` waffle flag and upgrades `edx-proctoring` to 3.8.0, fully rolling out the exam resume and grouped attempt features on the instructor dashboard.

## Supporting information

- [MST-678](https://openedx.atlassian.net/browse/MST-678)
- [edx-proctoring changelog](https://github.com/edx/edx-proctoring/blob/master/CHANGELOG.rst#380---2021-03-31)
- https://github.com/edx/edx-proctoring/pull/820