### PR TITLE
refactor: Move may_certify from xmodule lib to course overview

### DIFF
--- a/common/lib/xmodule/xmodule/course_metadata_utils.py
+++ b/common/lib/xmodule/xmodule/course_metadata_utils.py
@@ -133,41 +133,6 @@ def course_start_date_is_default(start, advertised_start):
     """
     return advertised_start is None and start == DEFAULT_START_DATE
 
-
-def may_certify_for_course(
-        certificates_display_behavior,
-        certificates_show_before_end,
-        has_ended,
-        certificate_available_date,
-        self_paced
-):
-    """
-    Returns whether it is acceptable to show the student a certificate download
-    link for a course, based on provided attributes of the course.
-
-    Arguments:
-        certificates_display_behavior (str): string describing the course's
-            certificate display behavior.
-            See CourseFields.certificates_display_behavior.help for more detail.
-        certificates_show_before_end (bool): whether user can download the
-            course's certificates before the course has ended.
-        has_ended (bool): Whether the course has ended.
-        certificate_available_date (datetime): the date the certificate is available on for the course.
-        self_paced (bool): Whether the course is self-paced.
-    """
-    show_early = (
-        certificates_display_behavior in ('early_with_info', 'early_no_info')
-        or certificates_show_before_end
-    )
-    past_available_date = (
-        certificate_available_date
-        and certificate_available_date < datetime.now(utc)
-    )
-    ended_without_available_date = (certificate_available_date is None) and has_ended
-
-    return any((self_paced, show_early, past_available_date, ended_without_available_date))
-
-
 def sorting_score(start, advertised_start, announcement):
     """
     Returns a tuple that can be used to sort the courses according

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -1197,18 +1197,6 @@ class CourseBlock(
         """
         return course_metadata_utils.has_course_ended(self.end)
 
-    def may_certify(self):
-        """
-        Return whether it is acceptable to show the student a certificate download link.
-        """
-        return course_metadata_utils.may_certify_for_course(
-            self.certificates_display_behavior,
-            self.certificates_show_before_end,
-            self.has_ended(),
-            self.certificate_available_date,
-            self.self_paced
-        )
-
     def has_started(self):
         return course_metadata_utils.has_course_started(self.start)
 

--- a/common/lib/xmodule/xmodule/tests/test_course_metadata_utils.py
+++ b/common/lib/xmodule/xmodule/tests/test_course_metadata_utils.py
@@ -20,7 +20,6 @@ from xmodule.course_metadata_utils import (
     course_start_date_is_default,
     has_course_ended,
     has_course_started,
-    may_certify_for_course,
     number_for_course_location
 )
 from xmodule.modulestore.tests.utils import (
@@ -161,18 +160,6 @@ class CourseMetadataUtilsTestCase(TestCase):
                 TestScenario((test_datetime, None), False),
                 TestScenario((DEFAULT_START_DATE, advertised_start_parsable), False),
                 TestScenario((DEFAULT_START_DATE, None), True),
-            ]),
-            FunctionTest(may_certify_for_course, [
-                TestScenario(('early_with_info', True, True, test_datetime, False), True),
-                TestScenario(('early_no_info', False, False, test_datetime, False), True),
-                TestScenario(('end', True, False, test_datetime, False), True),
-                TestScenario(('end', False, True, test_datetime, False), True),
-                TestScenario(('end', False, False, _NEXT_WEEK, False), False),
-                TestScenario(('end', False, False, _LAST_WEEK, False), True),
-                TestScenario(('end', False, False, None, False), False),
-                TestScenario(('early_with_info', False, False, None, False), True),
-                TestScenario(('end', False, False, _NEXT_WEEK, False), False),
-                TestScenario(('end', False, False, _NEXT_WEEK, True), True),
             ]),
         ]
 

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -23,6 +23,7 @@ from django.utils.encoding import python_2_unicode_compatible
 from django.utils.functional import cached_property
 from model_utils.models import TimeStampedModel
 from opaque_keys.edx.django.models import CourseKeyField, UsageKeyField
+from pytz import utc
 from simple_history.models import HistoricalRecords
 
 from lms.djangoapps.discussion import django_comment_client


### PR DESCRIPTION


## Description

Move directly to course overview since we don't use the xmodule version except when passing through course overview. Moving because it allows me to keep course overview imports out of the xmodule lib. But also because I can condense 3 identical functions into one. 

## Supporting information

This is part of a larger project of changing the Certificate Display Behavior field options. Part of that involves using constants instead of strings placed throughout the codebase. 