### PR TITLE
fix: Retrieve grade and enrollment mode only once

### DIFF
--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -2082,7 +2082,7 @@ class TestCertificateGeneration(InstructorTaskModuleTestCase):
             'failed': 0,
             'skipped': 2
         }
-        with self.assertNumQueries(66):
+        with self.assertNumQueries(71):
             self.assertCertificatesGenerated(task_input, expected_results)
 
     @ddt.data(


### PR DESCRIPTION
Retrieve _grade_ and _enrollment mode_ only once and pass their values to the generation task, so those values can be saved in the cert. 

Also protect against missing course grades.

MICROBA-1373