### PR TITLE
docs: Add README to lms/templates/oauth2_provider

### DIFF
--- a/lms/templates/oauth2_provider/README.rst
+++ b/lms/templates/oauth2_provider/README.rst
@@ -1,0 +1,16 @@
+Django Oauth Toolkit Templates
+------------------------------
+
+In an ideal world, these templates would live in the ``oauth_dispatch`` djangoapp along
+with our other oauth2 code. Unfortunately, this template is defined within the
+``django-oauth-toolkit`` library, which also defines its own version of the template.
+
+Due to `the way that Django's app_directories loader works`_, we cannot put this template
+in ``oauth_dispatch``, becuase the `template defined in the library`_ will take precendence
+over the one in ``oauth_dispatch``. The library must be defined first in ``INSTALLED_APPS``.
+
+So until we find another solution, this template will continue to live here.
+
+
+.. _the way that Django's app_directories loader works: https://docs.djangoproject.com/en/2.2/ref/templates/api/#django.template.loaders.app_directories.Loader
+.. _template defined in the library: https://github.com/jazzband/django-oauth-toolkit/blob/master/oauth2_provider/templates/oauth2_provider/authorize.html

--- a/lms/templates/oauth2_provider/README.rst
+++ b/lms/templates/oauth2_provider/README.rst
@@ -13,4 +13,4 @@ So until we find another solution, this template will continue to live here.
 
 
 .. _the way that Django's app_directories loader works: https://docs.djangoproject.com/en/2.2/ref/templates/api/#django.template.loaders.app_directories.Loader
-.. _template defined in the library: https://github.com/jazzband/django-oauth-toolkit/blob/master/oauth2_provider/templates/oauth2_provider/authorize.html
+.. _template defined in the django-oauth-toolkit: https://github.com/jazzband/django-oauth-toolkit/blob/master/oauth2_provider/templates/oauth2_provider/authorize.html

--- a/lms/templates/oauth2_provider/README.rst
+++ b/lms/templates/oauth2_provider/README.rst
@@ -1,13 +1,10 @@
 Django Oauth Toolkit Templates
 ------------------------------
 
-In an ideal world, these templates would live in the ``oauth_dispatch`` djangoapp along
-with our other oauth2 code. Unfortunately, this template is defined within the
-``django-oauth-toolkit`` library, which also defines its own version of the template.
+This Django app exists solely to provide a home for the ``authorize.html`` template. This overrides the default version of the template defined in the ``django-oauth-toolkit`` library.
 
-Due to `the way that Django's app_directories loader works`_, we cannot put this template
-in ``oauth_dispatch``, becuase the `template defined in the library`_ will take precendence
-over the one in ``oauth_dispatch``. The library must be defined first in ``INSTALLED_APPS``.
+In an ideal world, this template would live in the ``oauth_dispatch`` djangoapp along with our other oauth2 code. Unfortunately, due to `the way that Django's app_directories loader works`_, we cannot put this template
+in ``oauth_dispatch``, because the `template defined in django-oauth-toolkit`_ will take precedence over the one in ``oauth_dispatch``. The library must be defined first in ``INSTALLED_APPS``.
 
 So until we find another solution, this template will continue to live here.
 


### PR DESCRIPTION
We wanted to move this single template into a djangoapp,
but there are technical limitations to us doing so.
This README helps explain the limitations so
future generations will know why this is here.