### PR TITLE
Learner-8276 Fixed atmoic block error in course_status_info 

### DIFF
--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -33,6 +33,7 @@ from lms.djangoapps.mobile_api.testutils import (
 )
 from lms.djangoapps.mobile_api.utils import API_V1, API_V05
 from openedx.core.lib.courses import course_image_url
+from openedx.core.djangolib.testing.utils import CacheIsolationMixin
 from openedx.features.course_duration_limits.models import CourseDurationLimitConfig
 from openedx.features.course_experience.tests.views.helpers import add_course_mode
 from xmodule.course_module import DEFAULT_START_DATE
@@ -459,10 +460,12 @@ class TestCourseStatusGET(CourseStatusAPITestCase, MobileAuthUserTestMixin,
     @classmethod
     def setUpClass(cls):
         super(TestCase, cls).setUpClass()  # pylint: disable=bad-super-call
+        super(CacheIsolationMixin, cls).setUpClass()  # pylint: disable=bad-super-call
 
     @classmethod
     def tearDownClass(cls):
         super(TestCase, cls).tearDownClass()  # pylint: disable=bad-super-call
+        super(CacheIsolationMixin, cls).tearDownClass()  # pylint: disable=bad-super-call
 
     def _fixture_setup(self):
         return super(TestCase, self)._fixture_setup()  # pylint: disable=bad-super-call

--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -37,6 +37,7 @@ from openedx.features.course_duration_limits.models import CourseDurationLimitCo
 from openedx.features.course_experience.tests.views.helpers import add_course_mode
 from xmodule.course_module import DEFAULT_START_DATE
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from common.djangoapps.student.tests.factories import UserFactory
 
 from .. import errors
 from .serializers import CourseEnrollmentSerializer, CourseEnrollmentSerializerv05
@@ -439,6 +440,15 @@ class TestCourseStatusGET(CourseStatusAPITestCase, MobileAuthUserTestMixin,
     """
     Tests for GET of /api/mobile/v<version_number>/users/<user_name>/course_status_info/{course_id}
     """
+
+    def setUp(self):
+        """
+        Creates a basic course structure for our course
+        """
+        super().setUp()
+        self.user = UserFactory.create(username='course-status-user')
+        self.username = self.user.username
+
     def test_success_v0(self):
         self.login_and_enroll()
 

--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -458,17 +458,17 @@ class TestCourseStatusGET(CourseStatusAPITestCase, MobileAuthUserTestMixin,
     # By overriding following methods we are making this class non atomic since CourseStatusGET get is non atomic.
     @classmethod
     def setUpClass(cls):
-        super(TestCase, cls).setUpClass()
+        super(TestCase, cls).setUpClass()  # pylint: disable=bad-super-call
 
     @classmethod
     def tearDownClass(cls):
-        super(TestCase, cls).tearDownClass()
+        super(TestCase, cls).tearDownClass()  # pylint: disable=bad-super-call
 
     def _fixture_setup(self):
-        return super(TestCase, self)._fixture_setup()
+        return super(TestCase, self)._fixture_setup()  # pylint: disable=bad-super-call
 
     def _fixture_teardown(self):
-        return super(TestCase, self)._fixture_teardown()
+        return super(TestCase, self)._fixture_teardown()  # pylint: disable=bad-super-call
 
 
 class TestCourseStatusPATCH(CourseStatusAPITestCase, MobileAuthUserTestMixin,

--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -463,8 +463,8 @@ class TestCourseStatusGET(CourseStatusAPITestCase, MobileAuthUserTestMixin,
 
     @classmethod
     def tearDownClass(cls):
-        super(TestCase, cls).tearDownClass()  # pylint: disable=bad-super-call
         cls.end_cache_isolation()  # call this from CacheIsolationMixin
+        super(TestCase, cls).tearDownClass()  # pylint: disable=bad-super-call
 
     def _fixture_setup(self):
         return super(TestCase, self)._fixture_setup()  # pylint: disable=bad-super-call

--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -33,7 +33,6 @@ from lms.djangoapps.mobile_api.testutils import (
 )
 from lms.djangoapps.mobile_api.utils import API_V1, API_V05
 from openedx.core.lib.courses import course_image_url
-from openedx.core.djangolib.testing.utils import CacheIsolationMixin
 from openedx.features.course_duration_limits.models import CourseDurationLimitConfig
 from openedx.features.course_experience.tests.views.helpers import add_course_mode
 from xmodule.course_module import DEFAULT_START_DATE
@@ -460,12 +459,12 @@ class TestCourseStatusGET(CourseStatusAPITestCase, MobileAuthUserTestMixin,
     @classmethod
     def setUpClass(cls):
         super(TestCase, cls).setUpClass()  # pylint: disable=bad-super-call
-        super(CacheIsolationMixin, cls).setUpClass()  # pylint: disable=bad-super-call
+        cls.start_cache_isolation()  # call this from CacheIsolationMixin
 
     @classmethod
     def tearDownClass(cls):
         super(TestCase, cls).tearDownClass()  # pylint: disable=bad-super-call
-        super(CacheIsolationMixin, cls).tearDownClass()  # pylint: disable=bad-super-call
+        cls.end_cache_isolation()  # call this from CacheIsolationMixin
 
     def _fixture_setup(self):
         return super(TestCase, self)._fixture_setup()  # pylint: disable=bad-super-call

--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -12,7 +12,7 @@ import pytz
 from completion.test_utils import CompletionWaffleTestMixin, submit_completions_for_testing
 from django.conf import settings
 from django.template import defaultfilters
-from django.test import RequestFactory, override_settings
+from django.test import RequestFactory, override_settings, TestCase
 from django.utils import timezone
 from django.utils.timezone import now
 from milestones.tests.utils import MilestonesTestCaseMixin
@@ -453,6 +453,22 @@ class TestCourseStatusGET(CourseStatusAPITestCase, MobileAuthUserTestMixin,
         submit_completions_for_testing(self.user, [self.unit.location])
         response = self.api_response(api_version=API_V1)
         assert response.data['last_visited_block_id'] == str(self.unit.location)
+
+    # By inheriting from ModuleStoreTestCase and APITestCase this class is atomic by default
+    # By overriding following methods we are making this class non atomic since CourseStatusGET get is non atomic.
+    @classmethod
+    def setUpClass(cls):
+        super(TestCase, cls).setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TestCase, cls).tearDownClass()
+
+    def _fixture_setup(self):
+        return super(TestCase, self)._fixture_setup()
+
+    def _fixture_teardown(self):
+        return super(TestCase, self)._fixture_teardown()
 
 
 class TestCourseStatusPATCH(CourseStatusAPITestCase, MobileAuthUserTestMixin,

--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -412,7 +412,9 @@ class CourseStatusAPITestCase(MobileAPITestCase):
         Creates a basic course structure for our course
         """
         super().setUp()
+        self.add_course_content()
 
+    def add_course_content(self):
         self.section = ItemFactory.create(
             parent=self.course,
             category='chapter',
@@ -446,8 +448,15 @@ class TestCourseStatusGET(CourseStatusAPITestCase, MobileAuthUserTestMixin,
         Creates a basic course structure for our course
         """
         super().setUp()
+        self.course = CourseFactory.create(
+            mobile_available=True,
+            static_asset_path="needed_for_split",
+            end=datetime.datetime.now(pytz.UTC),
+            certificate_available_date=datetime.datetime.now(pytz.UTC)
+        )
         self.user = UserFactory.create(username='course-status-user')
         self.username = self.user.username
+        self.add_course_content()
 
     def test_success_v0(self):
         self.login_and_enroll()

--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -13,7 +13,7 @@ from completion.test_utils import CompletionWaffleTestMixin, submit_completions_
 from django.conf import settings
 from django.db import transaction
 from django.template import defaultfilters
-from django.test import RequestFactory, override_settings, TestCase
+from django.test import RequestFactory, override_settings
 from django.utils import timezone
 from django.utils.timezone import now
 from milestones.tests.utils import MilestonesTestCaseMixin
@@ -442,12 +442,6 @@ class TestCourseStatusGET(CourseStatusAPITestCase, MobileAuthUserTestMixin,
     Tests for GET of /api/mobile/v<version_number>/users/<user_name>/course_status_info/{course_id}
     """
 
-    def setUp(self):
-        """
-        Creates a basic course structure for our course
-        """
-        super().setUp()
-
     def test_success_v0(self):
         self.login_and_enroll()
 
@@ -465,6 +459,9 @@ class TestCourseStatusGET(CourseStatusAPITestCase, MobileAuthUserTestMixin,
 
     # Since we are testing an non atomic view in atomic test case, therefore we are expecting error on failures
     def api_error_response(self, reverse_args=None, data=None, **kwargs):
+        """
+            Same as api response from MobileAPITestCase but handle views which throw errors
+        """
         url = self.reverse_url(reverse_args, **kwargs)
         try:
             with transaction.atomic():

--- a/lms/djangoapps/mobile_api/users/views.py
+++ b/lms/djangoapps/mobile_api/users/views.py
@@ -152,7 +152,7 @@ class UserCourseStatus(views.APIView):
         Returns the course status
         """
         path = self._last_visited_module_path(request, course)
-        path_ids = [str(module.location) for module in path]
+        path_ids = [str(module.location) for module in path if module is not None]
         return Response({
             "last_visited_module_id": path_ids[0],
             "last_visited_module_path": path_ids,

--- a/lms/djangoapps/mobile_api/users/views.py
+++ b/lms/djangoapps/mobile_api/users/views.py
@@ -7,6 +7,7 @@ from completion.exceptions import UnavailableCompletionData
 from completion.utilities import get_key_to_last_completed_block
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.contrib.auth.signals import user_logged_in
+from django.db import transaction
 from django.shortcuts import redirect
 from django.utils import dateparse
 from opaque_keys import InvalidKeyError
@@ -186,6 +187,7 @@ class UserCourseStatus(views.APIView):
         save_positions_recursively_up(request.user, request, field_data_cache, module, course=course)
         return self._get_course_info(request, course)
 
+    @transaction.non_atomic_requests
     @mobile_course_access(depth=2)
     def get(self, request, course, *args, **kwargs):  # lint-amnesty, pylint: disable=unused-argument
         """

--- a/lms/djangoapps/mobile_api/users/views.py
+++ b/lms/djangoapps/mobile_api/users/views.py
@@ -10,6 +10,7 @@ from django.contrib.auth.signals import user_logged_in
 from django.db import transaction
 from django.shortcuts import redirect
 from django.utils import dateparse
+from django.utils.decorators import method_decorator
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import UsageKey
 from rest_framework import generics, views
@@ -77,6 +78,7 @@ class UserDetail(generics.RetrieveAPIView):
         return context
 
 
+@method_decorator(transaction.non_atomic_requests, name='dispatch')
 @mobile_view(is_user=True)
 class UserCourseStatus(views.APIView):
     """
@@ -187,7 +189,6 @@ class UserCourseStatus(views.APIView):
         save_positions_recursively_up(request.user, request, field_data_cache, module, course=course)
         return self._get_course_info(request, course)
 
-    @transaction.non_atomic_requests
     @mobile_course_access(depth=2)
     def get(self, request, course, *args, **kwargs):  # lint-amnesty, pylint: disable=unused-argument
         """

--- a/lms/djangoapps/mobile_api/users/views.py
+++ b/lms/djangoapps/mobile_api/users/views.py
@@ -78,8 +78,8 @@ class UserDetail(generics.RetrieveAPIView):
         return context
 
 
-@method_decorator(transaction.non_atomic_requests, name='dispatch')
 @mobile_view(is_user=True)
+@method_decorator(transaction.non_atomic_requests, name='dispatch')
 class UserCourseStatus(views.APIView):
     """
     **Use Cases**
@@ -124,6 +124,13 @@ class UserCourseStatus(views.APIView):
     """
 
     http_method_names = ["get", "patch"]
+
+    def dispatch(self, request, *args, **kwargs):
+        if request.method == 'PATCH':
+            with transaction.atomic():
+                return super(UserCourseStatus, self).dispatch(request, *args, **kwargs)
+        else:
+            return super(UserCourseStatus, self).dispatch(request, *args, **kwargs)
 
     def _last_visited_module_path(self, request, course):
         """

--- a/lms/djangoapps/mobile_api/users/views.py
+++ b/lms/djangoapps/mobile_api/users/views.py
@@ -128,9 +128,9 @@ class UserCourseStatus(views.APIView):
     def dispatch(self, request, *args, **kwargs):
         if request.method == 'PATCH':
             with transaction.atomic():
-                return super(UserCourseStatus, self).dispatch(request, *args, **kwargs)
+                return super().dispatch(request, *args, **kwargs)
         else:
-            return super(UserCourseStatus, self).dispatch(request, *args, **kwargs)
+            return super().dispatch(request, *args, **kwargs)
 
     def _last_visited_module_path(self, request, course):
         """


### PR DESCRIPTION
We are getting "An error occurred in the current transaction. You cant execute queries until the end of the atomic block."
error in get course status info on both versions i.e. 0.5 and 1. I was unable to reproduce it locally. But by looking
in django documentation and some other online helps I concluded that it might be because of some db integrity error
that we didnt handle properly and now the cursor is broken for this transaction. Therefore i am making it non atomic
transaction. Since its a get request we can make transactions run interdependently.

## Supporting information

Jira Ticket: https://openedx.atlassian.net/browse/LEARNER-8276

