### PR TITLE
[FAL-1813] fix: codejail issue when using matplotlib

### DIFF
--- a/common/lib/capa/capa/safe_exec/safe_exec.py
+++ b/common/lib/capa/capa/safe_exec/safe_exec.py
@@ -21,11 +21,14 @@ import os
 os.environ["OPENBLAS_NUM_THREADS"] = "1"    # See TNL-6456
 
 import random2 as random_module
+from random import SystemRandom
 import sys
 from six.moves import xrange
 
 random = random_module.Random(%r)
 random.Random = random_module.Random
+# numpy needs SystemRandom
+random.SystemRandom = SystemRandom
 sys.modules['random'] = random
 """
 

--- a/common/lib/capa/capa/safe_exec/tests/test_safe_exec.py
+++ b/common/lib/capa/capa/safe_exec/tests/test_safe_exec.py
@@ -387,3 +387,18 @@ class TestRealProblems(unittest.TestCase):  # lint-amnesty, pylint: disable=miss
         g = {}
         safe_exec(code, g)
         assert 'aVAP' in g
+
+    def test_matplot(self):
+        code = textwrap.dedent("""\
+            import matplotlib.pyplot as plt
+            import numpy as np
+
+            xpoints = np.array([0, 6])
+            ypoints = np.array([0, 250])
+
+            plt.plot(xpoints, ypoints)
+            plotted = plt.show()
+            """)
+        g = {}
+        safe_exec(code, g)
+        assert 'plotted' in g

--- a/common/lib/capa/capa/safe_exec/tests/test_safe_exec.py
+++ b/common/lib/capa/capa/safe_exec/tests/test_safe_exec.py
@@ -389,6 +389,8 @@ class TestRealProblems(unittest.TestCase):  # lint-amnesty, pylint: disable=miss
         assert 'aVAP' in g
 
     def test_matplot(self):
+        if not jail_code.is_configured("python"):
+            pytest.skip()
         code = textwrap.dedent("""\
             import matplotlib.pyplot as plt
             import numpy as np

--- a/requirements/edx-sandbox/py35.in
+++ b/requirements/edx-sandbox/py35.in
@@ -18,8 +18,7 @@
 chem                                # A helper library for chemistry calculations
 matplotlib==2.2.4                   # 2D plotting library
 networkx==2.2                       # Utilities for creating, manipulating, and studying network graphs
-numpy==1.16.5                       # Numeric array processing utilities; used by scipy
-openedx-calc<2.0.0
+openedx-calc<2.0.0                  # Helper library for mathematical calculations
 pyparsing==2.2.0                    # Python Parsing module
 random2                             # Implementation of random module that works identically under Python 2 and 3
 scipy==1.2.1                        # Math, science, and engineering library

--- a/requirements/edx-sandbox/py35.txt
+++ b/requirements/edx-sandbox/py35.txt
@@ -20,16 +20,15 @@ matplotlib==2.2.4         # via -c requirements/edx-sandbox/../constraints.txt, 
 mpmath==1.2.1             # via sympy
 networkx==2.2             # via -r requirements/edx-sandbox/py35.in
 nltk==3.6.1               # via -r requirements/edx-sandbox/shared.txt, chem
-numpy==1.16.5             # via -r requirements/edx-sandbox/py35.in, chem, matplotlib, openedx-calc, scipy
+numpy==1.20.2             # via chem, matplotlib, openedx-calc
 openedx-calc==1.0.9       # via -r requirements/edx-sandbox/py35.in
 pycparser==2.20           # via -r requirements/edx-sandbox/shared.txt, cffi
 pyparsing==2.2.0          # via -r requirements/edx-sandbox/py35.in, chem, matplotlib, openedx-calc
 python-dateutil==2.4.0    # via -c requirements/edx-sandbox/../constraints.txt, matplotlib
-pytz==2021.1              # via matplotlib
 random2==1.0.1            # via -r requirements/edx-sandbox/py35.in
 regex==2021.4.4           # via -r requirements/edx-sandbox/shared.txt, nltk
 scipy==1.2.1              # via -r requirements/edx-sandbox/py35.in, chem, openedx-calc
-six==1.15.0               # via -r requirements/edx-sandbox/shared.txt, chem, cryptography, cycler, matplotlib, openedx-calc, python-dateutil
+six==1.15.0               # via -r requirements/edx-sandbox/shared.txt, chem, cryptography, cycler, openedx-calc, python-dateutil
 sympy==1.6.2              # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/py35.in, symmath
 tqdm==4.60.0              # via -r requirements/edx-sandbox/shared.txt, nltk
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -108,7 +108,7 @@ edx-milestones==0.3.1     # via -r requirements/edx/base.in
 edx-opaque-keys[django]==2.2.0  # via -r requirements/edx/paver.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, lti-consumer-xblock, xmodule
 edx-organizations==6.9.0  # via -r requirements/edx/base.in
 edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/base.in
