### PR TITLE
feat: Upgrade to 3.27.7 edx-enterprise ENT-4746

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -36,7 +36,7 @@ django-storages<1.9
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==3.27.6
+edx-enterprise==3.27.7
 
 # Newer versions need a more recent version of python-dateutil
 freezegun==0.3.12

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -435,7 +435,7 @@ edx-drf-extensions==6.6.0
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.27.6
+edx-enterprise==3.27.7
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -528,7 +528,7 @@ edx-drf-extensions==6.6.0
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.27.6
+edx-enterprise==3.27.7
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -511,7 +511,7 @@ edx-drf-extensions==6.6.0
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.27.6
+edx-enterprise==3.27.7
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
ENT-4746

TLDR: Upgrades edx-enterprise to 3.27.7 which removes calls to EnrollmentApiClient (REST based) and replaces with a python api call newly added to edx-platform. This eliminates REST calls from enterprise to LMS which should help scale up bulk enrollment.

# Details 
All notes and testing in https://github.com/edx/edx-enterprise/pull/1305
