### PR TITLE
feat!: Enable the allowlist for all courses

### DIFF
--- a/lms/djangoapps/certificates/docs/decisions/001-allowlist-cert-requirements.rst
+++ b/lms/djangoapps/certificates/docs/decisions/001-allowlist-cert-requirements.rst
@@ -33,7 +33,3 @@ the time the certificate is generated:
 * The user must not have an invalidated certificate for the course run (see the *CertificateInvalidation* model)
 * HTML (web) certificates must be globally enabled, and also enabled for the course run
 * The user must be on the allowlist for the course run (see the *CertificateWhitelist* model)
-
-Note: the above requirements were written for the allowlist, which assumes the
-CourseWaffleFlag *certificates_revamp.use_allowlist* has been enabled for the
-course run. If it has not been enabled, the prior logic will apply.

--- a/lms/djangoapps/certificates/generation_handler.py
+++ b/lms/djangoapps/certificates/generation_handler.py
@@ -373,8 +373,12 @@ def is_using_certificate_allowlist_and_is_on_allowlist(user, course_key):
 def is_using_certificate_allowlist(course_key):
     """
     Check if the course run is using the allowlist, aka v2 of certificate whitelisting
+
+    Currently this returns True for all course runs, as we're enabling the allowlist for everyone.
+    If all goes well, we'll come back and remove this method and the flag entirely in MICROBA-1073.
     """
-    return CERTIFICATES_USE_ALLOWLIST.is_enabled(course_key)
+    return True
+#    return CERTIFICATES_USE_ALLOWLIST.is_enabled(course_key)
 
 
 def is_using_v2_course_certificates(course_key):

--- a/lms/djangoapps/certificates/tests/test_api.py
+++ b/lms/djangoapps/certificates/tests/test_api.py
@@ -56,7 +56,6 @@ from lms.djangoapps.certificates.api import (
     remove_allowlist_entry,
     set_cert_generation_enabled
 )
