### PR TITLE
fix: Pin lti-consumer-xblock version.

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -102,3 +102,6 @@ maxminddb<2.0.0         # maxminddb 2.0.0 has dropped support for Python 3.5
 path<13.2.0             # path 13.2.0 drops support for Python 3.5
 zipp==1.0.0             # zipp 2.0.0 requires Python >= 3.6
 geoip2<4.0.1            # geoip2 requires Python 3.6
+
+# There are corresponding changes in edx-platform that need to be made before we can update.
+lti-consumer-xblock<2.11.0


### PR DESCRIPTION
There are issues in lti-consumer-xblock version 2.11.0 that
we cannot merge into edx-platform. This pins to a previous
version until the issues are resolved.

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
