### PR TITLE
fix: Update discussions lti_configuration during provider_type change

### DIFF
--- a/openedx/core/djangoapps/discussions/models.py
+++ b/openedx/core/djangoapps/discussions/models.py
@@ -23,6 +23,17 @@ log = logging.getLogger(__name__)
 
 
 DEFAULT_PROVIDER_TYPE = 'legacy'
+PROVIDER_FEATURE_MAP = {
+    'legacy': [
+        'discussion-page',
+        'embedded-course-sections',
+        'wcag-2.1',
+    ],
+    'piazza': [
+        'discussion-page',
+        'lti',
+    ],
+}
 
 
 def get_supported_providers() -> list[str]:
@@ -178,6 +189,14 @@ class DiscussionsConfiguration(TimeStampedModel):
             provider=self.provider_type,
             enabled=self.enabled,
         )
+
+    def supports(self, feature: str) -> bool:
+        """
+        Check if the provider supports some feature
+        """
+        features = PROVIDER_FEATURE_MAP.get(self.provider_type) or []
+        has_support = bool(feature in features)
+        return has_support
 
     @classmethod
     def is_enabled(cls, context_key: CourseKey) -> bool:

--- a/openedx/core/djangoapps/discussions/views.py
+++ b/openedx/core/djangoapps/discussions/views.py
@@ -144,12 +144,7 @@ class DiscussionsConfigurationView(APIView):
                 'plugin_configuration': instance.plugin_configuration,
                 'providers': {
                     'active': instance.provider_type or DEFAULT_PROVIDER_TYPE,
-                    'available': {
-                        provider: {
-                            'features': PROVIDER_FEATURE_MAP.get(provider) or [],
-                        }
-                        for provider in instance.available_providers
-                    },
+                    'available': PROVIDER_FEATURE_MAP,
                 },
             })
             return payload

--- a/openedx/core/djangoapps/discussions/views.py
+++ b/openedx/core/djangoapps/discussions/views.py
@@ -120,7 +120,11 @@ class DiscussionsConfigurationView(APIView):
             Serialize data into a dictionary, to be used as a response
             """
             payload = super().to_representation(instance)
-            lti_configuration = LtiSerializer(instance.lti_configuration)
+            lti_configuration_data = {}
+            supports_lti = instance.supports('lti')
+            if supports_lti:
+                lti_configuration = LtiSerializer(instance.lti_configuration)
+                lti_configuration_data = lti_configuration.data
             payload.update({
                 'features': {
                     'discussion-page',
@@ -128,7 +132,7 @@ class DiscussionsConfigurationView(APIView):
                     'lti',
                     'wcag-2.1',
                 },
-                'lti_configuration': lti_configuration.data,
+                'lti_configuration': lti_configuration_data,
                 'plugin_configuration': instance.plugin_configuration,
                 'providers': {
                     'active': instance.provider_type or DEFAULT_PROVIDER_TYPE,

--- a/openedx/core/djangoapps/discussions/views.py
+++ b/openedx/core/djangoapps/discussions/views.py
@@ -16,19 +16,7 @@ from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiv
 
 from .models import DEFAULT_PROVIDER_TYPE
 from .models import DiscussionsConfiguration
-
-
-PROVIDER_FEATURE_MAP = {
-    'legacy': [
-        'discussion-page',
-        'embedded-course-sections',
-        'wcag-2.1',
-    ],
-    'piazza': [
-        'discussion-page',
-        'lti',
-    ],
-}
+from .models import PROVIDER_FEATURE_MAP
 
 
 class IsStaff(BasePermission):


### PR DESCRIPTION
Else, we risk updating it when we don't intend to, eg:
- changing from an LTI-backed provider (Piazza) to a non-LTI-backed
  provider (legacy)
  - the settings are no longer relevant
  - so let's set the configuration to empty/`None`
- changing from a non-LTI-backed provider (legacy) to an LTI-backed
  provider (Piazza)
  - the settings _are_ now relevant
  - ensure they are saved