### PR TITLE
fix: wrong start date is displayed in susbection modal

### DIFF
--- a/cms/static/js/spec/views/pages/course_outline_spec.js
+++ b/cms/static/js/spec/views/pages/course_outline_spec.js
@@ -2132,6 +2132,7 @@ describe('CourseOutlinePage', function() {
                 ]);
                 createCourseOutlinePage(this, mockCourseJSON, false);
                 setSelfPacedCustomPLS();
+                course.set('start', '2014-07-09T00:00:00Z');
             });
 
             setEditModalValuesForCustomPacing = function(grading_type, due_in) {
@@ -2149,7 +2150,6 @@ describe('CourseOutlinePage', function() {
                 createMockSubsectionJSON({
                     graded: true,
                     relative_weeks_due: 3,
-                    start: '2014-07-09T00:00:00Z',
                     format: 'Lab',
                     has_explicit_staff_lock: true,
                     staff_only_message: true,

--- a/cms/static/js/views/modals/course_outline_modals.js
+++ b/cms/static/js/views/modals/course_outline_modals.js
@@ -404,8 +404,8 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
         },
 
         showProjectedDate: function() {
-            if (!this.getValue()) return;
-            var startDate = new Date(this.model.get('start'));
+            if (!this.getValue() || !course.get('start')) return;
+            var startDate = new Date(course.get('start'));
             // The value returned by toUTCString() is a string in the form Www, dd Mmm yyyy hh:mm:ss GMT
             var startDateList = startDate.toUTCString().split(' ')
             // This text will look like Mmm dd, yyyy (i.e. Jul 26, 2021)
@@ -430,9 +430,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
             else {
                 this.$('#relative_weeks_due_warning_max').hide();
                 this.$('#relative_weeks_due_warning_min').hide();
-                if (this.model.get('start')){
-                    this.showProjectedDate();
-                }
+                this.showProjectedDate();
                 BaseModal.prototype.enableActionButton.call(this.parent, 'save');
             }
         },
@@ -447,9 +445,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
             }
             this.$('.field-due-in input').val(this.model.get('relative_weeks_due'));
             this.$('#relative_weeks_due_projected').hide();
-            if (this.getValue() && this.model.get('start')){
-                this.showProjectedDate();
-            }
+            this.showProjectedDate();
         },
 
         getRequestData: function() {

--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -157,7 +157,8 @@ from openedx.core.release import RELEASE_LINE
           display_course_number: "${context_course.display_coursenumber | n, js_escaped_string}",
           revision: "${context_course.location.branch | n, js_escaped_string}",
           self_paced: ${ context_course.self_paced | n, dump_js_escaped_json },
-          is_custom_relative_dates_active: ${CUSTOM_RELATIVE_DATES.is_enabled(context_course.id) | n, dump_js_escaped_json}
+          is_custom_relative_dates_active: ${CUSTOM_RELATIVE_DATES.is_enabled(context_course.id) | n, dump_js_escaped_json},
+          start: ${context_course.start | n, dump_js_escaped_json}
         });
       </script>
     % endif


### PR DESCRIPTION
## Description

The configuration settings for a subsection shows the projected date after the user submits an input for the relative date: 
“If a learner starts on {startDate}, this subsection will be due on {projectedDate}”
In production, there seems to be courses where the start date is not equivalent to the actual course’s start date. 

![image](https://user-images.githubusercontent.com/60379333/127676930-46f0d1ed-533c-4656-87fc-2e93721f0543.png)

This PR attempts to fix this bug by passing down the start date as one of course's attributes and using that attribute instead of the xblock's start date attribute. 

## Supporting information

[Jira Ticket AA-945](https://openedx.atlassian.net/browse/AA-945)
