### PR TITLE
feat!: Read from the allowlist model

### DIFF
--- a/lms/djangoapps/certificates/README.rst
+++ b/lms/djangoapps/certificates/README.rst
@@ -2,7 +2,7 @@ Status: Maintenance
 
 Responsibilities
 ================
-The Certificates app is responsible for creating and managing Course-Run certificates, including any relevant data models for invalidating and white-listing users' certificate eligibilities.
+The Certificates app is responsible for creating and managing course run certificates, including relevant data models for invalidating certificates and managing the allowlist.
 
 Direction: Move and Extract
 ===========================

--- a/lms/djangoapps/certificates/docs/decisions/001-allowlist-cert-requirements.rst
+++ b/lms/djangoapps/certificates/docs/decisions/001-allowlist-cert-requirements.rst
@@ -12,9 +12,11 @@ This doc covers requirements for allowlist course certificates.
 Users can earn a course certificate in a particular course run (the certificate
 is stored in the *GeneratedCertificate* model). If a user has not earned a certificate
 but the course staff would like them to have a certificate anyway, the user can
-be added to the certificate allowlist for the course run. The allowlist is currently
-stored in the *CertificateWhitelist* model, and was previously referred to as the
-certificate whitelist.
+be added to the certificate allowlist for the course run.
+
+The allowlist is stored in the *CertificateAllowlist* model. It was previously
+referred to as the certificate whitelist, and was previously stored in the
+*CertificateWhitelist* model.
 
 Requirements
 ------------
@@ -32,4 +34,4 @@ the time the certificate is generated:
 * The user must have an approved, unexpired, ID verification
 * The user must not have an invalidated certificate for the course run (see the *CertificateInvalidation* model)
 * HTML (web) certificates must be globally enabled, and also enabled for the course run
-* The user must be on the allowlist for the course run (see the *CertificateWhitelist* model)
+* The user must be on the allowlist for the course run (see the *CertificateAllowlist* model)

--- a/lms/djangoapps/certificates/generation_handler.py
+++ b/lms/djangoapps/certificates/generation_handler.py
@@ -14,8 +14,8 @@ from common.djangoapps.course_modes import api as modes_api
 from common.djangoapps.student.models import CourseEnrollment
 from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.certificates.models import (
+    CertificateAllowlist,
     CertificateInvalidation,
-    CertificateWhitelist,
     GeneratedCertificate
 )
 from lms.djangoapps.certificates.queue import XQueueCertInterface
@@ -356,7 +356,7 @@ def is_on_certificate_allowlist(user, course_key):
     """
     Check if the user is on the allowlist, and is enabled for the allowlist, for this course run
     """
-    return CertificateWhitelist.objects.filter(user=user, course_id=course_key, whitelist=True).exists()
+    return CertificateAllowlist.objects.filter(user=user, course_id=course_key, allowlist=True).exists()
 
 
 def _can_generate_certificate_for_status(user, course_key):

--- a/lms/djangoapps/certificates/models.py
+++ b/lms/djangoapps/certificates/models.py
@@ -69,51 +69,6 @@ class CertificateWhitelist(models.Model):
     created = AutoCreatedField(_('created'))
     notes = models.TextField(default=None, null=True)
 
