### PR TITLE
Move pages and resource mfe link to content menu

### DIFF
--- a/cms/djangoapps/contentstore/views/certificates.py
+++ b/cms/djangoapps/contentstore/views/certificates.py
@@ -47,7 +47,12 @@ from xmodule.modulestore import EdxJSONEncoder
 from xmodule.modulestore.django import modulestore
 
 from ..exceptions import AssetNotFoundException
-from ..utils import get_lms_link_for_certificate_web_view, get_proctored_exam_settings_url, reverse_course_url
+from ..utils import (
+    get_lms_link_for_certificate_web_view,
+    get_pages_and_resources_url,
+    get_proctored_exam_settings_url,
+    reverse_course_url
+)
 from .assets import delete_asset
 
 CERTIFICATE_SCHEMA_VERSION = 1
@@ -425,6 +430,7 @@ def certificates_list_handler(request, course_key_string):
                 'is_global_staff': GlobalStaff().has_user(request.user),
                 'certificate_activation_handler_url': activation_handler_url,
                 'mfe_proctored_exam_settings_url': get_proctored_exam_settings_url(course.id),
+                'pages_and_resources_mfe_link': get_pages_and_resources_url(course.id),
             })
         elif "application/json" in request.META.get('HTTP_ACCEPT'):
             # Retrieve the list of certificates for the specified course

--- a/cms/djangoapps/contentstore/views/checklists.py
+++ b/cms/djangoapps/contentstore/views/checklists.py
@@ -6,7 +6,7 @@ from opaque_keys.edx.keys import CourseKey
 
 from common.djangoapps.edxmako.shortcuts import render_to_response
 from common.djangoapps.student.auth import has_course_author_access
-from cms.djangoapps.contentstore.utils import get_proctored_exam_settings_url
+from cms.djangoapps.contentstore.utils import get_pages_and_resources_url, get_proctored_exam_settings_url
 from xmodule.modulestore.django import modulestore
 
 __all__ = ['checklists_handler']
@@ -32,4 +32,5 @@ def checklists_handler(request, course_key_string=None):
         'language_code': request.LANGUAGE_CODE,
         'context_course': course_module,
         'mfe_proctored_exam_settings_url': get_proctored_exam_settings_url(course_module.id),
+        'pages_and_resources_mfe_link': get_pages_and_resources_url(course_module.id),
     })

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -96,6 +96,7 @@ from ..toggles import split_library_view_on_dashboard
 from ..utils import (
     add_instructor,
     get_lms_link_for_item,
+    get_pages_and_resources_url,
     get_proctored_exam_settings_url,
     initialize_permissions,
     remove_all_instructors,
@@ -727,6 +728,7 @@ def course_index(request, course_key):
             'mfe_proctored_exam_settings_url': get_proctored_exam_settings_url(course_module.id),
             'advance_settings_url': reverse_course_url('advanced_settings_handler', course_module.id),
             'proctoring_errors': proctoring_errors,
+            'pages_and_resources_mfe_link': get_pages_and_resources_url(course_module.id),
         })
 
 
@@ -1163,6 +1165,7 @@ def settings_handler(request, course_key_string):  # lint-amnesty, pylint: disab
                 'enable_extended_course_details': enable_extended_course_details,
                 'upgrade_deadline': upgrade_deadline,
                 'mfe_proctored_exam_settings_url': get_proctored_exam_settings_url(course_module.id),
+                'pages_and_resources_mfe_link': get_pages_and_resources_url(course_module.id),
             }
             if is_prerequisite_courses_enabled():
                 courses, in_process_course_actions = get_courses_accessible_to_user(request)
@@ -1283,6 +1286,7 @@ def grading_handler(request, course_key_string, grader_index=None):
                 'grading_url': reverse_course_url('grading_handler', course_key),
                 'is_credit_course': is_credit_course(course_key),
                 'mfe_proctored_exam_settings_url': get_proctored_exam_settings_url(course_module.id),
+                'pages_and_resources_mfe_link': get_pages_and_resources_url(course_module.id),
             })
         elif 'application/json' in request.META.get('HTTP_ACCEPT', ''):
             if request.method == 'GET':
@@ -1388,6 +1392,7 @@ def advanced_settings_handler(request, course_key_string):
                 'advanced_settings_url': reverse_course_url('advanced_settings_handler', course_key),
                 'publisher_enabled': publisher_enabled,
                 'mfe_proctored_exam_settings_url': get_proctored_exam_settings_url(course_module.id),
+                'pages_and_resources_mfe_link': get_pages_and_resources_url(course_module.id),
                 'proctoring_errors': proctoring_errors,
             })
         elif 'application/json' in request.META.get('HTTP_ACCEPT', ''):
