### PR TITLE
feat: Show course enrollment with cert on dash

### DIFF
--- a/lms/static/js/learner_dashboard/models/course_card_model.js
+++ b/lms/static/js/learner_dashboard/models/course_card_model.js
@@ -17,7 +17,14 @@ class CourseCardModel extends Backbone.Model {
   }
 
   getCourseRun(course) {
-    const enrolledCourseRun = course.course_runs.find(run => run.is_enrolled);
+    // A learner might have have enrolled in a course multiple times,
+    // so we want to get the enrollment with a certificate if it exists
+    // otherwise any enrolled run.
+    let enrolledCourseRun = course.course_runs.find(run => run.is_enrolled && run.certificate_url);
+    if (!enrolledCourseRun) {
+      enrolledCourseRun = course.course_runs.find(run => run.is_enrolled);
+    }
+
     const openEnrollmentCourseRuns = this.getEnrollableCourseRuns();
     let desiredCourseRun;
 


### PR DESCRIPTION



## Description

Previously the programs dashboard picked the first course run enrollment for a course to display on the dash if the user had multiple. Now it has a preference for the enrolled course run that earned a certificate if there is one. 

## Supporting information

Fixes MICROBA-1047: "Programs record page is showing wrong dates of the course the learner actually took."

## Deadline

N/A
