### PR TITLE
BOM-2590: Removing constraints from edx-platform

### DIFF
--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -21,7 +21,7 @@ from path import Path as path
 
 from openedx.core.lib.derived import derive_settings
 
-from xmodule.modulestore.modulestore_settings import update_module_store_settings
+from xmodule.modulestore.modulestore_settings import update_module_store_settings  # pylint: disable=wrong-import-order
 
 from .common import *
 

--- a/pylintrc
+++ b/pylintrc
@@ -394,6 +394,7 @@ disable =
 	useless-suppression,
 	cyclic-import,
 	logging-format-interpolation,
+	wrong-import-order,
 
 [REPORTS]
 output-format = text
@@ -493,4 +494,4 @@ int-import-graph =
 [EXCEPTIONS]
 overgeneral-exceptions = Exception
 
-# c5312bad86f927500a51e6aba50677c3c19598d4
+# 09db2baee601ac448d0a7336689375646b15fa35

--- a/pylintrc_tweaks
+++ b/pylintrc_tweaks
@@ -15,6 +15,8 @@ disable+ =
     useless-suppression,
     cyclic-import,
     logging-format-interpolation,
+    # isort>5.0.0 introduced this warnings in a lot of import statements
+    wrong-import-order,
 
 [BASIC]
 attr-rgx = [a-z_][a-z0-9_]{2,40}$

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -12,6 +12,9 @@
 # This file contains all common constraints for edx-repos
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
 
+# celert>5.0.0 hasn't been tested yet, so the constraint will be removed after testing latest version
+celery<5.0.0
+
 # edx-platform currently only supported for Django 2.2.x
 django<2.3
 
@@ -88,14 +91,8 @@ click<8.0.0
 
 # constraints present due to Python35 support. Need to be tested and removed independently.
 
-celery<5.0              # celery 5.0 has dropped python3.5 support.
-inflect<4.0.0           # 4.0.0 dropped support for Python 3.5
-isort<5.0.0             # 5.0.0 dropped support for Python 3.5
 joblib<0.15.0           # 0.15.0 dropped support for Python 3.5
 jsonfield2<3.1.0        # jsonfield2 3.1.0 drops support for python 3.5
 kiwisolver<1.2.0        # kiwisolver 1.2.0 requires Python 3.6+
 matplotlib<3.1          # Matplotlib 3.1 requires Python 3.6
-maxminddb<2.0.0         # maxminddb 2.0.0 has dropped support for Python 3.5
-path<13.2.0             # path 13.2.0 drops support for Python 3.5
 zipp==1.0.0             # zipp 2.0.0 requires Python >= 3.6
-geoip2<4.0.1            # geoip2 requires Python 3.6

--- a/requirements/edx-sandbox/py35-constraints.txt
+++ b/requirements/edx-sandbox/py35-constraints.txt
@@ -1,13 +1,10 @@
 # constraints required for Python 3.5 support in sandbox codejail environments
 # All of these constraints require python3.6+ for larger versions
 
-celery<5.0              # celery 5.0 has dropped python3.5 support.
-
-geoip2<4.0.1            # geoip2 requires Python 3.6
-
-inflect<4.0.0           # 4.0.0 dropped support for Python 3.5
-
-isort<5.0.0             # 5.0.0 dropped support for Python 3.5
+# maxminddb 2.0.0 has dropped support for Python 3.5
+maxminddb<2.0.0
+# geoip2 requires Python 3.6 && geoip2>4.0.2 requires maxminddb>=2.0.0
+geoip2<4.0.1
 
 joblib<0.15.0           # 0.15.0 dropped support for Python 3.5
 
@@ -17,11 +14,7 @@ kiwisolver<1.2.0        # kiwisolver 1.2.0 requires Python 3.6+
 
 matplotlib<3.1          # Matplotlib 3.1 requires Python 3.6
 
