### PR TITLE
chore: Django3 has removed python_2_unicode_compatible.

### DIFF
--- a/openedx/core/djangoapps/ccxcon/models.py
+++ b/openedx/core/djangoapps/ccxcon/models.py
@@ -4,10 +4,8 @@ Models for the ccxcon
 
 
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 
-@python_2_unicode_compatible
 class CCXCon(models.Model):
     """
     Definition of the CCXCon model.

--- a/openedx/core/djangoapps/content/block_structure/config/models.py
+++ b/openedx/core/djangoapps/content/block_structure/config/models.py
@@ -5,10 +5,8 @@ Models for configuration of Block Structures.
 
 from config_models.models import ConfigurationModel
 from django.db.models import IntegerField
-from django.utils.encoding import python_2_unicode_compatible
 
 
-@python_2_unicode_compatible
 class BlockStructureConfiguration(ConfigurationModel):
     """
     Configuration model for Block Structures.

--- a/openedx/core/djangoapps/content/block_structure/models.py
+++ b/openedx/core/djangoapps/content/block_structure/models.py
@@ -12,7 +12,7 @@ from django.conf import settings
 from django.core.exceptions import SuspiciousOperation
 from django.core.files.base import ContentFile
 from django.db import models, transaction
-from django.utils.encoding import python_2_unicode_compatible
+
 from model_utils.models import TimeStampedModel
 
 from openedx.core.djangoapps.xmodule_django.models import UsageKeyWithRunField
@@ -148,7 +148,6 @@ def _storage_error_handling(bs_model, operation, is_read_operation=False):
             raise
 
 
-@python_2_unicode_compatible
 class BlockStructureModel(TimeStampedModel):
     """
     Model for storing Block Structure information.

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -18,7 +18,7 @@ from django.db.models.fields import (
 from django.db.models.signals import post_save, post_delete
 from django.db.utils import IntegrityError
 from django.template import defaultfilters
-from django.utils.encoding import python_2_unicode_compatible
+
 from django.utils.functional import cached_property
 from model_utils.models import TimeStampedModel
 from opaque_keys.edx.django.models import CourseKeyField, UsageKeyField
@@ -44,7 +44,6 @@ class CourseOverviewCaseMismatchException(Exception):
     pass
 
 
-@python_2_unicode_compatible
 class CourseOverview(TimeStampedModel):
     """
     Model for storing and caching basic information about a course.
@@ -907,7 +906,6 @@ class CourseOverviewTab(models.Model):
         return self.tab_id
 
 
-@python_2_unicode_compatible
 class CourseOverviewImageSet(TimeStampedModel):
     """
     Model for Course overview images. Each column is an image type/size.
@@ -1050,7 +1048,6 @@ class CourseOverviewImageSet(TimeStampedModel):
         )
 
 
-@python_2_unicode_compatible
 class CourseOverviewImageConfig(ConfigurationModel):
     """
     This sets the size of the thumbnail images that Course Overviews will generate
@@ -1086,7 +1083,6 @@ class CourseOverviewImageConfig(ConfigurationModel):
         )
 
 
-@python_2_unicode_compatible
 class SimulateCoursePublishConfig(ConfigurationModel):
     """
     Manages configuration for a run of the simulate_publish management command.

--- a/openedx/core/djangoapps/cors_csrf/models.py
+++ b/openedx/core/djangoapps/cors_csrf/models.py
@@ -3,11 +3,10 @@
 
 from config_models.models import ConfigurationModel
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
+
 from django.utils.translation import ugettext_lazy as _
 
 
-@python_2_unicode_compatible
 class XDomainProxyConfiguration(ConfigurationModel):
     """
     Cross-domain proxy configuration.

