### PR TITLE
fix: Hide cert availability on self paced courses

### DIFF
--- a/lms/templates/dashboard/_dashboard_certificate_information.html
+++ b/lms/templates/dashboard/_dashboard_certificate_information.html
@@ -49,7 +49,7 @@ else:
         % if should_display_grade(course_overview):
             ${_("Your final grade:")}
             <span class="grade-value">${"{0:.0f}%".format(float(cert_status['grade'])*100)}</span>.
-        % elif course_overview.certificate_available_date:
+        % elif course_overview.certificate_available_date and not course_overview.self_paced:
           <%
             cert_available_date = course_overview.certificate_available_date.strftime('%Y-%m-%d')
           %>


### PR DESCRIPTION
## Description
If a certificate available date was set on a self paced course, it would show text to the learner saying that the grades would be available in the future when that was inaccurate.


Useful information to include:
- This will fix a bug where self paced learners were seeing a delayed grade message.

## Supporting information

MICROBA-1197

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Other information

Cert available date should only ever matter for instructor-paced courses. This check was only seeing if the cert available date was actually set, not if it was going to be used. 
