### PR TITLE
refactor!: Remove `generate_example_certificates` and update Instructor Dashboard with updated messaging.

### DIFF
--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -351,33 +351,6 @@ def cert_generation_enabled(course_key):
     )
 
 
-def generate_example_certificates(course_key):
-    """Generate example (PDF) certificates for a course.
-
-    Example certificates were used to validate that certificates were configured correctly for the course.  Staff
-    members could view the example certificates before enabling the self-generated certificates button for students.
-
-    [07/20/2021 Update]
-    This function was updated to remove the references to queue.py, which has been removed as part of MICROBA-1227, and
-    no longer can fulfill the function it was originally created for. There is further cleanup around PDF certificate
-    generation code, part of DEPR-155, that will remove this function. See DEPR-155 and MICROBA-1094 for additional
-    info.
-
-    It may be important to note that this functionality has been broken since 2018 when the ability to generate PDF
-    certificates was ripped out of edx-platform. This will be removed as part of MICROBA-1394.
-
-    Arguments:
-        course_key (CourseKey): The course identifier.
-
-    Returns:
-        None
-    """
-    log.warning(
-        "Generating example certificates is no longer supported. Skipping generation of example certificates for "
-        f"course {course_key}"
-    )
-
-
 def example_certificates_status(course_key):
     """Check the status of example certificates for a course.
 

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -2825,23 +2825,6 @@ def _instructor_dash_url(course_key, section=None):
     return url
 
 
-@require_global_staff
-@require_POST
-def generate_example_certificates(request, course_id=None):
-    """Start generating a set of example certificates.
-
-    Example certificates are used to verify that certificates have
-    been configured correctly for the course.
-
-    Redirects back to the instructor dashboard once certificate
-    generation has begun.
-
-    """
-    course_key = CourseKey.from_string(course_id)
-    certs_api.generate_example_certificates(course_key)
-    return redirect(_instructor_dash_url(course_key, section='certificates'))
-
-
 @require_course_permission(permissions.ENABLE_CERTIFICATE_GENERATION)
 @require_POST
 def enable_certificate_generation(request, course_id=None):

--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -79,7 +79,6 @@ urlpatterns = [
     url(r'^add_users_to_cohorts$', api.add_users_to_cohorts, name='add_users_to_cohorts'),
 
     # Certificates
-    url(r'^generate_example_certificates$', api.generate_example_certificates, name='generate_example_certificates'),
     url(r'^enable_certificate_generation$', api.enable_certificate_generation, name='enable_certificate_generation'),
     url(r'^start_certificate_generation', api.start_certificate_generation, name='start_certificate_generation'),
     url(r'^start_certificate_regeneration', api.start_certificate_regeneration, name='start_certificate_regeneration'),

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -342,10 +342,6 @@ def _section_certificates(course):
         'certificate_generation_history':
             CertificateGenerationHistory.objects.filter(course_id=course.id).order_by("-created"),
         'urls': {
-            'generate_example_certificates': reverse(
-                'generate_example_certificates',
-                kwargs={'course_id': course.id}
-            ),
             'enable_certificate_generation': reverse(
                 'enable_certificate_generation',
                 kwargs={'course_id': course.id}

--- a/lms/templates/instructor/instructor_dashboard_2/certificates.html
+++ b/lms/templates/instructor/instructor_dashboard_2/certificates.html
@@ -21,12 +21,15 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
         <h3 class="hd hd-3">${_('Example Certificates')}</h3>
 
         <div class="generate-example-certificates-wrapper">
-            <p>${_('Generate example certificates for the course.')}</p>
-
-            <form id="generate-example-certificates-form" method="post" action="${section_data['urls']['generate_example_certificates']}">
-                <input type="hidden" name="csrfmiddlewaretoken" value="${csrf_token}">
-                <input type="submit" class="btn-blue" id="generate-example-certificates-submit" value="${_('Generate Example Certificates')}"/>
-            </form>
+            <p class="under-heading">
+                ${_('This course is configured to generate PDF certificates and this certificate type is no longer supported. Example certificates cannot be generated.')}
+            </p>
+            <!--
+            The endpoint called to generate example certificates has been removed. The form that previously called this endpoint has been
+            replaced with a (permanently disabled) button. Further cleanup of the Instructor Dashboard will be handled in MICROBA-1415
+            (as part of DEPR-157 and the MICROBA-1265 Epic that will remove the remaining PDF certificate viewing code in edx-platform).
+            -->
+            <button class="is-disabled">${_('Generate Example Certificates')}</button>
         </div>
         % endif
 
@@ -68,7 +71,9 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
                 <input type="submit" class="btn-blue" id="enable-certificates-submit" value="${_('Enable Student-Generated Certificates')}"/>
             </form>
         % else:
-            <p>${_("You must successfully generate example certificates before you enable student-generated certificates.")}</p>
+            <p class="under-heading">
+                ${_("You must successfully generate example certificates before you enable student-generated certificates.")}
+            </p>
             <button class="is-disabled" disabled>${_('Enable Student-Generated Certificates')}</button>
         % endif
     </div>


### PR DESCRIPTION
## Description

[MICROBA-1087]
[DEPR-155]

* Remove `generate_example_certificates` functionality
* Adjust Instructor dashboard slightly to prevent people from clicking the `Generate Example Certificates` button, remove form/code that called the `generate_example_certificates` endpoint.

The proposed changes to the instructor dashboard is a bandaid and this page could benefit from a re-design. I thought the band-aid is appropriate for now as:
* we still have courses that are configured to use PDF certificates (even if the ability to update/generate them has been ripped out of edx-platform for years),
* this page of the Instructor Dashboard is internally facing only, and
* HTML certificates are enabled by default for courses and I doubt few people will see these options 

Since we have a longer tail of supporting the viewing of PDF certificates, I didn't want to rip out all the PDF pieces now. The JIRA Epic that will continue the cleanup and deprecation of PDF certificate viewing is MICROBA-1265. Additional cleanup of the Instructor Dashboard will be considered in MICROBA-1415.

Before:
![image](https://user-images.githubusercontent.com/3229735/127700205-71b2b1ee-7dcc-4271-a82e-2ec779232808.png)

After:
![image](https://user-images.githubusercontent.com/3229735/127700239-52bb7d4f-7e48-4187-a89b-846a6fd27dc3.png)

**There are no visual changes to courses configured to use HTML certificates.**

[MICROBA-1087]: https://openedx.atlassian.net/browse/MICROBA-1087
[DEPR-155]: https://openedx.atlassian.net/browse/DEPR-155