### PR TITLE
ARCHBOM-1721: docs: update toggle docs

### DIFF
--- a/cms/djangoapps/contentstore/config/waffle.py
+++ b/cms/djangoapps/contentstore/config/waffle.py
@@ -12,19 +12,29 @@ from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 WAFFLE_NAMESPACE = 'studio'
 
 # Switches
+# TODO: Replace with WaffleSwitch(). See waffle() docstring.
 ENABLE_ACCESSIBILITY_POLICY_PAGE = 'enable_policy_page'
 
 
 def waffle():
     """
-    Returns the namespaced, cached, audited Waffle Switch class for Studio pages.
+    Deprecated: Returns the namespaced, cached, audited Waffle Switch class for Studio pages.
+
+    IMPORTANT: Do NOT copy this pattern and do NOT use this to reference new switches.
+      Instead, replace the string constant above with the actual switch instance.
+      For example::
+
+        ENABLE_ACCESSIBILITY_POLICY_PAGE = WaffleSwitch(f'{WAFFLE_NAMESPACE}.enable_policy_page')
     """
     return LegacyWaffleSwitchNamespace(name=WAFFLE_NAMESPACE, log_prefix='Studio: ')
 
 
 def waffle_flags():
     """
-    Returns the namespaced, cached, audited Waffle Flag class for Studio pages.
+    Deprecated: Returns the namespaced, cached, audited Waffle Flag class for Studio pages.
+
+    IMPORTANT: Do NOT copy this pattern and do NOT use this to reference new flags.
+      See waffle() docstring for more details.
     """
     return LegacyWaffleFlagNamespace(name=WAFFLE_NAMESPACE, log_prefix='Studio: ')
 

--- a/cms/djangoapps/contentstore/toggles.py
+++ b/cms/djangoapps/contentstore/toggles.py
@@ -22,15 +22,12 @@ EXPORT_GIT = SettingDictToggle(
 WAFFLE_NAMESPACE = 'contentstore'
 WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name=WAFFLE_NAMESPACE, log_prefix='Contentstore: ')
 
