### PR TITLE
fix: Use learning_sequences to remove bad sequences from outline.

### DIFF
--- a/lms/djangoapps/course_home_api/outline/v1/views.py
+++ b/lms/djangoapps/course_home_api/outline/v1/views.py
@@ -1,6 +1,7 @@
 """
 Outline Tab Views
 """
+from datetime import datetime, timezone
 
 from completion.exceptions import UnavailableCompletionData
 from completion.utilities import get_key_to_last_completed_block
@@ -37,6 +38,10 @@ from lms.djangoapps.courseware.courses import get_course_date_blocks, get_course
 from lms.djangoapps.courseware.date_summary import TodaysDate
 from lms.djangoapps.courseware.masquerade import is_masquerading, setup_masquerade
 from lms.djangoapps.courseware.views.views import get_cert_data
+from openedx.core.djangoapps.content.learning_sequences.api import (
+    get_user_course_outline,
+    public_api_available as learning_sequences_api_available,
+)
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from openedx.features.course_duration_limits.access import get_access_expiration_data
@@ -276,6 +281,35 @@ class OutlineTabView(RetrieveAPIView):
                                                'edX Support if you have questions.')
             elif course.invitation_only:
                 enroll_alert['can_enroll'] = False
+
+        # Sometimes there are sequences returned by Course Blocks that we
+        # don't actually want to show to the user, such as when a sequence is
+        # composed entirely of units that the user can't access. The Learning
+        # Sequences API knows how to roll this up, so we use it determine which
+        # sequences we should remove from course_blocks.
+        #
+        # The long term goal is to remove the Course Blocks API call entirely,
+        # so this is a tiny first step in that migration.
+        if course_blocks and learning_sequences_api_available(course_key, request.user):
+            user_course_outline = get_user_course_outline(
+                course_key, request.user, datetime.now(tz=timezone.utc)
+            )
+            available_seq_ids = {str(usage_key) for usage_key in user_course_outline.sequences}
+
+            # course_blocks is a reference to the root of the course, so we go
+            # through the chapters (sections) to look for sequences to remove.
+            for chapter_data in course_blocks['children']:
+                chapter_data['children'] = [
+                    seq_data
+                    for seq_data in chapter_data['children']
+                    if (
+                        seq_data['id'] in available_seq_ids or
+                        # Edge case: Sometimes we have weird course structures.
+                        # We expect only sequentials here, but if there is
+                        # another type, just skip it (don't filter it out).
+                        seq_data['type'] != 'sequential'
+                    )
+                ]
 
         data = {
             'access_expiration': access_expiration,

--- a/openedx/core/djangoapps/content/learning_sequences/api/__init__.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/__init__.py
@@ -6,5 +6,6 @@ from .outlines import (
     get_user_course_outline,
     get_user_course_outline_details,
     key_supports_outlines,
+    public_api_available,
     replace_course_outline,
 )

--- a/openedx/core/djangoapps/content/learning_sequences/api/outlines.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/outlines.py
@@ -39,7 +39,7 @@ from ..models import (
     PublishReport,
     UserPartitionGroup
 )
-from .permissions import can_see_all_content
+from .permissions import can_call_public_api, can_see_all_content
 from .processors.content_gating import ContentGatingOutlineProcessor
 from .processors.enrollment import EnrollmentOutlineProcessor
 from .processors.enrollment_track_partition_groups import EnrollmentTrackPartitionGroupsOutlineProcessor
@@ -58,6 +58,7 @@ __all__ = [
     'get_user_course_outline',
     'get_user_course_outline_details',
     'key_supports_outlines',
+    'public_api_available',
     'replace_course_outline',
 ]
 
@@ -82,6 +83,21 @@ def key_supports_outlines(opaque_key: OpaqueKey) -> bool:
         return not opaque_key.deprecated
 
     return False
+
+
+def public_api_available(course_key: CourseKey, user: types.User) -> bool:
+    """
+    Is the Public API available for this Course to this User?
+
+    This only really exists while we do the waffle-flag rollout of this feature,
+    so that in-process callers from other apps can determine whether they should
+    trust Learning Sequences API data for a particular user/course.
+    """
+    return (
+        key_supports_outlines(course_key) and
+        LearningContext.objects.filter(context_key=course_key).exists() and
+        can_call_public_api(user, course_key)
+    )
 
 
 @function_trace('learning_sequences.api.get_course_keys_with_outlines')

--- a/openedx/core/djangoapps/content/learning_sequences/api/permissions.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/permissions.py
@@ -1,8 +1,37 @@
 """
-This is a dummy placeholder for now, as access to this endpoint is currently
-limited to global staff.
+Simple permissions for Learning Sequences.
+
+Most access rules determining what a user will see are determined within the
+outline processors themselves. This is where we'd put permissions that are used
+to determine whether those processors even need to be run to filter the results.
 """
+from common.djangoapps.student.roles import (
+    GlobalStaff,
+    CourseInstructorRole,
+    CourseStaffRole,
+)
+
+from ..toggles import USE_FOR_OUTLINES
 
 
-def can_see_all_content(requesting_user, _course_key):
-    return requesting_user.is_staff
+def can_call_public_api(requesting_user, course_key):
+    """
+    Global staff can always call the public API. Otherwise, check waffle flag.
+
+    This is only intended for rollout purposes, and eventually everyone will be
+    able to call the public API for all courses.
+    """
+    return GlobalStaff().has_user(requesting_user) or USE_FOR_OUTLINES.is_enabled(course_key)
+
+
+def can_see_all_content(requesting_user, course_key):
+    """
+    Global staff, course staff, and instructors can see everything.
+
+    There's no need to run processors to restrict results for these users.
+    """
+    return (
+        GlobalStaff().has_user(requesting_user) or
+        CourseStaffRole(course_key).has_user(requesting_user) or
+        CourseInstructorRole(course_key).has_user(requesting_user)
+    )

--- a/openedx/core/djangoapps/content/learning_sequences/toggles.py
+++ b/openedx/core/djangoapps/content/learning_sequences/toggles.py
@@ -1,0 +1,24 @@
+"""
+Rollout waffle flags for the learning_sequences API.
+"""
+from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
+
+
+WAFFLE_NAMESPACE = 'learning_sequences'
+
+# .. toggle_name: learning_sequences.use_for_outlines
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_description: Waffle flag to enable the use of the Learning Sequences
+#   Course Outline API (/api/learning_sequences/v1/course_outline/{course_key}).
+#   Staff can always use this endpoint. If you are a student and this endpoint
+#   is not enabled, it will return a 403 error. The Courseware MFE should know
+#   how to detect this condition.
+#   This flag is also used to determine what is returned by the
+#   public_api_available learning_sequences API function, though other apps
+#   calling this API are always able to ignore this result and call any
+#   learning_sequences API directly (e.g. get_course_outline).
+# .. toggle_default: False
+# .. toggle_use_cases: temporary, open_edx
+# .. toggle_creation_date: 2021-06-07
+# .. toggle_target_removal_date: 2020-08-01
+USE_FOR_OUTLINES = CourseWaffleFlag(WAFFLE_NAMESPACE, 'use_for_outlines', __name__)


### PR DESCRIPTION
```
A common usage pattern is to make an exam that is restricted to a
particular enrollment track. Since there is no UI in Studio to do this
at the sequence/subsection level, course authors instead restrict every
unit in the sequence to that track (e.g. "verified"). The legacy
courseware experience could handle this, but the Course Blocks API does
not. It is likely that we'll want to permit toggling this at the
sequence level, but regardless of whether we do that going forward, we
still have to deal with this kind of content data in existing courses.

An entirely empty sequence is useless, and currently breaks the
Courseware MFE browsing experience. This commit introduces the first
part of that fix, invoking the new Learning Sequences API to remove
sequences that the user shouldn't be allowed to know about. The plan is
to switch over the entire course outline from the Course Blocks API to
the Learning Sequences API, and this is the first small step in that
direction.

This also creates CourseWaffleFlag learning_sequences.use_for_outlines
to control the gradual rollout of this feature. This will start as a
very limited rollout to address courses that show this specific bug
(TNL-8377).
```

A followup PR for frontend-app-learning is also necessary before we can toggle the `learning_sequences.use_for_outlines` flag.