### PR TITLE
feat: Update the course end date block display logic

### DIFF
--- a/openedx/features/course_experience/tests/views/test_course_dates.py
+++ b/openedx/features/course_experience/tests/views/test_course_dates.py
@@ -41,7 +41,7 @@ class TestCourseDatesFragmentView(ModuleStoreTestCase):
 
     def test_course_dates_fragment(self):
         response = self.client.get(self.dates_fragment_url)
-        self.assertContains(response, 'Course End')
+        self.assertContains(response, 'Course ends')
 
         self.client.logout()
         response = self.client.get(self.dates_fragment_url)


### PR DESCRIPTION
For self-paced courses, we have decided to switch to showing the end
date as long as it is within 365 days rather than the expected
duration of the course.

Also updates some of the text to be more clear.
