### PR TITLE
Add visit count session

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/logout.py
+++ b/openedx/core/djangoapps/user_authn/views/logout.py
@@ -80,7 +80,9 @@ class LogoutView(TemplateView):
 
         # Clear the cookie used by the edx.org marketing site
         delete_logged_in_cookies(response)
-
+        is_visit_count_session_exists = request.session.get('ip-address-and-visit-count', None)
+        if is_visit_count_session_exists:
+            del request.session['ip-address-and-visit-count']
         return response
 
     def _build_logout_url(self, url):


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Manage a session which would keep track the visit count number of a user so that an associated login failure alert would be displayed on front-end.

## Supporting information

https://openedx.atlassian.net/browse/VAN-66

## Testing instructions

After shipping this change to staging and production environment, user experience would be enhanced by a better readability in case of the failing login attempts.