### PR TITLE
feat: AA-802: Update the BlockCompletionTransformer

### DIFF
--- a/lms/djangoapps/course_api/blocks/api.py
+++ b/lms/djangoapps/course_api/blocks/api.py
@@ -88,6 +88,13 @@ def get_blocks(
             HiddenContentTransformer()
         ]
 
+    # Note: A change to the BlockCompletionTransformer (https://github.com/edx/edx-platform/pull/27622/)
+    # will be introducing a bug if hide_access_denials is True.  I'm accepting this risk because in
+    # the AccessDeniedMessageFilterTransformer, there is note about deleting it and I believe it is
+    # technically deprecated functionality. The only use case where hide_access_denials is True
+    # (outside of explicitly setting the temporary waffle flag) is in lms/djangoapps/course_api/blocks/urls.py
+    # for a v1 api that I also believe should have been deprecated and removed. When this code is removed,
+    # please also remove this comment. Thanks!
     if hide_access_denials:
         transformers += [AccessDeniedMessageFilterTransformer()]
 

--- a/lms/djangoapps/course_api/blocks/transformers/block_completion.py
+++ b/lms/djangoapps/course_api/blocks/transformers/block_completion.py
@@ -71,17 +71,17 @@ class BlockCompletionTransformer(BlockStructureTransformer):
             block_structure.override_xblock_field(block_key, self.COMPLETE, True)
             if str(block_key) == str(latest_complete_block_key):
                 block_structure.override_xblock_field(block_key, self.RESUME_BLOCK, True)
+        elif block_structure.get_xblock_field(block_key, 'completion_mode') == CompletionMode.AGGREGATOR:
+            children = block_structure.get_children(block_key)
+            all_children_complete = all(block_structure.get_xblock_field(child_key, self.COMPLETE)
+                                        for child_key in children
+                                        if not self._is_block_excluded(block_structure, child_key))
 
-        children = block_structure.get_children(block_key)
-        all_children_complete = all(block_structure.get_xblock_field(child_key, self.COMPLETE)
-                                    for child_key in children
-                                    if not self._is_block_excluded(block_structure, child_key))
+            if all_children_complete:
+                block_structure.override_xblock_field(block_key, self.COMPLETE, True)
 
-        if children and all_children_complete:
-            block_structure.override_xblock_field(block_key, self.COMPLETE, True)
-
-        if any(block_structure.get_xblock_field(child_key, self.RESUME_BLOCK) for child_key in children):
-            block_structure.override_xblock_field(block_key, self.RESUME_BLOCK, True)
+            if any(block_structure.get_xblock_field(child_key, self.RESUME_BLOCK) for child_key in children):
+                block_structure.override_xblock_field(block_key, self.RESUME_BLOCK, True)
 
     def transform(self, usage_info, block_structure):
         """

--- a/lms/djangoapps/course_api/blocks/transformers/tests/test_block_completion.py
+++ b/lms/djangoapps/course_api/blocks/transformers/tests/test_block_completion.py
@@ -21,6 +21,7 @@ class StubAggregatorXBlock(XBlock):
     when transforming aggregator XBlock.
     """
     completion_mode = XBlockCompletionMode.AGGREGATOR
+    has_children = True
 
 
 class StubExcludedXBlock(XBlock):
@@ -36,7 +37,6 @@ class StubCompletableXBlock(XBlock, CompletableXBlockMixin):
     XBlock to test behaviour of BlockCompletionTransformer
     when transforming completable XBlock.
     """
-    pass  # lint-amnesty, pylint: disable=unnecessary-pass
 
 
 class BlockCompletionTransformerTestCase(TransformerRegistryTestMixin, CompletionWaffleTestMixin, ModuleStoreTestCase):
@@ -44,7 +44,9 @@ class BlockCompletionTransformerTestCase(TransformerRegistryTestMixin, Completio
     Tests behaviour of BlockCompletionTransformer
     """
     TRANSFORMER_CLASS_TO_TEST = BlockCompletionTransformer
-    COMPLETION_TEST_VALUE = 0.4
+    # Has to be 1.0 for 'complete' to function properly. The Completion api only uses 0.0 and 1.0 right now
+    # so this better reflects reality anyway. Should be updated if Completion api ever supports more.
+    COMPLETION_TEST_VALUE = 1.0
 
     def setUp(self):
         super().setUp()
