### PR TITLE
feat: swap bootstrap for paragon sass

### DIFF
--- a/cms/static/sass/_build.scss
+++ b/cms/static/sass/_build.scss
@@ -3,9 +3,8 @@
 // Studio theme
 @import 'cms/theme/variables';
 
-// Core Bootstrap functions, variables and mixins
-@import 'bootstrap/variables';
-@import 'bootstrap/scss/functions';
-@import 'bootstrap/scss/variables';
-@import 'bootstrap/scss/mixins/breakpoints';
-@import 'bootstrap/scss/mixins/grid';
+// Legacy variables file
+@import './bootstrap/variables';
+
+// Paragon SASS framework
+@import '@edx/paragon-new/scss/core/core';

--- a/cms/static/sass/_build.scss
+++ b/cms/static/sass/_build.scss
@@ -3,8 +3,8 @@
 // Studio theme
 @import 'cms/theme/variables';
 
-// Legacy variables file
-@import './bootstrap/variables';
-
 // Paragon SASS framework
 @import 'paragon';
+
+// Legacy variables file
+@import './bootstrap/variables';

--- a/cms/static/sass/_build.scss
+++ b/cms/static/sass/_build.scss
@@ -7,4 +7,4 @@
 @import './bootstrap/variables';
 
 // Paragon SASS framework
-@import '@edx/paragon-new/scss/core/core';
+@import 'paragon';

--- a/cms/static/sass/_paragon.scss
+++ b/cms/static/sass/_paragon.scss
@@ -1,0 +1,14 @@
+// Paragon SASS framework plus variables that Studio expects.
+@import '@edx/paragon-new/scss/core/core';
+
+// Fill in variable gaps
+
+$inverse: $white !default;
+$pink: pink !default;
+
+$theme-colors: map-merge(
+  (
+    "inverse":    $inverse,
+  ),
+  $theme-colors
+);

