### PR TITLE
build: mention Lilac in the pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,13 @@
 <!--
+##
+####         Note: the Lilac master branch has been created.  Please consider whether your change
+    ####     should also be applied to Lilac.  If so, make another pull request against the
+####         open-release/lilac.master branch, or ping @nedbat for help or questions.
+##
+
 Please give the pull request a short but descriptive title.
-Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.
+Use conventional commits to separate and summarize commits logically:
+https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html
 
 Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
 More details about the template are at https://github.com/edx/open-edx-proposals/pull/180


### PR DESCRIPTION
## Description

This amends the pull request template to remind developers to consider Lilac when they make a change.

The ascii art arrow looks odd monospaced, but is presented to devs like this:

<img width="866" alt="image" src="https://user-images.githubusercontent.com/23789/114444776-42557680-9b9d-11eb-9cf8-c941a21bcdf3.png">
