### PR TITLE
refactor: remove unused `course` arguments from certificate generation functions

### DIFF
--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -198,14 +198,16 @@ def get_recently_modified_certificates(course_keys=None, start_date=None, end_da
     return GeneratedCertificate.objects.filter(**cert_filter_args).order_by('modified_date')
 
 
+# lint-amnesty, pylint: disable=unused-argument
 def generate_user_certificates(student, course_key, course=None, insecure=False, generation_mode='batch',
                                forced_grade=None):
-    return _generate_user_certificates(student, course_key, course, insecure, generation_mode, forced_grade)
+    return _generate_user_certificates(student, course_key, insecure, generation_mode, forced_grade)
 
 
+# lint-amnesty, pylint: disable=unused-argument
 def regenerate_user_certificates(student, course_key, course=None,
                                  forced_grade=None, template_file=None, insecure=False):
-    return _regenerate_user_certificates(student, course_key, course, forced_grade, template_file, insecure)
+    return _regenerate_user_certificates(student, course_key, forced_grade, template_file, insecure)
 
 
 def can_generate_certificate_task(user, course_key):

--- a/lms/djangoapps/certificates/generation.py
+++ b/lms/djangoapps/certificates/generation.py
@@ -98,8 +98,7 @@ def _generate_certificate(user, course_key):
     return cert
 
 
-def generate_user_certificates(student, course_key, course=None, insecure=False, generation_mode='batch',
-                               forced_grade=None):
+def generate_user_certificates(student, course_key, insecure=False, generation_mode='batch', forced_grade=None):
     """
     It will add the add-cert request into the xqueue.
 
@@ -117,8 +116,6 @@ def generate_user_certificates(student, course_key, course=None, insecure=False,
         course_key (CourseKey)
 
     Keyword Arguments:
-        course (Course): Optionally provide the course object; if not provided
-            it will be loaded.
         insecure - (Boolean)
         generation_mode - who has requested certificate generation. Its value should `batch`
         in case of django command and `self` if student initiated the request.
@@ -140,7 +137,6 @@ def generate_user_certificates(student, course_key, course=None, insecure=False,
     cert = xqueue.add_cert(
         student,
         course_key,
-        course=course,
         generate_pdf=generate_pdf,
         forced_grade=forced_grade
     )

--- a/lms/djangoapps/certificates/generation_handler.py
+++ b/lms/djangoapps/certificates/generation_handler.py
@@ -412,8 +412,7 @@ def _is_cert_downloadable(user, course_key):
     return True
 
 
-def generate_user_certificates(student, course_key, course=None, insecure=False, generation_mode='batch',
-                               forced_grade=None):
+def generate_user_certificates(student, course_key, insecure=False, generation_mode='batch', forced_grade=None):
     """
     It will add the add-cert request into the xqueue.
 
@@ -431,8 +430,6 @@ def generate_user_certificates(student, course_key, course=None, insecure=False,
         course_key (CourseKey)
 
     Keyword Arguments:
-        course (Course): Optionally provide the course object; if not provided
-            it will be loaded.
         insecure - (Boolean)
         generation_mode - who has requested certificate generation. Its value should `batch`
         in case of django command and `self` if student initiated the request.
@@ -461,7 +458,6 @@ def generate_user_certificates(student, course_key, course=None, insecure=False,
     cert = xqueue.add_cert(
         student,
         course_key,
-        course=course,
         generate_pdf=generate_pdf,
         forced_grade=forced_grade
     )
@@ -484,8 +480,7 @@ def generate_user_certificates(student, course_key, course=None, insecure=False,
     return cert.status
 
 
-def regenerate_user_certificates(student, course_key, course=None,
-                                 forced_grade=None, template_file=None, insecure=False):
+def regenerate_user_certificates(student, course_key, forced_grade=None, template_file=None, insecure=False):
     """
     Add the regen-cert request into the xqueue.
 
@@ -500,8 +495,6 @@ def regenerate_user_certificates(student, course_key, course=None,
         course_key (CourseKey)
 
     Keyword Arguments:
-        course (Course): Optionally provide the course object; if not provided
-            it will be loaded.
         grade_value - The grade string, such as "Distinction"
         template_file - The template file used to render this certificate
         insecure - (Boolean)
@@ -523,7 +516,6 @@ def regenerate_user_certificates(student, course_key, course=None,
     xqueue.regen_cert(
         student,
         course_key,
-        course=course,
         forced_grade=forced_grade,
         template_file=template_file,
         generate_pdf=generate_pdf

--- a/lms/djangoapps/certificates/management/commands/regenerate_user.py
+++ b/lms/djangoapps/certificates/management/commands/regenerate_user.py
@@ -103,7 +103,8 @@ class Command(BaseCommand):
 
             # Add the certificate request to the queue
             regenerate_user_certificates(
-                student, course_id, course=course,
+                student,
+                course_id,
                 forced_grade=options['grade_value'],
                 template_file=options['template_file'],
                 insecure=options['insecure']

--- a/lms/djangoapps/certificates/management/commands/tests/test_cert_management.py
+++ b/lms/djangoapps/certificates/management/commands/tests/test_cert_management.py
@@ -188,7 +188,6 @@ class RegenerateCertificatesTest(CertificateManagementTest):
             key,
         )
         regen_cert_call_kwargs = xqueue.return_value.regen_cert.call_args.kwargs
-        assert regen_cert_call_kwargs.pop('course').location == self.course.location
         assert regen_cert_call_kwargs == {
             'forced_grade': None,
             'template_file': None,

--- a/lms/djangoapps/certificates/queue.py
+++ b/lms/djangoapps/certificates/queue.py
@@ -106,7 +106,7 @@ class XQueueCertInterface:
         self.whitelist = CertificateWhitelist.objects.all()
         self.use_https = True
 
-    def regen_cert(self, student, course_id, course=None, forced_grade=None, template_file=None, generate_pdf=True):
+    def regen_cert(self, student, course_id, forced_grade=None, template_file=None, generate_pdf=True):
         """(Re-)Make certificate for a particular student in a particular course
 
         Arguments:
@@ -152,7 +152,6 @@ class XQueueCertInterface:
         return self.add_cert(
             student,
             course_id,
-            course=course,
             forced_grade=forced_grade,
             template_file=template_file,
             generate_pdf=generate_pdf
@@ -175,7 +174,7 @@ class XQueueCertInterface:
         raise NotImplementedError
 
     # pylint: disable=too-many-statements
-    def add_cert(self, student, course_id, course=None, forced_grade=None, template_file=None, generate_pdf=True):  # lint-amnesty, pylint: disable=unused-argument
+    def add_cert(self, student, course_id, forced_grade=None, template_file=None, generate_pdf=True):
         """
         Request a new certificate for a student.
 

--- a/lms/djangoapps/certificates/tests/test_support_views.py
+++ b/lms/djangoapps/certificates/tests/test_support_views.py
@@ -312,9 +312,7 @@ class CertificateRegenerateTests(CertificateSupportTestCase):
         with mock_passing_grade(percent=0.75):
             with patch('common.djangoapps.course_modes.models.CourseMode.mode_for_course') as mock_mode_for_course:
                 mock_mode_for_course.return_value = 'honor'
-                regenerate_user_certificates(self.student, self.course_key,
-                                             course=self.course)
-
+                regenerate_user_certificates(self.student, self.course_key)
                 mock_generate_cert.assert_called()
 
     def test_regenerate_certificate_missing_params(self):


### PR DESCRIPTION
## Description

[MICROBA-1238]
- Remove unused `course` arguments from certificate generation functions

Part of our cleanup after removing use of the modulestore from the Certificates app.



[MICROBA-1238]: https://openedx.atlassian.net/browse/MICROBA-1238