### PR TITLE
Deny course staff visibility of legacy courseware.

### DIFF
--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -3478,19 +3478,19 @@ class MFERedirectTests(BaseViewsTestCase):  # lint-amnesty, pylint: disable=miss
     def test_staff_no_redirect(self):
         lms_url, mfe_url = self._get_urls()  # lint-amnesty, pylint: disable=unused-variable
 
-        # course staff will not redirect
+        # course staff will redirect in an MFE-enabled course - and not redirect otherwise.
         course_staff = UserFactory.create(is_staff=False)
         CourseStaffRole(self.course_key).add_users(course_staff)
         self.client.login(username=course_staff.username, password='test')
 
         assert self.client.get(lms_url).status_code == 200
         with _set_mfe_flag(True):
-            assert self.client.get(lms_url).status_code == 200
+            assert self.client.get(lms_url).status_code == 302
 
         # global staff will never be redirected
         self._create_global_staff_user()
-        assert self.client.get(lms_url).status_code == 200
 
+        assert self.client.get(lms_url).status_code == 200
         with _set_mfe_flag(True):
             assert self.client.get(lms_url).status_code == 200
 

--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -176,7 +176,6 @@ def courseware_mfe_is_advertised(
 def courseware_legacy_is_visible(
         course_key: CourseKey,
         is_global_staff=False,
-        is_course_staff=False,
 ) -> bool:
     """
     Can we see a course run's content in the Legacy frontend?
@@ -186,9 +185,6 @@ def courseware_legacy_is_visible(
     """
     # ALLOW: Global staff may always see the Legacy experience.
     if is_global_staff:
-        return True
-    # ALLOW: The course team may always see their course in the Legacy experience.
-    if is_course_staff:
         return True
     # OTHERWISE: Legacy is only visible if it's the active (ie canonical) experience.
     #            Note that Old Mongo courses are never the active experience,

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -178,7 +178,6 @@ class CoursewareIndex(View):
         if courseware_legacy_is_visible(
                 course_key=self.course_key,
                 is_global_staff=self.request.user.is_staff,
-                is_course_staff=self.is_staff,
         ):
             return
         # STAY: if we are in a special (ie proctored/timed) exam, which isn't yet

--- a/openedx/core/djangoapps/courseware_api/serializers.py
+++ b/openedx/core/djangoapps/courseware_api/serializers.py
@@ -104,6 +104,7 @@ class CourseInfoSerializer(serializers.Serializer):  # pylint: disable=abstract-
     verified_mode = serializers.DictField()
     show_calculator = serializers.BooleanField()
     original_user_is_staff = serializers.BooleanField()
+    can_view_legacy_courseware = serializers.BooleanField()
     is_staff = serializers.BooleanField()
     can_load_courseware = serializers.DictField()
     notes = serializers.DictField()

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -33,7 +33,11 @@ from lms.djangoapps.courseware.courses import check_course_access
 from lms.djangoapps.courseware.masquerade import setup_masquerade
 from lms.djangoapps.courseware.module_render import get_module_by_usage_id
 from lms.djangoapps.courseware.tabs import get_course_tab_list
-from lms.djangoapps.courseware.toggles import courseware_mfe_is_visible, course_exit_page_is_active
+from lms.djangoapps.courseware.toggles import (
+    courseware_legacy_is_visible,
+    courseware_mfe_is_visible,
+    course_exit_page_is_active
+)
 from lms.djangoapps.courseware.views.views import get_cert_data
 from lms.djangoapps.grades.api import CourseGradeFactory
 from lms.djangoapps.verify_student.services import IDVerificationService
@@ -93,6 +97,10 @@ class CoursewareMeta:
         self.is_staff = has_access(self.effective_user, 'staff', self.overview).has_access
         self.enrollment_object = CourseEnrollment.get_enrollment(self.effective_user, self.course_key,
                                                                  select_related=['celebration', 'user__celebration'])
+        self.can_view_legacy_courseware = courseware_legacy_is_visible(
+            course_key=course_key,
+            is_global_staff=self.original_user_is_global_staff,
+        )
 
     def __getattr__(self, name):
         return getattr(self.overview, name)
@@ -386,6 +394,7 @@ class CoursewareInformation(RetrieveAPIView):
         * can_load_course: Whether the user can view the course (AccessResponse object)
         * is_staff: Whether the effective user has staff access to the course
         * original_user_is_staff: Whether the original user has staff access to the course
+        * can_view_legacy_courseware: Indicates whether the user is able to see the legacy courseware view
         * user_has_passing_grade: Whether or not the effective user's grade is equal to or above the courses minimum
             passing grade
         * course_exit_page_is_active: Flag for the learning mfe on whether or not the course exit page should display


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

https://openedx.atlassian.net/browse/TNL-8203

Currently, course staff can *always* view their courses in the Legacy courseware experience.

With this change, course staff will not be able to view their courses if the New (MFE) courseware experience has been enabled for them.

This change does not affect global staff, and it does not affect courses that are still running in the Legacy experience.

## Testing instructions

- Visit a course as course staff, then confirm that the "Legacy Experience" button is *not* present.
- Visit a course as global staff, then confirm that the "Legacy Experience" button:
   -  *is* present
   - redirects you to the legacy course experience when pressed

## Deadline

None

## Other information

None