### PR TITLE
chore: Django3 has removed python_2_unicode_compatible.

### DIFF
--- a/openedx/core/djangoapps/credit/models.py
+++ b/openedx/core/djangoapps/credit/models.py
@@ -17,7 +17,6 @@ from django.core.cache import cache
 from django.core.validators import RegexValidator
 from django.db import IntegrityError, models, transaction
 from django.dispatch import receiver
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext as _  # lint-amnesty, pylint: disable=unused-import
 from django.utils.translation import ugettext_lazy
 from edx_django_utils.cache import RequestCache
@@ -31,7 +30,6 @@ CREDIT_PROVIDER_ID_REGEX = "[a-z,A-Z,0-9,\\-]+"
 log = logging.getLogger(__name__)
 
 
-@python_2_unicode_compatible
 class CreditProvider(TimeStampedModel):
     """
     This model represents an institution that can grant credit for a course.
@@ -214,7 +212,6 @@ def invalidate_provider_cache(sender, **kwargs):  # pylint: disable=unused-argum
     cache.delete(CreditProvider.CREDIT_PROVIDERS_CACHE_KEY)
 
 
-@python_2_unicode_compatible
 class CreditCourse(models.Model):
     """
     Model for tracking a credit course.
@@ -277,7 +274,6 @@ def invalidate_credit_courses_cache(sender, **kwargs):   # pylint: disable=unuse
     cache.delete(CreditCourse.CREDIT_COURSES_CACHE_KEY)
 
 
-@python_2_unicode_compatible
 class CreditRequirement(TimeStampedModel):
     """
     This model represents a credit requirement.
@@ -546,7 +542,6 @@ def default_deadline_for_credit_eligibility():
     )
 
 
-@python_2_unicode_compatible
 class CreditEligibility(TimeStampedModel):
     """
     A record of a user's eligibility for credit for a specific course.
@@ -653,7 +648,6 @@ class CreditEligibility(TimeStampedModel):
         )
 
 
-@python_2_unicode_compatible
 class CreditRequest(TimeStampedModel):
     """
     A request for credit from a particular credit provider.
@@ -780,7 +774,6 @@ class CreditRequest(TimeStampedModel):
         )
 
 
-@python_2_unicode_compatible
 class CreditConfig(ConfigurationModel):
     """
     Manage credit configuration

--- a/openedx/core/djangoapps/embargo/models.py
+++ b/openedx/core/djangoapps/embargo/models.py
@@ -16,7 +16,6 @@ import ipaddress
 import json
 import logging
 
-from django.utils.encoding import python_2_unicode_compatible
 from config_models.models import ConfigurationModel
 from django.core.cache import cache
 from django.db import models
@@ -36,7 +35,6 @@ from .messages import COURSEWARE_MESSAGES, ENROLL_MESSAGES
 log = logging.getLogger(__name__)
 
 
-@python_2_unicode_compatible
 class EmbargoedCourse(models.Model):
     """
     Enable course embargo on a course-by-course basis.
@@ -73,7 +71,6 @@ class EmbargoedCourse(models.Model):
         return f"Course '{str(self.course_id)}' is {not_em}Embargoed"
 
 
-@python_2_unicode_compatible
 class EmbargoedState(ConfigurationModel):
     """
     Register countries to be embargoed.
@@ -101,7 +98,6 @@ class EmbargoedState(ConfigurationModel):
         return self.embargoed_countries
 
 
-@python_2_unicode_compatible
 class RestrictedCourse(models.Model):
     """
     Course with access restrictions.
@@ -373,7 +369,6 @@ class RestrictedCourse(models.Model):
         log.info("Invalidated cached messaging URLs ")
 
 
-@python_2_unicode_compatible
 class Country(models.Model):
     """Representation of a country.
 
@@ -399,7 +394,6 @@ class Country(models.Model):
         ordering = ['country']
 
 
-@python_2_unicode_compatible
 class CountryAccessRule(models.Model):
     """Course access rule based on the user's country.
 
@@ -682,7 +676,6 @@ post_delete.connect(CourseAccessRuleHistory.snapshot_post_delete_receiver, sende
 post_delete.connect(CourseAccessRuleHistory.snapshot_post_delete_receiver, sender=CountryAccessRule)
 
 
-@python_2_unicode_compatible
 class IPFilter(ConfigurationModel):
     """
     Register specific IP addresses to explicitly block or unblock.

