### PR TITLE
fix: add missing protocol to web link for assets

### DIFF
--- a/cms/djangoapps/contentstore/views/assets.py
+++ b/cms/djangoapps/contentstore/views/assets.py
@@ -6,6 +6,7 @@ import logging
 import math
 import re
 from functools import partial
+from urllib.parse import urljoin
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
@@ -592,7 +593,7 @@ def _get_asset_json(display_name, content_type, date, location, thumbnail_locati
     Helper method for formatting the asset information to send to client.
     '''
     asset_url = StaticContent.serialize_asset_key_with_slash(location)
-    external_url = configuration_helpers.get_value('LMS_ROOT_URL', settings.LMS_ROOT_URL) + asset_url
+    external_url = urljoin(configuration_helpers.get_value('LMS_ROOT_URL', settings.LMS_ROOT_URL), asset_url)
     return {
         'display_name': display_name,
         'content_type': content_type,

--- a/cms/djangoapps/contentstore/views/assets.py
+++ b/cms/djangoapps/contentstore/views/assets.py
@@ -22,6 +22,7 @@ from common.djangoapps.student.auth import has_course_author_access
 from common.djangoapps.util.date_utils import get_default_time_display
 from common.djangoapps.util.json_request import JsonResponse
 from openedx.core.djangoapps.contentserver.caching import del_cached_content
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from xmodule.contentstore.content import StaticContent
 from xmodule.contentstore.django import contentstore
 from xmodule.exceptions import NotFoundError
@@ -591,7 +592,7 @@ def _get_asset_json(display_name, content_type, date, location, thumbnail_locati
     Helper method for formatting the asset information to send to client.
     '''
     asset_url = StaticContent.serialize_asset_key_with_slash(location)
-    external_url = settings.LMS_BASE + asset_url
+    external_url = configuration_helpers.get_value('LMS_ROOT_URL', settings.LMS_ROOT_URL) + asset_url
     return {
         'display_name': display_name,
         'content_type': content_type,

--- a/cms/djangoapps/contentstore/views/tests/test_assets.py
+++ b/cms/djangoapps/contentstore/views/tests/test_assets.py
@@ -410,7 +410,7 @@ class AssetToJsonTestCase(AssetsTestCase):
     Unit test for transforming asset information into something
     we can send out to the client via JSON.
     """
-    @override_settings(LMS_BASE="lms_base_url")
+    @override_settings(LMS_ROOT_URL="https://lms_root_url")
     def test_basic(self):
         upload_date = datetime(2013, 6, 1, 10, 30, tzinfo=UTC)
         content_type = 'image/jpg'
@@ -425,7 +425,7 @@ class AssetToJsonTestCase(AssetsTestCase):
         self.assertEqual(output["date_added"], "Jun 01, 2013 at 10:30 UTC")
         self.assertEqual(output["url"], "/asset-v1:org+class+run+type@asset+block@my_file_name.jpg")
         self.assertEqual(
-            output["external_url"], "lms_base_url/asset-v1:org+class+run+type@asset+block@my_file_name.jpg"
+            output["external_url"], "https://lms_root_url/asset-v1:org+class+run+type@asset+block@my_file_name.jpg"
         )
         self.assertEqual(output["portable_url"], "/static/my_file_name.jpg")
         self.assertEqual(output["thumbnail"], "/asset-v1:org+class+run+type@thumbnail+block@my_file_name_thumb.jpg")


### PR DESCRIPTION
## Description

Affecting course authors: previously, getting the "Web" link for an asset from Studio (Studio > Content > Files & Uploads) did not include the web protocol for the asset (`http://` or `https://`). Using this link directly to add assets to a prompt in ORA would fail to properly link the asset.

Fix is to update the link copied from the Files & Uploads page to provide the protocol as well.

## Supporting information

JIRA: [EDUCATOR-5586](https://openedx.atlassian.net/browse/EDUCATOR-5586)
FYI: @edx/masters-devs-gta 

## Testing instructions

 In a course with an Open Response Assessment (ORA) and at least 1 uploaded asset in Studio > Content > Files & Uploads:

1. Next to the asset in the list, click the "Web" button to copy the link for the asset
2. Paste the link somewhere, verify that it has the full protocol (`http://` for devstack, `https://` for prod/stage/sandbox)
3. Go to an ORA in Studio
4. Click the ✏️ icon to edit the ORA
5. In the ORA prompt editor, click the “image” button to add an image
6. Paste copied URL into the “Source” field
7. Verify that the image shows up in the preview
8. Publish changes to the ORA
9. Click "View Live Version" to verify that the image also shows up in the published ORA.

## Deadline

None