--- a/cms/static/sass/_shame.scss
+++ b/cms/static/sass/_shame.scss
@@ -139,6 +139,34 @@ div.wrapper-comp-editor.is-inactive ~ div.launch-latex-compiler {
 
 // ====================
 
+// The Paragon SASS framework has been added to Studio in its totality.
+// There are a handful of places where class names conflict. The styles
+// below attempt to enforce Studio's existing styling rules while offering
+// an opt-in to the full Paragon/Bootstrap style rules.
+
+// Bootstrap .row is display: flex; with negative margins,
+// Studio assumes .row is display: block; and sets no left right margins.
+// If a Bootstrap style row is desired use: <div class="row bs-row">...</div>
+.row:not(.bs-row) {
+  display: block;
+  margin-left: 0;
+  margin-right: 0;
+}
+
+// A series of conflicts in modal styles... The existing Studio modal is
+// styled in this pretty specific selector cms/static/sass/elements/_modal-window.scss
+// So we enforce some styles here to prevent Paragon from messing things up.
+[class*="view-"] .modal-window {
+  max-width: 100%;
+
+  .modal-content {
+    display: block;
+    box-shadow: none;
+  }
+}
+
+// ====================
+
 // TODOs:
 
 // * font-weight syncing

--- a/cms/static/sass/bootstrap/studio-main.scss
+++ b/cms/static/sass/bootstrap/studio-main.scss
@@ -5,8 +5,8 @@
 // Studio theme variables
 @import 'cms/theme/variables';
 
-// Bootstrap
-@import 'bootstrap/scss/bootstrap';
+// Paragon SASS framework
+@import '@edx/paragon-new/scss/core/core';
 
 // Legacy support
 @import 'legacy';

--- a/cms/static/sass/bootstrap/studio-main.scss
+++ b/cms/static/sass/bootstrap/studio-main.scss
@@ -6,7 +6,7 @@
 @import 'cms/theme/variables';
 
 // Paragon SASS framework
-@import '@edx/paragon-new/scss/core/core';
+@import '../paragon';
 
 // Legacy support
 @import 'legacy';

--- a/cms/static/sass/partials/cms/theme/_variables.scss
+++ b/cms/static/sass/partials/cms/theme/_variables.scss
@@ -1,5 +1,3 @@
 // Default bootstrap theming
 
 $body-bg: #f5f5f5 !default;
-
-@import 'edx-bootstrap/sass/open-edx/theme';

--- a/cms/templates/container.html
+++ b/cms/templates/container.html
@@ -19,7 +19,7 @@ from openedx.core.djangolib.markup import HTML, Text
 %>
 
 <%block name="title">${xblock.display_name_with_default} ${xblock_type_display_name(xblock)}</%block>
-<%block name="bodyclass">is-signedin course container view-container</%block>
+<%block name="bodyclass">is-signedin course view-container</%block>
 
 <%namespace name='static' file='static_content.html'/>
 

--- a/common/static/sass/_mixins.scss
+++ b/common/static/sass/_mixins.scss
@@ -292,7 +292,7 @@
   &:focus {
     border: 1px solid $uxpl-blue-hover-active;
     background-color: $uxpl-blue-hover-active;
-    color: theme-color("inverse");
+    color: theme-color("inverse") !important;
   }
 
   &.is-disabled,

--- a/lms/static/certificates/sass/main-ltr.scss
+++ b/lms/static/certificates/sass/main-ltr.scss
@@ -9,7 +9,7 @@
 @import '../sass/vendor/bi-app/bi-app-ltr';
 
 // Paragon SASS Framework
-@import '@edx/paragon-new/scss/core/core';
+@import 'paragon';
 
 // Load the shared build
 @import 'build';

--- a/lms/static/certificates/sass/main-ltr.scss
+++ b/lms/static/certificates/sass/main-ltr.scss
@@ -7,9 +7,9 @@
 // It should mirror main-rtl w/ the exception of bi-app references.
 
 @import '../sass/vendor/bi-app/bi-app-ltr';
-@import 'bootstrap/scss/functions';
-@import 'bootstrap/scss/variables';
-@import 'bootstrap/scss/mixins';
+
+// Paragon SASS Framework
+@import '@edx/paragon-new/scss/core/core';
 
 // Load the shared build
 @import 'build';

--- a/lms/static/certificates/sass/main-rtl.scss
+++ b/lms/static/certificates/sass/main-rtl.scss
@@ -7,9 +7,9 @@
 // It should mirror main-ltr w/ the exception of bi-app references.
 
 @import '../sass/vendor/bi-app/bi-app-rtl';
-@import 'bootstrap/scss/functions';
-@import 'bootstrap/scss/variables';
-@import 'bootstrap/scss/mixins';
+
+// Paragon SASS Framework
+@import '@edx/paragon-new/scss/core/core';
 
 // Load the shared build
 @import 'build';

--- a/lms/static/certificates/sass/main-rtl.scss
+++ b/lms/static/certificates/sass/main-rtl.scss
@@ -9,7 +9,7 @@
 @import '../sass/vendor/bi-app/bi-app-rtl';
 
 // Paragon SASS Framework
-@import '@edx/paragon-new/scss/core/core';
+@import '../../sass/paragon';
 
 // Load the shared build
 @import 'build';

--- a/lms/static/sass/_build-footer-edx.scss
+++ b/lms/static/sass/_build-footer-edx.scss
@@ -6,7 +6,7 @@
 @import 'bootstrap/variables';
 
 // Paragon SASS Framework
-@import '@edx/paragon-new/scss/core/core';
+@import 'paragon';
 @import '../variables';
 @import 'lms/theme/variables-v1';
 @import 'base/mixins';

--- a/lms/static/sass/_build-footer-edx.scss
+++ b/lms/static/sass/_build-footer-edx.scss
@@ -1,10 +1,12 @@
 // ----------------------------------------
 // LMS edx.org Footer: Shared Build Compile
 @import 'lms/theme/variables';
+
+// Legacy variables that augmented Bootstrap
 @import 'bootstrap/variables';
-@import 'bootstrap/scss/functions';
-@import 'bootstrap/scss/variables';
-@import 'bootstrap/scss/mixins/breakpoints';
+
+// Paragon SASS Framework
+@import '@edx/paragon-new/scss/core/core';
 @import '../variables';
 @import 'lms/theme/variables-v1';
 @import 'base/mixins';

--- a/lms/static/sass/_paragon.scss
+++ b/lms/static/sass/_paragon.scss
@@ -1,0 +1,14 @@
+// Paragon SASS framework plus variables that LMS expects.
+@import '@edx/paragon-new/scss/core/core';
+
+// Fill in variable gaps
+
+$inverse: $white !default;
+$pink: pink !default;
+
+$theme-colors: map-merge(
+  (
+    "inverse":    $inverse,
+  ),
+  $theme-colors
+);

--- a/lms/static/sass/_variables.scss
+++ b/lms/static/sass/_variables.scss
@@ -6,7 +6,4 @@ $text-width-readability-max: 1080px;
 $audit-mode-color: rgb(74, 74, 74) !default;
 $honor-mode-color: theme-color("primary") !default;
 $verified-mode-color: theme-color("success") !default;
-$professional-certificate-color: #9a1f60 !default;
-
-// $pink existed in Bootstrap, but does not exist in Paragon
-$pink: pink !default;
+$professional-certificate-color: #9a1f60 !default;$pink: pink !default;

--- a/lms/static/sass/_variables.scss
+++ b/lms/static/sass/_variables.scss
@@ -7,3 +7,6 @@ $audit-mode-color: rgb(74, 74, 74) !default;
 $honor-mode-color: theme-color("primary") !default;
 $verified-mode-color: theme-color("purchase") !default;
 $professional-certificate-color: #9a1f60 !default;
+
+// $pink existed in Bootstrap, but does not exist in Paragon
+$pink: pink !default;

--- a/lms/static/sass/_variables.scss
+++ b/lms/static/sass/_variables.scss
@@ -5,7 +5,7 @@ $text-width-readability-max: 1080px;
 // LMS-only colors
 $audit-mode-color: rgb(74, 74, 74) !default;
 $honor-mode-color: theme-color("primary") !default;
-$verified-mode-color: theme-color("purchase") !default;
+$verified-mode-color: theme-color("success") !default;
 $professional-certificate-color: #9a1f60 !default;
 
 // $pink existed in Bootstrap, but does not exist in Paragon

--- a/lms/static/sass/base/_build.scss
+++ b/lms/static/sass/base/_build.scss
@@ -3,13 +3,11 @@
 // Theme-specific variables
 @import 'lms/theme/variables';
 
-// Core Bootstrap functions, variables and mixins
+// Legacy variables that augmented Bootstrap
 @import 'bootstrap/variables';
+
+// Paragon SASS Framework
 @import '@edx/paragon-new/scss/core/core';
-
-
-// Bootstrap components
-@import 'bootstrap/scss/popover';
 
 // LMS-specific variables
 @import '../variables';

--- a/lms/static/sass/base/_build.scss
+++ b/lms/static/sass/base/_build.scss
@@ -5,10 +5,7 @@
 
 // Core Bootstrap functions, variables and mixins
 @import 'bootstrap/variables';
-@import 'bootstrap/scss/functions';
-@import 'bootstrap/scss/variables';
-@import 'bootstrap/scss/mixins';
-@import 'bootstrap/scss/utilities';
+@import '@edx/paragon-new/scss/core/core';
 
 
 // Bootstrap components

--- a/lms/static/sass/base/_build.scss
+++ b/lms/static/sass/base/_build.scss
@@ -7,7 +7,7 @@
 @import 'bootstrap/variables';
 
 // Paragon SASS Framework
-@import '@edx/paragon-new/scss/core/core';
+@import '../paragon';
 
 // LMS-specific variables
 @import '../variables';

--- a/lms/static/sass/bootstrap/_build.scss
+++ b/lms/static/sass/bootstrap/_build.scss
@@ -5,7 +5,7 @@
 @import 'lms/theme/variables';
 
 // Paragon SASS Framework
-@import '@edx/paragon-new/scss/core/core';
+@import '../paragon';
 
 // LMS variables
 @import '../variables';

--- a/lms/static/sass/bootstrap/_build.scss
+++ b/lms/static/sass/bootstrap/_build.scss
@@ -4,8 +4,8 @@
 // LMS theme
 @import 'lms/theme/variables';
 
-// Bootstrap
-@import 'bootstrap/scss/bootstrap';
+// Paragon SASS Framework
+@import '@edx/paragon-new/scss/core/core';
 
 // LMS variables
 @import '../variables';

--- a/lms/static/sass/course/courseware/_courseware.scss
+++ b/lms/static/sass/course/courseware/_courseware.scss
@@ -573,7 +573,7 @@ html.video-fullscreen {
           @extend %h1-top-header !optional;
 
           border-radius: 0 4px 0 0;
-          margin-bottom: -16px;
+          margin-bottom: 0;
           border-bottom: 0;
 
           h1 {

--- a/lms/static/sass/course/wiki/_wiki.scss
+++ b/lms/static/sass/course/wiki/_wiki.scss
@@ -15,7 +15,8 @@
   @include clearfix();
 
   .breadcrumbs-header {
-    height: 33px;
+    @include clearfix();
+
     padding: 24px 0 26px;
     border-bottom: 1px solid $gray-l3;
     border-radius: 3px 3px 0 0;
@@ -31,8 +32,9 @@
 
   .breadcrumb {
     list-style: none;
-    padding-left: 0;
+    padding: 0;
     margin: 0 0 0 ($baseline*2);
+    background: none;
 
     li {
       float: left;
@@ -279,6 +281,7 @@
     list-style: none;
     padding: 0;
     margin: 0;
+    flex-direction: column;
 
     li {
       &.active {

--- a/lms/static/sass/discussion/_discussion.scss
+++ b/lms/static/sass/discussion/_discussion.scss
@@ -159,7 +159,7 @@ section.discussion-pagination {
           font-size: $forum-base-font-size;
           font-weight: 700;
           line-height: 32px;
-          color: theme-color("gray-dark");
+          color: $gray-700;
           text-shadow: 0 1px 0 rgba(255, 255, 255, 0.6);
         }
       }

--- a/lms/static/sass/discussion/_mixins.scss
+++ b/lms/static/sass/discussion/_mixins.scss
@@ -20,7 +20,7 @@
 
   border-color: #aaa;
   background-color: $white;
-  color: theme-color("gray-dark");
+  color: $gray-700;
 
   &:hover,
   &:focus {

--- a/lms/static/sass/discussion/lms-discussion-bootstrap.scss
+++ b/lms/static/sass/discussion/lms-discussion-bootstrap.scss
@@ -8,7 +8,7 @@ $static-path: '../..';
 @import 'lms/theme/variables';
 
 // Paragon SASS Framework
-@import '@edx/paragon-new/scss/core/core';
+@import '../paragon';
 
 // Legacy support
 @import '../bootstrap/legacy';

--- a/lms/static/sass/discussion/lms-discussion-bootstrap.scss
+++ b/lms/static/sass/discussion/lms-discussion-bootstrap.scss
@@ -7,8 +7,8 @@ $static-path: '../..';
 // Theme-specific variables
 @import 'lms/theme/variables';
 
-// Bootstrap
-@import 'bootstrap/scss/bootstrap';
+// Paragon SASS Framework
+@import '@edx/paragon-new/scss/core/core';
 
 // Legacy support
 @import '../bootstrap/legacy';

--- a/lms/static/sass/discussion/utilities/_variables-bootstrap.scss
+++ b/lms/static/sass/discussion/utilities/_variables-bootstrap.scss
@@ -1,9 +1,6 @@
 // discussion - utilities - variables
 // ====================
 
-// $pink existed in Bootstrap, but does not exist in Paragon
-$pink: pink !default;
-
 // base color variables
 $forum-color-primary: theme-color("primary") !default;
 $forum-color-copy-light: rgb(65, 65, 65) !default;

--- a/lms/static/sass/discussion/utilities/_variables-bootstrap.scss
+++ b/lms/static/sass/discussion/utilities/_variables-bootstrap.scss
@@ -1,6 +1,9 @@
 // discussion - utilities - variables
 // ====================
 
+// $pink existed in Bootstrap, but does not exist in Paragon
+$pink: pink !default;
+
 // base color variables
 $forum-color-primary: theme-color("primary") !default;
 $forum-color-copy-light: rgb(65, 65, 65) !default;

--- a/lms/static/sass/discussion/views/_create-edit-post.scss
+++ b/lms/static/sass/discussion/views/_create-edit-post.scss
@@ -132,7 +132,7 @@
     width: 100%;
     height: 40px;
     box-shadow: 0 1px 3px $shadow-l1 inset;
-    color: theme-color("gray-dark");
+    color: $gray-700;
     font-size: $forum-large-font-size;
     font-family: $font-family-sans-serif;
   }
@@ -151,7 +151,7 @@
   .post-type-label {
     @include margin-right($baseline);
 
-    color: theme-color("gray-dark");
+    color: $gray-700;
   }
 
   input[type=text].field-input {

--- a/lms/static/sass/discussion/views/_response.scss
+++ b/lms/static/sass/discussion/views/_response.scss
@@ -76,7 +76,7 @@
   display: block;
   padding: ($baseline/2) $baseline;
   width: 100%;
-  background: theme-color("lightest");
+  background: $light-300;
   box-shadow: 0 1px 3px -1px $shadow inset;
 }
 
@@ -146,7 +146,7 @@
 
   @include border-radius(0 0 $forum-border-radius $forum-border-radius);
 
-  background: theme-color("lightest");
+  background: $light-300;
   box-shadow: 0 1px 3px -1px $shadow inset;
 
   > li {

--- a/lms/static/sass/discussion/views/_thread.scss
+++ b/lms/static/sass/discussion/views/_thread.scss
@@ -44,7 +44,7 @@
   display: block;
   margin-bottom: $baseline;
   font-size: $forum-x-large-font-size;
-  color: theme-color("gray-dark");
+  color: $gray-700;
   font-weight: 600;
 }
 

--- a/lms/static/sass/features/_course-experience.scss
+++ b/lms/static/sass/features/_course-experience.scss
@@ -122,12 +122,12 @@
         flex-grow: 1;
 
         &:not(.dismissible):first-of-type {
-          color: theme-color("purchase");
-          border-color: theme-color("purchase");
+          color: theme-color("success");
+          border-color: theme-color("success");
 
           &:hover {
             color: theme-color("inverse");
-            background-color: theme-color("purchase");
+            background-color: theme-color("success");
           }
         }
 
@@ -142,7 +142,6 @@
           font-size: font-size(small);
           color: $link-color;
           text-decoration: underline;
-
           cursor: pointer;
 
           &:hover {

--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -212,7 +212,6 @@
 
                 .wrapper-course-actions {
                   margin-top: $baseline;
-
                   flex-grow: 1;
                   flex-shrink: 0;
                 }
@@ -243,6 +242,7 @@
 
             @include media-breakpoint-down(xs) {
               margin-bottom: $baseline;
+
               @include padding-left($baseline/2);
 
               .wrapper-course-info-actions {
@@ -251,7 +251,7 @@
 
                 .wrapper-course-info-row {
                   .wrapper-course-actions {
-                    margin-top: 0px;
+                    margin-top: 0;
                   }
                 }
               }
@@ -455,6 +455,7 @@
             @extend %btn-pl-white-base;
 
             @include float(right);
+
             margin-top: $baseline;
 
             &.archived {
@@ -662,7 +663,7 @@
   .messages-list {
     margin: 0;
     padding: 0;
-    background-color: theme-color("lightest");
+    background-color: $light-300;
   }
 
   .message {
@@ -776,7 +777,7 @@
       padding-left: $baseline;
       padding-top: $baseline;
       padding-bottom: $baseline;
-      background-color: #F2F0EF;
+      background-color: #f2f0ef;
 
       .wrapper-tip {
         @include clearfix();
@@ -803,7 +804,7 @@
       .wrapper-extended {
         display: flex;
         flex-flow: column wrap;
-        color: #00262B;
+        color: #00262b;
 
         .wrapper-icon-message {
           width: 100%;
@@ -828,7 +829,7 @@
           }
 
           a.verified-info {
-            color: #00262B;
+            color: #00262b;
             text-decoration: underline;
           }
         }

--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -1624,6 +1624,8 @@ a.fade-cover {
 
 #unenroll-modal {
   margin-top: -60px;
+  height: auto;
+  width: 480px;
 
   .modal-form-error {
     background: tint($red, 95%);

--- a/lms/static/sass/partials/lms/theme/_variables.scss
+++ b/lms/static/sass/partials/lms/theme/_variables.scss
@@ -1,3 +1,1 @@
-// Default bootstrap theming
-
-@import 'edx-bootstrap/sass/open-edx/theme';
+// theme variables

--- a/lms/static/sass/shared/_footer-edx.scss
+++ b/lms/static/sass/shared/_footer-edx.scss
@@ -2,9 +2,9 @@
 // ====================
 @import '../base/grid-settings';
 @import 'neat/neat'; // lib - Neat
-@import 'bootstrap/scss/functions';
-@import 'bootstrap/scss/variables';
-@import 'bootstrap/scss/mixins/breakpoints';
+
+// Paragon SASS Framework
+@import '@edx/paragon-new/scss/core/core';
 
 $edx-footer-link-color: $primary;
 $edx-footer-bg-color: rgb(252, 252, 252);

--- a/lms/static/sass/shared/_footer-edx.scss
+++ b/lms/static/sass/shared/_footer-edx.scss
@@ -4,7 +4,7 @@
 @import 'neat/neat'; // lib - Neat
 
 // Paragon SASS Framework
-@import '@edx/paragon-new/scss/core/core';
+@import '../paragon';
 
 $edx-footer-link-color: $primary;
 $edx-footer-bg-color: rgb(252, 252, 252);

--- a/package-lock.json
+++ b/package-lock.json
@@ -178,6 +178,117 @@
         "react-proptype-conditional-require": "^1.0.4"
       }
     },
+    "@edx/paragon-new": {
+      "version": "npm:@edx/paragon@14.12.4",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-14.12.4.tgz",
+      "integrity": "sha512-jSx+QKEGnM+Xo1KfwZycPD6O7Wa6CovC/Utg/ZjOpoBS0v8Gij8jnC3Va3vbpC4t0KA8jdgvf7gH6XDrFuitWA==",
+      "requires": {
+        "@fortawesome/fontawesome-svg-core": "^1.2.30",
+        "@fortawesome/free-solid-svg-icons": "^5.14.0",
+        "@fortawesome/react-fontawesome": "^0.1.11",
+        "@popperjs/core": "^2.6.0",
+        "airbnb-prop-types": "^2.12.0",
+        "bootstrap": "4.6.0",
+        "classnames": "^2.2.6",
+        "email-prop-type": "^3.0.0",
+        "font-awesome": "^4.7.0",
+        "mailto-link": "^1.0.0",
+        "prop-types": "^15.7.2",
+        "react-bootstrap": "^1.3.0",
+        "react-focus-on": "^3.5.0",
+        "react-popper": "^2.2.4",
+        "react-proptype-conditional-require": "^1.0.4",
+        "react-responsive": "^6.1.1",
+        "react-table": "^7.6.1",
+        "react-transition-group": "^4.0.0",
+        "sanitize-html": "^1.20.0",
+        "tabbable": "^4.0.0",
+        "uncontrollable": "7.2.1"
+      },
+      "dependencies": {
+        "classnames": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+          "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+        },
+        "dom-helpers": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+          "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+          "requires": {
+            "@babel/runtime": "^7.8.7",
+            "csstype": "^3.0.2"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.14.0",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
+              "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            }
+          }
+        },
+        "email-prop-type": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/email-prop-type/-/email-prop-type-3.0.1.tgz",
+          "integrity": "sha512-tONZGMEOOkadp5OBftuVXU8DsceWmINxYK+pqPFB4LT5ODjrPX/esel3WGqbV7d6in5/MnZE4n4QcqOr4gh7dg==",
+          "requires": {
+            "email-validator": "^2.0.4"
+          }
+        },
+        "email-validator": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/email-validator/-/email-validator-2.0.4.tgz",
+          "integrity": "sha512-gYCwo7kh5S3IDyZPLZf6hSS0MnZT8QmJFqYvbqlDZSbwdZlY6QZWxJ4i/6UhITOJ4XzyI647Bm2MXKCLqnJ4nQ=="
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        },
+        "react-responsive": {
+          "version": "6.1.2",
+          "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-6.1.2.tgz",
+          "integrity": "sha512-AXentVC/kN3KED9zhzJv2pu4vZ0i6cSHdTtbCScVV1MT6F5KXaG2qs5D7WLmhdaOvmiMX8UfmS4ZSO+WPwDt4g==",
+          "requires": {
+            "hyphenate-style-name": "^1.0.0",
+            "matchmediaquery": "^0.3.0",
+            "prop-types": "^15.6.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
+          "integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
+          "requires": {
+            "@babel/runtime": "^7.5.5",
+            "dom-helpers": "^5.0.1",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2"
+          }
+        }
+      }
+    },
     "@edx/studio-frontend": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/@edx/studio-frontend/-/studio-frontend-1.17.0.tgz",
@@ -280,15 +391,113 @@
         "stylelint-scss": "^2.1.0"
       }
     },
+    "@fortawesome/fontawesome-common-types": {
+      "version": "0.2.35",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.35.tgz",
+      "integrity": "sha512-IHUfxSEDS9dDGqYwIW7wTN6tn/O8E0n5PcAHz9cAaBoZw6UpG20IG/YM3NNLaGPwPqgjBAFjIURzqoQs3rrtuw=="
+    },
+    "@fortawesome/fontawesome-svg-core": {
+      "version": "1.2.35",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.35.tgz",
+      "integrity": "sha512-uLEXifXIL7hnh2sNZQrIJWNol7cTVIzwI+4qcBIq9QWaZqUblm0IDrtSqbNg+3SQf8SMGHkiSigD++rHmCHjBg==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.35"
+      }
+    },
+    "@fortawesome/free-solid-svg-icons": {
+      "version": "5.15.3",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.3.tgz",
+      "integrity": "sha512-XPeeu1IlGYqz4VWGRAT5ukNMd4VHUEEJ7ysZ7pSSgaEtNvSo+FLurybGJVmiqkQdK50OkSja2bfZXOeyMGRD8Q==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.35"
+      }
+    },
+    "@fortawesome/react-fontawesome": {
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.14.tgz",
+      "integrity": "sha512-4wqNb0gRLVaBm/h+lGe8UfPPivcbuJ6ecI4hIgW0LjI7kzpYB9FkN0L9apbVzg+lsBdcTf0AlBtODjcSX5mmKA==",
+      "requires": {
+        "prop-types": "^15.7.2"
+      },
+      "dependencies": {
+        "loose-envify": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
+      }
+    },
+    "@popperjs/core": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.9.2.tgz",
+      "integrity": "sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q=="
+    },
+    "@restart/context": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@restart/context/-/context-2.1.4.tgz",
+      "integrity": "sha512-INJYZQJP7g+IoDUh/475NlGiTeMfwTXUEr3tmRneckHIxNolGOW9CTq83S8cxq0CgJwwcMzMJFchxvlwe7Rk8Q=="
+    },
+    "@restart/hooks": {
+      "version": "0.3.26",
+      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.3.26.tgz",
+      "integrity": "sha512-7Hwk2ZMYm+JLWcb7R9qIXk1OoUg1Z+saKWqZXlrvFwT3w6UArVNWgxYOzf+PJoK9zZejp8okPAKTctthhXLt5g==",
+      "requires": {
+        "lodash": "^4.17.20",
+        "lodash-es": "^4.17.20"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
+        "lodash-es": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+          "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+        }
+      }
+    },
     "@sambego/storybook-styles": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@sambego/storybook-styles/-/storybook-styles-1.0.0.tgz",
       "integrity": "sha512-n0SqZwDewUDRaStEcoNMiYy9qovaLVStsh4Gb2dc2LLiG3IIK0UXdeR1N7puVuRihJq/192uOyGPCjZ/NAteuA=="
     },
+    "@types/classnames": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.3.1.tgz",
+      "integrity": "sha512-zeOWb0JGBoVmlQoznvqXbE0tEC/HONsnoUNH19Hc96NFsTAwTXbTqb8FMYkru1F/iqp7a18Ws3nWJvtA1sHD1A==",
+      "requires": {
+        "classnames": "*"
+      }
+    },
     "@types/cookie": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
       "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
+    },
+    "@types/invariant": {
+      "version": "2.2.34",
+      "resolved": "https://registry.npmjs.org/@types/invariant/-/invariant-2.2.34.tgz",
+      "integrity": "sha512-lYUtmJ9BqUN688fGY1U1HZoWT1/Jrmgigx2loq4ZcJpICECm/Om3V314BxdzypO0u5PORKGMM6x0OXaljV1YFg=="
     },
     "@types/node": {
       "version": "10.5.2",
@@ -300,6 +509,39 @@
       "version": "4.0.30",
       "resolved": "https://registry.npmjs.org/@types/object-assign/-/object-assign-4.0.30.tgz",
       "integrity": "sha1-iUk3HVqZ9Dge4PHfCpt6GH4H5lI="
+    },
+    "@types/prop-types": {
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
+    },
+    "@types/react": {
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.8.tgz",
+      "integrity": "sha512-3sx4c0PbXujrYAKwXxNONXUtRp9C+hE2di0IuxFyf5BELD+B+AXL8G7QrmSKhVwKZDbv0igiAjQAMhXj8Yg3aw==",
+      "requires": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "@types/react-transition-group": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.1.tgz",
+      "integrity": "sha512-vIo69qKKcYoJ8wKCJjwSgCTM+z3chw3g18dkrDfVX665tMH7tmbDxEAnPdey4gTlwZz5QuHGzd+hul0OVZDqqQ==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/scheduler": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
+      "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA=="
+    },
+    "@types/warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.0.tgz",
+      "integrity": "sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI="
     },
     "abab": {
       "version": "1.0.4",
@@ -625,6 +867,14 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "aria-hidden": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.1.3.tgz",
+      "integrity": "sha512-RhVWFtKH5BiGMycI72q2RAFMLQi8JP9bLuQXgR5a8Znp7P5KOIADSJeyfI8PCVxLEp067B2HbP5JIiI/PXIZeA==",
+      "requires": {
+        "tslib": "^1.0.0"
       }
     },
     "aria-query": {
@@ -3268,6 +3518,11 @@
         "cssom": "0.3.x"
       }
     },
