### PR TITLE
Re-enable Chrome 92+ iFrame JS dialog/modal creation

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -4682,3 +4682,7 @@ LOGO_URL_PNG = None
 LOGO_TRADEMARK_URL = None
 FAVICON_URL = None
 DEFAULT_EMAIL_LOGO_URL = 'https://edx-cdn.org/v3/default/logo.png'
+
+################# Settings for Chrome-specific origin trials ########
+# Token for " Disable Different Origin Subframe Dialog Suppression" for http://localhost:18000
+CHROME_DISABLE_SUBFRAME_DIALOG_SUPPRESSION_TOKEN = 'ArNBN7d1AkvMhJTGWXlJ8td/AN4lOokzOnqKRNkTnLqaqx0HpfYvmx8JePPs/emKh6O5fckx14LeZIGJ1AQYjgAAAABzeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjE4MDAwIiwiZmVhdHVyZSI6IkRpc2FibGVEaWZmZXJlbnRPcmlnaW5TdWJmcmFtZURpYWxvZ1N1cHByZXNzaW9uIiwiZXhwaXJ5IjoxNjM5NTI2Mzk5fQ=='  # pylint: disable=line-too-long

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -1048,3 +1048,9 @@ LOGO_IMAGE_EXTRA_TEXT = ENV_TOKENS.get('LOGO_IMAGE_EXTRA_TEXT', '')
 
 ############## XBlock extra mixins ############################
 XBLOCK_MIXINS += tuple(XBLOCK_EXTRA_MIXINS)
+
+################# Settings for Chrome-specific origin trials ########
+# Token for "Disable Different Origin Subframe Dialog Suppression" Chrome Origin Trial, which must be origin-specific.
+CHROME_DISABLE_SUBFRAME_DIALOG_SUPPRESSION_TOKEN = ENV_TOKENS.get(
+    'CHROME_DISABLE_SUBFRAME_DIALOG_SUPPRESSION_TOKEN', CHROME_DISABLE_SUBFRAME_DIALOG_SUPPRESSION_TOKEN
+)

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -34,6 +34,7 @@ from common.djangoapps.pipeline_mako import render_require_js_path_overrides
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="origin-trial" content="${settings.CHROME_DISABLE_SUBFRAME_DIALOG_SUPPRESSION_TOKEN}">
 
 ## Define a couple of helper functions to make life easier when
 ## embedding theme conditionals into templates. All inheriting


### PR DESCRIPTION
## Description

Add non-secret token which disables different origin subframe dialog suppression for Chrome version 92. This token is added via `<meta>` tag to the courseware iFrame HTML `<head>` section, which enables the iFrame to retain the ability to summon modals & alerts - or open new windows via JS.

An OpenEdx installation can generate their own token and provide via the `ENV_TOKENS` configuration.

## Supporting information

Details about the origin trial used:
https://developer.chrome.com/origintrials/#/registration/-710583578706051071

Details about Chrome origin trials:
https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md

The accompanying ticket:
https://openedx.atlassian.net/browse/TNL-8559

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Other information

- This fix is only a temporary workaround for Chrome browsers! It will only work until around mid-December. A more permanent solution needs to be designed and implemented well before that time.
