### PR TITLE
refactor: less confusing ACE configuration

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -4921,15 +4921,10 @@ HIBP_LOGIN_BLOCK_PASSWORD_FREQUENCY_THRESHOLD = 5
 ENABLE_DYNAMIC_REGISTRATION_FIELDS = False
 
 ############### Settings for the ace_common plugin #################
-ACE_ENABLED_CHANNELS = ['django_email']
-ACE_ENABLED_POLICIES = ['bulk_email_optout']
-ACE_CHANNEL_SAILTHRU_DEBUG = True
-ACE_CHANNEL_SAILTHRU_TEMPLATE_NAME = None
-ACE_ROUTING_KEY = 'edx.lms.core.default'
-ACE_CHANNEL_DEFAULT_EMAIL = 'django_email'
-ACE_CHANNEL_TRANSACTIONAL_EMAIL = 'django_email'
-ACE_CHANNEL_SAILTHRU_API_KEY = ""
-ACE_CHANNEL_SAILTHRU_API_SECRET = ""
+# Note that all settings are actually defined by the plugin
+# pylint: disable=wrong-import-position
+from openedx.core.djangoapps.ace_common.settings import common as ace_common_settings
+ACE_ROUTING_KEY = ace_common_settings.ACE_ROUTING_KEY
 
 ############### Settings swift #####################################
 SWIFT_USERNAME = None

--- a/openedx/core/djangoapps/ace_common/settings/common.py
+++ b/openedx/core/djangoapps/ace_common/settings/common.py
@@ -2,6 +2,8 @@
 Settings for ace_common app.
 """
 
+ACE_ROUTING_KEY = 'edx.lms.core.default'
+
 
 def plugin_settings(settings):  # lint-amnesty, pylint: disable=missing-function-docstring, missing-module-docstring
     settings.ACE_ENABLED_CHANNELS = [
@@ -17,6 +19,6 @@ def plugin_settings(settings):  # lint-amnesty, pylint: disable=missing-function
     settings.ACE_CHANNEL_DEFAULT_EMAIL = 'django_email'
     settings.ACE_CHANNEL_TRANSACTIONAL_EMAIL = 'django_email'
 
-    settings.ACE_ROUTING_KEY = 'edx.core.low'
+    settings.ACE_ROUTING_KEY = ACE_ROUTING_KEY
 
     settings.FEATURES['test_django_plugin'] = True


### PR DESCRIPTION
## Description

The ACE_* settings from lms/envs/common.py are all ignored because they are
overloaded by the plugin settings. We were recently bitten by this, as we
discovered that the ACE_ROUTING_KEY was incorrectly set to 'edx.core.low'.
Here, we fix this default value and remove ACE_* settings from
lms/envs/common.py to avoid confusion.

## Supporting information

See: https://github.com/overhangio/tutor/issues/439
