### PR TITLE
refactor: update contact us form

### DIFF
--- a/lms/djangoapps/support/static/support/jsx/logged_in_user.jsx
+++ b/lms/djangoapps/support/static/support/jsx/logged_in_user.jsx
@@ -40,7 +40,7 @@ function LoggedInUser({ userInformation, onChangeCallback, handleClick, showWarn
   const subjectElement = (<div>
     <label htmlFor="subject">{gettext('Subject')}</label>
     <select className="form-control select-subject" id="subject">
-      <option value="">--------</option>
+      <option value="">{gettext('Select a category')}</option>
       <option value="Account Settings">{gettext('Account Settings')}</option>
       <option value="Billing/Payment Options">{gettext('Billing/Payment Options')}</option>
       <option value="Certificates">{gettext('Certificates')}</option>
@@ -48,12 +48,8 @@ function LoggedInUser({ userInformation, onChangeCallback, handleClick, showWarn
       <option value="Deadlines">{gettext('Deadlines')}</option>
       <option value="Errors/Technical Issues">{gettext('Errors/Technical Issues')}</option>
       <option value="Financial Aid">{gettext('Financial Aid')}</option>
-      <option value="Masters">{gettext('Masters')}</option>
-      <option value="MicroMasters">{gettext('MicroMasters')}</option>
-      <option value="MicroBachelors">{gettext('MicroBachelors')}</option>
       <option value="Photo Verification">{gettext('Photo Verification')}</option>
       <option value="Proctoring">{gettext('Proctoring')}</option>
-      <option value="Security">{gettext('Security')}</option>
       <option value="Other">{gettext('Other')}</option>
     </select>
   </div>);

--- a/lms/djangoapps/support/static/support/jsx/single_support_form.jsx
+++ b/lms/djangoapps/support/static/support/jsx/single_support_form.jsx
@@ -208,9 +208,6 @@ class RenderForm extends React.Component {
 
         {/* Note: not using Paragon bc component shows in the DOM but not rendered, even when using
          version 2.6.4. */}
-        <div className="alert alert-warning" role="alert" style={{ marginBottom: '1rem', padding: '1.5rem', left: '0px', fontSize: '16px', backgroundColor: '#fffaed', color: '#171C29', border: '1px solid #FFD875', borderRadius: '0.3rem' }}>
-          <div>{gettext('Due to the recent increase in interest in online education and edX, we are currently experiencing an unusually high volume of support requests. We appreciate your patience as we work to review each request. Please check the ')}<a href="https://support.edx.org/hc/en-us" className="alert-link">Help Center</a>{gettext(' as many questions may have already been answered.')}</div>
-        </div>
 
         <div className="row">
           <div className="col-sm-12">


### PR DESCRIPTION
[PROD-2327](https://openedx.atlassian.net/browse/PROD-2327)
## Description
Some changes are asked for the contact us form in the prod ticket above. Mainly:

1. Removing the banner, `'Due to the recent increase in interest in online education and edX, we are currently experiencing an unusually high volume of support requests. We appreciate your patience as we work to review each request. Please check the Help Center as many questions may have already been answered.'` .
2. Removing the following options: Masters, MicroMasters, MicroBachelors and Security.
3. Changing "------" to "Select a category"

Before the changes:
<img width="1207" alt="Screenshot 2021-04-02 at 5 44 23 PM" src="https://user-images.githubusercontent.com/52413434/113418081-353ac980-93de-11eb-840e-ef9e129a7ccd.png">
<img width="521" alt="Screenshot 2021-04-02 at 5 44 39 PM" src="https://user-images.githubusercontent.com/52413434/113418140-556a8880-93de-11eb-99c7-44c068e5c2fb.png">


After the changes:
<img width="1207" alt="Screenshot 2021-04-02 at 5 52 34 PM" src="https://user-images.githubusercontent.com/52413434/113418297-a1b5c880-93de-11eb-8816-81279804bac6.png">
<img width="505" alt="Screenshot 2021-04-02 at 5 52 40 PM" src="https://user-images.githubusercontent.com/52413434/113418333-b4c89880-93de-11eb-99ac-01a009b2cfd9.png">

