### PR TITLE
fix: :bug: URGENT! Upgrade edx-enterprise: Fixes integrated_channels bug ...

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -31,7 +31,7 @@ django-storages<1.9
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==3.22.2
+edx-enterprise==3.22.4
 
 # Upgrading to 2.12.0 breaks several test classes due to API changes, need to update our code accordingly
 factory-boy==2.8.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -101,7 +101,7 @@ edx-django-release-util==1.0.0  # via -r requirements/edx/base.in
 edx-django-sites-extensions==3.0.0  # via -r requirements/edx/base.in
 edx-django-utils==3.16.0  # via -r requirements/edx/base.in, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-toggles, edx-when, ora2, super-csv
 edx-drf-extensions==6.5.0  # via -r requirements/edx/base.in, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
-edx-enterprise==3.22.2    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
+edx-enterprise==3.22.4    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
 edx-event-routing-backends==4.0.1  # via -r requirements/edx/base.in
 edx-i18n-tools==0.5.3     # via ora2
 edx-milestones==0.3.1     # via -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -113,7 +113,7 @@ edx-django-release-util==1.0.0  # via -r requirements/edx/testing.txt
 edx-django-sites-extensions==3.0.0  # via -r requirements/edx/testing.txt
 edx-django-utils==3.16.0  # via -r requirements/edx/testing.txt, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-toggles, edx-when, ora2, super-csv
 edx-drf-extensions==6.5.0  # via -r requirements/edx/testing.txt, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
-edx-enterprise==3.22.2    # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
+edx-enterprise==3.22.4    # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
 edx-event-routing-backends==4.0.1  # via -r requirements/edx/testing.txt
 edx-i18n-tools==0.5.3     # via -r requirements/edx/testing.txt, ora2
 edx-lint==5.0.0           # via -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -110,7 +110,7 @@ edx-django-release-util==1.0.0  # via -r requirements/edx/base.txt
 edx-django-sites-extensions==3.0.0  # via -r requirements/edx/base.txt
 edx-django-utils==3.16.0  # via -r requirements/edx/base.txt, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-toggles, edx-when, ora2, super-csv
 edx-drf-extensions==6.5.0  # via -r requirements/edx/base.txt, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
-edx-enterprise==3.22.2    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt
+edx-enterprise==3.22.4    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt
 edx-event-routing-backends==4.0.1  # via -r requirements/edx/base.txt
 edx-i18n-tools==0.5.3     # via -r requirements/edx/base.txt, -r requirements/edx/testing.in, ora2
 edx-lint==5.0.0           # via -r requirements/edx/testing.in


### PR DESCRIPTION
… during course details fetch

in learner_data transmission… CourseOverview model was being incorrectly used in the learner_data module of integrated_channels

ENT-4222, ENT-4428

## Description

Almost certainly fixes ENT-4452 too, but that ticket may have follow up work to send missed transmissions, after this is released, to close it

## Supporting information

ENT-4222
ENT-4258

Potential fix for ENT-4452

## Testing instructions

Local testing notes in tickets. Will be running a task from staging to verify before production release.

## Deadline

Urgent

## Testing notes

### course completion test
In lms shell:
 
```
make dev.shell.lms
%  ./manage.py lms transmit_learner_data --api_user edx --channel CANVAS
```

and verified the prior failures did not occur. Before this change, we observed the noted failures from CourseOverview model (See JIRA: ENT-4222 for details)

### subsection grading test:

when we completed a subsection in a course via the courseware page, we got some output like this in our logs (for this part we had to add two logging lines):

```
edx.devstack.lms                  | 2021-04-09 15:46:41,149 INFO 2814 [integrated_channels.integrated_channel.transmitters.learner_data] [user 35] [ip 172.18.0.1] learner_data.py:57 - edX+816
edx.devstack.lms                  | 2021-04-09 15:46:41,150 INFO 2814 [integrated_channels.integrated_channel.transmitters.learner_data] [user 35] [ip 172.18.0.1] learner_data.py:58 - block-v1:edX+816+3T2020+type@sequential+block@05584d82f5354b938bede0edaaef24b1
```

which verified for us that the transmission audit is correct after sending data over to blackboard (which was the test LMS here) 

We did not specifically test the transmitter side of this since the bug was in the exporter. but a full staging level testing of transmission will occur post merge.
