### PR TITLE
feat: redirect to 'contact' page if zendesk url is not defined

### DIFF
--- a/lms/djangoapps/support/tests/test_views.py
+++ b/lms/djangoapps/support/tests/test_views.py
@@ -15,6 +15,7 @@ from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imp
 from django.db.models import signals
 from django.http import HttpResponse
 from django.urls import reverse
+from django.test.utils import override_settings
 from organizations.tests.factories import OrganizationFactory
 from pytz import UTC
 from social_django.models import UserSocialAuth
@@ -65,11 +66,14 @@ class SupportViewManageUserTests(SupportViewTestCase):
     Base class for support view tests.
     """
 
+    ZENDESK_URL = 'http://zendesk.example.com/'
+
     def setUp(self):
         """Make the user support staff"""
         super().setUp()
         SupportStaffRole().add_users(self.user)
 
+    @override_settings(ZENDESK_URL=ZENDESK_URL)
     def test_get_contact_us(self):
         """
         Tests Support View contact us Page
@@ -77,6 +81,14 @@ class SupportViewManageUserTests(SupportViewTestCase):
         url = reverse('support:contact_us')
         response = self.client.get(url)
         assert response.status_code == 200
+
+    def test_get_contact_us_redirect_if_undefined_zendesk_url(self):
+        """
+        Tests the Support contact us Page redirects if ZENDESK_URL setting is not defined
+        """
+        url = reverse('support:contact_us')
+        response = self.client.get(url)
+        assert response.status_code == 302
 
     def test_get_password_assistance(self):
         """

--- a/lms/djangoapps/support/views/contact_us.py
+++ b/lms/djangoapps/support/views/contact_us.py
@@ -5,6 +5,7 @@ Signle support contact view
 
 from django.conf import settings
 from django.http import Http404
+from django.shortcuts import redirect
 from django.views.generic import View
 
 from common.djangoapps.edxmako.shortcuts import render_to_response
@@ -19,6 +20,11 @@ class ContactUsView(View):
     """
 
     def get(self, request):  # lint-amnesty, pylint: disable=missing-function-docstring
+        # If ZENDESK_URL is not defined, then it will redirect to the static contact page
+        # to avoid 500 error that arises due to missing Zendesk configuration
+        if not settings.ZENDESK_URL:
+            return redirect('contact')
+
         if not configuration_helpers.get_value('CONTACT_US_PAGE', True):
             raise Http404
 


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

- Added a redirection in contact_us view(lms) so if ZENDESK_URL setting `settings.ZENDESK_URL` is not defined then it will redirect to "/contact" page 

## Supporting information
Github issue: https://github.com/openedx/build-test-release-wg/issues/79

## Testing instructions

I've tested it by changing the ZENDESK_URL in devstack env variables for lms
