### PR TITLE
feat: added another 'Date' expose-headers for outline api clients

### DIFF
--- a/common/djangoapps/util/views.py
+++ b/common/djangoapps/util/views.py
@@ -213,3 +213,13 @@ def reset_course_deadlines(request):
 
     referrer = request.META.get('HTTP_REFERER')
     return redirect(referrer) if referrer else HttpResponse()
+
+
+def expose_header(header, response):
+        """
+        Add a header name to Access-Control-Expose-Headers to allow client code to access that header's value
+        """
+        exposedHeaders = response.get('Access-Control-Expose-Headers', '')
+        exposedHeaders += f', {header}' if exposedHeaders else header
+        response['Access-Control-Expose-Headers'] = exposedHeaders
+        return response

--- a/common/djangoapps/util/views.py
+++ b/common/djangoapps/util/views.py
@@ -216,10 +216,10 @@ def reset_course_deadlines(request):
 
 
 def expose_header(header, response):
-        """
-        Add a header name to Access-Control-Expose-Headers to allow client code to access that header's value
-        """
-        exposedHeaders = response.get('Access-Control-Expose-Headers', '')
-        exposedHeaders += f', {header}' if exposedHeaders else header
-        response['Access-Control-Expose-Headers'] = exposedHeaders
-        return response
+    """
+    Add a header name to Access-Control-Expose-Headers to allow client code to access that header's value
+    """
+    exposedHeaders = response.get('Access-Control-Expose-Headers', '')
+    exposedHeaders += f', {header}' if exposedHeaders else header
+    response['Access-Control-Expose-Headers'] = exposedHeaders
+    return response

--- a/lms/djangoapps/course_home_api/outline/v1/views.py
+++ b/lms/djangoapps/course_home_api/outline/v1/views.py
@@ -299,9 +299,11 @@ class OutlineTabView(RetrieveAPIView):
     def finalize_response(self, request, response, *args, **kwargs):
         """
         Return the final response, exposing the 'Date' header for computing relative time to the dates in the data.
+
+        Important dates such as 'access_expiration' are enforced server-side based on correct time; client-side clocks are frequently substantially far off which could lead to inaccurate messaging and incorrect expectations.  Therefore, any messaging about those dates should be based on the server time and preferably in relative terms (time remaining); the 'Date' header is a straightforward and generalizable way for client-side code to get this reference.
         """
         response = super().finalize_response(request, response, *args, **kwargs)
-        # Adding this header should be moved somewhere global, not just this endpoint
+        # Adding this header should be moved to global middleware, not just this endpoint
         return expose_header('Date', response)
 
 

--- a/lms/djangoapps/course_home_api/outline/v1/views.py
+++ b/lms/djangoapps/course_home_api/outline/v1/views.py
@@ -295,6 +295,17 @@ class OutlineTabView(RetrieveAPIView):
 
         return Response(serializer.data)
 
+    def finalize_response(self, request, response, *args, **kwargs):
+        """
+        Return the final response, exposing the 'Date' header for computing relative time to the dates in the data.
+        """
+        response = super().finalize_response(request, response, *args, **kwargs)
+        # Adding this header should be moved somewhere global, not just this endpoint
+        exposedHeaders = response.get('Access-Control-Expose-Headers', '')
+        exposedHeaders += ', Date' if exposedHeaders else 'Date'
+        response['Access-Control-Expose-Headers'] = exposedHeaders
+        return response
+
 
 @api_view(['POST'])
 @authentication_classes((JwtAuthentication,))

--- a/lms/djangoapps/course_home_api/outline/v1/views.py
+++ b/lms/djangoapps/course_home_api/outline/v1/views.py
@@ -300,7 +300,11 @@ class OutlineTabView(RetrieveAPIView):
         """
         Return the final response, exposing the 'Date' header for computing relative time to the dates in the data.
 
-        Important dates such as 'access_expiration' are enforced server-side based on correct time; client-side clocks are frequently substantially far off which could lead to inaccurate messaging and incorrect expectations.  Therefore, any messaging about those dates should be based on the server time and preferably in relative terms (time remaining); the 'Date' header is a straightforward and generalizable way for client-side code to get this reference.
+        Important dates such as 'access_expiration' are enforced server-side based on correct time; client-side clocks
+        are frequently substantially far off which could lead to inaccurate messaging and incorrect expectations.
+        Therefore, any messaging about those dates should be based on the server time and preferably in relative terms
+        (time remaining); the 'Date' header is a straightforward and generalizable way for client-side code to get this
+        reference.
         """
         response = super().finalize_response(request, response, *args, **kwargs)
         # Adding this header should be moved to global middleware, not just this endpoint

