### PR TITLE
refactor: AA-796 remove outline and dates tabs flags

### DIFF
--- a/lms/djangoapps/course_home_api/dates/v1/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/dates/v1/tests/test_views.py
@@ -6,12 +6,11 @@ from datetime import datetime
 
 import ddt
 from django.urls import reverse
-from edx_toggles.toggles.testutils import override_waffle_flag
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.models import CourseEnrollment
 from lms.djangoapps.course_home_api.tests.utils import BaseCourseHomeTests
-from lms.djangoapps.course_home_api.toggles import COURSE_HOME_MICROFRONTEND, COURSE_HOME_MICROFRONTEND_DATES_TAB
+from lms.djangoapps.course_home_api.toggles import COURSE_HOME_MICROFRONTEND
 from lms.djangoapps.experiments.testutils import override_experiment_waffle_flag
 from openedx.features.content_type_gating.models import ContentTypeGatingConfig
 
@@ -27,7 +26,6 @@ class DatesTabTestViews(BaseCourseHomeTests):
         ContentTypeGatingConfig.objects.create(enabled=True, enabled_as_of=datetime(2017, 1, 1))
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_DATES_TAB, active=True)
     @ddt.data(CourseMode.AUDIT, CourseMode.VERIFIED)
     def test_get_authenticated_enrolled_user(self, enrollment_mode):
         CourseEnrollment.enroll(self.user, self.course.id, enrollment_mode)
@@ -40,7 +38,6 @@ class DatesTabTestViews(BaseCourseHomeTests):
         assert all(block.get('learner_has_access') for block in date_blocks)
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_DATES_TAB, active=True)
     @ddt.data(True, False)
     def test_get_authenticated_user_not_enrolled(self, has_previously_enrolled):
         if has_previously_enrolled:
@@ -51,21 +48,18 @@ class DatesTabTestViews(BaseCourseHomeTests):
         assert response.status_code == 401
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_DATES_TAB, active=True)
     def test_get_unauthenticated_user(self):
         self.client.logout()
         response = self.client.get(self.url)
         assert response.status_code == 401
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_DATES_TAB, active=True)
     def test_get_unknown_course(self):
         url = reverse('course-home-dates-tab', args=['course-v1:unknown+course+2T2020'])
         response = self.client.get(url)
         assert response.status_code == 404
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_DATES_TAB, active=True)
     def test_banner_data_is_returned(self):
         CourseEnrollment.enroll(self.user, self.course.id)
         response = self.client.get(self.url)
@@ -76,7 +70,6 @@ class DatesTabTestViews(BaseCourseHomeTests):
         self.assertContains(response, 'verified_upgrade_link')
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_DATES_TAB, active=True)
     def test_masquerade(self):
         self.switch_to_staff()
         CourseEnrollment.enroll(self.user, self.course.id, 'audit')

--- a/lms/djangoapps/course_home_api/dates/v1/views.py
+++ b/lms/djangoapps/course_home_api/dates/v1/views.py
@@ -13,7 +13,7 @@ from rest_framework.response import Response
 
 from common.djangoapps.student.models import CourseEnrollment
 from lms.djangoapps.course_home_api.dates.v1.serializers import DatesTabSerializer
-from lms.djangoapps.course_home_api.toggles import course_home_mfe_dates_tab_is_active
+from lms.djangoapps.course_home_api.toggles import course_home_mfe_is_active
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.context_processor import user_timezone_locale_prefs
 from lms.djangoapps.courseware.courses import get_course_date_blocks, get_course_with_access
@@ -75,7 +75,7 @@ class DatesTabView(RetrieveAPIView):
         course_key_string = kwargs.get('course_key_string')
         course_key = CourseKey.from_string(course_key_string)
 
-        if not course_home_mfe_dates_tab_is_active(course_key):
+        if not course_home_mfe_is_active(course_key):
             raise Http404
 
         # Enable NR tracing for this view based on course

--- a/lms/djangoapps/course_home_api/outline/v1/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/outline/v1/tests/test_views.py
@@ -16,7 +16,7 @@ from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.roles import CourseInstructorRole
 from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.course_home_api.tests.utils import BaseCourseHomeTests
