### PR TITLE
fix: change buttons in wiki modal to anchor tags

### DIFF
--- a/lms/templates/wiki/history.html
+++ b/lms/templates/wiki/history.html
@@ -215,15 +215,15 @@
         {% trans "Back to history view" as tmsg %}{{tmsg|force_escape}}
       </a>
       {% if article|can_write:user %}
-        <button type="button" class="btn btn-large btn-primary switch-to-revision">
+        <a class="btn btn-large btn-primary switch-to-revision">
           <span class="icon fa fa-flag" aria-hidden="true"></span>
           {% trans "Switch to this version" as tmsg %}{{tmsg|force_escape}}
-        </button>
+        </a>
       {% else %}
-        <button type="button" class="btn btn-large btn-primary disabled">
+        <a class="btn btn-large btn-primary disabled">
           <span class="icon fa fa-lock" aria-hidden="true"></span>
           {% trans "Switch to this version" as tmsg%}{{tmsg|force_escape}}
-        </button>
+        </a>
       {% endif %}
       </div>
     </div>
@@ -250,15 +250,15 @@
           {% trans "Back to history view" as tmsg%}{{tmsg|force_escape}}
         </a>
         {% if article|can_write:user %}
-        <button type="button" class="btn btn-large btn-primary merge-revision-commit">
+        <a class="btn btn-large btn-primary merge-revision-commit">
           <span class="icon fa fa-file" aria-hidden="true"></span>
           {% trans "Create new merged version" as tmsg%}{{tmsg|force_escape}}
-        </button>
+        </a>
         {% else %}
-          <button type="button" class="btn btn-large btn-primary disabled">
+          <a type="button" class="btn btn-large btn-primary disabled">
             <span class="icon fa fa-lock" aria-hidden="true"></span>
             {% trans "Create new merged version" as tmsg%}{{tmsg|force_escape}}
-          </button>
+          </a>
         {% endif %}
       </div>
     </div>


### PR DESCRIPTION
### Description

The action buttons in wiki modal have href attribute
but do not have an event listener for click.
This PR changes the buttons to anchor tags so that they
work as expected when clicked.

### Related Tickets

- [OSPR-5888](https://openedx.atlassian.net/browse/OSPR-5888)
- [BB-4360](https://tasks.opencraft.com/browse/BB-4360)

### Reproducing the buggy behavior

1.  Enroll in any Course
2. Go to Wiki
3. Create an article
4. Make 2-3 edits and save after each edit
5. Click on Changes
6. Select any revision and click "Merge selected with current"
8. Click "Create new merged version". Check that this does not trigger any action.

### Testing Instructions

1. Checkout to this branch.
2. Go to Wiki
3. Create an article
4. Make 2-3 edits and save after each edit
5. Click on Changes
6. Select any revision and click "Merge selected with current"
8. Click "Create new merged version".
9. Verify that this triggers a merge request.
10. Wait for request to succeed and page to reload.
11. A new merged revision should be created.

#### Author Notes:
1. Merge versions action was pretty slow on my local devstack. Please wait for some time for the merge version request to succeed.