### PR TITLE
Pinning pyjwt and social-auth-core version

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -18,6 +18,11 @@ celery<5.0
 # cryptography 3.3 has dropped python3.5 support.
 cryptography<3.3
 
+# PYJWT[crypto]==2.0.1 requires cryptography>=3.3.1
+PyJWT[crypto]<2.0.0
+# social-auth-core>=4.0.0 requires PYJWT>=2.0.0
+social-auth-core<4.0.0
+
 # The CORS_ORIGIN_WHITELIST changes in a backwards incompatible way in 3.0.0, needs matching configuration repo changes
 django-cors-headers<3.0.0
 

--- a/requirements/edx-sandbox/py35.txt
+++ b/requirements/edx-sandbox/py35.txt
@@ -19,7 +19,7 @@ markupsafe==1.1.1         # via chem
 matplotlib==2.2.4         # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/py35.in
 mpmath==1.2.1             # via sympy
 networkx==2.2             # via -r requirements/edx-sandbox/py35.in
-nltk==3.6.1               # via -r requirements/edx-sandbox/shared.txt, chem
+nltk==3.6.2               # via -r requirements/edx-sandbox/shared.txt, chem
 numpy==1.16.5             # via -r requirements/edx-sandbox/py35.in, chem, matplotlib, openedx-calc, scipy
 openedx-calc==1.0.9       # via -r requirements/edx-sandbox/py35.in
 pycparser==2.20           # via -r requirements/edx-sandbox/shared.txt, cffi

--- a/requirements/edx-sandbox/shared.txt
+++ b/requirements/edx-sandbox/shared.txt
@@ -9,7 +9,7 @@ click==7.1.2              # via nltk
 cryptography==3.2.1       # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/shared.in
 joblib==0.14.1            # via -c requirements/edx-sandbox/../constraints.txt, nltk
 lxml==4.5.0               # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/shared.in
-nltk==3.6.1               # via -r requirements/edx-sandbox/shared.in
+nltk==3.6.2               # via -r requirements/edx-sandbox/shared.in
 pycparser==2.20           # via cffi
 regex==2021.4.4           # via nltk
 six==1.15.0               # via cryptography

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -75,7 +75,7 @@ django-ratelimit==3.0.1   # via -r requirements/edx/base.in
 django-require==1.0.11    # via -r requirements/edx/base.in
 django-sekizai==2.0.0     # via -r requirements/edx/base.in, django-wiki
 django-ses==2.0.0         # via -r requirements/edx/base.in
-django-simple-history==2.12.0  # via -r requirements/edx/base.in, edx-enterprise, edx-organizations, ora2
+django-simple-history==3.0.0  # via -r requirements/edx/base.in, edx-enterprise, edx-organizations, ora2
 django-splash==1.0.0      # via -r requirements/edx/base.in
 django-statici18n==2.0.1  # via -r requirements/edx/base.in
 django-storages==1.8      # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, edxval
@@ -140,7 +140,7 @@ itypes==1.2.0             # via coreapi
 jinja2==2.11.3            # via code-annotations, coreschema
 jmespath==0.10.0          # via boto3, botocore
 joblib==0.14.1            # via -c requirements/edx/../constraints.txt, -r requirements/edx/../edx-sandbox/shared.txt, nltk
-jsondiff==1.2.0           # via edx-enterprise
+jsondiff==1.3.0           # via edx-enterprise
 jsonfield2==3.0.3         # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, edx-celeryutils, edx-enterprise, edx-event-routing-backends, edx-proctoring, edx-submissions, lti-consumer-xblock, ora2
 kombu==4.6.11             # via celery
 laboratory==1.0.2         # via -r requirements/edx/base.in
@@ -161,7 +161,7 @@ mongoengine==0.23.0       # via -r requirements/edx/base.in
 mpmath==1.2.1             # via sympy
 mysqlclient==2.0.3        # via -r requirements/edx/base.in
 newrelic==6.2.0.156       # via -r requirements/edx/base.in, edx-django-utils