-# Waffle flag to split library to new view.
 # .. toggle_name: split_library_on_studio_dashboard
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
-# .. toggle_description: Studio dashboard
+# .. toggle_description: Enables data new view for library on studio dashboard.
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2020-07-8
-# .. toggle_target_removal_date: None
-# .. toggle_warnings: ??
 # .. toggle_tickets: TNL-7536
 SPLIT_LIBRARY_ON_DASHBOARD = LegacyWaffleFlag(
     waffle_namespace=LegacyWaffleFlagNamespace(name=WAFFLE_NAMESPACE),
@@ -38,15 +35,13 @@ SPLIT_LIBRARY_ON_DASHBOARD = LegacyWaffleFlag(
     module_name=__name__
 )
 
-# Waffle flag to enable olx validation during course import.
 # .. toggle_name: course_import_olx_validation
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
-# .. toggle_description: Studio Import
+# .. toggle_description: Enables olx validation during course import.
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2021-04-01
 # .. toggle_target_removal_date: 2021-05-01
-# .. toggle_warnings: ??
 # .. toggle_tickets: TNL-8151
 COURSE_IMPORT_OLX_VALIDATION = LegacyWaffleFlag(
     waffle_namespace=LegacyWaffleFlagNamespace(name=WAFFLE_NAMESPACE),

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -375,8 +375,6 @@ FEATURES = {
     #   default because enabling allows a method to bypass password policy.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2020-02-21
-    # .. toggle_target_removal_date: None
-    # .. toggle_warnings: None
     # .. toggle_tickets: 'https://github.com/edx/edx-platform/pull/21616'
     'ENABLE_CHANGE_USER_PASSWORD_ADMIN': False,
 
@@ -443,8 +441,6 @@ FEATURES = {
     #   otherwise the course creation functionality will work as it should.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2013-12-02
-    # .. toggle_target_removal_date: None
-    # .. toggle_tickets: None
     # .. toggle_warnings: Another toggle DISABLE_LIBRARY_CREATION overrides DISABLE_COURSE_CREATION, if present.
     'DISABLE_COURSE_CREATION': False,
 

--- a/common/djangoapps/util/milestones_helpers.py
+++ b/common/djangoapps/util/milestones_helpers.py
@@ -30,9 +30,6 @@ REQUEST_CACHE_NAME = "milestones"
 #   the Open edX platform. (see https://github.com/edx/edx-milestones)
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2014-11-21
-# .. toggle_target_removal_date: None
-# .. toggle_warnings: None
-# .. toggle_tickets: None
 ENABLE_MILESTONES_APP = SettingDictToggle("FEATURES", "MILESTONES_APP", default=False, module_name=__name__)
 
 

--- a/lms/djangoapps/bulk_email/models.py
+++ b/lms/djangoapps/bulk_email/models.py
@@ -484,9 +484,6 @@ class BulkEmailFlag(ConfigurationModel):
       is not available.
     .. toggle_use_cases:  open_edx
     .. toggle_creation_date: 2016-05-05
-    .. toggle_target_removal_date: None
-    .. toggle_warnings: None
-    .. toggle_tickets: None
     """
     # boolean field 'enabled' inherited from parent ConfigurationModel
     require_course_email_auth = models.BooleanField(default=True)

--- a/lms/djangoapps/course_api/__init__.py
+++ b/lms/djangoapps/course_api/__init__.py
@@ -12,8 +12,6 @@ WAFFLE_SWITCH_NAMESPACE = LegacyWaffleSwitchNamespace(name='course_list_api_rate
 #   users, this limit is 10 requests/minute.
 # .. toggle_use_cases: circuit_breaker
 # .. toggle_creation_date: 2018-06-12
-# .. toggle_target_removal_date: None
-# .. toggle_warnings: None
 # .. toggle_tickets: https://openedx.atlassian.net/browse/LEARNER-5527
 USE_RATE_LIMIT_2_FOR_COURSE_LIST_API = LegacyWaffleSwitch(WAFFLE_SWITCH_NAMESPACE, 'rate_limit_2', __name__)
 # .. toggle_name: course_list_api_rate_limit.rate_limit_10
@@ -23,7 +21,5 @@ USE_RATE_LIMIT_2_FOR_COURSE_LIST_API = LegacyWaffleSwitch(WAFFLE_SWITCH_NAMESPAC
 #   users, this limit is 20 requests/minute.
 # .. toggle_use_cases: circuit_breaker
 # .. toggle_creation_date: 2018-06-12
-# .. toggle_target_removal_date: None
-# .. toggle_warnings: None
 # .. toggle_tickets: https://openedx.atlassian.net/browse/LEARNER-5527
 USE_RATE_LIMIT_10_FOR_COURSE_LIST_API = LegacyWaffleSwitch(WAFFLE_SWITCH_NAMESPACE, 'rate_limit_10', __name__)

--- a/lms/djangoapps/course_api/blocks/toggles.py
+++ b/lms/djangoapps/course_api/blocks/toggles.py
@@ -15,7 +15,6 @@ COURSE_BLOCKS_API_NAMESPACE = LegacyWaffleFlagNamespace(name='course_blocks_api'
 # .. toggle_creation_date: 2019-09-27
 # .. toggle_target_removal_date: None
 # .. toggle_warnings: This temporary feature toggle does not have a target removal date.
-# .. toggle_tickets: None
 HIDE_ACCESS_DENIALS_FLAG = LegacyWaffleFlag(
     waffle_namespace=COURSE_BLOCKS_API_NAMESPACE,
     flag_name='hide_access_denials',

--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -46,7 +46,6 @@ COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW = CourseWaffleFlag(
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Supports staged rollout of the new micro-frontend-based implementation of the course exit page.
-# .. toggle_category: micro-frontend
 # .. toggle_use_cases: open_edx, temporary
 # .. toggle_creation_date: 2020-10-02
 # .. toggle_target_removal_date: None
@@ -95,7 +94,6 @@ COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES_STREAK_CELEBRATION = CourseWaffleFl
 # .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2020-10-07
 # .. toggle_target_removal_date: None
-# .. toggle_warnings: None
 # .. toggle_tickets: MST-432
 COURSEWARE_PROCTORING_IMPROVEMENTS = CourseWaffleFlag(
     WAFFLE_FLAG_NAMESPACE, 'proctoring_improvements', __name__
@@ -111,7 +109,6 @@ COURSEWARE_PROCTORING_IMPROVEMENTS = CourseWaffleFlag(
 # .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2021-02-09
 # .. toggle_target_removal_date: 2021-05-01
-# .. toggle_warnings: None
 COURSEWARE_OPTIMIZED_RENDER_XBLOCK = CourseWaffleFlag(
     WAFFLE_FLAG_NAMESPACE, 'optimized_render_xblock', __name__
 )

--- a/lms/djangoapps/discussion/config/settings.py
+++ b/lms/djangoapps/discussion/config/settings.py
@@ -11,9 +11,6 @@ from django.conf import settings
 #   for daily digest. This setting enables deprecation of daily digest.
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2020-03-09
-# .. toggle_target_removal_date: None
-# .. toggle_warnings: None
-# .. toggle_tickets: None
 ENABLE_FORUM_DAILY_DIGEST = 'enable_forum_daily_digest'
 
 

--- a/lms/djangoapps/discussion/settings/common.py
+++ b/lms/djangoapps/discussion/settings/common.py
@@ -9,8 +9,6 @@ def plugin_settings(settings):
     # .. toggle_description: If True, it adds an option to show/hide the discussions tab.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2015-06-15
-    # .. toggle_target_removal_date: None
-    # .. toggle_warnings: None
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/8474
     settings.FEATURES['ALLOW_HIDING_DISCUSSION_TAB'] = False
     settings.DISCUSSION_SETTINGS = {

--- a/lms/djangoapps/grades/config/models.py
+++ b/lms/djangoapps/grades/config/models.py
@@ -34,7 +34,6 @@ class PersistentGradesEnabledFlag(ConfigurationModel):
     .. toggle_use_cases: temporary
     .. toggle_creation_date: 2016-08-26
     .. toggle_target_removal_date: None
-    .. toggle_warnings: None
     .. toggle_tickets: https://github.com/edx/edx-platform/pull/13329
     """
     # this field overrides course-specific settings to enable the feature for all courses

--- a/lms/djangoapps/grades/config/waffle.py
+++ b/lms/djangoapps/grades/config/waffle.py
@@ -21,9 +21,9 @@ WAFFLE_NAMESPACE = 'grades'
 #   for all courses.
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2017-04-11
-# .. toggle_target_removal_date: None
 # .. toggle_tickets: https://github.com/edx/edx-platform/pull/14771
 # .. toggle_warnings: This requires the PersistentGradesEnabledFlag to be enabled.
+# TODO: Replace with WaffleSwitch(). See waffle_switch(name) docstring.
 ASSUME_ZERO_GRADE_IF_ABSENT = 'assume_zero_grade_if_absent'
 # .. toggle_name: grades.disable_regrade_on_policy_change
 # .. toggle_implementation: WaffleSwitch
@@ -31,9 +31,8 @@ ASSUME_ZERO_GRADE_IF_ABSENT = 'assume_zero_grade_if_absent'
 # .. toggle_description: When enabled, a change in grading policy will not trigger re-grading.
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2017-08-03
-# .. toggle_target_removal_date: None
-# .. toggle_warnings: None
 # .. toggle_tickets: https://github.com/edx/edx-platform/pull/15733
+# TODO: Replace with WaffleSwitch(). See waffle_switch(name) docstring.
 DISABLE_REGRADE_ON_POLICY_CHANGE = 'disable_regrade_on_policy_change'
 
 # Course Flags
@@ -45,9 +44,8 @@ DISABLE_REGRADE_ON_POLICY_CHANGE = 'disable_regrade_on_policy_change'
 #   in edx-platform, but only in edx-proctoring.
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2019-05-29
-# .. toggle_target_removal_date: None
-# .. toggle_warnings: None
 # .. toggle_tickets: https://github.com/edx/edx-platform/pull/20719
+# TODO: Replace with CourseWaffleFlag() from below. See waffle_flag(name) docstring.
 REJECTED_EXAM_OVERRIDES_GRADE = 'rejected_exam_overrides_grade'
 # .. toggle_name: grades.rejected_exam_overrides_grade
 # .. toggle_implementation: CourseWaffleFlag
@@ -56,9 +54,8 @@ REJECTED_EXAM_OVERRIDES_GRADE = 'rejected_exam_overrides_grade'
 #   is only valid for courses which actually have an end date.
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2018-10-01
-# .. toggle_target_removal_date: None
-# .. toggle_warnings: None
 # .. toggle_tickets: https://github.com/edx/edx-platform/pull/19026
+# TODO: Replace with CourseWaffleFlag() from below. See waffle_flag(name) docstring.
 ENFORCE_FREEZE_GRADE_AFTER_COURSE_END = 'enforce_freeze_grade_after_course_end'
 
 # .. toggle_name: grades.writable_gradebook
@@ -68,9 +65,9 @@ ENFORCE_FREEZE_GRADE_AFTER_COURSE_END = 'enforce_freeze_grade_after_course_end'
 #   the writable gradebook is added to the instructor dashboard.
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2018-10-03
-# .. toggle_target_removal_date: None
 # .. toggle_tickets: https://github.com/edx/edx-platform/pull/19054
 # .. toggle_warnings: Enabling this requires that the `WRITABLE_GRADEBOOK_URL` setting be properly defined.
+# TODO: Replace with CourseWaffleFlag() from below. See waffle_flag(name) docstring.
 WRITABLE_GRADEBOOK = 'writable_gradebook'
 
 # .. toggle_name: grades.bulk_management
@@ -80,35 +77,41 @@ WRITABLE_GRADEBOOK = 'writable_gradebook'
 #   as we understand, this feature is now unused and obsolete.
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2019-08-20
-# .. toggle_target_removal_date: None
-# .. toggle_warnings: None
 # .. toggle_tickets: https://github.com/edx/edx-platform/pull/21389
+# TODO: Replace with CourseWaffleFlag() from below. See waffle_flag(name) docstring.
 BULK_MANAGEMENT = 'bulk_management'
 
 
 def waffle():
     """
-    Returns the namespaced, cached, audited Waffle class for Grades.
+    Deprecated: Returns the namespaced, cached, audited Waffle class for Grades.
+
+    Note: Replace uses of this function with direct references to each switch.
+      See waffle_switch(name) docstring for details.
     """
     return LegacyWaffleSwitchNamespace(name=WAFFLE_NAMESPACE, log_prefix='Grades: ')
 
 
 def waffle_switch(name):
     """
-    Return the corresponding namespaced waffle switch.
+    Deprecated: Return the corresponding namespaced waffle switch.
 
-    WARNING: do not replicate this pattern. Instead of declaring waffle switch names as strings, you should create
-    LegacyWaffleSwitch objects as top-level constants.
+    IMPORTANT: Do NOT copy this pattern and do NOT use this to reference new switches.
+      Instead, replace the string constants above with the actual switch instances.
+      For example::
+
+        ASSUME_ZERO_GRADE_IF_ABSENT = WaffleSwitch(f'{WAFFLE_NAMESPACE}.assume_zero_grade_if_absent')
     """
     return LegacyWaffleSwitch(waffle(), name, module_name=__name__)
 
 
 def waffle_flags():
     """
-    Returns the namespaced, cached, audited Waffle flags dictionary for Grades.
+    Deprecated: Returns the namespaced, cached, audited Waffle flags dictionary for Grades.
 
-    WARNING: do not replicate this pattern. Instead of declaring waffle flag names as strings, you should create
-    LegacyWaffleFlag and CourseWaffleFlag objects as top-level constants.
+    IMPORTANT: Do NOT copy this pattern and do NOT use this to reference new flags.
+      Instead, replace the string constants above with the flag declarations below, and use
+      them directly.
     """
     namespace = LegacyWaffleFlagNamespace(name=WAFFLE_NAMESPACE, log_prefix='Grades: ')
     return {

--- a/lms/djangoapps/instructor/toggles.py
+++ b/lms/djangoapps/instructor/toggles.py
@@ -15,8 +15,6 @@ WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name=WAFFLE_NAMESPACE)
 # .. toggle_description: instructor
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2020-07-8
-# .. toggle_target_removal_date: None
-# .. toggle_warnings: ??
 # .. toggle_tickets: PROD-1309
 DATA_DOWNLOAD_V2 = LegacyWaffleFlag(
     waffle_namespace=WAFFLE_FLAG_NAMESPACE,
@@ -24,18 +22,15 @@ DATA_DOWNLOAD_V2 = LegacyWaffleFlag(
     module_name=__name__,
 )
 
-# Waffle flag to use optimised is_small_course.
 # .. toggle_name: verify_student.optimised_is_small_course
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Supports staged rollout to improved is_small_course method.
-# .. toggle_category: instructor
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2020-07-02
-# .. toggle_target_removal_date: None
-# .. toggle_warnings: n/a
+# .. toggle_warnings: Description mentions staged rollout, but the use case is not set as temporary.
+#      This may actually be a temporary toggle.
 # .. toggle_tickets: PROD-1740
-# .. toggle_status: supported
 OPTIMISED_IS_SMALL_COURSE = LegacyWaffleFlag(
     waffle_namespace=WAFFLE_FLAG_NAMESPACE,
     flag_name='optimised_is_small_course',

--- a/lms/djangoapps/instructor_task/config/waffle.py
+++ b/lms/djangoapps/instructor_task/config/waffle.py
@@ -8,20 +8,28 @@ from edx_toggles.toggles import LegacyWaffleFlagNamespace, LegacyWaffleSwitchNam
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
 WAFFLE_NAMESPACE = 'instructor_task'
+# TODO: Remove and replace with direct references to each flag.
 INSTRUCTOR_TASK_WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name=WAFFLE_NAMESPACE)
+# TODO: Remove and replace with direct references to each switch.
 WAFFLE_SWITCHES = LegacyWaffleSwitchNamespace(name=WAFFLE_NAMESPACE)
 
 # Waffle switches
+# TODO: Replace with WaffleSwitch(). See WAFFLE_SWITCHES comment.
 OPTIMIZE_GET_LEARNERS_FOR_COURSE = 'optimize_get_learners_for_course'
 
 # Course override flags
+# TODO: Replace with WaffleFlag(). See waffle_flags() docstring.
 GENERATE_PROBLEM_GRADE_REPORT_VERIFIED_ONLY = 'generate_problem_grade_report_verified_only'
+# TODO: Replace with WaffleFlag(). See waffle_flags() docstring.
 GENERATE_COURSE_GRADE_REPORT_VERIFIED_ONLY = 'generate_course_grade_report_verified_only'
 
 
 def waffle_flags():
     """
     Returns the namespaced, cached, audited Waffle flags dictionary for Grades.
+
+    IMPORTANT: Do NOT copy this dict pattern and do NOT add new flags to this dict.
+      Instead, replace the string constants above with the actual flag instances.
     """
     return {
         GENERATE_PROBLEM_GRADE_REPORT_VERIFIED_ONLY: CourseWaffleFlag(

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -85,8 +85,6 @@ FEATURES = {
     #   by course staff.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2015-09-04
-    # .. toggle_target_removal_date: None
-    # .. toggle_warnings: None
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/2425
     'DISPLAY_DEBUG_INFO_TO_STAFF': True,
 
@@ -110,7 +108,6 @@ FEATURES = {
     #   date.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2012-07-24
-    # .. toggle_target_removal_date: None
     # .. toggle_warnings: This will cause ALL courses to be immediately visible.
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/17913
     ## DO NOT SET TO True IN THIS FILE
@@ -136,7 +133,6 @@ FEATURES = {
     # .. toggle_description: Add PDF and HTML textbook tabs to the courseware.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2014-03-27
-    # .. toggle_target_removal_date: None
     # .. toggle_warnings: For consistency in user-experience, keep the value in sync with the setting of the same name
     #   in the CMS.
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/3064
@@ -176,8 +172,6 @@ FEATURES = {
     #   regular expression defined by USERNAME_REGEX_PARTIAL.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2017-06-27
-    # .. toggle_target_removal_date: None
-    # .. toggle_warnings: None
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/14729
     'ENABLE_UNICODE_USERNAME': False,
 
@@ -199,9 +193,6 @@ FEATURES = {
     # .. toggle_description: None
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2013-04-13
-    # .. toggle_target_removal_date: None
-    # .. toggle_warnings: None
-    # .. toggle_tickets: None
     'ENABLE_MASQUERADE': True,
 
     # .. toggle_name: FEATURES['ENABLE_SYSADMIN_DASHBOARD']
@@ -209,11 +200,10 @@ FEATURES = {
     # .. toggle_default: False
     # .. toggle_description: enables dashboard at /syadmin/ for django staff, for seeing overview of system status, for
     #   deleting and loading courses, for seeing log of git imports of courseware. Note that some views are noopen_edx
-    # .. toggle_use_cases: open_edx
+    # .. toggle_use_cases: temporary, open_edx
     # .. toggle_creation_date: 2013-12-12
     # .. toggle_target_removal_date: None
     # .. toggle_warnings: This feature is not supported anymore and should have a target removal date.
-    # .. toggle_tickets: None
     'ENABLE_SYSADMIN_DASHBOARD': False,  # sysadmin dashboard, to see what courses are loaded, to delete & load courses
 
     # .. toggle_name: FEATURES['DISABLE_LOGIN_BUTTON']
@@ -223,9 +213,6 @@ FEATURES = {
     #   Change is only at the UI level. Used in systems where login is automatic, eg MIT SSL
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2013-12-03
-    # .. toggle_target_removal_date: None
-    # .. toggle_warnings: None
-    # .. toggle_tickets: None
     'DISABLE_LOGIN_BUTTON': False,
 
     # .. toggle_name: FEATURES['ENABLE_OAUTH2_PROVIDER']
@@ -237,7 +224,6 @@ FEATURES = {
     # .. toggle_creation_date: 2014-09-09
     # .. toggle_target_removal_date: None
     # .. toggle_warnings: This temporary feature toggle does not have a target removal date.
-    # .. toggle_tickets: None
     'ENABLE_OAUTH2_PROVIDER': False,
 
     # .. toggle_name: FEATURES['ENABLE_XBLOCK_VIEW_ENDPOINT']
@@ -248,8 +234,6 @@ FEATURES = {
     #   https://github.com/edx-solutions/jquery-xblock
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2014-03-14
-    # .. toggle_target_removal_date: None
-    # .. toggle_warnings: None
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/2968
     'ENABLE_XBLOCK_VIEW_ENDPOINT': False,
 
@@ -346,8 +330,6 @@ FEATURES = {
     #   allows verified certificates, like courses.edx.org.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2019-05-14
-    # .. toggle_target_removal_date: None
-    # .. toggle_warnings: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/PROD-269
     'DISABLE_HONOR_CERTIFICATES': False,  # Toggle to disable honor certificates
 
@@ -375,8 +357,6 @@ FEATURES = {
     #   querystring parameters.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2018-05-07
-    # .. toggle_target_removal_date: None
-    # .. toggle_warnings: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/TE-2545
     'RESTRICT_AUTOMATIC_AUTH': True,
 
@@ -386,9 +366,7 @@ FEATURES = {
     # .. toggle_description: Enable the login micro frontend.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2018-05-07
-    # .. toggle_target_removal_date: None
     # .. toggle_warnings: The login MFE domain name should be listed in LOGIN_REDIRECT_WHITELIST.
-    # .. toggle_tickets: None
     'ENABLE_LOGIN_MICROFRONTEND': False,
 
     # .. toggle_name: FEATURES['SKIP_EMAIL_VALIDATION']
@@ -398,9 +376,7 @@ FEATURES = {
     #   Beware, as this leaves the door open to potential spam abuse.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2018-05-07
-    # .. toggle_target_removal_date: None
     # .. toggle_warnings: The login MFE domain name should be listed in LOGIN_REDIRECT_WHITELIST.
-    # .. toggle_tickets: None
     'SKIP_EMAIL_VALIDATION': False,
 
     # .. toggle_name: FEATURES['ENABLE_COSMETIC_DISPLAY_PRICE']
@@ -410,7 +386,6 @@ FEATURES = {
     #   cosmetic price is used when there is no registration price associated to the course.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2014-10-10
-    # .. toggle_target_removal_date: None
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/6876
     # .. toggle_warnings: The use case of this feature toggle is uncertain.
     'ENABLE_COSMETIC_DISPLAY_PRICE': False,
@@ -485,9 +460,6 @@ FEATURES = {
     #   backends with the AUTHENTICATION_BACKENDS setting.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2014-09-15
-    # .. toggle_target_removal_date: None
-    # .. toggle_warnings: None
-    # .. toggle_tickets: None
     'ENABLE_THIRD_PARTY_AUTH': False,
 
     # .. toggle_name: FEATURES['ENABLE_MKTG_SITE']
@@ -496,10 +468,8 @@ FEATURES = {
     # .. toggle_description: Toggle to enable alternate urls for marketing links.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2014-03-24
-    # .. toggle_target_removal_date: None
     # .. toggle_warnings: When this is enabled, the MKTG_URLS setting should be defined. The use case of this feature
     #   toggle is uncertain.
-    # .. toggle_tickets: None
     'ENABLE_MKTG_SITE': False,
 
     # Prevent concurrent logins per user
@@ -524,8 +494,6 @@ FEATURES = {
     #   by their start dates, latest first.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2015-03-27
-    # .. toggle_target_removal_date: None
-    # .. toggle_warnings: None
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/7548
     'ENABLE_COURSE_SORTING_BY_START_DATE': True,
 
@@ -537,8 +505,6 @@ FEATURES = {
     #   unified course tab (when the DISABLE_UNIFIED_COURSE_TAB_FLAG waffle is not enabled).
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2019-01-15
-    # .. toggle_target_removal_date: None
-    # .. toggle_warnings: None
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/19604
     'ENABLE_COURSE_HOME_REDIRECT': True,
 
@@ -553,8 +519,6 @@ FEATURES = {
     #   specific configuration.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2016-06-24
-    # .. toggle_target_removal_date: None
-    # .. toggle_warnings: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/OSPR-1320
     'ENABLE_COMBINED_LOGIN_REGISTRATION_FOOTER': False,
 
@@ -652,8 +616,6 @@ FEATURES = {
     #   license information to the courseware.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2015-05-14
-    # .. toggle_target_removal_date: None
-    # .. toggle_warnings: None
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/7315
     'LICENSING': False,
 
@@ -694,8 +656,6 @@ FEATURES = {
     # .. toggle_description: Enable to use special exams, aka timed and proctored exams.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2015-09-04
-    # .. toggle_target_removal_date: None
-    # .. toggle_warnings: None
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/9744
     'ENABLE_SPECIAL_EXAMS': False,
 
@@ -758,11 +718,9 @@ FEATURES = {
     #   student activities to MySQL, in a separate database.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2020-11-05
-    # .. toggle_target_removal_date: None
     # .. toggle_warnings: Even though most Open edX instances run with a separate CSMH database, it may not always be
     #   the case. When disabling this feature flag, remember to remove "lms.djangoapps.coursewarehistoryextended"
     #   from the INSTALLED_APPS and the "StudentModuleHistoryExtendedRouter" from the DATABASE_ROUTERS.
-    # .. toggle_tickets: None
     'ENABLE_CSMH_EXTENDED': True,
 
     # Read from both the CSMH and CSMHE history tables.
@@ -781,8 +739,6 @@ FEATURES = {
     #   the signup page.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2017-04-12
-    # .. toggle_target_removal_date: None
-    # .. toggle_warnings: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/YONK-513
     'ALLOW_PUBLIC_ACCOUNT_CREATION': True,
 
@@ -838,7 +794,6 @@ FEATURES = {
     #   re-publishing the course) for changes to this flag to take effect.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2017-08-28
-    # .. toggle_target_removal_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/OSPR-1880
     'ENABLE_HTML_XBLOCK_STUDENT_VIEW_DATA': False,
 
@@ -851,8 +806,6 @@ FEATURES = {
     #   with. This setting can be overridden by a site-specific configuration.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2017-07-20
-    # .. toggle_target_removal_date: None
-    # .. toggle_warnings: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/OSPR-1832
     'ENABLE_PASSWORD_RESET_FAILURE_EMAIL': False,
 
@@ -880,8 +833,6 @@ FEATURES = {
     #   default because enabling allows a method to bypass password policy.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2020-02-21
-    # .. toggle_target_removal_date: None
-    # .. toggle_warnings: None
     # .. toggle_tickets: 'https://github.com/edx/edx-platform/pull/21616'
     'ENABLE_CHANGE_USER_PASSWORD_ADMIN': False,
 
@@ -894,7 +845,7 @@ FEATURES = {
     # .. toggle_target_removal_date: None
     # .. toggle_tickets: 'https://github.com/edx/edx-platform/pull/24908'
     # .. toggle_warnings: Also set settings.AUTHN_MICROFRONTEND_URL for rollout. This temporary feature
-    # toggle does not have a target removal date.
+    #   toggle does not have a target removal date.
     'ENABLE_AUTHN_MICROFRONTEND': False,
 
     ### ORA Feature Flags ###
@@ -903,7 +854,7 @@ FEATURES = {
     # .. toggle_default: False
     # .. toggle_description: A "work-around" feature toggle meant to help in cases where some file uploads are not
     #   discoverable.  If enabled, will iterate through all possible file key suffixes up to the max for displaying
-    #  file metadata in staff assessments.
+    #   file metadata in staff assessments.
     # .. toggle_use_cases: temporary
     # .. toggle_creation_date: 2020-03-03
     # .. toggle_target_removal_date: None
@@ -944,18 +895,15 @@ FEATURES = {
     # .. toggle_creation_date: 2020-12-09
     # .. toggle_target_removal_date: 2021-02-01
     # .. toggle_tickets: https://openedx.atlassian.net/browse/ENT-3818
-    # .. toggle_warnings: None.
     'ENABLE_COURSE_ASSESSMENT_GRADE_CHANGE_SIGNAL': False,
 
-    # .. toggle_name: FEATURES['ALLOW_ADMIN_ENTERPRISE_COURSE_ENROLLMENT_DELETION']  # lint-amnesty, pylint: disable=annotation-invalid-choice
+    # .. toggle_name: FEATURES['ALLOW_ADMIN_ENTERPRISE_COURSE_ENROLLMENT_DELETION']
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
     # .. toggle_description: If true, allows for the deletion of EnterpriseCourseEnrollment records via Django Admin.
-    # .. toggle_use_cases: enterprise
+    # .. toggle_use_cases: opt_in
     # .. toggle_creation_date: 2021-01-27
-    # .. toggle_target_removal_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/ENT-4022
-    # .. toggle_warnings: None.
     'ALLOW_ADMIN_ENTERPRISE_COURSE_ENROLLMENT_DELETION': False,
 }
 
@@ -3342,8 +3290,6 @@ ENABLE_CREDIT_ELIGIBILITY = True
 #   Eligibility" section then appears for those courses in the LMS.
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2015-06-17
-# .. toggle_target_removal_date: None
-# .. toggle_warnings: None
 # .. toggle_tickets: https://github.com/edx/edx-platform/pull/8550
 FEATURES['ENABLE_CREDIT_ELIGIBILITY'] = ENABLE_CREDIT_ELIGIBILITY
 

--- a/openedx/core/djangoapps/certificates/config/waffle.py
+++ b/openedx/core/djangoapps/certificates/config/waffle.py
@@ -10,11 +10,18 @@ from edx_toggles.toggles import LegacyWaffleSwitchNamespace
 WAFFLE_NAMESPACE = 'certificates'
 
 # Switches
+# TODO: Replace with WaffleSwitch(). See waffle() docstring.
 AUTO_CERTIFICATE_GENERATION = 'auto_certificate_generation'
 
 
 def waffle():
     """
     Returns the namespaced, cached, audited Waffle class for Certificates.
+
+    IMPORTANT: Do NOT copy this pattern and do NOT use this to reference new switches.
+      Instead, replace the string constant above with the actual switch instance.
+      For example::
+
+        AUTO_CERTIFICATE_GENERATION = WaffleSwitch(f'{WAFFLE_NAMESPACE}.auto_certificate_generation')
     """
     return LegacyWaffleSwitchNamespace(name=WAFFLE_NAMESPACE, log_prefix='Certificates: ')

--- a/openedx/core/djangoapps/user_authn/toggles.py
+++ b/openedx/core/djangoapps/user_authn/toggles.py
@@ -12,13 +12,10 @@ from openedx.core.djangoapps.theming.helpers import get_current_request
 # .. toggle_name: ENABLE_REQUIRE_THIRD_PARTY_AUTH
 # .. toggle_implementation: DjangoSetting
 # .. toggle_default: False
-# .. toggle_description: Set to True to prevent using username/password login and registration and only allow authentication with third party auth
-# .. toggle_category: admin
+# .. toggle_description: Set to True to prevent using username/password login and registration and only allow
+#   authentication with third party auth
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2020-09-16
-# .. toggle_expiration_date: None
-# .. toggle_tickets: None
-# .. toggle_status: supported
 # .. toggle_warnings: Requires configuration of third party auth
 
 
@@ -29,7 +26,8 @@ def is_require_third_party_auth_enabled():
 # .. toggle_name: user_authn.redirect_to_microfrontend
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
-# .. toggle_description: Supports staged rollout of a new micro-frontend-based implementation of the login and registration pages
+# .. toggle_description: Supports staged rollout of a new micro-frontend-based implementation of the login and
+#   registration pages
 # .. toggle_use_cases: temporary, open_edx
 # .. toggle_creation_date: 2021-02-02
 # .. toggle_target_removal_date: None

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -105,7 +105,6 @@ REGISTER_USER = Signal(providing_args=["user", "registration"])
 # .. toggle_creation_date: 2020-04-30
 # .. toggle_target_removal_date: 2020-06-01
 # .. toggle_warnings: This temporary feature toggle does not have a target removal date.
-# .. toggle_tickets: None
 REGISTRATION_FAILURE_LOGGING_FLAG = LegacyWaffleFlag(
     waffle_namespace=LegacyWaffleFlagNamespace(name=u'registration'),
     flag_name=u'enable_failure_logging',

--- a/openedx/core/djangoapps/video_config/models.py
+++ b/openedx/core/djangoapps/video_config/models.py
@@ -30,8 +30,6 @@ class HLSPlaybackEnabledFlag(ConfigurationModel):
     .. toggle_description: Add the "hls" profile to all displayed videos on the platform.
     .. toggle_use_cases:  open_edx
     .. toggle_creation_date: 2017-04-19
-    .. toggle_target_removal_date: None
-    .. toggle_warnings: None
     .. toggle_tickets: https://github.com/edx/edx-platform/pull/14924
     """
     # this field overrides course-specific settings
@@ -82,8 +80,6 @@ class CourseHLSPlaybackEnabledFlag(ConfigurationModel):
     .. toggle_description: Add the "hls" profile to all displayed videos for a single course.
     .. toggle_use_cases:  open_edx
     .. toggle_creation_date: 2017-04-19
-    .. toggle_target_removal_date: None
-    .. toggle_warnings: None
     .. toggle_tickets: https://github.com/edx/edx-platform/pull/14924
     """
     KEY_FIELDS = ('course_id',)

--- a/openedx/core/djangoapps/video_pipeline/config/waffle.py
+++ b/openedx/core/djangoapps/video_pipeline/config/waffle.py
@@ -10,15 +10,14 @@ from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 WAFFLE_NAMESPACE = 'videos'
 
 # .. toggle_name: videos.deprecate_youtube
-# .. toggle_implementation: WaffleFlag
+# .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Waffle flag telling whether youtube is deprecated. When enabled, videos are no longer uploaded
 #   to YouTube as part of the video pipeline.
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2018-08-03
-# .. toggle_target_removal_date: None
-# .. toggle_warnings: None
 # .. toggle_tickets: https://github.com/edx/edx-platform/pull/18765
+# TODO: Replace with CourseWaffleFlag() from waffle_flags().
 DEPRECATE_YOUTUBE = 'deprecate_youtube'
 # .. toggle_name: videos.enable_devstack_video_uploads
 # .. toggle_implementation: WaffleFlag
@@ -28,17 +27,21 @@ DEPRECATE_YOUTUBE = 'deprecate_youtube'
 #   of enabling this feature toggle are uncertain.]
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2020-03-12
-# .. toggle_target_removal_date: None
 # .. toggle_warnings: Enabling this feature requires that the ROLE_ARN, MFA_SERIAL_NUMBER, MFA_TOKEN settings are
 #   properly defined.
 # .. toggle_tickets: https://github.com/edx/edx-platform/pull/23375
+# TODO: Replace with WaffleFlag() from waffle_flags().
 ENABLE_DEVSTACK_VIDEO_UPLOADS = 'enable_devstack_video_uploads'
+# TODO: Replace with CourseWaffleFlag() from waffle_flags().
 ENABLE_VEM_PIPELINE = 'enable_vem_pipeline'
 
 
 def waffle_flags():
     """
     Returns the namespaced, cached, audited Waffle flags dictionary for Videos.
+
+    IMPORTANT: Do NOT copy this dict pattern and do NOT add new flags to this dict.
+      Instead, replace the string constants above with the actual flag instances.
     """
     namespace = LegacyWaffleFlagNamespace(name=WAFFLE_NAMESPACE, log_prefix=u'Videos: ')
     return {

--- a/openedx/core/djangoapps/video_pipeline/models.py
+++ b/openedx/core/djangoapps/video_pipeline/models.py
@@ -24,8 +24,6 @@ class VEMPipelineIntegration(ConfigurationModel):
       video pipeline.
     .. toggle_use_cases:  open_edx
     .. toggle_creation_date: 2020-06-04
-    .. toggle_target_removal_date: None
-    .. toggle_warnings: None
     .. toggle_tickets: https://github.com/edx/edx-platform/pull/24093
     """
     client_name = models.CharField(
@@ -68,8 +66,6 @@ class VideoUploadsEnabledByDefault(ConfigurationModel):
       enables the "Video Uploads" menu in the CMS.
     .. toggle_use_cases:  open_edx
     .. toggle_creation_date: 2017-11-10
-    .. toggle_target_removal_date: None
-    .. toggle_warnings: None
     .. toggle_tickets: https://github.com/edx/edx-platform/pull/16536
     """
     # this field overrides course-specific settings
@@ -121,8 +117,6 @@ class CourseVideoUploadsEnabledByDefault(ConfigurationModel):
       "Video Uploads" menu in the CMS.
     .. toggle_use_cases:  open_edx
     .. toggle_creation_date: 2017-11-10
-    .. toggle_target_removal_date: None
-    .. toggle_warnings: None
     .. toggle_tickets: https://github.com/edx/edx-platform/pull/16536
     """
     KEY_FIELDS = ('course_id',)

--- a/openedx/core/toggles.py
+++ b/openedx/core/toggles.py
@@ -11,8 +11,6 @@ from edx_toggles.toggles import SettingDictToggle
 #   of the course.
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2015-12-01
-# .. toggle_target_removal_date: None
-# .. toggle_warnings: None
 # .. toggle_tickets: https://openedx.atlassian.net/browse/SOL-40
 ENTRANCE_EXAMS = SettingDictToggle(
     "FEATURES", "ENTRANCE_EXAMS", default=False, module_name=__name__

--- a/openedx/features/course_duration_limits/models.py
+++ b/openedx/features/course_duration_limits/models.py
@@ -27,9 +27,6 @@ class CourseDurationLimitConfig(StackedConfigurationModel):
        "enabled_as_of" flag: only enrollments created after this date will be affected.
     .. toggle_use_cases: opt_in
     .. toggle_creation_date: 2018-11-02
-    .. toggle_target_removal_date: None
-    .. toggle_warnings: None
-    .. toggle_tickets: None
     """
 
     STACKABLE_FIELDS = ('enabled', 'enabled_as_of')

--- a/openedx/features/course_experience/__init__.py
+++ b/openedx/features/course_experience/__init__.py
@@ -32,7 +32,6 @@ DISPLAY_COURSE_SOCK_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'display_cour
 # Waffle flag to let learners access a course before its start date.
 COURSE_PRE_START_ACCESS_FLAG = LegacyWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'pre_start_access', __name__)
 
-# Waffle flag to enable the setting of course goals.
 # .. toggle_name: course_experience.enable_course_goals
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False
@@ -41,7 +40,6 @@ COURSE_PRE_START_ACCESS_FLAG = LegacyWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'pre_star
 # .. toggle_creation_date: 2017-09-11
 # .. toggle_target_removal_date: None
 # .. toggle_warnings: This temporary feature toggle does not have a target removal date.
-# .. toggle_tickets: None
 ENABLE_COURSE_GOALS = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'enable_course_goals', __name__)
 
 # Waffle flag to control the display of the hero
@@ -50,18 +48,16 @@ SHOW_UPGRADE_MSG_ON_COURSE_HOME = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'show_
 # Waffle flag to control the display of the upgrade deadline message
 UPGRADE_DEADLINE_MESSAGE = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'upgrade_deadline_message', __name__)
 
-# Waffle flag to switch between the 'welcome message' and 'latest update' on the course home page.
 # .. toggle_name: course_experience.latest_update
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Used to switch between 'welcome message' and 'latest update' on the course home page.
-# .. toggle_use_cases: opt_out
+# .. toggle_use_cases: opt_out, temporary
 # .. toggle_creation_date: 2017-09-11
 # .. toggle_target_removal_date: None
 # .. toggle_warnings: This is meant to be configured using waffle_utils course override only. Either do not create the
 #   actual waffle flag, or be sure to unset the flag even for Superusers. This is no longer used in the learning MFE
 #   and can be removed when the outline tab is fully moved to the learning MFE.
-# .. toggle_tickets: None
 LATEST_UPDATE_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'latest_update', __name__)
 
 # Waffle flag to enable anonymous access to a course

--- a/openedx/features/course_experience/waffle.py
+++ b/openedx/features/course_experience/waffle.py
@@ -10,19 +10,23 @@ WAFFLE_NAMESPACE = u'course_experience'
 
 # Switches
 # .. toggle_name: course_experience.enable_about_sidebar_html
-# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_implementation: WaffleSwitch
 # .. toggle_default: False
 # .. toggle_description: Used to determine whether to show custom HTML in the sidebar on the internal course about page.
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2018-01-26
-# .. toggle_target_removal_date: None
-# .. toggle_warnings: None
-# .. toggle_tickets: None
+# TODO: Replace with WaffleSwitch(). See waffle() docstring.
 ENABLE_COURSE_ABOUT_SIDEBAR_HTML = u'enable_about_sidebar_html'
 
 
 def waffle():
     """
-    Returns the namespaced, cached, audited shared Waffle Switch class.
+    Deprecated: Returns the namespaced, cached, audited shared Waffle Switch class.
+
+    IMPORTANT: Do NOT copy this pattern and do NOT use this to reference new switches.
+      Instead, replace the string constant above with the actual switch instance.
+      For example::
+
+        ENABLE_COURSE_ABOUT_SIDEBAR_HTML = WaffleSwitch(f'{WAFFLE_NAMESPACE}.enable_about_sidebar_html')
     """
     return LegacyWaffleSwitchNamespace(name=WAFFLE_NAMESPACE, log_prefix=u'Course Experience: ')


### PR DESCRIPTION
## Description

**Note to Reviewers:** I suggest you move quickly over annotation deletions. We can rely on linting (current and future) to help ensure what I did was correct. In the meantime, it is cleaner and hopefully we'll have cleaner examples that are copy/pasted. 

A variety of updates were made to improve the toggle documentation:
* Added comments to help ensure that the waffle(), waffle_switches(),
  waffle_flags() anti-pattern won't be contagious (copied).
* Some minor toggle_description updates.
* Removed empty toggle_target_removal_date annotations for
  non-temporary toggles.
* Removed empty optional toggle_warnings annotations.
* Removed empty optional toggle_tickets annotations.
* Removed deprecated toggle_category, toggle_status,
  and toggle_expiration_date annotations.
* Fixed some indents, use cases, and implementations.

## Supporting information

ARCHBOM-1721