### PR TITLE
Revert "fix: Disable column-statistics during mysqldump command."

### DIFF
--- a/scripts/reset-test-db.sh
+++ b/scripts/reset-test-db.sh
@@ -89,11 +89,11 @@ rebuild_cache_for_db() {
     echo "Using the dumpdata command to save the $db fixture data to the filesystem."
     ./manage.py lms --settings $SETTINGS dumpdata --database $db > $DB_CACHE_DIR/bok_choy_data_$db.json --exclude=api_admin.Catalog
     echo "Saving the schema of the $db bok_choy DB to the filesystem."
-    mysqldump --column_statistics=0 $MYSQL_HOST -u root --no-data --skip-comments --skip-dump-date "${databases[$db]}" > $DB_CACHE_DIR/bok_choy_schema_$db.sql
+    mysqldump $MYSQL_HOST -u root --no-data --skip-comments --skip-dump-date "${databases[$db]}" > $DB_CACHE_DIR/bok_choy_schema_$db.sql
 
     # dump_data does not dump the django_migrations table so we do it separately.
     echo "Saving the django_migrations table of the $db bok_choy DB to the filesystem."
-    mysqldump --column_statistics=0 $MYSQL_HOST -u root --no-create-info --skip-comments --skip-dump-date "${databases["$db"]}" django_migrations > $DB_CACHE_DIR/bok_choy_migrations_data_$db.sql
+    mysqldump $MYSQL_HOST -u root --no-create-info --skip-comments --skip-dump-date "${databases["$db"]}" django_migrations > $DB_CACHE_DIR/bok_choy_migrations_data_$db.sql
 }
 
 for db in "${database_order[@]}"; do


### PR DESCRIPTION
This reverts commit b84e8937ffb04bf0d136d4647625da9c0f7aba6b.

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Reverts the fix to disable column statistics when dumping the MySQL bokchoy DB. Apparently, the Jenkins workers have a different version of mysqldump than devstack. The change is currently causing a11y testing to fail, demonstrated by these runs:

https://build.testeng.edx.org/job/edx-platform-accessibility-pr/85841/console
https://build.testeng.edx.org/job/edx-platform-accessibility-pr/85843/console

failing with this error:

```
15:52:35 Saving the schema of the default bok_choy DB to the filesystem.
15:52:35 mysqldump: [ERROR] unknown variable 'column_statistics=0'
```

