### PR TITLE
fix: webpack loader config to display error

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -250,3 +250,6 @@ FEATURES['ENABLE_PREREQUISITE_COURSES'] = True
 # Used in edx-proctoring for ID generation in lieu of SECRET_KEY - dummy value
 # (ref MST-637)
 PROCTORING_USER_OBFUSCATION_KEY = '85920908f28904ed733fe576320db18cabd7b6cd'
+
+#################### Webpack Configuration Settings ##############################
+WEBPACK_LOADER['DEFAULT']['TIMEOUT'] = 5

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -432,3 +432,6 @@ FEATURES['ENABLE_PREREQUISITE_COURSES'] = True
 # Used in edx-proctoring for ID generation in lieu of SECRET_KEY - dummy value
 # (ref MST-637)
 PROCTORING_USER_OBFUSCATION_KEY = '85920908f28904ed733fe576320db18cabd7b6cd'
+
+#################### Webpack Configuration Settings ##############################
+WEBPACK_LOADER['DEFAULT']['TIMEOUT'] = 5


### PR DESCRIPTION
## Description
Sometimes no helpful error messages are displayed when webpack is broken. This setting configuration will give a proper error message. 