### PR TITLE
[MST-740] Toggle verification approved emails from ACE

### DIFF
--- a/lms/djangoapps/verify_student/message_types.py
+++ b/lms/djangoapps/verify_student/message_types.py
@@ -4,16 +4,6 @@ ACE message types for the verify_student module.
 from openedx.core.djangoapps.ace_common.message import BaseMessageType
 
 
-class VerificationExpiry(BaseMessageType):  # lint-amnesty, pylint: disable=missing-class-docstring
-    APP_LABEL = 'verify_student'
-    Name = 'verificationexpiry'
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        self.options['transactional'] = True
-
-
 class VerificationApproved(BaseMessageType):
     """
     A message to the learner when their ID verification has been approved.
@@ -23,6 +13,16 @@ class VerificationApproved(BaseMessageType):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.options['transactional'] = True
+
+
+class VerificationExpiry(BaseMessageType):  # lint-amnesty, pylint: disable=missing-class-docstring
+    APP_LABEL = 'verify_student'
+    Name = 'verificationexpiry'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
         self.options['transactional'] = True
 
 

--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -1664,6 +1664,31 @@ class TestPhotoVerificationResultsCallback(ModuleStoreTestCase, TestVerification
         }
         mock_segment_track.assert_called_with(attempt.user.id, "edx.bi.experiment.verification.attempt.result", data)
 
+    @patch.dict(settings.VERIFY_STUDENT, {'USE_DJANGO_MAIL': True})
+    def test_approved_email_without_ace(self):
+        """
+        Test basic email for verification approved.
+        """
+        expiration_datetime = now() + timedelta(
+            days=settings.VERIFY_STUDENT["DAYS_GOOD_FOR"]
+        )
+
+        data = {
+            "EdX-ID": self.receipt_id,
+            "Result": "PASS",
+            "Reason": "",
+            "MessageType": "You have been verified."
+        }
+        json_data = json.dumps(data)
+        self.client.post(
+            reverse('verify_student_results_callback'), data=json_data,
+            content_type='application/json',
+            HTTP_AUTHORIZATION='test BBBBBBBBBBBBBBBBBBBB:testing',
+            HTTP_DATE='testdate'
+        )
+
+        self._assert_verification_approved_email(expiration_datetime.date())
+
     @patch(
         'lms.djangoapps.verify_student.ssencrypt.has_valid_signature',
         mock.Mock(side_effect=mocked_has_valid_signature)

--- a/lms/templates/emails/passed_verification_email.txt
+++ b/lms/templates/emails/passed_verification_email.txt
@@ -1,10 +1,11 @@
 <%! from django.utils.translation import ugettext as _ %>
 
 
-${_("Hi {full_name}").format(full_name=full_name)}
+${_("Hello {full_name},").format(full_name=full_name)}
 
-${_("Congratulations! Your ID verification process was successful.")}
-${_("Your verification is effective for two years. It will expire on {expiration_datetime}").format(expiration_date=expiration_datetime)}
+${_("Your {platform_name} ID verification photos have been approved.").format(platform_name=platform_name)}
 
-${_("Thank you,")}
-${_("The {platform_name} team").format(platform_name=platform_name)}
+${_("Your approval status remains valid for two years, and it will expire {expiration_datetime}.").format(expiration_datetime=expiration_datetime)}
+
+${_("Enjoy your studies,")}
+${_("The {platform_name} Team").format(platform_name=platform_name)}


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Adds a toggle to remove verification approved emails from ACE, in order to prevent them from inaccurately attributing revenue to GA campaign. This is active while `VERIFY_STUDENT['USE_DJANGO_MAIL']` is True.

## Supporting information

[MST-740](https://openedx.atlassian.net/browse/MST-740)
