### PR TITLE
fix: hide gated content message for library content questions (learning MFE only)

### DIFF
--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -649,6 +649,19 @@ class LibraryContentBlock(
         """
         return True
 
+    @property
+    def has_gated_content(self):
+        """
+        Tells whether library contains questions only accessible to upgraded learners
+        """
+        library_questions = self.get_children()
+
+        for ques in library_questions:
+            if ques.has_access_error:
+                return True
+
+        return False
+
     def get_content_titles(self):
         """
         Returns list of friendly titles for our selected children only; without

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -649,19 +649,6 @@ class LibraryContentBlock(
         """
         return True
 
-    @property
-    def has_gated_content(self):
-        """
-        Tells whether library contains questions only accessible to upgraded learners
-        """
-        library_questions = self.get_children()
-
-        for ques in library_questions:
-            if ques.has_access_error:
-                return True
-
-        return False
-
     def get_content_titles(self):
         """
         Returns list of friendly titles for our selected children only; without

--- a/common/lib/xmodule/xmodule/vertical_block.py
+++ b/common/lib/xmodule/xmodule/vertical_block.py
@@ -14,6 +14,7 @@ from web_fragments.fragment import Fragment
 
 from common.lib.xmodule.xmodule.util.misc import is_xblock_an_assignment
 from xblock.core import XBlock  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.library_content_module import LibraryContentBlock
 from xmodule.mako_module import MakoTemplateBlockBase
 from xmodule.progress import Progress
 from xmodule.seq_module import SequenceFields
@@ -82,7 +83,15 @@ class VerticalBlock(SequenceFields, XModuleFields, StudioEditableBlock, XmlParse
 
         # pylint: disable=no-member
         for child in child_blocks:
-            if context.get('hide_access_error_blocks') and getattr(child, 'has_access_error', False):
+
+            # Check access for regular question
+            child_has_access_error = getattr(child, 'has_access_error', False)
+
+            # Check access for randomized library question
+            if isinstance(child, LibraryContentBlock):
+                child_has_access_error = child.has_gated_content
+
+            if context.get('hide_access_error_blocks') and child_has_access_error:
                 continue
             child_block_context = copy(child_context)
             if child in list(child_blocks_to_complete_on_view):


### PR DESCRIPTION
## Description
When a learner is enrolled in the audit track for a course with gated content (not available unless the learner upgrades to the verified track), we display a message to that effect, prompting the learner to upgrade. [REV-2160](https://openedx.atlassian.net/browse/REV-2160) is the issue that we display multiple instances of the upgrade message when page has multiple gated content items. 

The learning MFE shows an overall gated content message at the page level, so we especially don't want to display the gated message at the question level when the unit is pulled into the learning MFE. (Fixing on the old courseware has a lower priority, not being addressed in this PR). 

Previous [PR 25986 ](https://github.com/edx/edx-platform/pull/25986) aimed to fix this problem on the learning MFE with two steps: 
1. requests from the learning MFE send a special `hide_access_error_blocks` argument
2. if we have that argument AND the question's `has_access_error` is true, then hide the block
This update fixed the issue for the learning MFE only for regular questions (falling directly inside the unit), but it didn't work for questions that come from randomized library content (where the structure is unit/library/question). 

This pull request adds logic to detect when the question comes from a library and check `has_access_error` on its child questions instead. 

## Testing instructions
1. in your local environment, set up a course with gated content: I imported course-v1:MichiganX+py4e101x+3T2020, then imported a library of questions, and updated the chapter 4 quiz questions to pull from the library for three questions, and include one normal question. 
2. As a learner, and viewing the course using the 'new experience' (aka learning MFE): 
a. view that page of that course using master branch (you get 'before' screenshot)
b. view that page of the course using this branch (you get 'after' screenshot below)

## Deadline
We'd like to get this fixed before deploying the updated Value Prop version of the gated content lock page, approved here: 
 https://github.com/edx/frontend-app-learning/pull/394

## Screenshots:
<img width="1405" alt="before" src="https://user-images.githubusercontent.com/5384216/113929250-d7cbc180-97bd-11eb-9a2c-74b46036ffde.png">
<img width="1365" alt="after" src="https://user-images.githubusercontent.com/5384216/113929263-da2e1b80-97bd-11eb-8553-5d6533f2fe6f.png">
