### PR TITLE
chore: update edx-proctoring version

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -457,7 +457,7 @@ edx-organizations==6.9.0
     # via -r requirements/edx/base.in
 edx-proctoring-proctortrack==1.0.5
     # via -r requirements/edx/base.in
-edx-proctoring==3.10.2
+edx-proctoring==3.11.0
     # via
     #   -r requirements/edx/base.in
     #   edx-proctoring-proctortrack

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -548,7 +548,7 @@ edx-organizations==6.9.0
     # via -r requirements/edx/testing.txt
 edx-proctoring-proctortrack==1.0.5
     # via -r requirements/edx/testing.txt
-edx-proctoring==3.10.2
+edx-proctoring==3.11.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-proctoring-proctortrack

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -532,7 +532,7 @@ edx-organizations==6.9.0
     # via -r requirements/edx/base.txt
 edx-proctoring-proctortrack==1.0.5
     # via -r requirements/edx/base.txt
-edx-proctoring==3.10.2
+edx-proctoring==3.11.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring-proctortrack


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This version of the edx-proctoring library includes changes to the onboarding status panel that is displayed in a learner's course outline. If all onboarding exams are past due, the button to go to the onboarding exam will be grayed out and will contain the text "Onboarding Past Due". If there are any available onboarding exams, the panel will work as before. If there are any onboarding exams that will be released in the future, they will be prioritized over the past due onboarding exams.



## Supporting information

* [MST-746](https://openedx.atlassian.net/browse/MST-746)
* https://github.com/edx/edx-proctoring/pull/855