+    "csstype": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
+      "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
+    },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -3559,6 +3814,11 @@
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
       "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
       "dev": true
+    },
+    "detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
     },
     "di": {
       "version": "0.0.1",
@@ -15048,6 +15308,11 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
       "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
     },
+    "get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="
+    },
     "get-stdin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
@@ -20180,6 +20445,15 @@
         }
       }
     },
+    "prop-types-extra": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.1.1.tgz",
+      "integrity": "sha512-59+AHNnHYCdiC+vMwY52WmvP5dM3QLeoumYuEyceQDi9aEhtwN9zIQ2ZNo25sMyXnbh32h+P1ezDsUpUH3JAew==",
+      "requires": {
+        "react-is": "^16.3.2",
+        "warning": "^4.0.0"
+      }
+    },
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -20365,6 +20639,109 @@
         "prop-types": "^15.6.0"
       }
     },
+    "react-bootstrap": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-1.6.0.tgz",
+      "integrity": "sha512-PaeOGeRC2+JH9Uf1PukJgXcIpfGlrKKHEBZIArymjenYzSJ/RhO2UdNX+e7nalsCFFZLRRgQ0/FKkscW2LmmRg==",
+      "requires": {
+        "@babel/runtime": "^7.13.8",
+        "@restart/context": "^2.1.4",
+        "@restart/hooks": "^0.3.26",
+        "@types/classnames": "^2.2.10",
+        "@types/invariant": "^2.2.33",
+        "@types/prop-types": "^15.7.3",
+        "@types/react": ">=16.9.35",
+        "@types/react-transition-group": "^4.4.1",
+        "@types/warning": "^3.0.0",
+        "classnames": "^2.2.6",
+        "dom-helpers": "^5.1.2",
+        "invariant": "^2.2.4",
+        "prop-types": "^15.7.2",
+        "prop-types-extra": "^1.1.0",
+        "react-overlays": "^5.0.0",
+        "react-transition-group": "^4.4.1",
+        "uncontrollable": "^7.2.1",
+        "warning": "^4.0.3"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.14.0",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
+          "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "classnames": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+          "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+        },
+        "dom-helpers": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+          "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+          "requires": {
+            "@babel/runtime": "^7.8.7",
+            "csstype": "^3.0.2"
+          }
+        },
+        "invariant": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+          "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          },
+          "dependencies": {
+            "loose-envify": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+              "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+              "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+              }
+            }
+          }
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        },
+        "react-transition-group": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
+          "integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
+          "requires": {
+            "@babel/runtime": "^7.5.5",
+            "dom-helpers": "^5.0.1",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2"
+          },
+          "dependencies": {
+            "loose-envify": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+              "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+              "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+              }
+            }
+          }
+        }
+      }
+    },
     "react-clientside-effect": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.2.tgz",
