### PR TITLE
feat: add flag to override streak logic and always show streak for testing purposes

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -72,7 +72,7 @@ from lms.djangoapps.courseware.models import (
     DynamicUpgradeDeadlineConfiguration,
     OrgDynamicUpgradeDeadlineConfiguration,
 )
-from lms.djangoapps.courseware.toggles import streak_celebration_is_active
+from lms.djangoapps.courseware.toggles import streak_celebration_is_active, STREAK_CELEBRATION_TESTING_FLAG
 from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.enrollments.api import (
@@ -3282,6 +3282,13 @@ class UserCelebration(TimeStampedModel):
             return the length of the streak the user should celebrate.
             Also update the streak data that is stored in the database."""
         # importing here to avoid a circular import
+
+        # Override streak logic to show streak for testing purposes
+        # Temporary flag for AA-759 to simplify testing so that waiting
+        # 3 days is not necessary to see a streak modal
+        if STREAK_CELEBRATION_TESTING_FLAG.is_enabled():
+            return 3
+
         from lms.djangoapps.courseware.masquerade import is_masquerading_as_specific_student
         if not user or user.is_anonymous:
             return None

--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -85,6 +85,24 @@ COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES_STREAK_CELEBRATION = CourseWaffleFl
     WAFFLE_FLAG_NAMESPACE, 'mfe_progress_milestones_streak_celebration', __name__
 )
 
+# .. toggle_name: courseware.streak_celebration_testing
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: End to end testing features around the streak celebration
+# .. is complex, since it requires waiting 3 days to hit the streak.
+# .. The purpose of this flag is to allow developers to test streak related features
+# .. end to end in production without having to wait 3 days to do so for each test case.
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2021-05-16
+# .. toggle_target_removal_date: None
+# .. toggle_warnings: Also set settings.LEARNING_MICROFRONTEND_URL and
+#   COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES and
+#   COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES_STREAK_CELEBRATION
+# .. toggle_tickets: AA-759
+STREAK_CELEBRATION_TESTING_FLAG = CourseWaffleFlag(
+    WAFFLE_FLAG_NAMESPACE, 'streak_celebration_testing', __name__
+)
+
 # .. toggle_name: courseware.optimized_render_xblock
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False


### PR DESCRIPTION
Per discussion with Jason it seems like having to wait 3 days to test the streak experiment adds some extra complexity to verifying the logic for this experiment

This is a temporary flag to simplify the process of testing the experiment end to end in production (or at least close to it)