### PR TITLE
chore: update edx-proctoring version

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -458,7 +458,7 @@ edx-organizations==6.9.0
     # via -r requirements/edx/base.in
 edx-proctoring-proctortrack==1.0.5
     # via -r requirements/edx/base.in
-edx-proctoring==3.11.2
+edx-proctoring==3.11.3
     # via
     #   -r requirements/edx/base.in
     #   edx-proctoring-proctortrack

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -549,7 +549,7 @@ edx-organizations==6.9.0
     # via -r requirements/edx/testing.txt
 edx-proctoring-proctortrack==1.0.5
     # via -r requirements/edx/testing.txt
-edx-proctoring==3.11.2
+edx-proctoring==3.11.3
     # via
     #   -r requirements/edx/testing.txt
     #   edx-proctoring-proctortrack

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -533,7 +533,7 @@ edx-organizations==6.9.0
     # via -r requirements/edx/base.txt
 edx-proctoring-proctortrack==1.0.5
     # via -r requirements/edx/base.txt
-edx-proctoring==3.11.2
+edx-proctoring==3.11.3
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring-proctortrack


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This version of the edx-proctoring library includes a fix to a bug in the onboarding status panel. This bug was preventing the appearance of the onboarding panel in a learner's course outline if an onboarding exam in the course was inaccessible to the learner in such a way that the Learning Sequences API did not return schedule information for the sequence. An onboarding exam that is content gated by enrollment track to an enrollment track in which the learner is not enrolled is an example of this. The bug was that the `StudentOnboardingStatusView` was not taking into account that an inaccessible sequence might not have a schedule.

## Supporting information

https://github.com/edx/edx-proctoring/pull/861