### PR TITLE
[WIP] feat: add preliminar Open edX events [BD-32]

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1611,13 +1611,14 @@ class CourseEnrollment(models.Model):
                         email=user.email,
                         name=user.profile.name,
                     ),
-                    course=CourseData(
-                        course_key=enrollment.course.id,
-                        display_name=enrollment.course.display_name
-                    ),
-                    mode=enrollment.mode,
-                    is_active=enrollment.is_active
-                )
+                ),
+                course=CourseData(
+                    course_key=enrollment.course.id,
+                    display_name=enrollment.course.display_name
+                ),
+                mode=enrollment.mode,
+                is_active=enrollment.is_active,
+                creation_date=enrollment.created,
             )
         )
 

--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -29,6 +29,8 @@ from edx_django_utils.monitoring import set_custom_attribute
 from ratelimit.decorators import ratelimit
 from rest_framework.views import APIView
 
+from openedx_events.learning.data import UserData, UserNonPersonalData, UserPersonalData
+from openedx_events.learning.signals import SESSION_LOGIN_COMPLETED
 from common.djangoapps.edxmako.shortcuts import render_to_response
 from openedx.core.djangoapps.password_policy import compliance as password_policy_compliance
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
@@ -298,6 +300,19 @@ def _handle_successful_authentication_and_login(user, request):
         django_login(request, user)
         request.session.set_expiry(604800 * 4)
         log.debug("Setting user session expiry to 4 weeks")
+        SESSION_LOGIN_COMPLETED.send_event(
+            user=UserData(
+                user_non_pii=UserNonPersonalData(
+                    id=user.id,
+                    is_active=user.is_active,
+                ),
+                user=UserPersonalData(
+                    username=user.username,
+                    email=user.email,
+                    name=user.profile.name,
+                )
+            ),
+        )
     except Exception as exc:
         AUDIT_LOG.critical("Login failed - Could not create session. Is memcached running?")
         log.critical("Login failed - Could not create session. Is memcached running?")

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -22,7 +22,7 @@ from django.views.decorators.csrf import csrf_exempt, ensure_csrf_cookie
 from django.views.decorators.debug import sensitive_post_parameters
 from edx_django_utils.monitoring import set_custom_attribute
 from edx_toggles.toggles import LegacyWaffleFlag, LegacyWaffleFlagNamespace
-from openedx_events.learning.data import StudentData, RegistrationFormData
+from openedx_events.learning.data import UserData, UserNonPersonalData, UserPersonalData
 from openedx_events.learning.signals import STUDENT_REGISTRATION_COMPLETED
 from pytz import UTC
 from ratelimit.decorators import ratelimit
