### PR TITLE
feat: Remove "Audit access expires" banner, save masquerade message

### DIFF
--- a/openedx/features/course_duration_limits/access.py
+++ b/openedx/features/course_duration_limits/access.py
@@ -141,6 +141,40 @@ def get_access_expiration_data(user, course):
     }
 
 
+def generate_masquerading_expired_message(expiration_date):
+    """
+    Generate the message for course admins to see if /when a learner lost their access.
+    """
+    upgrade_message = _('This learner does not have access to this course. '
+                        'Their access expired on {expiration_date}.')
+    return HTML(upgrade_message).format(
+        expiration_date=strftime_localized_html(expiration_date, 'SHORT_DATE')
+    )
+
+
+def generate_course_expired_fragment_masquerade_only(user, course):
+    message = generate_course_expired_message_masquerade_only(user, course)
+    if message:
+        return generate_fragment_from_message(message)
+
+
+def generate_course_expired_message_masquerade_only(user, course):
+    """
+    Generate only the masquerade expired message for admins.
+
+    Skips all of the other output generated in generate_course_expired_message.
+    """
+    expiration_data = get_access_expiration_data(user, course)
+    if not expiration_data:
+        return
+
+    expiration_date = expiration_data['expiration_date']
+    masquerading_expired_course = expiration_data['masquerading_expired_course']
+
+    if masquerading_expired_course:
+        return generate_masquerading_expired_message(expiration_date)
+
+
 def generate_course_expired_message(user, course):
     """
     Generate the message for the user course expiration date if it exists.
@@ -155,11 +189,7 @@ def generate_course_expired_message(user, course):
     upgrade_url = expiration_data['upgrade_url']
 
     if masquerading_expired_course:
-        upgrade_message = _('This learner does not have access to this course. '
-                            'Their access expired on {expiration_date}.')
-        return HTML(upgrade_message).format(
-            expiration_date=strftime_localized_html(expiration_date, 'SHORT_DATE')
-        )
+        return generate_masquerading_expired_message(expiration_date)
     else:
         expiration_message = _('{strong_open}Audit Access Expires {expiration_date}{strong_close}'
                                '{line_break}You lose all access to this course, including your progress, on '

--- a/openedx/features/course_experience/views/course_home.py
+++ b/openedx/features/course_experience/views/course_home.py
@@ -28,7 +28,7 @@ from lms.djangoapps.courseware.views.views import CourseTabView
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
 from openedx.core.djangoapps.util.maintenance_banner import add_maintenance_banner
-from openedx.features.course_duration_limits.access import generate_course_expired_fragment
+from openedx.features.course_duration_limits.access import generate_course_expired_fragment_masquerade_only
 from openedx.features.course_experience import (
     COURSE_ENABLE_UNENROLLED_ACCESS_FLAG,
     LATEST_UPDATE_FLAG,
@@ -159,7 +159,7 @@ class CourseHomeFragmentView(EdxFragmentView):
             )
             has_visited_course, resume_course_url = self._get_resume_course_info(request, course_id)
             handouts_html = self._get_course_handouts(request, course)
-            course_expiration_fragment = generate_course_expired_fragment(
+            course_expiration_fragment = generate_course_expired_fragment_masquerade_only(
                 request.user,
                 course_overview
             )


### PR DESCRIPTION
## Description

Remove most of this banner's potential messaging from the course home page in favor of the new, consolidated messaging (REV-2122). Keep the message that appears when an admin masquerades as a user so that they can see when the user's access expired.

## Supporting information

- REV-2233
