### PR TITLE
[SE-4304] feat: add celery beat configuration to Koa

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1208,6 +1208,10 @@ WEBPACK_CONFIG_PATH = 'webpack.prod.config.js'
 
 ################################# CELERY ######################################
 
+# Celery beat configuration
+
+CELERYBEAT_SCHEDULER = 'celery.beat:PersistentScheduler'
+
 # Message configuration
 
 CELERY_TASK_SERIALIZER = 'json'

--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -576,6 +576,10 @@ FAVICON_URL = ENV_TOKENS.get('FAVICON_URL', FAVICON_URL)
 
 ######################## CELERY ROTUING ########################
 
+# Celery beat configuration
+
+CELERYBEAT_SCHEDULER = ENV_TOKENS.get('CELERYBEAT_SCHEDULER', CELERYBEAT_SCHEDULER)
+
 # Defines alternate environment tasks, as a dict of form { task_name: alternate_queue }
 ALTERNATE_ENV_TASKS = {
     'completion_aggregator.tasks.update_aggregators': 'lms',

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2275,6 +2275,10 @@ DEBUG_TOOLBAR_PATCH_SETTINGS = False
 
 ################################# CELERY ######################################
 
+# Celery beat configuration
+
+CELERYBEAT_SCHEDULER = 'celery.beat:PersistentScheduler'
+
 # Message configuration
 
 CELERY_TASK_SERIALIZER = 'json'

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -116,6 +116,10 @@ CONFIG_PREFIX = SERVICE_VARIANT + "." if SERVICE_VARIANT else ""
 
 ###################################### CELERY  ################################
 
+# Celery beat configuration
+
+CELERYBEAT_SCHEDULER = ENV_TOKENS.get('CELERYBEAT_SCHEDULER', CELERYBEAT_SCHEDULER)
+
 # Don't use a connection pool, since connections are dropped by ELB.
 BROKER_POOL_LIMIT = 0
 BROKER_CONNECTION_TIMEOUT = 1


### PR DESCRIPTION
This Pull Request adds `CELERYBEAT_SCHEDULER` to the edx-platform and sets it to its default value defined by Celery [documentation](https://docs.celeryproject.org/en/v4.4.7/userguide/configuration.html#beat-scheduler).

The configuration repository PR: https://github.com/edx/configuration/pull/6407

Settings

```yaml
ADDL_INSTALLED_APPS:
- django_celery_beat

EDXAPP_ENABLE_CELERY_BEAT: true
SANDBOX_ENABLE_REDIS: true
EDXAPP_CELERY_BROKER_TRANSPORT: 'redis'
EDXAPP_CELERY_BROKER_HOSTNAME: '127.0.0.1:6379'
EDXAPP_CELERY_BROKER_USE_SSL: false
EDXAPP_CELERY_BROKER_VHOST: '/0'
EDXAPP_CELERY_USER: 'default'
EDXAPP_CELERY_PASSWORD: ''
EDXAPP_CELERYBEAT_SCHEDULER: django_celery_beat.schedulers:DatabaseScheduler
```

**Dependencies**:

* https://github.com/edx/configuration/pull/6407

**Sandbox URL**: https://pr28148.sandbox.opencraft.hosting/

**Merge deadline**: ASAP

**Testing instructions**:

* Login using the edX user
* Navigate to the Instructor dashboard's [download tab](https://pr28148.sandbox.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/instructor#view-data_download)
* Click on Download profile information as a CSV
* Scroll down to the bottom of the page and wait some seconds
* Validate that the generated report appears and downloadable

**Author notes and concerns**:

The configuration changes are already merged

**Reviewers**

- [ ] (OpenCraft internal reviewer's GitHub username goes here)
- [ ] edX reviewer[s] TBD