### PR TITLE
feat!: Enable v2 of course certificates for all course runs

### DIFF
--- a/lms/djangoapps/certificates/docs/decisions/002-cert-requirements.rst
+++ b/lms/djangoapps/certificates/docs/decisions/002-cert-requirements.rst
@@ -30,7 +30,3 @@ be true at the time the certificate is generated:
 * The user must have passed the course run
 * The user must not be a beta tester in the course run
 * The course run must not be a CCX (custom edX course)
-
-Note: the above requirements were written for V2 of course certificates, which
-assumes the CourseWaffleFlag *certificates_revamp.use_updated* has been enabled
-for the course run. If it has not been enabled, the prior logic will apply.

--- a/lms/djangoapps/certificates/generation_handler.py
+++ b/lms/djangoapps/certificates/generation_handler.py
@@ -342,11 +342,14 @@ def _can_set_cert_status_common(user, course_key):
     return True
 
 
-def is_using_v2_course_certificates(course_key):
+def is_using_v2_course_certificates(course_key):    # pylint: disable=unused-argument
     """
     Return True if the course run is using v2 course certificates
+
+    Note: this currently always returns True. This is an interim step as we roll out the feature to all course runs,
+    and the method will be removed entirely in MICROBA-1083.
     """
-    return CERTIFICATES_USE_UPDATED.is_enabled(course_key)
+    return True
 
 
 def is_on_certificate_allowlist(user, course_key):

--- a/lms/djangoapps/certificates/management/commands/tests/test_cert_management.py
+++ b/lms/djangoapps/certificates/management/commands/tests/test_cert_management.py
@@ -6,17 +6,13 @@ from unittest.mock import patch
 import ddt
 from django.core.management import call_command
 from django.core.management.base import CommandError
-from django.test.utils import override_settings
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
-from lms.djangoapps.badges.events.course_complete import get_completion_badge
-from lms.djangoapps.badges.models import BadgeAssertion
-from lms.djangoapps.badges.tests.factories import BadgeAssertionFactory, CourseCompleteImageConfigurationFactory
+from lms.djangoapps.badges.tests.factories import CourseCompleteImageConfigurationFactory
 from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.certificates.models import GeneratedCertificate
 from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
-from lms.djangoapps.grades.tests.utils import mock_passing_grade
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
@@ -68,56 +64,6 @@ class ResubmitErrorCertificatesTest(CertificateManagementTest):
     """Tests for the resubmit_error_certificates management command. """
     ENABLED_SIGNALS = ['course_published']
 
-    @ddt.data(CourseMode.HONOR, CourseMode.VERIFIED)
-    def test_resubmit_error_certificate(self, mode):
-        # Create a certificate with status 'error'
-        self._create_cert(self.courses[0].id, self.user, CertificateStatuses.error, mode)
-
-        # Re-submit all certificates with status 'error'
-        call_command(self.command)
-
-        # Expect that the certificate was re-submitted
-        self._assert_cert_status(self.courses[0].id, self.user, CertificateStatuses.notpassing)
-
-    def test_resubmit_error_certificate_in_a_course(self):
-        # Create a certificate with status 'error'
-        # in three courses.
-        for idx in range(3):
-            self._create_cert(self.courses[idx].id, self.user, CertificateStatuses.error)
-
-        # Re-submit certificates for two of the courses
-        call_command(self.command, course_key_list=[
-            str(self.courses[0].id),
-            str(self.courses[1].id)
-        ])
-
-        # Expect that the first two courses have been re-submitted,
-        # but not the third course.
-        self._assert_cert_status(self.courses[0].id, self.user, CertificateStatuses.notpassing)
-        self._assert_cert_status(self.courses[1].id, self.user, CertificateStatuses.notpassing)
-        self._assert_cert_status(self.courses[2].id, self.user, CertificateStatuses.error)
-
-    @ddt.data(
-        CertificateStatuses.deleted,
-        CertificateStatuses.deleting,
-        CertificateStatuses.downloadable,
-        CertificateStatuses.generating,
-        CertificateStatuses.notpassing,
-        CertificateStatuses.restricted,
-        CertificateStatuses.unavailable,
-    )
-    def test_resubmit_error_certificate_skips_non_error_certificates(self, other_status):
-        # Create certificates with an error status and some other status
-        self._create_cert(self.courses[0].id, self.user, CertificateStatuses.error)
-        self._create_cert(self.courses[1].id, self.user, other_status)
-
-        # Re-submit certificates for all courses
-        call_command(self.command)
-
-        # Only the certificate with status "error" should have been re-submitted
-        self._assert_cert_status(self.courses[0].id, self.user, CertificateStatuses.notpassing)
-        self._assert_cert_status(self.courses[1].id, self.user, other_status)
-
     def test_resubmit_error_certificate_none_found(self):
         self._create_cert(self.courses[0].id, self.user, CertificateStatuses.downloadable)
         call_command(self.command)
