### PR TITLE
perf: Cache get_course calls in Modulestore

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/__init__.py
+++ b/common/lib/xmodule/xmodule/modulestore/__init__.py
@@ -27,6 +27,7 @@ from openedx.core.lib.json_utils import EdxJSONEncoder
 from xmodule.assetstore import AssetMetadata
 from xmodule.errortracker import make_error_tracker
 
+from .caching import ModuleStoreCache
 from .exceptions import InsufficientSpecificationError, InvalidLocationError
 
 log = logging.getLogger('edx.modulestore')
@@ -173,6 +174,7 @@ class BulkOperationsMixin:
         super().__init__(*args, **kwargs)
         self._active_bulk_ops = ActiveBulkThread(self._bulk_ops_record_type)
         self.signal_handler = None
+        self.modulestore_cache = ModuleStoreCache()
 
     @contextmanager
     def bulk_operations(self, course_id, emit_signals=True, ignore_case=False):

--- a/common/lib/xmodule/xmodule/modulestore/caching.py
+++ b/common/lib/xmodule/xmodule/modulestore/caching.py
@@ -1,0 +1,89 @@
+"""
+Different ModuleStores have their own internal caching mechanisms, but sometimes
+we need utilities that can be used across multiple ModuleStore types.
+"""
+from collections import defaultdict
+from edx_django_utils.cache import RequestCache
+
+
+class ModuleStoreCache:
+    """
+    Used to cache certain ModuleStore queries at a request level.
+
+    This uses a RequestCache underneath, but tries to present a higher-level
+    interface.
+    """
+    def __init__(self):
+        self._request_cache = RequestCache('CachingModulestoreWrapper')
+        self._courses_to_depths = defaultdict(set)
+
+    def get_course(self, course_key, depth):
+        cache_key = (course_key, depth)
+        return self._request_cache.get_cached_response(cache_key)
+
+    def update_course(self, course_key, depth, course):
+        cache_key = (course_key, depth)
+        self._request_cache.set(cache_key, course)
+        self._courses_to_depths[course_key].add(depth)
+
+    def invalidate_course(self, course_key):
+        # Remember that there may be multiple keys for the same course
+        for depth in self._courses_to_depths[course_key]:
+            cache_key = (course_key, depth)
+            self._request_cache.delete(cache_key)
+        self._courses_to_depths[cache_key] = set()
+
+class CachingModuleStoreWrapper:
+    """
+    Wrap a modulestore and add request-level caching of get_course()
+
+    This class proxies most of its requests to its underlying Modulestore
+    object. It was necessary to do this as a separate wrapping layer because
+    our _MIXED_MODULESTORE can be a CCXModulestoreWrapper or a MixedModuleStore
+    depending on our settings. Putting this caching into MixedModuleStore itself
+    doesn't work because of the way CCXModulestoreWrapper pulls back results
+    from MixedModuleStore and changes their usage keys.
+
+    So yes, this means that content access is layered behind proxies like:
+
+      CachingModuleStoreWrapper ->
+        (CCXModulestoreWrapper -> if CCX enabled)
+          MixedModuleStore ->
+            DraftVersioningModuleStore (Split Mongo)
+            DraftModuleStore (Old Mongo)
+    """
+    def __init__(self, modulestore_obj, modulestore_cache):
+        self.__dict__['_modulestore'] = modulestore_obj
+        self.__dict__['_modulestore_cache'] = modulestore_cache
+
+    def __getattr__(self, name):
+        """Look up missing attributes on the wrapped modulestore"""
+        return getattr(self._modulestore, name)
+
+    def __setattr__(self, name, value):
+        """Set attributes only on the wrapped modulestore"""
+        setattr(self._modulestore, name, value)
+
+    def __delattr__(self, name):
+        """Delete attributes only on the wrapped modulestore"""
+        delattr(self._modulestore, name)
+
+    def get_course(self, course_key, depth=0, **kwargs):
+        """
+        Call get_course on wrapped modulestore, but with request-caching.
+
+        This is the only call that actually _uses_ caching at this layer.
+        """
+        # Only use the request cache if we're dealing with a simple query with
+        # no advanced params. (This is the vast, vast majority of queries.)
+        use_cache = not kwargs
+        if use_cache:
+            cache_response = self._modulestore_cache.get_course(course_key, depth)
+            if cache_response.is_found:
+                return cache_response.value
+
+        course = self._modulestore.get_course(course_key, depth, **kwargs)
+        if use_cache:
+            self._modulestore_cache.update_course(course_key, depth, course)
+
+        return course

--- a/common/lib/xmodule/xmodule/modulestore/caching.py
+++ b/common/lib/xmodule/xmodule/modulestore/caching.py
@@ -117,6 +117,7 @@ class CachingModuleStoreWrapper:
         if use_cache:
             cache_response = self._modulestore_cache.get_course(course_key, depth)
             if cache_response.is_found:
+                print(f"Cache hit for {course_key}!")
                 return cache_response.value
 
         course = self._modulestore.get_course(course_key, depth, **kwargs)

--- a/common/lib/xmodule/xmodule/modulestore/django.py
+++ b/common/lib/xmodule/xmodule/modulestore/django.py
@@ -484,7 +484,7 @@ class CachingModuleStoreWrapper:
         return result
 
     def convert_to_draft(self, location, user_id):
-        result = self._modulestore.convert_to_draft(self, location, user_id)
+        result = self._modulestore.convert_to_draft(location, user_id)
         self._remove_from_course_cache(location.course_key)
         return result
 
