### PR TITLE
perf: add monitoring for get_course and safe_exec

### DIFF
--- a/common/lib/capa/capa/safe_exec/safe_exec.py
+++ b/common/lib/capa/capa/safe_exec/safe_exec.py
@@ -6,6 +6,7 @@ import hashlib
 from codejail.safe_exec import SafeExecException, json_safe
 from codejail.safe_exec import not_safe_exec as codejail_not_safe_exec
 from codejail.safe_exec import safe_exec as codejail_safe_exec
+from edx_django_utils.monitoring import function_trace
 import six
 from six import text_type
 
@@ -79,6 +80,7 @@ def update_hash(hasher, obj):
         hasher.update(six.b(repr(obj)))
 
 
+@function_trace('safe_exec')
 def safe_exec(
     code,
     globals_dict,

--- a/common/lib/xmodule/xmodule/modulestore/mixed.py
+++ b/common/lib/xmodule/xmodule/modulestore/mixed.py
@@ -4,13 +4,12 @@ MixedModuleStore allows for aggregation between multiple modulestores.
 In this way, courses can be served up via either SplitMongoModuleStore or MongoModuleStore.
 
 """
-
-
 import functools
 import itertools
 import logging
 from contextlib import contextmanager
 
+from edx_django_utils.monitoring import function_trace
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import LibraryLocator
@@ -392,6 +391,7 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         store = self._get_modulestore_for_courselike(course_key)
         return store.make_course_usage_key(course_key)
 
+    @function_trace('get_course')
     @strip_key
     def get_course(self, course_key, depth=0, **kwargs):  # lint-amnesty, pylint: disable=arguments-differ
         """

--- a/common/lib/xmodule/xmodule/modulestore/mixed.py
+++ b/common/lib/xmodule/xmodule/modulestore/mixed.py
@@ -9,7 +9,6 @@ import itertools
 import logging
 from contextlib import contextmanager
 
-from edx_django_utils.monitoring import function_trace
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import LibraryLocator
@@ -391,7 +390,6 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         store = self._get_modulestore_for_courselike(course_key)
         return store.make_course_usage_key(course_key)
 
-    @function_trace('get_course')
     @strip_key
     def get_course(self, course_key, depth=0, **kwargs):  # lint-amnesty, pylint: disable=arguments-differ
         """

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split_draft.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split_draft.py
@@ -1,8 +1,7 @@
 """
 Module for the dual-branch fall-back Draft->Published Versioning ModuleStore
 """
-
-
+from edx_django_utils.monitoring import function_trace
 from opaque_keys.edx.locator import CourseLocator, LibraryLocator, LibraryUsageLocator
 
 from xmodule.exceptions import InvalidVersionError
@@ -56,6 +55,7 @@ class DraftVersioningModuleStore(SplitMongoModuleStore, ModuleStoreDraftAndPubli
 
             return item
 
+    @function_trace('get_course.split_modulestore')
     def get_course(self, course_id, depth=0, **kwargs):
         course_id = self._map_revision_to_branch(course_id)
         return super().get_course(course_id, depth=depth, **kwargs)


### PR DESCRIPTION
```
This is to help diagnose performance issues around the SequenceMetadata
API, as part of TNL-8330.
```
