### PR TITLE
chore: Django3 has removed python_2_unicode_compatible.

### DIFF
--- a/openedx/core/djangoapps/content/block_structure/store.py
+++ b/openedx/core/djangoapps/content/block_structure/store.py
@@ -6,7 +6,6 @@ Module for the Storage of BlockStructure objects.
 
 from logging import getLogger
 
-from django.utils.encoding import python_2_unicode_compatible
 
 from openedx.core.lib.cache_utils import zpickle, zunpickle
 
@@ -20,7 +19,6 @@ from .transformer_registry import TransformerRegistry
 logger = getLogger(__name__)  # pylint: disable=C0103
 
 
-@python_2_unicode_compatible
 class StubModel:
     """
     Stub model to use when storage backing is disabled.

--- a/openedx/core/djangoapps/safe_sessions/middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/middleware.py
@@ -78,7 +78,7 @@ from django.core import signing
 from django.http import HttpResponse
 from django.utils.crypto import get_random_string
 from django.utils.deprecation import MiddlewareMixin
-from django.utils.encoding import python_2_unicode_compatible
+
 from edx_django_utils.monitoring import set_custom_attribute
 
 from openedx.core.lib.mobile_utils import is_request_from_mobile_app
@@ -106,7 +106,6 @@ class SafeCookieError(Exception):
         log.error(error_message)
 
 
-@python_2_unicode_compatible
 class SafeCookieData:
     """
     Cookie data that cryptographically binds and timestamps the user

--- a/openedx/core/djangoapps/util/user_utils.py
+++ b/openedx/core/djangoapps/util/user_utils.py
@@ -2,12 +2,9 @@
 Custom user-related utility code.
 """
 
-
-from django.utils.encoding import python_2_unicode_compatible
 from django.contrib.auth.models import AnonymousUser
 
 
-@python_2_unicode_compatible
 class SystemUser(AnonymousUser):
     """
     A User that can act on behalf of system actions, when a user object is

--- a/openedx/features/announcements/models.py
+++ b/openedx/features/announcements/models.py
@@ -4,10 +4,8 @@ Models for Announcements
 
 
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 
-@python_2_unicode_compatible
 class Announcement(models.Model):
     """Site-wide announcements to be displayed on the dashboard"""
     class Meta:

--- a/openedx/features/content_type_gating/models.py
+++ b/openedx/features/content_type_gating/models.py
@@ -5,14 +5,13 @@ Content Type Gating Configuration Models
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils import timezone
-from django.utils.encoding import python_2_unicode_compatible
+
 from django.utils.translation import ugettext_lazy as _
 
 from openedx.core.djangoapps.config_model_utils.models import StackedConfigurationModel
 from openedx.features.content_type_gating.helpers import correct_modes_for_fbe, enrollment_date_for_fbe
 
 
-@python_2_unicode_compatible
 class ContentTypeGatingConfig(StackedConfigurationModel):
     """
     A ConfigurationModel used to manage configuration for Content Type Gating (Feature Based Enrollments).

--- a/openedx/features/course_duration_limits/models.py
+++ b/openedx/features/course_duration_limits/models.py
@@ -5,14 +5,13 @@ Course Duration Limit Configuration Models
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils import timezone
-from django.utils.encoding import python_2_unicode_compatible
+
 from django.utils.translation import ugettext_lazy as _
 
 from openedx.core.djangoapps.config_model_utils.models import StackedConfigurationModel
 from openedx.features.content_type_gating.helpers import correct_modes_for_fbe, enrollment_date_for_fbe
 
 
-@python_2_unicode_compatible
 class CourseDurationLimitConfig(StackedConfigurationModel):
     """
     Configuration to manage the Course Duration Limit facility.

--- a/openedx/features/discounts/models.py
+++ b/openedx/features/discounts/models.py
@@ -6,13 +6,12 @@ DiscountRestrictionConfig Models
 
 
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
+
 from django.utils.translation import ugettext_lazy as _
 
 from openedx.core.djangoapps.config_model_utils.models import StackedConfigurationModel
 
 
-@python_2_unicode_compatible
 class DiscountRestrictionConfig(StackedConfigurationModel):
     """
     A ConfigurationModel used to manage restrictons for lms-controlled discounts
@@ -41,7 +40,6 @@ class DiscountRestrictionConfig(StackedConfigurationModel):
         )
 
 
-@python_2_unicode_compatible
 class DiscountPercentageConfig(StackedConfigurationModel):
     """
     A ConfigurationModel to configure the discount percentage for the first purchase discount


### PR DESCRIPTION
chore: Django3 has removed python_2_unicode_compatible.