### PR TITLE
[MST-821] Require `create_zendesk_tickets` field

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/serializers.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers.py
@@ -21,7 +21,7 @@ class LimitedProctoredExamSettingsSerializer(serializers.Serializer):
     enable_proctored_exams = serializers.BooleanField()
     proctoring_provider = serializers.CharField()
     proctoring_escalation_email = serializers.CharField(allow_blank=True)
-    create_zendesk_tickets = serializers.BooleanField(required=False)
+    create_zendesk_tickets = serializers.BooleanField()
 
 
 class ProctoredExamConfigurationSerializer(serializers.Serializer):


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Makes `create_zendesk_tickets` a required field now that the frontend call is utilizing it as of: https://github.com/edx/frontend-app-course-authoring/pull/111

## Supporting information

[MST-821](https://openedx.atlassian.net/browse/MST-821)