### PR TITLE
[TNL-8235] - Fix breaking code by updating the exception when load_file fails during import.

### DIFF
--- a/common/lib/xmodule/xmodule/xml_module.py
+++ b/common/lib/xmodule/xmodule/xml_module.py
@@ -5,9 +5,7 @@ import copy
 import json
 import logging
 import os
-import sys
 
-import six
 from lxml import etree
 from lxml.etree import Element, ElementTree, XMLParser
 from xblock.core import XML_NAMESPACES
@@ -213,9 +211,7 @@ class XmlParserMixin:
                 return cls.file_to_xml(xml_file)
         except Exception as err:  # lint-amnesty, pylint: disable=broad-except
             # Add info about where we are, but keep the traceback
-            msg = 'Unable to load file contents at path {} for item {}: {} '.format(
-                filepath, def_id, err)
-            six.reraise(Exception, msg, sys.exc_info()[2])
+            raise Exception(f'Unable to load file contents at path {filepath} for item {def_id}: {err}') from err
 
     @classmethod
     def load_definition(cls, xml_object, system, def_id, id_generator):


### PR DESCRIPTION
### [TNL-8235](https://openedx.atlassian.net/browse/TNL-8235)

#### Description
Python3 updates to the exception raised when a file fails to load during the import process.

#### Breaking code traceback for current code

```  
...
File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/xml_module.py", line 219, in load_file
    six.reraise(Exception, msg, sys.exc_info()[2])
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/six.py", line 701, in reraise
    if value.__traceback__ is not tb:
AttributeError: 'str' object has no attribute '__traceback__'
```

#### New traceback example

```
Traceback (most recent call last):
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/xml_module.py", line 210, in load_file
    with fs.open(filepath) as xml_file:
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/fs/osfs.py", line 379, in open
    return io.open(
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/fs/error_tools.py", line 76, in __exit__
    reraise(
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/six.py", line 702, in reraise
    raise value.with_traceback(tb)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/fs/osfs.py", line 379, in open
    return io.open(
fs.errors.ResourceNotFound: resource 'sequential/<sequential>.xml' not found

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/seq_module.py", line 110, in definition_from_xml
    child_block = system.process_xml(etree.tostring(child, encoding='unicode'))
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/xml.py", line 167, in process_xml
    descriptor = self.xblock_from_node(
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1680, in xblock_from_node
    block = block_class.parse_xml(node, self, keys, id_generator)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/xml_module.py", line 568, in parse_xml
    return super(XmlParserMixin, cls).parse_xml(node, runtime, keys, id_generator)  # pylint: disable=bad-super-call
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1123, in parse_xml
    block = cls.from_xml(xml, runtime, id_generator)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/xml_module.py", line 553, in from_xml
    return super().parse_xml(
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/xml_module.py", line 338, in parse_xml
    definition_xml, filepath = cls.load_definition_xml(node, runtime, def_id)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/xml_module.py", line 422, in load_definition_xml
    definition_xml = cls.load_file(filepath, runtime.resources_fs, def_id)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/xml_module.py", line 214, in load_file
    raise Exception(f'Unable to load file contents at path {filepath} for item {def_id}: {err}') from err
Exception: Unable to load file contents at path sequential/<sequential>.xml for item <path>/sequential/<sequential>: resource 'sequential/<sequential>.xml' not found
```