### PR TITLE
feat: Add CourseWaffleFlag for overriding course discussion settings for legacy experience.

### DIFF
--- a/cms/djangoapps/contentstore/config/waffle.py
+++ b/cms/djangoapps/contentstore/config/waffle.py
@@ -67,19 +67,3 @@ REDIRECT_TO_LIBRARY_AUTHORING_MICROFRONTEND = LegacyWaffleFlag(
     flag_name='library_authoring_mfe',
     module_name=__name__,
 )
-
-
-# .. toggle_name: studio.pages_and_resources_mfe
-# .. toggle_implementation: CourseWaffleFlag
-# .. toggle_default: False
-# .. toggle_description: Waffle flag to link existing studio views to the new Pages and Resources experience.
-# .. toggle_use_cases: temporary, open_edx
-# .. toggle_creation_date: 2021-05-24
-# .. toggle_target_removal_date: 2021-12-31
-# .. toggle_warnings: Also set settings.COURSE_AUTHORING_MICROFRONTEND_URL.
-# .. toggle_tickets: None
-ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND = CourseWaffleFlag(
-    waffle_namespace=waffle_flags(),
-    flag_name='pages_and_resources_mfe',
-    module_name=__name__,
-)

--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -34,8 +34,10 @@ from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRol
 from common.djangoapps.student.tests.factories import UserFactory
 from common.djangoapps.util import milestones_helpers
 from common.djangoapps.xblock_django.models import XBlockStudioConfigurationFlag
-from openedx.core.djangoapps.discussions.config.waffle import ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND, \
+from openedx.core.djangoapps.discussions.config.waffle import (
+    ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND,
     OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG
+)
 from openedx.core.djangoapps.models.course_details import CourseDetails
 from xmodule.fields import Date
 from xmodule.modulestore import ModuleStoreEnum
