### PR TITLE
WIP [SE-4469] Refactor permission handling to use user.has_perm

### DIFF
--- a/cms/djangoapps/contentstore/permissions.py
+++ b/cms/djangoapps/contentstore/permissions.py
@@ -9,7 +9,7 @@ is_user_active = rules.is_authenticated & rules.is_active
 # Is the user global staff?
 is_global_staff = is_user_active & rules.is_staff
 
-EDIT_ACTIVE_CERTIFICATE = 'contentstore.edit_active_certificate' 
+EDIT_ACTIVE_CERTIFICATE = 'contentstore.edit_active_certificate'
 DELETE_ACTIVE_CERTIFICATE = 'contentstore.delete_active_certificate'
 REINDEX_COURSE = 'contentstore.reindex_course'
 RERUN_COURSE = 'contentstore.rerun_course'

--- a/cms/djangoapps/contentstore/permissions.py
+++ b/cms/djangoapps/contentstore/permissions.py
@@ -4,12 +4,17 @@ Permission definitions for the contentstore djangoapp
 
 from bridgekeeper import perms, rules
 
-from lms.djangoapps.courseware.rules import HasAccessRule
-
 # Is the user active (and their email verified)?
 is_user_active = rules.is_authenticated & rules.is_active
 # Is the user global staff?
 is_global_staff = is_user_active & rules.is_staff
 
 EDIT_ACTIVE_CERTIFICATE = 'contentstore.edit_active_certificate' 
+DELETE_ACTIVE_CERTIFICATE = 'contentstore.delete_active_certificate'
+REINDEX_COURSE = 'contentstore.reindex_course'
+RERUN_COURSE = 'contentstore.rerun_course'
+
 perms[EDIT_ACTIVE_CERTIFICATE] = is_global_staff
+perms[DELETE_ACTIVE_CERTIFICATE] = is_global_staff
+perms[REINDEX_COURSE] = is_global_staff
+perms[RERUN_COURSE] = is_global_staff

--- a/cms/djangoapps/contentstore/permissions.py
+++ b/cms/djangoapps/contentstore/permissions.py
@@ -3,6 +3,8 @@ Permission definitions for the contentstore djangoapp
 """
 
 from bridgekeeper import perms, rules
+from common.djangoapps.student.roles import CourseCreatorRole
+from lms.djangoapps.courseware.rules import HasRolesRule
 
 # Is the user active (and their email verified)?
 is_user_active = rules.is_authenticated & rules.is_active
@@ -13,8 +15,10 @@ EDIT_ACTIVE_CERTIFICATE = 'contentstore.edit_active_certificate'
 DELETE_ACTIVE_CERTIFICATE = 'contentstore.delete_active_certificate'
 REINDEX_COURSE = 'contentstore.reindex_course'
 RERUN_COURSE = 'contentstore.rerun_course'
+CREATE_COURSE = 'contentstore.create_course'
 
 perms[EDIT_ACTIVE_CERTIFICATE] = is_global_staff
 perms[DELETE_ACTIVE_CERTIFICATE] = is_global_staff
 perms[REINDEX_COURSE] = is_global_staff
 perms[RERUN_COURSE] = is_global_staff
+perms[CREATE_COURSE] = HasRolesRule(CourseCreatorRole())

--- a/cms/djangoapps/contentstore/permissions.py
+++ b/cms/djangoapps/contentstore/permissions.py
@@ -1,0 +1,15 @@
+"""
+Permission definitions for the contentstore djangoapp
+"""
+
+from bridgekeeper import perms, rules
+
+from lms.djangoapps.courseware.rules import HasAccessRule
+
+# Is the user active (and their email verified)?
+is_user_active = rules.is_authenticated & rules.is_active
+# Is the user global staff?
+is_global_staff = is_user_active & rules.is_staff
+
+EDIT_ACTIVE_CERTIFICATE = 'contentstore.edit_active_certificate' 
+perms[EDIT_ACTIVE_CERTIFICATE] = is_global_staff

--- a/cms/djangoapps/contentstore/permissions.py
+++ b/cms/djangoapps/contentstore/permissions.py
@@ -3,8 +3,6 @@ Permission definitions for the contentstore djangoapp
 """
 
 from bridgekeeper import perms, rules
-from common.djangoapps.student.roles import CourseCreatorRole
-from lms.djangoapps.courseware.rules import HasRolesRule
 
 is_user_active = rules.is_authenticated & rules.is_active
 is_global_staff = is_user_active & rules.is_staff

