### PR TITLE
Make sure hamburger menu text is right aligned in LTR mode

### DIFF
--- a/lms/static/sass/_header.scss
+++ b/lms/static/sass/_header.scss
@@ -366,7 +366,7 @@
         width: 100%;
         padding: $baseline*0.6 $baseline;
         border-bottom: 1px solid theme-color('light');
-        text-align: left;
+        @include text-align(left);
         cursor: pointer;
 
         &:hover,


### PR DESCRIPTION
## Description

When a LTR language is selected, the mobile hamburger menu text is left aligned, flowing out of the view.
It should be right aligned.

## Testing instructions

Try opening the menu in mobile view, before and after the change.
