### PR TITLE
fix: Remove V2 certificate checks from the certificates app

### DIFF
--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -23,7 +23,6 @@ from common.djangoapps.student.api import is_user_enrolled_in_course
 from common.djangoapps.student.models import CourseEnrollment
 from lms.djangoapps.branding import api as branding_api
 from lms.djangoapps.certificates.generation_handler import (
-    can_generate_certificate_task as _can_generate_certificate_task,
     generate_certificate_task as _generate_certificate_task,
     generate_user_certificates as _generate_user_certificates,
     is_on_certificate_allowlist as _is_on_certificate_allowlist,
@@ -207,17 +206,6 @@ def generate_user_certificates(student, course_key, insecure=False, generation_m
 
 def regenerate_user_certificates(student, course_key, forced_grade=None, template_file=None, insecure=False):
     return _regenerate_user_certificates(student, course_key, forced_grade, template_file, insecure)
-
-
-def can_generate_certificate_task(user, course_key):
-    """
-    Determine if we can create a task to generate a certificate for this user in this course run.
-
-    This will return True if either:
-    - the course run is using the allowlist and the user is on the allowlist, or
-    - the course run is using v2 course certificates
-    """
-    return _can_generate_certificate_task(user, course_key)
 
 
 def generate_certificate_task(user, course_key, generation_mode=None):

--- a/lms/djangoapps/certificates/tests/test_generation_handler.py
+++ b/lms/djangoapps/certificates/tests/test_generation_handler.py
@@ -12,12 +12,10 @@ from lms.djangoapps.certificates.generation_handler import (
     _can_generate_allowlist_certificate,
     _can_generate_certificate_for_status,
     _can_generate_v2_certificate,
-    can_generate_certificate_task,
     generate_allowlist_certificate_task,
     generate_certificate_task,
     generate_regular_certificate_task,
     is_on_certificate_allowlist,
-    is_using_v2_course_certificates,
     _set_allowlist_cert_status,
     _set_v2_cert_status
 )
@@ -145,7 +143,6 @@ class AllowlistTests(ModuleStoreTestCase):
         """
         Test handling of a valid user/course run combo for the general (non-allowlist) generation methods
         """
-        assert can_generate_certificate_task(self.user, self.course_run_key)
         assert generate_certificate_task(self.user, self.course_run_key)
 
     def test_can_generate_not_verified(self):
@@ -298,7 +295,6 @@ class CertificateTests(ModuleStoreTestCase):
         Test handling of a valid user/course run combo.
         """
         assert _can_generate_v2_certificate(self.user, self.course_run_key)
-        assert can_generate_certificate_task(self.user, self.course_run_key)
         assert generate_certificate_task(self.user, self.course_run_key)
 
     def test_handle_valid_task(self):
@@ -372,12 +368,6 @@ class CertificateTests(ModuleStoreTestCase):
             assert _set_v2_cert_status(different_user, self.course_run_key) == CertificateStatuses.notpassing
             assert generate_regular_certificate_task(different_user, self.course_run_key) is True
             assert not _can_generate_v2_certificate(different_user, self.course_run_key)
-
-    def test_is_using_updated_true(self):
-        """
-        Test the updated flag
-        """
-        assert is_using_v2_course_certificates(self.course_run_key)
 
     @ddt.data(
         (CertificateStatuses.deleted, True),


### PR DESCRIPTION
Remove V2 certificate checks from the certificates app, since V2 of course certificates has been enabled globally for all course runs

MICROBA-1083 DEPR-155

