### PR TITLE
fix: temporary constraint ora2 update

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -97,3 +97,6 @@ click<8.0.0
 
 # jsonfield2 will be replaced with jsonfield in https://openedx.atlassian.net/browse/BOM-1917.
 jsonfield2<3.1.0        # jsonfield2 3.1.0 drops support for python 3.5
+
+# temporary constraint ora update until new deployment ready
+ora2==3.6.11


### PR DESCRIPTION
## Description

There was error on `ora2==3.6.12` that can break the stage/prod. Until it is fix, I will keep the constraint on it for now.
