### PR TITLE
feat: AA-869: Add in logic to mark special exams as complete

### DIFF
--- a/lms/djangoapps/instructor/tasks.py
+++ b/lms/djangoapps/instructor/tasks.py
@@ -1,0 +1,99 @@
+""" Celery Tasks for the Instructor App """
+
+import logging
+
+from celery import shared_task
+from celery_utils.logged_task import LoggedTask
+from django.core.exceptions import ObjectDoesNotExist
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import UsageKey
+from xblock.completable import XBlockCompletionMode
+
+from common.djangoapps.student.models import get_user_by_username_or_email
+from lms.djangoapps.courseware.model_data import FieldDataCache
+from lms.djangoapps.courseware.module_render import get_module_for_descriptor
+from openedx.core.lib.request_utils import get_request_or_stub
+from xmodule.modulestore.django import modulestore
+from xmodule.modulestore.exceptions import ItemNotFoundError
+
+log = logging.getLogger(__name__)
+
+
+@shared_task(base=LoggedTask, ignore_result=True)
+def complete_student_attempt_task(user_identifier: str, content_id: str) -> None:
+    """
+    Marks all completable children of content_id as complete for the user
+
+    Submits all completable xblocks inside of the content_id block to the
+    Completion Service to mark them as complete. One use case of this function is
+    for special exams (timed/proctored) where regardless of submission status on
+    individual problems, we want to mark the entire exam as complete when the exam
+    is finished.
+
+    params:
+        user_identifier (str): username or email of a user
+        content_id (str): the block key for a piece of content
+    """
+    err_msg_prefix = (
+        'Error occurred while attempting to complete student attempt for user '
+        f'{user_identifier} for content_id {content_id}. '
+    )
+    err_msg = None
+    try:
+        user = get_user_by_username_or_email(user_identifier)
+        block_key = UsageKey.from_string(content_id)
+        root_descriptor = modulestore().get_item(block_key)
+    except ObjectDoesNotExist:
+        err_msg = err_msg_prefix + 'User does not exist!'
+    except InvalidKeyError:
+        err_msg = err_msg_prefix + 'Invalid content_id!'
+    except ItemNotFoundError:
+        err_msg = err_msg_prefix + 'Block not found in the modulestore!'
+    if err_msg:
+        log.error(err_msg)
+        return
+
+    # This logic has been copied over from openedx/core/djangoapps/schedules/content_highlights.py
+    # in the _get_course_module function.
+    # I'm not sure if this is an anti-pattern or not, so if you can avoid re-copying this, please do.
+    # We are using it here because we ran into issues with the User service being undefined when we
+    # encountered a split_test xblock.
+
+    # Fake a request to fool parts of the courseware that want to inspect it.
+    request = get_request_or_stub()
+    request.user = user
+
+    # Now evil modulestore magic to inflate our descriptor with user state and
+    # permissions checks.
+    field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
+        root_descriptor.course_id, user, root_descriptor, read_only=True,
+    )
+    root_module = get_module_for_descriptor(
+        user, request, root_descriptor, field_data_cache, root_descriptor.course_id,
+    )
+    if not root_module:
+        err_msg = err_msg_prefix + 'Module unable to be created from descriptor!'
+        log.error(err_msg)
+        return
+
+    def _submit_completions(block, user):
+        """
+        Recursively submits the children for completion to the Completion Service
+        """
+        mode = XBlockCompletionMode.get_mode(block)
+        if mode == XBlockCompletionMode.COMPLETABLE:
+            block.runtime.publish(block, 'completion', {'completion': 1.0, 'user_id': user.id})
+        elif mode == XBlockCompletionMode.AGGREGATOR:
+            # I know this looks weird, but at the time of writing at least, there isn't a good
+            # single way to get the children assigned for a partcular user. Some blocks define the
+            # child descriptors method, but others don't and with blocks like Randomized Content
+            # (Library Content), the get_children method returns all children and not just assigned
+            # children. So this is our way around situations like that. See also Split Test Module
+            # for another use case where user state has to be taken into account via get_child_descriptors
+            block_children = ((hasattr(block, 'get_child_descriptors') and block.get_child_descriptors())
+                              or (hasattr(block, 'get_children') and block.get_children())
+                              or [])
+            for child in block_children:
+                _submit_completions(child, user)
+
+    _submit_completions(root_module, user)

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -86,9 +86,6 @@ social-auth-core<4.0.0  # social-auth-core>=4.0.0 requires PYJWT>=2.0.0
 # celery requires click<8.0.0 which would be fixed once https://github.com/celery/celery/issues/6753 is done.
 click<8.0.0
 
-# https://openedx.atlassian.net/servicedesk/customer/portal/9/CR-3776
-edx-proctoring==3.13.2
-
 # constraints present due to Python35 support. Need to be tested and removed independently.
 
 celery<5.0              # celery 5.0 has dropped python3.5 support.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -454,9 +454,8 @@ edx-opaque-keys[django]==2.2.1
     #   xmodule
 edx-organizations==6.9.0
     # via -r requirements/edx/base.in
-edx-proctoring==3.13.2
+edx-proctoring==3.14.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   edx-proctoring-proctortrack
 edx-proctoring-proctortrack==1.0.5

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -542,9 +542,8 @@ edx-opaque-keys[django]==2.2.1
     #   xmodule
 edx-organizations==6.9.0
     # via -r requirements/edx/testing.txt
-edx-proctoring==3.13.2
+edx-proctoring==3.14.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   edx-proctoring-proctortrack
 edx-proctoring-proctortrack==1.0.5

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -528,9 +528,8 @@ edx-opaque-keys[django]==2.2.1
     #   xmodule
 edx-organizations==6.9.0
     # via -r requirements/edx/base.txt
-edx-proctoring==3.13.2
+edx-proctoring==3.14.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-proctoring-proctortrack
 edx-proctoring-proctortrack==1.0.5


### PR DESCRIPTION
## Description
This is technically a revert of a revert that also includes some new
logic. The original PR was https://github.com/edx/edx-platform/pull/27770
and the revert PR was https://github.com/edx/edx-platform/pull/27973.

The new logic is to mock a request and create a module with user state
taken into account. We also put this into a celery task to help avoid
any potential concerns with recursing through children.

Related JIRA tickets: https://openedx.atlassian.net/browse/AA-869 and https://openedx.atlassian.net/browse/AA-773