### PR TITLE
feat: edx-enterprise==3.26.22 | set the EnterpriseCatalogApiClient get_content_metadata request page_size parameter to 50

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -36,7 +36,7 @@ django-storages<1.9
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==3.26.17
+edx-enterprise==3.26.22
 
 # Newer versions need a more recent version of python-dateutil
 freezegun==0.3.12

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -429,7 +429,7 @@ edx-drf-extensions==6.5.0
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.26.17
+edx-enterprise==3.26.22
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -518,7 +518,7 @@ edx-drf-extensions==6.5.0
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.26.17
+edx-enterprise==3.26.22
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -503,7 +503,7 @@ edx-drf-extensions==6.5.0
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.26.17
+edx-enterprise==3.26.22
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
The enterprise-catalog service has a default page_size of 10.
This change means that we'll make a smaller overall number of SELECTs against the enterprise-catalog database.

Slightly more interesting details: https://github.com/edx/edx-enterprise/pull/1295
