### PR TITLE
[MST-806] Add CourseWaffleFlag for verified name

### DIFF
--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -125,6 +125,18 @@ COURSEWARE_MICROFRONTEND_PROCTORED_EXAMS = CourseWaffleFlag(
     WAFFLE_FLAG_NAMESPACE, 'mfe_proctored_exams', __name__
 )
 
+# .. toggle_name: courseware.verified_name
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Course waffle flag for verified name functionality (see https://github.com/edx/edx-name-affirmation)
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2021-7-14
+# .. toggle_target_removal_date: None
+# .. toggle_warnings: None
+COURSEWARE_VERIFIED_NAME_FLAG = CourseWaffleFlag(
+    WAFFLE_FLAG_NAMESPACE, 'verified_name', __name__
+)
+
 
 def mfe_special_exams_is_active(course_key: CourseKey) -> bool:
     """
@@ -279,6 +291,10 @@ def streak_celebration_is_active(course_key):
         courseware_mfe_progress_milestones_are_active(course_key) and
         COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES_STREAK_CELEBRATION.is_enabled(course_key)
     )
+
+
+def is_verified_name_enabled_for_course(course_key):
+    return COURSEWARE_VERIFIED_NAME_FLAG.is_enabled(course_key)
 
 
 # .. toggle_name: COURSES_INVITE_ONLY

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -64,7 +64,11 @@ from ..masquerade import check_content_start_date_for_masquerade_user, setup_mas
 from ..model_data import FieldDataCache
 from ..module_render import get_module_for_descriptor, toc_for_course
 from ..permissions import MASQUERADE_AS_STUDENT
-from ..toggles import courseware_legacy_is_visible, courseware_mfe_is_advertised
+from ..toggles import (
+    courseware_legacy_is_visible,
+    courseware_mfe_is_advertised,
+    is_verified_name_enabled_for_course
+)
 from .views import CourseTabView
 
 log = logging.getLogger("edx.courseware.views.index")
@@ -442,6 +446,7 @@ class CoursewareIndex(View):
             'sequence_title': None,
             'disable_accordion': not DISABLE_COURSE_OUTLINE_PAGE_FLAG.is_enabled(self.course.id),
             'show_search': show_search,
+            'is_verified_name_enabled': is_verified_name_enabled_for_course(self.course.id),
         }
         courseware_context.update(
             get_experiment_user_metadata_context(

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -244,7 +244,8 @@ ${HTML(fragment.foot_html())}
             </div>
         </header>
 
-        <main id="main" tabindex="-1" aria-label="Content">
+        <main id="main" tabindex="-1" aria-label="Content"
+        data-is-verified-name-enabled="${is_verified_name_enabled}">
             % if getattr(course, 'entrance_exam_enabled') and \
                getattr(course, 'entrance_exam_minimum_score_pct') and \
                entrance_exam_current_score is not UNDEFINED:


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Create a CourseWaffleFlag for verified name functionality and pass it into the courseware view, to be used by edx-proctoring.

## Supporting information

https://openedx.atlassian.net/browse/MST-806