### PR TITLE
fix: Handle missing user profile when setting a name in a course cert

### DIFF
--- a/common/djangoapps/student/models_api.py
+++ b/common/djangoapps/student/models_api.py
@@ -52,7 +52,7 @@ def get_course_enrollment(user, course_run_key):
 
 def get_phone_number(user_id):
     """
-    Get a users phone number from the profile, if
+    Get a user's phone number from the profile, if
     one exists. Otherwise, return None.
     """
     try:
@@ -61,6 +61,18 @@ def get_phone_number(user_id):
         log.exception(exception)
         return None
     return student.phone_number or None
+
+
+def get_name(user_id):
+    """
+    Get a user's name from their profile, if one exists. Otherwise, return None.
+    """
+    try:
+        student = _UserProfile.objects.get(user_id=user_id)
+    except _UserProfile.DoesNotExist:
+        log.exception(f'Could not find UserProfile for id {user_id}')
+        return None
+    return student.name or None
 
 
 def get_course_access_role(user, org, course_id, role):

--- a/common/djangoapps/student/tests/test_models.py
+++ b/common/djangoapps/student/tests/test_models.py
@@ -26,8 +26,10 @@ from common.djangoapps.student.models import (
     ManualEnrollmentAudit,
     PendingEmailChange,
     PendingNameChange,
-    UserCelebration
+    UserCelebration,
+    UserProfile
 )
+from common.djangoapps.student.models_api import get_name
 from common.djangoapps.student.tests.factories import AccountRecoveryFactory, CourseEnrollmentFactory, UserFactory
 from lms.djangoapps.courseware.models import DynamicUpgradeDeadlineConfiguration
 from lms.djangoapps.courseware.toggles import (
@@ -728,3 +730,30 @@ class TestUserPostSaveCallback(SharedModuleStoreTestCase):
                 course_enrollment.save()
 
         return user
+
+
+class TestProfile(SharedModuleStoreTestCase):
+    """
+    Tests for the user profile
+    """
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory.create()
+        self.profile = UserProfile.objects.get(user_id=self.user.id)
+        self.name = self.profile.name
+        self.course = CourseFactory.create()
+
+    def test_name(self):
+        """
+        Test retrieval of the name
+        """
+        assert self.name
+        name = get_name(self.user.id)
+        assert name == self.name
+
+    def test_name_missing_profile(self):
+        """
+        Test retrieval of the name when the user profile doesn't exist
+        """
+        name = get_name(None)
+        assert not name

--- a/lms/djangoapps/certificates/generation.py
+++ b/lms/djangoapps/certificates/generation.py
@@ -10,7 +10,7 @@ These methods should be called from tasks.
 import logging
 from uuid import uuid4
 
-from common.djangoapps.student.models import UserProfile
+from common.djangoapps.student import models_api as student_api
 from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.certificates.models import GeneratedCertificate
 from lms.djangoapps.certificates.utils import emit_certificate_event
@@ -66,8 +66,9 @@ def _generate_certificate(user, course_key, status, enrollment_mode, course_grad
     # Retrieve the existing certificate for the learner if it exists
     existing_certificate = GeneratedCertificate.certificate_for_student(user, course_key)
 
-    profile = UserProfile.objects.get(user=user)
-    profile_name = profile.name
+    profile_name = student_api.get_name(user.id)
+    if not profile_name:
+        profile_name = ''
 
     # Retain the `verify_uuid` from an existing certificate if possible, this will make it possible for the learner to
     # keep the existing URL to their certificate


### PR DESCRIPTION
Handle missing user profile when setting a name in a course certificate

MICROBA-1410