### PR TITLE
fix: only show 'View in New Exp.' to global staff if MFE preview enabled

### DIFF
--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -56,10 +56,9 @@ from lms.djangoapps.courseware.toggles import (
     COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW,
     COURSEWARE_OPTIMIZED_RENDER_XBLOCK,
     REDIRECT_TO_COURSEWARE_MICROFRONTEND,
-
+    courseware_mfe_is_advertised,
 )
 from lms.djangoapps.courseware.user_state_client import DjangoXBlockUserStateClient
-from lms.djangoapps.courseware.views.index import show_courseware_mfe_link
 from lms.djangoapps.grades.config.waffle import ASSUME_ZERO_GRADE_IF_ABSENT
 from lms.djangoapps.grades.config.waffle import waffle_switch as grades_waffle_switch
 from lms.djangoapps.verify_student.models import VerificationDeadline
@@ -3361,20 +3360,22 @@ class TestShowCoursewareMFE(TestCase):
         """Test every permutation"""
         old_course_key = CourseKey.from_string("OpenEdX/Old/2020")
         new_course_key = CourseKey.from_string("course-v1:OpenEdX+New+2020")
-        global_staff_user = UserFactory(username="global_staff", is_staff=True)
-        regular_user = UserFactory(username="normal", is_staff=False)
 
         # Old style course keys are never supported and should always return false...
         old_mongo_combos = itertools.product(
-            [regular_user, global_staff_user],  # User (is global staff)
+            [True, False],  # is_global_staff
             [True, False],  # is_course_staff
             [True, False],  # preview_active (COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW)
             [True, False],  # redirect_active (REDIRECT_TO_COURSEWARE_MICROFRONTEND)
         )
-        for user, is_course_staff, preview_active, redirect_active in old_mongo_combos:
+        for is_global_staff, is_course_staff, preview_active, redirect_active in old_mongo_combos:
             with _set_preview_mfe_flag(preview_active):
                 with _set_mfe_flag(redirect_active):
-                    assert show_courseware_mfe_link(user, is_course_staff, old_course_key) is False
+                    assert not courseware_mfe_is_advertised(
+                        is_global_staff=is_global_staff,
+                        is_course_staff=is_course_staff,
+                        course_key=old_course_key,
+                    )
 
         # We've checked all old-style course keys now, so we can test only the
         # new ones going forward. Now we check combinations of waffle flags and
@@ -3383,9 +3384,9 @@ class TestShowCoursewareMFE(TestCase):
             with _set_mfe_flag(True):
                 # (preview=on, redirect=on)
                 # Global and Course Staff can see the link.
-                assert show_courseware_mfe_link(global_staff_user, True, new_course_key)
-                assert show_courseware_mfe_link(global_staff_user, False, new_course_key)
-                assert show_courseware_mfe_link(regular_user, True, new_course_key)
+                assert courseware_mfe_is_advertised(new_course_key, True, True)
+                assert courseware_mfe_is_advertised(new_course_key, True, False)
+                assert courseware_mfe_is_advertised(new_course_key, False, True)
 
                 # (Regular users would see the link, but they can't see the Legacy
                 #  experience, so it doesn't matter.)
@@ -3393,38 +3394,37 @@ class TestShowCoursewareMFE(TestCase):
             with _set_mfe_flag(False):
                 # (preview=on, redirect=off)
                 # Global and Course Staff can see the link.
-                assert show_courseware_mfe_link(global_staff_user, True, new_course_key)
-                assert show_courseware_mfe_link(global_staff_user, False, new_course_key)
-                assert show_courseware_mfe_link(regular_user, True, new_course_key)
+                assert courseware_mfe_is_advertised(new_course_key, True, True)
+                assert courseware_mfe_is_advertised(new_course_key, True, False)
+                assert courseware_mfe_is_advertised(new_course_key, False, True)
 
                 # Regular users don't see the link.
-                assert not show_courseware_mfe_link(regular_user, False, new_course_key)
+                assert not courseware_mfe_is_advertised(new_course_key, False, False)
 
         with _set_preview_mfe_flag(False):
             with _set_mfe_flag(True):
                 # (preview=off, redirect=on)
                 # Global staff see the link anyway
-                assert show_courseware_mfe_link(global_staff_user, True, new_course_key)
-                assert show_courseware_mfe_link(global_staff_user, False, new_course_key)
+                assert courseware_mfe_is_advertised(new_course_key, True, True)
+                assert courseware_mfe_is_advertised(new_course_key, True, False)
 
                 # If redirect is active for their students, course staff see the link even
                 # if preview=off.
-                assert show_courseware_mfe_link(regular_user, True, new_course_key)
+                assert courseware_mfe_is_advertised(new_course_key, False, True)
 
                 # (Regular users would see the link, but they can't see the Legacy
                 #  experience, so it doesn't matter.)
 
             with _set_mfe_flag(False):
                 # (preview=off, redirect=off)
-                # Global staff see the link anyway
-                assert show_courseware_mfe_link(global_staff_user, True, new_course_key)
-                assert show_courseware_mfe_link(global_staff_user, False, new_course_key)
-
-                # Course teams can NOT see the link because both rollout waffle flags are false.
-                assert not show_courseware_mfe_link(regular_user, True, new_course_key)
+                # Global staff  and course teams can NOT see the link
+                # because both rollout waffle flags are false.
+                assert not courseware_mfe_is_advertised(new_course_key, True, True)
+                assert not courseware_mfe_is_advertised(new_course_key, True, False)
+                assert not courseware_mfe_is_advertised(new_course_key, False, True)
 
                 # Regular users don't see the link.
