### PR TITLE
feat: AA-885 show offsets in studio self paced course outline for a subsection

### DIFF
--- a/cms/djangoapps/contentstore/config/waffle.py
+++ b/cms/djangoapps/contentstore/config/waffle.py
@@ -69,13 +69,15 @@ REDIRECT_TO_LIBRARY_AUTHORING_MICROFRONTEND = LegacyWaffleFlag(
 )
 
 
-# .. toggle_name: studio.custom_pls
+# .. toggle_name: studio.custom_relative_dates
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False
-# .. toggle_description: Waffle flag to enable custom pacing for PLS
+# .. toggle_description: Waffle flag to enable custom pacing input for Personalized Learner Schedule (PLS).
+# ..    This flag guards an input in Studio for a self paced course, where the user can enter date offsets
+# ..    for a subsection.
 # .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2021-07-12
 # .. toggle_target_removal_date: 2021-12-31
-# .. toggle_warnings: For this flag to be active, add flag 'studio.custom_pls' in Django Admin
+# .. toggle_warnings: Flag course_experience.relative_dates should also be active for relative dates functionalities to work.
 # .. toggle_tickets: https://openedx.atlassian.net/browse/AA-844
-CUSTOM_PLS = CourseWaffleFlag(WAFFLE_NAMESPACE, 'custom_pls', module_name=__name__,)
+CUSTOM_RELATIVE_DATES = CourseWaffleFlag(WAFFLE_NAMESPACE, 'custom_relative_dates', module_name=__name__,)

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -1230,7 +1230,7 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
             'graded': xblock.graded,
             'due_date': get_default_time_display(xblock.due),
             'due': xblock.fields['due'].to_json(xblock.due),
-            'due_num_weeks': xblock.due_num_weeks,
+            'relative_weeks_due': xblock.relative_weeks_due,
             'format': xblock.format,
             'course_graders': [grader.get('type') for grader in graders],
             'has_changes': has_changes,

--- a/cms/static/js/views/modals/course_outline_modals.js
+++ b/cms/static/js/views/modals/course_outline_modals.js
@@ -390,12 +390,11 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
     });
 
     SelfPacedDueDateEditor = AbstractEditor.extend({
-        fieldName: 'due_num_weeks',
+        fieldName: 'relative_weeks_due',
         templateName: 'self-paced-due-date-editor',
         className: 'modal-section-content has-actions due-date-input grading-due-date',
-
         events: {
-            'click .clear-date': 'clearValue',
+            'change #due_in': 'validateDueIn',
             'keyup #due_in': 'validateDueIn',
             'blur #due_in': 'validateDueIn',
         },
@@ -404,43 +403,71 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
             return parseInt(this.$('#due_in').val());
         },
 
+        showProjectedDate: function() {
+            if (!this.getValue()) return;
+            var startDate = new Date(this.model.get('start'));
+            // The value returned by toUTCString() is a string in the form Www, dd Mmm yyyy hh:mm:ss GMT
+            var startDateList = startDate.toUTCString().split(' ')
+            // This text will look like Mmm dd, yyyy (i.e. Jul 26, 2021)
+            this.$("#relative_weeks_due_start_date").text(startDateList[2] + ' ' + startDateList[1] + ', ' + startDateList[3]);
+            var projectedDate = new Date(startDate)
+            projectedDate.setDate(projectedDate.getDate() + this.getValue()*7);
+            var projectedDateList = projectedDate.toUTCString().split(' ');
+            this.$("#relative_weeks_due_projected_due_in").text(projectedDateList[2] + ' ' + projectedDateList[1] + ', ' + projectedDateList[3]);
+            this.$('#relative_weeks_due_projected').show();
+        },
+
         validateDueIn: function() {
+            this.$('#relative_weeks_due_projected').hide();
             if (this.getValue() > 18){
-                this.$('#due-num-weeks-warning-max').show();
+                this.$('#relative_weeks_due_warning_max').show();
                 BaseModal.prototype.disableActionButton.call(this.parent, 'save');
             }
             else if (this.getValue() < 1){
-                this.$('#due-num-weeks-warning-min').show()
+                this.$('#relative_weeks_due_warning_min').show()
                 BaseModal.prototype.disableActionButton.call(this.parent, 'save');
             }
             else {
-                this.$('#due-num-weeks-warning-max').hide();
-                this.$('#due-num-weeks-warning-min').hide();
+                this.$('#relative_weeks_due_warning_max').hide();
+                this.$('#relative_weeks_due_warning_min').hide();
+                if (this.model.get('start')){
+                    this.showProjectedDate();
+                }
                 BaseModal.prototype.enableActionButton.call(this.parent, 'save');
             }
         },
 
-        clearValue: function(event) {
-            event.preventDefault();
-            this.$('#due_in').val('');
-        },
-
         afterRender: function() {
             AbstractEditor.prototype.afterRender.call(this);
-            this.$('.field-due-in input').val(this.model.get('due_num_weeks'));
+            if (this.model.get('graded')) {
+                this.$('#relative_date_input').show()
+            }
+            else {
+                this.$('#relative_date_input').hide()
+            }
+            this.$('.field-due-in input').val(this.model.get('relative_weeks_due'));
+            this.$('#relative_weeks_due_projected').hide();
+            if (this.getValue() && this.model.get('start')){
+                this.showProjectedDate();
+            }
         },
 
         getRequestData: function() {
-            if (this.getValue() < 19 && this.getValue() > 0) {
+            if (this.getValue() < 19 && this.getValue() > 0 && $('#grading_type').val() !== 'notgraded') {
                 return {
                     metadata: {
-                        due_num_weeks: this.getValue()
+                        relative_weeks_due: this.getValue()
                     }
                 };
+            } else {
+                return {
+                    metadata: {
+                        relative_weeks_due: null
+                    }
+                }
             }
-        }
+        },
     });
