### PR TITLE
Fix retrieving BadgeAssertion data from Badgr

### DIFF
--- a/lms/djangoapps/badges/admin.py
+++ b/lms/djangoapps/badges/admin.py
@@ -6,9 +6,15 @@ Admin registration for Badge Models
 from config_models.admin import ConfigurationModelAdmin
 from django.contrib import admin
 
-from lms.djangoapps.badges.models import BadgeClass, CourseCompleteImageConfiguration, CourseEventBadgesConfiguration
+from lms.djangoapps.badges.models import (
+    BadgeAssertion,
+    BadgeClass,
+    CourseCompleteImageConfiguration,
+    CourseEventBadgesConfiguration
+)
 
 admin.site.register(CourseCompleteImageConfiguration)
 admin.site.register(BadgeClass)
+admin.site.register(BadgeAssertion)
 # Use the standard Configuration Model Admin handler for this model.
 admin.site.register(CourseEventBadgesConfiguration, ConfigurationModelAdmin)

--- a/lms/djangoapps/badges/backends/tests/test_badgr_backend.py
+++ b/lms/djangoapps/badges/backends/tests/test_badgr_backend.py
@@ -13,7 +13,7 @@ from lazy.lazy import lazy  # lint-amnesty, pylint: disable=no-name-in-module
 
 from edx_django_utils.cache import TieredCache
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
-from common.djangoapps.track.tests import EventTrackingTestCase
+from common.djangoapps.track.tests import FROZEN_TIME, EventTrackingTestCase
 from lms.djangoapps.badges.backends.badgr import BadgrBackend
 from lms.djangoapps.badges.models import BadgeAssertion
 from lms.djangoapps.badges.tests.factories import BadgeClassFactory
@@ -178,10 +178,11 @@ class BadgrBackendTestCase(ModuleStoreTestCase, EventTrackingTestCase):
     @patch('requests.post')
     def test_badge_creation_event(self, post):
         result = {
-            'json': {'id': 'http://www.example.com/example'},
-            'image': 'http://www.example.com/example.png',
-            'badge': 'test_assertion_slug',
-            'issuer': 'https://example.com/v2/issuers/test-issuer',
+            'result': [{
+                'openBadgeId': 'http://www.example.com/example',
+                'image': 'http://www.example.com/example.png',
+                'issuer': 'https://example.com/v2/issuers/test-issuer'
+            }]
         }
         response = Mock()
         response.json.return_value = result
@@ -196,7 +197,7 @@ class BadgrBackendTestCase(ModuleStoreTestCase, EventTrackingTestCase):
             '/assertions')
         self.check_headers(kwargs['headers'])
         assertion = BadgeAssertion.objects.get(user=self.user, badge_class__course_id=self.course.location.course_key)
-        assert assertion.data == result
+        assert assertion.data == result['result'][0]
         assert assertion.image_url == 'http://www.example.com/example.png'
         assert assertion.assertion_url == 'http://www.example.com/example'
         assert kwargs['json'] == {"recipient": {"identity": 'example@example.com', "type": "email"},
@@ -215,7 +216,9 @@ class BadgrBackendTestCase(ModuleStoreTestCase, EventTrackingTestCase):
                 'assertion_image_url': 'http://www.example.com/example.png',
                 'assertion_json_url': 'http://www.example.com/example',
                 'issuer': 'https://example.com/v2/issuers/test-issuer',
-            }
+            },
+            'context': {},
+            'timestamp': FROZEN_TIME
         }, self.get_event())
 
     def test_get_new_tokens(self):


### PR DESCRIPTION
* Fix retrieving BadgeAssertion data from Badgr
With edx#27181, the integration with Badgr was updated and fixed to
be working with the Badgr v2 API. However, retrieving the badge assertion
data from Badgr still needs to be updated for the new json response
structure so we can save it at our end as well.

* Add BadgeAssertion table to LMS admin
Adding BadgeAssertion table to LMS admin is merely a suggestion
as I found it very helpful when configuring and testing the backend integration.
So this might be generally helpful for operators but I am happy to drop
this commit if there is any objections.

## Testing instructions

Same as for #27181 

Prerequisites:

An Issuer App is needed, either registered at https://badgr.org/app-developers/#issuer-apps or in your own instance of the Badgr Server.

Configuration examples:

in `studio.yml` and `lms.yml`:

```
FEATURES:
	ENABLE_OPENBADGES: true
```

in `lms.yml`:

```
BADGR_USERNAME = "example@example.com"
BADGR_PASSWORD = "password"
BADGR_TOKENS_CACHE_KEY = "secret-cache-key"
BADGR_BASE_URL = "http://localhost:8005"
BADGR_ISSUER_SLUG = "issuer-slug"
```
Make sure your Issuer App is configured properly, you can test creating and refreshing tokens as noted in https://api.badgr.io/docs/v2/ :

```
curl -X POST '$BADGR_BASE_URL/o/token' -d "username=$BADGR_USERNAME&password=$BADGR_PASSWORD"
```
```
curl -X POST '$BADGR_BASE_URL/o/token' -d "grant_type=refresh_token&refresh_token=<refresh_token>"
```

Noticeable result when applying this patch is that one can properly see the badge image under profile -> accomplishments, since the image url and other data about the badge assertion will then be properly retrieved from Badgr and saved.