### PR TITLE
refactor: normalize xmodule imports

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/serializers.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers.py
@@ -4,7 +4,7 @@ API Serializers for Contentstore
 
 from rest_framework import serializers
 
-from common.lib.xmodule.xmodule.course_module import get_available_providers
+from xmodule.course_module import get_available_providers
 
 
 class ProctoredExamSettingsSerializer(serializers.Serializer):

--- a/cms/djangoapps/contentstore/rest_api/v1/views.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views.py
@@ -9,7 +9,7 @@ from rest_framework.views import APIView
 
 from cms.djangoapps.contentstore.views.course import get_course_and_check_access
 from cms.djangoapps.models.settings.course_metadata import CourseMetadata
-from common.lib.xmodule.xmodule.course_module import get_available_providers
+from xmodule.course_module import get_available_providers
 from openedx.core.lib.api.view_utils import view_auth_classes
 from xmodule.modulestore.django import modulestore
 

--- a/cms/djangoapps/contentstore/tests/test_proctoring.py
+++ b/cms/djangoapps/contentstore/tests/test_proctoring.py
@@ -13,7 +13,7 @@ from pytz import UTC
 
 from cms.djangoapps.contentstore.signals.handlers import listen_for_course_publish
 from common.djangoapps.student.tests.factories import UserFactory
-from common.lib.xmodule.xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 

--- a/common/lib/xmodule/xmodule/vertical_block.py
+++ b/common/lib/xmodule/xmodule/vertical_block.py
@@ -12,7 +12,7 @@ import pytz
 from lxml import etree
 from web_fragments.fragment import Fragment
 
-from common.lib.xmodule.xmodule.util.misc import is_xblock_an_assignment
+from xmodule.util.misc import is_xblock_an_assignment
 from xblock.core import XBlock  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.mako_module import MakoTemplateBlockBase
 from xmodule.progress import Progress

--- a/lms/djangoapps/discussion/rest_api/tests/test_utils.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_utils.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 from pytz import UTC
 
 from common.djangoapps.student.tests.factories import UserFactory, CourseEnrollmentFactory
-from common.lib.xmodule.xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from lms.djangoapps.discussion.django_comment_client.tests.factories import RoleFactory
 from lms.djangoapps.discussion.rest_api.utils import discussion_open_for_user
 from xmodule.modulestore.tests.factories import CourseFactory

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1462,7 +1462,7 @@ XBLOCK_FS_STORAGE_PREFIX = None
 # .. setting_default: {}
 # .. setting_description: Dictionary containing server-wide configuration of XBlocks on a per-type basis.
 #     By default, keys should match the XBlock `block_settings_key` attribute/property. If the attribute/property
-#     is not defined, use the XBlock class name. Check `common.lib.xmodule.xmodule.services.SettingsService`
+#     is not defined, use the XBlock class name. Check `xmodule.services.SettingsService`
 #     for more reference.
 XBLOCK_SETTINGS = {}
 

--- a/openedx/core/djangoapps/content/learning_sequences/api/processors/enrollment_track_partition_groups.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/processors/enrollment_track_partition_groups.py
@@ -1,13 +1,13 @@
 # lint-amnesty, pylint: disable=missing-module-docstring
 import logging
 
