### PR TITLE
[MST-801] Pass verified name flag into account settings

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3968,6 +3968,7 @@ ACCOUNT_VISIBILITY_CONFIGURATION["admin_fields"] = (
         "year_of_birth",
         "phone_number",
         "activation_key",
+        "is_verified_name_enabled",
     ]
 )
 

--- a/openedx/core/djangoapps/user_api/accounts/serializers.py
+++ b/openedx/core/djangoapps/user_api/accounts/serializers.py
@@ -13,6 +13,8 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.urls import reverse
 from rest_framework import serializers
 
+from edx_name_affirmation.toggles import is_verified_name_enabled
+
 from common.djangoapps.student.models import UserPasswordToggleHistory
 from lms.djangoapps.badges.utils import badges_enabled
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
@@ -161,6 +163,7 @@ class UserReadOnlySerializer(serializers.Serializer):  # lint-amnesty, pylint: d
             "social_links": None,
             "extended_profile_fields": None,
             "phone_number": None,
+            "is_verified_name_enabled": is_verified_name_enabled(),
         }
 
         if user_profile:

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
@@ -554,7 +554,8 @@ class AccountSettingsOnCreationTest(CreateAccountMixin, TestCase):
             'secondary_email_enabled': None,
             'time_zone': None,
             'course_certificates': None,
-            'phone_number': None
+            'phone_number': None,
+            'is_verified_name_enabled': False,
         }
 
     def test_normalize_password(self):

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
@@ -276,7 +276,7 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
         Verify that all account fields are returned (even those that are not shareable).
         """
         data = response.data
-        assert 28 == len(data)
+        assert 29 == len(data)
 
         # public fields (3)
         expected_account_privacy = (
@@ -417,7 +417,7 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
         """
         self.different_client.login(username=self.different_user.username, password=TEST_PASSWORD)
         self.create_mock_profile(self.user)
-        with self.assertNumQueries(25):
+        with self.assertNumQueries(26):
             response = self.send_get(self.different_client)
         self._verify_full_shareable_account_response(response, account_privacy=ALL_USERS_VISIBILITY)
 
