### PR TITLE
feat: Allow shared cookies' domains to be set separately.

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -977,6 +977,9 @@ SESSION_SERIALIZER = 'openedx.core.lib.session_serializers.PickleSerializer'
 SESSION_COOKIE_DOMAIN = ""
 SESSION_COOKIE_NAME = 'sessionid'
 
+# This is the domain that is used to set shared cookies between various sub-domains.
+SHARED_COOKIE_DOMAIN = ""
+
 # Site info
 SITE_NAME = "localhost"
 HTTPS = 'on'

--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -207,6 +207,10 @@ if ENV_TOKENS.get('SESSION_COOKIE_NAME', None):
     # NOTE, there's a bug in Django (http://bugs.python.org/issue18012) which necessitates this being a str()
     SESSION_COOKIE_NAME = str(ENV_TOKENS.get('SESSION_COOKIE_NAME'))
 
+# This is the domain that is used to set shared cookies between various sub-domains.
+# By default, it's set to the same thing as the SESSION_COOKIE_DOMAIN, but we want to make it overrideable.
+SHARED_COOKIE_DOMAIN = ENV_TOKENS.get('SHARED_COOKIE_DOMAIN', SESSION_COOKIE_DOMAIN)
+
 # Determines whether the CSRF token can be transported on
 # unencrypted channels. It is set to False here for backward compatibility,
 # but it is highly recommended that this is True for environments accessed

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1625,6 +1625,9 @@ SESSION_COOKIE_NAME = 'sessionid'
 DCS_SESSION_COOKIE_SAMESITE = 'None'
 DCS_SESSION_COOKIE_SAMESITE_FORCE_ALL = True
 
+# This is the domain that is used to set shared cookies between various sub-domains.
+SHARED_COOKIE_DOMAIN = ""
+
 # CMS base
 CMS_BASE = 'localhost:18010'
 

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -190,6 +190,10 @@ if ENV_TOKENS.get('SESSION_COOKIE_NAME', None):
     # NOTE, there's a bug in Django (http://bugs.python.org/issue18012) which necessitates this being a str()
     SESSION_COOKIE_NAME = str(ENV_TOKENS.get('SESSION_COOKIE_NAME'))
 
+# This is the domain that is used to set shared cookies between various sub-domains.
+# By default, it's set to the same thing as the SESSION_COOKIE_DOMAIN, but we want to make it overrideable.
+SHARED_COOKIE_DOMAIN = ENV_TOKENS.get('SHARED_COOKIE_DOMAIN', SESSION_COOKIE_DOMAIN)
+
 CACHES = ENV_TOKENS['CACHES']
 # Cache used for location mapping -- called many times with the same key/value
 # in a given request.

--- a/openedx/core/djangoapps/user_authn/cookies.py
+++ b/openedx/core/djangoapps/user_authn/cookies.py
@@ -78,7 +78,7 @@ def delete_logged_in_cookies(response):
         response.delete_cookie(
             cookie_name,
             path='/',
-            domain=settings.SESSION_COOKIE_DOMAIN
+            domain=settings.SHARED_COOKIE_DOMAIN
         )
 
     return response
@@ -88,7 +88,7 @@ def standard_cookie_settings(request):
     """ Returns the common cookie settings (e.g. expiration time). """
 
     cookie_settings = {
-        'domain': settings.SESSION_COOKIE_DOMAIN,
+        'domain': settings.SHARED_COOKIE_DOMAIN,
         'path': '/',
         'httponly': None,
     }


### PR DESCRIPTION
Several of our cookies are meant to be shared between the LMS
and the marketing site. The previous assumption was that
SESSION_COOKIE_DOMAIN would cover both. We would like to make
it so that these can be set independently of each other.

https://openedx.atlassian.net/browse/ARCHBOM-1831

This should not have any impact on the behavior of the code until the `SHARED_COOKIE_DOMAIN` setting is changed.