### PR TITLE
[MST-785] Remove expiry_date from SoftwareSecurePhotoVerification

### DIFF
--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -640,9 +640,6 @@ class SoftwareSecurePhotoVerification(PhotoVerification):
     IMAGE_LINK_DURATION = 5 * 60 * 60 * 24  # 5 days in seconds
     copy_id_photo_from = models.ForeignKey("self", null=True, blank=True, on_delete=models.CASCADE)
 
-    # DEPRECATED: the `expiry_date` field has been replaced by `expiration_date`
-    expiry_date = models.DateTimeField(null=True, blank=True, db_index=True)
-
     # This field is used to maintain a check for learners to which email
     # to notify for expired verification is already sent.
     expiry_email_date = models.DateTimeField(null=True, blank=True, db_index=True)


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Removes model reference to `expiry_date`; all remaining references to the column have been removed here: https://github.com/edx/edx-platform/pull/27614

## Supporting information

[MST-785](https://openedx.atlassian.net/browse/MST-785)