### PR TITLE
fix: hide unavailable sequence title in course breadcrumbs [BB-4305]

### DIFF
--- a/common/static/sass/edx-pattern-library-shims/_breadcrumbs.scss
+++ b/common/static/sass/edx-pattern-library-shims/_breadcrumbs.scss
@@ -57,5 +57,10 @@
     @include rtl {
       @include transform(rotateY(180deg));
     }
+
+    // Hide a trailing separator.
+    &:last-child {
+      display: none;
+    }
   }
 }

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -195,7 +195,9 @@ ${HTML(fragment.foot_html())}
                                 </span>
                                 <span class="icon fa fa-angle-right" aria-hidden="true"></span>
                             % endif
-                            <span class="nav-item nav-item-sequence">${sequence_title}</span>
+                            % if sequence_title:
+                                <span class="nav-item nav-item-sequence">${sequence_title}</span>
+                            % endif
                         </div>
                     </div>
                 </nav>


### PR DESCRIPTION
## Description

When a sequence title is unavailable for a user (e.g. before starting a timed exam), the `None` value is displayed in course breadcrumbs. This hides it in such cases and ensures that a trailing breadcrumb separator is not displayed.

![image](https://user-images.githubusercontent.com/3189670/123307897-51548f80-d523-11eb-97fb-fc961be1d425.png)

This replaces #27900.

## Jira

[OSPR-5882](https://openedx.atlassian.net/browse/OSPR-5882)

## Sandbox

https://pr28028.sandbox.opencraft.hosting/

Note: the course navigation does not work properly in the legacy frontend, but it's an issue related to the `master` branch. Setting `courseware.use_legacy_frontend` didn't resolve this, so we've included a direct link to the exam in testing instructions.


## Testing instructions

1. Go to [this page](https://pr28028.sandbox.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/courseware/9fca584977d04885bc911ea76a9ef29e/07bc32474380492cb34f76e5f9d9a135/?child=first).
2. Log in as `audit`.
3. Check that the empty unit name is hidden.

## Manual testing instructions
1. Add the following to `envs/private.py`:
   ```python
   from .common import FEATURES
   FEATURES['ENABLE_SPECIAL_EXAMS'] = True
   ```
1. Go to the LMS shell and run `paver compile_sass`.
1. Set a subsection as a timed exam in Studio (Subsection -> Advanced -> Timed).
1. Log in as `honor` (or another non-staff user).
1. Go to the exam in LMS and check that `None` is no longer visible.

## Deadline

None.

## Reviewers

- [ ] @shimulch
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
EDXAPP_FEATURES_EXTRA:
  ENABLE_SPECIAL_EXAMS: true
```
