### PR TITLE
fix: fix bug with `revoke_program_certificates` task

### DIFF
--- a/lms/djangoapps/certificates/tests/test_models.py
+++ b/lms/djangoapps/certificates/tests/test_models.py
@@ -343,4 +343,4 @@ class CertificateInvalidationTest(SharedModuleStoreTestCase):
         self.certificate.invalidate()
 
         assert mock_revoke_task.call_count == 1
-        assert mock_revoke_task.call_args[0] == (self.user.username, self.course_id)
+        assert mock_revoke_task.call_args[0] == (self.user.username, str(self.course_id))

--- a/openedx/core/djangoapps/programs/signals.py
+++ b/openedx/core/djangoapps/programs/signals.py
@@ -169,15 +169,11 @@ def handle_course_cert_revoked(sender, user, course_key, mode, status, **kwargs)
 
     # schedule background task to process
     LOGGER.info(
-        'handling COURSE_CERT_REVOKED: username=%s, course_key=%s, mode=%s, status=%s',
-        user,
-        course_key,
-        mode,
-        status,
+        f"handling COURSE_CERT_REVOKED: user={user.id}, course_key={course_key}, mode={mode}, status={status}"
     )
     # import here, because signal is registered at startup, but items in tasks are not yet able to be loaded
     from openedx.core.djangoapps.programs.tasks import revoke_program_certificates
-    revoke_program_certificates.delay(user.username, course_key)
+    revoke_program_certificates.delay(user.username, str(course_key))
 
 
 @receiver(COURSE_CERT_DATE_CHANGE, dispatch_uid='course_certificate_date_change_handler')

--- a/openedx/core/djangoapps/programs/tasks.py
+++ b/openedx/core/djangoapps/programs/tasks.py
@@ -467,7 +467,7 @@ def revoke_program_certificates(self, username, course_key):  # lint-amnesty, py
 
     Args:
         username (str): The username of the student
-        course_key (str|CourseKey): The course identifier
+        course_key (str): The course identifier
 
     Returns:
         None
@@ -510,7 +510,7 @@ def revoke_program_certificates(self, username, course_key):  # lint-amnesty, py
 
     try:
         inverted_programs = get_inverted_programs(student)
-        course_specific_programs = inverted_programs.get(str(course_key))
+        course_specific_programs = inverted_programs.get(course_key)
         if not course_specific_programs:
             # No reason to continue beyond this point
             LOGGER.info(

--- a/openedx/core/djangoapps/programs/tests/test_signals.py
+++ b/openedx/core/djangoapps/programs/tests/test_signals.py
@@ -230,7 +230,7 @@ class CertRevokedReceiverTest(TestCase):
 
         assert mock_is_learner_issuance_enabled.call_count == 1
         assert mock_task.call_count == 1
-        assert mock_task.call_args[0] == (TEST_USERNAME, TEST_COURSE_KEY)
+        assert mock_task.call_args[0] == (TEST_USERNAME, str(TEST_COURSE_KEY))
 
 
 @skip_unless_lms


### PR DESCRIPTION
## Description

[MICROBA-838]
* cast `course_key` as a string when scheduling the `revoke_program_certificates` task
* Update existing unit tests
* Move test utility method in test_tasks.py out from the middle of the test cases
* Fix spelling in test function name


[MICROBA-1164]: https://openedx.atlassian.net/browse/MICROBA-838

[MICROBA-838]: https://openedx.atlassian.net/browse/MICROBA-838