### PR TITLE
[AA-759b] fix: pass course_key as a string in the edx.bi.experiment.AA759.bucketed event

### DIFF
--- a/lms/djangoapps/experiments/flags.py
+++ b/lms/djangoapps/experiments/flags.py
@@ -275,7 +275,7 @@ class ExperimentWaffleFlag(CourseWaffleFlag):
                         user_id=user.id,
                         event_name='edx.bi.experiment.AA759.bucketed',
                         properties={
-                            'course_id': course_key,
+                            'course_id': str(course_key),
                             'bucket': bucket,
                             'sku': verified_mode.sku,
                         }


### PR DESCRIPTION
It looks like the property was getting dropped because the course_key wasn't a string