### PR TITLE
feat: adding more parameters

### DIFF
--- a/openedx/core/lib/request_utils.py
+++ b/openedx/core/lib/request_utils.py
@@ -206,7 +206,6 @@ class CookieMonitoringMiddleware(MiddlewareMixin):
         total_cookie_size = sum(cookie_names_to_size.values())
         set_custom_attribute('cookies_total_size', total_cookie_size)
 
-        # Get the size of unmonitored cookies to allow us to see what cookies we are missing
         top_n_cookies = sorted(
             cookie_names_to_size,
             key=lambda x: cookie_names_to_size[x],

--- a/openedx/core/lib/request_utils.py
+++ b/openedx/core/lib/request_utils.py
@@ -149,7 +149,7 @@ class CookieMonitoringMiddleware(MiddlewareMixin):
         # .. setting_description: The number of the largest cookies to capture when monitoring. Capture fewer cookies
         #       if you need to save on monitoring resources.
         # .. setting_warning: Depends on the `request_utils.capture_cookie_sizes` toggle being enabled.
-        top_n_cookies_captured = getattr(settings, "TOP_N_COOKIES_CAPTURED", 5)
+        top_n_cookies_captured = getattr(settings, "TOP_N_COOKIES_CAPTURED", 8)
         # .. setting_name: TOP_N_COOKIE_GROUPS_CAPTURED
         # .. setting_default: 5
         # .. setting_description: The number of the largest cookie groups to capture when monitoring. Capture

--- a/openedx/core/lib/request_utils.py
+++ b/openedx/core/lib/request_utils.py
@@ -145,7 +145,7 @@ class CookieMonitoringMiddleware(MiddlewareMixin):
             return
 
         # .. setting_name: TOP_N_COOKIES_CAPTURED
-        # .. setting_default: 5
+        # .. setting_default: 8
         # .. setting_description: The number of the largest cookies to capture when monitoring. Capture fewer cookies
         #       if you need to save on monitoring resources.
         # .. setting_warning: Depends on the `request_utils.capture_cookie_sizes` toggle being enabled.
@@ -208,13 +208,13 @@ class CookieMonitoringMiddleware(MiddlewareMixin):
 
         # Get the size of unmonitored cookies to allow us to see what cookies we are missing
         top_n_cookies = sorted(
-            names_to_size,
-            key=lambda x: names_to_size[x],
+            cookie_names_to_size,
+            key=lambda x: cookie_names_to_size[x],
             reverse=True,
-        )[:top_n_captured]
-        top_n_cookies_size = sum([names_to_size[name] for name in top_n_cookies])
+        )[:top_n_cookies_captured]
+        top_n_cookies_size = sum([cookie_names_to_size[name] for name in top_n_cookies])
         set_custom_attribute('cookies_unaccounted_size', total_cookie_size - top_n_cookies_size)
-        set_custom_attribute('cookies_total_num', len(cookie_numes_to_size))
+        set_custom_attribute('cookies_total_num', len(cookie_names_to_size))
         log.debug('cookies_total_size = %d', total_cookie_size)
 
     def set_custom_attributes_for_top_n(self, names_to_size, top_n_captured, attribute_prefix):
@@ -231,10 +231,10 @@ class CookieMonitoringMiddleware(MiddlewareMixin):
             key=lambda x: names_to_size[x],
             reverse=True,
         )[:top_n_captured]
-        for index, name in enumerate(top_n_cookies, start=1):
+        for count, name in enumerate(top_n_cookies, start=1):
             size = names_to_size[name]
-            name_attribute = f'{attribute_prefix}.{index}.name'
-            size_attribute = f'{attribute_prefix}.{index}.size'
+            name_attribute = f'{attribute_prefix}.{count}.name'
+            size_attribute = f'{attribute_prefix}.{count}.size'
 
             set_custom_attribute(name_attribute, name)
             set_custom_attribute(size_attribute, size)

--- a/openedx/core/lib/request_utils.py
+++ b/openedx/core/lib/request_utils.py
@@ -205,6 +205,7 @@ class CookieMonitoringMiddleware(MiddlewareMixin):
 
         total_cookie_size = sum(cookie_names_to_size.values())
         set_custom_attribute('cookies_total_size', total_cookie_size)
