### PR TITLE
fix: remap explicit queues for program tasks

### DIFF
--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -1030,13 +1030,13 @@ EXPLICIT_QUEUES = {
         'queue': POLICY_CHANGE_GRADES_ROUTING_KEY},
     'lms.djangoapps.grades.tasks.recalculate_subsection_grade_v3': {
         'queue': RECALCULATE_GRADES_ROUTING_KEY},
-    'openedx.core.djangoapps.programs.tasks.v1.tasks.award_program_certificates': {
+    'openedx.core.djangoapps.programs.tasks.award_program_certificates': {
         'queue': PROGRAM_CERTIFICATES_ROUTING_KEY},
-    'openedx.core.djangoapps.programs.tasks.v1.tasks.revoke_program_certificates': {
+    'openedx.core.djangoapps.programs.tasks.revoke_program_certificates': {
         'queue': PROGRAM_CERTIFICATES_ROUTING_KEY},
-    'openedx.core.djangoapps.programs.tasks.v1.tasks.update_certificate_visible_date_on_course_update': {
+    'openedx.core.djangoapps.programs.tasks.update_certificate_visible_date_on_course_update': {
         'queue': PROGRAM_CERTIFICATES_ROUTING_KEY},
-    'openedx.core.djangoapps.programs.tasks.v1.tasks.award_course_certificate': {
+    'openedx.core.djangoapps.programs.tasks.award_course_certificate': {
         'queue': PROGRAM_CERTIFICATES_ROUTING_KEY},
     'openedx.core.djangoapps.coursegraph.dump_course_to_neo4j': {
         'queue': COURSEGRAPH_JOB_QUEUE},

--- a/openedx/core/djangoapps/programs/tasks.py
+++ b/openedx/core/djangoapps/programs/tasks.py
@@ -137,6 +137,9 @@ def award_program_certificates(self, username):  # lint-amnesty, pylint: disable
     change - for example, to backpopulate missing program credentials for a
     student.
 
+    If this function is moved, make sure to update it's entry in
+    EXPLICIT_QUEUES in the settings files so it runs in the correct queue.
+
     Args:
         username (str): The username of the student
 
@@ -364,6 +367,9 @@ def award_course_certificate(self, username, course_run_key, certificate_availab
     This task is designed to be called whenever a student GeneratedCertificate is updated.
     It can be called independently for a username and a course_run, but is invoked on each GeneratedCertificate.save.
 
+    If this function is moved, make sure to update it's entry in
+    EXPLICIT_QUEUES in the settings files so it runs in the correct queue.
+
     Arguments:
         username (str): The user to award the Credentials course cert to
         course_run_key (str): The course run key to award the certificate for
@@ -524,6 +530,9 @@ def revoke_program_certificates(self, username, course_key):  # lint-amnesty, py
     specified user's certificate should be revoked in one or more programs, and
     use the credentials service to revoke the said certificates if so.
 
+    If this function is moved, make sure to update it's entry in
+    EXPLICIT_QUEUES in the settings files so it runs in the correct queue.
+
     Args:
         username (str): The username of the student
         course_key (str): The course identifier
@@ -673,6 +682,9 @@ def update_certificate_visible_date_on_course_update(self, course_key, certifica
     It will get all users within the course that have a certificate and call
     the credentials API to update all these certificates visible_date value
     to keep certificates in sync on both sides.
+
+    If this function is moved, make sure to update it's entry in
+    EXPLICIT_QUEUES in the settings files so it runs in the correct queue.
 
     Arguments:
         course_key (str): The course identifier


### PR DESCRIPTION


## Description
This updates the explicit queue mapping to match the actual task names for  programs tasks.  Program tasks got moved from tasks.v1.tasks.py to just tasks.py, but the mapping was never updated.

## Testing instructions

## Other information

Queue should already exist, so this should just put tasks in it. 