### PR TITLE
perf: reduce calls to get_course_by_id

### DIFF
--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -162,8 +162,7 @@ class CoursewareMeta:
 
     @property
     def license(self):
-        course = get_course_by_id(self.course_key)
-        return course.license
+        return self.course.license
 
     @property
     def can_load_courseware(self) -> dict:
@@ -226,9 +225,8 @@ class CoursewareMeta:
     def user_has_passing_grade(self):
         """ Returns a boolean on if the effective_user has a passing grade in the course """
         if not self.effective_user.is_anonymous:
-            course = get_course_by_id(self.course_key)
-            user_grade = CourseGradeFactory().read(self.effective_user, course).percent
-            return user_grade >= course.lowest_passing_grade
+            user_grade = CourseGradeFactory().read(self.effective_user, self.course).percent
+            return user_grade >= self.course.lowest_passing_grade
         return False
 
     @property
@@ -242,9 +240,8 @@ class CoursewareMeta:
         Returns certificate data if the effective_user is enrolled.
         Note: certificate data can be None depending on learner and/or course state.
         """
-        course = get_course_by_id(self.course_key)
         if self.enrollment_object:
-            return get_cert_data(self.effective_user, course, self.enrollment_object.mode)
+            return get_cert_data(self.effective_user, self.course, self.enrollment_object.mode)
 
     @property
     def verify_identity_url(self):


### PR DESCRIPTION
```
CoursewareMeta alredy initializes self.course, so there's no need to
separately call get_course_by_id for various attributes. This was
resulting in separate modulestore fetches that would pull down the
structure document and re-do all the expensive top-level course queries
in modulestore.
```
