### PR TITLE
refactor: Cleanup student user factories

### DIFF
--- a/cms/djangoapps/contentstore/api/tests/base.py
+++ b/cms/djangoapps/contentstore/api/tests/base.py
@@ -6,8 +6,8 @@ Base test case for the course API views.
 from django.urls import reverse
 from rest_framework.test import APITestCase
 
+from common.djangoapps.student.tests.factories import StaffFactory
 from common.djangoapps.student.tests.factories import UserFactory
-from lms.djangoapps.courseware.tests.factories import StaffFactory
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 

--- a/cms/djangoapps/contentstore/api/tests/test_import.py
+++ b/cms/djangoapps/contentstore/api/tests/test_import.py
@@ -13,8 +13,8 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 from user_tasks.models import UserTaskStatus
 
+from common.djangoapps.student.tests.factories import StaffFactory
 from common.djangoapps.student.tests.factories import UserFactory
-from lms.djangoapps.courseware.tests.factories import StaffFactory
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 

--- a/cms/djangoapps/contentstore/api/tests/test_validation.py
+++ b/cms/djangoapps/contentstore/api/tests/test_validation.py
@@ -9,8 +9,8 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from common.djangoapps.student.tests.factories import StaffFactory
 from common.djangoapps.student.tests.factories import UserFactory
-from lms.djangoapps.courseware.tests.factories import StaffFactory
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 

--- a/cms/djangoapps/contentstore/rest_api/v1/tests/test_views.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/tests/test_views.py
@@ -9,8 +9,8 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
+from common.djangoapps.student.tests.factories import InstructorFactory
 from common.djangoapps.student.tests.factories import UserFactory
-from lms.djangoapps.courseware.tests.factories import InstructorFactory
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory

--- a/cms/djangoapps/contentstore/rest_api/v1/tests/test_views.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/tests/test_views.py
@@ -8,8 +8,9 @@ from opaque_keys.edx.keys import CourseKey
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from common.djangoapps.student.tests.factories import UserFactory
-from lms.djangoapps.courseware.tests.factories import GlobalStaffFactory, InstructorFactory
+from lms.djangoapps.courseware.tests.factories import InstructorFactory
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory

--- a/cms/djangoapps/contentstore/tests/test_users_default_role.py
+++ b/cms/djangoapps/contentstore/tests/test_users_default_role.py
@@ -7,7 +7,7 @@ after deleting it creates same course again
 from cms.djangoapps.contentstore.tests.utils import AjaxEnabledTestClient
 from cms.djangoapps.contentstore.utils import delete_course, reverse_url
 from common.djangoapps.student.models import CourseEnrollment
-from lms.djangoapps.courseware.tests.factories import UserFactory
+from common.djangoapps.student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 
 

--- a/common/djangoapps/student/tests/factories.py
+++ b/common/djangoapps/student/tests/factories.py
@@ -26,6 +26,7 @@ from common.djangoapps.student.models import (
     UserStanding
 )
 from common.djangoapps.student.roles import GlobalStaff
+from common.djangoapps.student.roles import CourseBetaTesterRole
 from common.djangoapps.student.roles import CourseInstructorRole
 from common.djangoapps.student.roles import CourseStaffRole
 
@@ -232,6 +233,20 @@ class AccountRecoveryFactory(DjangoModelFactory):  # lint-amnesty, pylint: disab
 
 
 # pylint: disable=unused-argument
+class BetaTesterFactory(UserFactory):
+    """
+    Given a course Location, returns a User object with beta-tester
+    permissions for `course`.
+    """
+    last_name = 'Beta-Tester'
+
+    @factory.post_generation
+    def course_key(self, _create, extracted, **kwargs):
+        if extracted is None:
+            raise ValueError('Must specify a CourseKey for a beta-tester user')
+        CourseBetaTesterRole(extracted).add_users(self)
+
+
 class GlobalStaffFactory(UserFactory):
     """
     Returns a User object with global staff access

--- a/common/djangoapps/student/tests/factories.py
+++ b/common/djangoapps/student/tests/factories.py
@@ -26,6 +26,7 @@ from common.djangoapps.student.models import (
     UserStanding
 )
 from common.djangoapps.student.roles import GlobalStaff
+from common.djangoapps.student.roles import CourseInstructorRole
 from common.djangoapps.student.roles import CourseStaffRole
 
 # Factories are self documenting
@@ -240,6 +241,20 @@ class GlobalStaffFactory(UserFactory):
     @factory.post_generation
     def set_staff(self, _create, _extracted, **kwargs):
         GlobalStaff().add_users(self)
+
+
+class InstructorFactory(UserFactory):
+    """
+    Given a course Location, returns a User object with instructor
+    permissions for `course`.
+    """
+    last_name = 'Instructor'
+
+    @factory.post_generation
+    def course_key(self, _create, extracted, **kwargs):
+        if extracted is None:
+            raise ValueError('Must specify a CourseKey for a course instructor user')
+        CourseInstructorRole(extracted).add_users(self)
 
 
 class StaffFactory(UserFactory):

--- a/common/djangoapps/student/tests/factories.py
+++ b/common/djangoapps/student/tests/factories.py
@@ -29,6 +29,7 @@ from common.djangoapps.student.roles import GlobalStaff
 from common.djangoapps.student.roles import CourseBetaTesterRole
 from common.djangoapps.student.roles import CourseInstructorRole
 from common.djangoapps.student.roles import CourseStaffRole
+from common.djangoapps.student.roles import OrgInstructorRole
 from common.djangoapps.student.roles import OrgStaffRole
 
 # Factories are self documenting
@@ -233,7 +234,6 @@ class AccountRecoveryFactory(DjangoModelFactory):  # lint-amnesty, pylint: disab
     is_active = True
 
 
-# pylint: disable=unused-argument
 class BetaTesterFactory(UserFactory):
     """
     Given a course Location, returns a User object with beta-tester
@@ -271,6 +271,20 @@ class InstructorFactory(UserFactory):
         if extracted is None:
             raise ValueError('Must specify a CourseKey for a course instructor user')
         CourseInstructorRole(extracted).add_users(self)
+
+
+class OrgInstructorFactory(UserFactory):
+    """
+    Given a course Location, returns a User object with org-instructor
+    permissions for `course`.
+    """
+    last_name = 'Org-Instructor'
+
+    @factory.post_generation
+    def course_key(self, _create, extracted, **kwargs):
+        if extracted is None:
+            raise ValueError('Must specify a CourseKey for an org-instructor user')
+        OrgInstructorRole(extracted.org).add_users(self)
 
 
 class OrgStaffFactory(UserFactory):

--- a/common/djangoapps/student/tests/factories.py
+++ b/common/djangoapps/student/tests/factories.py
@@ -29,6 +29,7 @@ from common.djangoapps.student.roles import GlobalStaff
 from common.djangoapps.student.roles import CourseBetaTesterRole
 from common.djangoapps.student.roles import CourseInstructorRole
 from common.djangoapps.student.roles import CourseStaffRole
+from common.djangoapps.student.roles import OrgStaffRole
 
 # Factories are self documenting
 
@@ -270,6 +271,20 @@ class InstructorFactory(UserFactory):
         if extracted is None:
             raise ValueError('Must specify a CourseKey for a course instructor user')
         CourseInstructorRole(extracted).add_users(self)
+
+
+class OrgStaffFactory(UserFactory):
+    """
+    Given a course Location, returns a User object with org-staff
+    permissions for `course`.
+    """
+    last_name = 'Org-Staff'
+
+    @factory.post_generation
+    def course_key(self, _create, extracted, **kwargs):
+        if extracted is None:
+            raise ValueError('Must specify a CourseKey for an org-staff user')
+        OrgStaffRole(extracted.org).add_users(self)
 
 
 class StaffFactory(UserFactory):

--- a/common/djangoapps/student/tests/factories.py
+++ b/common/djangoapps/student/tests/factories.py
@@ -26,6 +26,7 @@ from common.djangoapps.student.models import (
     UserStanding
 )
 from common.djangoapps.student.roles import GlobalStaff
+from common.djangoapps.student.roles import CourseStaffRole
 
 # Factories are self documenting
 
@@ -239,4 +240,17 @@ class GlobalStaffFactory(UserFactory):
     @factory.post_generation
     def set_staff(self, _create, _extracted, **kwargs):
         GlobalStaff().add_users(self)
-# pylint: enable=unused-argument
+
+
+class StaffFactory(UserFactory):
+    """
+    Given a course Location, returns a User object with staff
+    permissions for `course`.
+    """
+    last_name = 'Staff'
+
+    @factory.post_generation
+    def course_key(self, _create, extracted, **kwargs):
+        if extracted is None:
+            raise ValueError('Must specify a CourseKey for a course staff user')
+        CourseStaffRole(extracted).add_users(self)

--- a/common/djangoapps/student/tests/factories.py
+++ b/common/djangoapps/student/tests/factories.py
@@ -33,8 +33,6 @@ from common.djangoapps.student.roles import CourseStaffRole
 from common.djangoapps.student.roles import OrgInstructorRole
 from common.djangoapps.student.roles import OrgStaffRole
 
-# Factories are self documenting
-
 TEST_PASSWORD = 'test'
 
 

--- a/common/djangoapps/student/tests/factories.py
+++ b/common/djangoapps/student/tests/factories.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 import factory
 from django.contrib.auth.models import AnonymousUser, Group, Permission
 from django.contrib.contenttypes.models import ContentType
+from django.test.client import RequestFactory
 from factory.django import DjangoModelFactory
 from opaque_keys.edx.keys import CourseKey
 from pytz import UTC
@@ -113,6 +114,16 @@ class UserFactory(DjangoModelFactory):  # lint-amnesty, pylint: disable=missing-
 
         for group_name in extracted:
             self.groups.add(GroupFactory.simple_generate(create, name=group_name))  # lint-amnesty, pylint: disable=no-member
+
+
+class RequestFactoryNoCsrf(RequestFactory):
+    """
+    RequestFactory, which disables csrf checks.
+    """
+    def request(self, **kwargs):
+        request = super().request(**kwargs)
+        setattr(request, '_dont_enforce_csrf_checks', True)  # pylint: disable=literal-used-as-attribute
+        return request
 
 
 class AnonymousUserFactory(factory.Factory):

--- a/common/djangoapps/student/tests/factories.py
+++ b/common/djangoapps/student/tests/factories.py
@@ -12,8 +12,6 @@ from factory.django import DjangoModelFactory
 from opaque_keys.edx.keys import CourseKey
 from pytz import UTC
 
