### PR TITLE
[MST-723] Include proctoring escalation email in course validation

### DIFF
--- a/cms/djangoapps/contentstore/api/tests/test_validation.py
+++ b/cms/djangoapps/contentstore/api/tests/test_validation.py
@@ -5,6 +5,7 @@ Tests for the course import API views
 
 from datetime import datetime
 
+from django.test.utils import override_settings
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -15,6 +16,7 @@ from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, 
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
 
+@override_settings(PROCTORING_BACKENDS={'DEFAULT': 'null', 'proctortrack': {}})
 class CourseValidationViewTest(SharedModuleStoreTestCase, APITestCase):
     """
     Test course validation view via a RESTful API
@@ -25,7 +27,12 @@ class CourseValidationViewTest(SharedModuleStoreTestCase, APITestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.course = CourseFactory.create(display_name='test course', run="Testing_course")
+        cls.course = CourseFactory.create(
+            display_name='test course',
+            run="Testing_course",
+            proctoring_provider='proctortrack',
+            proctoring_escalation_email='test@example.com',
+        )
         cls.course_key = cls.course.id
 
         cls.password = 'test'
@@ -105,6 +112,10 @@ class CourseValidationViewTest(SharedModuleStoreTestCase, APITestCase):
             'grades': {
                 'has_grading_policy': False,
                 'sum_of_weights': 1.0,
+            },
+            'proctoring': {
+                'needs_proctoring_escalation_email': True,
+                'has_proctoring_escalation_email': True,
             },
             'is_self_paced': True,
         }

--- a/cms/djangoapps/contentstore/views/checklists.py
+++ b/cms/djangoapps/contentstore/views/checklists.py
@@ -6,6 +6,7 @@ from opaque_keys.edx.keys import CourseKey
 
 from common.djangoapps.edxmako.shortcuts import render_to_response
 from common.djangoapps.student.auth import has_course_author_access
+from cms.djangoapps.contentstore.utils import get_proctored_exam_settings_url
 from xmodule.modulestore.django import modulestore
 
 __all__ = ['checklists_handler']
@@ -27,7 +28,17 @@ def checklists_handler(request, course_key_string=None):
         raise PermissionDenied()
 
     course_module = modulestore().get_course(course_key)
+
+    course_authoring_microfrontend_url = get_proctored_exam_settings_url(course_module)
+    proctored_exam_settings_url = (
+        '{course_authoring_microfrontend_url}/proctored-exam-settings/{course_key_string}'.format(
+            course_authoring_microfrontend_url=course_authoring_microfrontend_url,
+            course_key_string=course_key_string,
+        )
+    )
+
     return render_to_response('checklists.html', {
         'language_code': request.LANGUAGE_CODE,
         'context_course': course_module,
+        'proctored_exam_settings_url': proctored_exam_settings_url,
     })

--- a/cms/templates/checklists.html
+++ b/cms/templates/checklists.html
@@ -66,7 +66,8 @@
                     "course_outline": ${utils.reverse_course_url('course_handler', course_key) | n, dump_js_escaped_json},
                     "course_updates": ${utils.reverse_course_url('course_info_handler', course_key) | n, dump_js_escaped_json},
                     "grading_policy": ${utils.reverse_course_url('grading_handler', course_key) | n, dump_js_escaped_json},
-                    "settings": ${utils.reverse_course_url('settings_handler', course_key) | n, dump_js_escaped_json}
+                    "settings": ${utils.reverse_course_url('settings_handler', course_key) | n, dump_js_escaped_json},
+                    "proctored_exam_settings": ${proctored_exam_settings_url | n, dump_js_escaped_json}
                 }
             }
         </%static:studiofrontend>


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

In the course validation view, include two new fields under `proctoring`:
- `needs_proctoring_escalation_email`: Whether the course's proctoring provider requires an escalation email (currently only true for Proctortrack)
- `has_proctoring_escalation_email`: Whether the course has a proctoring escalation email set

This will be used to determine whether the proctoring escalation email field should appear under the course launch checklist. Currently behind a waffle flag (`contentstore.proctoring_escalation_email_check`)

## Supporting information

- [MST-723](https://openedx.atlassian.net/browse/MST-723)
