### PR TITLE
BOM-2562: Move JS Tests To Github Action

### DIFF
--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -17,9 +17,6 @@ jobs:
         os: [ ubuntu-20.04 ]
         node-version: [ 12 ]
         python-version: [ 3.8 ]
-        include:
-          - os: ubuntu-20.04
-            path: ~/.cache/pip
 
     steps:
 

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -1,0 +1,86 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+jobs:
+  run_tests:
+    name: JS
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-20.04 ]
+        node-version: [ 12 ]
+        python-version: [ 3.8 ]
+        include:
+          - os: ubuntu-20.04
+            path: ~/.cache/pip
+
+    steps:
+
+    - uses: actions/checkout@v2
+    - name: Fetch master to compare coverage
+      run: git fetch --depth=1 origin master
+
+    - name: Setup Node
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Install Firefox 61.0
+      run: |
+        sudo apt-get purge firefox
+        wget "https://ftp.mozilla.org/pub/firefox/releases/61.0/linux-x86_64/en-US/firefox-61.0.tar.bz2"
+        tar -xjf firefox-61.0.tar.bz2
+        sudo mv firefox /opt/firefox
+        sudo ln -s /opt/firefox/firefox /usr/bin/firefox
+
+    - name: Install Required System Packages
+      run: sudo apt-get update && sudo apt-get install libxmlsec1-dev ubuntu-restricted-extras xvfb
+
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Get pip cache dir
+      id: pip-cache-dir
+      run: |
+        echo "::set-output name=dir::$(pip cache dir)"
+
+    - name: Cache pip dependencies
+      id: cache-dependencies
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.pip-cache-dir.outputs.dir }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements/edx/base.txt') }}
+        restore-keys: ${{ runner.os }}-pip-
+
+    - name: Install Required Python Dependencies
+      run: |
+        pip install -r requirements/pip.txt
+        pip install -r requirements/edx/base.txt
+
+    - uses: c-hive/gha-npm-cache@v1
+    - name: Run JS Tests
+      env:
+        TEST_SUITE: js-unit
+        SCRIPT_TO_RUN: ./scripts/generic-ci-tests.sh
+      run: |
+        npm install -g jest
+        xvfb-run --auto-servernum ./scripts/all-tests.sh
+
+    - name: Save Job Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: Build-Artifacts
+        path: |
+          reports/**/*
+          test_root/log/*.png
+          test_root/log/*.log
+          **/TEST-*.xml


### PR DESCRIPTION
Relevant JIRA : https://openedx.atlassian.net/browse/BOM-2562

Ticket A/C:

1. Run the same command that Jenkins uses to run the tests. ✅
2. Precede this command with any dependencies installation or other setup needed for that command to work (that aren't needed in the Jenkins job because the worker already has this set up on it). ✅
3. The tests pass. ✅
4. We save at least as many output artifacts as we do for the Jenkins jobs (log files, etc.)  Check some cases where the Jenkins job failed, in case those generate more artifacts that need to be preserved. ✅
5. Failures don't yet prevent PRs from being merged or master from being deployed. ✅

<del> I've skipped code coverage calculation for now because Jenkins is using Github branch comparison which we won't have here. So we might have to discuss how to proceed on that.