--- a/cms/djangoapps/contentstore/permissions.py
+++ b/cms/djangoapps/contentstore/permissions.py
@@ -6,19 +6,25 @@ from bridgekeeper import perms, rules
 from common.djangoapps.student.roles import CourseCreatorRole
 from lms.djangoapps.courseware.rules import HasRolesRule
 
-# Is the user active (and their email verified)?
 is_user_active = rules.is_authenticated & rules.is_active
-# Is the user global staff?
 is_global_staff = is_user_active & rules.is_staff
 
 EDIT_ACTIVE_CERTIFICATE = 'contentstore.edit_active_certificate'
 DELETE_ACTIVE_CERTIFICATE = 'contentstore.delete_active_certificate'
 REINDEX_COURSE = 'contentstore.reindex_course'
 RERUN_COURSE = 'contentstore.rerun_course'
-CREATE_COURSE = 'contentstore.create_course'
+ACCESS_COURSE = 'contentstore.access_course'
+EDIT_COURSE = 'contentstore.edit_course'
+OPTIMIZE_COURSE_LIST = 'contentstore.optimize_course_list'
+VIEW_CERTIFICATES_LIST_PAGE = 'contentstore.view_certificates_list_page'
+RERUN_CREATOR_STATUS = 'contentstore.rerun_creator_status'
 
 perms[EDIT_ACTIVE_CERTIFICATE] = is_global_staff
 perms[DELETE_ACTIVE_CERTIFICATE] = is_global_staff
 perms[REINDEX_COURSE] = is_global_staff
 perms[RERUN_COURSE] = is_global_staff
-perms[CREATE_COURSE] = HasRolesRule(CourseCreatorRole())
+perms[ACCESS_COURSE] = is_global_staff
+perms[EDIT_COURSE] = is_global_staff
+perms[OPTIMIZE_COURSE_LIST] = is_global_staff
+perms[VIEW_CERTIFICATES_LIST_PAGE] = is_global_staff
+perms[RERUN_CREATOR_STATUS] = is_global_staff

--- a/cms/djangoapps/contentstore/views/certificates.py
+++ b/cms/djangoapps/contentstore/views/certificates.py
@@ -37,6 +37,7 @@ from eventtracking import tracker
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import AssetKey, CourseKey
 
+from cms.djangoapps.contentstore.permissions import EDIT_ACTIVE_CERTIFICATE
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.edxmako.shortcuts import render_to_response
 from common.djangoapps.student.auth import has_studio_write_access
@@ -492,7 +493,7 @@ def certificates_detail_handler(request, course_key_string, certificate_id):
             active_certificates = CertificateManager.get_certificates(course, only_active=True)
             if int(certificate_id) in [int(certificate["id"]) for certificate in active_certificates]:
                 # Only global staff (PMs) are able to edit active certificate configuration
-                if not GlobalStaff().has_user(request.user):
+                if not request.user.has_perm(EDIT_ACTIVE_CERTIFICATE):
                     raise PermissionDenied()
         try:
             new_certificate = CertificateManager.deserialize_certificate(course, request.body)

--- a/cms/djangoapps/contentstore/views/certificates.py
+++ b/cms/djangoapps/contentstore/views/certificates.py
@@ -37,7 +37,7 @@ from eventtracking import tracker
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import AssetKey, CourseKey
 
-from cms.djangoapps.contentstore.permissions import EDIT_ACTIVE_CERTIFICATE
+from cms.djangoapps.contentstore.permissions import DELETE_ACTIVE_CERTIFICATE, EDIT_ACTIVE_CERTIFICATE
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.edxmako.shortcuts import render_to_response
 from common.djangoapps.student.auth import has_studio_write_access
@@ -522,7 +522,7 @@ def certificates_detail_handler(request, course_key_string, certificate_id):
         active_certificates = CertificateManager.get_certificates(course, only_active=True)
         if int(certificate_id) in [int(certificate["id"]) for certificate in active_certificates]:
             # Only global staff (PMs) are able to delete active certificate configuration
