### PR TITLE
fix: Fix translation string for studio settings

### DIFF
--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -276,22 +276,22 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url | n, js_escaped_string}'
                     <div id="certificate-display-behavior-collapsible-trigger" class="collapsible-trigger" role="button" tabindex="0" aria-expanded="false">
                       <span>
                         <span class="icon icon-inline fa fa-info-circle" aria-hidden="true"></span>
-                        {_("Read more about this setting")}
+                        ${_("Read more about this setting")}
                       </span>
                     </div>
                     <div id="certificate-display-behavior-collapsible-content" class="collapsible-content collapsed">
-                      <p>{_("In all configurations of this setting, certificates are generated for learners as soon as they achieve the passing threshold in the course (which can occur before a final assignment based on course design)")}</p>
+                      <p>${_("In all configurations of this setting, certificates are generated for learners as soon as they achieve the passing threshold in the course (which can occur before a final assignment based on course design)")}</p>
                       <div>
-                        <div class="collapsible-description-heading">{_("Immediately upon passing")}</div>
-                        <div class="collapsible-description-description">{_("Learners can access their certificate as soon as they achieve a passing grade above the course grade threshold. Note: learners can achieve a passing grade before encountering all assignments in some course configurations.")}</div>
+                        <div class="collapsible-description-heading">${_("Immediately upon passing")}</div>
+                        <div class="collapsible-description-description">${_("Learners can access their certificate as soon as they achieve a passing grade above the course grade threshold. Note: learners can achieve a passing grade before encountering all assignments in some course configurations.")}</div>
                       </div>
                       <div>
-                        <div class="collapsible-description-heading">{_("On course end date")}</div>
-                        <div class="collapsible-description-description">{_("Learners with passing grades can access their certificate once the end date of the course has elapsed.")}</div>
+                        <div class="collapsible-description-heading">${_("On course end date")}</div>
+                        <div class="collapsible-description-description">${_("Learners with passing grades can access their certificate once the end date of the course has elapsed.")}</div>
                       </div>
                       <div>
-                        <div class="collapsible-description-heading">{_("A date after the course end date")}</div>
-                        <div class="collapsible-description-description">{_("Learners with passing grades can access their certificate after the date that you set has elapsed.")}</div>
+                        <div class="collapsible-description-heading">${_("A date after the course end date")}</div>
+                        <div class="collapsible-description-description">${_("Learners with passing grades can access their certificate after the date that you set has elapsed.")}</div>
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This fixes the translations strings for the new studio certificate settings. I missed the $ causing them to show up like:
![image](https://user-images.githubusercontent.com/6179874/127900947-7b6b32ae-0a8f-487b-b755-ad0e26f6777d.png)

## Supporting information

Original PR: https://github.com/edx/edx-platform/pull/28286

