### PR TITLE
fix: don't override existing cert available date

### DIFF
--- a/lms/djangoapps/certificates/tests/test_api.py
+++ b/lms/djangoapps/certificates/tests/test_api.py
@@ -227,9 +227,9 @@ class CertificateDownloadableStatusTests(WebCertificateTestMixin, ModuleStoreTes
     @ddt.data(
         (True, timedelta(days=2), CertificatesDisplayBehaviors.END_WITH_DATE, True, None),
         (False, -timedelta(days=2), CertificatesDisplayBehaviors.EARLY_NO_INFO, True, None),
-        (False, timedelta(days=2), CertificatesDisplayBehaviors.EARLY_NO_INFO, True, None),
+        (False, timedelta(days=2), CertificatesDisplayBehaviors.EARLY_NO_INFO, False, True),
         (False, -timedelta(days=2), CertificatesDisplayBehaviors.END, True, None),
-        (False, timedelta(days=2), CertificatesDisplayBehaviors.END, True, None),
+        (False, timedelta(days=2), CertificatesDisplayBehaviors.END, False, True),
         (False, -timedelta(days=2), CertificatesDisplayBehaviors.END_WITH_DATE, True, None),
         (False, timedelta(days=2), CertificatesDisplayBehaviors.END_WITH_DATE, False, True),
     )

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -923,7 +923,7 @@ class CourseOverview(TimeStampedModel):
         certificates_display_behavior = course.certificates_display_behavior
         certificate_available_date = course.certificate_available_date
 
-        if certificates_display_behavior == "" and certificate_available_date:
+        if certificate_available_date:
             certificates_display_behavior = CertificatesDisplayBehaviors.END_WITH_DATE
 
         if not CertificatesDisplayBehaviors.includes_value(certificates_display_behavior):


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

2a7106a (#27830) added code to cache new values in the course overview by translating existing modulestore values. The bug happened when a course had set certificates_display_behavior to a non-null value, and also had a certificate_available_date set. I believe the certificate_available_date should still be store in Mongo, so this will recache a good value from Mongo.

## Supporting information
MICROBA-1374

## Deadline

Urgent

## Other information
Certificate available date will be broken for all courses that have a CDB and CAD set to any non-null value until this is deployed.