### PR TITLE
feat: add activation CTA popup on choose mode page

### DIFF
--- a/lms/static/js/dashboard/legacy.js
+++ b/lms/static/js/dashboard/legacy.js
@@ -228,54 +228,6 @@
              return false;
          });
 
-         $('#send_cta_email').click(function(e) {
-             $.ajax({
-                 type: 'POST',
-                 url: urls.sendAccountActivationEmail,
-                 data: $(this).serializeArray(),
-                 success: function() {
-                     setTimeout(
-                       function(){
-                         $('#activate-account-modal p svg').remove();
-                         // xss-lint: disable=javascript-jquery-append
-                         $('#activate-account-modal p').append(
-                         // xss-lint: disable=javascript-concat-html
-                         '<svg  style="vertical-align:bottom" width="20" height="20"' +
-                         // xss-lint: disable=javascript-concat-html
-                         'viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">\n' +
-                         // xss-lint: disable=javascript-concat-html
-                         '<path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z" fill="#178253"/>\n' +
-                         '</svg>'
-                         );
-                       }, 500); // adding timeout to make spinner animation longer
-                 }
-             });
-             e.preventDefault();
-             $('#activate-account-modal p svg').remove();
-             // xss-lint: disable=javascript-jquery-append
-             $('#activate-account-modal p').append(
-               // xss-lint: disable=javascript-concat-html
-               '<svg  class="fa-pulse" style="vertical-align:bottom" width="20" height="20"' +
-               // xss-lint: disable=javascript-concat-html
-               'viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">\n' +
-               // xss-lint: disable=javascript-concat-html
-               '<path d="M22 12A10 10 0 116.122 3.91l1.176 1.618A8 8 0 1020 12h2z" fill="#6c757d"/>\n' +
-               '</svg>'
-             );
-         });
-
-         $('#activate-account-modal').on('click', '#button', function() {
-             $('#activate-account-modal').css('display', 'none');
-             $('#lean_overlay').css({display: 'none'});
-         });
-         if ($('#activate-account-modal').css('display') === 'block') {
-             $('#lean_overlay').css({
-                 display: 'block',
-                 'z-index': 0
-             });
-             $('#activate-account-modal').focus()
-         }
-
          $('.action-email-settings').each(function(index) {
              $(this).attr('id', 'email-settings-' + index);
             // a bit of a hack, but gets the unique selector for the modal trigger

--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -1658,15 +1658,18 @@ a.fade-cover {
     box-shadow: none;
     background: none;
     outline: 0;
+    z-index: 10000;
+    padding: 0;
 
     .inner-wrapper {
-      h3 {
+      .activate-account-modal-title {
           font-family: inherit;
           padding: 1.5rem 1rem 1rem 1rem;
           text-align: left;
           font-weight: bold;
           font-size: 1.3rem;
           line-height: 1.75rem;
+          color: #000000;
       }
         border: none;
         border-radius: 5px;
@@ -1693,10 +1696,20 @@ a.fade-cover {
     .btn-primary {
         text-transform: none;
         font-weight: 500;
+        letter-spacing: 1px;
     }
 }
 .activate-account-modal-body {
     padding: 0 1rem;
+    color: #002121 !important;
+
+    strong {
+      font-weight: 700 !important;
+    }
+
+    a {
+      text-decoration: underline !important;
+    }
 }
 
 .reasons_survey {

--- a/lms/templates/_account-activation-modal.html
+++ b/lms/templates/_account-activation-modal.html
@@ -1,0 +1,87 @@
+<%page expression_filter="h"/>
+
+<%!
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from openedx.core.djangolib.js_utils import js_escaped_string
+from openedx.core.djangolib.markup import HTML, Text
+%>
+
+<script type="text/javascript">
+    $(document).ready(function() {
+        $('#send_cta_email').click(function(e) {
+            $.ajax({
+                type: 'POST',
+                url: "${reverse('send_account_activation_email') | n, js_escaped_string}",
+                data: $(this).serializeArray(),
+                success: function() {
+                    setTimeout(
+                    function(){
+                        $('#activate-account-modal p svg').remove();
+                        // xss-lint: disable=javascript-jquery-append
+                        $('#activate-account-modal p').append(
+                        // xss-lint: disable=javascript-concat-html
+                        '<svg  style="vertical-align:bottom" width="20" height="20"' +
+                        // xss-lint: disable=javascript-concat-html
+                        'viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">\n' +
+                        // xss-lint: disable=javascript-concat-html
+                        '<path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z" fill="#178253"/>\n' +
+                        '</svg>'
+                        );
+                    }, 500); // adding timeout to make spinner animation longer
+                }
+            });
+            e.preventDefault();
+            $('#activate-account-modal p svg').remove();
+            // xss-lint: disable=javascript-jquery-append
+            $('#activate-account-modal p').append(
+            // xss-lint: disable=javascript-concat-html
+            '<svg  class="fa-pulse" style="vertical-align:bottom" width="20" height="20"' +
+            // xss-lint: disable=javascript-concat-html
+            'viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">\n' +
+            // xss-lint: disable=javascript-concat-html
+            '<path d="M22 12A10 10 0 116.122 3.91l1.176 1.618A8 8 0 1020 12h2z" fill="#6c757d"/>\n' +
+            '</svg>'
+            );
+        });
+
+        $('#activate-account-modal').on('click', '#button', function() {
+            $('#activate-account-modal').css('display', 'none');
+            $('#lean_overlay').css({display: 'none'});
+        });
+        if ($('#activate-account-modal').css('display') === 'block') {
+            $('#lean_overlay').css({
+                display: 'block',
+                'z-index': 0
+            });
+            $('#activate-account-modal').focus()
+        }
+    });
+</script>
+
+<div id="activate-account-modal" class="modal activate-account-modal" aria-hidden="true" tabindex=0 >
+    <div class="inner-wrapper" role="dialog" aria-labelledby="activate-account-modal-title" aria-live="polite">
+        <h3 class="activate-account-modal-title">
+            ${_("Activate your account so you can log back in")}
+            <span class="sr">,
+            ## Translators: this text gives status on if the modal interface (a menu or piece of UI that takes the full focus of the screen) is open or not
+            ${_("window open")}
+            </span>
+        </h3>
+        <p class="activate-account-modal-body">${Text(_("We sent an email to {strong_start}{email}{strong_end} with a link to activate your account. Can’t find it? Check your spam folder or {link_start}resend the email{link_end}.")).format(
+            strong_start=HTML('<strong>'),
+            email=user.email,
+            strong_end=HTML('</strong>'),
+            link_start=HTML('<a href="#" id="send_cta_email" >'),
+            link_end=HTML('</a>')
+            )}
+        </p>
+        <div class="activate-account-modal-button">
+            <button class="btn btn-primary" id="button">
+                ${Text(_("Continue to {platform_name}")).format(platform_name=settings.PLATFORM_NAME)}
+                <svg  style="vertical-align:bottom" width="24" height="24" viewBox="0 0 24 24" fill="white" xmlns="http://www.w3.org/2000/svg"><path d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8-8-8z"/></svg>
+            </button>
+        </div>
+
+    </div>
+</div>

--- a/lms/templates/course_modes/choose.html
+++ b/lms/templates/course_modes/choose.html
@@ -7,7 +7,7 @@ from openedx.core.djangolib.js_utils import js_escaped_string
 from openedx.core.djangolib.markup import HTML, Text
 %>
 
-<%block name="bodyclass">register verification-process step-select-track</%block>
+<%block name="bodyclass">verification-process step-select-track</%block>
 <%block name="pagetitle">
     ${_("Enroll In {course_name} | Choose Your Track").format(course_name=course_name)}
 </%block>
@@ -229,4 +229,8 @@ from openedx.core.djangolib.markup import HTML, Text
             </div> <!-- /wrapper-content-main -->
         </section>
     </div>
+
+    %if show_account_activation_popup:
+      <%include file="../_account-activation-modal.html"/>
+    %endif
 </%block>

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -47,8 +47,7 @@ from common.djangoapps.student.models import CourseEnrollment
       edx.dashboard.legacy.init({
         dashboard: "${reverse('dashboard') | n, js_escaped_string}",
         signInUser: "${reverse('signin_user') | n, js_escaped_string}",
-        changeEmailSettings: "${reverse('change_email_settings') | n, js_escaped_string}",
-        sendAccountActivationEmail: "${reverse('send_account_activation_email') | n, js_escaped_string}"
+        changeEmailSettings: "${reverse('change_email_settings') | n, js_escaped_string}"
 
       });
     });
@@ -320,32 +319,7 @@ from common.djangoapps.student.models import CourseEnrollment
 </main>
 
 %if show_account_activation_popup:
-    <div id="activate-account-modal" class="modal activate-account-modal" aria-hidden="true" tabindex=0 >
-      <div class="inner-wrapper" role="dialog" aria-labelledby="activate-account-modal-title" aria-live="polite">
-          <h3>
-             ${_("Activate your account so you can log back in")}
-            <span class="sr">,
-              ## Translators: this text gives status on if the modal interface (a menu or piece of UI that takes the full focus of the screen) is open or not
-              ${_("window open")}
-            </span>
-        </h3>
-          <p class="activate-account-modal-body">${Text(_("We sent an email to {strong_start}{email}{strong_end} with a link to activate your account. Can’t find it? Check your spam folder or {link_start}resend the email{link_end}.")).format(
-              strong_start=HTML('<strong>'),
-              email=user.email,
-              strong_end=HTML('</strong>'),
-              link_start=HTML('<a href="#" id="send_cta_email" >'),
-              link_end=HTML('</a>')
-              )}
-          </p>
-           <div class="activate-account-modal-button">
-               <button class="btn btn-primary" id="button">
-                   ${Text(_("Continue to {platform_name}")).format(platform_name=settings.PLATFORM_NAME)}
-                   <svg  style="vertical-align:bottom" width="24" height="24" viewBox="0 0 24 24" fill="white" xmlns="http://www.w3.org/2000/svg"><path d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8-8-8z"/></svg>
-               </button>
-           </div>
-
-      </div>
-    </div>
+  <%include file="_account-activation-modal.html"/>
 %endif
 
 <div id="email-settings-modal" class="modal" aria-hidden="true">

--- a/themes/edx.org/lms/templates/course_modes/choose.html
+++ b/themes/edx.org/lms/templates/course_modes/choose.html
@@ -10,7 +10,7 @@ from openedx.core.djangolib.markup import HTML, Text
 %>
 
 <%namespace name='static' file='/static_content.html'/>
-<%block name="bodyclass">register verification-process step-select-track</%block>
+<%block name="bodyclass">verification-process step-select-track</%block>
 <%block name="pagetitle">
     ${_("Enroll In {course_name} | Choose Your Track").format(course_name=course_name)}
 </%block>
@@ -244,4 +244,8 @@ from openedx.core.djangolib.markup import HTML, Text
             </div> <!-- /wrapper-content-main -->
         </section>
     </div>
+
+    %if show_account_activation_popup:
+      <%include file="../_account-activation-modal.html"/>
+    %endif
 </%block>

--- a/themes/edx.org/lms/templates/dashboard.html
+++ b/themes/edx.org/lms/templates/dashboard.html
@@ -368,6 +368,10 @@ from common.djangoapps.student.models import CourseEnrollment
 </div>
 </section>
 
+%if show_account_activation_popup:
+  <%include file="_account-activation-modal.html"/>
+%endif
+
 <section id="email-settings-modal" class="modal" aria-hidden="true">
   <div class="inner-wrapper" role="dialog" aria-labelledby="email-settings-title">
     <button class="close-modal">


### PR DESCRIPTION
## Description

Added activation CTA popup on choose mode page to increase the user activation rate. Previously it was added on the courses dashboard page, refactored the code to utilize the same code for choose mode. Also fixed some CSS stylings.

[VAN-661](https://openedx.atlassian.net/browse/VAN-661)

## Testing:

1. Visit https://redesign-authn.sandbox.edx.org/course_modes/choose/course-v1:edX+DemoX+Demo_Course/ and It will redirect you to the login page with the next query param to choose mode page
2. Move to the register page and create a new account
3. You should see be redirected to choose mode page and see an account activation popup as described [here in Figma](https://www.figma.com/file/0uBm1o7nH2ExePrRXGvB7Z/Logistration?node-id=1139%3A16388)

### Dashboard:
<img width="1675" alt="Screenshot 2021-07-27 at 8 49 32 PM" src="https://user-images.githubusercontent.com/2851134/127185771-d6272501-cfec-4eee-8ac4-675d06b21918.png">

### Choose Mode:
<img width="1678" alt="Screenshot 2021-07-27 at 8 50 57 PM" src="https://user-images.githubusercontent.com/2851134/127185925-d8cf7c96-156f-4900-9277-12bf638d015f.png">