@@ -492,7 +492,7 @@ class CachingModuleStoreWrapper:
         # Intentionally clearing cache before the proxied call, in order to make
         # sure our cache can't affect the comparison being done in has_changes.
         self._remove_from_course_cache(xblock.location.course_key)
-        return self._modulestore.has_changes(self, xblock)
+        return self._modulestore.has_changes(xblock)
 
 
 def modulestore():

--- a/common/lib/xmodule/xmodule/modulestore/django.py
+++ b/common/lib/xmodule/xmodule/modulestore/django.py
@@ -239,7 +239,6 @@ def create_modulestore_instance(
         fs_service=None,
         user_service=None,
         signal_handler=None,
-        modulestore_cache=None
 ):
     """
     This will return a new instance of a modulestore given an engine and options
@@ -303,7 +302,6 @@ def create_modulestore_instance(
         fs_service=fs_service or xblock.reference.plugins.FSService(),
         user_service=user_service or xb_user_service,
         signal_handler=signal_handler or SignalHandler(class_),
-        modulestore_cache=modulestore_cache,
         **_options
     )
 
@@ -325,7 +323,6 @@ def modulestore():
             contentstore(),
             settings.MODULESTORE['default'].get('DOC_STORE_CONFIG', {}),
             settings.MODULESTORE['default'].get('OPTIONS', {}),
-            modulestore_cache=modulestore_cache,
         )
 
         if settings.FEATURES.get('CUSTOM_COURSES_EDX'):

--- a/common/lib/xmodule/xmodule/modulestore/django.py
+++ b/common/lib/xmodule/xmodule/modulestore/django.py
@@ -22,12 +22,14 @@ from django.core.cache import caches, InvalidCacheBackendError  # lint-amnesty, 
 import django.dispatch  # lint-amnesty, pylint: disable=wrong-import-position
 import django.utils  # lint-amnesty, pylint: disable=wrong-import-position
 from django.utils.translation import get_language, to_locale  # lint-amnesty, pylint: disable=wrong-import-position
-from edx_django_utils.cache import DEFAULT_REQUEST_CACHE, RequestCache  # lint-amnesty, pylint: disable=wrong-import-position
+from edx_django_utils.cache import DEFAULT_REQUEST_CACHE  # lint-amnesty, pylint: disable=wrong-import-position
 
 from xmodule.contentstore.django import contentstore  # lint-amnesty, pylint: disable=wrong-import-position
 from xmodule.modulestore.draft_and_published import BranchSettingMixin  # lint-amnesty, pylint: disable=wrong-import-position
 from xmodule.modulestore.mixed import MixedModuleStore  # lint-amnesty, pylint: disable=wrong-import-position
 from xmodule.util.xmodule_django import get_current_request_hostname  # lint-amnesty, pylint: disable=wrong-import-position
+
+from .caching import CachingModuleStoreWrapper, ModuleStoreCache
 
 # We also may not always have the current request user (crum) module available
 try:
@@ -237,6 +239,7 @@ def create_modulestore_instance(
         fs_service=None,
         user_service=None,
         signal_handler=None,
+        modulestore_cache=None
 ):
     """
     This will return a new instance of a modulestore given an engine and options
@@ -300,6 +303,7 @@ def create_modulestore_instance(
         fs_service=fs_service or xblock.reference.plugins.FSService(),
         user_service=user_service or xb_user_service,
         signal_handler=signal_handler or SignalHandler(class_),
+        modulestore_cache=modulestore_cache,
         **_options
     )
 
