### PR TITLE
fix: fixed the pylint violations causing quality failures

### DIFF
--- a/openedx/core/djangoapps/discussions/models.py
+++ b/openedx/core/djangoapps/discussions/models.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import logging
 from enum import Enum
 
+from collections import namedtuple
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
@@ -16,7 +17,6 @@ from model_utils.models import TimeStampedModel
 from opaque_keys.edx.django.models import LearningContextKeyField
 from opaque_keys.edx.keys import CourseKey
 from simple_history.models import HistoricalRecords
-from collections import namedtuple
 
 from openedx.core.djangoapps.config_model_utils.models import StackedConfigurationModel
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
@@ -26,7 +26,10 @@ log = logging.getLogger(__name__)
 DEFAULT_PROVIDER_TYPE = 'legacy'
 
 
-ProviderExternalLinks = namedtuple('ProviderExternalLinks', ['learn_more', 'configuration', 'general', 'accessibility', 'contact_email'])
+ProviderExternalLinks = namedtuple(
+    'ProviderExternalLinks',
+    ['learn_more', 'configuration', 'general', 'accessibility', 'contact_email']
+)
 
 
 class Features(Enum):


### PR DESCRIPTION
## Description
The [PR](https://github.com/edx/edx-platform/pull/27860) merged today caused the `pylint` violations on the master which is causing the quality builds to fail. Here is an example [failed build](https://build.testeng.edx.org/job/edx-platform-quality-pipeline-pr/29462/testReport/junit/pavelib/quality/Run_Tests___cms_openedx_pavelib_pylint___pylint_cms_openedx_pavelib/) showing the violation occuring on the master builds.

## Possible reason for the error
The [PR](https://github.com/edx/edx-platform/pull/27860) has the old quality check output on it which shows like the quality build was ran on the PR before the `diff-quality` changes had been merged in the master and hence that caused the error on master branch later on but it'll need to be investigated further.

## Fix
This PR fixes these `pylint` violations to allow the quality builds to pass.