### PR TITLE
test!: Switch to npm ci for building prereqs.

### DIFF
--- a/pavelib/prereqs.py
+++ b/pavelib/prereqs.py
@@ -136,7 +136,7 @@ def node_prereqs_installation():
     else:
         npm_log_file_path = f'{Env.GEN_LOG_DIR}/npm-install.log'
     npm_log_file = open(npm_log_file_path, 'wb')  # lint-amnesty, pylint: disable=consider-using-with
-    npm_command = 'npm install --verbose'.split()
+    npm_command = 'npm ci --verbose'.split()
 
     # The implementation of Paver's `sh` function returns before the forked
     # actually returns. Using a Popen object so that we can ensure that
@@ -147,11 +147,11 @@ def node_prereqs_installation():
         # Error handling around a race condition that produces "cb() never called" error. This
         # evinces itself as `cb_error_text` and it ought to disappear when we upgrade
         # npm to 3 or higher. TODO: clean this up when we do that.
-        print("npm install error detected. Retrying...")
+        print("npm ci error detected. Retrying...")
         proc = subprocess.Popen(npm_command, stderr=npm_log_file)  # lint-amnesty, pylint: disable=consider-using-with
         retcode = proc.wait()
         if retcode == 1:
-            raise Exception(f"npm install failed: See {npm_log_file_path}")
+            raise Exception(f"npm ci failed: See {npm_log_file_path}")
     print("Successfully installed NPM packages. Log found at {}".format(
         npm_log_file_path
     ))


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Having `paver install_node_prereqs` run `npm install` by default is causing issues because we run this in our test environment and it causes the lock file to get modified.  Have it run `npm ci` by default instead.

This change will most likely impact developers and operators. 

BREAKING_CHANGE: `paver install_node_prereqs` will no longer update the package-lock.json file.

## Supporting information
https://docs.npmjs.com/cli/v7/commands/npm-ci

## Testing instructions

Run `paver install_node_prereqs`. It should not change the `package-lock.json` file.

## Deadline

None
