### PR TITLE
revert: Removing read_committed argument when using outer_atomic

### DIFF
--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -268,7 +268,7 @@ class ChooseModeView(View):
 
     @method_decorator(transaction.non_atomic_requests)
     @method_decorator(login_required)
-    @method_decorator(outer_atomic(read_committed=True))
+    @method_decorator(outer_atomic())
     def post(self, request, course_id):
         """Takes the form submission from the page and parses it.
 

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -278,7 +278,7 @@ def _update_email_opt_in(request, org):
 
 @transaction.non_atomic_requests
 @require_POST
-@outer_atomic(read_committed=True)
+@outer_atomic()
 def change_enrollment(request, check_access=True):
     """
     Modify the enrollment status for the logged-in user.

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -815,7 +815,7 @@ class SubmitPhotosView(View):
         return super().dispatch(request, *args, **kwargs)
 
     @method_decorator(login_required)
-    @method_decorator(outer_atomic(read_committed=True))
+    @method_decorator(outer_atomic())
     def post(self, request):
         """
         Submit photos for verification.

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -209,7 +209,7 @@ def create_account_with_params(request, params):
     custom_form = get_registration_extension_form(data=params)
 
     # Perform operations within a transaction that are critical to account creation
-    with outer_atomic(read_committed=True):
+    with outer_atomic():
         # first, create the account
         (user, profile, registration) = do_create_account(form, custom_form)
 


### PR DESCRIPTION
## Description

revert: Removing read_committed argument when using outer_atomic

In this [PR](https://github.com/edx/edx-platform/pull/10659), the [outer_atomic](https://github.com/edx/edx-platform/blob/6cb62f2697bcca1380854e139857678b2ddc35e0/common/djangoapps/util/db.py#L184) decorator/context manager was created to prevent nested atomic blocks. This method receives a boolean parameter read_committed to enforce (when set to **true**) the **read committed** MySQL backend isolation level in specific views or code blocks. As you can see [here](https://github.com/edx/edx-platform/blob/6cb62f2697bcca1380854e139857678b2ddc35e0/common/djangoapps/util/db.py#L176-L179), this enforcement was achieved through the execution of a raw query to enable the right isolation level in the next transaction. In my opinion, this option was added because before Django 2.0, the framework did not set a default isolation level, and the default MySQL isolation level is **repeatable read**, which was not convenient for specific database transactions (for example [user registration](https://github.com/edx/edx-platform/blob/335a0f28deec5c30c538631a2fde7137ce5f88a3/openedx/core/djangoapps/user_authn/views/register.py#L210) ).

From Django 2, the default isolation level Django sets is **read committed** (more details [here](https://github.com/django/django/pull/7978) ), so the aforementioned parameter for outer_atomic method can be removed. This is what the PR is about: it removes the option to enforce the isolation level via a raw query. 

This change could affect installations where an isolation level other than **read committed** is configured. The [configuration](https://github.com/edx/configuration/blob/master/playbooks/roles/edxapp/defaults/main.yml#L94) repo allows to set a different isolation level, but I wonder if there are cases where this value is changed since [the Django docs](https://docs.djangoproject.com/en/2.2/ref/databases/#mysql-isolation-level) suggest, and indeed defaults to **read committed**.

@symbolist could you please take a look at this one? I'm asking for your review since I saw [this PR](https://github.com/edx/edx-platform/pull/5366) where this read-committed enforcement was introduced for the first time.

## Motivation: MySQL scalation with ProxySQL

Due to the necessity of scaling the MySQL layer of the OpenedX platform in our use case, I'm considering using **ProxySQL** to scale MySQL workloads horizontally. During the testing of the solution, I run into issues related to setting **Isolation levels** on the fly for a specific transaction. This was affecting especially the OpenedX built-in registration page when posting the form for new user creation. After a bit of investigation, I found that ProxySQL does not support setting an isolation level for just one transaction (https://github.com/sysown/proxysql/issues/2305). In an effort to solve this issue I propose this PR that has a very low impact on the LMS/CMS services functionality and removes no longer necessary code.