@@ -308,204 +312,20 @@ def create_modulestore_instance(
 _MIXED_MODULESTORE = None
 
 
-class CachingModuleStoreWrapper:
-    """
-    Wrap a modulestore and add request-level caching of get_course()
-
-    This class proxies most of its requests to its underlying Modulestore
-    object. It was necessary to do this as a separate wrapping layer because
-    our _MIXED_MODULESTORE can be a CCXModulestoreWrapper or a MixedModuleStore
-    depending on our settings. Putting this caching into MixedModuleStore itself
-    doesn't work because of the way CCXModulestoreWrapper pulls back results
-    from MixedModuleStore and changes their usage keys.
-
-    So yes, this means that content access is layered behind proxies like:
-
-      CachingModuleStoreWrapper ->
-        (CCXModulestoreWrapper -> if CCX enabled)
-          MixedModuleStore ->
-            DraftVersioningModuleStore (Split Mongo)
-            DraftModuleStore (Old Mongo)
-
-    The main thing we have to worry about in this class is to be able to detect
-    any call that might potentially invalidate the cache course, and to do that
-    invalidation before sending the call along.
-    """
-    def __init__(self, modulestore_obj):
-        self.__dict__['_modulestore'] = modulestore_obj
-        self.__dict__['_request_cache'] = RequestCache('CachingModulestoreWrapper')
-
-    def __getattr__(self, name):
-        """Look up missing attributes on the wrapped modulestore"""
-        return getattr(self._modulestore, name)
-
-    def __setattr__(self, name, value):
-        """Set attributes only on the wrapped modulestore"""
-        setattr(self._modulestore, name, value)
-
-    def __delattr__(self, name):
-        """Delete attributes only on the wrapped modulestore"""
-        delattr(self._modulestore, name)
-
-    def _remove_from_course_cache(self, course_key):
-        """
-        Remove all instances of this course_key from the local request cache.
-        """
-        # Remember that there may be multiple keys for the same course
-        cache_keys_to_del = [
-            cache_key
-            for cache_key in self._request_cache.data
-            if cache_key[0] == course_key  # cache_key is (course_key, depth)
-        ]
-        for cache_key in cache_keys_to_del:
-            self._request_cache.delete(cache_key)
-
-    def get_course(self, course_key, depth=0, **kwargs):
-        """
-        Call get_course on wrapped modulestore, but with request-caching.
-
-        This is the only call that actually _uses_ caching at this layer.
-        """
-        # Only use the request cache if we're dealing with a simple query with
-        # no advanced params. (This is the vast, vast majority of queries.)
-        use_cache = not kwargs
-        cache_key = (course_key, depth)
-        if use_cache:
-            cache_response = self._request_cache.get_cached_response(cache_key)
-            if cache_response.is_found:
-                return cache_response.value
-
-        course = self._modulestore.get_course(course_key, depth, **kwargs)
-        if use_cache:
-            self._request_cache.set(cache_key, course)
-
-        return course
-
-    # Everything that follows are method calls that would cause cache
-    # invalidation. Unfortunately, how we derive a course_key and when it's safe
-    # to use varies by method, so there's a lot of boilerplate copying. Some of
-    # these might not be necessary, but it's better to err on the side of
-    # invalidation than risk correctness.
-
-    def delete_course(self, course_key, user_id):
-        result = self._modulestore.delete_course(course_key, user_id)
-        self._remove_from_course_cache(course_key)
-        return result
-
-    def save_asset_metadata(self, asset_metadata, user_id, import_only=False):
-        result = self._modulestore.save_asset_metadata(asset_metadata, user_id, import_only)
-        self._remove_from_course_cache(asset_metadata.asset_id.course_key)
-        return result
-
-    def save_asset_metadata_list(self, asset_metadata_list, user_id, import_only=False):
-        result = self.modulestore.save_asset_metadata_list(asset_metadata_list, user_id, import_only)
-        if asset_metadata_list:
-            self._remove_from_course_cache(asset_metadata_list[0].asset_id.course_key)
-        return result
-
-    def delete_asset_metadata(self, asset_key, user_id):
-        result = self._modulestore.delete_asset_metadata(asset_key, user_id)
-        self._remove_from_course_cache(asset_key.course_key)
-        return result
-
-    def copy_all_asset_metadata(self, source_course_key, dest_course_key, user_id):
-        result = self._modulestore.copy_all_asset_metadata(source_course_key, dest_course_key, user_id)
-        self._remove_from_course_cache(dest_course_key)
-        return result
-
-    def set_asset_metadata_attr(self, asset_key, attr, value, user_id):
-        result = self._modulestore.set_asset_metadata_attr(asset_key, attr, value, user_id)
-        self._remove_from_course_cache(asset_key.course_key)
-        return result
-
-    def set_asset_metadata_attrs(self, asset_key, attr_dict, user_id):
-        result = self._modulestore.set_asset_metadata_attrs(asset_key, attr_dict, user_id)
-        self._remove_from_course_cache(asset_key.course_key)
-        return result
-
-    def clone_course(self, source_course_id, dest_course_id, user_id, fields=None, **kwargs):
-        result = self._modulestore.clone_course(source_course_id, dest_course_id, user_id, fields, **kwargs)
-        self._remove_from_course_cache(dest_course_id)
-        return result
-
-    def create_item(self, user_id, course_key, block_type, block_id=None, fields=None, **kwargs):
-        result = self._modulestore.create_item(user_id, course_key, block_type, block_id, fields, **kwargs)
-        self._remove_from_course_cache(course_key)
-        return result
-
-    def create_child(self, user_id, parent_usage_key, block_type, block_id=None, fields=None, **kwargs):
-        result = self._modulestore.create_child(user_id, parent_usage_key, block_type, block_id, fields, **kwargs)
-        self._remove_from_course_cache(parent_usage_key.course_key)
-        return result
-
-    def import_xblock(self, user_id, course_key, block_type, block_id, fields=None, runtime=None, **kwargs):
-        result = self._modulestore.import_xblock(user_id, course_key, block_type, block_id, fields, runtime, **kwargs)
-        self._remove_from_course_cache(course_key)
-        return result
-
-    def copy_from_template(self, source_keys, dest_key, user_id, **kwargs):
-        result = self._modulestore.copy_from_template(source_keys, dest_key, user_id, **kwargs)
-        self._remove_from_course_cache(dest_key.course_key)
-        return result
-
-    def update_item(self, xblock, user_id, allow_not_found=False, **kwargs):
-        result = self._modulestore.update_item(xblock, user_id, allow_not_found, **kwargs)
-        self._remove_from_course_cache(xblock.location.course_key)
-        return result
-
-    def delete_item(self, location, user_id, **kwargs):
-        result = self._modulestore.delete_item(location, user_id, **kwargs)
-        self._remove_from_course_cache(location.course_key)
-        return result
-
-    def revert_to_published(self, location, user_id):
-        result = self._modulestore.revert_to_published(location, user_id)
-        self._remove_from_course_cache(location.course_key)
-        return result
-
-    def reset_course_to_version(self, course_key, version_guid, user_id):
-        result = self._modulestore.reset_course_to_version(course_key, version_guid, user_id)
-        self._remove_from_course_cache(course_key)
-        return result
-
-    def create_xblock(self, runtime, course_key, block_type, block_id=None, fields=None, **kwargs):
-        result = self._modulestore.create_xblock(runtime, course_key, block_type, block_id, fields, **kwargs)
-        self._remove_from_course_cache(course_key)
-        return result
-
-    def publish(self, location, user_id, **kwargs):
-        result = self._modulestore.publish(location, user_id, **kwargs)
-        self._remove_from_course_cache(location.course_key)
-        return result
-
-    def unpublish(self, location, user_id, **kwargs):
-        result = self._modulestore.unpublish(location, user_id, **kwargs)
-        self._remove_from_course_cache(location.course_key)
-        return result
-
-    def convert_to_draft(self, location, user_id):
-        result = self._modulestore.convert_to_draft(location, user_id)
-        self._remove_from_course_cache(location.course_key)
-        return result
-
-    def has_changes(self, xblock):
-        # Intentionally clearing cache before the proxied call, in order to make
-        # sure our cache can't affect the comparison being done in has_changes.
-        self._remove_from_course_cache(xblock.location.course_key)
-        return self._modulestore.has_changes(xblock)
-
-
 def modulestore():
     """
     Returns the Mixed modulestore
     """
     global _MIXED_MODULESTORE  # pylint: disable=global-statement
+    modulestore_cache = ModuleStoreCache()
+
     if _MIXED_MODULESTORE is None:
         _MIXED_MODULESTORE = create_modulestore_instance(
             settings.MODULESTORE['default']['ENGINE'],
             contentstore(),
             settings.MODULESTORE['default'].get('DOC_STORE_CONFIG', {}),
-            settings.MODULESTORE['default'].get('OPTIONS', {})
+            settings.MODULESTORE['default'].get('OPTIONS', {}),
+            modulestore_cache=modulestore_cache,
         )
 
         if settings.FEATURES.get('CUSTOM_COURSES_EDX'):
@@ -517,7 +337,9 @@ def modulestore():
             from lms.djangoapps.ccx.modulestore import CCXModulestoreWrapper
             _MIXED_MODULESTORE = CCXModulestoreWrapper(_MIXED_MODULESTORE)
 
-    return CachingModuleStoreWrapper(_MIXED_MODULESTORE)
+        _MIXED_MODULESTORE = CachingModuleStoreWrapper(_MIXED_MODULESTORE, modulestore_cache)
+
+    return _MIXED_MODULESTORE
 
 
 def clear_existing_modulestores():

--- a/common/lib/xmodule/xmodule/modulestore/mixed.py
+++ b/common/lib/xmodule/xmodule/modulestore/mixed.py
@@ -4,12 +4,13 @@ MixedModuleStore allows for aggregation between multiple modulestores.
 In this way, courses can be served up via either SplitMongoModuleStore or MongoModuleStore.
 
 """
+
+
 import functools
 import itertools
 import logging
 from contextlib import contextmanager
 
-from edx_django_utils.cache import RequestCache
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import LibraryLocator
@@ -78,13 +79,6 @@ def strip_key(func):
                 else:
                     field_value = strip_key_func(field_value)
             return field_value
-
-        # Write an attribute just so we can scan for it later on when we want to
-        # determine if we're calling get_xxx methods with the default arguments
-        # (this is mixed in via decorator). We can't just compare direclty with
-        # the strip_key_collection function here because it's a local func that
-        # will be regenerated with every decorator.
-        strip_key_collection.default_strip_key_collection = True
 
         # call the decorated function
         retval = func(field_decorator=strip_key_collection, *args, **kwargs)
@@ -181,8 +175,6 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
                 if store_name == key:
                     self.mappings[course_key] = store
             self.modulestores.append(store)
-
-        self._course_request_cache = RequestCache('modulestore_course_block')
 
     def _clean_locator_for_mapping(self, locator):
         """
@@ -409,26 +401,9 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         :param course_key: must be a CourseKey
         """
         assert isinstance(course_key, CourseKey)
-        # Only use the request cache if we're dealing with a simple query with
-        # no advanced params. (This is the vast, vast majority of queries.)
-        # Unfortunately, we have to account for the slightly magical param added
-        # by the @strip_key decorator.
-        use_cache = (
-            ('field_decorator' in kwargs) and
-            getattr(kwargs['field_decorator'], 'default_strip_key_collection', False)
-        )
-        cache_key = (course_key, depth)
-        if use_cache:
-            cache_response = self._course_request_cache.get_cached_response(cache_key)
-            if cache_response.is_found:
-                return cache_response.value
-
         store = self._get_modulestore_for_courselike(course_key)
         try:
-            course = store.get_course(course_key, depth=depth, **kwargs)
-            if use_cache:
-                self._course_request_cache.set(cache_key, course)
-            return course
+            return store.get_course(course_key, depth=depth, **kwargs)
         except ItemNotFoundError:
             return None
 
@@ -471,7 +446,6 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         """
         assert isinstance(course_key, CourseKey)
         store = self._get_modulestore_for_courselike(course_key)
-        self._remove_from_course_cache(course_key)
         return store.delete_course(course_key, user_id)
 
     def save_asset_metadata(self, asset_metadata, user_id, import_only=False):
@@ -486,9 +460,7 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         Returns:
             True if info save was successful, else False
         """
-        course_key = asset_metadata.asset_id.course_key
-        store = self._get_modulestore_for_courselike(course_key)
-        self._remove_from_course_cache(course_key)
+        store = self._get_modulestore_for_courselike(asset_metadata.asset_id.course_key)
         return store.save_asset_metadata(asset_metadata, user_id, import_only)
 
     def save_asset_metadata_list(self, asset_metadata_list, user_id, import_only=False):
@@ -506,9 +478,7 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         """
         if len(asset_metadata_list) == 0:
             return True
-        course_key = asset_metadata_list[0].asset_id.course_key
-        self._remove_from_course_cache(course_key)
-        store = self._get_modulestore_for_courselike(course_key)
+        store = self._get_modulestore_for_courselike(asset_metadata_list[0].asset_id.course_key)
         return store.save_asset_metadata_list(asset_metadata_list, user_id, import_only)
 
     @strip_key
@@ -559,7 +529,6 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
             Number of asset metadata entries deleted (0 or 1)
         """
         store = self._get_modulestore_for_courselike(asset_key.course_key)
-        self._remove_from_course_cache(asset_key.course_key)
         return store.delete_asset_metadata(asset_key, user_id)
 
     def copy_all_asset_metadata(self, source_course_key, dest_course_key, user_id):
@@ -573,7 +542,6 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         """
         source_store = self._get_modulestore_for_courselike(source_course_key)
         dest_store = self._get_modulestore_for_courselike(dest_course_key)
-        self._remove_from_course_cache(dest_course_key)
         if source_store != dest_store:
             with self.bulk_operations(dest_course_key):
                 # Get all the asset metadata in the source course.
@@ -603,7 +571,6 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
             AttributeError is attr is one of the build in attrs.
         """
         store = self._get_modulestore_for_courselike(asset_key.course_key)
-        self._remove_from_course_cache(asset_key.course_key)
         return store.set_asset_metadata_attrs(asset_key, {attr: value}, user_id)
 
     def set_asset_metadata_attrs(self, asset_key, attr_dict, user_id):  # lint-amnesty, pylint: disable=arguments-differ
@@ -620,7 +587,6 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
             AttributeError is attr is one of the build in attrs.
         """
         store = self._get_modulestore_for_courselike(asset_key.course_key)
-        self._remove_from_course_cache(asset_key.course_key)
         return store.set_asset_metadata_attrs(asset_key, attr_dict, user_id)
 
     @strip_key
@@ -690,7 +656,6 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         """
         # first make sure an existing course doesn't already exist in the mapping
         course_key = self.make_course_key(org, course, run)
-        self._remove_from_course_cache(course_key)
 
         log.info('Creating course run %s...', course_key)
         if course_key in self.mappings and self.mappings[course_key].has_course(course_key):
@@ -723,7 +688,6 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         """
         # first make sure an existing course/lib doesn't already exist in the mapping
         lib_key = LibraryLocator(org=org, library=library)
-        self._remove_from_course_cache(lib_key)
         if lib_key in self.mappings:
             raise DuplicateCourseError(lib_key, lib_key)
 
@@ -747,7 +711,6 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
             * copy the assets
             * migrate the courseware
         """
-        self._remove_from_course_cache(dest_course_id)
 
         source_modulestore = self._get_modulestore_for_courselike(source_course_id)
         # for a temporary period of time, we may want to hardcode dest_modulestore as split if there's a split
@@ -787,9 +750,7 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
                 in the newly created block
         """
         modulestore = self._verify_modulestore_support(course_key, 'create_item')
-        self._remove_from_course_cache(course_key)
         return modulestore.create_item(user_id, course_key, block_type, block_id=block_id, fields=fields, **kwargs)
-
 
     @strip_key
     @prepare_asides
@@ -810,7 +771,6 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
                 in the newly created block
         """
         modulestore = self._verify_modulestore_support(parent_usage_key.course_key, 'create_child')
-        self._remove_from_course_cache(parent_usage_key.course_key)
         return modulestore.create_child(user_id, parent_usage_key, block_type, block_id=block_id, fields=fields, **kwargs)  # lint-amnesty, pylint: disable=line-too-long
 
     @strip_key
@@ -822,7 +782,6 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         Defer to the course's modulestore if it supports this method
         """
         store = self._verify_modulestore_support(course_key, 'import_xblock')
-        self._remove_from_course_cache(course_key)
         return store.import_xblock(user_id, course_key, block_type, block_id, fields, runtime, **kwargs)
 
     @strip_key
@@ -831,7 +790,6 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         See :py:meth `SplitMongoModuleStore.copy_from_template`
         """
         store = self._verify_modulestore_support(dest_key.course_key, 'copy_from_template')
-        self._remove_from_course_cache(dest_key.course_key)
         return store.copy_from_template(source_keys, dest_key, user_id)
 
     @strip_key
@@ -842,7 +800,6 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         (content, children, and metadata) attribute the change to the given user.
         """
         store = self._verify_modulestore_support(xblock.location.course_key, 'update_item')
-        self._remove_from_course_cache(xblock.location.course_key)
         return store.update_item(xblock, user_id, allow_not_found, **kwargs)
 
     @strip_key
@@ -851,7 +808,6 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         Delete the given item from persistence. kwargs allow modulestore specific parameters.
         """
         store = self._verify_modulestore_support(location.course_key, 'delete_item')
-        self._remove_from_course_cache(location.course_key)
         return store.delete_item(location, user_id=user_id, **kwargs)
 
     def revert_to_published(self, location, user_id):
@@ -865,7 +821,6 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         :raises InvalidVersionError: if no published version exists for the location specified
         """
         store = self._verify_modulestore_support(location.course_key, 'revert_to_published')
-        self._remove_from_course_cache(location.course_key)
         return store.revert_to_published(location, user_id)
 
     def reset_course_to_version(self, course_key, version_guid, user_id):
@@ -875,7 +830,6 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         :raises NotImplementedError: if not supported by store.
         """
         store = self._verify_modulestore_support(course_key, 'reset_course_to_version')
-        self._remove_from_course_cache(course_key)
         return store.reset_course_to_version(
             course_key=course_key,
             version_guid=version_guid,
@@ -921,7 +875,6 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
                 should be the pythonic types not the json serialized ones.
         """
         store = self._verify_modulestore_support(course_key, 'create_xblock')
-        self._remove_from_course_cache(course_key)
         return store.create_xblock(runtime, course_key, block_type, block_id, fields or {}, **kwargs)
 
     @strip_key
@@ -969,7 +922,6 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         Returns the newly published item.
         """
         store = self._verify_modulestore_support(location.course_key, 'publish')
-        self._remove_from_course_cache(location.course_key)
         return store.publish(location, user_id, **kwargs)
 
     @strip_key
@@ -979,7 +931,6 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         Returns the newly unpublished item.
         """
         store = self._verify_modulestore_support(location.course_key, 'unpublish')
-        self._remove_from_course_cache(location.course_key)
         return store.unpublish(location, user_id, **kwargs)
 
     def convert_to_draft(self, location, user_id):
@@ -990,7 +941,6 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         :param location: the location of the source (its revision must be None)
         """
         store = self._verify_modulestore_support(location.course_key, 'convert_to_draft')
-        self._remove_from_course_cache(location.course_key)
         return store.convert_to_draft(location, user_id)
 
     def has_changes(self, xblock):
@@ -1000,7 +950,6 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         :return: True if the draft and published versions differ
         """
         store = self._verify_modulestore_support(xblock.location.course_key, 'has_changes')
-        self._remove_from_course_cache(xblock.location.course_key)
         return store.has_changes(xblock)
 
     def check_supports(self, course_key, method):
@@ -1092,16 +1041,3 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         """
         for store in self.modulestores:
             store.ensure_indexes()
-
-    def _remove_from_course_cache(self, course_key):
-        """
-        Remove all instances of this course_key from the local request cache.
-        """
-        # Remember that there may be multiple keys for the same course
-        cache_keys_to_del = [
-            cache_key
-            for cache_key in self._course_request_cache.data
-            if cache_key[0] == course_key
-        ]
-        for cache_key in cache_keys_to_del:
-            self._course_request_cache.delete(cache_key)

--- a/common/lib/xmodule/xmodule/modulestore/mixed.py
+++ b/common/lib/xmodule/xmodule/modulestore/mixed.py
@@ -1000,7 +1000,7 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         :return: True if the draft and published versions differ
         """
         store = self._verify_modulestore_support(xblock.location.course_key, 'has_changes')
-        self._remove_from_course_cache(location.course_key)
+        self._remove_from_course_cache(xblock.location.course_key)
         return store.has_changes(xblock)
 
     def check_supports(self, course_key, method):

--- a/common/lib/xmodule/xmodule/modulestore/mixed.py
+++ b/common/lib/xmodule/xmodule/modulestore/mixed.py
@@ -446,6 +446,7 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         """
         assert isinstance(course_key, CourseKey)
         store = self._get_modulestore_for_courselike(course_key)
+        self.modulestore_cache.invalidate_course(course_key)
         return store.delete_course(course_key, user_id)
 
     def save_asset_metadata(self, asset_metadata, user_id, import_only=False):

--- a/common/lib/xmodule/xmodule/modulestore/mixed.py
+++ b/common/lib/xmodule/xmodule/modulestore/mixed.py
@@ -137,6 +137,7 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
             user_service=None,
             create_modulestore_instance=None,
             signal_handler=None,
+            modulestore_cache=None,
             **kwargs
     ):
         """
@@ -158,6 +159,8 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
                 log.exception("Invalid MixedModuleStore configuration. Unable to parse course_id %r", course_id)
                 continue
 
+#        import pudb; pu.db
+
         for store_settings in stores:
             key = store_settings['NAME']
             store = create_modulestore_instance(
@@ -169,6 +172,7 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
                 fs_service=fs_service,
                 user_service=user_service,
                 signal_handler=signal_handler,
+                modulestore_cache=modulestore_cache,
             )
             # replace all named pointers to the store into actual pointers
             for course_key, store_name in self.mappings.items():

--- a/common/lib/xmodule/xmodule/modulestore/mixed.py
+++ b/common/lib/xmodule/xmodule/modulestore/mixed.py
@@ -1100,7 +1100,7 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         # Remember that there may be multiple keys for the same course
         cache_keys_to_del = [
             cache_key
-            for cache_key, _course in self._course_request_cache.data
+            for cache_key in self._course_request_cache.data
             if cache_key[0] == course_key
         ]
         for cache_key in cache_keys_to_del:

--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -41,6 +41,7 @@ from xmodule.errortracker import exc_info_to_str, null_error_tracker
 from xmodule.exceptions import HeartbeatFailure
 from xmodule.mako_module import MakoDescriptorSystem
 from xmodule.modulestore import BulkOperationsMixin, BulkOpsRecord, ModuleStoreEnum, ModuleStoreWriteBase
+from xmodule.modulestore.caching import ModuleStoreCache
 from xmodule.modulestore.draft_and_published import DIRECT_ONLY_CATEGORIES, ModuleStoreDraftAndPublished
 from xmodule.modulestore.edit_info import EditInfoRuntimeMixin
 from xmodule.modulestore.exceptions import DuplicateCourseError, ItemNotFoundError, ReferentialIntegrityError
@@ -533,7 +534,6 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
                  user_service=None,
                  signal_handler=None,
                  retry_wait_time=0.1,
-                 modulestore_cache=None,
                  **kwargs):
         """
         :param doc_store_config: must have a host, db, and collection entries. Other common entries: port, tz_aware.
@@ -581,7 +581,7 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
 
         self._course_run_cache = {}
         self.signal_handler = signal_handler
-        self.modulestore_cache = modulestore_cache
+        self.modulestore_cache = ModuleStoreCache()
 
     def close_connections(self):
         """

