### PR TITLE
refactor: new logic for when to enable Gradebook bulk management

### DIFF
--- a/lms/djangoapps/grades/api.py
+++ b/lms/djangoapps/grades/api.py
@@ -16,7 +16,7 @@ from common.djangoapps.track.event_transaction_utils import create_new_event_tra
 from lms.djangoapps.grades import constants, context, course_data, events
 # Grades APIs that should NOT belong within the Grades subsystem
 # TODO move Gradebook to be an external feature outside of core Grades
-from lms.djangoapps.grades.config.waffle import gradebook_can_see_bulk_management, is_writable_gradebook_enabled
+from lms.djangoapps.grades.config.waffle import gradebook_bulk_management_enabled, is_writable_gradebook_enabled
 # Public Grades Factories
 from lms.djangoapps.grades.course_grade_factory import CourseGradeFactory
 from lms.djangoapps.grades.models_api import *

--- a/lms/djangoapps/grades/config/waffle.py
+++ b/lms/djangoapps/grades/config/waffle.py
@@ -150,10 +150,8 @@ def is_writable_gradebook_enabled(course_key):
     return waffle_flags()[WRITABLE_GRADEBOOK].is_enabled(course_key)
 
 
-def gradebook_can_see_bulk_management(course_key):
+def gradebook_bulk_management_enabled(course_key):
     """
-    Returns whether bulk management features should be visible for the given course.
-
-    (provided that course contains a masters track, as of this writing)
+    Returns whether bulk management features should be specially enabled for a given course.
     """
     return waffle_flags()[BULK_MANAGEMENT].is_enabled(course_key)

--- a/lms/djangoapps/grades/rest_api/v1/gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/gradebook_views.py
@@ -35,7 +35,7 @@ from lms.djangoapps.grades.api import CourseGradeFactory, clear_prefetched_cours
 from lms.djangoapps.grades.api import constants as grades_constants
 from lms.djangoapps.grades.api import context as grades_context
 from lms.djangoapps.grades.api import events as grades_events
-from lms.djangoapps.grades.api import gradebook_can_see_bulk_management as can_see_bulk_management
+from lms.djangoapps.grades.api import gradebook_bulk_management_enabled
 from lms.djangoapps.grades.api import is_writable_gradebook_enabled, prefetch_course_and_subsection_grades
 from lms.djangoapps.grades.course_data import CourseData
 from lms.djangoapps.grades.grade_utils import are_grades_frozen
@@ -281,7 +281,7 @@ class CourseGradingView(BaseCourseView):
                 'assignment_types': self._get_assignment_types(course),
                 'subsections': self._get_subsections(course, graded_only),
                 'grades_frozen': are_grades_frozen(course_key),
-                'can_see_bulk_management': can_see_bulk_management(course_key),
+                'can_see_bulk_management': gradebook_bulk_management_enabled(course_key),
             }
             return Response(results)
 