-from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
-from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from common.djangoapps.student.models import (
     AccountRecovery,
     CourseAccessRole,
@@ -32,6 +30,8 @@ from common.djangoapps.student.roles import CourseInstructorRole
 from common.djangoapps.student.roles import CourseStaffRole
 from common.djangoapps.student.roles import OrgInstructorRole
 from common.djangoapps.student.roles import OrgStaffRole
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 
 TEST_PASSWORD = 'test'
 

--- a/common/djangoapps/student/tests/factories.py
+++ b/common/djangoapps/student/tests/factories.py
@@ -25,6 +25,7 @@ from common.djangoapps.student.models import (
     UserProfile,
     UserStanding
 )
+from common.djangoapps.student.roles import GlobalStaff
 
 # Factories are self documenting
 
@@ -226,3 +227,16 @@ class AccountRecoveryFactory(DjangoModelFactory):  # lint-amnesty, pylint: disab
     user = None
     secondary_email = factory.Sequence('robot+test+recovery+{}@edx.org'.format)
     is_active = True
+
+
+# pylint: disable=unused-argument
+class GlobalStaffFactory(UserFactory):
+    """
+    Returns a User object with global staff access
+    """
+    last_name = 'GlobalStaff'
+
+    @factory.post_generation
+    def set_staff(self, _create, _extracted, **kwargs):
+        GlobalStaff().add_users(self)
+# pylint: enable=unused-argument

--- a/common/djangoapps/student/tests/test_roles.py
+++ b/common/djangoapps/student/tests/test_roles.py
@@ -8,7 +8,7 @@ import six
 from django.test import TestCase
 from opaque_keys.edx.keys import CourseKey
 
-from lms.djangoapps.courseware.tests.factories import InstructorFactory, StaffFactory, UserFactory
+from lms.djangoapps.courseware.tests.factories import InstructorFactory, UserFactory
 from common.djangoapps.student.roles import (
     CourseBetaTesterRole,
     CourseInstructorRole,
@@ -20,6 +20,7 @@ from common.djangoapps.student.roles import (
     RoleCache
 )
 from common.djangoapps.student.tests.factories import AnonymousUserFactory
+from common.djangoapps.student.tests.factories import StaffFactory
 
 
 class RolesTestCase(TestCase):

--- a/common/djangoapps/student/tests/test_roles.py
+++ b/common/djangoapps/student/tests/test_roles.py
@@ -8,7 +8,6 @@ import six
 from django.test import TestCase
 from opaque_keys.edx.keys import CourseKey
 
-from lms.djangoapps.courseware.tests.factories import InstructorFactory
 from common.djangoapps.student.roles import (
     CourseBetaTesterRole,
     CourseInstructorRole,
@@ -20,6 +19,7 @@ from common.djangoapps.student.roles import (
     RoleCache
 )
 from common.djangoapps.student.tests.factories import AnonymousUserFactory
+from common.djangoapps.student.tests.factories import InstructorFactory
 from common.djangoapps.student.tests.factories import StaffFactory
 from common.djangoapps.student.tests.factories import UserFactory
 

--- a/common/djangoapps/student/tests/test_roles.py
+++ b/common/djangoapps/student/tests/test_roles.py
@@ -8,7 +8,7 @@ import six
 from django.test import TestCase
 from opaque_keys.edx.keys import CourseKey
 
-from lms.djangoapps.courseware.tests.factories import InstructorFactory, UserFactory
+from lms.djangoapps.courseware.tests.factories import InstructorFactory
 from common.djangoapps.student.roles import (
     CourseBetaTesterRole,
     CourseInstructorRole,
@@ -21,6 +21,7 @@ from common.djangoapps.student.roles import (
 )
 from common.djangoapps.student.tests.factories import AnonymousUserFactory
 from common.djangoapps.student.tests.factories import StaffFactory
+from common.djangoapps.student.tests.factories import UserFactory
 
 
 class RolesTestCase(TestCase):

--- a/common/djangoapps/student/tests/test_tasks.py
+++ b/common/djangoapps/student/tests/test_tasks.py
@@ -8,9 +8,9 @@ from django.conf import settings
 from django.test import TestCase
 
 from edx_ace.errors import ChannelError, RecoverableChannelDeliveryError
-from lms.djangoapps.courseware.tests.factories import UserFactory
 from common.djangoapps.student.models import Registration
 from common.djangoapps.student.tasks import send_activation_email
+from common.djangoapps.student.tests.factories import UserFactory
 from common.djangoapps.student.views.management import compose_activation_email
 
 

--- a/common/lib/xmodule/xmodule/modulestore/tests/django_utils.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/django_utils.py
@@ -16,12 +16,12 @@ from django.db import connections
 from django.test import TestCase
 from django.test.utils import override_settings
 
-from lms.djangoapps.courseware.tests.factories import StaffFactory
 from lms.djangoapps.courseware.field_overrides import OverrideFieldData
 from openedx.core.djangolib.testing.utils import CacheIsolationMixin, CacheIsolationTestCase, FilteredQueryCountMixin
 from openedx.core.lib.tempdir import mkdtemp_clean
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import AdminFactory, UserFactory
+from common.djangoapps.student.tests.factories import StaffFactory
 from xmodule.contentstore.django import _CONTENTSTORE
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import SignalHandler, clear_existing_modulestores, modulestore

--- a/lms/djangoapps/bulk_email/tests/test_email.py
+++ b/lms/djangoapps/bulk_email/tests/test_email.py
@@ -22,8 +22,9 @@ from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.roles import CourseStaffRole
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
+from common.djangoapps.student.tests.factories import StaffFactory
 from lms.djangoapps.bulk_email.tasks import _get_course_email_context, _get_source_address
-from lms.djangoapps.courseware.tests.factories import InstructorFactory, StaffFactory
+from lms.djangoapps.courseware.tests.factories import InstructorFactory
 from lms.djangoapps.instructor_task.subtasks import update_subtask_status
 from openedx.core.djangoapps.course_groups.cohorts import add_user_to_cohort
 from openedx.core.djangoapps.course_groups.models import CourseCohort

--- a/lms/djangoapps/bulk_email/tests/test_email.py
+++ b/lms/djangoapps/bulk_email/tests/test_email.py
@@ -22,9 +22,9 @@ from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.roles import CourseStaffRole
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
+from common.djangoapps.student.tests.factories import InstructorFactory
 from common.djangoapps.student.tests.factories import StaffFactory
 from lms.djangoapps.bulk_email.tasks import _get_course_email_context, _get_source_address
-from lms.djangoapps.courseware.tests.factories import InstructorFactory
 from lms.djangoapps.instructor_task.subtasks import update_subtask_status
 from openedx.core.djangoapps.course_groups.cohorts import add_user_to_cohort
 from openedx.core.djangoapps.course_groups.models import CourseCohort

--- a/lms/djangoapps/certificates/tests/test_api.py
+++ b/lms/djangoapps/certificates/tests/test_api.py
@@ -29,6 +29,7 @@ from common.djangoapps.course_modes.tests.factories import CourseModeFactory
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import (
     CourseEnrollmentFactory,
+    GlobalStaffFactory,
     UserFactory
 )
 from common.djangoapps.util.testing import EventTestMixin
@@ -70,7 +71,6 @@ from lms.djangoapps.certificates.tests.factories import (
     GeneratedCertificateFactory,
     CertificateInvalidationFactory
 )
-from lms.djangoapps.courseware.tests.factories import GlobalStaffFactory
 from lms.djangoapps.grades.tests.utils import mock_passing_grade
 from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration
 

--- a/lms/djangoapps/course_blocks/transformers/tests/test_start_date.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_start_date.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 import ddt
 from django.utils.timezone import now
 
-from lms.djangoapps.courseware.tests.factories import BetaTesterFactory
+from common.djangoapps.student.tests.factories import BetaTesterFactory
 
 from ..start_date import DEFAULT_START_DATE, StartDateTransformer
 from .helpers import BlockParentsMapTestCase, update_block

--- a/lms/djangoapps/course_wiki/tests/test_access.py
+++ b/lms/djangoapps/course_wiki/tests/test_access.py
@@ -6,11 +6,11 @@ Tests for wiki permissions
 from django.contrib.auth.models import Group
 from wiki.models import URLPath
 
+from common.djangoapps.student.tests.factories import InstructorFactory
 from common.djangoapps.student.tests.factories import StaffFactory
 from lms.djangoapps.course_wiki import settings
 from lms.djangoapps.course_wiki.utils import course_wiki_slug, user_is_article_course_staff
 from lms.djangoapps.course_wiki.views import get_or_create_root
-from lms.djangoapps.courseware.tests.factories import InstructorFactory
 from common.djangoapps.student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory

--- a/lms/djangoapps/course_wiki/tests/test_access.py
+++ b/lms/djangoapps/course_wiki/tests/test_access.py
@@ -6,10 +6,11 @@ Tests for wiki permissions
 from django.contrib.auth.models import Group
 from wiki.models import URLPath
 
+from common.djangoapps.student.tests.factories import StaffFactory
 from lms.djangoapps.course_wiki import settings
 from lms.djangoapps.course_wiki.utils import course_wiki_slug, user_is_article_course_staff
 from lms.djangoapps.course_wiki.views import get_or_create_root
-from lms.djangoapps.courseware.tests.factories import InstructorFactory, StaffFactory
+from lms.djangoapps.courseware.tests.factories import InstructorFactory
 from common.djangoapps.student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory

--- a/lms/djangoapps/course_wiki/tests/test_comprehensive_theming.py
+++ b/lms/djangoapps/course_wiki/tests/test_comprehensive_theming.py
@@ -8,8 +8,8 @@ from unittest import skip
 from django.test.client import Client
 from wiki.models import URLPath
 
+from common.djangoapps.student.tests.factories import InstructorFactory
 from lms.djangoapps.course_wiki.views import get_or_create_root
-from lms.djangoapps.courseware.tests.factories import InstructorFactory
 from openedx.core.djangoapps.theming.tests.test_util import with_comprehensive_theme
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory

--- a/lms/djangoapps/course_wiki/tests/test_middleware.py
+++ b/lms/djangoapps/course_wiki/tests/test_middleware.py
@@ -6,8 +6,8 @@ Tests for wiki middleware.
 from django.test.client import Client
 from wiki.models import URLPath
 
+from common.djangoapps.student.tests.factories import InstructorFactory
 from lms.djangoapps.course_wiki.views import get_or_create_root
-from lms.djangoapps.courseware.tests.factories import InstructorFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 

--- a/lms/djangoapps/courseware/tests/factories.py
+++ b/lms/djangoapps/courseware/tests/factories.py
@@ -23,7 +23,7 @@ from common.djangoapps.student.roles import (
     OrgStaffRole
 )
 # Imported to re-export
-from common.djangoapps.student.tests.factories import UserFactory  # Imported to re-export
+from common.djangoapps.student.tests.factories import UserFactory
 from common.djangoapps.student.tests.factories import UserProfileFactory as StudentUserProfileFactory
 
 # TODO fix this (course_id and location are invalid names as constants, and course_id should really be COURSE_KEY)

--- a/lms/djangoapps/courseware/tests/factories.py
+++ b/lms/djangoapps/courseware/tests/factories.py
@@ -16,10 +16,6 @@ from lms.djangoapps.courseware.models import (
     XModuleStudentPrefsField,
     XModuleUserStateSummaryField
 )
-from common.djangoapps.student.roles import (
-    OrgInstructorRole,
-)
-# Imported to re-export
 from common.djangoapps.student.tests.factories import UserFactory
 from common.djangoapps.student.tests.factories import UserProfileFactory as StudentUserProfileFactory
 
@@ -31,26 +27,6 @@ location = partial(course_id.make_usage_key, 'problem')
 
 class UserProfileFactory(StudentUserProfileFactory):
     courseware = 'course.xml'
-
-
-# For the following factories, these are disabled because we're ok ignoring the
-# unused arguments create and **kwargs in the line:
-# course_key(self, create, extracted, **kwargs)
-# pylint: disable=unused-argument
-
-class OrgInstructorFactory(UserFactory):
-    """
-    Given a course Location, returns a User object with org-instructor
-    permissions for `course`.
-    """
-    last_name = "Org-Instructor"
-
-    @factory.post_generation
-    def course_key(self, create, extracted, **kwargs):
-        if extracted is None:
-            raise ValueError("Must specify a CourseKey for an org-instructor user")
-        OrgInstructorRole(extracted.org).add_users(self)
-# pylint: enable=unused-argument
 
 
 class StudentModuleFactory(DjangoModelFactory):  # lint-amnesty, pylint: disable=missing-class-docstring

--- a/lms/djangoapps/courseware/tests/factories.py
+++ b/lms/djangoapps/courseware/tests/factories.py
@@ -1,6 +1,9 @@
-# Factories are self documenting  # lint-amnesty, pylint: disable=missing-module-docstring
+"""
+Build courseware-centric test factories
 
-
+Generic, LMS-agnostic factories can be found in:
+`common.djangoapps.student.tests.factories.py`
+"""
 import json
 from functools import partial
 
@@ -21,7 +24,10 @@ COURSE_KEY = CourseKey.from_string('edX/test_course/test')
 LOCATION = partial(COURSE_KEY.make_usage_key, 'problem')
 
 
-class StudentModuleFactory(DjangoModelFactory):  # lint-amnesty, pylint: disable=missing-class-docstring
+class StudentModuleFactory(DjangoModelFactory):
+    """
+    Build StudentModule models
+    """
     class Meta:
         model = StudentModule
 
@@ -34,7 +40,10 @@ class StudentModuleFactory(DjangoModelFactory):  # lint-amnesty, pylint: disable
     done = 'na'
 
 
-class UserStateSummaryFactory(DjangoModelFactory):  # lint-amnesty, pylint: disable=missing-class-docstring
+class UserStateSummaryFactory(DjangoModelFactory):
+    """
+    Build XModuleUserStateSummaryField models
+    """
     class Meta:
         model = XModuleUserStateSummaryField
 
@@ -43,7 +52,10 @@ class UserStateSummaryFactory(DjangoModelFactory):  # lint-amnesty, pylint: disa
     usage_id = LOCATION('usage_id')
 
 
-class StudentPrefsFactory(DjangoModelFactory):  # lint-amnesty, pylint: disable=missing-class-docstring
+class StudentPrefsFactory(DjangoModelFactory):
+    """
+    Build XModuleStudentPrefsField models
+    """
     class Meta:
         model = XModuleStudentPrefsField
 
@@ -53,7 +65,10 @@ class StudentPrefsFactory(DjangoModelFactory):  # lint-amnesty, pylint: disable=
     module_type = 'mock_problem'
 
 
-class StudentInfoFactory(DjangoModelFactory):  # lint-amnesty, pylint: disable=missing-class-docstring
+class StudentInfoFactory(DjangoModelFactory):
+    """
+    Build XModuleStudentInfoField models
+    """
     class Meta:
         model = XModuleStudentInfoField
 

--- a/lms/djangoapps/courseware/tests/factories.py
+++ b/lms/djangoapps/courseware/tests/factories.py
@@ -17,10 +17,8 @@ from lms.djangoapps.courseware.models import (
 )
 from common.djangoapps.student.tests.factories import UserFactory
 
-# TODO fix this (course_id and location are invalid names as constants, and course_id should really be COURSE_KEY)
-# pylint: disable=invalid-name
-course_id = CourseKey.from_string('edX/test_course/test')
-location = partial(course_id.make_usage_key, 'problem')
+COURSE_KEY = CourseKey.from_string('edX/test_course/test')
+LOCATION = partial(COURSE_KEY.make_usage_key, 'problem')
 
 
 class StudentModuleFactory(DjangoModelFactory):  # lint-amnesty, pylint: disable=missing-class-docstring
@@ -42,7 +40,7 @@ class UserStateSummaryFactory(DjangoModelFactory):  # lint-amnesty, pylint: disa
 
     field_name = 'existing_field'
     value = json.dumps('old_value')
-    usage_id = location('usage_id')
+    usage_id = LOCATION('usage_id')
 
 
 class StudentPrefsFactory(DjangoModelFactory):  # lint-amnesty, pylint: disable=missing-class-docstring

--- a/lms/djangoapps/courseware/tests/factories.py
+++ b/lms/djangoapps/courseware/tests/factories.py
@@ -18,7 +18,6 @@ from lms.djangoapps.courseware.models import (
 )
 from common.djangoapps.student.roles import (
     OrgInstructorRole,
-    OrgStaffRole
 )
 # Imported to re-export
 from common.djangoapps.student.tests.factories import UserFactory
@@ -38,20 +37,6 @@ class UserProfileFactory(StudentUserProfileFactory):
 # unused arguments create and **kwargs in the line:
 # course_key(self, create, extracted, **kwargs)
 # pylint: disable=unused-argument
-
-class OrgStaffFactory(UserFactory):
-    """
-    Given a course Location, returns a User object with org-staff
-    permissions for `course`.
-    """
-    last_name = "Org-Staff"
-
-    @factory.post_generation
-    def course_key(self, create, extracted, **kwargs):
-        if extracted is None:
-            raise ValueError("Must specify a CourseKey for an org-staff user")
-        OrgStaffRole(extracted.org).add_users(self)
-
 
 class OrgInstructorFactory(UserFactory):
     """

--- a/lms/djangoapps/courseware/tests/factories.py
+++ b/lms/djangoapps/courseware/tests/factories.py
@@ -12,13 +12,13 @@ from factory.django import DjangoModelFactory
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import CourseLocator
 
+from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.courseware.models import (
     StudentModule,
     XModuleStudentInfoField,
     XModuleStudentPrefsField,
     XModuleUserStateSummaryField
 )
-from common.djangoapps.student.tests.factories import UserFactory
 
 COURSE_KEY = CourseKey.from_string('edX/test_course/test')
 LOCATION = partial(COURSE_KEY.make_usage_key, 'problem')

--- a/lms/djangoapps/courseware/tests/factories.py
+++ b/lms/djangoapps/courseware/tests/factories.py
@@ -5,7 +5,6 @@ import json
 from functools import partial
 
 import factory
-from django.test.client import RequestFactory
 from factory.django import DjangoModelFactory
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import CourseLocator
@@ -68,13 +67,3 @@ class StudentInfoFactory(DjangoModelFactory):  # lint-amnesty, pylint: disable=m
     field_name = 'existing_field'
     value = json.dumps('old_value')
     student = factory.SubFactory(UserFactory)
-
-
-class RequestFactoryNoCsrf(RequestFactory):
-    """
-    RequestFactory, which disables csrf checks.
-    """
-    def request(self, **kwargs):
-        request = super().request(**kwargs)
-        setattr(request, '_dont_enforce_csrf_checks', True)  # pylint: disable=literal-used-as-attribute
-        return request

--- a/lms/djangoapps/courseware/tests/factories.py
+++ b/lms/djangoapps/courseware/tests/factories.py
@@ -18,7 +18,6 @@ from lms.djangoapps.courseware.models import (
 )
 from common.djangoapps.student.roles import (
     CourseBetaTesterRole,
-    CourseInstructorRole,
     OrgInstructorRole,
     OrgStaffRole
 )
@@ -40,20 +39,6 @@ class UserProfileFactory(StudentUserProfileFactory):
 # unused arguments create and **kwargs in the line:
 # course_key(self, create, extracted, **kwargs)
 # pylint: disable=unused-argument
-
-class InstructorFactory(UserFactory):
-    """
-    Given a course Location, returns a User object with instructor
-    permissions for `course`.
-    """
-    last_name = "Instructor"
-
-    @factory.post_generation
-    def course_key(self, create, extracted, **kwargs):
-        if extracted is None:
-            raise ValueError("Must specify a CourseKey for a course instructor user")
-        CourseInstructorRole(extracted).add_users(self)
-
 
 class BetaTesterFactory(UserFactory):
     """

--- a/lms/djangoapps/courseware/tests/factories.py
+++ b/lms/djangoapps/courseware/tests/factories.py
@@ -17,7 +17,6 @@ from lms.djangoapps.courseware.models import (
     XModuleUserStateSummaryField
 )
 from common.djangoapps.student.roles import (
-    CourseBetaTesterRole,
     OrgInstructorRole,
     OrgStaffRole
 )
@@ -39,20 +38,6 @@ class UserProfileFactory(StudentUserProfileFactory):
 # unused arguments create and **kwargs in the line:
 # course_key(self, create, extracted, **kwargs)
 # pylint: disable=unused-argument
-
-class BetaTesterFactory(UserFactory):
-    """
-    Given a course Location, returns a User object with beta-tester
-    permissions for `course`.
-    """
-    last_name = "Beta-Tester"
-
-    @factory.post_generation
-    def course_key(self, create, extracted, **kwargs):
-        if extracted is None:
-            raise ValueError("Must specify a CourseKey for a beta-tester user")
-        CourseBetaTesterRole(extracted).add_users(self)
-
 
 class OrgStaffFactory(UserFactory):
     """

--- a/lms/djangoapps/courseware/tests/factories.py
+++ b/lms/djangoapps/courseware/tests/factories.py
@@ -20,7 +20,6 @@ from common.djangoapps.student.roles import (
     CourseBetaTesterRole,
     CourseInstructorRole,
     CourseStaffRole,
-    GlobalStaff,
     OrgInstructorRole,
     OrgStaffRole
 )
@@ -111,17 +110,6 @@ class OrgInstructorFactory(UserFactory):
         if extracted is None:
             raise ValueError("Must specify a CourseKey for an org-instructor user")
         OrgInstructorRole(extracted.org).add_users(self)
-
-
-class GlobalStaffFactory(UserFactory):
-    """
-    Returns a User object with global staff access
-    """
-    last_name = "GlobalStaff"
-
-    @factory.post_generation
-    def set_staff(self, create, extracted, **kwargs):
-        GlobalStaff().add_users(self)
 # pylint: enable=unused-argument
 
 

--- a/lms/djangoapps/courseware/tests/factories.py
+++ b/lms/djangoapps/courseware/tests/factories.py
@@ -16,16 +16,11 @@ from lms.djangoapps.courseware.models import (
     XModuleUserStateSummaryField
 )
 from common.djangoapps.student.tests.factories import UserFactory
-from common.djangoapps.student.tests.factories import UserProfileFactory as StudentUserProfileFactory
 
 # TODO fix this (course_id and location are invalid names as constants, and course_id should really be COURSE_KEY)
 # pylint: disable=invalid-name
 course_id = CourseKey.from_string('edX/test_course/test')
 location = partial(course_id.make_usage_key, 'problem')
-
-
-class UserProfileFactory(StudentUserProfileFactory):
-    courseware = 'course.xml'
 
 
 class StudentModuleFactory(DjangoModelFactory):  # lint-amnesty, pylint: disable=missing-class-docstring

--- a/lms/djangoapps/courseware/tests/factories.py
+++ b/lms/djangoapps/courseware/tests/factories.py
@@ -19,7 +19,6 @@ from lms.djangoapps.courseware.models import (
 from common.djangoapps.student.roles import (
     CourseBetaTesterRole,
     CourseInstructorRole,
-    CourseStaffRole,
     OrgInstructorRole,
     OrgStaffRole
 )
@@ -54,20 +53,6 @@ class InstructorFactory(UserFactory):
         if extracted is None:
             raise ValueError("Must specify a CourseKey for a course instructor user")
         CourseInstructorRole(extracted).add_users(self)
-
-
-class StaffFactory(UserFactory):
-    """
-    Given a course Location, returns a User object with staff
-    permissions for `course`.
-    """
-    last_name = "Staff"
-
-    @factory.post_generation
-    def course_key(self, create, extracted, **kwargs):
-        if extracted is None:
-            raise ValueError("Must specify a CourseKey for a course staff user")
-        CourseStaffRole(extracted).add_users(self)
 
 
 class BetaTesterFactory(UserFactory):

--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -22,9 +22,6 @@ from opaque_keys.edx.locator import CourseLocator
 import lms.djangoapps.courseware.access as access
 import lms.djangoapps.courseware.access_response as access_response
 from lms.djangoapps.courseware.masquerade import CourseMasquerade
-from lms.djangoapps.courseware.tests.factories import (
-    BetaTesterFactory,
-)
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase, masquerade_as_group_member
 from lms.djangoapps.ccx.models import CustomCourseForEdX
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
@@ -38,6 +35,7 @@ from common.djangoapps.student.tests.factories import (
     CourseEnrollmentAllowedFactory,
     CourseEnrollmentFactory
 )
+from common.djangoapps.student.tests.factories import BetaTesterFactory
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from common.djangoapps.student.tests.factories import InstructorFactory
 from common.djangoapps.student.tests.factories import StaffFactory

--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -24,7 +24,6 @@ import lms.djangoapps.courseware.access_response as access_response
 from lms.djangoapps.courseware.masquerade import CourseMasquerade
 from lms.djangoapps.courseware.tests.factories import (
     BetaTesterFactory,
-    GlobalStaffFactory,
     InstructorFactory,
     StaffFactory,
     UserFactory
@@ -42,6 +41,7 @@ from common.djangoapps.student.tests.factories import (
     CourseEnrollmentAllowedFactory,
     CourseEnrollmentFactory
 )
+from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from common.djangoapps.util.milestones_helpers import fulfill_course_milestone, set_prerequisite_courses
 from xmodule.course_module import (
     CATALOG_VISIBILITY_ABOUT,

--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -24,7 +24,6 @@ import lms.djangoapps.courseware.access_response as access_response
 from lms.djangoapps.courseware.masquerade import CourseMasquerade
 from lms.djangoapps.courseware.tests.factories import (
     BetaTesterFactory,
-    InstructorFactory,
 )
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase, masquerade_as_group_member
 from lms.djangoapps.ccx.models import CustomCourseForEdX
@@ -40,6 +39,7 @@ from common.djangoapps.student.tests.factories import (
     CourseEnrollmentFactory
 )
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
+from common.djangoapps.student.tests.factories import InstructorFactory
 from common.djangoapps.student.tests.factories import StaffFactory
 from common.djangoapps.student.tests.factories import UserFactory
 from common.djangoapps.util.milestones_helpers import fulfill_course_milestone, set_prerequisite_courses

--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -25,7 +25,6 @@ from lms.djangoapps.courseware.masquerade import CourseMasquerade
 from lms.djangoapps.courseware.tests.factories import (
     BetaTesterFactory,
     InstructorFactory,
-    StaffFactory,
     UserFactory
 )
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase, masquerade_as_group_member
@@ -42,6 +41,7 @@ from common.djangoapps.student.tests.factories import (
     CourseEnrollmentFactory
 )
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
+from common.djangoapps.student.tests.factories import StaffFactory
 from common.djangoapps.util.milestones_helpers import fulfill_course_milestone, set_prerequisite_courses
 from xmodule.course_module import (
     CATALOG_VISIBILITY_ABOUT,

--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -25,7 +25,6 @@ from lms.djangoapps.courseware.masquerade import CourseMasquerade
 from lms.djangoapps.courseware.tests.factories import (
     BetaTesterFactory,
     InstructorFactory,
-    UserFactory
 )
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase, masquerade_as_group_member
 from lms.djangoapps.ccx.models import CustomCourseForEdX
@@ -42,6 +41,7 @@ from common.djangoapps.student.tests.factories import (
 )
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from common.djangoapps.student.tests.factories import StaffFactory
+from common.djangoapps.student.tests.factories import UserFactory
 from common.djangoapps.util.milestones_helpers import fulfill_course_milestone, set_prerequisite_courses
 from xmodule.course_module import (
     CATALOG_VISIBILITY_ABOUT,

--- a/lms/djangoapps/courseware/tests/test_entrance_exam.py
+++ b/lms/djangoapps/courseware/tests/test_entrance_exam.py
@@ -18,13 +18,13 @@ from lms.djangoapps.courseware.entrance_exams import (
 )
 from lms.djangoapps.courseware.model_data import FieldDataCache
 from lms.djangoapps.courseware.module_render import get_module, handle_xblock_callback, toc_for_course
-from lms.djangoapps.courseware.tests.factories import RequestFactoryNoCsrf
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from openedx.core.djangolib.testing.utils import get_mock_request
 from openedx.features.course_experience import DISABLE_COURSE_OUTLINE_PAGE_FLAG, DISABLE_UNIFIED_COURSE_TAB_FLAG
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import AnonymousUserFactory, CourseEnrollmentFactory
 from common.djangoapps.student.tests.factories import InstructorFactory
+from common.djangoapps.student.tests.factories import RequestFactoryNoCsrf
 from common.djangoapps.student.tests.factories import StaffFactory
 from common.djangoapps.student.tests.factories import UserFactory
 from common.djangoapps.util.milestones_helpers import (

--- a/lms/djangoapps/courseware/tests/test_entrance_exam.py
+++ b/lms/djangoapps/courseware/tests/test_entrance_exam.py
@@ -18,12 +18,13 @@ from lms.djangoapps.courseware.entrance_exams import (
 )
 from lms.djangoapps.courseware.model_data import FieldDataCache
 from lms.djangoapps.courseware.module_render import get_module, handle_xblock_callback, toc_for_course
-from lms.djangoapps.courseware.tests.factories import InstructorFactory, RequestFactoryNoCsrf
+from lms.djangoapps.courseware.tests.factories import RequestFactoryNoCsrf
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from openedx.core.djangolib.testing.utils import get_mock_request
 from openedx.features.course_experience import DISABLE_COURSE_OUTLINE_PAGE_FLAG, DISABLE_UNIFIED_COURSE_TAB_FLAG
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import AnonymousUserFactory, CourseEnrollmentFactory
+from common.djangoapps.student.tests.factories import InstructorFactory
 from common.djangoapps.student.tests.factories import StaffFactory
 from common.djangoapps.student.tests.factories import UserFactory
 from common.djangoapps.util.milestones_helpers import (

--- a/lms/djangoapps/courseware/tests/test_entrance_exam.py
+++ b/lms/djangoapps/courseware/tests/test_entrance_exam.py
@@ -18,13 +18,14 @@ from lms.djangoapps.courseware.entrance_exams import (
 )
 from lms.djangoapps.courseware.model_data import FieldDataCache
 from lms.djangoapps.courseware.module_render import get_module, handle_xblock_callback, toc_for_course
-from lms.djangoapps.courseware.tests.factories import InstructorFactory, RequestFactoryNoCsrf, UserFactory
+from lms.djangoapps.courseware.tests.factories import InstructorFactory, RequestFactoryNoCsrf
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from openedx.core.djangolib.testing.utils import get_mock_request
 from openedx.features.course_experience import DISABLE_COURSE_OUTLINE_PAGE_FLAG, DISABLE_UNIFIED_COURSE_TAB_FLAG
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import AnonymousUserFactory, CourseEnrollmentFactory
 from common.djangoapps.student.tests.factories import StaffFactory
+from common.djangoapps.student.tests.factories import UserFactory
 from common.djangoapps.util.milestones_helpers import (
     add_course_content_milestone,
     add_course_milestone,

--- a/lms/djangoapps/courseware/tests/test_entrance_exam.py
+++ b/lms/djangoapps/courseware/tests/test_entrance_exam.py
@@ -18,12 +18,13 @@ from lms.djangoapps.courseware.entrance_exams import (
 )
 from lms.djangoapps.courseware.model_data import FieldDataCache
 from lms.djangoapps.courseware.module_render import get_module, handle_xblock_callback, toc_for_course
-from lms.djangoapps.courseware.tests.factories import InstructorFactory, RequestFactoryNoCsrf, StaffFactory, UserFactory
+from lms.djangoapps.courseware.tests.factories import InstructorFactory, RequestFactoryNoCsrf, UserFactory
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from openedx.core.djangolib.testing.utils import get_mock_request
 from openedx.features.course_experience import DISABLE_COURSE_OUTLINE_PAGE_FLAG, DISABLE_UNIFIED_COURSE_TAB_FLAG
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import AnonymousUserFactory, CourseEnrollmentFactory
+from common.djangoapps.student.tests.factories import StaffFactory
 from common.djangoapps.util.milestones_helpers import (
     add_course_content_milestone,
     add_course_milestone,

--- a/lms/djangoapps/courseware/tests/test_group_access.py
+++ b/lms/djangoapps/courseware/tests/test_group_access.py
@@ -7,8 +7,9 @@ access control rules.
 import ddt
 from stevedore.extension import Extension, ExtensionManager
 
+from common.djangoapps.student.tests.factories import StaffFactory
 import lms.djangoapps.courseware.access as access
-from lms.djangoapps.courseware.tests.factories import StaffFactory, UserFactory
+from lms.djangoapps.courseware.tests.factories import UserFactory
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory

--- a/lms/djangoapps/courseware/tests/test_group_access.py
+++ b/lms/djangoapps/courseware/tests/test_group_access.py
@@ -8,8 +8,8 @@ import ddt
 from stevedore.extension import Extension, ExtensionManager
 
 from common.djangoapps.student.tests.factories import StaffFactory
+from common.djangoapps.student.tests.factories import UserFactory
 import lms.djangoapps.courseware.access as access
-from lms.djangoapps.courseware.tests.factories import UserFactory
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory

--- a/lms/djangoapps/courseware/tests/test_masquerade.py
+++ b/lms/djangoapps/courseware/tests/test_masquerade.py
@@ -25,7 +25,6 @@ from lms.djangoapps.courseware.masquerade import (
     get_masquerading_user_group,
     setup_masquerade,
 )
-from lms.djangoapps.courseware.tests.factories import StaffFactory
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase, MasqueradeMixin, masquerade_as_group_member
 from lms.djangoapps.courseware.tests.test_submitting_problems import ProblemSubmissionTestMixin
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
@@ -33,6 +32,7 @@ from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preference, set_user_preference
 from openedx.features.course_experience import DISABLE_UNIFIED_COURSE_TAB_FLAG
 from common.djangoapps.student.models import CourseEnrollment
+from common.djangoapps.student.tests.factories import StaffFactory
 from common.djangoapps.student.tests.factories import UserFactory
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase

--- a/lms/djangoapps/courseware/tests/test_model_data.py
+++ b/lms/djangoapps/courseware/tests/test_model_data.py
@@ -1,12 +1,11 @@
 """
 Test for lms courseware app, module data (runtime data storage for XBlocks)
 """
-
-
 import json
 from functools import partial
 from unittest.mock import Mock, patch
 import pytest
+
 from django.db import connections, DatabaseError
 from django.test import TestCase
 from xblock.core import XBlock

--- a/lms/djangoapps/courseware/tests/test_model_data.py
+++ b/lms/djangoapps/courseware/tests/test_model_data.py
@@ -13,6 +13,7 @@ from xblock.core import XBlock
 from xblock.exceptions import KeyValueMultiSaveError
 from xblock.fields import BlockScope, Scope, ScopeIds
 
+from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.courseware.model_data import DjangoKeyValueStore, FieldDataCache, InvalidScopeError
 from lms.djangoapps.courseware.models import (
     StudentModule,
@@ -20,10 +21,12 @@ from lms.djangoapps.courseware.models import (
     XModuleStudentPrefsField,
     XModuleUserStateSummaryField
 )
+from lms.djangoapps.courseware.tests.factories import COURSE_KEY
+from lms.djangoapps.courseware.tests.factories import LOCATION
 from lms.djangoapps.courseware.tests.factories import StudentInfoFactory
 from lms.djangoapps.courseware.tests.factories import StudentModuleFactory as cmfStudentModuleFactory
-from lms.djangoapps.courseware.tests.factories import StudentPrefsFactory, UserStateSummaryFactory, course_id, location
-from common.djangoapps.student.tests.factories import UserFactory
+from lms.djangoapps.courseware.tests.factories import StudentPrefsFactory
+from lms.djangoapps.courseware.tests.factories import UserStateSummaryFactory
 
 
 def mock_field(scope, name):
@@ -35,7 +38,7 @@ def mock_field(scope, name):
 
 def mock_descriptor(fields=[]):  # lint-amnesty, pylint: disable=dangerous-default-value, missing-function-docstring
     descriptor = Mock(entry_point=XBlock.entry_point)
-    descriptor.scope_ids = ScopeIds('user1', 'mock_problem', location('def_id'), location('usage_id'))
+    descriptor.scope_ids = ScopeIds('user1', 'mock_problem', LOCATION('def_id'), LOCATION('usage_id'))
     descriptor.module_class.fields.values.return_value = fields
     descriptor.fields.values.return_value = fields
     descriptor.module_class.__name__ = 'MockProblemModule'
@@ -44,23 +47,27 @@ def mock_descriptor(fields=[]):  # lint-amnesty, pylint: disable=dangerous-defau
 # The user ids here are 1 because we make a student in the setUp functions, and
 # they get an id of 1.  There's an assertion in setUp to ensure that assumption
 # is still true.
-user_state_summary_key = partial(DjangoKeyValueStore.Key, Scope.user_state_summary, None, location('usage_id'))
-settings_key = partial(DjangoKeyValueStore.Key, Scope.settings, None, location('usage_id'))
-user_state_key = partial(DjangoKeyValueStore.Key, Scope.user_state, 1, location('usage_id'))
+user_state_summary_key = partial(DjangoKeyValueStore.Key, Scope.user_state_summary, None, LOCATION('usage_id'))
+settings_key = partial(DjangoKeyValueStore.Key, Scope.settings, None, LOCATION('usage_id'))
+user_state_key = partial(DjangoKeyValueStore.Key, Scope.user_state, 1, LOCATION('usage_id'))
 prefs_key = partial(DjangoKeyValueStore.Key, Scope.preferences, 1, 'mock_problem')
 user_info_key = partial(DjangoKeyValueStore.Key, Scope.user_info, 1, None)
 
 
 class StudentModuleFactory(cmfStudentModuleFactory):
-    module_state_key = location('usage_id')
-    course_id = course_id
+    module_state_key = LOCATION('usage_id')
+    course_id = COURSE_KEY
 
 
 class TestInvalidScopes(TestCase):  # lint-amnesty, pylint: disable=missing-class-docstring
     def setUp(self):
         super().setUp()
         self.user = UserFactory.create(username='user')
-        self.field_data_cache = FieldDataCache([mock_descriptor([mock_field(Scope.user_state, 'a_field')])], course_id, self.user)  # lint-amnesty, pylint: disable=line-too-long
+        self.field_data_cache = FieldDataCache(
+            [mock_descriptor([mock_field(Scope.user_state, 'a_field')])],
+            COURSE_KEY,
+            self.user,
+        )
         self.kvs = DjangoKeyValueStore(self.field_data_cache)
 
     def test_invalid_scopes(self):
@@ -102,7 +109,7 @@ class OtherUserFailureTestMixin:
 
 class TestStudentModuleStorage(OtherUserFailureTestMixin, TestCase):
     """Tests for user_state storage via StudentModule"""
-    other_key_factory = partial(DjangoKeyValueStore.Key, Scope.user_state, 2, location('usage_id'))  # user_id=2, not 1
+    other_key_factory = partial(DjangoKeyValueStore.Key, Scope.user_state, 2, LOCATION('usage_id'))  # user_id=2, not 1
     existing_field_name = "a_field"
     # Tell Django to clean out all databases, not just default
     databases = {alias for alias in connections}  # lint-amnesty, pylint: disable=unnecessary-comprehension
@@ -117,7 +124,9 @@ class TestStudentModuleStorage(OtherUserFailureTestMixin, TestCase):
         # There should be only one query to load a single descriptor with a single user_state field
         with self.assertNumQueries(1):
             self.field_data_cache = FieldDataCache(
-                [mock_descriptor([mock_field(Scope.user_state, 'a_field')])], course_id, self.user
+                [mock_descriptor([mock_field(Scope.user_state, 'a_field')])],
+                COURSE_KEY,
+                self.user,
             )
 
         self.kvs = DjangoKeyValueStore(self.field_data_cache)
@@ -244,7 +253,11 @@ class TestMissingStudentModule(TestCase):  # lint-amnesty, pylint: disable=missi
 
         # The descriptor has no fields, so FDC shouldn't send any queries
         with self.assertNumQueries(0):
-            self.field_data_cache = FieldDataCache([mock_descriptor()], course_id, self.user)
+            self.field_data_cache = FieldDataCache(
+                [mock_descriptor()],
+                COURSE_KEY,
+                self.user,
+            )
         self.kvs = DjangoKeyValueStore(self.field_data_cache)
 
     def test_get_field_from_missing_student_module(self):
@@ -273,8 +286,8 @@ class TestMissingStudentModule(TestCase):  # lint-amnesty, pylint: disable=missi
         student_module = StudentModule.objects.all()[0]
         assert {'a_field': 'a_value'} == json.loads(student_module.state)
         assert self.user == student_module.student
-        assert location('usage_id').replace(run=None) == student_module.module_state_key
-        assert course_id == student_module.course_id
+        assert LOCATION('usage_id').replace(run=None) == student_module.module_state_key
+        assert COURSE_KEY == student_module.course_id
 
     def test_delete_field_from_missing_student_module(self):
         "Test that deleting a field from a missing StudentModule raises a KeyError"
@@ -312,7 +325,11 @@ class StorageTestBase:
         # Each field is stored as a separate row in the table,
         # but we can query them in a single query
         with self.assertNumQueries(1):
-            self.field_data_cache = FieldDataCache([self.mock_descriptor], course_id, self.user)
+            self.field_data_cache = FieldDataCache(
+                [self.mock_descriptor],
+                COURSE_KEY,
+                self.user,
+            )
         self.kvs = DjangoKeyValueStore(self.field_data_cache)
 
     def test_set_and_get_existing_field(self):

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -43,6 +43,7 @@ from xblock.test.tools import TestRuntime  # lint-amnesty, pylint: disable=wrong
 from capa.tests.response_xml_factory import OptionResponseXMLFactory  # lint-amnesty, pylint: disable=reimported
 from common.djangoapps.course_modes.models import CourseMode  # lint-amnesty, pylint: disable=reimported
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
+from common.djangoapps.student.tests.factories import RequestFactoryNoCsrf
 from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.courseware import module_render as render
 from lms.djangoapps.courseware.access_response import AccessResponse
@@ -52,10 +53,7 @@ from lms.djangoapps.courseware.masquerade import CourseMasquerade
 from lms.djangoapps.courseware.model_data import FieldDataCache
 from lms.djangoapps.courseware.models import StudentModule
 from lms.djangoapps.courseware.module_render import get_module_for_descriptor, hash_resource
-from lms.djangoapps.courseware.tests.factories import (
-    RequestFactoryNoCsrf,
-    StudentModuleFactory,
-)
+from lms.djangoapps.courseware.tests.factories import StudentModuleFactory
 from lms.djangoapps.courseware.tests.test_submitting_problems import TestSubmittingProblems
 from lms.djangoapps.courseware.tests.tests import LoginEnrollmentTestCase
 from lms.djangoapps.lms_xblock.field_data import LmsFieldData

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -43,6 +43,7 @@ from xblock.test.tools import TestRuntime  # lint-amnesty, pylint: disable=wrong
 from capa.tests.response_xml_factory import OptionResponseXMLFactory  # lint-amnesty, pylint: disable=reimported
 from common.djangoapps.course_modes.models import CourseMode  # lint-amnesty, pylint: disable=reimported
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
+from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.courseware import module_render as render
 from lms.djangoapps.courseware.access_response import AccessResponse
 from lms.djangoapps.courseware.courses import get_course_info_section, get_course_with_access
@@ -54,7 +55,6 @@ from lms.djangoapps.courseware.module_render import get_module_for_descriptor, h
 from lms.djangoapps.courseware.tests.factories import (
     RequestFactoryNoCsrf,
     StudentModuleFactory,
-    UserFactory
 )
 from lms.djangoapps.courseware.tests.test_submitting_problems import TestSubmittingProblems
 from lms.djangoapps.courseware.tests.tests import LoginEnrollmentTestCase

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -42,6 +42,7 @@ from xblock.test.tools import TestRuntime  # lint-amnesty, pylint: disable=wrong
 
 from capa.tests.response_xml_factory import OptionResponseXMLFactory  # lint-amnesty, pylint: disable=reimported
 from common.djangoapps.course_modes.models import CourseMode  # lint-amnesty, pylint: disable=reimported
+from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from lms.djangoapps.courseware import module_render as render
 from lms.djangoapps.courseware.access_response import AccessResponse
 from lms.djangoapps.courseware.courses import get_course_info_section, get_course_with_access
@@ -51,7 +52,6 @@ from lms.djangoapps.courseware.model_data import FieldDataCache
 from lms.djangoapps.courseware.models import StudentModule
 from lms.djangoapps.courseware.module_render import get_module_for_descriptor, hash_resource
 from lms.djangoapps.courseware.tests.factories import (
-    GlobalStaffFactory,
     RequestFactoryNoCsrf,
     StudentModuleFactory,
     UserFactory

--- a/lms/djangoapps/courseware/tests/test_navigation.py
+++ b/lms/djangoapps/courseware/tests/test_navigation.py
@@ -11,7 +11,7 @@ from django.test.utils import override_settings
 from django.urls import reverse
 
 from edx_toggles.toggles.testutils import override_waffle_flag
-from lms.djangoapps.courseware.tests.factories import GlobalStaffFactory
+from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from openedx.features.course_experience import DISABLE_COURSE_OUTLINE_PAGE_FLAG
 from common.djangoapps.student.tests.factories import UserFactory

--- a/lms/djangoapps/courseware/tests/test_self_paced_overrides.py
+++ b/lms/djangoapps/courseware/tests/test_self_paced_overrides.py
@@ -6,8 +6,8 @@ from unittest.mock import patch
 import pytz
 from django.test.utils import override_settings
 
+from common.djangoapps.student.tests.factories import BetaTesterFactory
 from lms.djangoapps.courseware.access import has_access
-from lms.djangoapps.courseware.tests.factories import BetaTesterFactory
 from lms.djangoapps.ccx.tests.test_overrides import inject_field_overrides
 from lms.djangoapps.courseware.field_overrides import OverrideFieldData, OverrideModulestoreFieldData
 from lms.djangoapps.discussion.django_comment_client.utils import get_accessible_discussion_xblocks

--- a/lms/djangoapps/courseware/tests/test_services.py
+++ b/lms/djangoapps/courseware/tests/test_services.py
@@ -8,8 +8,9 @@ import json
 
 import ddt
 
+from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.courseware.services import UserStateService
-from lms.djangoapps.courseware.tests.factories import StudentModuleFactory, UserFactory
+from lms.djangoapps.courseware.tests.factories import StudentModuleFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 

--- a/lms/djangoapps/courseware/tests/test_tabs.py
+++ b/lms/djangoapps/courseware/tests/test_tabs.py
@@ -20,13 +20,14 @@ from lms.djangoapps.courseware.tabs import (
     ProgressTab,
     get_course_tab_list
 )
-from lms.djangoapps.courseware.tests.factories import InstructorFactory, StaffFactory
+from lms.djangoapps.courseware.tests.factories import InstructorFactory
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from lms.djangoapps.courseware.views.views import StaticCourseTabView, get_static_tab_fragment
 from openedx.core.djangolib.testing.utils import get_mock_request
 from openedx.core.lib.courses import get_course_by_id
 from openedx.features.course_experience import DISABLE_UNIFIED_COURSE_TAB_FLAG
 from common.djangoapps.student.models import CourseEnrollment
+from common.djangoapps.student.tests.factories import StaffFactory
 from common.djangoapps.student.tests.factories import UserFactory
 from common.djangoapps.util.milestones_helpers import (
     add_course_content_milestone,

--- a/lms/djangoapps/courseware/tests/test_tabs.py
+++ b/lms/djangoapps/courseware/tests/test_tabs.py
@@ -20,13 +20,13 @@ from lms.djangoapps.courseware.tabs import (
     ProgressTab,
     get_course_tab_list
 )
-from lms.djangoapps.courseware.tests.factories import InstructorFactory
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from lms.djangoapps.courseware.views.views import StaticCourseTabView, get_static_tab_fragment
 from openedx.core.djangolib.testing.utils import get_mock_request
 from openedx.core.lib.courses import get_course_by_id
 from openedx.features.course_experience import DISABLE_UNIFIED_COURSE_TAB_FLAG
 from common.djangoapps.student.models import CourseEnrollment
+from common.djangoapps.student.tests.factories import InstructorFactory
 from common.djangoapps.student.tests.factories import StaffFactory
 from common.djangoapps.student.tests.factories import UserFactory
 from common.djangoapps.util.milestones_helpers import (

--- a/lms/djangoapps/courseware/tests/test_user_state_client.py
+++ b/lms/djangoapps/courseware/tests/test_user_state_client.py
@@ -10,7 +10,7 @@ from django.db import connections
 
 from edx_user_state_client.tests import UserStateClientTestBase
 
-from lms.djangoapps.courseware.tests.factories import UserFactory
+from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.courseware.user_state_client import DjangoXBlockUserStateClient
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 

--- a/lms/djangoapps/courseware/tests/test_view_authentication.py
+++ b/lms/djangoapps/courseware/tests/test_view_authentication.py
@@ -12,11 +12,11 @@ from django.urls import reverse
 from common.djangoapps.student.tests.factories import BetaTesterFactory
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from common.djangoapps.student.tests.factories import InstructorFactory
+from common.djangoapps.student.tests.factories import OrgStaffFactory
 from common.djangoapps.student.tests.factories import StaffFactory
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.tests.factories import (
     OrgInstructorFactory,
-    OrgStaffFactory,
 )
 from lms.djangoapps.courseware.tests.helpers import CourseAccessTestMixin, LoginEnrollmentTestCase
 from openedx.features.enterprise_support.tests.mixins.enterprise import EnterpriseTestConsentRequired

--- a/lms/djangoapps/courseware/tests/test_view_authentication.py
+++ b/lms/djangoapps/courseware/tests/test_view_authentication.py
@@ -12,12 +12,10 @@ from django.urls import reverse
 from common.djangoapps.student.tests.factories import BetaTesterFactory
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from common.djangoapps.student.tests.factories import InstructorFactory
+from common.djangoapps.student.tests.factories import OrgInstructorFactory
 from common.djangoapps.student.tests.factories import OrgStaffFactory
 from common.djangoapps.student.tests.factories import StaffFactory
 from lms.djangoapps.courseware.access import has_access
-from lms.djangoapps.courseware.tests.factories import (
-    OrgInstructorFactory,
-)
 from lms.djangoapps.courseware.tests.helpers import CourseAccessTestMixin, LoginEnrollmentTestCase
 from openedx.features.enterprise_support.tests.mixins.enterprise import EnterpriseTestConsentRequired
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory

--- a/lms/djangoapps/courseware/tests/test_view_authentication.py
+++ b/lms/djangoapps/courseware/tests/test_view_authentication.py
@@ -10,13 +10,13 @@ import pytz
 from django.urls import reverse
 
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
+from common.djangoapps.student.tests.factories import StaffFactory
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.tests.factories import (
     BetaTesterFactory,
     InstructorFactory,
     OrgInstructorFactory,
     OrgStaffFactory,
-    StaffFactory
 )
 from lms.djangoapps.courseware.tests.helpers import CourseAccessTestMixin, LoginEnrollmentTestCase
 from openedx.features.enterprise_support.tests.mixins.enterprise import EnterpriseTestConsentRequired

--- a/lms/djangoapps/courseware/tests/test_view_authentication.py
+++ b/lms/djangoapps/courseware/tests/test_view_authentication.py
@@ -9,12 +9,12 @@ from unittest.mock import patch
 import pytz
 from django.urls import reverse
 
+from common.djangoapps.student.tests.factories import BetaTesterFactory
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from common.djangoapps.student.tests.factories import InstructorFactory
 from common.djangoapps.student.tests.factories import StaffFactory
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.tests.factories import (
-    BetaTesterFactory,
     OrgInstructorFactory,
     OrgStaffFactory,
 )

--- a/lms/djangoapps/courseware/tests/test_view_authentication.py
+++ b/lms/djangoapps/courseware/tests/test_view_authentication.py
@@ -10,11 +10,11 @@ import pytz
 from django.urls import reverse
 
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
+from common.djangoapps.student.tests.factories import InstructorFactory
 from common.djangoapps.student.tests.factories import StaffFactory
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.tests.factories import (
     BetaTesterFactory,
-    InstructorFactory,
     OrgInstructorFactory,
     OrgStaffFactory,
 )

--- a/lms/djangoapps/courseware/tests/test_view_authentication.py
+++ b/lms/djangoapps/courseware/tests/test_view_authentication.py
@@ -9,10 +9,10 @@ from unittest.mock import patch
 import pytz
 from django.urls import reverse
 
+from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.tests.factories import (
     BetaTesterFactory,
-    GlobalStaffFactory,
     InstructorFactory,
     OrgInstructorFactory,
     OrgStaffFactory,

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -35,6 +35,7 @@ from capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
 from freezegun import freeze_time  # lint-amnesty, pylint: disable=wrong-import-order
+from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from lms.djangoapps.certificates import api as certs_api
 from lms.djangoapps.certificates.models import (
     CertificateGenerationConfiguration,
@@ -47,7 +48,7 @@ from lms.djangoapps.commerce.utils import EcommerceService
 from lms.djangoapps.courseware.access_utils import check_course_open_for_learner
 from lms.djangoapps.courseware.model_data import FieldDataCache, set_score
 from lms.djangoapps.courseware.module_render import get_module, handle_xblock_callback
-from lms.djangoapps.courseware.tests.factories import GlobalStaffFactory, RequestFactoryNoCsrf, StudentModuleFactory
+from lms.djangoapps.courseware.tests.factories import RequestFactoryNoCsrf, StudentModuleFactory
 from lms.djangoapps.courseware.tests.helpers import get_expiration_banner_text
 from lms.djangoapps.courseware.testutils import RenderXBlockTestMixin
 from lms.djangoapps.courseware.toggles import (

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -36,6 +36,7 @@ from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
 from freezegun import freeze_time  # lint-amnesty, pylint: disable=wrong-import-order
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
+from common.djangoapps.student.tests.factories import RequestFactoryNoCsrf
 from lms.djangoapps.certificates import api as certs_api
 from lms.djangoapps.certificates.models import (
     CertificateGenerationConfiguration,
@@ -48,7 +49,7 @@ from lms.djangoapps.commerce.utils import EcommerceService
 from lms.djangoapps.courseware.access_utils import check_course_open_for_learner
 from lms.djangoapps.courseware.model_data import FieldDataCache, set_score
 from lms.djangoapps.courseware.module_render import get_module, handle_xblock_callback
-from lms.djangoapps.courseware.tests.factories import RequestFactoryNoCsrf, StudentModuleFactory
+from lms.djangoapps.courseware.tests.factories import StudentModuleFactory
 from lms.djangoapps.courseware.tests.helpers import get_expiration_banner_text
 from lms.djangoapps.courseware.testutils import RenderXBlockTestMixin
 from lms.djangoapps.courseware.toggles import (

--- a/lms/djangoapps/coursewarehistoryextended/tests.py
+++ b/lms/djangoapps/coursewarehistoryextended/tests.py
@@ -15,7 +15,9 @@ from django.db import connections
 from django.test import TestCase
 
 from lms.djangoapps.courseware.models import BaseStudentModuleHistory, StudentModule, StudentModuleHistory
-from lms.djangoapps.courseware.tests.factories import StudentModuleFactory, course_id, location
+from lms.djangoapps.courseware.tests.factories import COURSE_KEY
+from lms.djangoapps.courseware.tests.factories import LOCATION
+from lms.djangoapps.courseware.tests.factories import StudentModuleFactory
 
 
 @skipUnless(settings.FEATURES["ENABLE_CSMH_EXTENDED"], "CSMH Extended needs to be enabled")
@@ -28,9 +30,11 @@ class TestStudentModuleHistoryBackends(TestCase):
         super().setUp()
         for record in (1, 2, 3):
             # This will store into CSMHE via the post_save signal
-            csm = StudentModuleFactory.create(module_state_key=location('usage_id'),
-                                              course_id=course_id,
-                                              state=json.dumps({'type': 'csmhe', 'order': record}))
+            csm = StudentModuleFactory.create(
+                module_state_key=LOCATION('usage_id'),
+                course_id=COURSE_KEY,
+                state=json.dumps({'type': 'csmhe', 'order': record}),
+            )
             # This manually gets us a CSMH record to compare
             csmh = StudentModuleHistory(student_module=csm,
                                         version=None,

--- a/lms/djangoapps/discussion/django_comment_client/tests/test_utils.py
+++ b/lms/djangoapps/discussion/django_comment_client/tests/test_utils.py
@@ -19,8 +19,8 @@ from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
 from common.djangoapps.student.roles import CourseStaffRole
 from common.djangoapps.student.tests.factories import AdminFactory, CourseEnrollmentFactory, UserFactory
+from common.djangoapps.student.tests.factories import InstructorFactory
 from lms.djangoapps.courseware.tabs import get_course_tab_list
-from lms.djangoapps.courseware.tests.factories import InstructorFactory
 from lms.djangoapps.discussion.django_comment_client.constants import TYPE_ENTRY, TYPE_SUBCATEGORY
 from lms.djangoapps.discussion.django_comment_client.tests.factories import RoleFactory
 from lms.djangoapps.discussion.django_comment_client.tests.unicode import UnicodeTestMixin

--- a/lms/djangoapps/discussion/rest_api/tests/test_api.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api.py
@@ -17,11 +17,11 @@ from pytz import UTC
 from rest_framework.exceptions import PermissionDenied
 from six.moves.urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
+from common.djangoapps.student.tests.factories import BetaTesterFactory
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
 from common.djangoapps.student.tests.factories import StaffFactory
 from common.djangoapps.util.testing import UrlResetMixin
 from common.test.utils import MockSignalHandlerMixin, disable_signal
-from lms.djangoapps.courseware.tests.factories import BetaTesterFactory
 from lms.djangoapps.discussion.django_comment_client.tests.utils import ForumsEnableMixin
 from lms.djangoapps.discussion.rest_api import api
 from lms.djangoapps.discussion.rest_api.api import (

--- a/lms/djangoapps/discussion/rest_api/tests/test_api.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api.py
@@ -18,9 +18,10 @@ from rest_framework.exceptions import PermissionDenied
 from six.moves.urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
+from common.djangoapps.student.tests.factories import StaffFactory
 from common.djangoapps.util.testing import UrlResetMixin
 from common.test.utils import MockSignalHandlerMixin, disable_signal
-from lms.djangoapps.courseware.tests.factories import BetaTesterFactory, StaffFactory
+from lms.djangoapps.courseware.tests.factories import BetaTesterFactory
 from lms.djangoapps.discussion.django_comment_client.tests.utils import ForumsEnableMixin
 from lms.djangoapps.discussion.rest_api import api
 from lms.djangoapps.discussion.rest_api.api import (

--- a/lms/djangoapps/grades/rest_api/v1/tests/mixins.py
+++ b/lms/djangoapps/grades/rest_api/v1/tests/mixins.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from pytz import UTC
 
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
-from lms.djangoapps.courseware.tests.factories import GlobalStaffFactory
+from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from lms.djangoapps.program_enrollments.tests.factories import ProgramCourseEnrollmentFactory, ProgramEnrollmentFactory
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, SharedModuleStoreTestCase

--- a/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
@@ -28,9 +28,9 @@ from common.djangoapps.student.roles import (
     CourseStaffRole
 )
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
+from common.djangoapps.student.tests.factories import InstructorFactory
 from common.djangoapps.student.tests.factories import StaffFactory
 from lms.djangoapps.certificates.models import CertificateStatuses, GeneratedCertificate
-from lms.djangoapps.courseware.tests.factories import InstructorFactory
 from lms.djangoapps.grades.config.waffle import WRITABLE_GRADEBOOK, waffle_flags
 from lms.djangoapps.grades.constants import GradeOverrideFeatureEnum
 from lms.djangoapps.grades.course_data import CourseData

--- a/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
@@ -28,8 +28,9 @@ from common.djangoapps.student.roles import (
     CourseStaffRole
 )
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
+from common.djangoapps.student.tests.factories import StaffFactory
 from lms.djangoapps.certificates.models import CertificateStatuses, GeneratedCertificate
-from lms.djangoapps.courseware.tests.factories import InstructorFactory, StaffFactory
+from lms.djangoapps.courseware.tests.factories import InstructorFactory
 from lms.djangoapps.grades.config.waffle import WRITABLE_GRADEBOOK, waffle_flags
 from lms.djangoapps.grades.constants import GradeOverrideFeatureEnum
 from lms.djangoapps.grades.course_data import CourseData

--- a/lms/djangoapps/grades/rest_api/v1/tests/test_grading_policy_view.py
+++ b/lms/djangoapps/grades/rest_api/v1/tests/test_grading_policy_view.py
@@ -11,8 +11,8 @@ from pytz import UTC
 
 from capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
+from common.djangoapps.student.tests.factories import StaffFactory
 from common.djangoapps.student.tests.factories import UserFactory
-from lms.djangoapps.courseware.tests.factories import StaffFactory
 from openedx.core.djangoapps.oauth_dispatch.tests.factories import AccessTokenFactory, ApplicationFactory
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase

--- a/lms/djangoapps/grades/rest_api/v1/tests/test_grading_policy_view.py
+++ b/lms/djangoapps/grades/rest_api/v1/tests/test_grading_policy_view.py
@@ -10,8 +10,9 @@ from django.urls import reverse
 from pytz import UTC
 
 from capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
+from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from common.djangoapps.student.tests.factories import UserFactory
-from lms.djangoapps.courseware.tests.factories import GlobalStaffFactory, StaffFactory
+from lms.djangoapps.courseware.tests.factories import StaffFactory
 from openedx.core.djangoapps.oauth_dispatch.tests.factories import AccessTokenFactory, ApplicationFactory
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -54,6 +54,7 @@ from common.djangoapps.student.roles import (
 )
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
+from common.djangoapps.student.tests.factories import StaffFactory
 from lms.djangoapps.bulk_email.models import BulkEmailFlag, CourseEmail, CourseEmailTemplate
 from lms.djangoapps.certificates.api import generate_user_certificates
 from lms.djangoapps.certificates.models import CertificateStatuses
@@ -64,7 +65,6 @@ from lms.djangoapps.courseware.models import StudentModule
 from lms.djangoapps.courseware.tests.factories import (
     BetaTesterFactory,
     InstructorFactory,
-    StaffFactory,
 )
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from lms.djangoapps.instructor.tests.utils import FakeContentTask, FakeEmail, FakeEmailInfo

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -52,9 +52,10 @@ from common.djangoapps.student.roles import (
     CourseFinanceAdminRole,
     CourseInstructorRole,
 )
-from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
+from common.djangoapps.student.tests.factories import CourseEnrollmentFactory
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from common.djangoapps.student.tests.factories import StaffFactory
+from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.bulk_email.models import BulkEmailFlag, CourseEmail, CourseEmailTemplate
 from lms.djangoapps.certificates.api import generate_user_certificates
 from lms.djangoapps.certificates.models import CertificateStatuses

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -52,6 +52,7 @@ from common.djangoapps.student.roles import (
     CourseFinanceAdminRole,
     CourseInstructorRole,
 )
+from common.djangoapps.student.tests.factories import BetaTesterFactory
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from common.djangoapps.student.tests.factories import InstructorFactory
@@ -64,9 +65,6 @@ from lms.djangoapps.certificates.tests.factories import (
     GeneratedCertificateFactory
 )
 from lms.djangoapps.courseware.models import StudentModule
-from lms.djangoapps.courseware.tests.factories import (
-    BetaTesterFactory,
-)
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from lms.djangoapps.instructor.tests.utils import FakeContentTask, FakeEmail, FakeEmailInfo
 from lms.djangoapps.instructor.views.api import (

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -54,6 +54,7 @@ from common.djangoapps.student.roles import (
 )
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
+from common.djangoapps.student.tests.factories import InstructorFactory
 from common.djangoapps.student.tests.factories import StaffFactory
 from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.bulk_email.models import BulkEmailFlag, CourseEmail, CourseEmailTemplate
@@ -65,7 +66,6 @@ from lms.djangoapps.certificates.tests.factories import (
 from lms.djangoapps.courseware.models import StudentModule
 from lms.djangoapps.courseware.tests.factories import (
     BetaTesterFactory,
-    InstructorFactory,
 )
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from lms.djangoapps.instructor.tests.utils import FakeContentTask, FakeEmail, FakeEmailInfo

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -52,7 +52,8 @@ from common.djangoapps.student.roles import (
     CourseFinanceAdminRole,
     CourseInstructorRole,
 )
-from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory  # lint-amnesty, pylint: disable=unused-import
+from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
+from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from lms.djangoapps.bulk_email.models import BulkEmailFlag, CourseEmail, CourseEmailTemplate
 from lms.djangoapps.certificates.api import generate_user_certificates
 from lms.djangoapps.certificates.models import CertificateStatuses
@@ -62,7 +63,6 @@ from lms.djangoapps.certificates.tests.factories import (
 from lms.djangoapps.courseware.models import StudentModule
 from lms.djangoapps.courseware.tests.factories import (
     BetaTesterFactory,
-    GlobalStaffFactory,
     InstructorFactory,
     StaffFactory,
 )

--- a/lms/djangoapps/instructor/tests/test_api_email_localization.py
+++ b/lms/djangoapps/instructor/tests/test_api_email_localization.py
@@ -8,8 +8,8 @@ from django.test.utils import override_settings
 from django.urls import reverse
 
 from common.djangoapps.student.models import CourseEnrollment
+from common.djangoapps.student.tests.factories import InstructorFactory
 from common.djangoapps.student.tests.factories import UserFactory
-from lms.djangoapps.courseware.tests.factories import InstructorFactory
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
 from openedx.core.djangoapps.user_api.preferences.api import delete_user_preference, set_user_preference
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase

--- a/lms/djangoapps/instructor/tests/test_certificates.py
+++ b/lms/djangoapps/instructor/tests/test_certificates.py
@@ -21,6 +21,7 @@ from capa.xqueue_interface import XQueueInterface
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
+from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.certificates import api as certs_api
 from lms.djangoapps.certificates.models import (
     CertificateGenerationConfiguration,
@@ -34,7 +35,7 @@ from lms.djangoapps.certificates.tests.factories import (
     CertificateWhitelistFactory,
     GeneratedCertificateFactory
 )
-from lms.djangoapps.courseware.tests.factories import InstructorFactory, UserFactory
+from lms.djangoapps.courseware.tests.factories import InstructorFactory
 from lms.djangoapps.grades.tests.utils import mock_passing_grade
 from lms.djangoapps.verify_student.services import IDVerificationService
 from lms.djangoapps.verify_student.tests.factories import SoftwareSecurePhotoVerificationFactory

--- a/lms/djangoapps/instructor/tests/test_certificates.py
+++ b/lms/djangoapps/instructor/tests/test_certificates.py
@@ -20,6 +20,7 @@ from django.urls import reverse
 from capa.xqueue_interface import XQueueInterface
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.models import CourseEnrollment
+from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from lms.djangoapps.certificates import api as certs_api
 from lms.djangoapps.certificates.models import (
     CertificateGenerationConfiguration,
@@ -33,7 +34,7 @@ from lms.djangoapps.certificates.tests.factories import (
     CertificateWhitelistFactory,
     GeneratedCertificateFactory
 )
-from lms.djangoapps.courseware.tests.factories import GlobalStaffFactory, InstructorFactory, UserFactory
+from lms.djangoapps.courseware.tests.factories import InstructorFactory, UserFactory
 from lms.djangoapps.grades.tests.utils import mock_passing_grade
 from lms.djangoapps.verify_student.services import IDVerificationService
 from lms.djangoapps.verify_student.tests.factories import SoftwareSecurePhotoVerificationFactory

--- a/lms/djangoapps/instructor/tests/test_certificates.py
+++ b/lms/djangoapps/instructor/tests/test_certificates.py
@@ -21,6 +21,7 @@ from capa.xqueue_interface import XQueueInterface
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
+from common.djangoapps.student.tests.factories import InstructorFactory
 from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.certificates import api as certs_api
 from lms.djangoapps.certificates.models import (
@@ -35,7 +36,6 @@ from lms.djangoapps.certificates.tests.factories import (
     CertificateWhitelistFactory,
     GeneratedCertificateFactory
 )
-from lms.djangoapps.courseware.tests.factories import InstructorFactory
 from lms.djangoapps.grades.tests.utils import mock_passing_grade
 from lms.djangoapps.verify_student.services import IDVerificationService
 from lms.djangoapps.verify_student.tests.factories import SoftwareSecurePhotoVerificationFactory

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -21,9 +21,10 @@ from common.djangoapps.edxmako.shortcuts import render_to_response
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.roles import CourseFinanceAdminRole  # lint-amnesty, pylint: disable=unused-import
 from common.djangoapps.student.tests.factories import AdminFactory, CourseAccessRoleFactory, CourseEnrollmentFactory
+from common.djangoapps.student.tests.factories import StaffFactory
 from common.test.utils import XssTestMixin
 from lms.djangoapps.courseware.tabs import get_course_tab_list
-from lms.djangoapps.courseware.tests.factories import StaffFactory, StudentModuleFactory, UserFactory
+from lms.djangoapps.courseware.tests.factories import StudentModuleFactory, UserFactory
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from lms.djangoapps.grades.config.waffle import WRITABLE_GRADEBOOK, waffle_flags
 from lms.djangoapps.instructor.toggles import DATA_DOWNLOAD_V2

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -22,9 +22,10 @@ from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.roles import CourseFinanceAdminRole  # lint-amnesty, pylint: disable=unused-import
 from common.djangoapps.student.tests.factories import AdminFactory, CourseAccessRoleFactory, CourseEnrollmentFactory
 from common.djangoapps.student.tests.factories import StaffFactory
+from common.djangoapps.student.tests.factories import UserFactory
 from common.test.utils import XssTestMixin
 from lms.djangoapps.courseware.tabs import get_course_tab_list
-from lms.djangoapps.courseware.tests.factories import StudentModuleFactory, UserFactory
+from lms.djangoapps.courseware.tests.factories import StudentModuleFactory
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from lms.djangoapps.grades.config.waffle import WRITABLE_GRADEBOOK, waffle_flags
 from lms.djangoapps.instructor.toggles import DATA_DOWNLOAD_V2

--- a/lms/djangoapps/instructor_analytics/tests/test_basic.py
+++ b/lms/djangoapps/instructor_analytics/tests/test_basic.py
@@ -12,7 +12,6 @@ from edx_proctoring.api import create_exam
 from edx_proctoring.models import ProctoredExamStudentAttempt
 from opaque_keys.edx.locator import UsageKey
 from six.moves import range, zip
-from lms.djangoapps.courseware.tests.factories import InstructorFactory
 from lms.djangoapps.instructor_analytics.basic import (  # lint-amnesty, pylint: disable=unused-import
     AVAILABLE_FEATURES,
     PROFILE_FEATURES,
@@ -28,6 +27,7 @@ from lms.djangoapps.instructor_analytics.basic import (  # lint-amnesty, pylint:
 from lms.djangoapps.program_enrollments.tests.factories import ProgramEnrollmentFactory
 from openedx.core.djangoapps.course_groups.tests.helpers import CohortFactory
 from common.djangoapps.student.models import CourseEnrollment, CourseEnrollmentAllowed
+from common.djangoapps.student.tests.factories import InstructorFactory
 from common.djangoapps.student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory

--- a/lms/djangoapps/instructor_task/tests/test_api.py
+++ b/lms/djangoapps/instructor_task/tests/test_api.py
@@ -8,10 +8,10 @@ import pytest
 import ddt
 from celery.states import FAILURE
 
+from common.djangoapps.student.tests.factories import UserFactory
 from common.test.utils import normalize_repr
 from lms.djangoapps.bulk_email.models import SEND_TO_LEARNERS, SEND_TO_MYSELF, SEND_TO_STAFF, CourseEmail
 from lms.djangoapps.certificates.models import CertificateGenerationHistory, CertificateStatuses
-from lms.djangoapps.courseware.tests.factories import UserFactory
 from lms.djangoapps.instructor_task.api import (
     SpecificStudentIdMissingError,
     generate_certificates_for_students,

--- a/lms/djangoapps/mobile_api/testutils.py
+++ b/lms/djangoapps/mobile_api/testutils.py
@@ -25,8 +25,8 @@ from rest_framework.test import APITestCase
 
 from common.djangoapps.student import auth
 from common.djangoapps.student.models import CourseEnrollment
+from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.courseware.access_response import MobileAvailabilityError, StartDateError, VisibilityError
-from lms.djangoapps.courseware.tests.factories import UserFactory
 from lms.djangoapps.mobile_api.models import IgnoreMobileAvailableFlagConfig
 from lms.djangoapps.mobile_api.tests.test_milestones import MobileAPIMilestonesMixin
 from lms.djangoapps.mobile_api.utils import API_V1

--- a/lms/djangoapps/program_enrollments/rest_api/v1/tests/test_views.py
+++ b/lms/djangoapps/program_enrollments/rest_api/v1/tests/test_views.py
@@ -27,11 +27,11 @@ from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.roles import CourseStaffRole
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
+from common.djangoapps.student.tests.factories import InstructorFactory
 from common.djangoapps.third_party_auth.tests.factories import SAMLProviderConfigFactory
 from lms.djangoapps.bulk_email.models import BulkEmailFlag, Optout
 from lms.djangoapps.certificates.models import CertificateStatuses
 from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
-from lms.djangoapps.courseware.tests.factories import InstructorFactory
 from lms.djangoapps.grades.api import CourseGradeFactory
 from lms.djangoapps.program_enrollments.constants import ProgramCourseOperationStatuses as CourseStatuses
 from lms.djangoapps.program_enrollments.constants import ProgramOperationStatuses as ProgramStatuses

--- a/lms/djangoapps/program_enrollments/rest_api/v1/tests/test_views.py
+++ b/lms/djangoapps/program_enrollments/rest_api/v1/tests/test_views.py
@@ -26,11 +26,12 @@ from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.roles import CourseStaffRole
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
+from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from common.djangoapps.third_party_auth.tests.factories import SAMLProviderConfigFactory
 from lms.djangoapps.bulk_email.models import BulkEmailFlag, Optout
 from lms.djangoapps.certificates.models import CertificateStatuses
 from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
-from lms.djangoapps.courseware.tests.factories import GlobalStaffFactory, InstructorFactory
+from lms.djangoapps.courseware.tests.factories import InstructorFactory
 from lms.djangoapps.grades.api import CourseGradeFactory
 from lms.djangoapps.program_enrollments.constants import ProgramCourseOperationStatuses as CourseStatuses
 from lms.djangoapps.program_enrollments.constants import ProgramOperationStatuses as ProgramStatuses

--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -24,9 +24,9 @@ from search.search_engine_base import SearchEngine
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import AdminFactory, CourseEnrollmentFactory, UserFactory
+from common.djangoapps.student.tests.factories import StaffFactory
 from common.djangoapps.util.testing import EventTestMixin
 from common.test.utils import skip_signal
-from lms.djangoapps.courseware.tests.factories import StaffFactory
 from lms.djangoapps.program_enrollments.tests.factories import ProgramEnrollmentFactory
 from openedx.core.djangoapps.django_comment_common.models import FORUM_ROLE_COMMUNITY_TA, Role
 from openedx.core.djangoapps.django_comment_common.utils import seed_permissions_roles

--- a/lms/djangoapps/verify_student/management/commands/tests/test_verify_student.py
+++ b/lms/djangoapps/verify_student/management/commands/tests/test_verify_student.py
@@ -10,8 +10,6 @@ from django.conf import settings
 from django.core.management import call_command
 from testfixtures import LogCapture
 
-from common.djangoapps.student.tests.factories import \
-    UserFactory  # lint-amnesty, pylint: disable=import-error, unused-import, useless-suppression
 from common.test.utils import MockS3BotoMixin
 from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification, SSPVerificationRetryConfig
 from lms.djangoapps.verify_student.tests import TestVerificationBase

--- a/lms/lib/courseware_search/test/test_lms_result_processor.py
+++ b/lms/lib/courseware_search/test/test_lms_result_processor.py
@@ -3,7 +3,7 @@ Tests for the lms_result_processor
 """
 import pytest
 
-from lms.djangoapps.courseware.tests.factories import UserFactory
+from common.djangoapps.student.tests.factories import UserFactory
 from lms.lib.courseware_search.lms_result_processor import LmsSearchResultProcessor
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory

--- a/openedx/core/djangoapps/content/learning_sequences/api/tests/test_outlines.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/tests/test_outlines.py
@@ -16,11 +16,11 @@ from mock import patch
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import LibraryLocator
 from edx_toggles.toggles.testutils import override_waffle_flag
-from lms.djangoapps.courseware.tests.factories import BetaTesterFactory
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
 from openedx.features.course_experience import COURSE_ENABLE_UNENROLLED_ACCESS_FLAG
 from common.djangoapps.student.auth import user_has_role
 from common.djangoapps.student.roles import CourseBetaTesterRole
+from common.djangoapps.student.tests.factories import BetaTesterFactory
 
 from ...data import (
     ContentErrorData,

--- a/openedx/core/djangoapps/course_groups/tests/test_views.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_views.py
@@ -15,8 +15,8 @@ from opaque_keys.edx.locator import CourseLocator
 
 from openedx.core.djangoapps.django_comment_common.models import CourseDiscussionSettings
 from openedx.core.djangoapps.django_comment_common.utils import get_course_discussion_settings
-from lms.djangoapps.courseware.tests.factories import InstructorFactory
 from common.djangoapps.student.models import CourseEnrollment
+from common.djangoapps.student.tests.factories import InstructorFactory
 from common.djangoapps.student.tests.factories import StaffFactory
 from common.djangoapps.student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase

--- a/openedx/core/djangoapps/course_groups/tests/test_views.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_views.py
@@ -15,8 +15,9 @@ from opaque_keys.edx.locator import CourseLocator
 
 from openedx.core.djangoapps.django_comment_common.models import CourseDiscussionSettings
 from openedx.core.djangoapps.django_comment_common.utils import get_course_discussion_settings
-from lms.djangoapps.courseware.tests.factories import InstructorFactory, StaffFactory
+from lms.djangoapps.courseware.tests.factories import InstructorFactory
 from common.djangoapps.student.models import CourseEnrollment
+from common.djangoapps.student.tests.factories import StaffFactory
 from common.djangoapps.student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory

--- a/openedx/core/djangoapps/discussions/tests/test_views.py
+++ b/openedx/core/djangoapps/discussions/tests/test_views.py
@@ -10,8 +10,8 @@ from opaque_keys.edx.keys import CourseKey
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from common.djangoapps.student.tests.factories import UserFactory
-from lms.djangoapps.courseware.tests.factories import GlobalStaffFactory
 from lms.djangoapps.courseware.tests.factories import StaffFactory
 
 

--- a/openedx/core/djangoapps/discussions/tests/test_views.py
+++ b/openedx/core/djangoapps/discussions/tests/test_views.py
@@ -11,8 +11,8 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
+from common.djangoapps.student.tests.factories import StaffFactory
 from common.djangoapps.student.tests.factories import UserFactory
-from lms.djangoapps.courseware.tests.factories import StaffFactory
 
 
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'URLs are only configured in LMS')

--- a/openedx/core/djangoapps/theming/tests/test_views.py
+++ b/openedx/core/djangoapps/theming/tests/test_views.py
@@ -8,7 +8,7 @@ from django.contrib.messages.middleware import MessageMiddleware
 from django.contrib.sites.models import Site
 from django.test import TestCase
 
-from lms.djangoapps.courseware.tests.factories import GlobalStaffFactory
+from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from openedx.core.djangoapps.theming.middleware import CurrentSiteThemeMiddleware
 from common.djangoapps.student.tests.factories import UserFactory
 

--- a/openedx/features/content_type_gating/tests/test_access.py
+++ b/openedx/features/content_type_gating/tests/test_access.py
@@ -19,12 +19,10 @@ from common.djangoapps.course_modes.tests.factories import CourseModeFactory
 from common.djangoapps.student.tests.factories import BetaTesterFactory
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from common.djangoapps.student.tests.factories import InstructorFactory
+from common.djangoapps.student.tests.factories import OrgInstructorFactory
 from common.djangoapps.student.tests.factories import OrgStaffFactory
 from common.djangoapps.student.tests.factories import StaffFactory
 from lms.djangoapps.courseware.module_render import load_single_xblock
-from lms.djangoapps.courseware.tests.factories import (
-    OrgInstructorFactory,
-)
 from lms.djangoapps.courseware.tests.helpers import MasqueradeMixin
 from lms.djangoapps.discussion.django_comment_client.tests.factories import RoleFactory
 from openedx.core.djangoapps.django_comment_common.models import (

--- a/openedx/features/content_type_gating/tests/test_access.py
+++ b/openedx/features/content_type_gating/tests/test_access.py
@@ -19,11 +19,11 @@ from common.djangoapps.course_modes.tests.factories import CourseModeFactory
 from common.djangoapps.student.tests.factories import BetaTesterFactory
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from common.djangoapps.student.tests.factories import InstructorFactory
+from common.djangoapps.student.tests.factories import OrgStaffFactory
 from common.djangoapps.student.tests.factories import StaffFactory
 from lms.djangoapps.courseware.module_render import load_single_xblock
 from lms.djangoapps.courseware.tests.factories import (
     OrgInstructorFactory,
-    OrgStaffFactory,
 )
 from lms.djangoapps.courseware.tests.helpers import MasqueradeMixin
 from lms.djangoapps.discussion.django_comment_client.tests.factories import RoleFactory

--- a/openedx/features/content_type_gating/tests/test_access.py
+++ b/openedx/features/content_type_gating/tests/test_access.py
@@ -16,12 +16,12 @@ from pyquery import PyQuery as pq
 
 from lms.djangoapps.course_api.blocks.api import get_blocks
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
+from common.djangoapps.student.tests.factories import BetaTesterFactory
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from common.djangoapps.student.tests.factories import InstructorFactory
 from common.djangoapps.student.tests.factories import StaffFactory
 from lms.djangoapps.courseware.module_render import load_single_xblock
 from lms.djangoapps.courseware.tests.factories import (
-    BetaTesterFactory,
     OrgInstructorFactory,
     OrgStaffFactory,
 )

--- a/openedx/features/content_type_gating/tests/test_access.py
+++ b/openedx/features/content_type_gating/tests/test_access.py
@@ -17,11 +17,11 @@ from pyquery import PyQuery as pq
 from lms.djangoapps.course_api.blocks.api import get_blocks
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
+from common.djangoapps.student.tests.factories import InstructorFactory
 from common.djangoapps.student.tests.factories import StaffFactory
 from lms.djangoapps.courseware.module_render import load_single_xblock
 from lms.djangoapps.courseware.tests.factories import (
     BetaTesterFactory,
-    InstructorFactory,
     OrgInstructorFactory,
     OrgStaffFactory,
 )

--- a/openedx/features/content_type_gating/tests/test_access.py
+++ b/openedx/features/content_type_gating/tests/test_access.py
@@ -16,10 +16,10 @@ from pyquery import PyQuery as pq
 
 from lms.djangoapps.course_api.blocks.api import get_blocks
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
+from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from lms.djangoapps.courseware.module_render import load_single_xblock
 from lms.djangoapps.courseware.tests.factories import (
     BetaTesterFactory,
-    GlobalStaffFactory,
     InstructorFactory,
     OrgInstructorFactory,
     OrgStaffFactory,

--- a/openedx/features/content_type_gating/tests/test_access.py
+++ b/openedx/features/content_type_gating/tests/test_access.py
@@ -17,13 +17,13 @@ from pyquery import PyQuery as pq
 from lms.djangoapps.course_api.blocks.api import get_blocks
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
+from common.djangoapps.student.tests.factories import StaffFactory
 from lms.djangoapps.courseware.module_render import load_single_xblock
 from lms.djangoapps.courseware.tests.factories import (
     BetaTesterFactory,
     InstructorFactory,
     OrgInstructorFactory,
     OrgStaffFactory,
-    StaffFactory
 )
 from lms.djangoapps.courseware.tests.helpers import MasqueradeMixin
 from lms.djangoapps.discussion.django_comment_client.tests.factories import RoleFactory

--- a/openedx/features/content_type_gating/tests/test_partitions.py
+++ b/openedx/features/content_type_gating/tests/test_partitions.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 from opaque_keys.edx.keys import CourseKey
 
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
-from lms.djangoapps.courseware.tests.factories import GlobalStaffFactory
+from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
 from openedx.features.content_type_gating.helpers import CONTENT_GATING_PARTITION_ID, FULL_ACCESS, LIMITED_ACCESS
 from openedx.features.content_type_gating.models import ContentTypeGatingConfig

--- a/openedx/features/course_duration_limits/tests/test_course_expiration.py
+++ b/openedx/features/course_duration_limits/tests/test_course_expiration.py
@@ -17,11 +17,9 @@ from common.djangoapps.student.tests.factories import BetaTesterFactory
 from common.djangoapps.student.tests.factories import TEST_PASSWORD, CourseEnrollmentFactory, UserFactory
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from common.djangoapps.student.tests.factories import InstructorFactory
+from common.djangoapps.student.tests.factories import OrgInstructorFactory
 from common.djangoapps.student.tests.factories import OrgStaffFactory
 from common.djangoapps.student.tests.factories import StaffFactory
-from lms.djangoapps.courseware.tests.factories import (
-    OrgInstructorFactory,
-)
 from lms.djangoapps.courseware.tests.helpers import MasqueradeMixin
 from lms.djangoapps.discussion.django_comment_client.tests.factories import RoleFactory
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview

--- a/openedx/features/course_duration_limits/tests/test_course_expiration.py
+++ b/openedx/features/course_duration_limits/tests/test_course_expiration.py
@@ -13,12 +13,12 @@ from django.utils.timezone import now
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.models import CourseEnrollment, FBEEnrollmentExclusion
 from common.djangoapps.student.roles import CourseInstructorRole
+from common.djangoapps.student.tests.factories import BetaTesterFactory
 from common.djangoapps.student.tests.factories import TEST_PASSWORD, CourseEnrollmentFactory, UserFactory
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from common.djangoapps.student.tests.factories import InstructorFactory
 from common.djangoapps.student.tests.factories import StaffFactory
 from lms.djangoapps.courseware.tests.factories import (
-    BetaTesterFactory,
     OrgInstructorFactory,
     OrgStaffFactory,
 )

--- a/openedx/features/course_duration_limits/tests/test_course_expiration.py
+++ b/openedx/features/course_duration_limits/tests/test_course_expiration.py
@@ -17,10 +17,10 @@ from common.djangoapps.student.tests.factories import BetaTesterFactory
 from common.djangoapps.student.tests.factories import TEST_PASSWORD, CourseEnrollmentFactory, UserFactory
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from common.djangoapps.student.tests.factories import InstructorFactory
+from common.djangoapps.student.tests.factories import OrgStaffFactory
 from common.djangoapps.student.tests.factories import StaffFactory
 from lms.djangoapps.courseware.tests.factories import (
     OrgInstructorFactory,
-    OrgStaffFactory,
 )
 from lms.djangoapps.courseware.tests.helpers import MasqueradeMixin
 from lms.djangoapps.discussion.django_comment_client.tests.factories import RoleFactory

--- a/openedx/features/course_duration_limits/tests/test_course_expiration.py
+++ b/openedx/features/course_duration_limits/tests/test_course_expiration.py
@@ -15,10 +15,10 @@ from common.djangoapps.student.models import CourseEnrollment, FBEEnrollmentExcl
 from common.djangoapps.student.roles import CourseInstructorRole
 from common.djangoapps.student.tests.factories import TEST_PASSWORD, CourseEnrollmentFactory, UserFactory
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
+from common.djangoapps.student.tests.factories import InstructorFactory
 from common.djangoapps.student.tests.factories import StaffFactory
 from lms.djangoapps.courseware.tests.factories import (
     BetaTesterFactory,
-    InstructorFactory,
     OrgInstructorFactory,
     OrgStaffFactory,
 )

--- a/openedx/features/course_duration_limits/tests/test_course_expiration.py
+++ b/openedx/features/course_duration_limits/tests/test_course_expiration.py
@@ -14,9 +14,9 @@ from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.models import CourseEnrollment, FBEEnrollmentExclusion
 from common.djangoapps.student.roles import CourseInstructorRole
 from common.djangoapps.student.tests.factories import TEST_PASSWORD, CourseEnrollmentFactory, UserFactory
+from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from lms.djangoapps.courseware.tests.factories import (
     BetaTesterFactory,
-    GlobalStaffFactory,
     InstructorFactory,
     OrgInstructorFactory,
     OrgStaffFactory,

--- a/openedx/features/course_duration_limits/tests/test_course_expiration.py
+++ b/openedx/features/course_duration_limits/tests/test_course_expiration.py
@@ -15,12 +15,12 @@ from common.djangoapps.student.models import CourseEnrollment, FBEEnrollmentExcl
 from common.djangoapps.student.roles import CourseInstructorRole
 from common.djangoapps.student.tests.factories import TEST_PASSWORD, CourseEnrollmentFactory, UserFactory
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
+from common.djangoapps.student.tests.factories import StaffFactory
 from lms.djangoapps.courseware.tests.factories import (
     BetaTesterFactory,
     InstructorFactory,
     OrgInstructorFactory,
     OrgStaffFactory,
-    StaffFactory
 )
 from lms.djangoapps.courseware.tests.helpers import MasqueradeMixin
 from lms.djangoapps.discussion.django_comment_client.tests.factories import RoleFactory

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -22,6 +22,7 @@ from waffle.testutils import override_flag
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
+from common.djangoapps.student.tests.factories import StaffFactory
 from common.djangoapps.util.date_utils import strftime_localized_html
 from lms.djangoapps.experiments.models import ExperimentData
 from lms.djangoapps.commerce.models import CommerceConfiguration
@@ -32,7 +33,6 @@ from lms.djangoapps.courseware.tests.factories import (
     InstructorFactory,
     OrgInstructorFactory,
     OrgStaffFactory,
-    StaffFactory
 )
 from lms.djangoapps.courseware.tests.helpers import get_expiration_banner_text
 from lms.djangoapps.courseware.utils import verified_upgrade_deadline_link

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -21,6 +21,7 @@ from waffle.testutils import override_flag
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
+from common.djangoapps.student.tests.factories import BetaTesterFactory
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from common.djangoapps.student.tests.factories import InstructorFactory
 from common.djangoapps.student.tests.factories import StaffFactory
@@ -30,7 +31,6 @@ from lms.djangoapps.commerce.models import CommerceConfiguration
 from lms.djangoapps.commerce.utils import EcommerceService
 from lms.djangoapps.course_goals.api import add_course_goal, remove_course_goal
 from lms.djangoapps.courseware.tests.factories import (
-    BetaTesterFactory,
     OrgInstructorFactory,
     OrgStaffFactory,
 )

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -24,6 +24,7 @@ from common.djangoapps.course_modes.tests.factories import CourseModeFactory
 from common.djangoapps.student.tests.factories import BetaTesterFactory
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from common.djangoapps.student.tests.factories import InstructorFactory
+from common.djangoapps.student.tests.factories import OrgInstructorFactory
 from common.djangoapps.student.tests.factories import OrgStaffFactory
 from common.djangoapps.student.tests.factories import StaffFactory
 from common.djangoapps.util.date_utils import strftime_localized_html
@@ -31,9 +32,6 @@ from lms.djangoapps.experiments.models import ExperimentData
 from lms.djangoapps.commerce.models import CommerceConfiguration
 from lms.djangoapps.commerce.utils import EcommerceService
 from lms.djangoapps.course_goals.api import add_course_goal, remove_course_goal
-from lms.djangoapps.courseware.tests.factories import (
-    OrgInstructorFactory,
-)
 from lms.djangoapps.courseware.tests.helpers import get_expiration_banner_text
 from lms.djangoapps.courseware.utils import verified_upgrade_deadline_link
 from lms.djangoapps.discussion.django_comment_client.tests.factories import RoleFactory

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -21,6 +21,7 @@ from waffle.testutils import override_flag
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
+from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from common.djangoapps.util.date_utils import strftime_localized_html
 from lms.djangoapps.experiments.models import ExperimentData
 from lms.djangoapps.commerce.models import CommerceConfiguration
@@ -28,7 +29,6 @@ from lms.djangoapps.commerce.utils import EcommerceService
 from lms.djangoapps.course_goals.api import add_course_goal, remove_course_goal
 from lms.djangoapps.courseware.tests.factories import (
     BetaTesterFactory,
-    GlobalStaffFactory,
     InstructorFactory,
     OrgInstructorFactory,
     OrgStaffFactory,

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -22,6 +22,7 @@ from waffle.testutils import override_flag
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
+from common.djangoapps.student.tests.factories import InstructorFactory
 from common.djangoapps.student.tests.factories import StaffFactory
 from common.djangoapps.util.date_utils import strftime_localized_html
 from lms.djangoapps.experiments.models import ExperimentData
@@ -30,7 +31,6 @@ from lms.djangoapps.commerce.utils import EcommerceService
 from lms.djangoapps.course_goals.api import add_course_goal, remove_course_goal
 from lms.djangoapps.courseware.tests.factories import (
     BetaTesterFactory,
-    InstructorFactory,
     OrgInstructorFactory,
     OrgStaffFactory,
 )

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -24,6 +24,7 @@ from common.djangoapps.course_modes.tests.factories import CourseModeFactory
 from common.djangoapps.student.tests.factories import BetaTesterFactory
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from common.djangoapps.student.tests.factories import InstructorFactory
+from common.djangoapps.student.tests.factories import OrgStaffFactory
 from common.djangoapps.student.tests.factories import StaffFactory
 from common.djangoapps.util.date_utils import strftime_localized_html
 from lms.djangoapps.experiments.models import ExperimentData
@@ -32,7 +33,6 @@ from lms.djangoapps.commerce.utils import EcommerceService
 from lms.djangoapps.course_goals.api import add_course_goal, remove_course_goal
 from lms.djangoapps.courseware.tests.factories import (
     OrgInstructorFactory,
-    OrgStaffFactory,
 )
 from lms.djangoapps.courseware.tests.helpers import get_expiration_banner_text
 from lms.djangoapps.courseware.utils import verified_upgrade_deadline_link

--- a/openedx/features/course_experience/tests/views/test_course_outline.py
+++ b/openedx/features/course_experience/tests/views/test_course_outline.py
@@ -26,9 +26,9 @@ from waffle.models import Switch
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
+from common.djangoapps.student.tests.factories import StaffFactory
 from lms.djangoapps.course_api.blocks.transformers.milestones import MilestonesAndSpecialExamsTransformer
 from lms.djangoapps.gating import api as lms_gating_api
-from lms.djangoapps.courseware.tests.factories import StaffFactory
 from lms.djangoapps.courseware.tests.helpers import MasqueradeMixin
 from lms.urls import RESET_COURSE_DEADLINES_NAME
 from openedx.core.djangoapps.course_date_signals.models import SelfPacedRelativeDatesConfig

--- a/openedx/tests/xblock_integration/test_crowdsource_hinter.py
+++ b/openedx/tests/xblock_integration/test_crowdsource_hinter.py
@@ -9,7 +9,7 @@ import simplejson as json
 from django.conf import settings
 from django.urls import reverse
 
-from lms.djangoapps.courseware.tests.factories import GlobalStaffFactory
+from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from openedx.core.lib.url_utils import quote_slashes
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase

--- a/openedx/tests/xblock_integration/test_recommender.py
+++ b/openedx/tests/xblock_integration/test_recommender.py
@@ -15,7 +15,7 @@ from ddt import data, ddt
 from django.conf import settings
 from django.urls import reverse
 
-from lms.djangoapps.courseware.tests.factories import GlobalStaffFactory
+from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from openedx.core.lib.url_utils import quote_slashes
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase


### PR DESCRIPTION
for shared use (already in practice) across:
- cms
- common
- lms
- openedx

This pull request removes all direct dependencies on LMS from the following files:
- cms/djangoapps/contentstore/api/tests/base.py
- cms/djangoapps/contentstore/api/tests/test_import.py
- cms/djangoapps/contentstore/api/tests/test_validation.py
- cms/djangoapps/contentstore/rest_api/v1/tests/test_views.py
- cms/djangoapps/contentstore/tests/test_users_default_role.py
- common/djangoapps/student/tests/test_roles.py
- common/djangoapps/student/tests/test_tasks.py
- lms/djangoapps/course_blocks/transformers/tests/test_start_date.py
- lms/djangoapps/grades/rest_api/v1/tests/test_grading_policy_view.py
- lms/djangoapps/instructor/tests/test_api_email_localization.py
- openedx/core/djangoapps/content/learning_sequences/api/tests/test_outlines.py
- openedx/core/djangoapps/course_groups/tests/test_views.py
- openedx/core/djangoapps/theming/tests/test_views.py
- openedx/features/content_type_gating/tests/test_partitions.py