### PR TITLE
feat: Add Help Center search in Contact Us

### DIFF
--- a/lms/static/sass/_build-lms-v1.scss
+++ b/lms/static/sass/_build-lms-v1.scss
@@ -75,6 +75,7 @@
 
 // search
 @import 'search/search';
+@import 'search/instant-search';
 
 // news
 @import 'notifications';

--- a/lms/static/sass/search/_instant-search.scss
+++ b/lms/static/sass/search/_instant-search.scss
@@ -1,0 +1,31 @@
+$default-border-color: #ccc;
+
+.suggestions {
+  border: 1px solid $default-border-color;
+  border-radius: 4px;
+  border-top-width: 0;
+  list-style: none;
+  margin-top: 0;
+  overflow-y: auto;
+  padding-left: 0;
+}
+
+.suggestions li {
+  padding: 0.5rem;
+}
+
+$input-background-color: #000000;
+$input-text-color: #ffffff;
+
+.suggestion-active,
+.suggestions li:hover {
+  background-color: $input-background-color;
+  color: $input-text-color;
+  cursor: pointer;
+}
+
+$li-border-color: #999;
+
+.suggestions li:not(:last-of-type) {
+  border-bottom: 1px solid $li-border-color;
+}


### PR DESCRIPTION
Recreating PR #27728 (which was reverted in #27773) and making changes to the url and logic for custom zendesk instant search to be added in Contact Us page.

UI is exactly the same as #27728

### Stpes to test this on local

1. checkout this branch: `aakbar/contact-us-search`
2. run `make lms-shell`
3. run `paver update_assets` inside lms-shell
4. go to http://localhost:18000/support/contact_us
5. Verify that: 
- [ ] writing a keyword in the Learner Help Center input field fetches results from the API and displays a list below input file
- [ ] up, down, enter and click buttons work as expected 
- [ ] clicking Search button takes you to a search results page like [this](https://support.edx.org/hc/en-us/search?utf8=%E2%9C%93&query=course+learner)