-nltk==3.6.1               # via -r requirements/edx/../edx-sandbox/shared.txt, chem
+nltk==3.6.2               # via -r requirements/edx/../edx-sandbox/shared.txt, chem
 nodeenv==1.6.0            # via -r requirements/edx/base.in
 numpy==1.20.2             # via chem, openedx-calc, scipy
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
@@ -182,7 +182,7 @@ pycparser==2.20           # via -r requirements/edx/../edx-sandbox/shared.txt, c
 pycryptodomex==3.10.1     # via -r requirements/edx/base.in, edx-proctoring, lti-consumer-xblock, pyjwkest
 pygments==2.8.1           # via -r requirements/edx/base.in
 pyjwkest==1.4.2           # via -r requirements/edx/base.in, edx-drf-extensions, lti-consumer-xblock
-pyjwt[crypto]==1.7.1      # via -r requirements/edx/base.in, drf-jwt, edx-rest-api-client, social-auth-core
+pyjwt[crypto]==1.7.1      # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, drf-jwt, edx-rest-api-client, social-auth-core
 pylatexenc==2.10          # via olxcleaner
 pymongo==3.10.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, -r requirements/edx/paver.txt, edx-opaque-keys, event-tracking, mongodbproxy, mongoengine
 pynliner==0.8.0           # via -r requirements/edx/base.in
@@ -214,10 +214,10 @@ scipy==1.6.2              # via chem, openedx-calc
 semantic-version==2.8.5   # via edx-drf-extensions
 shapely==1.7.1            # via -r requirements/edx/base.in
 simplejson==3.17.2        # via -r requirements/edx/base.in, sailthru-client, super-csv, xblock-utils
-six==1.15.0               # via -r requirements/edx/../edx-sandbox/shared.txt, -r requirements/edx/base.in, -r requirements/edx/paver.txt, analytics-python, bleach, chem, codejail, crowdsourcehinter-xblock, cryptography, django-countries, django-simple-history, edx-ace, edx-bulk-grades, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-milestones, edx-rbac, event-tracking, fs, fs-s3fs, html5lib, isodate, libsass, paver, pycontracts, pyjwkest, python-dateutil, python-memcached, python-swiftclient, social-auth-app-django, social-auth-core, stevedore, xblock
+six==1.15.0               # via -r requirements/edx/../edx-sandbox/shared.txt, -r requirements/edx/base.in, -r requirements/edx/paver.txt, analytics-python, bleach, chem, codejail, crowdsourcehinter-xblock, cryptography, django-countries, edx-ace, edx-bulk-grades, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-milestones, edx-rbac, event-tracking, fs, fs-s3fs, html5lib, isodate, libsass, paver, pycontracts, pyjwkest, python-dateutil, python-memcached, python-swiftclient, social-auth-app-django, social-auth-core, stevedore, xblock
 slumber==0.7.1            # via edx-bulk-grades, edx-enterprise, edx-rest-api-client
 social-auth-app-django==4.0.0  # via -r requirements/edx/base.in
-social-auth-core==4.0.2   # via -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt, -r requirements/edx/base.in, social-auth-app-django
+social-auth-core==3.4.0   # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, social-auth-app-django
 sorl-thumbnail==12.7.0    # via -r requirements/edx/base.in, django-wiki
 sortedcontainers==2.3.0   # via -r requirements/edx/base.in
 soupsieve==2.2.1          # via beautifulsoup4
@@ -238,7 +238,7 @@ urllib3==1.26.4           # via -r requirements/edx/paver.txt, elasticsearch, ge
 user-util==1.0.0          # via -r requirements/edx/base.in
 vine==1.3.0               # via amqp, celery
 voluptuous==0.12.1        # via ora2
-watchdog==2.0.2           # via -r requirements/edx/paver.txt
+watchdog==2.0.3           # via -r requirements/edx/paver.txt
 web-fragments==1.0.0      # via -r requirements/edx/base.in, crowdsourcehinter-xblock, edx-sga, staff-graded-xblock, xblock, xblock-utils
 webencodings==0.5.1       # via bleach, html5lib
 webob==1.8.7              # via xblock, xmodule

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -6,7 +6,7 @@
 #
 coverage==5.5             # via -r requirements/edx/coverage.in
 diff-cover==4.0.0         # via -c requirements/edx/../constraints.txt, -r requirements/edx/coverage.in
