### PR TITLE
Move cert display decisions to certificates app

### DIFF
--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -39,10 +39,10 @@ from lms.djangoapps.certificates.api import (
     certificates_viewable_for_course,
     cert_generation_enabled,
     get_certificate_url,
-    has_html_certificates_enabled
+    has_html_certificates_enabled,
+    certificate_status_for_student,
 )
 from lms.djangoapps.certificates.data import CertificateStatuses
-from lms.djangoapps.certificates.models import certificate_status_for_student
 from lms.djangoapps.grades.api import CourseGradeFactory
 from lms.djangoapps.verify_student.models import VerificationDeadline
 from lms.djangoapps.verify_student.services import IDVerificationService

--- a/common/djangoapps/student/tests/test_views.py
+++ b/common/djangoapps/student/tests/test_views.py
@@ -131,7 +131,7 @@ class TestStudentDashboardUnenrollments(SharedModuleStoreTestCase):
     def test_cant_unenroll_status(self):
         """ Assert that the dashboard loads when cert_status does not allow for unenrollment"""
         with patch(
-            'lms.djangoapps.certificates.models.certificate_status_for_student',
+            'lms.djangoapps.certificates.api.certificate_status_for_student',
             return_value={'status': 'downloadable'},
         ):
             response = self.client.get(reverse('dashboard'))

--- a/common/lib/xmodule/xmodule/course_metadata_utils.py
+++ b/common/lib/xmodule/xmodule/course_metadata_utils.py
@@ -134,40 +134,6 @@ def course_start_date_is_default(start, advertised_start):
     return advertised_start is None and start == DEFAULT_START_DATE
 
 
-def may_certify_for_course(
-        certificates_display_behavior,
-        certificates_show_before_end,
-        has_ended,
-        certificate_available_date,
-        self_paced
-):
-    """
-    Returns whether it is acceptable to show the student a certificate download
-    link for a course, based on provided attributes of the course.
-
-    Arguments:
-        certificates_display_behavior (str): string describing the course's
-            certificate display behavior.
-            See CourseFields.certificates_display_behavior.help for more detail.
-        certificates_show_before_end (bool): whether user can download the
-            course's certificates before the course has ended.
-        has_ended (bool): Whether the course has ended.
-        certificate_available_date (datetime): the date the certificate is available on for the course.
-        self_paced (bool): Whether the course is self-paced.
-    """
-    show_early = (
-        certificates_display_behavior in ('early_with_info', 'early_no_info')
-        or certificates_show_before_end
-    )
-    past_available_date = (
-        certificate_available_date
-        and certificate_available_date < datetime.now(utc)
-    )
-    ended_without_available_date = (certificate_available_date is None) and has_ended
-
-    return any((self_paced, show_early, past_available_date, ended_without_available_date))
-
-
 def sorting_score(start, advertised_start, announcement):
     """
     Returns a tuple that can be used to sort the courses according

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -1197,18 +1197,6 @@ class CourseBlock(
         """
         return course_metadata_utils.has_course_ended(self.end)
 
-    def may_certify(self):
-        """
-        Return whether it is acceptable to show the student a certificate download link.
-        """
-        return course_metadata_utils.may_certify_for_course(
-            self.certificates_display_behavior,
-            self.certificates_show_before_end,
-            self.has_ended(),
-            self.certificate_available_date,
-            self.self_paced
-        )
-
     def has_started(self):
         return course_metadata_utils.has_course_started(self.start)
 

--- a/common/lib/xmodule/xmodule/tests/test_course_metadata_utils.py
+++ b/common/lib/xmodule/xmodule/tests/test_course_metadata_utils.py
@@ -20,7 +20,6 @@ from xmodule.course_metadata_utils import (
     course_start_date_is_default,
     has_course_ended,
     has_course_started,
-    may_certify_for_course,
     number_for_course_location
 )
 from xmodule.modulestore.tests.utils import (
@@ -161,18 +160,6 @@ class CourseMetadataUtilsTestCase(TestCase):
                 TestScenario((test_datetime, None), False),
                 TestScenario((DEFAULT_START_DATE, advertised_start_parsable), False),
                 TestScenario((DEFAULT_START_DATE, None), True),
-            ]),
-            FunctionTest(may_certify_for_course, [
-                TestScenario(('early_with_info', True, True, test_datetime, False), True),
-                TestScenario(('early_no_info', False, False, test_datetime, False), True),
-                TestScenario(('end', True, False, test_datetime, False), True),
-                TestScenario(('end', False, True, test_datetime, False), True),
-                TestScenario(('end', False, False, _NEXT_WEEK, False), False),
-                TestScenario(('end', False, False, _LAST_WEEK, False), True),
-                TestScenario(('end', False, False, None, False), False),
-                TestScenario(('early_with_info', False, False, None, False), True),
-                TestScenario(('end', False, False, _NEXT_WEEK, False), False),
-                TestScenario(('end', False, False, _NEXT_WEEK, True), True),
             ]),
         ]
 