@@ -20397,6 +20774,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/react-element-proptypes/-/react-element-proptypes-1.0.0.tgz",
       "integrity": "sha1-ygpafBYk646CrQjqeIzfyWvBpRc="
+    },
+    "react-fast-compare": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
     "react-focus-lock": {
       "version": "1.19.1",
@@ -20431,6 +20813,70 @@
           "version": "16.13.1",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
           "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
+      }
+    },
+    "react-focus-on": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/react-focus-on/-/react-focus-on-3.5.2.tgz",
+      "integrity": "sha512-tpPxLqw9tEuElWmcr5jqw/ULfJjdHEnom0nBW9p6y75Zsa0wOfwQNqCHqCoJcHUqSBtKXqTuYduZoSTfTOTdJw==",
+      "requires": {
+        "aria-hidden": "^1.1.2",
+        "react-focus-lock": "^2.5.0",
+        "react-remove-scroll": "^2.4.1",
+        "react-style-singleton": "^2.1.1",
+        "use-callback-ref": "^1.2.5",
+        "use-sidecar": "^1.0.5"
+      },
+      "dependencies": {
+        "focus-lock": {
+          "version": "0.9.1",
+          "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.9.1.tgz",
+          "integrity": "sha512-/2Nj60Cps6yOLSO+CkVbeSKfwfns5XbX6HOedIK9PdzODP04N9c3xqOcPXayN0WsT9YjJvAnXmI0NdqNIDf5Kw==",
+          "requires": {
+            "tslib": "^2.0.3"
+          }
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        },
+        "react-focus-lock": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.5.1.tgz",
+          "integrity": "sha512-gOToRZKVEymGEjFaTRUKgJsdYQrNosoiK7yZnXnnd8bYew4vMzk3Rxb0Q4nyrGwsFuUmgQiSAulQirA0J+v4hA==",
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "focus-lock": "^0.9.1",
+            "prop-types": "^15.6.2",
+            "react-clientside-effect": "^1.2.2",
+            "use-callback-ref": "^1.2.1",
+            "use-sidecar": "^1.0.1"
+          }
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        },
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
         }
       }
     },
