### PR TITLE
build: add course authoring mfe url in settings

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -160,6 +160,9 @@ FEATURES['FRONTEND_APP_PUBLISHER_URL'] = 'http://localhost:18400'
 ################### FRONTEND APPLICATION LIBRARY AUTHORING ###################
 LIBRARY_AUTHORING_MICROFRONTEND_URL = 'http://localhost:3001'
 
+################### FRONTEND APPLICATION COURSE AUTHORING ###################
+COURSE_AUTHORING_MICROFRONTEND_URL = 'http://localhost:2001'
+
 ################################# DJANGO-REQUIRE ###############################
 
 # Whether to run django-require in debug mode.


### PR DESCRIPTION
Related to https://github.com/edx/edx-platform/pull/26965

This is the follow-up PR that adds the URL of Course Authoring MFE in the devstack. With the current configuration, devstack users can not see the new button because the base URL is not defined. 

Testing:
Current behavior
1. Add and Enable Django Waffle flag: `studio.pages_and_resources_mfe` visit Pages view in the studio. 
2. Observe **no** button is visible "View new Pages and Resources Experience"

Verify Fix:
1. Add and Enable Django Waffle flag: `studio.pages_and_resources_mfe` visit Pages view in the studio. 
2. Observe  button is now visible "View new Pages and Resources Experience"
--


<br class="Apple-interchange-newline">