--- a/common/lib/xmodule/xmodule/tests/test_course_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_course_module.py
@@ -138,15 +138,6 @@ class HasEndedMayCertifyTestCase(unittest.TestCase):
         assert not self.future_show_certs_no_info.has_ended()
         assert not self.future_noshow_certs.has_ended()
 
-    def test_may_certify(self):
-        """Check that may_certify correctly tells us when a course may wrap."""
-        assert self.past_show_certs.may_certify()
-        assert self.past_noshow_certs.may_certify()
-        assert self.past_show_certs_no_info.may_certify()
-        assert self.future_show_certs.may_certify()
-        assert self.future_show_certs_no_info.may_certify()
-        assert not self.future_noshow_certs.may_certify()
-
 
 class CourseSummaryHasEnded(unittest.TestCase):
     """ Test for has_ended method when end date is missing timezone information. """

--- a/lms/djangoapps/certificates/queue.py
+++ b/lms/djangoapps/certificates/queue.py
@@ -23,8 +23,8 @@ from lms.djangoapps.certificates.models import (
     CertificateAllowlist,
     ExampleCertificate,
     GeneratedCertificate,
-    certificate_status_for_student
 )
+from lms.djangoapps.certificates.utils import certificate_status_for_student
 from lms.djangoapps.grades.api import CourseGradeFactory
 from lms.djangoapps.verify_student.services import IDVerificationService
 from openedx.core.djangoapps.content.course_overviews.api import get_course_overview_or_none

