### PR TITLE
[OSPR-5869][BB-4385] Prevent course details AJAX request from getting into browser history

### DIFF
--- a/cms/static/js/factories/settings.js
+++ b/cms/static/js/factories/settings.js
@@ -34,7 +34,8 @@ define([
                 editor.useV2CertDisplaySettings = useV2CertDisplaySettings;
                 editor.render();
             },
-            reset: true
+            reset: true,
+            cache: false
         });
     };
 });


### PR DESCRIPTION
Settings page is making AJAX request to course details URL (http://localhost:18010/settings/details/course_id). This PR adds `cache: false` argument to `fetch` call to prevent recording this request in browser history.

![Peek 2021-06-18 06-44](https://user-images.githubusercontent.com/18251194/122503232-c0505680-d000-11eb-83d0-337d042a586f.gif)

**JIRA tickets**:
- [BB-4385](https://tasks.opencraft.com/browse/BB-4385)
- [OSPR-5869](https://openedx.atlassian.net/browse/OSPR-5869)

**Testing instructions**:

1. Go to http://localhost:18010/settings/details/course-v1:edX+DemoX+Demo_Course
1. Wait for last request on page to http://localhost:18010/settings/details/course-v1:edX+DemoX+Demo_Course URL, with `application/json` content type.
1. Then click on the logo image in the top-left corner and wait for the page to completely load.
1. Go back one page. You should see raw JSON instead of platform page.
1. Then, apply a patch from this PR and repeat. You shouldn't see raw JSON.

**Reviewers**
- [x] @shimulch 