### PR TITLE
feat: Add multi device support for mobile in word cloud

### DIFF
--- a/common/lib/xmodule/xmodule/word_cloud_module.py
+++ b/common/lib/xmodule/xmodule/word_cloud_module.py
@@ -13,6 +13,7 @@ import logging
 from pkg_resources import resource_string
 
 from web_fragments.fragment import Fragment
+from xblock.core import XBlock
 from xblock.fields import Boolean, Dict, Integer, List, Scope, String
 from xmodule.editing_module import EditingMixin
 from xmodule.raw_module import EmptyDataRawMixin
@@ -272,6 +273,7 @@ class WordCloudBlock(  # pylint: disable=abstract-method
                 'error': 'Unknown Command!'
             })
 
+    @XBlock.supports('multi_device')
     def student_view(self, context):  # lint-amnesty, pylint: disable=unused-argument
         """
         Renders the output that a student will see.


### PR DESCRIPTION
Enable mobile support in word cloud.

LEARNER-8319

## Description
Add multi device support for mobile in word cloud.
## Testing instructions

call /api/courses/v2/blocks/?course_id={course id of a course having word cloud unit}&username={username}&depth=all&requested_fields=student_view_multi_device&nav_depth=3 

check if student enabled or not.
