### PR TITLE
fix: Language preferences change enhancement.

### DIFF
--- a/lms/static/js/views/fields.js
+++ b/lms/static/js/views/fields.js
@@ -401,7 +401,7 @@
 
             events: {
                 click: 'startEditing',
-                'focusout select': 'finishEditing'
+                'change select': 'finishEditing'
             },
 
             initialize: function(options) {


### PR DESCRIPTION
[CRI-229](https://openedx.atlassian.net/browse/CRI-229)

On "/account/settings" page, try to change the language. Language is
changed only after additional action click, page reload, etc.

Current fix changes that behavior in a way that new language preferences
take place just after the new language is chosen.