### PR TITLE
bug: Upgrade edx-enterprise for ENT-4593

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -41,7 +41,7 @@ django-storages<1.9
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==3.23.6
+edx-enterprise==3.23.7
 
 # Newer versions need a more recent version of python-dateutil
 freezegun==0.3.12
@@ -130,4 +130,3 @@ click<8.0
 
 # greater version has breaking changes and requires some migration steps.
 django-webpack-loader==0.7.0
-

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -429,7 +429,7 @@ edx-drf-extensions==6.5.0
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.23.6
+edx-enterprise==3.23.7
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -516,7 +516,7 @@ edx-drf-extensions==6.5.0
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.23.6
+edx-enterprise==3.23.7
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -499,7 +499,7 @@ edx-drf-extensions==6.5.0
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.23.6
+edx-enterprise==3.23.7
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
ENT-4593 to conclude courses in Canvas, instead of delete, on delete_content_metadata

JIRA: ENT-4593


This urgent change releases a fix where we will now 'conclude' a course when we issue a `delete_content_metadata` requset in the Canvas integrated channel client. This will unblock releasing a Canvas integration with a customer on 05/30/21. This means we can later revive the course from concluded to a 'offer' state meaning make it available for enrollment again. With 'delete', we don't have that option.

This change only addresses one of the pain points. The other pain points are detailed in https://openedx.atlassian.net/browse/ENT-4591

which are basically that:

* Once we delete a course in canvas, it gets into a soft delete state and we can no longer re-transmit that course in the future. This is due to 'delete' (and 'conclude') being soft deletes.
* But conclude will enable us to restore course to a usable state, which is one piece of the puzzle. We still need to make the canvas client handle the existing course case, that is a separate ticket.

## Deadline

Urgent

## Notes 

This is a relatively safe change and won't impact any existing courses that are already transmitted. For courses that were transmitted and now no longer in catalogs, they will be marked 'concluded' in Canvas.