### PR TITLE
feat: Add a create enrollment endpoint for support tools

### DIFF
--- a/lms/djangoapps/support/static/support/js/models/enrollment.js
+++ b/lms/djangoapps/support/static/support/js/models/enrollment.js
@@ -5,7 +5,7 @@
             updateEnrollment: function(new_mode, reason) {
                 return $.ajax({
                     url: this.url(),
-                    type: 'POST',
+                    type: 'PATCH',
                     contentType: 'application/json',
                     data: JSON.stringify({
                         course_id: this.get('course_id'),

--- a/lms/djangoapps/support/static/support/js/spec/models/enrollment_spec.js
+++ b/lms/djangoapps/support/static/support/js/spec/models/enrollment_spec.js
@@ -22,7 +22,7 @@ define([
                     reason: 'Financial Assistance'
                 };
             enrollment.updateEnrollment('verified', 'Financial Assistance');
-            AjaxHelpers.expectJsonRequest(requests, 'POST', '/support/enrollment/test-user', {
+            AjaxHelpers.expectJsonRequest(requests, 'PATCH', '/support/enrollment/test-user', {
                 course_id: EnrollmentHelpers.TEST_COURSE,
                 new_mode: 'verified',
                 old_mode: 'audit',

--- a/lms/djangoapps/support/static/support/js/spec/views/enrollment_modal_spec.js
+++ b/lms/djangoapps/support/static/support/js/spec/views/enrollment_modal_spec.js
@@ -73,7 +73,7 @@ define([
             $('.enrollment-new-mode').val('verified');
             $('.enrollment-reason').val('Financial Assistance');
             $('.enrollment-change-submit').click();
-            AjaxHelpers.expectJsonRequest(requests, 'POST', '/support/enrollment/test-user', {
+            AjaxHelpers.expectJsonRequest(requests, 'PATCH', '/support/enrollment/test-user', {
                 course_id: EnrollmentHelpers.TEST_COURSE,
                 new_mode: 'verified',
                 old_mode: 'audit',


### PR DESCRIPTION
## Description

This PR does the following:
1. Changes the existing `post` request method to change an enrollment to a `patch` request method.
2. Add a new `post` request method to create a new enrollment against a course run id

## Supporting information

[PROD-1637](https://openedx.atlassian.net/browse/PROD-1637)

- [x] A unit test to be added for the new create enrollment endpoint.