### PR TITLE
fix: Temporarily disable generating certificates with a non-downloada…

### DIFF
--- a/lms/djangoapps/certificates/generation_handler.py
+++ b/lms/djangoapps/certificates/generation_handler.py
@@ -95,9 +95,9 @@ def generate_allowlist_certificate_task(user, course_key, generation_mode=None):
     if _can_generate_allowlist_certificate(user, course_key):
         return _generate_certificate_task(user, course_key, generation_mode)
 
-    status = _set_allowlist_cert_status(user, course_key)
-    if status is not None:
-        return True
+#    status = _set_allowlist_cert_status(user, course_key)
+#    if status is not None:
+#        return True
 
     return False
 
@@ -110,9 +110,9 @@ def generate_regular_certificate_task(user, course_key, generation_mode=None):
     if _can_generate_v2_certificate(user, course_key):
         return _generate_certificate_task(user, course_key, generation_mode)
 
-    status = _set_v2_cert_status(user, course_key)
-    if status is not None:
-        return True
+#    status = _set_v2_cert_status(user, course_key)
+#    if status is not None:
+#        return True
 
     return False
 

--- a/lms/djangoapps/certificates/tests/test_generation_handler.py
+++ b/lms/djangoapps/certificates/tests/test_generation_handler.py
@@ -323,6 +323,36 @@ class CertificateTests(ModuleStoreTestCase):
         assert not generate_certificate_task(other_user, self.course_run_key)
         assert not generate_regular_certificate_task(other_user, self.course_run_key)
 
+    def test_handle_audit_status(self):
+        """
+        Test handling of a user who is not passing and is enrolled in audit mode
+        """
+        different_user = UserFactory()
+        CourseEnrollmentFactory(
+            user=different_user,
+            course_id=self.course_run_key,
+            is_active=True,
+            mode=GeneratedCertificate.MODES.audit,
+        )
+
+        assert _set_v2_cert_status(different_user, self.course_run_key) is None
+        assert not generate_regular_certificate_task(different_user, self.course_run_key)
+
+    def test_handle_verified_status(self):
+        """
+        Test handling of a user who is not passing and is enrolled in verified mode
+        """
+        different_user = UserFactory()
+        CourseEnrollmentFactory(
+            user=different_user,
+            course_id=self.course_run_key,
+            is_active=True,
+            mode=GeneratedCertificate.MODES.verified,
+        )
+
+        assert _set_v2_cert_status(different_user, self.course_run_key) == 'notpassing'
+        assert generate_regular_certificate_task(different_user, self.course_run_key)
+
     def test_is_using_updated_true(self):
         """
         Test the updated flag

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -2087,7 +2087,7 @@ class TestCertificateGeneration(InstructorTaskModuleTestCase):
             'failed': 0,
             'skipped': 2
         }
-        with self.assertNumQueries(74):
+        with self.assertNumQueries(55):
             self.assertCertificatesGenerated(task_input, expected_results)
 
     @ddt.data(


### PR DESCRIPTION
Temporarily disable generating certificates with a non-downloadable status

CR-3792

The ticket internal and so cannot be made public, unfortunately. This change was made to address an issue in production where more certificates than expected were generated.

A subsequent PR will provide more information, and a fix; I'll link to it when it's available.
