### PR TITLE
MB-1067: Management command to populate credentials availability date

### DIFF
--- a/openedx/core/djangoapps/credentials/management/commands/update_credentials_available_date.py
+++ b/openedx/core/djangoapps/credentials/management/commands/update_credentials_available_date.py
@@ -1,0 +1,46 @@
+"""
+A manangement command to populate the new available_date field in all CourseCertificates
+in credentials. Accomplished by sending the COURSE_CERT_DATE_CHANGE signal accross all
+course runs in the LMS to call a new API in credentials that will populate the date if one
+is found.
+
+This command is designed to be ran once to backpopulate data. New courses added or any time
+the COURSE_CERT_DATE_CHANGE signal fires, the API will automatically be called as a part of
+that flow.
+"""
+
+import time
+from celery.app import shared_task
+from celery_utils.logged_task import LoggedTask
+from edx_django_utils.monitoring.internal.code_owner.utils import set_code_owner_attribute
+from openedx.core.djangoapps.signals.signals import COURSE_CERT_DATE_CHANGE
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from django.core.management.base import BaseCommand
+
+
+
+class Command(BaseCommand):
+    """
+    A command to populate the available_date field in the CourseCertificate model for every
+    course run inside of the LMS.
+    """
+    def handle(self, *args, **options):
+        backfill_date_for_all_course_runs.delay()
+            
+
+@shared_task(base=LoggedTask, ignore_result=True)
+@set_code_owner_attribute
+def backfill_date_for_all_course_runs():
+    """
+    Pulls a list of every single course run and then sends a cert_date_changed signal. Every 10 courses,
+    it will sleep for a time, to create a delay as to not kill credentials/LMS.
+    """
+    course_run_list = CourseOverview.objects.exclude(self_paced=True, certificate_available_date=None)
+    for index, course_run in enumerate(course_run_list):
+        COURSE_CERT_DATE_CHANGE.send_robust(
+            sender=None,
+            course_key=str(course_run.id),
+            available_date=course_run.certificate_available_date.strftime('%Y-%m-%dT%H:%M:%SZ')
+        )
+        if index % 10 == 0:
+            time.sleep(3)

--- a/openedx/core/djangoapps/credentials/management/commands/update_credentials_available_date.py
+++ b/openedx/core/djangoapps/credentials/management/commands/update_credentials_available_date.py
@@ -37,7 +37,7 @@ def backfill_date_for_all_course_runs():
     Pulls a list of every single course run and then sends a cert_date_changed signal. Every 10 courses,
     it will sleep for a time, to create a delay as to not kill credentials/LMS.
     """
-    course_run_list = CourseOverview.objects.exclude(self_paced=True, certificate_available_date=None)
+    course_run_list = CourseOverview.objects.exclude(self_paced=True).exclude(certificate_available_date=None)
     for index, course_run in enumerate(course_run_list):
         COURSE_CERT_DATE_CHANGE.send_robust(
             sender=None,

--- a/openedx/core/djangoapps/credentials/management/commands/update_credentials_available_date.py
+++ b/openedx/core/djangoapps/credentials/management/commands/update_credentials_available_date.py
@@ -10,12 +10,14 @@ that flow.
 """
 
 import time
+
 from celery.app import shared_task
 from celery_utils.logged_task import LoggedTask
-from edx_django_utils.monitoring.internal.code_owner.utils import set_code_owner_attribute
-from openedx.core.djangoapps.signals.signals import COURSE_CERT_DATE_CHANGE
-from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from django.core.management.base import BaseCommand
+from edx_django_utils.monitoring.internal.code_owner.utils import set_code_owner_attribute
+
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from openedx.core.djangoapps.signals.signals import COURSE_CERT_DATE_CHANGE
 
 
 class Command(BaseCommand):

--- a/openedx/core/djangoapps/credentials/management/commands/update_credentials_available_date.py
+++ b/openedx/core/djangoapps/credentials/management/commands/update_credentials_available_date.py
@@ -18,15 +18,15 @@ from openedx.core.djangoapps.content.course_overviews.models import CourseOvervi
 from django.core.management.base import BaseCommand
 
 
-
 class Command(BaseCommand):
     """
     A command to populate the available_date field in the CourseCertificate model for every
     course run inside of the LMS.
     """
+
     def handle(self, *args, **options):
         backfill_date_for_all_course_runs.delay()
-            
+
 
 @shared_task(base=LoggedTask, ignore_result=True)
 @set_code_owner_attribute

--- a/openedx/core/djangoapps/programs/tasks.py
+++ b/openedx/core/djangoapps/programs/tasks.py
@@ -330,7 +330,8 @@ def update_credentials_course_certificate_configuration_available_date(
             available to the user. If not provided, it will be none.
     """
     LOGGER.info(
-        f"Running task update_credentials_course_certificate_configuration_available_date for course {course_key}"
+        f"Running task update_credentials_course_certificate_configuration_available_date for course {course_key} \
+        with certificate_available_date {certificate_available_date}"
     )
     course_key = str(course_key)
     course_modes = CourseMode.objects.filter(course_id=course_key)


### PR DESCRIPTION
This is a command to populate the new CredentialsCertificate model's
available_date for every existing course_run.

This command is meant to be ran only once.