-    @classmethod
-    def get_certificate_white_list(cls, course_id, student=None):
-        """
-        Return certificate white list for the given course as dict object,
-        returned dictionary will have the following key-value pairs
-
-        [{
-            id:         'id (pk) of CertificateWhitelist item'
-            user_id:    'User Id of the student'
-            user_name:  'name of the student'
-            user_email: 'email of the student'
-            course_id:  'Course key of the course to whom certificate exception belongs'
-            created:    'Creation date of the certificate exception'
-            notes:      'Additional notes for the certificate exception'
-        }, {...}, ...]
-
-        """
-        white_list = cls.objects.filter(course_id=course_id, whitelist=True)
-        if student:
-            white_list = white_list.filter(user=student)
-        result = []
-        generated_certificates = GeneratedCertificate.eligible_certificates.filter(
-            course_id=course_id,
-            user__in=[exception.user for exception in white_list],
-            status=CertificateStatuses.downloadable
-        )
-        generated_certificates = {
-            certificate['user']: certificate['created_date']
-            for certificate in generated_certificates.values('user', 'created_date')
-        }
-
-        for item in white_list:
-            certificate_generated = generated_certificates.get(item.user.id, '')
-            result.append({
-                'id': item.id,
-                'user_id': item.user.id,
-                'user_name': str(item.user.username),
-                'user_email': str(item.user.email),
-                'course_id': str(item.course_id),
-                'created': item.created.strftime("%B %d, %Y"),
-                'certificate_generated': certificate_generated and certificate_generated.strftime("%B %d, %Y"),
-                'notes': str(item.notes or ''),
-            })
-        return result
-
 
 class CertificateAllowlist(TimeStampedModel):
     """

--- a/lms/djangoapps/certificates/queue.py
+++ b/lms/djangoapps/certificates/queue.py
@@ -20,7 +20,7 @@ from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.models import CourseEnrollment, UserProfile
 from lms.djangoapps.certificates.data import CertificateStatuses as status
 from lms.djangoapps.certificates.models import (
-    CertificateWhitelist,
+    CertificateAllowlist,
     ExampleCertificate,
     GeneratedCertificate,
     certificate_status_for_student
@@ -103,7 +103,7 @@ class XQueueCertInterface:
             settings.XQUEUE_INTERFACE['django_auth'],
             requests_auth,
         )
-        self.allowlist = CertificateWhitelist.objects.all()
+        self.allowlist = CertificateAllowlist.objects.all()
         self.use_https = True
 
     def regen_cert(self, student, course_id, forced_grade=None, template_file=None, generate_pdf=True):
@@ -259,7 +259,7 @@ class XQueueCertInterface:
         self.request.user = student
         self.request.session = {}
 
-        is_allowlisted = self.allowlist.filter(user=student, course_id=course_id, whitelist=True).exists()
+        is_allowlisted = self.allowlist.filter(user=student, course_id=course_id, allowlist=True).exists()
         course_grade = CourseGradeFactory().read(student, course_key=course_id)
         enrollment_mode, __ = CourseEnrollment.enrollment_mode_for_user(student, course_id)
         mode_is_verified = enrollment_mode in GeneratedCertificate.VERIFIED_CERTS_MODES

--- a/lms/djangoapps/certificates/signals.py
+++ b/lms/djangoapps/certificates/signals.py
@@ -18,9 +18,9 @@ from lms.djangoapps.certificates.generation_handler import (
     is_on_certificate_allowlist
 )
 from lms.djangoapps.certificates.models import (
+    CertificateAllowlist,
     CertificateGenerationCourseSetting,
     CertificateStatuses,
-    CertificateWhitelist,
     GeneratedCertificate
 )
 from lms.djangoapps.certificates.tasks import CERTIFICATE_DELAY_SECONDS, generate_certificate
@@ -52,7 +52,7 @@ def _update_cert_settings_on_pacing_change(sender, updated_course_overview, **kw
     ))
 
 
-@receiver(post_save, sender=CertificateWhitelist, dispatch_uid="append_certificate_allowlist")
+@receiver(post_save, sender=CertificateAllowlist, dispatch_uid="append_certificate_allowlist")
 def _listen_for_certificate_allowlist_append(sender, instance, **kwargs):  # pylint: disable=unused-argument
     """
     Listen for a user being added to or modified on the allowlist

--- a/lms/djangoapps/certificates/tests/factories.py
+++ b/lms/djangoapps/certificates/tests/factories.py
@@ -13,7 +13,6 @@ from lms.djangoapps.certificates.models import (
     CertificateHtmlViewConfiguration,
     CertificateInvalidation,
     CertificateStatuses,
-    CertificateWhitelist,
     GeneratedCertificate
 )
 
@@ -36,21 +35,6 @@ class GeneratedCertificateFactory(DjangoModelFactory):
 class CertificateAllowlistFactory(DjangoModelFactory):
     """
     Certificate allowlist factory
-    """
-
-    class Meta:
-        model = CertificateWhitelist
-
-    course_id = None
-    whitelist = True
-    notes = 'Test Notes'
-
-
-class TemporaryCertificateAllowlistFactory(DjangoModelFactory):
-    """
-    Temporary certificate allowlist factory.
-
-    This will be removed once the CertificateAllowlistFactory uses the CertificateAllowlist as its model.
     """
 
     class Meta:

