### PR TITLE
feat: support adding custom editors to Studio [BB-4060]

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -13,6 +13,7 @@ from django.core.exceptions import PermissionDenied
 from django.http import Http404, HttpResponse, HttpResponseBadRequest
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
+from edx_django_utils.plugins import pluggable_override
 from edx_proctoring.api import (
     does_backend_support_onboarding,
     get_exam_by_content_id,
@@ -1116,6 +1117,7 @@ def _get_gating_info(course, xblock):
     return info
 
 
+@pluggable_override('OVERRIDE_CREATE_XBLOCK_INFO')
 def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=False, include_child_info=False,  # lint-amnesty, pylint: disable=too-many-statements
                        course_outline=False, include_children_predicate=NEVER, parent_xblock=None, graders=None,
                        user=None, course=None, is_concise=False):
@@ -1134,6 +1136,13 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
 
     In addition, an optional include_children_predicate argument can be provided to define whether or
     not a particular xblock should have its children included.
+
+    You can customize the behavior of this function using the `OVERRIDE_CREATE_XBLOCK_INFO` pluggable override point.
+    For example:
+    >>> def create_xblock_info(default_fn, xblock, *args, **kwargs):
+    ...     xblock_info = default_fn(xblock, *args, **kwargs)
+    ...     xblock_info['icon'] = xblock.icon_override
+    ...     return xblock_info
     """
     is_library_block = isinstance(xblock.location, LibraryUsageLocator)
     is_xblock_unit = is_unit(xblock, parent_xblock)

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -832,6 +832,7 @@ XBLOCK_MIXINS = (
     EditInfoMixin,
     AuthoringMixin,
 )
+XBLOCK_EXTRA_MIXINS = ()
 
 XBLOCK_SELECT_FUNCTION = prefer_xmodules
 

--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -591,6 +591,9 @@ EXPLICIT_QUEUES = {
 
 LOGO_IMAGE_EXTRA_TEXT = ENV_TOKENS.get('LOGO_IMAGE_EXTRA_TEXT', '')
 
+############## XBlock extra mixins ############################
+XBLOCK_MIXINS += tuple(XBLOCK_EXTRA_MIXINS)
+
 ############## Settings for course import olx validation ############################
 COURSE_OLX_VALIDATION_STAGE = ENV_TOKENS.get('COURSE_OLX_VALIDATION_STAGE', COURSE_OLX_VALIDATION_STAGE)
 COURSE_OLX_VALIDATION_IGNORE_LIST = ENV_TOKENS.get(

--- a/cms/static/js/views/modals/course_outline_modals.js
+++ b/cms/static/js/views/modals/course_outline_modals.js
@@ -1208,6 +1208,19 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
             }, options));
         },
 
+        /**
+         * This function allows comprehensive themes to create custom editors without adding boilerplate code.
+         *
+         * A simple example theme for this can be found at https://github.com/open-craft/custom-unit-icons-theme
+         **/
+        getCustomEditModal: function(tabs, editors, xblockInfo, options) {
+            return new SettingsXBlockModal($.extend({
+                tabs: tabs,
+                editors: editors,
+                model: xblockInfo
+            }, options));
+        },
+
         getPublishModal: function(xblockInfo, options) {
             return new PublishXBlockModal($.extend({
                 editors: [PublishEditor],

--- a/cms/static/js/views/pages/course_outline.js
+++ b/cms/static/js/views/pages/course_outline.js
@@ -34,6 +34,9 @@ define([
                 collapsedClass: 'is-collapsed'
             },
 
+            // Extracting this to a variable allows comprehensive themes to replace or extend `CourseOutlineView`.
+            outlineViewClass: CourseOutlineView,
+
             initialize: function() {
                 var self = this;
                 this.initialState = this.options.initialState;
@@ -90,7 +93,7 @@ define([
                     this.highlightsEnableView.render();
                 }
 
-                this.outlineView = new CourseOutlineView({
+                this.outlineView = new this.outlineViewClass({
                     el: this.$('.outline'),
                     model: this.model,
                     isRoot: true,

--- a/openedx/core/lib/xblock_utils/__init__.py
+++ b/openedx/core/lib/xblock_utils/__init__.py
@@ -558,6 +558,6 @@ def get_icon(block):
     """
     A function that returns the CSS class representing an icon to use for this particular
     XBlock (in the courseware navigation bar). Mostly used for Vertical/Unit XBlocks.
