### PR TITLE
BOM-2590: Removed unnecessary constraints - II

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -98,7 +98,5 @@ pylint==2.8.3
 
 # constraints present due to Python35 support. Need to be tested and removed independently.
 
-joblib<0.15.0           # 0.15.0 dropped support for Python 3.5
+# jsonfield2 will be replaced with jsonfield in https://openedx.atlassian.net/browse/BOM-1917.
 jsonfield2<3.1.0        # jsonfield2 3.1.0 drops support for python 3.5
-kiwisolver<1.2.0        # kiwisolver 1.2.0 requires Python 3.6+
-zipp==1.0.0             # zipp 2.0.0 requires Python >= 3.6

--- a/requirements/edx-sandbox/py35-constraints.txt
+++ b/requirements/edx-sandbox/py35-constraints.txt
@@ -16,13 +16,9 @@ matplotlib<3.1          # Matplotlib 3.1 requires Python 3.6
 
 numpy<1.19.0            # numpy 1.19.0 drops support for Python 3.5
 
-stevedore<2.0.0         # stevedore 2.0.0 requires python >= 3.6
-
 scipy<1.5.0             # scipy 1.5.0 drops support for Python 3.5
 
 sympy<1.7.0             # sympy 1.7.0 drops support for Python 3.5
-
-zipp==1.0.0             # zipp 2.0.0 requires Python >= 3.6
 
 markupsafe<2.0.0        # markupsafe 2.0.0 requires Python >= 3.6
 

--- a/requirements/edx-sandbox/py35.txt
+++ b/requirements/edx-sandbox/py35.txt
@@ -26,12 +26,10 @@ decorator==5.0.9
     # via networkx
 joblib==0.14.1
     # via
-    #   -c requirements/edx-sandbox/../constraints.txt
     #   -c requirements/edx-sandbox/py35-constraints.txt
     #   nltk
 kiwisolver==1.1.0
     # via
-    #   -c requirements/edx-sandbox/../constraints.txt
     #   -c requirements/edx-sandbox/py35-constraints.txt
     #   matplotlib
 lxml==4.5.0

--- a/requirements/edx-sandbox/py38.txt
+++ b/requirements/edx-sandbox/py38.txt
@@ -22,14 +22,10 @@ cycler==0.10.0
     # via matplotlib
 decorator==4.4.2
     # via networkx
-joblib==0.14.1
-    # via
-    #   -c requirements/edx-sandbox/../constraints.txt
-    #   nltk
-kiwisolver==1.1.0
-    # via
-    #   -c requirements/edx-sandbox/../constraints.txt
-    #   matplotlib
+joblib==1.0.1
+    # via nltk
+kiwisolver==1.3.1
+    # via matplotlib
 lxml==4.5.0
     # via
     #   -c requirements/edx-sandbox/../constraints.txt
@@ -94,6 +90,3 @@ sympy==1.6.2
     #   symmath
 tqdm==4.61.2
     # via nltk
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -560,10 +560,8 @@ jmespath==0.10.0
     # via
     #   boto3
     #   botocore
-joblib==0.14.1
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   nltk
+joblib==1.0.1
+    # via nltk
 jsondiff==1.3.0
     # via edx-enterprise
 jsonfield2==3.0.3

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -727,9 +727,8 @@ jmespath==0.10.0
     #   -r requirements/edx/testing.txt
     #   boto3
     #   botocore
-joblib==0.14.1
+joblib==1.0.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   nltk
 jsondiff==1.3.0
@@ -840,10 +839,6 @@ monotonic==1.6
     # via
     #   -r requirements/edx/testing.txt
     #   analytics-python
-more-itertools==8.8.0
-    # via
-    #   -r requirements/edx/testing.txt
-    #   zipp
 mpmath==1.2.1
     # via
     #   -r requirements/edx/testing.txt
@@ -1491,9 +1486,8 @@ yarl==1.6.3
     # via
     #   -r requirements/edx/testing.txt
     #   aiohttp
-zipp==1.0.0
+zipp==3.5.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   importlib-metadata
 

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -696,9 +696,8 @@ jmespath==0.10.0
     #   -r requirements/edx/base.txt
     #   boto3
     #   botocore
-joblib==0.14.1
+joblib==1.0.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   nltk
 jsondiff==1.3.0
@@ -800,8 +799,6 @@ monotonic==1.6
     # via
     #   -r requirements/edx/base.txt
     #   analytics-python
-more-itertools==8.8.0
-    # via zipp
 mpmath==1.2.1
     # via
     #   -r requirements/edx/base.txt
@@ -1383,10 +1380,8 @@ yarl==1.6.3
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
-zipp==1.0.0
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   importlib-metadata
+zipp==3.5.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
**JIRA ISSUE:** [BOM-2590](https://openedx.atlassian.net/browse/BOM-2590)

## Description
- Removing unnecessary constraints from `py35-constraints.txt` and `constraints.txt` files.

## Details
Updated constraints of following packages:
- `zipp`
- `stevedore`
- `kiwisolver`
- `joblib`

## Testing
- Sandbox [bom2590.sandbox.edx.org](https://bom2590.sandbox.edx.org/) created successfully with these changes.