### PR TITLE
fix(add teams config service to previewmodulesystem)

### DIFF
--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -35,7 +35,7 @@ from xmodule.error_module import ErrorBlock
 from xmodule.exceptions import NotFoundError, ProcessingError
 from xmodule.modulestore.django import ModuleI18nService, modulestore
 from xmodule.partitions.partitions_service import PartitionService
-from xmodule.services import SettingsService
+from xmodule.services import SettingsService, TeamsConfigurationService
 from xmodule.studio_editable import has_author_view
 from xmodule.util.sandboxing import can_execute_unsafe_code, get_python_lib_zip
 from xmodule.util.xmodule_django import add_webpack_to_fragment
@@ -217,7 +217,8 @@ def _preview_module_system(request, descriptor, field_data):
             "i18n": ModuleI18nService,
             "settings": SettingsService(),
             "user": DjangoXBlockUserService(request.user),
-            "partitions": StudioPartitionService(course_id=course_id)
+            "partitions": StudioPartitionService(course_id=course_id),
+            "teams_configuration": TeamsConfigurationService(),
         },
     )
 

--- a/cms/djangoapps/contentstore/views/tests/test_preview.py
+++ b/cms/djangoapps/contentstore/views/tests/test_preview.py
@@ -169,6 +169,7 @@ class GetPreviewHtmlTestCase(ModuleStoreTestCase):
 @XBlock.needs("field-data")
 @XBlock.needs("i18n")
 @XBlock.needs("user")
+@XBlock.needs("teams_configuration")
 class PureXBlock(XBlock):
     """
     Pure XBlock to use in tests.
@@ -192,7 +193,7 @@ class StudioXBlockServiceBindingTest(ModuleStoreTestCase):
         self.field_data = mock.Mock()
 
     @XBlock.register_temp_plugin(PureXBlock, identifier='pure')
-    @ddt.data("user", "i18n", "field-data")
+    @ddt.data("user", "i18n", "field-data", "teams_configuration")
     def test_expected_services_exist(self, expected_service):
         """
         Tests that the 'user' and 'i18n' services are provided by the Studio runtime.


### PR DESCRIPTION
## Description

[AU-48](https://openedx.atlassian.net/browse/AU-48)

Team ORAs rely on the Teams Config Service to render both the `student_view` and `studio_view` in studio. We added the service in https://github.com/edx/edx-platform/pull/22559, but from what I can tell now that only provides it in  `studio_view`. We recently jumped back into the code after a long absence and quickly noticed this was insufficient.

So I added it in here.
