### PR TITLE
refactor: remove use of modulestore in certificates app

### DIFF
--- a/lms/djangoapps/certificates/generation.py
+++ b/lms/djangoapps/certificates/generation.py
@@ -153,7 +153,7 @@ def generate_user_certificates(student, course_key, course=None, insecure=False,
         return
 
     if CertificateStatuses.is_passing_status(cert.status):
-        emit_certificate_event('created', student, course_key, course, {
+        emit_certificate_event('created', student, course_key, course_overview, {
             'user_id': student.id,
             'course_id': str(course_key),
             'certificate_id': cert.verify_uuid,

--- a/lms/djangoapps/certificates/generation_handler.py
+++ b/lms/djangoapps/certificates/generation_handler.py
@@ -520,7 +520,7 @@ def generate_user_certificates(student, course_key, course=None, insecure=False,
         return
 
     if CertificateStatuses.is_passing_status(cert.status):
-        emit_certificate_event('created', student, course_key, course, {
+        emit_certificate_event('created', student, course_key, course_overview, {
             'user_id': student.id,
             'course_id': str(course_key),
             'certificate_id': cert.verify_uuid,

--- a/lms/djangoapps/certificates/utils.py
+++ b/lms/djangoapps/certificates/utils.py
@@ -10,13 +10,13 @@ from eventtracking import tracker
 from opaque_keys.edx.keys import CourseKey
 
 from lms.djangoapps.certificates.models import GeneratedCertificate
+from openedx.core.djangoapps.content.course_overviews.api import get_course_overview
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
-from xmodule.modulestore.django import modulestore
 
 log = logging.getLogger(__name__)
 
 
-def emit_certificate_event(event_name, user, course_id, course=None, event_data=None):
+def emit_certificate_event(event_name, user, course_id, course_overview=None, event_data=None):
     """
     Emits certificate event.
 
@@ -24,10 +24,12 @@ def emit_certificate_event(event_name, user, course_id, course=None, event_data=
     https://github.com/edx/edx-documentation/blob/master/en_us/data/source/internal_data_formats/tracking_logs/student_event_types.rst # pylint: disable=line-too-long
     """
     event_name = '.'.join(['edx', 'certificate', event_name])
-    if course is None:
-        course = modulestore().get_course(course_id, depth=0)
+
+    if not course_overview:
+        course_overview = get_course_overview(course_id)
+
     context = {
-        'org_id': course.org,
+        'org_id': course_overview.org,
         'course_id': str(course_id)
     }
 

--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -396,7 +396,7 @@ def _track_certificate_events(request, course, user, user_certificate):
 
     # track certificate evidence_visited event for analytics when certificate_user and accessing_user are different
     if request.user and request.user.id != user.id:
-        emit_certificate_event('evidence_visited', user, str(course.id), course, {
+        emit_certificate_event('evidence_visited', user, str(course.id), event_data={
             'certificate_id': user_certificate.verify_uuid,
             'enrollment_mode': user_certificate.mode,
             'social_network': CertificateSocialNetworks.linkedin


### PR DESCRIPTION
## Description

[MICROBA-1178]

* remove use of modulestore in `utils.py` of the certificates django app

[MICROBA-1178]: https://openedx.atlassian.net/browse/MICROBA-1178