### PR TITLE
refactor: remove deprecated mongodb client class

### DIFF
--- a/common/lib/xmodule/xmodule/mongo_utils.py
+++ b/common/lib/xmodule/xmodule/mongo_utils.py
@@ -30,19 +30,6 @@ def connect_to_mongodb(
     handles AutoReconnect errors by retrying read operations, since these exceptions
     typically indicate a temporary step-down condition for MongoDB.
     """
-    # The MongoReplicaSetClient class is deprecated in Mongo 3.x, in favor of using
-    # the MongoClient class for all connections. Update/simplify this code when using
-    # PyMongo 3.x.
-    if kwargs.get('replicaSet'):
-        # Enable reading from secondary nodes in the MongoDB replicaset by using the
-        # MongoReplicaSetClient class.
-        # The 'replicaSet' parameter in kwargs is required for secondary reads.
-        # The read_preference should be set to a proper value, like SECONDARY_PREFERRED.
-        mongo_client_class = pymongo.MongoReplicaSetClient
-    else:
-        # No 'replicaSet' in kwargs - so no secondary reads.
-        mongo_client_class = pymongo.MongoClient
-
     # If the MongoDB server uses a separate authentication database that should be specified here
     auth_source = kwargs.get('authsource', '') or None
 
@@ -65,7 +52,7 @@ def connect_to_mongodb(
             kwargs['read_preference'] = read_preference
 
     mongo_conn = pymongo.database.Database(
-        mongo_client_class(
+        pymongo.MongoClient(
             host=host,
             port=port,
             tz_aware=tz_aware,


### PR DESCRIPTION
## Description

As of pymongo 3.X, the MongoReplicaSetClient is deprecated in favour of
MongoClient. Thus, the creation of mongodb clients is simplified.

## Supporting information

See: https://pymongo.readthedocs.io/en/stable/changelog.html#mongoclient-changes

## Deadline

None.

## Other information

For reference, this PR was spawned by a conversation [here](https://github.com/overhangio/tutor/pull/433) about connecting to Atlas.
