### PR TITLE
[AA-759] feat: add admin for the User Celebration Model

### DIFF
--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -41,6 +41,7 @@ from common.djangoapps.student.models import (
     Registration,
     RegistrationCookieConfiguration,
     UserAttribute,
+    UserCelebration,
     UserProfile,
     UserTestGroup
 )
@@ -537,6 +538,19 @@ class CourseEnrollmentCelebrationAdmin(DisableEnrollmentAdminMixin, admin.ModelA
         return obj.enrollment.user.username
     user.short_description = 'User'
 
+
+@admin.register(UserCelebration)
+class UserCelebrationAdmin(admin.ModelAdmin):
+    """Admin interface for the UserCelebration model."""
+    readonly_fields = ('user', )
+
+    class Meta:
+        model = UserCelebration
+
+    # Disables the index view to avoid possible performance issues when
+    # a large number of user celebrations are present.
+    def has_module_permission(self, request):
+        return False
 
 admin.site.register(UserTestGroup)
 admin.site.register(Registration)


### PR DESCRIPTION
This is to simplify testing the AA-759 experiment
<img width="489" alt="Screen Shot 2021-05-27 at 11 22 09 AM" src="https://user-images.githubusercontent.com/5958221/119854169-d9bd2180-bede-11eb-9147-592fde9d5ca0.png">