### PR TITLE
[BD-38][TNL-8438] Add `legacy_link` field to TextBook app

### DIFF
--- a/lms/djangoapps/courseware/plugins.py
+++ b/lms/djangoapps/courseware/plugins.py
@@ -1,6 +1,7 @@
 """Course app config for courseware apps."""
 from typing import Dict, Optional
 
+from django import urls
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.utils.translation import ugettext_noop as _
@@ -102,6 +103,10 @@ class TextbooksCourseApp(CourseApp):
             "enable": False,
             "configure": True,
         }
+
+    @staticmethod
+    def legacy_link(course_key: CourseKey):
+        return urls.reverse('textbooks_list_handler', kwargs={'course_key_string': course_key})
 
 
 class CalculatorCourseApp(CourseApp):

--- a/openedx/core/djangoapps/course_apps/rest_api/v1/views.py
+++ b/openedx/core/djangoapps/course_apps/rest_api/v1/views.py
@@ -58,16 +58,16 @@ class CourseAppSerializer(serializers.Serializer):  # pylint: disable=abstract-m
 
     def to_representation(self, instance: CourseApp) -> Dict:
         course_key = self.context.get("course_key")
-        user = self.context.get("user")
+        request = self.context.get("request")
         data = {
             "id": instance.app_id,
             "enabled": is_course_app_enabled(course_key, instance.app_id),
             "name": instance.name,
             "description": instance.description,
-            "allowed_operations": instance.get_allowed_operations(course_key, user),
+            "allowed_operations": instance.get_allowed_operations(course_key, request.user),
         }
         if hasattr(instance, "legacy_link"):
-            data["legacy_link"] = instance.legacy_link(course_key)
+            data["legacy_link"] = request.build_absolute_uri(instance.legacy_link(course_key))
         return data
 
 
@@ -132,7 +132,12 @@ class CourseAppsView(DeveloperErrorViewMixin, views.APIView):
         course_key = CourseKey.from_string(course_id)
         course_apps = CourseAppsPluginManager.get_apps_available_for_course(course_key)
         serializer = CourseAppSerializer(
-            course_apps, many=True, context={"course_key": course_key, "user": request.user}
+            course_apps,
+            many=True,
+            context={
+                "course_key": course_key,
+                "request": request,
+            }
         )
         return Response(serializer.data)
 
@@ -186,5 +191,11 @@ class CourseAppsView(DeveloperErrorViewMixin, views.APIView):
         if not course_app or not course_app.is_available(course_key):
             raise ValidationError({"id": "Invalid app ID"})
         set_course_app_enabled(course_key=course_key, app_id=app_id, enabled=enabled, user=request.user)
-        serializer = CourseAppSerializer(course_app, context={"course_key": course_key, "user": request.user})
+        serializer = CourseAppSerializer(
+            course_app,
+            context={
+                "course_key": course_key,
+                "request": request,
+            }
+        )
         return Response(serializer.data)


### PR DESCRIPTION
## Description

This implements the `legacy_link` method to the TextbooksCourseApp
and makes the `legacy_link` URL absolute in the API response.

For example, the response to `GET http://localhost:18010/api/course_apps/v1/apps/course-v1:edX+DemoX+Demo_Course` now returns
```json
[
  {
    "id": "textbooks",
    "enabled": true,
    "name": "Textbooks",
    "description": "Provide links to applicable resources for your course.",
    "allowed_operations": {
      "enable": false,
      "configure": true
    },
    "legacy_link": "http://localhost:18010/textbooks/course-v1:edX+DemoX+Demo_Course"
  },
  { "id": "redacted" }
]
```

## Supporting information

Related tickets:
* [TNL-8438](https://openedx.atlassian.net/browse/TNL-8438)
* [BB-4416 (OpenCraft Internal)](https://tasks.opencraft.com/browse/BB-4416)

## Testing instructions

1. Launch Studio and the course-authoring MFE
2. Open the Pages & Resources page for the demo course in the browser, with dev tools open: http://localhost:2001/course/course-v1:edX+DemoX+Demo_Course/pages-and-resources
3. Verify that the response to `http://localhost:18010/api/course_apps/v1/apps/course-v1:edX+DemoX+Demo_Course` contains the `legacy_link` field for the `textbooks` app.

## Deadline

None

## Other information

N/A