--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -1543,6 +1543,8 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
 
             # recompute (and update) the metadata inheritance tree which is cached
             self.refresh_cached_metadata_inheritance_tree(xblock.scope_ids.usage_id.course_key, xblock.runtime)
+
+            self.modulestore_cache.invalidate_course(course_key)
             # fire signal that we've written to DB
         except ItemNotFoundError:
             if not allow_not_found:  # lint-amnesty, pylint: disable=no-else-raise

--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -1467,6 +1467,7 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
             {'$set': update},
             upsert=allow_not_found,
         )
+        self.modulestore_cache.invalidate_course(location.course)
         if result.matched_count == 0 and result.upserted_id is None:
             raise ItemNotFoundError(location)
 
@@ -1602,6 +1603,7 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
                         {'$set': {'definition.children': []}},
                         upsert=True,
                     )
+                    self.modulestore_cache.invalidate_course(location.course)
                 elif ancestor_loc.block_type == 'course':
                     # once we reach the top location of the tree and if the location is not an orphan then the
                     # parent is not an orphan either

--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -533,6 +533,7 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
                  user_service=None,
                  signal_handler=None,
                  retry_wait_time=0.1,
+                 modulestore_cache=None,
                  **kwargs):
         """
         :param doc_store_config: must have a host, db, and collection entries. Other common entries: port, tz_aware.
@@ -580,6 +581,7 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
 
         self._course_run_cache = {}
         self.signal_handler = signal_handler
+        self.modulestore_cache = modulestore_cache
 
     def close_connections(self):
         """

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -53,8 +53,6 @@ Representation:
         *** 'original_version': definition_id of the root of the previous version relation on this
         definition. Acts as a pseudo-object identifier.
 """
-
-
 import copy
 import datetime
 import hashlib
@@ -93,6 +91,7 @@ from xmodule.modulestore import (
     SortedAssetList,
     inheritance
 )
+from xmodule.modulestore.caching import ModuleStoreCache
 from xmodule.modulestore.exceptions import (
     DuplicateCourseError,
     DuplicateItemError,
@@ -108,6 +107,7 @@ from xmodule.partitions.partitions_service import PartitionService
 
 from ..exceptions import ItemNotFoundError
 from .caching_descriptor_system import CachingDescriptorSystem
+
 
 log = logging.getLogger(__name__)
 
@@ -709,7 +709,7 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
                  default_class=None,
                  error_tracker=null_error_tracker,
                  i18n_service=None, fs_service=None, user_service=None,
-                 services=None, signal_handler=None, modulestore_cache=None, **kwargs):
+                 services=None, signal_handler=None, **kwargs):
         """
         :param doc_store_config: must have a host, db, and collection entries. Other common entries: port, tz_aware.
         """
@@ -741,7 +741,7 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
             self.services["request_cache"] = self.request_cache
 
         self.signal_handler = signal_handler
-        self.modulestore_cache = modulestore_cache
+        self.modulestore_cache = ModuleStoreCache()
 
     def close_connections(self):
         """

