### PR TITLE
feat: Adding multi device support in lti-consumer-xblock

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -593,7 +593,7 @@ libsass==0.10.0
     #   ora2
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==3.0.0
+lti-consumer-xblock==3.0.1
     # via -r requirements/edx/base.in
 lxml==4.5.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -774,7 +774,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/testing.txt
     #   ora2
-lti-consumer-xblock==3.0.0
+lti-consumer-xblock==3.0.1
     # via -r requirements/edx/testing.txt
 lxml==4.5.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -739,7 +739,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==3.0.0
+lti-consumer-xblock==3.0.1
     # via -r requirements/edx/base.txt
 lxml==4.5.0
     # via


### PR DESCRIPTION
Updating lti-consumer-xblock version to 3.0.1. This version only adds mutlti device support in student view of the xblock.

[LEARNBER-8413](https://openedx.atlassian.net/browse/LEARNER-8413)

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Edx mobile team has been working on this epic Open xBlocks in the Browser. To show xblock on mobile browser xblock needs to send student_view_multi_device as true. Therefore I have added its support.

A similar PR for word cloud xblock:
https://github.com/edx/edx-platform/pull/27386/files
