### PR TITLE
feat: remove use of ENABLE_ASYNC_REGISTER_EXAMS waffle flag

### DIFF
--- a/cms/djangoapps/contentstore/config/waffle.py
+++ b/cms/djangoapps/contentstore/config/waffle.py
@@ -52,22 +52,6 @@ SHOW_REVIEW_RULES_FLAG = CourseWaffleFlag(  # lint-amnesty, pylint: disable=togg
     module_name=__name__,
 )
 
-# Waffle flag to move the registration of special exams to an async celery task
-# .. toggle_name: contentstore.async_register_exams
-# .. toggle_implementation: CourseWaffleFlag
-# .. toggle_default: False
-# .. toggle_description: Toggles the asynchronous registration of special exams
-# .. toggle_use_cases: temporary, open_edx
-# .. toggle_creation_date: 2021-04-21
-# .. toggle_target_removal_date: 2021-05-07
-# .. toggle_warnings:
-# .. toggle_tickets: https://openedx.atlassian.net/browse/MST-757
-ENABLE_ASYNC_REGISTER_EXAMS = CourseWaffleFlag(
-    waffle_namespace=waffle_flags(),
-    flag_name='async_register_exams',
-    module_name=__name__,
-)
-
 # Waffle flag to redirect to the library authoring MFE.
 # .. toggle_name: contentstore.library_authoring_mfe
 # .. toggle_implementation: WaffleFlag

--- a/cms/djangoapps/contentstore/signals/handlers.py
+++ b/cms/djangoapps/contentstore/signals/handlers.py
@@ -14,17 +14,14 @@ from cms.djangoapps.contentstore.courseware_index import (
     CoursewareSearchIndexer,
     LibrarySearchIndexer
 )
-from cms.djangoapps.contentstore.proctoring import register_special_exams
 from common.djangoapps.track.event_transaction_utils import get_event_transaction_id, get_event_transaction_type
 from common.djangoapps.util.module_utils import yield_dynamic_descriptor_descendants
 from lms.djangoapps.grades.api import task_compute_all_grades_for_course
-from openedx.core.djangoapps.credit.signals import on_course_publish
 from openedx.core.djangoapps.content.learning_sequences.api import key_supports_outlines
 from openedx.core.lib.gating import api as gating_api
 from xmodule.modulestore.django import SignalHandler, modulestore
 
 from .signals import GRADING_POLICY_CHANGED
-from ..config.waffle import ENABLE_ASYNC_REGISTER_EXAMS
 
 log = logging.getLogger(__name__)
 
@@ -52,34 +49,25 @@ def listen_for_course_publish(sender, course_key, **kwargs):  # pylint: disable=
     registering proctored exams, building up credit requirements, and performing
     search indexing
     """
-    is_enabled = ENABLE_ASYNC_REGISTER_EXAMS.is_enabled(course_key)
-    if is_enabled:
-        from cms.djangoapps.contentstore.tasks import update_special_exams_and_publish
-        course_key_str = str(course_key)
-        update_special_exams_and_publish.delay(course_key_str)
-    else:
-        # first is to registered exams, the credit subsystem will assume that
-        # all proctored exams have already been registered, so we have to do that first
-        try:
-            register_special_exams(course_key)
-        # pylint: disable=broad-except
-        except Exception as exception:
-            log.exception(exception)
-
-        # then call into the credit subsystem (in /openedx/djangoapps/credit)
-        # to perform any 'on_publish' workflow
-        on_course_publish(course_key)
-
     # import here, because signal is registered at startup, but items in tasks are not yet able to be loaded
-    from cms.djangoapps.contentstore.tasks import update_outline_from_modulestore_task, update_search_index
+    from cms.djangoapps.contentstore.tasks import (
+        update_outline_from_modulestore_task,
+        update_search_index,
+        update_special_exams_and_publish
+    )
+
+    # register special exams asynchronously
+    course_key_str = str(course_key)
+    update_special_exams_and_publish.delay(course_key_str)
+
     if key_supports_outlines(course_key):
         # Push the course outline to learning_sequences asynchronously.
-        update_outline_from_modulestore_task.delay(str(course_key))
+        update_outline_from_modulestore_task.delay(course_key_str)
 
     # Finally call into the course search subsystem
     # to kick off an indexing action
     if CoursewareSearchIndexer.indexing_is_enabled() and CourseAboutSearchIndexer.indexing_is_enabled():
-        update_search_index.delay(str(course_key), datetime.now(UTC).isoformat())
+        update_search_index.delay(course_key_str, datetime.now(UTC).isoformat())
 
 
 @receiver(SignalHandler.library_updated)


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This commit addresses [MST-793](https://openedx.atlassian.net/browse/MST-793). In [MST-757](https://openedx.atlassian.net/browse/MST-757)(https://github.com/edx/edx-platform/pull/27398), exam registration was moved to an asychronous task to improve the performance of saving content in Studio. This feature was gated behind a waffle flag, ENABLE_ASYNC_REGISTER_EXAMS, to avoid interrupting course teams during the testing and roll out of this feature.

This feature has been tested and rolled out, and so the aforementioned waffle flag is ready to be removed.

The effect of this change is that asynchronous exam registration will no longer be gated by the aforementioned waffle flag, and this feature will be rolled out across all of the edX platform.

This change affects edX staff and course authors.

## Supporting information

[MST-793](https://openedx.atlassian.net/browse/MST-793)
