### PR TITLE
[FEAT]: Add mem caching to the API to create and retrieve IntegritySignature

### DIFF
--- a/openedx/core/djangoapps/agreements/cache.py
+++ b/openedx/core/djangoapps/agreements/cache.py
@@ -1,0 +1,13 @@
+# lint-amnesty, pylint: disable=missing-module-docstring
+# Template used to create cache keys for Integrity Signatures
+INTEGRITY_SIGNATURE_CACHE_KEY_TPL = 'integrity-signature-{course_id}-{username}'
+
+
+def get_integrity_signature_cache_key(username, course_id):
+    """
+    Util function to help form the cache key for integrity signature
+    """
+    return INTEGRITY_SIGNATURE_CACHE_KEY_TPL.format(
+        username=username,
+        course_id=course_id,
+    )

--- a/openedx/core/djangoapps/agreements/tests/test_api.py
+++ b/openedx/core/djangoapps/agreements/tests/test_api.py
@@ -3,13 +3,14 @@ Tests for the Agreements API
 """
 import logging
 
+from django.core.cache import cache
 from testfixtures import LogCapture
 
 from common.djangoapps.student.tests.factories import UserFactory
 from openedx.core.djangoapps.agreements.api import (
     create_integrity_signature,
     get_integrity_signature,
-    get_integrity_signatures_for_course,
+    get_integrity_signatures_for_course
 )
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
@@ -62,15 +63,17 @@ class TestIntegritySignatureApi(SharedModuleStoreTestCase):
         Test to get an integrity signature
         """
         create_integrity_signature(self.user.username, self.course_id)
-        signature = get_integrity_signature(self.user.username, self.course_id)
-        self._assert_integrity_signature(signature)
+        with self.assertNumQueries(0):
+            signature = get_integrity_signature(self.user.username, self.course_id)
+            self._assert_integrity_signature(signature)
 
     def test_get_nonexistent_integrity_signature(self):
         """
         Test that None is returned if an integrity signature does not exist
         """
-        signature = get_integrity_signature(self.user.username, self.course_id)
-        self.assertIsNone(signature)
+        with self.assertNumQueries(2):
+            signature = get_integrity_signature(self.user.username, self.course_id)
+            self.assertIsNone(signature)
 
     def test_get_integrity_signatures_for_course(self):
         """
@@ -98,3 +101,21 @@ class TestIntegritySignatureApi(SharedModuleStoreTestCase):
         """
         self.assertEqual(signature.user, self.user)
         self.assertEqual(signature.course_key, self.course.id)
+
+    def test_get_integrity_signatures_for_course_cached(self):
+        """
+        Test to ensure the integrity_signatures retrieved by course is also set into cache
+        """
+        create_integrity_signature(self.user.username, self.course_id)
+        second_user = UserFactory()
+        create_integrity_signature(second_user.username, self.course_id)
+        cache.clear()
+        with self.assertNumQueries(1):
+            get_integrity_signatures_for_course(self.course_id)
+
+        with self.assertNumQueries(0):
+            signature = get_integrity_signature(self.user.username, self.course_id)
+            self._assert_integrity_signature(signature)
+
+        with self.assertNumQueries(0):
+            get_integrity_signature(second_user.username, self.course_id)


### PR DESCRIPTION
## Description

With this change, whenever a IntegritySignature is created or retrieved, the result will be cached into mem cache for future use. This will save round trip to database significantly for honor code check


@edx/masters-devs-cosmonauts Please help review

