### PR TITLE
WIP: feat: Add feature toggle WARN_BEFORE_SPECIAL_EXAM_UNLOAD

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/sequence/display.js
+++ b/common/lib/xmodule/xmodule/js/src/sequence/display.js
@@ -178,6 +178,18 @@
                 this.updatedProblems[this.position] = {};
             }
 
+            // Update the problem in appropriate sequence contents.
+            var content = this.contents.eq(this.position - 1);
+            var tempEl = $('<div></div>')
+            edx.HtmlUtils.setHtml(tempEl, edx.HtmlUtils.HTML($(content).text()))
+            tempEl
+                .find("[data-problem-id='" + problemId + "']")
+                .attr('data-content', newContentState)
+                .attr('data-problem-score', newState.current_score)
+                .attr('data-problem-total-possible', newState.total_possible)
+                .attr('data-attempts-used', newState.attempts_used);
+            this.contents.eq(this.position - 1).text(tempEl.html())
+
             // Now, put problem content and score against problem id for current active sequence.
             this.updatedProblems[this.position][problemId] = [newContentState, newState];
         };

--- a/common/lib/xmodule/xmodule/js/src/sequence/special_exam.js
+++ b/common/lib/xmodule/xmodule/js/src/sequence/special_exam.js
@@ -1,0 +1,26 @@
+(function(){
+	window.onbeforeunload = function(event){
+        /*
+        Check if there are any unattempted problem in the sequence and
+        show a window unload popup if there is.
+        */
+        var unattempted_problems = []
+        var contents = $('.seq_contents')
+        contents.each(function(idx) {
+            var tempEl = $('<div></div>')
+            // load the content of sequence in a temporary element
+            edx.HtmlUtils.setHtml(tempEl, edx.HtmlUtils.HTML($(this).text()))
+            var problems = $('.problems-wrapper', tempEl)
+            problems.each(function(index) {
+                var el = $(this)
+                if (el.data('graded') && el.data('attempts-used') === 0) {
+                    unattempted_problems.push(el)
+                }
+            })
+        })
+        if (unattempted_problems.length > 0) {
+            event.preventDefault();
+            return "You have unattempted question? Are you sure you want to leave?"
+        }
+	}
+})();

--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -11,6 +11,7 @@ import logging
 from datetime import datetime
 from functools import reduce
 
+from django.conf import settings
 from lxml import etree
 from opaque_keys.edx.keys import UsageKey
 from pkg_resources import resource_string
@@ -584,6 +585,14 @@ class SequenceBlock(
 
         add_webpack_to_fragment(fragment, 'SequenceBlockPreview')
         shim_xmodule_js(fragment, 'Sequence')
+
+        if (
+            settings.FEATURES.get('WARN_BEFORE_SPECIAL_EXAM_UNLOAD', False)
+            and self.is_timed_exam
+            and view == STUDENT_VIEW
+        ):
+            fragment.add_javascript(resource_string(__name__, 'js/src/sequence/special_exam.js').decode('utf-8'))
+
         return fragment
 
     def _get_gated_content_info(self, prereq_met, prereq_meta_info):

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -947,6 +947,16 @@ FEATURES = {
     # .. toggle_target_removal_date: 2021-10-01
     # .. toggle_tickets: 'https://openedx.atlassian.net/browse/MICROBA-1405'
     'ENABLE_V2_CERT_DISPLAY_SETTINGS': False,
+
+    # .. toggle_name: FEATURES['WARN_BEFORE_SPECIAL_EXAM_UNLOAD']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Set to True to show window unload popup on special exam if
+    #   all problems are not attempted.
+    # .. toggle_use_cases: opt_in
+    # .. toggle_creation_date: 2021-07-30
+    # .. toggle_tickets: 'https://github.com/edx/edx-platform/pull/28325'
+    'WARN_BEFORE_SPECIAL_EXAM_UNLOAD': False,
 }
 
 # Specifies extra XBlock fields that should available when requested via the Course Blocks API


### PR DESCRIPTION
## Description

In some cases, users forget to press the "Submit" button under each problem (they only mark the answers) or press only the last one. This PR aims to add a check on `window.onbeforeunload` to check if all the problems in the exam are attempted. This feature is put behind the `WARN_BEFORE_SPECIAL_EXAM_UNLOAD` feature flag.

## Related Tickets

- [BB-4501](https://tasks.opencraft.com/browse/BB-4501)

## Testing instructions

1. [Enable Timed Exam](https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/enable_timed_exams.html#enable-timed-exams)
2. Add `FEATURES['WARN_BEFORE_SPECIAL_EXAM_UNLOAD'] = True` to `envs/private.py`.
1. Open studio and create a library with some questions
2. Open [demonstration course Advanced Settings](http://localhost:18010/settings/advanced/course-v1:edX+DemoX+Demo_Course) in studio and add `library_content` to `Advanced Module List`
3. Set `Enable Timed Exams` to `true`
4. Add a new section and unit with Randomized Content Block and select the library created above as the source.
5. Add more units and problems to the subsection.
5. [Offer the section as a timed exam](https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_features/timed_exams.html) and publish.
6. Visit the section in LMS and do some activity
7. Try reloading the page.
8. It should show a confirmation dialog. Note: that the dialog will not show if you have not performed any action on the page. Try clicking and scrolling on the page to register user activity with the browser.

