### PR TITLE
fix: xblock-poll's export to CSV feature is not working [TNL-8370] [MNG-2273]

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2593,6 +2593,12 @@ DEBUG_TOOLBAR_PATCH_SETTINGS = False
 
 ################################# CELERY ######################################
 
+CELERY_IMPORTS = (
+    # Since xblock-poll is not a Django app, and XBlocks don't get auto-imported
+    # by celery workers, its tasks will not get auto-discovered:
+    'poll.tasks',
+)
+
 # Message configuration
 
 CELERY_TASK_SERIALIZER = 'json'


### PR DESCRIPTION
## Summary

`xblock-poll`'s celery task was broken, then fixed in #23700, then broken again by #25479. This fixes it again.

## Description

XBlock-poll contains a feature to download a CSV of poll responses. It runs asynchronously in the LMS's celery workers.

<img width="878" alt="Screen Shot 2021-06-23 at 5 43 06 PM" src="https://user-images.githubusercontent.com/945577/123185319-80e39900-d44a-11eb-9c67-e7c1eab0d55b.png">

However, we received [a report (TNL-8370)](https://openedx.atlassian.net/browse/TNL-8370) that it is currently broken. Attempting to export the results to CSV only shows an error, which may appear in the UI or only in the browser console:

<img width="865" alt="Screen Shot 2021-06-23 at 5 44 45 PM" src="https://user-images.githubusercontent.com/945577/123185401-b8524580-d44a-11eb-86d7-f69b1ae409ff.png">

The reason for this error is that `xblock-poll`'s celery tasks (in [`tasks.py`](https://github.com/open-craft/xblock-poll/blob/master/poll/tasks.py)) are not being registered. They were previously registered because the default LMS settings in `common.py` explicitly set `CELERY_IMPORTS = ('poll.tasks', ...)`, but https://github.com/edx/edx-platform/pull/25479 removed all explicit celery imports from settings.

I think the reasoning was that all django apps would have their tasks.py auto-detected, but `poll` is not a django app. I tried making the main `poll.py` file import `tasks.py`, but it appears that the LMS celery workers do not load XBlock code at all unless they have some reason to, so I couldn't find any way to register these tasks only by changing the XBlock code.

I'm not sure if there's a better way to make these tasks detected, but this way definitely works.

## Supporting information

* Jira ticket: https://openedx.atlassian.net/browse/TNL-8370
* Previous fix for the exact same issue: https://github.com/edx/edx-platform/pull/23700
* PR that undid the previous fix: https://github.com/edx/edx-platform/pull/25479

## Testing instructions

It took me a while to figure out how to run celery workers on the docker devstack - am I missing some documentation?

First, use `make lms-shell` then edit `/edx/etc/lms.yml`. Make sure `CELERY_QUEUES` is as follows:

```
CELERY_QUEUES:
- edx.lms.core.default
- edx.lms.core.high
- edx.lms.core.high_mem
```
(for some reason, on my devstack, these all had wrong values like `edx.lms.core.defaultedx.lms.core.`, while `CELERY_DEFAULT_QUEUE` had a correct value, resulting in the worker never seeing the tasks)

Second, add this to `lms/envs/private.py`:

```
CELERY_ALWAYS_EAGER = False
BROKER_URL = 'redis://:password@edx.devstack.redis:6379/'
```

Third, start Redis with `make redis-up`

Fourth, restart the LMS.

Fifth: from `make lms-shell`, start a celery worker with

```
DJANGO_SETTINGS_MODULE=lms.envs.devstack_with_worker celery worker --app=lms.celery:APP
```

Sixth: add an `xblock-poll` to a course, answer it so it has some data, and try to export the CSV of results. It should fail. In the logs of the celery worker you should see `Received unregistered task of type 'poll.tasks.export_csv_data'.`.

Seventh: Check out this branch, and restart the celery worker. Try again - it should succeed.

## Deadline

None, this has been an issue for months and there is a workaround that can be used in the meantime.

## Other information

Nope.