### PR TITLE
feature: Updated the text when a learner earns a cert on the Dashboard

### DIFF
--- a/common/djangoapps/student/tests/test_certificates.py
+++ b/common/djangoapps/student/tests/test_certificates.py
@@ -275,5 +275,5 @@ class CertificateDisplayTestLinkedHtmlView(CertificateDisplayTestBase):
 
         response = self.client.get(reverse('dashboard'))
 
-        self.assertContains(response, 'View Test_Certificate')
+        self.assertContains(response, 'View my Test_Certificate')
         self.assertContains(response, test_url)

--- a/common/djangoapps/util/course.py
+++ b/common/djangoapps/util/course.py
@@ -7,7 +7,6 @@ import logging
 from urllib.parse import urlencode
 
 from django.conf import settings
-from django.utils.timezone import now
 
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
@@ -71,16 +70,3 @@ def has_certificates_enabled(course):
     if not settings.FEATURES.get('CERTIFICATES_HTML_VIEW', False):
         return False
     return course.cert_html_view_enabled
-
-
-def should_display_grade(course_overview):
-    """
-    Returns True or False depending upon either certificate available date
-    or course end date
-    """
-    cert_available_date = course_overview.certificate_available_date
-    current_date = now().replace(hour=0, minute=0, second=0, microsecond=0)
-    if cert_available_date:
-        return cert_available_date < current_date
-
-    return course_overview.end and course_overview.end < current_date

--- a/lms/djangoapps/course_home_api/outline/v1/serializers.py
+++ b/lms/djangoapps/course_home_api/outline/v1/serializers.py
@@ -6,6 +6,7 @@ from django.utils.translation import ngettext
 from rest_framework import serializers
 
 from lms.djangoapps.course_home_api.dates.v1.serializers import DateSummarySerializer
+from lms.djangoapps.course_home_api.progress.v1.serializers import CertificateDataSerializer
 from lms.djangoapps.course_home_api.mixins import DatesBannerSerializerMixin, VerifiedModeSerializerMixin
 
 
