### PR TITLE
Use github version of py2neo instead of PyPI

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -112,7 +112,6 @@ oauthlib                            # OAuth specification support for authentica
 pdfminer                            # Used in shoppingcart for extracting/parsing pdf text
 piexif==1.0.2                       # Exif image metadata manipulation, used in the profile_images app
 Pillow                              # Image manipulation library; used for course assets, profile images, invoice PDFs, etc.
-py2neo<4.0.0                       # Used to communicate with Neo4j, which is used internally for modulestore inspection
 PyContracts==1.7.1
 pycountry==1.20
 pycryptodomex==3.4.7

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -185,7 +185,7 @@ piexif==1.0.2
 pillow==5.4.1
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1
-py2neo==3.1.2
+git+https://github.com/technige/py2neo.git@py2neo-3.1.2#egg=py2neo==3.1.2             # via -r requirements/edx/base.in
 pycontracts==1.7.1
 pycountry==1.20
 pycparser==2.19

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -238,7 +238,7 @@ pip-tools==3.2.0
 pluggy==0.8.1
 polib==1.1.0
 psutil==1.2.1
-py2neo==3.1.2
+git+https://github.com/technige/py2neo.git@py2neo-3.1.2#egg=py2neo==3.1.2             # via -r requirements/edx/testing.txt
 py==1.7.0
 pyasn1-modules==0.2.3
 pyasn1==0.4.5

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -68,6 +68,7 @@
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev
 -e git+https://github.com/appliedsec/pygeoip.git@95e69341cebf5a6a9fbf7c4f5439d458898bdc3b#egg=pygeoip
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
+-e git+https://github.com/technige/py2neo.git@py2neo-3.1.2#egg=py2neo==3.1.2
 -e git+https://github.com/mitodl/django-cas.git@afac57bc523f145ae826f4ed3d4fa8b2c86c5364#egg=django-cas==2.1.1
 -e git+https://github.com/dgrtwo/ParsePy.git@7949b9f754d1445eff8e8f20d0e967b9a6420639#egg=parse_rest
 

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -228,7 +228,7 @@ pillow==5.4.1
 pluggy==0.8.1             # via pytest, tox
 polib==1.1.0
 psutil==1.2.1
-py2neo==3.1.2
+git+https://github.com/technige/py2neo.git@py2neo-3.1.2#egg=py2neo==3.1.2             # via -r requirements/edx/base.txt
 py==1.7.0                 # via pytest, tox
 pyasn1-modules==0.2.3     # via service-identity
 pyasn1==0.4.5             # via pyasn1-modules, service-identity


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Currently installing Ironwood is broken, because the py2neo authors decided to remove the installable packages of the versions we were using.

```
Could not find a version that satisfies the requirement py2neo==3.1.2 (from -r /edx/app/edxapp/edx-platform/requirements/edx/base.txt (line 188)) (from versions: 4.0.0, 4.1.0, 4.1.1, 4.1.2, 4.1.3, 4.2.0, 4.3.0, 2020.0.0, 2020.1.0, 2020.1.1, 2021.0.0, 2021.0.1)
```


## Supporting information

For details see:

https://discuss.openedx.org/t/py2neo-installation-failure-affects-at-least-ironwood-and-juniper/4762
https://groups.google.com/g/open-edx-btr-notifications/c/c_SB98vhwDs/m/nzVV8SDRCQAJ

This has been patched in upstream Juniper: https://github.com/edx/edx-platform/pull/27358

## Deadline

ASAP
