### PR TITLE
REV-2260: fix decimal display issue for enterprise learners

### DIFF
--- a/common/djangoapps/course_modes/helpers.py
+++ b/common/djangoapps/course_modes/helpers.py
@@ -2,7 +2,6 @@
 
 
 import logging
-from decimal import Decimal
 from django.utils.translation import ugettext_lazy as _
 
 from requests.exceptions import ConnectionError, Timeout  # pylint: disable=redefined-builtin
@@ -120,8 +119,7 @@ def get_course_final_price(user, sku, course_price):
 
     # When ecommerce price has zero cents, 'result' gets 149.0
     # As per REV-2260: if zero cents, then only show dollars
-    cents = Decimal(result) % 1
-    if cents == 0:
+    if int(result) == result:
         result = int(result)
 
     return result

--- a/common/djangoapps/course_modes/helpers.py
+++ b/common/djangoapps/course_modes/helpers.py
@@ -2,6 +2,7 @@
 
 
 import logging
+from decimal import Decimal
 from django.utils.translation import ugettext_lazy as _
 
 from requests.exceptions import ConnectionError, Timeout  # pylint: disable=redefined-builtin
@@ -115,4 +116,12 @@ def get_course_final_price(user, sku, course_price):
         user.username,
         price_details.get('total_incl_tax')
     )
-    return price_details.get('total_incl_tax', course_price)
+    result = price_details.get('total_incl_tax', course_price)
+
+    # When ecommerce price has zero cents, 'result' gets 149.0
+    # As per REV-2260: if zero cents, then only show dollars
+    cents = Decimal(result) % 1
+    if cents == 0:
+        result = int(result)
+
+    return result


### PR DESCRIPTION
## Description
The track selection page shows the price as an integer in the regular flow, but for enterprise learners we call get_course_final_price (added in [this commit](https://github.com/edx/edx-platform/commit/4cff92b0ad3a01c27c00137604fbf7699df67198)), which returns a float which can appear with one decimal place ($50.0)- see 'before' screenshot. (Though if the price is 149.99, it shows two places). As per REV-2260: stop showing cents if it's 0. 

This fix casts the result to an int when there are no cents. 

I haven't updated the test case; it still passes because it just checks the presence of a value (test_display_after_discounted_price)- 
`pytest common/djangoapps/course_modes/tests/test_views.py::CourseModeViewTest`

## Screenshots: 
Before: 
![before](https://user-images.githubusercontent.com/5384216/122416342-a6f2d000-cf56-11eb-94ae-5e300a8f828a.png)
After: 
![after](https://user-images.githubusercontent.com/5384216/122416350-a9552a00-cf56-11eb-9ee7-de2708f042b8.png)

## Testing notes: 
Tested locally by setting `enterprise_customer = True` in ChooseModeView get method (views.py), and going to the track selection page for the demo course: 
http://localhost:18000/course_modes/choose/course-v1:edX+DemoX+Demo_Course/

## Deadline
None