### PR TITLE
fix:link fix for the yellowdig general documentation

### DIFF
--- a/openedx/core/djangoapps/discussions/models.py
+++ b/openedx/core/djangoapps/discussions/models.py
@@ -128,7 +128,7 @@ AVAILABLE_PROVIDER_MAP = {
         'external_links': ProviderExternalLinks(
             'https://www.youtube.com/watch?v=ZACief-qMwY',
             '',
-            'https://hubs.ly/H0J5Bn7',
+            'https://hubs.ly/H0J5Bn70',
             '',
             'learnmore@yellowdig.com',
         )._asdict(),


### PR DESCRIPTION
yellowdig general documentation link was broken and is fixed in this PR.