### PR TITLE
fix: don't bubble up empty partition groups from units.

### DIFF
--- a/cms/djangoapps/contentstore/outlines.py
+++ b/cms/djangoapps/contentstore/outlines.py
@@ -101,6 +101,7 @@ def _bubbled_up_groups_from_units(group_access_from_units):
         return {
             user_partition_id: sorted(group_ids)  # sorted for easier comparison
             for user_partition_id, group_ids in group_access.items()
+            if group_ids  # Ignore empty groups
         }
 
     normalized_group_access_dicts = [

--- a/cms/djangoapps/contentstore/tests/test_outlines.py
+++ b/cms/djangoapps/contentstore/tests/test_outlines.py
@@ -348,7 +348,10 @@ class OutlineFromModuleStoreTestCase(ModuleStoreTestCase):
                 parent_location=seq_1.location,
                 category='vertical',
                 display_name='Single Vertical',
-                group_access={50: [1, 2]},
+                group_access={
+                    50: [1, 2],
+                    51: [],  # Empty group shouldn't bubble up.
+                },
             )
 
         outline, errs = get_outline_from_modulestore(self.course_key)


### PR DESCRIPTION
```
In dfb80acc1, we allowed group_access settings to bubble up from
Units to Sequences in the case where all Units had the same group
settings for a particular user partition. This caused an issue
where the group being bubbled up could be empty if the Unit was
misconfigured in OLX (this is already caught if done directly on
the Sequence). This commit fixes things so that empty partition
group settings never bubble up.

We don't want empty partition groups to bubble up because it would
mean that no groups are allowed to access the Sequence, which is
probably an error. (There is a separate visible_to_staff_only flag
when you want to hide content from all non-staff users.)
```