@@ -20503,13 +20949,78 @@
     "react-is": {
       "version": "16.4.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.4.1.tgz",
-      "integrity": "sha512-xpb0PpALlFWNw/q13A+1aHeyJyLYCg0/cCHPUA43zYluZuIPHaHL3k8OBsTgQtxqW0FhyDEMvi8fZ/+7+r4OSQ==",
-      "dev": true
+      "integrity": "sha512-xpb0PpALlFWNw/q13A+1aHeyJyLYCg0/cCHPUA43zYluZuIPHaHL3k8OBsTgQtxqW0FhyDEMvi8fZ/+7+r4OSQ=="
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-overlays": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-5.0.1.tgz",
+      "integrity": "sha512-plwUJieTBbLSrgvQ4OkkbTD/deXgxiJdNuKzo6n1RWE3OVnQIU5hffCGS/nvIuu6LpXFs2majbzaXY8rcUVdWA==",
+      "requires": {
+        "@babel/runtime": "^7.13.8",
+        "@popperjs/core": "^2.8.6",
+        "@restart/hooks": "^0.3.26",
+        "@types/warning": "^3.0.0",
+        "dom-helpers": "^5.2.0",
+        "prop-types": "^15.7.2",
+        "uncontrollable": "^7.2.1",
+        "warning": "^4.0.3"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.14.0",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
+          "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "dom-helpers": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+          "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+          "requires": {
+            "@babel/runtime": "^7.8.7",
+            "csstype": "^3.0.2"
+          }
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
+      }
+    },
+    "react-popper": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.5.tgz",
+      "integrity": "sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==",
+      "requires": {
+        "react-fast-compare": "^3.0.1",
+        "warning": "^4.0.2"
+      }
     },
     "react-proptype-conditional-require": {
       "version": "1.0.4",
@@ -20539,6 +21050,27 @@
         "lodash-es": "^4.17.5",
         "loose-envify": "^1.1.0",
         "prop-types": "^15.6.0"
+      }
+    },
+    "react-remove-scroll": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.4.2.tgz",
+      "integrity": "sha512-mMSIZYQF3jS2uRJXeFDRaVGA+BGs/hIryV64YUKsHFtpgwZloOUcdu0oW8K6OU8uLHt/kM5d0lUZbdpIVwgXtQ==",
+      "requires": {
+        "react-remove-scroll-bar": "^2.1.0",
+        "react-style-singleton": "^2.1.0",
+        "tslib": "^1.0.0",
+        "use-callback-ref": "^1.2.3",
+        "use-sidecar": "^1.0.1"
+      }
+    },
+    "react-remove-scroll-bar": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.2.0.tgz",
+      "integrity": "sha512-UU9ZBP1wdMR8qoUs7owiVcpaPwsQxUDC2lypP6mmixaGlARZa7ZIBx1jcuObLdhMOvCsnZcvetOho0wzPa9PYg==",
+      "requires": {
+        "react-style-singleton": "^2.1.0",
+        "tslib": "^1.0.0"
       }
     },
     "react-responsive": {
@@ -20682,6 +21214,31 @@
         "object-assign": "^4.1.0",
         "slick-carousel": "^1.6.0"
       }
