### PR TITLE
fix: Bug showing hidden sections for learners of a public course fixed

### DIFF
--- a/lms/djangoapps/course_api/blocks/api.py
+++ b/lms/djangoapps/course_api/blocks/api.py
@@ -90,6 +90,8 @@ def get_blocks(
             ),
             HiddenContentTransformer()
         ]
+    else:
+        transformers += [course_blocks_api.visibility.VisibilityTransformer()]
 
     # Note: A change to the BlockCompletionTransformer (https://github.com/edx/edx-platform/pull/27622/)
     # will be introducing a bug if hide_access_denials is True.  I'm accepting this risk because in

--- a/lms/djangoapps/course_api/blocks/tests/test_api.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_api.py
@@ -53,7 +53,9 @@ class TestGetBlocks(SharedModuleStoreTestCase):
 
     def test_no_user(self):
         blocks = get_blocks(self.request, self.course.location)
-        assert str(self.html_block.location) in blocks['blocks']
+        assert str(self.html_block.location) not in blocks['blocks']
+        vertical_block = self.store.get_item(self.course.id.make_usage_key('vertical', 'vertical_x1a'))
+        assert str(vertical_block.location) in blocks['blocks']
 
     def test_access_before_api_transformer_order(self):
         """


### PR DESCRIPTION
The bug is explained in https://openedx.atlassian.net/browse/CRI-233. Only is missing add the `VisibilityTransformer` in `get_blocks()` when the user is not enrolled to the course.

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

There is an unexpected behavior when a course is public and one of its section is hidden for learners. Currently, all sections are shown regardless of whether it is hidden or not. This PR fix that unexpected behavior. 

On `course_api/blocks/api.py` I added the `VisibilityTransformer()` to `get_blocks()`, when this function receives a `None` user (nor enrolled learner) to verify the visibility for learners flag.

## Supporting information

JIRA issue: https://openedx.atlassian.net/browse/CRI-233

## Testing instructions

- Create a course
- Create 2 or more sections
- Set the visibility of one section to hidden for learners
- Turn on public course outline or public course
- Login with a not enrolled learner
- Note that the hidden section are not in the list of sections
