### PR TITLE
BOM-2480: Remove cryptography constraint

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -15,9 +15,6 @@
 # celery 5.0 has dropped python3.5 support.
 celery<5.0
 
-# cryptography 3.3 has dropped python3.5 support.
-cryptography<3.3
-
 # The CORS_ORIGIN_WHITELIST changes in a backwards incompatible way in 3.0.0, needs matching configuration repo changes
 django-cors-headers<3.0.0
 

--- a/requirements/edx-sandbox/py35.txt
+++ b/requirements/edx-sandbox/py35.txt
@@ -9,7 +9,7 @@ common/lib/symmath  # via -r requirements/edx-sandbox/py35.in
 cffi==1.14.5              # via -r requirements/edx-sandbox/shared.txt, cryptography
 chem==1.2.0               # via -r requirements/edx-sandbox/py35.in
 click==7.1.2              # via -r requirements/edx-sandbox/shared.txt, nltk
-cryptography==3.2.1       # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/shared.txt
+cryptography==3.4.7       # via -r requirements/edx-sandbox/shared.txt
 cycler==0.10.0            # via matplotlib
 decorator==5.0.7          # via networkx
 joblib==0.14.1            # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/shared.txt, nltk
@@ -19,8 +19,8 @@ markupsafe==1.1.1         # via chem
 matplotlib==2.2.4         # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/py35.in
 mpmath==1.2.1             # via sympy
 networkx==2.2             # via -r requirements/edx-sandbox/py35.in
-nltk==3.6.1               # via -r requirements/edx-sandbox/shared.txt, chem
-numpy==1.16.5             # via -r requirements/edx-sandbox/py35.in, chem, matplotlib, openedx-calc, scipy
+nltk==3.6.2               # via -r requirements/edx-sandbox/shared.txt, chem
+numpy==1.16.5             # via -r requirements/edx-sandbox/py35.in, chem, matplotlib, openedx-calc
 openedx-calc==1.0.9       # via -r requirements/edx-sandbox/py35.in
 pycparser==2.20           # via -r requirements/edx-sandbox/shared.txt, cffi
 pyparsing==2.2.0          # via -r requirements/edx-sandbox/py35.in, chem, matplotlib, openedx-calc
@@ -29,7 +29,7 @@ pytz==2021.1              # via matplotlib
 random2==1.0.1            # via -r requirements/edx-sandbox/py35.in
 regex==2021.4.4           # via -r requirements/edx-sandbox/shared.txt, nltk
 scipy==1.2.1              # via -r requirements/edx-sandbox/py35.in, chem, openedx-calc
-six==1.15.0               # via -r requirements/edx-sandbox/shared.txt, chem, cryptography, cycler, matplotlib, openedx-calc, python-dateutil
+six==1.15.0               # via chem, cycler, matplotlib, openedx-calc, python-dateutil
 sympy==1.6.2              # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/py35.in, symmath
 tqdm==4.60.0              # via -r requirements/edx-sandbox/shared.txt, nltk
 

--- a/requirements/edx-sandbox/shared.txt
+++ b/requirements/edx-sandbox/shared.txt
@@ -6,11 +6,10 @@
 #
 cffi==1.14.5              # via cryptography
 click==7.1.2              # via nltk
-cryptography==3.2.1       # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/shared.in
+cryptography==3.4.7       # via -r requirements/edx-sandbox/shared.in
 joblib==0.14.1            # via -c requirements/edx-sandbox/../constraints.txt, nltk
 lxml==4.5.0               # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/shared.in
-nltk==3.6.1               # via -r requirements/edx-sandbox/shared.in
+nltk==3.6.2               # via -r requirements/edx-sandbox/shared.in
 pycparser==2.20           # via cffi
 regex==2021.4.4           # via nltk
-six==1.15.0               # via cryptography
 tqdm==4.60.0              # via nltk

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -43,7 +43,7 @@ contextlib2==0.6.0.post1  # via -r requirements/edx/base.in
 coreapi==2.3.3            # via drf-yasg
 coreschema==0.0.4         # via coreapi, drf-yasg
 crowdsourcehinter-xblock==0.6  # via -r requirements/edx/base.in
