### PR TITLE
refactor: update function calls outside of certificates app for updated `generate_user_certificates` and `regenerate_user_certificates` functions

### DIFF
--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -198,15 +198,11 @@ def get_recently_modified_certificates(course_keys=None, start_date=None, end_da
     return GeneratedCertificate.objects.filter(**cert_filter_args).order_by('modified_date')
 
 
-# lint-amnesty, pylint: disable=unused-argument
-def generate_user_certificates(student, course_key, course=None, insecure=False, generation_mode='batch',
-                               forced_grade=None):
+def generate_user_certificates(student, course_key, insecure=False, generation_mode='batch', forced_grade=None):
     return _generate_user_certificates(student, course_key, insecure, generation_mode, forced_grade)
 
 
-# lint-amnesty, pylint: disable=unused-argument
-def regenerate_user_certificates(student, course_key, course=None,
-                                 forced_grade=None, template_file=None, insecure=False):
+def regenerate_user_certificates(student, course_key, forced_grade=None, template_file=None, insecure=False):
     return _regenerate_user_certificates(student, course_key, forced_grade, template_file, insecure)
 
 

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1632,7 +1632,7 @@ def generate_user_cert(request, course_id):
         # mark the certificate with "error" status, so it can be re-run
         # with a management command.  From the user's perspective,
         # it will appear that the certificate task was submitted successfully.
-        certs_api.generate_user_certificates(student, course.id, course=course, generation_mode='self')
+        certs_api.generate_user_certificates(student, course.id, generation_mode='self')
         _track_successful_certificate_generation(student.id, course.id)
         return HttpResponse()
 

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -1915,7 +1915,7 @@ class TestInstructorAPIBulkBetaEnrollment(SharedModuleStoreTestCase, LoginEnroll
                 'Beta Tester.'
             )
 
-            generate_user_certificates(self.beta_tester, self.course.id, self.course)
+            generate_user_certificates(self.beta_tester, self.course.id)
             capture.check_present(('lms.djangoapps.certificates.generation_handler', 'INFO', message))
 
     def test_missing_params(self):

--- a/lms/djangoapps/instructor/tests/test_certificates.py
+++ b/lms/djangoapps/instructor/tests/test_certificates.py
@@ -382,11 +382,7 @@ class CertificatesInstructorApiTest(SharedModuleStoreTestCase):
 
         with mock_passing_grade():
             # Generate certificate for user and check that user has a audit passing certificate.
-            cert_status = certs_api.generate_user_certificates(
-                student=self.user,
-                course_key=self.course.id,
-                course=self.course,
-            )
+            cert_status = certs_api.generate_user_certificates(student=self.user, course_key=self.course.id)
 
             # Check that certificate status is 'audit_passing'.
             assert cert_status == CertificateStatuses.audit_passing

--- a/lms/djangoapps/instructor_task/tasks_helper/certs.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/certs.py
@@ -21,7 +21,6 @@ from lms.djangoapps.certificates.api import (
     is_using_v2_course_certificates,
 )
 from lms.djangoapps.certificates.models import CertificateStatuses, GeneratedCertificate
-from xmodule.modulestore.django import modulestore
 
 from .runner import TaskProgress
 
@@ -79,7 +78,6 @@ def generate_students_certificates(
     current_step = {'step': 'Generating Certificates'}
     task_progress.update_task_state(extra_meta=current_step)
 
-    course = modulestore().get_course(course_id, depth=0)
     # Generate certificate for each student
     for student in students_require_certs:
         task_progress.attempted += 1
@@ -89,11 +87,7 @@ def generate_students_certificates(
             generate_certificate_task(student, course_id)
         else:
             log.info(f'Attempt will be made to generate a certificate for user {student.id} in {course_id}.')
-            generate_user_certificates(
-                student,
-                course_id,
-                course=course
-            )
+            generate_user_certificates(student, course_id)
     return task_progress.update_task_state(extra_meta=current_step)
 
 


### PR DESCRIPTION
## Description

[MICROBA-1238]
* remove unused `course` argument from `generate_user_certificates` function in the certificates app
* remove unused `course` argument from `regenerate_user_certificates` functioni n the certificates app
* remove `course` argument if passed in edx-platform apps outside of the certificates app

[MICROBA-1238]: https://openedx.atlassian.net/browse/MICROBA-1238