### PR TITLE
refactor: Move CertificateStatuses to data.py file per OEP-49

### DIFF
--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -779,7 +779,7 @@ class CourseMode(models.Model):
         if settings.FEATURES['DISABLE_HONOR_CERTIFICATES']:
             # Adding check so that we can regenerate the certificate for learners who have
             # already earned the certificate using honor mode
-            from lms.djangoapps.certificates.models import CertificateStatuses
+            from lms.djangoapps.certificates.data import CertificateStatuses
             if mode_slug == cls.HONOR and status != CertificateStatuses.downloadable:
                 ineligible_modes.append(cls.HONOR)
 

--- a/common/djangoapps/entitlements/tests/test_models.py
+++ b/common/djangoapps/entitlements/tests/test_models.py
@@ -15,7 +15,7 @@ from common.djangoapps.course_modes.tests.factories import CourseModeFactory
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import TEST_PASSWORD, CourseEnrollmentFactory, UserFactory
 from lms.djangoapps.certificates.api import MODES
-from lms.djangoapps.certificates.models import CertificateStatuses
+from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase

--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -40,7 +40,8 @@ from lms.djangoapps.certificates.api import (
     get_certificate_url,
     has_html_certificates_enabled
 )
-from lms.djangoapps.certificates.models import CertificateStatuses, certificate_status_for_student
+from lms.djangoapps.certificates.data import CertificateStatuses
+from lms.djangoapps.certificates.models import certificate_status_for_student
 from lms.djangoapps.grades.api import CourseGradeFactory
 from lms.djangoapps.verify_student.models import VerificationDeadline
 from lms.djangoapps.verify_student.services import IDVerificationService
@@ -511,7 +512,7 @@ def _cert_info(user, course_overview, cert_status):
 
     if (
         not certificates_viewable_for_course(course_overview) and
-        (status in CertificateStatuses.PASSED_STATUSES) and
+        CertificateStatuses.is_passing_status(status) and
         course_overview.certificate_available_date
     ):
         status = certificate_earned_but_not_available_status

--- a/common/djangoapps/student/tests/test_certificates.py
+++ b/common/djangoapps/student/tests/test_certificates.py
@@ -14,7 +14,7 @@ from pytz import UTC
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
 from lms.djangoapps.certificates.api import get_certificate_url
