### PR TITLE
fix: handle opening verticals in new tabs with the "View In Studio" button [BB-4211]

### DIFF
--- a/lms/templates/preview_menu.html
+++ b/lms/templates/preview_menu.html
@@ -107,7 +107,7 @@ show_preview_menu = course and can_masquerade and supports_preview_menu
                 </a>
                 <script type="text/javascript">
                   $(function () {
-                      $('.wrapper-preview-menu a.view-in-studio').click(function (event) {
+                      $('.wrapper-preview-menu a.view-in-studio').focus(function (event) {
                           /*
                           When we start rendering this template, we
                           don't yet have a vertical in the context
@@ -115,9 +115,11 @@ show_preview_menu = course and can_masquerade and supports_preview_menu
                           if this is even on a unit-level page),
                           so we dynamically lookup the vertical element in
                           the DOM and use its data-* attributes to
-                          construct a Studio link directly to this unit.
-                          If no vertical is present, the link behaves as
-                          normal.
+                          construct a Studio link directly to this unit
+                          and replace the href attribute with it. If no
+                          vertical is present, the link directs to the
+                          course outline page in Studio.
+
                           */
                           var verticals = $('.xblock-student_view-vertical');
                           if (verticals.length > 0) {
@@ -127,12 +129,8 @@ show_preview_menu = course and can_masquerade and supports_preview_menu
                                 'container',
                                 blockId,
                               ].join('/');
-                              window.location.href = url;
-                              return false;
+                              $(this).attr("href", url);
                           }
-                          // There's no vertical, so let the event
-                          // bubble up, ie, work like a normal link.
-                          return true;
                       });
                     });
                   </script>


### PR DESCRIPTION
#24020 introduced a workaround for viewing the current vertical in Studio However, replacing `window.location.href` on `click` did not support opening it in a new tab.

## Jira

[OSPR-5821](https://openedx.atlassian.net/browse/OSPR-5821)

## Sandbox
https://pr27799.sandbox.opencraft.hosting/

## Testing instructions

1. Go to [this page](http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/courseware/interactive_demonstrations/19a30717eff543078a5d94ae9d6c18a5/?child=first) (or [this one](https://pr27799.sandbox.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/courseware/interactive_demonstrations/basic_questions/?activate_block_id=block-v1%3AedX%2BDemoX%2BDemo_Course%2Btype%40sequential%2Bblock%40basic_questions) in the sandbox).
1. Use the middle mouse button (or right-click + open link in new tab) on the "View in Studio" button.
1. Check that you have been redirected to the specific vertical instead of the course outline page in Studio.

## Deadline
None.

## Reviewers

- [ ] @arjunsinghy96 
- [ ] edX reviewer[s] TBD