### PR TITLE
[MST-840] Add integrity signature check to courseware API

### DIFF
--- a/openedx/core/djangoapps/courseware_api/serializers.py
+++ b/openedx/core/djangoapps/courseware_api/serializers.py
@@ -117,6 +117,7 @@ class CourseInfoSerializer(serializers.Serializer):  # pylint: disable=abstract-
     verification_status = serializers.CharField()
     linkedin_add_to_profile_url = serializers.URLField()
     is_mfe_special_exams_enabled = serializers.BooleanField()
+    user_needs_integrity_signature = serializers.BooleanField()
 
     def __init__(self, *args, **kwargs):
         """


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Adds a `user_needs_integrity_signature` field to the courseware metadata API, describing whether the user needs to sign the integrity agreement for the given course.

This field is true if the following conditions are met:
- The effective user is not staff
- The user is enrolled in a course mode that grants certificates
- The `is_integrity_signature_enabled` waffle flag is turned on
- The user has not yet signed the integrity signature for the course

## Supporting information

[MST-840](https://openedx.atlassian.net/browse/MST-840)