### PR TITLE
feature: Update text for downloadable certs

### DIFF
--- a/common/djangoapps/student/tests/test_certificates.py
+++ b/common/djangoapps/student/tests/test_certificates.py
@@ -81,7 +81,7 @@ class CertificateDisplayTestBase(SharedModuleStoreTestCase):
         Inspect the dashboard to see if a certificate can be downloaded.
         """
         response = self.client.get(reverse('dashboard'))
-        self.assertContains(response, 'Download Your ID Verified')
+        self.assertContains(response, 'Download my')
         self.assertContains(response, self.DOWNLOAD_URL)
 
     def _check_can_download_certificate_no_id(self):
@@ -91,7 +91,6 @@ class CertificateDisplayTestBase(SharedModuleStoreTestCase):
         """
         response = self.client.get(reverse('dashboard'))
         self.assertContains(response, 'Download')
-        self.assertContains(response, '(PDF)')
         self.assertContains(response, self.DOWNLOAD_URL)
 
     def _check_can_not_download_certificate(self):
@@ -100,8 +99,8 @@ class CertificateDisplayTestBase(SharedModuleStoreTestCase):
         """
         response = self.client.get(reverse('dashboard'))
         self.assertNotContains(response, 'View Test_Certificate')
-        self.assertNotContains(response, 'Download Your Test_Certificate (PDF)')
-        self.assertNotContains(response, 'Download Test_Certificate (PDF)')
+        self.assertNotContains(response, 'Download my Test_Certificate')
+        self.assertNotContains(response, 'Download my Test_Certificate')
         self.assertNotContains(response, self.DOWNLOAD_URL)
 
 

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -1484,8 +1484,8 @@ class ProgressPageTests(ProgressPageBaseTests):
             self.store.update_item(self.course, self.user.id)
 
             resp = self._get_progress_page()
-            self.assertNotContains(resp, "View Your Certificate")
-            self.assertNotContains(resp, "You can now view your certificate")
+            self.assertNotContains(resp, "View my Certificate")
+            self.assertNotContains(resp, "You can now View my Certificate")
             self.assertContains(resp, "Your certificate is available")
             self.assertContains(resp, "earned a certificate for this course.")
 
@@ -1875,8 +1875,8 @@ class ProgressPageTests(ProgressPageBaseTests):
         self.assertNotContains(resp, 'Request Certificate')
         self.assertContains(resp, 'Your certificate has been invalidated')
         self.assertContains(resp, 'Please contact your course team if you have any questions.')
-        self.assertNotContains(resp, 'View Your Certificate')
-        self.assertNotContains(resp, 'Download Your Certificate')
+        self.assertNotContains(resp, 'View my Certificate')
+        self.assertNotContains(resp, 'Download my Certificate')
 
     def generate_certificate(self, url, mode):
         """ Dry method to generate certificate. """

--- a/lms/templates/dashboard/_dashboard_certificate_information.html
+++ b/lms/templates/dashboard/_dashboard_certificate_information.html
@@ -91,21 +91,21 @@ else:
               <li>
                 <a class="btn btn-primary" href="${cert_status['download_url']}"
                    title="${_('This link will open/download a PDF document')}">
-                  ${_("Download {cert_name_short} (PDF)").format(cert_name_short=cert_name_short,)}
+                  ${_("Download my {cert_name_short}").format(cert_name_short=cert_name_short,)}
                 </a>
               </li>
             % elif cert_status['status'] == 'downloadable' and enrollment.mode == 'verified' and cert_status['mode'] == 'honor':
               <li>
                 <a class="btn btn-primary" href="${cert_status['download_url']}"
                    title="${_('This link will open/download a PDF document')}">
-                  ${_("Download Your {cert_name_short} (PDF)").format(cert_name_short=cert_name_short)}
+                  ${_("Download my {cert_name_short}").format(cert_name_short=cert_name_short)}
                 </a>
               </li>
             % elif cert_status['status'] == 'downloadable' and enrollment.mode in CourseMode.VERIFIED_MODES:
               <li>
                 <a class="btn btn-primary" href="${cert_status['download_url']}"
                    title="${_('This link will open/download a PDF document of your verified {cert_name_long}.').format(cert_name_long=cert_name_long)}">
-                  ${_("Download Your ID Verified {cert_name_short} (PDF)").format(cert_name_short=cert_name_short)}
+                  ${_("Download my {cert_name_short}").format(cert_name_short=cert_name_short)}
                 </a>
               </li>
             % endif


### PR DESCRIPTION
## Description

This PR updates the status text for Downloadable PDF certificates to help with clarity around certificate status.

Before: 
<img width="934" alt="Screen Shot 2021-06-15 at 5 09 31 PM" src="https://user-images.githubusercontent.com/2854941/122123850-87479480-cdfc-11eb-8288-7dafcb3ae98d.png">

After:
<img width="820" alt="Screen Shot 2021-06-15 at 4 41 00 PM" src="https://user-images.githubusercontent.com/2854941/122123869-8d3d7580-cdfc-11eb-8411-69665dc63640.png">