--- a/lms/djangoapps/ccx/overrides.py
+++ b/lms/djangoapps/ccx/overrides.py
@@ -14,6 +14,7 @@ from opaque_keys.edx.keys import CourseKey, UsageKey
 from lms.djangoapps.ccx.models import CcxFieldOverride, CustomCourseForEdX
 from lms.djangoapps.courseware.field_overrides import FieldOverrideProvider
 from openedx.core.lib.cache_utils import get_cache
+from xmodule.modulestore.django import modulestore
 
 log = logging.getLogger(__name__)
 
@@ -177,6 +178,8 @@ def override_field_for_ccx(ccx, block, name, value):
     _get_overrides_for_ccx(ccx).setdefault(clean_ccx_key, {})[name] = value_json
     _get_overrides_for_ccx(ccx).setdefault(clean_ccx_key, {})[name + "_instance"] = override
 
+    modulestore().modulestore_cache.invalidate_course(block.location.course)
+
 
 def clear_override_for_ccx(ccx, block, name):
     """
@@ -192,6 +195,7 @@ def clear_override_for_ccx(ccx, block, name):
             field=name).delete()
 
         clear_ccx_field_info_from_ccx_map(ccx, block, name)
+        modulestore().modulestore_cache.invalidate_course(block.location.course)
 
     except CcxFieldOverride.DoesNotExist:
         pass

--- a/lms/djangoapps/courseware/tests/test_courses.py
+++ b/lms/djangoapps/courseware/tests/test_courses.py
@@ -88,17 +88,11 @@ class CoursesTest(ModuleStoreTestCase):
         assert error.value.access_response.error_code == 'not_visible_to_user'
         assert not error.value.access_response.has_access
 
-    @ddt.data(
-        (GET_COURSE_WITH_ACCESS, 1),
-        (GET_COURSE_OVERVIEW_WITH_ACCESS, 0),
-    )
-    @ddt.unpack
-    def test_get_course_func_with_access(self, course_access_func_name, num_mongo_calls):
-        course_access_func = self.COURSE_ACCESS_FUNCS[course_access_func_name]
+    def test_overview_doesnt_call_mongo(self):
         user = UserFactory.create()
         course = CourseFactory.create(emit_signals=True)
-        with check_mongo_calls(num_mongo_calls):
-            course_access_func(user, 'load', course.id)
+        with check_mongo_calls(0):
+            get_course_overview_with_access(user, 'load', course.id)
 
     def test_get_courses_by_org(self):
         """