--- a/lms/djangoapps/grades/rest_api/v1/gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/gradebook_views.py
@@ -21,7 +21,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from common.djangoapps.student.auth import has_course_author_access
-from common.djangoapps.student.models import CourseEnrollment, CourseAccessRole
+from common.djangoapps.student.models import CourseAccessRole, CourseEnrollment, CourseMode
 from common.djangoapps.student.roles import BulkRoleCache
 from common.djangoapps.track.event_transaction_utils import (
     create_new_event_transaction_id,
@@ -56,6 +56,7 @@ from lms.djangoapps.grades.subsection_grade_factory import SubsectionGradeFactor
 from lms.djangoapps.grades.tasks import recalculate_subsection_grade_v3
 from lms.djangoapps.program_enrollments.api import get_external_key_by_user_and_course
 from openedx.core.djangoapps.course_groups import cohorts
+from openedx.core.djangoapps.enrollments.api import get_course_enrollment_details
 from openedx.core.djangoapps.util.forms import to_bool
 from openedx.core.lib.api.view_utils import (
     DeveloperErrorViewMixin,
@@ -281,9 +282,18 @@ class CourseGradingView(BaseCourseView):
                 'assignment_types': self._get_assignment_types(course),
                 'subsections': self._get_subsections(course, graded_only),
                 'grades_frozen': are_grades_frozen(course_key),
-                'can_see_bulk_management': gradebook_bulk_management_enabled(course_key),
+                'can_see_bulk_management': self._can_see_bulk_management(course_key),
             }
             return Response(results)
+
+    def _can_see_bulk_management(self, course_key):
+        """
+        Whether or not to show bulk management for this course. Currently, if a course has a
+        master's track or is enabled with the grades.bulk_management course waffle flag.
+        """
+        course_modes = get_course_enrollment_details(str(course_key), include_expired=True).get('course_modes', [])
+        course_has_masters_track = any([course_mode['slug'] == CourseMode.MASTERS for course_mode in course_modes])
+        return course_has_masters_track or gradebook_bulk_management_enabled(course_key)
 
     def _get_assignment_types(self, course):
         """

--- a/lms/djangoapps/grades/rest_api/v1/gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/gradebook_views.py
@@ -282,11 +282,11 @@ class CourseGradingView(BaseCourseView):
                 'assignment_types': self._get_assignment_types(course),
                 'subsections': self._get_subsections(course, graded_only),
                 'grades_frozen': are_grades_frozen(course_key),
-                'can_see_bulk_management': self._can_see_bulk_management(course_key),
+                'can_see_bulk_management': self.can_see_bulk_management(course_key),
             }
             return Response(results)
 
-    def _can_see_bulk_management(self, course_key):
+    def can_see_bulk_management(self, course_key):
         """
         Whether or not to show bulk management for this course. Currently, if a course has a
         master's track or is enabled with the grades.bulk_management course waffle flag.

--- a/lms/djangoapps/grades/rest_api/v1/gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/gradebook_views.py
@@ -292,7 +292,7 @@ class CourseGradingView(BaseCourseView):
         master's track or is enabled with the grades.bulk_management course waffle flag.
         """
         course_modes = get_course_enrollment_details(str(course_key), include_expired=True).get('course_modes', [])
-        course_has_masters_track = any([course_mode['slug'] == CourseMode.MASTERS for course_mode in course_modes])
+        course_has_masters_track = any((course_mode['slug'] == CourseMode.MASTERS for course_mode in course_modes))
         return course_has_masters_track or gradebook_bulk_management_enabled(course_key)
 
     def _get_assignment_types(self, course):

--- a/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
@@ -245,8 +245,11 @@ class CourseGradingViewTest(SharedModuleStoreTestCase, APITestCase):
             expected_data['grades_frozen'] = True
             assert expected_data == resp.data
 
-    def test_can_see_bulk_management_non_masters(self):
+    @patch('lms.djangoapps.grades.rest_api.v1.gradebook_views.get_course_enrollment_details')
+    def test_can_see_bulk_management_non_masters(self, mock_course_enrollment_details):
         # Given a course without a master's track
+        mock_course_enrollment_details.return_value = {'course_modes': [{'slug': 'not-masters'}]}
+
         # When getting course grading view
         self.client.login(username=self.staff.username, password=self.password)
         resp = self.client.get(self.get_url(self.course_key))

--- a/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
@@ -256,7 +256,7 @@ class CourseGradingViewTest(SharedModuleStoreTestCase, APITestCase):
 
         # Course staff should not be shown bulk management controls
         assert resp.status_code == status.HTTP_200_OK
-        assert resp.data['can_see_bulk_management'] == False
+        assert resp.data['can_see_bulk_management'] is False
 
     @patch('lms.djangoapps.grades.rest_api.v1.gradebook_views.get_course_enrollment_details')
     def test_can_see_bulk_management_masters(self, mock_course_enrollment_details):
@@ -269,7 +269,7 @@ class CourseGradingViewTest(SharedModuleStoreTestCase, APITestCase):
 
         # Course staff should be shown bulk management controls (default on for master's track courses)
         assert resp.status_code == status.HTTP_200_OK
-        assert resp.data['can_see_bulk_management'] == True
+        assert resp.data['can_see_bulk_management'] is True
 
     @override_waffle_flag(waffle_flags()[BULK_MANAGEMENT], active=True)
     def test_can_see_bulk_management_force_enabled(self):
@@ -280,7 +280,7 @@ class CourseGradingViewTest(SharedModuleStoreTestCase, APITestCase):
 
         # # Course staff should be able to see bulk management
         assert resp.status_code == status.HTTP_200_OK
-        assert resp.data['can_see_bulk_management'] == True
+        assert resp.data['can_see_bulk_management'] is True
 
 
 class GradebookViewTestBase(GradeViewTestMixin, APITestCase):

--- a/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
@@ -32,7 +32,7 @@ from common.djangoapps.student.tests.factories import InstructorFactory
 from common.djangoapps.student.tests.factories import StaffFactory
 from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.certificates.models import GeneratedCertificate
-from lms.djangoapps.grades.config.waffle import WRITABLE_GRADEBOOK, waffle_flags
+from lms.djangoapps.grades.config.waffle import BULK_MANAGEMENT, WRITABLE_GRADEBOOK, waffle_flags
 from lms.djangoapps.grades.constants import GradeOverrideFeatureEnum
 from lms.djangoapps.grades.course_data import CourseData
 from lms.djangoapps.grades.course_grade import CourseGrade
@@ -244,6 +244,40 @@ class CourseGradingViewTest(SharedModuleStoreTestCase, APITestCase):
             expected_data = self._get_expected_data()
             expected_data['grades_frozen'] = True
             assert expected_data == resp.data
+
+    def test_can_see_bulk_management_non_masters(self):
+        # Given a course without a master's track
+        # When getting course grading view
+        self.client.login(username=self.staff.username, password=self.password)
+        resp = self.client.get(self.get_url(self.course_key))
+
+        # Course staff should not be shown bulk management controls
+        assert resp.status_code == status.HTTP_200_OK
+        assert resp.data['can_see_bulk_management'] == False
+
+    @patch('lms.djangoapps.grades.rest_api.v1.gradebook_views.get_course_enrollment_details')
+    def test_can_see_bulk_management_masters(self, mock_course_enrollment_details):
+        # Given a course with a master's track
+        mock_course_enrollment_details.return_value = {'course_modes': [{'slug': 'not-masters'}, {'slug': 'masters'}]}
+
+        # When getting course grading view
+        self.client.login(username=self.staff.username, password=self.password)
+        resp = self.client.get(self.get_url(self.course_key))
+
+        # Course staff should be shown bulk management controls (default on for master's track courses)
+        assert resp.status_code == status.HTTP_200_OK
+        assert resp.data['can_see_bulk_management'] == True
+
+    @override_waffle_flag(waffle_flags()[BULK_MANAGEMENT], active=True)
+    def test_can_see_bulk_management_force_enabled(self):
+        # Given a course without (or with) a master's track where bulk management is enabled with the config flag
+        # When getting course grading view
+        self.client.login(username=self.staff.username, password=self.password)
+        resp = self.client.get(self.get_url(self.course_key))
+
+        # # Course staff should be able to see bulk management
+        assert resp.status_code == status.HTTP_200_OK
+        assert resp.data['can_see_bulk_management'] == True
 
 
 class GradebookViewTestBase(GradeViewTestMixin, APITestCase):


### PR DESCRIPTION
## Description

Change logic for when to enable bulk management in Gradebook: default enabled for courses with a master's track, selectively enabled for courses when the `grades.bulk_management` course waffle flag is set.

JIRA: 
* Drafted as part of [EDUCATOR-5624](https://openedx.atlassian.net/browse/EDUCATOR-5624)
* To be merged with https://github.com/edx/frontend-app-gradebook/pull/200 as part of [AU-36](https://openedx.atlassian.net/browse/AU-36).

Formerly, bulk management had to be enabled through a feature flag AND a master's track had to be available in the course for bulk management to be enabled. These two pieces of info were separately sent to Gradebook which would own the final determination for when to show bulk management features. Paired with https://github.com/edx/frontend-app-gradebook/pull/200, this moves the logic into `edx-platform` which checks for a master's track OR the feature flag and sends `can_see_bulk_management` as the data to enable/disable that functionality in Gradebook.

~**⚠️  NOTE** - this must not merge until after currently allow-listed courses are enabled through course waffle flags in PROD ([AU-35](https://openedx.atlassian.net/browse/AU-35)).~ Complete.

## Testing instructions

Verify that:
- Visiting a course without a master's track and without the `grades.bulk_management` CourseWaffleFlag "Enabled" does not show bulk management functionality in Gradebook.
- Visiting a course with a master's track shows bulk management functionality in Gradebook.
- Visiting a course with the `grades.bulk_management` CourseWaffleFlag "Enabled" from Django Admin shows bulk management functionality in Gradebook.