-cryptography==3.2.1       # via -c requirements/edx/../constraints.txt, -r requirements/edx/../edx-sandbox/shared.txt, django-fernet-fields, edx-enterprise, pyjwt, social-auth-core
+cryptography==3.4.7       # via -r requirements/edx/../edx-sandbox/shared.txt, django-fernet-fields, edx-enterprise, pyjwt, social-auth-core
 cssutils==2.2.0           # via pynliner
 ddt==1.4.2                # via xblock-drag-and-drop-v2, xblock-poll
 decorator==5.0.7          # via pycontracts
@@ -75,7 +75,7 @@ django-ratelimit==3.0.1   # via -r requirements/edx/base.in
 django-require==1.0.11    # via -r requirements/edx/base.in
 django-sekizai==2.0.0     # via -r requirements/edx/base.in, django-wiki
 django-ses==2.0.0         # via -r requirements/edx/base.in
-django-simple-history==2.12.0  # via -r requirements/edx/base.in, edx-enterprise, edx-organizations, ora2
+django-simple-history==3.0.0  # via -r requirements/edx/base.in, edx-enterprise, edx-organizations, ora2
 django-splash==1.0.0      # via -r requirements/edx/base.in
 django-statici18n==2.0.1  # via -r requirements/edx/base.in
 django-storages==1.8      # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, edxval
@@ -140,7 +140,7 @@ itypes==1.2.0             # via coreapi
 jinja2==2.11.3            # via code-annotations, coreschema
 jmespath==0.10.0          # via boto3, botocore
 joblib==0.14.1            # via -c requirements/edx/../constraints.txt, -r requirements/edx/../edx-sandbox/shared.txt, nltk
-jsondiff==1.2.0           # via edx-enterprise
+jsondiff==1.3.0           # via edx-enterprise
 jsonfield2==3.0.3         # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, edx-celeryutils, edx-enterprise, edx-event-routing-backends, edx-proctoring, edx-submissions, lti-consumer-xblock, ora2
 kombu==4.6.11             # via celery
 laboratory==1.0.2         # via -r requirements/edx/base.in
@@ -161,7 +161,7 @@ mongoengine==0.23.0       # via -r requirements/edx/base.in
 mpmath==1.2.1             # via sympy
 mysqlclient==2.0.3        # via -r requirements/edx/base.in
 newrelic==6.2.0.156       # via -r requirements/edx/base.in, edx-django-utils
-nltk==3.6.1               # via -r requirements/edx/../edx-sandbox/shared.txt, chem
+nltk==3.6.2               # via -r requirements/edx/../edx-sandbox/shared.txt, chem
 nodeenv==1.6.0            # via -r requirements/edx/base.in
 numpy==1.20.2             # via chem, openedx-calc, scipy
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
@@ -182,7 +182,7 @@ pycparser==2.20           # via -r requirements/edx/../edx-sandbox/shared.txt, c
 pycryptodomex==3.10.1     # via -r requirements/edx/base.in, edx-proctoring, lti-consumer-xblock, pyjwkest
 pygments==2.8.1           # via -r requirements/edx/base.in
 pyjwkest==1.4.2           # via -r requirements/edx/base.in, edx-drf-extensions, lti-consumer-xblock
-pyjwt[crypto]==1.7.1      # via -r requirements/edx/base.in, drf-jwt, edx-rest-api-client, social-auth-core
+pyjwt[crypto]==2.0.1      # via -r requirements/edx/base.in, drf-jwt, edx-rest-api-client, social-auth-core
 pylatexenc==2.10          # via olxcleaner
 pymongo==3.10.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, -r requirements/edx/paver.txt, edx-opaque-keys, event-tracking, mongodbproxy, mongoengine
 pynliner==0.8.0           # via -r requirements/edx/base.in