--- a/openedx/core/djangoapps/dark_lang/models.py
+++ b/openedx/core/djangoapps/dark_lang/models.py
@@ -5,10 +5,8 @@ Models for the dark-launching languages
 
 from config_models.models import ConfigurationModel
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 
-@python_2_unicode_compatible
 class DarkLangConfig(ConfigurationModel):
     """
     Configuration for the dark_lang django app.

--- a/openedx/core/djangoapps/oauth_dispatch/models.py
+++ b/openedx/core/djangoapps/oauth_dispatch/models.py
@@ -6,7 +6,7 @@ Specialized models for oauth_dispatch djangoapp
 from datetime import datetime
 
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
+
 from django.utils.translation import ugettext_lazy as _
 from django_mysql.models import ListCharField
 from oauth2_provider.settings import oauth2_settings
@@ -17,7 +17,6 @@ from openedx.core.djangolib.markup import HTML
 from openedx.core.lib.request_utils import get_request_or_stub
 
 
-@python_2_unicode_compatible
 class RestrictedApplication(models.Model):
     """
     This model lists which django-oauth-toolkit Applications are considered 'restricted'
@@ -57,7 +56,6 @@ class RestrictedApplication(models.Model):
         return access_token.expires == datetime(1970, 1, 1, tzinfo=utc)
 
 
-@python_2_unicode_compatible
 class ApplicationAccess(models.Model):
     """
     Specifies access control information for the associated Application.
@@ -123,7 +121,6 @@ class ApplicationAccess(models.Model):
         )
 
 
-@python_2_unicode_compatible
 class ApplicationOrganization(models.Model):
     """
     DEPRECATED: Associates a DOT Application to an Organization.

--- a/openedx/core/djangoapps/site_configuration/models.py
+++ b/openedx/core/djangoapps/site_configuration/models.py
@@ -10,14 +10,13 @@ from django.contrib.sites.models import Site
 from django.db import models
 from django.db.models.signals import post_save
 from django.dispatch import receiver
-from django.utils.encoding import python_2_unicode_compatible
+
 from jsonfield.fields import JSONField
 from model_utils.models import TimeStampedModel
 
 logger = getLogger(__name__)  # pylint: disable=invalid-name
 
 
-@python_2_unicode_compatible
 class SiteConfiguration(models.Model):
     """
     Model for storing site configuration. These configuration override OpenEdx configurations and settings.
@@ -158,7 +157,6 @@ def save_siteconfig_without_historical_record(siteconfig, *args, **kwargs):
     return ret
 
 
-@python_2_unicode_compatible
 class SiteConfigurationHistory(TimeStampedModel):
     """
     This is an archive table for SiteConfiguration, so that we can maintain a history of

--- a/openedx/core/djangoapps/verified_track_content/models.py
+++ b/openedx/core/djangoapps/verified_track_content/models.py
@@ -9,7 +9,7 @@ from config_models.models import ConfigurationModel
 from django.db import models
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
-from django.utils.encoding import python_2_unicode_compatible
+
 from django.utils.translation import ugettext_lazy
 from edx_django_utils.cache import RequestCache
 from opaque_keys.edx.django.models import CourseKeyField
@@ -92,7 +92,6 @@ def pre_save_callback(sender, instance, **kwargs):  # pylint: disable=unused-arg
         instance._old_mode = None  # pylint: disable=protected-access
 
 
-@python_2_unicode_compatible
 class VerifiedTrackCohortedCourse(models.Model):
     """
     Tracks which courses have verified track auto-cohorting enabled.

--- a/openedx/core/djangoapps/video_pipeline/models.py
+++ b/openedx/core/djangoapps/video_pipeline/models.py
@@ -5,7 +5,7 @@ Model to hold edx-video-pipeline configurations.
 from config_models.models import ConfigurationModel
 from django.contrib.auth import get_user_model
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
+
 from django.utils.translation import ugettext_lazy as _
 from opaque_keys.edx.django.models import CourseKeyField
 
@@ -51,7 +51,6 @@ class VEMPipelineIntegration(ConfigurationModel):
         return User.objects.get(username=self.service_username)
 
 
-@python_2_unicode_compatible
 class VideoUploadsEnabledByDefault(ConfigurationModel):
     """
     Enables video uploads across the platform.
@@ -102,7 +101,6 @@ class VideoUploadsEnabledByDefault(ConfigurationModel):
         )
 
 
-@python_2_unicode_compatible
 class CourseVideoUploadsEnabledByDefault(ConfigurationModel):
     """
     Enables video uploads for a specific course.


### PR DESCRIPTION
chore: Django3 has removed python_2_unicode_compatible.