@@ -248,17 +248,17 @@ def create_account_with_params(request, params):
 
     # Announce registration
     STUDENT_REGISTRATION_COMPLETED.send_event(
-        user=StudentData(
-            username=user.username,
-            email=user.email,
-            is_active=user.is_active,
-            meta=user.profile.meta,
-            name=user.profile.name,
+        user=UserData(
+            user_non_pii=UserNonPersonalData(
+                id=user.id,
+                is_active=user.is_active,
+            ),
+            user=UserPersonalData(
+                username=user.username,
+                email=user.email,
+                name=user.profile.name,
+            )
         ),
-        registration_form=RegistrationFormData(
-            account_form=form,
-            extension_form=custom_form,
-        )
     )
 
     create_comments_service_user(user)

--- a/openedx/core/djangoapps/user_authn/views/tests/test_events.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_events.py
@@ -17,9 +17,9 @@ from openedx.core.djangolib.testing.utils import skip_unless_lms
 @skip_unless_lms
 class RegistrationEventTest(UserAPITestCase):
     """
-    Tests for the events associated with the registration process through the user API.
+    Tests for the Open edX Events associated with the registration process through the user API.
 
-    This class guarantees that STUDENT_REGISTRATION_COMPLETED event is sent while registering
+    This class guarantees that STUDENT_REGISTRATION_COMPLETED event is sent after registering
     a user, with the exact Data Attributes as the event definition stated.
     """
 
@@ -66,7 +66,12 @@ class RegistrationEventTest(UserAPITestCase):
 @skip_unless_lms
 class LoginSessionEventTest(UserAPITestCase):
     """
-    Tests for the events associated with the login process through the user API.
+    Tests for the Open edX Events associated with the login process through the user API.
+
+    This class guarantees that the following events are sent after the user's session
+    creation, with the exact Data Attributes as the event definition stated:
+
+        - SESSION_LOGIN_COMPLETED: after login has been completed.
     """
 
     def setUp(self):  # pylint: disable=arguments-differ
@@ -82,7 +87,7 @@ class LoginSessionEventTest(UserAPITestCase):
     @patch("openedx.core.djangoapps.user_authn.views.login.SESSION_LOGIN_COMPLETED")
     def test_send_login_event(self, login_event):
         """
-        Test whether the student login event is sent during the user's
+        Test whether the student login event is sent after the user's
         login process.
 
         Expected result:

--- a/openedx/core/djangoapps/user_authn/views/tests/test_events.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_events.py
@@ -9,6 +9,7 @@ from django.urls import reverse
 from mock import patch
 from openedx_events.learning.data import UserData, UserNonPersonalData, UserPersonalData
 
+from common.djangoapps.student.tests.factories import UserFactory, UserProfileFactory
 from openedx.core.djangoapps.user_api.tests.test_views import UserAPITestCase
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 
@@ -57,6 +58,54 @@ class RegistrationEventTest(UserAPITestCase):
                     username=user.username,
                     email=user.email,
                     name=user.profile.name,
+                )
+            ),
+        )
+
+
+@skip_unless_lms
+class LoginSessionEventTest(UserAPITestCase):
+    """
+    Tests for the events associated with the login process through the user API.
+    """
+
+    def setUp(self):  # pylint: disable=arguments-differ
+        super().setUp()
+        self.url = reverse("user_api_login_session", kwargs={"api_version": "v1"})
+        self.user = UserFactory.create(
+            username="test",
+            email="test@example.com",
+            password="password",
+        )
+        self.user_profile = UserProfileFactory.create(user=self.user, name="Test Example")
+
+    @patch("openedx.core.djangoapps.user_authn.views.login.SESSION_LOGIN_COMPLETED")
+    def test_send_login_event(self, login_event):
+        """
+        Test whether the student login event is sent during the user's
+        login process.
+
+        Expected result:
+            - SESSION_LOGIN_COMPLETED is sent via send_event.
+            - The arguments match the event definition.
+        """
+        data = {
+            "email": "test@example.com",
+            "password": "password",
+        }
+
+        self.client.post(self.url, data)
+
+        login_event.send_event.assert_called_once_with(
+            user=UserData(
+                user_non_pii=UserNonPersonalData(
+                    id=self.user.id,
+                    is_active=self.user.is_active,
+                ),
+                user=UserPersonalData(
+                    username=self.user.username,
+                    email=self.user.email,
+                    name=self.user.profile.name,
                 )
             ),
         )

--- a/openedx/core/djangoapps/user_authn/views/tests/test_events.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_events.py
@@ -1,0 +1,62 @@
+"""
+Test classes for the events sent in the registration process.
+
+Classes:
+    RegistrationEventTest: Test event sent while registering a user through the user API.
+"""
+from django.contrib.auth.models import User
+from django.urls import reverse
+from mock import patch
+from openedx_events.learning.data import UserData, UserNonPersonalData, UserPersonalData
+
+from openedx.core.djangoapps.user_api.tests.test_views import UserAPITestCase
+from openedx.core.djangolib.testing.utils import skip_unless_lms
+
+
+@skip_unless_lms
+class RegistrationEventTest(UserAPITestCase):
+    """
+    Tests for the events associated with the registration process through the user API.
+
+    This class guarantees that STUDENT_REGISTRATION_COMPLETED event is sent while registering
+    a user, with the exact Data Attributes as the event definition stated.
+    """
+
+    def setUp(self):  # pylint: disable=arguments-differ
+        super().setUp()
+        self.url = reverse("user_api_registration")
+        self.user_info = {
+            "email": "user@example.com",
+            "name": "Test User",
+            "username": "test",
+            "password": "password",
+            "honor_code": "true",
+        }
+
+
+    @patch("openedx.core.djangoapps.user_authn.views.register.STUDENT_REGISTRATION_COMPLETED")
+    def test_send_registration_event(self, registration_event):
+        """
+        Test whether the student registration event is sent during the user's
+        registration process.
+
+        Expected result:
+            - STUDENT_REGISTRATION_COMPLETED is sent via send_event.
+            - The arguments match the event definition.
+        """
+        self.client.post(self.url, self.user_info)
+
+        user = User.objects.get(username=self.user_info.get("username"))
+        registration_event.send_event.assert_called_once_with(
+            user=UserData(
+                user_non_pii=UserNonPersonalData(
+                    id=user.id,
+                    is_active=user.is_active,
+                ),
+                user=UserPersonalData(
+                    username=user.username,
+                    email=user.email,
+                    name=user.profile.name,
+                )
+            ),
+        )

--- a/openedx/core/djangoapps/user_authn/views/tests/test_register.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_register.py
@@ -19,7 +19,6 @@ from pytz import UTC
 from social_django.models import Partial, UserSocialAuth
 
 from edx_toggles.toggles.testutils import override_waffle_flag
-from openedx_events.learning.data import StudentData, RegistrationData, UserProfileData
 from openedx.core.djangoapps.site_configuration.helpers import get_value
 from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration
 from openedx.core.djangoapps.user_api.accounts import (
@@ -2446,53 +2445,4 @@ class RegistrationValidationViewTests(test_utils.ApiTestCase):
         self.assertValidationDecision(
             {'username': 'user', 'email': 'user@email.com', 'is_authn_mfe': True, 'form_field_key': 'email'},
             {'email': AUTHN_EMAIL_CONFLICT_MSG}
-        )
-
-
-@skip_unless_lms
-class RegistrationEventTest(UserAPITestCase):
-    """Tests for the events associated with the registration process through the user API."""
-
-    def setUp(self):  # pylint: disable=arguments-differ
-        super().setUp()
-        self.url = reverse("user_api_registration")
-        self.user_info = {
-            "email": "bob@example.com",
-            "name": "Bob Smith",
-            "username": "bob",
-            "password": "password",
-            "honor_code": "true",
-        }
-
-
-    @mock.patch("common.djangoapps.student.helpers.Registration")
-    @mock.patch("openedx.core.djangoapps.user_authn.views.register.STUDENT_REGISTRATION_COMPLETED")
-    def test_send_registration_event(self, registration_event, registration_mock):
-        """
-        Test whether the student registration event is sent during the user's
-        registration process.
-
-        Expected result:
-            - STUDENT_REGISTRATION_COMPLETED is sent via send_event.
-            - The arguments match the event definition.
-        """
-        registration_mock.return_value.activation_key = "user_activation_key"
-
-        self.client.post(self.url, self.user_info)
-
-        registration_event.send_event.assert_called_once_with(
-            user=StudentData(
-                username="bob",
-                email="bob@example.com",
-                first_name="",
-                last_name="",
-                is_active=False,
-                profile=UserProfileData(
-                    meta="",
-                    name="Bob Smith",
-                )
-            ),
-            registration=RegistrationData(
-                activation_key="user_activation_key",
-            )
         )


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