@@ -1740,6 +1745,7 @@ def group_configurations_list_handler(request, course_key_string):
                 'all_group_configurations': displayable_partitions,
                 'should_show_enrollment_track': should_show_enrollment_track,
                 'mfe_proctored_exam_settings_url': get_proctored_exam_settings_url(course.id),
+                'pages_and_resources_mfe_link': get_pages_and_resources_url(course.id),
             })
         elif "application/json" in request.META.get('HTTP_ACCEPT'):
             if request.method == 'POST':

--- a/cms/djangoapps/contentstore/views/tabs.py
+++ b/cms/djangoapps/contentstore/views/tabs.py
@@ -15,7 +15,7 @@ from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 from xmodule.tabs import CourseTab, CourseTabList, InvalidTabsException, StaticTab
 
-from ..utils import get_lms_link_for_item, get_pages_and_resources_url
+from ..utils import get_lms_link_for_item
 __all__ = ['tabs_handler']
 
 
@@ -71,7 +71,6 @@ def tabs_handler(request, course_key_string):
             'context_course': course_item,
             'tabs_to_render': tabs_to_render,
             'lms_link': get_lms_link_for_item(course_item.location),
-            'pages_and_resources_mfe_link': get_pages_and_resources_url(course_item.id),
         })
     else:
         return HttpResponseNotFound()

--- a/cms/djangoapps/contentstore/views/tests/test_tabs.py
+++ b/cms/djangoapps/contentstore/views/tests/test_tabs.py
@@ -2,10 +2,7 @@
 
 
 import json
-import ddt
-from edx_toggles.toggles.testutils import override_waffle_flag
 
-from cms.djangoapps.contentstore.config.waffle import ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
 from cms.djangoapps.contentstore.utils import reverse_course_url
 from cms.djangoapps.contentstore.views import tabs
@@ -16,7 +13,6 @@ from xmodule.tabs import CourseTabList
 from xmodule.x_module import STUDENT_VIEW
 
 
-@ddt.ddt
 class TabsPageTests(CourseTestCase):
     """Test cases for Tabs (a.k.a Pages) page"""
 
@@ -74,18 +70,6 @@ class TabsPageTests(CourseTestCase):
 
         resp = self.client.get_html(self.url)
         self.assertContains(resp, 'course-nav-list')
-
-    @ddt.data(
-        # toggle active, assert count
-        (True, 1),
-        (False, 0),
-    )
-    @ddt.unpack
-    def test_pages_and_resources_toggle(self, toggle_active, assert_count):
-        """Basic check that the Pages page responds correctly"""
-        with override_waffle_flag(ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND, active=toggle_active):
-            resp = self.client.get_html(self.url)
-            self.assertContains(resp, 'View new Pages and Resources Experience', count=assert_count)
 
     def test_reorder_tabs(self):
         """Test re-ordering of tabs"""

--- a/cms/templates/edit-tabs.html
+++ b/cms/templates/edit-tabs.html
@@ -43,11 +43,6 @@
         <li class="nav-item">
           <a href="${lms_link}" rel="external" class="button view-button view-live-button">${_("View Live")}</a>
         </li>
-        % if pages_and_resources_mfe_link:
-        <li class="nav-item">
-          <a href="${pages_and_resources_mfe_link}" rel="external" class="button"><span class="icon fa fa-link" aria-hidden="true"></span>${_("View new Pages and Resources Experience")}</a>
-        </li>
-        % endif
       </ul>
     </nav>
   </header>

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -81,6 +81,11 @@
                     <a href="${videos_url}">${_("Video Uploads")}</a>
                   </li>
                   % endif
+                  % if pages_and_resources_mfe_link:
+                  <li class="nav-item nav-course-courseware-pages-resources">
+                    <a href="${pages_and_resources_mfe_link}" rel="external">${_("Pages & Resources")}</a>
+                  </li>
+                  % endif
                 </ul>
               </div>
             </div>


### PR DESCRIPTION
[TNL-8388](https://openedx.atlassian.net/browse/TNL-8388)

Moved the pages and resource MFE link to content menu. The link will not appear in the header content on all the URLs. I have followed the same pattern as mfe_proctored_exam_settings_url. mfe_proctored_exam_settings_url also occurs on some URLs and this link will appear on the same urls as well

<img width="1098" alt="Screenshot 2021-06-11 at 10 20 08 PM" src="https://user-images.githubusercontent.com/10988308/121730002-8d8df600-cb08-11eb-91b9-2bae8c472c2d.png">


