### PR TITLE
fix: Update logic for certificate generation status

### DIFF
--- a/lms/djangoapps/certificates/docs/decisions/004-cert-status.rst
+++ b/lms/djangoapps/certificates/docs/decisions/004-cert-status.rst
@@ -1,0 +1,56 @@
+Course certificate Status
+=========================
+
+Status
+------
+Accepted
+
+Background
+----------
+Course certificates can have any one of a number of status values (for the
+full list, see the `CertificateStatuses model`_). For a certificate to be
+available for the user to see, it must be in the *downloadable* state, meaning
+it must have a status value of *downloadable*.
+
+Decision
+--------
+The course certificate code will only set the following certificate statuses:
+
+* downloadable - The user has been granted this certificate and the certificate is ready and available
+* notpassing - The user has not achieved a passing grade
+* unavailable - Certificate has been invalidated
+* unverified - The user does not have an approved, unexpired identity verification
+
+Other status values are kept for historical reasons and because existing course
+certificates may have been granted that status.
+
+Consequences
+------------
+If a certificate has been invalidated, its status will be *unavailable*.
+
+If all requirements have been met, a *downloadable* certificate will be
+generated (created or updated).
+
+If all requirements *except* for identity verification have been met, an
+*unverified* certificate will be generated.
+
+If all requirements *except* for passing the course have been met and a
+certificate already exists, its status will be *notpassing*. Alternately, if a
+*downloadable* certificate exists and a failing grade signal is received for
+a user who is not on the allowlist, the certificate's status will be
+*notpassing*.
+
+Note that this does not create a hierarchy of certificate statuses. For
+example, a certificate could have a *notpassing* status even if the user
+has not the passed identity verification requirement.
+
+References
+----------
+For a full list of requirements for a course certificate to be granted, please
+see the `allowlist certificate requirements`_ and `certificate requirements`_.
+
+For a full list of certificate statuses, see the `CertificateStatuses model`_.
+
+.. _allowlist certificate requirements: ./001-allowlist-cert-requirements.rst
+.. _certificate requirements: ./002-cert-requirements.rst
+.. _CertificateStatuses model: ../../data.py

--- a/lms/djangoapps/certificates/tasks.py
+++ b/lms/djangoapps/certificates/tasks.py
@@ -10,6 +10,7 @@ from django.contrib.auth import get_user_model
 from edx_django_utils.monitoring import set_code_owner_attribute
 from opaque_keys.edx.keys import CourseKey
 
