### PR TITLE
fix: close modal on escape keydown

### DIFF
--- a/lms/static/js/learner_dashboard/EnterpriseLearnerPortalModal.jsx
+++ b/lms/static/js/learner_dashboard/EnterpriseLearnerPortalModal.jsx
@@ -13,6 +13,7 @@ class EnterpriseLearnerPortalModal extends React.Component {
     this.openModal = this.openModal.bind(this);
     this.closeModal = this.closeModal.bind(this);
     this.handleClick = this.handleClick.bind(this);
+    this.handleEsc = this.handleEsc.bind(this);
   }
 
   componentDidMount() {
@@ -22,6 +23,7 @@ class EnterpriseLearnerPortalModal extends React.Component {
       this.openModal();
       document.addEventListener('mousedown', this.handleClick, false);
       window.sessionStorage.setItem(storageKey, true);
+      document.addEventListener('keydown', this.handleEsc, false);
     }
   }
 
@@ -41,6 +43,7 @@ class EnterpriseLearnerPortalModal extends React.Component {
     // remove the class to allow the dashboard content to scroll
     document.body.classList.remove('modal-open');
     document.removeEventListener('mousedown', this.handleClick, false);
+    document.removeEventListener('keydown', this.handleEsc, false);
   }
 
   handleClick(e) {
@@ -50,6 +53,13 @@ class EnterpriseLearnerPortalModal extends React.Component {
     }
 
     this.closeModal();
+  }
+
+  handleEsc(e) {
+    const { key } = e;
+    if (key === "Escape") {
+      this.closeModal();
+    }
   }
 
   closeModal() {


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

For a11y, adds the ability to close the Enterprise Learner Portal modal by pressing the "Escape" key.

## Testing instructions

1. Be an Enterprise Learner user using the edx.org-next theme, who's `EnterpriseCustomer` has the learner portal enabled.
2. Go to edx-platform dashboard page to view the Learner Portal modal messaging.
3. Press the "Escape" key and see the modal close.