### PR TITLE
fix: re-order the discussion features

### DIFF
--- a/openedx/core/djangoapps/discussions/models.py
+++ b/openedx/core/djangoapps/discussions/models.py
@@ -36,31 +36,32 @@ class Features(Enum):
     """
     Features to be used/mapped in discussion providers
     """
-    ADVANCED_IN_CONTEXT_DISCUSSION = 'advanced-in-context-discussion'
     ANONYMOUS_POSTING = 'anonymous-posting'
     AUTOMATIC_LEARNER_ENROLLMENT = 'automatic-learner-enrollment'
     BLACKOUT_DISCUSSION_DATES = 'blackout-discussion-dates'
     COMMUNITY_TA_SUPPORT = 'community-ta-support'
     COURSE_COHORT_SUPPORT = 'course-cohort-support'
-    DIRECT_MESSAGES_FROM_INSTRUCTORS = 'direct-messages-from-instructors'
     DISCUSSION_PAGE = 'discussion-page'
+    INTERNATIONALIZATION_SUPPORT = 'internationalization-support'
+    PRIMARY_DISCUSSION_APP_EXPERIENCE = 'primary-discussion-app-experience'
+    QUESTION_DISCUSSION_SUPPORT = 'question-discussion-support'
+    REPORT_FLAG_CONTENT_TO_MODERATORS = 'report/flag-content-to-moderators'
+    RESEARCH_DATA_EVENTS = 'research-data-events'
+    WCAG_2_0_SUPPORT = 'wcag-2.0-support'
+    WCAG_2_1 = 'wcag-2.1'
+    ADVANCED_IN_CONTEXT_DISCUSSION = 'advanced-in-context-discussion'
+    DIRECT_MESSAGES_FROM_INSTRUCTORS = 'direct-messages-from-instructors'
     DISCUSSION_CONTENT_PROMPTS = 'discussion-content-prompts'
     EMAIL_NOTIFICATIONS = 'email-notifications'
     EMBEDDED_COURSE_SECTIONS = 'embedded-course-sections'
     GRADED_DISCUSSIONS = 'graded-discussions'
     IN_PLATFORM_NOTIFICATIONS = 'in-platform-notifications'
-    INTERNATIONALIZATION_SUPPORT = 'internationalization-support'
-    LTI = 'lti'
     LTI_ADVANCED_SHARING_MODE = 'lti-advanced-sharing-mode'
     LTI_BASIC_CONFIGURATION = 'lti-basic-configuration'
-    PRIMARY_DISCUSSION_APP_EXPERIENCE = 'primary-discussion-app-experience'
-    QUESTION_DISCUSSION_SUPPORT = 'question-discussion-support'
-    REPORT_FLAG_CONTENT_TO_MODERATORS = 'report/flag-content-to-moderators'
-    RESEARCH_DATA_EVENTS = 'research-data-events'
+    LTI = 'lti'
     SIMPLIFIED_IN_CONTEXT_DISCUSSION = 'simplified-in-context-discussion'
     USER_MENTIONS = 'user-mentions'
-    WCAG_2_1 = 'wcag-2.1'
-    WCAG_2_0_SUPPORT = 'wcag-2.0-support'
+
 
 AVAILABLE_PROVIDER_MAP = {
     'legacy': {


### PR DESCRIPTION
https://openedx.atlassian.net/browse/TNL-8404

Re order the discussion features to match the latest figma

features order before:
<img width="243" alt="Screenshot 2021-06-28 at 5 44 45 PM" src="https://user-images.githubusercontent.com/10988308/123638440-9f75d580-d838-11eb-96b2-7afe36f6c466.png">

features order after:
<img width="237" alt="Screenshot 2021-06-28 at 5 42 09 PM" src="https://user-images.githubusercontent.com/10988308/123638532-b6b4c300-d838-11eb-9962-ff0e3f86bbe2.png">
