### PR TITLE
Fixed make upgrade failure 

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -55,6 +55,10 @@ django-oauth-toolkit<=1.3.2
 python-dateutil==2.4.0
 # matplotlib>=3.4.0 requires python-dateutil>=2.7
 matplotlib<3.4.0
+# pandas>0.22.0 requires python-dateutil>=2.5.0
+pandas==0.22.0
+# networkx>=2.6 requires pandas>=1.1
+networkx<2.6
 
 # Constraint from astroid 2.3.3
 wrapt==1.11.*
@@ -89,10 +93,12 @@ social-auth-core<4.0.0  # social-auth-core>=4.0.0 requires PYJWT>=2.0.0
 # celery requires click<8.0.0 which would be fixed once https://github.com/celery/celery/issues/6753 is done.
 click<8.0.0
 
+# pylint==2.9.3 introduced a lot of new warnings. It will be removed in https://openedx.atlassian.net/browse/BOM-2667.
+pylint==2.8.3
+
 # constraints present due to Python35 support. Need to be tested and removed independently.
 
 joblib<0.15.0           # 0.15.0 dropped support for Python 3.5
 jsonfield2<3.1.0        # jsonfield2 3.1.0 drops support for python 3.5
 kiwisolver<1.2.0        # kiwisolver 1.2.0 requires Python 3.6+
-matplotlib<3.1          # Matplotlib 3.1 requires Python 3.6
 zipp==1.0.0             # zipp 2.0.0 requires Python >= 3.6

--- a/requirements/edx-sandbox/py35.txt
+++ b/requirements/edx-sandbox/py35.txt
@@ -50,7 +50,9 @@ matplotlib==2.2.4
 mpmath==1.2.1
     # via sympy
 networkx==2.2
-    # via -r requirements/edx-sandbox/py35.in
+    # via
+    #   -c requirements/edx-sandbox/../constraints.txt
+    #   -r requirements/edx-sandbox/py35.in
 nltk==3.6.2
     # via
     #   -r requirements/edx-sandbox/py35.in

--- a/requirements/edx-sandbox/py38.txt
+++ b/requirements/edx-sandbox/py38.txt
@@ -36,14 +36,16 @@ lxml==4.5.0
     #   -r requirements/edx-sandbox/py38.in
 markupsafe==2.0.1
     # via chem
-matplotlib==3.0.3
+matplotlib==3.3.4
     # via
     #   -c requirements/edx-sandbox/../constraints.txt
     #   -r requirements/edx-sandbox/py38.in
 mpmath==1.2.1
     # via sympy
 networkx==2.5.1
-    # via -r requirements/edx-sandbox/py38.in
+    # via
+    #   -c requirements/edx-sandbox/../constraints.txt
+    #   -r requirements/edx-sandbox/py38.in
 nltk==3.6.2
     # via
     #   -r requirements/edx-sandbox/py38.in
@@ -57,6 +59,8 @@ numpy==1.21.0
     #   scipy
 openedx-calc==2.0.1
     # via -r requirements/edx-sandbox/py38.in
+pillow==8.3.1
+    # via matplotlib
 pycparser==2.20
     # via cffi
 pyparsing==2.4.7

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -201,7 +201,6 @@ django==2.2.24
     #   edx-event-routing-backends
     #   edx-i18n-tools
     #   edx-milestones
-    #   edx-opaque-keys
     #   edx-organizations
     #   edx-proctoring
     #   edx-rbac
@@ -377,10 +376,8 @@ djangorestframework-xml==2.0.0
     # via edx-enterprise
 docopt==0.6.2
     # via xmodule
-docutils==0.16
-    # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   botocore
+docutils==0.17.1
+    # via botocore
 done-xblock==2.0.4
     # via -r requirements/edx/base.in
 drf-jwt==1.19.0
@@ -686,9 +683,8 @@ packaging==20.9
     # via
     #   bleach
     #   drf-yasg
-path==13.1.0
+path==16.0.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/paver.txt
     #   path.py
 path.py==12.5.0
@@ -706,7 +702,7 @@ pbr==5.6.0
     #   stevedore
 piexif==1.1.3
     # via -r requirements/edx/base.in
-pillow==8.2.0
+pillow==8.3.1
     # via
     #   -r requirements/edx/base.in
     #   edx-enterprise

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -12,8 +12,6 @@ diff-cover==4.0.0
     #   -r requirements/edx/coverage.in
 inflect==5.3.0
     # via jinja2-pluralize
-importlib-metadata==4.6.0
-    # via inflect
 jinja2==3.0.1
     # via
     #   diff-cover

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -267,7 +267,6 @@ django==2.2.24
     #   edx-i18n-tools
     #   edx-lint
     #   edx-milestones
-    #   edx-opaque-keys
     #   edx-organizations
     #   edx-proctoring
     #   edx-rbac
@@ -459,9 +458,8 @@ docopt==0.6.2
     # via
     #   -r requirements/edx/testing.txt
     #   xmodule
