### PR TITLE
build: assign edx/community-engineering for squad-owned directories

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,7 +10,6 @@ lms/djangoapps/grades/
 lms/djangoapps/instructor/
 lms/djangoapps/instructor_task/
 lms/djangoapps/mobile_api/
-openedx/core/djangoapps/contentserver/
 openedx/core/djangoapps/heartbeat/
 openedx/core/djangoapps/oauth_dispatch
 openedx/core/djangoapps/user_api/
@@ -39,3 +38,23 @@ lms/djangoapps/learner_dashboard/          @edx/platform-discovery
 openedx/features/content_type_gating/      @edx/rev-team
 openedx/features/course_duration_limits/   @edx/rev-team
 openedx/features/discounts/                @edx/rev-team
+
+# Community Engineering Squad
+common/djangoapps/edxmako                  @edx/community-engineering
+common/djangoapps/pipeline_mako            @edx/community-engineering
+common/static                              @edx/community-engineering
+common/templates                           @edx/community-engineering
+lms/djangoapps/ccx                         @edx/community-engineering
+lms/djangoapps/dashboard                   @edx/community-engineering
+lms/djangoapps/lti_provider                @edx/community-engineering
+lms/djangoapps/static_template_view        @edx/community-engineering
+lms/static                                 @edx/community-engineering
+lms/templates                              @edx/community-engineering
+openedx/core/djangoapps/ccxcon             @edx/community-engineering
+openedx/core/djangoapps/contentserver      @edx/community-engineering
+openedx/core/djangoapps/profile_images     @edx/community-engineering
+openedx/core/djangoapps/theming            @edx/community-engineering
+openedx/features/lti_course_tab            @edx/community-engineering
+openedx/features/learner_profile           @edx/community-engineering
+vendor_extra                               @edx/community-engineering
+webpack-config                             @edx/community-engineering


### PR DESCRIPTION
A couple of these (*/static, */templates) may prove to be too noisy, but
most of them seem low-traffic enough. If we find any of these
directories to be unhelpful, we can/should remove them.