-from lms.djangoapps.course_home_api.toggles import COURSE_HOME_MICROFRONTEND, COURSE_HOME_MICROFRONTEND_OUTLINE_TAB
+from lms.djangoapps.course_home_api.toggles import COURSE_HOME_MICROFRONTEND
 from lms.djangoapps.experiments.testutils import override_experiment_waffle_flag
 from openedx.core.djangoapps.course_date_signals.utils import MIN_DURATION
 from openedx.core.djangoapps.user_api.preferences.api import set_user_preference
@@ -44,7 +44,6 @@ class OutlineTabTestViews(BaseCourseHomeTests):
 
     @override_waffle_flag(ENABLE_COURSE_GOALS, active=True)
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
     @ddt.data(CourseMode.AUDIT, CourseMode.VERIFIED)
     def test_get_authenticated_enrolled_user(self, enrollment_mode):
         CourseEnrollment.enroll(self.user, self.course.id, enrollment_mode)
@@ -77,7 +76,6 @@ class OutlineTabTestViews(BaseCourseHomeTests):
             assert 'http://' in resume_course_url
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
     @ddt.data(True, False)
     def test_get_authenticated_user_not_enrolled(self, has_previously_enrolled):
         if has_previously_enrolled:
@@ -100,7 +98,6 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         assert all(block.get('date') for block in date_blocks)
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
     def test_get_unauthenticated_user(self):
         self.client.logout()
         response = self.client.get(self.url)
@@ -118,7 +115,6 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         assert len(date_blocks) == 0
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
     def test_masquerade(self):
         user = UserFactory()
         set_user_preference(user, 'time_zone', 'Asia/Tokyo')
