### PR TITLE
BOM-2477: Apply lint-amnesty to pylint violations

### DIFF
--- a/cms/djangoapps/export_course_metadata/toggles.py
+++ b/cms/djangoapps/export_course_metadata/toggles.py
@@ -12,4 +12,4 @@ from edx_toggles.toggles import WaffleFlag
 # .. toggle_creation_date: 2021-03-01
 # .. toggle_target_removal_date: None
 # .. toggle_tickets: AA-461
-EXPORT_COURSE_METADATA_FLAG = WaffleFlag('cms.export_course_metadata', __name__)
+EXPORT_COURSE_METADATA_FLAG = WaffleFlag('cms.export_course_metadata', __name__)  # lint-amnesty, pylint: disable=toggle-missing-annotation

--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -8,7 +8,7 @@ import json
 import logging
 
 import six
-import waffle
+import waffle  # lint-amnesty, pylint: disable=invalid-django-waffle-import
 from babel.dates import format_datetime
 from babel.numbers import get_currency_symbol
 from django.contrib.auth.decorators import login_required

--- a/common/djangoapps/entitlements/tests/test_models.py
+++ b/common/djangoapps/entitlements/tests/test_models.py
@@ -109,7 +109,7 @@ class TestCourseEntitlementModelHelpers(ModuleStoreTestCase):
             )
             assert not CourseEnrollment.is_enrolled(user=self.user, course_key=new_course.id)
         except AttributeError as error:
-            self.fail(error.message)  # lint-amnesty, pylint: disable=no-member
+            self.fail(error.message)  # lint-amnesty, pylint: disable=no-member, exception-message-attribute
 
 
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')

--- a/common/djangoapps/student/tests/test_email.py
+++ b/common/djangoapps/student/tests/test_email.py
@@ -1,3 +1,4 @@
+# lint-amnesty, pylint: disable=missing-module-docstring
 import json
 import unittest
 from string import capwords

