### PR TITLE
[MST-718] Validate the media type of uploaded IDV images

### DIFF
--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -1230,7 +1230,7 @@ class TestSubmitPhotosForVerification(MockS3BotoMixin, TestVerificationBase):
     """
     USERNAME = "test_user"
     PASSWORD = "test_password"
-    IMAGE_DATA = "abcd,1234"
+    IMAGE_DATA = "data:image/png;base64,1234"
     FULL_NAME = "Ḟüḷḷ Ṅäṁë"
     EXPERIMENT_NAME = "test-experiment"
 
@@ -1337,6 +1337,22 @@ class TestSubmitPhotosForVerification(MockS3BotoMixin, TestVerificationBase):
         params[invalid_param] = ""
         response = self._submit_photos(expected_status_code=400, **params)
         assert response.content.decode('utf-8') == 'Image data is not valid.'
+
+    @ddt.data(
+        ('data:image/png;base64,1234', 200),
+        ('data:image/jpeg;base64,1234', 200),
+        ('data:image/webp;base64,1234', 200),
+        ('data:application/pdf;base64,1234', 400),
+        ('data:text/html;base64,1234', 400),
+        ('invalid_image_data', 400),
+    )
+    @ddt.unpack
+    def test_validate_media_type(self, image_data, status_code):
+        params = {
+            'face_image': image_data,
+            'photo_id_image': image_data,
+        }
+        self._submit_photos(expected_status_code=status_code, **params)
 
     def test_invalid_name(self):
         response = self._submit_photos(


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Add extra validation to the photos being submitted for IDV, and throw a 400 error if they are not in a supported format (.png, .jpg, or .jpeg).

## Supporting information

- [MST-718](https://openedx.atlassian.net/browse/MST-718)
- https://github.com/edx/frontend-app-account/pull/422