### PR TITLE
Update validation messages for register endpoint

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/__init__.py
+++ b/openedx/core/djangoapps/user_api/accounts/__init__.py
@@ -53,6 +53,7 @@ USERNAME_INVALID_CHARS_UNICODE = _(
 # Translators: This message is shown to users who attempt to create a new account using
 # an invalid email format.
 EMAIL_INVALID_MSG = _('"{email}" is not a valid email address.')
+AUTHN_EMAIL_INVALID_MSG = _('Enter a valid email address')
 
 # Translators: This message is shown to users who attempt to create a new
 # account using an username/email associated with an existing account.
@@ -60,10 +61,12 @@ EMAIL_CONFLICT_MSG = _(
     "It looks like {email_address} belongs to an existing account. "
     "Try again with a different email address."
 )
+AUTHN_EMAIL_CONFLICT_MSG = _("It looks like this email address is already registered")
 USERNAME_CONFLICT_MSG = _(
     "It looks like {username} belongs to an existing account. "
     "Try again with a different username."
 )
+AUTHN_USERNAME_CONFLICT_MSG = _("It looks like this username is already taken")
 
 # Translators: This message is shown to users who enter a username/email/password
 # with an inappropriate length (too short or too long).

--- a/openedx/core/djangoapps/user_api/accounts/api.py
+++ b/openedx/core/djangoapps/user_api/accounts/api.py
@@ -363,16 +363,17 @@ def get_username_validation_error(username):
     return _validate(_validate_username, errors.AccountUsernameInvalid, username)
 
 
-def get_email_validation_error(email):
+def get_email_validation_error(email, api_version='v1'):
     """Get the built-in validation error message for when
     the email is invalid in some way.
 
     :param email: The proposed email (unicode).
+    :param api_version: registration validation api version
     :param default: The message to default to in case of no error.
     :return: Validation error message.
 
     """
-    return _validate(_validate_email, errors.AccountEmailInvalid, email)
+    return _validate(_validate_email, errors.AccountEmailInvalid, email, api_version)
 
 
 def get_secondary_email_validation_error(email):
@@ -425,28 +426,30 @@ def get_country_validation_error(country):
     return _validate(_validate_country, errors.AccountCountryInvalid, country)
 
 
-def get_username_existence_validation_error(username):
+def get_username_existence_validation_error(username, api_version='v1'):
     """Get the built-in validation error message for when
     the username has an existence conflict.
 
     :param username: The proposed username (unicode).
+    :param api_version: registration validation api version
     :param default: The message to default to in case of no error.
     :return: Validation error message.
 
     """
-    return _validate(_validate_username_doesnt_exist, errors.AccountUsernameAlreadyExists, username)
+    return _validate(_validate_username_doesnt_exist, errors.AccountUsernameAlreadyExists, username, api_version)
 
 
-def get_email_existence_validation_error(email):
+def get_email_existence_validation_error(email, api_version='v1'):
     """Get the built-in validation error message for when
     the email has an existence conflict.
 
     :param email: The proposed email (unicode).
+    :param api_version: registration validation api version
     :param default: The message to default to in case of no error.
     :return: Validation error message.
 
     """
-    return _validate(_validate_email_doesnt_exist, errors.AccountEmailAlreadyExists, email)
+    return _validate(_validate_email_doesnt_exist, errors.AccountEmailAlreadyExists, email, api_version)
 
 
 def _get_user_and_profile(username):
@@ -513,11 +516,12 @@ def _validate_username(username):
         raise errors.AccountUsernameInvalid(validation_err.message)
 
 
-def _validate_email(email):
+def _validate_email(email, api_version='v1'):
     """Validate the format of the email address.
 
     Arguments:
         email (unicode): The proposed email.
+        api_version(str): Validation API version; it is used to determine the error message
 
     Returns:
         None
@@ -530,7 +534,9 @@ def _validate_email(email):
         _validate_unicode(email)
         _validate_type(email, str, accounts.EMAIL_BAD_TYPE_MSG)
         _validate_length(email, accounts.EMAIL_MIN_LENGTH, accounts.EMAIL_MAX_LENGTH, accounts.EMAIL_BAD_LENGTH_MSG)
-        validate_email.message = accounts.EMAIL_INVALID_MSG.format(email=email)
+        validate_email.message = (
+            accounts.EMAIL_INVALID_MSG.format(email=email) if api_version == 'v1' else accounts.AUTHN_EMAIL_INVALID_MSG
+        )
         validate_email(email)
     except (UnicodeError, errors.AccountDataBadType, errors.AccountDataBadLength) as invalid_email_err:
         raise errors.AccountEmailInvalid(str(invalid_email_err))
@@ -590,26 +596,37 @@ def _validate_country(country):
         raise errors.AccountCountryInvalid(accounts.REQUIRED_FIELD_COUNTRY_MSG)
 
 
-def _validate_username_doesnt_exist(username):
+def _validate_username_doesnt_exist(username, api_version='v1'):
     """Validate that the username is not associated with an existing user.
 
     :param username: The proposed username (unicode).
+    :param api_version: Validation API version; it is used to determine the error message
     :return: None
     :raises: errors.AccountUsernameAlreadyExists
     """
+    if api_version == 'v1':
+        error_message = accounts.USERNAME_CONFLICT_MSG.format(username=username)
+    else:
+        error_message = accounts.AUTHN_USERNAME_CONFLICT_MSG
     if username is not None and username_exists_or_retired(username):
-        raise errors.AccountUsernameAlreadyExists(_(accounts.USERNAME_CONFLICT_MSG).format(username=username))  # lint-amnesty, pylint: disable=translation-of-non-string
+        raise errors.AccountUsernameAlreadyExists(_(error_message))  # lint-amnesty, pylint: disable=translation-of-non-string
 
 
-def _validate_email_doesnt_exist(email):
+def _validate_email_doesnt_exist(email, api_version='v1'):
     """Validate that the email is not associated with an existing user.
 
     :param email: The proposed email (unicode).
+    :param api_version: Validation API version; it is used to determine the error message
     :return: None
     :raises: errors.AccountEmailAlreadyExists
     """
+    if api_version == 'v1':
+        error_message = accounts.EMAIL_CONFLICT_MSG.format(email_address=email)
+    else:
+        error_message = accounts.AUTHN_EMAIL_CONFLICT_MSG
+
     if email is not None and email_exists_or_retired(email):
-        raise errors.AccountEmailAlreadyExists(_(accounts.EMAIL_CONFLICT_MSG).format(email_address=email))  # lint-amnesty, pylint: disable=translation-of-non-string
+        raise errors.AccountEmailAlreadyExists(_(error_message))  # lint-amnesty, pylint: disable=translation-of-non-string
 
 
 def _validate_secondary_email_doesnt_exist(email):


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

As part of authn redesign, validation messages have been updated.
- created a new endpoint for validations
- updated username/email conflict message in registration api based on authn check

## Supporting information

Ticket: https://openedx.atlassian.net/browse/VAN-288

## Testing instructions

Added unit tests for the updates
