### PR TITLE
fix: Import missing function in server_error template.

### DIFF
--- a/cms/templates/error.html
+++ b/cms/templates/error.html
@@ -4,6 +4,7 @@
 from django.utils.translation import ugettext as _
 from django.urls import reverse
 from django.conf import settings
+from openedx.core.djangolib.markup import Text
 %>
 <%block name="bodyclass">error</%block>
 <%block name="title">


### PR DESCRIPTION
## Description

If we open the /server_error page in Studio it fails to a missing import: 

![image](https://user-images.githubusercontent.com/22335041/114736476-1e687100-9d14-11eb-9eec-8b99647b514e.png)

Once this change is applied the error dissapears:


![image](https://user-images.githubusercontent.com/22335041/114736628-3dff9980-9d14-11eb-9609-d8cff0c663aa.png)


## Supporting information

I think that this is an straightforward change that we could apply in the lilac branch @nedbat 

## Testing instructions

Open /server_error in Studio in the devstack (in any production environment it will be rendered the 500 error page instead).