@@ -214,10 +214,10 @@ scipy==1.6.2              # via chem, openedx-calc
 semantic-version==2.8.5   # via edx-drf-extensions
 shapely==1.7.1            # via -r requirements/edx/base.in
 simplejson==3.17.2        # via -r requirements/edx/base.in, sailthru-client, super-csv, xblock-utils
-six==1.15.0               # via -r requirements/edx/../edx-sandbox/shared.txt, -r requirements/edx/base.in, -r requirements/edx/paver.txt, analytics-python, bleach, chem, codejail, crowdsourcehinter-xblock, cryptography, django-countries, django-simple-history, edx-ace, edx-bulk-grades, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-milestones, edx-rbac, event-tracking, fs, fs-s3fs, html5lib, isodate, libsass, paver, pycontracts, pyjwkest, python-dateutil, python-memcached, python-swiftclient, social-auth-app-django, social-auth-core, stevedore, xblock
+six==1.15.0               # via -r requirements/edx/base.in, -r requirements/edx/paver.txt, analytics-python, bleach, chem, codejail, crowdsourcehinter-xblock, django-countries, edx-ace, edx-bulk-grades, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-milestones, edx-rbac, event-tracking, fs, fs-s3fs, html5lib, isodate, libsass, paver, pycontracts, pyjwkest, python-dateutil, python-memcached, python-swiftclient, social-auth-app-django, stevedore, xblock
 slumber==0.7.1            # via edx-bulk-grades, edx-enterprise, edx-rest-api-client
 social-auth-app-django==4.0.0  # via -r requirements/edx/base.in
-social-auth-core==4.0.2   # via -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt, -r requirements/edx/base.in, social-auth-app-django
+social-auth-core==4.1.0   # via -r requirements/edx/base.in, social-auth-app-django
 sorl-thumbnail==12.7.0    # via -r requirements/edx/base.in, django-wiki
 sortedcontainers==2.3.0   # via -r requirements/edx/base.in
 soupsieve==2.2.1          # via beautifulsoup4

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -6,7 +6,7 @@
 #
 coverage==5.5             # via -r requirements/edx/coverage.in
 diff-cover==4.0.0         # via -c requirements/edx/../constraints.txt, -r requirements/edx/coverage.in
-importlib-metadata==4.0.0  # via inflect
+importlib-metadata==4.0.1  # via inflect
 inflect==3.0.2            # via -c requirements/edx/../constraints.txt, jinja2-pluralize
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.11.3            # via diff-cover, jinja2-pluralize

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -50,7 +50,7 @@ coreschema==0.0.4         # via -r requirements/edx/testing.txt, coreapi, drf-ya
 coverage==5.5             # via -r requirements/edx/testing.txt, pytest-cov
 git+https://github.com/nedbat/coverage_pytest_plugin.git@29de030251471e200ff255eb9e549218cd60e872#egg=coverage_pytest_plugin==0.0  # via -r requirements/edx/testing.txt
 crowdsourcehinter-xblock==0.6  # via -r requirements/edx/testing.txt
-cryptography==3.2.1       # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, django-fernet-fields, edx-enterprise, pyjwt, social-auth-core
+cryptography==3.4.7       # via -r requirements/edx/testing.txt, django-fernet-fields, edx-enterprise, pyjwt, social-auth-core
 cssselect==1.1.0          # via -r requirements/edx/testing.txt, pyquery
 cssutils==2.2.0           # via -r requirements/edx/testing.txt, pynliner
 ddt==1.4.2                # via -r requirements/edx/testing.txt, xblock-drag-and-drop-v2, xblock-poll
@@ -86,7 +86,7 @@ django-ratelimit==3.0.1   # via -r requirements/edx/testing.txt
 django-require==1.0.11    # via -r requirements/edx/testing.txt
 django-sekizai==2.0.0     # via -r requirements/edx/testing.txt, django-wiki
 django-ses==2.0.0         # via -r requirements/edx/testing.txt
