### PR TITLE
refactor: remove obsolete setting ENABLE_INSTRUCTOR_ANALYTICS

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -340,7 +340,6 @@ FEATURES = {
     # Prevent auto auth from creating superusers or modifying existing users
     'RESTRICT_AUTOMATIC_AUTH': True,
 
-    'ENABLE_INSTRUCTOR_ANALYTICS': False,
     'PREVIEW_LMS_BASE': "preview.localhost:18000",
     'ENABLE_GRADE_DOWNLOADS': True,
     'ENABLE_MKTG_SITE': False,


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

ENABLE_INSTRUCTOR_ANALYTICS was removed in 2015 by https://github.com/edx/edx-platform/pull/7322. A non-functional feature flag was reintroduced, probably by being copied from the [configuration repo](https://github.com/edx/configuration/search?q=ENABLE_INSTRUCTOR_ANALYTICS). This PR removes it again. 

## Testing instructions

No testing needed

## Deadline

None

## Other information

Since the flag is non-functional, a deprecation isn't necessary. 
