### PR TITLE
add validation to capa problem markdown for missing option text and fix response report generation for old problems

### DIFF
--- a/cms/static/js/views/modals/edit_xblock.js
+++ b/cms/static/js/views/modals/edit_xblock.js
@@ -177,7 +177,7 @@ define(['jquery', 'underscore', 'backbone', 'gettext', 'js/views/modals/base_mod
                     data = editorView.getXBlockFieldData();
                 } catch (e) {
                     ViewUtils.showErrorMeassage(
-                        gettext("Studio's having trouble while parsing the problem content"),
+                        gettext("Studio's having trouble parsing the problem component's content"),
                         e.message,
                         10000
                     );

--- a/cms/static/js/views/modals/edit_xblock.js
+++ b/cms/static/js/views/modals/edit_xblock.js
@@ -172,7 +172,18 @@ define(['jquery', 'underscore', 'backbone', 'gettext', 'js/views/modals/base_mod
                 var self = this,
                     editorView = this.editorView,
                     xblockInfo = this.xblockInfo,
+                    data = null;
+                try {
                     data = editorView.getXBlockFieldData();
+                } catch (e) {
+                    ViewUtils.showErrorMeassage(
+                        gettext("Studio's having trouble while parsing the problem content"),
+                        e.message,
+                        10000
+                    );
+                    ViewUtils.setScrollOffset(editorView.$el, 100);
+                    return null;
+                }
                 event.preventDefault();
                 if (data) {
                     ViewUtils.runOperationShowingMessage(gettext('Saving'),
@@ -182,6 +193,7 @@ define(['jquery', 'underscore', 'backbone', 'gettext', 'js/views/modals/base_mod
                             self.onSave();
                         });
                 }
+                return null;
             },
 
             onSave: function() {

--- a/common/lib/capa/capa/capa_problem.py
+++ b/common/lib/capa/capa/capa_problem.py
@@ -669,11 +669,17 @@ class LoncapaProblem(object):
                 answer_id=answer_id,
                 choice_number=current_answer
             ))
-            assert len(elems) == 1
-            choicegroup = elems[0].getparent()
-            input_cls = inputtypes.registry.get_class_for_tag(choicegroup.tag)
-            choices_map = dict(input_cls.extract_choices(choicegroup, self.capa_system.i18n, text_only=True))
-            answer_text = choices_map[current_answer]
+            if len(elems) == 0:
+                log.warning("Answer Text Missing for answer id: %s and choice number: %s", answer_id, current_answer)
+                answer_text = "Answer Text Missing"
+            elif len(elems) == 1:
+                choicegroup = elems[0].getparent()
+                input_cls = inputtypes.registry.get_class_for_tag(choicegroup.tag)
+                choices_map = dict(input_cls.extract_choices(choicegroup, self.capa_system.i18n, text_only=True))
+                answer_text = choices_map.get(current_answer, "Answer Text Missing")
+            else:
+                log.warning("Multiple answers found for answer id: %s and choice number: %s", answer_id, current_answer)
+                answer_text = "Multiple answers found"
 
         elif isinstance(current_answer, six.string_types):
             # Already a string with the answer
@@ -682,7 +688,7 @@ class LoncapaProblem(object):
         else:
             raise NotImplementedError()
 
-        return answer_text
+        return answer_text or "Answer Text Missing"
 
     def do_targeted_feedback(self, tree):
         """

--- a/common/lib/capa/capa/tests/test_capa_problem.py
+++ b/common/lib/capa/capa/tests/test_capa_problem.py
@@ -629,6 +629,43 @@ class CAPAProblemReportHelpersTest(unittest.TestCase):
 
     @ddt.data(
         # Test for ChoiceResponse
+        ('1_2_1', 'choice_0', 'Answer Text Missing'),
+        ('1_2_1', 'choice_1', 'funny'),
+        # Test for MultipleChoiceResponse
+        ('1_3_1', 'choice_0', 'The iPad'),
+        ('1_3_1', 'choice_2', 'Answer Text Missing'),
+        ('1_3_1', ['choice_0', 'choice_1'], 'The iPad, Answer Text Missing'),
+        # Test for OptionResponse
+        ('1_4_1', '', 'Answer Text Missing'),
+    )
+    @ddt.unpack
+    def test_find_answer_text_choices_with_missing_text(self, answer_id, choice_id, answer_text):
+        problem = new_loncapa_problem(
+            """
+            <problem>
+                <choiceresponse>
+                    <checkboxgroup label="Select the correct synonym of paranoid?">
+                        <choice correct="true"></choice>
+                        <choice correct="false">funny</choice>
+                    </checkboxgroup>
+                </choiceresponse>
+                <multiplechoiceresponse>
+                    <choicegroup type="MultipleChoice">
+                        <choice correct="false">The iPad</choice>
+                        <choice correct="false"></choice>
+                        <choice correct="true"></choice>
+                    </choicegroup>
+                </multiplechoiceresponse>
+                <optionresponse>
+                    <optioninput options="('yellow','blue','green')" correct="blue" label="Color_1"/>
+                </optionresponse>
+            </problem>
+            """
+        )
+        assert problem.find_answer_text(answer_id, choice_id) == answer_text
+
+    @ddt.data(
+        # Test for ChoiceResponse
         ('1_2_1', 'over-suspicious'),
         # Test for MultipleChoiceResponse
         ('1_3_1', 'The iPad, Napster'),

--- a/common/lib/xmodule/xmodule/js/spec/problem/edit_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/problem/edit_spec.js
@@ -1046,5 +1046,27 @@ third
 </problem>\
 `);
     });
+
+    it('should throw error if an option does not have any text associated with it', function() {
+      let problemContent = `\
+>>The following languages are in the Indo-European family:||<<
+[ ]
+[x] Urdu
+[ ] Finnish\
+`
+      expect(function(){ MarkdownEditingDescriptor.markdownToXml(problemContent); }).toThrow(
+        new Error(gettext("One of the provided options doesn't have a valid text value"))
+      );
+
+      problemContent = `\
+>>The following languages are in the Indo-European family:||<<
+( )
+(x) Urdu
+( ) Finnish\
+`
+      expect(function(){ MarkdownEditingDescriptor.markdownToXml(problemContent); }).toThrow(
+        new Error(gettext("One of the provided options doesn't have a valid text value"))
+      );
+    });
   });
 });

--- a/common/lib/xmodule/xmodule/js/spec/problem/edit_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/problem/edit_spec.js
@@ -1055,7 +1055,7 @@ third
 [ ] Finnish\
 `
       expect(function(){ MarkdownEditingDescriptor.markdownToXml(problemContent); }).toThrow(
-        new Error(gettext("One of the provided options doesn't have a valid text value"))
+        new Error(gettext("An answer option has been left blank. Please review and edit the component."))
       );
 
       problemContent = `\
@@ -1065,7 +1065,7 @@ third
 ( ) Finnish\
 `
       expect(function(){ MarkdownEditingDescriptor.markdownToXml(problemContent); }).toThrow(
-        new Error(gettext("One of the provided options doesn't have a valid text value"))
+        new Error(gettext("An answer option has been left blank. Please review and edit the component."))
       );
     });
   });

--- a/common/lib/xmodule/xmodule/js/src/problem/edit.js
+++ b/common/lib/xmodule/xmodule/js/src/problem/edit.js
@@ -403,7 +403,7 @@
                         if (line.length > 0) {
                             textHint = extractHint(line, true);
                             if (!textHint.nothint) {
-                                throw new Error(gettext("One of the provided options doesn't have a valid text value"));
+                                throw new Error(gettext("An answer option has been left blank. Please review and edit the component."));
                             }
                             correctstr = ' correct="' + (textHint.parens ? 'True' : 'False') + '"';
                             hintstr = '';
@@ -438,7 +438,7 @@
                         if (options[i].length > 0) {
                             value = options[i].split(/^\s*\(.{0,3}\)\s*/)[1];
                             if (!value) {
-                                throw new Error(gettext("One of the provided options doesn't have a valid text value"));
+                                throw new Error(gettext("An answer option has been left blank. Please review and edit the component."));
                             }
                             inparens = /^\s*\((.{0,3})\)\s*/.exec(options[i])[1];
                             correct = /x/i.test(inparens);
@@ -501,7 +501,7 @@
 
                             value = options[i].split(/^\s*\[.?\]\s*/)[1];
                             if (!value) {
-                                throw new Error(gettext("One of the provided options doesn't have a valid text value"));
+                                throw new Error(gettext("An answer option has been left blank. Please review and edit the component."));
                             }
                             correct = /^\s*\[x\]/i.test(options[i]);
                             hints = '';

--- a/common/lib/xmodule/xmodule/js/src/problem/edit.js
+++ b/common/lib/xmodule/xmodule/js/src/problem/edit.js
@@ -402,6 +402,9 @@
                         line = lines[i].trim();
                         if (line.length > 0) {
                             textHint = extractHint(line, true);
+                            if (!textHint.nothint) {
+                                throw new Error(gettext("One of the provided options doesn't have a valid text value"));
+                            }
                             correctstr = ' correct="' + (textHint.parens ? 'True' : 'False') + '"';
                             hintstr = '';
                             if (textHint.hint) {
@@ -434,6 +437,9 @@
                         options[i] = options[i].trim();                   // trim off leading/trailing whitespace
                         if (options[i].length > 0) {
                             value = options[i].split(/^\s*\(.{0,3}\)\s*/)[1];
+                            if (!value) {
+                                throw new Error(gettext("One of the provided options doesn't have a valid text value"));
+                            }
                             inparens = /^\s*\((.{0,3})\)\s*/.exec(options[i])[1];
                             correct = /x/i.test(inparens);
                             fixed = '';
@@ -494,6 +500,9 @@
                             }
 
                             value = options[i].split(/^\s*\[.?\]\s*/)[1];
+                            if (!value) {
+                                throw new Error(gettext("One of the provided options doesn't have a valid text value"));
+                            }
                             correct = /^\s*\[x\]/i.test(options[i]);
                             hints = '';
                             //  {{ selected: You’re right that apple is a fruit. },

--- a/common/static/common/js/components/utils/view_utils.js
+++ b/common/static/common/js/components/utils/view_utils.js
@@ -16,7 +16,7 @@
     /* End Webpack */
 
             var toggleExpandCollapse, showLoadingIndicator, hideLoadingIndicator, confirmThenRunOperation,
-                runOperationShowingMessage, withDisabledElement, disableElementWhileRunning,
+                runOperationShowingMessage, showErrorMeassage, withDisabledElement, disableElementWhileRunning,
                 getScrollOffset, setScrollOffset, setScrollTop, redirect, reload, hasChangedAttributes,
                 deleteNotificationHandler, validateRequiredField, validateURLItemEncoding,
                 validateTotalKeyLength, checkTotalKeyLengthViolations, loadJavaScript;
@@ -95,6 +95,21 @@
                 });
             };
 
+            /**
+             * Shows an error notification message for a specifc period of time.
+             * @param heading The heading of notification.
+             * @param message The message to show.
+             * @param timeInterval The time interval to hide the notification.
+             */
+            showErrorMeassage = function(heading, message, timeInterval) {
+                var errorNotificationView = new NotificationView.Error({
+                    title: gettext(heading),
+                    message: gettext(message)
+                });
+                errorNotificationView.show();
+
+                setTimeout(function() { errorNotificationView.hide(); }, timeInterval);
+            };
             /**
              * Wraps a Backbone event callback to disable the event's target element.
              *
@@ -295,6 +310,7 @@
                 hideLoadingIndicator: hideLoadingIndicator,
                 confirmThenRunOperation: confirmThenRunOperation,
                 runOperationShowingMessage: runOperationShowingMessage,
+                showErrorMeassage: showErrorMeassage,
                 withDisabledElement: withDisabledElement,
                 disableElementWhileRunning: disableElementWhileRunning,
                 deleteNotificationHandler: deleteNotificationHandler,


### PR DESCRIPTION
## Description

If an author has created a capa problem like an mcqs or something similar `without providing answer text to an option` and some learner selects that option then the `response report generation` will fail due to that missing answer text. The current PR will `add default text to be substituted and prevents report generation crash`, along with `adding some validation on course authoring side to prevent the issue in future CAPA problems`.

**Summary**:
This PR does two things:
1) adds validation to capa problem markdown for missing option text
2) adds default texts for missing answer texts in capa problems to fix response report generation for old questions

## Testing instructions

**Generate the issue without this PR's fix:**
1) Create a Checkbox Problem on studio
2) Don't put any text against one of the options
![image](https://user-images.githubusercontent.com/42243411/107644036-b906ee00-6c98-11eb-9616-7d064a2871f3.png)
3) Through LMS select that option with no text and submit
4) Go to `Data Download` under `Instructor` tab
5) Under the `Reports` section, select the Problem and press `Create a report of problem responses`
The report generation will crash.

**Now try creating the same scenario with this PR's fix:**
1) You will notice that the editor will not allow saving such content and mentions an error message instead.
<img width="1416" alt="Screen Shot 2021-06-17 at 4 10 23 PM" src="https://user-images.githubusercontent.com/42243411/122386209-1680b380-cf87-11eb-890c-7a41c5d2f710.png">

2) If you try generating the response report for the old CAPA problem it will not fail