--- a/common/djangoapps/student/tests/test_views.py
+++ b/common/djangoapps/student/tests/test_views.py
@@ -26,12 +26,12 @@ from common.djangoapps.student.helpers import DISABLE_UNENROLL_CERT_STATES
 from common.djangoapps.student.models import CourseEnrollment, UserProfile
 from common.djangoapps.student.signals import REFUND_ORDER
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
-from common.djangoapps.util.milestones_helpers import (  # lint-amnesty, pylint: disable=line-too-long
+from common.djangoapps.util.milestones_helpers import (
     get_course_milestones,
     remove_prerequisite_course,
     set_prerequisite_courses
 )
-from common.djangoapps.util.testing import UrlResetMixin
+from common.djangoapps.util.testing import UrlResetMixin  # lint-amnesty, pylint: disable=unused-import
 from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
 from openedx.core.djangoapps.catalog.tests.factories import ProgramFactory
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview

--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -637,7 +637,7 @@ def student_dashboard(request):  # lint-amnesty, pylint: disable=too-many-statem
     inverted_programs = meter.invert_programs()
 
     urls, programs_data = {}, {}
-    bundles_on_dashboard_flag = LegacyWaffleFlag(experiments_namespace, 'bundles_on_dashboard', __name__)
+    bundles_on_dashboard_flag = LegacyWaffleFlag(experiments_namespace, 'bundles_on_dashboard', __name__)  # lint-amnesty, pylint: disable=toggle-missing-annotation
 
     # TODO: Delete this code and the relevant HTML code after testing LEARNER-3072 is complete
     if bundles_on_dashboard_flag.is_enabled() and inverted_programs and list(inverted_programs.items()):

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -44,7 +44,7 @@ from openedx.core.djangoapps.ace_common.template_context import get_base_templat
 from openedx.core.djangoapps.catalog.utils import get_programs_with_type
 from openedx.core.djangoapps.embargo import api as embargo_api
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
-from openedx.core.djangoapps.programs.models import ProgramsApiConfig
+from openedx.core.djangoapps.programs.models import ProgramsApiConfig  # lint-amnesty, pylint: disable=unused-import
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.theming import helpers as theming_helpers
 from openedx.core.djangoapps.user_api.preferences import api as preferences_api

--- a/common/djangoapps/third_party_auth/saml.py
+++ b/common/djangoapps/third_party_auth/saml.py
@@ -94,7 +94,7 @@ class SAMLAuthBackend(SAMLAuth):  # pylint: disable=abstract-method
             log.warning(
                 '[THIRD_PARTY_AUTH] Error in SAML authentication flow. '
                 'Provider: {idp_name}, Message: {message}'.format(
-                    message=ex.message,  # lint-amnesty, pylint: disable=no-member
+                    message=ex.message,  # lint-amnesty, pylint: disable=no-member, exception-message-attribute
                     idp_name=response.get('idp_name')
                 )
             )

--- a/openedx/core/djangoapps/bookmarks/views.py
+++ b/openedx/core/djangoapps/bookmarks/views.py
@@ -91,7 +91,7 @@ class BookmarksViewMixin:
         return Response(
             {
                 "developer_message": developer_message,
-                "user_message": _(user_message)
+                "user_message": _(user_message)  # lint-amnesty, pylint: disable=translation-of-non-string
             },
             status=error_status
         )
@@ -202,7 +202,7 @@ class BookmarksListView(ListCreateAPIView, BookmarksViewMixin):
         return page
 
     @apidocs.schema()
-    def post(self, request, *unused_args, **unused_kwargs):
+    def post(self, request, *unused_args, **unused_kwargs):  # lint-amnesty, pylint: disable=unused-argument
         """Create a new bookmark for a user.
 
         The POST request only needs to contain one parameter "usage_id".
@@ -312,7 +312,7 @@ class BookmarksDetailView(APIView, BookmarksViewMixin):
             return self.error_response(error_message, error_status=status.HTTP_404_NOT_FOUND)
 
     @apidocs.schema()
-    def get(self, request, username=None, usage_id=None):
+    def get(self, request, username=None, usage_id=None):  # lint-amnesty, pylint: disable=unused-argument
         """
         Get a specific bookmark for a user.
 

--- a/openedx/core/djangoapps/content/learning_sequences/api/tests/test_outlines.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/tests/test_outlines.py
@@ -12,7 +12,7 @@ from django.conf import settings
 from django.contrib.auth.models import AnonymousUser, User  # lint-amnesty, pylint: disable=imported-auth-user
 from edx_proctoring.exceptions import ProctoredExamNotFoundException
 from edx_when.api import set_dates_for_course
-from mock import patch
+from mock import patch  # lint-amnesty, pylint: disable=reimported
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import LibraryLocator
 from edx_toggles.toggles.testutils import override_waffle_flag
@@ -361,10 +361,11 @@ class ContentGatingTestCase(OutlineProcessorTestCase):
         # Enroll student in the course
         cls.student.courseenrollment_set.create(course_id=cls.course_key, is_active=True, mode="verified")
 
+    # lint-amnesty, pylint: disable=pointless-string-statement
     """
     Currently returns all, and only, sequences in required content, not just the first.
     This logic matches the existing transformer. Is this right?
-    """  # lint-amnesty, pylint: disable=pointless-string-statement
+    """
 
     @patch('openedx.core.djangoapps.content.learning_sequences.api.processors.content_gating.EntranceExamConfiguration.user_can_skip_entrance_exam')  # lint-amnesty, pylint: disable=line-too-long
     @patch('openedx.core.djangoapps.content.learning_sequences.api.processors.content_gating.milestones_helpers.get_required_content')  # lint-amnesty, pylint: disable=line-too-long
@@ -1217,7 +1218,7 @@ class SequentialVisibilityTestCase(CacheIsolationTestCase):
 
                 assert len(user_course_outline.sections) == 3
                 assert len(user_course_outline.sequences) == 6
-                assert all([(seq.usage_key in user_course_outline.accessible_sequences) for seq in
+                assert all([(seq.usage_key in user_course_outline.accessible_sequences) for seq in  # lint-amnesty, pylint: disable=use-a-generator
                             user_course_outline.sequences.values()]),\
                     'Sequences should be accessible to all users for a public course'
 

--- a/openedx/core/djangoapps/coursegraph/management/commands/tests/test_dump_to_neo4j.py
+++ b/openedx/core/djangoapps/coursegraph/management/commands/tests/test_dump_to_neo4j.py
@@ -297,7 +297,7 @@ class TestModuleStoreSerializer(TestDumpToNeo4jCommandBase):
               constituent nodes.
         """
         relationship_pairs = [
-            tuple([node["location"] for node in rel.nodes()])
+            tuple([node["location"] for node in rel.nodes()])  # lint-amnesty, pylint: disable=consider-using-generator
             for rel in relationships if rel.type() == relationship_type
         ]
         return relationship_pairs

--- a/openedx/core/djangoapps/credentials/tasks/v1/tasks.py
+++ b/openedx/core/djangoapps/credentials/tasks/v1/tasks.py
@@ -47,7 +47,7 @@ def send_grade_to_credentials(self, username, course_run_key, verified, letter_g
 
         logger.info(f"Sent grade for course {course_run_key} to user {username}")
 
-    except Exception as exc:
+    except Exception as exc:  # lint-amnesty, pylint: disable=unused-variable
         error_msg = f"Failed to send grade for course {course_run_key} to user {username}."
         logger.exception(error_msg)
         exception = MaxRetriesExceededError(

--- a/openedx/core/djangoapps/user_api/management/tests/test_bulk_user_org_email_optout.py
+++ b/openedx/core/djangoapps/user_api/management/tests/test_bulk_user_org_email_optout.py
@@ -3,7 +3,7 @@ Test the test_bulk_user_org_email_optout management command
 """
 
 
-import io
+import io  # lint-amnesty, pylint: disable=unused-import
 import os
 import tempfile
 from contextlib import contextmanager

--- a/openedx/core/djangolib/blockstore_cache.py
+++ b/openedx/core/djangolib/blockstore_cache.py
@@ -262,7 +262,7 @@ def get_bundle_draft_direct_links_cached(bundle_uuid, draft_name):
     cache_key = ('bundle_draft_direct_links', )
     result = bundle_cache.get(cache_key)
     if result is None:
-        links = blockstore_api.get_bundle_links(bundle_uuid, use_draft=draft_name).values()
+        links = blockstore_api.get_bundle_links(bundle_uuid, use_draft=draft_name).values()  # lint-amnesty, pylint: disable=dict-values-not-iterating
         result = {link.name: link.direct for link in links}
         bundle_cache.set(cache_key, result)
     return result

--- a/openedx/core/djangolib/js_utils.py
+++ b/openedx/core/djangolib/js_utils.py
@@ -69,7 +69,7 @@ def dump_js_escaped_json(obj, cls=EdxJSONEncoder):
         (string) Escaped encoded JSON.
 
     """
-    obj = list(obj) if isinstance(obj, type({}.values())) else obj  # lint-amnesty, pylint: disable=isinstance-second-argument-not-valid-type
+    obj = list(obj) if isinstance(obj, type({}.values())) else obj  # lint-amnesty, pylint: disable=isinstance-second-argument-not-valid-type, dict-values-not-iterating, line-too-long
     json_string = json.dumps(obj, ensure_ascii=True, cls=cls)
     json_string = _escape_json_for_js(json_string)
     return json_string

--- a/openedx/features/course_experience/__init__.py
+++ b/openedx/features/course_experience/__init__.py
@@ -4,7 +4,7 @@ Unified course experience settings and helper methods.
 import crum
 from django.utils.translation import ugettext as _
 from edx_django_utils.monitoring import set_custom_attribute
-from waffle import flag_is_active
+from waffle import flag_is_active  # lint-amnesty, pylint: disable=invalid-django-waffle-import
 
 from edx_toggles.toggles import LegacyWaffleFlag, LegacyWaffleFlagNamespace
 from openedx.core.djangoapps.util.user_messages import UserMessageCollection
@@ -16,20 +16,20 @@ WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name='course_experience')
 COURSE_EXPERIENCE_WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name='course_experience')
 
 # Waffle flag to disable the separate course outline page and full width content.
-DISABLE_COURSE_OUTLINE_PAGE_FLAG = CourseWaffleFlag(
+DISABLE_COURSE_OUTLINE_PAGE_FLAG = CourseWaffleFlag(  # lint-amnesty, pylint: disable=toggle-missing-annotation
     COURSE_EXPERIENCE_WAFFLE_FLAG_NAMESPACE, 'disable_course_outline_page', __name__
 )
 
 # Waffle flag to enable a single unified "Course" tab.
-DISABLE_UNIFIED_COURSE_TAB_FLAG = CourseWaffleFlag(
+DISABLE_UNIFIED_COURSE_TAB_FLAG = CourseWaffleFlag(  # lint-amnesty, pylint: disable=toggle-missing-annotation
     COURSE_EXPERIENCE_WAFFLE_FLAG_NAMESPACE, 'disable_unified_course_tab', __name__
 )
 
 # Waffle flag to enable the sock on the footer of the home and courseware pages.
-DISPLAY_COURSE_SOCK_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'display_course_sock', __name__)
+DISPLAY_COURSE_SOCK_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'display_course_sock', __name__)  # lint-amnesty, pylint: disable=toggle-missing-annotation
 
 # Waffle flag to let learners access a course before its start date.
-COURSE_PRE_START_ACCESS_FLAG = LegacyWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'pre_start_access', __name__)
+COURSE_PRE_START_ACCESS_FLAG = LegacyWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'pre_start_access', __name__)  # lint-amnesty, pylint: disable=toggle-missing-annotation
 
 # .. toggle_name: course_experience.enable_course_goals
 # .. toggle_implementation: CourseWaffleFlag
