### PR TITLE
refactor: Using Waffle flag to enable Account MFE globally.

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/toggles.py
+++ b/openedx/core/djangoapps/user_api/accounts/toggles.py
@@ -29,16 +29,15 @@ def should_redirect_to_order_history_microfrontend():
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Supports staged rollout of a new micro-frontend-based implementation of the account page.
+#   Its action can be overridden using site's ENABLE_ACCOUNT_MICROFRONTEND setting.
 # .. toggle_use_cases: temporary, open_edx
 # .. toggle_creation_date: 2019-04-30
-# .. toggle_target_removal_date: 2020-12-31
-# .. toggle_warnings: Also set settings.ACCOUNT_MICROFRONTEND_URL and site's ENABLE_ACCOUNT_MICROFRONTEND.
+# .. toggle_target_removal_date: 2021-12-31
+# .. toggle_warnings: Also set settings.ACCOUNT_MICROFRONTEND_URL.
 # .. toggle_tickets: DEPR-17
 REDIRECT_TO_ACCOUNT_MICROFRONTEND = LegacyWaffleFlag('account', 'redirect_to_microfrontend', __name__)
 
 
 def should_redirect_to_account_microfrontend():
-    return (
-        configuration_helpers.get_value('ENABLE_ACCOUNT_MICROFRONTEND') and
-        REDIRECT_TO_ACCOUNT_MICROFRONTEND.is_enabled()
-    )
+    return configuration_helpers.get_value('ENABLE_ACCOUNT_MICROFRONTEND',
+                                           REDIRECT_TO_ACCOUNT_MICROFRONTEND.is_enabled())


### PR DESCRIPTION
## Description

This PR refactors the way the Account MFE is activated in the platform. The main objective is to control the global activation/deactivation of the MFE through the `account.redirect_to_microfrontend` waffle flag and use the Site Configurations to control MFE activation/deactivation with per-site granularity. Notice that the Site Configuration object will have precedence over the waffle flag value.
Since the classic Account Django view will be most likely supported during Lilac, the expiration of this temporary waffle flag was extended till the end of 2021

With this PR:

- There's no need to create a Site Configuration object to get the MFE activated. Settings the waffle flag to True is enough.
- It helps multisite installations to better handling granular per-site activation/deactivation.

## Notes for operators

This is a backwards-compatible change, so the MFE will remain activated for installations where this is already enabled. The only point to take in mind is in multisite installations, where the activation of the waffle flag will activate the MFE for all sites.