+from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.certificates.generation import (
     generate_course_certificate,
     generate_user_certificates
@@ -45,10 +46,11 @@ def generate_certificate(self, **kwargs):
     course_key = CourseKey.from_string(kwargs.pop('course_key'))
     expected_verification_status = kwargs.pop('expected_verification_status', None)
     v2_certificate = kwargs.pop('v2_certificate', False)
+    status = kwargs.pop('status', CertificateStatuses.downloadable)
     generation_mode = kwargs.pop('generation_mode', 'batch')
 
     if v2_certificate:
-        generate_course_certificate(user=student, course_key=course_key, generation_mode=generation_mode)
+        generate_course_certificate(user=student, course_key=course_key, status=status, generation_mode=generation_mode)
         return
 
     if expected_verification_status:

--- a/lms/djangoapps/certificates/tests/test_generation.py
+++ b/lms/djangoapps/certificates/tests/test_generation.py
@@ -43,7 +43,7 @@ class CertificateTests(EventTestMixin, ModuleStoreTestCase):
         certs = GeneratedCertificate.objects.filter(user=self.u, course_id=self.key)
         assert len(certs) == 0
 
-        generated_cert = generate_course_certificate(self.u, self.key, self.gen_mode)
+        generated_cert = generate_course_certificate(self.u, self.key, CertificateStatuses.downloadable, self.gen_mode)
         assert generated_cert.status, CertificateStatuses.downloadable
 
         certs = GeneratedCertificate.objects.filter(user=self.u, course_id=self.key)
@@ -67,7 +67,7 @@ class CertificateTests(EventTestMixin, ModuleStoreTestCase):
         mock_tracker = analytics_patcher.start()
         self.addCleanup(analytics_patcher.stop)
 
-        generated_cert = generate_course_certificate(self.u, self.key, self.gen_mode)
+        generated_cert = generate_course_certificate(self.u, self.key, CertificateStatuses.downloadable, self.gen_mode)
         assert generated_cert.status, CertificateStatuses.downloadable
 
         mock_tracker.track.assert_called_once_with(
@@ -96,8 +96,8 @@ class CertificateTests(EventTestMixin, ModuleStoreTestCase):
         cert = GeneratedCertificate.objects.get(user=self.u, course_id=self.key)
         assert cert.error_reason == error_reason
 
-        generated_cert = generate_course_certificate(self.u, self.key, self.gen_mode)
-        assert generated_cert.status, CertificateStatuses.downloadable
+        generated_cert = generate_course_certificate(self.u, self.key, CertificateStatuses.unverified, self.gen_mode)
+        assert generated_cert.status, CertificateStatuses.unverified
 
         cert = GeneratedCertificate.objects.get(user=self.u, course_id=self.key)
         assert cert.error_reason == ''
@@ -106,7 +106,7 @@ class CertificateTests(EventTestMixin, ModuleStoreTestCase):
         """
         Test that the `verify_uuid` value of a certificate does not change when it is revoked and re-awarded.
         """
-        generated_cert = generate_course_certificate(self.u, self.key, self.gen_mode)
+        generated_cert = generate_course_certificate(self.u, self.key, CertificateStatuses.downloadable, self.gen_mode)
         assert generated_cert.status, CertificateStatuses.downloadable
 
         verify_uuid = generated_cert.verify_uuid
@@ -115,7 +115,7 @@ class CertificateTests(EventTestMixin, ModuleStoreTestCase):
         assert generated_cert.status, CertificateStatuses.unavailable
         assert generated_cert.verify_uuid, verify_uuid
 
-        generated_cert = generate_course_certificate(self.u, self.key, self.gen_mode)
+        generated_cert = generate_course_certificate(self.u, self.key, CertificateStatuses.downloadable, self.gen_mode)
         assert generated_cert.status, CertificateStatuses.downloadable
         assert generated_cert.verify_uuid, verify_uuid
 
@@ -123,7 +123,7 @@ class CertificateTests(EventTestMixin, ModuleStoreTestCase):
         assert generated_cert.status, CertificateStatuses.notpassing
         assert generated_cert.verify_uuid, verify_uuid
 
-        generated_cert = generate_course_certificate(self.u, self.key, self.gen_mode)
+        generated_cert = generate_course_certificate(self.u, self.key, CertificateStatuses.downloadable, self.gen_mode)
         assert generated_cert.status, CertificateStatuses.downloadable
         assert generated_cert.verify_uuid, verify_uuid
 
@@ -139,6 +139,6 @@ class CertificateTests(EventTestMixin, ModuleStoreTestCase):
             verify_uuid=''
         )
 
-        generated_cert = generate_course_certificate(self.u, self.key, self.gen_mode)
+        generated_cert = generate_course_certificate(self.u, self.key, CertificateStatuses.downloadable, self.gen_mode)
         assert generated_cert.status, CertificateStatuses.downloadable
         assert generated_cert.verify_uuid != ''

--- a/lms/djangoapps/certificates/tests/test_tasks.py
+++ b/lms/djangoapps/certificates/tests/test_tasks.py
@@ -11,6 +11,7 @@ from django.test import TestCase
 from opaque_keys.edx.keys import CourseKey
 
 from common.djangoapps.student.tests.factories import UserFactory
+from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.certificates.tasks import generate_certificate
 from lms.djangoapps.verify_student.models import IDVerificationAttempt
 
@@ -104,6 +105,7 @@ class GenerateUserCertificateTest(TestCase):
             mock_generate_cert.assert_called_with(
                 user=self.user,
                 course_key=CourseKey.from_string(course_key),
+                status=CertificateStatuses.downloadable,
                 generation_mode='batch'
             )
 
@@ -129,5 +131,6 @@ class GenerateUserCertificateTest(TestCase):
             mock_generate_cert.assert_called_with(
                 user=self.user,
                 course_key=CourseKey.from_string(course_key),
+                status=CertificateStatuses.downloadable,
                 generation_mode=gen_mode
             )

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -2087,7 +2087,7 @@ class TestCertificateGeneration(InstructorTaskModuleTestCase):
             'failed': 0,
             'skipped': 2
         }
-        with self.assertNumQueries(55):
+        with self.assertNumQueries(74):
             self.assertCertificatesGenerated(task_input, expected_results)
 
     @ddt.data(


### PR DESCRIPTION
Update logic for certificate generation status, and create cert with all available info. Also add an ADR describing course certificate statuses.

This re-enables the cert status code that was temporarily commented out in https://github.com/edx/edx-platform/pull/28000

MICROBA-1306 CR-3792