### PR TITLE
fix: don't escape assignment names in grades API

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/tests/factories.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/factories.py
@@ -300,7 +300,7 @@ class ItemFactory(XModuleFactory):
         if self.display_name is None:
             dest_name = uuid4().hex
         else:
-            dest_name = self.display_name.replace(" ", "_")  # lint-amnesty, pylint: disable=no-member
+            dest_name = BlockUsageLocator.clean(self.display_name)
 
         new_location = self.parent_location.course_key.make_usage_key(
             self.category,

--- a/lms/djangoapps/grades/course_grade.py
+++ b/lms/djangoapps/grades/course_grade.py
@@ -8,7 +8,6 @@ from collections import OrderedDict, defaultdict
 
 from ccx_keys.locator import CCXLocator
 from django.conf import settings
-from django.utils.encoding import python_2_unicode_compatible
 from lazy import lazy
 
 from openedx.core.lib.grade_utils import round_away_from_zero
@@ -20,7 +19,6 @@ from .subsection_grade import ZeroSubsectionGrade
 from .subsection_grade_factory import SubsectionGradeFactory
 
 
-@python_2_unicode_compatible
 class CourseGradeBase:
     """
     Base class for Course Grades.
@@ -221,8 +219,7 @@ class CourseGradeBase:
         """
         chapter_subsection_grades = self._get_subsection_grades(course_structure, chapter.location)
         return {
-            # xss-lint: disable=python-deprecated-display-name
-            'display_name': block_metadata_utils.display_name_with_default_escaped(chapter),
+            'display_name': block_metadata_utils.display_name_with_default(chapter),
             'url_name': block_metadata_utils.url_name_for_block(chapter),
             'sections': chapter_subsection_grades,
         }

--- a/lms/djangoapps/grades/subsection_grade.py
+++ b/lms/djangoapps/grades/subsection_grade.py
@@ -7,7 +7,6 @@ from abc import ABCMeta
 from collections import OrderedDict
 from logging import getLogger
 
-from django.utils.html import escape
 from lazy import lazy
 
 from lms.djangoapps.grades.models import BlockRecord, PersistentSubsectionGrade
@@ -25,7 +24,7 @@ class SubsectionGradeBase(metaclass=ABCMeta):
 
     def __init__(self, subsection):
         self.location = subsection.location
-        self.display_name = escape(block_metadata_utils.display_name_with_default(subsection))
+        self.display_name = block_metadata_utils.display_name_with_default(subsection)
         self.url_name = block_metadata_utils.url_name_for_block(subsection)
 
         self.format = getattr(subsection, 'format', '')

--- a/lms/djangoapps/grades/tests/base.py
+++ b/lms/djangoapps/grades/tests/base.py
@@ -34,7 +34,7 @@ class GradeTestBase(SharedModuleStoreTestCase):
             cls.sequence = ItemFactory.create(
                 parent=cls.chapter,
                 category='sequential',
-                display_name="Test Sequential X",
+                display_name="Test Sequential X with an & Ampersand",
                 graded=True,
                 format="Homework"
             )

--- a/lms/djangoapps/grades/tests/test_course_grade_factory.py
+++ b/lms/djangoapps/grades/tests/test_course_grade_factory.py
@@ -215,7 +215,7 @@ class TestCourseGradeFactory(GradeTestBase):
             'section_breakdown': [
                 {
                     'category': 'Homework',
-                    'detail': 'Homework 1 - Test Sequential X - 50% (1/2)',
+                    'detail': 'Homework 1 - Test Sequential X with an & Ampersand - 50% (1/2)',
                     'label': 'HW 01',
                     'percent': 0.5
                 },

--- a/lms/djangoapps/grades/tests/test_subsection_grade_factory.py
+++ b/lms/djangoapps/grades/tests/test_subsection_grade_factory.py
@@ -172,3 +172,9 @@ class TestSubsectionGradeFactory(ProblemSubmissionTestMixin, GradeTestBase):
             if possible_graded_override is None:
                 expected_possible = persistent_grade.possible_graded
             self.assert_grade(grade, expected_earned, expected_possible)
+
+    def test_display_name_not_escaped(self):
+        """Confirm that we don't escape the display name - downstream consumers will do that instead"""
+        # first, do an update to create a persistent grade
+        grade = self.subsection_grade_factory.update(self.sequence)
+        assert grade.display_name == 'Test Sequential X with an & Ampersand'


### PR DESCRIPTION
We had been pre-escaping display names like 'Math & Science' as 'Math &amp;amp; Science" in the REST API itself - which meant that consumers like MFEs that do their own escaping displayed the wrong thing.

It's better for the API to just leave the string as-is. As far as I know, this only affects the gradebook and progress pages, both of which do their own escaping of the result from the API already.

https://openedx.atlassian.net/browse/AA-808