### PR TITLE
feat: send course access error along to course home MFE

### DIFF
--- a/lms/djangoapps/course_home_api/course_metadata/v1/serializers.py
+++ b/lms/djangoapps/course_home_api/course_metadata/v1/serializers.py
@@ -33,15 +33,17 @@ class CourseHomeMetadataSerializer(VerifiedModeSerializerMixin, serializers.Seri
     """
     Serializer for the Course Home Course Metadata
     """
+    can_load_courseware = serializers.BooleanField()
+    celebrations = serializers.DictField()
+    course_access = serializers.DictField()
     course_id = serializers.CharField()
-    username = serializers.CharField()
     is_enrolled = serializers.BooleanField()
     is_self_paced = serializers.BooleanField()
     is_staff = serializers.BooleanField()
     number = serializers.CharField()
     org = serializers.CharField()
     original_user_is_staff = serializers.BooleanField()
+    start = serializers.DateTimeField()  # used for certain access denied errors
     tabs = CourseTabSerializer(many=True)
     title = serializers.CharField()
-    can_load_courseware = serializers.BooleanField()
-    celebrations = serializers.DictField()
+    username = serializers.CharField()

--- a/openedx/core/djangoapps/courseware_api/serializers.py
+++ b/openedx/core/djangoapps/courseware_api/serializers.py
@@ -106,7 +106,8 @@ class CourseInfoSerializer(serializers.Serializer):  # pylint: disable=abstract-
     original_user_is_staff = serializers.BooleanField()
     can_view_legacy_courseware = serializers.BooleanField()
     is_staff = serializers.BooleanField()
-    can_load_courseware = serializers.DictField()
+    course_access = serializers.DictField()
+    can_load_courseware = serializers.DictField(source='course_access')  # can be removed once MFE updates
     notes = serializers.DictField()
     marketing_url = serializers.CharField()
     celebrations = serializers.DictField()

--- a/openedx/core/djangoapps/courseware_api/tests/test_views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/test_views.py
@@ -198,9 +198,9 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
                 # multiple checks use this handler
                 check_public_access.assert_called()
                 assert response.data['enrollment']['mode'] is None
-                assert response.data['can_load_courseware']['has_access']
+                assert response.data['course_access']['has_access']
             else:
-                assert not response.data['can_load_courseware']['has_access']
+                assert not response.data['course_access']['has_access']
 
     @ddt.data(
         # Who has access to MFE courseware?
@@ -210,7 +210,7 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
             "username": "student",
             "enroll_user": True,
             "masquerade_role": None,
-            "expect_can_load_courseware": True,
+            "expect_course_access": True,
         },
         {
             # Un-enrolled learners should NOT have access.
@@ -218,7 +218,7 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
             "username": "student",
             "enroll_user": False,
             "masquerade_role": None,
-            "expect_can_load_courseware": False,
+            "expect_course_access": False,
         },
         {
             # Un-enrolled instructors should have access.
@@ -226,7 +226,7 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
             "username": "instructor",
             "enroll_user": False,
             "masquerade_role": None,
-            "expect_can_load_courseware": True,
+            "expect_course_access": True,
         },
         {
             # Un-enrolled instructors masquerading as students should have access.
@@ -234,7 +234,7 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
             "username": "instructor",
             "enroll_user": False,
             "masquerade_role": "student",
-            "expect_can_load_courseware": True,
+            "expect_course_access": True,
         },
         {
             # If MFE is not visible, enrolled learners shouldn't have access.
@@ -242,7 +242,7 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
             "username": "student",
             "enroll_user": True,
             "masquerade_role": None,
-            "expect_can_load_courseware": False,
+            "expect_course_access": False,
         },
         {
             # If MFE is not visible, instructors shouldn't have access.
@@ -250,7 +250,7 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
             "username": "instructor",
             "enroll_user": False,
             "masquerade_role": None,
-            "expect_can_load_courseware": False,
+            "expect_course_access": False,
         },
         {
             # If MFE is not visible, masquerading instructors shouldn't have access.
@@ -258,20 +258,20 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
             "username": "instructor",
             "enroll_user": False,
             "masquerade_role": "student",
-            "expect_can_load_courseware": False,
+            "expect_course_access": False,
         },
     )
     @ddt.unpack
-    def test_can_load_courseware(
+    def test_course_access(
             self,
             mfe_is_visible: bool,
             username: str,
             enroll_user: bool,
             masquerade_role: Optional[str],
-            expect_can_load_courseware: bool,
+            expect_course_access: bool,
     ):
         """
-        Test that can_load_courseware is calculated correctly based on
+        Test that course_access is calculated correctly based on
         access to MFE and access to the course itself.
         """
         user = User.objects.get(username=username)
@@ -289,10 +289,13 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
             response = self.client.get(self.url)
 
         assert response.status_code == 200
-        if expect_can_load_courseware:
-            assert response.data['can_load_courseware']['has_access']
+        if expect_course_access:
+            assert response.data['course_access']['has_access']
         else:
-            assert not response.data['can_load_courseware']['has_access']
+            assert not response.data['course_access']['has_access']
+
+        # Remove this once can_load_courseware is also removed
+        assert response.data['course_access'] == response.data['can_load_courseware']
 
     def test_streak_data_in_response(self):
         """ Test that metadata endpoint returns data for the streak celebration """

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -86,7 +86,6 @@ class CoursewareMeta:
             self.request.user,
             'load',
             check_if_enrolled=True,
-            check_survey_complete=False,
             check_if_authenticated=True,
         )
         self.original_user_is_staff = has_access(self.request.user, 'staff', self.overview).has_access
@@ -166,7 +165,7 @@ class CoursewareMeta:
         return course.license
 
     @property
-    def can_load_courseware(self) -> dict:
+    def course_access(self) -> dict:
         """
         Can the user load this course in the learning micro-frontend?
 


### PR DESCRIPTION
We previously only sent it to the courseware MFE. Also unify the naming of this access error to 'course_access' in courseware and course home APIs.
