### PR TITLE
Fix: Make Upgrade job failure

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -15,6 +15,9 @@
 # edx-platform currently only supported for Django 2.2.x
 django<2.3
 
+# Newer versions need celery >= 5.0
+django-celery-results<2.1
+
 # We do not support version django-config-models<1.0.0
 django-config-models>=1.0.0
 

--- a/requirements/edx-sandbox/py35.txt
+++ b/requirements/edx-sandbox/py35.txt
@@ -103,7 +103,7 @@ sympy==1.6.2
     #   -c requirements/edx-sandbox/py35-constraints.txt
     #   -r requirements/edx-sandbox/py35.in
     #   symmath
-tqdm==4.61.0
+tqdm==4.61.1
     # via nltk
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/edx-sandbox/py38.txt
+++ b/requirements/edx-sandbox/py38.txt
@@ -88,7 +88,7 @@ sympy==1.6.2
     #   -c requirements/edx-sandbox/../constraints.txt
     #   -r requirements/edx-sandbox/py38.in
     #   symmath
-tqdm==4.61.0
+tqdm==4.61.1
     # via nltk
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -161,7 +161,9 @@ django-appconf==1.0.4
 django-cache-memoize==0.1.9
     # via edx-enterprise
 django-celery-results==2.0.1
-    # via -r requirements/edx/base.in
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   -r requirements/edx/base.in
 django-classy-tags==2.0.0
     # via django-sekizai
 django-config-models==2.1.1
@@ -388,7 +390,7 @@ edx-analytics-data-api-client==0.17.0
     # via -r requirements/edx/base.in
 edx-api-doc-tools==1.4.0
     # via -r requirements/edx/base.in
-edx-bulk-grades==0.8.10
+edx-bulk-grades==0.8.11
     # via
     #   -r requirements/edx/base.in
     #   staff-graded-xblock
@@ -673,7 +675,7 @@ oauthlib==3.0.1
     #   social-auth-core
 openedx-calc==2.0.1
     # via -r requirements/edx/base.in
-ora2==3.6.2
+ora2==3.6.3
     # via -r requirements/edx/base.in
 packaging==20.9
     # via
@@ -974,7 +976,7 @@ text-unidecode==1.3
     # via python-slugify
 tincan==1.0.0
     # via edx-event-routing-backends
-tqdm==4.61.0
+tqdm==4.61.1
     # via nltk
 ua-parser==0.10.0
     # via django-cookies-samesite

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -49,10 +49,6 @@ aniso8601==9.0.1
     #   -r requirements/edx/testing.txt
     #   edx-tincan-py35
     #   tincan
-apipkg==1.5
-    # via
-    #   -r requirements/edx/testing.txt
-    #   execnet
 appdirs==1.4.4
     # via
     #   -r requirements/edx/testing.txt
@@ -229,7 +225,9 @@ django-cache-memoize==0.1.9
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
 django-celery-results==2.0.1
-    # via -r requirements/edx/testing.txt
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   -r requirements/edx/testing.txt
 django-classy-tags==2.0.0
     # via
     #   -r requirements/edx/testing.txt
@@ -478,7 +476,7 @@ edx-analytics-data-api-client==0.17.0
     # via -r requirements/edx/testing.txt
 edx-api-doc-tools==1.4.0
     # via -r requirements/edx/testing.txt
-edx-bulk-grades==0.8.10
+edx-bulk-grades==0.8.11
     # via
     #   -r requirements/edx/testing.txt
     #   staff-graded-xblock
@@ -607,13 +605,13 @@ event-tracking==1.0.4
     #   edx-event-routing-backends
     #   edx-proctoring
     #   edx-search
-execnet==1.8.1
+execnet==1.9.0
     # via
     #   -r requirements/edx/testing.txt
     #   pytest-xdist
 factory-boy==3.2.0
     # via -r requirements/edx/testing.txt
-faker==8.6.0
+faker==8.8.0
     # via
     #   -r requirements/edx/testing.txt
     #   factory-boy
@@ -883,7 +881,7 @@ oauthlib==3.0.1
     #   social-auth-core
 openedx-calc==2.0.1
     # via -r requirements/edx/testing.txt
-ora2==3.6.2
+ora2==3.6.3
     # via -r requirements/edx/testing.txt
 packaging==20.9
     # via
@@ -1370,7 +1368,7 @@ tox==3.23.1
     # via
     #   -r requirements/edx/testing.txt
     #   tox-battery
-tqdm==4.61.0
+tqdm==4.61.1
     # via
     #   -r requirements/edx/testing.txt
     #   nltk

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -47,8 +47,6 @@ aniso8601==9.0.1
     #   -r requirements/edx/base.txt
     #   edx-tincan-py35
     #   tincan
-apipkg==1.5
-    # via execnet
 appdirs==1.4.4
     # via
     #   -r requirements/edx/base.txt
@@ -218,7 +216,9 @@ django-cache-memoize==0.1.9
     #   -r requirements/edx/base.txt
     #   edx-enterprise
 django-celery-results==2.0.1
-    # via -r requirements/edx/base.txt
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   -r requirements/edx/base.txt
 django-classy-tags==2.0.0
     # via
     #   -r requirements/edx/base.txt
@@ -461,7 +461,7 @@ edx-analytics-data-api-client==0.17.0
     # via -r requirements/edx/base.txt
 edx-api-doc-tools==1.4.0
     # via -r requirements/edx/base.txt
-edx-bulk-grades==0.8.10
+edx-bulk-grades==0.8.11
     # via
     #   -r requirements/edx/base.txt
     #   staff-graded-xblock
@@ -589,11 +589,11 @@ event-tracking==1.0.4
     #   edx-event-routing-backends
     #   edx-proctoring
     #   edx-search
-execnet==1.8.1
+execnet==1.9.0
     # via pytest-xdist
 factory-boy==3.2.0
     # via -r requirements/edx/testing.in
-faker==8.6.0
+faker==8.8.0
     # via factory-boy
 filelock==3.0.12
     # via
@@ -839,7 +839,7 @@ oauthlib==3.0.1
     #   social-auth-core
 openedx-calc==2.0.1
     # via -r requirements/edx/base.txt
-ora2==3.6.2
+ora2==3.6.3
     # via -r requirements/edx/base.txt
 packaging==20.9
     # via
@@ -1277,7 +1277,7 @@ tox==3.23.1
     # via
     #   -r requirements/edx/testing.in
     #   tox-battery
-tqdm==4.61.0
+tqdm==4.61.1
     # via
     #   -r requirements/edx/base.txt
     #   nltk


### PR DESCRIPTION
Make upgrade job failed in the morning due to a new release of `django-celery-results`, We have to pin it until we upgrade `celery` first.