### PR TITLE
fix: upgrade bootstrap to 4.6.0

### DIFF
--- a/cms/static/sass/views/_updates.scss
+++ b/cms/static/sass/views/_updates.scss
@@ -196,7 +196,7 @@
   padding: 20px 30px;
   margin: 0;
 
-  @include border-radius(0, 3px, 3px, 0);
+  @include border-radius(0 3px 3px 0);
   @include border-left(none);
 
   background: $uxpl-light-blue-base;

--- a/lms/static/sass/base/_build.scss
+++ b/lms/static/sass/base/_build.scss
@@ -7,18 +7,7 @@
 @import 'bootstrap/variables';
 @import 'bootstrap/scss/functions';
 @import 'bootstrap/scss/variables';
-@import 'bootstrap/scss/mixins/background-variant';
-@import 'bootstrap/scss/mixins/box-shadow';
-@import 'bootstrap/scss/mixins/breakpoints';
-@import 'bootstrap/scss/mixins/float';
-@import 'bootstrap/scss/mixins/grid';
-@import 'bootstrap/scss/mixins/hover';
-@import 'bootstrap/scss/mixins/reset-text';
-@import 'bootstrap/scss/mixins/screen-reader';
-@import 'bootstrap/scss/mixins/text-truncate';
-@import 'bootstrap/scss/mixins/text-emphasis';
-@import 'bootstrap/scss/mixins/text-hide';
-@import 'bootstrap/scss/mixins/visibility';
+@import 'bootstrap/scss/mixins';
 @import 'bootstrap/scss/utilities';
 
 

--- a/lms/static/sass/bootstrap/_components.scss
+++ b/lms/static/sass/bootstrap/_components.scss
@@ -92,6 +92,7 @@
 
     .all-topics {
       border: none;
+      color: $primary;
     }
   }
 

--- a/lms/static/sass/bootstrap/_components.scss
+++ b/lms/static/sass/bootstrap/_components.scss
@@ -93,6 +93,7 @@
     .all-topics {
       border: none;
       color: $primary;
+      background-color: transparent;
     }
   }
 

--- a/lms/static/sass/course/courseware/_sidebar.scss
+++ b/lms/static/sass/course/courseware/_sidebar.scss
@@ -1,7 +1,7 @@
 .course-index {
   @include transition(all 0.2s $ease-in-out-quad 0s);
   @include border-right(1px solid $border-color-2);
-  @include border-radius(3px, 0, 0, 3px);
+  @include border-radius(3px 0 0 3px);
 
   display: table-cell; // needed to extend the sidebar the full height of the area
 

--- a/lms/static/sass/discussion/_mixins.scss
+++ b/lms/static/sass/discussion/_mixins.scss
@@ -29,7 +29,7 @@
 }
 
 @mixin discussion-wmd-input {
-  @include border-radius($forum-border-radius, $forum-border-radius, 0, 0);
+  @include border-radius($forum-border-radius $forum-border-radius 0 0);
 
   box-sizing: border-box;
   margin-top: 0;
@@ -44,7 +44,7 @@
 }
 
 @mixin discussion-wmd-preview-container {
-  @include border-radius(0, 0, $forum-border-radius, $forum-border-radius);
+  @include border-radius(0 0 $forum-border-radius $forum-border-radius);
 
   box-sizing: border-box;
   border: 1px solid $forum-color-border;

--- a/lms/static/sass/discussion/elements/_actions.scss
+++ b/lms/static/sass/discussion/elements/_actions.scss
@@ -162,7 +162,7 @@
       }
 
       .action-icon {
-        @include border-radius(0, $forum-border-radius, $forum-border-radius, 0);
+        @include border-radius(0 $forum-border-radius $forum-border-radius 0);
       }
     }
 