-            if not GlobalStaff().has_user(request.user):
+            if not request.user.has_perm(DELETE_ACTIVE_CERTIFICATE):
                 raise PermissionDenied()
 
         CertificateManager.remove_certificate(

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -32,7 +32,14 @@ from opaque_keys.edx.locator import BlockUsageLocator
 from organizations.api import add_organization_course, ensure_organization
 from organizations.exceptions import InvalidOrganizationException
 
-from cms.djangoapps.contentstore.permissions import ACCESS_COURSE, EDIT_COURSE, REINDEX_COURSE, RERUN_COURSE, OPTIMIZE_COURSE_LIST, RERUN_CREATOR_STATUS
+from cms.djangoapps.contentstore.permissions import (
+    ACCESS_COURSE,
+    EDIT_COURSE,
+    REINDEX_COURSE,
+    RERUN_COURSE,
+    OPTIMIZE_COURSE_LIST,
+    RERUN_CREATOR_STATUS
+)
 from cms.djangoapps.course_creators.views import add_user_with_status_unrequested, get_course_creator_status
 from cms.djangoapps.models.settings.course_grading import CourseGradingModel
 from cms.djangoapps.models.settings.course_metadata import CourseMetadata
@@ -47,7 +54,6 @@ from common.djangoapps.student.roles import (
     CourseCreatorRole,
     CourseInstructorRole,
     CourseStaffRole,
-    GlobalStaff,
     UserBasedRole
 )
 from common.djangoapps.util.course import get_link_for_about_page

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -32,7 +32,7 @@ from opaque_keys.edx.locator import BlockUsageLocator
 from organizations.api import add_organization_course, ensure_organization
 from organizations.exceptions import InvalidOrganizationException
 
-from cms.djangoapps.contentstore.permissions import REINDEX_COURSE, RERUN_COURSE
+from cms.djangoapps.contentstore.permissions import CREATE_COURSE, REINDEX_COURSE, RERUN_COURSE
 from cms.djangoapps.course_creators.views import add_user_with_status_unrequested, get_course_creator_status
 from cms.djangoapps.models.settings.course_grading import CourseGradingModel
 from cms.djangoapps.models.settings.course_metadata import CourseMetadata
@@ -850,7 +850,7 @@ def _create_or_rerun_course(request):
     Returns the destination course_key and overriding fields for the new course.
     Raises DuplicateCourseError and InvalidKeyError
     """
-    if not auth.user_has_role(request.user, CourseCreatorRole()):
+    if not request.user.has_perm(CREATE_COURSE):
         raise PermissionDenied()
 
     try:

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -14,6 +14,7 @@ from collections import defaultdict
 
 import django.utils
 from ccx_keys.locator import CCXLocator
+from cms.djangoapps.contentstore.permissions import REINDEX_COURSE, RERUN_COURSE
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied, ValidationError
@@ -305,7 +306,7 @@ def course_rerun_handler(request, course_key_string):
         html: return html page with form to rerun a course for the given course id
     """
     # Only global staff (PMs) are able to rerun courses during the soft launch
-    if not GlobalStaff().has_user(request.user):
+    if not request.user.has_perm(RERUN_COURSE):
         raise PermissionDenied()
     course_key = CourseKey.from_string(course_key_string)
     with modulestore().bulk_operations(course_key):
@@ -331,7 +332,7 @@ def course_search_index_handler(request, course_key_string):
         json: return status of indexing task
     """
     # Only global staff (PMs) are able to index courses
-    if not GlobalStaff().has_user(request.user):
+    if not request.user.has_perm(REINDEX_COURSE):
         raise PermissionDenied()
     course_key = CourseKey.from_string(course_key_string)
     content_type = request.META.get('CONTENT_TYPE', None)

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -14,7 +14,6 @@ from collections import defaultdict
 
 import django.utils
 from ccx_keys.locator import CCXLocator
-from cms.djangoapps.contentstore.permissions import REINDEX_COURSE, RERUN_COURSE
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied, ValidationError
@@ -33,6 +32,7 @@ from opaque_keys.edx.locator import BlockUsageLocator
 from organizations.api import add_organization_course, ensure_organization
 from organizations.exceptions import InvalidOrganizationException
 
+from cms.djangoapps.contentstore.permissions import REINDEX_COURSE, RERUN_COURSE
 from cms.djangoapps.course_creators.views import add_user_with_status_unrequested, get_course_creator_status
 from cms.djangoapps.models.settings.course_grading import CourseGradingModel
 from cms.djangoapps.models.settings.course_metadata import CourseMetadata

--- a/cms/djangoapps/contentstore/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_index.py
@@ -385,13 +385,13 @@ class TestCourseIndexArchived(CourseTestCase):
 
     @ddt.data(
         # Staff user has course staff access
-        (True, 'staff', None, 3, 18),
-        (False, 'staff', None, 3, 18),
+        (True, 'staff', None, 3, 20),
+        (False, 'staff', None, 3, 20),
         # Base user has global staff access
-        (True, 'user', ORG, 3, 18),
-        (False, 'user', ORG, 3, 18),
-        (True, 'user', None, 3, 18),
-        (False, 'user', None, 3, 18),
+        (True, 'user', ORG, 3, 20),
+        (False, 'user', ORG, 3, 20),
+        (True, 'user', None, 3, 20),
+        (False, 'user', None, 3, 20),
     )
     @ddt.unpack
     def test_separate_archived_courses(self, separate_archived_courses, username, org, mongo_queries, sql_queries):

--- a/lms/djangoapps/course_api/api.py
+++ b/lms/djangoapps/course_api/api.py
@@ -25,7 +25,7 @@ from openedx.core.lib.api.view_utils import LazySequence
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
 
-from .permissions import can_view_courses_for_username
+from .permissions import can_view_courses_for_username, PREVIEW_COURSE_KEY
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -173,7 +173,7 @@ def list_course_keys(request, username, role):
     all_course_keys = CourseOverview.get_all_course_keys()
 
     # Global staff have access to all courses. Filter courses for non-global staff.
-    if GlobalStaff().has_user(user):
+    if user.has_perm(PREVIEW_COURSE_KEY):
         return all_course_keys
 
     if role == 'staff':

--- a/lms/djangoapps/course_api/api.py
+++ b/lms/djangoapps/course_api/api.py
@@ -13,7 +13,6 @@ from opaque_keys.edx.django.models import CourseKeyField
 from rest_framework.exceptions import PermissionDenied
 
 from common.djangoapps.student.models import CourseAccessRole
-from common.djangoapps.student.roles import GlobalStaff
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.courses import (
     get_course_overview_with_access,

--- a/lms/djangoapps/course_api/permissions.py
+++ b/lms/djangoapps/course_api/permissions.py
@@ -8,6 +8,11 @@ from common.djangoapps.student.roles import GlobalStaff
 is_user_active = rules.is_authenticated & rules.is_active
 is_global_staff = is_user_active & rules.is_staff
 
+PREVIEW_COURSE_KEY = 'course_api.preview_course_key'
+
+perms[PREVIEW_COURSE_KEY] = is_global_staff
+
+
 def can_view_courses_for_username(requesting_user, target_username):
     """
     Determine whether `requesting_user` has permission to view courses available
@@ -36,7 +41,3 @@ def can_view_courses_for_username(requesting_user, target_username):
     else:
         staff = GlobalStaff()
         return staff.has_user(requesting_user)
-
-PREVIEW_COURSE_KEY = 'course_api.preview_course_key'
-
-perms[PREVIEW_COURSE_KEY] = is_global_staff

--- a/lms/djangoapps/course_api/permissions.py
+++ b/lms/djangoapps/course_api/permissions.py
@@ -2,9 +2,11 @@
 Course API Authorization functions
 """
 
-
+from bridgekeeper import perms, rules
 from common.djangoapps.student.roles import GlobalStaff
 
+is_user_active = rules.is_authenticated & rules.is_active
+is_global_staff = is_user_active & rules.is_staff
 
 def can_view_courses_for_username(requesting_user, target_username):
     """
@@ -34,3 +36,7 @@ def can_view_courses_for_username(requesting_user, target_username):
     else:
         staff = GlobalStaff()
         return staff.has_user(requesting_user)
+
+PREVIEW_COURSE_KEY = 'course_api.preview_course_key'
+
+perms[PREVIEW_COURSE_KEY] = is_global_staff

--- a/lms/djangoapps/discussion/django_comment_client/permissions.py
+++ b/lms/djangoapps/discussion/django_comment_client/permissions.py
@@ -21,6 +21,7 @@ from openedx.core.lib.cache_utils import request_cached
 is_user_active = rules.is_authenticated & rules.is_active
 is_global_staff = is_user_active & rules.is_staff
 
+
 def has_permission(user, permission, course_id=None):  # lint-amnesty, pylint: disable=missing-function-docstring
     assert isinstance(course_id, (type(None), CourseKey))
     request_cache_dict = DEFAULT_REQUEST_CACHE.data
@@ -204,6 +205,7 @@ def check_permissions_by_view(user, course_id, content, name, group_id=None, con
     assert isinstance(course_id, CourseKey)
     p = VIEW_PERMISSIONS.get(name)
     return _check_conditions_permissions(user, p, course_id, content, group_id, content_user_group)
+
 
 CAN_REPORT = 'discussion.can_report'
 perms[CAN_REPORT] = is_global_staff

--- a/lms/djangoapps/discussion/django_comment_client/permissions.py
+++ b/lms/djangoapps/discussion/django_comment_client/permissions.py
@@ -5,6 +5,7 @@ Module for checking permissions with the comment_client backend
 
 import logging
 
+from bridgekeeper import perms, rules
 from edx_django_utils.cache import DEFAULT_REQUEST_CACHE
 from opaque_keys.edx.keys import CourseKey
 
@@ -16,6 +17,9 @@ from openedx.core.djangoapps.django_comment_common.models import (
 )
 from openedx.core.lib.cache_utils import request_cached
 
+
+is_user_active = rules.is_authenticated & rules.is_active
+is_global_staff = is_user_active & rules.is_staff
 
 def has_permission(user, permission, course_id=None):  # lint-amnesty, pylint: disable=missing-function-docstring
     assert isinstance(course_id, (type(None), CourseKey))
@@ -200,3 +204,6 @@ def check_permissions_by_view(user, course_id, content, name, group_id=None, con
     assert isinstance(course_id, CourseKey)
     p = VIEW_PERMISSIONS.get(name)
     return _check_conditions_permissions(user, p, course_id, content, group_id, content_user_group)
+
+CAN_REPORT = 'discussion.can_report'
+perms[CAN_REPORT] = is_global_staff

--- a/lms/djangoapps/discussion/django_comment_client/utils.py
+++ b/lms/djangoapps/discussion/django_comment_client/utils.py
@@ -20,6 +20,7 @@ from common.djangoapps.student.roles import GlobalStaff
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.discussion.django_comment_client.constants import TYPE_ENTRY, TYPE_SUBCATEGORY
 from lms.djangoapps.discussion.django_comment_client.permissions import (
+    CAN_REPORT,
     check_permissions_by_view,
     get_team,
     has_permission
@@ -604,7 +605,7 @@ def get_ability(course_id, content, user):
             course_id,
             content,
             "flag_abuse_for_thread" if content['type'] == 'thread' else "flag_abuse_for_comment"
-        ) or GlobalStaff().has_user(user))
+        ) or user.has_perm(CAN_REPORT))
     }
 
 # TODO: RENAME

