### PR TITLE
chore: update studio-frontend to 1.17.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -179,9 +179,9 @@
       }
     },
     "@edx/studio-frontend": {
-      "version": "1.16.22",
-      "resolved": "https://registry.npmjs.org/@edx/studio-frontend/-/studio-frontend-1.16.22.tgz",
-      "integrity": "sha512-nIs0xpb+Q6Jb8fdAmMlPtV+lXkPvZw1xT/DX99u7r1yaJNurV6cRWHFX4DY9ze3ufSQQZN2wH8VpnK+pNtaHrA==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@edx/studio-frontend/-/studio-frontend-1.17.0.tgz",
+      "integrity": "sha512-lWULlPavlL5IxXUV3WBJWJlStB8AFIYZxzX3UROnISspCnNMSmyu94VsVOJrJGdFNmmh+5Bj6UVpmTSdTyL3mg==",
       "requires": {
         "@edx/edx-bootstrap": "^1.0.0",
         "@edx/paragon": "3.4.8",
@@ -230,9 +230,9 @@
           }
         },
         "react": {
-          "version": "16.12.0",
-          "resolved": "https://registry.npmjs.org/react/-/react-16.12.0.tgz",
-          "integrity": "sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==",
+          "version": "16.14.0",
+          "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+          "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
           "requires": {
             "loose-envify": "^1.1.0",
             "object-assign": "^4.1.1",
@@ -262,9 +262,9 @@
           }
         },
         "react-is": {
-          "version": "16.12.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
-          "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q=="
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
       }
     },
@@ -579,7 +579,7 @@
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+      "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo="
     },
     "are-we-there-yet": {
       "version": "1.1.5",
@@ -2979,9 +2979,9 @@
       "dev": true
     },
     "copy-to-clipboard": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.2.0.tgz",
-      "integrity": "sha512-eOZERzvCmxS8HWzugj4Uxl8OJxa7T2k1Gi0X5qavwydHIfuSHq2dTD09LOg/XyGq4Zpb5IsR/2OJ5lbOegz78w==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
+      "integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
       "requires": {
         "toggle-selection": "^1.0.6"
       }
@@ -11252,17 +11252,17 @@
       },
       "dependencies": {
         "hoist-non-react-statics": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
-          "integrity": "sha512-wbg3bpgA/ZqWrZuMOeJi8+SKMhr7X9TesL/rXMjTzh0p0JUBo3II8DHboYbuIXWRlttrUFxwcu/5kygrCw8fJw==",
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+          "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
           "requires": {
             "react-is": "^16.7.0"
           }
         },
         "react-is": {
-          "version": "16.12.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
-          "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q=="
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
       }
     },
@@ -11530,9 +11530,9 @@
           }
         },
         "react-is": {
-          "version": "16.12.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
-          "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q=="
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
       }
     },
@@ -11688,9 +11688,9 @@
       }
     },
     "redux-devtools-extension": {
-      "version": "2.13.8",
-      "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.8.tgz",
-      "integrity": "sha512-8qlpooP2QqPtZHQZRhx3x3OP5skEV1py/zUdMY28WNAocbafxdG2tRD1MWE7sp8obGMNYuLWanhhQ7EQvT1FBg=="
+      "version": "2.13.9",
+      "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.9.tgz",
+      "integrity": "sha512-cNJ8Q/EtjhQaZ71c8I9+BPySIBVEKssbPpskBfsXqb8HJ002A3KRVHfeRzwRo6mGPqsm7XuHTqNSNeS1Khig0A=="
     },
     "redux-thunk": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@edx/edx-proctoring": "^1.5.0",
     "@edx/frontend-component-cookie-policy-banner": "1.0.0",
     "@edx/paragon": "2.6.4",
-    "@edx/studio-frontend": "^1.16.22",
+    "@edx/studio-frontend": "^1.17.0",
     "axios": "^0.21.1",
     "babel-core": "6.26.0",
     "babel-loader": "6.4.1",


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This update enables the Proctortrack Escalation Email section for studio checklists.

## Supporting information

Release notes: https://github.com/edx/studio-frontend/releases/tag/v1.17.0