### PR TITLE
perf: Remove Modulestore call from Credit Service.

### DIFF
--- a/openedx/core/djangoapps/credit/services.py
+++ b/openedx/core/djangoapps/credit/services.py
@@ -1,8 +1,6 @@
 """
 Implementation of "credit" XBlock service
 """
-
-
 import logging
 
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
@@ -10,7 +8,8 @@ from django.core.exceptions import ObjectDoesNotExist
 from opaque_keys.edx.keys import CourseKey
 
 from common.djangoapps.student.models import CourseEnrollment
-from xmodule.modulestore.django import modulestore
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+
 
 log = logging.getLogger(__name__)
 
@@ -101,10 +100,10 @@ class CreditService:
         }
 
         if return_course_info:
-            course = modulestore().get_course(course_key, depth=0)
+            course_overview = CourseOverview.get_from_id(course_key)
             result.update({
-                'course_name': course.display_name,
-                'course_end_date': course.end,
+                'course_name': course_overview.display_name,
+                'course_end_date': course_overview.end_date,
             })
         return result
 


### PR DESCRIPTION
```
We can get the same information much more cheaply and predictably
by using CourseOverviews. This was contributing to slow traces for
the edx_proctoring.views:StudentOnboardingStatusView.get
transaction.
```

