### PR TITLE
chore: update edx-proctoring version

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -455,7 +455,7 @@ edx-organizations==6.9.0
     # via -r requirements/edx/base.in
 edx-proctoring-proctortrack==1.0.5
     # via -r requirements/edx/base.in
-edx-proctoring==3.13.0
+edx-proctoring==3.13.1
     # via
     #   -r requirements/edx/base.in
     #   edx-proctoring-proctortrack

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -549,7 +549,7 @@ edx-organizations==6.9.0
     # via -r requirements/edx/testing.txt
 edx-proctoring-proctortrack==1.0.5
     # via -r requirements/edx/testing.txt
-edx-proctoring==3.13.0
+edx-proctoring==3.13.1
     # via
     #   -r requirements/edx/testing.txt
     #   edx-proctoring-proctortrack

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -533,7 +533,7 @@ edx-organizations==6.9.0
     # via -r requirements/edx/base.txt
 edx-proctoring-proctortrack==1.0.5
     # via -r requirements/edx/base.txt
-edx-proctoring==3.13.0
+edx-proctoring==3.13.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring-proctortrack


### PR DESCRIPTION
Release notes for latest version:

Previously we would make a request to the proctoring provider backend each time an attempt transitioned to started. With this release we will only notify the backend for the first time an attempt transitions to started