-edx-proctoring==3.8.5     # via -r requirements/edx/base.in, edx-proctoring-proctortrack
+edx-proctoring==3.8.5     # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, edx-proctoring-proctortrack
 edx-rbac==1.4.2           # via edx-enterprise
 edx-rest-api-client==5.3.0  # via -r requirements/edx/base.in, edx-enterprise, edx-proctoring
 edx-search==3.0.0         # via -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -120,7 +120,7 @@ edx-milestones==0.3.1     # via -r requirements/edx/testing.txt
 edx-opaque-keys[django]==2.2.0  # via -r requirements/edx/testing.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, lti-consumer-xblock, xmodule
 edx-organizations==6.9.0  # via -r requirements/edx/testing.txt
 edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/testing.txt
-edx-proctoring==3.8.5     # via -r requirements/edx/testing.txt, edx-proctoring-proctortrack
+edx-proctoring==3.8.5     # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, edx-proctoring-proctortrack
 edx-rbac==1.4.2           # via -r requirements/edx/testing.txt, edx-enterprise
 edx-rest-api-client==5.3.0  # via -r requirements/edx/testing.txt, edx-enterprise, edx-proctoring
 edx-search==3.0.0         # via -r requirements/edx/testing.txt
@@ -224,7 +224,8 @@ pylatexenc==2.10          # via -r requirements/edx/testing.txt, olxcleaner
 pylint-celery==0.3        # via -r requirements/edx/testing.txt, edx-lint
 pylint-django==2.4.3      # via -r requirements/edx/testing.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/edx/testing.txt, pylint-celery, pylint-django
-pylint==2.7.4             # via -r requirements/edx/testing.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint-pytest==0.3.0      # via -r requirements/edx/testing.txt
+pylint==2.7.4             # via -r requirements/edx/testing.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils, pylint-pytest
 pymongo==3.10.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, edx-opaque-keys, event-tracking, mongodbproxy, mongoengine
 pynliner==0.8.0           # via -r requirements/edx/testing.txt
 pyparsing==2.4.7          # via -r requirements/edx/testing.txt, chem, openedx-calc, packaging, pycontracts
@@ -239,7 +240,7 @@ pytest-json-report==1.2.4  # via -r requirements/edx/testing.txt
 pytest-metadata==1.8.0    # via -r requirements/edx/testing.txt, pytest-json-report
 pytest-randomly==3.7.0    # via -r requirements/edx/testing.txt
 pytest-xdist[psutil]==2.2.1  # via -r requirements/edx/testing.txt
-pytest==6.2.3             # via -r requirements/edx/testing.txt, pytest-attrib, pytest-cov, pytest-django, pytest-forked, pytest-json-report, pytest-metadata, pytest-randomly, pytest-xdist
+pytest==6.2.3             # via -r requirements/edx/testing.txt, pylint-pytest, pytest-attrib, pytest-cov, pytest-django, pytest-forked, pytest-json-report, pytest-metadata, pytest-randomly, pytest-xdist
 python-dateutil==2.4.0    # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, analytics-python, botocore, edx-ace, edx-drf-extensions, edx-enterprise, edx-event-routing-backends, edx-proctoring, faker, freezegun, icalendar, olxcleaner, ora2, xblock
 python-levenshtein==0.12.2  # via -r requirements/edx/testing.txt
 python-memcached==1.59    # via -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -117,7 +117,7 @@ edx-milestones==0.3.1     # via -r requirements/edx/base.txt
 edx-opaque-keys[django]==2.2.0  # via -r requirements/edx/base.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, lti-consumer-xblock, xmodule
 edx-organizations==6.9.0  # via -r requirements/edx/base.txt
 edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/base.txt
-edx-proctoring==3.8.5     # via -r requirements/edx/base.txt, edx-proctoring-proctortrack
+edx-proctoring==3.8.5     # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, edx-proctoring-proctortrack
 edx-rbac==1.4.2           # via -r requirements/edx/base.txt, edx-enterprise
 edx-rest-api-client==5.3.0  # via -r requirements/edx/base.txt, edx-enterprise, edx-proctoring
 edx-search==3.0.0         # via -r requirements/edx/base.txt
