### PR TITLE
ENT-4361 | Added user's "id" and "email" as public fields in ACCOUNT_VISIBILITY_CONFIGURATION.

### DIFF
--- a/lms/djangoapps/teams/tests/test_serializers.py
+++ b/lms/djangoapps/teams/tests/test_serializers.py
@@ -56,6 +56,8 @@ class MembershipSerializerTestCase(SerializerTestCase):
         username = self.user.username
         assert data['user'] == {'url': ('http://testserver/api/user/v1/accounts/' + username),
                                 'username': username,
+                                'id': self.user.id,
+                                'email': self.user.email,
                                 'profile_image': {'image_url_full': 'http://testserver/static/default_500.png',
                                                   'image_url_large': 'http://testserver/static/default_120.png',
                                                   'image_url_medium': 'http://testserver/static/default_50.png',

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3903,6 +3903,8 @@ ACCOUNT_VISIBILITY_CONFIGURATION = {
         'account_privacy',
         'profile_image',
         'username',
+        "email",
+        "id",
     ],
 }
 
@@ -3933,8 +3935,6 @@ ACCOUNT_VISIBILITY_CONFIGURATION["custom_shareable_fields"] = (
 # The list of account fields that are visible only to staff and users viewing their own profiles
 ACCOUNT_VISIBILITY_CONFIGURATION["admin_fields"] = (
     ACCOUNT_VISIBILITY_CONFIGURATION["custom_shareable_fields"] + [
-        "email",
-        "id",
         "extended_profile",
         "gender",
         "state",

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
@@ -121,20 +121,20 @@ class TestAccountApi(UserSettingsEventTestMixin, EmailTemplateTagMixin, CreateAc
         config = {
             "default_visibility": "private",
             "public_fields": [
-                'email', 'name',
+                'gender', 'name',
             ],
         }
 
-        # With default configuration settings, email is not shared with other (non-staff) users.
+        # With default configuration settings, gender is not shared with other (non-staff) users.
         account_settings = get_account_settings(self.default_request, [self.different_user.username])[0]
-        assert 'email' not in account_settings
+        assert 'gender' not in account_settings
 
         account_settings = get_account_settings(
             self.default_request,
             [self.different_user.username],
             configuration=config,
         )[0]
-        assert self.different_user.email == account_settings['email']
+        assert self.different_user.profile.gender == account_settings['gender']
 
     def test_get_user_not_found(self):
         """Test that UserNotFound is thrown if there is no user with username."""

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
@@ -230,14 +230,16 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
         Verify that the shareable fields from the account are returned
         """
         data = response.data
-        assert 12 == len(data)
+        assert 14 == len(data)
 
-        # public fields (3)
+        # public fields (5)
         assert account_privacy == data['account_privacy']
         self._verify_profile_image_data(data, True)
         assert self.user.username == data['username']
+        assert self.user.id == data['id']
+        assert self.user.email == data['email']
 
-        # additional shareable fields (8)
+        # additional shareable fields (9)
         assert TEST_BIO_VALUE == data['bio']
         assert 'US' == data['country']
         assert data['date_joined'] is not None
@@ -246,16 +248,19 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
         assert data['social_links'] is not None
         assert data['time_zone'] is None
         assert badges_enabled == data['accomplishments_shared']
+        assert 'course_certificates' in data
 
     def _verify_private_account_response(self, response, requires_parental_consent=False):
         """
         Verify that only the public fields are returned if a user does not want to share account fields
         """
         data = response.data
-        assert 3 == len(data)
+        assert 5 == len(data)
         assert PRIVATE_VISIBILITY == data['account_privacy']
         self._verify_profile_image_data(data, not requires_parental_consent)
         assert self.user.username == data['username']
+        assert self.user.id == data['id']
+        assert self.user.email == data['email']
 
     def _verify_full_account_response(self, response, requires_parental_consent=False, year_of_birth=2000):
         """
@@ -437,10 +442,12 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
         # verify response
         if requesting_username == "different_user":
             data = response.data
-            assert 6 == len(data)
+            assert 8 == len(data)
 
             # public fields
             assert self.user.username == data['username']
+            assert self.user.id == data['id']
+            assert self.user.email == data['email']
             assert UserPreference.get_value(self.user, 'account_privacy') == data['account_privacy']
             self._verify_profile_image_data(data, has_profile_image=True)
 

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -130,8 +130,8 @@ class AccountViewSet(ViewSet):
         **Example Requests**
 
             GET /api/user/v1/me[?view=shared]
-            GET /api/user/v1/accounts?usernames={username1,username2}[?view=shared]
-            GET /api/user/v1/accounts?email={user_email}
+            GET /api/user/v1/accounts?usernames={username1},{username2}[?view=shared]
+            GET /api/user/v1/accounts?email={user_email1},{user_email2}
             GET /api/user/v1/accounts/{username}/[?view=shared]
 
             PATCH /api/user/v1/accounts/{username}/{"key":"value"} "application/merge-patch+json"
@@ -292,22 +292,20 @@ class AccountViewSet(ViewSet):
 
     def list(self, request):
         """
-        GET /api/user/v1/accounts?username={username1,username2}
-        GET /api/user/v1/accounts?email={user_email}
+        GET /api/user/v1/accounts?username={username1},{username2}
+        GET /api/user/v1/accounts?email={user_email1},{user_email2}
         """
         usernames = request.GET.get('username')
-        user_email = request.GET.get('email')
+        user_emails = request.GET.get('email')
         search_usernames = []
 
         if usernames:
             search_usernames = usernames.strip(',').split(',')
-        elif user_email:
-            user_email = user_email.strip('')
-            try:
-                user = User.objects.get(email=user_email)
-            except (UserNotFound, User.DoesNotExist):
+        elif user_emails:
+            user_emails = user_emails.strip(',').split(',')
+            search_usernames = User.objects.filter(email__in=user_emails).values_list('username')
+            if not search_usernames:
                 return Response(status=status.HTTP_404_NOT_FOUND)
-            search_usernames = [user.username]
         try:
             account_settings = get_account_settings(
                 request, search_usernames, view=request.query_params.get('view'))


### PR DESCRIPTION
* Added user's "id" and "email" as public fields in ACCOUNT_VISIBILITY_CONFIGURATION.
* Updated `api/user/v1/accounts` list view to search based on multiple emails as well.

<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
