### PR TITLE
build: add script to list installed XBlocks

### DIFF
--- a/scripts/xblock/list-installed.py
+++ b/scripts/xblock/list-installed.py
@@ -1,0 +1,31 @@
+"""
+Lookup list of installed XBlocks, to aid XBlock developers
+"""
+import pkg_resources
+
+
+def get_without_builtins():
+    """
+    Get all installed XBlocks
+
+    but try to omit built-in XBlocks, else the output is less helpful
+    """
+    xblocks = [
+        entry_point.name
+        for entry_point in pkg_resources.iter_entry_points('xblock.v1')
+        if not entry_point.module_name.startswith('xmodule')
+    ]
+    xblocks = sorted(xblocks)
+    return xblocks
+
+
+def main():
+    """
+    Run the main script
+    """
+    for name in get_without_builtins():
+        print(name)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Story
=====
As an XBlock developer,
I want to know which XBlocks are installed
so I can debug (and know which to add to Advanced Settings in Studio).

Testing
=======
- `make studio-shell`
- `python scripts/xblock/list-installed.py`

Integration
===========
I plan to invoke this from `devstack` (after installing XBlocks).