### PR TITLE
BOM-2477: Apply lint-amnesty on existing violations-II

### DIFF
--- a/common/djangoapps/student/management/commands/assigngroups.py
+++ b/common/djangoapps/student/management/commands/assigngroups.py
@@ -54,7 +54,7 @@ class Command(BaseCommand):  # lint-amnesty, pylint: disable=missing-class-docst
         print("Groups", groups)
 
         # Confirm group probabilities add up to 1
-        total = sum(zip(*groups)[1])  # lint-amnesty, pylint: disable=unsubscriptable-object
+        total = sum(zip(*groups)[1])  # lint-amnesty, pylint: disable=unsubscriptable-object, zip-builtin-not-iterating
         print("Total:", total)
         if abs(total - 1) > 0.01:
             print("Total not 1")

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -13,16 +13,16 @@ file and check it in at the same time as your model changes. To do that,
 
 
 import crum
-import hashlib
-import json
-import logging
-import uuid
-from collections import defaultdict, namedtuple
-from datetime import datetime, timedelta
-from functools import total_ordering
-from importlib import import_module
-from urllib.parse import urlencode
-import warnings
+import hashlib  # lint-amnesty, pylint: disable=wrong-import-order
+import json  # lint-amnesty, pylint: disable=wrong-import-order
+import logging  # lint-amnesty, pylint: disable=wrong-import-order
+import uuid  # lint-amnesty, pylint: disable=wrong-import-order
+from collections import defaultdict, namedtuple  # lint-amnesty, pylint: disable=wrong-import-order
+from datetime import datetime, timedelta  # lint-amnesty, pylint: disable=wrong-import-order
+from functools import total_ordering  # lint-amnesty, pylint: disable=wrong-import-order
+from importlib import import_module  # lint-amnesty, pylint: disable=wrong-import-order
+from urllib.parse import urlencode  # lint-amnesty, pylint: disable=wrong-import-order
+import warnings  # lint-amnesty, pylint: disable=wrong-import-order
 
 from config_models.models import ConfigurationModel
 from django.apps import apps
@@ -910,7 +910,7 @@ class Registration(models.Model):
         self.user = user
         self.save()
 
-    def activate(self):
+    def activate(self):  # lint-amnesty, pylint: disable=missing-function-docstring
         self.user.is_active = True
         self.user.save(update_fields=['is_active'])
         self.activation_timestamp = datetime.utcnow()

--- a/common/djangoapps/util/models.py
+++ b/common/djangoapps/util/models.py
@@ -35,7 +35,7 @@ def decompress_string(value):
     """
 
     try:
-        val = value.encode('utf').decode('base64')
+        val = value.encode('utf').decode('base64')  # lint-amnesty, pylint: disable=invalid-str-codec
         zbuf = BytesIO(val)
         zfile = gzip.GzipFile(fileobj=zbuf)
         ret = zfile.read()
@@ -60,7 +60,7 @@ class CompressedTextField(CreatorMixin, models.TextField):
             if isinstance(value, str):
                 value = value.encode('utf8')
             value = compress_string(value)
-            value = value.encode('base64').decode('utf8')
+            value = value.encode('base64').decode('utf8')  # lint-amnesty, pylint: disable=invalid-str-codec
         return value
 
     def to_python(self, value):

--- a/common/lib/xmodule/xmodule/assetstore/__init__.py
+++ b/common/lib/xmodule/xmodule/assetstore/__init__.py
@@ -306,4 +306,4 @@ class CourseAssetsFromStorage:
         """
         Iterates over the items of the asset dict. (Python 3 naming convention)
         """
-        return self.iteritems()
+        return self.iteritems()  # lint-amnesty, pylint: disable=dict-iter-method

--- a/common/lib/xmodule/xmodule/contentstore/mongo.py
+++ b/common/lib/xmodule/xmodule/contentstore/mongo.py
@@ -324,7 +324,7 @@ class MongoContentStore(ContentStore):
         count = 0
         assets = []
         try:
-            result = cursor.next()
+            result = cursor.next()  # lint-amnesty, pylint: disable=next-method-called
             if result:
                 count = result['count']
                 assets = list(result['results'])

--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -1310,7 +1310,7 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
         ])
         courses = self.collection.find(course_search_location, projection={'_id': True})
         try:
-            course = courses.next()
+            course = courses.next()  # lint-amnesty, pylint: disable=next-method-called
             raise DuplicateCourseError(course_id, course['_id'])
         except StopIteration:
             pass

--- a/common/lib/xmodule/xmodule/partitions/partitions_service.py
+++ b/common/lib/xmodule/xmodule/partitions/partitions_service.py
@@ -71,7 +71,7 @@ def _get_dynamic_partitions(course):
     Return the dynamic user partitions for this course.
     If none exists, returns an empty array.
     """
