### PR TITLE
fix: explicitly allow courseware media access in HTTP response

### DIFF
--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -65,7 +65,7 @@ from ..model_data import FieldDataCache
 from ..module_render import get_module_for_descriptor, toc_for_course
 from ..permissions import MASQUERADE_AS_STUDENT
 from ..toggles import courseware_legacy_is_visible, courseware_mfe_is_visible
-from .views import CourseTabView
+from .views import CourseTabView, set_feature_policy_for_courseware
 
 log = logging.getLogger("edx.courseware.views.index")
 
@@ -254,7 +254,9 @@ class CoursewareIndex(View):
                     )
                 )
 
-        return render_to_response('courseware/courseware.html', self._create_courseware_context(request))
+        response = render_to_response('courseware/courseware.html', self._create_courseware_context(request))
+        set_feature_policy_for_courseware(response)
+        return response
 
     def _redirect_if_not_requested_section(self):
         """


### PR DESCRIPTION
## Description

Set the experimental HTTP Feature-Policy response header to
allow content rendered by (i) the chromeless xblock view and
(ii) the legacy courseware index to request access to mic,
camera, MIDI, location, and encrpyted media.

Access to these features was implicitly allowed in older
browser versions. However, in experimental versions of
Chromium and in near-future versions of Firefox,
ability for content to request media access will require
that media to be explicitly allowed in the HTTP response
headers.

## Supporting information

https://openedx.atlassian.net/browse/TNL-7675
https://openedx.atlassian.net/browse/CR-2748

edX-only: [Security ticket confirming that this change is OK to make](https://openedx.atlassian.net/browse/SEC-1223)

## Testing instructions

Requires a [browser that supports the experimental Feature Policy header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy#browser_compatibility). Chromium >=89 seems to work.

### Setup
* Create a unit in Studio.
* Add a raw HTML component.
* Set the following as the content of the HTML component, and publish:
```html
<p id="mic-access-status">Mic access pending...</p>

<script type="text/javascript">
  var accessStatus = document.getElementById("mic-access-status");
  navigator.mediaDevices.getUserMedia({audio:true})
	.then(function() { accessStatus.innerText = "Got mic access"; })
	.catch(function() { accessStatus.innerText = "Failed to get mic access"; });
</script>

```

### On master

* Load the unit you prepared above in Legacy courseware.
* Your browser may ask you whether you want to grant mic access. Whether or not you do, you should see `Failed to get mic access` as the block's content.

### On my branch

* Load the unit you prepared above in Legacy courseware.
* Your browser may ask you whether you want to grant mic access. If you allow access, then you should see `Got mic access!` as the block's content.

## Deadline

None.

## Other information

We have made a similar [change in frontend-app-learning](https://github.com/edx/frontend-app-learning/pull/412) to allow these permissions through the Unit iframe.

If this PR turns out to be necessary, then we will need to make a corresponding change to the HTTP response headers of the Learning MFE, likely in our Terraform code.

