### PR TITLE
feat [BD-26]: waffle flag to enable proctored exams in learning MFE

### DIFF
--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -542,6 +542,7 @@ class SequenceBlock(
             'element_id': self.location.html_id(),
             'item_id': str(self.location),
             'is_time_limited': self.is_time_limited,
+            'is_proctored': self.is_proctored_enabled,
             'position': self.position,
             'tag': self.location.block_type,
             'next_url': context.get('next_url'),

--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -113,6 +113,19 @@ COURSEWARE_MICROFRONTEND_SPECIAL_EXAMS = CourseWaffleFlag(
     WAFFLE_FLAG_NAMESPACE, 'mfe_special_exams', __name__
 )
 
+# .. toggle_name: courseware.mfe_proctored_exams
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Waffle flag to enable proctored exams experience without
+#   redirecting students to LMS.
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2021-5-25
+# .. toggle_target_removal_date: 2021-6-30
+# .. toggle_warnings: None
+COURSEWARE_MICROFRONTEND_PROCTORED_EXAMS = CourseWaffleFlag(
+    WAFFLE_FLAG_NAMESPACE, 'mfe_proctored_exams', __name__
+)
+
 
 def mfe_special_exams_is_active(course_key: CourseKey) -> bool:
     """
@@ -123,6 +136,17 @@ def mfe_special_exams_is_active(course_key: CourseKey) -> bool:
         return False
     # OTHERWISE: Defer to value of waffle flag for this course run and user.
     return COURSEWARE_MICROFRONTEND_SPECIAL_EXAMS.is_enabled(course_key)
+
+
+def mfe_proctored_exams_is_active(course_key: CourseKey) -> bool:
+    """
+    Can we see a course special exams in the Learning MFE?
+    """
+    # DENY: Old Mongo courses don't work in the MFE.
+    if course_key.deprecated:
+        return False
+    # OTHERWISE: Defer to value of waffle flag for this course run and user.
+    return COURSEWARE_MICROFRONTEND_PROCTORED_EXAMS.is_enabled(course_key)
 
 
 def courseware_mfe_is_active(course_key: CourseKey) -> bool:

--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -119,7 +119,7 @@ COURSEWARE_MICROFRONTEND_SPECIAL_EXAMS = CourseWaffleFlag(
 # .. toggle_description: Waffle flag to enable proctored exams experience without
 #   redirecting students to LMS.
 # .. toggle_use_cases: temporary
-# .. toggle_creation_date: 2021-5-25
+# .. toggle_creation_date: 2021-5-24
 # .. toggle_target_removal_date: 2021-6-30
 # .. toggle_warnings: None
 COURSEWARE_MICROFRONTEND_PROCTORED_EXAMS = CourseWaffleFlag(

--- a/openedx/core/djangoapps/courseware_api/serializers.py
+++ b/openedx/core/djangoapps/courseware_api/serializers.py
@@ -117,6 +117,7 @@ class CourseInfoSerializer(serializers.Serializer):  # pylint: disable=abstract-
     verification_status = serializers.CharField()
     linkedin_add_to_profile_url = serializers.URLField()
     is_mfe_special_exams_enabled = serializers.BooleanField()
+    is_mfe_proctored_exams_enabled = serializers.BooleanField()
     user_needs_integrity_signature = serializers.BooleanField()
 
     def __init__(self, *args, **kwargs):

--- a/openedx/core/djangoapps/courseware_api/tests/test_views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/test_views.py
@@ -369,11 +369,11 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
                 assert courseware_data['is_mfe_special_exams_enabled'] == (is_globaly_enabled and is_waffle_enabled)
 
     @ddt.data(
-            (False, False),
-            (False, True),
-            (True, False),
-            (True, True),
-        )
+        (False, False),
+        (False, True),
+        (True, False),
+        (True, True),
+    )
     @ddt.unpack
     def test_proctored_exams_enabled_for_course(self, is_globaly_enabled, is_waffle_enabled):
         """ Ensure that proctored exams flag present in courseware meta data with expected value """

--- a/openedx/core/djangoapps/courseware_api/tests/test_views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/test_views.py
@@ -27,6 +27,7 @@ from lms.djangoapps.courseware.toggles import (
     COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES,
     COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES_STREAK_CELEBRATION,
     COURSEWARE_MICROFRONTEND_SPECIAL_EXAMS,
+    COURSEWARE_MICROFRONTEND_PROCTORED_EXAMS,
 )
 from lms.djangoapps.experiments.testutils import override_experiment_waffle_flag
 from lms.djangoapps.experiments.utils import STREAK_DISCOUNT_EXPERIMENT_FLAG
@@ -259,7 +260,6 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
             "masquerade_role": "student",
             "expect_can_load_courseware": False,
         },
-
     )
     @ddt.unpack
     def test_can_load_courseware(
@@ -350,6 +350,40 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
         courseware_data = response.json()
         assert 'user_needs_integrity_signature' in courseware_data
         assert courseware_data['user_needs_integrity_signature'] == needs_integrity_signature
+
+    @ddt.data(
+        (False, False),
+        (False, True),
+        (True, False),
+        (True, True),
+    )
+    @ddt.unpack
+    def test_special_exams_enabled_for_course(self, is_globaly_enabled, is_waffle_enabled):
+        """ Ensure that special exams flag present in courseware meta data with expected value """
+        with mock.patch.dict('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': is_globaly_enabled}):
+            with override_waffle_flag(COURSEWARE_MICROFRONTEND_SPECIAL_EXAMS, active=is_waffle_enabled):
+                response = self.client.get(self.url)
+                assert response.status_code == 200
+                courseware_data = response.json()
+                assert 'is_mfe_special_exams_enabled' in courseware_data
+                assert courseware_data['is_mfe_special_exams_enabled'] == (is_globaly_enabled and is_waffle_enabled)
+
+    @ddt.data(
+            (False, False),
+            (False, True),
+            (True, False),
+            (True, True),
+        )
+    @ddt.unpack
+    def test_proctored_exams_enabled_for_course(self, is_globaly_enabled, is_waffle_enabled):
+        """ Ensure that proctored exams flag present in courseware meta data with expected value """
+        with mock.patch.dict('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': is_globaly_enabled}):
+            with override_waffle_flag(COURSEWARE_MICROFRONTEND_PROCTORED_EXAMS, active=is_waffle_enabled):
+                response = self.client.get(self.url)
+                assert response.status_code == 200
+                courseware_data = response.json()
+                assert 'is_mfe_proctored_exams_enabled' in courseware_data
+                assert courseware_data['is_mfe_proctored_exams_enabled'] == (is_globaly_enabled and is_waffle_enabled)
 
 
 class SequenceApiTestViews(BaseCoursewareTests):

--- a/openedx/core/djangoapps/courseware_api/tests/test_views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/test_views.py
@@ -358,23 +358,6 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
         (True, True),
     )
     @ddt.unpack
-    def test_special_exams_enabled_for_course(self, is_globaly_enabled, is_waffle_enabled):
-        """ Ensure that special exams flag present in courseware meta data with expected value """
-        with mock.patch.dict('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': is_globaly_enabled}):
-            with override_waffle_flag(COURSEWARE_MICROFRONTEND_SPECIAL_EXAMS, active=is_waffle_enabled):
-                response = self.client.get(self.url)
-                assert response.status_code == 200
-                courseware_data = response.json()
-                assert 'is_mfe_special_exams_enabled' in courseware_data
-                assert courseware_data['is_mfe_special_exams_enabled'] == (is_globaly_enabled and is_waffle_enabled)
-
-    @ddt.data(
-        (False, False),
-        (False, True),
-        (True, False),
-        (True, True),
-    )
-    @ddt.unpack
     def test_proctored_exams_enabled_for_course(self, is_globaly_enabled, is_waffle_enabled):
         """ Ensure that proctored exams flag present in courseware meta data with expected value """
         with mock.patch.dict('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': is_globaly_enabled}):

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -39,6 +39,7 @@ from lms.djangoapps.courseware.toggles import (
     courseware_mfe_is_visible,
     course_exit_page_is_active,
     mfe_special_exams_is_active,
+    mfe_proctored_exams_is_active,
 )
 from lms.djangoapps.courseware.views.views import get_cert_data
 from lms.djangoapps.grades.api import CourseGradeFactory
@@ -123,6 +124,10 @@ class CoursewareMeta:
     @property
     def is_mfe_special_exams_enabled(self):
         return settings.FEATURES.get('ENABLE_SPECIAL_EXAMS', False) and mfe_special_exams_is_active(self.course_key)
+
+    @property
+    def is_mfe_proctored_exams_enabled(self):
+        return settings.FEATURES.get('ENABLE_SPECIAL_EXAMS', False) and mfe_proctored_exams_is_active(self.course_key)
 
     @property
     def enrollment(self):


### PR DESCRIPTION
Description: add temporary waffle flag for enabling disabling proctored exams in the learning MFE

Jira: https://openedx.atlassian.net/browse/EDUCATOR-5799