+    },
+    "react-style-singleton": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.1.1.tgz",
+      "integrity": "sha512-jNRp07Jza6CBqdRKNgGhT3u9umWvils1xsuMOjZlghBDH2MU0PL2WZor4PGYjXpnRCa9DQSlHMs/xnABWOwYbA==",
+      "requires": {
+        "get-nonce": "^1.0.0",
+        "invariant": "^2.2.4",
+        "tslib": "^1.0.0"
+      },
+      "dependencies": {
+        "invariant": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+          "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        }
+      }
+    },
+    "react-table": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/react-table/-/react-table-7.7.0.tgz",
+      "integrity": "sha512-jBlj70iBwOTvvImsU9t01LjFjy4sXEtclBovl3mTiqjz23Reu0DKnRza4zlLtOPACx6j2/7MrQIthIK1Wi+LIA=="
     },
     "react-test-renderer": {
       "version": "16.4.0",
@@ -20901,6 +21458,11 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
       "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
+    },
+    "regenerator-runtime": {
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     },
     "regenerator-transform": {
       "version": "0.10.1",
@@ -23305,6 +23867,11 @@
       "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
       "dev": true
     },
+    "tabbable": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-4.0.0.tgz",
+      "integrity": "sha512-H1XoH1URcBOa/rZZWxLxHCtOdVUEev+9vo5YdYhC9tCY4wnybX+VQrCYuy9ubkg69fCBxCONJOSLGfw0DWMffQ=="
+    },
     "table": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
