### PR TITLE
test: Add model tests

### DIFF
--- a/lms/djangoapps/certificates/models.py
+++ b/lms/djangoapps/certificates/models.py
@@ -135,7 +135,7 @@ class CertificateAllowlist(TimeStampedModel):
     @classmethod
     def get_certificate_allowlist(cls, course_id, student=None):
         """
-        Return the certificate allowlist for the given course as dict object
+        Return the certificate allowlist for the given course as a list of dict objects
         with the following key-value pairs:
 
         [{

--- a/lms/djangoapps/certificates/tests/factories.py
+++ b/lms/djangoapps/certificates/tests/factories.py
@@ -9,6 +9,7 @@ from factory.django import DjangoModelFactory
 
 from common.djangoapps.student.models import LinkedInAddToProfileConfiguration
 from lms.djangoapps.certificates.models import (
+    CertificateAllowlist,
     CertificateHtmlViewConfiguration,
     CertificateInvalidation,
     CertificateStatuses,
@@ -45,6 +46,21 @@ class CertificateAllowlistFactory(DjangoModelFactory):
     notes = 'Test Notes'
 
 
+class TemporaryCertificateAllowlistFactory(DjangoModelFactory):
+    """
+    Temporary certificate allowlist factory.
+
+    This will be removed once the CertificateAllowlistFactory uses the CertificateAllowlist as its model.
+    """
+
+    class Meta:
+        model = CertificateAllowlist
+
+    course_id = None
+    allowlist = True
+    notes = 'Test Notes'
+
+
 class CertificateInvalidationFactory(DjangoModelFactory):
     """
     CertificateInvalidation factory
@@ -70,18 +86,18 @@ class CertificateHtmlViewConfigurationFactory(DjangoModelFactory):
             "default": {
                 "accomplishment_class_append": "accomplishment-certificate",
                 "platform_name": "edX",
-                "company_about_url": "http://www.edx.org/about-us",
-                "company_privacy_url": "http://www.edx.org/edx-privacy-policy",
-                "company_tos_url": "http://www.edx.org/edx-terms-service",
-                "company_verified_certificate_url": "http://www.edx.org/verified-certificate",
+                "company_about_url": "https://www.edx.org/about-us",
+                "company_privacy_url": "https://www.edx.org/edx-privacy-policy",
+                "company_tos_url": "https://www.edx.org/edx-terms-service",
+                "company_verified_certificate_url": "https://www.edx.org/verified-certificate",
                 "document_stylesheet_url_application": "/static/certificates/sass/main-ltr.css",
                 "logo_src": "/static/certificates/images/logo-edx.png",
-                "logo_url": "http://www.edx.org"
+                "logo_url": "https://www.edx.org"
             },
             "honor": {
                 "certificate_type": "Honor Code",
                 "certificate_title": "Certificate of Achievement",
-                "logo_url": "http://www.edx.org/honor_logo.png"
+                "logo_url": "https://www.edx.org/honor_logo.png"
             },
             "verified": {
                 "certificate_type": "Verified",


### PR DESCRIPTION
Add tests for the new allowlist model. This is using the new _TemporaryCertificateAllowlistFactory_ for now, until we get more of the code switched over to calling the new _CertificateAllowlist_ model.

Also fixes a method description, and changes _http_ to _https_ in tests since that makes PyCharm happier.

MICROBA-982