### PR TITLE
fix: Corrected issue with request cert showing when user was in mode that is not eligible for certs

### DIFF
--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -776,7 +776,7 @@ class CourseMode(models.Model):
         """
         ineligible_modes = [cls.AUDIT]
 
-        if settings.FEATURES['DISABLE_HONOR_CERTIFICATES']:
+        if settings.FEATURES.get('DISABLE_HONOR_CERTIFICATES', False):
             # Adding check so that we can regenerate the certificate for learners who have
             # already earned the certificate using honor mode
             from lms.djangoapps.certificates.data import CertificateStatuses

--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -441,32 +441,32 @@ class AccountValidationError(Exception):
         self.error_code = error_code
 
 
-def cert_info(user, course_overview):
+def cert_info(user, enrollment):
     """
     Get the certificate info needed to render the dashboard section for the given
     student and course.
 
     Arguments:
         user (User): A user.
-        course_overview (CourseOverview): A course.
+        enrollment (CourseEnrollment): A course enrollment.
 
     Returns:
         See _cert_info
     """
     return _cert_info(
         user,
-        course_overview,
-        certificate_status_for_student(user, course_overview.id),
+        enrollment,
+        certificate_status_for_student(user, enrollment.course_overview.id),
     )
 
 
-def _cert_info(user, course_overview, cert_status):
+def _cert_info(user, enrollment, cert_status):
     """
     Implements the logic for cert_info -- split out for testing.
 
     Arguments:
         user (User): A user.
-        course_overview (CourseOverview): A course.
+        enrollment (CourseEnrollment): A course enrollment.
         cert_status (dict): dictionary containing information about certificate status for the user
 
     Returns:
@@ -506,9 +506,10 @@ def _cert_info(user, course_overview, cert_status):
         'can_unenroll': True,
     }
 
-    if cert_status is None:
+    if cert_status is None or enrollment is None:
         return default_info
 
+    course_overview = enrollment.course_overview if enrollment else None
     status = template_state.get(cert_status['status'], default_status)
     is_hidden_status = status in ('processing', 'generating', 'notpassing', 'auditing')
 
@@ -523,6 +524,9 @@ def _cert_info(user, course_overview, cert_status):
         course_overview.certificates_display_behavior == 'early_no_info' and
         is_hidden_status
     ):
+        return default_info
+
+    if not CourseMode.is_eligible_for_certificate(enrollment.mode, status=status):
         return default_info
 
     status_dict = {

--- a/common/djangoapps/student/tests/test_views.py
+++ b/common/djangoapps/student/tests/test_views.py
@@ -154,10 +154,13 @@ class TestStudentDashboardUnenrollments(SharedModuleStoreTestCase):
 
     def test_course_run_refund_status_invalid_course_key(self):
         """ Assert that view:course_run_refund_status returns correct Json for Invalid Course Key ."""
-        with patch('opaque_keys.edx.keys.CourseKey.from_string') as mock_method:
-            mock_method.side_effect = InvalidKeyError('CourseKey', 'The course key used to get refund status caused \
-                                                        InvalidKeyError during look up.')
-            response = self.client.get(reverse('course_run_refund_status', kwargs={'course_id': self.course.id}))
+        test_url = reverse('course_run_refund_status', kwargs={'course_id': self.course.id})
+        with patch('common.djangoapps.student.views.management.CourseKey.from_string') as mock_method:
+            mock_method.side_effect = InvalidKeyError(
+                'CourseKey',
+                'The course key used to get refund status caused InvalidKeyError during look up.'
+            )
+            response = self.client.get(test_url)
 
         assert json.loads(response.content.decode('utf-8')) == {'course_refundable_status': ''}
         assert response.status_code == 406
@@ -229,7 +232,7 @@ class StudentDashboardTests(SharedModuleStoreTestCase, MilestonesTestCaseMixin, 
             certificate_available_date=TOMORROW,
             lowest_passing_grade=0.3
         )
-        CourseEnrollmentFactory(course_id=course.id, user=self.user)
+        CourseEnrollmentFactory(course_id=course.id, user=self.user, mode=CourseMode.VERIFIED)
         GeneratedCertificateFactory(
             status=CertificateStatuses.downloadable, course_id=course.id, user=self.user, grade=0.45
         )
@@ -244,7 +247,7 @@ class StudentDashboardTests(SharedModuleStoreTestCase, MilestonesTestCaseMixin, 
             certificate_available_date=TOMORROW,
             lowest_passing_grade=0.3
         )
-        CourseEnrollmentFactory(course_id=course.id, user=self.user)
+        CourseEnrollmentFactory(course_id=course.id, user=self.user, mode=CourseMode.VERIFIED)
         GeneratedCertificateFactory(
             status=CertificateStatuses.downloadable, course_id=course.id, user=self.user, grade=0.45
         )
@@ -259,7 +262,7 @@ class StudentDashboardTests(SharedModuleStoreTestCase, MilestonesTestCaseMixin, 
             certificate_available_date=now(),
             lowest_passing_grade=0.3
         )
-        CourseEnrollmentFactory(course_id=course.id, user=self.user)
+        CourseEnrollmentFactory(course_id=course.id, user=self.user, mode=CourseMode.VERIFIED)
         GeneratedCertificateFactory(
             status=CertificateStatuses.downloadable, course_id=course.id, user=self.user, grade=0.45
         )

--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -676,7 +676,7 @@ def student_dashboard(request):  # lint-amnesty, pylint: disable=too-many-statem
     # there is no verification messaging to display.
     verify_status_by_course = check_verify_status_by_course(user, course_enrollments)
     cert_statuses = {
-        enrollment.course_id: cert_info(request.user, enrollment.course_overview)
+        enrollment.course_id: cert_info(request.user, enrollment)
         for enrollment in course_enrollments
     }
 

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -401,7 +401,7 @@ def change_enrollment(request, check_access=True):
         if not enrollment:
             return HttpResponseBadRequest(_("You are not enrolled in this course"))
 
-        certificate_info = cert_info(user, enrollment.course_overview)
+        certificate_info = cert_info(user, enrollment)
         if certificate_info.get('status') in DISABLE_UNENROLL_CERT_STATES:
             return HttpResponseBadRequest(_("Your certificate prevents you from unenrolling from this course"))
 


### PR DESCRIPTION
 Corrects an issue with request cert showing when the user is not enrolled in a mode that is eligible for Certificates.


Steps to reproduce:
* Created a new account
* Enrolled in a (completable) course in my devstack in the Audit track.
* Enrollment mode was changed to verified via the LMS Support tools (http://localhost:18000/support/enrollment)
* Took the test in my devstack course and earned a passing score (100%)
* Certificate generation was attempted, but the test account did not earn a `downloadable` certificate as it doesn't have a current, approved ID verification (my certificate record's status is `unverified`)
* Enrollment mode was updated from verified to audit
* Went to course dashboard and see a `Request Certificate` button and a message saying `Congratulations! Your certificate is ready.`.

