### PR TITLE
Use integer user IDs consistently for modulestore APIs/tests

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_courseware_index.py
+++ b/cms/djangoapps/contentstore/tests/test_courseware_index.py
@@ -320,7 +320,7 @@ class TestCoursewareSearchIndexer(MixedWithOptionsTestCase):
         self.assertEqual(response["total"], 1)
 
         # delete the course and look course in search_index
-        modulestore().delete_course(self.course.id, self.user_id)
+        modulestore().delete_course(self.course.id, ModuleStoreEnum.UserID.test)
         self.assertIsNone(modulestore().get_course(self.course.id))
         response = self.search()
         self.assertEqual(response["total"], 0)

--- a/cms/djangoapps/contentstore/tests/test_crud.py
+++ b/cms/djangoapps/contentstore/tests/test_crud.py
@@ -54,7 +54,7 @@ class TemplateTests(ModuleStoreTestCase):
             course='course',
             run='2014',
             display_name='fun test course',
-            user_id='testbot'
+            user_id=ModuleStoreEnum.UserID.test,
         )
         self.assertIsInstance(test_course, CourseBlock)
         self.assertEqual(test_course.display_name, 'fun test course')
@@ -79,7 +79,7 @@ class TemplateTests(ModuleStoreTestCase):
                 course='course',
                 run='2014',
                 display_name='fun test course',
-                user_id='testbot'
+                user_id=ModuleStoreEnum.UserID.test,
             )
 
     def test_temporary_xblocks(self):
@@ -88,7 +88,7 @@ class TemplateTests(ModuleStoreTestCase):
         """
         test_course = CourseFactory.create(
             course='course', run='2014', org='testx',
-            display_name='fun test course', user_id='testbot'
+            display_name='fun test course', user_id=ModuleStoreEnum.UserID.test,
         )
 
         test_chapter = self.store.create_xblock(
@@ -117,7 +117,8 @@ class TemplateTests(ModuleStoreTestCase):
             course='history',
             run='doomed',
             display_name='doomed test course',
-            user_id='testbot')
+            user_id=ModuleStoreEnum.UserID.test,
+        )
         ItemFactory.create(
             parent_location=test_course.location,
             category='chapter',
@@ -131,7 +132,7 @@ class TemplateTests(ModuleStoreTestCase):
         # guid_locator = test_course.location.course_agnostic()
         # Verify it can be retrieved by guid
         # self.assertIsInstance(self.store.get_item(guid_locator), CourseBlock)
-        self.store.delete_course(id_locator, 'testbot')
+        self.store.delete_course(id_locator, ModuleStoreEnum.UserID.test)
         # Test can no longer retrieve by id.
         self.assertIsNone(self.store.get_course(id_locator))
         # But can retrieve by guid -- same TODO as above

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_cross_modulestore_import_export.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_cross_modulestore_import_export.py
@@ -23,6 +23,7 @@ import ddt
 from path import Path as path
 
 from openedx.core.lib.tests import attr
+from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.utils import (
     CONTENTSTORE_SETUPS,
     MODULESTORE_SETUPS,
@@ -86,7 +87,7 @@ class CrossStoreXMLRoundtrip(CourseComparisonTest, PartitionTestCase):
 
                         import_course_from_xml(
                             source_store,
-                            'test_user',
+                            ModuleStoreEnum.UserID.test,
                             TEST_DATA_DIR,
                             source_dirs=[course_data_name],
                             static_content_store=source_content,
@@ -105,7 +106,7 @@ class CrossStoreXMLRoundtrip(CourseComparisonTest, PartitionTestCase):
 
                         import_course_from_xml(
                             dest_store,
-                            'test_user',
+                            ModuleStoreEnum.UserID.test,
                             self.export_dir,
                             source_dirs=[EXPORTED_COURSE_DIR_NAME],
                             static_content_store=dest_content,
@@ -169,7 +170,7 @@ class CrossStoreXMLRoundtrip(CourseComparisonTest, PartitionTestCase):
 
                         import_course_from_xml(
                             source_store,
-                            'test_user',
+                            ModuleStoreEnum.UserID.test,
                             TEST_DATA_DIR,
                             source_dirs=['split_course_with_static_tabs'],
                             static_content_store=source_content,
@@ -197,7 +198,7 @@ class CrossStoreXMLRoundtrip(CourseComparisonTest, PartitionTestCase):
 
                         import_course_from_xml(
                             dest_store,
-                            'test_user',
+                            ModuleStoreEnum.UserID.test,
                             self.export_dir,
                             source_dirs=[EXPORTED_COURSE_DIR_NAME],
                             static_content_store=dest_content,

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mongo_call_count.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mongo_call_count.py
@@ -11,6 +11,7 @@ from unittest import skip
 import ddt
 from django.test import TestCase  # lint-amnesty, pylint: disable=reimported
 
+from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.factories import check_mongo_calls
 from xmodule.modulestore.tests.utils import (
     TEST_DATA_DIR,
@@ -55,7 +56,7 @@ class CountMongoCallsXMLRoundtrip(TestCase):
                 with check_mongo_calls(import_reads, first_import_writes):
                     import_course_from_xml(
                         source_store,
-                        'test_user',
+                        ModuleStoreEnum.UserID.test,
                         TEST_DATA_DIR,
                         source_dirs=['manual-testing-complete'],
                         static_content_store=source_content,
@@ -76,7 +77,7 @@ class CountMongoCallsXMLRoundtrip(TestCase):
                 with check_mongo_calls(import_reads, second_import_writes):
                     import_course_from_xml(
                         dest_store,
-                        'test_user',
+                        ModuleStoreEnum.UserID.test,
                         self.export_dir,
                         source_dirs=['exported_source_course'],
                         static_content_store=dest_content,
@@ -123,7 +124,7 @@ class CountMongoCallsCourseTraversal(TestCase):
         course_key = modulestore.make_course_key('a', 'course', 'course')
         import_course_from_xml(
             modulestore,
-            'test_user',
+            ModuleStoreEnum.UserID.test,
             TEST_DATA_DIR,
             source_dirs=['manual-testing-complete'],
             static_content_store=content_store,


### PR DESCRIPTION
## Description

Some actions in split modulestore record the user ID who requested the action. Currently, split modulestore doesn't care what data type you use for those user IDs. Most of the codebase uses integers, but some tests use username or email address strings.

My PR https://github.com/edx/edx-platform/pull/27565 moves split modulestore's "course index" data from MongoDB into MySQL. In doing so, it requires that user IDs are always numeric. So this PR paves the way for that one by using numeric IDs consistently in all test cases. I believe the actual non-test code was already consistently using integer IDs.

Roles impacted: Developers

## Testing instructions

Shouldn't need any testing beyond ensuring that the tests are passing.

## Deadline

None