@@ -39,13 +39,13 @@ COURSE_PRE_START_ACCESS_FLAG = LegacyWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'pre_star
 # .. toggle_creation_date: 2017-09-11
 # .. toggle_target_removal_date: None
 # .. toggle_warnings: This temporary feature toggle does not have a target removal date.
-ENABLE_COURSE_GOALS = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'enable_course_goals', __name__)
+ENABLE_COURSE_GOALS = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'enable_course_goals', __name__)  # lint-amnesty, pylint: disable=toggle-missing-annotation
 
 # Waffle flag to control the display of the hero
-SHOW_UPGRADE_MSG_ON_COURSE_HOME = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'show_upgrade_msg_on_course_home', __name__)
+SHOW_UPGRADE_MSG_ON_COURSE_HOME = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'show_upgrade_msg_on_course_home', __name__)  # lint-amnesty, pylint: disable=toggle-missing-annotation
 
 # Waffle flag to control the display of the upgrade deadline message
-UPGRADE_DEADLINE_MESSAGE = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'upgrade_deadline_message', __name__)
+UPGRADE_DEADLINE_MESSAGE = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'upgrade_deadline_message', __name__)  # lint-amnesty, pylint: disable=toggle-missing-annotation
 
 # .. toggle_name: course_experience.latest_update
 # .. toggle_implementation: CourseWaffleFlag
