### PR TITLE
BOM-2715: Update the post-pip-compile script

### DIFF
--- a/requirements/edx-sandbox/py38.txt
+++ b/requirements/edx-sandbox/py38.txt
@@ -4,9 +4,9 @@
 #
 #    make upgrade
 #
--e common/lib/sandbox-packages
+common/lib/sandbox-packages
     # via -r requirements/edx-sandbox/py38.in
--e common/lib/symmath
+common/lib/symmath
     # via -r requirements/edx-sandbox/py38.in
 cffi==1.14.6
     # via cryptography

--- a/scripts/post-pip-compile.sh
+++ b/scripts/post-pip-compile.sh
@@ -28,7 +28,8 @@ function clean_file {
     # Code sandbox local package installs must be non-editable due to file
     # permissions issues.  edxapp ones must stay editable until assorted
     # packaging bugs are fixed.
-    if [[ "${FILE_PATH}" == "requirements/edx-sandbox/py35.txt" ]]; then
+    if [[ "${FILE_PATH}" == "requirements/edx-sandbox/py35.txt" ||
+        "${FILE_PATH}" == "requirements/edx-sandbox/py38.txt" ]]; then
         sed "s|-e common/lib/|common/lib/|" ${FILE_PATH} > ${TEMP_FILE}
         mv ${TEMP_FILE} ${FILE_PATH}
     fi


### PR DESCRIPTION
**Issue:** [BOM-2715](https://openedx.atlassian.net/browse/BOM-2715)

### Description
- Updated the `post-pip-compile.sh` script to remove `-e` flags from sandbox-py38 requirements.
- Not removing these parameters causes the sandbox creation to fail.