### PR TITLE
Add audit_access_deadline to context and connect Value Prop Track Selection template

### DIFF
--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -35,6 +35,7 @@ from openedx.core.djangoapps.embargo import api as embargo_api
 from openedx.core.djangoapps.enrollments.permissions import ENROLL_IN_COURSE
 from openedx.features.content_type_gating.models import ContentTypeGatingConfig
 from openedx.features.course_duration_limits.models import CourseDurationLimitConfig
+from openedx.features.course_duration_limits.access import get_user_course_duration, get_user_course_expiration_date
 from openedx.features.enterprise_support.api import enterprise_customer_for_request
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.util.db import outer_atomic
@@ -233,6 +234,10 @@ class ChooseModeView(View):
                     context['currency_data'] = json.dumps(currency_data)
                 except TypeError:
                     pass
+
+        duration = get_user_course_duration(request.user, course)
+        deadline = duration and get_user_course_expiration_date(request.user, course)
+        context['audit_access_deadline'] = deadline
         return render_to_response("course_modes/choose.html", context)
 
     @method_decorator(transaction.non_atomic_requests)

--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -240,11 +240,14 @@ class ChooseModeView(View):
         context['audit_access_deadline'] = deadline
         fbe_is_on = deadline and gated_content
 
-        # REV-2133 TODO Value Prop: remove waffle after testing is completed
+        # REV-2133 TODO Value Prop: remove waffle flag after testing is completed
         # and happy path version is ready to be rolled out to all users.
         if waffle.flag_is_active(request, 'course_modes.use_new_track_selection'):
-            if not error:  # Happy path does not handle errors.
-                if verified_mode and fbe_is_on and not enterprise_customer:  # Happy path conditions
+            # First iteration of happy path does not handle errors. If there are enrollment errors for a learner that is
+            # technically considered happy path, old Track Selection page will be displayed.
+            if not error:
+                # Happy path conditions.
+                if verified_mode and fbe_is_on and not enterprise_customer:
                     return render_to_response("course_modes/track_selection.html", context)
         return render_to_response("course_modes/choose.html", context)
 


### PR DESCRIPTION
[REV-2133](https://openedx.atlassian.net/browse/REV-2133). 

Current Track Selection page doesn't display any deadline dates. For Value Prop, the new Track Selection (happy path) has the access expiration date displayed in the audit mode track option. 

**This PR:**
- Adds `audit_access_deadline` to context to be accessible by the new HTML template for Value Prop. 
- Adds waffle flag conditional and happy-path conditional to hook up the new Track Selection template. The new template is added in [this PR](https://github.com/edx/edx-platform/pull/28418).

**Note:**
- This will not be visible for testing yet until [this PR](https://github.com/edx/edx-platform/pull/28373) is merged that hooks up this new template. 
- The new Track Selection will be merged under a flag for testing purposes and subsequently rolled out to all learners, as well as openedX. Current Track Selection page will be deprecated.
- Error handling for happy path will be done in https://openedx.atlassian.net/browse/REV-2325.

**What is this audit access deadline?** 
Description from [Dates Appendix](https://openedx.atlassian.net/wiki/spaces/ENGAGE/pages/2925101669/Dates+Appendix):
> The course duration limits feature of FBE limits the amount of time that audit learners can access a course - learners are required to upgrade to regain access to the course content once the audit access expiration deadline has passed (if the course upgrade deadline has not passed). 

**What is considered _happy path_?** 
- FBE is on (learner has an `audit_access_deadline` and is able to see `gated_content`).
- Learner can upgrade (`verified_mode`). 
- Not an enterprise customer. 

<img width="740" alt="Screen Shot 2021-08-02 at 5 32 16 PM" src="https://user-images.githubusercontent.com/13632680/127926938-7776a5e2-d181-42e1-bc88-d2180c5f026e.png">

**This ticket will follow the below steps:**
1) Create waffle flag (Done in https://openedx.atlassian.net/browse/REV-2322).
2) Add the new template in `edx-platform` ([PR here](https://github.com/edx/edx-platform/pull/28418)).
3) Add the waffle code in `edx-platform` and hook up the new template (this PR). 
4) Turn on the waffle for a set of users (revenue and UX) for testing purposes.
5) Remove the waffle flag and point to just the new file for happy path.
6) Address the non-happy path and other scenarios.
7) Remove the old `edx-themes` and `edx-platform` templates and CSS files.

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->
