### PR TITLE
Refactor: disable xsslint for numerous files

### DIFF
--- a/common/static/js/capa/editamolecule.js
+++ b/common/static/js/capa/editamolecule.js
@@ -148,9 +148,10 @@
 
     function formatInfo(raw_info) {
         var results = [];
+        var fragment;
 
         if (raw_info.search('It is not possible') == -1) {
-            var fragment = $('<div>').append(raw_info);
+            fragment = $('<div>').append(raw_info); // xss-lint: disable=javascript-jquery-append
             fragment.find('font').each(function() {
                 results.push($(this).html());
             });
@@ -173,7 +174,7 @@
     function updateMessages(message_field, values) {
         var error = values.error;
         if (error) {
-            message_field.html(error).show();
+            message_field.html(error).show(); // xss-lint: disable=javascript-jquery-html
         } else {
             // Clear messages
             message_field.html('').hide();

--- a/common/static/js/capa/jsmolcalc/jsmolcalc.nocache.js
+++ b/common/static/js/capa/jsmolcalc/jsmolcalc.nocache.js
@@ -89,7 +89,7 @@ function jsmolcalc(){
       if (typeof isBodyLoaded == 'undefined' || !isBodyLoaded()) {
         var markerId = '__gwt_marker_jsmolcalc';
         var markerScript;
-        $doc_0.write('<script id="' + markerId + '"><\/script>');
+        $doc_0.write('<script id="' + markerId + '"><\/script>'); // xss-lint: disable=javascript-concat-html
         markerScript = $doc_0.getElementById(markerId);
         thisScript = markerScript && markerScript.previousSibling;
         while (thisScript && thisScript.tagName != 'SCRIPT') {

--- a/common/static/js/capa/schematicinput.js
+++ b/common/static/js/capa/schematicinput.js
@@ -2,6 +2,7 @@ $(function() {
     // TODO: someone should fix all of this...
     // $("a[rel*=leanModal]").leanModal(); //TODO: Make this work with the new modal library. Try and integrate this with the "slices"
 
+    // xss-lint: disable=javascript-jquery-append
     $('body').append('\
     <div id="circuit_editor_modal" class="modal hide fade"> \
       <div class="modal-body"> \

--- a/common/static/js/capa/src/jsinput.js
+++ b/common/static/js/capa/src/jsinput.js
@@ -82,7 +82,7 @@ var JSInput = (function($, undefined) {
                 // Setting state presumes getting state, so don't get state
                 // unless set state is defined.
                 if (stateGetter && stateSetter) {
-                    state = unescape(_deepKey(cWindow, stateGetter)());
+                    state = unescape(_deepKey(cWindow, stateGetter)()); // xss-lint: disable=javascript-escape
                     store = {
                         answer: answer,
                         state: state

--- a/lms/static/js/Markdown.Converter.js
+++ b/lms/static/js/Markdown.Converter.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 var Markdown;
 
 if (typeof exports === 'object' && typeof require === 'function') // we're in a CommonJS (e.g. Node.js) module
@@ -580,7 +581,7 @@ else
                 }
             }
             url = attributeSafeUrl(url);
-            var result = '<a href="' + url + '"';
+            var result = '<a href="' + url + '"'; // xss-lint: disable=javascript-concat-html
 
             if (title != '') {
                 title = attributeEncode(title);
@@ -588,7 +589,7 @@ else
                 result += ' title="' + title + '"';
             }
 
-            result += '>' + link_text + '</a>';
+            result += '>' + link_text + '</a>'; // xss-lint: disable=javascript-concat-html
 
             return result;
         }
@@ -686,7 +687,7 @@ else
 
             alt_text = escapeCharacters(attributeEncode(alt_text), '*_[]()');
             url = escapeCharacters(url, '*_');
-            var result = '<img src="' + url + '" alt="' + alt_text + '"';
+            var result = '<img src="' + url + '" alt="' + alt_text + '"'; // xss-lint: disable=javascript-concat-html
 
             // attacklab: Markdown.pl adds empty title attributes to images.
             // Replicate this bug.
@@ -711,11 +712,11 @@ else
             //  --------
             //
             text = text.replace(/^(.+)[ \t]*\n=+[ \t]*\n+/gm,
-                function(wholeMatch, m1) { return '<h1>' + _RunSpanGamut(m1) + '</h1>\n\n'; }
+                function(wholeMatch, m1) { return '<h1>' + _RunSpanGamut(m1) + '</h1>\n\n'; } // xss-lint: disable=javascript-concat-html
             );
 
             text = text.replace(/^(.+)[ \t]*\n-+[ \t]*\n+/gm,
-                function(matchFound, m1) { return '<h2>' + _RunSpanGamut(m1) + '</h2>\n\n'; }
+                function(matchFound, m1) { return '<h2>' + _RunSpanGamut(m1) + '</h2>\n\n'; } // xss-lint: disable=javascript-concat-html
             );
 
             // atx-style headers:
@@ -740,7 +741,7 @@ else
             text = text.replace(/^(\#{1,6})[ \t]*(.+?)[ \t]*\#*\n+/gm,
                 function(wholeMatch, m1, m2) {
                     var h_level = m1.length;
-                    return '<h' + h_level + '>' + _RunSpanGamut(m2) + '</h' + h_level + '>\n\n';
+                    return '<h' + h_level + '>' + _RunSpanGamut(m2) + '</h' + h_level + '>\n\n'; // xss-lint: disable=javascript-concat-html
                 }
             );
 
@@ -794,7 +795,7 @@ else
                     // HTML block parser. This is a hack to work around the terrible
                     // hack that is the HTML block parser.
                     result = result.replace(/\s+$/, '');
-                    result = '<' + list_type + '>' + result + '</' + list_type + '>\n';
+                    result = '<' + list_type + '>' + result + '</' + list_type + '>\n'; // xss-lint: disable=javascript-concat-html
                     return result;
                 });
             } else {
@@ -805,7 +806,7 @@ else
 
                     var list_type = (m3.search(/[*+-]/g) > -1) ? 'ul' : 'ol';
                     var result = _ProcessListItems(list, list_type);
-                    result = runup + '<' + list_type + '>\n' + result + '</' + list_type + '>\n';
+                    result = runup + '<' + list_type + '>\n' + result + '</' + list_type + '>\n'; // xss-lint: disable=javascript-concat-html
                     return result;
                 });
             }
@@ -898,7 +899,7 @@ else
                         item = _RunSpanGamut(item);
                     }
                     last_item_had_a_double_newline = ends_with_double_newline;
-                    return '<li>' + item + '</li>\n';
+                    return '<li>' + item + '</li>\n'; // xss-lint: disable=javascript-concat-html
                 }
             );
 
@@ -940,7 +941,7 @@ else
                     codeblock = codeblock.replace(/^\n+/g, ''); // trim leading newlines
                     codeblock = codeblock.replace(/\n+$/g, ''); // trim trailing whitespace
 
-                    codeblock = '<pre><code>' + codeblock + '\n</code></pre>';
+                    codeblock = '<pre><code>' + codeblock + '\n</code></pre>'; // xss-lint: disable=javascript-concat-html
 
                     return '\n\n' + codeblock + '\n\n' + nextChar;
                 }
@@ -1003,7 +1004,7 @@ else
                     c = c.replace(/[ \t]*$/g, ''); // trailing whitespace
                     c = _EncodeCode(c);
                     c = c.replace(/:\/\//g, '~P'); // to prevent auto-linking. Not necessary in code *blocks*, but in code spans. Will be converted back after the auto-linker runs.
-                    return m1 + '<code>' + c + '</code>';
+                    return m1 + '<code>' + c + '</code>'; // xss-lint: disable=javascript-concat-html
                 }
             );
 
@@ -1092,7 +1093,7 @@ else
                             return pre;
                         });
 
