### PR TITLE
Translate prerequisite section banner text

### DIFF
--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -531,6 +531,7 @@ class SequenceBlock(
 
     def _get_render_metadata(self, context, display_items, prereq_met, prereq_meta_info, banner_text=None, view=STUDENT_VIEW, fragment=None):  # lint-amnesty, pylint: disable=line-too-long, missing-function-docstring
         if prereq_met and not self._is_gate_fulfilled():
+            _ = self.runtime.service(self, "i18n").ugettext
             banner_text = _(
                 'This section is a prerequisite. You must complete this section in order to unlock additional content.'
             )


### PR DESCRIPTION
## Description

This pull request purpose is to make the prerequisite section banner text translatable.
This is done by using the XBlock runtime i18n service to translate the banner text in place of the [no-op lambda function](https://github.com/edx/edx-platform/blob/master/common/lib/xmodule/xmodule/seq_module.py#L59) used currently.

Before the change:

![Before the change](https://user-images.githubusercontent.com/7050097/124748466-741f7480-df23-11eb-94a1-18ddbbecd155.jpeg)

After the change:

![After the change](https://user-images.githubusercontent.com/7050097/124748485-784b9200-df23-11eb-8d29-4664796abd88.jpeg)

## Testing instructions

- Set your platform language to `eo` by changing the `LANGUAGE_CODE` Django setting
- [Enable prerequisite subsections](https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/enable_prerequisites.html#enable-course-prerequisites) feature on the platform
- [Enable prerequisite subsections](https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/developing_course/controlling_content_visibility.html#enable-subsection-prerequisites) in your test course
- Create one section with two subsections and set one as prerequisite for the other by following the "[Create a prerequisite subsection](https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/developing_course/controlling_content_visibility.html#create-a-prerequisite-subsection)" instructions
- Navigate **as staff** to the subsection which was set as prerequisite. The banner text "This section is a prerequisite. You must complete this section in order to unlock additional content." should be displayed

## Deadline

None