--- a/lms/djangoapps/certificates/tests/test_api.py
+++ b/lms/djangoapps/certificates/tests/test_api.py
@@ -52,14 +52,14 @@ from lms.djangoapps.certificates.api import (
     is_certificate_invalidated,
     is_on_allowlist,
     remove_allowlist_entry,
-    set_cert_generation_enabled
+    set_cert_generation_enabled,
+    certificate_status_for_student,
 )
 from lms.djangoapps.certificates.models import (
     CertificateGenerationConfiguration,
     CertificateStatuses,
     ExampleCertificate,
     GeneratedCertificate,
-    certificate_status_for_student
 )
 from lms.djangoapps.certificates.queue import XQueueAddToQueueError, XQueueCertInterface
 from lms.djangoapps.certificates.tests.factories import (

--- a/lms/djangoapps/certificates/tests/test_utils.py
+++ b/lms/djangoapps/certificates/tests/test_utils.py
@@ -1,14 +1,23 @@
 """
 Tests for Certificates app utility functions
 """
+from datetime import datetime, timedelta
 from unittest.mock import patch
 
+import ddt
 from django.test import TestCase
+from pytz import utc
 
-from lms.djangoapps.certificates.utils import has_html_certificates_enabled
+from lms.djangoapps.certificates.utils import has_html_certificates_enabled, should_certificate_be_visible
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 
+_TODAY = datetime.now(utc)
+_LAST_MONTH = _TODAY - timedelta(days=30)
+_LAST_WEEK = _TODAY - timedelta(days=7)
+_NEXT_WEEK = _TODAY + timedelta(days=7)
 
+
+@ddt.ddt
 class CertificateUtilityTests(TestCase):
     """
     Tests for course certificate utility functions
@@ -43,3 +52,34 @@ class CertificateUtilityTests(TestCase):
         self.course_overview.save()
 
         assert not has_html_certificates_enabled(self.course_overview)
+
+    @ddt.data(
+        ('early_with_info', True, True, _LAST_MONTH, False, True),
+        ('early_no_info', False, False, _LAST_MONTH, False, True),
+        ('end', True, False, _LAST_MONTH, False, True),
+        ('end', False, True, _LAST_MONTH, False, True),
+        ('end', False, False, _NEXT_WEEK, False, False),
+        ('end', False, False, _LAST_WEEK, False, True),
+        ('end', False, False, None, False, False),
+        ('early_with_info', False, False, None, False, True),
+        ('end', False, False, _NEXT_WEEK, False, False),
+        ('end', False, False, _NEXT_WEEK, True, True),
+    )
+    @ddt.unpack
+    def test_should_certificate_be_visible(
+        self,
+        certificates_display_behavior,
+        certificates_show_before_end,
+        has_ended,
+        certificate_available_date,
+        self_paced,
+        expected_value
+    ):
+        """Test whether the certificate should be visible to user given multiple usecases"""
+        assert should_certificate_be_visible(
+            certificates_display_behavior,
+            certificates_show_before_end,
+            has_ended,
+            certificate_available_date,
+            self_paced
+        ) == expected_value

--- a/lms/djangoapps/certificates/tests/tests.py
+++ b/lms/djangoapps/certificates/tests/tests.py
@@ -15,11 +15,10 @@ from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
 from common.djangoapps.util.milestones_helpers import milestones_achieved_by_user, set_prerequisite_courses
 from lms.djangoapps.badges.tests.factories import CourseCompleteImageConfigurationFactory
+from lms.djangoapps.certificates.api import certificate_info_for_user, certificate_status_for_student
 from lms.djangoapps.certificates.models import (
     CertificateStatuses,
     GeneratedCertificate,
-    certificate_info_for_user,
-    certificate_status_for_student
 )
 from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase

--- a/lms/djangoapps/certificates/utils.py
+++ b/lms/djangoapps/certificates/utils.py
@@ -1,14 +1,16 @@
 """
 Certificates utilities
 """
-
+from datetime import datetime
 import logging
 
 from django.conf import settings
 from django.urls import reverse
 from eventtracking import tracker
 from opaque_keys.edx.keys import CourseKey
+from pytz import utc
 
+from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.certificates.models import GeneratedCertificate
 from openedx.core.djangoapps.content.course_overviews.api import get_course_overview_or_none
 
@@ -126,3 +128,87 @@ def _safe_course_key(course_key):
     if not isinstance(course_key, CourseKey):
         return CourseKey.from_string(course_key)
     return course_key
+
+
+def should_certificate_be_visible(
+    certificates_display_behavior,
+    certificates_show_before_end,
+    has_ended,
+    certificate_available_date,
+    self_paced
+):
+    """
+    Returns whether it is acceptable to show the student a certificate download
+    link for a course, based on provided attributes of the course.
+    Arguments:
+        certificates_display_behavior (str): string describing the course's
+            certificate display behavior.
+            See CourseFields.certificates_display_behavior.help for more detail.
+        certificates_show_before_end (bool): whether user can download the
+            course's certificates before the course has ended.
+        has_ended (bool): Whether the course has ended.
+        certificate_available_date (datetime): the date the certificate is available on for the course.
+        self_paced (bool): Whether the course is self-paced.
+    """
+    show_early = (
+        certificates_display_behavior in ('early_with_info', 'early_no_info')
+        or certificates_show_before_end
+    )
+    past_available_date = (
+        certificate_available_date
+        and certificate_available_date < datetime.now(utc)
+    )
+    ended_without_available_date = (certificate_available_date is None) and has_ended
+
+    return any((self_paced, show_early, past_available_date, ended_without_available_date))
+
+
+def certificate_status(generated_certificate):
+    """
+    This returns a dictionary with a key for status, and other information.
+
+    If the status is "downloadable", the dictionary also contains
+    "download_url".
+
+    If the student has been graded, the dictionary also contains their
+    grade for the course with the key "grade".
+    """
+    # Import here instead of top of file since this module gets imported before
+    # the course_modes app is loaded, resulting in a Django deprecation warning.
+    from common.djangoapps.course_modes.models import CourseMode  # pylint: disable=redefined-outer-name, reimported
+
+    if generated_certificate:
+        cert_status = {
+            'status': generated_certificate.status,
+            'mode': generated_certificate.mode,
+            'uuid': generated_certificate.verify_uuid,
+        }
+        if generated_certificate.grade:
+            cert_status['grade'] = generated_certificate.grade
+
+        if generated_certificate.mode == 'audit':
+            course_mode_slugs = [mode.slug for mode in CourseMode.modes_for_course(generated_certificate.course_id)]
+            # Short term fix to make sure old audit users with certs still see their certs
+            # only do this if there if no honor mode
+            if 'honor' not in course_mode_slugs:
+                cert_status['status'] = CertificateStatuses.auditing
+                return cert_status
+
+        if generated_certificate.status == CertificateStatuses.downloadable:
+            cert_status['download_url'] = generated_certificate.download_url
+
+        return cert_status
+    else:
+        return {'status': CertificateStatuses.unavailable, 'mode': GeneratedCertificate.MODES.honor, 'uuid': None}
+
+
+def certificate_status_for_student(student, course_id):
+    """
+    This returns a dictionary with a key for status, and other information.
+    See certificate_status for more information.
+    """
+    try:
+        generated_certificate = GeneratedCertificate.objects.get(user=student, course_id=course_id)
+    except GeneratedCertificate.DoesNotExist:
+        generated_certificate = None
+    return certificate_status(generated_certificate)

--- a/lms/djangoapps/certificates/views/xqueue.py
+++ b/lms/djangoapps/certificates/views/xqueue.py
@@ -19,8 +19,8 @@ from lms.djangoapps.certificates.api import generate_certificate_task
 from lms.djangoapps.certificates.models import (
     ExampleCertificate,
     GeneratedCertificate,
-    certificate_status_for_student
 )
+from lms.djangoapps.certificates.utils import certificate_status_for_student
 
 log = logging.getLogger(__name__)
 User = get_user_model()

--- a/lms/djangoapps/instructor_task/tasks_helper/grades.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/grades.py
@@ -20,7 +20,7 @@ from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.roles import BulkRoleCache
 from lms.djangoapps.certificates import api as certs_api
-from lms.djangoapps.certificates.models import GeneratedCertificate, certificate_info_for_user
+from lms.djangoapps.certificates.models import GeneratedCertificate
 from lms.djangoapps.course_blocks.api import get_course_blocks
 from lms.djangoapps.courseware.user_state_client import DjangoXBlockUserStateClient
 from lms.djangoapps.grades.api import CourseGradeFactory
@@ -677,7 +677,7 @@ class CourseGradeReport:
         Returns the course certification information for the given user.
         """
         is_allowlisted = user.id in bulk_certs.allowlisted_user_ids
-        certificate_info = certificate_info_for_user(
+        certificate_info = certs_api.certificate_info_for_user(
             user,
             context.course_id,
             course_grade.letter_grade,

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -585,19 +585,6 @@ class CourseOverview(TimeStampedModel):
         else:
             return None
 
-    def may_certify(self):
-        """
-        Returns whether it is acceptable to show the student a certificate
-        download link.
-        """
-        return course_metadata_utils.may_certify_for_course(
-            self.certificates_display_behavior,
-            self.certificates_show_before_end,
-            self.has_ended(),
-            self.certificate_available_date,
-            self.self_paced
-        )
-
     @property
     def pre_requisite_courses(self):
         """

--- a/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
+++ b/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
@@ -141,7 +141,6 @@ class CourseOverviewTestCase(CatalogIntegrationMixin, ModuleStoreTestCase, Cache
             ('clean_id', ('#',)),
             ('has_ended', ()),
             ('has_started', ()),
-            ('may_certify', ()),
         ]
         for method_name, method_args in methods_to_test:
             course_value = getattr(course, method_name)(*method_args)

--- a/openedx/core/djangoapps/programs/utils.py
+++ b/openedx/core/djangoapps/programs/utils.py
@@ -444,9 +444,18 @@ class ProgramProgressMeter:
             }
 
             try:
-                may_certify = CourseOverview.get_from_id(course_key).may_certify()
+                course_overview = CourseOverview.get_from_id(course_key)
             except CourseOverview.DoesNotExist:
                 may_certify = True
+            else:
+                may_certify = certificate_api.should_certificate_be_visible(
+                    course_overview.certificates_display_behavior,
+                    course_overview.certificates_show_before_end,
+                    course_overview.has_ended(),
+                    course_overview.certificate_available_date,
+                    course_overview.self_paced
+                )
+
             if (
                 CertificateStatuses.is_passing_status(certificate['status'])
                 and may_certify
@@ -583,7 +592,13 @@ class ProgramDataExtender:
             run_mode['upgrade_url'] = None
 
     def _attach_course_run_may_certify(self, run_mode):
-        run_mode['may_certify'] = self.course_overview.may_certify()
+        run_mode['may_certify'] = certificate_api.should_certificate_be_visible(
+            self.course_overview.certificates_display_behavior,
+            self.course_overview.certificates_show_before_end,
+            self.course_overview.has_ended(),
+            self.course_overview.certificate_available_date,
+            self.course_overview.self_paced
+        )
 
     def _attach_course_run_is_mobile_only(self, run_mode):
         run_mode['is_mobile_only'] = self.mobile_only


### PR DESCRIPTION
## Description

The `may_certify` function is used to determine whether a learner should be able to see that their certificate is ready. It is therefore entirely in the certificates domain. This removes `may_certifiy` and `may_certify_for_course` from the `xmodule` and `course_overview` apps and into the `certificates` app. The `xmodule` `may_certify` was not called anywhere outside of tests prior to this so no functionality was changed here.

In order to facilitate this move I had to move around some functions in the `certificates` app. The moves are all for the better though. The general change was moving code out of the `models.py` until `utils.py` then exposing any of those function that would be needed by external apps into the `api.py` file. With things in better spots, it's clear there's a lot of code that's doing similar things that we would probably refactor further, but I am *not* doing any functional changes in this PR, just moves.

I generally followed this for this PR:
models.py -> model code
utils.py -> functions needed within the certificates app
apy.py -> functions needed external of the certificates app (sometimes just exposing a utils.py function)

This PR should affect nothing. It's just code movement so I don't have to do it in a separate larger PR. 

## Supporting information

Larger PR that this is being pulled from: https://github.com/edx/edx-platform/pull/28122

## Testing instructions

Normal test suite

## Deadline

None

## Other information
None
