### PR TITLE
Revert "chore: bump ora2 version to 3.6.12"

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -684,7 +684,7 @@ oauthlib==3.0.1
     #   social-auth-core
 openedx-calc==2.0.1
     # via -r requirements/edx/base.in
-ora2==3.6.12
+ora2==3.6.11
     # via -r requirements/edx/base.in
 packaging==21.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -893,7 +893,7 @@ oauthlib==3.0.1
     #   social-auth-core
 openedx-calc==2.0.1
     # via -r requirements/edx/testing.txt
-ora2==3.6.12
+ora2==3.6.11
     # via -r requirements/edx/testing.txt
 packaging==21.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -847,7 +847,7 @@ oauthlib==3.0.1
     #   social-auth-core
 openedx-calc==2.0.1
     # via -r requirements/edx/base.txt
-ora2==3.6.12
+ora2==3.6.11
     # via -r requirements/edx/base.txt
 packaging==21.0
     # via


### PR DESCRIPTION
Reverts edx/edx-platform#28306

The generated `json` file cannot be found/disappear.