### PR TITLE
fix: update MathJax configs to use Common HTML as default renderer.

### DIFF
--- a/cms/djangoapps/pipeline_js/js/xmodule.js
+++ b/cms/djangoapps/pipeline_js/js/xmodule.js
@@ -19,7 +19,7 @@ define(
 
         $script(
             'https://cdn.jsdelivr.net/npm/mathjax@2.7.5/MathJax.js' +
-            '?config=TeX-MML-AM_HTMLorMML&delayStartupUntil=configured',
+            '?config=TeX-MML-AM_CHTML&delayStartupUntil=configured',
             'mathjax',
             function() {
                 window.MathJax.Hub.Config({

--- a/cms/static/cms/js/require-config.js
+++ b/cms/static/cms/js/require-config.js
@@ -137,7 +137,7 @@
             'jquery_extend_patch': 'js/src/jquery_extend_patch',
 
             // externally hosted files
-            mathjax: 'https://cdn.jsdelivr.net/npm/mathjax@2.7.5/MathJax.js?config=TeX-MML-AM_HTMLorMML&delayStartupUntil=configured',  // eslint-disable-line max-len
+            mathjax: 'https://cdn.jsdelivr.net/npm/mathjax@2.7.5/MathJax.js?config=TeX-MML-AM_CHTML&delayStartupUntil=configured',  // eslint-disable-line max-len
             'youtube': [
                 // youtube URL does not end in '.js'. We add '?noext' to the path so
                 // that require.js adds the '.js' to the query component of the URL,

--- a/cms/static/cms/js/spec/main.js
+++ b/cms/static/cms/js/spec/main.js
@@ -69,7 +69,7 @@
             'domReady': 'xmodule_js/common_static/js/vendor/domReady',
             'URI': 'xmodule_js/common_static/js/vendor/URI.min',
             'mock-ajax': 'xmodule_js/common_static/js/vendor/mock-ajax',
-            mathjax: 'https://cdn.jsdelivr.net/npm/mathjax@2.7.5/MathJax.js?config=TeX-MML-AM_HTMLorMML&delayStartupUntil=configured',   // eslint-disable-line max-len
+            mathjax: 'https://cdn.jsdelivr.net/npm/mathjax@2.7.5/MathJax.js?config=TeX-MML-AM_CHTML&delayStartupUntil=configured',   // eslint-disable-line max-len
             'youtube': '//www.youtube.com/player_api?noext',
             'js/src/ajax_prefix': 'xmodule_js/common_static/js/src/ajax_prefix',
             'js/spec/test_utils': 'js/spec/test_utils'

--- a/cms/static/cms/js/spec/main_squire.js
+++ b/cms/static/cms/js/spec/main_squire.js
@@ -48,7 +48,7 @@
             'draggabilly': 'xmodule_js/common_static/js/vendor/draggabilly',
             'domReady': 'xmodule_js/common_static/js/vendor/domReady',
             'URI': 'xmodule_js/common_static/js/vendor/URI.min',
-            mathjax: 'https://cdn.jsdelivr.net/npm/mathjax@2.7.5/MathJax.js?config=TeX-MML-AM_HTMLorMML&delayStartupUntil=configured',   // eslint-disable-line max-len
+            mathjax: 'https://cdn.jsdelivr.net/npm/mathjax@2.7.5/MathJax.js?config=TeX-MML-AM_CHTML&delayStartupUntil=configured',   // eslint-disable-line max-len
             'youtube': '//www.youtube.com/player_api?noext',
             'js/src/ajax_prefix': 'xmodule_js/common_static/js/src/ajax_prefix'
         },

--- a/common/templates/mathjax_include.html
+++ b/common/templates/mathjax_include.html
@@ -89,5 +89,5 @@
 <!-- This must appear after all mathjax-config blocks, so it is after the imports from the other templates.
      It can't be run through static.url because MathJax uses crazy url introspection to do lazy loading of
      MathJax extension libraries -->
-<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@2.7.5/MathJax.js?config=TeX-MML-AM_HTMLorMML"></script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@2.7.5/MathJax.js?config=TeX-MML-AM_CHTML"></script>
 %endif


### PR DESCRIPTION
## Description
### [TNL-8319](https://openedx.atlassian.net/browse/TNL-8319)
### Update MathJax configs to use Common HTML as default renderer

Update the default renderer from `CSS-HTML` to `Common HTML`.
Different courses have reported having issues with rendering of MathJax problems and have encountered `MATH PROCESSING ERROR`. The issue seems to be reduced when changing from the `CSS-HTML` (current default) renderer to `Common HTML` renderer.

### Supporting information
#### MathJax 2.7 config options
https://docs.mathjax.org/en/v2.7-latest/config-files.html

### Testing information

Verify that the output for the problem is rendered by default on `Common HTML`.

Sandbox link: https://saadyousafarbi.sandbox.edx.org/

Studio link for problem: https://studio-saadyousafarbi.sandbox.edx.org/container/block-v1:edX+DemoX+Demo_Course+type@vertical+block@45c7cedb4bfe46f4a68c78787151cfb5

LMS link for problem: https://saadyousafarbi.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/9fca584977d04885bc911ea76a9ef29e/07bc32474380492cb34f76e5f9d9a135/1?activate_block_id=block-v1%3AedX%2BDemoX%2BDemo_Course%2Btype%40vertical%2Bblock%4045c7cedb4bfe46f4a68c78787151cfb5

Screenshot for Studio:
<img width="1440" alt="Screen Shot 2021-06-09 at 2 31 21 PM" src="https://user-images.githubusercontent.com/30112155/121330809-c626a780-c92f-11eb-90b7-7d722f59b35e.png">
 
Screenshot for LMS:
<img width="1440" alt="Screen Shot 2021-06-09 at 2 30 53 PM" src="https://user-images.githubusercontent.com/30112155/121330777-bf983000-c92f-11eb-8f94-e219fc9d35a4.png">