### PR TITLE
feat: AA-741: Enables the dates tab for all enrolled learners

### DIFF
--- a/lms/djangoapps/course_home_api/course_metadata/v1/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/course_metadata/v1/tests/test_views.py
@@ -35,7 +35,7 @@ class CourseHomeMetadataTests(BaseCourseHomeTests):
         assert response.status_code == 200
         assert not response.data.get('is_staff')
         # 'Course', 'Wiki', 'Progress' tabs
-        assert len(response.data.get('tabs', [])) == 3
+        assert len(response.data.get('tabs', [])) == 4
 
     def test_get_authenticated_staff_user(self):
         self.client.logout()
@@ -51,7 +51,7 @@ class CourseHomeMetadataTests(BaseCourseHomeTests):
         assert response.data['is_staff']
         # This differs for a staff user because they also receive the Instructor tab
         # 'Course', 'Wiki', 'Progress', and 'Instructor' tabs
-        assert len(response.data.get('tabs', [])) == 4
+        assert len(response.data.get('tabs', [])) == 5
 
     def test_get_unknown_course(self):
         url = reverse('course-home-course-metadata', args=['course-v1:unknown+course+2T2020'])

--- a/lms/djangoapps/courseware/tabs.py
+++ b/lms/djangoapps/courseware/tabs.py
@@ -12,7 +12,7 @@ from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.entrance_exams import user_can_skip_entrance_exam
 from lms.djangoapps.course_home_api.toggles import course_home_mfe_dates_tab_is_active, course_home_mfe_outline_tab_is_active, course_home_mfe_progress_tab_is_active  # lint-amnesty, pylint: disable=line-too-long
 from openedx.core.lib.course_tabs import CourseTabPluginManager
-from openedx.features.course_experience import RELATIVE_DATES_FLAG, DISABLE_UNIFIED_COURSE_TAB_FLAG, default_course_url_name  # lint-amnesty, pylint: disable=line-too-long
+from openedx.features.course_experience import DISABLE_UNIFIED_COURSE_TAB_FLAG, default_course_url_name
 from openedx.features.course_experience.url_helpers import get_learning_mfe_home_url
 from common.djangoapps.student.models import CourseEnrollment
 from xmodule.tabs import CourseTab, CourseTabList, course_reverse_func_from_name_func, key_checker
@@ -341,13 +341,6 @@ class DatesTab(EnrolledTab):
 
         tab_dict['link_func'] = link_func
         super().__init__(tab_dict)
-
-    @classmethod
-    def is_enabled(cls, course, user=None):
-        """Returns true if this tab is enabled."""
-        if not super().is_enabled(course, user=user):
-            return False
-        return RELATIVE_DATES_FLAG.is_enabled(course.id)
 
 
 def get_course_tab_list(user, course):

--- a/openedx/core/djangoapps/courseware_api/tests/test_views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/test_views.py
@@ -139,7 +139,7 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
                 enrollment = response.data['enrollment']
                 assert enrollment_mode == enrollment['mode']
                 assert enrollment['is_active']
-                assert len(response.data['tabs']) == 5
+                assert len(response.data['tabs']) == 6
                 found = False
                 for tab in response.data['tabs']:
                     if tab['type'] == 'external_link':


### PR DESCRIPTION
Removes the relative dates flag check as it is no longer
necessary to show the dates tab