### PR TITLE
feat: Add CertificateDateOverride model to admin

### DIFF
--- a/lms/djangoapps/certificates/admin.py
+++ b/lms/djangoapps/certificates/admin.py
@@ -13,6 +13,7 @@ from django.utils.safestring import mark_safe
 from organizations.api import get_organizations
 
 from lms.djangoapps.certificates.models import (
+    CertificateDateOverride,
     CertificateGenerationConfiguration,
     CertificateGenerationCommandConfiguration,
     CertificateGenerationCourseSetting,
@@ -96,9 +97,23 @@ class CertificateGenerationCommandConfigurationAdmin(ConfigurationModelAdmin):
     pass
 
 
+class CertificateDateOverrideAdmin(admin.ModelAdmin):
+    """
+    # Django admin customizations for CertificateDateOverride model
+    """
+    list_display = ('generated_certificate', 'date', 'reason', 'overridden_by')
+    raw_id_fields = ('generated_certificate',)
+    readonly_fields = ('overridden_by',)
+
+    def save_model(self, request, obj, form, change):
+        obj.overridden_by = request.user
+        super().save_model(request, obj, form, change)
+
+
 admin.site.register(CertificateGenerationConfiguration)
 admin.site.register(CertificateGenerationCourseSetting, CertificateGenerationCourseSettingAdmin)
 admin.site.register(CertificateHtmlViewConfiguration, ConfigurationModelAdmin)
 admin.site.register(CertificateTemplate, CertificateTemplateAdmin)
 admin.site.register(CertificateTemplateAsset, CertificateTemplateAssetAdmin)
 admin.site.register(GeneratedCertificate, GeneratedCertificateAdmin)
+admin.site.register(CertificateDateOverride, CertificateDateOverrideAdmin)


### PR DESCRIPTION
## Description

Register the new CertificateDateOverride model with the Django admin.
Customize the `generated_certificate` field to accept the certificate id
(with search); and autosave the admin user making the change to the
`overridden_by` field, and make it read-only.

For MICROBA-1417, toward MICROBA-1239.

Eventually, course teams / support will use this page to override the "Issued On" date for a given course certificate. However, this page will not be visible in the admin until we adjust the permissions model. (It also isn’t hooked up to actually _do_ anything yet, at the time of this PR.) 

More PRs coming soon to: use the new date override in platform, ensure the date override is sent to credentials, etc.

## Supporting information

For [MICROBA-1417](https://openedx.atlassian.net/browse/MICROBA-1417), toward [MICROBA-1239](https://openedx.atlassian.net/browse/MICROBA-1239).

## Testing instructions

To test locally:

1. Pull this branch. You may need to restart your container to see the admin changes take effect.
2. Locally, go to the CERTIFICATES section of the LMS Django Admin: http://localhost:18000/admin/certificates/
3. You should see a **Certificate date override** table there now. Open it.
4. Add a Certificate date override.
    - It should not let you leave any of the fields blank; and you should get an error if you try.
    - You should not be able to associate this with a certificate that doesn’t exist.
    - You should not be able to associate this with a certificate for which there _is already_ a Certificate date override.
    - Saving should autosave your user in the `overridden_by` field; otherwise this field should not be able to be edited by you.

## Deadline

None.