@@ -57,11 +57,11 @@ UPGRADE_DEADLINE_MESSAGE = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'upgrade_dead
 # .. toggle_warnings: This is meant to be configured using waffle_utils course override only. Either do not create the
 #   actual waffle flag, or be sure to unset the flag even for Superusers. This is no longer used in the learning MFE
 #   and can be removed when the outline tab is fully moved to the learning MFE.
-LATEST_UPDATE_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'latest_update', __name__)
+LATEST_UPDATE_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'latest_update', __name__)  # lint-amnesty, pylint: disable=toggle-missing-annotation
 
 # Waffle flag to enable anonymous access to a course
 SEO_WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name='seo')
-COURSE_ENABLE_UNENROLLED_ACCESS_FLAG = CourseWaffleFlag(
+COURSE_ENABLE_UNENROLLED_ACCESS_FLAG = CourseWaffleFlag(  # lint-amnesty, pylint: disable=toggle-missing-annotation
     SEO_WAFFLE_FLAG_NAMESPACE,
     'enable_anonymous_courseware_access',
     __name__,
@@ -77,7 +77,7 @@ COURSE_ENABLE_UNENROLLED_ACCESS_FLAG = CourseWaffleFlag(
 # .. toggle_warnings: To set a relative due date for self-paced courses, the weeks_to_complete field for a course run
 #   needs to be set. Currently it can be set through the publisher app.
 # .. toggle_tickets: https://openedx.atlassian.net/browse/AA-27
-RELATIVE_DATES_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'relative_dates', __name__)
+RELATIVE_DATES_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'relative_dates', __name__)  # lint-amnesty, pylint: disable=toggle-missing-annotation
 
 # .. toggle_name: course_experience.calendar_sync
 # .. toggle_implementation: CourseWaffleFlag
@@ -91,7 +91,7 @@ RELATIVE_DATES_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'relative_dates', 
 # .. toggle_creation_date: 2021-01-26
 # .. toggle_target_removal_date: 2021-04-26
 # .. toggle_tickets: https://openedx.atlassian.net/browse/AA-36
-CALENDAR_SYNC_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'calendar_sync', __name__)
+CALENDAR_SYNC_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'calendar_sync', __name__)  # lint-amnesty, pylint: disable=toggle-missing-annotation
 
 
 def course_home_page_title(course):  # pylint: disable=unused-argument


### PR DESCRIPTION
**Issue:** [BOM-2477](https://openedx.atlassian.net/browse/BOM-2477)

## Description
- Applied [lint-amnesty](https://github.com/edx/edx-lint#using-lint-amnesty) on the existing pylint violations.

## Result
- Fixed 28 warnings and dropped violation count to [1 warning](https://build.testeng.edx.org/job/edx-platform-quality-pipeline-pr/27388/).