--- a/lms/djangoapps/certificates/tests/test_api.py
+++ b/lms/djangoapps/certificates/tests/test_api.py
@@ -32,7 +32,6 @@ from common.djangoapps.student.tests.factories import (
 )
 from common.djangoapps.util.testing import EventTestMixin
 from lms.djangoapps.certificates.api import (
-    _get_allowlist_entry_from_new_model,
     can_be_added_to_allowlist,
     cert_generation_enabled,
     certificate_downloadable_status,
@@ -790,7 +789,7 @@ class CertificateAllowlistTests(ModuleStoreTestCase):
         result, __ = create_or_update_certificate_allowlist_entry(self.user, self.course_run_key, "New test", False)
 
         assert result.notes == "New test"
-        assert not result.whitelist
+        assert not result.allowlist
 
     def test_remove_allowlist_entry(self):
         """
@@ -879,7 +878,7 @@ class CertificateAllowlistTests(ModuleStoreTestCase):
         """
         Test to verify that we will return False when the allowlist entry if it is disabled.
         """
-        CertificateAllowlistFactory.create(course_id=self.course_run_key, user=self.user, whitelist=False)
+        CertificateAllowlistFactory.create(course_id=self.course_run_key, user=self.user, allowlist=False)
 
         result = is_on_allowlist(self.user, self.course_run_key)
         assert not result
@@ -970,8 +969,8 @@ class CertificateAllowlistTests(ModuleStoreTestCase):
 
         # Add user to the allowlist
         CertificateAllowlistFactory.create(course_id=key1, user=u1)
-        # Add user to the allowlist, but set whitelist to false
-        CertificateAllowlistFactory.create(course_id=key1, user=u2, whitelist=False)
+        # Add user to the allowlist, but set allowlist to false
+        CertificateAllowlistFactory.create(course_id=key1, user=u2, allowlist=False)
         # Add user to the allowlist in the other course
         CertificateAllowlistFactory.create(course_id=key2, user=u4)
 
@@ -994,25 +993,19 @@ class CertificateAllowlistTests(ModuleStoreTestCase):
         notes = 'blah'
 
         # Check before adding user
-        old_entry = get_allowlist_entry(u1, self.course_run_key)
-        assert old_entry is None
-        new_entry = _get_allowlist_entry_from_new_model(u1, self.course_run_key)
-        assert new_entry is None
+        entry = get_allowlist_entry(u1, self.course_run_key)
+        assert entry is None
 
         # Add user
         create_or_update_certificate_allowlist_entry(u1, self.course_run_key, notes)
-        old_entry = get_allowlist_entry(u1, self.course_run_key)
-        assert old_entry.notes == notes
-        new_entry = _get_allowlist_entry_from_new_model(u1, self.course_run_key)
-        assert new_entry.notes == notes
+        entry = get_allowlist_entry(u1, self.course_run_key)
+        assert entry.notes == notes
 
         # Update user
         new_notes = 'really useful info'
         create_or_update_certificate_allowlist_entry(u1, self.course_run_key, new_notes)
-        old_entry = get_allowlist_entry(u1, self.course_run_key)
-        assert old_entry.notes == new_notes
-        new_entry = _get_allowlist_entry_from_new_model(u1, self.course_run_key)
-        assert new_entry.notes == new_notes
+        entry = get_allowlist_entry(u1, self.course_run_key)
+        assert entry.notes == new_notes
 
     def test_remove(self):
         """
@@ -1023,17 +1016,13 @@ class CertificateAllowlistTests(ModuleStoreTestCase):
 
         # Add user
         create_or_update_certificate_allowlist_entry(u1, self.course_run_key, notes)
-        old_entry = get_allowlist_entry(u1, self.course_run_key)
-        assert old_entry.notes == notes
-        new_entry = _get_allowlist_entry_from_new_model(u1, self.course_run_key)
-        assert new_entry.notes == notes
+        entry = get_allowlist_entry(u1, self.course_run_key)
+        assert entry.notes == notes
 
         # Remove user
         remove_allowlist_entry(u1, self.course_run_key)
-        old_entry = get_allowlist_entry(u1, self.course_run_key)
-        assert old_entry is None
-        new_entry = _get_allowlist_entry_from_new_model(u1, self.course_run_key)
-        assert new_entry is None
+        entry = get_allowlist_entry(u1, self.course_run_key)
+        assert entry is None
 
 
 class CertificateInvalidationTests(ModuleStoreTestCase):

--- a/lms/djangoapps/certificates/tests/test_generation_handler.py
+++ b/lms/djangoapps/certificates/tests/test_generation_handler.py
@@ -84,7 +84,7 @@ class AllowlistTests(ModuleStoreTestCase):
             is_active=True,
             mode="verified",
         )
-        CertificateAllowlistFactory.create(course_id=self.course_run_key, user=u, whitelist=False)
+        CertificateAllowlistFactory.create(course_id=self.course_run_key, user=u, allowlist=False)
         assert not is_on_certificate_allowlist(u, self.course_run_key)
 
     @ddt.data(

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -3025,7 +3025,7 @@ def add_certificate_exception(course_key, student, certificate_exception):
         'user_name': student.username,
         'user_id': student.id,
         'certificate_generated': generated_certificate and generated_certificate.created_date.strftime("%B %d, %Y"),
-        'created': certificate_allowlist_entry.created.strftime("%A, %B %d, %Y"),
+        'created': certificate_allowlist_entry.created.strftime("%B %d, %Y"),
     })
 
     return exception


### PR DESCRIPTION
Read from the certificate allowlist model, instead of from the certificate whitelist model. Only write to the certificate allowlist model. This also includes a fix so that newly-added allowlist entries have the same date format as existing entries.

With this PR, changes are no longer saved to the certificate whitelist model.

MICROBA-982