### PR TITLE
Fixed spacing on special exam dropdown headers

### DIFF
--- a/lms/static/js/instructor_dashboard/proctoring.js
+++ b/lms/static/js/instructor_dashboard/proctoring.js
@@ -1,7 +1,7 @@
 $(function() {
     var icons = {
-        header: 'ui-icon-carat-1-e',
-        activeHeader: 'ui-icon-carat-1-s'
+        header: 'ui-icon-carat-1-s',
+        activeHeader: 'ui-icon-carat-1-n'
     };
     var $proctoringAccordionPane = $('#proctoring-accordion');
     $proctoringAccordionPane.accordion(

--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -2584,6 +2584,10 @@ input[name="subject"] {
       font-size: em(13);
     }
   }
+
+  div.special-exam-header {
+    padding-left: 25px;
+  }
 }
 
 .special-allowance-container,

--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -2585,7 +2585,7 @@ input[name="subject"] {
     }
   }
 
-  div.special-exam-header {
+  .special-exam-header {
     padding-left: 25px;
   }
 }

--- a/lms/templates/instructor/instructor_dashboard_2/special_exams.html
+++ b/lms/templates/instructor/instructor_dashboard_2/special_exams.html
@@ -10,22 +10,22 @@ import pytz
   % endif
   <div id="proctoring-accordion">
     <div class="wrap">
-      <h3 class="hd hd-3">${_('Allowance Section')}</h3>
+      <h3 class="hd hd-3"><div class="special-exam-header">${_('Allowance Section')}</div></h3>
       <div class="special-allowance-container" data-course-id="${ section_data['course_id'] }"data-enable-bulk-allowance="${ section_data['enable_bulk_allowance'] }"></div>
     </div>
     % if section_data['show_onboarding']:
     <div class="wrap">
-      <h3 class="hd hd-3">${_('Student Onboarding Status')}</h3>
+      <h3 class="hd hd-3"><div class="special-exam-header">${_('Student Onboarding Status')}</div></h3>
       <div class="student-onboarding-status-container" data-course-id="${ section_data['course_id'] }"></div>
     </div>
     % endif
     <div class="wrap">
-      <h3 class="hd hd-3">${_('Student Special Exam Attempts')}</h3>
+      <h3 class="hd hd-3"><div class="special-exam-header">${_('Student Special Exam Attempts')}</div></h3>
       <div class="student-proctored-exam-container" data-course-id="${ section_data['course_id'] }"></div>
     </div>
     % if section_data['show_dashboard']:
     <div class="wrap">
-      <h3 class="hd hd-3">${_('Review Dashboard')}</h3>
+      <h3 class="hd hd-3"><div class="special-exam-header">${_('Review Dashboard')}</div></h3>
       <div class="student-review-dashboard-container" data-course-id="${ section_data['course_id'] }"></div>
     </div>
     % endif

--- a/lms/templates/instructor/instructor_dashboard_2/special_exams.html
+++ b/lms/templates/instructor/instructor_dashboard_2/special_exams.html
@@ -10,22 +10,22 @@ import pytz
   % endif
   <div id="proctoring-accordion">
     <div class="wrap">
-      <h3 class="hd hd-3"><div class="special-exam-header">${_('Allowance Section')}</div></h3>
+      <h3 class="hd hd-3 special-exam-header">${_('Allowance Section')}</h3>
       <div class="special-allowance-container" data-course-id="${ section_data['course_id'] }"data-enable-bulk-allowance="${ section_data['enable_bulk_allowance'] }"></div>
     </div>
     % if section_data['show_onboarding']:
     <div class="wrap">
-      <h3 class="hd hd-3"><div class="special-exam-header">${_('Student Onboarding Status')}</div></h3>
+      <h3 class="hd hd-3 special-exam-header">${_('Student Onboarding Status')}</h3>
       <div class="student-onboarding-status-container" data-course-id="${ section_data['course_id'] }"></div>
     </div>
     % endif
     <div class="wrap">
-      <h3 class="hd hd-3"><div class="special-exam-header">${_('Student Special Exam Attempts')}</div></h3>
+      <h3 class="hd hd-3 special-exam-header">${_('Student Special Exam Attempts')}</h3>
       <div class="student-proctored-exam-container" data-course-id="${ section_data['course_id'] }"></div>
     </div>
     % if section_data['show_dashboard']:
     <div class="wrap">
-      <h3 class="hd hd-3"><div class="special-exam-header">${_('Review Dashboard')}</div></h3>
+      <h3 class="hd hd-3 special-exam-header">${_('Review Dashboard')}</h3>
       <div class="student-review-dashboard-container" data-course-id="${ section_data['course_id'] }"></div>
     </div>
     % endif


### PR DESCRIPTION
## Description

-Adjusted the spacing of the caret on the drop-downs within the special exam section of the instructor dashboard so they wouldn't cover the header text
-Changed the direction of the carets on the drop-downs so they are consistent with the rest of the page.
Screenshot of updated view:
<img width="1440" alt="Screen Shot 2021-08-04 at 4 15 52 PM" src="https://user-images.githubusercontent.com/59623984/128248866-5d0b709d-e828-4ce1-ab4b-099674b6a409.png">