-django-simple-history==2.12.0  # via -r requirements/edx/testing.txt, edx-enterprise, edx-organizations, ora2
+django-simple-history==3.0.0  # via -r requirements/edx/testing.txt, edx-enterprise, edx-organizations, ora2
 django-splash==1.0.0      # via -r requirements/edx/testing.txt
 django-statici18n==2.0.1  # via -r requirements/edx/testing.txt
 django-storages==1.8      # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, edxval
@@ -146,7 +146,7 @@ fs==2.0.18                # via -r requirements/edx/testing.txt, django-pyfs, fs
 future==0.18.2            # via -r requirements/edx/testing.txt, django-ses, edx-celeryutils, edx-enterprise, pycontracts, pyjwkest
 geoip2==3.0.0             # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
 gitdb==4.0.7              # via -r requirements/edx/testing.txt, gitpython
-gitpython==3.1.14         # via -r requirements/edx/testing.txt, transifex-client
+gitpython==3.1.15         # via -r requirements/edx/testing.txt, transifex-client
 glob2==0.7                # via -r requirements/edx/testing.txt
 gunicorn==20.1.0          # via -r requirements/edx/testing.txt
 help-tokens==2.0.0        # via -r requirements/edx/testing.txt
@@ -155,7 +155,7 @@ httpretty==0.9.7          # via -c requirements/edx/../constraints.txt, -r requi
 icalendar==4.0.7          # via -r requirements/edx/testing.txt
 idna==2.10                # via -r requirements/edx/testing.txt, requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==4.0.0  # via -r requirements/edx/testing.txt, inflect, pytest-randomly
+importlib-metadata==4.0.1  # via -r requirements/edx/testing.txt, inflect, pytest-randomly
 inflect==3.0.2            # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, jinja2-pluralize
 inflection==0.5.1         # via -r requirements/edx/testing.txt, drf-yasg
 iniconfig==1.1.1          # via -r requirements/edx/testing.txt, pytest
@@ -167,7 +167,7 @@ jinja2-pluralize==0.3.0   # via -r requirements/edx/testing.txt, diff-cover
 jinja2==2.11.3            # via -r requirements/edx/testing.txt, code-annotations, coreschema, diff-cover, jinja2-pluralize, sphinx
 jmespath==0.10.0          # via -r requirements/edx/testing.txt, boto3, botocore
 joblib==0.14.1            # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, nltk
-jsondiff==1.2.0           # via -r requirements/edx/testing.txt, edx-enterprise
+jsondiff==1.3.0           # via -r requirements/edx/testing.txt, edx-enterprise
 jsonfield2==3.0.3         # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, edx-celeryutils, edx-enterprise, edx-event-routing-backends, edx-proctoring, edx-submissions, lti-consumer-xblock, ora2
 jsonschema==3.2.0         # via sphinxcontrib-openapi
 kombu==4.6.11             # via -r requirements/edx/testing.txt, celery
@@ -194,7 +194,7 @@ more-itertools==8.7.0     # via -r requirements/edx/testing.txt, zipp
 mpmath==1.2.1             # via -r requirements/edx/testing.txt, sympy
 mysqlclient==2.0.3        # via -r requirements/edx/testing.txt
 newrelic==6.2.0.156       # via -r requirements/edx/testing.txt, edx-django-utils
-nltk==3.6.1               # via -r requirements/edx/testing.txt, chem
+nltk==3.6.2               # via -r requirements/edx/testing.txt, chem
 nodeenv==1.6.0            # via -r requirements/edx/testing.txt
 numpy==1.20.2             # via -r requirements/edx/testing.txt, chem, openedx-calc, scipy
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
@@ -219,7 +219,7 @@ pycparser==2.20           # via -r requirements/edx/testing.txt, cffi
 pycryptodomex==3.10.1     # via -r requirements/edx/testing.txt, edx-proctoring, lti-consumer-xblock, pyjwkest
 pygments==2.8.1           # via -r requirements/edx/testing.txt, diff-cover, sphinx
 pyjwkest==1.4.2           # via -r requirements/edx/testing.txt, edx-drf-extensions, lti-consumer-xblock
