### PR TITLE
Support Learning MFE hosted on subpath.

### DIFF
--- a/openedx/features/course_experience/url_helpers.py
+++ b/openedx/features/course_experience/url_helpers.py
@@ -13,7 +13,7 @@ from django.contrib.auth import get_user_model
 from django.http import HttpRequest
 from django.urls import reverse
 from opaque_keys.edx.keys import CourseKey, UsageKey
-from six.moves.urllib.parse import urlencode
+from six.moves.urllib.parse import urlencode, urlparse
 
 from lms.djangoapps.courseware.toggles import courseware_mfe_is_active
 from xmodule.modulestore.django import modulestore
@@ -213,7 +213,9 @@ def is_request_from_learning_mfe(request: HttpRequest):
     """
     Returns whether the given request was made by the frontend-app-learning MFE.
     """
-    return (
-        settings.LEARNING_MICROFRONTEND_URL and
-        request.META.get('HTTP_REFERER', '').startswith(settings.LEARNING_MICROFRONTEND_URL)
-    )
+    if not settings.LEARNING_MICROFRONTEND_URL:
+        return False
+
+    url = urlparse(settings.LEARNING_MICROFRONTEND_URL)
+    mfe_url_base = f'{url.scheme}://{url.netloc}'
+    return request.META.get('HTTP_REFERER', '').startswith(mfe_url_base)


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This fixes a problem where XBlocks would not load in the learning MFE when the MFE was hosted on a URL subpath.

The Referrer header from the MFE hosted on a different origin does not include the path, so make sure to ignore the path portion of the learning MFE base URL when determining whether the request is coming from the new MFE or the old courseware view.

## Testing instructions

1. Log in to [the sandbox](https://pr27879.sandbox.opencraft.hosting/).
2. Go to the demo course.
3. Verify that it successfully loads in the new learning MFE.

## Sandbox

The sandbox is set up to host the learning MFE on the "/learning/" URL subpath.

- https://pr27879.sandbox.opencraft.hosting/

## Deadline

None

- - -
**Settings**
```yaml
MFE_DEPLOY_STANDALONE_NGINX: false
MFE_DEPLOY_NGINX_PORT: 80
MFE_BASE: "app.{{ EDXAPP_LMS_BASE }}"
MFE_BASE_SCHEMA: "https"
MFE_DEPLOY_COMMON_HOSTNAME: "app.*"
MFE_SITE_NAME: "{{ EDXAPP_PLATFORM_NAME }}"
MFE_DEPLOY_VERSION: "master"
MFES:
  - name: learning
    repo: frontend-app-learning
    public_path: "/learning/"
MFE_FLAGS_SETUP_FLAGS_LIST:
  - courseware.courseware_mfe

EDXAPP_FEATURES:
  ENABLE_COURSEWARE_MICROFRONTEND: true
  ENABLE_CORS_HEADERS: true
  ENABLE_CROSS_DOMAIN_CSRF_COOKIE: true
EDXAPP_SESSION_COOKIE_DOMAIN: ".{{ EDXAPP_LMS_BASE }}"
EDXAPP_CSRF_COOKIE_SECURE: true
EDXAPP_SESSION_COOKIE_SECURE: true
EDXAPP_CROSS_DOMAIN_CSRF_COOKIE_DOMAIN: ".{{ EDXAPP_LMS_BASE }}"
EDXAPP_CROSS_DOMAIN_CSRF_COOKIE_NAME: "cross-domain-cookie-mfe"
EDXAPP_CORS_ORIGIN_WHITELIST:
  - "{{ EDXAPP_CMS_BASE }}"
  - "{{ MFE_BASE }}"
EDXAPP_LEARNING_MICROFRONTEND_URL: 'https://{{ MFE_BASE }}/learning'

EDXAPP_VIDEO_IMAGE_SETTINGS:
 VIDEO_IMAGE_MAX_BYTES : 2097152
 VIDEO_IMAGE_MIN_BYTES : 2048                                               
 STORAGE_KWARGS:
  location: "video-images/"
  bucket: "{{ EDXAPP_AWS_STORAGE_BUCKET_NAME }}"                            
EDXAPP_VIDEO_TRANSCRIPTS_SETTINGS:                                          
 VIDEO_TRANSCRIPTS_MAX_BYTES : 3145728
 STORAGE_KWARGS:
  location: "video-transcripts/"                                            
  bucket: "{{ EDXAPP_AWS_STORAGE_BUCKET_NAME }}"
EDXAPP_CELERY_BROKER_TRANSPORT: 'amqp'
COMMON_ECOMMERCE_BASE_URL: "{{ EDXAPP_ECOMMERCE_PUBLIC_URL_ROOT }}"
```
