### PR TITLE
refactor: update name of `cert_generation_enabled` function name to reflect actual purpose

### DIFF
--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -37,7 +37,7 @@ from common.djangoapps.student.models import (
 from common.djangoapps.util.password_policy_validators import normalize_password
 from lms.djangoapps.certificates.api import (
     certificates_viewable_for_course,
-    cert_generation_enabled,
+    has_self_generated_certificates_enabled,
     get_certificate_url,
     has_html_certificates_enabled,
     certificate_status_for_student,
@@ -599,7 +599,7 @@ def _cert_info(user, enrollment, cert_status):
         # is enabled for a course then we need to provide the option to the learner
         if (
             status_dict['status'] != CertificateStatuses.downloadable and
-            (cert_generation_enabled(course_overview.id) or auto_certificate_generation_enabled()) and
+            (has_self_generated_certificates_enabled(course_overview.id) or auto_certificate_generation_enabled()) and
             persisted_grade and persisted_grade.passed
         ):
             status_dict['status'] = CertificateStatuses.requesting

--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -335,8 +335,8 @@ def is_certificate_invalidated(student, course_key):
     return False
 
 
-def cert_generation_enabled(course_key):
-    """Check whether certificate generation is enabled for a course.
+def has_self_generated_certificates_enabled(course_key):
+    """Check whether the self-generated certificates feature is enabled for a given course.
 
     There are two "switches" that control whether self-generated certificates
     are enabled for a course:

--- a/lms/djangoapps/certificates/tests/test_api.py
+++ b/lms/djangoapps/certificates/tests/test_api.py
@@ -32,7 +32,7 @@ from common.djangoapps.student.tests.factories import (
 from common.djangoapps.util.testing import EventTestMixin
 from lms.djangoapps.certificates.api import (
     can_be_added_to_allowlist,
-    cert_generation_enabled,
+    has_self_generated_certificates_enabled,
     certificate_downloadable_status,
     create_certificate_invalidation_entry,
     create_or_update_certificate_allowlist_entry,
@@ -696,7 +696,7 @@ class CertificateGenerationEnabledTest(EventTestMixin, TestCase):
 
     def _assert_enabled_for_course(self, course_key, expect_enabled):
         """Check that self-generated certificates are enabled or disabled for the course. """
-        actual_enabled = cert_generation_enabled(course_key)
+        actual_enabled = has_self_generated_certificates_enabled(course_key)
         assert expect_enabled == actual_enabled
 
 

--- a/lms/djangoapps/certificates/tests/test_signals.py
+++ b/lms/djangoapps/certificates/tests/test_signals.py
@@ -11,7 +11,7 @@ from edx_toggles.toggles import LegacyWaffleSwitch
 from edx_toggles.toggles.testutils import override_waffle_flag, override_waffle_switch
 
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
-from lms.djangoapps.certificates.api import cert_generation_enabled
+from lms.djangoapps.certificates.api import has_self_generated_certificates_enabled
 from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.certificates.models import (
     CertificateGenerationConfiguration,
@@ -44,15 +44,15 @@ class SelfGeneratedCertsSignalTest(ModuleStoreTestCase):
         according to course-pacing.
         """
         course = CourseFactory.create(self_paced=False, emit_signals=True)
-        assert not cert_generation_enabled(course.id)
+        assert not has_self_generated_certificates_enabled(course.id)
 
         course.self_paced = True
         self.store.update_item(course, self.user.id)
-        assert cert_generation_enabled(course.id)
+        assert has_self_generated_certificates_enabled(course.id)
 
         course.self_paced = False
         self.store.update_item(course, self.user.id)
-        assert not cert_generation_enabled(course.id)
+        assert not has_self_generated_certificates_enabled(course.id)
 
 
 class AllowlistGeneratedCertificatesTest(ModuleStoreTestCase):

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1289,7 +1289,7 @@ def get_cert_data(student, course, enrollment_mode, course_grade=None):
     if cert_data.cert_status == EARNED_BUT_NOT_AVAILABLE_CERT_STATUS:
         return cert_data
 
-    certificates_enabled_for_course = certs_api.cert_generation_enabled(course.id)
+    certificates_enabled_for_course = certs_api.has_self_generated_certificates_enabled(course.id)
     if course_grade is None:
         course_grade = CourseGradeFactory().read(student, course)
 

--- a/lms/djangoapps/instructor/tests/test_certificates.py
+++ b/lms/djangoapps/instructor/tests/test_certificates.py
@@ -256,7 +256,7 @@ class CertificatesInstructorApiTest(SharedModuleStoreTestCase):
         self._assert_redirects_to_instructor_dash(response)
 
         # Expect that certificate generation is now enabled for the course
-        actual_enabled = certs_api.cert_generation_enabled(self.course.id)
+        actual_enabled = certs_api.has_self_generated_certificates_enabled(self.course.id)
         assert is_enabled == actual_enabled
 
     def _assert_redirects_to_instructor_dash(self, response):

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -332,7 +332,7 @@ def _section_certificates(course):
         'section_display_name': _('Certificates'),
         'example_certificate_status': example_cert_status,
         'can_enable_for_course': can_enable_for_course,
-        'enabled_for_course': certs_api.cert_generation_enabled(course.id),
+        'enabled_for_course': certs_api.has_self_generated_certificates_enabled(course.id),
         'is_self_paced': course.self_paced,
         'instructor_generation_enabled': instructor_generation_enabled,
         'html_cert_enabled': html_cert_enabled,


### PR DESCRIPTION
## Description

[MICROBA-1354]

* Update Python API function named `cert_generated_enabled` to `has_self_generated_certificates_enabled` to more accurately reflect the purpose of the function.

This function isn't used to determine if certificate generation is enabled (as the name suggests), it is used to determine if _self-generated_ (or student-generated) certificates are enabled for a given course run.

[MICROBA-1354]: https://openedx.atlassian.net/browse/MICROBA-1354