--- a/lms/djangoapps/discussion/django_comment_client/base/tests.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/tests.py
@@ -401,8 +401,8 @@ class ViewsQueryCountTestCase(
         return inner
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 3, 4, 39),
-        (ModuleStoreEnum.Type.split, 3, 13, 39),
+        (ModuleStoreEnum.Type.mongo, 3, 2, 39),
+        (ModuleStoreEnum.Type.split, 3, 7, 39),
     )
     @ddt.unpack
     @count_queries
@@ -410,8 +410,8 @@ class ViewsQueryCountTestCase(
         self.create_thread_helper(mock_request)
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 3, 3, 35),
-        (ModuleStoreEnum.Type.split, 3, 10, 35),
+        (ModuleStoreEnum.Type.mongo, 3, 2, 35),
+        (ModuleStoreEnum.Type.split, 3, 7, 35),
     )
     @ddt.unpack
     @count_queries

--- a/lms/djangoapps/discussion/tests/test_views.py
+++ b/lms/djangoapps/discussion/tests/test_views.py
@@ -1891,6 +1891,7 @@ class DividedDiscussionsTestCase(CohortViewsTestCase):  # lint-amnesty, pylint: 
             discussion_topics=discussion_topics,
             divided_discussions=divided_discussions
         )
+
         return divided_inline_discussions, divided_course_wide_discussions
 
 

