### PR TITLE
Use a "through" model for the ManyToManyField fields - phase 2

### DIFF
--- a/openedx/core/djangoapps/content/learning_sequences/api/outlines.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/outlines.py
@@ -139,11 +139,11 @@ def get_course_outline(course_key: CourseKey) -> CourseOutlineData:
     # represented (so query CourseSection explicitly instead of relying only on
     # select_related from CourseSectionSequence).
     section_models = CourseSection.objects \
-        .prefetch_related('user_partition_groups') \
+        .prefetch_related('new_user_partition_groups') \
         .filter(course_context=course_context) \
         .order_by('ordering')
     section_sequence_models = CourseSectionSequence.objects \
-        .prefetch_related('user_partition_groups') \
+        .prefetch_related('new_user_partition_groups') \
         .filter(course_context=course_context) \
         .order_by('ordering') \
         .select_related('sequence', 'exam')
@@ -173,7 +173,7 @@ def get_course_outline(course_key: CourseKey) -> CourseOutlineData:
             ),
             exam=exam_data,
             user_partition_groups=_get_user_partition_groups_from_qset(
-                sec_seq_model.user_partition_groups.all()
+                sec_seq_model.new_user_partition_groups.all()
             ),
         )
         sec_ids_to_sequence_list[sec_seq_model.section_id].append(sequence_data)
@@ -188,7 +188,7 @@ def get_course_outline(course_key: CourseKey) -> CourseOutlineData:
                 visible_to_staff_only=section_model.visible_to_staff_only,
             ),
             user_partition_groups=_get_user_partition_groups_from_qset(
-                section_model.user_partition_groups.all()
+                section_model.new_user_partition_groups.all()
             ),
         )
         for section_model in section_models
@@ -552,17 +552,6 @@ def _update_user_partition_groups(upg_data: Dict[int, FrozenSet[int]],
     """
     Replace UserPartitionGroups associated with this content with `upg_data`.
     """
-    model_obj.user_partition_groups.all().delete()
-    if upg_data:
-        for partition_id, group_ids in upg_data.items():
-            for group_id in group_ids:
-                upg, _ = UserPartitionGroup.objects.get_or_create(
-                    partition_id=partition_id, group_id=group_id
-                )
-                model_obj.user_partition_groups.add(upg)
-
-    # Temporarily fill-in the new and old user_partition_group fields.
-    # Switchover to the new field will occur after all models have been repopulated.
     model_obj.new_user_partition_groups.all().delete()
     if upg_data:
         for partition_id, group_ids in upg_data.items():


### PR DESCRIPTION
## Description

Use a "through" model for the ManyToManyField fields in CourseSection and CourseSectionSequence to ensure that cascading deletes will occur to delete the relation upon deletion of a foreign-keyed object.

This commit is phase 2 of 4 in order to ensure a smooth deploy. The phases:
1) Add separate through models for user partition groups, add fields to point to the
   separate models, and start writing to those fields as well. (COMPLETE)
2) After all models have been re-generated, switch code over to use separate through
   model fields backed by the separate through models *and* stop writing to the old/original field. (This PR!)
3) After phase 2 is deployed smoothly, remove the original ManyToManyField fields.
4) After phase 3 is deployed smoothly, rename the new fields to have the same name
   as the old fields, so `new_user_partition_groups` -> `user_partition_groups`.

This PR is designed to be able to easily be rolled-back if anything goes wrong.

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Supporting information

https://openedx.atlassian.net/browse/TNL-8314

Phase 1 PR: https://github.com/edx/edx-platform/pull/27941

## Testing instructions

- Ensure that old/new ManyToManyField tables have the same entries.
- Ensure that course outlines are properly displayed.
