### PR TITLE
fix: convert integrity signature waffle flag to CourseWaffleFlag

### DIFF
--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -894,7 +894,7 @@ class SequenceBlock(
                 'allow_proctoring_opt_out': self.allow_proctoring_opt_out,
                 'due_date': self.due,
                 'grace_period': self.graceperiod,  # lint-amnesty, pylint: disable=no-member
-                'is_integrity_signature_enabled': is_integrity_signature_enabled(),
+                'is_integrity_signature_enabled': is_integrity_signature_enabled(course_id),
             }
 
             # inject the user's credit requirements and fulfillments

--- a/openedx/core/djangoapps/agreements/toggles.py
+++ b/openedx/core/djangoapps/agreements/toggles.py
@@ -2,10 +2,13 @@
 Toggles for the Agreements app
 """
 
-from edx_toggles.toggles import WaffleFlag
+from opaque_keys.edx.keys import CourseKey
+
+from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
+
 
 # .. toggle_name: agreements.enable_integrity_signature
-# .. toggle_implementation: WaffleFlag
+# .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Supports rollout of the integrity signature feature
 # .. toggle_use_cases: temporary, open_edx
@@ -14,8 +17,12 @@ from edx_toggles.toggles import WaffleFlag
 # .. toggle_warnings: None
 # .. toggle_tickets: MST-786
 
-ENABLE_INTEGRITY_SIGNATURE = WaffleFlag('agreements.enable_integrity_signature', __name__)
+ENABLE_INTEGRITY_SIGNATURE = CourseWaffleFlag(  # lint-amnesty, pylint: disable=toggle-missing-annotation
+    'agreements', 'enable_integrity_signature', __name__,
+)
 
 
-def is_integrity_signature_enabled():
-    return ENABLE_INTEGRITY_SIGNATURE.is_enabled()
+def is_integrity_signature_enabled(course_key):
+    if isinstance(course_key, str):
+        course_key = CourseKey.from_string(course_key)
+    return ENABLE_INTEGRITY_SIGNATURE.is_enabled(course_key)

--- a/openedx/core/djangoapps/agreements/views.py
+++ b/openedx/core/djangoapps/agreements/views.py
@@ -68,7 +68,7 @@ class IntegritySignatureView(AuthenticatedAPIView):
         Only staff should be able to access this endpoint for other users.
         """
         # check that waffle flag is enabled
-        if not is_integrity_signature_enabled():
+        if not is_integrity_signature_enabled(CourseKey.from_string(course_id)):
             return Response(
                 status=status.HTTP_404_NOT_FOUND,
             )
@@ -112,7 +112,7 @@ class IntegritySignatureView(AuthenticatedAPIView):
             }
         """
         # check that waffle flag is enabled
-        if not is_integrity_signature_enabled():
+        if not is_integrity_signature_enabled(CourseKey.from_string(course_id)):
             return Response(
                 status=status.HTTP_404_NOT_FOUND,
             )

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -300,10 +300,10 @@ class CoursewareMeta:
         Boolean describing whether the user needs to sign the integrity agreement for a course.
         """
         if (
-            not self.is_staff
+            is_integrity_signature_enabled(self.course_key)
+            and not self.is_staff
             and self.enrollment_object
             and self.enrollment_object.mode in CourseMode.CERTIFICATE_RELEVANT_MODES
-            and is_integrity_signature_enabled()
         ):
             signature = get_integrity_signature(self.effective_user.username, str(self.course_key))
             if not signature:


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Convert `agreements.enable_integrity_signature` to a `CourseWaffleFlag` in order to turn the feature on by course.