### PR TITLE
feat: documentation links added in discussion api

### DIFF
--- a/openedx/core/djangoapps/discussions/docs/decisions/0003-configuration-rest-api.rst
+++ b/openedx/core/djangoapps/discussions/docs/decisions/0003-configuration-rest-api.rst
@@ -76,7 +76,7 @@ The payload is expected to be shaped like this (key names subject to change):
             'active': configuration.provider_type or '',
             'available': {
                 provider: {
-                    'features': PROVIDER_FEATURE_MAP.get(provider) or [],
+                    'features': AVAILABLE_PROVIDER_MAP.get(provider).get('features') or [],
                 }
                 for provider in configuration.available_providers
             },

--- a/openedx/core/djangoapps/discussions/models.py
+++ b/openedx/core/djangoapps/discussions/models.py
@@ -26,7 +26,7 @@ log = logging.getLogger(__name__)
 DEFAULT_PROVIDER_TYPE = 'legacy'
 
 
-DocumentLinks = namedtuple('DocumentLinks', ['learn_more', 'configuration_documentation', 'documentation', 'accessibility_documentation', 'email_id'])
+ProviderExternalLinks = namedtuple('ProviderExternalLinks', ['learn_more', 'configuration', 'general', 'accessibility', 'contact_email'])
 
 
 class Features(Enum):
@@ -75,7 +75,7 @@ AVAILABLE_PROVIDER_MAP = {
             Features.COURSE_COHORT_SUPPORT.value,
             Features.RESEARCH_DATA_EVENTS.value,
         ],
