### PR TITLE
fix: add python35 compatibility tests

### DIFF
--- a/common/lib/symmath/symmath/test_python_compatibility.py
+++ b/common/lib/symmath/symmath/test_python_compatibility.py
@@ -1,0 +1,34 @@
+"""
+Tests to check Python syntax
+"""
+
+import os
+import unittest
+
+
+class Python35CompatibilityTest(unittest.TestCase):
+    """
+    Temporary tests to verify that the python syntax is python35 compatible.
+    """
+    def setUp(self):
+        """
+        setting up Test environment.
+        """
+        super().setUp()
+        self.module_path = 'common/lib/symmath/symmath/'
+
+    def test_no_fstring_syntax(self):
+        """
+        Test to verify that no string has the `f-string` syntax
+        in it which is incompatible with Python35.
+        steps:
+        - load file data
+        - match for fstring pattern
+        - fail the test if fstring pattern matched in any file
+        """
+        fstring_pattern = "fr?'.*'"
+        files = [f for f in os.listdir(self.module_path) if f.endswith('.py') and not f.startswith('test')]
+        for file in files:
+            file_lines = open(os.path.join(self.module_path, file)).readlines()
+            for line in file_lines:
+                self.assertNotRegexpMatches(line, fstring_pattern)


### PR DESCRIPTION
Adding tests in `common/lib/symmath` module to check `Python 35` compatibility in the tests to avoid any code upgrade untill codejail is upgraded.