### PR TITLE
Non-persistent grading fails with start dates in the future [BB-4005]

### DIFF
--- a/lms/djangoapps/grades/course_data.py
+++ b/lms/djangoapps/grades/course_data.py
@@ -120,4 +120,16 @@ class CourseData:
 
     @property
     def effective_structure(self):
+        """
+        Get whichever course block structure is already loaded, if any.
+
+        This may give either the user-specific course structure or the generic
+        structure, depending on which is cached at the moment. Because of that,
+        this should only be used for queries related to the root block of the
+        course, which will always exist in either structure.
+
+        For anything else, such as queries involving course sections or blocks,
+        use either .structure or .collected_structure to explicitly state
+        whether you want the user-specific version of the course or not.
+        """
         return self._structure or self._collected_block_structure

--- a/lms/djangoapps/grades/course_grade.py
+++ b/lms/djangoapps/grades/course_grade.py
@@ -55,12 +55,23 @@ class CourseGradeBase:
         """
         Returns the subsection grade for the given subsection usage key.
 
-        Note: does NOT check whether the user has access to the subsection.
-        Assumes that if a grade exists, the user has access to it.  If the
-        grade doesn't exist then either the user does not have access to
-        it or hasn't attempted any problems in the subsection.
+        Raises `KeyError` if the course structure does not contain the key.
+
+        If the course structure contains the key, this will always succeed
+        (and return a grade) regardless of whether the user can access that section;
+        it is up to the caller to ensure that the grade isn't
+        shown to users that shouldn't be able to access it
+        (e.g. a student shouldn't see a grade for an unreleased subsection);
         """
-        return self._get_subsection_grade(self.course_data.effective_structure[subsection_key])
+        # look in the user structure first and fallback to the collected;
+        # however, we assume the state of course_data is intentional,
+        # so we use effective_structure to avoid additional fetching
+        subsection = (
+            self.course_data.effective_structure[subsection_key]
+            if subsection_key in self.course_data.effective_structure
+            else self.course_data.collected_structure[subsection_key]
+        )
+        return self._get_subsection_grade(subsection)
 
     @lazy
     def graded_subsections_by_format(self):


### PR DESCRIPTION
This adds a test case for generating grade reports when persistent grades
are disabled and some sections have future start dates.

## Description

The added test case reproduces the issue that #22475 meant to fix.

When persistent grades are disabled:
1. the grade report generator collects a list of locations for graded subsections **using the collected block structure**;
2. the grade report generator makes a call to `CourseData.structure`, which loads the user specific block structure;
3. when loading said structure, the `StartDateTransformer` will remove blocks that have start dates in the future;
4. later, when `CourseGrade.subsection_grade` is called, `KeyError` is raised because the user block structure (accessed through `CourseData.effective_structure`) doesn't contain some of the locations collected in step 1.

## Testing instructions

```sh
pytest lms/djangoapps/instructor_task/tests/test_tasks_helper.py::TestGradeReport
```

## Deadline

None

## Other information

I think part of the issue here is that the value of `CourseData.effective_structure` depends on what other calls were made before: IMO you'd expect it to return the same value in the same context;
however, when persistent grades are enabled, `CourseData.structure` is never called, so the collected structure is returned (as opposed to the user structure, as described above when persistent grades are disabled).

## Related Tickets

* [BB-4005 in OpenCraft JIRA (Private)](https://tasks.opencraft.com/browse/BB-4005)