### PR TITLE
feat: Supply documentaion links for course apps from the backend [BD-38] [TNL-8446] [BB-4462]

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2452,3 +2452,14 @@ COURSE_OLX_VALIDATION_IGNORE_LIST = None
 ################# show account activate cta after register ########################
 SHOW_ACTIVATE_CTA_POPUP_COOKIE_NAME = 'show-account-activation-popup'
 SHOW_ACCOUNT_ACTIVATION_CTA = False
+
+################# Documentation links for course apps #################
+
+# pylint: disable=line-too-long
+CALCULATOR_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/exercises_tools/calculator.html"
+DISCUSSIONS_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_components/create_discussion.html"
+EDXNOTES_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/exercises_tools/notes.html"
+PROGRESS_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_assets/pages.html?highlight=progress#hiding-or-showing-the-wiki-or-progress-pages"
+TEAMS_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_features/teams/teams_setup.html"
+TEXTBOOKS_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_assets/textbooks.html"
+WIKI_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_assets/course_wiki.html"

--- a/lms/djangoapps/course_wiki/plugins/__init__.py
+++ b/lms/djangoapps/course_wiki/plugins/__init__.py
@@ -25,6 +25,9 @@ class WikiCourseApp(CourseApp):
     app_id = "wiki"
     name = _("Wiki")
     description = _("Enable learners to access, and collaborate on course related information.")
+    documentation_links = {
+        "learn_more_configuration": settings.WIKI_HELP_URL,
+    }
 
     @classmethod
     def is_available(cls, course_key: CourseKey) -> bool:  # pylint: disable=unused-argument

--- a/lms/djangoapps/courseware/plugins.py
+++ b/lms/djangoapps/courseware/plugins.py
@@ -25,6 +25,9 @@ class ProgressCourseApp(CourseApp):
     app_id = "progress"
     name = _("Progress")
     description = _("Keep learners engaged and on track throughout the course.")
+    documentation_links = {
+        "learn_more_configuration": settings.PROGRESS_HELP_URL,
+    }
 
     @classmethod
     def is_available(cls, course_key: CourseKey) -> bool:
@@ -69,6 +72,9 @@ class TextbooksCourseApp(CourseApp):
     app_id = "textbooks"
     name = _("Textbooks")
     description = _("Create and manage a library of course readings, textbooks, and chapters.")
+    documentation_links = {
+        "learn_more_configuration": settings.TEXTBOOKS_HELP_URL,
+    }
 
     @classmethod
     def is_available(cls, course_key: CourseKey) -> bool:  # pylint: disable=unused-argument
@@ -117,6 +123,9 @@ class CalculatorCourseApp(CourseApp):
     app_id = "calculator"
     name = _("Calculator")
     description = _("Provide an in-course calculator for simple and complex calculations.")
+    documentation_links = {
+        "learn_more_configuration": settings.CALCULATOR_HELP_URL,
+    }
 
     @classmethod
     def is_available(cls, course_key: CourseKey) -> bool:

--- a/lms/djangoapps/edxnotes/plugins.py
+++ b/lms/djangoapps/edxnotes/plugins.py
@@ -54,6 +54,9 @@ class EdxNotesCourseApp(CourseApp):
     app_id = "edxnotes"
     name = _("Notes")
     description = _("Allow learners to highlight passages and make notes right in the course.")
+    documentation_links = {
+        "learn_more_configuration": settings.EDXNOTES_HELP_URL,
+    }
 
     @classmethod
     def is_available(cls, course_key: CourseKey) -> bool:  # pylint: disable=unused-argument

--- a/lms/djangoapps/teams/plugins.py
+++ b/lms/djangoapps/teams/plugins.py
@@ -48,6 +48,9 @@ class TeamsCourseApp(CourseApp):
     app_id = "teams"
     name = _("Teams")
     description = _("Leverage teams to allow learners to connect by topic of interest.")
