### PR TITLE
[BD-27] FEAT: Add new API endpoint for uploading transcripts

### DIFF
--- a/cms/djangoapps/contentstore/views/transcript_settings.py
+++ b/cms/djangoapps/contentstore/views/transcript_settings.py
@@ -202,11 +202,13 @@ def upload_transcript(request):
         )
         response = JsonResponse(status=201)
     except (TranscriptsGenerationException, UnicodeDecodeError):
+        LOGGER.error("Unable to update transcript on edX video %s for language %s", edx_video_id, new_language_code)
         response = JsonResponse(
             {'error': _('There is a problem with this transcript file. Try to upload a different file.')},
             status=400
         )
     finally:
+        LOGGER.info("Updated transcript on edX video %s for language %s", edx_video_id, new_language_code)
         return response
 
 

--- a/cms/djangoapps/contentstore/views/transcript_settings.py
+++ b/cms/djangoapps/contentstore/views/transcript_settings.py
@@ -20,11 +20,14 @@ from edxval.api import (
     update_transcript_credentials_state_for_org
 )
 from opaque_keys.edx.keys import CourseKey
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
 
 from common.djangoapps.student.auth import has_studio_write_access
 from common.djangoapps.util.json_request import JsonResponse, expect_json
 from openedx.core.djangoapps.video_config.models import VideoTranscriptEnabledFlag
 from openedx.core.djangoapps.video_pipeline.api import update_3rd_party_transcription_service_credentials
+from openedx.core.lib.api.view_utils import view_auth_classes
 from xmodule.video_module.transcripts_utils import Transcript, TranscriptsGenerationException
 
 from .videos import TranscriptProvider
@@ -33,7 +36,8 @@ __all__ = [
     'transcript_credentials_handler',
     'transcript_download_handler',
     'transcript_upload_handler',
-    'transcript_delete_handler'
+    'transcript_delete_handler',
+    'transcript_upload_api',
 ]
 
 LOGGER = logging.getLogger(__name__)
@@ -173,6 +177,39 @@ def transcript_download_handler(request):
     return response
 
 
