### PR TITLE
BOM-2477: Fixing pylint violations & removing thresholds

### DIFF
--- a/requirements/edx-sandbox/py35.in
+++ b/requirements/edx-sandbox/py35.in
@@ -28,5 +28,6 @@ sympy==1.6.2                        # Symbolic math library
 # Install these packages from the edx-platform working tree
 # NOTE: if you change code in these packages, you MUST change the version
 # number in its setup.py or the code WILL NOT be installed during deploy.
--e common/lib/sandbox-packages
+-e common/lib/sandbox-packages/loncapa
+-e common/lib/sandbox-packages/verifiers
 -e common/lib/symmath

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -24,7 +24,9 @@
     # via -r requirements/edx/github.in
 -e common/lib/safe_lxml
     # via -r requirements/edx/local.in
--e common/lib/sandbox-packages
+-e common/lib/sandbox-packages/loncapa
+    # via -r requirements/edx/local.in
+-e common/lib/sandbox-packages/verifiers
     # via -r requirements/edx/local.in
 -e common/lib/symmath
     # via -r requirements/edx/local.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -24,7 +24,9 @@
     # via -r requirements/edx/testing.txt
 -e common/lib/safe_lxml
     # via -r requirements/edx/testing.txt
--e common/lib/sandbox-packages
+-e common/lib/sandbox-packages/loncapa
+    # via -r requirements/edx/testing.txt
+-e common/lib/sandbox-packages/verifiers
     # via -r requirements/edx/testing.txt
 -e common/lib/symmath
     # via -r requirements/edx/testing.txt

--- a/requirements/edx/local.in
+++ b/requirements/edx/local.in
@@ -2,7 +2,8 @@
 -e .
 -e common/lib/capa
 -e common/lib/safe_lxml
--e common/lib/sandbox-packages
+-e common/lib/sandbox-packages/loncapa
+-e common/lib/sandbox-packages/verifiers
 -e common/lib/symmath
 -e common/lib/xmodule
 

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -24,7 +24,9 @@
     # via -r requirements/edx/base.txt
 -e common/lib/safe_lxml
     # via -r requirements/edx/base.txt
--e common/lib/sandbox-packages
+-e common/lib/sandbox-packages/loncapa
+    # via -r requirements/edx/base.txt
+-e common/lib/sandbox-packages/verifiers
     # via -r requirements/edx/base.txt
 -e common/lib/symmath
     # via -r requirements/edx/base.txt


### PR DESCRIPTION
**Issue:** [BOM-2477](https://openedx.atlassian.net/browse/BOM-2477)

### Description
- fix: add __init__.py in sandbox-packages
- Fixing pylint violations and removing thresholds completely.