### PR TITLE
fix: update libsass to v0.21.0

### DIFF
--- a/cms/static/sass/bootstrap/_components.scss
+++ b/cms/static/sass/bootstrap/_components.scss
@@ -70,8 +70,8 @@
     list-style: none;
 
     .cta-show-sock {
-      @extend %ui-btn-pill;
-      @extend %t-action4;
+      @extend %ui-btn-pill !optional;
+      @extend %t-action4 !optional;
 
       background: theme-color("light");
       padding: ($baseline/2) $baseline;
@@ -145,7 +145,7 @@
             display: block;
 
             .icon {
-              @extend %t-icon4;
+              @extend %t-icon4 !optional;
 
               vertical-align: middle;
               margin-right: $baseline/4;

--- a/cms/static/sass/bootstrap/_footer.scss
+++ b/cms/static/sass/bootstrap/_footer.scss
@@ -13,7 +13,7 @@
   padding: $baseline;
 
   footer.primary {
-    @extend %t-copy-sub2;
+    @extend %t-copy-sub2 !optional;
 
     @include clearfix();
 

--- a/cms/static/sass/bootstrap/_header.scss
+++ b/cms/static/sass/bootstrap/_header.scss
@@ -74,8 +74,8 @@
   // basic layout - nav items
   nav {
     > ol > .nav-item {
-      @extend %t-action3;
-      @extend %t-strong;
+      @extend %t-action3 !optional;
+      @extend %t-strong !optional;
 
       display: inline-block;
       vertical-align: middle;
@@ -163,8 +163,8 @@
     }
 
     .course-title {
-      @extend %t-action2;
-      @extend %t-strong;
+      @extend %t-action2 !optional;
+      @extend %t-strong !optional;
 
       display: block;
       width: 100%;
@@ -422,8 +422,8 @@
     }
 
     .nav-item {
-      @extend %t-action3;
-      @extend %t-regular;
+      @extend %t-action3 !optional;
+      @extend %t-regular !optional;
 
       display: block;
       margin: 0 0 ($baseline/4) 0;

--- a/cms/static/sass/bootstrap/_layouts.scss
+++ b/cms/static/sass/bootstrap/_layouts.scss
@@ -119,8 +119,8 @@
 
         // buttons
         .button {
-          @extend %btn-primary-blue;
-          @extend %sizing;
+          @extend %btn-primary-blue !optional;
+          @extend %sizing !optional;
 
           .action-button-text {
             display: inline-block;
@@ -135,8 +135,8 @@
           // CASE: new/create button
           &.new-button,
           &.button-new {
-            @extend %btn-primary-green;
-            @extend %sizing;
+            @extend %btn-primary-green !optional;
+            @extend %sizing !optional;
           }
         }
       }
@@ -164,7 +164,7 @@
         color: $body-color;
 
         &.navigation-current {
-          @extend %ui-disabled;
+          @extend %ui-disabled !optional;
 
           color: color("gray");
           max-width: 250px;
@@ -199,7 +199,7 @@
   // CASE: wizard-based mast
   .mast-wizard {
     .page-header-sub {
-      @extend %t-title4;
+      @extend %t-title4 !optional;
 
       color: color("gray");
       font-weight: 300;
@@ -247,7 +247,7 @@
     padding-bottom: ($baseline/2);
 
     .title-sub {
-      @extend %t-copy-sub1;
+      @extend %t-copy-sub1 !optional;
 
       display: block;
       margin: 0;
@@ -255,7 +255,7 @@
     }
 
     .title-1 {
-      @extend %t-title3;
+      @extend %t-title3 !optional;
       @extend %t-strong;
 
       margin: 0;
@@ -283,7 +283,7 @@
   }
 
   .title-3 {
-    @extend %t-title6;
+    @extend %t-title6 !optional;
 
     margin: 0 0 ($baseline/2) 0;
   }

--- a/lms/static/sass/_build-footer-edx.scss
+++ b/lms/static/sass/_build-footer-edx.scss
@@ -2,6 +2,7 @@
 // LMS edx.org Footer: Shared Build Compile
 @import 'lms/theme/variables';
 @import 'bootstrap/variables';
+@import 'bootstrap/scss/functions';
 @import 'bootstrap/scss/variables';
 @import 'bootstrap/scss/mixins/breakpoints';
 @import '../variables';

--- a/lms/static/sass/course/_info.scss
+++ b/lms/static/sass/course/_info.scss
@@ -325,8 +325,8 @@ div.info-wrapper {
             filter: alpha(opacity=60);
 
             + h4 {
-              @extend a:hover;
-
+              opacity: 1;
+              filter: alpha(opacity=100);
               text-decoration: underline;
             }
           }

--- a/lms/static/sass/course/_profile.scss
+++ b/lms/static/sass/course/_profile.scss
@@ -134,7 +134,7 @@
 
     header {
       @extend .clearfix;
-      @extend h1.top-header;
+      @extend %h1-top-header;
 
       margin-bottom: lh();
 

--- a/lms/static/sass/course/courseware/_courseware.scss
+++ b/lms/static/sass/course/courseware/_courseware.scss
@@ -570,7 +570,7 @@ html.video-fullscreen {
         }
 
         header {
-          @extend h1.top-header;
+          @extend %h1-top-header !optional;
 
           border-radius: 0 4px 0 0;
           margin-bottom: -16px;

--- a/lms/static/sass/course/layout/_courseware_preview.scss
+++ b/lms/static/sass/course/layout/_courseware_preview.scss
@@ -13,7 +13,7 @@ $proctoring-banner-text-size: 14px;
   }
 
   .preview-menu {
-    @extend %inner-wrapper;
+    @extend %inner-wrapper !optional;
 
     width: auto;
 
@@ -65,7 +65,7 @@ $proctoring-banner-text-size: 14px;
 .proctored_exam_status {
   // STATE: Fixed to viewport (used for scrolling)
   &.is-fixed {
-    @extend %ui-depth4;
+    @extend %ui-depth4 !optional;
 
     box-shadow: 0 3px 3px $shadow-d1;
     position: fixed;
@@ -170,9 +170,9 @@ $proctoring-banner-text-size: 14px;
     }
 
     .exam-button-turn-in-exam {
-      @extend %btn-pl-primary-base;
-      @extend %t-action3;
-      @extend %t-weight4;
+      @extend %btn-pl-primary-base !optional;
+      @extend %t-action3 !optional;
+      @extend %t-weight4 !optional;
 
       margin-right: $baseline;
       border: 0;

--- a/lms/static/sass/discussion/_discussion.scss
+++ b/lms/static/sass/discussion/_discussion.scss
@@ -128,7 +128,7 @@ section.discussion {
 }
 
 .xblock-student_view-discussion {
-  @extend %ui-print-excluded;
+  @extend %ui-print-excluded !optional;
   // Overrides overspecific courseware CSS from:
   // https://github.com/edx/edx-platform/blob/master/lms/static/sass/course/courseware/_courseware.scss#L499
   padding-top: 15px !important;

--- a/lms/static/sass/discussion/elements/_editor.scss
+++ b/lms/static/sass/discussion/elements/_editor.scss
@@ -120,7 +120,7 @@
 }
 
 .wmd-prompt-dialog {
-  @extend .modal;
+  @extend .modal !optional;
 
   background: $forum-color-background;
   padding: $baseline;

--- a/lms/static/sass/discussion/elements/_navigation.scss
+++ b/lms/static/sass/discussion/elements/_navigation.scss
@@ -340,7 +340,7 @@
 
 .forum-nav-thread-comments-count {
   @extend %forum-nav-thread-wrapper-2-content;
-  @extend %t-weight4;
+  @extend %t-weight4 !optional;
 
   position: relative;
 

--- a/lms/static/sass/discussion/views/_response.scss
+++ b/lms/static/sass/discussion/views/_response.scss
@@ -49,7 +49,7 @@
 
     // CASE: larger username for responses
     .username {
-      @extend %t-weight5;
+      @extend %t-weight5 !optional;
 
       font-size: $forum-base-font-size;
     }

--- a/lms/static/sass/features/_bookmarks.scss
+++ b/lms/static/sass/features/_bookmarks.scss
@@ -103,11 +103,11 @@ $bookmarked-icon: "\f02e"; // .fa-bookmark
 }
 
 .bookmarks-empty-header {
-  @extend %t-title5;
+  @extend %t-title5 !optional;
 
   margin-bottom: ($baseline/2);
 }
 
 .bookmarks-empty-detail {
-  @extend %t-copy-sub1;
+  @extend %t-copy-sub1 !optional;
 }

--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -149,11 +149,6 @@
                 display: inline-block;
                 margin-bottom: ($baseline/2);
                 text-decoration: none;
-
-                // Responsive behavior
-                @include media-breakpoint-down(sm) {
-                  @extend %t-title4;
-                }
               }
             }
 

--- a/lms/static/sass/shared/_alerts_pattern_library_shim.scss
+++ b/lms/static/sass/shared/_alerts_pattern_library_shim.scss
@@ -142,7 +142,7 @@ $bp-screen-md: 768px !default;
 
   .alert-title {
     @extend %hd-5;
-    @extend %headings-emphasized;
+    @extend %headings-emphasized !optional;
 
     @media (min-width: $bp-screen-md) {
       // shift the section up to make the alert more compact

--- a/lms/static/sass/shared/_help-tab.scss
+++ b/lms/static/sass/shared/_help-tab.scss
@@ -18,7 +18,7 @@
 }
 
 .help-tab {
-  @extend %ui-depth2;
+  @extend %ui-depth2 !optional;
   @extend %ui-print-excluded;
 
   transform: rotate(-90deg);

--- a/lms/static/sass/shared/_modal.scss
+++ b/lms/static/sass/shared/_modal.scss
@@ -10,7 +10,7 @@
 }
 
 .modal {
-  @extend %ui-depth1;
+  @extend %ui-depth1 !optional;
 
   display: none;
   position: absolute;
@@ -89,7 +89,7 @@
       }
 
       hr {
-        @extend %faded-hr-divider-light;
+        @extend %faded-hr-divider-light !optional;
 
         border: none;
         margin: 0;
@@ -97,7 +97,7 @@
         z-index: 2;
 
         &::after {
-          @extend %faded-hr-divider;
+          @extend %faded-hr-divider !optional;
 
           bottom: 0;
           content: "";
@@ -352,7 +352,7 @@
   // general reset
   .list-input,
   .list-actions {
-    @extend %ui-no-list;
+    @extend %ui-no-list !optional;
   }
 
   .settings-language-select .select {
@@ -367,7 +367,7 @@
     padding: 0 ($baseline*2) $baseline ($baseline*2);
 
     .list-actions-item {
-      @extend %t-copy-sub1;
+      @extend %t-copy-sub1 !optional;
 
       color: $body-color;
       text-align: center;
@@ -379,4 +379,3 @@
     }
   }
 }
-

--- a/lms/static/sass/shared/_modal.scss
+++ b/lms/static/sass/shared/_modal.scss
@@ -51,7 +51,7 @@
   }
 
   .inner-wrapper {
-    @extend %ui-depth1;
+    @extend %ui-depth1 !optional;
 
     background: $modal-content-bg;
     border-radius: 0;
@@ -69,7 +69,7 @@
     }
 
     header {
-      @extend %ui-depth1;
+      @extend %ui-depth1 !optional;
 
       margin-bottom: ($baseline*1.5);
       overflow: hidden;

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -589,7 +589,7 @@ lazy==1.4
     #   acid-xblock
     #   lti-consumer-xblock
     #   ora2
-libsass==0.20.1
+libsass==0.21.0
     # via
     #   -r requirements/edx/paver.txt
     #   ora2

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -589,7 +589,7 @@ lazy==1.4
     #   acid-xblock
     #   lti-consumer-xblock
     #   ora2
-libsass==0.10.0
+libsass==0.20.1
     # via
     #   -r requirements/edx/paver.txt
     #   ora2

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -768,7 +768,7 @@ lazy==1.4
     #   bok-choy
     #   lti-consumer-xblock
     #   ora2
-libsass==0.20.1
+libsass==0.21.0
     # via
     #   -r requirements/edx/testing.txt
     #   ora2

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -768,7 +768,7 @@ lazy==1.4
     #   bok-choy
     #   lti-consumer-xblock
     #   ora2
-libsass==0.10.0
+libsass==0.20.1
     # via
     #   -r requirements/edx/testing.txt
     #   ora2

--- a/requirements/edx/paver.in
+++ b/requirements/edx/paver.in
@@ -12,7 +12,7 @@
 
 edx-opaque-keys                     # Create and introspect course and xblock identities
 lazy                                # Lazily-evaluated attributes for Python objects
-libsass==0.10.0                     # Python bindings for the LibSass CSS compiler
+libsass==0.20.1                     # Python bindings for the LibSass CSS compiler
 markupsafe                          # XML/HTML/XHTML Markup safe strings
 mock                                # Stub out code with mock objects and make assertions about how they have been used
 path                                # Easier manipulation of filesystem paths

--- a/requirements/edx/paver.in
+++ b/requirements/edx/paver.in
@@ -12,7 +12,7 @@
 
 edx-opaque-keys                     # Create and introspect course and xblock identities
 lazy                                # Lazily-evaluated attributes for Python objects
-libsass==0.20.1                     # Python bindings for the LibSass CSS compiler
+libsass==0.21.0                     # Python bindings for the LibSass CSS compiler
 markupsafe                          # XML/HTML/XHTML Markup safe strings
 mock                                # Stub out code with mock objects and make assertions about how they have been used
 path                                # Easier manipulation of filesystem paths

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -14,7 +14,7 @@ idna==2.10
     # via requests
 lazy==1.4
     # via -r requirements/edx/paver.in
-libsass==0.20.1
+libsass==0.21.0
     # via -r requirements/edx/paver.in
 markupsafe==1.1.1
     # via

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -14,7 +14,7 @@ idna==2.10
     # via requests
 lazy==1.4
     # via -r requirements/edx/paver.in
-libsass==0.10.0
+libsass==0.20.1
     # via -r requirements/edx/paver.in
 markupsafe==1.1.1
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -733,7 +733,7 @@ lazy==1.4
     #   bok-choy
     #   lti-consumer-xblock
     #   ora2
-libsass==0.20.1
+libsass==0.21.0
     # via
     #   -r requirements/edx/base.txt
     #   ora2

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -733,7 +733,7 @@ lazy==1.4
     #   bok-choy
     #   lti-consumer-xblock
     #   ora2
-libsass==0.10.0
+libsass==0.20.1
     # via
     #   -r requirements/edx/base.txt
     #   ora2


### PR DESCRIPTION
Updates libsass to latest. Requires an update to the edx.org-next theme https://github.com/edx/edx-themes/pull/737

- [ ] Merge https://github.com/edx/edx-themes/pull/737 before this PR

- Libsass is now stricter about undefined placeholder mixins, and so we had to mark a bunch of broken code as `!optional`. We had upgraded libsass until it broke with this version: https://github.com/sass/libsass/releases/tag/3.3.3 That release of libsass included a fix for a missing error on undefined placeholders. Our code was has existing missing placeholders, now it just complains.  This PR fixes those.
- Libsass `@extend` seems to have changed behavior in such a way that our usage of it our theme bloats the css output to a point where it's either 10s of megabytes or simply fails to compile. https://github.com/edx/edx-themes/pull/737 addresses this.

Key file sizes

| File                         | Production | This PR + https://github.com/edx/edx-themes/pull/737 |
|------------------------------|------------|---------|
| lms-course.css               | 778kb      | 1.3mb   |
| lms-discussion-bootstrap.css | 189kb      | 189kb   |
| lms-footer-edx.css           | 389kb      | 105kb   |
| lms-main-v1.css              | 2.2mb      | 1.2mb   |
| lms-main.css                 | 1.3mb      | 351kb   |
| studio-main-v1.css           | 1.1mb      | 2.1mb   |


Sandbox: https://libsass-upgrade.sandbox.edx.org/
(edx-app: djoy/update_libsass_to_0.20.1)
(edx-themes: abutterworth/libsass-upgrade)

Create Sandbox Job: https://tools-edx-jenkins.edx.org/job/sandboxes/job/CreateSandbox/39080/


### Testing

- [ ] Confirm CSS outputs are not unreasonably large for both no theme and edx.org-next theme
- [ ] Confirm edx.org verified track upsells are not affected