--- a/openedx/core/djangoapps/theming/models.py
+++ b/openedx/core/djangoapps/theming/models.py
@@ -5,10 +5,8 @@ Django models supporting the Comprehensive Theming subsystem
 
 from django.contrib.sites.models import Site
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 
-@python_2_unicode_compatible
 class SiteTheme(models.Model):
     """
     This is where the information about the site's theme gets stored to the db.

--- a/openedx/core/djangoapps/video_config/models.py
+++ b/openedx/core/djangoapps/video_config/models.py
@@ -6,14 +6,13 @@ Configuration models for Video XModule
 from config_models.models import ConfigurationModel
 from django.db import models
 from django.db.models import BooleanField, PositiveIntegerField, TextField
-from django.utils.encoding import python_2_unicode_compatible
 from model_utils.models import TimeStampedModel
 from opaque_keys.edx.django.models import CourseKeyField
 
 URL_REGEX = r'^[a-zA-Z0-9\-_]*$'
 
 
-@python_2_unicode_compatible
+
 class HLSPlaybackEnabledFlag(ConfigurationModel):
     """
     Enables HLS Playback across the platform.
@@ -65,7 +64,6 @@ class HLSPlaybackEnabledFlag(ConfigurationModel):
         )
 
 
-@python_2_unicode_compatible
 class CourseHLSPlaybackEnabledFlag(ConfigurationModel):
     """
     Enables HLS Playback for a specific course. Global feature must be
@@ -96,7 +94,6 @@ class CourseHLSPlaybackEnabledFlag(ConfigurationModel):
         )
 
 
-@python_2_unicode_compatible
 class CourseYoutubeBlockedFlag(ConfigurationModel):
     """
     Disables the playback of youtube videos for a given course.
@@ -132,7 +129,6 @@ class CourseYoutubeBlockedFlag(ConfigurationModel):
         )
 
 
-@python_2_unicode_compatible
 class VideoTranscriptEnabledFlag(ConfigurationModel):
     """
     Enables Video Transcript across the platform.
@@ -178,7 +174,6 @@ class VideoTranscriptEnabledFlag(ConfigurationModel):
         )
 
 
-@python_2_unicode_compatible
 class CourseVideoTranscriptEnabledFlag(ConfigurationModel):
     """
     Enables Video Transcript for a specific course. Global feature must be
@@ -203,7 +198,6 @@ class CourseVideoTranscriptEnabledFlag(ConfigurationModel):
         )
 
 
-@python_2_unicode_compatible
 class TranscriptMigrationSetting(ConfigurationModel):
     """
     Arguments for the Transcript Migration management command
@@ -247,7 +241,6 @@ class TranscriptMigrationSetting(ConfigurationModel):
         return self.command_run
 
 
-@python_2_unicode_compatible
 class MigrationEnqueuedCourse(TimeStampedModel):
     """
     Temporary model to persist the course IDs who has been enqueued for transcripts migration to S3.
@@ -263,7 +256,6 @@ class MigrationEnqueuedCourse(TimeStampedModel):
         )
 
 
-@python_2_unicode_compatible
 class VideoThumbnailSetting(ConfigurationModel):
     """
     Arguments for the Video Thumbnail management command
@@ -306,7 +298,6 @@ class VideoThumbnailSetting(ConfigurationModel):
         )
 
 
-@python_2_unicode_compatible
 class UpdatedCourseVideos(TimeStampedModel):
     """
     Temporary model to persist the course videos which have been enqueued to update video thumbnails.

--- a/openedx/core/djangoapps/video_config/models.py
+++ b/openedx/core/djangoapps/video_config/models.py
@@ -12,7 +12,6 @@ from opaque_keys.edx.django.models import CourseKeyField
 URL_REGEX = r'^[a-zA-Z0-9\-_]*$'
 
 
-
 class HLSPlaybackEnabledFlag(ConfigurationModel):
     """
     Enables HLS Playback across the platform.


### PR DESCRIPTION
chore: Django3 has removed python_2_unicode_compatible.
execute codemods on few files.