--- a/lms/djangoapps/discussion/tests/test_views.py
+++ b/lms/djangoapps/discussion/tests/test_views.py
@@ -480,18 +480,18 @@ class SingleThreadQueryCountTestCase(ForumsEnableMixin, ModuleStoreTestCase):
         # course is outside the context manager that is verifying the number of queries,
         # and with split mongo, that method ends up querying disabled_xblocks (which is then
         # cached and hence not queried as part of call_single_thread).
-        (ModuleStoreEnum.Type.mongo, False, 1, 5, 2, 21, 7),
-        (ModuleStoreEnum.Type.mongo, False, 50, 5, 2, 21, 7),
+        (ModuleStoreEnum.Type.mongo, False, 1, 5, 2, 23, 7),
+        (ModuleStoreEnum.Type.mongo, False, 50, 5, 2, 23, 7),
         # split mongo: 3 queries, regardless of thread response size.
-        (ModuleStoreEnum.Type.split, False, 1, 3, 3, 21, 8),
-        (ModuleStoreEnum.Type.split, False, 50, 3, 3, 21, 8),
+        (ModuleStoreEnum.Type.split, False, 1, 3, 3, 23, 8),
+        (ModuleStoreEnum.Type.split, False, 50, 3, 3, 23, 8),
 
         # Enabling Enterprise integration should have no effect on the number of mongo queries made.
