### PR TITLE
refactor: make embargo app go through geoinfo API

### DIFF
--- a/openedx/core/djangoapps/geoinfo/api.py
+++ b/openedx/core/djangoapps/geoinfo/api.py
@@ -1,0 +1,29 @@
+"""
+Simple Python API to identify the country of origin of page requests.
+"""
+
+import geoip2.database
+from django.conf import settings
+
+
+def country_code_from_ip(ip_addr: str) -> str:
+    """
+    Return the country code associated with an IP address.
+    Handles both IPv4 and IPv6 addresses.
+
+    Args:
+        ip_addr: The IP address to look up.
+
+    Returns:
+        A 2-letter country code,
+        or an empty string if lookup failed.
+    """
+    reader = geoip2.database.Reader(settings.GEOIP_PATH)
+    try:
+        response = reader.country(ip_addr)
+        # pylint: disable=no-member
+        country_code = response.country.iso_code
+    except geoip2.errors.AddressNotFoundError:
+        country_code = ""
+    reader.close()
+    return country_code

--- a/openedx/core/djangoapps/geoinfo/middleware.py
+++ b/openedx/core/djangoapps/geoinfo/middleware.py
@@ -10,12 +10,12 @@ decorator `django.utils.decorators.decorator_from_middleware(middleware_class)`
 
 """
 import logging
-import geoip2.database
 
-from django.conf import settings
 from django.utils.deprecation import MiddlewareMixin
 from ipware.ip import get_client_ip
 from ipware.utils import is_public_ip
+
+from .api import country_code_from_ip
 
 log = logging.getLogger(__name__)
 
@@ -37,14 +37,7 @@ class CountryMiddleware(MiddlewareMixin):
             del request.session['ip_address']
             del request.session['country_code']
         elif new_ip_address != old_ip_address and is_public_ip(new_ip_address):
-            reader = geoip2.database.Reader(settings.GEOIP_PATH)
-            try:
-                response = reader.country(new_ip_address)
-                country_code = response.country.iso_code
-            except geoip2.errors.AddressNotFoundError:
-                country_code = ""
-
+            country_code = country_code_from_ip(new_ip_address)
             request.session['country_code'] = country_code
             request.session['ip_address'] = new_ip_address
             log.debug('Country code for IP: %s is set to %s', new_ip_address, country_code)
-            reader.close()


### PR DESCRIPTION
## Description

refactor: make embargo app go through geoinfo API

Consolidates all usage of geoip database within
geoinfo app.

## Supporting information

This was inspired a [geoipupdate fix that T&L got pulled into](https://github.com/edx/edx-internal/pull/4954), since we're the owners of the `embargo` app in edx-platform, which depends on the geoip database. 

The `geoinfo` app, which Arch-BOM owns, also depends on the geoip database.

In this PR, we make the `embargo` app a client of the `geoinfo` app, we make it less ambiguous that Arch-BOM is responsible for the underlying geoip database.

## Deadline

None