@@ -125,7 +127,8 @@ class CourseAdvanceSettingViewTest(CourseTestCase, MilestonesTestCaseMixin):
     @ddt.data(
         (False, False, True),
         (True, False, False),
-        (True, True, True)
+        (True, True, True),
+        (False, True, True)
     )
     @ddt.unpack
     def test_discussion_fields_available(self, is_pages_and_resources_enabled,

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -14,11 +14,11 @@ from opaque_keys.edx.keys import CourseKey, UsageKey
 from opaque_keys.edx.locator import LibraryLocator
 from pytz import UTC
 
-from cms.djangoapps.contentstore.config.waffle import ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND
 from cms.djangoapps.contentstore.toggles import exam_setting_view_enabled
 from common.djangoapps.student import auth
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole
+from openedx.core.djangoapps.discussions.config.waffle import ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND
 from openedx.core.djangoapps.django_comment_common.models import assign_default_role
 from openedx.core.djangoapps.django_comment_common.utils import seed_permissions_roles
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers

--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -13,9 +13,9 @@ from django.utils.translation import ugettext as _
 from xblock.fields import Scope
 
 from cms.djangoapps.contentstore import toggles
-from cms.djangoapps.contentstore.config.waffle import ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND
 from common.djangoapps.xblock_django.models import XBlockStudioConfigurationFlag
-from openedx.core.djangoapps.discussions.config.waffle import OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG
+from openedx.core.djangoapps.discussions.config.waffle import OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG, \
+    ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND
 from openedx.core.lib.teams_config import TeamsetType
 from openedx.features.course_experience import COURSE_ENABLE_UNENROLLED_ACCESS_FLAG
 from xmodule.modulestore.django import modulestore

--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -13,7 +13,9 @@ from django.utils.translation import ugettext as _
 from xblock.fields import Scope
 
 from cms.djangoapps.contentstore import toggles
+from cms.djangoapps.contentstore.config.waffle import ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND
 from common.djangoapps.xblock_django.models import XBlockStudioConfigurationFlag
+from openedx.core.djangoapps.discussions.config.waffle import OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG
 from openedx.core.lib.teams_config import TeamsetType
 from openedx.features.course_experience import COURSE_ENABLE_UNENROLLED_ACCESS_FLAG
 from xmodule.modulestore.django import modulestore
@@ -140,6 +142,13 @@ class CourseMetadata:
         # an available proctoring backend.
         if not settings.PROCTORING_BACKENDS or settings.PROCTORING_BACKENDS.get('proctortrack') is None:
             exclude_list.append('proctoring_escalation_email')
+
+        if (ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND.is_enabled(course_key) and
+                not OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG.is_enabled(course_key)):
+            exclude_list.append('discussion_blackouts')
+            exclude_list.append('allow_anonymous')
+            exclude_list.append('allow_anonymous_to_peers')
+            exclude_list.append('discussion_topics')
 
         return exclude_list
 

--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -14,8 +14,7 @@ from xblock.fields import Scope
 
 from cms.djangoapps.contentstore import toggles
 from common.djangoapps.xblock_django.models import XBlockStudioConfigurationFlag
-from openedx.core.djangoapps.discussions.config.waffle import OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG, \
-    ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND
+from openedx.core.djangoapps.discussions.config.waffle_utils import legacy_discussion_experience_enabled
 from openedx.core.lib.teams_config import TeamsetType
 from openedx.features.course_experience import COURSE_ENABLE_UNENROLLED_ACCESS_FLAG
 from xmodule.modulestore.django import modulestore
@@ -143,8 +142,7 @@ class CourseMetadata:
         if not settings.PROCTORING_BACKENDS or settings.PROCTORING_BACKENDS.get('proctortrack') is None:
             exclude_list.append('proctoring_escalation_email')
 
-        if (ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND.is_enabled(course_key) and
-                not OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG.is_enabled(course_key)):
+        if not legacy_discussion_experience_enabled(course_key):
             exclude_list.append('discussion_blackouts')
             exclude_list.append('allow_anonymous')
             exclude_list.append('allow_anonymous_to_peers')

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -30,8 +30,10 @@ from lms.djangoapps.grades.config.waffle import WRITABLE_GRADEBOOK, waffle_flags
 from lms.djangoapps.instructor.toggles import DATA_DOWNLOAD_V2
 from lms.djangoapps.instructor.views.gradebook_api import calculate_page_info
 from openedx.core.djangoapps.course_groups.cohorts import set_course_cohorted
-from openedx.core.djangoapps.discussions.config.waffle import ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND, \
+from openedx.core.djangoapps.discussions.config.waffle import (
+    ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND,
     OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG
+)
 from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, ModuleStoreTestCase

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -2,7 +2,6 @@
 Unit tests for instructor_dashboard.py.
 """
 
-
 import datetime
 import re
 from unittest.mock import patch
@@ -30,6 +29,9 @@ from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from lms.djangoapps.grades.config.waffle import WRITABLE_GRADEBOOK, waffle_flags
 from lms.djangoapps.instructor.toggles import DATA_DOWNLOAD_V2
 from lms.djangoapps.instructor.views.gradebook_api import calculate_page_info
+from openedx.core.djangoapps.course_groups.cohorts import set_course_cohorted
+from openedx.core.djangoapps.discussions.config.waffle import ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND, \
+    OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG
 from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, ModuleStoreTestCase
@@ -104,6 +106,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         """
         Verify that the instructor tab appears for staff only.
         """
+
         def has_instructor_tab(user, course):
             """Returns true if the "Instructor" tab is shown."""
             tabs = get_course_tab_list(user, course)
@@ -136,6 +139,33 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         assert has_instructor_tab(org_researcher, self.course)
 
     @ddt.data(
+        ('staff', False, False, True),
+        ('staff', True, False, False),
+        ('staff', True, True, True),
+    )
+    @ddt.unpack
+    def test_discussion_tab(self, access_role, is_pages_and_resources_enabled, is_legacy_discussion_setting_enabled,
+                            is_discussion_tab_available):
+        """
+        Verify that the Discussion tab only shows up when Pages & Resources flag is off for course
+        """
+        discussion_section = '<li class="nav-item"><button type="button" class="btn-link discussions_management" ' \
+                             'data-section="discussions_management">Discussions</button></li>'
+
+        with override_waffle_flag(ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND, is_pages_and_resources_enabled):
+            with override_waffle_flag(OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG, is_legacy_discussion_setting_enabled):
+                CourseAccessRoleFactory(
+                    course_id=self.course.id,
+                    user=self.user,
+                    role=access_role,
+                    org=self.course.id.org
+                )
+                set_course_cohorted(self.course.id, True)
+                self.client.login(username=self.user.username, password='test')
+                response = self.client.get(self.url).content.decode('utf-8')
+                self.assertEqual(discussion_section in response, is_discussion_tab_available)
+
+    @ddt.data(
         ('staff', False, False),
         ('instructor', False, False),
         ('data_researcher', True, False),
@@ -154,7 +184,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
             download_section = '<li class="nav-item"><button type="button" class="btn-link data_download" ' \
                                'data-section="data_download">Data Download</button></li>'
             if waffle_status:
-                download_section = '<li class="nav-item"><button type="button" class="btn-link data_download_2" '\
+                download_section = '<li class="nav-item"><button type="button" class="btn-link data_download_2" ' \
                                    'data-section="data_download_2">Data Download</button></li>'
             user = UserFactory.create(is_staff=access_role == 'global_staff')
             CourseAccessRoleFactory(
@@ -438,7 +468,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
     )
     @ddt.unpack
     def test_ccx_coaches_option_on_admin_list_management_instructor(
-            self, ccx_feature_flag, enable_ccx, expected_result
+        self, ccx_feature_flag, enable_ccx, expected_result
     ):
         """
         Test whether the "CCX Coaches" option is visible or hidden depending on the value of course.enable_ccx.

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -144,26 +144,55 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         ('staff', False, False, True),
         ('staff', True, False, False),
         ('staff', True, True, True),
+        ('staff', False, True, True),
+        ('instructor', False, False, True),
+        ('instructor', True, False, False),
+        ('instructor', True, True, True),
+        ('instructor', False, True, True)
     )
     @ddt.unpack
