### PR TITLE
bump: bump edx-enterprise version to 3.26.7

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -33,7 +33,7 @@ django-storages<1.9
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==3.26.6
+edx-enterprise==3.26.7
 
 # Newer versions need a more recent version of python-dateutil
 freezegun==0.3.12

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -427,7 +427,7 @@ edx-drf-extensions==6.5.0
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.26.6
+edx-enterprise==3.26.7
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -513,7 +513,7 @@ edx-drf-extensions==6.5.0
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.26.6
+edx-enterprise==3.26.7
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -498,7 +498,7 @@ edx-drf-extensions==6.5.0
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.26.6
+edx-enterprise==3.26.7
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
Bumps the edx-enterprise version to 3.26.7
## Description

This version bump to 3.26.7 should only affect Developers: it improves the edx-enterprise plugin's logging logic around Integrated Channels to use a more consistent format that will make log diving a shorter and more informative activity. There are no frontend or user (admin, learner, or operator) facing changes.

## Supporting information

See https://github.com/edx/edx-enterprise/pull/1248 for full edx-enterprise change set. 

## Deadline

"None" 

## Other information

Not applicable. 