### PR TITLE
[feat] MICROBA-1324: Add has_scheduled_content to outline API

### DIFF
--- a/lms/djangoapps/course_home_api/outline/v1/serializers.py
+++ b/lms/djangoapps/course_home_api/outline/v1/serializers.py
@@ -54,6 +54,7 @@ class CourseBlockSerializer(serializers.Serializer):
                 'legacy_web_url': block['legacy_web_url'] if enable_links else None,
                 'resume_block': block.get('resume_block', False),
                 'type': block_type,
+                'has_scheduled_content': block.get('has_scheduled_content'),
             },
         }
         for child in children:

--- a/lms/djangoapps/course_home_api/outline/v1/views.py
+++ b/lms/djangoapps/course_home_api/outline/v1/views.py
@@ -102,6 +102,7 @@ class OutlineTabView(RetrieveAPIView):
                 children: (list) If the block has child blocks, a list of IDs of
                     the child blocks.
                 resume_block: (bool) Whether the block is the resume block
+                has_scheduled_content: (bool) Whether the block has more content scheduled for the future
         course_goals:
             goal_options: (list) A list of goals where each goal is represented as a tuple (goal_key, goal_string)
             selected_goal:

--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -105,6 +105,7 @@ def get_course_outline_block_tree(request, course_id, user=None, allow_start_dat
             'effort_time',
             'format',
             'graded',
+            'has_scheduled_content',
             'has_score',
             'show_gated_sections',
             'special_exam_info',


### PR DESCRIPTION
In order for a new alert in the learning MFE to function, we need to add an indicator that a course has upcoming content to the outline API. Relevant Alert PR: [PR-515]( https://github.com/edx/frontend-app-learning/pull/515)