### PR TITLE
fix: Autoscroll on page when using jump_to_id

### DIFF
--- a/lms/templates/courseware/courseware-chromeless.html
+++ b/lms/templates/courseware/courseware-chromeless.html
@@ -153,7 +153,21 @@ ${HTML(fragment.foot_html())}
             })
           return;
         }
-
+        // Monitor for messages and checks if the message contains an id. If
+        // there is an id, then the location of the selected focus element
+        // is sent through its offset attribute. The offset will allow the
+        // page to scroll to the location of the focus element so that it is
+        // at the top of the page. Unique ids and names are required for
+        // proper scrolling.
+        window.addEventListener('message', function (event) {
+          if (event.data.id) {
+            var targetId = event.data.id;
+            var targetName = event.data.id.slice(1);
+            // Checks if the target uses an id or name to focus and gets offset.
+            var targetOffset = $(targetId).offset() || $(document.getElementsByName(targetName)[0]).offset();
+            window.parent.postMessage({"offset": targetOffset.top}, document.referrer);
+          }
+        })
 
         window.parent.postMessage({
             type: 'plugin.resize',

--- a/lms/templates/courseware/courseware-chromeless.html
+++ b/lms/templates/courseware/courseware-chromeless.html
@@ -160,12 +160,12 @@ ${HTML(fragment.foot_html())}
         // at the top of the page. Unique ids and names are required for
         // proper scrolling.
         window.addEventListener('message', function (event) {
-          if (event.data.id) {
-            var targetId = event.data.id;
-            var targetName = event.data.id.slice(1);
+          if (event.data.hashName) {
+            var targetId = event.data.hashName;
+            var targetName = event.data.hashName.slice(1);
             // Checks if the target uses an id or name to focus and gets offset.
             var targetOffset = $(targetId).offset() || $(document.getElementsByName(targetName)[0]).offset();
-            window.parent.postMessage({"offset": targetOffset.top}, document.referrer);
+            window.parent.postMessage({ 'offset': targetOffset.top }, document.referrer);
           }
         })
 


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This PR changes the default function of HTML anchor tags that focus on another element on a different page in the course. Previously the anchor tags that were set to scroll on a different page would open up the page but remain at the top of the page. As a result, users would have to manually scroll to the correct part of the page if that information is known or they will read the entire page. Now when the anchor tag is used to focus on a different page, the link of the new page is checked for a hash and sends the location of the hash to the parent page to scroll to the correct location.  This change will impact the Learner in the New Experience view.


## Supporting information

Jira issue: [TNL-8312](https://openedx.atlassian.net/browse/TNL-8312)

## Testing instructions

- In Studio view, add a new unit (Unit 2) and a large amount of text. 
- Someplace lower in the block, add a header (or similar element like a paragraph, span, div, etc.) tag like below:
`<h1 id="test">Heading 1</h1>`
- In the right panel, Unit Location, copy the Location ID. 
- Publish the changes.
- In Unit 1, add a raw HTML block and add an anchor tag like below:
`<a href="/jump_to_id/{location_id}#test" target="_blank">test scroll</a>`
- Replace `location_id` with the Location ID copied from Unit 2.
- Publish the changes and click "View Live Version".
- In the New Experience view, locate the anchor tag and click on it.
- A new page will open and scroll to the text "Heading 1" on the page.

**NOTE:** To see full changes, the user must be using [this branch](https://github.com/edx/frontend-app-learning/pull/487) in the frontend-app-learning repo.

## Deadline

None

## Other information

This change depends on [PR 487](https://github.com/edx/frontend-app-learning/pull/487) in Frontend-App-Learning
