### PR TITLE
Fix: from_address not pull from site configuration

### DIFF
--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -227,8 +227,7 @@ def compose_and_send_activation_email(user, profile, user_registration=None, red
     """
     route_enabled = settings.FEATURES.get('REROUTE_ACTIVATION_EMAIL')
 
-    root_url = configuration_helpers.get_value('LMS_ROOT_URL', settings.LMS_ROOT_URL)
-    msg = compose_activation_email(root_url, user, user_registration, route_enabled, profile.name)
+    msg = compose_activation_email(user, user_registration, route_enabled, profile.name, redirect_url)
     from_address = configuration_helpers.get_value('ACTIVATION_EMAIL_FROM_ADDRESS') or (
         configuration_helpers.get_value('email_from_address', settings.DEFAULT_FROM_EMAIL)
     )

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -227,9 +227,13 @@ def compose_and_send_activation_email(user, profile, user_registration=None, red
     """
     route_enabled = settings.FEATURES.get('REROUTE_ACTIVATION_EMAIL')
 
-    msg = compose_activation_email(user, user_registration, route_enabled, profile.name, redirect_url)
+    root_url = configuration_helpers.get_value('LMS_ROOT_URL', settings.LMS_ROOT_URL)
+    msg = compose_activation_email(root_url, user, user_registration, route_enabled, profile.name)
+    from_address = configuration_helpers.get_value('ACTIVATION_EMAIL_FROM_ADDRESS') or (
+        configuration_helpers.get_value('email_from_address', settings.DEFAULT_FROM_EMAIL)
+    )
 
-    send_activation_email.delay(str(msg))
+    send_activation_email.delay(str(msg), from_address)
 
 
 @login_required


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This PR fixes the issue where the `from_address` not pull the `site_configuration` . `send_activation_email` function is a celery task and they run in worker instances and configuration_helpers  rely on `crum`  package to get a current site from request object and in celery tasks, we don’t have request so from email address is taken from `settings.DEFAULT_FROM_EMAIL`