-maxminddb<2.0.0         # maxminddb 2.0.0 has dropped support for Python 3.5
-
 numpy<1.19.0            # numpy 1.19.0 drops support for Python 3.5
-
-path<13.2.0             # path 13.2.0 drops support for Python 3.5
 
 stevedore<2.0.0         # stevedore 2.0.0 requires python >= 3.6
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -36,6 +36,8 @@
     # via -r requirements/edx/local.in
 acid-xblock==0.2.1
     # via -r requirements/edx/base.in
+aiohttp==3.7.4.post0
+    # via geoip2
 amqp==2.6.1
     # via kombu
 analytics-python==1.3.1
@@ -46,9 +48,12 @@ aniso8601==9.0.1
     #   tincan
 appdirs==1.4.4
     # via fs
+async-timeout==3.0.1
+    # via aiohttp
 attrs==21.2.0
     # via
     #   -r requirements/edx/base.in
+    #   aiohttp
     #   edx-ace
 babel==2.9.1
     # via
@@ -106,6 +111,7 @@ cffi==1.14.5
 chardet==4.0.0
     # via
     #   -r requirements/edx/paver.txt
+    #   aiohttp
     #   pysrt
     #   requests
 chem==1.2.0
@@ -520,10 +526,8 @@ future==0.18.2
     #   edx-celeryutils
     #   edx-enterprise
     #   pyjwkest
-geoip2==3.0.0
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/base.in
+geoip2==4.2.0
+    # via -r requirements/edx/base.in
 glob2==0.7
     # via -r requirements/edx/base.in
 gunicorn==20.1.0
@@ -540,6 +544,7 @@ idna==2.10
     # via
     #   -r requirements/edx/paver.txt
     #   requests
+    #   yarl
 inflection==0.5.1
     # via drf-yasg
 ipaddress==1.0.23
@@ -629,10 +634,8 @@ markupsafe==2.0.1
     #   jinja2
     #   mako
     #   xblock
-maxminddb==1.5.4
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   geoip2
+maxminddb==2.0.3
+    # via geoip2
 mock==4.0.3
     # via
     #   -r requirements/edx/paver.txt
@@ -646,6 +649,10 @@ monotonic==1.6
     # via analytics-python
 mpmath==1.2.1
     # via sympy
+multidict==5.1.0
+    # via
+    #   aiohttp
+    #   yarl
 mysqlclient==2.0.3
     # via -r requirements/edx/base.in
 newrelic==6.4.3.160
@@ -970,6 +977,8 @@ tincan==1.0.0
     # via edx-event-routing-backends
 tqdm==4.61.1
     # via nltk
+typing-extensions==3.10.0.0
+    # via aiohttp
 ua-parser==0.10.0
     # via django-cookies-samesite
 unicodecsv==0.14.1
@@ -1051,6 +1060,8 @@ xmlsec==1.3.11
     # via python3-saml
 xss-utils==0.2.0
     # via -r requirements/edx/base.in
+yarl==1.6.3
+    # via aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -10,12 +10,10 @@ diff-cover==4.0.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/coverage.in
+inflect==5.3.0
+    # via jinja2-pluralize
 importlib-metadata==4.6.0
     # via inflect
-inflect==3.0.2
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   jinja2-pluralize
 jinja2==3.0.1
     # via
     #   diff-cover
@@ -24,13 +22,7 @@ jinja2-pluralize==0.3.0
     # via diff-cover
 markupsafe==2.0.1
     # via jinja2
-more-itertools==8.8.0
-    # via zipp
 pluggy==0.13.1
     # via diff-cover
 pygments==2.9.0
     # via diff-cover
-zipp==1.0.0
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   importlib-metadata

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -36,6 +36,10 @@
     # via -r requirements/edx/testing.txt
 acid-xblock==0.2.1
     # via -r requirements/edx/testing.txt
+aiohttp==3.7.4.post0
+    # via
+    #   -r requirements/edx/testing.txt
+    #   geoip2
 alabaster==0.7.12
     # via sphinx
 amqp==2.6.1
