### PR TITLE
Refactored InvalidProctoringProvider exception code

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/exceptions.py
+++ b/common/lib/xmodule/xmodule/modulestore/exceptions.py
@@ -108,15 +108,7 @@ class InvalidBranchSetting(Exception):
         self.actual_setting = actual_setting
 
 
-class CourseImportException(Exception):
-    """
-    Base exception for course import raised when course import fails
-    """
-    def __init__(self, args, kwargs):
-        super().__init__(args, kwargs)
-
-
-class InvalidProctoringProvider(CourseImportException):
+class InvalidProctoringProvider(Exception):
     """
     Error with selected proctoring provider raised when the provided is unknown.
     """
@@ -124,3 +116,5 @@ class InvalidProctoringProvider(CourseImportException):
     def __init__(self, proctoring_provider, available_providers):
         super().__init__(f"The selected proctoring provider, {proctoring_provider}, is not a valid provider. "
                          f"Please select from one of {available_providers}.")
+        self.proctoring_provider = proctoring_provider
+        self.available_providers = available_providers

--- a/common/lib/xmodule/xmodule/modulestore/exceptions.py
+++ b/common/lib/xmodule/xmodule/modulestore/exceptions.py
@@ -114,13 +114,5 @@ class InvalidProctoringProvider(Exception):
     """
 
     def __init__(self, proctoring_provider, available_providers):
-        super().__init__()
-        self.proctoring_provider = proctoring_provider
-        self.available_providers = available_providers
-
-    def __str__(self, *args, **kwargs):
-        """
-        Print details about error
-        """
-        return f"The selected proctoring provider, {self.proctoring_provider}, is not a valid provider. " \
-               f"Please select from one of {self.available_providers}."
+        super().__init__(f"The selected proctoring provider, {proctoring_provider}, is not a valid provider. "
+                         f"Please select from one of {available_providers}.")

--- a/common/lib/xmodule/xmodule/modulestore/exceptions.py
+++ b/common/lib/xmodule/xmodule/modulestore/exceptions.py
@@ -108,7 +108,12 @@ class InvalidBranchSetting(Exception):
         self.actual_setting = actual_setting
 
 
-class InvalidProctoringProvider(Exception):
+class CourseImportException(Exception):
+    def __init__(self, args, kwargs):
+        super().__init__(args, kwargs)
+
+
+class InvalidProctoringProvider(CourseImportException):
     """
     Error with selected proctoring provider raised when the provided is unknown.
     """

--- a/common/lib/xmodule/xmodule/modulestore/exceptions.py
+++ b/common/lib/xmodule/xmodule/modulestore/exceptions.py
@@ -109,6 +109,9 @@ class InvalidBranchSetting(Exception):
 
 
 class CourseImportException(Exception):
+    """
+    Base exception for course import raised when course import fails
+    """
     def __init__(self, args, kwargs):
         super().__init__(args, kwargs)
 


### PR DESCRIPTION
Refactored `InvalidProctoringProvider` exception code removed `__str__()` because it  was redundant .