### PR TITLE
[MST-838] Pass integrity signature waffle flag to timed exam view

### DIFF
--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -33,6 +33,8 @@ from xmodule.x_module import (
     XModuleToXBlockMixin,
 )
 
+from openedx.core.djangoapps.agreements.toggles import is_integrity_signature_enabled
+
 from .exceptions import NotFoundError
 from .fields import Date
 from .mako_module import MakoTemplateBlockBase
@@ -891,7 +893,8 @@ class SequenceBlock(
                 'is_practice_exam': self.is_practice_exam,
                 'allow_proctoring_opt_out': self.allow_proctoring_opt_out,
                 'due_date': self.due,
-                'grace_period': self.graceperiod  # lint-amnesty, pylint: disable=no-member
+                'grace_period': self.graceperiod,  # lint-amnesty, pylint: disable=no-member
+                'is_integrity_signature_enabled': is_integrity_signature_enabled(),
             }
 
             # inject the user's credit requirements and fulfillments


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Pass the `is_integrity_signature_enabled` waffle flag into the timed exam view; if this waffle flag is enabled, users should not be blocked from entering a proctored exam if they have not complete ID verification.

## Supporting information

- [MST-838](https://openedx.atlassian.net/browse/MST-838)
- https://github.com/edx/edx-proctoring/pull/869