--- a/lms/djangoapps/course_home_api/outline/v1/views.py
+++ b/lms/djangoapps/course_home_api/outline/v1/views.py
@@ -19,6 +19,7 @@ from rest_framework.response import Response
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.models import CourseEnrollment
+from common.djangoapps.util.views import expose_header
 from lms.djangoapps.course_goals.api import (
     add_course_goal,
     get_course_goal,
@@ -301,10 +302,7 @@ class OutlineTabView(RetrieveAPIView):
         """
         response = super().finalize_response(request, response, *args, **kwargs)
         # Adding this header should be moved somewhere global, not just this endpoint
-        exposedHeaders = response.get('Access-Control-Expose-Headers', '')
-        exposedHeaders += ', Date' if exposedHeaders else 'Date'
-        response['Access-Control-Expose-Headers'] = exposedHeaders
-        return response
+        return expose_header('Date', response)
 
 
 @api_view(['POST'])

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -446,7 +446,11 @@ class CoursewareInformation(RetrieveAPIView):
         """
         Return the final response, exposing the 'Date' header for computing relative time to the dates in the data.
 
-        Important dates such as 'access_expiration' are enforced server-side based on correct time; client-side clocks are frequently substantially far off which could lead to inaccurate messaging and incorrect expectations.  Therefore, any messaging about those dates should be based on the server time and preferably in relative terms (time remaining); the 'Date' header is a straightforward and generalizable way for client-side code to get this reference.
+        Important dates such as 'access_expiration' are enforced server-side based on correct time; client-side clocks
+        are frequently substantially far off which could lead to inaccurate messaging and incorrect expectations.
+        Therefore, any messaging about those dates should be based on the server time and preferably in relative terms
+        (time remaining); the 'Date' header is a straightforward and generalizable way for client-side code to get this
+        reference.
         """
         response = super().finalize_response(request, response, *args, **kwargs)
         # Adding this header should be moved to global middleware, not just this endpoint

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -445,9 +445,11 @@ class CoursewareInformation(RetrieveAPIView):
     def finalize_response(self, request, response, *args, **kwargs):
         """
         Return the final response, exposing the 'Date' header for computing relative time to the dates in the data.
+
+        Important dates such as 'access_expiration' are enforced server-side based on correct time; client-side clocks are frequently substantially far off which could lead to inaccurate messaging and incorrect expectations.  Therefore, any messaging about those dates should be based on the server time and preferably in relative terms (time remaining); the 'Date' header is a straightforward and generalizable way for client-side code to get this reference.
         """
         response = super().finalize_response(request, response, *args, **kwargs)
-        # Adding this header should be moved somewhere global, not just this endpoint
+        # Adding this header should be moved to global middleware, not just this endpoint
         return expose_header('Date', response)
 
 

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -19,6 +19,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from common.djangoapps.course_modes.models import CourseMode
+from common.djangoapps.util.views import expose_header
 from lms.djangoapps.edxnotes.helpers import is_feature_enabled
 from lms.djangoapps.certificates.api import get_certificate_url
 from lms.djangoapps.certificates.models import GeneratedCertificate
@@ -447,10 +448,7 @@ class CoursewareInformation(RetrieveAPIView):
         """
         response = super().finalize_response(request, response, *args, **kwargs)
         # Adding this header should be moved somewhere global, not just this endpoint
-        exposedHeaders = response.get('Access-Control-Expose-Headers', '')
-        exposedHeaders += ', Date' if exposedHeaders else 'Date'
-        response['Access-Control-Expose-Headers'] = exposedHeaders
-        return response
+        return expose_header('Date', response)
 
 
 class SequenceMetadata(DeveloperErrorViewMixin, APIView):


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

_(This PR was originally #27067, a bad rebase caused that one to auto-close and I haven't figured out how to re-open it, starting fresh)_

Exposed the `Date` header on the outline api so clients can accurately compute times relative to the dates returned by the API; this was previously done with the course API (#26979)

Browser time is notoriously unreliable for this, especially for a Learner-facing countdown call-to-action based on the access expiration date.  ([REV-2126](https://openedx.atlassian.net/browse/REV-2126))

Using the `Date` header for this allows the client to make use of information that is already sent, does not require additional calls nor modifying the API, and could be generalized to more or all our APIs without modifying them.

## Testing instructions

The `Access-Control-Expose-Headers` header can be seen in requests to the `api/course_home/v1/outline/{course_key}` endpoint if the `course_home_mfe_outline_tab_is_active` toggle is set.

## Deadline

This will be needed for the [frontend-app-learning PR for the countdown](https://github.com/edx/frontend-app-learning/pull/377)
