### PR TITLE
fix: oblige non-studio-authoring submit settings

### DIFF
--- a/common/lib/xmodule/xmodule/capa_module.py
+++ b/common/lib/xmodule/xmodule/capa_module.py
@@ -1724,7 +1724,7 @@ class ProblemBlock(
                 return {'success': msg, 'html': ''}
 
         # Wait time between resets: check if is too soon for submission.
-        if self.last_submission_time is not None and self.submission_wait_seconds != 0:
+        if self.last_submission_time is not None and self.submission_wait_seconds not in [0, None]:
             seconds_since_submission = (current_time - self.last_submission_time).total_seconds()
             if seconds_since_submission < self.submission_wait_seconds:
                 remaining_secs = int(self.submission_wait_seconds - seconds_since_submission)


### PR DESCRIPTION
Problem blocks offer a setting to make users wait a set time between submissions. If a course is not authored in studio, it might not set a value for this setting. Consequently, the problem block must handle the submission_wait_seconds field to be none, so it doesn't break the submitted responses.

These kinds of errors here will prevent learners from submitting any answer, and has for several learners. Adding in this one-line change will prevent future errors without having to change the authoring practices of those ambitious enough to write their courses with import.

This also catches the case that some internal process other than studio might be creating problems with "none" as the setting.

In response to [TNL-8234](https://openedx.atlassian.net/secure/RapidBoard.jspa?rapidView=580&projectKey=TNL&modal=detail&selectedIssue=TNL-8234)

Testing:  hand-testing by importing the following problem xml file within a course and attempting to answer as learner(answer is 10.4).