+def upload_transcript(request):
+    edx_video_id = request.POST['edx_video_id']
+    language_code = request.POST['language_code']
+    new_language_code = request.POST['new_language_code']
+    transcript_file = request.FILES['file']
+    try:
+        # Convert SRT transcript into an SJSON format
+        # and upload it to S3.
+        sjson_subs = Transcript.convert(
+            content=transcript_file.read().decode('utf-8'),
+            input_format=Transcript.SRT,
+            output_format=Transcript.SJSON
+        ).encode()
+        create_or_update_video_transcript(
+            video_id=edx_video_id,
+            language_code=language_code,
+            metadata={
+                'provider': TranscriptProvider.CUSTOM,
+                'file_format': Transcript.SJSON,
+                'language_code': new_language_code
+            },
+            file_data=ContentFile(sjson_subs),
+        )
+        response = JsonResponse(status=201)
+    except (TranscriptsGenerationException, UnicodeDecodeError):
+        response = JsonResponse(
+            {'error': _('There is a problem with this transcript file. Try to upload a different file.')},
+            status=400
+        )
+    finally:
+        return response
+
+
 def validate_transcript_upload_data(data, files):
     """
     Validates video transcript file.
@@ -202,6 +239,30 @@ def validate_transcript_upload_data(data, files):
     return error
 
 
+@api_view(['POST'])
+@view_auth_classes()
+@expect_json
+def transcript_upload_api(request):
+    """
+    API View for uploading transcript files.
+
+    Arguments:
+        request: A WSGI request object
+
+        Transcript file in SRT format
+
+        Returns:
+            - A 400 if any validation fails
+            - A 200 if the transcript has been uploaded successfully
+    """
+    error = validate_transcript_upload_data(data=request.POST, files=request.FILES)
+    if error:
+        response = JsonResponse({'error': error}, status=400)
+    else:
+        response = upload_transcript(request)
+    return response
+
+
 @login_required
 @require_POST
 def transcript_upload_handler(request):
@@ -222,35 +283,7 @@ def transcript_upload_handler(request):
     if error:
         response = JsonResponse({'error': error}, status=400)
     else:
-        edx_video_id = request.POST['edx_video_id']
-        language_code = request.POST['language_code']
-        new_language_code = request.POST['new_language_code']
-        transcript_file = request.FILES['file']
-        try:
-            # Convert SRT transcript into an SJSON format
-            # and upload it to S3.
-            sjson_subs = Transcript.convert(
-                content=transcript_file.read().decode('utf-8'),
-                input_format=Transcript.SRT,
-                output_format=Transcript.SJSON
-            ).encode()
-            create_or_update_video_transcript(
-                video_id=edx_video_id,
-                language_code=language_code,
-                metadata={
-                    'provider': TranscriptProvider.CUSTOM,
-                    'file_format': Transcript.SJSON,
-                    'language_code': new_language_code
-                },
-                file_data=ContentFile(sjson_subs),
-            )
-            response = JsonResponse(status=201)
-        except (TranscriptsGenerationException, UnicodeDecodeError):
-            response = JsonResponse(
-                {'error': _('There is a problem with this transcript file. Try to upload a different file.')},
-                status=400
-            )
-
+        response = upload_transcript(request)
     return response
 
 

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -169,6 +169,7 @@ urlpatterns = [
     url(r'^transcript_delete/{}(?:/(?P<edx_video_id>[-\w]+))?(?:/(?P<language_code>[^/]*))?$'.format(
         settings.COURSE_KEY_PATTERN
     ), contentstore_views.transcript_delete_handler, name='transcript_delete_handler'),
+    url(r'^transcript_upload_api/$', contentstore_views.transcript_upload_api, name='transcript_upload_api'),
     url(fr'^video_encodings_download/{settings.COURSE_KEY_PATTERN}$',
         contentstore_views.video_encodings_download, name='video_encodings_download'),
     url(fr'^group_configurations/{settings.COURSE_KEY_PATTERN}$',


### PR DESCRIPTION
## Description
This adds another view and URL route for an endpoint which accepts transcript uploads. As opposed to the existing endpoints, this accepts JWT tokens as credentials. The existing endpoints only work for currently logged in users. This fills a need to programmatically upload transcripts from external scripts.

This doesn't alter existing behavior, but does extend and re-use code from the existing [`transcript_upload_handler()`](https://github.com/open-craft/edx-platform/blob/aec8c0057fcf6293356cf2cb601e4675062d1e3c/cms/djangoapps/contentstore/views/transcript_settings.py#L203) view.

Useful information to include:
- Which edX user roles will this change impact? Course Authors and Developers

## Supporting information

This was needed for use on https://github.com/edx/cc2olx/pull/61. Initial discussion for the change began there.

## Testing instructions

1. Create a test video with edx video ID in the devstack, note edx video ID for step #3.
2. Get JWT access token: `curl -d 'token_type=jwt&grant_type=client_credentials&client_id=xxxxxxxxxxxxxxxxxxx&client_secret=xxxxxxxxxxxxxx' http://localhost:18000/oauth2/access_token`
3. Upload transcript: `curl -H 'Authorizations: JWT xxxxxxxxxx' http://localhost:18010/upload_transcript_api/ -F file=@${HOME}/devstack/edx-platform/common/test/data/uploads/uk_transcripts.srt -F language_code=en -F edx_video_id=ae5f4ec8-7b27-447b-b094-080f74657e03`


## Deadline

June 7th, 2021

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
No, but will be utilized in cc2olx.
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
The naming in the repurposing of `validate_transcript_upload_data()` feels a bit awkward, but in the pursuit of DRY it seems better to re-use the form validation as these are very similar endpoints.

cc: @alangsto 