### PR TITLE
[refactor] Ttracy/MICROBA-1297: ID verify messaging updates on dashboard

### DIFF
--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -1068,12 +1068,12 @@
       }
 
       &.course-status-processing {
-        color: $danger-500;
+        color: theme-color('error');
       }
 
       &.course-status-earned-not-available,
       &.course-status-certavailable {
-        color: #0d7d4d;
+        color: theme-color('success');
       }
 
       &.course-status-certavailable {

--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -1067,6 +1067,10 @@
         }
       }
 
+      &.course-status-processing {
+        color: $danger-500;
+      }
+
       &.course-status-earned-not-available,
       &.course-status-certavailable {
         color: #0d7d4d;

--- a/lms/templates/dashboard/_dashboard_certificate_information.html
+++ b/lms/templates/dashboard/_dashboard_certificate_information.html
@@ -66,7 +66,6 @@ else:
         % elif cert_status['status'] == 'unverified':
           <p class="message-copy">
             ${Text(_("Your certificate was not issued because you do not have a current verified identity with {platform_name}. ")).format(platform_name=settings.PLATFORM_NAME)}
-            <a href="${reverify_link}"> ${Text(_("Verify your identity now."))}</a>
           </p>
         % endif
       </div>

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -366,7 +366,7 @@ from lms.djangoapps.experiments.utils import UPSELL_TRACKING_FLAG
             % if verification_status['status'] == VERIFY_STATUS_NEED_TO_VERIFY:
               <div class="verification-reminder">
                 % if verification_status['days_until_deadline'] is not None:
-                  <h4 class="message-title">${_('Verification not yet complete.')}</h4>
+                  <h4 class="message-title">${_('To earn a certificate, you must verify your ID')}</h4>
                   <p class="message-copy">${ungettext(
                     'You only have {days} day left to verify for this course.',
                     'You only have {days} days left to verify for this course.',


### PR DESCRIPTION
Small change to reword ID verification messaging on the course dashboard and remove one of the buttons to make the messaging more streamlined.

When a certificate is not yet earned and user is not ID verified:
![image](https://user-images.githubusercontent.com/16495365/123151130-2427b480-d431-11eb-8b6b-e8a66012a1b9.png)

when a certificate has been earned, but user is not ID verified:
![image](https://user-images.githubusercontent.com/16495365/123151230-40c3ec80-d431-11eb-825a-5eb79a718c21.png)

