### PR TITLE
MST-757 Move exam registration to async task

### DIFF
--- a/cms/djangoapps/contentstore/config/waffle.py
+++ b/cms/djangoapps/contentstore/config/waffle.py
@@ -52,6 +52,22 @@ SHOW_REVIEW_RULES_FLAG = CourseWaffleFlag(  # lint-amnesty, pylint: disable=togg
     module_name=__name__,
 )
 
+# Waffle flag to move the registration of special exams to an async celery task
+# .. toggle_name: contentstore.async_register_exams
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Toggles the asynchronous registration of special exams
+# .. toggle_use_cases: temporary, open_edx
+# .. toggle_creation_date: 2021-04-21
+# .. toggle_target_removal_date: 2021-05-07
+# .. toggle_warnings:
+# .. toggle_tickets: https://openedx.atlassian.net/browse/MST-757
+ENABLE_ASYNC_REGISTER_EXAMS = CourseWaffleFlag(
+    waffle_namespace=waffle_flags(),
+    flag_name='async_register_exams',
+    module_name=__name__,
+)
+
 # Waffle flag to redirect to the library authoring MFE.
 # .. toggle_name: contentstore.library_authoring_mfe
 # .. toggle_implementation: WaffleFlag

--- a/cms/djangoapps/contentstore/tests/test_proctoring.py
+++ b/cms/djangoapps/contentstore/tests/test_proctoring.py
@@ -9,9 +9,11 @@ from unittest.mock import patch
 import ddt
 from django.conf import settings
 from edx_proctoring.api import get_all_exams_for_course, get_review_policy_by_exam_id
+from edx_toggles.toggles.testutils import override_waffle_flag
 from pytz import UTC
 
 from cms.djangoapps.contentstore.signals.handlers import listen_for_course_publish
+from cms.djangoapps.contentstore.config.waffle import ENABLE_ASYNC_REGISTER_EXAMS
 from common.djangoapps.student.tests.factories import UserFactory
 from common.lib.xmodule.xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
@@ -100,7 +102,9 @@ class TestProctoredExams(ModuleStoreTestCase):
             is_onboarding_exam=is_onboarding_exam,
         )
 
-        listen_for_course_publish(self, self.course.id)
+        with patch('cms.djangoapps.contentstore.tasks.update_special_exams_and_publish') as mock_task:
+            listen_for_course_publish(self, self.course.id)
+            mock_task.delay.assert_not_called()
 
         self._verify_exam_data(sequence, True)
 
@@ -314,3 +318,45 @@ class TestProctoredExams(ModuleStoreTestCase):
         listen_for_course_publish(self, self.course.id)
         exams = get_all_exams_for_course(str(self.course.id))
         assert exams[0]['due_date'] is not None
+
+    @override_waffle_flag(ENABLE_ASYNC_REGISTER_EXAMS, active=True)
+    def test_async_waffle_flag_publishes(self):
+        chapter = ItemFactory.create(parent=self.course, category='chapter', display_name='Test Section')
+        sequence = ItemFactory.create(
+            parent=chapter,
+            category='sequential',
+            display_name='Test Proctored Exam',
+            graded=True,
+            is_time_limited=True,
+            default_time_limit_minutes=10,
+            is_proctored_exam=True,
+            hide_after_due=False,
+            is_onboarding_exam=False,
+            exam_review_rules="allow_use_of_paper",
+        )
+
+        listen_for_course_publish(self, self.course.id)
+
+        exams = get_all_exams_for_course(str(self.course.id))
+        self.assertEqual(len(exams), 1)
+        self._verify_exam_data(sequence, True)
+
+    @override_waffle_flag(ENABLE_ASYNC_REGISTER_EXAMS, active=True)
+    def test_async_waffle_flag_task(self):
+        chapter = ItemFactory.create(parent=self.course, category='chapter', display_name='Test Section')
+        ItemFactory.create(
+            parent=chapter,
+            category='sequential',
+            display_name='Test Proctored Exam',
+            graded=True,
+            is_time_limited=True,
+            default_time_limit_minutes=10,
+            is_proctored_exam=True,
+            hide_after_due=False,
+            is_onboarding_exam=False,
+            exam_review_rules="allow_use_of_paper",
+        )
+
+        with patch('cms.djangoapps.contentstore.tasks.update_special_exams_and_publish') as mock_task:
+            listen_for_course_publish(self, self.course.id)
+            mock_task.delay.assert_called()


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Synchronously registering proctored exams while saving content to studio is causing a significant slow down. The function that registers the exams has been moved to an async task. In addition, a signal handler on_course_publish has also been moved to the async task, as it relies on exam registration being complete before being executed.

This new workflow should be rolled out using a course waffle flag `studio.async_register_exams` to ensure that it works as expected on stage and prod without interrupting course teams.