@@ -59,9 +63,14 @@ astroid==2.5.6
     #   -r requirements/edx/testing.txt
     #   pylint
     #   pylint-celery
+async-timeout==3.0.1
+    # via
+    #   -r requirements/edx/testing.txt
+    #   aiohttp
 attrs==21.2.0
     # via
     #   -r requirements/edx/testing.txt
+    #   aiohttp
     #   edx-ace
     #   jsonschema
     #   pytest
@@ -132,6 +141,7 @@ cffi==1.14.5
 chardet==4.0.0
     # via
     #   -r requirements/edx/testing.txt
+    #   aiohttp
     #   pysrt
     #   requests
 chem==1.2.0
@@ -638,10 +648,8 @@ future==0.18.2
     #   edx-celeryutils
     #   edx-enterprise
     #   pyjwkest
-geoip2==3.0.0
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/testing.txt
+geoip2==4.2.0
+    # via -r requirements/edx/testing.txt
 gitdb==4.0.7
     # via
     #   -r requirements/edx/testing.txt
@@ -670,16 +678,15 @@ idna==2.10
     # via
     #   -r requirements/edx/testing.txt
     #   requests
+    #   yarl
 imagesize==1.2.0
     # via sphinx
 importlib-metadata==4.6.0
     # via
     #   -r requirements/edx/testing.txt
-    #   inflect
     #   pytest-randomly
-inflect==3.0.2
+inflect==5.3.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   jinja2-pluralize
 inflection==0.5.1
@@ -697,9 +704,8 @@ isodate==0.6.0
     #   -r requirements/edx/testing.txt
     #   edx-event-routing-backends
     #   python3-saml
-isort==4.3.21
+isort==5.8.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   pylint
 itypes==1.2.0
@@ -813,9 +819,8 @@ markupsafe==2.0.1
     #   jinja2
     #   mako
     #   xblock
-maxminddb==1.5.4
+maxminddb==2.0.3
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   geoip2
 mccabe==0.6.1
@@ -845,6 +850,13 @@ mpmath==1.2.1
     # via
     #   -r requirements/edx/testing.txt
     #   sympy
+multidict==5.1.0
+    # via
+    #   -r requirements/edx/testing.txt
+    #   aiohttp
+    #   yarl
+mypy-extensions==0.4.3
+    # via mypy
 mypy==0.910
     # via -r requirements/edx/development.in
 mypy-extensions==0.4.3
@@ -1369,7 +1381,10 @@ tqdm==4.61.1
 transifex-client==0.14.3
     # via -r requirements/edx/testing.txt
 typing-extensions==3.10.0.0
-    # via mypy
+    # via
+    #   -r requirements/edx/testing.txt
+    #   aiohttp
+    #   mypy
 ua-parser==0.10.0
     # via
     #   -r requirements/edx/testing.txt
@@ -1476,6 +1491,10 @@ xmlsec==1.3.11
     #   python3-saml
 xss-utils==0.2.0
     # via -r requirements/edx/testing.txt
+yarl==1.6.3
+    # via
+    #   -r requirements/edx/testing.txt
+    #   aiohttp
 zipp==1.0.0
     # via
     #   -c requirements/edx/../constraints.txt

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -20,10 +20,8 @@ markupsafe==2.0.1
     # via -r requirements/edx/paver.in
 mock==4.0.3
     # via -r requirements/edx/paver.in
-path==13.1.0
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/paver.in
+path==15.1.2
+    # via -r requirements/edx/paver.in
 paver==1.3.4
     # via -r requirements/edx/paver.in
 pbr==5.6.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -36,6 +36,10 @@
     # via -r requirements/edx/base.txt
 acid-xblock==0.2.1
     # via -r requirements/edx/base.txt
+aiohttp==3.7.4.post0
+    # via
+    #   -r requirements/edx/base.txt
+    #   geoip2
 amqp==2.6.1
     # via
     #   -r requirements/edx/base.txt
