### PR TITLE
feat: Allow language preferences to be shared.

### DIFF
--- a/openedx/core/djangoapps/lang_pref/views.py
+++ b/openedx/core/djangoapps/lang_pref/views.py
@@ -27,7 +27,7 @@ def update_session_language(request):
         response.set_cookie(
             settings.LANGUAGE_COOKIE,
             language,
-            domain=settings.SESSION_COOKIE_DOMAIN,
+            domain=settings.SHARED_COOKIE_DOMAIN,
             max_age=COOKIE_DURATION,
             secure=request.is_secure(),
         )


### PR DESCRIPTION
We are planning on limiting session cookies for LMS, which
will mean that under the old cookie domain, MFEs and other
IDAs would not have access to the language preference of a user.

This moves language preference cookies to use a different setting,
which means that this cookie can be shared.