### PR TITLE
fix: add created and modified fields to integrity signature admin

### DIFF
--- a/openedx/core/djangoapps/agreements/admin.py
+++ b/openedx/core/djangoapps/agreements/admin.py
@@ -11,9 +11,10 @@ class IntegritySignatureAdmin(admin.ModelAdmin):
     """
     Admin for the IntegritySignature Model
     """
-    list_display = ('user', 'course_key',)
-    readonly_fields = ('user', 'course_key',)
+    list_display = ('user', 'course_key', 'created', 'modified')
+    readonly_fields = ('user', 'course_key', 'created', 'modified')
     search_fields = ('user__username', 'course_key',)
+    ordering = ['-modified']
 
     class Meta:
         model = IntegritySignature


### PR DESCRIPTION
## [MST-861](https://openedx.atlassian.net/browse/MST-861)

The Django admin page for `IntegritySignature` only displays the `user` and `course_key` for a signature. This adds the `created` and `modified` fields, and will order signatures by the `modified` field.
