### PR TITLE
REV-2131: remove course_home_course_tools upsell link

### DIFF
--- a/lms/djangoapps/courseware/course_tools.py
+++ b/lms/djangoapps/courseware/course_tools.py
@@ -1,80 +1,18 @@
 """
-Platform plugins to support a verified upgrade tool.
+Platform plugins to support course tools.
 """
 
 
 import datetime
 
 import pytz
-from crum import get_current_request
 from django.conf import settings
 from django.utils.translation import ugettext as _
 from django.urls import reverse
 from common.djangoapps.course_modes.models import CourseMode
-from lms.djangoapps.courseware.utils import verified_upgrade_deadline_link
 from openedx.features.course_experience.course_tools import CourseTool
 from common.djangoapps.student.models import CourseEnrollment
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
-
-
-class VerifiedUpgradeTool(CourseTool):
-    """
-    The verified upgrade tool.
-    """
-    @classmethod
-    def analytics_id(cls):
-        """
-        Returns an id to uniquely identify this tool in analytics events.
-        """
-        return 'edx.tool.verified_upgrade'
-
-    @classmethod
-    def is_enabled(cls, request, course_key):
-        """
-        Show this tool to all learners who are eligible to upgrade.
-        """
-        enrollment = CourseEnrollment.get_enrollment(request.user, course_key)
-        if enrollment is None:
-            return False
-
-        if enrollment.dynamic_upgrade_deadline is None:
-            return False
-
-        if not enrollment.is_active:
-            return False
-
-        if enrollment.mode not in CourseMode.UPSELL_TO_VERIFIED_MODES:
-            return False
-
-        if enrollment.course_upgrade_deadline is None:
-            return False
-
-        if datetime.datetime.now(pytz.UTC) >= enrollment.course_upgrade_deadline:
-            return False
-
-        return True
-
-    @classmethod
-    def title(cls):  # lint-amnesty, pylint: disable=arguments-differ
-        """
-        Returns the title of this tool.
-        """
-        return _('Upgrade to Verified')
-
-    @classmethod
-    def icon_classes(cls):  # lint-amnesty, pylint: disable=arguments-differ
-        """
-        Returns the icon classes needed to represent this tool.
-        """
-        return 'fa fa-certificate'
-
-    @classmethod
-    def url(cls, course_key):
-        """
-        Returns the URL for this tool for the specified course key.
-        """
-        request = get_current_request()
-        return verified_upgrade_deadline_link(request.user, course_id=course_key)
 
 
 class FinancialAssistanceTool(CourseTool):

