### PR TITLE
[TNL-8051] - bump olxcleaner version with latest update.

### DIFF
--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -73,8 +73,6 @@ FILE_READ_CHUNK = 1024  # bytes
 FULL_COURSE_REINDEX_THRESHOLD = 1
 ALL_ALLOWED_XBLOCKS = frozenset(
     [entry_point.name for entry_point in pkg_resources.iter_entry_points("xblock.v1")]
-    +
-    ['wiki']  # Adding wiki here as it is not an xblock.
 )
 
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -10,7 +10,7 @@
 -e git+https://github.com/edx/django-wiki.git@1.0.0#egg=django-wiki  # via -r requirements/edx/github.in
 -e git+https://github.com/edx/DoneXBlock.git@2.0.3#egg=done-xblock  # via -r requirements/edx/github.in
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme  # via -r requirements/edx/github.in
--e git+https://github.com/openedx/olxcleaner.git@63279318de9d0ceca8488c11f5187e38c1139241#egg=olxcleaner  # via -r requirements/edx/github.in
+-e git+https://github.com/openedx/olxcleaner.git@dbe03f73ed8b354eaca8f234958a7b3cff4f0ceb#egg=olxcleaner  # via -r requirements/edx/github.in
 -e .  # via -r requirements/edx/local.in
 -e git+https://github.com/technige/py2neo.git@py2neo-3.1.2#egg=py2neo==3.1.2  # via -r requirements/edx/github.in
 -e git+https://github.com/edx/RateXBlock.git@2.0.1#egg=rate-xblock  # via -r requirements/edx/github.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -10,7 +10,7 @@
 -e git+https://github.com/edx/django-wiki.git@1.0.0#egg=django-wiki  # via -r requirements/edx/testing.txt
 -e git+https://github.com/edx/DoneXBlock.git@2.0.3#egg=done-xblock  # via -r requirements/edx/testing.txt
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme  # via -r requirements/edx/testing.txt
--e git+https://github.com/openedx/olxcleaner.git@63279318de9d0ceca8488c11f5187e38c1139241#egg=olxcleaner  # via -r requirements/edx/testing.txt
+-e git+https://github.com/openedx/olxcleaner.git@dbe03f73ed8b354eaca8f234958a7b3cff4f0ceb#egg=olxcleaner  # via -r requirements/edx/testing.txt
 -e .  # via -r requirements/edx/testing.txt
 -e git+https://github.com/technige/py2neo.git@py2neo-3.1.2#egg=py2neo==3.1.2  # via -r requirements/edx/testing.txt
 -e git+https://github.com/edx/RateXBlock.git@2.0.1#egg=rate-xblock  # via -r requirements/edx/testing.txt

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -55,7 +55,7 @@
 
 # Third-party:
 -e git+https://github.com/edx/django-wiki.git@1.0.0#egg=django-wiki
--e git+https://github.com/openedx/olxcleaner.git@63279318de9d0ceca8488c11f5187e38c1139241#egg=olxcleaner
+-e git+https://github.com/openedx/olxcleaner.git@dbe03f73ed8b354eaca8f234958a7b3cff4f0ceb#egg=olxcleaner
 git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
 -e git+https://github.com/technige/py2neo.git@py2neo-3.1.2#egg=py2neo==3.1.2

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -10,7 +10,7 @@
 -e git+https://github.com/edx/django-wiki.git@1.0.0#egg=django-wiki  # via -r requirements/edx/base.txt
 -e git+https://github.com/edx/DoneXBlock.git@2.0.3#egg=done-xblock  # via -r requirements/edx/base.txt
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme  # via -r requirements/edx/base.txt
--e git+https://github.com/openedx/olxcleaner.git@63279318de9d0ceca8488c11f5187e38c1139241#egg=olxcleaner  # via -r requirements/edx/base.txt
+-e git+https://github.com/openedx/olxcleaner.git@dbe03f73ed8b354eaca8f234958a7b3cff4f0ceb#egg=olxcleaner  # via -r requirements/edx/base.txt
 -e .  # via -r requirements/edx/base.txt
 -e git+https://github.com/technige/py2neo.git@py2neo-3.1.2#egg=py2neo==3.1.2  # via -r requirements/edx/base.txt
 -e git+https://github.com/edx/RateXBlock.git@2.0.1#egg=rate-xblock  # via -r requirements/edx/base.txt


### PR DESCRIPTION
### [TNL-8051](https://openedx.atlassian.net/browse/TNL-8051) -- Epic
#### [TNL-8170](https://openedx.atlassian.net/browse/TNL-8170) -- Subtask

Update Olxcleaner after the merge of: https://github.com/openedx/olxcleaner/pull/8
Using the following commit. https://github.com/openedx/olxcleaner/commit/dbe03f73ed8b354eaca8f234958a7b3cff4f0ceb

In addition, `wiki` has been removed as fix is within latest `olxcleaner` updates. 