-                assert not show_courseware_mfe_link(regular_user, False, new_course_key)
+                assert not courseware_mfe_is_advertised(new_course_key, False, False)
 
     @override_settings(LEARNING_MICROFRONTEND_URL='https://learningmfe.openedx.org')
     def test_url_generation(self):

--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -148,6 +148,31 @@ def courseware_mfe_is_visible(
     return courseware_mfe_is_active(course_key)
 
 
+def courseware_mfe_is_advertised(
+        course_key: CourseKey,
+        is_global_staff=False,
+        is_course_staff=False,
+) -> bool:
+    """
+    Should we invite the user to view a course run's content in the Learning MFE?
+
+    This check is slightly different than `courseware_mfe_is_visible`, in that
+    we always *permit* global staff to view MFE content (assuming it's deployed),
+    but we do not shove the New Experience in their face if the preview isn't
+    enabled.
+    """
+    # DENY: Old Mongo courses don't work in the MFE.
+    if course_key.deprecated:
+        return False
+    # ALLOW: Both global and course staff can see the MFE link if the course team
+    #        preview is enabled.
+    is_staff = is_global_staff or is_course_staff
+    if is_staff and COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW.is_enabled(course_key):
+        return True
+    # OTHERWISE: The MFE is only advertised if it's the active (ie canonical) experience.
+    return courseware_mfe_is_active(course_key)
+
+
 def courseware_legacy_is_visible(
         course_key: CourseKey,
         is_global_staff=False,

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -64,7 +64,7 @@ from ..masquerade import check_content_start_date_for_masquerade_user, setup_mas
 from ..model_data import FieldDataCache
 from ..module_render import get_module_for_descriptor, toc_for_course
 from ..permissions import MASQUERADE_AS_STUDENT
-from ..toggles import courseware_legacy_is_visible, courseware_mfe_is_visible
+from ..toggles import courseware_legacy_is_visible, courseware_mfe_is_advertised
 from .views import CourseTabView
 
 log = logging.getLogger("edx.courseware.views.index")
@@ -495,7 +495,11 @@ class CoursewareIndex(View):
                 self._add_sequence_title_to_context(courseware_context)
 
         # Courseware MFE link
-        if show_courseware_mfe_link(request.user, staff_access, self.course.id):
+        if courseware_mfe_is_advertised(
+                is_global_staff=request.user.is_staff,
+                is_course_staff=staff_access,
+                course_key=self.course.id,
+        ):
             courseware_context['microfrontend_link'] = self.microfrontend_url
         else:
             courseware_context['microfrontend_link'] = None
@@ -618,14 +622,3 @@ def save_positions_recursively_up(user, request, field_data_cache, xmodule, cour
             save_child_position(parent, current_module.location.block_id)
 
         current_module = parent
-
-
-def show_courseware_mfe_link(user, staff_access, course_key):
-    """
-    Return whether to display the button to switch to the Courseware MFE.
-    """
-    return courseware_mfe_is_visible(
-        course_key=course_key,
-        is_global_staff=user.is_staff,
-        is_course_staff=staff_access,
-    )


### PR DESCRIPTION
## Supporting information
 
This is intended to resolve https://github.com/openedx/build-test-release-wg/issues/49. This PR might make more sense if you read that issue first.

## Description

Since the ENABLE_COURSEWARE_MICROFRONTEND Django setting
was removed, the "View in New Experience" button began
to always appear in Legacy courseware for global staff
members in *all* environments.

This was OK for edx.org's purposes, since the Learning MFE
is deployed in all of our production environments.
However, many (perhaps most) Lilac Open edX instances will
*not* deploy the Learning MFE. So, we need to make sure that
this button is not shown by default.

Since we cannot programmatically tell from LMS whether
or not the Learning MFE is deployed, we will depend on
the value of the `courseware.microfrontend_course_team_preview`
flag, which is already being used to decide whether
course staff can see the "View in New Experience" button.

Whether or not the button is shown, global staff will
still be permitted to browse courses in the Learning
MFE if it is deployed.

## Testing instructions

Setup:
* Log in to LMS as a global staff member (on devstack, that's edx@example.com / password  `edx`)
* Make sure that neither `courseware.courseware_mfe` or `courseware.microfrontend_course_team_preview` are globally enabled.
* Pick a course, making sure the neither waffle flag is locally enabled for the course.

On master:
* Navigate to any unit in the course (the outline will not suffice; you need to be *in* the course)
* You should be find yourself in legacy courseware.
* The bug: Observe that "View in New Experience" is visible.

Switch to my branch, restart LMS, and then:
* Reload the unit you were in
* You should still be in legacy courseware.
* The fix: Observe that "View in New Experience" is not longer visible.
* Go into Django admin and enable  `courseware.microfrontend_course_team_preview`, either globally or for the course run.
* Ensure that "View in New Experience" becomes visible again.
* Go back to Django admin. Disable  `courseware.microfrontend_course_team_preview` and enable `courseware.courseware_mfe`.
* Ensure that "View in New Experience" remains visible again.


## Deadline

Merge by Friday if possible so this can be cherry-picked in time for the first Lilac release candidate, which will be cut Monday.

## Other information

@doctoryes - This change will remove the "View in New Experience" button for us global staff on edge.edx.org , but we can specifically enable the `courseware.microfrontend_course_team_preview` flag for ourselves (either via our user IDs or by using edX test courses) if we want it back for easier testing.
