### PR TITLE
Django3 has removed python_2_unicode_compatible.

### DIFF
--- a/cms/djangoapps/course_creators/models.py
+++ b/cms/djangoapps/course_creators/models.py
@@ -8,7 +8,7 @@ from django.db import models
 from django.db.models.signals import post_init, post_save
 from django.dispatch import Signal, receiver
 from django.utils import timezone
-from django.utils.encoding import python_2_unicode_compatible
+
 from django.utils.translation import ugettext_lazy as _
 
 # A signal that will be sent when users should be added or removed from the creator group
@@ -19,9 +19,6 @@ send_admin_notification = Signal(providing_args=["user"])
 
 # A signal that will be sent when user should be notified of change in course creator privileges
 send_user_notification = Signal(providing_args=["user", "state"])
-
-
-@python_2_unicode_compatible
 class CourseCreator(models.Model):
     """
     Creates the database table model.

--- a/cms/djangoapps/course_creators/models.py
+++ b/cms/djangoapps/course_creators/models.py
@@ -19,6 +19,8 @@ send_admin_notification = Signal(providing_args=["user"])
 
 # A signal that will be sent when user should be notified of change in course creator privileges
 send_user_notification = Signal(providing_args=["user", "state"])
+
+
 class CourseCreator(models.Model):
     """
     Creates the database table model.

--- a/cms/lib/xblock/tagging/models.py
+++ b/cms/lib/xblock/tagging/models.py
@@ -4,10 +4,7 @@ Django Model for tags
 
 
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
-
-@python_2_unicode_compatible
 class TagCategories(models.Model):
     """
     This model represents tag categories.
@@ -33,7 +30,6 @@ class TagCategories(models.Model):
         return [t.value for t in TagAvailableValues.objects.filter(category=self)]
 
 
-@python_2_unicode_compatible
 class TagAvailableValues(models.Model):
     """
     This model represents available values for tags.

--- a/cms/lib/xblock/tagging/models.py
+++ b/cms/lib/xblock/tagging/models.py
@@ -5,6 +5,7 @@ Django Model for tags
 
 from django.db import models
 
+
 class TagCategories(models.Model):
     """
     This model represents tag categories.

--- a/lms/djangoapps/courseware/models.py
+++ b/lms/djangoapps/courseware/models.py
@@ -22,7 +22,7 @@ from django.conf import settings
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.db import models
 from django.db.models.signals import post_save
-from django.utils.encoding import python_2_unicode_compatible
+
 from django.utils.translation import ugettext_lazy as _
 from model_utils.models import TimeStampedModel
 from opaque_keys.edx.django.models import BlockTypeKeyField, CourseKeyField, LearningContextKeyField, UsageKeyField
@@ -74,7 +74,6 @@ class ChunkingManager(models.Manager):
         return res
 
 
-@python_2_unicode_compatible
 class StudentModule(models.Model):
     """
     Keeps student state for a particular XBlock usage and particular student.
@@ -234,7 +233,6 @@ class BaseStudentModuleHistory(models.Model):
         return history_entries
 
 
-@python_2_unicode_compatible
 class StudentModuleHistory(BaseStudentModuleHistory):
     """Keeps a complete history of state changes for a given XModule for a given
     Student. Right now, we restrict this to problems so that the table doesn't
@@ -271,7 +269,6 @@ class StudentModuleHistory(BaseStudentModuleHistory):
         post_save.connect(save_history, sender=StudentModule)
 
 
-@python_2_unicode_compatible
 class XBlockFieldBase(models.Model):
     """
     Base class for all XBlock field storage.
@@ -341,7 +338,6 @@ class XModuleStudentInfoField(XBlockFieldBase):  # lint-amnesty, pylint: disable
     student = models.ForeignKey(User, db_index=True, on_delete=models.CASCADE)
 
 
-@python_2_unicode_compatible
 class OfflineComputedGrade(models.Model):
     """
     Table of grades computed offline for a given user and course.
@@ -364,7 +360,6 @@ class OfflineComputedGrade(models.Model):
         return f"[OfflineComputedGrade] {self.user}: {self.course_id} ({self.created}) = {self.gradeset}"
 
 
-@python_2_unicode_compatible
 class OfflineComputedGradeLog(models.Model):
     """
     Log of when offline grades are computed.

--- a/openedx/core/djangoapps/api_admin/models.py
+++ b/openedx/core/djangoapps/api_admin/models.py
@@ -24,6 +24,8 @@ from common.djangoapps.edxmako.shortcuts import render_to_string
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 log = logging.getLogger(__name__)
+
+
 class ApiAccessRequest(TimeStampedModel):
     """
     Model to track API access for a user.

--- a/openedx/core/djangoapps/api_admin/models.py
+++ b/openedx/core/djangoapps/api_admin/models.py
@@ -16,7 +16,7 @@ from django.dispatch import receiver
 from django.urls import reverse
 from django.utils.translation import ugettext as _u
 from django.utils.translation import ugettext_lazy as _
-from django.utils.encoding import python_2_unicode_compatible
+
 
 from model_utils.models import TimeStampedModel
 
@@ -24,9 +24,6 @@ from common.djangoapps.edxmako.shortcuts import render_to_string
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 log = logging.getLogger(__name__)
-
-
-@python_2_unicode_compatible
 class ApiAccessRequest(TimeStampedModel):
     """
     Model to track API access for a user.
@@ -132,7 +129,6 @@ class ApiAccessRequest(TimeStampedModel):
         return f'ApiAccessRequest {self.website} [{self.status}]'
 
 
-@python_2_unicode_compatible
 class ApiAccessConfig(ConfigurationModel):
     """
     Configuration for API management.
@@ -224,7 +220,6 @@ def _send_decision_email(instance):
         log.exception('Error sending API user notification email for request [%s].', instance.id)
 
 
-@python_2_unicode_compatible
 class Catalog(models.Model):
     """
     A (non-Django-managed) model for Catalogs in the course discovery service.


### PR DESCRIPTION
Django3 has removed python_2_unicode_compatible.
Execute the codemodes on these file and removed all usage.

https://openedx.atlassian.net/browse/BOM-2674