### PR TITLE
[AA-759] fix: pass in course key when checking the bucket for the streak discount experiment

### DIFF
--- a/lms/djangoapps/experiments/flags.py
+++ b/lms/djangoapps/experiments/flags.py
@@ -175,6 +175,8 @@ class ExperimentWaffleFlag(CourseWaffleFlag):
 
         Arguments:
             course_key (Optional[CourseKey])
+                This argument should always be passed in a course-aware context even if
+                course aware bucketing is False.
             track (bool):
                 Whether an analytics event should be generated if the user is
                 bucketed for the first time.

--- a/openedx/core/djangoapps/courseware_api/utils.py
+++ b/openedx/core/djangoapps/courseware_api/utils.py
@@ -37,7 +37,7 @@ def get_celebrations_dict(user, enrollment, course, browser_timezone):
         # We only want to bucket people into the AA-759 experiment
         # if the course has not ended, is upgradeable and the user is not an enterprise learner
         if can_show_streak_discount_experiment_coupon(user, course):
-            celebrations['streak_discount_experiment_enabled'] = STREAK_DISCOUNT_EXPERIMENT_FLAG.is_enabled()
+            celebrations['streak_discount_experiment_enabled'] = STREAK_DISCOUNT_EXPERIMENT_FLAG.is_enabled(course.id)
     return celebrations
 
 


### PR DESCRIPTION
This is necessary for the experiment event to send
Added a comment around the point I was previously confused by