### PR TITLE
docs: update grades docs

### DIFF
--- a/lms/djangoapps/grades/docs/background.rst
+++ b/lms/djangoapps/grades/docs/background.rst
@@ -157,19 +157,24 @@ As described above in the Grade Computation section, the grading policy is distr
 Grade Overrides/Exceptions
 --------------------------
 
-Today, we support the following features to `adjust grades <https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-birch/running_course/course_grades.html#adjust-grades>`_, but don't have a general feature to override a grade for any xBlock:
+Today, we support the following features to `adjust grades <https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/open-release-koa.master/student_progress/course_grades.html#adjust-grades-for-one-or-all-learners>`_, but don't have a general feature to override a grade for any xBlock:
 
 * In `ORA Studio settings <http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/open_response_assessments/Manage_ORA_Assignment.html#override-a-learner-s-assessment-grade>`_:
 
   - override a learner's grade for an ORA2 block
-  
+
 * In LMS Instructor Dashboard or `Staff Debug Info <http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/manage_live_course/staff_debug_info.html>`_:
 
   - reset the number of attempts a learner has made for a problem back to 0
-  
+
   - force a rescore on a submission to update all stored scores
-  
+
   - delete a student state for a problem
+
+* In `Gradebook <https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/open-release-koa.master/student_progress/course_grades.html#adjust-grades-for-one-or-all-learners>`_: 
+
+  - override a subsection grade for a learner
+  - override subsection grades in bulk (master's track only)
 
 ORA2's Immutable Data
 ---------------------

--- a/lms/djangoapps/grades/docs/background.rst
+++ b/lms/djangoapps/grades/docs/background.rst
@@ -116,16 +116,18 @@ Problem Scores
 * *weighted_possible* (*a.k.a. max_grade*).  The weighted_possible value is the maximum possible score that is achievable on the problem post-weight-computation.
 * *weighted_earned* (*a.k.a. grade*). The weighted_earned value is the learner's score computed from the learner's response to the problem. The process for computing this score can be classified into the following types:
 
- - **automatically scored, synchronously** at the time of submission, such as for most Capa-based problems
- 
- - **automatically scored, asynchronously** via an `external grader service <http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/external_graders.html>`_
- 
- - **manually scored**, such as for `Open Response Assessments <http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/open_response_assessments/OpenResponseAssessments.html>`_, where the calculation requires human input from either
- 
-   - a single course staff (staff assessment)
-   - a number of peers (peer assessment)
-   - the self learner (self assessment)
-   
+  - **automatically scored, synchronously** at the time of submission, such as for most Capa-based problems
+
+  - **automatically scored, asynchronously** via an `external grader service <http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/external_graders.html>`_
+
+  - **manually scored**, such as for `Open Response Assessments <http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/open_response_assessments/OpenResponseAssessments.html>`_, where the calculation requires human input from either
+
+    - a single course staff (staff assessment)
+
+    - a number of peers (peer assessment)
+
+    - the self learner (self assessment)
+
 .. image:: images/background_problem_score.png
 
 Grading Policy
@@ -136,21 +138,21 @@ As described above in the Grade Computation section, the grading policy is distr
 * Course level (adjusted in *Settings->Grading page in Studio*)
 
   - Grade Range policy: Pass cutoff and letter grade thresholds
-  
+
   - Assignment Type policy: Weights and Allowable drops
-  
+
 * Subsection level (adjusted in *Content->Outline->Subsection->Settings* modal in Studio)
 
   - A subsection's designation to an assignment type
-  
+
   - A subsection's setting of whether it is 'graded'
-  
+
 * Problem level (adjusted in *Content->Outline->Subsection->Unit->Problem->Edit* modal in Studio)
 
   - A problem's weight
-  
+
   - A problem's external grader configuration
-  
+
   - A problem's individual grading policy - as currently supported by `ORA's assessment configuration <http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/open_response_assessments/OpenResponseAssessments.html#how-scores-for-open-response-assessments-are-calculated>`_
 
 

--- a/lms/djangoapps/grades/docs/data-model.rst
+++ b/lms/djangoapps/grades/docs/data-model.rst
@@ -12,16 +12,16 @@ Course Grades
 
 **Indices from Uniqueness Constraint**: ('course_id', 'user_id')
 
- * course_id
- * course_id, user_id
+* course_id
+* course_id, user_id
 
 **Additional Indices:**
 
- * user_id
- * course_id, passed_timestamp
- 
- **Fields:**
- 
+* user_id
+* course_id, passed_timestamp
+
+**Fields:**
+
 +-------------------------+--------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------+
 | Field name              | Type         | Description                                                                                                                                                                                                                                   | Include in Data Package |
 +-------------------------+--------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------+
@@ -92,13 +92,13 @@ Subsection Grade Table
 
 **Indices from Uniqueness Constraint:** ('course_id', 'user_id', 'usage_key')
 
-course_id
-course_id, user_id
-course_id, user_id, usage_key
+* course_id
+* course_id, user_id
+* course_id, user_id, usage_key
 
 **Additional Indices:**
 
-visible_blocks_hash
+* visible_blocks_hash
 
 **Fields:**
 
@@ -165,13 +165,13 @@ Visible Blocks Table
 
 **Table Description:** Stores an ordered list of visible blocks within a subsection for a learner at the time of computing the subsection grade.  It is expected that multiple learners will share access to the same list of visible blocks and hence this data is stored in a separate table so it can be referred to by multiple rows in the Subsection Grade table.
 
-**Indices from Uniqueness Constraint:** ('hashed)
+**Indices from Uniqueness Constraint:** ('hashed')
 
- * hashed
- 
+* hashed
+
 **Additional Indices:**
 
- * course_id
+* course_id
 
 **Fields:**
 
@@ -201,7 +201,7 @@ Courseware Student Module
 
 **Table Description:** A general-purpose storage for user-specific state for any xBlock/xModule (not just problem-types).  In addition to user-state, separate fields exist to store "earned" and "possible" grades for scorable blocks.
 
-**Indices from Uniqueness Constraint: ('student', 'module_id', 'course_id')**
+**Indices from Uniqueness Constraint:** ('student', 'module_id', 'course_id')
 
 * student
 * student, module_id
@@ -251,16 +251,16 @@ ORA Submissions
 
 **Table Description:** One of the tables amongst the suite of tables used for ORA submissions.  This particular table stores the scores for ORA problems.
 
-**Indices from Uniqueness Constraint: ('id')**
+**Indices from Uniqueness Constraint:** ('id')
 
- * id
- 
+* id
+
 **Additional Indices:**
 
- * student_item_id
- * submission_id
- * created_at
- 
+* student_item_id
+* submission_id
+* created_at
+
 **Fields:**
 
 +-----------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -279,6 +279,3 @@ ORA Submissions
 +-----------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | submission      | Submission       | Foreign key to the submissions_submission table.                                                                                                                                                              |
 +-----------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-
-
-

--- a/lms/djangoapps/grades/docs/data-model.rst
+++ b/lms/djangoapps/grades/docs/data-model.rst
@@ -83,6 +83,9 @@ Subsection Grades
 
 There are two tables that work in conjunction for storing subsection grades: Subsection Grade and Visible Blocks.
 
+Subsection grades can also be overridden by staff/instructors. The most recent override for a subsection lives in the Subsection Grade Override table.
+A history of subsection gtade overrides is also saved in the Subsection Grade Override History table, for auditing purposes.
+
 Subsection Grade Table
 ^^^^^^^^^^^^^^^^^^^^^^
 
@@ -188,6 +191,51 @@ Visible Blocks Table
 |             |              | blocks: An ordered list of serialized UsageKeys of all blocks that are accessible to the user within a particular subsection.                                                                                                                                                                                                                                                                                                         |               |
 |             |              | Note: The blocks field contains a list of usage keys of all blocks within a subsection that are visible to the user at the time of computing the user's subsection grade.  The value changes whenever users' access to content within the subsection changes: cohort assignment change, role change, course team adds/removes unit/problem, etc. When changed, a new row is created in the table with a corresponding new hash value. |               |
 +-------------+--------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------+
+
+Subsection Grade Overrides
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Table Name:** grades_persistentsubsectiongradeoverride
+
+**Table Description:** Stores the most recent override for a given subsection. In grade calculation, supersedes persisted subsection grade totals. The historical version of this table (grades_historicalpersistentsubsectiongradeoverride) captures a rolling list of previous overrides for audit purposes.
+
+**Indices from Uniqueness Constraint:** ('id')
+
+* id
+
+**Additional Indices:**
+
+* created
+* modified
+* grade_id
+
+**Fields:**
+
++--------------------------+---------------------+---------------------------------------------------------------------------------------------------------------------------+
+| Field name               | Type                | Description                                                                                                               |
++--------------------------+---------------------+---------------------------------------------------------------------------------------------------------------------------+
+| id                       | int(11)             | Auto-incrementing ID of the override.                                                                                     |
++--------------------------+---------------------+---------------------------------------------------------------------------------------------------------------------------+
+| created                  | datetime(6)         | When the override was first created.                                                                                      |
++--------------------------+---------------------+---------------------------------------------------------------------------------------------------------------------------+
+| modified                 | datetime(6)         | When the override was last modified.                                                                                      |
++--------------------------+---------------------+---------------------------------------------------------------------------------------------------------------------------+
+| earned_all_override      | double              | The total number of earned points (graded and ungraded) to be overridden.                                                 |
+|                          |                     | Note: It’s unclear how this is actually used since this is null in some cases and wouldn’t factor into grade calculation. |
++--------------------------+---------------------+---------------------------------------------------------------------------------------------------------------------------+
+| possible_all_override    | double              | Total number of possible points (both graded and ungraded) for a subsection.                                              |
++--------------------------+---------------------+---------------------------------------------------------------------------------------------------------------------------+
+| earned_graded_override   | double              | The points to be overridden for for the subsection.                                                                       |
++--------------------------+---------------------+---------------------------------------------------------------------------------------------------------------------------+
+| possible_graded_override | double              | The total possible graded score for the subsection.                                                                       |
++--------------------------+---------------------+---------------------------------------------------------------------------------------------------------------------------+
+| grade_id                 | bigint(20) unsigned | 1:1 mapping to a grades_persistentsubsectiongrade.id, specifying which grade this override applies to.                    |
++--------------------------+---------------------+---------------------------------------------------------------------------------------------------------------------------+
+| override_reason          | varchar(300)        | Instructor provided reason for override. Example: Student bribed me with doughnuts so I’m increasing their score.         |
++--------------------------+---------------------+---------------------------------------------------------------------------------------------------------------------------+
+| system                   | varchar(100)        | Where the override was performed.                                                                                         |
+|                          |                     | Examples: GRADEBOOK, grade-import                                                                                         |
++--------------------------+---------------------+---------------------------------------------------------------------------------------------------------------------------+
 
 
 Problem Scores


### PR DESCRIPTION
## Description

As part of [EDUCATOR-5323](https://openedx.atlassian.net/browse/EDUCATOR-5323), found some outdated grading docs. Have updated with info about Gradebook and Subsection overrides

## Testing instructions

- Do the docs render without issue?
- Does it spark joy?

## Deadline

n/a