+    documentation_links = {
+        "learn_more_configuration": settings.TEAMS_HELP_URL,
+    }
 
     @classmethod
     def is_available(cls, course_key: CourseKey) -> bool:

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -4785,3 +4785,14 @@ SHOW_ACCOUNT_ACTIVATION_CTA = False
 ################# Settings for Chrome-specific origin trials ########
 # Token for " Disable Different Origin Subframe Dialog Suppression" for http://localhost:18000
 CHROME_DISABLE_SUBFRAME_DIALOG_SUPPRESSION_TOKEN = 'ArNBN7d1AkvMhJTGWXlJ8td/AN4lOokzOnqKRNkTnLqaqx0HpfYvmx8JePPs/emKh6O5fckx14LeZIGJ1AQYjgAAAABzeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjE4MDAwIiwiZmVhdHVyZSI6IkRpc2FibGVEaWZmZXJlbnRPcmlnaW5TdWJmcmFtZURpYWxvZ1N1cHByZXNzaW9uIiwiZXhwaXJ5IjoxNjM5NTI2Mzk5fQ=='  # pylint: disable=line-too-long
+
+################# Documentation links for course apps #################
+
+# pylint: disable=line-too-long
+CALCULATOR_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/exercises_tools/calculator.html"
+DISCUSSIONS_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_components/create_discussion.html"
+EDXNOTES_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/exercises_tools/notes.html"
+PROGRESS_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_assets/pages.html?highlight=progress#hiding-or-showing-the-wiki-or-progress-pages"
+TEAMS_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_features/teams/teams_setup.html"
+TEXTBOOKS_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_assets/textbooks.html"
+WIKI_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_assets/course_wiki.html"

--- a/openedx/core/djangoapps/course_apps/plugins.py
+++ b/openedx/core/djangoapps/course_apps/plugins.py
@@ -23,6 +23,11 @@ class CourseApp(ABC):
     name: str = ""
     # A description for the app.
     description: str = ""
+    # A map of documentation links for the app
+    documentation_links: Dict = {
+        # eg:
+        # "learn_more_configuration": "https://..."
+    }
 
     @classmethod
     @abstractmethod

--- a/openedx/core/djangoapps/course_apps/rest_api/v1/views.py
+++ b/openedx/core/djangoapps/course_apps/rest_api/v1/views.py
@@ -51,6 +51,7 @@ class CourseAppSerializer(serializers.Serializer):  # pylint: disable=abstract-m
     name = serializers.CharField(read_only=True, help_text="Friendly name of the course app.")
     description = serializers.CharField(read_only=True, help_text="A friendly description of what the course app does.")
     legacy_link = serializers.URLField(required=False, help_text="A link to the course app in the legacy studio view.")
+    documentation_links = serializers.JSONField(required=True)
     allowed_operations = serializers.DictField(
         read_only=True,
         help_text="What all operations are supported by the app.",
@@ -65,6 +66,7 @@ class CourseAppSerializer(serializers.Serializer):  # pylint: disable=abstract-m
             "name": instance.name,
             "description": instance.description,
             "allowed_operations": instance.get_allowed_operations(course_key, request.user),
+            "documentation_links": instance.documentation_links,
         }
         if hasattr(instance, "legacy_link"):
             data["legacy_link"] = request.build_absolute_uri(instance.legacy_link(course_key))

--- a/openedx/core/djangoapps/discussions/plugins.py
+++ b/openedx/core/djangoapps/discussions/plugins.py
@@ -3,6 +3,7 @@ Course app configuration for discussions.
 """
 from typing import Dict, Optional
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.utils.translation import ugettext_noop as _
 from opaque_keys.edx.keys import CourseKey
@@ -21,6 +22,9 @@ class DiscussionCourseApp(CourseApp):
     app_id = "discussion"
     name = _("Discussion")
     description = _("Encourage participation and engagement in your course with discussions.")
+    documentation_links = {
+        "learn_more_configuration": settings.DISCUSSIONS_HELP_URL,
+    }
 
     @classmethod
     def is_available(cls, course_key: CourseKey) -> bool:


### PR DESCRIPTION
Instead of hard-coding the "Learn More" and potentially other links for course apps in the course authoring  MFEs this change loads those URLs from the Django settings as part of each individual course app.

**JIRA tickets**: TNL-8446

**Dependencies**: None

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: "None" 

**Testing instructions**:

1. Check the course apps API at <CMS>/api/course_apps/v1/apps/{course_id}
2. It should now include a new entry called "documentation_links" with a learn more link at "learn_more_configuration"
3. If you change the relevant djangos setting, the value should be updated in the API. 

**Reviewers**
- [ ] @arjunsinghy96 
- [ ] edX reviewer[s] TBD