### PR TITLE
fix: Prevent Transcripts from Failing Export, Edit

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
@@ -1006,9 +1006,10 @@ class TestGetTranscript(SharedModuleStoreTestCase):
         """
         Verify that `get transcript` function returns a working json file if the original throws an error
         """
-        mock_get_video_transcript_data.side_effect = Exception
+        error_transcript = {"start": [1], "end": [2], "text": ["An error occured obtaining the transcript."]}
+        mock_get_video_transcript_data.side_effect = ValueError
         content, _, _ = transcripts_utils.get_transcript(self.video, 'zh')
-        assert content == '{"start": [],"end": [],"text": ["An error occured obtaining the transcript."]}'
+        assert error_transcript["text"][0] in content
 
     @ddt.data(
         transcripts_utils.TranscriptsGenerationException,

--- a/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
@@ -640,6 +640,12 @@ class TestTranscript(unittest.TestCase):
         with self.assertRaises(transcripts_utils.TranscriptsGenerationException):
             transcripts_utils.Transcript.convert(invalid_srt_transcript, 'srt', 'sjson')
 
+    def test_convert_invalid_invalid_sjson_to_srt(self):
+        invalid_content = "Text with special character /\"\'\b\f\t\r\n."
+        error_transcript = {"start": [1], "end": [2], "text": ["An error occured obtaining the transcript."]}
+        assert transcripts_utils.Transcript.convert(invalid_content, 'sjson', 'txt') == error_transcript['text'][0]
+        assert error_transcript["text"][0] in transcripts_utils.Transcript.convert(invalid_content, 'sjson', 'srt')
+
     def test_dummy_non_existent_transcript(self):
         """
         Test `Transcript.asset` raises `NotFoundError` for dummy non-existent transcript.
@@ -994,6 +1000,15 @@ class TestGetTranscript(SharedModuleStoreTestCase):
 
         exception_message = str(no_en_transcript_exception.exception)
         self.assertEqual(exception_message, 'No transcript for `en` language')
+
+    @patch('xmodule.video_module.transcripts_utils.edxval_api.get_video_transcript_data')
+    def test_get_transcript_incorrect_json_(self,mock_get_video_transcript_data):
+        """
+        Verify that `get transcript` function returns a working json file if the original throws an error
+        """
+        mock_get_video_transcript_data.side_effect = Exception
+        content, _, _ = transcripts_utils.get_transcript(self.video, 'zh')
+        assert content == '{"start": [],"end": [],"text": ["An error occured obtaining the transcript."]}'
 
     @ddt.data(
         transcripts_utils.TranscriptsGenerationException,

--- a/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
@@ -1002,7 +1002,7 @@ class TestGetTranscript(SharedModuleStoreTestCase):
         self.assertEqual(exception_message, 'No transcript for `en` language')
 
     @patch('xmodule.video_module.transcripts_utils.edxval_api.get_video_transcript_data')
-    def test_get_transcript_incorrect_json_(self,mock_get_video_transcript_data):
+    def test_get_transcript_incorrect_json_(self, mock_get_video_transcript_data):
         """
         Verify that `get transcript` function returns a working json file if the original throws an error
         """

--- a/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
+++ b/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
@@ -585,7 +585,8 @@ def get_video_transcript_content(edx_video_id, language_code):
             )
             content = '{"start": [1],"end": [2],"text": ["An error occured obtaining the transcript."]}'
             transcript = dict(
-                file_name='error-{edx_video_id}-{language_code}.srt', content=Transcript.convert(content, 'sjson', 'srt')
+                file_name='error-{edx_video_id}-{language_code}.srt',
+                content=Transcript.convert(content, 'sjson', 'srt')
             )
     return transcript
 

--- a/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
+++ b/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
@@ -690,7 +690,7 @@ class Transcript:
             try:
                 content_dict = json.loads(content_str)
             except ValueError:
-                truncated = content_str[0:min(len(content), 100)].strip()
+                truncated = content_str[:100].strip()
                 log.exception(
                     f"Failed to convert {input_format} to {output_format} for {repr(truncated)}..."
                 )

--- a/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
+++ b/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
@@ -581,10 +581,12 @@ def get_video_transcript_content(edx_video_id, language_code):
             transcript = edxval_api.get_video_transcript_data(edx_video_id, language_code)
         except ValueError:
             log.exception(
-                "Error getting transcript from edx-val id: {edx_video_id}: language code {language_code}"
+                f"Error getting transcript from edx-val id: {edx_video_id}: language code {language_code}"
             )
-            content = '{"start": [],"end": [],"text": ["An error occured obtaining the transcript."]}'
-            transcript = dict(file_name='error-{language_code}.srt', content=content)
+            content = '{"start": [1],"end": [2],"text": ["An error occured obtaining the transcript."]}'
+            transcript = dict(
+                file_name='error-{edx_video_id}-{language_code}.srt', content=Transcript.convert(content, 'sjson', 'srt')
+                )
     return transcript
 
 
@@ -689,8 +691,9 @@ class Transcript:
             try:
                 content_dict = json.loads(content_str)
             except ValueError:
+                truncated = content_str[0:min(len(content), 100)].strip()  # lint-amnesty, pylint: disable=unused-variable
                 log.exception(
-                    "Failed to convert {input_format} to {output_format} for {content_str}."
+                    f"Failed to convert {input_format} to {output_format} for {repr(truncated)}..."
                 )
                 content_dict = {"start": [1], "end": [2], "text": ["An error occured obtaining the transcript."]}
             if output_format == 'txt':

--- a/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
+++ b/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
@@ -690,7 +690,7 @@ class Transcript:
             try:
                 content_dict = json.loads(content_str)
             except ValueError:
-                truncated = content_str[0:min(len(content), 100)].strip()  # lint-amnesty, pylint: disable=unused-variable
+                truncated = content_str[0:min(len(content), 100)].strip()
                 log.exception(
                     f"Failed to convert {input_format} to {output_format} for {repr(truncated)}..."
                 )

--- a/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
+++ b/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
@@ -589,6 +589,7 @@ def get_video_transcript_content(edx_video_id, language_code):
             )
     return transcript
 
+
 def get_available_transcript_languages(edx_video_id):
     """
     Gets available transcript languages for a video.

--- a/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
+++ b/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
@@ -586,9 +586,8 @@ def get_video_transcript_content(edx_video_id, language_code):
             content = '{"start": [1],"end": [2],"text": ["An error occured obtaining the transcript."]}'
             transcript = dict(
                 file_name='error-{edx_video_id}-{language_code}.srt', content=Transcript.convert(content, 'sjson', 'srt')
-                )
+            )
     return transcript
