### PR TITLE
[BACKPORT] fix: Hide enterprise/login button if enterprise integration disabled.

### DIFF
--- a/lms/static/js/spec/student_account/login_spec.js
+++ b/lms/static/js/spec/student_account/login_spec.js
@@ -19,6 +19,7 @@
                     authComplete = false,
                     PLATFORM_NAME = 'edX',
                     ENTERPRISE_SLUG_LOGIN_URL = 'enterprise/login',
+                    IS_ENTERPRISE_ENABLE = true,
                     USER_DATA = {
                         email: 'xsy@edx.org',
                         password: 'xsyisawesome',
@@ -90,7 +91,8 @@
                         resetModel: resetModel,
                         thirdPartyAuth: THIRD_PARTY_AUTH,
                         platformName: PLATFORM_NAME,
-                        enterpriseSlugLoginURL: ENTERPRISE_SLUG_LOGIN_URL
+                        enterpriseSlugLoginURL: ENTERPRISE_SLUG_LOGIN_URL,
+                        isEnterpriseEnable: IS_ENTERPRISE_ENABLE
                     });
 
                 // Spy on AJAX requests
@@ -206,6 +208,20 @@
 
                     expect(thirdPartyAuthView).not.toContain(view.$submitButton);
                     expect(thirdPartyAuthView).not.toContain($('form-field'));
+                });
+
+                it('does not display the enterprise login button', function() {
+                    var enterpriseDisabledLoginView = new LoginView({
+                        fields: FORM_DESCRIPTION.fields,
+                        model: model,
+                        resetModel: resetModel,
+                        thirdPartyAuth: THIRD_PARTY_AUTH,
+                        platformName: PLATFORM_NAME,
+                        enterpriseSlugLoginURL: ENTERPRISE_SLUG_LOGIN_URL,
+                        isEnterpriseEnable: false
+                    });
+
+                    expect(enterpriseDisabledLoginView).not.toContain($('.enterprise-login'));
                 });
 
                 it('displays a link to the signin help', function() {

--- a/lms/static/js/student_account/views/AccessView.js
+++ b/lms/static/js/student_account/views/AccessView.js
@@ -79,6 +79,7 @@
                     this.pipelineUserDetails = options.third_party_auth.pipeline_user_details;
                     this.enterpriseName = options.enterprise_name || '';
                     this.enterpriseSlugLoginURL = options.enterprise_slug_login_url || '';
+                    this.isEnterpriseEnable = options.is_enterprise_enable || false;
                     this.isAccountRecoveryFeatureEnabled = options.is_account_recovery_feature_enabled || false;
                     this.isMultipleUserEnterprisesFeatureEnabled =
                         options.is_multiple_user_enterprises_feature_enabled || false;
@@ -164,6 +165,7 @@
                             pipelineUserDetails: this.pipelineUserDetails,
                             enterpriseName: this.enterpriseName,
                             enterpriseSlugLoginURL: this.enterpriseSlugLoginURL,
+                            isEnterpriseEnable: this.isEnterpriseEnable,
                             is_require_third_party_auth_enabled: this.is_require_third_party_auth_enabled
                         });
 

--- a/lms/static/js/student_account/views/FormView.js
+++ b/lms/static/js/student_account/views/FormView.js
@@ -31,6 +31,7 @@
             */
             optionalStr: gettext('(optional)'),
             submitButton: '',
+            isEnterpriseEnable: false,
 
             initialize: function(data) {
                 this.model = data.model;
@@ -95,7 +96,8 @@
                         optionalStr: this.optionalStr,
                         supplementalText: data[i].supplementalText || '',
                         supplementalLink: data[i].supplementalLink || '',
-                        loginIssueSupportLink: data[i].loginIssueSupportLink || ''
+                        loginIssueSupportLink: data[i].loginIssueSupportLink || '',
+                        isEnterpriseEnable: this.isEnterpriseEnable
                     })));
                 }
 

--- a/lms/static/js/student_account/views/LoginView.js
+++ b/lms/static/js/student_account/views/LoginView.js
@@ -36,6 +36,7 @@
             authWarningJsHook: 'js-auth-warning',
             passwordResetSuccessJsHook: 'js-password-reset-success',
             defaultFormErrorsTitle: gettext('We couldn\'t sign you in.'),
+            isEnterpriseEnable: false,
 
             preRender: function(data) {
                 this.providers = data.thirdPartyAuth.providers || [];
@@ -57,6 +58,7 @@
                 this.pipelineUserDetails = data.pipelineUserDetails;
                 this.enterpriseName = data.enterpriseName;
                 this.enterpriseSlugLoginURL = data.enterpriseSlugLoginURL;
+                this.isEnterpriseEnable = data.isEnterpriseEnable;
                 this.is_require_third_party_auth_enabled = data.is_require_third_party_auth_enabled || false;
 
                 this.listenTo(this.model, 'sync', this.saveSuccess);

--- a/lms/templates/student_account/form_field.underscore
+++ b/lms/templates/student_account/form_field.underscore
@@ -140,7 +140,9 @@
                 <span><a class="field-link" href="<%- loginIssueSupportLink %>"><%- gettext("Other sign-in issues") %></a></span>
             <% } %>
         </div>
-        <button type="button" class="enterprise-login field-link"><%- gettext("Sign in with your company or school") %></button>
+        <% if ( isEnterpriseEnable ) { %>
+            <button type="button" class="enterprise-login field-link"><%- gettext("Sign in with your company or school") %></button>
+        <% } %>
     <% } %>
     <% if( form === 'password-reset' && name === 'email' ) { %>
         <button type="button" class="reset-help field-link" ><i class="fa fa-caret-right" /><%- gettext("Need other help signing in?") %></button>

--- a/openedx/core/djangoapps/user_authn/views/login_form.py
+++ b/openedx/core/djangoapps/user_authn/views/login_form.py
@@ -29,7 +29,7 @@ from openedx.core.djangoapps.user_authn.views.password_reset import get_password
 from openedx.core.djangoapps.user_authn.views.registration_form import RegistrationFormFactory
 from openedx.core.djangoapps.user_authn.views.utils import third_party_auth_context
 from openedx.core.djangoapps.user_authn.toggles import is_require_third_party_auth_enabled
-from openedx.features.enterprise_support.api import enterprise_customer_for_request
+from openedx.features.enterprise_support.api import enterprise_customer_for_request, enterprise_enabled
 from openedx.features.enterprise_support.utils import (
     get_enterprise_slug_login_url,
     handle_enterprise_cookies_for_logistration,
@@ -251,6 +251,7 @@ def login_and_registration_form(request, initial_mode="login"):
             'is_account_recovery_feature_enabled': is_secondary_email_feature_enabled(),
             'is_multiple_user_enterprises_feature_enabled': is_multiple_user_enterprises_feature_enabled(),
             'enterprise_slug_login_url': get_enterprise_slug_login_url(),
+            'is_enterprise_enable': enterprise_enabled(),
             'is_require_third_party_auth_enabled': is_require_third_party_auth_enabled(),
         },
         'login_redirect_url': redirect_to,  # This gets added to the query string of the "Sign In" button in header


### PR DESCRIPTION
Backport for https://github.com/edx/edx-platform/pull/27130 to Lilac.master

Description:

Fix an issue with an existing button for enterprise login on the login page
when enterprise integration is disabled.

[Jira](https://openedx.atlassian.net/browse/BTR-52)
[BTR issue](https://github.com/openedx/build-test-release-wg/issues/2)