-        'documentation_urls': DocumentLinks(
+        'external_links': ProviderExternalLinks(
             '',
             '',
             '',
@@ -98,7 +98,7 @@ AVAILABLE_PROVIDER_MAP = {
             Features.DIRECT_MESSAGES_FROM_INSTRUCTORS.value,
             Features.USER_MENTIONS.value,
         ],
-        'documentation_urls': DocumentLinks(
+        'external_links': ProviderExternalLinks(
             'https://piazza.com/product/overview',
             'https://support.piazza.com/support/solutions/articles/48001065447-configure-piazza-within-edx',
             'https://support.piazza.com/',
@@ -124,7 +124,7 @@ AVAILABLE_PROVIDER_MAP = {
             Features.DISCUSSION_CONTENT_PROMPTS.value,
             Features.GRADED_DISCUSSIONS.value,
         ],
-        'documentation_urls': DocumentLinks(
+        'external_links': ProviderExternalLinks(
             '',
             '',
             '',
@@ -146,7 +146,7 @@ AVAILABLE_PROVIDER_MAP = {
             Features.DIRECT_MESSAGES_FROM_INSTRUCTORS.value,
             Features.USER_MENTIONS.value,
         ],
-        'documentation_urls': DocumentLinks(
+        'external_links': ProviderExternalLinks(
             'https://www.youtube.com/watch?v=ZACief-qMwY',
             '',
             'https://hubs.ly/H0J5Bn7',
@@ -159,7 +159,7 @@ AVAILABLE_PROVIDER_MAP = {
             Features.PRIMARY_DISCUSSION_APP_EXPERIENCE.value,
             Features.LTI_BASIC_CONFIGURATION.value,
         ],
-        'documentation_urls': DocumentLinks(
+        'external_links': ProviderExternalLinks(
             '',
             '',
             'https://www.inscribeapp.com/',
@@ -173,7 +173,7 @@ AVAILABLE_PROVIDER_MAP = {
             Features.LTI_BASIC_CONFIGURATION.value,
             Features.LTI_ADVANCED_SHARING_MODE.value,
         ],
-        'documentation_urls': DocumentLinks(
+        'external_links': ProviderExternalLinks(
             '',
             '',
             'http://discourse.org/',
@@ -193,7 +193,7 @@ AVAILABLE_PROVIDER_MAP = {
             Features.COMMUNITY_TA_SUPPORT.value,
             Features.EMAIL_NOTIFICATIONS.value,
         ],
-        'documentation_urls': DocumentLinks(
+        'external_links': ProviderExternalLinks(
             '',
             '',
             'https://edstem.org/us/',
@@ -362,7 +362,7 @@ class DiscussionsConfiguration(TimeStampedModel):
         """
         Check if the provider supports some feature
         """
-        features = AVAILABLE_PROVIDER_MAP.get(self.provider_type).get('features') or []
+        features = AVAILABLE_PROVIDER_MAP.get(self.provider_type)['features'] or []
         has_support = bool(feature in features)
         return has_support
 

--- a/openedx/core/djangoapps/discussions/models.py
+++ b/openedx/core/djangoapps/discussions/models.py
@@ -55,85 +55,158 @@ class Features(Enum):
     WCAG_2_1 = 'wcag-2.1'
     WCAG_2_0_SUPPORT = 'wcag-2.0-support'
 
+class LINKS(Enum):
+    """
+       Links to be used in discussion providers for documentation
+    """
+    PIAZZA_DOCUMENTATION: ''
+    PIAZZA_ACCESSIBILITY_DOCUMENTATION: ''
+    PIAZZA_EMAIL: ''
+    PIAZZA_CONFIGURATION_DOCUMENTATION: ''
+    PIAZZA_LEARN_MORE: ''
+
 PROVIDER_FEATURE_MAP = {
-    'legacy': [
-        Features.DISCUSSION_PAGE.value,
-        Features.WCAG_2_1.value,
-        Features.AUTOMATIC_LEARNER_ENROLLMENT.value,
-        Features.WCAG_2_0_SUPPORT.value,
-        Features.INTERNATIONALIZATION_SUPPORT.value,
-        Features.ANONYMOUS_POSTING.value,
-        Features.REPORT_FLAG_CONTENT_TO_MODERATORS.value,
-        Features.QUESTION_DISCUSSION_SUPPORT.value,
-        Features.COMMUNITY_TA_SUPPORT.value,
-        Features.BLACKOUT_DISCUSSION_DATES.value,
-        Features.COURSE_COHORT_SUPPORT.value,
-        Features.RESEARCH_DATA_EVENTS.value,
-    ],
-    'piazza': [
-        Features.DISCUSSION_PAGE.value,
-        Features.LTI.value,
-        Features.WCAG_2_0_SUPPORT.value,
-        Features.ANONYMOUS_POSTING.value,
-        Features.REPORT_FLAG_CONTENT_TO_MODERATORS.value,
-        Features.QUESTION_DISCUSSION_SUPPORT.value,
-        Features.COMMUNITY_TA_SUPPORT.value,
-        Features.EMAIL_NOTIFICATIONS.value,
-        Features.BLACKOUT_DISCUSSION_DATES.value,
-        Features.DISCUSSION_CONTENT_PROMPTS.value,
-        Features.DIRECT_MESSAGES_FROM_INSTRUCTORS.value,
-        Features.USER_MENTIONS.value,
-    ],
-    'edx-next': [
-        Features.AUTOMATIC_LEARNER_ENROLLMENT.value,
-        Features.WCAG_2_0_SUPPORT.value,
-        Features.INTERNATIONALIZATION_SUPPORT.value,
-        Features.ANONYMOUS_POSTING.value,
-        Features.REPORT_FLAG_CONTENT_TO_MODERATORS.value,
-        Features.QUESTION_DISCUSSION_SUPPORT.value,
-        Features.COMMUNITY_TA_SUPPORT.value,
-        Features.EMAIL_NOTIFICATIONS.value,
-        Features.BLACKOUT_DISCUSSION_DATES.value,
-        Features.SIMPLIFIED_IN_CONTEXT_DISCUSSION.value,
-        Features.ADVANCED_IN_CONTEXT_DISCUSSION.value,
-        Features.COURSE_COHORT_SUPPORT.value,
-        Features.RESEARCH_DATA_EVENTS.value,
-        Features.DISCUSSION_CONTENT_PROMPTS.value,
-        Features.GRADED_DISCUSSIONS.value,
-    ],
-    'yellowdig': [
-        Features.WCAG_2_0_SUPPORT.value,
-        Features.ANONYMOUS_POSTING.value,
-        Features.REPORT_FLAG_CONTENT_TO_MODERATORS.value,
-        Features.QUESTION_DISCUSSION_SUPPORT.value,
-        Features.COMMUNITY_TA_SUPPORT.value,
-        Features.EMAIL_NOTIFICATIONS.value,
-        Features.RESEARCH_DATA_EVENTS.value,
-        Features.IN_PLATFORM_NOTIFICATIONS.value,
-        Features.GRADED_DISCUSSIONS.value,
-        Features.DIRECT_MESSAGES_FROM_INSTRUCTORS.value,
-        Features.USER_MENTIONS.value,
-    ],
-    'inscribe': [
-        Features.PRIMARY_DISCUSSION_APP_EXPERIENCE.value,
-        Features.LTI_BASIC_CONFIGURATION.value,
-    ],
-    'discourse': [
-        Features.PRIMARY_DISCUSSION_APP_EXPERIENCE.value,
-        Features.LTI_BASIC_CONFIGURATION.value,
-        Features.LTI_ADVANCED_SHARING_MODE.value,
-    ],
-    'ed-discuss': [
-        Features.PRIMARY_DISCUSSION_APP_EXPERIENCE.value,
-        Features.LTI_BASIC_CONFIGURATION.value,
-        Features.WCAG_2_0_SUPPORT.value,
-        Features.INTERNATIONALIZATION_SUPPORT.value,
-        Features.ANONYMOUS_POSTING.value,
-        Features.REPORT_FLAG_CONTENT_TO_MODERATORS.value,
-        Features.QUESTION_DISCUSSION_SUPPORT.value,
-        Features.COMMUNITY_TA_SUPPORT.value,
-        Features.EMAIL_NOTIFICATIONS.value,
-    ]
+    'legacy': {
+        'features': [
+            Features.DISCUSSION_PAGE.value,
+            Features.WCAG_2_1.value,
+            Features.AUTOMATIC_LEARNER_ENROLLMENT.value,
+            Features.WCAG_2_0_SUPPORT.value,
+            Features.INTERNATIONALIZATION_SUPPORT.value,
+            Features.ANONYMOUS_POSTING.value,
+            Features.REPORT_FLAG_CONTENT_TO_MODERATORS.value,
+            Features.QUESTION_DISCUSSION_SUPPORT.value,
+            Features.COMMUNITY_TA_SUPPORT.value,
+            Features.BLACKOUT_DISCUSSION_DATES.value,
+            Features.COURSE_COHORT_SUPPORT.value,
+            Features.RESEARCH_DATA_EVENTS.value,
+        ],
+        'documentation_urls': {
+            'learnMore': '',
+            'configurationDocumentation': '',
+            'documentation': '',
+            'accessibilityDocumentation': '',
+            'emailId': '',
+        }
+    },
+    'piazza': {
+        'features':[
+            Features.DISCUSSION_PAGE.value,
+            Features.LTI.value,
+            Features.WCAG_2_0_SUPPORT.value,
+            Features.ANONYMOUS_POSTING.value,
+            Features.REPORT_FLAG_CONTENT_TO_MODERATORS.value,
+            Features.QUESTION_DISCUSSION_SUPPORT.value,
+            Features.COMMUNITY_TA_SUPPORT.value,
+            Features.EMAIL_NOTIFICATIONS.value,
+            Features.BLACKOUT_DISCUSSION_DATES.value,
+            Features.DISCUSSION_CONTENT_PROMPTS.value,
+            Features.DIRECT_MESSAGES_FROM_INSTRUCTORS.value,
+            Features.USER_MENTIONS.value,
+        ],
+        'documentation_urls': {
+            'learnMore': 'https://piazza.com/product/overview',
+            'configurationDocumentation': 'https://support.piazza.com/support/solutions/articles/48001065447-configure-piazza-within-edx',
+            'documentation': 'https://support.piazza.com/',
+            'accessibilityDocumentation': 'https://piazza.com/product/accessibility',
+            'emailId': 'team@piazza.com',
+        }
+    },
+    'edx-next': {
+        'features': [
+            Features.AUTOMATIC_LEARNER_ENROLLMENT.value,
+            Features.WCAG_2_0_SUPPORT.value,
+            Features.INTERNATIONALIZATION_SUPPORT.value,
+            Features.ANONYMOUS_POSTING.value,
+            Features.REPORT_FLAG_CONTENT_TO_MODERATORS.value,
+            Features.QUESTION_DISCUSSION_SUPPORT.value,
+            Features.COMMUNITY_TA_SUPPORT.value,
+            Features.EMAIL_NOTIFICATIONS.value,
+            Features.BLACKOUT_DISCUSSION_DATES.value,
+            Features.SIMPLIFIED_IN_CONTEXT_DISCUSSION.value,
+            Features.ADVANCED_IN_CONTEXT_DISCUSSION.value,
+            Features.COURSE_COHORT_SUPPORT.value,
+            Features.RESEARCH_DATA_EVENTS.value,
+            Features.DISCUSSION_CONTENT_PROMPTS.value,
+            Features.GRADED_DISCUSSIONS.value,
+        ],
+        'documentation_urls': {
+            'learnMore': '',
+            'configurationDocumentation': '',
+            'documentation': '',
+            'accessibilityDocumentation': '',
+            'emailId': '',
+        }
+    },
+    'yellowdig': {
+        'features': [
+            Features.WCAG_2_0_SUPPORT.value,
+            Features.ANONYMOUS_POSTING.value,
+            Features.REPORT_FLAG_CONTENT_TO_MODERATORS.value,
+            Features.QUESTION_DISCUSSION_SUPPORT.value,
+            Features.COMMUNITY_TA_SUPPORT.value,
+            Features.EMAIL_NOTIFICATIONS.value,
+            Features.RESEARCH_DATA_EVENTS.value,
+            Features.IN_PLATFORM_NOTIFICATIONS.value,
+            Features.GRADED_DISCUSSIONS.value,
+            Features.DIRECT_MESSAGES_FROM_INSTRUCTORS.value,
+            Features.USER_MENTIONS.value,
+        ],
+        'documentation_urls': {
+            'learnMore': 'https://www.youtube.com/watch?v=ZACief-qMwY',
+            'configurationDocumentation': '',
+            'documentation': 'https://hubs.ly/H0J5Bn70',
+            'accessibilityDocumentation': 'https://drive.google.com/file/d/1FT6E2ajMabFQI3NqgInPgGsQnLH7e2Mb/view?usp=sharing',
+            'emailId': 'learnmore@yellowdig.com',
+        }
+    },
+    'inscribe': {
+        'features': [
+            Features.PRIMARY_DISCUSSION_APP_EXPERIENCE.value,
+            Features.LTI_BASIC_CONFIGURATION.value,
+        ],
+        'documentation_urls': {
+            'learnMore': '',
+            'configurationDocumentation': '',
+            'documentation': 'https://www.inscribeapp.com/',
+            'accessibilityDocumentation': '',
+            'emailId': '',
+        }
+    },
+    'discourse': {
+        'features': [
+            Features.PRIMARY_DISCUSSION_APP_EXPERIENCE.value,
+            Features.LTI_BASIC_CONFIGURATION.value,
+            Features.LTI_ADVANCED_SHARING_MODE.value,
+        ],
+        'documentation_urls': {
+            'learnMore': '',
+            'configurationDocumentation': '',
+            'documentation': 'http://discourse.org/',
+            'accessibilityDocumentation': '',
+            'emailId': '',
+        }
+    },
+    'ed-discuss': {
+        'features': [
+            Features.PRIMARY_DISCUSSION_APP_EXPERIENCE.value,
+            Features.LTI_BASIC_CONFIGURATION.value,
+            Features.WCAG_2_0_SUPPORT.value,
+            Features.INTERNATIONALIZATION_SUPPORT.value,
+            Features.ANONYMOUS_POSTING.value,
+            Features.REPORT_FLAG_CONTENT_TO_MODERATORS.value,
+            Features.QUESTION_DISCUSSION_SUPPORT.value,
+            Features.COMMUNITY_TA_SUPPORT.value,
+            Features.EMAIL_NOTIFICATIONS.value,
+        ],
+        'documentation_urls': {
+            'learnMore': '',
+            'configurationDocumentation': '',
+            'documentation': 'https://edstem.org/us/',
+            'accessibilityDocumentation': '',
+            'emailId': '',
+        }
+    }
 }
 
 

--- a/openedx/core/djangoapps/discussions/models.py
+++ b/openedx/core/djangoapps/discussions/models.py
@@ -16,6 +16,7 @@ from model_utils.models import TimeStampedModel
 from opaque_keys.edx.django.models import LearningContextKeyField
 from opaque_keys.edx.keys import CourseKey
 from simple_history.models import HistoricalRecords
+from collections import namedtuple
 
 from openedx.core.djangoapps.config_model_utils.models import StackedConfigurationModel
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
@@ -23,6 +24,9 @@ from openedx.core.djangoapps.content.course_overviews.models import CourseOvervi
 log = logging.getLogger(__name__)
 
 DEFAULT_PROVIDER_TYPE = 'legacy'
+
+
+DocumentLinks = namedtuple('DocumentLinks', ['learn_more', 'configuration_documentation', 'documentation', 'accessibility_documentation', 'email_id'])
 
 
 class Features(Enum):
@@ -55,17 +59,7 @@ class Features(Enum):
     WCAG_2_1 = 'wcag-2.1'
     WCAG_2_0_SUPPORT = 'wcag-2.0-support'
 
-class LINKS(Enum):
-    """
-       Links to be used in discussion providers for documentation
-    """
-    PIAZZA_DOCUMENTATION: ''
-    PIAZZA_ACCESSIBILITY_DOCUMENTATION: ''
-    PIAZZA_EMAIL: ''
-    PIAZZA_CONFIGURATION_DOCUMENTATION: ''
-    PIAZZA_LEARN_MORE: ''
-
-PROVIDER_FEATURE_MAP = {
+AVAILABLE_PROVIDER_MAP = {
     'legacy': {
         'features': [
             Features.DISCUSSION_PAGE.value,
@@ -81,16 +75,16 @@ PROVIDER_FEATURE_MAP = {
             Features.COURSE_COHORT_SUPPORT.value,
             Features.RESEARCH_DATA_EVENTS.value,
         ],
-        'documentation_urls': {
-            'learnMore': '',
-            'configurationDocumentation': '',
-            'documentation': '',
-            'accessibilityDocumentation': '',
-            'emailId': '',
-        }
+        'documentation_urls': DocumentLinks(
+            '',
+            '',
+            '',
+            '',
+            '',
+        )._asdict(),
     },
     'piazza': {
-        'features':[
+        'features': [
             Features.DISCUSSION_PAGE.value,
             Features.LTI.value,
             Features.WCAG_2_0_SUPPORT.value,
@@ -104,13 +98,13 @@ PROVIDER_FEATURE_MAP = {
             Features.DIRECT_MESSAGES_FROM_INSTRUCTORS.value,
             Features.USER_MENTIONS.value,
         ],
-        'documentation_urls': {
-            'learnMore': 'https://piazza.com/product/overview',
-            'configurationDocumentation': 'https://support.piazza.com/support/solutions/articles/48001065447-configure-piazza-within-edx',
-            'documentation': 'https://support.piazza.com/',
-            'accessibilityDocumentation': 'https://piazza.com/product/accessibility',
-            'emailId': 'team@piazza.com',
-        }
+        'documentation_urls': DocumentLinks(
+            'https://piazza.com/product/overview',
+            'https://support.piazza.com/support/solutions/articles/48001065447-configure-piazza-within-edx',
+            'https://support.piazza.com/',
+            'https://piazza.com/product/accessibility',
+            'team@piazza.com',
+        )._asdict()
     },
     'edx-next': {
         'features': [
@@ -130,13 +124,13 @@ PROVIDER_FEATURE_MAP = {
             Features.DISCUSSION_CONTENT_PROMPTS.value,
             Features.GRADED_DISCUSSIONS.value,
         ],
-        'documentation_urls': {
-            'learnMore': '',
-            'configurationDocumentation': '',
-            'documentation': '',
-            'accessibilityDocumentation': '',
-            'emailId': '',
-        }
+        'documentation_urls': DocumentLinks(
+            '',
+            '',
+            '',
+            '',
+            '',
+        )._asdict(),
     },
     'yellowdig': {
         'features': [
@@ -152,26 +146,26 @@ PROVIDER_FEATURE_MAP = {
             Features.DIRECT_MESSAGES_FROM_INSTRUCTORS.value,
             Features.USER_MENTIONS.value,
         ],
-        'documentation_urls': {
-            'learnMore': 'https://www.youtube.com/watch?v=ZACief-qMwY',
-            'configurationDocumentation': '',
-            'documentation': 'https://hubs.ly/H0J5Bn70',
-            'accessibilityDocumentation': 'https://drive.google.com/file/d/1FT6E2ajMabFQI3NqgInPgGsQnLH7e2Mb/view?usp=sharing',
-            'emailId': 'learnmore@yellowdig.com',
-        }
+        'documentation_urls': DocumentLinks(
+            'https://www.youtube.com/watch?v=ZACief-qMwY',
+            '',
+            'https://hubs.ly/H0J5Bn7',
+            'https://drive.google.com/file/d/1FT6E2ajMabFQI3NqgInPgGsQnLH7e2Mb/view?usp=sharing',
+            'learnmore@yellowdig.com',
+        )._asdict(),
     },
     'inscribe': {
         'features': [
             Features.PRIMARY_DISCUSSION_APP_EXPERIENCE.value,
             Features.LTI_BASIC_CONFIGURATION.value,
         ],
-        'documentation_urls': {
-            'learnMore': '',
-            'configurationDocumentation': '',
-            'documentation': 'https://www.inscribeapp.com/',
-            'accessibilityDocumentation': '',
-            'emailId': '',
-        }
+        'documentation_urls': DocumentLinks(
+            '',
+            '',
+            'https://www.inscribeapp.com/',
+            '',
+            '',
+        )._asdict(),
     },
     'discourse': {
         'features': [
@@ -179,13 +173,13 @@ PROVIDER_FEATURE_MAP = {
             Features.LTI_BASIC_CONFIGURATION.value,
             Features.LTI_ADVANCED_SHARING_MODE.value,
         ],
-        'documentation_urls': {
-            'learnMore': '',
-            'configurationDocumentation': '',
-            'documentation': 'http://discourse.org/',
-            'accessibilityDocumentation': '',
-            'emailId': '',
-        }
+        'documentation_urls': DocumentLinks(
+            '',
+            '',
+            'http://discourse.org/',
+            '',
+            '',
+        )._asdict(),
     },
     'ed-discuss': {
         'features': [
@@ -199,13 +193,13 @@ PROVIDER_FEATURE_MAP = {
             Features.COMMUNITY_TA_SUPPORT.value,
             Features.EMAIL_NOTIFICATIONS.value,
         ],
-        'documentation_urls': {
-            'learnMore': '',
-            'configurationDocumentation': '',
-            'documentation': 'https://edstem.org/us/',
-            'accessibilityDocumentation': '',
-            'emailId': '',
-        }
+        'documentation_urls': DocumentLinks(
+            '',
+            '',
+            'https://edstem.org/us/',
+            '',
+            '',
+        )._asdict(),
     }
 }
 
@@ -368,7 +362,7 @@ class DiscussionsConfiguration(TimeStampedModel):
         """
         Check if the provider supports some feature
         """
-        features = PROVIDER_FEATURE_MAP.get(self.provider_type) or []
+        features = AVAILABLE_PROVIDER_MAP.get(self.provider_type).get('features') or []
         has_support = bool(feature in features)
         return has_support
 

--- a/openedx/core/djangoapps/discussions/models.py
+++ b/openedx/core/djangoapps/discussions/models.py
@@ -150,7 +150,7 @@ AVAILABLE_PROVIDER_MAP = {
             'https://www.youtube.com/watch?v=ZACief-qMwY',
             '',
             'https://hubs.ly/H0J5Bn7',
-            'https://drive.google.com/file/d/1FT6E2ajMabFQI3NqgInPgGsQnLH7e2Mb/view?usp=sharing',
+            '',
             'learnmore@yellowdig.com',
         )._asdict(),
     },

--- a/openedx/core/djangoapps/discussions/serializers.py
+++ b/openedx/core/djangoapps/discussions/serializers.py
@@ -10,7 +10,7 @@ from openedx.core.djangoapps.django_comment_common.models import CourseDiscussio
 from openedx.core.lib.courses import get_course_by_id
 from xmodule.modulestore.django import modulestore
 
-from .models import DEFAULT_PROVIDER_TYPE, PROVIDER_FEATURE_MAP, DiscussionsConfiguration, Features
+from .models import DEFAULT_PROVIDER_TYPE, AVAILABLE_PROVIDER_MAP, DiscussionsConfiguration, Features
 
 
 class LtiSerializer(serializers.ModelSerializer):
@@ -209,7 +209,7 @@ class DiscussionsConfigurationSerializer(serializers.ModelSerializer):
             'plugin_configuration': plugin_configuration,
             'providers': {
                 'active': provider_type or DEFAULT_PROVIDER_TYPE,
-                'available': PROVIDER_FEATURE_MAP,
+                'available': AVAILABLE_PROVIDER_MAP,
             },
         })
         return payload

--- a/openedx/core/djangoapps/discussions/tests/test_views.py
+++ b/openedx/core/djangoapps/discussions/tests/test_views.py
@@ -16,7 +16,7 @@ from common.lib.xmodule.xmodule.modulestore.tests.django_utils import ModuleStor
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.factories import CourseFactory
 
-from ..models import PROVIDER_FEATURE_MAP
+from ..models import AVAILABLE_PROVIDER_MAP
 
 
 DATA_LEGACY_COHORTS = {
@@ -143,7 +143,7 @@ class DataTest(AuthorizedApiTest):
         assert response.status_code == self.expected_response_code
         assert not data['enabled']
         assert data['provider_type'] == 'legacy'
-        assert data['providers']['available']['legacy'] == PROVIDER_FEATURE_MAP['legacy']
+        assert data['providers']['available']['legacy'] == AVAILABLE_PROVIDER_MAP['legacy']
         assert data['lti_configuration'] == {}
         assert data['plugin_configuration'] == {
             'allow_anonymous': True,
@@ -188,7 +188,7 @@ class DataTest(AuthorizedApiTest):
         data = self._setup_lti()
         assert data['enabled']
         assert data['provider_type'] == 'piazza'
-        assert data['providers']['available']['piazza'] == PROVIDER_FEATURE_MAP['piazza']
+        assert data['providers']['available']['piazza'] == AVAILABLE_PROVIDER_MAP['piazza']
         assert data['lti_configuration'] == DATA_LTI_CONFIGURATION
         assert len(data['plugin_configuration']) == 0
         assert len(data['lti_configuration']) > 0


### PR DESCRIPTION
## Description
Piazza (and other providers, have) documentation on how to integrate with edX, which is based on our LTI XBlock: (ex https://support.piazza.com/support/solutions/articles/48001065447-configure-piazza-within-edx). similarly, for each app, we will now have multiple documentation links which we need to send to the frontend.

This change is for powering documentation links for apps from the backend to avoid hardcoding links at the frontend.
the related frontend [PR](https://github.com/edx/frontend-app-course-authoring/pull/123) for the ticket.

## Supporting information

Jira Ticket: [TNL-7832](https://openedx.atlassian.net/browse/TNL-7832)
Links [Documentation](https://docs.google.com/spreadsheets/d/1jOzHk8iYVisxdrv2zrChoRPhqq6IBQyEFC7d9J-DLBo/edit#gid=0)


## Other information

also, note that this change will change the payload of an API response that has already been handled in frontend PR.