### PR TITLE
feat: edx-enterprise to 3.23.11

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -41,7 +41,7 @@ django-storages<1.9
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==3.23.10
+edx-enterprise==3.23.11
 
 # Newer versions need a more recent version of python-dateutil
 freezegun==0.3.12

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -429,7 +429,7 @@ edx-drf-extensions==6.5.0
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.23.10
+edx-enterprise==3.23.11
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -516,7 +516,7 @@ edx-drf-extensions==6.5.0
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.23.10
+edx-enterprise==3.23.11
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -499,7 +499,7 @@ edx-drf-extensions==6.5.0
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.23.10
+edx-enterprise==3.23.11
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
Log more specific information about HTTP client errors that are caught when using the LMS enrollment API. Also send an exception event to the monitoring service when this happens, even though we handle the exception 'gracefully'.

https://github.com/edx/edx-enterprise/pull/1258