-importlib-metadata==4.0.0  # via inflect
+importlib-metadata==4.0.1  # via inflect
 inflect==3.0.2            # via -c requirements/edx/../constraints.txt, jinja2-pluralize
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.11.3            # via diff-cover, jinja2-pluralize

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -85,7 +85,7 @@ django-ratelimit==3.0.1   # via -r requirements/edx/testing.txt
 django-require==1.0.11    # via -r requirements/edx/testing.txt
 django-sekizai==2.0.0     # via -r requirements/edx/testing.txt, django-wiki
 django-ses==2.0.0         # via -r requirements/edx/testing.txt
-django-simple-history==2.12.0  # via -r requirements/edx/testing.txt, edx-enterprise, edx-organizations, ora2
+django-simple-history==3.0.0  # via -r requirements/edx/testing.txt, edx-enterprise, edx-organizations, ora2
 django-splash==1.0.0      # via -r requirements/edx/testing.txt
 django-statici18n==2.0.1  # via -r requirements/edx/testing.txt
 django-storages==1.8      # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, edxval
@@ -154,7 +154,7 @@ httpretty==0.9.7          # via -c requirements/edx/../constraints.txt, -r requi
 icalendar==4.0.7          # via -r requirements/edx/testing.txt
 idna==2.10                # via -r requirements/edx/testing.txt, requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==4.0.0  # via -r requirements/edx/testing.txt, inflect, pytest-randomly
+importlib-metadata==4.0.1  # via -r requirements/edx/testing.txt, inflect, pytest-randomly
 inflect==3.0.2            # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, jinja2-pluralize
 inflection==0.5.1         # via -r requirements/edx/testing.txt, drf-yasg
 iniconfig==1.1.1          # via -r requirements/edx/testing.txt, pytest
@@ -166,7 +166,7 @@ jinja2-pluralize==0.3.0   # via -r requirements/edx/testing.txt, diff-cover
 jinja2==2.11.3            # via -r requirements/edx/testing.txt, code-annotations, coreschema, diff-cover, jinja2-pluralize, sphinx
 jmespath==0.10.0          # via -r requirements/edx/testing.txt, boto3, botocore
 joblib==0.14.1            # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, nltk
-jsondiff==1.2.0           # via -r requirements/edx/testing.txt, edx-enterprise
+jsondiff==1.3.0           # via -r requirements/edx/testing.txt, edx-enterprise
 jsonfield2==3.0.3         # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, edx-celeryutils, edx-enterprise, edx-event-routing-backends, edx-proctoring, edx-submissions, lti-consumer-xblock, ora2
 jsonschema==3.2.0         # via sphinxcontrib-openapi
 kombu==4.6.11             # via -r requirements/edx/testing.txt, celery
@@ -193,7 +193,7 @@ more-itertools==8.7.0     # via -r requirements/edx/testing.txt, zipp
 mpmath==1.2.1             # via -r requirements/edx/testing.txt, sympy
 mysqlclient==2.0.3        # via -r requirements/edx/testing.txt
 newrelic==6.2.0.156       # via -r requirements/edx/testing.txt, edx-django-utils
-nltk==3.6.1               # via -r requirements/edx/testing.txt, chem
+nltk==3.6.2               # via -r requirements/edx/testing.txt, chem
 nodeenv==1.6.0            # via -r requirements/edx/testing.txt
 numpy==1.20.2             # via -r requirements/edx/testing.txt, chem, openedx-calc, scipy
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
@@ -218,7 +218,7 @@ pycparser==2.20           # via -r requirements/edx/testing.txt, cffi
 pycryptodomex==3.10.1     # via -r requirements/edx/testing.txt, edx-proctoring, lti-consumer-xblock, pyjwkest
 pygments==2.8.1           # via -r requirements/edx/testing.txt, diff-cover, sphinx
 pyjwkest==1.4.2           # via -r requirements/edx/testing.txt, edx-drf-extensions, lti-consumer-xblock
-pyjwt[crypto]==1.7.1      # via -r requirements/edx/testing.txt, drf-jwt, edx-rest-api-client, social-auth-core
+pyjwt[crypto]==1.7.1      # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, drf-jwt, edx-rest-api-client, social-auth-core
 pylatexenc==2.10          # via -r requirements/edx/testing.txt, olxcleaner
 pylint-celery==0.3        # via -r requirements/edx/testing.txt, edx-lint
 pylint-django==2.4.3      # via -r requirements/edx/testing.txt, edx-lint
