### PR TITLE
[BD-38] [TNL-8142][BB-4253] fix!: Disable changing discussions providers once a course run has started

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/tests/django_utils.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/django_utils.py
@@ -338,6 +338,7 @@ class ModuleStoreTestUsersMixin():
         Create a test user for a course.
         """
         if user_type is CourseUserType.ANONYMOUS:
+            self.client.logout()
             return AnonymousUser()
 
         is_enrolled = user_type is CourseUserType.ENROLLED

--- a/openedx/core/djangoapps/discussions/views.py
+++ b/openedx/core/djangoapps/discussions/views.py
@@ -7,10 +7,12 @@ from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from rest_framework import serializers
 from rest_framework.permissions import BasePermission
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from common.djangoapps.student.roles import CourseStaffRole
+from common.djangoapps.student.roles import CourseStaffRole, GlobalStaff
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 
 from .models import DiscussionsConfiguration
@@ -39,6 +41,33 @@ class IsStaff(BasePermission):
         ).has_user(request.user)
 
 
+def user_permissions_for_course(course, user):
+    """
+    Return the user's permissions over the discussion configuration of the course.
+    """
+    return {
+        "change_provider": not course.has_started() or GlobalStaff().has_user(user),
+    }
+
+PERMISSION_MESSAGES = {
+    "change_provider": "Must be global staff to change discussion provider after the course has started.",
+}
+
+DEFAULT_MESSAGE = "You're not authorized to perform this operation."
+
+
+def check_course_permissions(course, user, permission):
+    """
+    Check the user has permissions for the operation over the course configuration.
+
+    Raises PermissionDenied if the user does not have permission
+    """
+    permissions = user_permissions_for_course(course, user)
+    granted = permissions.get(permission)
+    if not granted:
+        raise PermissionDenied(PERMISSION_MESSAGES.get(permission, DEFAULT_MESSAGE))
+
+
 class DiscussionsConfigurationView(APIView):
     """
     Handle configuration-related view-logic
@@ -57,7 +86,12 @@ class DiscussionsConfigurationView(APIView):
         """
         course_key = _validate_course_key(course_key_string)
         configuration = DiscussionsConfiguration.get(course_key)
-        serializer = DiscussionsConfigurationSerializer(configuration)
+        serializer = DiscussionsConfigurationSerializer(
+            configuration,
+            context={
+                'user_id': request.user.id,
+            }
+        )
         return Response(serializer.data)
 
     def post(self, request, course_key_string: str, **_kwargs) -> Response:
@@ -66,6 +100,7 @@ class DiscussionsConfigurationView(APIView):
         """
         course_key = _validate_course_key(course_key_string)
         configuration = DiscussionsConfiguration.get(course_key)
+        course = CourseOverview.get_from_id(course_key)
         serializer = DiscussionsConfigurationSerializer(
             configuration,
             context={
@@ -75,6 +110,9 @@ class DiscussionsConfigurationView(APIView):
             partial=True,
         )
         if serializer.is_valid(raise_exception=True):
+            if serializer.validated_data['provider_type'] != configuration.provider_type:
+                check_course_permissions(course, request.user, 'change_provider')
+
             serializer.save()
         return Response(serializer.data)
 


### PR DESCRIPTION
For authenticated users that are not global staff, changing discussion
providers after a course has started fails with 403 Forbidden.

Related issues:
* [BB-4253](https://tasks.opencraft.com/browse/BB-4253)
* [TNL-8142](https://openedx.atlassian.net/browse/TNL-8142)

BREAKING CHANGE:
Course staff, who were previously allowed to do this operation,
will instead receive a 403 Forbidden response.

## Testing instructions

This adds test cases to `openedx/core/djangoapps/discussions/tests/test_views.py`:
```sh
pytest openedx/core/djangoapps/discussions/tests/test_views.py
```