### PR TITLE
[fix]: studio display of ungraded subs.s w/useless due dates

### DIFF
--- a/cms/templates/js/course-outline.underscore
+++ b/cms/templates/js/course-outline.underscore
@@ -235,7 +235,7 @@ if (is_proctored_exam) {
                         <% } %>
                     </p>
                 </div>
-            <% } else if (xblockInfo.get('due_date') || xblockInfo.get('graded')) { %>
+            <% } else if ((xblockInfo.get('due_date') && !course.get('self_paced')) || xblockInfo.get('graded')) { %>
                 <div class="status-grading">
                     <p>
                         <span class="sr status-grading-label"> <%- gettext('Graded as:') %> </span>


### PR DESCRIPTION
By "useless" due dates I'm specifically talking about due dates which
are erroneously set in the course strucutre, but which don't matter
because the entire course is self-paced, rather than instructor-paced.

[JIRA:EDUCATOR-5713](https://openedx.atlassian.net/browse/EDUCATOR-5713)


## Testing instructions

Create an instructor-paced course with a subsection, set a due date in the future. Convert the course to self-paced (or create a re-run which is self-paced) & make sure the subsection is marked as Ungraded. Before this change, such a subsection will display a checkmark indicating it's "ungraded" in the studio course outline. After this change, it will show nothing, similarly to subsections which never had a due date set.