--- a/lms/static/sass/discussion/elements/_navigation.scss
+++ b/lms/static/sass/discussion/elements/_navigation.scss
@@ -115,7 +115,7 @@
 
 .forum-nav-refine-bar {
   @include clearfix();
-  @include border-radius($forum-border-radius, $forum-border-radius, 0, 0);
+  @include border-radius($forum-border-radius $forum-border-radius 0 0);
 
   font-size: $forum-small-font-size;
   border-bottom: 1px solid $forum-color-border;

--- a/lms/static/sass/discussion/utilities/_shame.scss
+++ b/lms/static/sass/discussion/utilities/_shame.scss
@@ -9,7 +9,6 @@
 
     .all-topics {
       font-size: 14px;
-      color: $primary;
 
       .fa {
         @include margin-right(10px);

--- a/lms/static/sass/discussion/utilities/_shame.scss
+++ b/lms/static/sass/discussion/utilities/_shame.scss
@@ -9,6 +9,7 @@
 
     .all-topics {
       font-size: 14px;
+      color: $primary;
 
       .fa {
         @include margin-right(10px);

--- a/lms/static/sass/discussion/views/_response.scss
+++ b/lms/static/sass/discussion/views/_response.scss
@@ -32,7 +32,7 @@
   .discussion-response {
     box-sizing: border-box;
 
-    @include border-radius($forum-border-radius, $forum-border-radius, 0, 0);
+    @include border-radius($forum-border-radius $forum-border-radius 0 0);
 
     padding: $baseline;
     background-color: $forum-color-background;
@@ -98,7 +98,7 @@
 
   // CASE: banner - staff response
   .staff-banner {
-    @include border-radius($forum-border-radius, $forum-border-radius, 0, 0);
+    @include border-radius($forum-border-radius $forum-border-radius 0 0);
     @include left(0);
 
     position: absolute;
@@ -115,7 +115,7 @@
 
   // CASE: banner - community TA response
   .community-ta-banner {
-    @include border-radius($forum-border-radius, $forum-border-radius, 0, 0);
+    @include border-radius($forum-border-radius $forum-border-radius 0 0);
     @include left(0);
 
     position: absolute;
@@ -144,7 +144,7 @@
 .discussion .comments {
   @extend %ui-no-list;
 
-  @include border-radius(0, 0, $forum-border-radius, $forum-border-radius);
+  @include border-radius(0 0 $forum-border-radius $forum-border-radius);
 
   background: theme-color("lightest");
   box-shadow: 0 1px 3px -1px $shadow inset;

--- a/lms/static/sass/discussion/views/_thread.scss
+++ b/lms/static/sass/discussion/views/_thread.scss
@@ -217,7 +217,7 @@
     @include transition(all 0.2s linear 0s);
 
     .thread-wrapper {
-      @include border-radius($forum-border-radius, $forum-border-radius, 0, 0);
+      @include border-radius($forum-border-radius $forum-border-radius 0 0);
 
       position: relative;
       overflow-x: hidden;

--- a/lms/static/sass/multicourse/_home.scss
+++ b/lms/static/sass/multicourse/_home.scss
@@ -140,7 +140,7 @@ $course-search-input-height: ($button-size);
 
         .search-button {
           @include right($baseline*1.5);
-          @include border-radius(1px, 3px, 3px, 1px);
+          @include border-radius(1px 3px 3px 1px);
 
           @extend %ui-depth2;
           @extend %t-icon3;

--- a/lms/static/sass/shared/_header.scss
+++ b/lms/static/sass/shared/_header.scss
@@ -561,7 +561,7 @@
 
       &:last-child {
         > a {
-          @include border-radius(0, 4px, 4px, 0);
+          @include border-radius(0 4px 4px 0);
           @include border-left(none);
 
           padding: ($baseline/2) ($baseline/2);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2182,9 +2182,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.0.0.tgz",
-      "integrity": "sha512-gulJE5dGFo6Q61V/whS6VM4WIyrlydXfCgkE+Gxe5hjrJ8rXLLZlALq7zq2RPhOc45PSwQpJkrTnc2KgD6cvmA=="
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.0.tgz",
+      "integrity": "sha512-Io55IuQY3kydzHtbGvQya3H+KorS/M9rSNyfCGCg9WZ4pyT/lCxIlpJgG1GXW/PswzC84Tr2fBYi+7+jFVQQBw=="
     },
     "brace-expansion": {
       "version": "1.1.11",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "backbone": "1.4.0",
     "backbone-associations": "0.6.2",
     "backbone.paginator": "2.0.8",
-    "bootstrap": "4.0.0",
+    "bootstrap": "^4.6.0",
     "camelize": "1.0.0",
     "classnames": "2.2.5",
     "css-loader": "0.28.8",


### PR DESCRIPTION
Upgrade bootstrap to 4.6.0. This version of bootstrap requires a newer version of libsass than exists in the platform today. So it builds off of https://github.com/edx/edx-platform/pull/27683. 

Changes:
- The `border-radius` mixin now accepts a single parameter instead of 4. Usages have been updated to reflect this.
- In a build.scss file a handful of mixins were imported, but not all. This caused a break since some mixins depend on others. This PR just imports all the bootstrap mixins.

| file | prod | this PR + https://github.com/edx/edx-themes/pull/737 |
|----|------|-------|
| lms-course.css               | 778kb      | 1.4mb   |
| lms-discussion-bootstrap.css | 189kb      | 210kb   |
| lms-footer-edx.css           | 389kb      | 105kb   |
| lms-main-v1.css              | 2.2mb      | 1.3mb   |
| lms-main.css                 | 1.3mb      | 371kb   |
| studio-main-v1.css           | 1.1mb      | 2.1mb   |