### PR TITLE
feat: add & expose courseware.use_learning_sequences_api flag

### DIFF
--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -25,6 +25,20 @@ COURSEWARE_USE_LEGACY_FRONTEND = CourseWaffleFlag(
     WAFFLE_FLAG_NAMESPACE, 'use_legacy_frontend', __name__
 )
 
+# .. toggle_name: courseware.use_learning_sequences_api
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: When enbled, the Learning MFE's courseware pages will use the
+#   new Learning Sequences API (from ``openedx.core.djangoapps.content.learning_sequences``)
+#   instead of the Course Blocks API (from ``lms.djangoapps.course_api.blocks``)
+#   in order to load course structure data.
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2021-07-01
+# .. toggle_target_removal_date: 2021-09-01
+COURSEWARE_USE_LEARNING_SEQUENCES_API = CourseWaffleFlag(
+    WAFFLE_FLAG_NAMESPACE, 'use_learning_sequences_api', __name__
+)
+
 # .. toggle_name: courseware.microfrontend_course_team_preview
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False

--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -28,12 +28,15 @@ COURSEWARE_USE_LEGACY_FRONTEND = CourseWaffleFlag(
 # .. toggle_name: courseware.use_learning_sequences_api
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False
-# .. toggle_description: When enbled, the Learning MFE's courseware pages will use the
+# .. toggle_description: When enbled, frontend-app-learning's courseware pages should use the
 #   new Learning Sequences API (from ``openedx.core.djangoapps.content.learning_sequences``)
 #   instead of the Course Blocks API (from ``lms.djangoapps.course_api.blocks``)
 #   in order to load course structure data.
+# .. toggle_warnings: As of 2021-06-25, the frontend-app-learning changes necessary to honor this
+#   flag's value have not yet been implemented. We expect that they will be implemented in
+#   the coming weeks.
 # .. toggle_use_cases: temporary
-# .. toggle_creation_date: 2021-07-01
+# .. toggle_creation_date: 2021-06-25
 # .. toggle_target_removal_date: 2021-09-01
 COURSEWARE_USE_LEARNING_SEQUENCES_API = CourseWaffleFlag(
     WAFFLE_FLAG_NAMESPACE, 'use_learning_sequences_api', __name__

--- a/openedx/core/djangoapps/courseware_api/serializers.py
+++ b/openedx/core/djangoapps/courseware_api/serializers.py
@@ -116,6 +116,7 @@ class CourseInfoSerializer(serializers.Serializer):  # pylint: disable=abstract-
     verify_identity_url = AbsoluteURLField()
     verification_status = serializers.CharField()
     linkedin_add_to_profile_url = serializers.URLField()
+    is_learning_sequences_api_enabled = serializers.BooleanField()
     is_mfe_special_exams_enabled = serializers.BooleanField()
     is_mfe_proctored_exams_enabled = serializers.BooleanField()
     user_needs_integrity_signature = serializers.BooleanField()

--- a/openedx/core/djangoapps/courseware_api/tests/test_views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/test_views.py
@@ -28,6 +28,7 @@ from lms.djangoapps.courseware.toggles import (
     COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES_STREAK_CELEBRATION,
     COURSEWARE_MICROFRONTEND_SPECIAL_EXAMS,
     COURSEWARE_MICROFRONTEND_PROCTORED_EXAMS,
+    COURSEWARE_USE_LEARNING_SEQUENCES_API,
 )
 from lms.djangoapps.experiments.testutils import override_experiment_waffle_flag
 from lms.djangoapps.experiments.utils import STREAK_DISCOUNT_EXPERIMENT_FLAG
@@ -293,6 +294,17 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
             assert response.data['can_load_courseware']['has_access']
         else:
             assert not response.data['can_load_courseware']['has_access']
+
+    @ddt.data(True, False)
+    def test_is_learning_sequences_api_enabled(self, enable_new_api):
+        """
+        Test that the Courseware API exposes the Learning Sequences API flag.
+        """
+        with override_waffle_flag(COURSEWARE_USE_LEARNING_SEQUENCES_API, active=enable_new_api):
+            response = self.client.get(self.url)
+            assert response.status_code == 200
+            courseware_data = response.json()
+            assert courseware_data['is_learning_sequences_api_enabled'] is enable_new_api
 
     def test_streak_data_in_response(self):
         """ Test that metadata endpoint returns data for the streak celebration """

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -40,6 +40,7 @@ from lms.djangoapps.courseware.toggles import (
     course_exit_page_is_active,
     mfe_special_exams_is_active,
     mfe_proctored_exams_is_active,
+    COURSEWARE_USE_LEARNING_SEQUENCES_API,
 )
 from lms.djangoapps.courseware.views.views import get_cert_data
 from lms.djangoapps.grades.api import CourseGradeFactory
@@ -120,6 +121,20 @@ class CoursewareMeta:
             is_global_staff=self.original_user_is_global_staff,
             is_course_staff=self.original_user_is_staff
         )
+
+    @property
+    def is_learning_sequences_api_enabled(self):
+        """
+        Should the Learning Sequences API be used to load course structure data?
+
+        Courseware views in the Learning MFE need to load course structure data
+        from the backend to display feaures like breadcrumbs, the smart "Next"
+        button, etc. This has been done so far using the Course Blocks API.
+        We are switching the views to instead use the Learning Sequences API,
+        which we expect to be significantly faster. We are putting the transition
+        behind a flag, for now, to allow incremental rollout and comparison testing.
+        """
+        return COURSEWARE_USE_LEARNING_SEQUENCES_API.is_enabled(self.course_key)
 
     @property
     def is_mfe_special_exams_enabled(self):

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -127,12 +127,15 @@ class CoursewareMeta:
         """
         Should the Learning Sequences API be used to load course structure data?
 
-        Courseware views in the Learning MFE need to load course structure data
+        Courseware views in frontend-app-learning need to load course structure data
         from the backend to display feaures like breadcrumbs, the smart "Next"
         button, etc. This has been done so far using the Course Blocks API.
-        We are switching the views to instead use the Learning Sequences API,
-        which we expect to be significantly faster. We are putting the transition
-        behind a flag, for now, to allow incremental rollout and comparison testing.
+
+        Over the next few weeks (starting 2021-06-25), we will be incrementally
+        transitioning said views to instead use the Learning Sequences API,
+        which we expect to be significantly faster. Once the transition is in
+        progress, this function will surface to frontend-app-learning whether
+        the old Course Blocks API or Learning Sequences API should be used.
         """
         return COURSEWARE_USE_LEARNING_SEQUENCES_API.is_enabled(self.course_key)
 


### PR DESCRIPTION
## Description

    feat: add & expose courseware.use_learning_sequences_api flag 
    
    Add a Waffle Flag. When enabled, the courseware pages of the
    Learning MFE should use the Learning Sequences HTTP API instead
    of the Course Blocks HTTP API in order to load course structure
    data. We expect that this switchover will lead to performance
    improvements and a more comprehensible system.
    
    (We are putting the switchover behind a temporary flag in order to
    enable debugging, incremental rollout, and comparison testing.)
    
    The flag is exposed to the MFE via the Course API.
    As of this commit, the new flag is not enabled in any environment,
    and the MFE does not have any code to act on the flag's value.
    So, this commit on its own should have no production impact.


## Supporting information

[TNL-8330](https://openedx.atlassian.net/browse/TNL-8403)

## Deadline

Soft deadline of 6/25 (weekly goal)
