### PR TITLE
[AA-759] update name of flag in bucketing check

### DIFF
--- a/lms/djangoapps/experiments/flags.py
+++ b/lms/djangoapps/experiments/flags.py
@@ -265,7 +265,7 @@ class ExperimentWaffleFlag(CourseWaffleFlag):
             request.session[session_key] = True
 
             # Temporary event for AA-759 experiment
-            if course_key and self._experiment_name == 'AA-759':
+            if course_key and self._experiment_name == 'discount_experiment_AA759':
                 modes_dict = CourseMode.modes_for_course_dict(course_id=course_key, include_expired=False)
                 verified_mode = modes_dict.get('verified', None)
                 if verified_mode:

--- a/lms/djangoapps/experiments/utils.py
+++ b/lms/djangoapps/experiments/utils.py
@@ -74,7 +74,7 @@ UPSELL_TRACKING_FLAG = LegacyWaffleFlag(
 )
 # TODO END: Clean up as part of REV-1205 (End)
 
-# .. toggle_name: streak_celebration.AA-759
+# .. toggle_name: streak_celebration.discount_experiment_AA759
 # .. toggle_implementation: ExperimentWaffleFlag
 # .. toggle_default: False
 # .. toggle_description: This experiment flag enables an engagement discount incentive message.


### PR DESCRIPTION
I updated the name of the flag based on a PR comment but missed a spot that is necessary for users to be bucketed properly

(The flag name is now streak_celebration.discount_experiment_AA759 in the toggle definition and in django admin)