### PR TITLE
fix: extra ")}" in 500 error page

### DIFF
--- a/cms/templates/500.html
+++ b/cms/templates/500.html
@@ -29,7 +29,6 @@ ${Text(_("{studio_name} Server Error")).format(
           studio_name=Text(settings.STUDIO_SHORT_NAME),
         )}
         ${_("We've logged the error and our staff is currently working to resolve this error as soon as possible.")}
-        )}
       </p>
     </article>
   </section>


### PR DESCRIPTION
## Description

The 500 page included ugly ")}" characters.
Here is a screenshot of the studio error page before the fix.

![cms-500](https://user-images.githubusercontent.com/44319/114605718-aad64d80-9c9a-11eb-9960-07e5542c97fb.png)


## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Open the /500 url in the studio.

@nedbat This is a minor bugfix, but it wouldn't cost much to include it in Lilac.