### PR TITLE
fix: stop redirecting MFE api requests, and instead give back json

### DIFF
--- a/lms/djangoapps/course_home_api/dates/v1/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/dates/v1/tests/test_views.py
@@ -41,7 +41,8 @@ class DatesTabTestViews(BaseCourseHomeTests):
             CourseEnrollment.enroll(self.user, self.course.id)
             CourseEnrollment.unenroll(self.user, self.course.id)
         response = self.client.get(self.url)
-        assert response.status_code == 401
+        assert response.status_code == 403
+        assert response.json() == {'redirect': f'http://learning-mfe/course/{self.course.id}/home'}
 
     def test_get_unauthenticated_user(self):
         self.client.logout()

--- a/lms/djangoapps/course_home_api/decorators.py
+++ b/lms/djangoapps/course_home_api/decorators.py
@@ -1,0 +1,71 @@
+"""
+Decorators for Course Home APIs.
+"""
+
+import functools
+
+from django.http import QueryDict
+from django.urls import reverse
+from rest_framework.response import Response
+
+from lms.djangoapps.courseware.courseware_access_exception import CoursewareAccessException
+from lms.djangoapps.courseware.exceptions import Redirect
+
+
+def course_home_redirects(func):
+    """
+    Method decorator for a course home API endpoint that verifies the user has access to the course.
+
+    A lot of old platform code is written in a way that assumes the request is for the main html page, rather than an
+    ajax call. So it will frequently raise redirect exceptions in cases like access errors.
+
+    However for ajax calls, the browser will follow those redirects and try to parse some html page as json. So we need
+    to instead return some json that tells the frontend to change browser locations.
+
+    And that's what this decorator does. It handles the following exceptions, thrown by your wrapped method:
+
+    * courseware.courseware_access_exception.CoursewareAccessException:
+      - generic access error
+      - we'll redirect to the dashboard with your error message
+
+    * courseware.exceptions.Redirect (and its subclasses like courseware.exceptions.CourseAccessRedirect):
+      - used for a most access errors
+      - we'll redirect to the provided url, making it absolute first
+
+    The response we give, which the frontend knows how to parse, looks like a standard 403 response, with a json body:
+    {
+        'redirect': 'https://.../my/new/path'
+    }
+
+    We use 403 as the error code just because it roughly matches the usual reason for these redirects (permission
+    denied) but also because at the time of writing, the MFE does not already have conflicting handling for 403.
+    Really, the error code can be anything, as long as the MFE knows to parse it for the redirect. The browser/user
+    does not need to understand the error code as having any particular meaning. So 403 it is.
+
+    (Remember that we can't simply return a 3xx status code because the browser will automatically follow those, and
+     you can't ask it not to. So the MFE would end up trying to parse html as json.)
+    """
+    @functools.wraps(func)
+    def _wrapper(self, request, *args, **kwargs):
+        """This is the actual function wrapper that handles exceptions"""
+
+        def create_response(url):
+            return Response(status=403, data={'redirect': request.build_absolute_uri(url)})
+
+        try:
+            return func(self, request, *args, **kwargs)
+        except CoursewareAccessException as exc:
+            # Extend this 404 exception with a redirect to the user's dashboard, plus an error message.
+            params = QueryDict(mutable=True)
+            # Prefer a message with course context, if available
+            user_message = exc.access_response.additional_context_user_message or exc.access_response.user_message
+            if user_message:
+                params['access_response_error'] = user_message
+            return create_response('{dashboard_url}?{params}'.format(
+                dashboard_url=reverse('dashboard'),
+                params=params.urlencode(),
+            ))
+        except Redirect as exc:
+            return create_response(exc.url)
+
+    return _wrapper

--- a/lms/djangoapps/course_home_api/progress/v1/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/progress/v1/tests/test_views.py
@@ -64,7 +64,8 @@ class ProgressTabTestViews(BaseCourseHomeTests):
             CourseEnrollment.enroll(self.user, self.course.id)
             CourseEnrollment.unenroll(self.user, self.course.id)
         response = self.client.get(self.url)
-        assert response.status_code == 401
+        assert response.status_code == 403
+        assert response.json() == {'redirect': f'http://learning-mfe/course/{self.course.id}/home'}
 
     @override_waffle_flag(COURSE_HOME_MICROFRONTEND_PROGRESS_TAB, active=True)
     def test_get_unauthenticated_user(self):
@@ -83,7 +84,8 @@ class ProgressTabTestViews(BaseCourseHomeTests):
     def test_waffle_flag_disabled(self, enrollment_mode):
         CourseEnrollment.enroll(self.user, self.course.id, enrollment_mode)
         response = self.client.get(self.url)
-        assert response.status_code == 404
+        assert response.status_code == 403
+        assert response.json() == {'redirect': f'http://testserver/courses/{self.course.id}/progress'}
 
     @override_waffle_flag(COURSE_HOME_MICROFRONTEND_PROGRESS_TAB, active=True)
     def test_masquerade(self):
@@ -155,7 +157,8 @@ class ProgressTabTestViews(BaseCourseHomeTests):
         DisableProgressPageStackedConfig.objects.create(disabled=True, course=course_overview)
 
         response = self.client.get(self.url)
-        assert response.status_code == 404
+        assert response.status_code == 403
+        assert response.json() == {'redirect': f'http://testserver/courses/{self.course.id}/progress'}
 
     @override_waffle_flag(COURSE_HOME_MICROFRONTEND_PROGRESS_TAB, active=True)
     def test_learner_has_access(self):

--- a/lms/djangoapps/mobile_api/decorators.py
+++ b/lms/djangoapps/mobile_api/decorators.py
@@ -49,7 +49,7 @@ def mobile_course_access(depth=0):
                     if error.access_error is not None:
                         return Response(data=error.access_error.to_json(), status=status.HTTP_404_NOT_FOUND)
                     # Raise a 404 if the user does not have course access
-                    raise Http404  # lint-amnesty, pylint: disable=raise-missing-from
+                    raise Http404 from error
                 return func(self, request, course=course, *args, **kwargs)
 
         return _wrapper


### PR DESCRIPTION
For access denied errors and the like, we were returning 302 redirects to the dashboard or other course pages in our MFE rest api responses. This would end up causing the MFE to try to parse html as json and resulted in errors for the user.

See [the code](https://github.com/edx/edx-platform/blob/e81fcbf5d75e65416f92c16b2b548a506795a475/lms/djangoapps/courseware/courses.py#L196) for a list of weird redirect cases that we weren't handling (course access expired, must do a survey first, course isn't live yet, etc).

This introduces a new 403 response with json content that indicates where we want to redirect to - the MFE can now read that and reroute the user as needed.

Related to https://github.com/edx/frontend-app-learning/pull/550