### PR TITLE
chore: Django3 has removed python_2_unicode_compatible.

### DIFF
--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -13,7 +13,7 @@ from django.core.validators import validate_comma_separated_integer_list
 from django.db import models
 from django.db.models import Q
 from django.dispatch import receiver
-from django.utils.encoding import python_2_unicode_compatible
+
 from django.utils.timezone import now
 from django.utils.translation import ugettext_lazy as _
 from edx_django_utils.cache import RequestCache
@@ -39,7 +39,6 @@ Mode = namedtuple('Mode',
                   ])
 
 
-@python_2_unicode_compatible
 class CourseMode(models.Model):
     """
     We would like to offer a course in a variety of modes.
@@ -916,7 +915,6 @@ class CourseModesArchive(models.Model):
     expiration_datetime = models.DateTimeField(default=None, null=True, blank=True)
 
 
-@python_2_unicode_compatible
 class CourseModeExpirationConfig(ConfigurationModel):
     """
     Configuration for time period from end of course to auto-expire a course mode.

--- a/common/djangoapps/entitlements/models.py
+++ b/common/djangoapps/entitlements/models.py
@@ -8,7 +8,7 @@ from datetime import timedelta
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.db import IntegrityError, models, transaction
-from django.utils.encoding import python_2_unicode_compatible
+
 from django.utils.timezone import now
 from model_utils import Choices
 from model_utils.models import TimeStampedModel
@@ -27,7 +27,6 @@ from openedx.core.djangoapps.content.course_overviews.models import CourseOvervi
 log = logging.getLogger("common.entitlements.models")
 
 
-@python_2_unicode_compatible
 class CourseEntitlementPolicy(models.Model):
     """
     Represents the Entitlement's policy for expiration, refunds, and regaining a used certificate
@@ -464,7 +463,6 @@ class CourseEntitlement(TimeStampedModel):
         super().save(*args, **kwargs)
 
 
-@python_2_unicode_compatible
 class CourseEntitlementSupportDetail(TimeStampedModel):
     """
     Table recording support interactions with an entitlement

--- a/common/djangoapps/static_replace/models.py
+++ b/common/djangoapps/static_replace/models.py
@@ -5,10 +5,8 @@ Models for static_replace
 
 from config_models.models import ConfigurationModel
 from django.db.models.fields import TextField
-from django.utils.encoding import python_2_unicode_compatible
 
 
-@python_2_unicode_compatible
 class AssetBaseUrlConfig(ConfigurationModel):
     """
     Configuration for the base URL used for static assets.
@@ -36,7 +34,6 @@ class AssetBaseUrlConfig(ConfigurationModel):
         return str(repr(self))
 
 
-@python_2_unicode_compatible
 class AssetExcludedExtensionsConfig(ConfigurationModel):
     """
     Configuration for the the excluded file extensions when canonicalizing static asset paths.

--- a/common/djangoapps/status/models.py
+++ b/common/djangoapps/status/models.py
@@ -8,13 +8,12 @@ from config_models.models import ConfigurationModel
 from django.contrib import admin
 from django.core.cache import cache
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
+
 from opaque_keys.edx.django.models import CourseKeyField
 
 from openedx.core.djangolib.markup import HTML
 
 
-@python_2_unicode_compatible
 class GlobalStatusMessage(ConfigurationModel):
     """
     Model that represents the current status message.
@@ -55,7 +54,6 @@ class GlobalStatusMessage(ConfigurationModel):
         return f"{self.change_date} - {self.enabled} - {self.message}"
 
 
-@python_2_unicode_compatible
 class CourseMessage(models.Model):
     """
     Model that allows the administrator to specify banner messages for individual courses.


### PR DESCRIPTION
chore: Django3 has removed python_2_unicode_compatible.