### PR TITLE
feat: allow marking Library Content Block as complete on view [BB-4503]

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -484,6 +484,19 @@ FEATURES = {
     # .. toggle_target_removal_date: None
     # .. toggle_tickets: 'https://openedx.atlassian.net/browse/MST-1348'
     'ENABLE_INTEGRITY_SIGNATURE': False,
+
+    # .. toggle_name: MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: If enabled, the Library Content Block is marked as complete when users view it.
+    #   Otherwise (by default), all children of this block must be completed.
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2022-03-22
+    # .. toggle_target_removal_date: None
+    # .. toggle_tickets: https://github.com/edx/edx-platform/pull/28268
+    # .. toggle_warnings: For consistency in user-experience, keep the value in sync with the setting of the same name
+    #   in the LMS and CMS.
+    'MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW': False,
 }
 
 # .. toggle_name: ENABLE_COPPA_COMPLIANCE

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -10,6 +10,8 @@ from copy import copy
 from gettext import ngettext
 
 import bleach
+from django.conf import settings
+from django.utils.functional import classproperty
 from lazy import lazy
 from lxml import etree
 from lxml.etree import XMLSyntaxError
@@ -116,7 +118,18 @@ class LibraryContentBlock(
 
     show_in_read_only_mode = True
 
-    completion_mode = XBlockCompletionMode.AGGREGATOR
+    # noinspection PyMethodParameters
+    @classproperty
+    def completion_mode(cls):  # pylint: disable=no-self-argument
+        """
+        Allow overriding the completion mode with a feature flag.
+
+        This is a property, so it can be dynamically overridden in tests, as it is not evaluated at runtime.
+        """
+        if settings.FEATURES.get('MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW', False):
+            return XBlockCompletionMode.COMPLETABLE
+
+        return XBlockCompletionMode.AGGREGATOR
 
     display_name = String(
         display_name=_("Display Name"),

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -972,6 +972,19 @@ FEATURES = {
     # .. toggle_target_removal_date: None
     # .. toggle_tickets: 'https://openedx.atlassian.net/browse/MICROBA-1758'
     'ENABLE_NEW_BULK_EMAIL_EXPERIENCE': False,
+
+    # .. toggle_name: MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: If enabled, the Library Content Block is marked as complete when users view it.
+    #   Otherwise (by default), all children of this block must be completed.
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2022-03-22
+    # .. toggle_target_removal_date: None
+    # .. toggle_tickets: https://github.com/edx/edx-platform/pull/28268
+    # .. toggle_warnings: For consistency in user-experience, keep the value in sync with the setting of the same name
+    #   in the LMS and CMS.
+    'MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW': False,
 }
 
 # Specifies extra XBlock fields that should available when requested via the Course Blocks API

--- a/openedx/tests/completion_integration/test_services.py
+++ b/openedx/tests/completion_integration/test_services.py
@@ -7,6 +7,8 @@ import ddt
 from completion.models import BlockCompletion
 from completion.services import CompletionService
 from completion.test_utils import CompletionWaffleTestMixin
+from django.conf import settings
+from django.test import override_settings
 from opaque_keys.edx.keys import CourseKey
 from xmodule.library_tools import LibraryToolsService
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
@@ -181,6 +183,19 @@ class CompletionServiceTestCase(CompletionWaffleTestMixin, SharedModuleStoreTest
         assert self.completion_service.can_mark_block_complete_on_view(self.html) is True
         assert self.completion_service.can_mark_block_complete_on_view(self.problem) is False
 
+    @override_settings(FEATURES={**settings.FEATURES, 'MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW': True})
+    def test_can_mark_library_content_complete_on_view(self):
+        library = LibraryFactory.create(modulestore=self.store)
+        lib_vertical = ItemFactory.create(parent=self.sequence, category='vertical', publish_item=False)
+        library_content_block = ItemFactory.create(
+            parent=lib_vertical,
+            category='library_content',
+            max_count=1,
+            source_library_id=str(library.location.library_key),
+            user_id=self.user.id,
+        )
+        self.assertTrue(self.completion_service.can_mark_block_complete_on_view(library_content_block))
+
     def test_vertical_completion_with_library_content(self):
         library = LibraryFactory.create(modulestore=self.store)
         ItemFactory.create(parent=library, category='problem', publish_item=False, user_id=self.user.id)
@@ -202,6 +217,9 @@ class CompletionServiceTestCase(CompletionWaffleTestMixin, SharedModuleStoreTest
             source_library_id=str(library.location.library_key),
             user_id=self.user.id,
         )
+        # Library Content Block needs its children to be completed.
+        self.assertFalse(self.completion_service.can_mark_block_complete_on_view(library_content_block))
+
         library_content_block.refresh_children()
         lib_vertical = self.store.get_item(lib_vertical.location)
         self._bind_course_module(lib_vertical)


### PR DESCRIPTION
## Description

edx/edx-platform#24365 has changed the completion mode of these blocks.
Before Koa, it was sufficient to view the block to get a completion checkmark.
Since Koa, all children of the block must be completed.

This adds the `MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW` toggle to change the completion behavior back to the previous one so that the user experience can be consistent if needed.

## Use case

Our client offers a Certificate of Completion additionally to the one received after passing a course. In order to receive it, learners need to "complete" all of the course material, including the final exam (Randomized Content Block). The final exam is considered "complete" for the purposes of these criteria even if the learner has not submitted every question. This way, the learners who have spent some time in the final exam would still get this certificate - even if they haven't submitted everything.

## Jira

[OSPR-5930](https://openedx.atlassian.net/browse/OSPR-5930)
[BB-4503](https://tasks.opencraft.com/browse/BB-4503)

## Sandbox

https://pr28268.sandbox.opencraft.hosting/ (provisioning)


## Testing instructions
1. Add the `completion.enable_completion_tracking`  [Waffle Switch|http://localhost:18000/admin/waffle/switch/] (marked as active).
2. Create a new library in [Studio](http://localhost:18010). Add an example problem there.
3. Create a new course. Add `"library_content"` to "Advanced Module List".
4. Add a "Randomized Content Block" to the course and set the new library as its source.
5. Copy the subsection with this unit and publish the section.
6. Visit the first unit in the LMS and see that it's not marked as completed on the Course Outline page.
7. Complete the first unit and see that you have the completion checkmark on the Course Outline page.
8. Add `FEATURES['MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW'] = True` to `envs/private.py`.
9. Visit the second unit and wait for a few seconds. You should be able to see two `publish_completion` `POST` requests in the browser's Network tab. The first one will return 200, and the second one 400 (because it's not going to affect the problem block itself).
10. Go to the Course Outline page and check that the second subsection is now completed as well.

## Deadline

None.

## Reviewers

- [x] @arjunsinghy96 
- [ ] CC reviewer: @mtyaka

**Settings**
```yaml
EDXAPP_FEATURES_EXTRA:
  MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW: true
```