-pyjwt[crypto]==1.7.1      # via -r requirements/edx/testing.txt, drf-jwt, edx-rest-api-client, social-auth-core
+pyjwt[crypto]==2.0.1      # via -r requirements/edx/testing.txt, drf-jwt, edx-rest-api-client, social-auth-core
 pylatexenc==2.10          # via -r requirements/edx/testing.txt, olxcleaner
 pylint-celery==0.3        # via -r requirements/edx/testing.txt, edx-lint
 pylint-django==2.4.3      # via -r requirements/edx/testing.txt, edx-lint
@@ -270,12 +270,12 @@ semantic-version==2.8.5   # via -r requirements/edx/testing.txt, edx-drf-extensi
 shapely==1.7.1            # via -r requirements/edx/testing.txt
 simplejson==3.17.2        # via -r requirements/edx/testing.txt, sailthru-client, super-csv, xblock-utils
 singledispatch==3.6.1     # via -r requirements/edx/testing.txt
-six==1.15.0               # via -r requirements/edx/pip-tools.txt, -r requirements/edx/testing.txt, analytics-python, bleach, bok-choy, chem, codejail, crowdsourcehinter-xblock, cryptography, django-countries, django-simple-history, edx-ace, edx-bulk-grades, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-lint, edx-milestones, edx-rbac, edx-sphinx-theme, event-tracking, freezegun, fs, fs-s3fs, html5lib, httpretty, isodate, jsonschema, libsass, paver, pip-tools, pycontracts, pyjwkest, python-dateutil, python-memcached, python-swiftclient, singledispatch, social-auth-app-django, social-auth-core, sphinxcontrib-httpdomain, stevedore, tox, transifex-client, virtualenv, xblock
+six==1.15.0               # via -r requirements/edx/pip-tools.txt, -r requirements/edx/testing.txt, analytics-python, bleach, bok-choy, chem, codejail, crowdsourcehinter-xblock, django-countries, edx-ace, edx-bulk-grades, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-lint, edx-milestones, edx-rbac, edx-sphinx-theme, event-tracking, freezegun, fs, fs-s3fs, html5lib, httpretty, isodate, jsonschema, libsass, paver, pip-tools, pycontracts, pyjwkest, python-dateutil, python-memcached, python-swiftclient, singledispatch, social-auth-app-django, sphinxcontrib-httpdomain, stevedore, tox, transifex-client, virtualenv, xblock
 slumber==0.7.1            # via -r requirements/edx/testing.txt, edx-bulk-grades, edx-enterprise, edx-rest-api-client
 smmap==4.0.0              # via -r requirements/edx/testing.txt, gitdb
 snowballstemmer==2.1.0    # via sphinx
 social-auth-app-django==4.0.0  # via -r requirements/edx/testing.txt
-social-auth-core==4.0.2   # via -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt, -r requirements/edx/testing.txt, social-auth-app-django
+social-auth-core==4.1.0   # via -r requirements/edx/testing.txt, social-auth-app-django
 sorl-thumbnail==12.7.0    # via -r requirements/edx/testing.txt, django-wiki
 sortedcontainers==2.3.0   # via -r requirements/edx/testing.txt
 soupsieve==2.2.1          # via -r requirements/edx/testing.txt, beautifulsoup4
@@ -302,6 +302,7 @@ tox-battery==0.6.1        # via -r requirements/edx/testing.txt
 tox==3.23.0               # via -r requirements/edx/testing.txt, tox-battery
 tqdm==4.60.0              # via -r requirements/edx/testing.txt, nltk
 transifex-client==0.14.2  # via -r requirements/edx/testing.txt
+typing-extensions==3.7.4.3  # via -r requirements/edx/testing.txt, gitpython
 ua-parser==0.10.0         # via -r requirements/edx/testing.txt, django-cookies-samesite
 unicodecsv==0.14.1        # via -r requirements/edx/testing.txt, edx-enterprise
 unidiff==0.6.0            # via -r requirements/edx/testing.txt, coverage-pytest-plugin
