### PR TITLE
feat: add `edx.certificate.revoked` event

### DIFF
--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -647,7 +647,7 @@ def remove_allowlist_entry(user, course_key):
         certificate = get_certificate_for_user(user.username, course_key, False)
         if certificate:
             log.info(f"Invalidating certificate for student {user.id} in course {course_key} before allowlist removal.")
-            certificate.invalidate()
+            certificate.invalidate(source='allowlist_removal')
 
         log.info(f"Removing student {user.id} from the allowlist in course {course_key}.")
         allowlist_entry.delete()

--- a/lms/djangoapps/certificates/generation_handler.py
+++ b/lms/djangoapps/certificates/generation_handler.py
@@ -258,7 +258,7 @@ def _set_v2_cert_status(user, course_key):
         if cert is None:
             cert = GeneratedCertificate.objects.create(user=user, course_id=course_key)
         if cert.status != CertificateStatuses.notpassing:
-            cert.mark_notpassing(course_grade.percent)
+            cert.mark_notpassing(course_grade.percent, source='certificate_generation')
         return CertificateStatuses.notpassing
 
     return None
@@ -275,14 +275,14 @@ def _get_cert_status_common(user, course_key, cert):
         if cert is None:
             cert = GeneratedCertificate.objects.create(user=user, course_id=course_key)
         if cert.status != CertificateStatuses.unavailable:
-            cert.invalidate()
+            cert.invalidate(source='certificate_generation')
         return CertificateStatuses.unavailable
 
     if not IDVerificationService.user_is_verified(user):
         if cert is None:
             cert = GeneratedCertificate.objects.create(user=user, course_id=course_key)
         if cert.status != CertificateStatuses.unverified:
-            cert.mark_unverified()
+            cert.mark_unverified(source='certificate_generation')
         return CertificateStatuses.unverified
 
     return None

--- a/lms/djangoapps/certificates/queue.py
+++ b/lms/djangoapps/certificates/queue.py
@@ -140,7 +140,7 @@ class XQueueCertInterface:
                 )
                 return None
 
-            certificate.invalidate()
+            certificate.invalidate(source='certificate_regeneration')
 
             LOGGER.info(
                 f"The certificate status for student {student.id} in course '{course_id} has been changed to "

--- a/lms/djangoapps/certificates/services.py
+++ b/lms/djangoapps/certificates/services.py
@@ -35,7 +35,7 @@ class CertificateService:
                 user=user_id,
                 course_id=course_key
             )
