### PR TITLE
fix: display relative due date on limited time assignments (AA-943)

### DIFF
--- a/cms/templates/js/course-outline.underscore
+++ b/cms/templates/js/course-outline.underscore
@@ -235,6 +235,25 @@ if (is_proctored_exam) {
                         <% } %>
                     </p>
                 </div>
+                <% if (course.get('self_paced') && course.get('is_custom_relative_dates_active') && xblockInfo.get('relative_weeks_due')) { %>
+                    <div class="status-grading">
+                        <p>
+                            <span class="icon fa fa-calendar" aria-hidden="true"></span>
+                            <span class="status-custom-grading-date">
+                                <%- edx.StringUtils.interpolate(
+                                        ngettext(
+                                            'Custom due date: {relativeWeeks} week from enrollment',
+                                            'Custom due date: {relativeWeeks} weeks from enrollment',
+                                            xblockInfo.get('relative_weeks_due')),
+                                        {
+                                            relativeWeeks: xblockInfo.get('relative_weeks_due')
+                                        }
+                                    )
+                                %>
+                            </span>
+                        <p>
+                    </div>
+                <% } %>
             <% } else if ((xblockInfo.get('due_date') && !course.get('self_paced')) || xblockInfo.get('graded')) { %>
                 <div class="status-grading">
                     <p>


### PR DESCRIPTION
## Description

After a user puts in a relative due date in a self paced course in Studio, the input value should show up in the outline in the form “Custom due date: x weeks from enrollment”. This text was not shown for assignments with limited time, so this PR fixes the display such that now ALL graded assignment types have custom due dates show up if they exist. 

![image](https://user-images.githubusercontent.com/60379333/127555589-8546ed52-e1e3-437f-be53-bc78ed6a9d82.png)

## Supporting information

[Jira Ticket AA-943](https://openedx.atlassian.net/browse/AA-943) 