@@ -53,31 +55,54 @@ class BlockCompletionTransformerTestCase(TransformerRegistryTestMixin, Completio
         self.override_waffle_switch(True)
 
     @XBlock.register_temp_plugin(StubAggregatorXBlock, identifier='aggregator')
-    def test_transform_gives_none_for_aggregator(self):
+    @XBlock.register_temp_plugin(StubCompletableXBlock, identifier='comp')
+    def test_transform_aggregators(self):
+        """
+        If there is an aggregator (such as a unit) that contains no children for some reason
+        (likely a mistake by the course team), it should be marked 'complete'. 'completion' should
+        still be None.
+        We mark 'complete' so learners are still able to have their subsections/sections/course
+        marked as complete and are not blocked by this one empty aggregator.
+        """
         course = CourseFactory.create()
-        block = ItemFactory.create(category='aggregator', parent=course)
-        block_structure = get_course_blocks(
-            self.user, course.location, self.transformers
+        # Have to have at least one complete block to trigger entering the marking 'complete' flow
+        filled_aggregator = ItemFactory.create(category='aggregator', parent=course)
+        block = ItemFactory.create(category='comp', parent=filled_aggregator)
+        BlockCompletion.objects.submit_completion(
+            user=self.user,
+            block_key=block.location,
+            completion=self.COMPLETION_TEST_VALUE,
         )
+        empty_aggregator = ItemFactory.create(category='aggregator', parent=course)
+        block_structure = get_course_blocks(self.user, course.location, self.transformers)
 
-        self._assert_block_has_proper_completion_value(
-            block_structure, block.location, None
+        self._assert_block_has_proper_completion_values(
+            block_structure, block.location, self.COMPLETION_TEST_VALUE, True
+        )
+        self._assert_block_has_proper_completion_values(
+            block_structure, filled_aggregator.location, None, True
+        )
+        self._assert_block_has_proper_completion_values(
+            block_structure, empty_aggregator.location, None, True
         )
 
     @XBlock.register_temp_plugin(StubExcludedXBlock, identifier='excluded')
     def test_transform_gives_none_for_excluded(self):
+        """
+        Excluded blocks always receive None for 'completion' and False for 'complete'
+        """
         course = CourseFactory.create()
         block = ItemFactory.create(category='excluded', parent=course)
-        block_structure = get_course_blocks(
-            self.user, course.location, self.transformers
-        )
+        block_structure = get_course_blocks(self.user, course.location, self.transformers)
 
-        self._assert_block_has_proper_completion_value(
-            block_structure, block.location, None
-        )
+        self._assert_block_has_proper_completion_values(block_structure, block.location, None, False)
 
     @XBlock.register_temp_plugin(StubCompletableXBlock, identifier='comp')
     def test_transform_gives_value_for_completable(self):
+        """
+        If a block is actually complete, make sure that value shows up in the transformed fields.
+        'completion' should have the value and 'complete' should be True in these cases.
+        """
         course = CourseFactory.create()
         block = ItemFactory.create(category='comp', parent=course)
         BlockCompletion.objects.submit_completion(
@@ -85,34 +110,33 @@ class BlockCompletionTransformerTestCase(TransformerRegistryTestMixin, Completio
             block_key=block.location,
             completion=self.COMPLETION_TEST_VALUE,
         )
-        block_structure = get_course_blocks(
-            self.user, course.location, self.transformers
-        )
+        block_structure = get_course_blocks(self.user, course.location, self.transformers)
 
-        self._assert_block_has_proper_completion_value(
-            block_structure, block.location, self.COMPLETION_TEST_VALUE
+        self._assert_block_has_proper_completion_values(
+            block_structure, block.location, self.COMPLETION_TEST_VALUE, True
         )
 
     def test_transform_gives_zero_for_ordinary_block(self):
+        """
+        I _think_ this is testing 'completion' is 0.0 before an ordinary block is viewed.
+        'html' blocks end up receiving a 'completion' of 1.0 after being viewed.
+        """
         course = CourseFactory.create()
         block = ItemFactory.create(category='html', parent=course)
-        block_structure = get_course_blocks(
-            self.user, course.location, self.transformers
-        )
+        block_structure = get_course_blocks(self.user, course.location, self.transformers)
 
-        self._assert_block_has_proper_completion_value(
-            block_structure, block.location, 0.0
-        )
+        self._assert_block_has_proper_completion_values(block_structure, block.location, 0.0, False)
 
-    def _assert_block_has_proper_completion_value(
-            self, block_structure, block_key, expected_value
+    def _assert_block_has_proper_completion_values(
+            self, block_structure, block_key, expected_completion, expected_complete
     ):
         """
-        Checks whether block's completion has expected value.
+        Checks whether block's completion and complete have expected values.
         """
-        block_data = block_structure.get_transformer_block_data(
-            block_key, self.TRANSFORMER_CLASS_TO_TEST
-        )
+        block_data = block_structure.get_transformer_block_data(block_key, self.TRANSFORMER_CLASS_TO_TEST)
         completion_value = block_data.fields['completion']
+        # complete isn't saved as a transformer field, but just a regular xblock field /shrug
+        complete_value = block_structure.get_xblock_field(block_key, 'complete', False)
 
-        assert completion_value == expected_value
+        assert completion_value == expected_completion
+        assert complete_value == expected_complete


### PR DESCRIPTION
We discovered a subsection that contained a unit without any content
inside, but because of our logic requiring children, it would never be
marked complete (meaning the subsection, section, and course could thus
never be marked complete). This fixes that by removing the children
check from setting completion, but first gating that code path on the
xblock being an aggregator (to prevent leaves from marking as true
simply because there are no children).

Test fixes include adding a test for the empty aggregator case as 
well as some changes to not have an entire course marked complete
because they are all empty aggregators.
