### PR TITLE
fix: invalidate certificate properly when regenerating certs from the support tool

### DIFF
--- a/lms/djangoapps/certificates/queue.py
+++ b/lms/djangoapps/certificates/queue.py
@@ -114,12 +114,12 @@ class XQueueCertInterface:
           student   - User.object
           course_id - courseenrollment.course_id (string)
 
+        [PDF Certificates only]
         WARNING: this command will leave the old certificate, if one exists,
                  laying around in AWS taking up space. If this is a problem,
                  take pains to clean up storage before running this command.
 
-        Change the certificate status to unavailable (if it exists) and request
-        grading. Passing grades will put a certificate request on the queue.
+        Invalidate the certificate (if it exists) and request a new certificate.
 
         Return the certificate.
         """
@@ -131,14 +131,8 @@ class XQueueCertInterface:
             certificate = GeneratedCertificate.eligible_certificates.get(user=student, course_id=course_id)
 
             LOGGER.info(
-                (
-                    "Found an existing certificate entry for student %s "
-                    "in course '%s' "
-                    "with status '%s' while regenerating certificates. "
-                ),
-                student.id,
-                str(course_id),
-                certificate.status
+                f"Found an existing certificate entry for student {student.id} in course '{course_id}' with status "
+                f"'{certificate.status}' while regenerating certificates."
             )
 
             if certificate.download_url:
@@ -147,19 +141,12 @@ class XQueueCertInterface:
                 )
                 return None
 
-            certificate.status = status.unavailable
-            certificate.save()
+            certificate.invalidate()
 
             LOGGER.info(
-                (
-                    "The certificate status for student %s "
-                    "in course '%s' has been changed to '%s'."
-                ),
-                student.id,
-                str(course_id),
-                certificate.status
+                f"The certificate status for student {student.id} in course '{course_id} has been changed to "
+                f"'{certificate.status}'."
             )
-
         except GeneratedCertificate.DoesNotExist:
             pass
 


### PR DESCRIPTION
## Description
[MICROBA-974]
* Update `regen_cert` function to call the certificate objects `invalidate` method, instead of just setting the certificate status as 'unavailable'. This change will make it so the certificate revoked signal is sent in an attempt to keep data in the Credentials IDA in sync


[MICROBA-974]: https://openedx.atlassian.net/browse/MICROBA-974