### PR TITLE
chore: Removed constraint on django-countries

### DIFF
--- a/openedx/core/djangoapps/user_api/tests/test_constants.py
+++ b/openedx/core/djangoapps/user_api/tests/test_constants.py
@@ -72,7 +72,7 @@ SORTED_COUNTRIES = [
     ("EE", "Estonia"),
     ("SZ", "Eswatini"),
     ("ET", "Ethiopia"),
-    ("FK", "Falkland Islands  [Malvinas]"),
+    ("FK", "Falkland Islands (Malvinas)"),
     ("FO", "Faroe Islands"),
     ("FJ", "Fiji"),
     ("FI", "Finland"),

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -27,9 +27,6 @@ django-config-models>=1.0.0
 # The CORS_ORIGIN_WHITELIST changes in a backwards incompatible way in 3.0.0, needs matching configuration repo changes
 django-cors-headers<3.0.0
 
-# It seems like django-countries > 5.5 may cause performance issues for us.
-django-countries==5.5
-
 # django-storages version 1.9 drops support for boto storage backend.
 django-storages<1.9
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -124,7 +124,7 @@ click==7.1.2
     #   code-annotations
     #   nltk
     #   user-util
-code-annotations==1.1.2
+code-annotations==1.2.0
     # via
     #   edx-enterprise
     #   edx-toggles
@@ -226,7 +226,7 @@ django-appconf==1.0.4
     # via
     #   -r requirements/edx/base.in
     #   django-statici18n
-django-cache-memoize==0.1.9
+django-cache-memoize==0.1.10
     # via edx-enterprise
 django-celery-results==2.0.1
     # via
@@ -240,6 +240,7 @@ django-config-models==2.2.0
     #   -r requirements/edx/base.in
     #   edx-enterprise
     #   edx-event-routing-backends
+    #   edx-name-affirmation
     #   lti-consumer-xblock
 django-cookies-samesite==0.9.0
     # via -r requirements/edx/base.in
@@ -247,9 +248,8 @@ django-cors-headers==2.5.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
-django-countries==5.5
+django-countries==7.2.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   edx-enterprise
 django-crum==0.7.9
@@ -391,13 +391,13 @@ drf-jwt==1.19.0
     #   edx-drf-extensions
 drf-yasg==1.20.0
     # via edx-api-doc-tools
-edx-ace==1.1.1
+edx-ace==1.2.0
     # via -r requirements/edx/base.in
 edx-analytics-data-api-client==0.17.0
     # via -r requirements/edx/base.in
 edx-api-doc-tools==1.4.3
     # via -r requirements/edx/base.in
-edx-bulk-grades==0.8.12
+edx-bulk-grades==0.9.0
     # via
     #   -r requirements/edx/base.in
     #   staff-graded-xblock
@@ -409,7 +409,7 @@ edx-celeryutils==1.1.0
     #   super-csv
 edx-completion==4.1.0
     # via -r requirements/edx/base.in
-edx-django-release-util==1.0.0
+edx-django-release-util==1.1.0
     # via -r requirements/edx/base.in
 edx-django-sites-extensions==3.1.0
     # via -r requirements/edx/base.in
@@ -441,7 +441,7 @@ edx-enterprise==3.27.11
     #   -r requirements/edx/base.in
 edx-event-routing-backends==4.1.0
     # via -r requirements/edx/base.in
-edx-i18n-tools==0.5.3
+edx-i18n-tools==0.7.0
     # via ora2
 edx-milestones==0.3.2
     # via -r requirements/edx/base.in
@@ -463,7 +463,7 @@ edx-opaque-keys[django]==2.2.2
     #   lti-consumer-xblock
     #   ora2
     #   xmodule
-edx-organizations==6.9.0
+edx-organizations==6.10.0
     # via -r requirements/edx/base.in
 edx-proctoring==3.22.0
     # via
@@ -478,7 +478,7 @@ edx-rest-api-client==5.4.0
     #   -r requirements/edx/base.in
     #   edx-enterprise
     #   edx-proctoring
-edx-search==3.0.0
+edx-search==3.1.0
     # via -r requirements/edx/base.in
 edx-sga==0.16.0
     # via -r requirements/edx/base.in
@@ -498,19 +498,19 @@ edx-toggles==4.2.0
     #   ora2
 edx-user-state-client==1.3.2
     # via -r requirements/edx/base.in
-edx-when==2.0.0
+edx-when==2.1.0
     # via
     #   -r requirements/edx/base.in
     #   edx-proctoring
 edxval==2.0.3
     # via -r requirements/edx/base.in
-elasticsearch==7.13.3
+elasticsearch==7.13.4
     # via edx-search
 enmerkar==0.7.1
     # via enmerkar-underscore
 enmerkar-underscore==2.1.0
     # via -r requirements/edx/base.in
-event-tracking==1.0.4
+event-tracking==1.1.0
     # via
     #   -r requirements/edx/base.in
     #   edx-event-routing-backends
@@ -684,20 +684,20 @@ oauthlib==3.0.1
     #   social-auth-core
 openedx-calc==2.0.1
     # via -r requirements/edx/base.in
-ora2==3.6.11
+ora2==3.6.13
     # via -r requirements/edx/base.in
 packaging==21.0
     # via
     #   bleach
     #   drf-yasg
-path==16.0.0
+path==16.2.0
     # via
     #   -r requirements/edx/paver.txt
+    #   edx-i18n-tools
     #   path.py
 path.py==12.5.0
     # via
     #   edx-enterprise
-    #   edx-i18n-tools
     #   ora2
     #   staff-graded-xblock
     #   xmodule
@@ -904,7 +904,6 @@ six==1.16.0
     #   chem
     #   codejail
     #   crowdsourcehinter-xblock
-    #   django-countries
     #   edx-ace
     #   edx-bulk-grades
     #   edx-ccx-keys
@@ -962,7 +961,7 @@ stevedore==3.3.0
     #   edx-django-utils
     #   edx-enterprise
     #   edx-opaque-keys
-super-csv==2.0.1
+super-csv==2.1.0
     # via
     #   -r requirements/edx/base.in
     #   edx-bulk-grades
@@ -1028,7 +1027,7 @@ wrapt==1.11.2
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/paver.txt
-xblock==1.4.2
+xblock==1.5.0
     # via
     #   -r requirements/edx/base.in
     #   acid-xblock

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -57,7 +57,7 @@ appdirs==1.4.4
     # via
     #   -r requirements/edx/testing.txt
     #   fs
-astroid==2.6.2
+astroid==2.6.5
     # via
     #   -r requirements/edx/testing.txt
     #   pylint
@@ -168,7 +168,7 @@ click-log==0.3.2
     # via
     #   -r requirements/edx/testing.txt
     #   edx-lint
-code-annotations==1.1.2
+code-annotations==1.2.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
@@ -296,7 +296,7 @@ django-appconf==1.0.4
     # via
     #   -r requirements/edx/testing.txt
     #   django-statici18n
-django-cache-memoize==0.1.9
+django-cache-memoize==0.1.10
     # via
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
@@ -314,6 +314,7 @@ django-config-models==2.2.0
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
     #   edx-event-routing-backends
+    #   edx-name-affirmation
     #   lti-consumer-xblock
 django-cookies-samesite==0.9.0
     # via -r requirements/edx/testing.txt
@@ -321,9 +322,8 @@ django-cors-headers==2.5.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
-django-countries==5.5
+django-countries==7.2.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
 django-crum==0.7.9
@@ -484,13 +484,13 @@ drf-yasg==1.20.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-api-doc-tools
-edx-ace==1.1.1
+edx-ace==1.2.0
     # via -r requirements/edx/testing.txt
 edx-analytics-data-api-client==0.17.0
     # via -r requirements/edx/testing.txt
 edx-api-doc-tools==1.4.3
     # via -r requirements/edx/testing.txt
-edx-bulk-grades==0.8.12
+edx-bulk-grades==0.9.0
     # via
     #   -r requirements/edx/testing.txt
     #   staff-graded-xblock
@@ -502,7 +502,7 @@ edx-celeryutils==1.1.0
     #   super-csv
 edx-completion==4.1.0
     # via -r requirements/edx/testing.txt
-edx-django-release-util==1.0.0
+edx-django-release-util==1.1.0
     # via -r requirements/edx/testing.txt
 edx-django-sites-extensions==3.1.0
     # via -r requirements/edx/testing.txt
@@ -534,7 +534,7 @@ edx-enterprise==3.27.11
     #   -r requirements/edx/testing.txt
 edx-event-routing-backends==4.1.0
     # via -r requirements/edx/testing.txt
-edx-i18n-tools==0.5.3
+edx-i18n-tools==0.7.0
     # via
     #   -r requirements/edx/testing.txt
     #   ora2
@@ -560,7 +560,7 @@ edx-opaque-keys[django]==2.2.2
     #   lti-consumer-xblock
     #   ora2
     #   xmodule
-edx-organizations==6.9.0
+edx-organizations==6.10.0
     # via -r requirements/edx/testing.txt
 edx-proctoring==3.22.0
     # via
@@ -577,7 +577,7 @@ edx-rest-api-client==5.4.0
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
     #   edx-proctoring
-edx-search==3.0.0
+edx-search==3.1.0
     # via -r requirements/edx/testing.txt
 edx-sga==0.16.0
     # via -r requirements/edx/testing.txt
@@ -601,13 +601,13 @@ edx-toggles==4.2.0
     #   ora2
 edx-user-state-client==1.3.2
     # via -r requirements/edx/testing.txt
-edx-when==2.0.0
+edx-when==2.1.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-proctoring
 edxval==2.0.3
     # via -r requirements/edx/testing.txt
-elasticsearch==7.13.3
+elasticsearch==7.13.4
     # via
     #   -r requirements/edx/testing.txt
     #   edx-search
@@ -617,7 +617,7 @@ enmerkar==0.7.1
     #   enmerkar-underscore
 enmerkar-underscore==2.1.0
     # via -r requirements/edx/testing.txt
-event-tracking==1.0.4
+event-tracking==1.1.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-event-routing-backends
@@ -629,7 +629,7 @@ execnet==1.9.0
     #   pytest-xdist
 factory-boy==3.2.0
     # via -r requirements/edx/testing.txt
-faker==8.10.1
+faker==8.10.3
     # via
     #   -r requirements/edx/testing.txt
     #   factory-boy
@@ -715,7 +715,7 @@ isodate==0.6.0
     #   -r requirements/edx/testing.txt
     #   edx-event-routing-backends
     #   python3-saml
-isort==5.9.2
+isort==5.9.3
     # via
     #   -r requirements/edx/testing.txt
     #   pylint
@@ -893,7 +893,7 @@ oauthlib==3.0.1
     #   social-auth-core
 openedx-calc==2.0.1
     # via -r requirements/edx/testing.txt
-ora2==3.6.11
+ora2==3.6.13
     # via -r requirements/edx/testing.txt
 packaging==21.0
     # via
@@ -903,15 +903,15 @@ packaging==21.0
     #   pytest
     #   sphinx
     #   tox
-path==16.0.0
+path==16.2.0
     # via
     #   -r requirements/edx/testing.txt
+    #   edx-i18n-tools
     #   path.py
 path.py==12.5.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
-    #   edx-i18n-tools
     #   ora2
     #   staff-graded-xblock
     #   xmodule
@@ -934,7 +934,7 @@ pillow==8.3.1
     #   edx-organizations
 pip-tools==6.2.0
     # via -r requirements/edx/pip-tools.txt
-platformdirs==2.0.2
+platformdirs==2.2.0
     # via
     #   -r requirements/edx/testing.txt
     #   virtualenv
@@ -996,7 +996,7 @@ pylatexenc==2.10
     # via
     #   -r requirements/edx/testing.txt
     #   olxcleaner
-pylint==2.9.3
+pylint==2.9.6
     # via
     #   -r requirements/edx/testing.txt
     #   edx-lint
@@ -1241,7 +1241,6 @@ six==1.16.0
     #   chem
     #   codejail
     #   crowdsourcehinter-xblock
-    #   django-countries
     #   edx-ace
     #   edx-bulk-grades
     #   edx-ccx-keys
@@ -1303,7 +1302,7 @@ soupsieve==2.2.1
     # via
     #   -r requirements/edx/testing.txt
     #   beautifulsoup4
-sphinx==4.1.1
+sphinx==4.1.2
     # via
     #   edx-sphinx-theme
     #   sphinxcontrib-httpdomain
@@ -1338,7 +1337,7 @@ stevedore==3.3.0
     #   edx-django-utils
     #   edx-enterprise
     #   edx-opaque-keys
-super-csv==2.0.1
+super-csv==2.1.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-bulk-grades
@@ -1373,7 +1372,7 @@ toml==0.10.2
     #   pytest-cov
     #   tox
     #   vulture
-tomli==1.0.4
+tomli==1.1.0
     # via
     #   -r requirements/edx/pip-tools.txt
     #   pep517
@@ -1463,7 +1462,7 @@ wrapt==1.11.2
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   astroid
-xblock==1.4.2
+xblock==1.5.0
     # via
     #   -r requirements/edx/testing.txt
     #   acid-xblock

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -16,7 +16,7 @@ click==7.1.2
     # via
     #   -c requirements/edx/../constraints.txt
     #   code-annotations
-code-annotations==1.1.2
+code-annotations==1.2.0
     # via -r requirements/edx/doc.in
 docutils==0.17.1
     # via sphinx
@@ -60,7 +60,7 @@ smmap==4.0.0
     # via gitdb
 snowballstemmer==2.1.0
     # via sphinx
-sphinx==4.1.1
+sphinx==4.1.2
     # via
     #   -r requirements/edx/doc.in
     #   edx-sphinx-theme

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -20,7 +20,7 @@ markupsafe==2.0.1
     # via -r requirements/edx/paver.in
 mock==4.0.3
     # via -r requirements/edx/paver.in
-path==16.0.0
+path==16.2.0
     # via -r requirements/edx/paver.in
 paver==1.3.4
     # via -r requirements/edx/paver.in

--- a/requirements/edx/pip-tools.txt
+++ b/requirements/edx/pip-tools.txt
@@ -12,7 +12,7 @@ pep517==0.11.0
     # via pip-tools
 pip-tools==6.2.0
     # via -r requirements/edx/pip-tools.in
-tomli==1.0.4
+tomli==1.1.0
     # via pep517
 wheel==0.36.2
     # via pip-tools

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -55,7 +55,7 @@ appdirs==1.4.4
     # via
     #   -r requirements/edx/base.txt
     #   fs
-astroid==2.6.2
+astroid==2.6.5
     # via
     #   pylint
     #   pylint-celery
@@ -157,7 +157,7 @@ click==7.1.2
     #   user-util
 click-log==0.3.2
     # via edx-lint
-code-annotations==1.1.2
+code-annotations==1.2.0
     # via
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/testing.in
@@ -283,7 +283,7 @@ django-appconf==1.0.4
     # via
     #   -r requirements/edx/base.txt
     #   django-statici18n
-django-cache-memoize==0.1.9
+django-cache-memoize==0.1.10
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -301,6 +301,7 @@ django-config-models==2.2.0
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   edx-event-routing-backends
+    #   edx-name-affirmation
     #   lti-consumer-xblock
 django-cookies-samesite==0.9.0
     # via -r requirements/edx/base.txt
@@ -308,9 +309,8 @@ django-cors-headers==2.5.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
-django-countries==5.5
+django-countries==7.2.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-enterprise
 django-crum==0.7.9
@@ -467,13 +467,13 @@ drf-yasg==1.20.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-api-doc-tools
-edx-ace==1.1.1
+edx-ace==1.2.0
     # via -r requirements/edx/base.txt
 edx-analytics-data-api-client==0.17.0
     # via -r requirements/edx/base.txt
 edx-api-doc-tools==1.4.3
     # via -r requirements/edx/base.txt
-edx-bulk-grades==0.8.12
+edx-bulk-grades==0.9.0
     # via
     #   -r requirements/edx/base.txt
     #   staff-graded-xblock
@@ -485,7 +485,7 @@ edx-celeryutils==1.1.0
     #   super-csv
 edx-completion==4.1.0
     # via -r requirements/edx/base.txt
-edx-django-release-util==1.0.0
+edx-django-release-util==1.1.0
     # via -r requirements/edx/base.txt
 edx-django-sites-extensions==3.1.0
     # via -r requirements/edx/base.txt
@@ -517,7 +517,7 @@ edx-enterprise==3.27.11
     #   -r requirements/edx/base.txt
 edx-event-routing-backends==4.1.0
     # via -r requirements/edx/base.txt
-edx-i18n-tools==0.5.3
+edx-i18n-tools==0.7.0
     # via
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/testing.in
@@ -544,7 +544,7 @@ edx-opaque-keys[django]==2.2.2
     #   lti-consumer-xblock
     #   ora2
     #   xmodule
-edx-organizations==6.9.0
+edx-organizations==6.10.0
     # via -r requirements/edx/base.txt
 edx-proctoring==3.22.0
     # via
@@ -561,7 +561,7 @@ edx-rest-api-client==5.4.0
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   edx-proctoring
-edx-search==3.0.0
+edx-search==3.1.0
     # via -r requirements/edx/base.txt
 edx-sga==0.16.0
     # via -r requirements/edx/base.txt
@@ -583,13 +583,13 @@ edx-toggles==4.2.0
     #   ora2
 edx-user-state-client==1.3.2
     # via -r requirements/edx/base.txt
-edx-when==2.0.0
+edx-when==2.1.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring
 edxval==2.0.3
     # via -r requirements/edx/base.txt
-elasticsearch==7.13.3
+elasticsearch==7.13.4
     # via
     #   -r requirements/edx/base.txt
     #   edx-search
@@ -599,7 +599,7 @@ enmerkar==0.7.1
     #   enmerkar-underscore
 enmerkar-underscore==2.1.0
     # via -r requirements/edx/base.txt
-event-tracking==1.0.4
+event-tracking==1.1.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-event-routing-backends
@@ -609,7 +609,7 @@ execnet==1.9.0
     # via pytest-xdist
 factory-boy==3.2.0
     # via -r requirements/edx/testing.in
-faker==8.10.1
+faker==8.10.3
     # via factory-boy
 filelock==3.0.12
     # via
@@ -682,7 +682,7 @@ isodate==0.6.0
     #   -r requirements/edx/base.txt
     #   edx-event-routing-backends
     #   python3-saml
-isort==5.9.2
+isort==5.9.3
     # via
     #   -r requirements/edx/testing.in
     #   pylint
@@ -847,7 +847,7 @@ oauthlib==3.0.1
     #   social-auth-core
 openedx-calc==2.0.1
     # via -r requirements/edx/base.txt
-ora2==3.6.11
+ora2==3.6.13
     # via -r requirements/edx/base.txt
 packaging==21.0
     # via
@@ -856,15 +856,15 @@ packaging==21.0
     #   drf-yasg
     #   pytest
     #   tox
-path==16.0.0
+path==16.2.0
     # via
     #   -r requirements/edx/base.txt
+    #   edx-i18n-tools
     #   path.py
 path.py==12.5.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-    #   edx-i18n-tools
     #   ora2
     #   staff-graded-xblock
     #   xmodule
@@ -881,7 +881,7 @@ pillow==8.3.1
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   edx-organizations
-platformdirs==2.0.2
+platformdirs==2.2.0
     # via virtualenv
 pluggy==0.13.1
     # via
@@ -941,7 +941,7 @@ pylatexenc==2.10
     # via
     #   -r requirements/edx/base.txt
     #   olxcleaner
-pylint==2.9.3
+pylint==2.9.6
     # via
     #   edx-lint
     #   pylint-celery
@@ -1172,7 +1172,6 @@ six==1.16.0
     #   chem
     #   codejail
     #   crowdsourcehinter-xblock
-    #   django-countries
     #   edx-ace
     #   edx-bulk-grades
     #   edx-ccx-keys
@@ -1241,7 +1240,7 @@ stevedore==3.3.0
     #   edx-django-utils
     #   edx-enterprise
     #   edx-opaque-keys
-super-csv==2.0.1
+super-csv==2.1.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-bulk-grades
@@ -1351,7 +1350,7 @@ wrapt==1.11.2
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   astroid
-xblock==1.4.2
+xblock==1.5.0
     # via
     #   -r requirements/edx/base.txt
     #   acid-xblock


### PR DESCRIPTION
As we are moving to django3.2 and Django-countries v5.5 doesn't have support for Django 3.2 so we need to remove this constraint and use latest versions of the package.

Updated the countries list in [test_constants.py](openedx/core/djangoapps/user_api/tests/test_constants.py) as it got updated in [Django-counties v6.1.1](https://github.com/SmileyChris/django-countries/blob/master/CHANGES.rst#611-26-march-2020)