### PR TITLE
BOM-2499: pin python-slugify<5.0.0

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -114,3 +114,7 @@ diff-cover==4.0.0
 
 # 3.8.6 causes an issue in the instructor dashboard
 edx-proctoring<=3.8.5
+
+# transifex-client==0.14.2(latest) requires python-slugify<5.0.0 for Python 2.0 support.
+# This can be removed once transifex-client drops support for Python 2.0 and removes the required constraint.
+python-slugify<5.0.0

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -191,7 +191,7 @@ pysrt==1.1.2              # via -r requirements/edx/base.in, edxval
 python-dateutil==2.4.0    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, analytics-python, botocore, edx-ace, edx-drf-extensions, edx-enterprise, edx-event-routing-backends, edx-proctoring, icalendar, olxcleaner, ora2, xblock
 python-levenshtein==0.12.2  # via -r requirements/edx/base.in
 python-memcached==1.59    # via -r requirements/edx/paver.txt
-python-slugify==4.0.1     # via code-annotations
+python-slugify==4.0.1     # via -c requirements/edx/../constraints.txt, code-annotations
 python-swiftclient==3.11.1  # via ora2
 python3-openid==3.2.0 ; python_version >= "3"  # via -r requirements/edx/base.in, social-auth-core
 python3-saml==1.9.0       # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -243,7 +243,7 @@ pytest==6.2.3             # via -r requirements/edx/testing.txt, pylint-pytest, 
 python-dateutil==2.4.0    # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, analytics-python, botocore, edx-ace, edx-drf-extensions, edx-enterprise, edx-event-routing-backends, edx-proctoring, faker, freezegun, icalendar, olxcleaner, ora2, xblock
 python-levenshtein==0.12.2  # via -r requirements/edx/testing.txt
 python-memcached==1.59    # via -r requirements/edx/testing.txt
-python-slugify==4.0.1     # via -r requirements/edx/testing.txt, code-annotations, transifex-client
+python-slugify==4.0.1     # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, code-annotations, transifex-client
 python-swiftclient==3.11.1  # via -r requirements/edx/testing.txt, ora2
 python3-openid==3.2.0 ; python_version >= "3"  # via -r requirements/edx/testing.txt, social-auth-core
 python3-saml==1.9.0       # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -23,7 +23,7 @@ packaging==20.9           # via sphinx
 pbr==5.6.0                # via stevedore
 pygments==2.8.1           # via sphinx
 pyparsing==2.4.7          # via packaging
-python-slugify==4.0.1     # via code-annotations
+python-slugify==4.0.1     # via -c requirements/edx/../constraints.txt, code-annotations
 pytz==2021.1              # via babel, django
 pyyaml==5.4.1             # via code-annotations
 requests==2.25.1          # via sphinx

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -233,7 +233,7 @@ pytest==6.2.3             # via -r requirements/edx/testing.in, pylint-pytest, p
 python-dateutil==2.4.0    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, analytics-python, botocore, edx-ace, edx-drf-extensions, edx-enterprise, edx-event-routing-backends, edx-proctoring, faker, freezegun, icalendar, olxcleaner, ora2, xblock
 python-levenshtein==0.12.2  # via -r requirements/edx/base.txt
 python-memcached==1.59    # via -r requirements/edx/base.txt
-python-slugify==4.0.1     # via -r requirements/edx/base.txt, code-annotations, transifex-client
+python-slugify==4.0.1     # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, code-annotations, transifex-client
 python-swiftclient==3.11.1  # via -r requirements/edx/base.txt, ora2
 python3-openid==3.2.0 ; python_version >= "3"  # via -r requirements/edx/base.txt, social-auth-core
 python3-saml==1.9.0       # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt


### PR DESCRIPTION
**Issue:** [BOM-2499](https://openedx.atlassian.net/browse/BOM-2499)

## Change
- `transifex-client` requires `python-slugify<5.0.0` for `Python 2.0` support which conflicts with the latest `python-slugify` version causing the [requirements upgrade build](https://build.testeng.edx.org/job/edx-platform-upgrade-python-requirements/1322/display/redirect?page=changes) to fail.
- It can be removed once `transifex-client` drops support of `Python 2.0` and removes the required constraint.