### PR TITLE
fix: Reduce safe-sessions false alarms.

### DIFF
--- a/lms/djangoapps/support/tests/test_views.py
+++ b/lms/djangoapps/support/tests/test_views.py
@@ -81,6 +81,9 @@ class SupportViewManageUserTests(SupportViewTestCase):
         """
         Tests password assistance
         """
+        # Ensure that user is not logged in if they need
+        # password assistance.
+        self.client.logout()
         url = '/password_assistance'
         response = self.client.get(url)
         assert response.status_code == 200

--- a/openedx/core/djangoapps/safe_sessions/middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/middleware.py
@@ -387,21 +387,21 @@ class SafeSessionMiddleware(SessionMiddleware, MiddlewareMixin):
                 # If a view overrode the request.user with a masqueraded user, this will
                 #   revert/clean-up that change during response processing.
                 request.user = request.user.real_user
-            if request.safe_cookie_verified_user_id != request.user.id:
-                # The user at response time is expected to be None when the user
-                # is logging out. To prevent extra noise in the logs,
-                # conditionally set the log level.
-                log_func = log.debug if request.user.id is None else log.warning
-                log_func(
+            # The user at response time is expected to be None when the user
+            # is logging out.  We won't log that.
+            if request.safe_cookie_verified_user_id != request.user.id and request.user.id is not None:
+                log.warning(
                     (
                         "SafeCookieData user at request '{0}' does not match user at response: '{1}' "
                         "for request path '{2}'"
-                    ).format(
+                    ).format(  # pylint: disable=logging-format-interpolation
                         request.safe_cookie_verified_user_id, request.user.id, request.path,
                     ),
                 )
                 set_custom_attribute("safe_sessions.user_mismatch", "request-response-mismatch")
-            if request.safe_cookie_verified_user_id != userid_in_session:
+            # The user session at response time is expected to be None when the user
+            # is logging out.  We won't log that.
+            if request.safe_cookie_verified_user_id != userid_in_session and userid_in_session is not None:
                 log.warning(
                     (
                         "SafeCookieData user at request '{0}' does not match user in session: '{1}' "

--- a/openedx/core/djangoapps/safe_sessions/middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/middleware.py
@@ -535,7 +535,7 @@ def log_request_user_changes(request):
             if name == 'user':
                 stack = inspect.stack()
                 # Written this way in case you need more of the stack for debugging.
-                location = "\n".join("%30s : %s:%d" % (t[3], t[1], t[2]) for t in stack[0:6])
+                location = "\n".join("%30s : %s:%d" % (t[3], t[1], t[2]) for t in stack[0:12])
 
                 if not hasattr(request, name):
                     original_user = value

--- a/openedx/core/djangoapps/safe_sessions/tests/test_middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/tests/test_middleware.py
@@ -213,8 +213,7 @@ class TestSafeSessionProcessResponse(TestSafeSessionsLogMixin, TestCase):
         self.request.user = AnonymousUser()
         self.request.session[SESSION_KEY] = self.user.id
         with self.assert_no_error_logged():
-            with self.assert_logged_for_request_user_mismatch(self.user.id, None, 'debug', self.request.path):
-                self.assert_response(set_request_user=False, set_session_cookie=True)
+            self.assert_response(set_request_user=False, set_session_cookie=True)
 
     def test_update_cookie_data_at_step_3(self):
         self.assert_response(set_request_user=True, set_session_cookie=True)

--- a/openedx/core/djangoapps/user_authn/views/login_form.py
+++ b/openedx/core/djangoapps/user_authn/views/login_form.py
@@ -23,7 +23,7 @@ from openedx.core.djangoapps.user_api.accounts.utils import (
     is_secondary_email_feature_enabled
 )
 from openedx.core.djangoapps.user_api.helpers import FormDescription
-from openedx.core.djangoapps.user_authn.cookies import are_logged_in_cookies_set
+from openedx.core.djangoapps.user_authn.cookies import set_logged_in_cookies
 from openedx.core.djangoapps.user_authn.toggles import should_redirect_to_authn_microfrontend
 from openedx.core.djangoapps.user_authn.views.password_reset import get_password_reset_form
 from openedx.core.djangoapps.user_authn.views.registration_form import RegistrationFormFactory
@@ -150,11 +150,13 @@ def login_and_registration_form(request, initial_mode="login"):
     redirect_to = get_next_url_for_login_page(request)
 
     # If we're already logged in, redirect to the dashboard
-    # Note: We check for the existence of login-related cookies in addition to is_authenticated
+    # Note: If the session is valid, we update all logged_in cookies(in particular JWTs)
     #  since Django's SessionAuthentication middleware auto-updates session cookies but not
-    #  the other login-related cookies. See ARCH-282.
-    if request.user.is_authenticated and are_logged_in_cookies_set(request):
-        return redirect(redirect_to)
+    #  the other login-related cookies. See ARCH-282 and ARCHBOM-1718
+    if request.user.is_authenticated:
+        response = redirect(redirect_to)
+        response = set_logged_in_cookies(request, response, request.user)
+        return response
 
     # Retrieve the form descriptions from the user API
     form_descriptions = _get_form_descriptions(request)


### PR DESCRIPTION
## Description

Improve some logging and add tests for some of the coupling we added earlier to deal with the fact that masquerading was throwing off SafeSessionsMiddleware.  Also fix a bug in the login flow that gave precedence to JWTs over the session.

Individual commits have more details.