-
 
     ReleaseDateEditor = BaseDateEditor.extend({
         fieldName: 'start',
@@ -692,6 +719,18 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
     GradingEditor = AbstractEditor.extend({
         templateName: 'grading-editor',
         className: 'edit-settings-grading',
+        events: {
+            'change #grading_type': 'handleGradingSelect',
+        },
+
+        handleGradingSelect: function(event) {
+            event.preventDefault();
+            if (this.$('#grading_type').val() !== 'notgraded' && course.get('self_paced') && course.get('is_custom_relative_dates_active')) {
+                $('#relative_date_input').show();
+            } else {
+                $('#relative_date_input').hide();
+            }
+        },
 
         afterRender: function() {
             AbstractEditor.prototype.afterRender.call(this);
@@ -1130,10 +1169,9 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
                 } else if (xblockInfo.isSequential()) {
                     tabs[0].editors = [ReleaseDateEditor, GradingEditor, DueDateEditor];
                     tabs[1].editors = [ContentVisibilityEditor, ShowCorrectnessEditor];
-                    if (course.get('self_paced') && course.get('is_custom_pls_active')) {
+                    if (course.get('self_paced') && course.get('is_custom_relative_dates_active')) {
                         tabs[0].editors.push(SelfPacedDueDateEditor);
                     }
-
                     if (options.enable_proctored_exams || options.enable_timed_exams) {
                         advancedTab.editors.push(TimedExaminationPreferenceEditor);
                     }

--- a/cms/static/sass/elements/_modules.scss
+++ b/cms/static/sass/elements/_modules.scss
@@ -652,7 +652,8 @@ $outline-indent-width: $baseline;
     }
 
     .status-grading-value,
-    .status-proctored-exam-value {
+    .status-proctored-exam-value,
+    .status-custom-grading-date {
       display: inline-block;
       vertical-align: middle;
     }

--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -10,7 +10,7 @@
 <%!
 from django.utils.translation import ugettext as _
 
-from cms.djangoapps.contentstore.config.waffle import CUSTOM_PLS
+from cms.djangoapps.contentstore.config.waffle import CUSTOM_RELATIVE_DATES
 from lms.djangoapps.branding import api as branding_api
 from openedx.core.djangoapps.util.user_messages import PageLevelMessages
 from openedx.core.djangolib.js_utils import (
@@ -157,7 +157,7 @@ from openedx.core.release import RELEASE_LINE
           display_course_number: "${context_course.display_coursenumber | n, js_escaped_string}",
           revision: "${context_course.location.branch | n, js_escaped_string}",
           self_paced: ${ context_course.self_paced | n, dump_js_escaped_json },
-          is_custom_pls_active: ${CUSTOM_PLS.is_enabled(context_course.id) | n, dump_js_escaped_json}
+          is_custom_relative_dates_active: ${CUSTOM_RELATIVE_DATES.is_enabled(context_course.id) | n, dump_js_escaped_json}
         });
       </script>
     % endif

--- a/cms/templates/js/course-outline.underscore
+++ b/cms/templates/js/course-outline.underscore
@@ -246,6 +246,50 @@ if (is_proctored_exam) {
                         <% } %>
                     </p>
                 </div>
+                <% if (course.get('self_paced') && course.get('is_custom_relative_dates_active') && xblockInfo.get('relative_weeks_due')) { %>
+                    <div class="status-grading">
+                        <p>
+                            <span class="icon fa fa-calendar" aria-hidden="true"></span>
+                            <span class="status-custom-grading-date">
+                                <%- edx.StringUtils.interpolate(
+                                        ngettext(
+                                            'Custom due date: {relativeWeeks} week from enrollment',
+                                            'Custom due date: {relativeWeeks} weeks from enrollment',
+                                            xblockInfo.get('relative_weeks_due')),
+                                        {
+                                            relativeWeeks: xblockInfo.get('relative_weeks_due')
+                                        }
+                                    )
+                                %>
+                            </span>
+                        <p>
+                    </div>
+                <% } %>
+            <% } else if (course.get('self_paced') && course.get('is_custom_relative_dates_active') && xblockInfo.get('relative_weeks_due')) { %>
+                <div class="status-grading">
+                    <p>
+                        <span class="sr status-grading-label"> <%- gettext('Graded as:') %> </span>
+                        <span class="icon fa fa-check" aria-hidden="true"></span>
+                        <span class="status-grading-value"> <%- gradingType %> </span>
+                    </p>
+                </div>
+                <div class="status-grading">
+                    <p>
+                        <span class="icon fa fa-calendar" aria-hidden="true"></span>
+                        <span class="status-custom-grading-date">
+                            <%- edx.StringUtils.interpolate(
+                                    ngettext(
+                                        'Custom due date: {relativeWeeks} week from enrollment',
+                                        'Custom due date: {relativeWeeks} weeks from enrollment',
+                                        xblockInfo.get('relative_weeks_due')),
+                                    {
+                                        relativeWeeks: xblockInfo.get('relative_weeks_due')
+                                    }
+                                )
+                            %>
+                        </span>
+                    <p>
+                </div>
             <% } %>
             <div class="status-hide-after-due">
                 <p>

--- a/cms/templates/js/self-paced-due-date-editor.underscore
+++ b/cms/templates/js/self-paced-due-date-editor.underscore
@@ -1,24 +1,30 @@
-<ul class="list-fields list-input date-setter">
-    <li class="field field-text field-due-in">
-        <label for="due_in"><%- gettext('Due in:') %></label>
-        <input type="number" id="due_in" name="due_in" value=""
-            placeholder="" autocomplete="off" min="1" max="18"/> weeks
-    </li>
-</ul>
+<div id="relative_date_input">
+    <ul class="list-fields list-input date-setter">
+        <li class="field field-text field-due-in">
+            <!-- Translators: Please use a generic pluralization that makes sense in most contexts for the second half of the sentence "weeks from learner enrollment date" which is preceded by "Due in: [input entry]" -->
+            <label for="due_in"><%- gettext('Due in:') %></label>
+            <input type="number" id="due_in" name="due_in" value=""
+                placeholder="" autocomplete="off" min="1" max="18" style="width:20%"/>
+            <%- gettext('weeks from learner enrollment date')%>
+        </li>
+    </ul>
 
-<ul class="list-actions">
-    <li class="action-item">
-        <a href="#" data-tooltip="<%- gettext('Clear Due Date') %>" class="clear-date action-button action-clear">
-            <span class="icon fa fa-undo" aria-hidden="true"></span>
-            <span class="sr"><%- gettext('Clear Due Date') %></span>
-        </a>
-    </li>
-</ul>
+    <div id="relative_weeks_due_projected" class="message">
+        <%= edx.HtmlUtils.interpolateHtml(
+            gettext('If a learner starts on {startDate}, this subsection will be due on {projectedDueIn}.'),
+            {
+                startDate: edx.HtmlUtils.HTML('<span id="relative_weeks_due_start_date"></span>'),
+                projectedDueIn: edx.HtmlUtils.HTML('<span id="relative_weeks_due_projected_due_in"></span>')
+            })
+        %>
+    </div>
 
-<div id="due-num-weeks-warning-max" class="message-status error">
-    <%- gettext('The maximum number of weeks this subsection can be due in is 18 weeks.') %>
+    <div id="relative_weeks_due_warning_max" class="message-status error">
+        <%- gettext('The maximum number of weeks this subsection can be due in is 18 weeks from the learner enrollment date.') %>
+    </div>
+
+    <div id="relative_weeks_due_warning_min" class="message-status error">
+        <%- gettext('The minimum number of weeks this subsection can be due in is 1 week from the learner enrollment date.') %>
+    </div>
 </div>
 
-<div id="due-num-weeks-warning-min" class="message-status error">
-    <%- gettext('The minimum number of weeks this subsection can be due in is 1 week.') %>
-</div>

--- a/common/lib/xmodule/xmodule/modulestore/inheritance.py
+++ b/common/lib/xmodule/xmodule/modulestore/inheritance.py
@@ -46,10 +46,10 @@ class InheritanceMixin(XBlockMixin):
         help=_("Enter the default date by which problems are due."),
         scope=Scope.settings,
     )
-    # This attribute is for custom pacing in self paced courses for Studio if CUSTOM_PLS flag is active
-    due_num_weeks = Integer(
-        display_name=_("Number of Weeks Due By"),
-        help=_("Enter the number of weeks the problems are due by relative to the learner's start date"),
+    # This attribute is for custom pacing in self paced courses for Studio if CUSTOM_RELATIVE_DATES flag is active
+    relative_weeks_due = Integer(
+        display_name=_("Number of Relative Weeks Due By"),
+        help=_("Enter the number of weeks the problems are due by relative to the learner's enrollment date"),
         scope=Scope.settings,
     )
     visible_to_staff_only = Boolean(

--- a/common/lib/xmodule/xmodule/modulestore/xml_importer.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml_importer.py
@@ -1051,7 +1051,7 @@ def allowed_metadata_by_category(category):
     return {
         'vertical': [],
         'chapter': ['start'],
-        'sequential': ['due', 'due_num_weeks', 'format', 'start', 'graded']
+        'sequential': ['due', 'relative_weeks_due', 'format', 'start', 'graded']
     }.get(category, ['*'])
 
 

--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -78,10 +78,10 @@ class SequenceFields:  # lint-amnesty, pylint: disable=missing-class-docstring
         help=_("Enter the date by which problems are due."),
         scope=Scope.settings,
     )
-    # This attribute is for custom pacing in self paced courses for Studio if CUSTOM_PLS flag is active
-    due_num_weeks = Integer(
-        display_name=_("Number of Weeks Due By"),
-        help=_("Enter the number of weeks the problems are due by relative to the learner's start date"),
+    # This attribute is for custom pacing in self paced courses for Studio if CUSTOM_RELATIVE_DATES flag is active
+    relative_weeks_due = Integer(
+        display_name=_("Number of Relative Weeks Due By"),
+        help=_("Enter the number of weeks the problems are due by relative to the learner's enrollment date"),
         scope=Scope.settings,
     )
 

--- a/openedx/core/djangoapps/course_date_signals/handlers.py
+++ b/openedx/core/djangoapps/course_date_signals/handlers.py
@@ -8,7 +8,7 @@ from django.dispatch import receiver
 from edx_when.api import FIELDS_TO_EXTRACT, set_dates_for_course
 from xblock.fields import Scope
 
-from cms.djangoapps.contentstore.config.waffle import CUSTOM_PLS
+from cms.djangoapps.contentstore.config.waffle import CUSTOM_RELATIVE_DATES
 from openedx.core.lib.graph_traversals import get_children, leaf_filter, traverse_pre_order
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import SignalHandler, modulestore
@@ -111,19 +111,22 @@ def extract_dates_from_course(course):
             # unless that item already has a relative date set
             for _, section, weeks_to_complete in spaced_out_sections(course):
                 section_date_items = []
+                # section_due_date will end up being the max of all due dates of its subsections
+                section_due_date = timedelta(weeks=1)
                 for subsection in section.get_children():
                     # If custom pacing is set on a subsection, apply the set relative
                     # date to all the content inside the subsection. Otherwise
                     # apply the default Personalized Learner Schedules (PLS)
                     # logic for self paced courses.
-                    due_num_weeks = subsection.fields['due_num_weeks'].read_from(subsection)
-                    if (CUSTOM_PLS.is_enabled(course.id) and due_num_weeks):
-                        section_date_items.extend(_get_custom_pacing_children(subsection, due_num_weeks))
+                    relative_weeks_due = subsection.fields['relative_weeks_due'].read_from(subsection)
+                    if (CUSTOM_RELATIVE_DATES.is_enabled(course.id) and relative_weeks_due):
+                        section_due_date = max(section_due_date, timedelta(weeks=relative_weeks_due))
+                        section_date_items.extend(_get_custom_pacing_children(subsection, relative_weeks_due))
                     else:
+                        section_due_date = max(section_due_date, weeks_to_complete)
                         section_date_items.extend(_gather_graded_items(subsection, weeks_to_complete))
-                # if custom pls is active, we will allow due dates to be set for ungraded items as well
-                if section_date_items and (section.graded or CUSTOM_PLS.is_enabled(course.id)):
-                    date_items.append((section.location, weeks_to_complete))
+                if section_date_items and (section.graded or CUSTOM_RELATIVE_DATES.is_enabled(course.id)):
+                    date_items.append((section.location, {'due': section_due_date}))
                 date_items.extend(section_date_items)
     else:
         date_items = []


### PR DESCRIPTION
## Description

After a user sets the relative due dates for a subsection in a self paced course, they want to see all the set relative due dates in the course outline for a subsection in Studio. This PR displays the relative due dates in the course outline and modal in Studio for self paced courses.

![image](https://user-images.githubusercontent.com/60379333/126172660-79bb1732-1412-47d1-b35c-164a81fffe15.png)
![image](https://user-images.githubusercontent.com/60379333/127055025-5a1e042a-bf9e-4ec9-a79d-3f2c70949e68.png)
![image](https://user-images.githubusercontent.com/60379333/127055055-08e5b812-3dd8-4bdd-9acd-5c1dd946d293.png)
![image](https://user-images.githubusercontent.com/60379333/127055095-8a7c706c-5d59-442a-99bc-f83b8192bc1c.png)

## Supporting information

[Jira Ticket](https://openedx.atlassian.net/browse/AA-885)

Previous tickets for custom due dates personalized learner schedule in self paced courses:

[Spike Ticket](https://openedx.atlassian.net/browse/AA-843)
[Custom PLS Flag Ticket](https://openedx.atlassian.net/browse/AA-844)
[Basic Prototype Ticket](https://openedx.atlassian.net/browse/AA-883)

## Testing instructions

Add flag `studio.custom_relative_dates` in Django Admin
