### PR TITLE
chore: update edx-proctoring to 3.22.0

### DIFF
--- a/common/djangoapps/util/tests/test_db.py
+++ b/common/djangoapps/util/tests/test_db.py
@@ -197,9 +197,6 @@ class MigrationTests(TestCase):
     """
 
     @override_settings(MIGRATION_MODULES={})
-    @unittest.skip(
-        "Temporary skip for MST-872 while the ip and name columns are removed from proctored exam attempt"
-    )
     def test_migrations_are_in_sync(self):
         """
         Tests that the migration files are in sync with the models.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -465,7 +465,7 @@ edx-opaque-keys[django]==2.2.2
     #   xmodule
 edx-organizations==6.9.0
     # via -r requirements/edx/base.in
-edx-proctoring==3.20.6
+edx-proctoring==3.22.0
     # via
     #   -r requirements/edx/base.in
     #   edx-proctoring-proctortrack

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -562,7 +562,7 @@ edx-opaque-keys[django]==2.2.2
     #   xmodule
 edx-organizations==6.9.0
     # via -r requirements/edx/testing.txt
-edx-proctoring==3.20.6
+edx-proctoring==3.22.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-proctoring-proctortrack

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -546,7 +546,7 @@ edx-opaque-keys[django]==2.2.2
     #   xmodule
 edx-organizations==6.9.0
     # via -r requirements/edx/base.txt
-edx-proctoring==3.20.6
+edx-proctoring==3.22.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring-proctortrack


### PR DESCRIPTION
This completes the removal of unused fields in exam attempt,
so the migration test skip is no longer necessary.

MST-872
