### PR TITLE
test: Remove flaky test

### DIFF
--- a/common/lib/xmodule/xmodule/partitions/tests/test_partitions.py
+++ b/common/lib/xmodule/xmodule/partitions/tests/test_partitions.py
@@ -552,18 +552,6 @@ class TestGetCourseUserPartitions(PartitionServiceBaseClass):
         """
         FEATURES['ENABLE_ENROLLMENT_TRACK_USER_PARTITION'] = enable
 
-    def test_enrollment_track_partition_added(self):
-        """
-        Test that the dynamic enrollment track scheme is added if there is no conflict with the user partition ID.
-        """
-        all_partitions = get_all_partitions_for_course(self.course)
-        assert 2 == len(all_partitions)
-        assert self.TEST_SCHEME_NAME == all_partitions[0].scheme.name
-        enrollment_track_partition = all_partitions[1]
-        assert self.ENROLLMENT_TRACK_SCHEME_NAME == enrollment_track_partition.scheme.name
-        assert str(self.course.id) == enrollment_track_partition.parameters['course_id']
-        assert ENROLLMENT_TRACK_PARTITION_ID == enrollment_track_partition.id
-
     def test_enrollment_track_partition_not_added_if_conflict(self):
         """
         Test that the dynamic enrollment track scheme is NOT added if a UserPartition exists with that ID.


### PR DESCRIPTION
Remove flaky test

CR-3732

Failing test result: https://build.testeng.edx.org/job/edx-platform-python-pipeline-pr/31393/testReport/junit/xmodule.xmodule.partitions.tests.test_partitions/TestGetCourseUserPartitions/Run_Tests___commonlib_unit___test_enrollment_track_partition_added/

> Regression
>   Run Tests / commonlib-unit / xmodule.xmodule.partitions.tests.test_partitions.TestGetCourseUserPartitions.test_enrollment_track_partition_added (from pytest)
>   
>   Failing for the past 1 build (Since Failed#31393 )
>   Took 4 ms.
>   Error Message
>   AssertionError: assert 2 == 1
>     +2
>     -1
>   Stacktrace
>   self = <xmodule.partitions.tests.test_partitions.TestGetCourseUserPartitions testMethod=test_enrollment_track_partition_added>
>   
>       def test_enrollment_track_partition_added(self):
>           """
>           Test that the dynamic enrollment track scheme is added if there is no conflict with the user partition ID.
>           """
>           all_partitions = get_all_partitions_for_course(self.course)
>   >       assert 2 == len(all_partitions)
>   E       AssertionError: assert 2 == 1
>   E         +2
>   E         -1
>   
>   common/lib/xmodule/xmodule/partitions/tests/test_partitions.py:560: AssertionError