@@ -309,7 +310,7 @@ uritemplate==3.0.1        # via -r requirements/edx/testing.txt, coreapi, drf-ya
 urllib3==1.26.4           # via -r requirements/edx/testing.txt, elasticsearch, geoip2, requests, selenium, transifex-client
 user-util==1.0.0          # via -r requirements/edx/testing.txt
 vine==1.3.0               # via -r requirements/edx/testing.txt, amqp, celery
-virtualenv==20.4.3        # via -r requirements/edx/testing.txt, tox
+virtualenv==20.4.4        # via -r requirements/edx/testing.txt, tox
 voluptuous==0.12.1        # via -r requirements/edx/testing.txt, ora2
 vulture==2.3              # via -r requirements/edx/development.in
 watchdog==2.0.2           # via -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -14,7 +14,7 @@ django==2.2.20            # via -c https://raw.githubusercontent.com/edx/edx-lin
 docutils==0.16            # via -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt, sphinx
 edx-sphinx-theme==2.1.0   # via -r requirements/edx/doc.in
 gitdb==4.0.7              # via gitpython
-gitpython==3.1.14         # via -r requirements/edx/doc.in
+gitpython==3.1.15         # via -r requirements/edx/doc.in
 idna==2.10                # via requests
 imagesize==1.2.0          # via sphinx
 jinja2==2.11.3            # via code-annotations, sphinx
@@ -40,6 +40,7 @@ sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 sqlparse==0.4.1           # via django
 stevedore==1.32.0         # via -c requirements/edx/../constraints.txt, code-annotations
 text-unidecode==1.3       # via python-slugify
+typing-extensions==3.7.4.3  # via gitpython
 urllib3==1.26.4           # via requests
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -49,7 +49,7 @@ coreschema==0.0.4         # via -r requirements/edx/base.txt, coreapi, drf-yasg
 coverage==5.5             # via -r requirements/edx/coverage.txt, pytest-cov
 git+https://github.com/nedbat/coverage_pytest_plugin.git@29de030251471e200ff255eb9e549218cd60e872#egg=coverage_pytest_plugin==0.0  # via -r requirements/edx/testing.in
 crowdsourcehinter-xblock==0.6  # via -r requirements/edx/base.txt
-cryptography==3.2.1       # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, django-fernet-fields, edx-enterprise, pyjwt, social-auth-core
+cryptography==3.4.7       # via -r requirements/edx/base.txt, django-fernet-fields, edx-enterprise, pyjwt, social-auth-core
 cssselect==1.1.0          # via -r requirements/edx/testing.in, pyquery
 cssutils==2.2.0           # via -r requirements/edx/base.txt, pynliner
 ddt==1.4.2                # via -r requirements/edx/base.txt, -r requirements/edx/testing.in, xblock-drag-and-drop-v2, xblock-poll
@@ -84,7 +84,7 @@ django-ratelimit==3.0.1   # via -r requirements/edx/base.txt
 django-require==1.0.11    # via -r requirements/edx/base.txt
 django-sekizai==2.0.0     # via -r requirements/edx/base.txt, django-wiki
 django-ses==2.0.0         # via -r requirements/edx/base.txt
-django-simple-history==2.12.0  # via -r requirements/edx/base.txt, edx-enterprise, edx-organizations, ora2
+django-simple-history==3.0.0  # via -r requirements/edx/base.txt, edx-enterprise, edx-organizations, ora2
 django-splash==1.0.0      # via -r requirements/edx/base.txt
 django-statici18n==2.0.1  # via -r requirements/edx/base.txt
 django-storages==1.8      # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, edxval
@@ -142,7 +142,7 @@ fs==2.0.18                # via -r requirements/edx/base.txt, django-pyfs, fs-s3
 future==0.18.2            # via -r requirements/edx/base.txt, django-ses, edx-celeryutils, edx-enterprise, pycontracts, pyjwkest
 geoip2==3.0.0             # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt
 gitdb==4.0.7              # via gitpython
