### PR TITLE
refactor: Updating cert availability messaging.

### DIFF
--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -267,6 +267,7 @@ def certificate_downloadable_status(student, course_key):
         course_overview.certificate_available_date
     ):
         response_data['earned_but_not_available'] = True
+        response_data['certificate_available_date'] = course_overview.certificate_available_date
 
     may_view_certificate = course_overview.may_certify()
     if current_status['status'] == CertificateStatuses.downloadable and may_view_certificate:

--- a/lms/djangoapps/course_home_api/progress/v1/serializers.py
+++ b/lms/djangoapps/course_home_api/progress/v1/serializers.py
@@ -69,6 +69,7 @@ class CertificateDataSerializer(serializers.Serializer):
     cert_status = serializers.CharField()
     cert_web_view_url = serializers.CharField()
     download_url = serializers.CharField()
+    certificate_available_date = serializers.DateTimeField()
 
 
 class VerificationDataSerializer(serializers.Serializer):

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -149,7 +149,7 @@ log = logging.getLogger("edx.courseware")
 REQUIREMENTS_DISPLAY_MODES = CourseMode.CREDIT_MODES + [CourseMode.VERIFIED]
 
 CertData = namedtuple(
-    "CertData", ["cert_status", "title", "msg", "download_url", "cert_web_view_url"]
+    "CertData", ["cert_status", "title", "msg", "download_url", "cert_web_view_url", "certificate_available_date"]
 )
 EARNED_BUT_NOT_AVAILABLE_CERT_STATUS = 'earned_but_not_available'
 
@@ -158,7 +158,8 @@ AUDIT_PASSING_CERT_DATA = CertData(
     _('Your enrollment: Audit track'),
     _('You are enrolled in the audit track for this course. The audit track does not include a certificate.'),
     download_url=None,
-    cert_web_view_url=None
+    cert_web_view_url=None,
+    certificate_available_date=None
 )
 
 HONOR_PASSING_CERT_DATA = CertData(
@@ -166,7 +167,8 @@ HONOR_PASSING_CERT_DATA = CertData(
     _('Your enrollment: Honor track'),
     _('You are enrolled in the honor track for this course. The honor track does not include a certificate.'),
     download_url=None,
-    cert_web_view_url=None
+    cert_web_view_url=None,
+    certificate_available_date=None
 )
 
 INELIGIBLE_PASSING_CERT_DATA = {
@@ -182,7 +184,8 @@ GENERATING_CERT_DATA = CertData(
         "to it will appear here and on your Dashboard when it is ready."
     ),
     download_url=None,
-    cert_web_view_url=None
+    cert_web_view_url=None,
+    certificate_available_date=None
 )
 
 INVALID_CERT_DATA = CertData(
@@ -190,7 +193,8 @@ INVALID_CERT_DATA = CertData(
     _('Your certificate has been invalidated'),
     _('Please contact your course team if you have any questions.'),
     download_url=None,
-    cert_web_view_url=None
+    cert_web_view_url=None,
+    certificate_available_date=None
 )
 
 REQUESTING_CERT_DATA = CertData(
@@ -198,7 +202,8 @@ REQUESTING_CERT_DATA = CertData(
     _('Congratulations, you qualified for a certificate!'),
     _("You've earned a certificate for this course."),
     download_url=None,
-    cert_web_view_url=None
+    cert_web_view_url=None,
+    certificate_available_date=None
 )
 
 UNVERIFIED_CERT_DATA = CertData(
@@ -209,16 +214,20 @@ UNVERIFIED_CERT_DATA = CertData(
         'verified identity.'
     ).format(platform_name=configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME)),
     download_url=None,
-    cert_web_view_url=None
+    cert_web_view_url=None,
+    certificate_available_date=None
 )
 
-EARNED_BUT_NOT_AVAILABLE_CERT_DATA = CertData(
-    EARNED_BUT_NOT_AVAILABLE_CERT_STATUS,
-    _('Your certificate will be available soon!'),
-    _('After this course officially ends, you will receive an email notification with your certificate.'),
-    download_url=None,
-    cert_web_view_url=None
-)
+
+def _earned_but_not_available_cert_data(cert_downloadable_status):
+    return CertData(
+        EARNED_BUT_NOT_AVAILABLE_CERT_STATUS,
+        _('Your certificate will be available soon!'),
+        _('After this course officially ends, you will receive an email notification with your certificate.'),
+        download_url=None,
+        cert_web_view_url=None,
+        certificate_available_date=cert_downloadable_status.get('certificate_available_date')
+    )
 
 
 def _downloadable_cert_data(download_url=None, cert_web_view_url=None):
@@ -227,7 +236,8 @@ def _downloadable_cert_data(download_url=None, cert_web_view_url=None):
         _('Your certificate is available'),
         _("You've earned a certificate for this course."),
         download_url=download_url,
-        cert_web_view_url=cert_web_view_url
+        cert_web_view_url=cert_web_view_url,
+        certificate_available_date=None
     )
 
 
@@ -1239,7 +1249,7 @@ def _certificate_message(student, course, enrollment_mode):  # lint-amnesty, pyl
     cert_downloadable_status = certs_api.certificate_downloadable_status(student, course.id)
 
     if cert_downloadable_status.get('earned_but_not_available'):
-        return EARNED_BUT_NOT_AVAILABLE_CERT_DATA
+        return _earned_but_not_available_cert_data(cert_downloadable_status)
 
     if cert_downloadable_status['is_generating']:
         return GENERATING_CERT_DATA

--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -956,6 +956,10 @@
         margin: 0;
       }
 
+      &.course-status-processing {
+        color: #0d7d4d;
+      }
+
       .credit-action {
         .credit-btn {
           @extend %btn-pl-yellow-base;

--- a/lms/templates/dashboard/_dashboard_certificate_information.html
+++ b/lms/templates/dashboard/_dashboard_certificate_information.html
@@ -37,7 +37,7 @@ else:
       <p class="message-copy">
         <%
           certificate_available_date_string = course_overview.certificate_available_date.strftime('%Y-%m-%dT%H:%M:%S%z')
-          container_string = _("Your certificate will be available on or after {date}")
+          container_string = _("Your grade and certificate will be ready after {date}.")
           format = 'shortDate'
         %>
         <span class="info-date-block localized-datetime" data-language="${user_language}" data-timezone="${user_timezone}" data-datetime="${certificate_available_date_string}" data-format=${format} data-string="${container_string}"></span>


### PR DESCRIPTION
[MICROBA-678]

Added cert availability date to the API used to get certificate status
by the learning MFE to support updated messaging.

Updated the cert availability messaging in the Coruse Dashboard,
including a text color change.

The changes in this PR can be seen in the following situation:

The course is Instructor paced
The course has ended
Display Behavior: End
Cert availability has not passed.
Cert Earned

[MICROBA-678]: https://openedx.atlassian.net/browse/MICROBA-678