@@ -134,7 +130,6 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         assert self.client.get(self.url).data['dates_widget']['user_timezone'] == 'Asia/Tokyo'
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
     def test_course_staff_can_see_non_user_specific_content_in_masquerade(self):
         """
         Test that course staff can see the outline and other non-user-specific content when masquerading as a learner
@@ -157,7 +152,6 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         assert response.data['handouts_html'] is not None
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
     @override_waffle_flag(COURSE_ENABLE_UNENROLLED_ACCESS_FLAG, active=True)
     def test_handouts(self):
         CourseEnrollment.enroll(self.user, self.course.id)
@@ -165,14 +159,12 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         assert self.client.get(self.url).data['handouts_html'] == '<p>Hi</p>'
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
     def test_get_unknown_course(self):
         url = reverse('course-home-outline-tab', args=['course-v1:unknown+course+2T2020'])
         response = self.client.get(url)
         assert response.status_code == 404
 
-    @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=False)
+    @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=False)
     @ddt.data(CourseMode.AUDIT, CourseMode.VERIFIED)
     def test_waffle_flag_disabled(self, enrollment_mode):
         CourseEnrollment.enroll(self.user, self.course.id, enrollment_mode)
@@ -180,7 +172,6 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         assert response.status_code == 404
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
     @ddt.data(True, False)
     def test_welcome_message(self, welcome_message_is_dismissed):
         CourseEnrollment.enroll(self.user, self.course.id)
@@ -207,7 +198,6 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         assert welcome_message_html == (None if welcome_message_is_dismissed else '<p>Welcome</p>')
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
     def test_offer(self):
         CourseEnrollment.enroll(self.user, self.course.id)
 
@@ -221,7 +211,6 @@ class OutlineTabTestViews(BaseCourseHomeTests):
             assert response.data['offer']['code'] == 'EDXWELCOME'
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
     def test_access_expiration(self):
         enrollment = CourseEnrollment.enroll(self.user, self.course.id, CourseMode.VERIFIED)
         CourseDurationLimitConfig.objects.create(enabled=True, enabled_as_of=datetime(2018, 1, 1))
@@ -238,7 +227,6 @@ class OutlineTabTestViews(BaseCourseHomeTests):
 
     @override_waffle_flag(ENABLE_COURSE_GOALS, active=True)
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
     def test_post_course_goal(self):
         CourseEnrollment.enroll(self.user, self.course.id, CourseMode.AUDIT)
 
@@ -258,7 +246,6 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         assert selected_goal['key'] == 'certify'
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
     @patch.dict('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': True})
     @patch('lms.djangoapps.course_api.blocks.transformers.milestones.get_attempt_status_summary')
     def test_proctored_exam(self, mock_summary):
@@ -302,7 +289,6 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         assert exam_data['icon'] == 'fa-foo-bar'
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
     def test_assignment(self):
         course = CourseFactory.create()
         with self.store.bulk_operations(course.id):
@@ -329,7 +315,6 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         assert ungraded_data['icon'] is None
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
     @override_waffle_flag(COURSE_ENABLE_UNENROLLED_ACCESS_FLAG, active=True)
     @patch('lms.djangoapps.course_home_api.outline.v1.views.generate_offer_data', new=Mock(return_value={'a': 1}))
     @patch('lms.djangoapps.course_home_api.outline.v1.views.get_access_expiration_data', new=Mock(return_value={'b': 1}))
@@ -368,7 +353,6 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         assert (data['resume_course']['url'] is not None) == show_enrolled
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
     @ddt.data(True, False)
     def test_can_show_upgrade_sock(self, sock_enabled):
         with override_waffle_flag(DISPLAY_COURSE_SOCK_FLAG, active=sock_enabled):
@@ -376,7 +360,6 @@ class OutlineTabTestViews(BaseCourseHomeTests):
             assert response.data['can_show_upgrade_sock'] == sock_enabled
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
     def test_verified_mode(self):
         enrollment = CourseEnrollment.enroll(self.user, self.course.id)
         CourseDurationLimitConfig.objects.create(enabled=True, enabled_as_of=datetime(2018, 1, 1))

--- a/lms/djangoapps/course_home_api/outline/v1/views.py
+++ b/lms/djangoapps/course_home_api/outline/v1/views.py
@@ -29,8 +29,7 @@ from lms.djangoapps.course_goals.api import (
 )
 from lms.djangoapps.course_home_api.outline.v1.serializers import OutlineTabSerializer
 from lms.djangoapps.course_home_api.toggles import (
-    course_home_mfe_dates_tab_is_active,
-    course_home_mfe_outline_tab_is_active
+    course_home_mfe_is_active
 )
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.context_processor import user_timezone_locale_prefs
@@ -162,7 +161,7 @@ class OutlineTabView(RetrieveAPIView):
         course_key = CourseKey.from_string(course_key_string)
         course_usage_key = modulestore().make_course_usage_key(course_key)
 
-        if not course_home_mfe_outline_tab_is_active(course_key):
+        if not course_home_mfe_is_active(course_key):
             raise Http404
 
         # Enable NR tracing for this view based on course
@@ -192,7 +191,7 @@ class OutlineTabView(RetrieveAPIView):
         user_timezone = user_timezone_locale['user_timezone']
 
         dates_tab_link = request.build_absolute_uri(reverse('dates', args=[course.id]))
-        if course_home_mfe_dates_tab_is_active(course.id):
+        if course_home_mfe_is_active(course.id):
             dates_tab_link = get_learning_mfe_home_url(course_key=course.id, view_name='dates')
 
         # Set all of the defaults

--- a/lms/djangoapps/course_home_api/toggles.py
+++ b/lms/djangoapps/course_home_api/toggles.py
@@ -21,10 +21,6 @@ WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name='course_home')
 # .. toggle_tickets: https://openedx.atlassian.net/browse/AA-117
 COURSE_HOME_MICROFRONTEND = ExperimentWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'course_home_mfe', __name__)
 
-COURSE_HOME_MICROFRONTEND_DATES_TAB = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'course_home_mfe_dates_tab', __name__)  # lint-amnesty, pylint: disable=toggle-missing-annotation
-
-COURSE_HOME_MICROFRONTEND_OUTLINE_TAB = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'course_home_mfe_outline_tab', __name__)  # lint-amnesty, pylint: disable=toggle-missing-annotation
-
 COURSE_HOME_MICROFRONTEND_PROGRESS_TAB = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'course_home_mfe_progress_tab',  # lint-amnesty, pylint: disable=toggle-missing-annotation
                                                           __name__)
 
@@ -33,20 +29,6 @@ def course_home_mfe_is_active(course_key):
     return (
         COURSE_HOME_MICROFRONTEND.is_enabled(course_key) and
         not course_key.deprecated
-    )
-
-
-def course_home_mfe_dates_tab_is_active(course_key):
-    return (
-        course_home_mfe_is_active(course_key) and
-        COURSE_HOME_MICROFRONTEND_DATES_TAB.is_enabled(course_key)
-    )
-
-
-def course_home_mfe_outline_tab_is_active(course_key):
-    return (
-        course_home_mfe_is_active(course_key) and
-        COURSE_HOME_MICROFRONTEND_OUTLINE_TAB.is_enabled(course_key)
     )
 
 

--- a/lms/djangoapps/courseware/tabs.py
+++ b/lms/djangoapps/courseware/tabs.py
@@ -10,7 +10,7 @@ from django.utils.translation import ugettext_noop
 
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.entrance_exams import user_can_skip_entrance_exam
-from lms.djangoapps.course_home_api.toggles import course_home_mfe_is_active, course_home_mfe_progress_tab_is_active  # lint-amnesty, pylint: disable=line-too-long
+from lms.djangoapps.course_home_api.toggles import course_home_mfe_is_active, course_home_mfe_progress_tab_is_active
 from openedx.core.lib.course_tabs import CourseTabPluginManager
 from openedx.features.course_experience import DISABLE_UNIFIED_COURSE_TAB_FLAG, default_course_url_name
 from openedx.features.course_experience.url_helpers import get_learning_mfe_home_url

--- a/lms/djangoapps/courseware/tabs.py
+++ b/lms/djangoapps/courseware/tabs.py
@@ -10,7 +10,7 @@ from django.utils.translation import ugettext_noop
 
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.entrance_exams import user_can_skip_entrance_exam
-from lms.djangoapps.course_home_api.toggles import course_home_mfe_dates_tab_is_active, course_home_mfe_outline_tab_is_active, course_home_mfe_progress_tab_is_active  # lint-amnesty, pylint: disable=line-too-long
+from lms.djangoapps.course_home_api.toggles import course_home_mfe_is_active, course_home_mfe_progress_tab_is_active  # lint-amnesty, pylint: disable=line-too-long
 from openedx.core.lib.course_tabs import CourseTabPluginManager
 from openedx.features.course_experience import DISABLE_UNIFIED_COURSE_TAB_FLAG, default_course_url_name
 from openedx.features.course_experience.url_helpers import get_learning_mfe_home_url
@@ -42,7 +42,7 @@ class CoursewareTab(EnrolledTab):
 
     def __init__(self, tab_dict):
         def link_func(course, reverse_func):
-            if course_home_mfe_outline_tab_is_active(course.id):
+            if course_home_mfe_is_active(course.id):
                 return get_learning_mfe_home_url(course_key=course.id, view_name='home')
             else:
                 reverse_name_func = lambda course: default_course_url_name(course.id)
@@ -334,7 +334,7 @@ class DatesTab(EnrolledTab):
 
     def __init__(self, tab_dict):
         def link_func(course, reverse_func):
-            if course_home_mfe_dates_tab_is_active(course.id):
+            if course_home_mfe_is_active(course.id):
                 return get_learning_mfe_home_url(course_key=course.id, view_name=self.view_name)
             else:
                 return reverse_func(self.view_name, args=[str(course.id)])

--- a/lms/djangoapps/courseware/tests/test_date_summary.py
+++ b/lms/djangoapps/courseware/tests/test_date_summary.py
@@ -17,6 +17,7 @@ from pytz import utc
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
 from lms.djangoapps.commerce.models import CommerceConfiguration
+from lms.djangoapps.course_home_api.toggles import COURSE_HOME_MICROFRONTEND
 from lms.djangoapps.courseware.courses import get_course_date_blocks
 from lms.djangoapps.courseware.date_summary import (
     CertificateAvailableDate,
@@ -33,6 +34,7 @@ from lms.djangoapps.courseware.models import (
     DynamicUpgradeDeadlineConfiguration,
     OrgDynamicUpgradeDeadlineConfiguration
 )
+from lms.djangoapps.experiments.testutils import override_experiment_waffle_flag
 from lms.djangoapps.verify_student.models import VerificationDeadline
 from lms.djangoapps.verify_student.services import IDVerificationService
 from lms.djangoapps.verify_student.tests.factories import SoftwareSecurePhotoVerificationFactory
@@ -709,24 +711,38 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
             block = VerificationDeadlineDate(course, user)
             assert block.relative_datestring == expected_date_string
 
-    @ddt.data('info', 'openedx.course_experience.course_home')
+    @ddt.data(
+        ('info', True),
+        ('info', False),
+        ('openedx.course_experience.course_home', True),
+        ('openedx.course_experience.course_home', False),
+    )
+    @ddt.unpack
     @override_waffle_flag(DISABLE_UNIFIED_COURSE_TAB_FLAG, active=False)
     @override_waffle_flag(RELATIVE_DATES_FLAG, active=True)
-    def test_dates_tab_link_render(self, url_name):
+    def test_dates_tab_link_render(self, url_name, mfe_active):
         """ The dates tab link should only show for enrolled or staff users """
         course = create_course_run()
         html_elements = [
             'class="dates-tab-link"',
             'View all course dates</a>',
-            '/courses/' + str(course.id) + '/dates'
         ]
+        # The url should change based on the mfe being active.
+        if mfe_active:
+            html_elements.append('/course/' + str(course.id) + '/dates')
+        else:
+            html_elements.append('/courses/' + str(course.id) + '/dates')
         url = reverse(url_name, args=(course.id,))
 
         def assert_html_elements(assert_function, user):
             self.client.login(username=user.username, password=TEST_PASSWORD)
-            response = self.client.get(url, follow=True)
-            for html in html_elements:
-                assert_function(response, html)
+            with override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=mfe_active):
+                response = self.client.get(url, follow=True)
+            if mfe_active and not user.is_staff:
+                assert 404 == response.status_code
+            else:
+                for html in html_elements:
+                    assert_function(response, html)
             self.client.logout()
 
         with freeze_time('2015-01-02'):

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -55,8 +55,8 @@ from lms.djangoapps.certificates import api as certs_api
 from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.commerce.utils import EcommerceService
 from lms.djangoapps.course_home_api.toggles import (
-    course_home_mfe_progress_tab_is_active,
-    course_home_mfe_is_active
+    course_home_mfe_is_active,
+    course_home_mfe_progress_tab_is_active
 )
 from openedx.features.course_experience.url_helpers import get_learning_mfe_home_url, is_request_from_learning_mfe
 from lms.djangoapps.courseware.access import has_access, has_ccx_coach_role

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -55,8 +55,8 @@ from lms.djangoapps.certificates import api as certs_api
 from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.commerce.utils import EcommerceService
 from lms.djangoapps.course_home_api.toggles import (
-    course_home_mfe_dates_tab_is_active,
-    course_home_mfe_progress_tab_is_active
+    course_home_mfe_progress_tab_is_active,
+    course_home_mfe_is_active
 )
 from openedx.features.course_experience.url_helpers import get_learning_mfe_home_url, is_request_from_learning_mfe
 from lms.djangoapps.courseware.access import has_access, has_ccx_coach_role
@@ -1048,7 +1048,7 @@ def dates(request, course_id):
     from lms.urls import COURSE_DATES_NAME, RESET_COURSE_DEADLINES_NAME
 
     course_key = CourseKey.from_string(course_id)
-    if course_home_mfe_dates_tab_is_active(course_key) and not request.user.is_staff:
+    if course_home_mfe_is_active(course_key) and not request.user.is_staff:
         microfrontend_url = get_learning_mfe_home_url(course_key=course_key, view_name=COURSE_DATES_NAME)
         raise Redirect(microfrontend_url)
 

--- a/openedx/features/course_experience/api/v1/views.py
+++ b/openedx/features/course_experience/api/v1/views.py
@@ -20,7 +20,7 @@ from edx_rest_framework_extensions.auth.session.authentication import SessionAut
 from opaque_keys.edx.keys import CourseKey
 
 from lms.djangoapps.course_api.api import course_detail
-from lms.djangoapps.course_home_api.toggles import course_home_mfe_dates_tab_is_active
+from lms.djangoapps.course_home_api.toggles import course_home_mfe_is_active
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.courses import get_course_with_access
 from lms.djangoapps.courseware.masquerade import is_masquerading, setup_masquerade
@@ -90,7 +90,7 @@ def reset_course_deadlines(request):
             })
             tracker.emit('edx.ui.lms.reset_deadlines.clicked', research_event_data)
 
-        if course_home_mfe_dates_tab_is_active(course_key):
+        if course_home_mfe_is_active(course_key):
             body_link = get_learning_mfe_home_url(course_key=str(course_key), view_name='dates')
         else:
             body_link = '{}{}'.format(settings.LMS_ROOT_URL, reverse('dates', args=[str(course_key)]))

--- a/openedx/features/course_experience/views/course_dates.py
+++ b/openedx/features/course_experience/views/course_dates.py
@@ -14,7 +14,7 @@ from web_fragments.fragment import Fragment
 
 from lms.djangoapps.courseware.courses import get_course_date_blocks, get_course_with_access
 from lms.djangoapps.courseware.tabs import DatesTab
-from lms.djangoapps.course_home_api.toggles import course_home_mfe_dates_tab_is_active
+from lms.djangoapps.course_home_api.toggles import course_home_mfe_is_active
 from openedx.features.course_experience.url_helpers import get_learning_mfe_home_url
 from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
 
@@ -34,7 +34,7 @@ class CourseDatesFragmentView(EdxFragmentView):
         course_date_blocks = get_course_date_blocks(course, request.user, request, num_assignments=1)
 
         dates_tab_enabled = DatesTab.is_enabled(course, request.user)
-        if course_home_mfe_dates_tab_is_active(course_key):
+        if course_home_mfe_is_active(course_key):
             dates_tab_link = get_learning_mfe_home_url(course_key=course.id, view_name='dates')
         else:
             dates_tab_link = reverse('dates', args=[course.id])

--- a/openedx/features/course_experience/views/course_home.py
+++ b/openedx/features/course_experience/views/course_home.py
@@ -13,7 +13,7 @@ from django.views.decorators.csrf import ensure_csrf_cookie
 from opaque_keys.edx.keys import CourseKey
 from web_fragments.fragment import Fragment
 
-from lms.djangoapps.course_home_api.toggles import course_home_mfe_outline_tab_is_active
+from lms.djangoapps.course_home_api.toggles import course_home_mfe_is_active
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.courses import can_self_enroll_in_course, get_course_info_section, get_course_with_access
 from lms.djangoapps.course_goals.api import (
@@ -67,7 +67,7 @@ class CourseHomeView(CourseTabView):
 
     def render_to_fragment(self, request, course=None, tab=None, **kwargs):  # lint-amnesty, pylint: disable=arguments-differ, unused-argument
         course_id = str(course.id)
-        if course_home_mfe_outline_tab_is_active(course.id) and not request.user.is_staff:
+        if course_home_mfe_is_active(course.id) and not request.user.is_staff:
             microfrontend_url = get_learning_mfe_home_url(course_key=course_id, view_name="home")
             raise Redirect(microfrontend_url)
         home_fragment_view = CourseHomeFragmentView()


### PR DESCRIPTION
## Description

Removed outline and dates tabs flags, and replaced uses of them to only check for the parent course home flag instead.

~~Changed [test_dates_tab_link_render](https://github.com/edx/edx-platform/blob/77f5afa4ac456258592dbfd81066bdeb8f4f5caa/lms/djangoapps/courseware/tests/test_date_summary.py#L714-L746) in test_date_summary.py that used to check dates tab link rendering with cases when dates tab and parent course home flags were active (but since we don't have dates tab waffle flags anymore the conditions that used to check them are outdated).~~ 

Changed [test_waffle_flag_disabled](https://github.com/edx/edx-platform/blob/d644186470a57cb584c48d2b4217e16e480df931/lms/djangoapps/course_home_api/outline/v1/tests/test_views.py#L167-L172) for outline tab under outline/v1/tests/test_views.py so that we check if the response is 404 when parent home flag is disabled instead of only when outline waffle flag is disabled (because we do not even have the outline waffle flag anymore that can be disabled).  

EDIT: 
Changed [test_dates_tab_link_render](https://github.com/edx/edx-platform/blob/b737544715d9b35ed7eb7c4aa263411e93e8b2b6/lms/djangoapps/courseware/tests/test_date_summary.py#L714-L758) in test_date_summary.py that used to check dates tab link rendering with cases when dates tab and parent course home flags were active (but since we don't have dates tab waffle flags anymore the conditions that used to check them are outdated). If MFE is active and the user isn't a staff, the response status code is asserted against 404.
## Supporting information

[Jira AA-796](https://openedx.atlassian.net/browse/AA-796)