### PR TITLE
fix: user info cookie name for Edge

### DIFF
--- a/lms/static/js/student_account/utils.js
+++ b/lms/static/js/student_account/utils.js
@@ -10,6 +10,7 @@
                 var hostname = this.getHostname();
                 var isLocalhost = hostname.indexOf('localhost') >= 0;
                 var isStage = hostname.indexOf('stage') >= 0;
+                var isEdge = hostname.indexOf('edge') >= 0;
                 var cookie, edxUserCookie, prefix, user, userCookie;
 
                 if (isLocalhost) {
@@ -18,6 +19,7 @@
                 } else {
                     // does not take sandboxes into account
                     prefix = isStage ? 'stage' : 'prod';
+                    prefix = isEdge ? 'edge' : prefix;
                     edxUserCookie = prefix + '-edx-user-info';
                 }
 


### PR DESCRIPTION
## Description
We were generating cookie name for only stage and prod, the script was raising an error on the Edge environment due to different cookie name.

VAN-659