@@ -146,111 +92,3 @@ class ResubmitErrorCertificatesTest(CertificateManagementTest):
         invalid_key = "invalid/"
         with self.assertRaisesRegex(CommandError, invalid_key):
             call_command(self.command, course_key_list=[invalid_key])
-
-
-@ddt.ddt
-class RegenerateCertificatesTest(CertificateManagementTest):
-    """
-    Tests for regenerating certificates.
-    """
-    command = 'regenerate_user'
-
-    def setUp(self):
-        """
-        We just need one course here.
-        """
-        super().setUp()
-        self.course = self.courses[0]
-
-    @ddt.data(True, False)
-    @override_settings(CERT_QUEUE='test-queue')
-    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_OPENBADGES': True})
-    @patch('lms.djangoapps.certificates.generation_handler.XQueueCertInterface', spec=True)
-    def test_clear_badge(self, issue_badges, xqueue):
-        """
-        Given that I have a user with a badge
-        If I run regeneration for a user
-        Then certificate generation will be requested
-        And the badge will be deleted if badge issuing is enabled
-        """
-        key = self.course.location.course_key
-        self._create_cert(key, self.user, CertificateStatuses.downloadable)
-        badge_class = get_completion_badge(key, self.user)
-        BadgeAssertionFactory(badge_class=badge_class, user=self.user)
-        assert BadgeAssertion.objects.filter(user=self.user, badge_class=badge_class)
-        self.course.issue_badges = issue_badges
-        self.store.update_item(self.course, None)
-
-        args = f'-u {self.user.email} -c {str(key)}'
-        call_command(self.command, *args.split(' '))
-
-        assert xqueue.return_value.regen_cert.call_args.args == (
-            self.user,
-            key,
-        )
-        regen_cert_call_kwargs = xqueue.return_value.regen_cert.call_args.kwargs
-        assert regen_cert_call_kwargs == {
-            'forced_grade': None,
-            'template_file': None,
-            'generate_pdf': True,
-        }
-
-        assert bool(BadgeAssertion.objects.filter(user=self.user, badge_class=badge_class)) == (not issue_badges)
-
-    @override_settings(CERT_QUEUE='test-queue')
-    @patch('capa.xqueue_interface.XQueueInterface.send_to_queue', spec=True)
-    def test_regenerating_certificate(self, mock_send_to_queue):
-        """
-        Given that I have a user who has not passed course
-        If I run regeneration for that user
-        Then certificate generation will be not be requested
-        """
-        key = self.course.location.course_key
-        self._create_cert(key, self.user, CertificateStatuses.downloadable)
-
-        args = f'-u {self.user.email} -c {str(key)} --insecure'
-        call_command(self.command, *args.split(' '))
-
-        certificate = GeneratedCertificate.eligible_certificates.get(
-            user=self.user,
-            course_id=key
-        )
-        assert certificate.status == CertificateStatuses.notpassing
-        assert not mock_send_to_queue.called
-
-
-class UngenerateCertificatesTest(CertificateManagementTest):
-    """
-    Tests for generating certificates.
-    """
-    command = 'ungenerated_certs'
-
-    def setUp(self):
-        """
-        We just need one course here.
-        """
-        super().setUp()
-        self.course = self.courses[0]
-
-    @override_settings(CERT_QUEUE='test-queue')
-    @patch('capa.xqueue_interface.XQueueInterface.send_to_queue', spec=True)
-    def test_ungenerated_certificate(self, mock_send_to_queue):
-        """
-        Given that I have ended course
-        If I run ungenerated certs command
-        Then certificates should be generated for all users who passed course
-        """
-        mock_send_to_queue.return_value = (0, "Successfully queued")
-        key = self.course.location.course_key
-        self._create_cert(key, self.user, CertificateStatuses.unavailable)
-
-        with mock_passing_grade():
-            args = f'-c {str(key)} --insecure'
-            call_command(self.command, *args.split(' '))
-
-        assert mock_send_to_queue.called
-        certificate = GeneratedCertificate.eligible_certificates.get(
-            user=self.user,
-            course_id=key
-        )
-        assert certificate.status == CertificateStatuses.generating