-from lms.djangoapps.certificates.generation_handler import CERTIFICATES_USE_ALLOWLIST
 from lms.djangoapps.certificates.models import (
     CertificateGenerationConfiguration,
     CertificateStatuses,
@@ -802,7 +801,6 @@ class CertificatesBrandingTest(ModuleStoreTestCase):
         assert self.configuration['urls']['TOS_AND_HONOR'] in data['company_tos_url']
 
 
-@override_waffle_flag(CERTIFICATES_USE_ALLOWLIST, active=True)
 class AllowlistTests(ModuleStoreTestCase):
     """
     Tests for handling allowlist certificates
@@ -867,20 +865,6 @@ class AllowlistTests(ModuleStoreTestCase):
         users = get_allowlisted_users(self.second_course_run_key)
         assert 1 == users.count()
         assert users[0].id == self.user4.id
-
-        users = get_allowlisted_users(self.third_course_run_key)
-        assert 0 == users.count()
-
-    @override_waffle_flag(CERTIFICATES_USE_ALLOWLIST, active=False)
-    def test_get_users_allowlist_false(self):
-        """
-        Test
-        """
-        users = get_allowlisted_users(self.course_run_key)
-        assert 0 == users.count()
-
-        users = get_allowlisted_users(self.second_course_run_key)
-        assert 0 == users.count()
 
         users = get_allowlisted_users(self.third_course_run_key)
         assert 0 == users.count()

--- a/lms/djangoapps/certificates/tests/test_generation_handler.py
+++ b/lms/djangoapps/certificates/tests/test_generation_handler.py
@@ -9,7 +9,6 @@ from edx_toggles.toggles.testutils import override_waffle_flag
 
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
 from lms.djangoapps.certificates.generation_handler import (
-    CERTIFICATES_USE_ALLOWLIST,
     CERTIFICATES_USE_UPDATED,
     _can_generate_allowlist_certificate,
     _can_generate_certificate_for_status,
@@ -42,7 +41,6 @@ PASSING_GRADE_METHOD = 'lms.djangoapps.certificates.generation_handler._has_pass
 WEB_CERTS_METHOD = 'lms.djangoapps.certificates.generation_handler.has_html_certificates_enabled'
 
 
-@override_waffle_flag(CERTIFICATES_USE_ALLOWLIST, active=True)
 @mock.patch(ID_VERIFIED_METHOD, mock.Mock(return_value=True))
 @mock.patch(WEB_CERTS_METHOD, mock.Mock(return_value=True))
 @ddt.ddt
@@ -74,25 +72,11 @@ class AllowlistTests(ModuleStoreTestCase):
         """
         assert is_using_certificate_allowlist(self.course_run_key)
 
-    @override_waffle_flag(CERTIFICATES_USE_ALLOWLIST, active=False)
-    def test_is_using_allowlist_false(self):
-        """
-        Test the allowlist flag without the override
-        """
-        assert not is_using_certificate_allowlist(self.course_run_key)
-
     def test_is_using_allowlist_and_is_on_list(self):
         """
         Test the allowlist flag and the presence of the user on the list
         """
         assert is_using_certificate_allowlist_and_is_on_allowlist(self.user, self.course_run_key)
-
-    @override_waffle_flag(CERTIFICATES_USE_ALLOWLIST, active=False)
-    def test_is_using_allowlist_and_is_on_list_with_flag_off(self):
-        """
-        Test the allowlist flag and the presence of the user on the list when the flag is off
-        """
-        assert not is_using_certificate_allowlist_and_is_on_allowlist(self.user, self.course_run_key)
 
     def test_is_using_allowlist_and_is_on_list_true(self):
         """
@@ -146,7 +130,6 @@ class AllowlistTests(ModuleStoreTestCase):
         """
         assert _can_generate_certificate_for_status(None, None)
 
-    @override_waffle_flag(CERTIFICATES_USE_ALLOWLIST, active=False)
     def test_handle_invalid(self):
         """
         Test handling of an invalid user/course run combo

--- a/lms/djangoapps/certificates/tests/test_services.py
+++ b/lms/djangoapps/certificates/tests/test_services.py
@@ -5,7 +5,6 @@ Unit Tests for the Certificate service
 from edx_toggles.toggles.testutils import override_waffle_flag
 
 from common.djangoapps.student.tests.factories import UserFactory
-from lms.djangoapps.certificates.generation_handler import CERTIFICATES_USE_ALLOWLIST
 from lms.djangoapps.certificates.models import CertificateStatuses, GeneratedCertificate
 from lms.djangoapps.certificates.services import CertificateService
 from lms.djangoapps.certificates.tests.factories import CertificateWhitelistFactory, GeneratedCertificateFactory
@@ -66,7 +65,6 @@ class CertificateServiceTests(ModuleStoreTestCase):
             }
         )
 
-    @override_waffle_flag(CERTIFICATES_USE_ALLOWLIST, active=True)
     def test_invalidate_certificate_allowlist(self):
         """
         Verify that CertificateService does not invalidate the certificate if it is allowlisted

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -1526,7 +1526,7 @@ class ProgressPageTests(ProgressPageBaseTests):
 
     @patch.dict(settings.FEATURES, {'ASSUME_ZERO_GRADE_IF_ABSENT_FOR_ALL_TESTS': False})
     @ddt.data(
-        (False, 61, 44),
+        (False, 62, 45),
         (True, 54, 39)
     )
     @ddt.unpack

--- a/lms/djangoapps/grades/tests/test_course_grade_factory.py
+++ b/lms/djangoapps/grades/tests/test_course_grade_factory.py
@@ -119,7 +119,7 @@ class TestCourseGradeFactory(GradeTestBase):
         with self.assertNumQueries(3):
             _assert_read(expected_pass=True, expected_percent=1.0)  # updated to grade of 1.0
 
-        num_queries = 30
+        num_queries = 29
         with self.assertNumQueries(num_queries), mock_get_score(0, 0):  # the subsection now is worth zero
             grade_factory.update(self.request.user, self.course, force_update_subsections=True)
 

--- a/lms/djangoapps/grades/tests/test_tasks.py
+++ b/lms/djangoapps/grades/tests/test_tasks.py
@@ -162,10 +162,10 @@ class RecalculateSubsectionGradeTest(HasCourseWithProblemsMixin, ModuleStoreTest
             assert mock_block_structure_create.call_count == 1
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 1, 40, True),
-        (ModuleStoreEnum.Type.mongo, 1, 40, False),
-        (ModuleStoreEnum.Type.split, 3, 40, True),
-        (ModuleStoreEnum.Type.split, 3, 40, False),
+        (ModuleStoreEnum.Type.mongo, 1, 39, True),
+        (ModuleStoreEnum.Type.mongo, 1, 39, False),
+        (ModuleStoreEnum.Type.split, 3, 39, True),
+        (ModuleStoreEnum.Type.split, 3, 39, False),
     )
     @ddt.unpack
     def test_query_counts(self, default_store, num_mongo_calls, num_sql_calls, create_multiple_subsections):
