### PR TITLE
fix: :bug: hinted login page is broken when tpa_hint is provided in r…

### DIFF
--- a/lms/static/js/student_account/views/HintedLoginView.js
+++ b/lms/static/js/student_account/views/HintedLoginView.js
@@ -22,6 +22,7 @@
                 },
 
                 render: function() {
+                    if (!this.hintedProvider) return this;
                     HtmlUtils.setHtml(
                         $(this.el),
                         HtmlUtils.template(this.tpl)({

--- a/openedx/core/djangoapps/user_authn/views/login_form.py
+++ b/openedx/core/djangoapps/user_authn/views/login_form.py
@@ -161,7 +161,7 @@ def login_and_registration_form(request, initial_mode="login"):
     # Retrieve the form descriptions from the user API
     form_descriptions = _get_form_descriptions(request)
 
-    # Our ?next= URL may itself contain a parameter 'tpa_hint=x' that we need to check.
+    # Our URL may itself contain a parameter 'tpa_hint=x' that we need to check.
     # If present, we display a login page focused on third-party auth with that provider.
     third_party_auth_hint = None
     if '?' in redirect_to:  # lint-amnesty, pylint: disable=too-many-nested-blocks

--- a/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
@@ -407,11 +407,25 @@ class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleSto
             error_message=dummy_error_message,
             line_break=HTML('<br/>')
         )
+        expected_providers = [
+            {
+                "id": "oa2-dummy", "name": "Dummy", "iconClass": None, "iconImage": "/static/uploads/icon.svg", "skipHintedLogin": False, "loginUrl": "/auth/login/dummy/?auth_entry=login&next=%2Fdashboard", "registerUrl": "/auth/login/dummy/?auth_entry=register&next=%2Fdashboard"
+            },
+            {
+                "id": "oa2-facebook", "name": "Facebook", "iconClass": "fa-facebook", "iconImage": None, "skipHintedLogin": False, "loginUrl": "/auth/login/facebook/?auth_entry=login&next=%2Fdashboard", "registerUrl": "/auth/login/facebook/?auth_entry=register&next=%2Fdashboard"
+            },
+            {
+                "id": "oa2-google-oauth2", "name": "Google", "iconClass": "fa-google-plus", "iconImage": None, "skipHintedLogin": False, "loginUrl": "/auth/login/google-oauth2/?auth_entry=login&next=%2Fdashboard", "registerUrl": "/auth/login/google-oauth2/?auth_entry=register&next=%2Fdashboard"
+            },
+            {
+                "id": "saml-testshib", "name": "TestShib", "iconClass": "fa-university", "iconImage": None, "skipHintedLogin": True, "loginUrl": "/auth/login/tpa-saml/?auth_entry=login&next=%2Fdashboard&idp=testshib", "registerUrl": "/auth/login/tpa-saml/?auth_entry=register&next=%2Fdashboard&idp=testshib"
+            }]
         self._assert_saml_auth_data_with_error(
             response,
             current_backend,
             current_provider,
-            expected_error_message
+            expected_error_message,
+            expected_providers,
         )
 
     def test_hinted_login(self):
@@ -612,7 +626,12 @@ class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleSto
         self.assertContains(response, expected_data)
 
     def _assert_saml_auth_data_with_error(
-            self, response, current_backend, current_provider, expected_error_message
+            self,
+            response,
+            current_backend,
+            current_provider,
+            expected_error_message,
+            expected_providers=[],
     ):
         """
         Verify that third party auth info is rendered correctly in a DOM data attribute.
@@ -624,7 +643,7 @@ class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleSto
         auth_info = {
             'currentProvider': current_provider,
             'platformName': settings.PLATFORM_NAME,
-            'providers': [],
+            'providers': expected_providers,
             'secondaryProviders': [],
             'finishAuthUrl': finish_auth_url,
             'errorMessage': expected_error_message,

--- a/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
@@ -639,9 +639,6 @@ class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleSto
             "syncLearnerProfileData": False,
             "pipeline_user_details": {"email": "test@test.com"} if add_user_details else {}
         }
-        if expected_ec is not None:
-            # If we set an EnterpriseCustomer, third-party auth providers ought to be hidden.
-            auth_info['providers'] = []
         auth_info = dump_js_escaped_json(auth_info)
 
         expected_data = '"third_party_auth": {auth_info}'.format(

--- a/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
@@ -409,16 +409,40 @@ class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleSto
         )
         expected_providers = [
             {
-                "id": "oa2-dummy", "name": "Dummy", "iconClass": None, "iconImage": "/static/uploads/icon.svg", "skipHintedLogin": False, "loginUrl": "/auth/login/dummy/?auth_entry=login&next=%2Fdashboard", "registerUrl": "/auth/login/dummy/?auth_entry=register&next=%2Fdashboard"
+                "id":
+                "oa2-dummy",
+                "name": "Dummy",
+                "iconClass": None,
+                "iconImage": "/static/uploads/icon.svg",
+                "skipHintedLogin": False,
+                "loginUrl": "/auth/login/dummy/?auth_entry=login&next=%2Fdashboard",
+                "registerUrl": "/auth/login/dummy/?auth_entry=register&next=%2Fdashboard",
             },
             {
-                "id": "oa2-facebook", "name": "Facebook", "iconClass": "fa-facebook", "iconImage": None, "skipHintedLogin": False, "loginUrl": "/auth/login/facebook/?auth_entry=login&next=%2Fdashboard", "registerUrl": "/auth/login/facebook/?auth_entry=register&next=%2Fdashboard"
+                "id": "oa2-facebook",
+                "name": "Facebook",
+                "iconClass": "fa-facebook",
+                "iconImage": None,
+                "skipHintedLogin": False,
+                "loginUrl": "/auth/login/facebook/?auth_entry=login&next=%2Fdashboard",
+                "registerUrl": "/auth/login/facebook/?auth_entry=register&next=%2Fdashboard",
             },
             {
-                "id": "oa2-google-oauth2", "name": "Google", "iconClass": "fa-google-plus", "iconImage": None, "skipHintedLogin": False, "loginUrl": "/auth/login/google-oauth2/?auth_entry=login&next=%2Fdashboard", "registerUrl": "/auth/login/google-oauth2/?auth_entry=register&next=%2Fdashboard"
+                "id": "oa2-google-oauth2",
+                "name": "Google",
+                "iconClass": "fa-google-plus",
+                "iconImage": None,
+                "skipHintedLogin": False,
+                "loginUrl": "/auth/login/google-oauth2/?auth_entry=login&next=%2Fdashboard",
+                "registerUrl": "/auth/login/google-oauth2/?auth_entry=register&next=%2Fdashboard",
             },
             {
-                "id": "saml-testshib", "name": "TestShib", "iconClass": "fa-university", "iconImage": None, "skipHintedLogin": True, "loginUrl": "/auth/login/tpa-saml/?auth_entry=login&next=%2Fdashboard&idp=testshib", "registerUrl": "/auth/login/tpa-saml/?auth_entry=register&next=%2Fdashboard&idp=testshib"
+                "id": "saml-testshib",
+                "name": "TestShib",
+                "iconClass": "fa-university",
+                "iconImage": None, "skipHintedLogin": True,
+                "loginUrl": "/auth/login/tpa-saml/?auth_entry=login&next=%2Fdashboard&idp=testshib",
+                "registerUrl": "/auth/login/tpa-saml/?auth_entry=register&next=%2Fdashboard&idp=testshib",
             }]
         self._assert_saml_auth_data_with_error(
             response,

--- a/openedx/features/enterprise_support/tests/test_utils.py
+++ b/openedx/features/enterprise_support/tests/test_utils.py
@@ -211,7 +211,6 @@ class TestEnterpriseUtils(TestCase):
 
         assert 'We are sorry, you are not authorized' in str(context['data']['third_party_auth']['errorMessage'])
         assert 'Widget error.' in str(context['data']['third_party_auth']['errorMessage'])
-        assert [] == context['data']['third_party_auth']['providers']
         assert [] == context['data']['third_party_auth']['secondaryProviders']
         assert not context['data']['third_party_auth']['autoSubmitRegForm']
         assert 'Just a couple steps' in str(context['data']['third_party_auth']['autoRegisterWelcomeMessage'])

--- a/openedx/features/enterprise_support/utils.py
+++ b/openedx/features/enterprise_support/utils.py
@@ -183,8 +183,10 @@ def update_third_party_auth_context_for_enterprise(request, context, enterprise_
             line_break=HTML('<br/>')
         )
 
+    # The hinted login frontend `HintedLoginView.js`, expects a list of providers
+    # so not clearing `providers` here anymore. It is unclear if removing the `secondaryProviders`
+    # is necessary either.
     if enterprise_customer:
-        context['data']['third_party_auth']['providers'] = []
         context['data']['third_party_auth']['secondaryProviders'] = []
 
     running_pipeline = third_party_auth.pipeline.get(request)


### PR DESCRIPTION
…edirect_uri

This is a prerequisite in order to submit / merge: https://github.com/edx/edx-enterprise/pull/1214 because as soon as we fix that bug (which requires a `tpa_hint` in the redirect_uri (not the one in the next param, but the one as a query param), the hinted login view rendering is kicked, and that rendering has a bug due to two issues:

* the `providers` context data is for some reason cleared when enterprise_customer is found, in the `update_third_party_auth_context_for_enterprise` function. This causes the frontend HintedLoginView.js to never see a provider and it errors
* the HintedLoginView.js has a bug where it is referring to a global (context global), which should actually be referenced using `this`


### How to reproduce this?

See ENT-4383 for basically visit http://localhost:8734/<slug> for an enterprise with:
* IDP configured to be something like a samltest.id instance
* the option `skip hinted login dialog` should be unchecked. If the option is checked, we will never hit this codepath (since we skip trying to render that view)
* If this bug exists you will see a login page that has an empty login area (and a console error)
* If this bug is absent, you will see a page that looks ike this (the blue button should take you to the samltest.id login page, in this case)

<img width="721" alt="Screen Shot 2021-04-23 at 4 10 26 PM" src="https://user-images.githubusercontent.com/528166/115927321-3e094300-a452-11eb-9b17-caa6a83726d9.png">


A `tpa_hint` was added to the redirect_uri from enterprise proxylogin, but that breaks the hinted login page unless we remove the clearing of the 'providers' context data used in the rendering

ENT-4383


## Testing instructions

See above. Also test with a customer with no idp configured, in that case you just want to be taken to the regular login page (not the hinted login)


## Testing plan for staging

Once this is in staging, plan is to test these cases:

Login via LMS:

* login via LMS (https://courses.stage.edx.org) redirecting for a learner without Enterprise association
* login via LMS (https://courses.stage.edx.org) redirecting for a learner with Enterprise association AND IDP, hinted login OFF
* login via LMS (https://courses.stage.edx.org) redirecting for a learner with Enterprise association AND without IDP, hinted login OFF
* login via LMS (https://courses.stage.edx.org) redirecting for a learner with Enterprise association AND IDP, hinted login ON
* login via LMS (https://courses.stage.edx.org) redirecting for a learner with Enterprise association AND without IDP, hinted login ON

Login from Enterprise learner portal via redirection:
* enterprise has IDP, hinted login OFF
* enterprise has IDP, hinted login ON
* enterprise has No IDP, hinted login OFF
* enterprise has No IDP, hinted login ON

## Deadline

ASAP 

This blocks ENT-4383 bug fix which prevents some customers from even seeing a valid login page