### PR TITLE
Fix unsupported course key handling when regenerating all course outlines.

### DIFF
--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -685,7 +685,7 @@ def update_all_outlines_from_modulestore_task():
                     ),
                     course_key_str
                 )
-                return
+                continue
 
             update_outline_from_modulestore_task.delay(course_key_str)
         except Exception:  # pylint: disable=broad-except


### PR DESCRIPTION
## Description

When running the task-creating task which regenerates all course outlines, `continue` instead of `return`ing when an unsupported course key is encountered.

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Supporting information

Part of https://openedx.atlassian.net/browse/TNL-8314

## Testing instructions

- Run a "Regenerate *all* course outlines" in the Studio contentserver admin, including an old-style course key (org/course/run).
- Verify that all course outlines were requested to be regenerated.
