### PR TITLE
fix: allow staff or superuser to reset password from support tools

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/password_reset.py
+++ b/openedx/core/djangoapps/user_authn/views/password_reset.py
@@ -594,7 +594,7 @@ def password_change_request_handler(request):
 
     """
     user = request.user
-    if user.is_staff and user.is_superuser and request.POST.get('email_from_support_tools'):
+    if (user.is_staff or user.is_superuser) and request.POST.get('email_from_support_tools'):
         email = request.POST.get('email_from_support_tools')
     else:
         # Prefer logged-in user's email


### PR DESCRIPTION
## Description
I've made a change that allows either a staff OR a superuser from support tools to reset password for a user/learner. Previously it was supposed to be a staff AND a superuser

Also added a new edge case test.