### PR TITLE
refactor!: remove the `get_course_overview` function in favor of `get_course_overview_or_none`

### DIFF
--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -46,6 +46,7 @@ from lms.djangoapps.certificates.utils import (
     get_certificate_url as _get_certificate_url,
     has_html_certificates_enabled as _has_html_certificates_enabled
 )
+from openedx.core.djangoapps.content.course_overviews.api import get_course_overview_or_none
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 
 log = logging.getLogger("edx.certificate")
@@ -55,7 +56,7 @@ MODES = GeneratedCertificate.MODES
 
 def _format_certificate_for_user(username, cert):
     """
-    Helper function to serialize an user certificate.
+    Helper function to serialize a user certificate.
 
     Arguments:
         username (unicode): The identifier of the user.
@@ -63,7 +64,8 @@ def _format_certificate_for_user(username, cert):
 
     Returns: dict
     """
-    try:
+    course_overview = get_course_overview_or_none(cert.course_id)
+    if cert.download_url or course_overview:
         return {
             "username": username,
             "course_key": cert.course_id,
@@ -81,8 +83,8 @@ def _format_certificate_for_user(username, cert):
                 else None
             ),
         }
-    except CourseOverview.DoesNotExist:
-        return None
+
+    return None
 
 
 def get_certificates_for_user(username):

--- a/lms/djangoapps/certificates/apis/v0/tests/test_views.py
+++ b/lms/djangoapps/certificates/apis/v0/tests/test_views.py
@@ -318,7 +318,7 @@ class CertificatesListRestApiTest(AuthAndScopesTestMixin, SharedModuleStoreTestC
             assert len(resp.data) == 0
 
         # Test student with 1 certificate
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(12):
             resp = self.get_response(
                 AuthType.jwt,
                 requesting_user=self.global_staff,
@@ -358,7 +358,7 @@ class CertificatesListRestApiTest(AuthAndScopesTestMixin, SharedModuleStoreTestC
             download_url='www.google.com',
             grade="0.88",
         )
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(12):
             resp = self.get_response(
                 AuthType.jwt,
                 requesting_user=self.global_staff,

--- a/lms/djangoapps/certificates/utils.py
+++ b/lms/djangoapps/certificates/utils.py
@@ -10,7 +10,7 @@ from eventtracking import tracker
 from opaque_keys.edx.keys import CourseKey
 
 from lms.djangoapps.certificates.models import GeneratedCertificate
-from openedx.core.djangoapps.content.course_overviews.api import get_course_overview
+from openedx.core.djangoapps.content.course_overviews.api import get_course_overview_or_none
 
 log = logging.getLogger(__name__)
 
@@ -42,7 +42,7 @@ def emit_certificate_event(event_name, user, course_id, course_overview=None, ev
     event_name = '.'.join(['edx', 'certificate', event_name])
 
     if not course_overview:
-        course_overview = get_course_overview(course_id)
+        course_overview = get_course_overview_or_none(course_id)
 
     context = {
         'org_id': course_overview.org,
@@ -67,7 +67,7 @@ def get_certificate_url(user_id=None, course_id=None, uuid=None, user_certificat
     """
     url = ''
 
-    course_overview = _course_from_key(course_id)
+    course_overview = get_course_overview_or_none(_safe_course_key(course_id))
     if not course_overview:
         return url
 
@@ -117,13 +117,6 @@ def _certificate_download_url(user_id, course_id, user_certificate=None):
         return user_certificate.download_url
 
     return ''
-
-
-def _course_from_key(course_key):
-    """
-    Returns the course overview
-    """
-    return get_course_overview(_safe_course_key(course_key))
 
 
 def _safe_course_key(course_key):

--- a/lms/djangoapps/certificates/views/support.py
+++ b/lms/djangoapps/certificates/views/support.py
@@ -24,7 +24,7 @@ from common.djangoapps.util.json_request import JsonResponse
 from lms.djangoapps.certificates.api import get_certificates_for_user, regenerate_user_certificates
 from lms.djangoapps.certificates.permissions import GENERATE_ALL_CERTIFICATES, VIEW_ALL_CERTIFICATES
 from lms.djangoapps.instructor_task.api import generate_certificates_for_students
-from openedx.core.djangoapps.content.course_overviews.api import get_course_overview
+from openedx.core.djangoapps.content.course_overviews.api import get_course_overview_or_none
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 
 log = logging.getLogger(__name__)
@@ -187,9 +187,8 @@ def regenerate_certificate_for_user(request):
     user = params["user"]
     course_key = params["course_key"]
 
-    try:
-        get_course_overview(course_key)
-    except CourseOverview.DoesNotExist:
+    course_overview = get_course_overview_or_none(course_key)
+    if not course_overview:
         msg = _("The course {course_key} does not exist").format(course_key=course_key)
         return HttpResponseBadRequest(msg)
 

--- a/openedx/core/djangoapps/content/course_overviews/api.py
+++ b/openedx/core/djangoapps/content/course_overviews/api.py
@@ -11,13 +11,6 @@ from openedx.core.djangoapps.content.course_overviews.serializers import (
 log = logging.getLogger(__name__)
 
 
-def get_course_overview(course_id):
-    """
-    Retrieve and return course overview data for the provided course id.
-    """
-    return CourseOverview.get_from_id(course_id)
-
-
 def get_course_overview_or_none(course_id):
     """
     Retrieve and return course overview data for the provided course id.
@@ -25,7 +18,7 @@ def get_course_overview_or_none(course_id):
     If the course overview does not exist, return None.
     """
     try:
-        return get_course_overview(course_id)
+        return CourseOverview.get_from_id(course_id)
     except CourseOverview.DoesNotExist:
         log.warning(f"Course overview does not exist for {course_id}")
         return None

--- a/openedx/core/djangoapps/content/course_overviews/tests/test_api.py
+++ b/openedx/core/djangoapps/content/course_overviews/tests/test_api.py
@@ -5,7 +5,6 @@ course_overview api tests
 from opaque_keys.edx.keys import CourseKey
 
 from openedx.core.djangoapps.content.course_overviews.api import (
-    get_course_overview,
     get_course_overview_or_none,
     get_course_overviews
 )
@@ -23,14 +22,6 @@ class TestCourseOverviewsApi(ModuleStoreTestCase):
         super().setUp()
         for _ in range(3):
             CourseOverviewFactory.create()
-
-    def test_get_course_overview(self):
-        """
-        Test for `get_course_overview` function to retrieve a single course overview.
-        """
-        course_overview = CourseOverviewFactory.create()
-        retrieved_course_overview = get_course_overview(course_overview.id)
-        assert course_overview.id == retrieved_course_overview.id
 
     def test_get_course_overview_or_none(self):
         """


### PR DESCRIPTION
## Description

[MICROBA-1289]
* Remove `get_course_overview` function in favor of `get_course_overview_or_none`
* Make a few adjustments to existing code to account for `None` being returned over throwing a `DoesNotExist` exception




[MICROBA-1289]: https://openedx.atlassian.net/browse/MICROBA-1289