### PR TITLE
fix: [AA-939] Don't show View As Learner if partitions exist

### DIFF
--- a/lms/djangoapps/courseware/masquerade.py
+++ b/lms/djangoapps/courseware/masquerade.py
@@ -4,7 +4,6 @@ Allow course staff to see a student or staff view of courseware.
 Which kind of view has been selected is stored in the session state.
 '''
 
-
 import logging
 from datetime import datetime
 
@@ -49,6 +48,7 @@ class CourseMasquerade:
     """
     Masquerade settings for a particular course.
     """
+
     def __init__(self, course_key, role='student', user_partition_id=None, group_id=None, user_name=None):
         # All parameters to this function must be named identically to the corresponding attribute.
         # If you remove or rename an attribute, also update the __setstate__() method to migrate
@@ -131,7 +131,7 @@ class MasqueradeView(View):
             ],
         }
         if len(partitions) == 0:
-            data['available'].append( {
+            data['available'].append({
                 'name': 'Learner',
                 'role': 'student',
             })
@@ -211,9 +211,9 @@ def setup_masquerade(request, course_key, staff_access=False, reset_masquerade_d
     If the reset_masquerade_data flag is set, the field data stored in the session will be cleared.
     """
     if (
-            request.user is None or
-            not settings.FEATURES.get('ENABLE_MASQUERADE', False) or
-            not staff_access
+        request.user is None or
+        not settings.FEATURES.get('ENABLE_MASQUERADE', False) or
+        not staff_access
     ):
         return None, request.user
     if reset_masquerade_data:
@@ -414,6 +414,7 @@ class MasqueradingKeyValueStore(KeyValueStore):
     This `KeyValueStore` wraps an underlying `KeyValueStore`.  Reads are forwarded to the underlying
     store, but writes go to a Django session (or other dictionary-like object).
     """
+
     def __init__(self, kvs, session):  # lint-amnesty, pylint: disable=super-init-not-called
         """
         Arguments:

--- a/lms/djangoapps/courseware/masquerade.py
+++ b/lms/djangoapps/courseware/masquerade.py
@@ -128,17 +128,19 @@ class MasqueradeView(View):
                     'name': 'Staff',
                     'role': 'staff',
                 },
-                {
-                    'name': 'Learner',
-                    'role': 'student',
-                },
-                {
-                    'name': 'Specific Student...',
-                    'role': 'student',
-                    'user_name': course.user_name or '',
-                },
             ],
         }
+        if len(partitions) == 0:
+            data['available'].append( {
+                'name': 'Learner',
+                'role': 'student',
+            })
+
+        data['available'].append({
+            'name': 'Specific Student...',
+            'role': 'student',
+            'user_name': course.user_name or '',
+        })
         for partition in partitions:
             if partition.active:
                 data['available'].extend([

--- a/lms/djangoapps/courseware/tests/test_masquerade.py
+++ b/lms/djangoapps/courseware/tests/test_masquerade.py
@@ -10,6 +10,7 @@ from importlib import import_module
 from unittest.mock import patch
 import pytest
 import ddt
+from operator import itemgetter
 from django.conf import settings
 from django.test import TestCase, RequestFactory
 from django.urls import reverse
@@ -171,6 +172,7 @@ class MasqueradeTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase, Mas
         assert self.problem_display_name in problem_html
         assert show_answer_expected == ('Show answer' in problem_html)
 
+
     def verify_learner_masquerade_available(self, learner_option_expected):
         """
         Verifies if learner masquerade option is available
@@ -178,10 +180,9 @@ class MasqueradeTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase, Mas
             exists: True to test if Learner is in options, False to test it is NOT
         """
         response = self.get_available_masquerade_identities()
-        items = response.content.json['available'].items()
-        is_it_there = (('name', 'Learner') in items)
+        items = response.json()['available']
+        is_it_there = 'Learner' in map(itemgetter('name'), items)
         assert learner_option_expected == is_it_there
-        assert learner_option_expected == (('name', 'Learner') in content.items())
 
     def ensure_masquerade_as_group_member(self, partition_id, group_id):
         """
@@ -233,7 +234,7 @@ class StaffMasqueradeTestCase(MasqueradeTestCase):
         return StaffFactory(course_key=self.course.id)
 
 
-class TestMasqueradeOptionsForNoPartitions(MasqueradeTestCase):
+class TestMasqueradeOptionsForNoPartitions(StaffMasqueradeTestCase):
     """
     Check that 'Learner' option is available if there are no groups or partitions
     """
@@ -243,7 +244,7 @@ class TestMasqueradeOptionsForNoPartitions(MasqueradeTestCase):
         self.verify_learner_masquerade_available(True)
 
 
-class TestMasqueradeOptionsForUserPartition(MasqueradeTestCase):
+class TestMasqueradeOptionsForUserPartition(StaffMasqueradeTestCase):
     """
     Check that 'Learner' option is NOT available if there are no groups or partitions
     """

--- a/lms/djangoapps/courseware/tests/test_masquerade.py
+++ b/lms/djangoapps/courseware/tests/test_masquerade.py
@@ -176,7 +176,7 @@ class MasqueradeTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase, Mas
         """
         Verifies if learner masquerade option is available
         Args:
-            exists: True to test if Learner is in options, False to test it is NOT
+            learner_option_expected: True to test if Learner is in options, False to test it is NOT
         """
         response = self.get_available_masquerade_identities()
         items = response.json()['available']
@@ -247,8 +247,8 @@ class TestMasqueradeOptionsForUserPartition(StaffMasqueradeTestCase):
     """
     Check that 'Learner' option is NOT available if there are no groups or partitions
     """
-    @ patch.dict('django.conf.settings.FEATURES', {'ENABLE_ENROLLMENT_TRACK_USER_PARTITION': True})
     @ patch.dict('django.conf.settings.FEATURES', {'ENABLE_MASQUERADE': True})
+    @ patch.dict('django.conf.settings.FEATURES', {'ENABLE_ENROLLMENT_TRACK_USER_PARTITION': True})
     def test_masquerade_options_no_cohort(self):
         self.verify_learner_masquerade_available(False)
 

--- a/lms/djangoapps/courseware/tests/test_masquerade.py
+++ b/lms/djangoapps/courseware/tests/test_masquerade.py
@@ -172,7 +172,6 @@ class MasqueradeTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase, Mas
         assert self.problem_display_name in problem_html
         assert show_answer_expected == ('Show answer' in problem_html)
 
-
     def verify_learner_masquerade_available(self, learner_option_expected):
         """
         Verifies if learner masquerade option is available


### PR DESCRIPTION
fix: [AA-939] Don't show View As Learner if partitions exist
Remove the option to masquerade as a generic learner
if there are enrollment tracks or partition groups
because the behavior is unpredictable and unhelpful.
Includes unit tests in test_masquerade.py

Fixes: AA-939




[AA-939]: https://openedx.atlassian.net/browse/AA-939