### PR TITLE
refactor: uninstall user_tasks app from lms

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3101,13 +3101,6 @@ INSTALLED_APPS = [
     # Bulk User Retirement
     'lms.djangoapps.bulk_user_retirement',
 
-    # management of user-triggered async tasks (course import/export, etc.)
-    # This is only used by Studio, but is being added here because the
-    # app-permissions script that assigns users to Django admin roles only runs
-    # in the LMS process at the moment, so anything that has Django admin access
-    # permissions needs to be listed as an LMS app or the script will fail.
-    'user_tasks',
-
     # Agreements
     'openedx.core.djangoapps.agreements'
 ]


### PR DESCRIPTION

## Description

The user_tasks app is only needed by a cms feature.
However, it has been listed under INSTALLED_APPS
for both cms and lms because app-permissions only ran
in an lms context until recently.

Since app-permissions now creates the user_tasks_admin
group in a cms context, the app can be safely removed
from lms's INSTALLED_APPS.

## Supporting information

https://openedx.atlassian.net/browse/TNL-8274

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

No deadline. Would be cool to have this approved before Friday so we can call this weekly goal "done", though.

## Other information
(Blocked by https://github.com/edx/app-permissions/pull/1453)