-    def test_discussion_tab(self, access_role, is_pages_and_resources_enabled, is_legacy_discussion_setting_enabled,
-                            is_discussion_tab_available):
+    def test_discussion_tab_for_course_staff_role(self, access_role, is_pages_and_resources_enabled,
+                                                  is_legacy_discussion_setting_enabled, is_discussion_tab_available):
         """
-        Verify that the Discussion tab only shows up when Pages & Resources flag is off for course
+        Verify that the Discussion tab is available for course for course staff role.
         """
-        discussion_section = '<li class="nav-item"><button type="button" class="btn-link discussions_management" ' \
-                             'data-section="discussions_management">Discussions</button></li>'
+        discussion_section = ('<li class="nav-item"><button type="button" class="btn-link discussions_management" '
+                              'data-section="discussions_management">Discussions</button></li>')
 
         with override_waffle_flag(ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND, is_pages_and_resources_enabled):
             with override_waffle_flag(OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG, is_legacy_discussion_setting_enabled):
+                user = UserFactory.create()
                 CourseAccessRoleFactory(
                     course_id=self.course.id,
-                    user=self.user,
+                    user=user,
                     role=access_role,
                     org=self.course.id.org
                 )
                 set_course_cohorted(self.course.id, True)
                 self.client.login(username=self.user.username, password='test')
+                response = self.client.get(self.url).content.decode('utf-8')
+                self.assertEqual(discussion_section in response, is_discussion_tab_available)
+
+    @ddt.data(
+        (False, False, True),
+        (True, False, False),
+        (True, True, True),
+        (False, True, True),
+    )
+    @ddt.unpack
+    def test_discussion_tab_for_global_user(self, is_pages_and_resources_enabled,
+                                            is_legacy_discussion_setting_enabled, is_discussion_tab_available):
+        """
+        Verify that the Discussion tab is available for course for global user.
+        """
+        discussion_section = ('<li class="nav-item"><button type="button" class="btn-link discussions_management" '
+                              'data-section="discussions_management">Discussions</button></li>')
+
+        with override_waffle_flag(ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND, is_pages_and_resources_enabled):
+            with override_waffle_flag(OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG, is_legacy_discussion_setting_enabled):
+                user = UserFactory.create(is_staff=True)
+                set_course_cohorted(self.course.id, True)
+                self.client.login(username=user.username, password='test')
                 response = self.client.get(self.url).content.decode('utf-8')
                 self.assertEqual(discussion_section in response, is_discussion_tab_available)
 

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -52,8 +52,7 @@ from lms.djangoapps.courseware.module_render import get_module_by_usage_id
 from lms.djangoapps.discussion.django_comment_client.utils import available_division_schemes, has_forum_access
 from lms.djangoapps.grades.api import is_writable_gradebook_enabled
 from openedx.core.djangoapps.course_groups.cohorts import DEFAULT_COHORT_NAME, get_course_cohorts, is_course_cohorted
