### PR TITLE
feat!: Remove allow_certificate field from the user profile

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -614,7 +614,6 @@ class UserProfile(models.Model):
     )
     state = models.CharField(blank=True, null=True, max_length=2, choices=STATE_CHOICES)
     goals = models.TextField(blank=True, null=True)
-    allow_certificate = models.BooleanField(default=1, null=True)
     bio = models.CharField(blank=True, null=True, max_length=3000, db_index=False)
     profile_image_uploaded_at = models.DateTimeField(null=True, blank=True)
     phone_regex = RegexValidator(regex=r'^\+?1?\d*$', message="Phone number can only contain numbers.")

--- a/common/djangoapps/util/tests/test_db.py
+++ b/common/djangoapps/util/tests/test_db.py
@@ -197,6 +197,9 @@ class MigrationTests(TestCase):
     """
 
     @override_settings(MIGRATION_MODULES={})
+    @unittest.skip(
+        "Temporary skip for DEPR-140 / MICROBA-985 where the allow_certificate column is being removed"
+    )
     def test_migrations_are_in_sync(self):
         """
         Tests that the migration files are in sync with the models.


### PR DESCRIPTION
Remove the _allow_certificate_ field from the user profile as the field is no longer used

https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations#EverythingAboutDatabaseMigrations-Howtodropacolumn

DEPR-140 MICROBA-985
