### PR TITLE
[FAL-249] chore: update DnD xblock version

### DIFF
--- a/requirements/edx-sandbox/py35.txt
+++ b/requirements/edx-sandbox/py35.txt
@@ -62,7 +62,6 @@ numpy==1.16.5
     #   chem
     #   matplotlib
     #   openedx-calc
-    #   scipy
 openedx-calc==1.0.9
     # via -r requirements/edx-sandbox/py35.in
 pycparser==2.20

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -1038,7 +1038,7 @@ wrapt==1.11.2
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/paver.txt
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.3.4#egg=xblock-drag-and-drop-v2==2.3.4
+git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.3.5#egg=xblock-drag-and-drop-v2==2.3.5
     # via -r requirements/edx/github.in
 git+https://github.com/open-craft/xblock-poll@922cd36fb1c3cfe00b4ce03b19a13185d136447d#egg=xblock-poll==1.10.2
     # via -r requirements/edx/github.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1442,7 +1442,7 @@ wrapt==1.11.2
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   astroid
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.3.4#egg=xblock-drag-and-drop-v2==2.3.4
+git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.3.5#egg=xblock-drag-and-drop-v2==2.3.5
     # via -r requirements/edx/testing.txt
 git+https://github.com/open-craft/xblock-poll@922cd36fb1c3cfe00b4ce03b19a13185d136447d#egg=xblock-poll==1.10.2
     # via -r requirements/edx/testing.txt

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -72,4 +72,4 @@ git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a5#egg=django-rate
 # Third Party XBlocks
 
 git+https://github.com/open-craft/xblock-poll@922cd36fb1c3cfe00b4ce03b19a13185d136447d#egg=xblock-poll==1.10.2
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.3.4#egg=xblock-drag-and-drop-v2==2.3.4
+git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.3.5#egg=xblock-drag-and-drop-v2==2.3.5

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1349,7 +1349,7 @@ wrapt==1.11.2
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   astroid
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.3.4#egg=xblock-drag-and-drop-v2==2.3.4
+git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.3.5#egg=xblock-drag-and-drop-v2==2.3.5
     # via -r requirements/edx/base.txt
 git+https://github.com/open-craft/xblock-poll@922cd36fb1c3cfe00b4ce03b19a13185d136447d#egg=xblock-poll==1.10.2
     # via -r requirements/edx/base.txt


### PR DESCRIPTION
## Description

This PR is about updating the version of of the [xblock-drag-and-drop-v2](https://github.com/edx-solutions/xblock-drag-and-drop-v2) xblock

The update is necessary to include the xblock translations, specifically added to https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/271

## Testing instructions

No need to test this as it doesn't introduce breaking changes and this was already tested in https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/271

## Reviewers
- [ ] @pomegranited 