-                    return hashBlock('<blockquote>\n' + bq + '\n</blockquote>');
+                    return hashBlock('<blockquote>\n' + bq + '\n</blockquote>'); // xss-lint: disable=javascript-concat-html
                 }
             );
             return text;
@@ -1193,7 +1194,7 @@ else
 
             //  autolink anything like <http://example.com>
 
-            var replacer = function(wholematch, m1) { return '<a href="' + m1 + '">' + pluginHooks.plainLinkText(m1) + '</a>'; };
+            var replacer = function(wholematch, m1) { return '<a href="' + m1 + '">' + pluginHooks.plainLinkText(m1) + '</a>'; }; // xss-lint: disable=javascript-concat-html
             text = text.replace(/<((https?|ftp):[^'">\s]+)>/gi, replacer);
 
             // Email addresses: <address@domain.foo>

--- a/lms/static/js/Markdown.Editor.js
+++ b/lms/static/js/Markdown.Editor.js
@@ -870,7 +870,7 @@
             var sibling = preview.nextSibling;
             parent.removeChild(preview);
             preview.innerHTML = text;
-            if (!sibling) { parent.appendChild(preview); } else { parent.insertBefore(preview, sibling); }
+            if (!sibling) { parent.appendChild(preview); } else { parent.insertBefore(preview, sibling); } // eslint-disable-line max-len, xss-lint: disable=javascript-jquery-insert-into-target
         };
 
         var nonSuckyBrowserPreviewSet = function(text) {
@@ -1053,7 +1053,7 @@
                 }
 
                 document.getElementById('wmd-editor-dialog-form-errors').textContent = [
-                    interpolate(
+                    interpolate( // eslint-disable-line no-undef, xss-lint: disable=javascript-interpolate
                         ngettext(
                             // Translators: 'errorCount' is the number of errors found in the form.
                             '%(errorCount)s error found in form.', '%(errorCount)s errors found in form.',
@@ -1523,7 +1523,7 @@
     };
 
     commandProto.wrap = function(chunk, len) {
-        this.unwrap(chunk);
+        this.unwrap(chunk); // xss-lint: disable=javascript-jquery-insertion
         var regex = new re('(.{1,' + len + '})( +|$\\n?)', 'gm'),
             that = this;
 
@@ -1935,13 +1935,13 @@
         };
 
         if (/^(?![ ]{0,3}>)/m.test(chunk.selection)) {
-            this.wrap(chunk, SETTINGS.lineLength - 2);
+            this.wrap(chunk, SETTINGS.lineLength - 2); // xss-lint: disable=javascript-jquery-insertion
             chunk.selection = chunk.selection.replace(/^/gm, '> ');
             replaceBlanksInTags(true);
             chunk.skipLines();
         } else {
             chunk.selection = chunk.selection.replace(/^[ ]{0,3}> ?/gm, '');
-            this.unwrap(chunk);
+            this.unwrap(chunk); // xss-lint: disable=javascript-jquery-insertion
             replaceBlanksInTags(false);
 
             if (!/^(\n|^)[ ]{0,3}>/.test(chunk.selection) && chunk.startTag) {
@@ -2073,7 +2073,7 @@
             var hasDigits = /\d+[.]/.test(chunk.startTag);
             chunk.startTag = '';
             chunk.selection = chunk.selection.replace(/\n[ ]{4}/g, '\n');
-            this.unwrap(chunk);
+            this.unwrap(chunk); // xss-lint: disable=javascript-jquery-insertion
             chunk.skipLines();
 
             if (hasDigits) {
@@ -2114,7 +2114,7 @@
         chunk.skipLines(nLinesUp, nLinesDown, true);
         chunk.startTag = prefix;
         var spaces = prefix.replace(/./g, ' ');
-        this.wrap(chunk, SETTINGS.lineLength - spaces.length);
+        this.wrap(chunk, SETTINGS.lineLength - spaces.length); // xss-lint: disable=javascript-jquery-insertion
         chunk.selection = chunk.selection.replace(/\n/g, '\n' + spaces);
     };
 


### PR DESCRIPTION
## Description

Disabling xsslint for the following files as it is safe to do so:


[PROD-2306](https://openedx.atlassian.net/browse/PROD-2306)
[PROD-2307](https://openedx.atlassian.net/browse/PROD-2307)
[PROD-2308](https://openedx.atlassian.net/browse/PROD-2308)
[PROD-2309](https://openedx.atlassian.net/browse/PROD-2309)
[PROD-2310](https://openedx.atlassian.net/browse/PROD-2310)
[PROD-2311](https://openedx.atlassian.net/browse/PROD-2311)