### PR TITLE
[Fix]: CR-3731 correct the spelling of the error message on password reset screen

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/password_reset.py
+++ b/openedx/core/djangoapps/user_authn/views/password_reset.py
@@ -640,9 +640,9 @@ def password_change_request_handler(request):
                 )
                 ace.send(msg)
         except errors.UserAPIInternalError as err:
-            log.exception('Error occured during password change for user {email}: {error}'
+            log.exception('Error occurred during password change for user {email}: {error}'
                           .format(email=email, error=err))
-            return HttpResponse(_("Some error occured during password change. Please try again"), status=500)
+            return HttpResponse(_("Some error occurred during password change. Please try again"), status=500)
 
         return HttpResponse(status=200)
     else:


### PR DESCRIPTION
## Description

The error message for password reset screen has `occured` spelled wrong. This was pointed out by an educator from IU.

