### PR TITLE
[Chore]:MST-677 Roll out the onboarding status panel for Proctoring

### DIFF
--- a/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
@@ -84,10 +84,8 @@ from openedx.features.course_experience.course_tools import HttpMethod
             % endif
         </div>
         <aside class="page-content-secondary course-sidebar">
-            % if show_proctoring_info_panel:
-                <div class="proctoring-info-panel"
-                     data-course-id="${course_key}" data-username="${username}"></div>
-            % endif
+            <div class="proctoring-info-panel"
+                    data-course-id="${course_key}" data-username="${username}"></div>
             % if has_goal_permission:
                 <div class="section section-goals ${'' if current_goal else 'hidden'}">
                     <div class="current-goal-container">

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -456,7 +456,7 @@ edx-organizations==6.9.0
     # via -r requirements/edx/base.in
 edx-proctoring-proctortrack==1.0.5
     # via -r requirements/edx/base.in
-edx-proctoring==3.9.1
+edx-proctoring==3.9.2
     # via
     #   -r requirements/edx/base.in
     #   edx-proctoring-proctortrack

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -548,7 +548,7 @@ edx-organizations==6.9.0
     # via -r requirements/edx/testing.txt
 edx-proctoring-proctortrack==1.0.5
     # via -r requirements/edx/testing.txt
-edx-proctoring==3.9.1
+edx-proctoring==3.9.2
     # via
     #   -r requirements/edx/testing.txt
     #   edx-proctoring-proctortrack

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -532,7 +532,7 @@ edx-organizations==6.9.0
     # via -r requirements/edx/base.txt
 edx-proctoring-proctortrack==1.0.5
     # via -r requirements/edx/base.txt
-edx-proctoring==3.9.1
+edx-proctoring==3.9.2
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring-proctortrack


### PR DESCRIPTION
## Description
[MST-677](https://openedx.atlassian.net/browse/MST-677)
This PR rolls out the waffle flag `courseware.proctoring_improvements` waffle flag on the frontend so learners always sees proctoring onboarding status panel