-from openedx.core.djangoapps.discussions.config.waffle import ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND, \
-    OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG
+from openedx.core.djangoapps.discussions.config.waffle_utils import legacy_discussion_experience_enabled
 from openedx.core.djangoapps.django_comment_common.models import FORUM_ROLE_ADMINISTRATOR, CourseDiscussionSettings
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.verified_track_content.models import VerifiedTrackCohortedCourse
@@ -142,11 +141,7 @@ def instructor_dashboard_2(request, course_id):  # lint-amnesty, pylint: disable
             _section_student_admin(course, access),
         ]
 
-        discussion_section_visible = bool((ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND.is_enabled(course_key) and
-                                          OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG.is_enabled(course_key)) or not
-                                          ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND.is_enabled(course_key))
-
-        if discussion_section_visible:
+        if legacy_discussion_experience_enabled(course_key):
             sections_content.append(_section_discussions_management(course, access))
         sections.extend(sections_content)
 

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -27,6 +27,7 @@ from opaque_keys.edx.keys import CourseKey
 from xblock.field_data import DictFieldData
 from xblock.fields import ScopeIds
 
+from cms.djangoapps.contentstore.config.waffle import ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND
 from common.djangoapps.course_modes.models import CourseMode, CourseModesArchive
 from common.djangoapps.edxmako.shortcuts import render_to_response
 from common.djangoapps.student.models import CourseEnrollment
@@ -133,13 +134,16 @@ def instructor_dashboard_2(request, course_id):  # lint-amnesty, pylint: disable
 
     sections = []
     if access['staff']:
-        sections.extend([
+        sections_content = [
             _section_course_info(course, access),
             _section_membership(course, access),
             _section_cohort_management(course, access),
-            _section_discussions_management(course, access),
             _section_student_admin(course, access),
-        ])
+        ]
+        if not ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND.is_enabled(course_key):
+            sections_content.append(_section_discussions_management(course, access))
+        sections.extend(sections_content)
+
     if access['data_researcher']:
         sections.append(_section_data_download(course, access))
 

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -52,7 +52,8 @@ from lms.djangoapps.courseware.module_render import get_module_by_usage_id
 from lms.djangoapps.discussion.django_comment_client.utils import available_division_schemes, has_forum_access
 from lms.djangoapps.grades.api import is_writable_gradebook_enabled
 from openedx.core.djangoapps.course_groups.cohorts import DEFAULT_COHORT_NAME, get_course_cohorts, is_course_cohorted
-from openedx.core.djangoapps.discussions.config.waffle import ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND
+from openedx.core.djangoapps.discussions.config.waffle import ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND, \
+    OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG
 from openedx.core.djangoapps.django_comment_common.models import FORUM_ROLE_ADMINISTRATOR, CourseDiscussionSettings
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.verified_track_content.models import VerifiedTrackCohortedCourse
@@ -140,7 +141,12 @@ def instructor_dashboard_2(request, course_id):  # lint-amnesty, pylint: disable
             _section_cohort_management(course, access),
             _section_student_admin(course, access),
         ]
-        if not ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND.is_enabled(course_key):
+
+        discussion_section_visible = bool((ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND.is_enabled(course_key) and
+                                          OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG.is_enabled(course_key)) or not
+                                          ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND.is_enabled(course_key))
+
+        if discussion_section_visible:
             sections_content.append(_section_discussions_management(course, access))
         sections.extend(sections_content)
 

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -27,7 +27,6 @@ from opaque_keys.edx.keys import CourseKey
 from xblock.field_data import DictFieldData
 from xblock.fields import ScopeIds
 
-from cms.djangoapps.contentstore.config.waffle import ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND
 from common.djangoapps.course_modes.models import CourseMode, CourseModesArchive
 from common.djangoapps.edxmako.shortcuts import render_to_response
 from common.djangoapps.student.models import CourseEnrollment
