### PR TITLE
feat: updated course end text AA-827

### DIFF
--- a/lms/djangoapps/courseware/date_summary.py
+++ b/lms/djangoapps/courseware/date_summary.py
@@ -333,8 +333,9 @@ class CourseEndDate(DateSummary):
         if self.date and self.current_time <= self.date:
             mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course_id)
             if is_active and CourseMode.is_eligible_for_certificate(mode):
-                return _('This course will be archived, which means you can review the course content '
-                         'but can no longer participate in graded assignments or earn a certificate.')
+                return _('After this date, the course will be archived, which means you can review the '
+                         'course content but can no longer participate in graded assignments or work towards earning '
+                         'a certificate.')
             else:
                 return _('After the course ends, the course content will be archived and no longer active.')
         elif self.date:

--- a/lms/djangoapps/courseware/tests/test_date_summary.py
+++ b/lms/djangoapps/courseware/tests/test_date_summary.py
@@ -520,8 +520,9 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
         user = create_user()
         CourseEnrollmentFactory(course_id=course.id, user=user, mode=CourseMode.VERIFIED)
         block = CourseEndDate(course, user)
-        assert block.description == ('This course will be archived, which means you can review the course content '
-                                     'but can no longer participate in graded assignments or earn a certificate.')
+        assert block.description == ('After this date, the course will be archived, which means you can review the '
+                                     'course content but can no longer participate in graded assignments or work '
+                                     'towards earning a certificate.')
 
     def test_course_end_date_for_non_certificate_eligible_mode(self):
         course = create_course_run(days_till_start=-1)


### PR DESCRIPTION
## Description

Updates course end text from 

"This course will be archived, which means you can review the course content but can no longer participate in graded assignments or earn a certificate."

to 

"After this date, the course will be archived, which means you can review the course content but can no longer participate in graded assignments or work towards earning a certificate."

on the Course Outline and Dates pages. 

<img width="438" alt="Screen Shot 2021-06-04 at 2 09 05 PM" src="https://user-images.githubusercontent.com/60379333/120847355-5e441b80-c541-11eb-92a7-76560bbc5937.png">

<img width="1161" alt="Screen Shot 2021-06-04 at 2 09 29 PM" src="https://user-images.githubusercontent.com/60379333/120847364-60a67580-c541-11eb-832a-a5b17cc0aba8.png">


## Supporting information

[Jira Ticket AA-827](https://openedx.atlassian.net/browse/AA-827?atlOrigin=eyJpIjoiZGQyZWNhOTQ2YjBiNDdjMmJmZmRmNzQ1NjYzZjMzYWUiLCJwIjoiaiJ9)
