### PR TITLE
chore: Executed codemods on openedx module

### DIFF
--- a/openedx/core/lib/teams_config.py
+++ b/openedx/core/lib/teams_config.py
@@ -27,7 +27,7 @@ class TeamsConfig:  # pylint: disable=eq-without-hash
         """
         self._data = data if isinstance(data, dict) else {}
 
-    def __unicode__(self):
+    def __str__(self):
         """
         Return user-friendly string.
 

--- a/openedx/features/course_bookmarks/views/course_bookmarks.py
+++ b/openedx/features/course_bookmarks/views/course_bookmarks.py
@@ -4,7 +4,7 @@ Views to show a course's bookmarks.
 
 
 from django.contrib.auth.decorators import login_required
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.template.context_processors import csrf
 from django.template.loader import render_to_string
 from django.urls import reverse
@@ -57,7 +57,7 @@ class CourseBookmarksView(View):
             'disable_courseware_js': True,
             'uses_bootstrap': True,
         }
-        return render_to_response('course_bookmarks/course-bookmarks.html', context)
+        return render(request, 'course_bookmarks/course-bookmarks.html', context)
 
 
 class CourseBookmarksFragmentView(EdxFragmentView):


### PR DESCRIPTION
Need to execute codemods for Django 3.2 upgrade. Executed the following codemods:

- replace_render_to_response
- script_to_replace_static
- replace_unicode_with_str

JIRA: https://openedx.atlassian.net/browse/BOM-2655