### PR TITLE
fix: ORA problems' due dates are not set when in a mix of non-ORA problems

### DIFF
--- a/openedx/core/djangoapps/course_date_signals/handlers.py
+++ b/openedx/core/djangoapps/course_date_signals/handlers.py
@@ -63,9 +63,15 @@ def _gather_graded_items(root, due):  # lint-amnesty, pylint: disable=missing-fu
             # Sequentials can be marked as graded, while only containing ungraded problems
             # To handle this case, we can look at the leaf blocks within a sequential
             # and check that they are a graded assignment
-            # (if they have graded/has_score attributes and nonzero weight)
-            # TODO: Once studio can manually set relative dates, we would need to manually check for them here
-            collected_items.append((next_item.location, {'due': due if _has_assignment_blocks(next_item) else None}))
+            # (if they have graded/has_score attributes and nonzero weight).
+            # Open response assessments (ORA) contain their own set of due dates
+            # and we do not want to potentially conflict with due dates that are set from Studio.
+            # So here we do not assign a due date to items that are ORA.
+            if next_item.category != 'openassessment':
+                collected_items.append((
+                    next_item.location,
+                    {'due': due if _has_assignment_blocks(next_item) else None}
+                ))
             # TODO: This is pretty gross, and should maybe be configurable in the future,
             # especially if we find ourselves needing more exceptions.
             has_non_ora_scored_content = (

--- a/openedx/core/djangoapps/course_date_signals/tests.py
+++ b/openedx/core/djangoapps/course_date_signals/tests.py
@@ -122,6 +122,37 @@ class SelfPacedDueDatesTests(ModuleStoreTestCase):  # lint-amnesty, pylint: disa
             sequence = self.store.get_item(sequence.location)
             self.assertCountEqual(_gather_graded_items(sequence, 5), expected_graded_items)
 
+    def test_sequence_with_ora_and_non_ora_assignments(self):
+        """
+        _gather_graded_items should not set a due date for ORA problems
+        """
+        with self.store.bulk_operations(self.course.id):
+            sequence = ItemFactory(parent=self.course, category="sequential")
+            vertical = ItemFactory(parent=sequence, category="vertical")
+            ItemFactory.create(
+                parent=vertical,
+                category='openassessment',
+                graded=True
+            )
+            ungraded_problem_2 = ItemFactory.create(
+                parent=vertical,
+                category='problem',
+                graded=True,
+                weight=0,
+            )
+            graded_problem_1 = ItemFactory.create(
+                parent=vertical,
+                category='problem',
+                graded=True,
+                weight=1,
+            )
+            expected_graded_items = [
+                (ungraded_problem_2.location, {'due': None}),
+                (graded_problem_1.location, {'due': 5}),
+            ]
+            sequence = self.store.get_item(sequence.location)
+            self.assertCountEqual(_gather_graded_items(sequence, 5), expected_graded_items)
+
     def test_get_custom_pacing_children(self):
         """
         _get_custom_pacing_items should return a list of (block item location, field metadata dictionary)


### PR DESCRIPTION
## Description

For self paced courses, ORA problems would be assigned a due date (but is unused) when in a mix of non-ORA graded problems. This PR makes sure due dates are not set to ORA problems even when it is not the only problem under a subsection. 

## Supporting information

[Jira Ticket AA-895](https://openedx.atlassian.net/browse/AA-895)