@@ -23882,6 +24449,11 @@
         "glob": "^7.1.2"
       }
     },
+    "tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
     "tty-browserify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
@@ -23997,6 +24569,27 @@
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
       "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
       "dev": true
+    },
+    "uncontrollable": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-7.2.1.tgz",
+      "integrity": "sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==",
+      "requires": {
+        "@babel/runtime": "^7.6.3",
+        "@types/react": ">=16.9.11",
+        "invariant": "^2.2.4",
+        "react-lifecycles-compat": "^3.0.4"
+      },
+      "dependencies": {
+        "invariant": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+          "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        }
+      }
     },
     "underscore": {
       "version": "1.8.3",
@@ -24261,6 +24854,20 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
+    "use-callback-ref": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.2.5.tgz",
+      "integrity": "sha512-gN3vgMISAgacF7sqsLPByqoePooY3n2emTH59Ur5d/M8eg4WTWu1xp8i8DHjohftIyEx0S08RiYxbffr4j8Peg=="
+    },
+    "use-sidecar": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.0.5.tgz",
+      "integrity": "sha512-k9jnrjYNwN6xYLj1iaGhonDghfvmeTmYjAiGvOr7clwKfPjMXJf4/HOr7oT5tJwYafgp2tG2l3eZEOfoELiMcA==",
+      "requires": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^1.9.3"
+      }
+    },
     "user-home": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
