### PR TITLE
build: no need for this hackathon testing plugin

### DIFF
--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -48,7 +48,6 @@ contextlib2==0.6.0.post1  # via -r requirements/edx/testing.txt
 coreapi==2.3.3            # via -r requirements/edx/testing.txt, drf-yasg
 coreschema==0.0.4         # via -r requirements/edx/testing.txt, coreapi, drf-yasg
 coverage==5.5             # via -r requirements/edx/testing.txt, pytest-cov
-git+https://github.com/nedbat/coverage_pytest_plugin.git@29de030251471e200ff255eb9e549218cd60e872#egg=coverage_pytest_plugin==0.0  # via -r requirements/edx/testing.txt
 crowdsourcehinter-xblock==0.6  # via -r requirements/edx/testing.txt
 cryptography==3.2.1       # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, django-fernet-fields, edx-enterprise, pyjwt, social-auth-core
 cssselect==1.1.0          # via -r requirements/edx/testing.txt, pyquery

--- a/requirements/edx/testing.in
+++ b/requirements/edx/testing.in
@@ -35,7 +35,6 @@ pyquery                   # jQuery-like API for retrieving fragments of HTML and
 pytest                    # Testing framework
 pytest-attrib             # Select tests based on attributes
 pytest-cov                # pytest plugin for measuring code coverage
-git+https://github.com/nedbat/coverage_pytest_plugin.git@29de030251471e200ff255eb9e549218cd60e872#egg=coverage_pytest_plugin==0.0
 pytest-django             # Django support for pytest
 pytest-json-report        # Output json formatted warnings after running pytest
 pytest-metadata==1.8.0     # To prevent 'make upgrade' failure, dependency of pytest-json-report

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -47,7 +47,6 @@ contextlib2==0.6.0.post1  # via -r requirements/edx/base.txt
 coreapi==2.3.3            # via -r requirements/edx/base.txt, drf-yasg
 coreschema==0.0.4         # via -r requirements/edx/base.txt, coreapi, drf-yasg
 coverage==5.5             # via -r requirements/edx/coverage.txt, pytest-cov
-git+https://github.com/nedbat/coverage_pytest_plugin.git@29de030251471e200ff255eb9e549218cd60e872#egg=coverage_pytest_plugin==0.0  # via -r requirements/edx/testing.in
 crowdsourcehinter-xblock==0.6  # via -r requirements/edx/base.txt
 cryptography==3.2.1       # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, django-fernet-fields, edx-enterprise, pyjwt, social-auth-core
 cssselect==1.1.0          # via -r requirements/edx/testing.in, pyquery


### PR DESCRIPTION
This was to support an experiment in using coverage test contexts to
record what tests ran each line of code (informally known as
who-tests-what, or wtw).   It never became operational.

This plugin is no longer needed.  There should be no observable difference from this pull request.