### PR TITLE
Handle a codejail exception normally in problem rescoring.

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -298,7 +298,7 @@ class CapaMixin(ScorableXBlockMixin, CapaFields):
         except Exception as err:  # pylint: disable=broad-except
             msg = 'cannot create LoncapaProblem {loc}: {err}'.format(
                 loc=str(self.location), err=err)
-            raise Exception(msg).with_traceback(sys.exc_info()[2])
+            raise LoncapaProblemError(msg).with_traceback(sys.exc_info()[2])
 
         if self.score is None:
             self.set_score(self.score_from_lcp(lcp))

--- a/common/lib/xmodule/xmodule/tests/__init__.py
+++ b/common/lib/xmodule/xmodule/tests/__init__.py
@@ -132,7 +132,7 @@ def get_test_system(
         replace_urls=str,
         user=user,
         get_real_user=lambda __: user,
-        filestore=Mock(name='get_test_system.filestore'),
+        filestore=Mock(name='get_test_system.filestore', root_path='.'),
         debug=True,
         hostname="edx.org",
         xqueue={

--- a/lms/djangoapps/instructor_task/tasks_helper/module_state.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/module_state.py
@@ -170,7 +170,18 @@ def rescore_problem_module_state(xmodule_instance_args, module_descriptor, stude
         # specific events from CAPA are not propagated up the stack. Do we want this?
         try:
             instance.rescore(only_if_higher=task_input['only_if_higher'])
-        except (LoncapaProblemError, StudentInputError, ResponseError):
+        except (LoncapaProblemError, ResponseError):
+            # Capture a backtrace for these errors, but only a warning below for student input errors.
+            TASK_LOG.exception(
+                "error processing rescore call for course %(course)s, problem %(loc)s "
+                "and student %(student)s",
+                dict(
+                    course=course_id,
+                    loc=usage_key,
+                    student=student
+                )
+            )
+        except StudentInputError:
             TASK_LOG.warning(
                 "error processing rescore call for course %(course)s, problem %(loc)s "
                 "and student %(student)s",


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

When codejail fails when rescoring a particular problem, it raises a `SafeExecException` exception. This exception wasn't being caught, which was causing the rescoring of a problem for the remaining students to fail. This PR adds handling for that particular exception and treats it like other problem rescoring errors - noting the error by logging and incrementing an error counter - but then continuing to other problem/student rescores.

## Supporting information

https://openedx.atlassian.net/browse/TNL-8233

## Testing instructions

Re-score a problematic course via the Instructor Dashboard's Student Admin tab by clicking the "Rescore Learner's Submission" or "Rescore Only If Score Improves" buttons.

## Deadline

This PR is a work-around for a CAT-2 ticket here: https://openedx.atlassian.net/browse/TNL-8218
So it needs to be expedited.