-        (ModuleStoreEnum.Type.mongo, True, 1, 5, 2, 21, 7),
-        (ModuleStoreEnum.Type.mongo, True, 50, 5, 2, 21, 7),
+        (ModuleStoreEnum.Type.mongo, True, 1, 5, 2, 23, 7),
+        (ModuleStoreEnum.Type.mongo, True, 50, 5, 2, 23, 7),
         # split mongo: 3 queries, regardless of thread response size.
-        (ModuleStoreEnum.Type.split, True, 1, 3, 3, 21, 8),
-        (ModuleStoreEnum.Type.split, True, 50, 3, 3, 21, 8),
+        (ModuleStoreEnum.Type.split, True, 1, 3, 3, 23, 8),
+        (ModuleStoreEnum.Type.split, True, 50, 3, 3, 23, 8),
     )
     @ddt.unpack
     def test_number_of_mongo_queries(

--- a/openedx/core/djangoapps/enrollments/permissions.py
+++ b/openedx/core/djangoapps/enrollments/permissions.py
@@ -2,9 +2,18 @@
 Permission definitions for the enrollments djangoapp
 """
 
-from bridgekeeper import perms
+from bridgekeeper import perms, rules
 from lms.djangoapps.courseware.rules import HasAccessRule
 
+is_user_active = rules.is_authenticated & rules.is_active
+is_global_staff = is_user_active & rules.is_staff
+
 ENROLL_IN_COURSE = 'enrollment.enroll_in_course'
+VIEW_ENROLLMENT_DATA = 'enrollment.view_enrollment_data'
+CREATE_ENROLLMENT = 'enrollment.create_enrollment'
+DEACTIVATE_ENROLLMENT = 'enrollment.deactivate_enrollment'
 
 perms[ENROLL_IN_COURSE] = HasAccessRule('enroll')
+perms[VIEW_ENROLLMENT_DATA] = is_global_staff
+perms[CREATE_ENROLLMENT] = is_global_staff
+perms[DEACTIVATE_ENROLLMENT] = is_global_staff

--- a/openedx/core/djangoapps/theming/permissions.py
+++ b/openedx/core/djangoapps/theming/permissions.py
@@ -1,0 +1,12 @@
+"""
+Permission definitions for the theming djangoapp
+"""
+
+from bridgekeeper import perms, rules
+
+is_user_active = rules.is_authenticated & rules.is_active
+is_global_staff = is_user_active & rules.is_staff
+
+PREVIEW_THEME = 'theming.preview_theme'
+
+perms[PREVIEW_THEME] = is_global_staff

--- a/openedx/core/djangoapps/theming/views.py
+++ b/openedx/core/djangoapps/theming/views.py
@@ -12,6 +12,7 @@ from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _
 from web_fragments.fragment import Fragment
 
+from openedx.core.djangoapps.theming.permissions import PREVIEW_THEME
 from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
 from openedx.core.djangoapps.user_api.preferences.api import (
     delete_user_preference,
@@ -40,7 +41,7 @@ def user_can_preview_themes(user):
         return True
 
     # Otherwise, only global staff can preview themes
-    return GlobalStaff().has_user(user)
+    return user.has_perm(PREVIEW_THEME)
 
 
 def get_user_preview_site_theme(request):


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description
This PR implements best practice for handling the permission by following Django's recommended way of using ```user.has_perm```. 

## Supporting information
JIRA ticket: [SE-4469](https://tasks.opencraft.com/browse/SE-4469)

INCR project  tickets:
- [INCR-563](https://openedx.atlassian.net/browse/INCR-563)
- [INCR-564](https://openedx.atlassian.net/browse/INCR-564)
- [INCR-565](https://openedx.atlassian.net/browse/INCR-565)
- [INCR-566](https://openedx.atlassian.net/browse/INCR-566)
- [INCR-567](https://openedx.atlassian.net/browse/INCR-567)
- [INCR-568](https://openedx.atlassian.net/browse/INCR-568)
- [INCR-569](https://openedx.atlassian.net/browse/INCR-569)

## Author Note
At few places using `GlobalStaff.has_user` feels more appropriate rather than using `has_perm`. Mention these lines from the code here

 - Unit Test code using GlobalStaff
 - [Decorator Method](https://github.com/open-craft/edx-platform/blob/8b12d7dd8e602b441f67199c82f466550ccccf20/common/djangoapps/util/views.py#L73)
 - [Test method Global staff role](https://github.com/open-craft/edx-platform/blob/8b12d7dd8e602b441f67199c82f466550ccccf20/common/djangoapps/student/tests/test_roles.py#L42)
 - [Staff role check](https://github.com/open-craft/edx-platform/blob/8b12d7dd8e602b441f67199c82f466550ccccf20/common/djangoapps/student/role_helpers.py#L35)

## Deadline

"None"

## Other information
"None"

## Reviewers
- [ ] @gabor-boros 