### PR TITLE
fix: import+export management commands

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/export_content_library.py
+++ b/cms/djangoapps/contentstore/management/commands/export_content_library.py
@@ -61,6 +61,6 @@ class Command(BaseCommand):
                 filename = prefix + suffix
                 target = os.path.join(dest_path, filename)
                 tarball.file.seek(0)
-                with open(target, 'w') as f:
+                with open(target, 'wb') as f:
                     shutil.copyfileobj(tarball.file, f)
                 print(f'Library "{library.location.library_key}" exported to "{target}"')

--- a/cms/djangoapps/contentstore/management/commands/import_content_library.py
+++ b/cms/djangoapps/contentstore/management/commands/import_content_library.py
@@ -43,13 +43,13 @@ class Command(BaseCommand):
         username = options['owner_username']
 
         data_root = Path(settings.GITHUB_REPO_ROOT)
-        subdir = base64.urlsafe_b64encode(os.path.basename(archive_path))
+        subdir = base64.urlsafe_b64encode(os.path.basename(archive_path).encode('utf-8')).decode('utf-8')
         course_dir = data_root / subdir
 
         # Extract library archive
         tar_file = tarfile.open(archive_path)  # lint-amnesty, pylint: disable=consider-using-with
         try:
-            safetar_extractall(tar_file, course_dir.encode('utf-8'))
+            safetar_extractall(tar_file, course_dir)
         except SuspiciousOperation as exc:
             raise CommandError(f'\n=== Course import {archive_path}: Unsafe tar file - {exc.args[0]}\n')  # lint-amnesty, pylint: disable=raise-missing-from
         finally:


### PR DESCRIPTION
**Description**

PR provides with fix for Studio management commands:

    export_content_library
    import_content_library

**Background**

    export_content_library command has a file encoding issue. It has been fixed by opening file in binary mode.
    import_content_library command has a string path encoding issue. It has been fixed by using .encode() and decode() in the right places.

Studio Updates: The commands above are working normally

LMS Updates: None
Testing:

Run commands on an existing library with id <library_id>. Save it in /tmp and import it using staff user as owner:

```
./manage.py cms export_content_library <library_id> <folder>
./manage.py cms export_content_library /tmp/<library_id>.tar.gz staff
```