@@ -56,9 +60,14 @@ astroid==2.5.6
     # via
     #   pylint
     #   pylint-celery
+async-timeout==3.0.1
+    # via
+    #   -r requirements/edx/base.txt
+    #   aiohttp
 attrs==21.2.0
     # via
     #   -r requirements/edx/base.txt
+    #   aiohttp
     #   edx-ace
     #   pytest
 babel==2.9.1
@@ -128,6 +137,7 @@ cffi==1.14.5
 chardet==4.0.0
     # via
     #   -r requirements/edx/base.txt
+    #   aiohttp
     #   pysrt
     #   requests
 chem==1.2.0
@@ -617,10 +627,8 @@ future==0.18.2
     #   edx-celeryutils
     #   edx-enterprise
     #   pyjwkest
-geoip2==3.0.0
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/base.txt
+geoip2==4.2.0
+    # via -r requirements/edx/base.txt
 gitdb==4.0.7
     # via gitpython
 gitpython==3.1.18
@@ -645,14 +653,11 @@ idna==2.10
     # via
     #   -r requirements/edx/base.txt
     #   requests
+    #   yarl
 importlib-metadata==4.6.0
+    # via pytest-randomly
+inflect==5.3.0
     # via
-    #   -r requirements/edx/coverage.txt
-    #   inflect
-    #   pytest-randomly
-inflect==3.0.2
-    # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/coverage.txt
     #   jinja2-pluralize
 inflection==0.5.1
@@ -668,9 +673,8 @@ isodate==0.6.0
     #   -r requirements/edx/base.txt
     #   edx-event-routing-backends
     #   python3-saml
-isort==4.3.21
+isort==5.8.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.in
     #   pylint
 itypes==1.2.0
@@ -779,9 +783,8 @@ markupsafe==2.0.1
     #   jinja2
     #   mako
     #   xblock
-maxminddb==1.5.4
+maxminddb==2.0.3
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   geoip2
 mccabe==0.6.1
@@ -800,13 +803,16 @@ monotonic==1.6
     #   -r requirements/edx/base.txt
     #   analytics-python
 more-itertools==8.8.0
-    # via
-    #   -r requirements/edx/coverage.txt
-    #   zipp
+    # via zipp
 mpmath==1.2.1
     # via
     #   -r requirements/edx/base.txt
     #   sympy
+multidict==5.1.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   aiohttp
+    #   yarl
 mysqlclient==2.0.3
     # via -r requirements/edx/base.txt
 newrelic==6.4.3.160
@@ -1273,6 +1279,10 @@ tqdm==4.61.1
     #   nltk
 transifex-client==0.14.3
     # via -r requirements/edx/testing.in
+typing-extensions==3.10.0.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   aiohttp
 ua-parser==0.10.0
     # via
     #   -r requirements/edx/base.txt
@@ -1371,10 +1381,13 @@ xmlsec==1.3.11
     #   python3-saml
 xss-utils==0.2.0
     # via -r requirements/edx/base.txt
+yarl==1.6.3
+    # via
+    #   -r requirements/edx/base.txt
+    #   aiohttp
 zipp==1.0.0
     # via
     #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/coverage.txt
     #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
**JIRA ISSUE:** [BOM-2590](https://openedx.atlassian.net/browse/BOM-2590)

## Description
- Removing unnecessary constraints from `py35-constraints.txt` and `constraints.txt` files.

## Details
Updated constraints of following packages:
- `inflect`, `geoip2`, `maxmindb`, `path`, `isort` 
(isort>5.0.0 introduced `wrong-import-order` warnings so disabled the warning and created [BOM-2606](https://openedx.atlassian.net/browse/BOM-2606) to apply lint-amnesty on these warnings in a later PR.)

## How to Test
- Sandbox successfully created to test these change: https://constraintstest.sandbox.edx.org/

## TODO
- The remaining constraints will be removed in a later PR.