### PR TITLE
feat: add activation_key in accounts view

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3902,6 +3902,7 @@ ACCOUNT_VISIBILITY_CONFIGURATION["admin_fields"] = (
         "secondary_email_enabled",
         "year_of_birth",
         "phone_number",
+        "activation_key",
     ]
 )
 

--- a/openedx/core/djangoapps/user_api/accounts/serializers.py
+++ b/openedx/core/djangoapps/user_api/accounts/serializers.py
@@ -123,6 +123,11 @@ class UserReadOnlySerializer(serializers.Serializer):  # lint-amnesty, pylint: d
         except ObjectDoesNotExist:
             account_recovery = None
 
+        try:
+            activation_key = user.registration.activation_key
+        except ObjectDoesNotExist:
+            activation_key = None
+
         accomplishments_shared = badges_enabled()
         data = {
             "username": user.username,
@@ -138,6 +143,7 @@ class UserReadOnlySerializer(serializers.Serializer):  # lint-amnesty, pylint: d
             "date_joined": user.date_joined.replace(microsecond=0),
             "last_login": user.last_login,
             "is_active": user.is_active,
+            "activation_key": activation_key,
             "bio": None,
             "country": None,
             "state": None,

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
@@ -508,14 +508,12 @@ class AccountSettingsOnCreationTest(CreateAccountMixin, TestCase):
     USERNAME = 'frank-underwood'
     PASSWORD = 'ṕáśśẃőŕd'
     EMAIL = 'frank+underwood@example.com'
-    ID = -1
 
     def test_create_account(self):
         # Create a new account, which should have empty account settings by default.
         self.create_account(self.USERNAME, self.PASSWORD, self.EMAIL)
         # Retrieve the account settings
         user = User.objects.get(username=self.USERNAME)
-        self.ID = user.id
         request = RequestFactory().get("/api/user/v1/accounts/")
         request.user = user
         account_settings = get_account_settings(request)[0]
@@ -530,8 +528,9 @@ class AccountSettingsOnCreationTest(CreateAccountMixin, TestCase):
         assert account_settings == {
             'username': self.USERNAME,
             'email': self.EMAIL,
-            'id': self.ID,
+            'id': user.id,
             'name': self.USERNAME,
+            'activation_key': user.registration.activation_key,
             'gender': None, 'goals': '',
             'is_active': False,
             'level_of_education': None,

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -170,6 +170,7 @@ class AccountViewSet(ViewSet):
             values.
 
             * id: numerical lms user id in db
+            * activation_key: auto-genrated activation key when signed up via email
             * bio: null or textual representation of user biographical
               information ("about me").
             * country: An ISO 3166 country code or null.


### PR DESCRIPTION
### [PROD-2333](https://openedx.atlassian.net/browse/PROD-2333)

### Description
This PR is adding the `activation_key` field in user_api, under the **list of account fields that are visible only to staff and users viewing their own profiles**. This field will be needed by the support tools to display the account activation link for a requested user. 