### PR TITLE
update cache key for DSC

### DIFF
--- a/openedx/features/enterprise_support/api.py
+++ b/openedx/features/enterprise_support/api.py
@@ -600,7 +600,13 @@ def consent_needed_for_course(request, user, course_id, enrollment_exists=False)
         )
     )
 
-    consent_cache_key = get_data_consent_share_cache_key(user.id, course_id)
+    enterprise_learner_details = get_enterprise_learner_data_from_db(user)
+    enterprise_customer_uuid = None
+    if enterprise_learner_details:
+        enterprise_customer = enterprise_learner_details[0]['enterprise_customer']
+        enterprise_customer_uuid = enterprise_customer['uuid']
+
+    consent_cache_key = get_data_consent_share_cache_key(user.id, course_id, enterprise_customer_uuid)
     data_sharing_consent_needed_cache = TieredCache.get_cached_response(consent_cache_key)
     if data_sharing_consent_needed_cache.is_found and data_sharing_consent_needed_cache.value == 0:
         LOGGER.info(
@@ -613,7 +619,6 @@ def consent_needed_for_course(request, user, course_id, enrollment_exists=False)
         return False
 
     consent_needed = False
-    enterprise_learner_details = get_enterprise_learner_data_from_db(user)
     if not enterprise_learner_details:
         LOGGER.info(
             "Consent from user [{username}] is not needed for course [{course_id}]. The user is not linked to an"

--- a/openedx/features/enterprise_support/signals.py
+++ b/openedx/features/enterprise_support/signals.py
@@ -51,7 +51,8 @@ def update_dsc_cache_on_course_enrollment(sender, instance, **kwargs):  # pylint
     """
     clear_data_consent_share_cache(
         instance.enterprise_customer_user.user_id,
-        instance.course_id
+        instance.course_id,
+        str(instance.enterprise_customer_user.enterprise_customer.uuid)
     )
 
 

--- a/openedx/features/enterprise_support/tasks.py
+++ b/openedx/features/enterprise_support/tasks.py
@@ -33,7 +33,8 @@ def clear_enterprise_customer_data_consent_share_cache(enterprise_customer_uuid)
     for enrollment in enterprise_course_enrollments:
         clear_data_consent_share_cache(
             enrollment.enterprise_customer_user.user_id,
-            enrollment.course_id
+            enrollment.course_id,
+            enterprise_customer_uuid,
         )
     log.info('Ended Clearing data_sharing_consent_needed cache for enterprise customer {uuid}'.format(
         uuid=enterprise_customer_uuid,

--- a/openedx/features/enterprise_support/tests/test_api.py
+++ b/openedx/features/enterprise_support/tests/test_api.py
@@ -263,7 +263,7 @@ class TestEnterpriseApi(EnterpriseServiceMockMixin, CacheIsolationTestCase):
         # cache is working fine
         assert not consent_needed_for_course(request, user, course_id)
         # Removing cache
-        clear_data_consent_share_cache(user.id, course_id)
+        clear_data_consent_share_cache(user.id, course_id, ec_uuid)
         # Now test again
         assert consent_needed_for_course(request, user, course_id)
 
@@ -272,7 +272,7 @@ class TestEnterpriseApi(EnterpriseServiceMockMixin, CacheIsolationTestCase):
         assert not consent_needed_for_course(request, user, course_id)
 
         # test when the enrollment already exists without a consent record existing.
-        clear_data_consent_share_cache(user.id, course_id)
+        clear_data_consent_share_cache(user.id, course_id, ec_uuid)
         self.mock_consent_missing(user.username, course_id, ec_uuid)
         assert not consent_needed_for_course(request, user, course_id, enrollment_exists=True)
 

--- a/openedx/features/enterprise_support/tests/test_signals.py
+++ b/openedx/features/enterprise_support/tests/test_signals.py
@@ -50,16 +50,17 @@ class EnterpriseSupportSignals(SharedModuleStoreTestCase):
         self.user = UserFactory.create(username='test', email=TEST_EMAIL)
         self.course_id = 'course-v1:edX+DemoX+Demo_Course'
         self.enterprise_customer = EnterpriseCustomerFactory()
+        self.enterprise_customer_uuid = str(self.enterprise_customer.uuid)
         super().setUp()
 
     @staticmethod
-    def _create_dsc_cache(user_id, course_id):
-        consent_cache_key = get_data_consent_share_cache_key(user_id, course_id)
+    def _create_dsc_cache(user_id, course_id, enterprise_customer_uuid):
+        consent_cache_key = get_data_consent_share_cache_key(user_id, course_id, enterprise_customer_uuid)
         TieredCache.set_all_tiers(consent_cache_key, 0)
 
     @staticmethod
-    def _is_dsc_cache_found(user_id, course_id):
-        consent_cache_key = get_data_consent_share_cache_key(user_id, course_id)
+    def _is_dsc_cache_found(user_id, course_id, enterprise_customer_uuid):
+        consent_cache_key = get_data_consent_share_cache_key(user_id, course_id, enterprise_customer_uuid)
         data_sharing_consent_needed_cache = TieredCache.get_cached_response(consent_cache_key)
         return data_sharing_consent_needed_cache.is_found
 
@@ -96,11 +97,11 @@ class EnterpriseSupportSignals(SharedModuleStoreTestCase):
         takes place
         """
 
-        self._create_dsc_cache(self.user.id, self.course_id)
-        assert self._is_dsc_cache_found(self.user.id, self.course_id)
+        self._create_dsc_cache(self.user.id, self.course_id, self.enterprise_customer_uuid)
+        assert self._is_dsc_cache_found(self.user.id, self.course_id, self.enterprise_customer_uuid)
 
         self._create_enterprise_enrollment(self.user.id, self.course_id)
-        assert not self._is_dsc_cache_found(self.user.id, self.course_id)
+        assert not self._is_dsc_cache_found(self.user.id, self.course_id, self.enterprise_customer_uuid)
 
     def test_signal_update_dsc_cache_on_enterprise_customer_update(self):
         """
@@ -109,14 +110,14 @@ class EnterpriseSupportSignals(SharedModuleStoreTestCase):
         """
 
         self._create_enterprise_enrollment(self.user.id, self.course_id)
-        self._create_dsc_cache(self.user.id, self.course_id)
-        assert self._is_dsc_cache_found(self.user.id, self.course_id)
+        self._create_dsc_cache(self.user.id, self.course_id, self.enterprise_customer_uuid)
+        assert self._is_dsc_cache_found(self.user.id, self.course_id, self.enterprise_customer_uuid)
 
         # updating enable_data_sharing_consent flag
         self.enterprise_customer.enable_data_sharing_consent = False
         self.enterprise_customer.save()
 
-        assert not self._is_dsc_cache_found(self.user.id, self.course_id)
+        assert not self._is_dsc_cache_found(self.user.id, self.course_id, self.enterprise_customer_uuid)
 
     def _create_enrollment_to_refund(self, no_of_days_placed=10, enterprise_enrollment_exists=True):
         """Create enrollment to refund. """

--- a/openedx/features/enterprise_support/tests/test_utils.py
+++ b/openedx/features/enterprise_support/tests/test_utils.py
@@ -58,12 +58,17 @@ class TestEnterpriseUtils(TestCase):
     def test_get_data_consent_share_cache_key(self, mock_get_cache_key):
         expected_cache_key = mock_get_cache_key.return_value
 
-        assert expected_cache_key == get_data_consent_share_cache_key('some-user-id', 'some-course-id')
+        assert expected_cache_key == get_data_consent_share_cache_key(
+            'some-user-id',
+            'some-course-id',
+            '1a9cae8f-abb7-4336-b075-6ff32ecf73de'
+        )
 
         mock_get_cache_key.assert_called_once_with(
             type='data_sharing_consent_needed',
             user_id='some-user-id',
             course_id='some-course-id',
+            enterprise_customer_uuid='1a9cae8f-abb7-4336-b075-6ff32ecf73de'
         )
 
     @mock.patch('openedx.features.enterprise_support.utils.get_cache_key')
@@ -71,13 +76,15 @@ class TestEnterpriseUtils(TestCase):
     def test_clear_data_consent_share_cache(self, mock_tiered_cache, mock_get_cache_key):
         user_id = 'some-user-id'
         course_id = 'some-course-id'
+        enterprise_customer_uuid = '1a9cae8f-abb7-4336-b075-6ff32ecf73de'
 
-        clear_data_consent_share_cache(user_id, course_id)
+        clear_data_consent_share_cache(user_id, course_id, enterprise_customer_uuid)
 
         mock_get_cache_key.assert_called_once_with(
             type='data_sharing_consent_needed',
             user_id='some-user-id',
             course_id='some-course-id',
+            enterprise_customer_uuid=enterprise_customer_uuid
         )
         mock_tiered_cache.delete_all_tiers.assert_called_once_with(mock_get_cache_key.return_value)
 

--- a/openedx/features/enterprise_support/utils.py
+++ b/openedx/features/enterprise_support/utils.py
@@ -26,12 +26,20 @@ from common.djangoapps.student.helpers import get_next_url_for_login_page
 ENTERPRISE_HEADER_LINKS = LegacyWaffleFlag('enterprise', 'enterprise_header_links', __name__)
 
 
-def get_data_consent_share_cache_key(user_id, course_id):
+def get_data_consent_share_cache_key(user_id, course_id, enterprise_customer_uuid=None):
     """
-        Returns cache key for data sharing consent needed against user_id and course_id
+        Returns cache key for data sharing consent needed against user_id, course_id and enterprise_customer_uuid
     """
+    cache_key_params = dict(
+        type='data_sharing_consent_needed',
+        user_id=user_id,
+        course_id=course_id,
+    )
 
-    return get_cache_key(type='data_sharing_consent_needed', user_id=user_id, course_id=course_id)
+    if enterprise_customer_uuid:
+        cache_key_params['enterprise_customer_uuid'] = enterprise_customer_uuid
+
+    return get_cache_key(**cache_key_params)
 
 
 def get_is_enterprise_cache_key(user_id):
@@ -41,11 +49,11 @@ def get_is_enterprise_cache_key(user_id):
     return get_cache_key(type='is_enterprise_learner', user_id=user_id)
 
 
-def clear_data_consent_share_cache(user_id, course_id):
+def clear_data_consent_share_cache(user_id, course_id, enterprise_customer_uuid):
     """
         clears data_sharing_consent_needed cache
     """
-    consent_cache_key = get_data_consent_share_cache_key(user_id, course_id)
+    consent_cache_key = get_data_consent_share_cache_key(user_id, course_id, enterprise_customer_uuid)
     TieredCache.delete_all_tiers(consent_cache_key)
 
 


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description
Currently DSC cache key does not take into account the enterprise customer uuid. This PR will make enterprise customer uuid part of the cache key. This will ensure that a learner linked to multiple enterprises will be prompted for DSC for same course with different enterprise.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
