### PR TITLE
Add log message when password reset requested

### DIFF
--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -726,6 +726,7 @@ def do_email_change_request(user, new_email, activation_key=None, secondary_emai
 
     try:
         ace.send(msg)
+        log.info("Email activation link sent to user [%s].", new_email)
     except Exception:
         from_address = configuration_helpers.get_value('email_from_address', settings.DEFAULT_FROM_EMAIL)
         log.error('Unable to send email activation link to user from "%s"', from_address, exc_info=True)


### PR DESCRIPTION
Logs an INFO message whenever a password reset email is generated.
The intent is to detect abuse of this feature.

SEG-48

## Testing instructions

1. Through the Account Settings page, request a new recovery email.
2. Confirm log is created in Splunk. Search for "Email activation link sent to user"