-docutils==0.16
+docutils==0.17.1
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/edx/testing.txt
     #   botocore
     #   m2r
@@ -681,7 +679,7 @@ idna==2.10
     #   yarl
 imagesize==1.2.0
     # via sphinx
-importlib-metadata==4.6.0
+importlib-metadata==4.6.1
     # via
     #   -r requirements/edx/testing.txt
     #   pytest-randomly
@@ -855,8 +853,6 @@ multidict==5.1.0
     #   -r requirements/edx/testing.txt
     #   aiohttp
     #   yarl
-mypy-extensions==0.4.3
-    # via mypy
 mypy==0.910
     # via -r requirements/edx/development.in
 mypy-extensions==0.4.3
@@ -899,9 +895,8 @@ packaging==20.9
     #   pytest
     #   sphinx
     #   tox
-path==13.1.0
+path==16.0.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   path.py
 path.py==12.5.0
@@ -924,7 +919,7 @@ pep517==0.10.0
     #   pip-tools
 piexif==1.1.3
     # via -r requirements/edx/testing.txt
-pillow==8.2.0
+pillow==8.3.1
     # via
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
@@ -991,6 +986,7 @@ pylatexenc==2.10
     #   olxcleaner
 pylint==2.8.3
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   edx-lint
     #   pylint-celery
@@ -1296,7 +1292,7 @@ soupsieve==2.2.1
     # via
     #   -r requirements/edx/testing.txt
     #   beautifulsoup4
-sphinx==4.0.2
+sphinx==4.0.3
     # via
     #   edx-sphinx-theme
     #   sphinxcontrib-httpdomain

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -18,10 +18,8 @@ click==7.1.2
     #   code-annotations
 code-annotations==1.1.2
     # via -r requirements/edx/doc.in
-docutils==0.16
-    # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   sphinx
+docutils==0.17.1
+    # via sphinx
 edx-sphinx-theme==2.1.0
     # via -r requirements/edx/doc.in
 gitdb==4.0.7
@@ -62,7 +60,7 @@ smmap==4.0.0
     # via gitdb
 snowballstemmer==2.1.0
     # via sphinx
-sphinx==4.0.2
+sphinx==4.0.3
     # via
     #   -r requirements/edx/doc.in
     #   edx-sphinx-theme

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -8,7 +8,7 @@ certifi==2021.5.30
     # via requests
 chardet==4.0.0
     # via requests
-edx-opaque-keys==2.2.1
+edx-opaque-keys==2.2.2
     # via -r requirements/edx/paver.in
 idna==2.10
     # via requests
@@ -20,7 +20,7 @@ markupsafe==2.0.1
     # via -r requirements/edx/paver.in
 mock==4.0.3
     # via -r requirements/edx/paver.in
-path==15.1.2
+path==16.0.0
     # via -r requirements/edx/paver.in
 paver==1.3.4
     # via -r requirements/edx/paver.in

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -256,7 +256,6 @@ distlib==0.3.2
     #   edx-i18n-tools
     #   edx-lint
     #   edx-milestones
-    #   edx-opaque-keys
     #   edx-organizations
     #   edx-proctoring
     #   edx-rbac
@@ -446,9 +445,8 @@ docopt==0.6.2
     # via
     #   -r requirements/edx/base.txt
     #   xmodule
-docutils==0.16
+docutils==0.17.1
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/edx/base.txt
     #   botocore
 done-xblock==2.0.4
@@ -654,7 +652,7 @@ idna==2.10
     #   -r requirements/edx/base.txt
     #   requests
     #   yarl
-importlib-metadata==4.6.0
+importlib-metadata==4.6.1
     # via pytest-randomly
 inflect==5.3.0
     # via
@@ -850,9 +848,8 @@ packaging==20.9
     #   drf-yasg
     #   pytest
     #   tox
-path==13.1.0
+path==16.0.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   path.py
 path.py==12.5.0
@@ -871,7 +868,7 @@ pbr==5.6.0
     #   stevedore
 piexif==1.1.3
     # via -r requirements/edx/base.txt
-pillow==8.2.0
+pillow==8.3.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -936,6 +933,7 @@ pylatexenc==2.10
     #   olxcleaner
 pylint==2.8.3
     # via
+    #   -c requirements/edx/../constraints.txt
     #   edx-lint
     #   pylint-celery
     #   pylint-django


### PR DESCRIPTION
## Description

- https://github.com/edx/edx-platform/blob/master/requirements/constraints.txt#L97 is causing conflicts with the package `networkx==2.6.1` and causing failure in the `make upgrade` [build](https://github.com/edx/edx-platform/runs/3028409566?check_suite_focus=true) so removed this constraint to fix this issue.

- Pinned following packages to resolve the conflicts
> matplotlib<3.4.0 (matplotlib>=3.4.0 requires python-dateutil>=2.7)
> pandas==0.22.0 (pandas>0.22.0 requires python-dateutil>=2.5.0)
> networkx<2.6 (networkx>=2.6 requires pandas>=1.1)

