### PR TITLE
fix: Add callback function to Facebook share

### DIFF
--- a/lms/static/js/utils/facebook.js
+++ b/lms/static/js/utils/facebook.js
@@ -21,13 +21,18 @@ var FaceBook = (function() {
             }(document, 'script', 'facebook-jssdk'));
         },
         share: function(feed_data) {
-            FB.ui({
-                method: 'feed',
-                name: feed_data.share_text,
-                link: feed_data.share_link,
-                picture: feed_data.picture_link,
-                description: feed_data.description
-            });
+            FB.ui( // eslint-disable-line no-undef
+                {
+                    method: 'feed',
+                    name: feed_data.share_text,
+                    link: feed_data.share_link,
+                    picture: feed_data.picture_link,
+                    description: feed_data.description
+                },
+                // The Facebook API now requires a callback. Since we weren't doing anything after posting before,
+                // I'm leaving this as an empty function.
+                function(response) {} // eslint-disable-line no-unused-vars
+            );
         }
     };
 }());


### PR DESCRIPTION


<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

## Description

Fix Facebook share button on course certificates. This adds a required callback function to the `.ui()` call that the API now requires. I don't know when this changed, but the share button is currently broken on course certificates.



## Supporting information

Facebook documentation of the `.ui()` method:
https://developers.facebook.com/docs/javascript/reference/FB.ui/
