### PR TITLE
chore: Django3 has removed python_2_unicode_compatible.

### DIFF
--- a/openedx/core/djangoapps/bookmarks/models.py
+++ b/openedx/core/djangoapps/bookmarks/models.py
@@ -7,7 +7,7 @@ import logging
 
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
+
 from jsonfield.fields import JSONField
 from model_utils.models import TimeStampedModel
 from opaque_keys.edx.django.models import CourseKeyField, UsageKeyField
@@ -41,7 +41,6 @@ def parse_path_data(path_data):
     return path
 
 
-@python_2_unicode_compatible
 class Bookmark(TimeStampedModel):
     """
     Bookmarks model.
@@ -192,7 +191,6 @@ class Bookmark(TimeStampedModel):
         return path_data
 
 
-@python_2_unicode_compatible
 class XBlockCache(TimeStampedModel):
     """
     XBlockCache model to store info about xblocks.

--- a/openedx/core/djangoapps/course_groups/models.py
+++ b/openedx/core/djangoapps/course_groups/models.py
@@ -11,7 +11,7 @@ from django.core.exceptions import ValidationError
 from django.db import models, transaction
 from django.db.models.signals import pre_delete
 from django.dispatch import receiver
-from django.utils.encoding import python_2_unicode_compatible
+
 from opaque_keys.edx.django.models import CourseKeyField
 
 from openedx.core.djangolib.model_mixins import DeletableByUserValue
@@ -19,7 +19,6 @@ from openedx.core.djangolib.model_mixins import DeletableByUserValue
 log = logging.getLogger(__name__)
 
 
-@python_2_unicode_compatible
 class CourseUserGroup(models.Model):
     """
     This model represents groups of users in a course.  Groups may have different types,

--- a/openedx/core/djangoapps/crawlers/models.py
+++ b/openedx/core/djangoapps/crawlers/models.py
@@ -6,10 +6,8 @@ appropriately in other parts of the code.
 
 from config_models.models import ConfigurationModel
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 
-@python_2_unicode_compatible
 class CrawlersConfig(ConfigurationModel):
     """
     Configuration for the crawlers django app.

--- a/openedx/core/djangoapps/credentials/models.py
+++ b/openedx/core/djangoapps/credentials/models.py
@@ -8,7 +8,7 @@ from urllib.parse import urljoin  # pylint: disable=import-error
 from config_models.models import ConfigurationModel
 from django.conf import settings
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
+
 from django.utils.translation import ugettext_lazy as _
 
 from openedx.core.djangoapps.site_configuration import helpers
@@ -18,7 +18,6 @@ from .helpers import is_learner_records_enabled
 API_VERSION = 'v2'
 
 
-@python_2_unicode_compatible
 class CredentialsApiConfig(ConfigurationModel):
     """
     Manages configuration for connecting to the Credential service and using its
@@ -117,7 +116,6 @@ class CredentialsApiConfig(ConfigurationModel):
         return self.cache_ttl > 0
 
 
-@python_2_unicode_compatible
 class NotifyCredentialsConfig(ConfigurationModel):
     """
     Manages configuration for a run of the notify_credentials management command.

--- a/openedx/core/djangoapps/django_comment_common/models.py
+++ b/openedx/core/djangoapps/django_comment_common/models.py
@@ -10,7 +10,7 @@ from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imp
 from django.db import models
 from django.db.models.signals import post_save
 from django.dispatch import receiver
-from django.utils.encoding import python_2_unicode_compatible
+
 from django.utils.translation import ugettext_noop
 from jsonfield.fields import JSONField
 from opaque_keys.edx.django.models import CourseKeyField
@@ -68,7 +68,6 @@ def assign_role(course_id, user, rolename):
     user.roles.add(role)
 
 
-@python_2_unicode_compatible
 class Role(models.Model):
     """
     Maps users to django_comment_client roles for a given course
@@ -128,7 +127,6 @@ class Role(models.Model):
         return Role.objects.filter(course_id=course_id, name__in=role_names, users=user).exists()
 
 
-@python_2_unicode_compatible
 class Permission(models.Model):
     """
     Permissions for django_comment_client
@@ -195,7 +193,6 @@ def all_permissions_for_user_in_course(user, course_id):
     return permission_names
 
 
-@python_2_unicode_compatible
 class ForumsConfig(ConfigurationModel):
     """
     Config for the connection to the cs_comments_service forums backend.


### PR DESCRIPTION
chore: Django3 has removed python_2_unicode_compatible.