### PR TITLE
fix: fix issue where we were not generating a certificate `verify_uuid` when needed

### DIFF
--- a/lms/djangoapps/certificates/generation.py
+++ b/lms/djangoapps/certificates/generation.py
@@ -66,9 +66,13 @@ def _generate_certificate(user, course_key):
     course = modulestore().get_course(course_key, depth=0)
     course_grade = CourseGradeFactory().read(user, course)
     enrollment_mode, __ = CourseEnrollment.enrollment_mode_for_user(user, course_key)
+
     # Retain the `verify_uuid` from an existing certificate if possible, this will make it possible for the learner to
     # keep the existing URL to their certificate
-    uuid = getattr(existing_certificate, 'verify_uuid', uuid4().hex)
+    if existing_certificate and existing_certificate.verify_uuid:
+        uuid = existing_certificate.verify_uuid
+    else:
+        uuid = uuid4().hex
 
     cert, created = GeneratedCertificate.objects.update_or_create(
         user=user,

--- a/lms/djangoapps/certificates/tests/test_generation.py
+++ b/lms/djangoapps/certificates/tests/test_generation.py
@@ -83,7 +83,6 @@ class CertificateTests(EventTestMixin, ModuleStoreTestCase):
         """
         Test that the `verify_uuid` value of a certificate does not change when it is revoked and re-awarded.
         """
-        # Create user, a course run, and an enrollment
         generated_cert = generate_course_certificate(self.u, self.key, self.gen_mode)
         assert generated_cert.status, CertificateStatuses.downloadable
 
@@ -104,3 +103,19 @@ class CertificateTests(EventTestMixin, ModuleStoreTestCase):
         generated_cert = generate_course_certificate(self.u, self.key, self.gen_mode)
         assert generated_cert.status, CertificateStatuses.downloadable
         assert generated_cert.verify_uuid, verify_uuid
+
+    def test_generation_creates_verify_uuid_when_needed(self):
+        """
+        Test that ensures we will create a verify_uuid when needed.
+        """
+        GeneratedCertificateFactory(
+            user=self.u,
+            course_id=self.key,
+            mode='verified',
+            status=CertificateStatuses.unverified,
+            verify_uuid=''
+        )
+
+        generated_cert = generate_course_certificate(self.u, self.key, self.gen_mode)
+        assert generated_cert.status, CertificateStatuses.downloadable
+        assert generated_cert.verify_uuid != ''


### PR DESCRIPTION
[MICROBA-1181]
- change how we determine if we need to generate a verify_uuid for a learner's certificate record

[MICROBA-1181]: https://openedx.atlassian.net/browse/MICROBA-1181