### PR TITLE
fix: deleted courses do not break program details page

### DIFF
--- a/openedx/core/djangoapps/programs/utils.py
+++ b/openedx/core/djangoapps/programs/utils.py
@@ -206,7 +206,7 @@ class ProgramProgressMeter:
         ]
 
         if runs_with_required_mode:
-            not_failed_runs = [run for run in runs_with_required_mode if run not in self.failed_course_runs]
+            not_failed_runs = [run for run in runs_with_required_mode if run['key'] not in self.failed_course_runs]
             if not_failed_runs:
                 return True
 
@@ -417,7 +417,7 @@ class ProgramProgressMeter:
         Determine which course runs have been failed by the user.
 
         Returns:
-            list of dicts, each a course run ID
+            list of strings, each a course run ID
         """
         return [run['course_run_id'] for run in self.course_runs_with_state['failed']]
 
@@ -442,9 +442,13 @@ class ProgramProgressMeter:
                 'type': self._certificate_mode_translation(certificate['type']),
             }
 
+            try:
+                may_certify = CourseOverview.get_from_id(course_key).may_certify()
+            except CourseOverview.DoesNotExist:
+                may_certify = True
             if (
                 certificate_api.is_passing_status(certificate['status'])
-                and CourseOverview.get_from_id(course_key).may_certify()
+                and may_certify
             ):
                 completed_runs.append(course_data)
             else:


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Sometimes learners have certificates in old course runs which've been
deleted. When this happens loading the learner's program progress can
result in 500 errors. This corrects those by choosing to count any
non-existent course the learner has certificates for as counting
towards program completion, effectively assuming that availability
dates have passed for all such courses.

Also fixes an error with a condition related to how we determine
whether an enrolled course is considered "in progress". The previous
version of the code had a bug that would result in a lot more courses
being marked "in progress" for the purpose of program completion than
actually were.

## Supporting information

[JIRA:EDUCATOR-5787](https://openedx.atlassian.net/browse/EDUCATOR-5787)

## Testing instructions

```sh
pytest openedx/core/djangoapps/programs/tests/test_utils.py::TestProgramProgressMeter::test_old_course_runs --rootdir lms
```