-gitpython==3.1.14         # via transifex-client
+gitpython==3.1.15         # via transifex-client
 glob2==0.7                # via -r requirements/edx/base.txt
 gunicorn==20.1.0          # via -r requirements/edx/base.txt
 help-tokens==2.0.0        # via -r requirements/edx/base.txt
@@ -150,7 +150,7 @@ html5lib==1.1             # via -r requirements/edx/base.txt, ora2
 httpretty==0.9.7          # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.in
 icalendar==4.0.7          # via -r requirements/edx/base.txt
 idna==2.10                # via -r requirements/edx/base.txt, requests
-importlib-metadata==4.0.0  # via -r requirements/edx/coverage.txt, inflect, pytest-randomly
+importlib-metadata==4.0.1  # via -r requirements/edx/coverage.txt, inflect, pytest-randomly
 inflect==3.0.2            # via -c requirements/edx/../constraints.txt, -r requirements/edx/coverage.txt, jinja2-pluralize
 inflection==0.5.1         # via -r requirements/edx/base.txt, drf-yasg
 iniconfig==1.1.1          # via pytest
@@ -162,7 +162,7 @@ jinja2-pluralize==0.3.0   # via -r requirements/edx/coverage.txt, diff-cover
 jinja2==2.11.3            # via -r requirements/edx/base.txt, -r requirements/edx/coverage.txt, code-annotations, coreschema, diff-cover, jinja2-pluralize
 jmespath==0.10.0          # via -r requirements/edx/base.txt, boto3, botocore
 joblib==0.14.1            # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, nltk
-jsondiff==1.2.0           # via -r requirements/edx/base.txt, edx-enterprise
+jsondiff==1.3.0           # via -r requirements/edx/base.txt, edx-enterprise
 jsonfield2==3.0.3         # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, edx-celeryutils, edx-enterprise, edx-event-routing-backends, edx-proctoring, edx-submissions, lti-consumer-xblock, ora2
 kombu==4.6.11             # via -r requirements/edx/base.txt, celery
 laboratory==1.0.2         # via -r requirements/edx/base.txt
@@ -186,7 +186,7 @@ more-itertools==8.7.0     # via -r requirements/edx/coverage.txt, zipp
 mpmath==1.2.1             # via -r requirements/edx/base.txt, sympy
 mysqlclient==2.0.3        # via -r requirements/edx/base.txt
 newrelic==6.2.0.156       # via -r requirements/edx/base.txt, edx-django-utils
-nltk==3.6.1               # via -r requirements/edx/base.txt, chem
+nltk==3.6.2               # via -r requirements/edx/base.txt, chem
 nodeenv==1.6.0            # via -r requirements/edx/base.txt
 numpy==1.20.2             # via -r requirements/edx/base.txt, chem, openedx-calc, scipy
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
@@ -210,7 +210,7 @@ pycparser==2.20           # via -r requirements/edx/base.txt, cffi
 pycryptodomex==3.10.1     # via -r requirements/edx/base.txt, edx-proctoring, lti-consumer-xblock, pyjwkest
 pygments==2.8.1           # via -r requirements/edx/base.txt, -r requirements/edx/coverage.txt, diff-cover
 pyjwkest==1.4.2           # via -r requirements/edx/base.txt, edx-drf-extensions, lti-consumer-xblock
-pyjwt[crypto]==1.7.1      # via -r requirements/edx/base.txt, drf-jwt, edx-rest-api-client, social-auth-core
+pyjwt[crypto]==2.0.1      # via -r requirements/edx/base.txt, drf-jwt, edx-rest-api-client, social-auth-core
 pylatexenc==2.10          # via -r requirements/edx/base.txt, olxcleaner
 pylint-celery==0.3        # via edx-lint
 pylint-django==2.4.3      # via edx-lint
