### PR TITLE
[BD-05][TNL-7915][BB-3611] Improve ZIP File content structure

### DIFF
--- a/lms/djangoapps/instructor_task/tasks_helper/misc.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/misc.py
@@ -448,7 +448,7 @@ def upload_ora2_submission_files(
             'Failed to download and compress submissions attachments.',
             'Error while downloading and compressing submissions attachments',
         ):
-            compressed = OraDownloadData.create_zip_with_attachments(zip_file, course_id, submission_files_data)
+            compressed = OraDownloadData.create_zip_with_attachments(zip_file, submission_files_data)
 
         if compressed is None:
             return UPDATE_STATUS_FAILED

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -129,6 +129,3 @@ click<8.0
 # greater version has breaking changes and requires some migration steps.
 django-webpack-loader==0.7.0
 
-# greater version was failing in quality. Too many positional arguments for classmethod call.
-edx-ora2==3.5.0
-

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -677,7 +677,7 @@ oauthlib==3.0.1
     #   social-auth-core
 openedx-calc==2.0.1
     # via -r requirements/edx/base.in
-ora2==3.5.0
+ora2==3.5.1
     # via -r requirements/edx/base.in
 packaging==20.9
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -880,7 +880,7 @@ oauthlib==3.0.1
     #   social-auth-core
 openedx-calc==2.0.1
     # via -r requirements/edx/testing.txt
-ora2==3.5.0
+ora2==3.5.1
     # via -r requirements/edx/testing.txt
 packaging==20.9
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -840,7 +840,7 @@ oauthlib==3.0.1
     #   social-auth-core
 openedx-calc==2.0.1
     # via -r requirements/edx/base.txt
-ora2==3.5.0
+ora2==3.5.1
     # via -r requirements/edx/base.txt
 packaging==20.9
     # via


### PR DESCRIPTION
Signature of `edx-ora2`'s `OraDownloadData.create_zip_with_attachments` method has changed. This PR contains a respective fix.

**JIRA tickets**:
- [BB-3611](https://tasks.opencraft.com/browse/BB-3611).
- [TNL-7915](https://openedx.atlassian.net/browse/TNL-7915).
- [BLENDED-812](https://openedx.atlassian.net/browse/BLENDED-812).

**Sandboxes**:
- https://pr27218.sandbox.opencraft.hosting/

**Discussions**:
- [First Slack thread](https://openedx.slack.com/archives/C014VAUJUJ0/p1612272008003000).
- [Second Slack thread](https://openedx.slack.com/archives/C014VAUJUJ0/p1612968435011100).
- [Third Slack thread](https://openedx.slack.com/archives/C014VAUJUJ0/p1617028572003900).

**Dependencies**:
- Depends on https://github.com/edx/edx-ora2/pull/1610.

**Testing instructions**:

1. `cd $(devstack_root)`
1. `cd ../edx-platform`
1. `git remote add opencraft https://github.com/open-craft/edx-platform`
1. `git fetch opencraft 0x29a/bb3611/improve_zip_file_content_structure`
1. `git checkout 0x29a/bb3611/improve_zip_file_content_structure`
1. `cd $(devstack_root)`
1. `make lms-update-db`
1. Go to LMS, add ORA block to the demo course, submit answer.
1. Go to the instructor dashboard, download submission files.
1. Make sure that resulting archive has the same structure as described in https://github.com/edx/edx-ora2/pull/1610.

**Notes**:
Since PR against `edx-ora2` isn't merged yet, this PR contains pinned `ora2` dependency. After merge, I will replace this commit with `ora2` version bump.

**Reviewers**
- [ ] @giovannicimolin 
- [ ] @jnlapierre 