@@ -53,6 +52,7 @@ from lms.djangoapps.courseware.module_render import get_module_by_usage_id
 from lms.djangoapps.discussion.django_comment_client.utils import available_division_schemes, has_forum_access
 from lms.djangoapps.grades.api import is_writable_gradebook_enabled
 from openedx.core.djangoapps.course_groups.cohorts import DEFAULT_COHORT_NAME, get_course_cohorts, is_course_cohorted
+from openedx.core.djangoapps.discussions.config.waffle import ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND
 from openedx.core.djangoapps.django_comment_common.models import FORUM_ROLE_ADMINISTRATOR, CourseDiscussionSettings
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.verified_track_content.models import VerifiedTrackCohortedCourse

--- a/openedx/core/djangoapps/discussions/config/waffle.py
+++ b/openedx/core/djangoapps/discussions/config/waffle.py
@@ -1,0 +1,26 @@
+"""
+This module contains various configuration settings via
+waffle switches for the discussions app.
+"""
+
+from edx_toggles.toggles import LegacyWaffleFlagNamespace
+
+from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
+
+
+WAFFLE_DISCUSSION_LEGACY_SETTINGS_NAMESPACE = LegacyWaffleFlagNamespace(name='discussions')
+
+# .. toggle_name: discussions.override_discussion_legacy_settings
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Waffle flag to override visibility of discussion settings for legacy experience.
+# .. toggle_use_cases: temporary, open_edx
+# .. toggle_creation_date: 2021-06-15
+# .. toggle_target_removal_date: 2021-12-31
+# .. toggle_warnings: Discussion settings will be visible when this flag is enabled with Pages & Resources flag enabled.
+# .. toggle_tickets: https://openedx.atlassian.net/browse/TNL-8389
+OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG = CourseWaffleFlag(
+    waffle_namespace=WAFFLE_DISCUSSION_LEGACY_SETTINGS_NAMESPACE,
+    flag_name='override_discussion_legacy_settings',
+    module_name=__name__,
+)

--- a/openedx/core/djangoapps/discussions/config/waffle.py
+++ b/openedx/core/djangoapps/discussions/config/waffle.py
@@ -8,7 +8,7 @@ from edx_toggles.toggles import LegacyWaffleFlagNamespace
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
 
-WAFFLE_DISCUSSION_LEGACY_SETTINGS_NAMESPACE = LegacyWaffleFlagNamespace(name='discussions')
+WAFFLE_NAMESPACE = LegacyWaffleFlagNamespace(name='discussions')
 
 # .. toggle_name: discussions.override_discussion_legacy_settings
 # .. toggle_implementation: CourseWaffleFlag