@@ -432,7 +432,7 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
         """
         self.different_client.login(username=self.different_user.username, password=TEST_PASSWORD)
         self.create_mock_profile(self.user)
-        with self.assertNumQueries(25):
+        with self.assertNumQueries(26):
             response = self.send_get(self.different_client)
         self._verify_private_account_response(response)
 
@@ -556,7 +556,7 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
             with self.assertNumQueries(queries):
                 response = self.send_get(self.client)
             data = response.data
-            assert 28 == len(data)
+            assert 29 == len(data)
             assert self.user.username == data['username']
             assert ((self.user.first_name + ' ') + self.user.last_name) == data['name']
             for empty_field in ("year_of_birth", "level_of_education", "mailing_address", "bio"):
@@ -579,7 +579,7 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
             assert data['accomplishments_shared'] is False
 
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
-        verify_get_own_information(23)
+        verify_get_own_information(24)
 
         # Now make sure that the user can get the same information, even if not active
         self.user.is_active = False
@@ -599,7 +599,7 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
         legacy_profile.save()
 
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
-        with self.assertNumQueries(23):
+        with self.assertNumQueries(24):
             response = self.send_get(self.client)
         for empty_field in ("level_of_education", "gender", "country", "state", "bio",):
             assert response.data[empty_field] is None
@@ -955,7 +955,7 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
         response = self.send_get(client)
         if has_full_access:
             data = response.data
-            assert 28 == len(data)
+            assert 29 == len(data)
             assert self.user.username == data['username']
             assert ((self.user.first_name + ' ') + self.user.last_name) == data['name']
             assert self.user.email == data['email']

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -246,6 +246,9 @@ class AccountViewSet(ViewSet):
             * phone_number: The phone number for the user. String of numbers with
               an optional `+` sign at the start.
 
+            * is_verified_name_enabled: Temporary flag to control verified name field - see
+              https://github.com/edx/edx-name-affirmation/blob/main/edx_name_affirmation/toggles.py
+
             For all text fields, plain text instead of HTML is supported. The
             data is stored exactly as specified. Clients must HTML escape
             rendered values to avoid script injections.

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -85,6 +85,7 @@ edx-drf-extensions
 edx-enterprise
 edx-event-routing-backends
 edx-milestones
+edx-name-affirmation>=0.1.2
 edx-organizations
 edx-proctoring>=2.0.1
 edx-proctoring-proctortrack==1.0.5  # Intentionally and permanently pinned to ensure code changes are reviewed

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -201,6 +201,8 @@ django==2.2.24
     #   edx-event-routing-backends
     #   edx-i18n-tools
     #   edx-milestones
+    #   edx-name-affirmation
+    #   edx-opaque-keys
     #   edx-organizations
     #   edx-proctoring
     #   edx-rbac
@@ -287,6 +289,7 @@ django-model-utils==4.1.1
     #   edx-completion
     #   edx-enterprise
     #   edx-milestones
+    #   edx-name-affirmation
     #   edx-organizations
     #   edx-proctoring
     #   edx-rbac
@@ -366,6 +369,7 @@ djangorestframework==3.12.4
     #   edx-completion
     #   edx-drf-extensions
     #   edx-enterprise
+    #   edx-name-affirmation
     #   edx-organizations
     #   edx-proctoring
     #   edx-submissions
@@ -424,6 +428,7 @@ edx-drf-extensions==6.5.0
     #   -r requirements/edx/base.in
     #   edx-completion
     #   edx-enterprise
+    #   edx-name-affirmation
     #   edx-organizations
     #   edx-proctoring
     #   edx-rbac
@@ -438,6 +443,8 @@ edx-event-routing-backends==4.0.1
 edx-i18n-tools==0.5.3
     # via ora2
 edx-milestones==0.3.1
+    # via -r requirements/edx/base.in
+edx-name-affirmation==0.1.2
     # via -r requirements/edx/base.in
 edx-opaque-keys[django]==2.2.2
     # via
@@ -485,6 +492,7 @@ edx-toggles==4.2.0
     #   -r requirements/edx/base.in
     #   edx-completion
     #   edx-event-routing-backends
+    #   edx-name-affirmation
     #   edxval
     #   ora2
 edx-user-state-client==1.3.2

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -267,6 +267,8 @@ django==2.2.24
     #   edx-i18n-tools
     #   edx-lint
     #   edx-milestones
+    #   edx-name-affirmation
+    #   edx-opaque-keys
     #   edx-organizations
     #   edx-proctoring
     #   edx-rbac
@@ -361,6 +363,7 @@ django-model-utils==4.1.1
     #   edx-completion
     #   edx-enterprise
     #   edx-milestones
+    #   edx-name-affirmation
     #   edx-organizations
     #   edx-proctoring
     #   edx-rbac
@@ -444,6 +447,7 @@ djangorestframework==3.12.4
     #   edx-completion
     #   edx-drf-extensions
     #   edx-enterprise
+    #   edx-name-affirmation
     #   edx-organizations
     #   edx-proctoring
     #   edx-submissions
@@ -513,6 +517,7 @@ edx-drf-extensions==6.5.0
     #   -r requirements/edx/testing.txt
     #   edx-completion
     #   edx-enterprise
+    #   edx-name-affirmation
     #   edx-organizations
     #   edx-proctoring
     #   edx-rbac
@@ -531,6 +536,8 @@ edx-i18n-tools==0.5.3
 edx-lint==5.0.0
     # via -r requirements/edx/testing.txt
 edx-milestones==0.3.1
+    # via -r requirements/edx/testing.txt
+edx-name-affirmation==0.1.2
     # via -r requirements/edx/testing.txt
 edx-opaque-keys[django]==2.2.2
     # via
@@ -584,6 +591,7 @@ edx-toggles==4.2.0
     #   -r requirements/edx/testing.txt
     #   edx-completion
     #   edx-event-routing-backends
+    #   edx-name-affirmation
     #   edxval
     #   ora2
 edx-user-state-client==1.3.2

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -256,6 +256,8 @@ distlib==0.3.2
     #   edx-i18n-tools
     #   edx-lint
     #   edx-milestones
+    #   edx-name-affirmation
+    #   edx-opaque-keys
     #   edx-organizations
     #   edx-proctoring
     #   edx-rbac
@@ -348,6 +350,7 @@ django-model-utils==4.1.1
     #   edx-completion
     #   edx-enterprise
     #   edx-milestones
+    #   edx-name-affirmation
     #   edx-organizations
     #   edx-proctoring
     #   edx-rbac
@@ -431,6 +434,7 @@ djangorestframework==3.12.4
     #   edx-completion
     #   edx-drf-extensions
     #   edx-enterprise
+    #   edx-name-affirmation
     #   edx-organizations
     #   edx-proctoring
     #   edx-submissions
@@ -498,6 +502,7 @@ edx-drf-extensions==6.5.0
     #   -r requirements/edx/base.txt
     #   edx-completion
     #   edx-enterprise
+    #   edx-name-affirmation
     #   edx-organizations
     #   edx-proctoring
     #   edx-rbac
@@ -517,6 +522,8 @@ edx-i18n-tools==0.5.3
 edx-lint==5.0.0
     # via -r requirements/edx/testing.in
 edx-milestones==0.3.1
+    # via -r requirements/edx/base.txt
+edx-name-affirmation==0.1.2
     # via -r requirements/edx/base.txt
 edx-opaque-keys[django]==2.2.2
     # via
@@ -568,6 +575,7 @@ edx-toggles==4.2.0
     #   -r requirements/edx/base.txt
     #   edx-completion
     #   edx-event-routing-backends
+    #   edx-name-affirmation
     #   edxval
     #   ora2
 edx-user-state-client==1.3.2


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Install the [edx-name-affirmation](https://github.com/edx/edx-name-affirmation) package and add the `name_affirmation.verified_name` waffle flag to the account settings API, in order to control the verified name field on the account MFE.

## Supporting information

* [MST-801: Create waffle flag for Name Affirmation](https://openedx.atlassian.net/browse/MST-801)
* [MST-883: Release edx-name-affirmation to PyPI and install in edx-platform](https://openedx.atlassian.net/browse/MST-883)
* [MST-800: Add verified name field and messaging to account settings](https://openedx.atlassian.net/browse/MST-800)