### PR TITLE
Re-enable Chrome 92+ iFrame JS dialog/modal creation

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -4760,3 +4760,7 @@ SHOW_ACTIVATE_CTA_POPUP_COOKIE_NAME = 'show-account-activation-popup'
 # .. toggle_tickets: https://github.com/edx/edx-platform/pull/27661
 # .. toggle_creation_date: 2021-06-10
 SHOW_ACCOUNT_ACTIVATION_CTA = False
+
+################# Settings for Chrome-specific origin trials ########
+# Token for " Disable Different Origin Subframe Dialog Suppression" for http://localhost:18000
+CHROME_DISABLE_SUBFRAME_DIALOG_SUPPRESSION_TOKEN = 'ArNBN7d1AkvMhJTGWXlJ8td/AN4lOokzOnqKRNkTnLqaqx0HpfYvmx8JePPs/emKh6O5fckx14LeZIGJ1AQYjgAAAABzeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjE4MDAwIiwiZmVhdHVyZSI6IkRpc2FibGVEaWZmZXJlbnRPcmlnaW5TdWJmcmFtZURpYWxvZ1N1cHByZXNzaW9uIiwiZXhwaXJ5IjoxNjM5NTI2Mzk5fQ=='  # pylint: disable=line-too-long

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -34,6 +34,7 @@ from common.djangoapps.pipeline_mako import render_require_js_path_overrides
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="origin-trial" content="${settings.CHROME_DISABLE_SUBFRAME_DIALOG_SUPPRESSION_TOKEN}">
 
 ## Define a couple of helper functions to make life easier when
 ## embedding theme conditionals into templates. All inheriting


### PR DESCRIPTION
## Description

Add non-secret token which disables different origin subframe dialog suppression for Chrome version 92. This token is added via `<meta>` tag to the courseware iFrame HTML `<head>` section, which enables the iFrame to retain the ability to summon modals & alerts - or open new windows via JS.

## Supporting information

Details about the origin trial used:
https://developer.chrome.com/origintrials/#/registration/-710583578706051071

Details about Chrome origin trials:
https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md

Accompanying configuration PRs:
https://github.com/edx/sandbox-internal/pull/180
https://github.com/edx/edge-internal/pull/354
https://github.com/edx/edx-internal/pull/5308

The accompanying ticket:
https://openedx.atlassian.net/browse/TNL-8559

Here's a screenshot of the token parameters:
<img width="1792" alt="Screen Shot 2021-07-27 at 2 53 24 PM" src="https://user-images.githubusercontent.com/7285237/127348502-e51a7299-3606-46ba-a20a-12fd65e48e22.png">

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Testing instructions

- Using Chrome 92 (or higher), visit this unit on this sandbox which I've built using this branch and the sandbox-internal branch.
-- https://learning-lti-test.sandbox.edx.org/course/course-v1:edX+DemoX+Demo_Course/block-v1:edX+DemoX+Demo_Course+type@sequential+block@19a30717eff543078a5d94ae9d6c18a5/block-v1:edX+DemoX+Demo_Course+type@vertical+block@7874cede582b465c88890d25b54892ab
- Verify that the `origin-trial` `<meta>` tag exists in the iFrame.
- Click on the "View resource in a new window" button.
- Click through the presented modal with "OK".
- Confirm that a new window/tab is opened to this URL: https://www.tsugi.org/lti-test/tool.php

## Deadline

CAT-2, so ASAP.

## Other information

- This fix is only a temporary workaround! It will only work until around mid-December. A more permanent solution needs to be designed and implemented well before that time.
- A single token is used which works across all edx.org domains, as Google supports the generation of a token that works for all subdomains of a particular origin.
