### PR TITLE
refactor: noop migration for testing

### DIFF
--- a/openedx/core/djangoapps/oauth_dispatch/migrations/0011_noop_migration_to_test_rollback.py
+++ b/openedx/core/djangoapps/oauth_dispatch/migrations/0011_noop_migration_to_test_rollback.py
@@ -1,0 +1,15 @@
+"""
+Noop migration to test rollback
+"""
+
+from django.db import migrations
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('oauth_dispatch', '0010_noop_migration_to_test_rollback'),
+    ]
+
+    operations = [
+        migrations.RunSQL(migrations.RunSQL.noop, reverse_sql=migrations.RunSQL.noop)
+    ]


### PR DESCRIPTION
This is a noop migration for testing changes
to the deployment pipeline.

This is a copy of: https://github.com/edx/edx-platform/pull/28052

Testing instructions
Tested on devstack:

```docker-compose exec lms env TERM=xterm-256color /edx/app/edxapp/devstack.sh open
root@lms:/edx/app/edxapp/edx-platform# ./manage.py lms --settings=devstack_docker migrate oauth_dispatch
2021-07-01 15:10:57,430 WARNING 517 [py.warnings] [user None] [ip None] warnings.py:109 - /edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/newrelic/core/application.py:26: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
  import imp

2021-07-01 15:10:57,768 WARNING 517 [py.warnings] [user None] [ip None] warnings.py:109 - /edx/app/edxapp/edx-platform/lms/djangoapps/course_wiki/plugins/markdownedx/wiki_plugin.py:5: DeprecationWarning: 'etree' is deprecated. Use 'xml.etree.ElementTree' instead.
  from lms.djangoapps.course_wiki.plugins.markdownedx import mdx_mathjax, mdx_video

2021-07-01 15:10:59,517 WARNING 517 [py.warnings] [user None] [ip None] warnings.py:109 - /edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/botocore/vendored/requests/packages/urllib3/_collections.py:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
  from collections import Mapping, MutableMapping

2021-07-01 15:11:00,832 WARNING 517 [py.warnings] [user None] [ip None] warnings.py:109 - /edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/xblock/django/request.py:24: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
  class HeaderDict(MutableMapping, collections.Iterator):  # pylint: disable=useless-object-inheritance

2021-07-01 15:11:01,211 WARNING 517 [py.warnings] [user None] [ip None] warnings.py:109 - /edx/app/edxapp/edx-platform/openedx/core/lib/api/view_utils.py:5: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
  from collections import Sequence  # lint-amnesty, pylint: disable=no-name-in-module

2021-07-01 15:11:01,463 WARNING 517 [py.warnings] [user None] [ip None] warnings.py:109 - /edx/app/edxapp/venvs/edxapp/src/django-wiki/wiki/plugins/links/wiki_plugin.py:9: DeprecationWarning: 'etree' is deprecated. Use 'xml.etree.ElementTree' instead.
  from wiki.plugins.links.mdx.djangowikilinks import WikiPathExtension

Operations to perform:
  Apply all migrations: oauth_dispatch
Running migrations:
  Applying oauth_dispatch.0011_noop_migration_to_test_rollback... OK
```

And in devstack mysql:
```
mysql> select * from django_migrations WHERE app = 'oauth_dispatch';
+-----+----------------+------------------------------------------------------+----------------------------+
| id  | app            | name                                                 | applied                    |
+-----+----------------+------------------------------------------------------+----------------------------+
| 560 | oauth_dispatch | 0001_initial                                         | 2021-05-13 20:01:31.919542 |
| 561 | oauth_dispatch | 0002_scopedapplication_scopedapplicationorganization | 2021-05-13 20:01:32.621852 |
| 562 | oauth_dispatch | 0003_application_data                                | 2021-05-13 20:01:33.133491 |
| 563 | oauth_dispatch | 0004_auto_20180626_1349                              | 2021-05-13 20:01:34.094030 |
| 564 | oauth_dispatch | 0005_applicationaccess_type                          | 2021-05-13 20:01:34.263939 |
| 565 | oauth_dispatch | 0006_drop_application_id_constraints                 | 2021-05-13 20:01:35.373384 |
| 566 | oauth_dispatch | 0007_restore_application_id_constraints              | 2021-05-13 20:01:35.608639 |
| 567 | oauth_dispatch | 0008_applicationaccess_filters                       | 2021-05-13 20:01:35.677938 |
| 568 | oauth_dispatch | 0009_delete_enable_scopes_waffle_switch              | 2021-05-13 20:01:36.093354 |
| 781 | oauth_dispatch | 0010_noop_migration_to_test_rollback                 | 2021-06-30 13:57:58.873654 |
| 786 | oauth_dispatch | 0011_noop_migration_to_test_rollback                 | 2021-07-01 15:11:08.100436 |
+-----+----------------+------------------------------------------------------+----------------------------+
11 rows in set (0.00 sec)

```