### PR TITLE
feat: AA-773: Add in logic to mark special exams as complete

### DIFF
--- a/lms/djangoapps/instructor/services.py
+++ b/lms/djangoapps/instructor/services.py
@@ -9,14 +9,16 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.utils.translation import ugettext as _
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, UsageKey
+from xblock.completable import XBlockCompletionMode
 
 import lms.djangoapps.instructor.enrollment as enrollment
 from common.djangoapps.student import auth
+from common.djangoapps.student.models import get_user_by_username_or_email
 from common.djangoapps.student.roles import CourseStaffRole
 from lms.djangoapps.commerce.utils import create_zendesk_ticket
 from lms.djangoapps.courseware.models import StudentModule
-from lms.djangoapps.instructor.views.tools import get_student_from_identifier
 from xmodule.modulestore.django import modulestore
+from xmodule.modulestore.exceptions import ItemNotFoundError
 
 log = logging.getLogger(__name__)
 
@@ -44,15 +46,12 @@ class InstructorService:
         course_id = CourseKey.from_string(course_id)
 
         try:
-            student = get_student_from_identifier(student_identifier)
+            student = get_user_by_username_or_email(student_identifier)
         except ObjectDoesNotExist:
             err_msg = (
                 'Error occurred while attempting to reset student attempts for user '
-                '{student_identifier} for content_id {content_id}. '
-                'User does not exist!'.format(
-                    student_identifier=student_identifier,
-                    content_id=content_id
-                )
+                f'{student_identifier} for content_id {content_id}. '
+                'User does not exist!'
             )
             log.error(err_msg)
             return
@@ -78,12 +77,60 @@ class InstructorService:
             except (StudentModule.DoesNotExist, enrollment.sub_api.SubmissionError):
                 err_msg = (
                     'Error occurred while attempting to reset student attempts for user '
-                    '{student_identifier} for content_id {content_id}.'.format(
-                        student_identifier=student_identifier,
-                        content_id=content_id
-                    )
+                    f'{student_identifier} for content_id {content_id}.'
                 )
                 log.error(err_msg)
+
+    def complete_student_attempt(self, user_identifier, content_id):
+        """
+        Submits all completable xblocks inside of the content_id block to the
+        Completion Service to mark them as complete. One use case of this function is
+        for special exams (timed/proctored) where regardless of submission status on
+        individual problems, we want to mark the entire exam as complete when the exam
+        is finished.
+
+        params:
+            user_identifier (String): username or email of a user
+            content_id (String): the block key for a piece of content
+        """
+        err_msg_prefix = (
+            'Error occurred while attempting to complete student attempt for user '
+            f'{user_identifier} for content_id {content_id}. '
+        )
+        err_msg = None
+        try:
+            user = get_user_by_username_or_email(user_identifier)
+            block_key = UsageKey.from_string(content_id)
+            root_block = modulestore().get_item(block_key)
+        except ObjectDoesNotExist:
+            err_msg = err_msg_prefix + 'User does not exist!'
+        except InvalidKeyError:
+            err_msg = err_msg_prefix + 'Invalid content_id!'
+        except ItemNotFoundError:
+            err_msg = err_msg_prefix + 'Block not found in the modulestore!'
+        if err_msg:
+            log.error(err_msg)
+            return
+
+        def _submit_completions(block, user):
+            """
+            Recursively submits the children for completion to the Completion Service
+            """
+            mode = XBlockCompletionMode.get_mode(block)
+            if mode == XBlockCompletionMode.COMPLETABLE:
+                block.runtime.publish(block, 'completion', {'completion': 1.0, 'user_id': user.id})
+            elif mode == XBlockCompletionMode.AGGREGATOR:
+                # I know this looks weird, but at the time of writing at least, there isn't a good
+                # single way to get the children assigned for a partcular user. Some blocks define the
+                # child descriptors method, but others don't and with blocks like Randomized Content
+                # (Library Content), the get_children method returns all children and not just assigned
+                # children. So this is our way around situations like that.
+                block_children = ((hasattr(block, 'get_child_descriptors') and block.get_child_descriptors())
+                                  or (hasattr(block, 'get_children') and block.get_children()))
+                for child in block_children:
+                    _submit_completions(child, user)
+
+        _submit_completions(root_block, user)
 
     def is_course_staff(self, user, course_id):
         """

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -455,7 +455,7 @@ edx-organizations==6.9.0
     # via -r requirements/edx/base.in
 edx-proctoring-proctortrack==1.0.5
     # via -r requirements/edx/base.in
-edx-proctoring==3.13.2
+edx-proctoring==3.14.0
     # via
     #   -r requirements/edx/base.in
     #   edx-proctoring-proctortrack

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -549,7 +549,7 @@ edx-organizations==6.9.0
     # via -r requirements/edx/testing.txt
 edx-proctoring-proctortrack==1.0.5
     # via -r requirements/edx/testing.txt
-edx-proctoring==3.13.2
+edx-proctoring==3.14.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-proctoring-proctortrack

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -533,7 +533,7 @@ edx-organizations==6.9.0
     # via -r requirements/edx/base.txt
 edx-proctoring-proctortrack==1.0.5
     # via -r requirements/edx/base.txt
-edx-proctoring==3.13.2
+edx-proctoring==3.14.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring-proctortrack


### PR DESCRIPTION
We have had numerous support tickets/bugs related to special exams
not properly displaying completeness (see https://openedx.atlassian.net/browse/AA-773 for
details). Along with a corresponding [edx-proctoring PR](https://github.com/edx/edx-proctoring/pull/871), this will now
submit completions for all completable children within a special
exam upon the exam being completed for the first time (as dictated by
the logic in the edx-proctoring PR).

https://github.com/edx/edx-proctoring/pull/871