@@ -269,12 +269,12 @@ semantic-version==2.8.5   # via -r requirements/edx/testing.txt, edx-drf-extensi
 shapely==1.7.1            # via -r requirements/edx/testing.txt
 simplejson==3.17.2        # via -r requirements/edx/testing.txt, sailthru-client, super-csv, xblock-utils
 singledispatch==3.6.1     # via -r requirements/edx/testing.txt
-six==1.15.0               # via -r requirements/edx/pip-tools.txt, -r requirements/edx/testing.txt, analytics-python, bleach, bok-choy, chem, codejail, crowdsourcehinter-xblock, cryptography, django-countries, django-simple-history, edx-ace, edx-bulk-grades, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-lint, edx-milestones, edx-rbac, edx-sphinx-theme, event-tracking, freezegun, fs, fs-s3fs, html5lib, httpretty, isodate, jsonschema, libsass, paver, pip-tools, pycontracts, pyjwkest, python-dateutil, python-memcached, python-swiftclient, singledispatch, social-auth-app-django, social-auth-core, sphinxcontrib-httpdomain, stevedore, tox, transifex-client, virtualenv, xblock
+six==1.15.0               # via -r requirements/edx/pip-tools.txt, -r requirements/edx/testing.txt, analytics-python, bleach, bok-choy, chem, codejail, crowdsourcehinter-xblock, cryptography, django-countries, edx-ace, edx-bulk-grades, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-lint, edx-milestones, edx-rbac, edx-sphinx-theme, event-tracking, freezegun, fs, fs-s3fs, html5lib, httpretty, isodate, jsonschema, libsass, paver, pip-tools, pycontracts, pyjwkest, python-dateutil, python-memcached, python-swiftclient, singledispatch, social-auth-app-django, social-auth-core, sphinxcontrib-httpdomain, stevedore, tox, transifex-client, virtualenv, xblock
 slumber==0.7.1            # via -r requirements/edx/testing.txt, edx-bulk-grades, edx-enterprise, edx-rest-api-client
 smmap==4.0.0              # via -r requirements/edx/testing.txt, gitdb
 snowballstemmer==2.1.0    # via sphinx
 social-auth-app-django==4.0.0  # via -r requirements/edx/testing.txt
-social-auth-core==4.0.2   # via -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt, -r requirements/edx/testing.txt, social-auth-app-django
+social-auth-core==3.4.0   # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, social-auth-app-django
 sorl-thumbnail==12.7.0    # via -r requirements/edx/testing.txt, django-wiki
 sortedcontainers==2.3.0   # via -r requirements/edx/testing.txt
 soupsieve==2.2.1          # via -r requirements/edx/testing.txt, beautifulsoup4
@@ -308,10 +308,10 @@ uritemplate==3.0.1        # via -r requirements/edx/testing.txt, coreapi, drf-ya
 urllib3==1.26.4           # via -r requirements/edx/testing.txt, elasticsearch, geoip2, requests, selenium, transifex-client
 user-util==1.0.0          # via -r requirements/edx/testing.txt
 vine==1.3.0               # via -r requirements/edx/testing.txt, amqp, celery
-virtualenv==20.4.3        # via -r requirements/edx/testing.txt, tox
+virtualenv==20.4.4        # via -r requirements/edx/testing.txt, tox
 voluptuous==0.12.1        # via -r requirements/edx/testing.txt, ora2
 vulture==2.3              # via -r requirements/edx/development.in
-watchdog==2.0.2           # via -r requirements/edx/testing.txt
+watchdog==2.0.3           # via -r requirements/edx/testing.txt
 web-fragments==1.0.0      # via -r requirements/edx/testing.txt, crowdsourcehinter-xblock, edx-sga, staff-graded-xblock, xblock, xblock-utils
 webencodings==0.5.1       # via -r requirements/edx/testing.txt, bleach, html5lib
 webob==1.8.7              # via -r requirements/edx/testing.txt, xblock, xmodule

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -22,5 +22,5 @@ requests==2.25.1          # via -r requirements/edx/paver.in
 six==1.15.0               # via libsass, paver, python-memcached, stevedore
 stevedore==1.32.0         # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.in, edx-opaque-keys
 urllib3==1.26.4           # via requests
