### PR TITLE
[MST-738] Pass username into CourseHomeMetadataView

### DIFF
--- a/lms/djangoapps/course_home_api/course_metadata/v1/serializers.py
+++ b/lms/djangoapps/course_home_api/course_metadata/v1/serializers.py
@@ -32,6 +32,7 @@ class CourseHomeMetadataSerializer(serializers.Serializer):
     Serializer for the Course Home Course Metadata
     """
     course_id = serializers.CharField()
+    username = serializers.CharField()
     is_enrolled = serializers.BooleanField()
     is_self_paced = serializers.BooleanField()
     is_staff = serializers.BooleanField()

--- a/lms/djangoapps/course_home_api/course_metadata/v1/views.py
+++ b/lms/djangoapps/course_home_api/course_metadata/v1/views.py
@@ -36,6 +36,8 @@ class CourseHomeMetadataView(RetrieveAPIView):
         Body consists of the following fields:
 
         course_id: (str) The Course's id (Course Run key)
+        username: (str) The requesting (or masqueraded) user. Returns None for an
+            unauthenticated user.
         is_enrolled: (bool) Indicates if the user is enrolled in the course
         is_self_paced: (bool) Indicates if the course is self paced
         is_staff: (bool) Indicates if the user is staff
@@ -77,6 +79,7 @@ class CourseHomeMetadataView(RetrieveAPIView):
             reset_masquerade_data=True,
         )
 
+        username = request.user.username if request.user.username else None
         course = course_detail(request, request.user.username, course_key)
         user_is_enrolled = CourseEnrollment.is_enrolled(request.user, course_key_string)
         browser_timezone = request.query_params.get('browser_timezone', None)
@@ -91,6 +94,7 @@ class CourseHomeMetadataView(RetrieveAPIView):
 
         data = {
             'course_id': course.id,
+            'username': username,
             'is_staff': has_access(request.user, 'staff', course_key).has_access,
             'original_user_is_staff': original_user_is_staff,
             'number': course.display_number_with_default,

--- a/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
@@ -85,7 +85,8 @@ from openedx.features.course_experience.course_tools import HttpMethod
         </div>
         <aside class="page-content-secondary course-sidebar">
             % if show_proctoring_info_panel:
-                <div class="proctoring-info-panel" data-course-id="${course_key}"></div>
+                <div class="proctoring-info-panel"
+                     data-course-id="${course_key}" data-username="${username}"></div>
             % endif
             % if has_goal_permission:
                 <div class="section section-goals ${'' if current_goal else 'hidden'}">


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

- Passes the request username into the course metadata view so that masquerade functionality can be used with the proctoring info panel on frontend-app-learning.
- Also adds username to the legacy view.

## Supporting information

- [MST-738](https://openedx.atlassian.net/browse/MST-738)
- https://github.com/edx/edx-proctoring/pull/828
- https://github.com/edx/frontend-app-learning/pull/406