### PR TITLE
fix: increase grading rounding precision to avoid incorrect grades

### DIFF
--- a/lms/djangoapps/grades/rest_api/v1/tests/test_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/tests/test_views.py
@@ -302,7 +302,7 @@ class SectionGradesBreakdownTest(GradeViewTestMixin, APITestCase):
             + [
                 {
                     'category': 'Homework',
-                    'detail': 'Homework Average = 0%',
+                    'detail': 'Homework Average = 0.00%',
                     'label': 'HW Avg', 'percent': 0.0,
                     'prominent': True
                 }
@@ -332,21 +332,21 @@ class SectionGradesBreakdownTest(GradeViewTestMixin, APITestCase):
                 },
                 {
                     'category': 'Lab',
-                    'detail': 'Lab Average = 0%',
+                    'detail': 'Lab Average = 0.00%',
                     'label': 'Lab Avg',
                     'percent': 0.0,
                     'prominent': True
                 },
                 {
                     'category': 'Midterm Exam',
-                    'detail': 'Midterm Exam = 0%',
+                    'detail': 'Midterm Exam = 0.00%',
                     'label': 'Midterm',
                     'percent': 0.0,
                     'prominent': True
                 },
                 {
                     'category': 'Final Exam',
-                    'detail': 'Final Exam = 0%',
+                    'detail': 'Final Exam = 0.00%',
                     'label': 'Final',
                     'percent': 0.0,
                     'prominent': True

--- a/lms/djangoapps/grades/scores.py
+++ b/lms/djangoapps/grades/scores.py
@@ -162,8 +162,8 @@ def compute_percent(earned, possible):
      Returns the percentage of the given earned and possible values.
      """
     if possible > 0:
-        # Rounds to two decimal places.
-        return around(earned / possible, decimals=2)
+        # Rounds to four decimal places.
+        return around(earned / possible, decimals=4)
     else:
         return 0.0
 

--- a/lms/djangoapps/grades/tests/test_course_grade_factory.py
+++ b/lms/djangoapps/grades/tests/test_course_grade_factory.py
@@ -185,26 +185,26 @@ class TestCourseGradeFactory(GradeTestBase):
             'section_breakdown': [
                 {
                     'category': 'Homework',
-                    'detail': 'Homework 1 - Test Sequential X with an & Ampersand - 50% (1/2)',
+                    'detail': 'Homework 1 - Test Sequential X with an & Ampersand - 50.00% (1/2)',
                     'label': 'HW 01',
                     'percent': 0.5
                 },
                 {
                     'category': 'Homework',
-                    'detail': 'Homework 2 - Test Sequential A - 0% (0/1)',
+                    'detail': 'Homework 2 - Test Sequential A - 0.00% (0/1)',
                     'label': 'HW 02',
                     'percent': 0.0
                 },
                 {
                     'category': 'Homework',
-                    'detail': 'Homework Average = 25%',
+                    'detail': 'Homework Average = 25.00%',
                     'label': 'HW Avg',
                     'percent': 0.25,
                     'prominent': True
                 },
                 {
                     'category': 'NoCredit',
-                    'detail': 'NoCredit Average = 0%',
+                    'detail': 'NoCredit Average = 0.00%',
                     'label': 'NC Avg',
                     'percent': 0,
                     'prominent': True

--- a/lms/djangoapps/grades/tests/test_subsection_grade.py
+++ b/lms/djangoapps/grades/tests/test_subsection_grade.py
@@ -14,7 +14,7 @@ from .utils import mock_get_score
 @ddt
 class SubsectionGradeTest(GradeTestBase):  # lint-amnesty, pylint: disable=missing-class-docstring
 
-    @data((50, 100, .50), (59.49, 100, .59), (59.51, 100, .60), (59.50, 100, .60), (60.5, 100, .60))
+    @data((50, 100, .5), (.5949, 100, .0059), (.5951, 100, .006), (.595, 100, .0059), (.605, 100, .006))
     @unpack
     def test_create_and_read(self, mock_earned, mock_possible, expected_result):
         with mock_get_score(mock_earned, mock_possible):

--- a/xmodule/graders.py
+++ b/xmodule/graders.py
@@ -387,7 +387,7 @@ class AssignmentFormatGrader(CourseGrader):
                     section_name = scores[i].display_name
 
                 percentage = scores[i].percent_graded
-                summary_format = "{section_type} {index} - {name} - {percent:.0%} ({earned:.3n}/{possible:.3n})"
+                summary_format = "{section_type} {index} - {name} - {percent:.2%} ({earned:.3n}/{possible:.3n})"
                 summary = summary_format.format(
                     index=i + self.starting_index,
                     section_type=self.section_type,
@@ -421,7 +421,7 @@ class AssignmentFormatGrader(CourseGrader):
         if len(breakdown) == 1:
             # if there is only one entry in a section, suppress the existing individual entry and the average,
             # and just display a single entry for the section.
-            total_detail = "{section_type} = {percent:.0%}".format(
+            total_detail = "{section_type} = {percent:.2%}".format(
                 percent=total_percent,
                 section_type=self.section_type,
             )
@@ -430,7 +430,7 @@ class AssignmentFormatGrader(CourseGrader):
                           'detail': total_detail, 'category': self.category, 'prominent': True}, ]
         else:
             # Translators: "Homework Average = 0%"
-            total_detail = _("{section_type} Average = {percent:.0%}").format(
+            total_detail = _("{section_type} Average = {percent:.2%}").format(
                 percent=total_percent,
                 section_type=self.section_type
             )


### PR DESCRIPTION
Enabling the rounding in #16837 has been causing noticeable (up to 1 percentage point) differences between non-rounded subsection grades and a total grade for a course. This increases the grade precision to reduce the negative implications of double rounding.

## Jira

[OSPR-5819](https://openedx.atlassian.net/browse/OSPR-5819)

## Sandbox
https://pr27788.sandbox.opencraft.hosting/
[Direct link](https://pr27788.sandbox.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/progress) to the progress page (you can log in as staff).

## Testing instructions

1. Import [this course](https://github.com/openedx/edx-platform/files/15449379/grades_rounding_course.tar.gz) in Studio.
1. Complete two units from there.
1. Go to the `Progress` page and see that the score without this PR is 35%. After this change, it should be 34%.

## Explanation
This course contains two subsections graded as `Homework` (weight: 75%):
1. In the first subsection, users can get 2 out of 3 points (66.67%).
1. In the second one, users can get 1 out of 4 points (25%).

In the current approach, the grades of subsections are rounded. Therefore, in this case, we're getting `(67% + 25%) / 2 / 4 * 3` (`/ 4 * 3` is because of the weight (75%)), which gives us `34.5`. This is rounded up to `35%`.

This PR changes these calculations to `(66.67% + 25%) / 2 / 4 * 3`, which returns `34.37625`, which is then rounded down to `34%`.

## Deadline
None.

## Reviewers

- [x] @arjunsinghy96 
- [ ] edX reviewer[s] TBD

## Other information
Private-ref: [BB-4210](https://tasks.opencraft.com/browse/BB-4210)
Product Review: https://github.com/openedx/platform-roadmap/issues/238
**Settings**
```yaml
```

**Tutor requirements**
```
git+https://github.com/overhangio/tutor.git@nightly
git+https://github.com/overhangio/tutor-discovery.git@nightly
git+https://github.com/overhangio/tutor-ecommerce.git@nightly
git+https://github.com/overhangio/tutor-xqueue.git@nightly
git+https://github.com/overhangio/tutor-forum.git@nightly

git+https://gitlab.com/opencraft/dev/tutor-contrib-grove.git@v16.0.0
git+https://github.com/hastexo/tutor-contrib-s3.git@v1.2.0
```