-from lms.djangoapps.certificates.models import CertificateStatuses
+from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.certificates.tests.factories import (
     GeneratedCertificateFactory,
     LinkedInAddToProfileConfigurationFactory

--- a/common/djangoapps/student/tests/test_refunds.py
+++ b/common/djangoapps/student/tests/test_refunds.py
@@ -24,7 +24,8 @@ from edx_django_utils.cache import TieredCache, get_cache_key
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
 from common.djangoapps.student.models import CourseEnrollment, CourseEnrollmentAttribute, EnrollmentRefundConfiguration
 from common.djangoapps.student.tests.factories import UserFactory
-from lms.djangoapps.certificates.models import CertificateStatuses, GeneratedCertificate
+from lms.djangoapps.certificates.data import CertificateStatuses
+from lms.djangoapps.certificates.models import GeneratedCertificate
 from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
 from openedx.core.djangoapps.commerce.utils import ECOMMERCE_DATE_FORMAT
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase

--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -38,7 +38,7 @@ from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, U
 from common.djangoapps.student.views import complete_course_mode_info
 from common.djangoapps.util.model_utils import USER_SETTINGS_CHANGED_EVENT_NAME
 from common.djangoapps.util.testing import EventTestMixin
-from lms.djangoapps.certificates.models import CertificateStatuses
+from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
 from lms.djangoapps.verify_student.tests import TestVerificationBase
 from openedx.core.djangoapps.catalog.tests.factories import CourseFactory as CatalogCourseFactory

--- a/lms/djangoapps/badges/events/course_meta.py
+++ b/lms/djangoapps/badges/events/course_meta.py
@@ -51,7 +51,7 @@ def completion_check(user):
     completed courses. This badge will not work if certificate generation isn't
     enabled and run.
     """
-    from lms.djangoapps.certificates.models import CertificateStatuses
+    from lms.djangoapps.certificates.data import CertificateStatuses
     config = CourseEventBadgesConfiguration.current().completed_settings
     certificates = user.generatedcertificate_set.filter(status__in=CertificateStatuses.PASSED_STATUSES).count()
     award_badge(config, certificates, user)
@@ -62,7 +62,7 @@ def course_group_check(user, course_key):
     """
     Awards a badge if a user has completed every course in a defined set.
     """
-    from lms.djangoapps.certificates.models import CertificateStatuses
+    from lms.djangoapps.certificates.data import CertificateStatuses
     config = CourseEventBadgesConfiguration.current().course_group_settings
     awards = []
     for slug, keys in config.items():

--- a/lms/djangoapps/badges/events/tests/test_course_meta.py
+++ b/lms/djangoapps/badges/events/tests/test_course_meta.py
@@ -12,7 +12,8 @@ from django.test.utils import override_settings
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.badges.tests.factories import CourseEventBadgesConfigurationFactory, RandomBadgeClassFactory
-from lms.djangoapps.certificates.models import CertificateStatuses, GeneratedCertificate
+from lms.djangoapps.certificates.data import CertificateStatuses
+from lms.djangoapps.certificates.models import GeneratedCertificate
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 

--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -30,11 +30,11 @@ from lms.djangoapps.certificates.generation_handler import (
     is_using_v2_course_certificates as _is_using_v2_course_certificates,
     regenerate_user_certificates as _regenerate_user_certificates
 )
+from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.certificates.models import (
     CertificateGenerationConfiguration,
     CertificateGenerationCourseSetting,
     CertificateInvalidation,
-    CertificateStatuses,
     CertificateTemplate,
     CertificateTemplateAsset,
     CertificateWhitelist,
@@ -263,7 +263,7 @@ def certificate_downloadable_status(student, course_key):
     course_overview = CourseOverview.get_from_id(course_key)
     if (
         not certificates_viewable_for_course(course_overview) and
-        (current_status['status'] in CertificateStatuses.PASSED_STATUSES) and
+        CertificateStatuses.is_passing_status(current_status['status']) and
         course_overview.certificate_available_date
     ):
         response_data['earned_but_not_available'] = True

--- a/lms/djangoapps/certificates/apis/v0/tests/test_views.py
+++ b/lms/djangoapps/certificates/apis/v0/tests/test_views.py
@@ -16,7 +16,7 @@ from rest_framework.test import APITestCase
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.certificates.apis.v0.views import CertificatesDetailView, CertificatesListView
-from lms.djangoapps.certificates.models import CertificateStatuses
+from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from openedx.core.djangoapps.user_api.tests.factories import UserPreferenceFactory

--- a/lms/djangoapps/certificates/data.py
+++ b/lms/djangoapps/certificates/data.py
@@ -1,0 +1,68 @@
+"""
+Certificates Data
+
+This provides Data models to represent Certificates data.
+"""
+
+
+class CertificateStatuses:
+    """
+    Enum for certificate statuses.
+
+    Not all of these statuses are currently used. Some are kept for historical reasons and because existing course
+    certificates may have been granted that status.
+
+    audit_notpassing    - User is in the audit track and has not achieved a passing grade.
+    audit_passing       - User is in the audit track and has achieved a passing grade.
+    deleted             - The PDF certificate has been deleted.
+    deleting            - A request has been made to delete the PDF certificate.
+    downloadable        - The user has been granted this certificate and the certificate is ready and available.
+    error               - An error occurred during PDF certificate generation.
+    generating          - A request has been made to generate a PDF certificate, but it has not been generated yet.
+    honor_passing       - User is in the honor track and has achieved a passing grade.
+    invalidated         - Certificate is not valid.
+    notpassing          - The user has not achieved a passing grade.
+    requesting          - A request has been made to generate the PDF certificate.
+    restricted          - The user is restricted from receiving a certificate.
+    unavailable         - Certificate has been invalidated.
+    unverified          - The user does not have an approved, unexpired identity verification.
+
+    The following statuses are set by V2 of course certificates:
+      downloadable - See generation.py
+      notpassing - See GeneratedCertificate.mark_notpassing()
+      unavailable - See GeneratedCertificate.invalidate()
+      unverified - See GeneratedCertificate.mark_unverified()
+    """
+    deleted = 'deleted'
+    deleting = 'deleting'
+    downloadable = 'downloadable'
+    error = 'error'
+    generating = 'generating'
+    notpassing = 'notpassing'
+    restricted = 'restricted'
+    unavailable = 'unavailable'
+    auditing = 'auditing'
+    audit_passing = 'audit_passing'
+    audit_notpassing = 'audit_notpassing'
+    honor_passing = 'honor_passing'
+    unverified = 'unverified'
+    invalidated = 'invalidated'
+    requesting = 'requesting'
+
+    readable_statuses = {
+        downloadable: "already received",
+        notpassing: "didn't receive",
+        error: "error states",
+        audit_passing: "audit passing states",
+        audit_notpassing: "audit not passing states",
+    }
+
+    PASSED_STATUSES = (downloadable, generating)
+
+    @classmethod
+    def is_passing_status(cls, status):
+        """
+        Given the status of a certificate, return a boolean indicating whether
+        the student passed the course.
+        """
+        return status in cls.PASSED_STATUSES

--- a/lms/djangoapps/certificates/generation.py
+++ b/lms/djangoapps/certificates/generation.py
@@ -13,7 +13,8 @@ import logging
 from uuid import uuid4
 
 from common.djangoapps.student.models import CourseEnrollment, UserProfile
-from lms.djangoapps.certificates.models import CertificateStatuses, GeneratedCertificate
+from lms.djangoapps.certificates.data import CertificateStatuses
+from lms.djangoapps.certificates.models import GeneratedCertificate
 from lms.djangoapps.certificates.queue import XQueueCertInterface
 from lms.djangoapps.certificates.utils import emit_certificate_event, has_html_certificates_enabled
 from lms.djangoapps.grades.api import CourseGradeFactory

--- a/lms/djangoapps/certificates/generation_handler.py
+++ b/lms/djangoapps/certificates/generation_handler.py
@@ -12,9 +12,9 @@ from edx_toggles.toggles import LegacyWaffleFlagNamespace
 
 from common.djangoapps.course_modes import api as modes_api
 from common.djangoapps.student.models import CourseEnrollment
+from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.certificates.models import (
     CertificateInvalidation,
-    CertificateStatuses,
     CertificateWhitelist,
     GeneratedCertificate
 )

--- a/lms/djangoapps/certificates/management/commands/resubmit_error_certificates.py
+++ b/lms/djangoapps/certificates/management/commands/resubmit_error_certificates.py
@@ -26,7 +26,8 @@ from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 
 from lms.djangoapps.certificates.api import generate_user_certificates
-from lms.djangoapps.certificates.models import CertificateStatuses, GeneratedCertificate
+from lms.djangoapps.certificates.data import CertificateStatuses
+from lms.djangoapps.certificates.models import GeneratedCertificate
 from openedx.core.djangoapps.content.course_overviews.api import get_course_overview
 
 LOGGER = logging.getLogger(__name__)

--- a/lms/djangoapps/certificates/management/commands/tests/test_cert_management.py
+++ b/lms/djangoapps/certificates/management/commands/tests/test_cert_management.py
@@ -13,7 +13,8 @@ from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, U
 from lms.djangoapps.badges.events.course_complete import get_completion_badge
 from lms.djangoapps.badges.models import BadgeAssertion
 from lms.djangoapps.badges.tests.factories import BadgeAssertionFactory, CourseCompleteImageConfigurationFactory
-from lms.djangoapps.certificates.models import CertificateStatuses, GeneratedCertificate
+from lms.djangoapps.certificates.data import CertificateStatuses
+from lms.djangoapps.certificates.models import GeneratedCertificate
 from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
 from lms.djangoapps.grades.tests.utils import mock_passing_grade
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory

--- a/lms/djangoapps/certificates/management/commands/ungenerated_certs.py
+++ b/lms/djangoapps/certificates/management/commands/ungenerated_certs.py
@@ -13,7 +13,8 @@ from opaque_keys.edx.keys import CourseKey
 from pytz import UTC
 
 from lms.djangoapps.certificates.api import generate_user_certificates
-from lms.djangoapps.certificates.models import CertificateStatuses, certificate_status_for_student
+from lms.djangoapps.certificates.data import CertificateStatuses
+from lms.djangoapps.certificates.models import certificate_status_for_student
 
 LOGGER = logging.getLogger(__name__)
 User = get_user_model()

--- a/lms/djangoapps/certificates/models.py
+++ b/lms/djangoapps/certificates/models.py
@@ -28,6 +28,7 @@ from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.util.milestones_helpers import fulfill_course_milestone, is_prerequisite_courses_enabled
 from lms.djangoapps.badges.events.course_complete import course_badge_check
 from lms.djangoapps.badges.events.course_meta import completion_check, course_group_check
+from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.instructor_task.models import InstructorTask
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.signals.signals import COURSE_CERT_AWARDED, COURSE_CERT_CHANGED, COURSE_CERT_REVOKED
@@ -35,69 +36,6 @@ from openedx.core.djangoapps.xmodule_django.models import NoneToEmptyManager
 
 log = logging.getLogger(__name__)
 User = get_user_model()
-
-
-class CertificateStatuses:
-    """
-    Enum for certificate statuses.
-
-    Not all of these statuses are currently used. Some are kept for historical reasons and because existing course
-    certificates may have been granted that status.
-
-    audit_notpassing    - User is in the audit track and has not achieved a passing grade.
-    audit_passing       - User is in the audit track and has achieved a passing grade.
-    deleted             - The PDF certificate has been deleted.
-    deleting            - A request has been made to delete the PDF certificate.
-    downloadable        - The user has been granted this certificate and the certificate is ready and available.
-    error               - An error occurred during PDF certificate generation.
-    generating          - A request has been made to generate a PDF certificate, but it has not been generated yet.
-    honor_passing       - User is in the honor track and has achieved a passing grade.
-    invalidated         - Certificate is not valid.
-    notpassing          - The user has not achieved a passing grade.
-    requesting          - A request has been made to generate the PDF certificate.
-    restricted          - The user is restricted from receiving a certificate.
-    unavailable         - Certificate has been invalidated.
-    unverified          - The user does not have an approved, unexpired identity verification.
-
-    The following statuses are set by V2 of course certificates:
-      downloadable - See generation.py
-      notpassing - See GeneratedCertificate.mark_notpassing()
-      unavailable - See GeneratedCertificate.invalidate()
-      unverified - See GeneratedCertificate.mark_unverified()
-    """
-    deleted = 'deleted'
-    deleting = 'deleting'
-    downloadable = 'downloadable'
-    error = 'error'
-    generating = 'generating'
-    notpassing = 'notpassing'
-    restricted = 'restricted'
-    unavailable = 'unavailable'
-    auditing = 'auditing'
-    audit_passing = 'audit_passing'
-    audit_notpassing = 'audit_notpassing'
-    honor_passing = 'honor_passing'
-    unverified = 'unverified'
-    invalidated = 'invalidated'
-    requesting = 'requesting'
-
-    readable_statuses = {
-        downloadable: "already received",
-        notpassing: "didn't receive",
-        error: "error states",
-        audit_passing: "audit passing states",
-        audit_notpassing: "audit not passing states",
-    }
-
-    PASSED_STATUSES = (downloadable, generating)
-
-    @classmethod
-    def is_passing_status(cls, status):
-        """
-        Given the status of a certificate, return a boolean indicating whether
-        the student passed the course.
-        """
-        return status in cls.PASSED_STATUSES
 
 
 class CertificateSocialNetworks:

--- a/lms/djangoapps/certificates/queue.py
+++ b/lms/djangoapps/certificates/queue.py
@@ -18,7 +18,7 @@ from capa.xqueue_interface import XQueueInterface, make_hashkey, make_xheader
 from common.djangoapps.course_modes import api as modes_api
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.models import CourseEnrollment, UserProfile
-from lms.djangoapps.certificates.models import CertificateStatuses as status
+from lms.djangoapps.certificates.data import CertificateStatuses as status
 from lms.djangoapps.certificates.models import (
     CertificateWhitelist,
     ExampleCertificate,

--- a/lms/djangoapps/certificates/tests/test_generation.py
+++ b/lms/djangoapps/certificates/tests/test_generation.py
@@ -6,7 +6,8 @@ import logging
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
 from common.djangoapps.util.testing import EventTestMixin
 from lms.djangoapps.certificates.generation import generate_course_certificate
-from lms.djangoapps.certificates.models import CertificateStatuses, GeneratedCertificate
+from lms.djangoapps.certificates.data import CertificateStatuses
+from lms.djangoapps.certificates.models import GeneratedCertificate
 from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory

--- a/lms/djangoapps/certificates/tests/test_generation_handler.py
+++ b/lms/djangoapps/certificates/tests/test_generation_handler.py
@@ -22,7 +22,8 @@ from lms.djangoapps.certificates.generation_handler import (
     _set_allowlist_cert_status,
     _set_v2_cert_status
 )
-from lms.djangoapps.certificates.models import CertificateStatuses, GeneratedCertificate
+from lms.djangoapps.certificates.data import CertificateStatuses
+from lms.djangoapps.certificates.models import GeneratedCertificate
 from lms.djangoapps.certificates.tests.factories import (
     CertificateAllowlistFactory,
     CertificateInvalidationFactory,

--- a/lms/djangoapps/certificates/tests/test_services.py
+++ b/lms/djangoapps/certificates/tests/test_services.py
@@ -4,7 +4,8 @@ Unit Tests for the Certificate service
 
 
 from common.djangoapps.student.tests.factories import UserFactory
-from lms.djangoapps.certificates.models import CertificateStatuses, GeneratedCertificate
+from lms.djangoapps.certificates.data import CertificateStatuses
+from lms.djangoapps.certificates.models import GeneratedCertificate
 from lms.djangoapps.certificates.services import CertificateService
 from lms.djangoapps.certificates.tests.factories import CertificateAllowlistFactory, GeneratedCertificateFactory
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory

--- a/lms/djangoapps/certificates/tests/test_signals.py
+++ b/lms/djangoapps/certificates/tests/test_signals.py
@@ -13,9 +13,9 @@ from edx_toggles.toggles.testutils import override_waffle_flag, override_waffle_
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
 from lms.djangoapps.certificates.api import cert_generation_enabled
 from lms.djangoapps.certificates.generation_handler import CERTIFICATES_USE_UPDATED
+from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.certificates.models import (
     CertificateGenerationConfiguration,
-    CertificateStatuses,
     GeneratedCertificate
 )
 from lms.djangoapps.certificates.signals import _fire_ungenerated_certificate_task

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -52,7 +52,7 @@ from common.djangoapps.edxmako.shortcuts import marketing_link, render_to_respon
 from lms.djangoapps.edxnotes.helpers import is_feature_enabled
 from lms.djangoapps.ccx.custom_exception import CCXLocatorValidationException
 from lms.djangoapps.certificates import api as certs_api
-from lms.djangoapps.certificates.models import CertificateStatuses
+from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.commerce.utils import EcommerceService
 from lms.djangoapps.course_home_api.toggles import (
     course_home_mfe_dates_tab_is_active,

--- a/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
@@ -30,7 +30,8 @@ from common.djangoapps.student.roles import (
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
 from common.djangoapps.student.tests.factories import InstructorFactory
 from common.djangoapps.student.tests.factories import StaffFactory
-from lms.djangoapps.certificates.models import CertificateStatuses, GeneratedCertificate
+from lms.djangoapps.certificates.data import CertificateStatuses
+from lms.djangoapps.certificates.models import GeneratedCertificate
 from lms.djangoapps.grades.config.waffle import WRITABLE_GRADEBOOK, waffle_flags
 from lms.djangoapps.grades.constants import GradeOverrideFeatureEnum
 from lms.djangoapps.grades.course_data import CourseData

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -60,7 +60,7 @@ from common.djangoapps.student.tests.factories import StaffFactory
 from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.bulk_email.models import BulkEmailFlag, CourseEmail, CourseEmailTemplate
 from lms.djangoapps.certificates.api import generate_user_certificates
-from lms.djangoapps.certificates.models import CertificateStatuses
+from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.certificates.tests.factories import (
     GeneratedCertificateFactory
 )

--- a/lms/djangoapps/instructor/tests/test_certificates.py
+++ b/lms/djangoapps/instructor/tests/test_certificates.py
@@ -24,10 +24,10 @@ from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from common.djangoapps.student.tests.factories import InstructorFactory
 from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.certificates import api as certs_api
+from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.certificates.models import (
     CertificateGenerationConfiguration,
     CertificateInvalidation,
-    CertificateStatuses,
     GeneratedCertificate
 )
 from lms.djangoapps.certificates.tests.factories import (

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -39,11 +39,11 @@ from common.djangoapps.student.roles import (
 from common.djangoapps.util.json_request import JsonResponse
 from lms.djangoapps.bulk_email.api import is_bulk_email_feature_enabled
 from lms.djangoapps.certificates import api as certs_api
+from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.certificates.models import (
     CertificateGenerationConfiguration,
     CertificateGenerationHistory,
     CertificateInvalidation,
-    CertificateStatuses,
     GeneratedCertificate
 )
 from lms.djangoapps.courseware.access import has_access

--- a/lms/djangoapps/instructor_analytics/basic.py
+++ b/lms/djangoapps/instructor_analytics/basic.py
@@ -20,7 +20,8 @@ from opaque_keys.edx.keys import CourseKey, UsageKey
 
 import xmodule.graders as xmgraders
 from common.djangoapps.student.models import CourseEnrollment, CourseEnrollmentAllowed
-from lms.djangoapps.certificates.models import CertificateStatuses, GeneratedCertificate
+from lms.djangoapps.certificates.data import CertificateStatuses
+from lms.djangoapps.certificates.models import GeneratedCertificate
 from lms.djangoapps.courseware.models import StudentModule
 from lms.djangoapps.grades.api import context as grades_context
 from lms.djangoapps.program_enrollments.api import fetch_program_enrollments_by_students

--- a/lms/djangoapps/instructor_task/tasks_helper/certs.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/certs.py
@@ -20,7 +20,8 @@ from lms.djangoapps.certificates.api import (
     get_enrolled_allowlisted_not_passing_users,
     is_using_v2_course_certificates,
 )
-from lms.djangoapps.certificates.models import CertificateStatuses, GeneratedCertificate
+from lms.djangoapps.certificates.data import CertificateStatuses
+from lms.djangoapps.certificates.models import GeneratedCertificate
 
 from .runner import TaskProgress
 

--- a/lms/djangoapps/instructor_task/tests/test_api.py
+++ b/lms/djangoapps/instructor_task/tests/test_api.py
@@ -11,7 +11,8 @@ from celery.states import FAILURE
 from common.djangoapps.student.tests.factories import UserFactory
 from common.test.utils import normalize_repr
 from lms.djangoapps.bulk_email.models import SEND_TO_LEARNERS, SEND_TO_MYSELF, SEND_TO_STAFF, CourseEmail
-from lms.djangoapps.certificates.models import CertificateGenerationHistory, CertificateStatuses
+from lms.djangoapps.certificates.data import CertificateStatuses
+from lms.djangoapps.certificates.models import CertificateGenerationHistory
 from lms.djangoapps.instructor_task.api import (
     SpecificStudentIdMissingError,
     generate_certificates_for_students,

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -31,7 +31,8 @@ from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.models import CourseEnrollment, CourseEnrollmentAllowed
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
 from lms.djangoapps.certificates.generation_handler import CERTIFICATES_USE_UPDATED
-from lms.djangoapps.certificates.models import CertificateStatuses, GeneratedCertificate
+from lms.djangoapps.certificates.data import CertificateStatuses
+from lms.djangoapps.certificates.models import GeneratedCertificate
 from lms.djangoapps.certificates.tests.factories import CertificateAllowlistFactory, GeneratedCertificateFactory
 from lms.djangoapps.courseware.models import StudentModule
 from lms.djangoapps.grades.course_data import CourseData

--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -23,7 +23,7 @@ from common.djangoapps.student.tests.factories import CourseEnrollmentFactory
 from common.djangoapps.util.milestones_helpers import set_prerequisite_courses
 from common.djangoapps.util.testing import UrlResetMixin
 from lms.djangoapps.certificates.api import generate_user_certificates
-from lms.djangoapps.certificates.models import CertificateStatuses
+from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
 from lms.djangoapps.courseware.access_response import MilestoneAccessError, StartDateError, VisibilityError
 from lms.djangoapps.grades.tests.utils import mock_passing_grade

--- a/lms/djangoapps/program_enrollments/rest_api/v1/tests/test_views.py
+++ b/lms/djangoapps/program_enrollments/rest_api/v1/tests/test_views.py
@@ -30,7 +30,7 @@ from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from common.djangoapps.student.tests.factories import InstructorFactory
 from common.djangoapps.third_party_auth.tests.factories import SAMLProviderConfigFactory
 from lms.djangoapps.bulk_email.models import BulkEmailFlag, Optout
-from lms.djangoapps.certificates.models import CertificateStatuses
+from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
 from lms.djangoapps.grades.api import CourseGradeFactory
 from lms.djangoapps.program_enrollments.constants import ProgramCourseOperationStatuses as CourseStatuses

--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -4,7 +4,7 @@
 <%def name="online_help_token()"><% return "progress" %></%def>
 <%!
 from common.djangoapps.course_modes.models import CourseMode
-from lms.djangoapps.certificates.models import CertificateStatuses
+from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.grades.api import constants as grades_constants
 from django.utils.translation import ugettext as _
 from openedx.core.djangolib.markup import HTML, Text
@@ -259,4 +259,4 @@ username = get_enterprise_learner_generic_name(request) or student.username
       linkCategory: "FBE_banner"
   });
 
-</%static:require_module_async> 
+</%static:require_module_async>

--- a/openedx/core/djangoapps/certificates/api.py
+++ b/openedx/core/djangoapps/certificates/api.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from pytz import UTC
 
 from lms.djangoapps.certificates import api as certs_api
-from lms.djangoapps.certificates.models import CertificateStatuses
+from lms.djangoapps.certificates.data import CertificateStatuses
 from openedx.core.djangoapps.certificates.config import waffle
 from common.djangoapps.student.models import CourseEnrollment
 

--- a/openedx/core/djangoapps/credentials/tasks/v1/tasks.py
+++ b/openedx/core/djangoapps/credentials/tasks/v1/tasks.py
@@ -18,7 +18,8 @@ from opaque_keys.edx.keys import CourseKey
 
 from common.djangoapps.course_modes.models import CourseMode
 from lms.djangoapps.certificates.api import get_recently_modified_certificates
-from lms.djangoapps.certificates.models import CertificateStatuses, GeneratedCertificate
+from lms.djangoapps.certificates.data import CertificateStatuses
+from lms.djangoapps.certificates.models import GeneratedCertificate
 from lms.djangoapps.grades.api import CourseGradeFactory, get_recently_modified_grades
 from openedx.core.djangoapps.catalog.utils import get_programs
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview

--- a/openedx/core/djangoapps/credentials/tests/test_tasks.py
+++ b/openedx/core/djangoapps/credentials/tests/test_tasks.py
@@ -14,7 +14,8 @@ from freezegun import freeze_time
 from opaque_keys.edx.keys import CourseKey
 
 from common.djangoapps.student.tests.factories import UserFactory
-from lms.djangoapps.certificates.models import GeneratedCertificate, CertificateStatuses
+from lms.djangoapps.certificates.data import CertificateStatuses
+from lms.djangoapps.certificates.models import GeneratedCertificate
 from lms.djangoapps.grades.models import PersistentCourseGrade
 from lms.djangoapps.grades.tests.utils import mock_passing_grade
 from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory


### PR DESCRIPTION
[MICROBA-678]

To allow access to CertificateStatuses constants in other Django apps we are moving the
CertificateStatuses enum to data.py per OEP-49.



[MICROBA-678]: https://openedx.atlassian.net/browse/MICROBA-678