### PR TITLE
[TNL-8051] - Version bump for olxcleaner.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -10,7 +10,7 @@
 -e git+https://github.com/edx/django-wiki.git@1.0.0#egg=django-wiki  # via -r requirements/edx/github.in
 -e git+https://github.com/edx/DoneXBlock.git@2.0.3#egg=done-xblock  # via -r requirements/edx/github.in
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme  # via -r requirements/edx/github.in
--e git+https://github.com/openedx/olxcleaner.git@dbe03f73ed8b354eaca8f234958a7b3cff4f0ceb#egg=olxcleaner  # via -r requirements/edx/github.in
+-e git+https://github.com/openedx/olxcleaner.git@07b6e7ea0e79348c5009f61bb0c4b7df3c3d2d7a#egg=olxcleaner  # via -r requirements/edx/github.in
 -e .  # via -r requirements/edx/local.in
 -e git+https://github.com/technige/py2neo.git@py2neo-3.1.2#egg=py2neo==3.1.2  # via -r requirements/edx/github.in
 -e git+https://github.com/edx/RateXBlock.git@2.0.1#egg=rate-xblock  # via -r requirements/edx/github.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -10,7 +10,7 @@
 -e git+https://github.com/edx/django-wiki.git@1.0.0#egg=django-wiki  # via -r requirements/edx/testing.txt
 -e git+https://github.com/edx/DoneXBlock.git@2.0.3#egg=done-xblock  # via -r requirements/edx/testing.txt
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme  # via -r requirements/edx/testing.txt
--e git+https://github.com/openedx/olxcleaner.git@dbe03f73ed8b354eaca8f234958a7b3cff4f0ceb#egg=olxcleaner  # via -r requirements/edx/testing.txt
+-e git+https://github.com/openedx/olxcleaner.git@07b6e7ea0e79348c5009f61bb0c4b7df3c3d2d7a#egg=olxcleaner  # via -r requirements/edx/testing.txt
 -e .  # via -r requirements/edx/testing.txt
 -e git+https://github.com/technige/py2neo.git@py2neo-3.1.2#egg=py2neo==3.1.2  # via -r requirements/edx/testing.txt
 -e git+https://github.com/edx/RateXBlock.git@2.0.1#egg=rate-xblock  # via -r requirements/edx/testing.txt

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -55,7 +55,7 @@
 
 # Third-party:
 -e git+https://github.com/edx/django-wiki.git@1.0.0#egg=django-wiki
--e git+https://github.com/openedx/olxcleaner.git@dbe03f73ed8b354eaca8f234958a7b3cff4f0ceb#egg=olxcleaner
+-e git+https://github.com/openedx/olxcleaner.git@07b6e7ea0e79348c5009f61bb0c4b7df3c3d2d7a#egg=olxcleaner
 git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
 -e git+https://github.com/technige/py2neo.git@py2neo-3.1.2#egg=py2neo==3.1.2

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -10,7 +10,7 @@
 -e git+https://github.com/edx/django-wiki.git@1.0.0#egg=django-wiki  # via -r requirements/edx/base.txt
 -e git+https://github.com/edx/DoneXBlock.git@2.0.3#egg=done-xblock  # via -r requirements/edx/base.txt
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme  # via -r requirements/edx/base.txt
--e git+https://github.com/openedx/olxcleaner.git@dbe03f73ed8b354eaca8f234958a7b3cff4f0ceb#egg=olxcleaner  # via -r requirements/edx/base.txt
+-e git+https://github.com/openedx/olxcleaner.git@07b6e7ea0e79348c5009f61bb0c4b7df3c3d2d7a#egg=olxcleaner  # via -r requirements/edx/base.txt
 -e .  # via -r requirements/edx/base.txt
 -e git+https://github.com/technige/py2neo.git@py2neo-3.1.2#egg=py2neo==3.1.2  # via -r requirements/edx/base.txt
 -e git+https://github.com/edx/RateXBlock.git@2.0.1#egg=rate-xblock  # via -r requirements/edx/base.txt


### PR DESCRIPTION
### [TNL-8051](https://openedx.atlassian.net/browse/TNL-8051) -- Epic
#### [TNL-8170](https://openedx.atlassian.net/browse/TNL-8170) -- Subtask

Update Olxcleaner after the merge of: https://github.com/openedx/olxcleaner/pull/9
Using the following commit. https://github.com/openedx/olxcleaner/commit/07b6e7ea0e79348c5009f61bb0c4b7df3c3d2d7a