--- a/lms/djangoapps/discussion/tests/test_views.py
+++ b/lms/djangoapps/discussion/tests/test_views.py
@@ -480,18 +480,18 @@ class SingleThreadQueryCountTestCase(ForumsEnableMixin, ModuleStoreTestCase):
         # course is outside the context manager that is verifying the number of queries,
         # and with split mongo, that method ends up querying disabled_xblocks (which is then
         # cached and hence not queried as part of call_single_thread).
-        (ModuleStoreEnum.Type.mongo, False, 1, 5, 2, 21, 7),
-        (ModuleStoreEnum.Type.mongo, False, 50, 5, 2, 21, 7),
+        (ModuleStoreEnum.Type.mongo, False, 1, 3, 0, 21, 7),
+        (ModuleStoreEnum.Type.mongo, False, 50, 3, 0, 21, 7),
         # split mongo: 3 queries, regardless of thread response size.
-        (ModuleStoreEnum.Type.split, False, 1, 3, 3, 21, 8),
-        (ModuleStoreEnum.Type.split, False, 50, 3, 3, 21, 8),
+        (ModuleStoreEnum.Type.split, False, 1, 3, 1, 21, 8),
+        (ModuleStoreEnum.Type.split, False, 50, 3, 1, 21, 8),
 
         # Enabling Enterprise integration should have no effect on the number of mongo queries made.
