### PR TITLE
Add an option to enable Badgr notifications

### DIFF
--- a/lms/djangoapps/badges/backends/badgr.py
+++ b/lms/djangoapps/badges/backends/badgr.py
@@ -173,7 +173,8 @@ class BadgrBackend(BadgeBackend):
                 {
                     "url": evidence_url
                 }
-            ]
+            ],
+            "notify": settings.BADGR_ENABLE_NOTIFICATIONS,
         }
         response = requests.post(
             self._assertion_url(badge_class.badgr_server_slug),

--- a/lms/djangoapps/badges/backends/tests/test_badgr_backend.py
+++ b/lms/djangoapps/badges/backends/tests/test_badgr_backend.py
@@ -201,7 +201,8 @@ class BadgrBackendTestCase(ModuleStoreTestCase, EventTrackingTestCase):
         assert assertion.image_url == 'http://www.example.com/example.png'
         assert assertion.assertion_url == 'http://www.example.com/example'
         assert kwargs['json'] == {"recipient": {"identity": 'example@example.com', "type": "email"},
-                                  "evidence": [{"url": 'https://example.com/irrefutable_proof'}]}
+                                  "evidence": [{"url": 'https://example.com/irrefutable_proof'}],
+                                  "notify": False}
         assert_event_matches({
             'name': 'edx.badge.assertion.created',
             'data': {

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3478,6 +3478,16 @@ BADGR_TOKENS_CACHE_KEY = None
 # .. setting_warning: Review FEATURES['ENABLE_OPENBADGES'] for further context.
 BADGR_TIMEOUT = 10
 
+# .. toggle_name: BADGR_ENABLE_NOTIFICATIONS
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Optional setting for enabling email notifications. When set to "True",
+#    learners will be notified by email when they earn a badge.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2021-07-29
+# .. toggle_warnings: Review FEATURES['ENABLE_OPENBADGES'] for further context.
+BADGR_ENABLE_NOTIFICATIONS = False
+
 ###################### Grade Downloads ######################
 # These keys are used for all of our asynchronous downloadable files, including
 # the ones that contain information other than grades.


### PR DESCRIPTION
With Badgr v2 API, notification emails for earning badges are
no longer sent to learners by default. However, the request to
create a badge assertion accepts an optional boolean property
"notify", that can be used to enable/disable email notifications.

Make it configurable by an optional setting `BADGR_ENABLE_NOTIFICATIONS`
(defaults to False).

Doc patch for the setting: https://github.com/edx/edx-documentation/pull/1964