@@ -215,7 +215,8 @@ pylatexenc==2.10          # via -r requirements/edx/base.txt, olxcleaner
 pylint-celery==0.3        # via edx-lint
 pylint-django==2.4.3      # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==2.7.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint-pytest==0.3.0      # via -r requirements/edx/testing.in
+pylint==2.7.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils, pylint-pytest
 pymongo==3.10.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, edx-opaque-keys, event-tracking, mongodbproxy, mongoengine
 pynliner==0.8.0           # via -r requirements/edx/base.txt
 pyparsing==2.4.7          # via -r requirements/edx/base.txt, chem, openedx-calc, packaging, pycontracts
@@ -229,7 +230,7 @@ pytest-json-report==1.2.4  # via -r requirements/edx/testing.in
 pytest-metadata==1.8.0    # via -r requirements/edx/testing.in, pytest-json-report
 pytest-randomly==3.7.0    # via -r requirements/edx/testing.in
 pytest-xdist[psutil]==2.2.1  # via -r requirements/edx/testing.in
-pytest==6.2.3             # via -r requirements/edx/testing.in, pytest-attrib, pytest-cov, pytest-django, pytest-forked, pytest-json-report, pytest-metadata, pytest-randomly, pytest-xdist
+pytest==6.2.3             # via -r requirements/edx/testing.in, pylint-pytest, pytest-attrib, pytest-cov, pytest-django, pytest-forked, pytest-json-report, pytest-metadata, pytest-randomly, pytest-xdist
 python-dateutil==2.4.0    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, analytics-python, botocore, edx-ace, edx-drf-extensions, edx-enterprise, edx-event-routing-backends, edx-proctoring, faker, freezegun, icalendar, olxcleaner, ora2, xblock
 python-levenshtein==0.12.2  # via -r requirements/edx/base.txt
 python-memcached==1.59    # via -r requirements/edx/base.txt
@@ -301,7 +302,6 @@ xblock==1.4.0             # via -r requirements/edx/base.txt, acid-xblock, crowd
 xmlsec==1.3.9             # via -r requirements/edx/base.txt, python3-saml
 xss-utils==0.2.0          # via -r requirements/edx/base.txt
 zipp==1.0.0               # via -c requirements/edx/../constraints.txt, -r requirements/edx/coverage.txt, importlib-metadata
-pylint-pytest==0.3.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Upgrades numpy in the edx-sandbox to fix runtime error triggered by added test case:
```
    RuntimeError: module compiled against API version 0xe but this version of numpy is 0xd
```

Upgraded numpy now imports secrets, which requires random.SystemRandom, so this module has been added to the safe_exec code prolog.

