### PR TITLE
Use allowed_xblocks settings

### DIFF
--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -74,7 +74,7 @@ FULL_COURSE_REINDEX_THRESHOLD = 1
 ALL_ALLOWED_XBLOCKS = frozenset(
     [entry_point.name for entry_point in pkg_resources.iter_entry_points("xblock.v1")]
     +
-    ['wiki']
+    ['wiki']  # Adding wiki here as it is not an xblock.
 )
 
 


### PR DESCRIPTION
This PR uses the `allowed_xblocks` settings in olxcleaner to pass validation for currently active xblocks. 

https://openedx.atlassian.net/browse/TNL-8193