### PR TITLE
feat: Adds a new flag for discussions LTI configuration for admin only config [BD-38] [TNL-8442]

### DIFF
--- a/openedx/core/djangoapps/discussions/models.py
+++ b/openedx/core/djangoapps/discussions/models.py
@@ -162,7 +162,8 @@ AVAILABLE_PROVIDER_MAP = {
             contact_email='learnmore@yellowdig.com',
         )._asdict(),
         'messages': [pii_sharing_required_message('Yellowdig')],
-        'has_full_support': False
+        'has_full_support': False,
+        'admin_only_config': True,
     },
     'inscribe': {
         'features': [


### PR DESCRIPTION
Some providers need special considerations when being set up so should only be configured by people with global staff privileges. This adds an admin_only_config flag to such providers (only YellowDig for now).

**JIRA tickets**: TNL-8442

**Screenshots**: https://github.com/edx/frontend-app-course-authoring/pull/176

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: "None"

**Testing instructions**:

See: https://github.com/edx/frontend-app-course-authoring/pull/176

**Reviewers**
- [ ] (OpenCraft internal reviewer's GitHub username goes here)
- [ ] edX reviewer[s] TBD

**Settings**
```yaml

```
