### PR TITLE
feat: Bulk enrollment emails, and default email templates are now in …

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -30,7 +30,7 @@ django-storages<1.9
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==3.23.11
+edx-enterprise==3.23.12
 
 # Newer versions need a more recent version of python-dateutil
 freezegun==0.3.12

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -425,7 +425,7 @@ edx-drf-extensions==6.5.0
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.23.11
+edx-enterprise==3.23.12
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -515,7 +515,7 @@ edx-drf-extensions==6.5.0
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.23.11
+edx-enterprise==3.23.12
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -498,7 +498,7 @@ edx-drf-extensions==6.5.0
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.23.11
+edx-enterprise==3.23.12
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION

## Description

Default global templates used for enrollment emails, and newly bulk enrollment emails, now in database model `EnrollmentEmailNotificationTemplate` instead of previously files in git. This allows for more flexible editing of templates, by anyone with access to Django admin. This also helps support a different template (global or per customer), for bulk enrollment.

No more file templates, also supports notion of template_type now (self and admin for now)

ENT-4322

When deployed, the migration contained in the change from edx-enterprise will add a column template_type, to the model, and also populate default templates (one for SELF_ENROLL type and one for ADMIN_ENROLL type). Existing templates will not be affected (there is only one in prod for `Boeing (MITxPro)` customer as of now at https://courses-internal.edx.org/admin/enterprise/enrollmentnotificationemailtemplate/ )


In Django admin, templates should now look something like this:

<img width="872" alt="Screen Shot 2021-06-09 at 8 27 39 AM" src="https://user-images.githubusercontent.com/528166/121407409-44357f00-c92d-11eb-9575-74209b2b1074.png">


## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