-watchdog==2.0.2           # via -r requirements/edx/paver.in
+watchdog==2.0.3           # via -r requirements/edx/paver.in
 wrapt==1.11.2             # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.in

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -83,7 +83,7 @@ django-ratelimit==3.0.1   # via -r requirements/edx/base.txt
 django-require==1.0.11    # via -r requirements/edx/base.txt
 django-sekizai==2.0.0     # via -r requirements/edx/base.txt, django-wiki
 django-ses==2.0.0         # via -r requirements/edx/base.txt
-django-simple-history==2.12.0  # via -r requirements/edx/base.txt, edx-enterprise, edx-organizations, ora2
+django-simple-history==3.0.0  # via -r requirements/edx/base.txt, edx-enterprise, edx-organizations, ora2
 django-splash==1.0.0      # via -r requirements/edx/base.txt
 django-statici18n==2.0.1  # via -r requirements/edx/base.txt
 django-storages==1.8      # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, edxval
@@ -149,7 +149,7 @@ html5lib==1.1             # via -r requirements/edx/base.txt, ora2
 httpretty==0.9.7          # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.in
 icalendar==4.0.7          # via -r requirements/edx/base.txt
 idna==2.10                # via -r requirements/edx/base.txt, requests
-importlib-metadata==4.0.0  # via -r requirements/edx/coverage.txt, inflect, pytest-randomly
+importlib-metadata==4.0.1  # via -r requirements/edx/coverage.txt, inflect, pytest-randomly
 inflect==3.0.2            # via -c requirements/edx/../constraints.txt, -r requirements/edx/coverage.txt, jinja2-pluralize
 inflection==0.5.1         # via -r requirements/edx/base.txt, drf-yasg
 iniconfig==1.1.1          # via pytest
@@ -161,7 +161,7 @@ jinja2-pluralize==0.3.0   # via -r requirements/edx/coverage.txt, diff-cover
 jinja2==2.11.3            # via -r requirements/edx/base.txt, -r requirements/edx/coverage.txt, code-annotations, coreschema, diff-cover, jinja2-pluralize
 jmespath==0.10.0          # via -r requirements/edx/base.txt, boto3, botocore
 joblib==0.14.1            # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, nltk
-jsondiff==1.2.0           # via -r requirements/edx/base.txt, edx-enterprise
+jsondiff==1.3.0           # via -r requirements/edx/base.txt, edx-enterprise
 jsonfield2==3.0.3         # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, edx-celeryutils, edx-enterprise, edx-event-routing-backends, edx-proctoring, edx-submissions, lti-consumer-xblock, ora2
 kombu==4.6.11             # via -r requirements/edx/base.txt, celery
 laboratory==1.0.2         # via -r requirements/edx/base.txt
@@ -185,7 +185,7 @@ more-itertools==8.7.0     # via -r requirements/edx/coverage.txt, zipp
 mpmath==1.2.1             # via -r requirements/edx/base.txt, sympy
 mysqlclient==2.0.3        # via -r requirements/edx/base.txt
 newrelic==6.2.0.156       # via -r requirements/edx/base.txt, edx-django-utils
-nltk==3.6.1               # via -r requirements/edx/base.txt, chem
+nltk==3.6.2               # via -r requirements/edx/base.txt, chem
 nodeenv==1.6.0            # via -r requirements/edx/base.txt
 numpy==1.20.2             # via -r requirements/edx/base.txt, chem, openedx-calc, scipy
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
@@ -209,7 +209,7 @@ pycparser==2.20           # via -r requirements/edx/base.txt, cffi
 pycryptodomex==3.10.1     # via -r requirements/edx/base.txt, edx-proctoring, lti-consumer-xblock, pyjwkest
 pygments==2.8.1           # via -r requirements/edx/base.txt, -r requirements/edx/coverage.txt, diff-cover
 pyjwkest==1.4.2           # via -r requirements/edx/base.txt, edx-drf-extensions, lti-consumer-xblock
-pyjwt[crypto]==1.7.1      # via -r requirements/edx/base.txt, drf-jwt, edx-rest-api-client, social-auth-core
+pyjwt[crypto]==1.7.1      # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, drf-jwt, edx-rest-api-client, social-auth-core
 pylatexenc==2.10          # via -r requirements/edx/base.txt, olxcleaner
 pylint-celery==0.3        # via edx-lint
 pylint-django==2.4.3      # via edx-lint
