### PR TITLE
[bug] Updated confusing text about when a certificated is available

### DIFF
--- a/lms/templates/dashboard/_dashboard_certificate_information.html
+++ b/lms/templates/dashboard/_dashboard_certificate_information.html
@@ -37,7 +37,7 @@ else:
       <p class="message-copy">
         <%
           certificate_available_date_string = course_overview.certificate_available_date.strftime('%Y-%m-%dT%H:%M:%S%z')
-          container_string = _("Your certificate will be available on or before {date}")
+          container_string = _("Your certificate will be available on or after {date}")
           format = 'shortDate'
         %>
         <span class="info-date-block localized-datetime" data-language="${user_language}" data-timezone="${user_timezone}" data-datetime="${certificate_available_date_string}" data-format=${format} data-string="${container_string}"></span>


### PR DESCRIPTION
Currently when a certificate availability date is set the text on the
course dasboard is confusing to the learner and could lead them to the
wrong conclusions. The cert should not be available until on or after
the available date.

Before
<img width="1200" alt="Screen Shot 2021-04-16 at 7 34 07 AM" src="https://user-images.githubusercontent.com/2854941/115578971-bbd32000-a293-11eb-9357-3e98b48a18f1.png">


After
<img width="1022" alt="Screen Shot 2021-04-21 at 11 21 17 AM" src="https://user-images.githubusercontent.com/2854941/115579012-c2619780-a293-11eb-8b29-41860a5c7115.png">
