### PR TITLE
fix: handle unenrolled users in course home APIs (AA-790)

### DIFF
--- a/lms/djangoapps/course_home_api/course_metadata/v1/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/course_metadata/v1/tests/test_views.py
@@ -46,6 +46,16 @@ class CourseHomeMetadataTests(BaseCourseHomeTests):
         # 'Course', 'Wiki', 'Progress' tabs
         assert len(response.data.get('tabs', [])) == 4
 
+    @ddt.data(True, False)
+    def test_get_authenticated_not_enrolled(self, has_previously_enrolled):
+        if has_previously_enrolled:
+            # Create an enrollment, then unenroll to set is_active to False
+            CourseEnrollment.enroll(self.user, self.course.id)
+            CourseEnrollment.unenroll(self.user, self.course.id)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        assert response.data['is_enrolled'] is False
+
     def test_get_authenticated_staff_user(self):
         self.client.logout()
         self.client.login(username=self.staff_user.username, password='bar')

--- a/lms/djangoapps/course_home_api/course_metadata/v1/views.py
+++ b/lms/djangoapps/course_home_api/course_metadata/v1/views.py
@@ -83,7 +83,7 @@ class CourseHomeMetadataView(RetrieveAPIView):
         username = request.user.username if request.user.username else None
         course = course_detail(request, request.user.username, course_key)
         enrollment = CourseEnrollment.get_enrollment(request.user, course_key_string)
-        user_is_enrolled = bool(enrollment)
+        user_is_enrolled = bool(enrollment and enrollment.is_active)
 
         courseware_meta = CoursewareMeta(course_key, request, request.user.username)
         can_load_courseware = courseware_meta.is_microfrontend_enabled_for_user()

--- a/lms/djangoapps/course_home_api/dates/v1/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/dates/v1/tests/test_views.py
@@ -41,10 +41,14 @@ class DatesTabTestViews(BaseCourseHomeTests):
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @override_waffle_flag(COURSE_HOME_MICROFRONTEND_DATES_TAB, active=True)
-    def test_get_authenticated_user_not_enrolled(self):
+    @ddt.data(True, False)
+    def test_get_authenticated_user_not_enrolled(self, has_previously_enrolled):
+        if has_previously_enrolled:
+            # Create an enrollment, then unenroll to set is_active to False
+            CourseEnrollment.enroll(self.user, self.course.id)
+            CourseEnrollment.unenroll(self.user, self.course.id)
         response = self.client.get(self.url)
-        assert response.status_code == 200
-        assert not response.data.get('learner_is_full_access')
+        assert response.status_code == 401
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @override_waffle_flag(COURSE_HOME_MICROFRONTEND_DATES_TAB, active=True)
@@ -63,6 +67,7 @@ class DatesTabTestViews(BaseCourseHomeTests):
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @override_waffle_flag(COURSE_HOME_MICROFRONTEND_DATES_TAB, active=True)
     def test_banner_data_is_returned(self):
+        CourseEnrollment.enroll(self.user, self.course.id)
         response = self.client.get(self.url)
         assert response.status_code == 200
         self.assertContains(response, 'missed_deadlines')

--- a/lms/djangoapps/course_home_api/outline/v1/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/outline/v1/tests/test_views.py
@@ -78,7 +78,12 @@ class OutlineTabTestViews(BaseCourseHomeTests):
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
-    def test_get_authenticated_user_not_enrolled(self):
+    @ddt.data(True, False)
+    def test_get_authenticated_user_not_enrolled(self, has_previously_enrolled):
+        if has_previously_enrolled:
+            # Create an enrollment, then unenroll to set is_active to False
+            CourseEnrollment.enroll(self.user, self.course.id)
+            CourseEnrollment.unenroll(self.user, self.course.id)
         response = self.client.get(self.url)
         assert response.status_code == 200
 

--- a/lms/djangoapps/course_home_api/progress/v1/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/progress/v1/tests/test_views.py
@@ -61,10 +61,14 @@ class ProgressTabTestViews(BaseCourseHomeTests):
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @override_waffle_flag(COURSE_HOME_MICROFRONTEND_PROGRESS_TAB, active=True)
-    def test_get_authenticated_user_not_enrolled(self):
+    @ddt.data(True, False)
+    def test_get_authenticated_user_not_enrolled(self, has_previously_enrolled):
+        if has_previously_enrolled:
+            # Create an enrollment, then unenroll to set is_active to False
+            CourseEnrollment.enroll(self.user, self.course.id)
+            CourseEnrollment.unenroll(self.user, self.course.id)
         response = self.client.get(self.url)
-        # expecting a redirect
-        assert response.status_code == 302
+        assert response.status_code == 401
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @override_waffle_flag(COURSE_HOME_MICROFRONTEND_PROGRESS_TAB, active=True)


### PR DESCRIPTION
- fixed a regression in course home course metadata API
- updated progress tab API to account for unenrolled users
- updated course home tests to include a check for users who are not enrolled