### PR TITLE
feat: Generate more certificate status for V2 course certs

### DIFF
--- a/lms/djangoapps/certificates/generation.py
+++ b/lms/djangoapps/certificates/generation.py
@@ -10,10 +10,8 @@ These methods should be called from tasks.
 """
 
 import logging
-import random  # lint-amnesty, pylint: disable=unused-import
 from uuid import uuid4
 
-from capa.xqueue_interface import make_hashkey  # lint-amnesty, pylint: disable=unused-import
 from common.djangoapps.student.models import CourseEnrollment, UserProfile
 from lms.djangoapps.certificates.models import CertificateStatuses, GeneratedCertificate
 from lms.djangoapps.certificates.queue import XQueueCertInterface

--- a/lms/djangoapps/certificates/management/commands/tests/test_cert_generation.py
+++ b/lms/djangoapps/certificates/management/commands/tests/test_cert_generation.py
@@ -6,7 +6,6 @@ from unittest import mock
 
 import pytest
 from django.core.management import CommandError, call_command
-from waffle.testutils import override_switch  # lint-amnesty, pylint: disable=unused-import
 
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
 from lms.djangoapps.certificates.tests.test_generation_handler import ID_VERIFIED_METHOD

--- a/lms/djangoapps/certificates/tests/test_models.py
+++ b/lms/djangoapps/certificates/tests/test_models.py
@@ -344,3 +344,60 @@ class CertificateInvalidationTest(SharedModuleStoreTestCase):
 
         assert mock_revoke_task.call_count == 1
         assert mock_revoke_task.call_args[0] == (self.user.username, str(self.course_id))
+
+
+class GeneratedCertificateTest(SharedModuleStoreTestCase):
+    """
+    Test GeneratedCertificates
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory()
+
+        self.course = CourseOverviewFactory()
+        self.course_key = self.course.id
+
+    def test_invalidate(self):
+        """
+        Test the invalidate method
+        """
+        cert = GeneratedCertificateFactory.create(
+            status=CertificateStatuses.downloadable,
+            user=self.user,
+            course_id=self.course_key
+        )
+        cert.invalidate()
+
+        cert = GeneratedCertificate.objects.get(user=self.user, course_id=self.course_key)
+        assert cert.status == CertificateStatuses.unavailable
+
+    def test_notpassing(self):
+        """
+        Test the notpassing method
+        """
+        cert = GeneratedCertificateFactory.create(
+            status=CertificateStatuses.downloadable,
+            user=self.user,
+            course_id=self.course_key
+        )
+        grade = '.3'
+        cert.mark_notpassing(grade)
+
+        cert = GeneratedCertificate.objects.get(user=self.user, course_id=self.course_key)
+        assert cert.status == CertificateStatuses.notpassing
+        assert cert.grade == grade
+
+    def test_unverified(self):
+        """
+        Test the unverified method
+        """
+        cert = GeneratedCertificateFactory.create(
+            status=CertificateStatuses.downloadable,
+            user=self.user,
+            course_id=self.course_key
+        )
+        cert.mark_unverified()
+
+        cert = GeneratedCertificate.objects.get(user=self.user, course_id=self.course_key)
+        assert cert.status == CertificateStatuses.unverified


### PR DESCRIPTION
Generate more certificate status for V2 course certs. 

If we can't generate a cert with a _downloadable_ status, see if we can generate a _notpassing_, _unavailable_ or _unverified_ status.

This also fixes a few random unused imports, and deletes an empty test file.

MICROBA-1106