### PR TITLE
REV-2131: remove 3 old upsell links from course home page

### DIFF
--- a/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
@@ -66,9 +66,6 @@ from openedx.features.course_experience.course_tools import HttpMethod
             % if offer_banner_fragment:
                 ${HTML(offer_banner_fragment.content)}
             % endif
-            % if course_expiration_fragment:
-                ${HTML(course_expiration_fragment.content)}
-            % endif
             % if course_home_message_fragment:
                 ${HTML(course_home_message_fragment.body_html())}
             % endif
@@ -195,7 +192,6 @@ from openedx.features.course_experience.course_tools import HttpMethod
 <%static:require_module_async module_name="js/commerce/track_ecommerce_events" class_name="TrackECommerceEvents">
 
   var personalizedLearnerSchedulesLink = $(".personalized_learner_schedules_button");
-  var fbeLink = $("#FBE_banner");
   var welcomeLink = $("#welcome");
   var sockLink = $("#sock");
   var upgradeDateLink = $("#course_home_dates");
@@ -208,12 +204,6 @@ from openedx.features.course_experience.course_tools import HttpMethod
       pageName: "course_home",
       linkType: "button",
       linkCategory: "personalized_learner_schedules"
-    });
-
-    TrackECommerceEvents.trackUpsellClick(fbeLink, 'course_home_audit_access_expires', {
-      pageName: "course_home",
-      linkType: "link",
-      linkCategory: "FBE_banner"
     });
 
     TrackECommerceEvents.trackUpsellClick(welcomeLink, 'course_home_welcome', {

--- a/openedx/features/course_experience/views/course_home.py
+++ b/openedx/features/course_experience/views/course_home.py
@@ -141,7 +141,6 @@ class CourseHomeFragmentView(EdxFragmentView):
         update_message_fragment = None
         course_sock_fragment = None
         offer_banner_fragment = None
-        course_expiration_fragment = None
         has_visited_course = None
         resume_course_url = None
         handouts_html = None
@@ -165,10 +164,6 @@ class CourseHomeFragmentView(EdxFragmentView):
             has_visited_course, resume_course_url = self._get_resume_course_info(request, course_id)
             handouts_html = self._get_course_handouts(request, course)
             offer_banner_fragment = get_first_purchase_offer_banner_fragment(
-                request.user,
-                course_overview
-            )
-            course_expiration_fragment = generate_course_expired_fragment(
                 request.user,
                 course_overview
             )
@@ -231,7 +226,6 @@ class CourseHomeFragmentView(EdxFragmentView):
             'handouts_html': handouts_html,
             'course_home_message_fragment': course_home_message_fragment,
             'offer_banner_fragment': offer_banner_fragment,
-            'course_expiration_fragment': course_expiration_fragment,
             'has_visited_course': has_visited_course,
             'resume_course_url': resume_course_url,
             'course_tools': course_tools,


### PR DESCRIPTION

## Description
The Value Prop redesign is redesigning the various upsell links, and now that we've added the new Expiration Box on the course home page, we want to remove three of the older upsell links: 
- blue banner: access expiring, upgrade by this date (aka course_home_audit_access_expires)- *from only the course home page and not discussion and progress tabs*
- blue banner: first purchase discount (aka course_home_welcome)- *from only the course home page and not discussion and progress tabs*
- Course tools menu: upgrade link

Before: 

After: 


## Supporting information
Relevant Jira ticket: REV-2131](https://openedx.atlassian.net/browse/REV-2131

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
