### PR TITLE
TNL-8080 ][: Use module mixin and fix permissions for proxy models.

### DIFF
--- a/cms/djangoapps/contentstore/admin.py
+++ b/cms/djangoapps/contentstore/admin.py
@@ -8,6 +8,7 @@ from config_models.admin import ConfigurationModelAdmin
 from django.contrib import admin
 from django.contrib.admin.helpers import ACTION_CHECKBOX_NAME
 from django.utils.translation import ugettext as _
+from edx_django_utils.admin.mixins import ReadOnlyAdminMixin
 
 from cms.djangoapps.contentstore.models import VideoUploadConfig
 from cms.djangoapps.contentstore.outlines_regenerate import CourseOutlineRegenerate
@@ -17,37 +18,6 @@ from .tasks import update_outline_from_modulestore_task, update_all_outlines_fro
 
 
 log = logging.getLogger(__name__)
-
-
-class ReadOnlyAdminMixin(object):
-    """
-    Disables all editing capabilities for the admin's model.
-    """
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.list_display_links = None
-        self.readonly_fields = [f.name for f in self.model._meta.get_fields()]
-
-    def get_actions(self, request):
-        actions = super().get_actions(request)
-        if 'delete_selected' in actions:
-            del actions["delete_selected"]
-        return actions
-
-    def has_add_permission(self, request):
-        return False
-
-    def has_delete_permission(self, request, obj=None):  # pylint: disable=unused-argument
-        return False
-
-    def save_model(self, request, obj, form, change):
-        pass
-
-    def delete_model(self, request, obj):
-        pass
-
-    def save_related(self, request, form, formsets, change):
-        pass
 
 
 def regenerate_course_outlines_subset(modeladmin, request, queryset):

--- a/common/djangoapps/student/management/commands/manage_group.py
+++ b/common/djangoapps/student/management/commands/manage_group.py
@@ -103,7 +103,8 @@ class Command(BaseCommand):  # lint-amnesty, pylint: disable=missing-class-docst
             except LookupError as exc:
                 raise CommandError(str(exc))  # lint-amnesty, pylint: disable=raise-missing-from
 
-            content_type = ContentType.objects.get_for_model(model_class)
+            # Fetch content type for model, including proxy models.
+            content_type = ContentType.objects.get_for_model(model_class, for_concrete_model=False)
             try:
                 new_permission = Permission.objects.get(
                     content_type=content_type,

--- a/requirements/edx-sandbox/py35.txt
+++ b/requirements/edx-sandbox/py35.txt
@@ -62,7 +62,6 @@ numpy==1.16.5
     #   chem
     #   matplotlib
     #   openedx-calc
-    #   scipy
 openedx-calc==1.0.9
     # via -r requirements/edx-sandbox/py35.in
 pycparser==2.20

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -410,7 +410,7 @@ edx-django-release-util==1.0.0
     # via -r requirements/edx/base.in
 edx-django-sites-extensions==3.0.0
     # via -r requirements/edx/base.in
-edx-django-utils==4.0.0
+edx-django-utils==4.1.0
     # via
     #   -r requirements/edx/base.in
     #   django-config-models

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -173,7 +173,7 @@ coreschema==0.0.4
     #   -r requirements/edx/testing.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==5.5
+coverage==5.5
     # via
     #   -r requirements/edx/testing.txt
     #   pytest-cov
@@ -497,7 +497,7 @@ edx-django-release-util==1.0.0
     # via -r requirements/edx/testing.txt
 edx-django-sites-extensions==3.0.0
     # via -r requirements/edx/testing.txt
-edx-django-utils==4.0.0
+edx-django-utils==4.1.0
     # via
     #   -r requirements/edx/testing.txt
     #   django-config-models
@@ -1039,7 +1039,7 @@ pysrt==1.1.2
     #   edxval
 pytest-attrib==0.1.3
     # via -r requirements/edx/testing.txt
-pytest-cov==2.12.0
+pytest-cov==2.12.1
     # via -r requirements/edx/testing.txt
 pytest-django==4.3.0
     # via -r requirements/edx/testing.txt
@@ -1366,9 +1366,9 @@ tincan==1.0.0
 toml==0.10.2
     # via
     #   -r requirements/edx/testing.txt
-    #   coverage
     #   pylint
     #   pytest
+    #   pytest-cov
     #   tox
     #   vulture
 tox-battery==0.6.1

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -163,7 +163,7 @@ coreschema==0.0.4
     #   -r requirements/edx/base.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==5.5
+coverage==5.5
     # via
     #   -r requirements/edx/coverage.txt
     #   pytest-cov
@@ -480,7 +480,7 @@ edx-django-release-util==1.0.0
     # via -r requirements/edx/base.txt
 edx-django-sites-extensions==3.0.0
     # via -r requirements/edx/base.txt
-edx-django-utils==4.0.0
+edx-django-utils==4.1.0
     # via
     #   -r requirements/edx/base.txt
     #   django-config-models
@@ -982,7 +982,7 @@ pysrt==1.1.2
     #   edxval
 pytest-attrib==0.1.3
     # via -r requirements/edx/testing.in
-pytest-cov==2.12.0
+pytest-cov==2.12.1
     # via -r requirements/edx/testing.in
 pytest-django==4.3.0
     # via -r requirements/edx/testing.in
@@ -1274,9 +1274,9 @@ tincan==1.0.0
     #   edx-event-routing-backends
 toml==0.10.2
     # via
-    #   coverage
     #   pylint
     #   pytest
+    #   pytest-cov
     #   tox
 tox-battery==0.6.1
     # via -r requirements/edx/testing.in


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Phase 2 of the work for this JIRA ticket:
https://openedx.atlassian.net/browse/TNL-8080

Upgrade all Python requirements via `make upgrade` in order to use the newest version of edx-django-utils.
Shift to using that module's `ReadOnlyAdminMixin` and delete the included implementation.
Allow for permission-granting to proxy models as well as concrete models via app-permissions.

## Supporting information

https://openedx.atlassian.net/browse/TNL-8080