--- a/lms/djangoapps/courseware/tests/test_course_info.py
+++ b/lms/djangoapps/courseware/tests/test_course_info.py
@@ -420,8 +420,8 @@ class SelfPacedCourseInfoTestCase(LoginEnrollmentTestCase, SharedModuleStoreTest
 
     def test_num_queries_instructor_paced(self):
         # TODO: decrease query count as part of REVO-28
-        self.fetch_course_info_with_queries(self.instructor_paced_course, 43, 3)
+        self.fetch_course_info_with_queries(self.instructor_paced_course, 42, 3)
 
     def test_num_queries_self_paced(self):
         # TODO: decrease query count as part of REVO-28
-        self.fetch_course_info_with_queries(self.self_paced_course, 43, 3)
+        self.fetch_course_info_with_queries(self.self_paced_course, 42, 3)

--- a/lms/djangoapps/courseware/tests/test_course_tools.py
+++ b/lms/djangoapps/courseware/tests/test_course_tools.py
@@ -12,88 +12,12 @@ from django.test import RequestFactory
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
-from lms.djangoapps.courseware.course_tools import FinancialAssistanceTool, VerifiedUpgradeTool
+from lms.djangoapps.courseware.course_tools import FinancialAssistanceTool
 from lms.djangoapps.courseware.models import DynamicUpgradeDeadlineConfiguration
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
-from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
+from common.djangoapps.student.tests.factories import CourseEnrollmentFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
-
-
-class VerifiedUpgradeToolTest(SharedModuleStoreTestCase):  # lint-amnesty, pylint: disable=missing-class-docstring
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.now = datetime.datetime.now(pytz.UTC)
-
-        cls.course = CourseFactory.create(
-            org='edX',
-            number='test',
-            display_name='Test Course',
-            self_paced=True,
-            start=cls.now - datetime.timedelta(days=30),
-        )
-        cls.course_overview = CourseOverview.get_from_id(cls.course.id)
-
-    def setUp(self):
-        super().setUp()
-
-        self.course_verified_mode = CourseModeFactory(
-            course_id=self.course.id,
-            mode_slug=CourseMode.VERIFIED,
-            expiration_datetime=self.now + datetime.timedelta(days=30),
-        )
-
-        DynamicUpgradeDeadlineConfiguration.objects.create(enabled=True)
-
-        self.request = RequestFactory().request()
-        crum.set_current_request(self.request)
-        self.addCleanup(crum.set_current_request, None)
-        self.enrollment = CourseEnrollmentFactory(
-            course_id=self.course.id,
-            mode=CourseMode.AUDIT,
-            course=self.course_overview,
-        )
-        self.request.user = self.enrollment.user
-
-    def test_tool_visible(self):
-        assert VerifiedUpgradeTool().is_enabled(self.request, self.course.id)
-
-    def test_not_visible_when_no_enrollment_exists(self):
-        self.enrollment.delete()
-
-        request = RequestFactory().request()
-        request.user = UserFactory()
-        assert not VerifiedUpgradeTool().is_enabled(self.request, self.course.id)
-
-    def test_not_visible_when_using_deadline_from_course_mode(self):
-        DynamicUpgradeDeadlineConfiguration.objects.create(enabled=False)
-        assert not VerifiedUpgradeTool().is_enabled(self.request, self.course.id)
-
-    def test_not_visible_when_enrollment_is_inactive(self):
-        self.enrollment.is_active = False
-        self.enrollment.save()
-        assert not VerifiedUpgradeTool().is_enabled(self.request, self.course.id)
-
-    def test_not_visible_when_already_verified(self):
-        self.enrollment.mode = CourseMode.VERIFIED
-        self.enrollment.save()
-        assert not VerifiedUpgradeTool().is_enabled(self.request, self.course.id)
-
-    def test_not_visible_when_no_verified_track(self):
-        self.course_verified_mode.delete()
-        assert not VerifiedUpgradeTool().is_enabled(self.request, self.course.id)
-
-    def test_not_visible_when_course_deadline_has_passed(self):
-        self.course_verified_mode.expiration_datetime = self.now - datetime.timedelta(days=1)
-        self.course_verified_mode.save()
-        assert not VerifiedUpgradeTool().is_enabled(self.request, self.course.id)
-
-    def test_not_visible_when_course_mode_has_no_deadline(self):
-        self.course_verified_mode.expiration_datetime = None
-        self.course_verified_mode.save()
-        assert not VerifiedUpgradeTool().is_enabled(self.request, self.course.id)
 
 
 class FinancialAssistanceToolTest(SharedModuleStoreTestCase):

--- a/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
@@ -200,7 +200,6 @@ from openedx.features.course_experience.course_tools import HttpMethod
   var sockLink = $("#sock");
   var upgradeDateLink = $("#course_home_dates");
   var GreenUpgradeLink = $("#green_upgrade");
-  var courseToolsUpgradeLink = $(document.querySelectorAll("[data-analytics-id='edx.tool.verified_upgrade']"));
   var GreenUpgradeLink = $("#green_upgrade");
   var certificateUpsellLink = $("#certificate_upsell");
 
@@ -238,12 +237,6 @@ from openedx.features.course_experience.course_tools import HttpMethod
       pageName: "course_home",
       linkType: "button",
       linkCategory: "green_upgrade"
-    });
-
-    TrackECommerceEvents.trackUpsellClick(courseToolsUpgradeLink, 'course_home_course_tools', {
-      pageName: "course_home",
-      linkType: "link",
-      linkCategory: "(none)"
     });
 
     TrackECommerceEvents.trackUpsellClick(certificateUpsellLink, 'course_home_certificate', {

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ setup(
             "calendar_sync_toggle = openedx.features.calendar_sync.plugins:CalendarSyncToggleTool",
             "course_bookmarks = openedx.features.course_bookmarks.plugins:CourseBookmarksTool",
             "course_updates = openedx.features.course_experience.plugins:CourseUpdatesTool",
-            "verified_upgrade = lms.djangoapps.courseware.course_tools:VerifiedUpgradeTool",
             "financial_assistance = lms.djangoapps.courseware.course_tools:FinancialAssistanceTool",
         ],
         "openedx.user_partition_scheme": [


### PR DESCRIPTION
## Description
The Value Prop redesign is redesigning the various upsell links, and now that we've added the new Expiration Box on the course home page, we want to start removing the older upsell links. **This PR covers the "Upgrade to Verified" link in the Course tools menu.** 

## Supporting information
Relevant Jira ticket: https://openedx.atlassian.net/browse/REV-2131

## Deadline
None- this upsell link is redundant now that the new expiration box is live (5/6), so removing it will cut down on clutter, desired as a reasonably-fast-follow

## Other information
The course tools code is a little bit abstracted- there were several of those in the past, but now financial assistance is the only one, but I left the overall structure in place since we're not getting rid of that area outright, just the verified upgrade one right now for its upsell link


Before: 
![before- course tools](https://user-images.githubusercontent.com/5384216/117886139-c4a88780-b27c-11eb-8810-e520993f2653.png)

After: 
![after- course tools](https://user-images.githubusercontent.com/5384216/117886167-cc682c00-b27c-11eb-8558-3ec03d251b68.png)
