### PR TITLE
Display an XBlock's version as part of Staff Debug Info

### DIFF
--- a/lms/templates/staff_problem_info.html
+++ b/lms/templates/staff_problem_info.html
@@ -101,6 +101,7 @@ ${block_content | n, decode.utf8}
     <div class="staff_info" style="display:block">
       is_released = ${is_released}
       location = ${text_type(location)}
+      block_version = ${block_version}
 
       <table summary="${_('Module Fields')}">
         <tr><th>${_('Module Fields')}</th></tr>


### PR DESCRIPTION
If a course author works on several Open edX instances and they all have third-party XBlocks installed, it sometimes comes in handy to be able to tell which version of an XBlock they are working with. For example, they might want to determine whether a feature that just recently landed in an XBlock is available to them.

Add an additional field, `block_version`, to the context passed to the "Staff Debug Info" modal. Populate that field by using the inspect module to sort out the package that the XBlock belongs to, and then looking up that package's version via the `version()` method from `importlib.metadata`.

In the event that we are unable to discern the package version at runtime, do not throw a 500. Instead, show `block_version` as `None`, and log a warning.

Related discussion on Open edX Discourse:
https://discuss.openedx.org/t/whats-the-best-way-to-track-show-an-xblocks-version/