### PR TITLE
fix: remove MathJax loading status bar in courseware (TNL-8448)

### DIFF
--- a/common/templates/mathjax_include.html
+++ b/common/templates/mathjax_include.html
@@ -36,6 +36,7 @@
 %else:
 <script type="text/x-mathjax-config">
   MathJax.Hub.Config({
+    messageStyle: "none",
     tex2jax: {
       inlineMath: [
         ["\\(","\\)"],


### PR DESCRIPTION
```
Loading messages for MathJax are distracting and not actionable. They
also delay the time to final render for many pages that do not actually
have math on them. This removes them.
```