@@ -258,11 +258,11 @@ semantic-version==2.8.5   # via -r requirements/edx/base.txt, edx-drf-extensions
 shapely==1.7.1            # via -r requirements/edx/base.txt
 simplejson==3.17.2        # via -r requirements/edx/base.txt, sailthru-client, super-csv, xblock-utils
 singledispatch==3.6.1     # via -r requirements/edx/testing.in
-six==1.15.0               # via -r requirements/edx/base.txt, analytics-python, bleach, bok-choy, chem, codejail, crowdsourcehinter-xblock, cryptography, django-countries, django-simple-history, edx-ace, edx-bulk-grades, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-lint, edx-milestones, edx-rbac, event-tracking, freezegun, fs, fs-s3fs, html5lib, httpretty, isodate, libsass, paver, pycontracts, pyjwkest, python-dateutil, python-memcached, python-swiftclient, singledispatch, social-auth-app-django, social-auth-core, stevedore, tox, transifex-client, virtualenv, xblock
+six==1.15.0               # via -r requirements/edx/base.txt, analytics-python, bleach, bok-choy, chem, codejail, crowdsourcehinter-xblock, cryptography, django-countries, edx-ace, edx-bulk-grades, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-lint, edx-milestones, edx-rbac, event-tracking, freezegun, fs, fs-s3fs, html5lib, httpretty, isodate, libsass, paver, pycontracts, pyjwkest, python-dateutil, python-memcached, python-swiftclient, singledispatch, social-auth-app-django, social-auth-core, stevedore, tox, transifex-client, virtualenv, xblock
 slumber==0.7.1            # via -r requirements/edx/base.txt, edx-bulk-grades, edx-enterprise, edx-rest-api-client
 smmap==4.0.0              # via gitdb
 social-auth-app-django==4.0.0  # via -r requirements/edx/base.txt
-social-auth-core==4.0.2   # via -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt, -r requirements/edx/base.txt, social-auth-app-django
+social-auth-core==3.4.0   # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, social-auth-app-django
 sorl-thumbnail==12.7.0    # via -r requirements/edx/base.txt, django-wiki
 sortedcontainers==2.3.0   # via -r requirements/edx/base.txt
 soupsieve==2.2.1          # via -r requirements/edx/base.txt, beautifulsoup4
@@ -287,9 +287,9 @@ uritemplate==3.0.1        # via -r requirements/edx/base.txt, coreapi, drf-yasg
 urllib3==1.26.4           # via -r requirements/edx/base.txt, elasticsearch, geoip2, requests, selenium, transifex-client
 user-util==1.0.0          # via -r requirements/edx/base.txt
 vine==1.3.0               # via -r requirements/edx/base.txt, amqp, celery
-virtualenv==20.4.3        # via tox
+virtualenv==20.4.4        # via tox
 voluptuous==0.12.1        # via -r requirements/edx/base.txt, ora2
-watchdog==2.0.2           # via -r requirements/edx/base.txt
+watchdog==2.0.3           # via -r requirements/edx/base.txt
 web-fragments==1.0.0      # via -r requirements/edx/base.txt, crowdsourcehinter-xblock, edx-sga, staff-graded-xblock, xblock, xblock-utils
 webencodings==0.5.1       # via -r requirements/edx/base.txt, bleach, html5lib
 webob==1.8.7              # via -r requirements/edx/base.txt, xblock, xmodule


### PR DESCRIPTION
[Python requirements upgrade build](https://build.testeng.edx.org/job/edx-platform-upgrade-python-requirements/1316/console) failed due to `cryptography` constraint. 
`PyJWT>=2.0.0` requires `cryptography>=3.3.1,<4.0.0` that conflicts with the existing constraint of [cryptography<3.3](https://github.com/edx/edx-platform/blob/2ab1f8f9c9ed40f240749e28c005868766c9a4e4/requirements/constraints.txt#L18). 
To resolve this conflict, this PR pinned `PYJWT<2.0.0` and `social-auth-core<4.0.0` because `social-auth-core>=4.0.0` requires `PYJWT>=2.0.0` so pinned following versions to resolve this conflict: 
- `PYJWT<2.0.0`
- `social-auth-core<4.0.0`