### PR TITLE
[Chore]: Add the readme file documenting the Agreements app

### DIFF
--- a/openedx/core/djangoapps/agreements/readme.rst
+++ b/openedx/core/djangoapps/agreements/readme.rst
@@ -1,0 +1,23 @@
+############
+Agreements App
+############
+
+Status: Active
+
+Purpose
+=======
+The intention of this app is to host logic and data associated with the agreements learners needs to "sign" or "confirm".
+These agreements includes, but not limited to, Honor Code to affirm they are who they say they are.
+
+
+Responsibilities
+================
+
+The app intend to store all logic associated with agreements edX needs to display and record for either learners or educators.
+Currently, the app only store the Honor Code signature for learners. 
+In order to reinforce academic integrity, learners will be required to agree to the honor code before entering the first assignment on paid track.
+
+Glossary
+========
+* *Signature*: It's a record of any form to store user's action against an agreement or code. For example: A record denoting the time of a user's agreement to Honor Code of a course.
+


### PR DESCRIPTION
## Description
[MST-843](https://openedx.atlassian.net/browse/MST-843)
This is a simple housekeeping action to help other edx-platform development to understand the current state of Agreements app
You can see the preview of the readme file at https://github.com/edx/edx-platform/blob/d56fa24cce684c1e787efd93df998d5535700dc0/openedx/core/djangoapps/agreements/readme.rst
