### PR TITLE
refactor: update verified upgrade sections on course dasboard [REV-2129]

### DIFF
--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -781,6 +781,7 @@
       padding-left: $baseline;
       padding-top: $baseline;
       padding-bottom: $baseline;
+      background-color: #F5F5F5;
 
       .wrapper-tip {
         @include clearfix();
@@ -815,8 +816,8 @@
 
           svg {
             flex-shrink: 0;
-            width: 41px;
-            height: 41px;
+            width: 43px;
+            height: 43px;
             margin-left: -5px;
           }
 
@@ -828,6 +829,11 @@
             .message-copy-bold {
               font-weight: 600;
             }
+          }
+
+          a.verified-info {
+            color: #454545;
+            text-decoration: underline;
           }
         }
 

--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -781,7 +781,7 @@
       padding-left: $baseline;
       padding-top: $baseline;
       padding-bottom: $baseline;
-      background-color: #F5F5F5;
+      background-color: #F2F0EF;
 
       .wrapper-tip {
         @include clearfix();

--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -808,6 +808,7 @@
       .wrapper-extended {
         display: flex;
         flex-flow: column wrap;
+        color: #00262B;
 
         .wrapper-icon-message {
           width: 100%;

--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -778,6 +778,10 @@
 
     // TYPE: upsell
     &.message-upsell {
+      padding-left: $baseline;
+      padding-top: $baseline;
+      padding-bottom: $baseline;
+
       .wrapper-tip {
         @include clearfix();
 
@@ -801,13 +805,55 @@
       }
 
       .wrapper-extended {
-        padding: ($baseline/4) 0;
+        display: flex;
+        flex-flow: column wrap;
 
-        .message-copy {
-          display: inline-block;
+        .wrapper-icon-message {
+          width: 100%;
+          display: inline-flex;
+          flex-wrap: wrap;
 
-          .message-copy-bold {
-            font-weight: 600;
+          svg {
+            flex-shrink: 0;
+            width: 41px;
+            height: 41px;
+            margin-left: -5px;
+          }
+
+          .message-copy {
+            margin-left: $baseline/2;
+            min-width: 15rem;
+            flex: 2;
+
+            .message-copy-bold {
+              font-weight: 600;
+            }
+          }
+        }
+
+        .action-upgrade-container {
+          flex-shrink: 0;
+          flex-grow: 1;
+          align-self: flex-end;
+        }
+
+        @include media-breakpoint-down(xs) {
+          .action-upgrade-container {
+            width: 100%;
+            margin-top: $baseline;
+          }
+
+          .action-upgrade {
+            width: 100%;
+            flex: 2 100%;
+          }
+        }
+
+        @include media-breakpoint-up(xl) {
+          flex-flow: nowrap;
+
+          .action-upgrade-container {
+            margin-left: 16px;
           }
         }
       }

--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -833,7 +833,7 @@
           }
 
           a.verified-info {
-            color: $gray-700;
+            color: #00262B;
             text-decoration: underline;
           }
         }

--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -827,12 +827,12 @@
             flex: 2;
 
             .message-copy-bold {
-              font-weight: 600;
+              font-weight: $font-weight-bold;
             }
           }
 
           a.verified-info {
-            color: #454545;
+            color: $gray-700;
             text-decoration: underline;
           }
         }

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -405,22 +405,22 @@ from lms.djangoapps.experiments.utils import UPSELL_TRACKING_FLAG
         % if course_mode_info and course_mode_info['show_upsell'] and not entitlement:
           <div class="message message-upsell has-actions is-shown">
             <div class="wrapper-extended">
-              <p class="message-copy" align="auto">
-                <b class="message-copy-bold">
-                  ${_("Pursue a {cert_name_long} to highlight the knowledge and skills you gain in this course.").format(cert_name_long=cert_name_long)}
-                </b><br>
-                  ${Text(_("It's official. It's easily shareable. "
-                      "It's a proven motivator to complete the course. {line_break}"
-                      "{link_start}Learn more about the verified {cert_name_long}{link_end}.")).format(
-                        line_break=HTML('<br>'),
-                        link_start=HTML('<a href="{}" class="verified-info" data-course-key="{}">').format(
-                          marketing_link('WHAT_IS_VERIFIED_CERT'),
-                          enrollment.course_id
-                        ),
-                        link_end=HTML('</a>'),
-                        cert_name_long=cert_name_long
-                      )}
-              </p>
+              <div class="wrapper-icon-message">
+                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="" aria-hidden="true" focusable="false">
+                  <path d="M19 5h-2V3H7v2H5c-1.1 0-2 .9-2 2v1c0 2.55 1.92 4.63 4.39 4.94A5.01 5.01 0 0011 15.9V19H7v2h10v-2h-4v-3.1a5.01 5.01 0 003.61-2.96C19.08 12.63 21 10.55 21 8V7c0-1.1-.9-2-2-2zM5 8V7h2v3.82C5.84 10.4 5 9.3 5 8zm14 0c0 1.3-.84 2.4-2 2.82V7h2v1z" fill="currentColor"></path>
+                </svg>
+                <div class="message-copy" align="auto">
+  ${Text(_("Get the most out of your course! Upgrade to get full access to the course material, unlock both graded and non-graded assignments, and earn a {link_start}verified certificate{link_end} to showcase on your resume.")).format(
+                          link_start=HTML('<a href="{}" class="verified-info" data-course-key="{}">').format(
+                            marketing_link('WHAT_IS_VERIFIED_CERT'),
+                            enrollment.course_id
+                          ),
+                          link_end=HTML('</a>'),
+                          cert_name_long=cert_name_long
+                        )}
+
+                </div>
+              </div>
               <div class="action-upgrade-container">
                 % if use_ecommerce_payment_flow and course_mode_info['verified_sku']:
                   <a class="action action-upgrade track_course_dashboard_green_button" href="${ecommerce_payment_page}?sku=${course_mode_info['verified_sku']}">

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -411,8 +411,8 @@ from lms.djangoapps.experiments.utils import UPSELL_TRACKING_FLAG
                 </svg>
                 <div class="message-copy" align="auto">
                   ${Text(_("{start_bold}Get the most out of your course!{end_bold} Upgrade to get full access to the course material, unlock both graded and non-graded assignments, and earn a {link_start}verified certificate{link_end} to showcase on your resume.")).format(
-                          start_bold=HTML('<b class="message-copy-bold">'),
-                          end_bold=HTML('</b>'),
+                          start_bold=HTML('<strong class="message-copy-bold">'),
+                          end_bold=HTML('</strong>'),
                           link_start=HTML('<a href="{}" class="verified-info" data-course-key="{}">').format(
                             marketing_link('WHAT_IS_VERIFIED_CERT'),
                             enrollment.course_id

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -428,7 +428,6 @@ from lms.djangoapps.experiments.utils import UPSELL_TRACKING_FLAG
                 % else:
                   <a class="action action-upgrade track_course_dashboard_green_button" href="${IDVerificationService.get_verify_location(course_id=course_overview.id)}" data-course-id="${course_overview.id}" data-user="${user.username}">
                 % endif
-                    <span class="action-upgrade-icon" aria-hidden="true"></span>
                   <span class="wrapper-copy">
                     <span class="copy" id="upgrade-to-verified">${_("Upgrade")}</span>
                       <span class="sr">&nbsp;${_(course_overview.display_name_with_default)}</span>

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -410,7 +410,9 @@ from lms.djangoapps.experiments.utils import UPSELL_TRACKING_FLAG
                   <path d="M19 5h-2V3H7v2H5c-1.1 0-2 .9-2 2v1c0 2.55 1.92 4.63 4.39 4.94A5.01 5.01 0 0011 15.9V19H7v2h10v-2h-4v-3.1a5.01 5.01 0 003.61-2.96C19.08 12.63 21 10.55 21 8V7c0-1.1-.9-2-2-2zM5 8V7h2v3.82C5.84 10.4 5 9.3 5 8zm14 0c0 1.3-.84 2.4-2 2.82V7h2v1z" fill="currentColor"></path>
                 </svg>
                 <div class="message-copy" align="auto">
-  ${Text(_("Get the most out of your course! Upgrade to get full access to the course material, unlock both graded and non-graded assignments, and earn a {link_start}verified certificate{link_end} to showcase on your resume.")).format(
+                  ${Text(_("{start_bold}Get the most out of your course!{end_bold} Upgrade to get full access to the course material, unlock both graded and non-graded assignments, and earn a {link_start}verified certificate{link_end} to showcase on your resume.")).format(
+                          start_bold=HTML('<b class="message-copy-bold">'),
+                          end_bold=HTML('</b>'),
                           link_start=HTML('<a href="{}" class="verified-info" data-course-key="{}">').format(
                             marketing_link('WHAT_IS_VERIFIED_CERT'),
                             enrollment.course_id
@@ -418,7 +420,6 @@ from lms.djangoapps.experiments.utils import UPSELL_TRACKING_FLAG
                           link_end=HTML('</a>'),
                           cert_name_long=cert_name_long
                         )}
-
                 </div>
               </div>
               <div class="action-upgrade-container">
@@ -429,7 +430,7 @@ from lms.djangoapps.experiments.utils import UPSELL_TRACKING_FLAG
                 % endif
                     <span class="action-upgrade-icon" aria-hidden="true"></span>
                   <span class="wrapper-copy">
-                    <span class="copy" id="upgrade-to-verified">${_("Upgrade to Verified")}</span>
+                    <span class="copy" id="upgrade-to-verified">${_("Upgrade")}</span>
                       <span class="sr">&nbsp;${_(course_overview.display_name_with_default)}</span>
                   </span>
                 </a>


### PR DESCRIPTION
## Description
Similar to https://github.com/edx/edx-platform/pull/27107, this PR changes the styling and verbiage used in the course upgrade sections of the course dashboard cards. 
 
The main objective is to make the mobile/small viewport conform to the new UX designs; however, in the process of changing the layout the other viewports were affected (i.e. the HTML structures were changed). The changes to the additional viewports may not exactly match what's in production (e.g. button placement is might be different in different viewports) but looked ok while testing locally.

Impacted Audience:
-Learners who use the course dashboard
-OpenEdx installations using the default OpenEdx theme

Potential Downstream Effects:
-Javascript events that rely on a strict HTML class hierarchy for their selectors may no longer work (e.g. selectors that are too specific/tied to the original HTML structure). 
-Comprehensive theming: This change affects the OpenEdx/default theme. 

## Supporting information
Relevant JIRA ticket: https://openedx.atlassian.net/browse/REV-2129
XS viewport mocks: https://www.figma.com/file/1EaMYJ8FecwzbbSv5YIpEC/Value-Prop-Final-Designs?node-id=0%3A1

Screenshots:
<img width="912" alt="Screen Shot 2021-04-29 at 12 02 20 PM" src="https://user-images.githubusercontent.com/34042537/116597750-fd974280-a8f3-11eb-91cb-59d140ac30d1.png">
<img width="932" alt="Screen Shot 2021-04-29 at 12 02 34 PM" src="https://user-images.githubusercontent.com/34042537/116597754-fec86f80-a8f3-11eb-97d1-5504d1d630ee.png">
<img width="383" alt="Screen Shot 2021-04-29 at 12 03 41 PM" src="https://user-images.githubusercontent.com/34042537/116597767-012ac980-a8f4-11eb-88ee-57aca1e18d31.png">
<img width="1038" alt="Screen Shot 2021-04-29 at 12 07 09 PM" src="https://user-images.githubusercontent.com/34042537/116597769-01c36000-a8f4-11eb-9b4b-0095bcf1cd1e.png">

With the $light-300 background color on the upgrade box:
<img width="537" alt="Screen Shot 2021-05-04 at 3 57 55 PM" src="https://user-images.githubusercontent.com/34042537/117063899-75e67500-acf3-11eb-8481-0b625257fa77.png">


## Testing instructions
Testing instructions
Start up devstack (or whichever environment you are testing in), log in as a learner, and navigate to the course dashboard (e.g. http://localhost:18000/dashboard). Open up the Chrome console and resize the window widths to see all viewports.
To view the changes with the edx.org-next theme locally, follow these instructions: https://openedx.atlassian.net/wiki/spaces/microb/pages/2047673326/Switching+the+theme+in+edx-platform

## Deadline
"None" if there's no rush

## Other information
[x] TODO: add in screenshots for all widths
[x] TODO: UX review
[x] TODO: a11y review (checked in with Jeff W)
[] TODO: does this change apply to Lilac; if so, make another PR against open-release/lilac.master or ping @nedbat
