### PR TITLE
refactor: noop migration for testing

### DIFF
--- a/openedx/core/djangoapps/oauth_dispatch/migrations/0010_noop_migration_to_test_rollback.py
+++ b/openedx/core/djangoapps/oauth_dispatch/migrations/0010_noop_migration_to_test_rollback.py
@@ -1,0 +1,15 @@
+"""
+Noop migration to test rollback
+"""
+
+from django.db import migrations
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('oauth_dispatch', '0009_delete_enable_scopes_waffle_switch'),
+    ]
+
+    operations = [
+        migrations.RunSQL(migrations.RunSQL.noop, reverse_sql=migrations.RunSQL.noop)
+    ]


### PR DESCRIPTION
## Description

This is a noop migration for testing changes
to the deployment pipeline.

## Testing instructions

Tested on devstack:
```
root@lms:/edx/app/edxapp/edx-platform# ./manage.py lms --settings=devstack_docker migrate oauth_dispatch
2021-06-28 19:57:13,409 WARNING 314 [py.warnings] [user None] [ip None] warnings.py:109 - /edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/newrelic/console.py:84: DeprecationWarning: `formatargspec` is deprecated since Python 3.5. Use `signature` and the `Signature` object directly
  prototype = wrapper.__name__[3:] + ' ' + inspect.formatargspec(

2021-06-28 19:57:13,680 WARNING 314 [py.warnings] [user None] [ip None] warnings.py:109 - /edx/app/edxapp/edx-platform/lms/djangoapps/course_wiki/plugins/markdownedx/wiki_plugin.py:5: DeprecationWarning: 'etree' is deprecated. Use 'xml.etree.ElementTree' instead.
  from lms.djangoapps.course_wiki.plugins.markdownedx import mdx_mathjax, mdx_video

2021-06-28 19:57:16,688 WARNING 314 [py.warnings] [user None] [ip None] warnings.py:109 - /edx/app/edxapp/venvs/edxapp/src/django-wiki/wiki/plugins/links/wiki_plugin.py:9: DeprecationWarning: 'etree' is deprecated. Use 'xml.etree.ElementTree' instead.
  from wiki.plugins.links.mdx.djangowikilinks import WikiPathExtension

Operations to perform:
  Apply all migrations: oauth_dispatch
Running migrations:
  Applying oauth_dispatch.0010_noop_migration_to_test_rollback... OK
```

And in devstack mysql:
```
mysql> select * from django_migrations WHERE app = 'oauth_dispatch';
+-----+----------------+------------------------------------------------------+----------------------------+
| id  | app            | name                                                 | applied                    |
+-----+----------------+------------------------------------------------------+----------------------------+
| 444 | oauth_dispatch | 0001_initial                                         | 2020-04-06 20:32:43.302469 |
| 445 | oauth_dispatch | 0002_scopedapplication_scopedapplicationorganization | 2020-04-06 20:32:46.384928 |
| 446 | oauth_dispatch | 0003_application_data                                | 2020-04-06 20:32:47.542463 |
| 447 | oauth_dispatch | 0004_auto_20180626_1349                              | 2020-04-06 20:32:53.451878 |
| 448 | oauth_dispatch | 0005_applicationaccess_type                          | 2020-04-06 20:32:54.254469 |
| 449 | oauth_dispatch | 0006_drop_application_id_constraints                 | 2020-04-06 20:32:54.833895 |
| 455 | oauth_dispatch | 0007_restore_application_id_constraints              | 2020-04-06 20:33:30.299343 |
| 456 | oauth_dispatch | 0008_applicationaccess_filters                       | 2020-04-06 20:33:30.910483 |
| 457 | oauth_dispatch | 0009_delete_enable_scopes_waffle_switch              | 2020-04-06 20:33:31.445534 |
| 859 | oauth_dispatch | 0010_noop_migration_to_test_rollback                 | 2021-06-28 19:57:22.425039 |
+-----+----------------+------------------------------------------------------+----------------------------+
10 rows in set (0.00 sec)
```