@@ -24433,6 +25040,14 @@
       "dev": true,
       "requires": {
         "makeerror": "1.0.x"
+      }
+    },
+    "warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "requires": {
+        "loose-envify": "^1.0.0"
       }
     },
     "watch": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@edx/edx-proctoring": "^1.5.0",
     "@edx/frontend-component-cookie-policy-banner": "1.0.0",
     "@edx/paragon": "2.6.4",
+    "@edx/paragon-new": "npm:@edx/paragon@^14.12.4",
     "@edx/studio-frontend": "^1.17.0",
     "axios": "^0.21.1",
     "babel-core": "6.26.0",

--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -529,6 +529,12 @@ def _compile_sass(system, theme, debug, force, timing_info):
         source_comments = False
         output_style = 'compressed'
 
+    def tilda_node_modules_importer(existing_path):
+        if existing_path.startswith('~'):
+            new_path = existing_path.replace('~', path('node_modules/'))
+            return [(new_path,)]
+        return None
+
     for dirs in sass_dirs:
         start = datetime.now()
         css_dir = dirs['css_destination_dir']
@@ -560,6 +566,7 @@ def _compile_sass(system, theme, debug, force, timing_info):
                 include_paths=COMMON_LOOKUP_PATHS + lookup_paths,
                 source_comments=source_comments,
                 output_style=output_style,
+                importers=[(0, tilda_node_modules_importer)]
             )
 
         # For Sass files without explicit RTL versions, generate

--- a/pavelib/utils/test/utils.py
+++ b/pavelib/utils/test/utils.py
@@ -51,7 +51,6 @@ def ensure_clean_package_lock():
     """
     Ensure no untracked changes have been made in the current git context.
     """
-    sh("git diff")
     sh("""
       git diff --name-only --exit-code package-lock.json ||
       (echo \"Dirty package-lock.json, run 'npm install' and commit the generated changes\" && exit 1)

--- a/pavelib/utils/test/utils.py
+++ b/pavelib/utils/test/utils.py
@@ -51,6 +51,7 @@ def ensure_clean_package_lock():
     """
     Ensure no untracked changes have been made in the current git context.
     """
+    sh("git diff")
     sh("""
       git diff --name-only --exit-code package-lock.json ||
       (echo \"Dirty package-lock.json, run 'npm install' and commit the generated changes\" && exit 1)


### PR DESCRIPTION
Swap Bootstrap SASS for Paragon SASS throughout studio and lms.

Builds off https://github.com/edx/edx-platform/pull/27751 and depends on https://github.com/edx/edx-themes/pull/737.

- Augment the SASS importer to understand the common `~` in imports to mean `node_modules/` that Paragon relies upon
- Swap Paragon SASS for Bootstrap anywhere it's used. In some cases this means adding all of Paragon in places where only Bootstrap mixins were used. Paragon doesn't offer pulling mixins, variables, and functions independently from the component css.
- Remove edx-bootstrap from default themes
- Map some missing colors in Paragon to reasonable defaults (inverse -> white, purchase -> success, lightest -> light-300)
- Fixes for some minor layout and color regressions

Key file sizes:

| file | prod | https://github.com/edx/edx-platform/pull/27751 + https://github.com/edx/edx-themes/pull/737 | This PR + https://github.com/edx/edx-themes/pull/737 |
|----|------|-------|--------|
| lms-course.css               | 778kb      | 1.4mb   | 1.6mb |
| lms-discussion-bootstrap.css | 189kb      | 210kb   | 350kb |
| lms-footer-edx.css           | 389kb      | 105kb   | 841kb |
| lms-main-v1.css              | 2.2mb      | 1.3mb   | 2.3mb |
| lms-main.css                 | 1.3mb      | 371kb   | 549kb |
| studio-main-v1.css           | 1.1mb      | 2.1mb   | 2.5mb |