+        log.debug('cookies_total_size = %d', total_cookie_size)
 
         top_n_cookies = sorted(
             cookie_names_to_size,
@@ -213,8 +214,8 @@ class CookieMonitoringMiddleware(MiddlewareMixin):
         )[:top_n_cookies_captured]
         top_n_cookies_size = sum([cookie_names_to_size[name] for name in top_n_cookies])
         set_custom_attribute('cookies_unaccounted_size', total_cookie_size - top_n_cookies_size)
+
         set_custom_attribute('cookies_total_num', len(cookie_names_to_size))
-        log.debug('cookies_total_size = %d', total_cookie_size)
 
     def set_custom_attributes_for_top_n(self, names_to_size, top_n_captured, attribute_prefix):
         """

--- a/openedx/core/lib/request_utils.py
+++ b/openedx/core/lib/request_utils.py
@@ -205,6 +205,8 @@ class CookieMonitoringMiddleware(MiddlewareMixin):
 
         total_cookie_size = sum(cookie_names_to_size.values())
         set_custom_attribute('cookies_total_size', total_cookie_size)
+
+        # Get the size of unmonitored cookies to allow us to see what cookies we are missing
         top_n_cookies = sorted(
             names_to_size,
             key=lambda x: names_to_size[x],

--- a/openedx/core/lib/request_utils.py
+++ b/openedx/core/lib/request_utils.py
@@ -205,6 +205,14 @@ class CookieMonitoringMiddleware(MiddlewareMixin):
 
         total_cookie_size = sum(cookie_names_to_size.values())
         set_custom_attribute('cookies_total_size', total_cookie_size)
+        top_n_cookies = sorted(
+            names_to_size,
+            key=lambda x: names_to_size[x],
+            reverse=True,
+        )[:top_n_captured]
+        top_n_cookies_size = sum([names_to_size[name] for name in top_n_cookies])
+        set_custom_attribute('cookies_unaccounted_size', total_cookie_size - top_n_cookies_size)
+        set_custom_attribute('cookies_total_num', len(cookie_numes_to_size))
         log.debug('cookies_total_size = %d', total_cookie_size)
 
     def set_custom_attributes_for_top_n(self, names_to_size, top_n_captured, attribute_prefix):

--- a/openedx/core/lib/tests/test_request_utils.py
+++ b/openedx/core/lib/tests/test_request_utils.py
@@ -114,6 +114,7 @@ class RequestUtilTestCase(unittest.TestCase):
             "b.": "." * 13,
             "b_a": "." * 15,
             "b_c": "." * 15,
+            "d": "." * 3,
         }
 
         middleware.process_request(mock_request)
@@ -129,6 +130,12 @@ class RequestUtilTestCase(unittest.TestCase):
             call('cookies.4.size', 13),
             call('cookies.5.name', '_c_'),
             call('cookies.5.size', 13),
+            call('cookies.6.name', 'b.'),
+            call('cookies.6.size', 13),
+            call('cookies.7.name', 'a.b'),
+            call('cookies.7.size', 10),
+            call('cookies.8.name', 'a.c'),
+            call('cookies.8.size', 10),
             call('cookies.group.1.name', 'b'),
             call('cookies.group.1.size', 43),
             call('cookies.group.2.name', 'a'),
@@ -137,7 +144,9 @@ class RequestUtilTestCase(unittest.TestCase):
             call('cookies.max.size', 100),
             call('cookies.max.group.name', 'a'),
             call('cookies.max.group.size', 100),
-            call('cookies_total_size', 189),
+            call('cookies_total_size', 192),
+            call('cookies_unaccounted_size', 3),
+            call('cookies_total_num', 9),
         ], any_order=True)
 
     @patch("openedx.core.lib.request_utils.CAPTURE_COOKIE_SIZES")


### PR DESCRIPTION
Added: cookies_total_num, cookies_unaccounted_size. Both are to help us
gauge how many cookies we are not collecting data for.

plus increased default of # of cookies collected.

Impacts:

Developers