### PR TITLE
refactor: install DoneXBlock from PyPI instead of github hash

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -69,6 +69,7 @@ django-user-tasks
 django-waffle
 django-webpack-loader               # Used to wire webpack bundles into the django asset pipeline
 djangorestframework
+done-xblock
 edx-ace
 edx-analytics-data-api-client
 edx-api-doc-tools

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -8,7 +8,6 @@
 -e common/lib/capa  # via -r requirements/edx/local.in, xmodule
 -e git+https://github.com/edx/codejail.git@3.1.3#egg=codejail==3.1.3  # via -r requirements/edx/github.in
 -e git+https://github.com/edx/django-wiki.git@1.0.0#egg=django-wiki  # via -r requirements/edx/github.in
--e git+https://github.com/edx/DoneXBlock.git@2.0.3#egg=done-xblock  # via -r requirements/edx/github.in
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme  # via -r requirements/edx/github.in
 -e git+https://github.com/openedx/olxcleaner.git@07b6e7ea0e79348c5009f61bb0c4b7df3c3d2d7a#egg=olxcleaner  # via -r requirements/edx/github.in
 -e .  # via -r requirements/edx/local.in
@@ -88,6 +87,7 @@ djangorestframework-xml==2.0.0  # via edx-enterprise
 djangorestframework==3.12.4  # via -r requirements/edx/base.in, django-config-models, django-user-tasks, drf-jwt, drf-yasg, edx-api-doc-tools, edx-completion, edx-drf-extensions, edx-enterprise, edx-organizations, edx-proctoring, edx-submissions, ora2, rest-condition, super-csv
 docopt==0.6.2             # via xmodule
 docutils==0.16            # via -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt, botocore
+done-xblock==2.0.4        # via -r requirements/edx/base.in
 drf-jwt==1.19.0           # via edx-drf-extensions
 drf-yasg==1.20.0          # via edx-api-doc-tools
 edx-ace==1.1.0            # via -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -8,7 +8,6 @@
 -e common/lib/capa  # via -r requirements/edx/testing.txt, xmodule
 -e git+https://github.com/edx/codejail.git@3.1.3#egg=codejail==3.1.3  # via -r requirements/edx/testing.txt
 -e git+https://github.com/edx/django-wiki.git@1.0.0#egg=django-wiki  # via -r requirements/edx/testing.txt
--e git+https://github.com/edx/DoneXBlock.git@2.0.3#egg=done-xblock  # via -r requirements/edx/testing.txt
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme  # via -r requirements/edx/testing.txt
 -e git+https://github.com/openedx/olxcleaner.git@07b6e7ea0e79348c5009f61bb0c4b7df3c3d2d7a#egg=olxcleaner  # via -r requirements/edx/testing.txt
 -e .  # via -r requirements/edx/testing.txt
@@ -99,6 +98,7 @@ djangorestframework-xml==2.0.0  # via -r requirements/edx/testing.txt, edx-enter
 djangorestframework==3.12.4  # via -r requirements/edx/testing.txt, django-config-models, django-user-tasks, drf-jwt, drf-yasg, edx-api-doc-tools, edx-completion, edx-drf-extensions, edx-enterprise, edx-organizations, edx-proctoring, edx-submissions, ora2, rest-condition, super-csv
 docopt==0.6.2             # via -r requirements/edx/testing.txt, xmodule
 docutils==0.16            # via -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt, -r requirements/edx/testing.txt, botocore, m2r, sphinx
+done-xblock==2.0.4        # via -r requirements/edx/testing.txt
 drf-jwt==1.19.0           # via -r requirements/edx/testing.txt, edx-drf-extensions
 drf-yasg==1.20.0          # via -r requirements/edx/testing.txt, edx-api-doc-tools
 edx-ace==1.1.0            # via -r requirements/edx/testing.txt

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -68,7 +68,6 @@ git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a5#egg=django-rate
 -e git+https://github.com/edx/codejail.git@3.1.3#egg=codejail==3.1.3
 -e git+https://github.com/edx/acid-block.git@758855a67d2f12bd74db4d5e7a0862d6e65f079c#egg=acid-xblock
 -e git+https://github.com/edx/RateXBlock.git@2.0.1#egg=rate-xblock
--e git+https://github.com/edx/DoneXBlock.git@2.0.3#egg=done-xblock
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive
 
 # Third Party XBlocks

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -8,7 +8,6 @@
 -e common/lib/capa  # via -r requirements/edx/base.txt, xmodule
 -e git+https://github.com/edx/codejail.git@3.1.3#egg=codejail==3.1.3  # via -r requirements/edx/base.txt
 -e git+https://github.com/edx/django-wiki.git@1.0.0#egg=django-wiki  # via -r requirements/edx/base.txt
--e git+https://github.com/edx/DoneXBlock.git@2.0.3#egg=done-xblock  # via -r requirements/edx/base.txt
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme  # via -r requirements/edx/base.txt
 -e git+https://github.com/openedx/olxcleaner.git@07b6e7ea0e79348c5009f61bb0c4b7df3c3d2d7a#egg=olxcleaner  # via -r requirements/edx/base.txt
 -e .  # via -r requirements/edx/base.txt
@@ -96,6 +95,7 @@ djangorestframework-xml==2.0.0  # via -r requirements/edx/base.txt, edx-enterpri
 djangorestframework==3.12.4  # via -r requirements/edx/base.txt, django-config-models, django-user-tasks, drf-jwt, drf-yasg, edx-api-doc-tools, edx-completion, edx-drf-extensions, edx-enterprise, edx-organizations, edx-proctoring, edx-submissions, ora2, rest-condition, super-csv
 docopt==0.6.2             # via -r requirements/edx/base.txt, xmodule
 docutils==0.16            # via -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt, -r requirements/edx/base.txt, botocore
+done-xblock==2.0.4        # via -r requirements/edx/base.txt
 drf-jwt==1.19.0           # via -r requirements/edx/base.txt, edx-drf-extensions
 drf-yasg==1.20.0          # via -r requirements/edx/base.txt, edx-api-doc-tools
 edx-ace==1.1.0            # via -r requirements/edx/base.txt


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

As [BOM-1875: Create PyPi Releases of DoneXBlock](https://openedx.atlassian.net/browse/BOM-1875) is completed now, we should install it from PyPI.

PyPI release: https://pypi.org/project/done-xblock/

## Supporting information

**JIRA:** https://openedx.atlassian.net/browse/BOM-2456

## Deadline

None