-    It can be overridden by setting `GET_UNIT_ICON_IMPL` to an alternative implementation.
+    It can be overridden by setting `OVERRIDE_GET_UNIT_ICON` to an alternative implementation.
     """
     return block.get_icon_class()


### PR DESCRIPTION
## Description

This:
1. Introduces a variable for the Course Outline view in Studio.
    A custom theme can override it to add new editors.
2. Exports a function for creating new editor modals.
    A custom theme can use it to create editors without adding boilerplate code.
3. Adds a [pluggable override](https://github.com/edx/edx-django-utils/pull/64) for XBlock fields that are passed to the Studio.
    A plugin can [inject a custom field](https://github.com/open-craft/custom-unit-icons/blob/5e1f83a96249db2d56084cb49b378b147dc3c1c2/custom_unit_icons/icons.py#L31-L38) here.

An example custom editor can look like this. The [fa-eye](https://fontawesome.com/v4.7.0/icon/eye) icon is a button for opening it.
![image](https://user-images.githubusercontent.com/3189670/118171219-65d54080-b42b-11eb-8371-e2d7a5619d0c.png)


## Jira

[OSPR-5764](https://openedx.atlassian.net/browse/OSPR-5764)

## Sandbox
https://pr27466.sandbox.opencraft.hosting

## Prerequisites

1. [custom-unit-icons](https://github.com/open-craft/custom-unit-icons) plugin.
1. [custom-unit-icons-theme](https://github.com/open-craft/custom-unit-icons-theme).

## Testing instructions

1. Install the prerequisites and set up the comprehensive theme.
1. Add the following to `lms/envs/private.py`:
   ```python
   from .common import XBLOCK_MIXINS
   OVERRIDE_GET_UNIT_ICON = 'custom_unit_icons.icons.get_icon'
   XBLOCK_MIXINS += ('custom_unit_icons.icons.IconOverrideMixin',)
   ```
1. Add the following to `cms/envs/private.py`:
   ```python
   from .common import XBLOCK_MIXINS
   OVERRIDE_CREATE_XBLOCK_INFO = 'custom_unit_icons.icons.create_xblock_info'
   OVERRIDE_GET_UNIT_ICON = 'custom_unit_icons.icons.get_icon'
   XBLOCK_MIXINS += ('custom_unit_icons.icons.IconOverrideMixin',)
   ```
1. Restart LMS and Studio.
1. Go to the Course Outline page [in Studio](http://localhost:18010/course/course-v1:edX+DemoX+Demo_Course) ([sandbox link](https://studio.pr27466.sandbox.opencraft.hosting/course/course-v1:edX+DemoX+Demo_Course)).
1. Click on the `fa-eye` icon next to one of the verticals and change the icon. Visit this page in LMS to see that the icon has been changed.

## Deadline

It would be great if this could make it to some iteration of Lilac.

## Reviewers

- [x] @0x29a
- [ ] @bradenmacdonald / edX reviewer[s] TBD

## Background

This is a follow-up to #21433. That PR initially:
1. Introduced a way to add custom editors via a theme. This was a big theming change, which included splitting a template monolith, to achieve pluggability). This has been removed from the scope of that PR. We have revisited the approach and found a simpler way to do this, which is a part of this PR.
1. Had an `icon` field added directly to the `VerticalBlock` class. We have [changed](https://github.com/edx/edx-platform/pull/21433#discussion_r488245837) the approach and decided to add it [via a mixin](https://github.com/open-craft/custom-unit-icons/blob/5e1f83a96249db2d56084cb49b378b147dc3c1c2/custom_unit_icons/icons.py#L8-L19). Unfortunately, this makes the fields write-only for Studio, because the custom field cannot be passed to the `create_xblock_info` function.

**Settings**
```yaml
# Theme
EDXAPP_ENABLE_COMPREHENSIVE_THEMING: true
EDXAPP_COMPREHENSIVE_THEME_DIRS:
  - /edx/app/edxapp/themes
EDXAPP_DEFAULT_SITE_THEME: icons
edxapp_theme_name: "{{ EDXAPP_DEFAULT_SITE_THEME }}"
edxapp_theme_source_repo: https://github.com/open-craft/custom-unit-icons-theme.git

EDXAPP_EXTRA_REQUIREMENTS:
  - name: git+https://github.com/open-craft/custom-unit-icons.git@v0.4.0#egg=custom-unit-icons

EDXAPP_LMS_ENV_EXTRA:
  OVERRIDE_GET_UNIT_ICON: custom_unit_icons.icons.get_icon
  XBLOCK_EXTRA_MIXINS:
    - custom_unit_icons.icons.IconOverrideMixin

EDXAPP_CMS_ENV_EXTRA:
  OVERRIDE_CREATE_XBLOCK_INFO: custom_unit_icons.icons.create_xblock_info
  OVERRIDE_GET_UNIT_ICON: custom_unit_icons.icons.get_icon
  XBLOCK_EXTRA_MIXINS:
    - custom_unit_icons.icons.IconOverrideMixin
```