-from common.lib.xmodule.xmodule.partitions.enrollment_track_partition_generator import (
+from xmodule.partitions.enrollment_track_partition_generator import (
     create_enrollment_track_partition_with_course_id
 )
-from common.lib.xmodule.xmodule.partitions.partitions import (
+from xmodule.partitions.partitions import (
     ENROLLMENT_TRACK_PARTITION_ID,
 )
-from common.lib.xmodule.xmodule.partitions.partitions_service import get_user_partition_groups
+from xmodule.partitions.partitions_service import get_user_partition_groups
 
 from .base import OutlineProcessor
 

--- a/openedx/core/djangoapps/content/learning_sequences/api/tests/test_outlines.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/tests/test_outlines.py
@@ -24,7 +24,7 @@ from common.djangoapps.course_modes.signals import update_masters_access_course
 from common.djangoapps.student.auth import user_has_role
 from common.djangoapps.student.roles import CourseBetaTesterRole
 from common.djangoapps.student.tests.factories import BetaTesterFactory
-from common.lib.xmodule.xmodule.partitions.partitions import (
+from xmodule.partitions.partitions import (
     ENROLLMENT_TRACK_PARTITION_ID,
 )
 

--- a/openedx/core/djangoapps/course_date_signals/handlers.py
+++ b/openedx/core/djangoapps/course_date_signals/handlers.py
@@ -6,7 +6,7 @@ import logging
 from django.dispatch import receiver
 from edx_when.api import FIELDS_TO_EXTRACT, set_dates_for_course
 
-from common.lib.xmodule.xmodule.util.misc import is_xblock_an_assignment
+from xmodule.util.misc import is_xblock_an_assignment
 from openedx.core.lib.graph_traversals import get_children, leaf_filter, traverse_pre_order
 from xblock.fields import Scope  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore import ModuleStoreEnum

--- a/openedx/core/djangoapps/discussions/tests/test_views.py
+++ b/openedx/core/djangoapps/discussions/tests/test_views.py
@@ -11,8 +11,8 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from common.lib.xmodule.xmodule.modulestore.tests.django_utils import CourseUserType
-from common.lib.xmodule.xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import CourseUserType
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.factories import CourseFactory
 

--- a/openedx/features/personalized_learner_schedules/call_to_action.py
+++ b/openedx/features/personalized_learner_schedules/call_to_action.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.urls import reverse
 from django.utils.translation import ngettext, gettext as _
 
-from common.lib.xmodule.xmodule.util.misc import is_xblock_an_assignment
+from xmodule.util.misc import is_xblock_an_assignment
 from openedx.core.lib.mobile_utils import is_request_from_mobile_app
 from openedx.features.course_experience.url_helpers import is_request_from_learning_mfe
 from openedx.features.course_experience.utils import dates_banner_should_display

--- a/openedx/features/personalized_learner_schedules/show_answer/show_answer_field_override.py
+++ b/openedx/features/personalized_learner_schedules/show_answer/show_answer_field_override.py
@@ -3,9 +3,9 @@ FieldOverride that forces Show Answer values that use Past Due logic to
 new Show Answer values that remove the Past Due check (keeping the rest intact)
 """
 
-from common.lib.xmodule.xmodule.capa_module import SHOWANSWER
 from lms.djangoapps.courseware.field_overrides import FieldOverrideProvider
 from openedx.features.course_experience import RELATIVE_DATES_FLAG
+from xmodule.capa_module import SHOWANSWER
 
 
 class ShowAnswerFieldOverride(FieldOverrideProvider):

--- a/openedx/features/personalized_learner_schedules/show_answer/tests/test_show_answer_override.py
+++ b/openedx/features/personalized_learner_schedules/show_answer/tests/test_show_answer_override.py
@@ -6,11 +6,11 @@ from django.test.utils import override_settings
 
 from edx_toggles.toggles.testutils import override_waffle_flag
 
-from common.lib.xmodule.xmodule.capa_module import SHOWANSWER
 from lms.djangoapps.ccx.tests.test_overrides import inject_field_overrides
 from lms.djangoapps.courseware.model_data import FieldDataCache
 from lms.djangoapps.courseware.module_render import get_module
 from openedx.features.course_experience import RELATIVE_DATES_FLAG
+from xmodule.capa_module import SHOWANSWER
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 


### PR DESCRIPTION
## Description

Code in common/lib/xmodule/xmodule should
be imported as `from xmodule`, since `xmodule`
is a locally-installed package.

This is weird, but as long as it is the case,
we should be consistent. Importing the same code
from inconsistent import paths can lead to strange
and confusing bugs, since an object imported from
one path is not guaranteed to be totally equivalent
to the same object imported from a different path.

## Deadline

None

## Other information

I came across this issue while preparing https://openedx.atlassian.net/browse/BOM-2576 and https://openedx.atlassian.net/browse/BOM-2579. I decided to tackle it now before the inconsistency spread more.