@@ -20,7 +20,23 @@ WAFFLE_DISCUSSION_LEGACY_SETTINGS_NAMESPACE = LegacyWaffleFlagNamespace(name='di
 # .. toggle_warnings: Discussion settings will be visible when this flag is enabled with Pages & Resources flag enabled.
 # .. toggle_tickets: https://openedx.atlassian.net/browse/TNL-8389
 OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG = CourseWaffleFlag(
-    waffle_namespace=WAFFLE_DISCUSSION_LEGACY_SETTINGS_NAMESPACE,
+    waffle_namespace=WAFFLE_NAMESPACE,
     flag_name='override_discussion_legacy_settings',
+    module_name=__name__,
+)
+
+
+# .. toggle_name: discussions.pages_and_resources_mfe
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Waffle flag to link existing studio views to the new Pages and Resources experience.
+# .. toggle_use_cases: temporary, open_edx
+# .. toggle_creation_date: 2021-05-24
+# .. toggle_target_removal_date: 2021-12-31
+# .. toggle_warnings: Also set settings.COURSE_AUTHORING_MICROFRONTEND_URL.
+# .. toggle_tickets: None
+ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND = CourseWaffleFlag(
+    waffle_namespace=WAFFLE_NAMESPACE,
+    flag_name='pages_and_resources_mfe',
     module_name=__name__,
 )

--- a/openedx/core/djangoapps/discussions/config/waffle.py
+++ b/openedx/core/djangoapps/discussions/config/waffle.py
@@ -29,12 +29,12 @@ OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG = CourseWaffleFlag(
 # .. toggle_name: discussions.pages_and_resources_mfe
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False
-# .. toggle_description: Waffle flag to link existing studio views to the new Pages and Resources experience.
+# .. toggle_description: Waffle flag to enable new Pages and Resources experience for course.
 # .. toggle_use_cases: temporary, open_edx
 # .. toggle_creation_date: 2021-05-24
 # .. toggle_target_removal_date: 2021-12-31
 # .. toggle_warnings: Also set settings.COURSE_AUTHORING_MICROFRONTEND_URL.
-# .. toggle_tickets: None
+# .. toggle_tickets: https://openedx.atlassian.net/browse/TNL-7791
 ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND = CourseWaffleFlag(
     waffle_namespace=WAFFLE_NAMESPACE,
     flag_name='pages_and_resources_mfe',

--- a/openedx/core/djangoapps/discussions/config/waffle.py
+++ b/openedx/core/djangoapps/discussions/config/waffle.py
@@ -17,8 +17,8 @@ WAFFLE_NAMESPACE = LegacyWaffleFlagNamespace(name='discussions')
 # .. toggle_use_cases: temporary, open_edx
 # .. toggle_creation_date: 2021-06-15
 # .. toggle_target_removal_date: 2021-12-31
-# .. toggle_warnings: Discussion settings will be visible when this flag is enabled with Pages & Resources flag enabled.
-# .. toggle_tickets: https://openedx.atlassian.net/browse/TNL-8389
+# .. toggle_warnings: When the flag is ON, the discussion settings will be available on legacy experience.
+# .. toggle_tickets: TNL-8389
 OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG = CourseWaffleFlag(
     waffle_namespace=WAFFLE_NAMESPACE,
     flag_name='override_discussion_legacy_settings',
@@ -33,8 +33,8 @@ OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG = CourseWaffleFlag(
 # .. toggle_use_cases: temporary, open_edx
 # .. toggle_creation_date: 2021-05-24
 # .. toggle_target_removal_date: 2021-12-31
-# .. toggle_warnings: Also set settings.COURSE_AUTHORING_MICROFRONTEND_URL.
-# .. toggle_tickets: https://openedx.atlassian.net/browse/TNL-7791
+# .. toggle_warnings: When the flag is ON, the new experience for Pages and Resources will be enabled.
+# .. toggle_tickets: TNL-7791
 ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND = CourseWaffleFlag(
     waffle_namespace=WAFFLE_NAMESPACE,
     flag_name='pages_and_resources_mfe',

--- a/openedx/core/djangoapps/discussions/config/waffle_utils.py
+++ b/openedx/core/djangoapps/discussions/config/waffle_utils.py
@@ -1,0 +1,16 @@
+"""
+Utils methods for Discussion app waffle flags.
+"""
+
+from openedx.core.djangoapps.discussions.config.waffle import (
+    ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND,
+    OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG
+)
+
+
+def legacy_discussion_experience_enabled(course_key):
+    """
+    Checks for relevant flags and returns a boolean whether to show legacy discussion settings or not
+    """
+    return bool(OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG.is_enabled(course_key) or
+                not ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND.is_enabled(course_key))


### PR DESCRIPTION
## Description
### [TNL-8389](https://openedx.atlassian.net/browse/TNL-8389)

This PR addressing the need for a new `CourseWaffleFlag` that will override the visibility of the discussion-related settings and tab. The targetted settings are present in the **Advanced Settings in Studio** and the **Discussions tab in Instructor Dashboard in LMS**.

_**NOTE: This flag is to be used with the [**ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND** flag](https://github.com/edx/edx-platform/blob/7abb417b0f6dc7bfb3c0cc21dc980a66ca7d0e0a/cms/djangoapps/contentstore/config/waffle.py#L81)**_

### CASES HOW THE FLAGS WILL WORK

- Check if **ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND** is enabled  => NO => Show legacy discussion settings

- Check if **ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND** is enabled  => YES => Check  **OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG** => YES =>  Show legacy discussion settings

- Check if ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND is enabled  => YES => Check  **OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG** => NO =>  Hide legacy discussion settings

#### Tab hidden on Instructor Dashboard in LMS
- **Discussions Tab**

#### Fields hidden on Course Advanced Settings in Studio
- **Allow Anonymous Discussion Posts**
- **Allow Anonymous Discussion Posts to Peers**
- **Discussion Blackout Dates**
- **Discussion Topic Mapping**