-            generated_certificate.invalidate()
+            generated_certificate.invalidate(source='certificate_service')
         except ObjectDoesNotExist:
             log.warning(
                 'Invalidation failed because a certificate for user %d in course %s does not exist.',

--- a/lms/djangoapps/certificates/signals.py
+++ b/lms/djangoapps/certificates/signals.py
@@ -114,7 +114,7 @@ def _listen_for_failing_grade(sender, user, course_id, grade, **kwargs):  # pyli
     cert = GeneratedCertificate.certificate_for_student(user, course_id)
     if cert is not None:
         if CertificateStatuses.is_passing_status(cert.status):
-            cert.mark_notpassing(grade.percent)
+            cert.mark_notpassing(grade.percent, source='notpassing_signal')
             log.info('Certificate marked not passing for {user} : {course} via failing grade: {grade}'.format(
                 user=user.id,
                 course=course_id,

--- a/lms/djangoapps/certificates/tests/test_api.py
+++ b/lms/djangoapps/certificates/tests/test_api.py
@@ -67,6 +67,7 @@ from lms.djangoapps.certificates.tests.factories import (
     CertificateInvalidationFactory
 )
 from lms.djangoapps.grades.tests.utils import mock_passing_grade
+from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration
 
 FEATURES_WITH_CERTS_ENABLED = settings.FEATURES.copy()
@@ -252,6 +253,9 @@ class CertificateIsInvalid(WebCertificateTestMixin, ModuleStoreTestCase):
             org='edx',
             number='verified',
             display_name='Verified Course'
+        )
+        self.course_overview = CourseOverviewFactory.create(
+            id=self.course.id
         )
         self.global_staff = GlobalStaffFactory()
         self.request_factory = RequestFactory()

--- a/lms/djangoapps/certificates/tests/test_services.py
+++ b/lms/djangoapps/certificates/tests/test_services.py
@@ -7,6 +7,7 @@ from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.certificates.models import CertificateStatuses, GeneratedCertificate
 from lms.djangoapps.certificates.services import CertificateService
 from lms.djangoapps.certificates.tests.factories import CertificateAllowlistFactory, GeneratedCertificateFactory
+from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
@@ -20,6 +21,9 @@ class CertificateServiceTests(ModuleStoreTestCase):
         super().setUp()
         self.service = CertificateService()
         self.course = CourseFactory()
+        self.course_overview = CourseOverviewFactory.create(
+            id=self.course.id
+        )
         self.user = UserFactory()
         self.user_id = self.user.id
         self.course_id = self.course.id  # pylint: disable=no-member

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -3332,7 +3332,7 @@ def invalidate_certificate(request, generated_certificate, certificate_invalidat
     )
 
     # Invalidate the certificate
-    generated_certificate.invalidate()
+    generated_certificate.invalidate(source='certificate_invalidation_list')
 
     return {
         'id': certificate_invalidation.id,

--- a/lms/djangoapps/instructor_task/tasks_helper/certs.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/certs.py
@@ -157,4 +157,4 @@ def _invalidate_generated_certificates(course_id, enrolled_students, certificate
                          f'for course {course_id}')
             else:
                 log.info(f'About to invalidate certificate for user {c.user.id} in course {course_id}')
-                c.invalidate()
+                c.invalidate(source='bulk_certificate_regeneration')


### PR DESCRIPTION
## Description

[MICROBA-1075]
- Adds a new `edx.certificate.revoked` event to the LMS.
- Refactor of our certificate revocation functions in the GeneratedCertificate model.

## Supporting information

This new event will be emit when a GeneratedCertificate with the status of `downloadable` is revoked (through the `invalidate()`, `mark_notpassing()`, or `mark_unverified()` functions). Event will have a `source` field that will allow us how our certificates are being revoked from learners and can be broken down in the following way:
*Invalidate*
- allowlist_removal
- certificate_generation
- certificate_regeneration
- certificate_service
- certificate_invalidation_list
- bulk_certificate_regeneration

*mark_notpassing*
- certificate_generation
- notpassing_signal

*unverified*
- certificate_generation

Example event:
{
  "name": "edx.certificate.revoked",
  "context": {
    "course_id": "course-v1:edX+Hynes101+1T2021",
    "course_user_tags": {
      "view-welcome-message": "8b1a9953c4611296a827abf8c47804d7,512fed79306bca7259114ef8b4ee5d22"
    },
    "user_id": 3,
    "path": "/courses/course-v1:edX+Hynes101+1T2021/instructor/api/certificate_invalidation_view/",
    "org_id": "edX"
  },
  "username": "edx",
  "session": "f78b929cb03341df53ef6af046ca80d4",
  "ip": "172.19.0.1",
  "agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.82 Safari/537.36",
  "host": "localhost:18000",
  "referer": "http://localhost:18000/courses/course-v1:edX+Hynes101+1T2021/instructor",
  "accept_language": "en-US,en;q=0.9,es-MX;q=0.8,es-ES;q=0.7,es;q=0.6,de;q=0.5,fr;q=0.4",
  "event": {
    "user_id": 3,
    "course_id": "course-v1:edX+Hynes101+1T2021",
    "certificate_id": "25bd9f47a7b14a5f9a3f77e5ac8fa6a7",
    "enrollment_mode": "verified",
    "source": "certificate_invalidation_list",
    "certificate_url": "/certificates/25bd9f47a7b14a5f9a3f77e5ac8fa6a7"
  },
  "time": "2021-05-25T14:25:22.583323+00:00",
  "event_type": "edx.certificate.revoked",
  "event_source": "server",
  "page": null
}

[MICROBA-1075]: https://openedx.atlassian.net/browse/MICROBA-1075