@@ -113,6 +114,7 @@ class OutlineTabSerializer(DatesBannerSerializerMixin, VerifiedModeSerializerMix
     Serializer for the Outline Tab
     """
     access_expiration = serializers.DictField()
+    cert_data = CertificateDataSerializer()
     course_blocks = CourseBlockSerializer()
     course_goals = CourseGoalsSerializer()
     course_tools = CourseToolSerializer(many=True)

--- a/lms/djangoapps/course_home_api/outline/v1/views.py
+++ b/lms/djangoapps/course_home_api/outline/v1/views.py
@@ -37,6 +37,7 @@ from lms.djangoapps.courseware.context_processor import user_timezone_locale_pre
 from lms.djangoapps.courseware.courses import get_course_date_blocks, get_course_info_section, get_course_with_access
 from lms.djangoapps.courseware.date_summary import TodaysDate
 from lms.djangoapps.courseware.masquerade import is_masquerading, setup_masquerade
+from lms.djangoapps.courseware.views.views import get_cert_data
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from openedx.features.course_duration_limits.access import get_access_expiration_data
@@ -196,6 +197,7 @@ class OutlineTabView(RetrieveAPIView):
 
         # Set all of the defaults
         access_expiration = None
+        cert_data = None
         course_blocks = None
         course_goals = {
             'goal_options': [],
@@ -232,6 +234,7 @@ class OutlineTabView(RetrieveAPIView):
 
             offer_data = generate_offer_data(request.user, course_overview)
             access_expiration = get_access_expiration_data(request.user, course_overview)
+            cert_data = get_cert_data(request.user, course, enrollment.mode) if is_enrolled else None
 
             # Only show the set course goal message for enrolled, unverified
             # users in a course that allows for verified statuses.
@@ -277,6 +280,7 @@ class OutlineTabView(RetrieveAPIView):
 
         data = {
             'access_expiration': access_expiration,
+            'cert_data': cert_data,
             'course_blocks': course_blocks,
             'course_goals': course_goals,
             'course_tools': course_tools,

--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -956,10 +956,6 @@
         margin: 0;
       }
 
-      &.course-status-processing {
-        color: #0d7d4d;
-      }
-
       .credit-action {
         .credit-btn {
           @extend %btn-pl-yellow-base;
@@ -1069,6 +1065,11 @@
         .btn {
           margin-top: 2px;
         }
+      }
+
+      &.course-status-earned-not-available,
+      &.course-status-certavailable {
+        color: #0d7d4d;
       }
 
       &.course-status-certavailable {

--- a/lms/templates/dashboard/_dashboard_certificate_information.html
+++ b/lms/templates/dashboard/_dashboard_certificate_information.html
@@ -4,7 +4,7 @@
 from django.utils.translation import ugettext as _
 from openedx.core.djangolib.markup import HTML, Text
 from common.djangoapps.course_modes.models import CourseMode
-from common.djangoapps.util.course import should_display_grade
+from lms.djangoapps.certificates.data import CertificateStatuses
 %>
 <%namespace name='static' file='../static_content.html'/>
 
@@ -20,7 +20,7 @@ from common.djangoapps.util.course import should_display_grade
 
 <%
 if cert_status['status'] == 'certificate_earned_but_not_available':
-    status_css_class = 'course-status-processing'
+    status_css_class = 'course-status-earned-not-available'
 elif cert_status['status'] == 'generating':
     status_css_class = 'course-status-certrendering'
 elif cert_status['status'] == 'downloadable':
@@ -44,18 +44,11 @@ else:
       </p>
     </div>
   % else:
-    <div class="message message-status ${status_css_class} is-shown">
-      <p class="message-copy">
-        % if should_display_grade(course_overview):
-            ${_("Your final grade:")}
-            <span class="grade-value">${"{0:.0f}%".format(float(cert_status['grade'])*100)}</span>.
-        % elif course_overview.certificate_available_date and not course_overview.self_paced:
-          <%
-            cert_available_date = course_overview.certificate_available_date.strftime('%Y-%m-%d')
-          %>
-          ${_("Grades will be finalized on {cert_available_date}".format(cert_available_date=cert_available_date))}
-        % endif
-        % if cert_status['status'] == 'notpassing':
+    <div class="message message-status ${status_css_class} d-flex justify-content-between align-items-center">
+      <div class="message-copy">
+        % if cert_status['status'] == CertificateStatuses.downloadable:
+            ${_("Congratulations! Your certificate is ready.")}
+        % elif cert_status['status'] == 'notpassing':
           % if enrollment.mode != 'audit':
             ${_("Grade required for a {cert_name_short}:").format(cert_name_short=cert_name_short)}
           % else:
@@ -76,8 +69,7 @@ else:
             <a href="${reverify_link}"> ${Text(_("Verify your identity now."))}</a>
           </p>
         % endif
-
-      </p>
+      </div>
 
       % if cert_status['status'] == 'generating' or cert_status['status'] == 'downloadable' or cert_status['show_survey_button']:
         <div class="wrapper-message-primary">
@@ -92,7 +84,7 @@ else:
               <li>
                 <a class="btn btn-primary" href="${cert_status['cert_web_view_url']}" rel="noopener" target="_blank"
                    title="${_('This link will open the certificate web view')}">
-                  ${_("View {cert_name_short}").format(cert_name_short=cert_name_short,)}
+                  ${_("View my {cert_name_short}").format(cert_name_short=cert_name_short,)}
                 </a>
               </li>
             % elif cert_status['status'] == 'downloadable' and enrollment.mode in CourseMode.NON_VERIFIED_MODES:


### PR DESCRIPTION
[MICROBA-678]

This patch will update the text on the course dashboard when a learner
successfully earns a certificate and that certificate is available. It
also adds to the Outline API for the Outline in the Learning MFE so that
the same changes can be made there.

<img width="1231" alt="Screen Shot 2021-06-07 at 8 18 58 PM" src="https://user-images.githubusercontent.com/2854941/121103453-fc4c1600-c7cd-11eb-86b3-083d8f4c67b4.png">



[MICROBA-678]: https://openedx.atlassian.net/browse/MICROBA-678