### PR TITLE
refactor: reformat the manual verifications command to allow for single user verification

### DIFF
--- a/lms/djangoapps/verify_student/management/commands/manual_verifications.py
+++ b/lms/djangoapps/verify_student/management/commands/manual_verifications.py
@@ -102,6 +102,5 @@ class Command(BaseCommand):
             )
             return True
         except User.DoesNotExist:
-            err_msg = 'Tried to verify email {}, but user not found'
-            log.error(err_msg.format(email_id))
+            log.error(f'Tried to verify email {email_id}, but user not found')
             return False

--- a/lms/djangoapps/verify_student/management/commands/manual_verifications.py
+++ b/lms/djangoapps/verify_student/management/commands/manual_verifications.py
@@ -92,7 +92,7 @@ class Command(BaseCommand):
 
     def _add_user_to_manual_verification(self, email_id):
         """
-        Generates a single verification for a user. 
+        Generates a single verification for a user.
 
         Arguments:
             email_id (str): email of the user to be verified

--- a/lms/djangoapps/verify_student/management/commands/manual_verifications.py
+++ b/lms/djangoapps/verify_student/management/commands/manual_verifications.py
@@ -32,10 +32,23 @@ class Command(BaseCommand):
             default=None,
             help='Path of the file to read email id from.',
             type=str,
-            required=True
+        )
+        parser.add_argument(
+            '--email',
+            default=None,
+            help='Single email to verify one user',
+            type=str,
         )
 
     def handle(self, *args, **options):
+
+        single_email = options['email']
+
+        if single_email:
+            successfully_verified =  self._add_user_to_manual_verification(single_email)
+            if successfully_verified is False:
+                log.error(f'Manual verification of {single_email} failed')
+            return
 
         email_ids_file = options['email_ids_file']
 
@@ -72,17 +85,23 @@ class Command(BaseCommand):
             total_emails = len(email_ids)
             log.info(f'Creating manual verification for {total_emails} emails.')
             for email_id in email_ids:
-                try:
-                    email_id = email_id.strip()
-                    user = User.objects.get(email=email_id)
-                    ManualVerification.objects.get_or_create(
-                        user=user,
-                        status='approved',
-                        created_at__gte=earliest_allowed_verification_date(),
-                        defaults={'name': user.profile.name},
-                    )
-                except User.DoesNotExist:
+                successfully_verified = self._add_user_to_manual_verification(email_id)
+                if successfully_verified is False:
                     failed_emails.append(email_id)
-                    err_msg = 'Tried to verify email {}, but user not found'
-                    log.error(err_msg.format(email_id))
         return total_emails, failed_emails
+
+    def _add_user_to_manual_verification(self, email_id):
+        try:
+            email_id = email_id.strip()
+            user = User.objects.get(email=email_id)
+            ManualVerification.objects.get_or_create(
+                user=user,
+                status='approved',
+                created_at__gte=earliest_allowed_verification_date(),
+                defaults={'name': user.profile.name},
+            )
+            return True
+        except User.DoesNotExist:
+            err_msg = 'Tried to verify email {}, but user not found'
+            log.error(err_msg.format(email_id))
+            return False

--- a/lms/djangoapps/verify_student/management/commands/manual_verifications.py
+++ b/lms/djangoapps/verify_student/management/commands/manual_verifications.py
@@ -91,6 +91,15 @@ class Command(BaseCommand):
         return total_emails, failed_emails
 
     def _add_user_to_manual_verification(self, email_id):
+        """
+        Generates a single verification for a user. 
+
+        Arguments:
+            email_id (str): email of the user to be verified
+
+        Returns:
+            (success): boolean to show if the user has been successfully verified.
+        """
         try:
             email_id = email_id.strip()
             user = User.objects.get(email=email_id)

--- a/lms/djangoapps/verify_student/management/commands/manual_verifications.py
+++ b/lms/djangoapps/verify_student/management/commands/manual_verifications.py
@@ -45,7 +45,7 @@ class Command(BaseCommand):
         single_email = options['email']
 
         if single_email:
-            successfully_verified =  self._add_user_to_manual_verification(single_email)
+            successfully_verified = self._add_user_to_manual_verification(single_email)
             if successfully_verified is False:
                 log.error(f'Manual verification of {single_email} failed')
             return


### PR DESCRIPTION
This changes the `manual_verifications` command to accept a single user along side the old way (a file list). I'd like to do it this way so that the command can be incorporated in a larger provisioning file that talks between services to issue a program cert to the edX user on devstack.