-        (ModuleStoreEnum.Type.mongo, True, 1, 5, 2, 21, 7),
-        (ModuleStoreEnum.Type.mongo, True, 50, 5, 2, 21, 7),
+        (ModuleStoreEnum.Type.mongo, True, 1, 3, 0, 21, 7),
+        (ModuleStoreEnum.Type.mongo, True, 50, 3, 0, 21, 7),
         # split mongo: 3 queries, regardless of thread response size.
-        (ModuleStoreEnum.Type.split, True, 1, 3, 3, 21, 8),
-        (ModuleStoreEnum.Type.split, True, 50, 3, 3, 21, 8),
+        (ModuleStoreEnum.Type.split, True, 1, 3, 1, 21, 8),
+        (ModuleStoreEnum.Type.split, True, 50, 3, 1, 21, 8),
     )
     @ddt.unpack
     def test_number_of_mongo_queries(

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -371,7 +371,7 @@ class TestInstructorGradeReport(InstructorGradeReportTestCase):
         self._verify_cell_data_for_user(verified_user.username, course.id, 'Certificate Eligible', 'Y', num_rows=2)
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 4),
+        (ModuleStoreEnum.Type.mongo, 3),
         (ModuleStoreEnum.Type.split, 3),
     )
     @ddt.unpack

--- a/openedx/core/lib/courses.py
+++ b/openedx/core/lib/courses.py
@@ -5,7 +5,6 @@ Common utility functions related to courses.
 from django import forms
 from django.conf import settings
 from django.http import Http404
-from edx_django_utils.cache import RequestCache
 
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.locator import CourseKey

--- a/openedx/core/lib/courses.py
+++ b/openedx/core/lib/courses.py
@@ -5,7 +5,7 @@ Common utility functions related to courses.
 from django import forms
 from django.conf import settings
 from django.http import Http404
-from openedx.core.lib.cache_utils import RequestCache
+from edx_django_utils.cache import RequestCache
 
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.locator import CourseKey
@@ -94,17 +94,9 @@ def get_course_by_id(course_key, depth=0):
 
     depth: The number of levels of children for the modulestore to cache. None means infinite depth
     """
-    # Do we be extra defensive and make this LMS-only?
-    request_cache = RequestCache('get_course_by_id')
-    cache_key = (course_key, depth)
-    cache_response = request_cache.get_cached_response(cache_key)
-    if cache_response.is_found:
-        return cache_response.value
-
     with modulestore().bulk_operations(course_key):
         course = modulestore().get_course(course_key, depth=depth)
     if course:
-        request_cache.set(cache_key, course)
         return course
     else:
         raise Http404(f"Course not found: {str(course_key)}.")

--- a/openedx/core/lib/courses.py
+++ b/openedx/core/lib/courses.py
@@ -94,6 +94,7 @@ def get_course_by_id(course_key, depth=0):
 
     depth: The number of levels of children for the modulestore to cache. None means infinite depth
     """
+    # Do we be extra defensive and make this LMS-only?
     request_cache = RequestCache('get_course_by_id')
     cache_key = (course_key, depth)
     cache_response = request_cache.get_cached_response(cache_key)


### PR DESCRIPTION
```
There are many repeated calls to get_course_by_id in various courseware
views. Fetching a course has a very high overhead, particularly for
large courses, because even small queries looking at just the root
course block require the full structure document for the entire course
to be loaded from the SplitMongo Modulestore.
```

Let's see just how many tests this breaks...

