### PR TITLE
refactor: delete reference to old course home microfrontend flag

### DIFF
--- a/lms/djangoapps/course_home_api/outline/v1/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/outline/v1/tests/test_views.py
@@ -354,7 +354,6 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         response = self.client.get(self.url)
         assert response.data['verified_mode'] == {'access_expiration_date': (enrollment.created + MIN_DURATION), 'currency': 'USD', 'currency_symbol': '$', 'price': 149, 'sku': 'ABCD1234', 'upgrade_url': '/dashboard'}
 
-    @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     def test_hide_learning_sequences(self):
         """
         Check that Learning Sequences filters out sequences.


### PR DESCRIPTION
## Description

Deleted reference to COURSE_HOME_MICROFRONTEND flag that is now outdated. 
