### PR TITLE
feat: Increase max file upload size from 10 MB to 20 MB.

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1753,7 +1753,7 @@ DATA_UPLOAD_MAX_NUMBER_FIELDS = None
 UPLOAD_CHUNK_SIZE_IN_MB = 10
 
 ### Max size of asset uploads to GridFS
-MAX_ASSET_UPLOAD_FILE_SIZE_IN_MB = 10
+MAX_ASSET_UPLOAD_FILE_SIZE_IN_MB = 20
 
 # FAQ url to direct users to if they upload
 # a file that exceeds the above size


### PR DESCRIPTION
## Description

Increases maximum file upload size from 10 MB to 20 MB in the Studio "Files & Uploads" interface.

The limit of 10 MB was set in a PR from seven years ago here:
https://github.com/edx/edx-platform/pull/5731

I will add SRE as a reviewer, as this change might possibly change the volume of files stored in GridFS/MongoDB - and will certainly change the maximum file sizes stored there.

https://openedx.atlassian.net/browse/TNL-8412

Before the change - uploading a 15 MB file:
<img width="1792" alt="Screen Shot 2021-06-22 at 10 53 09 AM" src="https://user-images.githubusercontent.com/7285237/122963318-27993e00-d354-11eb-9ebc-39a7e62b612e.png">

After the change - and uploading a 15 MB file:
<img width="1792" alt="Screen Shot 2021-06-22 at 12 18 18 PM" src="https://user-images.githubusercontent.com/7285237/122963363-33850000-d354-11eb-8a41-9d04283afb09.png">




<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Supporting information

https://openedx.atlassian.net/browse/TNL-8412

## Testing instructions

In a test course:
- attempt to upload a file > 10MB and < 20MB in size.
- attempt to upload a file > 20MB in size.

## Deadline

Course team is waiting on this fix.
