### PR TITLE
[fix]: MST-698 Remove escaping for Proctoring Requirements email on course_name and proctoring backend name

### DIFF
--- a/common/djangoapps/student/tests/test_email.py
+++ b/common/djangoapps/student/tests/test_email.py
@@ -227,10 +227,15 @@ class ProctoringRequirementsEmailTests(EmailTemplateTagMixin, ModuleStoreTestCas
     # pylint: disable=no-member
     def setUp(self):
         super().setUp()
-        self.course = CourseFactory(enable_proctored_exams=True)
+        self.course = None
         self.user = UserFactory()
 
-    def test_send_proctoring_requirements_email(self):
+    @ddt.data('course_run_1', 'matt''s course', 'matt＇s run')
+    def test_send_proctoring_requirements_email(self, course_run_name):
+        self.course = CourseFactory(
+            display_name=course_run_name,
+            enable_proctored_exams=True
+        )
         context = generate_proctoring_requirements_email_context(self.user, self.course.id)
         send_proctoring_requirements_email(context)
         self._assert_email()
@@ -249,7 +254,7 @@ class ProctoringRequirementsEmailTests(EmailTemplateTagMixin, ModuleStoreTestCas
 
         for fragment in self._get_fragments():
             assert fragment in text
-            assert escape(fragment) in html
+            assert fragment in html
 
     def _get_fragments(self):
         course_module = modulestore().get_course(self.course.id)
@@ -267,12 +272,12 @@ class ProctoringRequirementsEmailTests(EmailTemplateTagMixin, ModuleStoreTestCas
                 "your computer's desktop, webcam video, and audio."
             ),
             proctoring_provider,
-            (
+            escape(
                 "Carefully review the system requirements as well as the steps to take a proctored "
                 "exam in order to ensure that you are prepared."
             ),
             settings.PROCTORING_SETTINGS.get('LINK_URLS', {}).get('faq', ''),
-            ("Before taking a graded proctored exam, you must have approved ID verification photos."),
+            escape("Before taking a graded proctored exam, you must have approved ID verification photos."),
             id_verification_url
         ]
 

--- a/common/templates/student/edx_ace/proctoringrequirements/email/body.html
+++ b/common/templates/student/edx_ace/proctoringrequirements/email/body.html
@@ -7,11 +7,11 @@
     <tr>
         <td>
             <h1>
-                {% filter force_escape %}
-                {% blocktrans %}
+                {% autoescape off %}
+                {% blocktrans %}  # xss-lint: disable=django-blocktrans-missing-escape-filter
                     Proctoring requirements for {{ course_name }}
                 {% endblocktrans %}
-                {% endfilter %}
+                {% endautoescape %}
             </h1>
 
             <p style="color: rgba(0,0,0,.75);">
@@ -23,19 +23,19 @@
             </p>
 
             <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}
+                {% autoescape off %}
+                {% blocktrans %}  # xss-lint: disable=django-blocktrans-missing-escape-filter
                     You are enrolled in {{ course_name }} at {{ platform_name }}. This course contains proctored exams.
                 {% endblocktrans %}
-                {% endfilter %}
+                {% endautoescape %}
             </p>
 
             <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}
+                {% autoescape off %}
+                {% blocktrans %}  # xss-lint: disable=django-blocktrans-missing-escape-filter
                     Proctored exams are timed exams that you take while proctoring software monitors your computer's desktop, webcam video, and audio. Your course uses {{ proctoring_provider }} software for proctoring.
                 {% endblocktrans %}
-                {% endfilter %}
+                {% endautoescape %}
             </p>
 
             <p style="color: rgba(0,0,0,.75);">


### PR DESCRIPTION

## Description

The course name can contain apostrophes and other special characters. The email template right now escapes every words. This is not desired because it can render apostrophes like #39;. Update the email templates so only second half of the email template is escaped


Useful information to include:
- Which edX user roles will this change impact? Learners enrolled into Proctoring enabled courses with paying track

