### PR TITLE
fix: handle invalid source library version on course import [BB-4436]

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_import_export.py
+++ b/cms/djangoapps/contentstore/views/tests/test_import_export.py
@@ -2,6 +2,7 @@
 Unit tests for course import and export
 """
 import copy
+import itertools
 import json
 import logging
 import os
@@ -15,6 +16,7 @@ from uuid import uuid4
 
 import ddt
 import lxml
+from bson import ObjectId
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import SuspiciousOperation
@@ -1076,7 +1078,7 @@ class TestCourseExportImport(LibraryTestCase):
         self.source_course = CourseFactory.create(default_store=ModuleStoreEnum.Type.split)
         self.addCleanup(shutil.rmtree, self.export_dir, ignore_errors=True)
 
-    def _setup_source_course_with_library_content(self, publish=False):
+    def _setup_source_course_with_library_content(self, publish=False, version=None):
         """
         Sets up course with library content.
         """
@@ -1095,7 +1097,9 @@ class TestCourseExportImport(LibraryTestCase):
             parent_location=sequential.location,
             display_name='Test Unit'
         )
-        lc_block = self._add_library_content_block(vertical, self.lib_key, publish_item=publish)
+        lc_block = self._add_library_content_block(
+            vertical, self.lib_key, publish_item=publish, other_settings=dict(source_library_version=version)
+        )
         self._refresh_children(lc_block)
 
     def get_lib_content_block_children(self, block_location):
@@ -1134,13 +1138,18 @@ class TestCourseExportImport(LibraryTestCase):
         dest_child = self.store.get_item(dest_child_location)
         self.assertEqual(source_child.display_name, dest_child.display_name)
 
-    @ddt.data(True, False)
-    def test_library_content_on_course_export_import(self, publish_item):
+    @ddt.data(*itertools.product([False, True], repeat=2))
+    @ddt.unpack
+    def test_library_content_on_course_export_import(self, publish_item, generate_version):
         """
         Verify that library contents in destination and source courses are same after importing
         the source course into destination course.
+
+        If a library with the specified version does not exist in the modulestore, the import should not fail.
         """
-        self._setup_source_course_with_library_content(publish=publish_item)
+        self._setup_source_course_with_library_content(
+            publish=publish_item, version=str(ObjectId()) if generate_version else None
+        )
 
         # Create a course to import source course.
         dest_course = CourseFactory.create(default_store=ModuleStoreEnum.Type.split)


### PR DESCRIPTION
## Description

Example scenario: we have two environments - stage and prod. We use content libraries in the courses. A library with the same key exists in both environments. When we're trying to import a course from the prod to the stage (to test it), the import fails. However, when we're importing a course with a content library that doesn't exist on stage, then it succeeds.

Currently, it's only possible to solve this by manually removing the `source_library_version` from the exported course package.

This handles the missing source library version gracefully, just like the missing source library key is being handled.

## Jira

[OSPR-5920](https://openedx.atlassian.net/browse/OSPR-5920)

## Sandbox

https://pr28207.sandbox.opencraft.hosting/


### Content of the test package
The `source_library_version` in `course/library_content/6fb3887d93774666846ba735f81afe92.xml` has been changed from `6154717851682c85c4ae75ec` to `6154717851682c85c4ae75ed`. The import will still fail if the version will not be a valid `version_guid`,

### Sandbox testing instructions
1. There is a bug with logging in, but you can just refresh the page after clicking "Sign in" and it will work properly.
2. Go to [this page](https://studio.pr28207.sandbox.opencraft.hosting/import/course-v1:import+import+import) and check that you can import [test_course.tar.gz](https://github.com/edx/edx-platform/files/7252558/test_course.tar.gz).


## Manual testing instructions
1. Create a new library in [Studio](http://localhost:18010). Add an example problem there.
2. Create a new course. Add `"library_content"` to "Advanced Module List".
3. Add a "Randomized Content Block" to the course and set the new library as its source. Publish the unit.
4. Export the course.
5. In the exported package, add anything to the value of `source_library_version` in `course/library_content/SOME_ID.xml`.
6. Import the course. It should succeed.

## Deadline

None.

## Reviewers

- [x] @arjunsinghy96 
- [ ] edX reviewer[s] TBD

**Settings**
```yaml

```

