### PR TITLE
fix: upgrade bootstrap to 4.6.0

### DIFF
--- a/cms/static/sass/bootstrap/_components.scss
+++ b/cms/static/sass/bootstrap/_components.scss
@@ -70,8 +70,8 @@
     list-style: none;
 
     .cta-show-sock {
-      @extend %ui-btn-pill;
-      @extend %t-action4;
+      @extend %ui-btn-pill !optional;
+      @extend %t-action4 !optional;
 
       background: theme-color("light");
       padding: ($baseline/2) $baseline;
@@ -145,7 +145,7 @@
             display: block;
 
             .icon {
-              @extend %t-icon4;
+              @extend %t-icon4 !optional;
 
               vertical-align: middle;
               margin-right: $baseline/4;

--- a/cms/static/sass/bootstrap/_footer.scss
+++ b/cms/static/sass/bootstrap/_footer.scss
@@ -13,7 +13,7 @@
   padding: $baseline;
 
   footer.primary {
-    @extend %t-copy-sub2;
+    @extend %t-copy-sub2 !optional;
 
     @include clearfix();
 

--- a/cms/static/sass/bootstrap/_header.scss
+++ b/cms/static/sass/bootstrap/_header.scss
@@ -74,8 +74,8 @@
   // basic layout - nav items
   nav {
     > ol > .nav-item {
-      @extend %t-action3;
-      @extend %t-strong;
+      @extend %t-action3 !optional;
+      @extend %t-strong !optional;
 
       display: inline-block;
       vertical-align: middle;
@@ -163,8 +163,8 @@
     }
 
     .course-title {
-      @extend %t-action2;
-      @extend %t-strong;
+      @extend %t-action2 !optional;
+      @extend %t-strong !optional;
 
       display: block;
       width: 100%;
@@ -422,8 +422,8 @@
     }
 
     .nav-item {
-      @extend %t-action3;
-      @extend %t-regular;
+      @extend %t-action3 !optional;
+      @extend %t-regular !optional;
 
       display: block;
       margin: 0 0 ($baseline/4) 0;

--- a/cms/static/sass/bootstrap/_layouts.scss
+++ b/cms/static/sass/bootstrap/_layouts.scss
@@ -119,8 +119,8 @@
 
         // buttons
         .button {
-          @extend %btn-primary-blue;
-          @extend %sizing;
+          @extend %btn-primary-blue !optional;
+          @extend %sizing !optional;
 
           .action-button-text {
             display: inline-block;
@@ -135,8 +135,8 @@
           // CASE: new/create button
           &.new-button,
           &.button-new {
-            @extend %btn-primary-green;
-            @extend %sizing;
+            @extend %btn-primary-green !optional;
+            @extend %sizing !optional;
           }
         }
       }
@@ -164,7 +164,7 @@
         color: $body-color;
 
         &.navigation-current {
-          @extend %ui-disabled;
+          @extend %ui-disabled !optional;
 
           color: color("gray");
           max-width: 250px;
@@ -199,7 +199,7 @@
   // CASE: wizard-based mast
   .mast-wizard {
     .page-header-sub {
-      @extend %t-title4;
+      @extend %t-title4 !optional;
 
       color: color("gray");
       font-weight: 300;
@@ -247,7 +247,7 @@
     padding-bottom: ($baseline/2);
 
     .title-sub {
-      @extend %t-copy-sub1;
+      @extend %t-copy-sub1 !optional;
 
       display: block;
       margin: 0;
@@ -255,7 +255,7 @@
     }
 
     .title-1 {
-      @extend %t-title3;
+      @extend %t-title3 !optional;
       @extend %t-strong;
 
       margin: 0;
@@ -283,7 +283,7 @@
   }
 
   .title-3 {
-    @extend %t-title6;
+    @extend %t-title6 !optional;
 
     margin: 0 0 ($baseline/2) 0;
   }

--- a/cms/static/sass/views/_updates.scss
+++ b/cms/static/sass/views/_updates.scss
@@ -196,7 +196,7 @@
   padding: 20px 30px;
   margin: 0;
 
-  @include border-radius(0, 3px, 3px, 0);
+  @include border-radius(0 3px 3px 0);
   @include border-left(none);
 
   background: $uxpl-light-blue-base;

--- a/lms/static/sass/base/_build.scss
+++ b/lms/static/sass/base/_build.scss
@@ -7,18 +7,7 @@
 @import 'bootstrap/variables';
 @import 'bootstrap/scss/functions';
 @import 'bootstrap/scss/variables';
-@import 'bootstrap/scss/mixins/background-variant';
-@import 'bootstrap/scss/mixins/box-shadow';
-@import 'bootstrap/scss/mixins/breakpoints';
-@import 'bootstrap/scss/mixins/float';
-@import 'bootstrap/scss/mixins/grid';
-@import 'bootstrap/scss/mixins/hover';
-@import 'bootstrap/scss/mixins/reset-text';
-@import 'bootstrap/scss/mixins/screen-reader';
-@import 'bootstrap/scss/mixins/text-truncate';
-@import 'bootstrap/scss/mixins/text-emphasis';
-@import 'bootstrap/scss/mixins/text-hide';
-@import 'bootstrap/scss/mixins/visibility';
+@import 'bootstrap/scss/mixins';
 @import 'bootstrap/scss/utilities';
 
 

--- a/lms/static/sass/course/courseware/_sidebar.scss
+++ b/lms/static/sass/course/courseware/_sidebar.scss
@@ -1,7 +1,7 @@
 .course-index {
   @include transition(all 0.2s $ease-in-out-quad 0s);
   @include border-right(1px solid $border-color-2);
-  @include border-radius(3px, 0, 0, 3px);
+  @include border-radius(3px 0 0 3px);
 
   display: table-cell; // needed to extend the sidebar the full height of the area
 

--- a/lms/static/sass/course/layout/_courseware_preview.scss
+++ b/lms/static/sass/course/layout/_courseware_preview.scss
@@ -13,7 +13,7 @@ $proctoring-banner-text-size: 14px;
   }
 
   .preview-menu {
-    @extend %inner-wrapper;
+    @extend %inner-wrapper !optional;
 
     width: auto;
 
@@ -65,7 +65,7 @@ $proctoring-banner-text-size: 14px;
 .proctored_exam_status {
   // STATE: Fixed to viewport (used for scrolling)
   &.is-fixed {
-    @extend %ui-depth4;
+    @extend %ui-depth4 !optional;
 
     box-shadow: 0 3px 3px $shadow-d1;
     position: fixed;
@@ -170,9 +170,9 @@ $proctoring-banner-text-size: 14px;
     }
 
     .exam-button-turn-in-exam {
-      @extend %btn-pl-primary-base;
-      @extend %t-action3;
-      @extend %t-weight4;
+      @extend %btn-pl-primary-base !optional;
+      @extend %t-action3 !optional;
+      @extend %t-weight4 !optional;
 
       margin-right: $baseline;
       border: 0;

--- a/lms/static/sass/discussion/_discussion.scss
+++ b/lms/static/sass/discussion/_discussion.scss
@@ -128,7 +128,7 @@ section.discussion {
 }
 
 .xblock-student_view-discussion {
-  @extend %ui-print-excluded;
+  @extend %ui-print-excluded !optional;
   // Overrides overspecific courseware CSS from:
   // https://github.com/edx/edx-platform/blob/master/lms/static/sass/course/courseware/_courseware.scss#L499
   padding-top: 15px !important;

--- a/lms/static/sass/discussion/_mixins.scss
+++ b/lms/static/sass/discussion/_mixins.scss
@@ -29,7 +29,7 @@
 }
 
 @mixin discussion-wmd-input {
-  @include border-radius($forum-border-radius, $forum-border-radius, 0, 0);
+  @include border-radius($forum-border-radius $forum-border-radius 0 0);
 
   box-sizing: border-box;
   margin-top: 0;
@@ -44,7 +44,7 @@
 }
 
 @mixin discussion-wmd-preview-container {
-  @include border-radius(0, 0, $forum-border-radius, $forum-border-radius);
+  @include border-radius(0 0 $forum-border-radius $forum-border-radius);
 
   box-sizing: border-box;
   border: 1px solid $forum-color-border;

--- a/lms/static/sass/discussion/elements/_actions.scss
+++ b/lms/static/sass/discussion/elements/_actions.scss
@@ -162,7 +162,7 @@
       }
 
       .action-icon {
-        @include border-radius(0, $forum-border-radius, $forum-border-radius, 0);
+        @include border-radius(0 $forum-border-radius $forum-border-radius 0);
       }
     }
 

--- a/lms/static/sass/discussion/elements/_editor.scss
+++ b/lms/static/sass/discussion/elements/_editor.scss
@@ -120,7 +120,7 @@
 }
 
 .wmd-prompt-dialog {
-  @extend .modal;
+  @extend .modal !optional;
 
   background: $forum-color-background;
   padding: $baseline;

--- a/lms/static/sass/discussion/elements/_navigation.scss
+++ b/lms/static/sass/discussion/elements/_navigation.scss
@@ -115,7 +115,7 @@
 
 .forum-nav-refine-bar {
   @include clearfix();
-  @include border-radius($forum-border-radius, $forum-border-radius, 0, 0);
+  @include border-radius($forum-border-radius $forum-border-radius 0 0);
 
   font-size: $forum-small-font-size;
   border-bottom: 1px solid $forum-color-border;

--- a/lms/static/sass/discussion/views/_response.scss
+++ b/lms/static/sass/discussion/views/_response.scss
@@ -32,7 +32,7 @@
   .discussion-response {
     box-sizing: border-box;
 
-    @include border-radius($forum-border-radius, $forum-border-radius, 0, 0);
+    @include border-radius($forum-border-radius $forum-border-radius 0 0);
 
     padding: $baseline;
     background-color: $forum-color-background;
@@ -98,7 +98,7 @@
 
   // CASE: banner - staff response
   .staff-banner {
-    @include border-radius($forum-border-radius, $forum-border-radius, 0, 0);
+    @include border-radius($forum-border-radius $forum-border-radius 0 0);
     @include left(0);
 
     position: absolute;
@@ -115,7 +115,7 @@
 
   // CASE: banner - community TA response
   .community-ta-banner {
-    @include border-radius($forum-border-radius, $forum-border-radius, 0, 0);
+    @include border-radius($forum-border-radius $forum-border-radius 0 0);
     @include left(0);
 
     position: absolute;
@@ -144,7 +144,7 @@
 .discussion .comments {
   @extend %ui-no-list;
 
-  @include border-radius(0, 0, $forum-border-radius, $forum-border-radius);
+  @include border-radius(0 0 $forum-border-radius $forum-border-radius);
 
   background: theme-color("lightest");
   box-shadow: 0 1px 3px -1px $shadow inset;

--- a/lms/static/sass/discussion/views/_response.scss
+++ b/lms/static/sass/discussion/views/_response.scss
@@ -49,7 +49,7 @@
 
     // CASE: larger username for responses
     .username {
-      @extend %t-weight5;
+      @extend %t-weight5 !optional;
 
       font-size: $forum-base-font-size;
     }

--- a/lms/static/sass/discussion/views/_thread.scss
+++ b/lms/static/sass/discussion/views/_thread.scss
@@ -217,7 +217,7 @@
     @include transition(all 0.2s linear 0s);
 
     .thread-wrapper {
-      @include border-radius($forum-border-radius, $forum-border-radius, 0, 0);
+      @include border-radius($forum-border-radius $forum-border-radius 0 0);
 
       position: relative;
       overflow-x: hidden;

--- a/lms/static/sass/features/_bookmarks.scss
+++ b/lms/static/sass/features/_bookmarks.scss
@@ -103,11 +103,11 @@ $bookmarked-icon: "\f02e"; // .fa-bookmark
 }
 
 .bookmarks-empty-header {
-  @extend %t-title5;
+  @extend %t-title5 !optional;
 
   margin-bottom: ($baseline/2);
 }
 
 .bookmarks-empty-detail {
-  @extend %t-copy-sub1;
+  @extend %t-copy-sub1 !optional;
 }

--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -149,11 +149,6 @@
                 display: inline-block;
                 margin-bottom: ($baseline/2);
                 text-decoration: none;
-
-                // Responsive behavior
-                @include media-breakpoint-down(sm) {
-                  @extend %t-title4;
-                }
               }
             }
 

--- a/lms/static/sass/multicourse/_home.scss
+++ b/lms/static/sass/multicourse/_home.scss
@@ -140,7 +140,7 @@ $course-search-input-height: ($button-size);
 
         .search-button {
           @include right($baseline*1.5);
-          @include border-radius(1px, 3px, 3px, 1px);
+          @include border-radius(1px 3px 3px 1px);
 
           @extend %ui-depth2;
           @extend %t-icon3;

--- a/lms/static/sass/shared/_alerts_pattern_library_shim.scss
+++ b/lms/static/sass/shared/_alerts_pattern_library_shim.scss
@@ -142,7 +142,7 @@ $bp-screen-md: 768px !default;
 
   .alert-title {
     @extend %hd-5;
-    @extend %headings-emphasized;
+    @extend %headings-emphasized !optional;
 
     @media (min-width: $bp-screen-md) {
       // shift the section up to make the alert more compact

--- a/lms/static/sass/shared/_header.scss
+++ b/lms/static/sass/shared/_header.scss
@@ -561,7 +561,7 @@
 
       &:last-child {
         > a {
-          @include border-radius(0, 4px, 4px, 0);
+          @include border-radius(0 4px 4px 0);
           @include border-left(none);
 
           padding: ($baseline/2) ($baseline/2);

--- a/lms/static/sass/shared/_help-tab.scss
+++ b/lms/static/sass/shared/_help-tab.scss
@@ -18,7 +18,7 @@
 }
 
 .help-tab {
-  @extend %ui-depth2;
+  @extend %ui-depth2 !optional;
   @extend %ui-print-excluded;
 
   transform: rotate(-90deg);

--- a/lms/static/sass/shared/_modal.scss
+++ b/lms/static/sass/shared/_modal.scss
@@ -10,7 +10,7 @@
 }
 
 .modal {
-  @extend %ui-depth1;
+  @extend %ui-depth1 !optional;
 
   display: none;
   position: absolute;
@@ -89,7 +89,7 @@
       }
 
       hr {
-        @extend %faded-hr-divider-light;
+        @extend %faded-hr-divider-light !optional;
 
         border: none;
         margin: 0;
@@ -97,7 +97,7 @@
         z-index: 2;
 
         &::after {
-          @extend %faded-hr-divider;
+          @extend %faded-hr-divider !optional;
 
           bottom: 0;
           content: "";
@@ -352,7 +352,7 @@
   // general reset
   .list-input,
   .list-actions {
-    @extend %ui-no-list;
+    @extend %ui-no-list !optional;
   }
 
   .settings-language-select .select {
@@ -367,7 +367,7 @@
     padding: 0 ($baseline*2) $baseline ($baseline*2);
 
     .list-actions-item {
-      @extend %t-copy-sub1;
+      @extend %t-copy-sub1 !optional;
 
       color: $body-color;
       text-align: center;
@@ -379,4 +379,3 @@
     }
   }
 }
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -2182,9 +2182,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.0.0.tgz",
-      "integrity": "sha512-gulJE5dGFo6Q61V/whS6VM4WIyrlydXfCgkE+Gxe5hjrJ8rXLLZlALq7zq2RPhOc45PSwQpJkrTnc2KgD6cvmA=="
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.0.tgz",
+      "integrity": "sha512-Io55IuQY3kydzHtbGvQya3H+KorS/M9rSNyfCGCg9WZ4pyT/lCxIlpJgG1GXW/PswzC84Tr2fBYi+7+jFVQQBw=="
     },
     "brace-expansion": {
       "version": "1.1.11",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "backbone": "1.4.0",
     "backbone-associations": "0.6.2",
     "backbone.paginator": "2.0.8",
-    "bootstrap": "4.0.0",
+    "bootstrap": "^4.6.0",
     "camelize": "1.0.0",
     "classnames": "2.2.5",
     "css-loader": "0.28.8",

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -589,7 +589,7 @@ lazy==1.4
     #   acid-xblock
     #   lti-consumer-xblock
     #   ora2
-libsass==0.10.0
+libsass==0.20.1
     # via
     #   -r requirements/edx/paver.txt
     #   ora2

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -769,7 +769,7 @@ lazy==1.4
     #   bok-choy
     #   lti-consumer-xblock
     #   ora2
-libsass==0.10.0
+libsass==0.20.1
     # via
     #   -r requirements/edx/testing.txt
     #   ora2

--- a/requirements/edx/paver.in
+++ b/requirements/edx/paver.in
@@ -12,7 +12,7 @@
 
 edx-opaque-keys                     # Create and introspect course and xblock identities
 lazy                                # Lazily-evaluated attributes for Python objects
-libsass==0.10.0                     # Python bindings for the LibSass CSS compiler
+libsass==0.20.1                     # Python bindings for the LibSass CSS compiler
 markupsafe                          # XML/HTML/XHTML Markup safe strings
 mock                                # Stub out code with mock objects and make assertions about how they have been used
 path                                # Easier manipulation of filesystem paths

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -14,7 +14,7 @@ idna==2.10
     # via requests
 lazy==1.4
     # via -r requirements/edx/paver.in
-libsass==0.10.0
+libsass==0.20.1
     # via -r requirements/edx/paver.in
 markupsafe==1.1.1
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -734,7 +734,7 @@ lazy==1.4
     #   bok-choy
     #   lti-consumer-xblock
     #   ora2
-libsass==0.10.0
+libsass==0.20.1
     # via
     #   -r requirements/edx/base.txt
     #   ora2


### PR DESCRIPTION
Upgrade Bootstrap from 4.0.0 to 4.6.0. This is a step toward swapping Bootstrap SASS for Paragon SASS (which is a superset of Bootstrap 4.6.0).

The only apparent change in Bootstrap that caused breakage for us was the mixin signature change for `border-radius`