### PR TITLE
[OSPR-5796] [BB-2862] "LANGUAGE_CODE" site configuration option

### DIFF
--- a/openedx/core/djangoapps/dark_lang/middleware.py
+++ b/openedx/core/djangoapps/dark_lang/middleware.py
@@ -16,6 +16,7 @@ from django.utils.deprecation import MiddlewareMixin
 
 from openedx.core.djangoapps.dark_lang import DARK_LANGUAGE_KEY
 from openedx.core.djangoapps.dark_lang.models import DarkLangConfig
+from openedx.core.djangoapps.site_configuration.helpers import get_value
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preference
 
 # If django 1.7 or higher is used, the right-side can be updated with new-style codes.
@@ -90,7 +91,16 @@ class DarkLangMiddleware(MiddlewareMixin):
             return
 
         self._clean_accept_headers(request)
+        self._set_site_or_microsite_language(request)
         self._activate_preview_language(request)
+
+    def _set_site_or_microsite_language(self, request):
+        """
+        Apply language specified in site configuration.
+        """
+        language = get_value('LANGUAGE_CODE', None)
+        if language:
+            request.session[LANGUAGE_SESSION_KEY] = language
 
     def _fuzzy_match(self, lang_code):
         """Returns a fuzzy match for lang_code"""

--- a/openedx/core/djangoapps/dark_lang/tests.py
+++ b/openedx/core/djangoapps/dark_lang/tests.py
@@ -13,6 +13,7 @@ from django.utils.translation import LANGUAGE_SESSION_KEY
 
 from openedx.core.djangoapps.dark_lang.middleware import DarkLangMiddleware
 from openedx.core.djangoapps.dark_lang.models import DarkLangConfig
+from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
 from common.djangoapps.student.tests.factories import UserFactory
 
@@ -255,6 +256,16 @@ class DarkLangMiddlewareTests(CacheIsolationTestCase):
         session = self.client.session
         session[LANGUAGE_SESSION_KEY] = session_language
         session.save()
+
+    @with_site_configuration(configuration={'LANGUAGE_CODE': 'rel'})
+    def test_site_configuration_language(self):
+        # `LANGUAGE_CODE` in site configuration should override session lang
+        self._set_client_session_language('notrel')
+        self.client.get('/home')
+        self.assert_session_lang_equals(
+            'rel',
+            self.client.session
+        )
 
     def test_preview_lang_with_released_language(self):
         # Preview lang should always override selection


### PR DESCRIPTION
One of our clients has an Arabic site and asked us if it's possible to show it in Arabic regardless of user's language settings. We discovered, that as is, it's impossible to do this in platform.

So, this PR is adding support of `LANGUAGE_CODE` site configuration option, which makes it possible to change translation of the entire site for all learners from Django admin panel.

**JIRA tickets**: 
- [OSPR-5796](https://openedx.atlassian.net/browse/OSPR-5796)
- [BB-2862](https://tasks.opencraft.com/browse/BB-2862)

**Sandbox URL**:
- https://pr27696.sandbox.opencraft.hosting/

**Testing instructions**:

https://pr27696.sandbox.opencraft.hosting/ has default configuration.

1. Open https://pr27696.sandbox.opencraft.hosting/admin/site_configuration/siteconfiguration/3/change/ (`staff:edx`).
2. Change `LANGUAGE_CODE` to `ar` and save.
3. Open https://pr27696.sandbox.opencraft.hosting in a new anonymous browser tab. Sign in (`staff@example.com:edx`).
4. Verify that language changed to Arabian.

**Reviewers**
- [x] @viadanna 
- [x] @DawoudSheraz 