### PR TITLE
Fix: SplitTestBlock error in Course Outlines

### DIFF
--- a/cms/djangoapps/contentstore/outlines.py
+++ b/cms/djangoapps/contentstore/outlines.py
@@ -213,6 +213,15 @@ def _make_not_bubbled_up_error(seq_usage_key, seq_group_access, user_partition_i
 
 
 def _make_sequence_data(sequence, sequence_group_access):
+    """
+    Return  a (SequenceData, List[SequenceErrorData]) from a SequnceBlock.
+
+    This method formats SequenceBlocks so they can be added to CourseSectionData.
+    The SequenceData formats the data so that it  willbe more readable for
+    partner support and also attaches the units (children of sequences) to the
+    correct SequenceBlock.
+
+    """
     sequence_errors = []
     seq_user_partition_groups, error = _make_user_partition_groups(
         sequence.location, sequence.group_access
@@ -264,6 +273,12 @@ def _make_sequence_data(sequence, sequence_group_access):
 
 
 def _make_split_test_data(split_test):
+    """
+    Return  a (SplitTestData, List[SplitTestErrorData]) from a SplitTestBlock.
+
+    This method renders the SplitTestBlock into its subcomponents (SequenceBlocks)
+    so that it can be used added to CourseSectionData.
+    """
     split_test_errors = []
     split_test_data = []
 
@@ -320,6 +335,10 @@ def _make_section_data(section, unique_sequences):
 
     for sequence in section.get_children():
         if sequence.location.block_type not in valid_sequence_tags:
+            # We need to check if the current sequence is a Split Test block. If
+            # the sequence is a Split Test, the block will read through and will
+            # return the sequences ans the sequences' children to add to the
+            # other sequences.
             if sequence.location.block_type == 'split_test':
                 split_test_sequences, split_test_errors = _make_split_test_data(sequence)
                 if split_test_sequences:

--- a/cms/djangoapps/contentstore/tests/test_outlines.py
+++ b/cms/djangoapps/contentstore/tests/test_outlines.py
@@ -206,18 +206,21 @@ class OutlineFromModuleStoreTestCase(ModuleStoreTestCase):
 
     def test_split_test(self):
         """
-        Test when the structure is Course -> Section -> Split Test -> Unit.
+        Test when the structure is Course -> Section -> Split Test -> Sequence.
+
+        Studio disallows this, but it's possible to craft with the older Course
+        Blocks API. This type of structure creates A/B testing and should be
+        split in the course outline.
         """
 
         base_url_sequential = 'i4x://' + self.draft_course.org + '/' + self.course_key.course + '/sequential/'
-        # Course -> Section -> Unit (No Sequence)
+        # Course -> Section -> SpliTest -> Sequence
         with self.store.bulk_operations(self.course_key):
             section_1 = ItemFactory.create(
                 parent_location=self.draft_course.location,
                 category='chapter',
                 display_name="Section",
             )
-            # This Unit should be skipped
             split_test_1 = ItemFactory.create(
                 parent_location=section_1.location,
                 category='split_test',
@@ -241,6 +244,7 @@ class OutlineFromModuleStoreTestCase(ModuleStoreTestCase):
         assert len(outline.sections) == 1
         assert len(outline.sections[0].sequences) == 2
         assert len(outline.sequences) == 2
+        assert len(errs) == 0
 
     def test_unit_in_section(self):
         """

--- a/cms/djangoapps/contentstore/tests/test_outlines.py
+++ b/cms/djangoapps/contentstore/tests/test_outlines.py
@@ -204,6 +204,44 @@ class OutlineFromModuleStoreTestCase(ModuleStoreTestCase):
         assert errs[0].usage_key == seq_loc
         assert errs[1].usage_key == seq_loc
 
+    def test_split_test(self):
+        """
+        Test when the structure is Course -> Section -> Split Test -> Unit.
+        """
+
+        base_url_sequential = 'i4x://' + self.draft_course.org + '/' + self.course_key.course + '/sequential/'
+        # Course -> Section -> Unit (No Sequence)
+        with self.store.bulk_operations(self.course_key):
+            section_1 = ItemFactory.create(
+                parent_location=self.draft_course.location,
+                category='chapter',
+                display_name="Section",
+            )
+            # This Unit should be skipped
+            split_test_1 = ItemFactory.create(
+                parent_location=section_1.location,
+                category='split_test',
+                display_name="st1",
+                user_partition_id='12',
+                group_id_to_child={"0": base_url_sequential + "split_test_cond0",
+                                   "1": base_url_sequential + "split_test_cond1"}
+            )
+            ItemFactory.create(
+                parent_location=split_test_1.location,
+                category='sequential',
+                display_name="split_test_cond0",
+            )
+            ItemFactory.create(
+                parent_location=split_test_1.location,
+                category='sequential',
+                display_name="split_test_cond1",
+            )
+
+        outline, errs = get_outline_from_modulestore(self.course_key)
+        assert len(outline.sections) == 1
+        assert len(outline.sections[0].sequences) == 2
+        assert len(outline.sequences) == 2
+
     def test_unit_in_section(self):
         """
         Test when the structure is Course -> Section -> Unit.

--- a/cms/djangoapps/contentstore/tests/test_outlines.py
+++ b/cms/djangoapps/contentstore/tests/test_outlines.py
@@ -249,7 +249,7 @@ class OutlineFromModuleStoreTestCase(ModuleStoreTestCase):
                 parent_location=self.draft_course.location,
                 category='chapter',
                 display_name="Section_2",
-                children = [seq.location]
+                children=[seq.location]
             )
 
         self.store.update_item(section_2, self.user.id)


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This PR fixes Course Outline with a SplitTestBlock. Previously when a course outline had SplitTestBlocks, the outline would generate and log an error because SplitTestBlock is not a valid sequence type. In Studio there is no way to create a SplitTestBlock, but it is supported in older Course Block APIs. Now before the course outline is generated, it will be checked for split tests. If a split test is found its children will be looped through and checked for valid logic.  The children will be added to the course outline. This change will impact the Course Author.

## Supporting information

Jira issue: [TNL-8078](https://openedx.atlassian.net/browse/TNL-8078)

## Testing instructions

- In Studio, open an existing course or create a new course.
- Go to Tools>Import and import [this OLX](https://github.com/edx/edx-platform/files/6771919/testFile.tar.gz).
- Check that a course outline was generated with [Django Admin](http://localhost:18000/admin/learning_sequences/coursecontext).
  - _**Need to be connected to VPN**_
- Check that there are not Content Errors logged with the course outline.

## Deadline

None

## Other information

None