### PR TITLE
feat: Add tracking event for IDV photo mode

### DIFF
--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -832,6 +832,8 @@ class SubmitPhotosView(View):
             photo_id_image (str): base64-encoded image data of the user's photo ID.
             full_name (str): The user's full name, if the user is requesting a name change as well.
             experiment_name (str): The name of an A/B experiment associated with this attempt
+            portrait_photo_mode (str): The mode in which the portrait photo was taken
+            id_photo_mode (str): The mode in which the id photo was taken
 
         """
         # If the user already has an initial verification attempt, we can re-use the photo ID
@@ -873,6 +875,14 @@ class SubmitPhotosView(View):
         }
         self._fire_event(request.user, "edx.bi.experiment.verification.attempt", data)
 
+        if params.get("portrait_photo_mode"):
+            mode_data = {
+                "attempt_id": attempt.id,
+                "portrait_photo_mode": params.get("portrait_photo_mode"),
+                "id_photo_mode": params.get("id_photo_mode")
+            }
+            self._fire_event(request.user, "edx.bi.experiment.verification.attempt.photo.mode", mode_data)
+
         self._fire_event(request.user, "edx.bi.verify.submitted", {"category": "verification"})
         self._send_confirmation_email(request.user)
         return JsonResponse({})
@@ -896,7 +906,9 @@ class SubmitPhotosView(View):
                 "face_image",
                 "photo_id_image",
                 "full_name",
-                "experiment_name"
+                "experiment_name",
+                "portrait_photo_mode",
+                "id_photo_mode"
             ]
             if param_name in request.POST
         }


### PR DESCRIPTION
## Description
As part of the ongoing A/B experiment for IDV, we would like to know how users submitted their photos (either by upload or camera) in addition to the other information we are tracking