-    dynamic_partition_generators = DynamicPartitionGeneratorsPluginManager.get_available_plugins().values()
+    dynamic_partition_generators = DynamicPartitionGeneratorsPluginManager.get_available_plugins().values()  # lint-amnesty, pylint: disable=dict-values-not-iterating
     generated_partitions = []
     for generator in dynamic_partition_generators:
         generated_partition = generator(course)

--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -57,7 +57,7 @@ class_priority = ['video', 'problem']
 #  `django.utils.translation.ugettext_noop` because Django cannot be imported in this file
 _ = lambda text: text
 
-TIMED_EXAM_GATING_WAFFLE_FLAG = LegacyWaffleFlag(
+TIMED_EXAM_GATING_WAFFLE_FLAG = LegacyWaffleFlag(  # lint-amnesty, pylint: disable=toggle-missing-annotation
     waffle_namespace="xmodule",
     flag_name='rev_1377_rollout',
     module_name=__name__,
@@ -402,7 +402,7 @@ class SequenceBlock(
                 self, self.course_id
             )
 
-    def student_view(self, context):
+    def student_view(self, context):  # lint-amnesty, pylint: disable=missing-function-docstring
         _ = self.runtime.service(self, "i18n").ugettext
         context = context or {}
         self._capture_basic_metrics()

--- a/common/lib/xmodule/xmodule/split_test_module.py
+++ b/common/lib/xmodule/xmodule/split_test_module.py
@@ -125,7 +125,7 @@ def get_split_user_partitions(user_partitions):
 @XBlock.needs('user_tags')  # pylint: disable=abstract-method
 @XBlock.needs('partitions')
 @XBlock.needs('user')
-class SplitTestBlock(
+class SplitTestBlock(  # lint-amnesty, pylint: disable=abstract-method
     SplitTestFields,
     SequenceMixin,
     ProctoringFields,

--- a/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
+++ b/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
@@ -5,9 +5,9 @@ from io import BytesIO
 from unittest import mock
 
 import pytest
-import datetime
-import itertools
-import math
+import datetime  # lint-amnesty, pylint: disable=wrong-import-order
+import itertools  # lint-amnesty, pylint: disable=wrong-import-order
+import math  # lint-amnesty, pylint: disable=wrong-import-order
 import ddt
 import pytz
 from django.conf import settings

--- a/openedx/core/djangoapps/content_libraries/library_bundle.py
+++ b/openedx/core/djangoapps/content_libraries/library_bundle.py
@@ -179,7 +179,7 @@ class LibraryBundle:
         Get the set of usage keys in this bundle that have no parent.
         """
         own_usage_keys = self.get_all_usages()
-        usage_keys_with_parents = self.get_bundle_includes().keys()
+        usage_keys_with_parents = self.get_bundle_includes().keys()  # lint-amnesty, pylint: disable=dict-keys-not-iterating
         return [usage_key for usage_key in own_usage_keys if usage_key not in usage_keys_with_parents]
 
     def get_bundle_includes(self):

--- a/openedx/core/djangoapps/profile_images/tests/test_images.py
+++ b/openedx/core/djangoapps/profile_images/tests/test_images.py
@@ -5,9 +5,9 @@ from contextlib import closing
 from unittest import mock
 
 import pytest
-from itertools import product
-import os
-from tempfile import NamedTemporaryFile
+from itertools import product  # lint-amnesty, pylint: disable=wrong-import-order
+import os  # lint-amnesty, pylint: disable=wrong-import-order
+from tempfile import NamedTemporaryFile  # lint-amnesty, pylint: disable=wrong-import-order
 
 from django.core.files.uploadedfile import UploadedFile
 from django.test import TestCase

--- a/openedx/core/djangoapps/profile_images/tests/test_views.py
+++ b/openedx/core/djangoapps/profile_images/tests/test_views.py
@@ -6,7 +6,7 @@ from unittest import mock
 from unittest.mock import patch
 
 import pytest
-import datetime
+import datetime  # lint-amnesty, pylint: disable=wrong-import-order
 from pytz import UTC
 
 from django.urls import reverse

--- a/openedx/core/djangoapps/programs/__init__.py
+++ b/openedx/core/djangoapps/programs/__init__.py
@@ -15,7 +15,7 @@ from edx_toggles.toggles import LegacyWaffleSwitch, LegacyWaffleSwitchNamespace 
 PROGRAMS_WAFFLE_SWITCH_NAMESPACE = LegacyWaffleSwitchNamespace(name='programs')
 
 # This is meant to be enabled until https://openedx.atlassian.net/browse/LEARNER-5573 needs to be resolved
-ALWAYS_CALCULATE_PROGRAM_PRICE_AS_ANONYMOUS_USER = LegacyWaffleSwitch(
+ALWAYS_CALCULATE_PROGRAM_PRICE_AS_ANONYMOUS_USER = LegacyWaffleSwitch(  # lint-amnesty, pylint: disable=toggle-missing-annotation
     PROGRAMS_WAFFLE_SWITCH_NAMESPACE,
     'always_calculate_program_price_as_anonymous_user',
     __name__

--- a/openedx/core/djangoapps/programs/tasks.py
+++ b/openedx/core/djangoapps/programs/tasks.py
@@ -456,7 +456,7 @@ def revoke_program_certificate(client, username, program_uuid):
 
 @shared_task(bind=True, ignore_result=True)
 @set_code_owner_attribute
-def revoke_program_certificates(self, username, course_key):
+def revoke_program_certificates(self, username, course_key):  # lint-amnesty, pylint: disable=too-many-statements
     """
     This task is designed to be called whenever a student's course certificate is
     revoked.

--- a/openedx/core/djangoapps/schedules/config.py
+++ b/openedx/core/djangoapps/schedules/config.py
@@ -19,7 +19,7 @@ WAFFLE_SWITCH_NAMESPACE = LegacyWaffleSwitchNamespace(name='schedules')
 # .. toggle_creation_date: 2017-09-17
 DEBUG_MESSAGE_WAFFLE_FLAG = WaffleFlag('schedules.enable_debugging', __name__)
 
-COURSE_UPDATE_SHOW_UNSUBSCRIBE_WAFFLE_SWITCH = LegacyWaffleSwitch(
+COURSE_UPDATE_SHOW_UNSUBSCRIBE_WAFFLE_SWITCH = LegacyWaffleSwitch(  # lint-amnesty, pylint: disable=toggle-missing-annotation
     WAFFLE_SWITCH_NAMESPACE,
     'course_update_show_unsubscribe',
     __name__
@@ -31,7 +31,7 @@ COURSE_UPDATE_SHOW_UNSUBSCRIBE_WAFFLE_SWITCH = LegacyWaffleSwitch(
 # methods below. We save this flag decision at enrollment time and don't change it even if the flag changes. So you
 # can't just directly look at flag result.
 _EXTERNAL_COURSE_UPDATES_EXPERIMENT_ID = 18
-_EXTERNAL_COURSE_UPDATES_FLAG = ExperimentWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'external_updates', __name__,
+_EXTERNAL_COURSE_UPDATES_FLAG = ExperimentWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'external_updates', __name__,  # lint-amnesty, pylint: disable=toggle-missing-annotation
                                                      experiment_id=_EXTERNAL_COURSE_UPDATES_EXPERIMENT_ID,
                                                      use_course_aware_bucketing=False)
 

--- a/openedx/core/djangoapps/schedules/management/commands/__init__.py
+++ b/openedx/core/djangoapps/schedules/management/commands/__init__.py
@@ -17,7 +17,7 @@ class SendEmailBaseCommand(PrefixedDebugLoggerMixin, BaseCommand):  # lint-amnes
 
     # An iterable of day offsets (e.g. -7, -14, -21, -28, ...) that defines the days for
     # which emails are sent out, relative to the 'date' parameter
-    offsets = range(-7, -77, -7)
+    offsets = range(-7, -77, -7)  # lint-amnesty, pylint: disable=range-builtin-not-iterating
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -42,7 +42,7 @@ class SendEmailBaseCommand(PrefixedDebugLoggerMixin, BaseCommand):  # lint-amnes
         num_weeks = options.get('weeks')
         if num_weeks:
             num_days = (7 * num_weeks) + 1
-            self.offsets = range(-7, -num_days, -7)
+            self.offsets = range(-7, -num_days, -7)  # lint-amnesty, pylint: disable=range-builtin-not-iterating
 
         current_date = datetime.datetime(
             *[int(x) for x in options['date'].split('-')],

--- a/openedx/core/djangoapps/schedules/models.py
+++ b/openedx/core/djangoapps/schedules/models.py
@@ -38,7 +38,7 @@ class Schedule(TimeStampedModel):
 
     def get_experience_type(self):
         try:
-            return self.experience.experience_type
+            return self.experience.experience_type  # lint-amnesty, pylint: disable=no-member
         except ScheduleExperience.DoesNotExist:
             return ScheduleExperience.EXPERIENCES.default
 

--- a/openedx/core/djangoapps/schedules/tests/test_content_highlights.py
+++ b/openedx/core/djangoapps/schedules/tests/test_content_highlights.py
@@ -1,3 +1,4 @@
+# lint-amnesty, pylint: disable=missing-module-docstring
 import datetime
 from unittest.mock import patch
 import pytest

--- a/openedx/core/djangoapps/user_api/accounts/utils.py
+++ b/openedx/core/djangoapps/user_api/accounts/utils.py
@@ -6,7 +6,7 @@ Utility methods for the account settings.
 import re
 from urllib.parse import urlparse  # pylint: disable=import-error
 
-import waffle
+import waffle  # lint-amnesty, pylint: disable=invalid-django-waffle-import
 from completion.waffle import ENABLE_COMPLETION_TRACKING_SWITCH
 from completion.models import BlockCompletion
 from django.conf import settings

--- a/openedx/core/djangoapps/user_api/management/commands/sync_hubspot_contacts.py
+++ b/openedx/core/djangoapps/user_api/management/commands/sync_hubspot_contacts.py
@@ -145,7 +145,7 @@ class Command(BaseCommand):
             return len(contacts)
         except (HttpClientError, HttpServerError) as ex:
             message = 'An error occurred while syncing batch of contacts for site {domain}, {message}'.format(
-                domain=site_conf.site.domain, message=ex.message  # lint-amnesty, pylint: disable=no-member
+                domain=site_conf.site.domain, message=ex.message  # lint-amnesty, pylint: disable=no-member, exception-message-attribute
             )
             self.stderr.write(message)
             return 0

--- a/openedx/core/djangoapps/util/tests/test_print_setting.py
+++ b/openedx/core/djangoapps/util/tests/test_print_setting.py
@@ -1,3 +1,4 @@
+# lint-amnesty, pylint: disable=missing-module-docstring
 import pytest
 from django.core.management import CommandError, call_command
 

--- a/openedx/core/djangoapps/video_pipeline/config/waffle.py
+++ b/openedx/core/djangoapps/video_pipeline/config/waffle.py
@@ -55,7 +55,7 @@ def waffle_flags():
             flag_name=ENABLE_DEVSTACK_VIDEO_UPLOADS,
             module_name=__name__,
         ),
-        ENABLE_VEM_PIPELINE: CourseWaffleFlag(
+        ENABLE_VEM_PIPELINE: CourseWaffleFlag(  # lint-amnesty, pylint: disable=toggle-missing-annotation
             waffle_namespace=namespace,
             flag_name=ENABLE_VEM_PIPELINE,
             module_name=__name__,

--- a/openedx/core/lib/blockstore_api/methods.py
+++ b/openedx/core/lib/blockstore_api/methods.py
@@ -323,7 +323,7 @@ def get_bundle_files(bundle_uuid, use_draft=None):
     """
     Get an iterator over all the files in the specified bundle or draft.
     """
-    return get_bundle_files_dict(bundle_uuid, use_draft).values()
+    return get_bundle_files_dict(bundle_uuid, use_draft).values()  # lint-amnesty, pylint: disable=dict-values-not-iterating
 
 
 def get_bundle_links(bundle_uuid, use_draft=None):

--- a/openedx/features/effort_estimation/toggles.py
+++ b/openedx/features/effort_estimation/toggles.py
@@ -13,5 +13,5 @@ WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name='effort_estimation')
 # - Bucket 0: off
 # - Bucket 1: section (chapter) estimations
 # - Bucket 2: subsection (sequential) estimations
-EFFORT_ESTIMATION_LOCATION_FLAG = ExperimentWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'location', __name__, num_buckets=3,
+EFFORT_ESTIMATION_LOCATION_FLAG = ExperimentWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'location', __name__, num_buckets=3,  # lint-amnesty, pylint: disable=toggle-missing-annotation
                                                        use_course_aware_bucketing=False)

--- a/openedx/features/enterprise_support/utils.py
+++ b/openedx/features/enterprise_support/utils.py
@@ -23,7 +23,7 @@ from openedx.core.djangoapps.user_authn.cookies import standard_cookie_settings
 from openedx.core.djangolib.markup import HTML, Text
 from common.djangoapps.student.helpers import get_next_url_for_login_page
 
-ENTERPRISE_HEADER_LINKS = LegacyWaffleFlag('enterprise', 'enterprise_header_links', __name__)
+ENTERPRISE_HEADER_LINKS = LegacyWaffleFlag('enterprise', 'enterprise_header_links', __name__)  # lint-amnesty, pylint: disable=toggle-missing-annotation
 
 
 def get_data_consent_share_cache_key(user_id, course_id, enterprise_customer_uuid=None):


### PR DESCRIPTION
**Issue:** [BOM-2477](https://openedx.atlassian.net/browse/BOM-2477)

## Description
- Applied [lint-amnesty](https://github.com/edx/edx-lint#using-lint-amnesty) to existing pylint violations.

## Result
- 44 violations suppressed and the total violation count dropped to [29 warnings](https://build.testeng.edx.org/job/edx-platform-quality-pipeline-pr/27382/).
