### PR TITLE
[MST-894]: Use verified name for certificates if enabled

### DIFF
--- a/lms/djangoapps/certificates/generation.py
+++ b/lms/djangoapps/certificates/generation.py
@@ -10,10 +10,9 @@ These methods should be called from tasks.
 import logging
 from uuid import uuid4
 
-from common.djangoapps.student import models_api as student_api
 from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.certificates.models import GeneratedCertificate
-from lms.djangoapps.certificates.utils import emit_certificate_event
+from lms.djangoapps.certificates.utils import emit_certificate_event, get_preferred_certificate_name
 
 log = logging.getLogger(__name__)
 
@@ -66,9 +65,7 @@ def _generate_certificate(user, course_key, status, enrollment_mode, course_grad
     # Retrieve the existing certificate for the learner if it exists
     existing_certificate = GeneratedCertificate.certificate_for_student(user, course_key)
 
-    profile_name = student_api.get_name(user.id)
-    if not profile_name:
-        profile_name = ''
+    preferred_name = get_preferred_certificate_name(user)
 
     # Retain the `verify_uuid` from an existing certificate if possible, this will make it possible for the learner to
     # keep the existing URL to their certificate
@@ -84,7 +81,7 @@ def _generate_certificate(user, course_key, status, enrollment_mode, course_grad
             'user': user,
             'course_id': course_key,
             'mode': enrollment_mode,
-            'name': profile_name,
+            'name': preferred_name,
             'status': status,
             'grade': course_grade,
             'download_url': '',

--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -43,7 +43,11 @@ from lms.djangoapps.certificates.models import (
     GeneratedCertificate
 )
 from lms.djangoapps.certificates.permissions import PREVIEW_CERTIFICATES
-from lms.djangoapps.certificates.utils import emit_certificate_event, get_certificate_url
+from lms.djangoapps.certificates.utils import (
+    emit_certificate_event,
+    get_certificate_url,
+    get_preferred_certificate_name
+)
 from openedx.core.djangoapps.catalog.api import get_course_run_details
 from openedx.core.djangoapps.certificates.api import display_date_for_certificate
 from openedx.core.djangoapps.content.course_overviews.api import get_course_overview_or_none
@@ -305,7 +309,8 @@ def _update_context_with_user_info(context, user, user_certificate):
     """
     Updates context dictionary with user related info.
     """
-    user_fullname = user.profile.name
+    user_fullname = get_preferred_certificate_name(user)
+
     context['username'] = user.username
     context['course_mode'] = user_certificate.mode
     context['accomplishment_user_id'] = user.id


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

If the verified name feature is enabled and the user has their preference set to use verified name for certificates, create and display certificates with their verified name rather than their profile name.

## Supporting information

[MST-894](https://openedx.atlassian.net/browse/MST-894)