@@ -177,8 +177,8 @@ class RecalculateSubsectionGradeTest(HasCourseWithProblemsMixin, ModuleStoreTest
                     self._apply_recalculate_subsection_grade()
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 1, 40),
-        (ModuleStoreEnum.Type.split, 3, 40),
+        (ModuleStoreEnum.Type.mongo, 1, 39),
+        (ModuleStoreEnum.Type.split, 3, 39),
     )
     @ddt.unpack
     def test_query_counts_dont_change_with_more_content(self, default_store, num_mongo_calls, num_sql_calls):
@@ -223,8 +223,8 @@ class RecalculateSubsectionGradeTest(HasCourseWithProblemsMixin, ModuleStoreTest
         )
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 1, 23),
-        (ModuleStoreEnum.Type.split, 3, 23),
+        (ModuleStoreEnum.Type.mongo, 1, 22),
+        (ModuleStoreEnum.Type.split, 3, 22),
     )
     @ddt.unpack
     def test_persistent_grades_not_enabled_on_course(self, default_store, num_mongo_queries, num_sql_queries):
@@ -238,8 +238,8 @@ class RecalculateSubsectionGradeTest(HasCourseWithProblemsMixin, ModuleStoreTest
             assert len(PersistentSubsectionGrade.bulk_read_grades(self.user.id, self.course.id)) == 0
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 1, 41),
-        (ModuleStoreEnum.Type.split, 3, 41),
+        (ModuleStoreEnum.Type.mongo, 1, 40),
+        (ModuleStoreEnum.Type.split, 3, 40),
     )
     @ddt.unpack
     def test_persistent_grades_enabled_on_course(self, default_store, num_mongo_queries, num_sql_queries):

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -30,10 +30,7 @@ from capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.models import CourseEnrollment, CourseEnrollmentAllowed
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
-from lms.djangoapps.certificates.generation_handler import (
-    CERTIFICATES_USE_ALLOWLIST,
-    CERTIFICATES_USE_UPDATED
-)
+from lms.djangoapps.certificates.generation_handler import CERTIFICATES_USE_UPDATED
 from lms.djangoapps.certificates.models import CertificateStatuses, GeneratedCertificate
 from lms.djangoapps.certificates.tests.factories import CertificateWhitelistFactory, GeneratedCertificateFactory
 from lms.djangoapps.courseware.models import StudentModule
@@ -2024,7 +2021,7 @@ class TestCertificateGeneration(InstructorTaskModuleTestCase):
             'failed': 0,
             'skipped': 2
         }
-        with self.assertNumQueries(170):
+        with self.assertNumQueries(114):
             self.assertCertificatesGenerated(task_input, expected_results)
 
     @ddt.data(
@@ -2423,7 +2420,6 @@ class TestCertificateGeneration(InstructorTaskModuleTestCase):
 
         self.assertCertificatesGenerated(task_input, expected_results)
 
-    @override_waffle_flag(CERTIFICATES_USE_ALLOWLIST, active=True)
     def test_invalidation(self):
         # Create students
         students = self._create_students(2)


### PR DESCRIPTION
Enable the allowlist for all courses. 

This changes the code to no longer check the value of the certificates_revamp.use_allowlist flag, and instead will always assume that flag's value is true. This enables the allowlist for all courses.

MICROBA-1013