### PR TITLE
fix: Update default provider_type for discussions API

### DIFF
--- a/openedx/core/djangoapps/discussions/models.py
+++ b/openedx/core/djangoapps/discussions/models.py
@@ -22,6 +22,9 @@ from openedx.core.djangoapps.content.course_overviews.models import CourseOvervi
 log = logging.getLogger(__name__)
 
 
+DEFAULT_PROVIDER_TYPE = 'legacy'
+
+
 def get_supported_providers() -> list[str]:
     """
     Return the list of supported discussion providers
@@ -198,6 +201,7 @@ class DiscussionsConfiguration(TimeStampedModel):
             configuration = cls(
                 context_key=context_key,
                 enabled=False,
+                provider_type=DEFAULT_PROVIDER_TYPE,
             )
         return configuration
     # pylint: enable=undefined-variable

--- a/openedx/core/djangoapps/discussions/models.py
+++ b/openedx/core/djangoapps/discussions/models.py
@@ -195,7 +195,10 @@ class DiscussionsConfiguration(TimeStampedModel):
         try:
             configuration = cls.objects.get(context_key=context_key)
         except cls.DoesNotExist:
-            configuration = cls(context_key=context_key, enabled=False)
+            configuration = cls(
+                context_key=context_key,
+                enabled=False,
+            )
         return configuration
     # pylint: enable=undefined-variable
 

--- a/openedx/core/djangoapps/discussions/tests/test_models.py
+++ b/openedx/core/djangoapps/discussions/tests/test_models.py
@@ -9,6 +9,7 @@ from django.test import TestCase
 from opaque_keys.edx.keys import CourseKey
 from organizations.models import Organization
 
+from ..models import DEFAULT_PROVIDER_TYPE
 from ..models import DiscussionsConfiguration
 from ..models import ProviderFilter
 
@@ -215,16 +216,16 @@ class DiscussionsConfigurationModelTest(TestCase):
         is_enabled = DiscussionsConfiguration.is_enabled(self.course_key_with_values)
         assert not is_enabled
 
-    def test_get_nonexistent_empty(self):
+    def test_get_nonexistent_defaults_to_legacy(self):
         """
-        Assert we get an "empty" model back for nonexistent records
+        Assert we get a "legacy" model back for nonexistent records
         """
         configuration = DiscussionsConfiguration.get(self.course_key_without_config)
         assert configuration is not None
         assert not configuration.enabled
         assert not configuration.lti_configuration
         assert not configuration.plugin_configuration
-        assert not configuration.provider_type
+        assert configuration.provider_type == DEFAULT_PROVIDER_TYPE
 
     def test_get_defaults(self):
         """

--- a/openedx/core/djangoapps/discussions/views.py
+++ b/openedx/core/djangoapps/discussions/views.py
@@ -11,6 +11,7 @@ from rest_framework.views import APIView
 from openedx.core.lib.api.permissions import IsStaff
 from openedx.core.lib.api.view_utils import view_auth_classes
 
+from .models import DEFAULT_PROVIDER_TYPE
 from .models import DiscussionsConfiguration
 
 
@@ -69,7 +70,7 @@ class DiscussionsConfigurationView(APIView):
                 'enabled': data.get('enabled', False),
                 'lti_configuration': data.get('lti_configuration', {}),
                 'plugin_configuration': data.get('plugin_configuration', {}),
-                'provider_type': data.get('provider_type', ''),
+                'provider_type': data.get('provider_type', DEFAULT_PROVIDER_TYPE),
             }
             return payload
 
@@ -89,7 +90,7 @@ class DiscussionsConfigurationView(APIView):
                 'lti_configuration': lti_configuration.data,
                 'plugin_configuration': instance.plugin_configuration,
                 'providers': {
-                    'active': instance.provider_type or None,
+                    'active': instance.provider_type or DEFAULT_PROVIDER_TYPE,
                     'available': {
                         provider: {
                             'features': PROVIDER_FEATURE_MAP.get(provider) or [],


### PR DESCRIPTION
This had been using an empty string which wasn't particularly useful.
This meant the MFE needed to set its own, more useful default.
And given how the `cs_comments_service` integration works, this truly is the "default" anyway, even if it's not (yet) specified in the database.