### PR TITLE
chore: remove pymongo<3.11 constraint to unblock mongo4.4 upgrade 

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -59,9 +59,6 @@ matplotlib<3.4.0
 # Constraint from astroid 2.3.3
 wrapt==1.11.*
 
-# tests failing for pymongo==3.11
-pymongo<3.11
-
 # sympy latest version causing test failures.
 # may be related to python35 version drop in 1.7.0. Needs to be tested before removing.
 sympy==1.6.2

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -745,9 +745,8 @@ pyjwt[crypto]==1.7.1
     #   social-auth-core
 pylatexenc==2.10
     # via olxcleaner
-pymongo==3.10.1
+pymongo==3.11.4
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   -r requirements/edx/paver.txt
     #   edx-opaque-keys

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1012,9 +1012,8 @@ pylint-plugin-utils==0.6
     #   pylint-django
 pylint-pytest==0.3.0
     # via -r requirements/edx/testing.txt
-pymongo==3.10.1
+pymongo==3.11.4
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   edx-opaque-keys
     #   event-tracking

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -28,9 +28,8 @@ pbr==5.6.0
     # via stevedore
 psutil==5.8.0
     # via -r requirements/edx/paver.in
-pymongo==3.10.1
+pymongo==3.11.4
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/paver.in
     #   edx-opaque-keys
 python-memcached==1.59

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -951,9 +951,8 @@ pylint-plugin-utils==0.6
     #   pylint-django
 pylint-pytest==0.3.0
     # via -r requirements/edx/testing.in
-pymongo==3.10.1
+pymongo==3.11.4
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-opaque-keys
     #   event-tracking


### PR DESCRIPTION
## Description

chore: remove pymongo<3.11 constraint to unblock mongo4.4 upgrade

manually update the pymongo pin from 3.10.11 to 3.11.4

pymongo >=3.11 adds support for mongo4.4 and thus is a prereq to
the edx-platform mongo db upgrade. It was previously constrained
because it was causing test failures at the time.

No breaking changes are expected as part of this upgrade.
pymongo changelog:
https://pymongo.readthedocs.io/en/stable/changelog.html#changes-in-version-3-11-4

## Supporting information

Ticket: https://openedx.atlassian.net/browse/TNL-8463

General Mongo 4.4 upgrade info: https://openedx.atlassian.net/wiki/spaces/AC/pages/2922316338/MongoDB+4.4+Upgrade

## Testing instructions

Smoke test setup for devstack:
* Check out this branch of edx-platform.
* Boot up LMS, Studio, and the Learning MFE in devstack (`make dev.up.lms+studio+frontend-app-learning`).
* Within `make dev.shell.lms`:
  * run `make requirements`, or
  * run `pip install pymongo==3.11.4` (much quicker)
* Repeat the previous step in `make dev.shell.studio`.
* Restart both LMS and Studio: `make dev.restart-devserver.lms dev.restart-devserver.studio`

Smoke test steps:
* Ensure a course can be created and published in Studio.
* Ensure said course can be enrolled in interacted with in LMS.
* Ensure the LMS student dashboard (`/dashboard`) can be loaded.

I recommend testing on devstack pre-merge, and on staging post-merge. No setup is required for testing on staging.

## Deadline

Ideally soon, since this blocking Mongo upgrade work.

## Blockers

This PR is nearly ready to go, except that it fails the devstack smoke test. When trying to access any page that needs Mongo (for example: http://localhost:2000/course/course-v1:edX+DemoX+Demo_Course), the page fails to load, with an LMS stack trace like:
```2021-07-08 20:21:04,262 ERROR 617 [django.request] [user None] [ip None] log.py:222 - Internal Server Error: /api/courseware/course/course-v1:edX+DemoX+Demo_Course
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/base.py", line 115, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/base.py", line 113, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/lib/python3.8/contextlib.py", line 75, in inner
    return func(*args, **kwds)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/views/generic/base.py", line 71, in view
    return self.dispatch(request, *args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/rest_framework/views.py", line 509, in dispatch
    response = self.handle_exception(exc)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/rest_framework/views.py", line 469, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
    raise exc
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/rest_framework/generics.py", line 208, in get
    return self.retrieve(request, *args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/rest_framework/mixins.py", line 54, in retrieve
    instance = self.get_object()
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/courseware_api/views.py", line 465, in get_object
    overview = CoursewareMeta(
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/courseware_api/views.py", line 76, in __init__
    self.overview = course_detail(
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/course_api/api.py", line 72, in course_detail
    overview = get_course_overview_with_access(
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/courses.py", line 130, in get_course_overview_with_access
    course_overview = CourseOverview.get_from_id(course_key)
  File "/edx/app/edxapp/edx-platform/openedx/core/lib/cache_utils.py", line 74, in decorator
    result = wrapped(*args, **kwargs)
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/content/course_overviews/models.py", line 384, in get_from_id
    course_overview = cls.load_from_module_store(course_id)
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/content/course_overviews/models.py", line 275, in load_from_module_store
    store = modulestore()
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/django.py", line 319, in modulestore
    contentstore(),
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/contentstore/django.py", line 29, in contentstore
    _CONTENTSTORE[name] = class_(**options)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/contentstore/mongo.py", line 44, in __init__
    mongo_db = connect_to_mongodb(
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/mongo_utils.py", line 72, in connect_to_mongodb
    mongo_conn.authenticate(user, password, source=auth_source)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/pymongo/database.py", line 1492, in authenticate
    self.client._cache_credentials(
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/pymongo/mongo_client.py", line 775, in _cache_credentials
    server = self._get_topology().select_server(
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/pymongo/topology.py", line 241, in select_server
    return random.choice(self.select_servers(selector,
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/pymongo/topology.py", line 199, in select_servers
    server_descriptions = self._select_servers_loop(
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/pymongo/topology.py", line 215, in _select_servers_loop
    raise ServerSelectionTimeoutError(
pymongo.errors.ServerSelectionTimeoutError: client is configured to connect to a replica set named '' but this node belongs to a set named 'None', Timeout: 30s, Topology Description: <TopologyDescription id: 60e75e1175d1a287bfcc6e87, topology_type: Single, servers: [<ServerDescription ('edx.devstack.mongo', 27017) server_type: Unknown, rtt: None, error=ConfigurationError("client is configured to connect to a replica set named '' but this node belongs to a set named 'None'")>]>
```