-
 
 def get_available_transcript_languages(edx_video_id):
     """

--- a/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
+++ b/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
@@ -582,7 +582,7 @@ def get_video_transcript_content(edx_video_id, language_code):
         except Exception:
             log.exception(
                 "Error getting transcript from edx-val id: {edx_video_id}: language code {language_code}"
-                )
+            )
             content = '{"start": [],"end": [],"text": ["An error occured obtaining the transcript."]}'
             transcript = dict(file_name='error-{language_code}.srt', content=content)
     return transcript
@@ -691,8 +691,8 @@ class Transcript:
             except Exception:
                 log.exception(
                     "Failed to convert {input_format} to {output_format} for {content_str}."
-                    )
-                content_dict = {"start": [1],"end": [2],"text": ["An error occured obtaining the transcript."]}
+                )
+                content_dict = {"start": [1], "end": [2], "text": ["An error occured obtaining the transcript."]}
             if output_format == 'txt':
                 text = content_dict['text']
                 text_without_none = [line if line else '' for line in text]

--- a/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
+++ b/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
@@ -579,7 +579,7 @@ def get_video_transcript_content(edx_video_id, language_code):
     if edxval_api and edx_video_id:
         try:
             transcript = edxval_api.get_video_transcript_data(edx_video_id, language_code)
-        except Exception:
+        except ValueError:
             log.exception(
                 "Error getting transcript from edx-val id: {edx_video_id}: language code {language_code}"
             )
@@ -688,7 +688,7 @@ class Transcript:
                 content_str = content
             try:
                 content_dict = json.loads(content_str)
-            except Exception:
+            except ValueError:
                 log.exception(
                     "Failed to convert {input_format} to {output_format} for {content_str}."
                 )

--- a/lms/djangoapps/courseware/tests/test_video_handlers.py
+++ b/lms/djangoapps/courseware/tests/test_video_handlers.py
@@ -1296,15 +1296,16 @@ class TestGetTranscript(TestVideo):  # lint-amnesty, pylint: disable=test-inheri
         assert filename == 'zh_塞.srt'
         assert mime_type == 'application/x-subrip; charset=utf-8'
 
-    def test_value_error(self):
+    def test_value_error_handled(self):
         good_sjson = _create_file(content='bad content')
 
         _upload_sjson_file(good_sjson, self.item.location)
         self.item.sub = _get_subs_id(good_sjson.name)
 
         transcripts = self.item.get_transcripts_info()  # lint-amnesty, pylint: disable=unused-variable
-        with pytest.raises(ValueError):
-            get_transcript(self.item)
+        error_transcript = {"start": [], "end": [], "text": ["An error occured obtaining the transcript."]}
+        content, _, _ = get_transcript(self.item)
+        assert error_transcript["text"][0] in content
 
     def test_key_error(self):
         good_sjson = _create_file(content="""


### PR DESCRIPTION
fix: Prevent Transcript json Errors from Failing Export, Edit.

Instead of having json errors in transcript acquisition and conversion cause errors, have transcription conversion and acquisition simply return an error message in the transcription which can prompt a change from the user.

Although not uploading a transcript is handled, transcripts can often cause errors in edit, export, and other activities due to json errors. These errors block the entire use of these features, so to allow for reupload, etc, we add an error message instead of transcript and log the event.

In response to [TNL-8539](https://openedx.atlassian.net/secure/RapidBoard.jspa?rapidView=580&projectKey=TNL&modal=detail&selectedIssue=TNL-8539)

Testing: Unit tests coverage is included in the PR. Upload, import, and export of courses with transcriptions is also easily hand-testable. Just create a video in studio, add an irrelevant transcript. Then try to import, export, and edit the problem. Expected behavior is sucess.

Deadline: This is in response to a CAT-3 bug, but the relevant course team has a workaround so the priority is simply for future errors.