This bug impacts Course Authors and Learners using [Custom Python-Evaluated Input problems](https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/custom_python.html#create-a-custom-python-evaluated-input-problem-in-studio) which rely on `matplotlib`.

## Supporting information

No public supporting details -- bug was reported by one of OpenCraft's users.

## Sandbox instance

* LMS: https://pr27372.sandbox.opencraft.hosting/
* Studio: https://studio.pr27372.sandbox.opencraft.hosting/

See [unit for working example](https://studio.pr27372.sandbox.opencraft.hosting/container/block-v1:OpenCraft+CodeJail+2021_1+type@vertical+block@cdd689976dd6447e89422db1abeb7c49?action=new)

## Testing instructions

To verify the issue, use latest `master`.

1. Login to Studio and create a course + section + subsection + unit.
1. Add a Blank Common Problem to the unit, and paste in the following OLX into the Advanced editor:
   <details><summary>Show OLX</summary>

   ```xml
   <problem>
   <script type="loncapa/python">
   import matplotlib.pyplot as plt
   import numpy as np
   
   xpoints = np.array([0, 6])
   ypoints = np.array([0, 250])
   
   plt.plot(xpoints, ypoints)
   plt.show()
   </script>
   <p>  Given center C = \( ($Cx, $Cy) \), radius \( r = $a \) and point P = \( ($Px,$Py) \)  draw tangets PA and PB to the circle from point P.</p>    
      
     <table> 
     <tbody>
         <tr>
           <td> </td> 
           <td> x coordinate </td>
           <td> y coordinate </td>
         </tr>
         <tr>
           <td>Point A</td>
           <td>
             <numericalresponse answer="$T1x">           
              <responseparam type="tolerance" default="0.01%" name="tol"
                         description="Numerical Tolerance"/>
              <textline size="10"/>
             </numericalresponse>
           </td>
           
           <td>
             <numericalresponse answer="$T1y">           
               <responseparam type="tolerance" default="0.01%" name="tol"
                         description="Numerical Tolerance"/>
               <textline size="10"/>
             </numericalresponse>
           </td>
         </tr>
           <tr>
           <td>Point B</td> 
           <td>
             <numericalresponse answer="$T2x">           
               <responseparam type="tolerance" default="0.01%" name="tol"
                         description="Numerical Tolerance"/>
               <textline size="10"/>
             </numericalresponse>
           </td>
           
           <td>
             <numericalresponse answer="$T2y">           
               <responseparam type="tolerance" default="0.01%" name="tol"
                         description="Numerical Tolerance"/>
               <textline size="10"/>
             </numericalresponse>
           </td>
       </tr>
       </tbody>
     </table>

   <solution> 
     <p> <img src="data:image/jpeg;base64,$figstr"/> </p> 
     <p> Length of line segment AC is equal to radius of given circle, |AC| = \( $a \) </p>
     <p> Length of line segment PC can be calculated from oordinates of points P and C.  |PC| = \( $b \) </p>
     <p> Slope \( m \) of line segment PC can also be computed from points P and C, \(m = $slope_PC \) </p>
     <p> \( \alpha = {tan}^ {-1} (m) = $d \) is the angle line segment PC make with x-axis </p>
     <p> Let  angle CPA \(  =\theta  \), we can compute   \( \theta = {cos} ^ {-1} (\frac {|AC|}{|PC|}) = $th \) </p>
     <p> Let \( \beta  \) be the angle line segment PA makes with x-axis, then \( \beta = \alpha + \theta \) </p>
     <p> x-coordinate of point A = x-coordinate of center of the circle + |AC| * cos ( \( \beta \) )</p>
     <p> y-coordinate of point A = y-coordinate of center of the circle + |AC| * sin ( \( \beta \)) </p>
   </solution>
   </problem>
   ```
   </details>
1. Save the problem -- note the error shown:
      ![codejail error](https://user-images.githubusercontent.com/7556571/115100638-08a9b480-9f7d-11eb-99d2-5d800e3ed701.png)

To verify fix:

1. In the devstack `studio-shell`, update the dependencies:
   ```bash
   root@studio:/edx/app/edxapp/edx-platform# source ../venvs/edxapp-sandbox/bin/activate
   (edxapp-sandbox) root@studio:/edx/app/edxapp/edx-platform# pip install -r requirements/edx-sandbox/py35.txt 
   ```
1. Reload the problem in Studio, and note that the error is no longer present.
   ![codejail_fixed](https://user-images.githubusercontent.com/7556571/115100016-fb8ac680-9f78-11eb-86eb-f5e80887f86c.png)
1. In the `studio-shell`, run the updated test to ensure it works (since it's skipped by CI):
   ```
   pytest common/lib/capa/capa/safe_exec/tests/test_safe_exec.py -k test_matplot
   ```

## Deadline

None.

## Other information

1. The [added `test_matplot` fails](https://build.testeng.edx.org/job/edx-platform-python-pipeline-pr/29466/testReport/junit/capa.capa.safe_exec.tests.test_safe_exec/TestRealProblems/Run_Tests___commonlib_unit___test_matplot/) in CI with:
   ```
   codejail.safe_exec.SafeExecException: ModuleNotFoundError: No module named 'matplotlib'
   ```
   It succeeds when run on the devstack, so I've just skipped it here: 1e7f563.
   Is there some way to update CI to ensure the updated sandbox requirements are deployed there?
1. I'm unsure why [`numpy` was constrained to `1.16.5`](https://github.com/edx/edx-platform/blob/db152dda45b4c588441afcd6a776560967e236a1/requirements/edx-sandbox/py35.in#L21), while the [platform `numpy`'s version was unconstrained](https://github.com/edx/edx-platform/blob/4134809b96c6ab5a8d8c954333c759ce11d4fdc5/requirements/edx/base.txt#L166).
   Are there any Course Authors relying on this older version?
1. [`matplotlib` is constrained to `<3.1`](https://github.com/edx/edx-platform/blob/4134809b96c6ab5a8d8c954333c759ce11d4fdc5/requirements/constraints.txt#L59-L60) because Matplotlib 3.1 requires Python 3.6.
   We're now using python 3.8. Can/should this constraint be removed?
1. No actual changes were made to the `requirements/edx` files -- just comments updated when running `make upgrade`.
1. Needs to be added to lilac; will submit a follow-up PR once this is accepted.