--- a/lms/djangoapps/certificates/tests/test_generation_handler.py
+++ b/lms/djangoapps/certificates/tests/test_generation_handler.py
@@ -133,7 +133,6 @@ class AllowlistTests(ModuleStoreTestCase):
 
         assert not _can_generate_allowlist_certificate(u, self.course_run_key)
         assert not generate_allowlist_certificate_task(u, self.course_run_key)
-        assert not can_generate_certificate_task(u, self.course_run_key)
         assert not generate_certificate_task(u, self.course_run_key)
         assert _set_allowlist_cert_status(u, self.course_run_key) is None
 
@@ -321,7 +320,6 @@ class CertificateTests(ModuleStoreTestCase):
         """
         other_user = UserFactory()
         assert not _can_generate_v2_certificate(other_user, self.course_run_key)
-        assert not can_generate_certificate_task(other_user, self.course_run_key)
         assert not generate_certificate_task(other_user, self.course_run_key)
         assert not generate_regular_certificate_task(other_user, self.course_run_key)
 
@@ -330,13 +328,6 @@ class CertificateTests(ModuleStoreTestCase):
         Test the updated flag
         """
         assert is_using_v2_course_certificates(self.course_run_key)
-
-    @override_waffle_flag(CERTIFICATES_USE_UPDATED, active=False)
-    def test_is_using_updated_false(self):
-        """
-        Test the updated flag without the override
-        """
-        assert not is_using_v2_course_certificates(self.course_run_key)
 
     @ddt.data(
         (CertificateStatuses.deleted, True),
@@ -478,13 +469,6 @@ class CertificateTests(ModuleStoreTestCase):
         with mock.patch(COURSE_OVERVIEW_METHOD, return_value=None):
             assert not _can_generate_v2_certificate(self.user, self.course_run_key)
             assert _set_v2_cert_status(self.user, self.course_run_key) is None
-
-    @override_waffle_flag(CERTIFICATES_USE_UPDATED, active=False)
-    def test_cert_status_v1(self):
-        """
-        Test cert status with V1 of course certs
-        """
-        assert _set_v2_cert_status(self.user, self.course_run_key) is None
 
     def test_cert_status_downloadable(self):
         """

--- a/lms/djangoapps/certificates/tests/test_webview_views.py
+++ b/lms/djangoapps/certificates/tests/test_webview_views.py
@@ -41,7 +41,6 @@ from lms.djangoapps.certificates.tests.factories import (
     LinkedInAddToProfileConfigurationFactory
 )
 from lms.djangoapps.certificates.utils import get_certificate_url
-from lms.djangoapps.grades.tests.utils import mock_passing_grade
 from openedx.core.djangoapps.certificates.config import waffle
 from openedx.core.djangoapps.dark_lang.models import DarkLangConfig
 from openedx.core.djangoapps.site_configuration.tests.test_util import (
@@ -966,21 +965,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         response = self.client.post(request_certificate_url, {'course_id': str(self.course.id)})
         assert response.status_code == 200
         response_json = json.loads(response.content.decode('utf-8'))
-        assert CertificateStatuses.notpassing == response_json['add_status']
-
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_DISABLED)
-    @override_settings(CERT_QUEUE='test-queue')
-    def test_request_certificate_after_passing(self):
-        self.cert.status = CertificateStatuses.unavailable
-        self.cert.save()
-        request_certificate_url = reverse('request_certificate')
-        with patch('capa.xqueue_interface.XQueueInterface.send_to_queue') as mock_queue:
-            mock_queue.return_value = (0, "Successfully queued")
-            with mock_passing_grade():
-                response = self.client.post(request_certificate_url, {'course_id': str(self.course.id)})
-                assert response.status_code == 200
-                response_json = json.loads(response.content.decode('utf-8'))
-                assert CertificateStatuses.generating == response_json['add_status']
+        assert CertificateStatuses.unavailable == response_json['add_status']
 
     # TEMPLATES WITHOUT LANGUAGE TESTS
     @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -2271,15 +2271,6 @@ class GenerateUserCertTests(ModuleStoreTestCase):
             resp = self.client.post(self.url)
             assert resp.status_code == 200
 
-            # Verify Google Analytics event fired after generating certificate
-            mock_tracker.track.assert_called_once_with(
-                self.student.id,
-                'edx.bi.user.certificate.generate',
-                {
-                    'category': 'certificates',
-                    'label': str(self.course.id)
-                },
-            )
             mock_tracker.reset_mock()
 
     def test_user_with_passing_existing_generating_cert(self):


### PR DESCRIPTION
Enable v2 of course certificates for all course runs

This moves all course runs that use certificates over to V2 of course certificates, and disables the option for a course run to use V1 of course certificates. The flag will be removed entirely in a future ticket (MICROBA-1083).

MICROBA-1082