### PR TITLE
BOM-2477: Apply lint-amnesty on pylint violations-I

### DIFF
--- a/cms/djangoapps/contentstore/config/waffle.py
+++ b/cms/djangoapps/contentstore/config/waffle.py
@@ -40,13 +40,13 @@ def waffle_flags():
 
 
 # TODO: After removing this flag, add a migration to remove waffle flag in a follow-up deployment.
-ENABLE_CHECKLISTS_QUALITY = CourseWaffleFlag(
+ENABLE_CHECKLISTS_QUALITY = CourseWaffleFlag(  # lint-amnesty, pylint: disable=toggle-missing-annotation
     waffle_namespace=waffle_flags(),
     flag_name='enable_checklists_quality',
     module_name=__name__,
 )
 
-SHOW_REVIEW_RULES_FLAG = CourseWaffleFlag(
+SHOW_REVIEW_RULES_FLAG = CourseWaffleFlag(  # lint-amnesty, pylint: disable=toggle-missing-annotation
     waffle_namespace=waffle_flags(),
     flag_name='show_review_rules',
     module_name=__name__,

--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -5,10 +5,10 @@ This file contains celery tasks for contentstore views
 import base64
 import json
 import os
-import shutil
-import tarfile
-from datetime import datetime
-from tempfile import NamedTemporaryFile, mkdtemp
+import shutil  # lint-amnesty, pylint: disable=wrong-import-order
+import tarfile  # lint-amnesty, pylint: disable=wrong-import-order
+from datetime import datetime  # lint-amnesty, pylint: disable=wrong-import-order
+from tempfile import NamedTemporaryFile, mkdtemp  # lint-amnesty, pylint: disable=wrong-import-order
 
 import olxcleaner
 import pkg_resources

--- a/cms/djangoapps/contentstore/views/import_export.py
+++ b/cms/djangoapps/contentstore/views/import_export.py
@@ -114,7 +114,7 @@ def _save_request_status(request, key, status):
     request.session.save()
 
 
-def _write_chunk(request, courselike_key):
+def _write_chunk(request, courselike_key):  # lint-amnesty, pylint: disable=too-many-statements
     """
     Write the OLX file data chunk from the given request to the local filesystem.
     """

--- a/cms/djangoapps/contentstore/views/tests/test_videos.py
+++ b/cms/djangoapps/contentstore/views/tests/test_videos.py
@@ -52,7 +52,7 @@ from ..videos import (
     convert_video_status
 )
 
-VIDEO_IMAGE_UPLOAD_ENABLED_SWITCH = LegacyWaffleSwitch(WAFFLE_SWITCHES, VIDEO_IMAGE_UPLOAD_ENABLED)
+VIDEO_IMAGE_UPLOAD_ENABLED_SWITCH = LegacyWaffleSwitch(WAFFLE_SWITCHES, VIDEO_IMAGE_UPLOAD_ENABLED)  # lint-amnesty, pylint: disable=toggle-missing-annotation
 
 
 class VideoUploadTestBase:

--- a/cms/djangoapps/contentstore/views/videos.py
+++ b/cms/djangoapps/contentstore/views/videos.py
@@ -80,7 +80,7 @@ VIDEO_IMAGE_UPLOAD_ENABLED = 'video_image_upload_enabled'
 # Waffle flag namespace for studio
 WAFFLE_STUDIO_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name='studio')
 
-ENABLE_VIDEO_UPLOAD_PAGINATION = CourseWaffleFlag(
+ENABLE_VIDEO_UPLOAD_PAGINATION = CourseWaffleFlag(  # lint-amnesty, pylint: disable=toggle-missing-annotation
     waffle_namespace=WAFFLE_STUDIO_FLAG_NAMESPACE,
     flag_name='enable_video_upload_pagination',
     module_name=__name__,

--- a/cms/djangoapps/models/settings/waffle.py
+++ b/cms/djangoapps/models/settings/waffle.py
@@ -8,7 +8,7 @@ WAFFLE_NAMESPACE = 'grades'
 # edx/edx-platform feature
 MATERIAL_RECOMPUTE_ONLY = 'MATERIAL_RECOMPUTE_ONLY'
 
-MATERIAL_RECOMPUTE_ONLY_FLAG = CourseWaffleFlag(
+MATERIAL_RECOMPUTE_ONLY_FLAG = CourseWaffleFlag(  # lint-amnesty, pylint: disable=toggle-missing-annotation
     waffle_namespace=WAFFLE_NAMESPACE,
     flag_name=MATERIAL_RECOMPUTE_ONLY,
     module_name=__name__,

--- a/lms/djangoapps/certificates/generation.py
+++ b/lms/djangoapps/certificates/generation.py
@@ -10,10 +10,10 @@ These methods should be called from tasks.
 """
 
 import logging
-import random
+import random  # lint-amnesty, pylint: disable=unused-import
 from uuid import uuid4
 
-from capa.xqueue_interface import make_hashkey
+from capa.xqueue_interface import make_hashkey  # lint-amnesty, pylint: disable=unused-import
 from common.djangoapps.student.models import CourseEnrollment, UserProfile
 from lms.djangoapps.certificates.models import CertificateStatuses, GeneratedCertificate
 from lms.djangoapps.certificates.queue import XQueueCertInterface

--- a/lms/djangoapps/certificates/management/commands/tests/test_cert_generation.py
+++ b/lms/djangoapps/certificates/management/commands/tests/test_cert_generation.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 import pytest
 from django.core.management import CommandError, call_command
-from waffle.testutils import override_switch
+from waffle.testutils import override_switch  # lint-amnesty, pylint: disable=unused-import
 
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
 from lms.djangoapps.certificates.tests.test_generation_handler import ID_VERIFIED_METHOD

--- a/lms/djangoapps/certificates/tests/test_signals.py
+++ b/lms/djangoapps/certificates/tests/test_signals.py
@@ -28,7 +28,7 @@ from openedx.core.djangoapps.certificates.config import waffle
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
-AUTO_CERTIFICATE_GENERATION_SWITCH = LegacyWaffleSwitch(waffle.waffle(), waffle.AUTO_CERTIFICATE_GENERATION)
+AUTO_CERTIFICATE_GENERATION_SWITCH = LegacyWaffleSwitch(waffle.waffle(), waffle.AUTO_CERTIFICATE_GENERATION)  # lint-amnesty, pylint: disable=toggle-missing-annotation
 
 
 class SelfGeneratedCertsSignalTest(ModuleStoreTestCase):

--- a/lms/djangoapps/certificates/tests/test_webview_views.py
+++ b/lms/djangoapps/certificates/tests/test_webview_views.py
@@ -54,7 +54,7 @@ from openedx.core.lib.tests.assertions.events import assert_event_matches
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
-AUTO_CERTIFICATE_GENERATION_SWITCH = LegacyWaffleSwitch(waffle.waffle(), waffle.AUTO_CERTIFICATE_GENERATION)
+AUTO_CERTIFICATE_GENERATION_SWITCH = LegacyWaffleSwitch(waffle.waffle(), waffle.AUTO_CERTIFICATE_GENERATION)  # lint-amnesty, pylint: disable=toggle-missing-annotation
 FEATURES_WITH_CERTS_ENABLED = settings.FEATURES.copy()
 FEATURES_WITH_CERTS_ENABLED['CERTIFICATES_HTML_VIEW'] = True
 FEATURES_WITH_BADGES_ENABLED = FEATURES_WITH_CERTS_ENABLED.copy()

--- a/lms/djangoapps/commerce/utils.py
+++ b/lms/djangoapps/commerce/utils.py
@@ -6,7 +6,7 @@ import logging
 from urllib.parse import urlencode, urljoin
 
 import requests
-import waffle
+import waffle  # lint-amnesty, pylint: disable=invalid-django-waffle-import
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.urls import reverse

--- a/lms/djangoapps/course_home_api/course_metadata/v1/views.py
+++ b/lms/djangoapps/course_home_api/course_metadata/v1/views.py
@@ -6,7 +6,7 @@ from opaque_keys.edx.keys import CourseKey
 from rest_framework.generics import RetrieveAPIView
 from rest_framework.response import Response
 
-from opaque_keys.edx.keys import CourseKey
+from opaque_keys.edx.keys import CourseKey  # lint-amnesty, pylint: disable=reimported
 
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser

--- a/lms/djangoapps/course_home_api/toggles.py
+++ b/lms/djangoapps/course_home_api/toggles.py
@@ -21,11 +21,11 @@ WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name='course_home')
 # .. toggle_tickets: https://openedx.atlassian.net/browse/AA-117
 COURSE_HOME_MICROFRONTEND = ExperimentWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'course_home_mfe', __name__)
 
-COURSE_HOME_MICROFRONTEND_DATES_TAB = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'course_home_mfe_dates_tab', __name__)
+COURSE_HOME_MICROFRONTEND_DATES_TAB = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'course_home_mfe_dates_tab', __name__)  # lint-amnesty, pylint: disable=toggle-missing-annotation
 
-COURSE_HOME_MICROFRONTEND_OUTLINE_TAB = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'course_home_mfe_outline_tab', __name__)
+COURSE_HOME_MICROFRONTEND_OUTLINE_TAB = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'course_home_mfe_outline_tab', __name__)  # lint-amnesty, pylint: disable=toggle-missing-annotation
 
-COURSE_HOME_MICROFRONTEND_PROGRESS_TAB = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'course_home_mfe_progress_tab',
+COURSE_HOME_MICROFRONTEND_PROGRESS_TAB = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'course_home_mfe_progress_tab',  # lint-amnesty, pylint: disable=toggle-missing-annotation
                                                           __name__)
 
 

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -464,7 +464,7 @@ def get_course_date_blocks(course, user, request=None, include_access=False,
     ]
     blocks.extend([cls(course, user) for cls in default_block_classes])
 
-    blocks = filter(lambda b: b.is_allowed and b.date and (include_past_dates or b.is_enabled), blocks)
+    blocks = filter(lambda b: b.is_allowed and b.date and (include_past_dates or b.is_enabled), blocks)  # lint-amnesty, pylint: disable=filter-builtin-not-iterating
     return sorted(blocks, key=date_block_key_fn)
 
 

--- a/lms/djangoapps/courseware/tabs.py
+++ b/lms/djangoapps/courseware/tabs.py
@@ -210,7 +210,7 @@ class HtmlTextbookTabs(TextbookTabsBase):
             )
 
 
-class LinkTab(CourseTab):
+class LinkTab(CourseTab):  # lint-amnesty, pylint: disable=eq-without-hash
     """
     Abstract class for tabs that contain external links.
     """

--- a/lms/djangoapps/courseware/tests/test_date_summary.py
+++ b/lms/djangoapps/courseware/tests/test_date_summary.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 from unittest.mock import patch
 import crum
 import ddt
-import waffle
+import waffle  # lint-amnesty, pylint: disable=invalid-django-waffle-import
 from django.contrib.messages.middleware import MessageMiddleware
 from django.test import RequestFactory
 from django.urls import reverse

--- a/lms/djangoapps/experiments/flags.py
+++ b/lms/djangoapps/experiments/flags.py
@@ -76,7 +76,7 @@ class ExperimentWaffleFlag(CourseWaffleFlag):
         self.num_buckets = num_buckets
         self.experiment_id = experiment_id
         self.bucket_flags = [
-            CourseWaffleFlag(waffle_namespace, f'{flag_name}.{bucket}', module_name)
+            CourseWaffleFlag(waffle_namespace, f'{flag_name}.{bucket}', module_name)  # lint-amnesty, pylint: disable=toggle-missing-annotation
             for bucket in range(num_buckets)
         ]
         self.use_course_aware_bucketing = use_course_aware_bucketing

--- a/lms/djangoapps/experiments/tests/test_flags.py
+++ b/lms/djangoapps/experiments/tests/test_flags.py
@@ -38,7 +38,7 @@ class ExperimentWaffleFlagTests(SharedModuleStoreTestCase):
         self.addCleanup(set_current_request, None)
         set_current_request(self.request)
 
-        self.flag = ExperimentWaffleFlag('experiments', 'test', __name__, num_buckets=2, experiment_id=0)
+        self.flag = ExperimentWaffleFlag('experiments', 'test', __name__, num_buckets=2, experiment_id=0)  # lint-amnesty, pylint: disable=toggle-missing-annotation
         self.key = CourseKey.from_string('a/b/c')
 
         bucket_patch = patch('lms.djangoapps.experiments.flags.stable_bucketing_hash_group', return_value=1)
@@ -105,7 +105,7 @@ class ExperimentWaffleFlagTests(SharedModuleStoreTestCase):
     )
     @ddt.unpack
     def test_forcing_bucket(self, active, expected_bucket):
-        bucket_flag = CourseWaffleFlag('experiments', 'test.0', __name__)
+        bucket_flag = CourseWaffleFlag('experiments', 'test.0', __name__)  # lint-amnesty, pylint: disable=toggle-missing-annotation
         with override_waffle_flag(bucket_flag, active=active):
             assert self.get_bucket() == expected_bucket
 
@@ -163,7 +163,7 @@ class ExperimentWaffleFlagTests(SharedModuleStoreTestCase):
         assert 'experiments' == self.flag._app_label
         assert 'test' == self.flag._experiment_name
 
-        flag = ExperimentWaffleFlag("namespace", "flag.name", __name__)
+        flag = ExperimentWaffleFlag("namespace", "flag.name", __name__)  # lint-amnesty, pylint: disable=toggle-missing-annotation
         assert 'namespace' == flag._app_label
         assert 'flag.name' == flag._experiment_name
 
@@ -173,15 +173,15 @@ class ExperimentWaffleFlagCourseAwarenessTest(SharedModuleStoreTestCase):
     Tests for how course context awareness/unawareness interacts with the
     ExperimentWaffleFlag class.
     """
-    course_aware_flag = ExperimentWaffleFlag(
+    course_aware_flag = ExperimentWaffleFlag(  # lint-amnesty, pylint: disable=toggle-missing-annotation
         'exp', 'aware', __name__, num_buckets=20, use_course_aware_bucketing=True,
     )
-    course_aware_subflag = CourseWaffleFlag('exp', 'aware.1', __name__)
+    course_aware_subflag = CourseWaffleFlag('exp', 'aware.1', __name__)  # lint-amnesty, pylint: disable=toggle-missing-annotation
 
-    course_unaware_flag = ExperimentWaffleFlag(
+    course_unaware_flag = ExperimentWaffleFlag(  # lint-amnesty, pylint: disable=toggle-missing-annotation
         'exp', 'unaware', __name__, num_buckets=20, use_course_aware_bucketing=False,
     )
-    course_unaware_subflag = CourseWaffleFlag('exp', 'unaware.1', __name__)
+    course_unaware_subflag = CourseWaffleFlag('exp', 'unaware.1', __name__)  # lint-amnesty, pylint: disable=toggle-missing-annotation
 
     course_key_1 = CourseKey.from_string("x/y/1")
     course_key_2 = CourseKey.from_string("x/y/22")

--- a/lms/djangoapps/experiments/views.py
+++ b/lms/djangoapps/experiments/views.py
@@ -8,15 +8,15 @@ from django.http import Http404
 from django_filters.rest_framework import DjangoFilterBackend
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
-from lms.djangoapps.courseware import courses
+from lms.djangoapps.courseware import courses  # lint-amnesty, pylint: disable=unused-import
 from opaque_keys.edx.keys import CourseKey  # lint-amnesty, pylint: disable=wrong-import-order
 from rest_framework import permissions, viewsets  # lint-amnesty, pylint: disable=wrong-import-order
 from rest_framework.views import APIView  # lint-amnesty, pylint: disable=wrong-import-order
 from common.djangoapps.util.json_request import JsonResponse
 
 from common.djangoapps.student.models import get_user_by_username_or_email
-from common.djangoapps.util.json_request import JsonResponse
-from lms.djangoapps.courseware import courses
+from common.djangoapps.util.json_request import JsonResponse  # lint-amnesty, pylint: disable=reimported
+from lms.djangoapps.courseware import courses  # lint-amnesty, pylint: disable=reimported
 from lms.djangoapps.experiments import filters, serializers
 from lms.djangoapps.experiments.models import ExperimentData, ExperimentKeyValue
 from lms.djangoapps.experiments.permissions import IsStaffOrOwner, IsStaffOrReadOnly, IsStaffOrReadOnlyForSelf

--- a/lms/djangoapps/instructor/settings/common.py
+++ b/lms/djangoapps/instructor/settings/common.py
@@ -71,7 +71,7 @@ def plugin_settings(settings):
         # .. toggle_tickets: https://github.com/edx/edx-platform/pull/5670
         'ALLOW_AUTOMATED_SIGNUPS': False,
 
-        # .. toggle_name: FEATURES['CERTIFICATES_INSTRUCTOR_GENERATION']
+        # .. toggle_name: FEATURES['CERTIFICATES_INSTRUCTOR_GENERATION']  # lint-amnesty, pylint: disable=annotation-missing-token
         # .. toggle_implementation: DjangoSetting
         # .. toggle_default: False
         # .. toggle_description: Enable to allow batch generation of certificates from the instructor dashboard.

--- a/lms/djangoapps/instructor/tests/test_enrollment.py
+++ b/lms/djangoapps/instructor/tests/test_enrollment.py
@@ -796,7 +796,7 @@ class EnrollmentObjects:
         self.cea = cea
 
 
-class SettableEnrollmentState(EmailEnrollmentState):
+class SettableEnrollmentState(EmailEnrollmentState):  # lint-amnesty, pylint: disable=eq-without-hash
     """
     Settable enrollment state.
     Used for testing state changes.

--- a/lms/djangoapps/instructor/tests/test_proctoring.py
+++ b/lms/djangoapps/instructor/tests/test_proctoring.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.urls import reverse
 from edx_proctoring.api import create_exam
 from edx_proctoring.backends.tests.test_backend import TestBackendProvider
-from edx_toggles.toggles.testutils import override_waffle_flag
+from edx_toggles.toggles.testutils import override_waffle_flag  # lint-amnesty, pylint: disable=unused-import
 
 from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole
 from common.djangoapps.student.tests.factories import AdminFactory

--- a/lms/djangoapps/instructor_task/config/waffle.py
+++ b/lms/djangoapps/instructor_task/config/waffle.py
@@ -32,12 +32,12 @@ def waffle_flags():
       Instead, replace the string constants above with the actual flag instances.
     """
     return {
-        GENERATE_PROBLEM_GRADE_REPORT_VERIFIED_ONLY: CourseWaffleFlag(
+        GENERATE_PROBLEM_GRADE_REPORT_VERIFIED_ONLY: CourseWaffleFlag(  # lint-amnesty, pylint: disable=toggle-missing-annotation
             waffle_namespace=INSTRUCTOR_TASK_WAFFLE_FLAG_NAMESPACE,
             flag_name=GENERATE_PROBLEM_GRADE_REPORT_VERIFIED_ONLY,
             module_name=__name__,
         ),
-        GENERATE_COURSE_GRADE_REPORT_VERIFIED_ONLY: CourseWaffleFlag(
+        GENERATE_COURSE_GRADE_REPORT_VERIFIED_ONLY: CourseWaffleFlag(  # lint-amnesty, pylint: disable=toggle-missing-annotation
             waffle_namespace=INSTRUCTOR_TASK_WAFFLE_FLAG_NAMESPACE,
             flag_name=GENERATE_COURSE_GRADE_REPORT_VERIFIED_ONLY,
             module_name=__name__,

--- a/lms/djangoapps/instructor_task/tests/test_integration.py
+++ b/lms/djangoapps/instructor_task/tests/test_integration.py
@@ -19,7 +19,6 @@ from celery.states import FAILURE, SUCCESS
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.test.utils import override_settings
 from django.urls import reverse
-from mock import patch
 
 from capa.responsetypes import StudentInputError
 from capa.tests.response_xml_factory import CodeResponseXMLFactory, CustomResponseXMLFactory

--- a/lms/djangoapps/program_enrollments/rest_api/v1/views.py
+++ b/lms/djangoapps/program_enrollments/rest_api/v1/views.py
@@ -770,7 +770,7 @@ class UserProgramReadOnlyAccessView(DeveloperErrorViewMixin, PaginatedAPIView):
                 if course_run_program and course_run_program.get('type').lower() == program_type_filter:
                     program_dict[course_run_program['uuid']] = course_run_program
 
-        return program_dict.values()
+        return program_dict.values()  # lint-amnesty, pylint: disable=dict-values-not-iterating
 
 
 class UserProgramCourseEnrollmentView(


### PR DESCRIPTION
**Issue:** [BOM-2477](https://openedx.atlassian.net/browse/BOM-2477)

## Description
- Applied [lint-amnesty](https://github.com/edx/edx-lint#using-lint-amnesty) to existing pylint violations.

## Results
- 41 violations suppressed and the total violation count dropped to [73 warnings](https://build.testeng.edx.org/job/edx-platform-quality-pipeline-pr/27270/).