### PR TITLE
fix: Milestones app feature flag docs

### DIFF
--- a/common/djangoapps/util/milestones_helpers.py
+++ b/common/djangoapps/util/milestones_helpers.py
@@ -23,11 +23,12 @@ NAMESPACE_CHOICES = {
 REQUEST_CACHE_NAME = "milestones"
 
 # TODO this should be moved to edx/edx-milestones
-# .. toggle_name: FEATURES['ENABLE_MILESTONES_APP']
+# .. toggle_name: FEATURES['MILESTONES_APP']
 # .. toggle_implementation: SettingDictToggle
 # .. toggle_default: False
 # .. toggle_description: Enable the milestones application, which manages significant Course and/or Student events in
-#   the Open edX platform. (see https://github.com/edx/edx-milestones)
+#   the Open edX platform. (see https://github.com/edx/edx-milestones) Note that this feature is required to enable
+#   course pre-requisites.
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2014-11-21
 ENABLE_MILESTONES_APP = SettingDictToggle("FEATURES", "MILESTONES_APP", default=False, module_name=__name__)


### PR DESCRIPTION
## Description

The feature flag that should be set is not ENABLE_MILESTONES_APP but
MILESTONES_APP.

## Supporting information

This issue as first discussed and discovered here: https://discuss.overhang.io/t/enable-section-milestones/1658/5?u=regis