@@ -259,11 +259,11 @@ semantic-version==2.8.5   # via -r requirements/edx/base.txt, edx-drf-extensions
 shapely==1.7.1            # via -r requirements/edx/base.txt
 simplejson==3.17.2        # via -r requirements/edx/base.txt, sailthru-client, super-csv, xblock-utils
 singledispatch==3.6.1     # via -r requirements/edx/testing.in
-six==1.15.0               # via -r requirements/edx/base.txt, analytics-python, bleach, bok-choy, chem, codejail, crowdsourcehinter-xblock, cryptography, django-countries, django-simple-history, edx-ace, edx-bulk-grades, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-lint, edx-milestones, edx-rbac, event-tracking, freezegun, fs, fs-s3fs, html5lib, httpretty, isodate, libsass, paver, pycontracts, pyjwkest, python-dateutil, python-memcached, python-swiftclient, singledispatch, social-auth-app-django, social-auth-core, stevedore, tox, transifex-client, virtualenv, xblock
+six==1.15.0               # via -r requirements/edx/base.txt, analytics-python, bleach, bok-choy, chem, codejail, crowdsourcehinter-xblock, django-countries, edx-ace, edx-bulk-grades, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-lint, edx-milestones, edx-rbac, event-tracking, freezegun, fs, fs-s3fs, html5lib, httpretty, isodate, libsass, paver, pycontracts, pyjwkest, python-dateutil, python-memcached, python-swiftclient, singledispatch, social-auth-app-django, stevedore, tox, transifex-client, virtualenv, xblock
 slumber==0.7.1            # via -r requirements/edx/base.txt, edx-bulk-grades, edx-enterprise, edx-rest-api-client
 smmap==4.0.0              # via gitdb
 social-auth-app-django==4.0.0  # via -r requirements/edx/base.txt
-social-auth-core==4.0.2   # via -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt, -r requirements/edx/base.txt, social-auth-app-django
+social-auth-core==4.1.0   # via -r requirements/edx/base.txt, social-auth-app-django
 sorl-thumbnail==12.7.0    # via -r requirements/edx/base.txt, django-wiki
 sortedcontainers==2.3.0   # via -r requirements/edx/base.txt
 soupsieve==2.2.1          # via -r requirements/edx/base.txt, beautifulsoup4
@@ -281,6 +281,7 @@ tox-battery==0.6.1        # via -r requirements/edx/testing.in
 tox==3.23.0               # via -r requirements/edx/testing.in, tox-battery
 tqdm==4.60.0              # via -r requirements/edx/base.txt, nltk
 transifex-client==0.14.2  # via -r requirements/edx/testing.in
+typing-extensions==3.7.4.3  # via gitpython
 ua-parser==0.10.0         # via -r requirements/edx/base.txt, django-cookies-samesite
 unicodecsv==0.14.1        # via -r requirements/edx/base.txt, edx-enterprise
 unidiff==0.6.0            # via -r requirements/edx/testing.in, coverage-pytest-plugin
@@ -288,7 +289,7 @@ uritemplate==3.0.1        # via -r requirements/edx/base.txt, coreapi, drf-yasg
 urllib3==1.26.4           # via -r requirements/edx/base.txt, elasticsearch, geoip2, requests, selenium, transifex-client
 user-util==1.0.0          # via -r requirements/edx/base.txt
 vine==1.3.0               # via -r requirements/edx/base.txt, amqp, celery
-virtualenv==20.4.3        # via tox
+virtualenv==20.4.4        # via tox
 voluptuous==0.12.1        # via -r requirements/edx/base.txt, ora2
 watchdog==2.0.2           # via -r requirements/edx/base.txt
 web-fragments==1.0.0      # via -r requirements/edx/base.txt, crowdsourcehinter-xblock, edx-sga, staff-graded-xblock, xblock, xblock-utils


### PR DESCRIPTION
**Issue:** [BOM-2480](https://openedx.atlassian.net/browse/BOM-2480)

### Description
- Removed `cryptography<3.3` constraint which was placed for `Python 3.5` support.