### PR TITLE
[BB-4386] Remove the url change for the page

### DIFF
--- a/lms/static/js/student_account/views/AccessView.js
+++ b/lms/static/js/student_account/views/AccessView.js
@@ -285,7 +285,7 @@
                     this.element.show($form);
 
                 // Update url without reloading page
-                    if (type != 'institution_login') {
+                    if (type != 'institution_login' && type != 'reset') {
                         History.pushState(null, document.title, '/' + type + queryStr);
                     }
                     analytics.page('login_and_registration', type);


### PR DESCRIPTION
The password-reset page throws page not found error on refresh. This started happening in koa.

**JIRA tickets**: [BB-4386](https://tasks.opencraft.com/browse/BB-4386)

~~**Discussions**: Link to any public dicussions about this PR or the design/architecture. Otherwise omit this.~~

~~**Dependencies**: None~~

**Screenshots**:

Juniper Behaviour

![juniper-password-reset](https://user-images.githubusercontent.com/7670449/122634108-f9202680-d0f9-11eb-810a-52064e427e0b.gif)

Koa Behaviour
![koa-password-reset](https://user-images.githubusercontent.com/7670449/122634120-0a693300-d0fa-11eb-86ac-96be893aba9a.gif)


**Sandbox URL**: TBD - sandbox is being provisioned.

~~**Merge deadline**: "None" if there's no rush, "ASAP" if it's critical, or provide a specific date if there is one.~~

**Testing instructions**:

1.  Use master devstack
2.  Go to the sign-in page  click on need more help and then password-reset page
3. Hit refresh you will get a page not found error
4. Pull in this branch code, do a `make lms-static` and `make lms-restart`
5. Repeat the above steps the error should not change.

**Author notes and concerns**:

1.  Error happened because of change in URL which was not required

**Reviewers**
- [ ] @0x29a 