### PR TITLE
feat: Adding new CookieNameChange middleware

### DIFF
--- a/openedx/core/djangoapps/cookie_metadata/__init__.py
+++ b/openedx/core/djangoapps/cookie_metadata/__init__.py
@@ -1,0 +1,1 @@
+#!/usr/bin/env python3

--- a/openedx/core/djangoapps/cookie_metadata/__init__.py
+++ b/openedx/core/djangoapps/cookie_metadata/__init__.py
@@ -1,1 +1,0 @@
-#!/usr/bin/env python3

--- a/openedx/core/djangoapps/cookie_metadata/middleware.py
+++ b/openedx/core/djangoapps/cookie_metadata/middleware.py
@@ -1,4 +1,4 @@
-"""Middleware to changes name of an incoming cookie"""
+"""Middleware to change name of an incoming cookie"""
 from django.conf import settings
 
 
@@ -17,7 +17,6 @@ class CookieNameChange:
         - COOKIE_NAME_CHANGE_EXPAND_INFO is a dict and has following info:
             "old_name": Previous name of cookie
             "new_name": New name of cookie
-            if you also want to delete the cookie in user's browser, set "old_domain" as well
 
         Actions taken by middleware:
             - will delete any cookie with "old_name"
@@ -26,21 +25,21 @@ class CookieNameChange:
         """
 
         # .. toggle_name: COOKIE_NAME_CHANGE_ACTIVATE_EXPAND_PHASE
-        # .. toggle_implementation: SettingToggle
+        # .. toggle_implementation: DjangoSetting
         # .. toggle_default: False
         # .. toggle_description: Used to enable CookieNameChange middleware which changes a cookie name in request.COOKIES
         # .. toggle_warnings: This should be set at the same time you set COOKIE_NAME_CHANGE_EXPAND_INFO setting
         # .. toggle_use_cases: temporary
         # .. toggle_creation_date: 2021-08-04
-        # .. toggle_removal_date: 2021-09-01
-        # .. toggle_tickets: TODO
+        # .. toggle_target_removal_date: 2021-10-01
+        # .. toggle_tickets: https://openedx.atlassian.net/browse/ARCHBOM-1872
         if getattr(settings, "COOKIE_NAME_CHANGE_ACTIVATE_EXPAND_PHASE", False):
             old_cookie_in_request = False
             expand_settings = getattr(settings, "COOKIE_NAME_CHANGE_EXPAND_INFO", None)
 
             if (
                 expand_settings is not None
-                and type(expand_settings) is dict
+                and isinstance(expand_settings, dict)
                 and "new_name" in expand_settings
                 and "old_name" in expand_settings
             ):

--- a/openedx/core/djangoapps/cookie_metadata/middleware.py
+++ b/openedx/core/djangoapps/cookie_metadata/middleware.py
@@ -1,0 +1,71 @@
+"""Middleware to changes name of an incoming cookie"""
+from django.conf import settings
+
+
+class CookieNameChange:
+    """Changes name of an incoming cookie"""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+        # One-time configuration and initialization.
+
+    def __call__(self, request):
+        """
+        Changes the names of a cookie in request.COOKIES
+
+        For this middleware to run:
+        - set COOKIE_NAME_CHANGE_ACTIVATE_EXPAND_PHASE =  True
+        - COOKIE_NAME_CHANGE__EXPAND_INFO is a dict and has following info:
+            "old_name": Previous name of cookie
+            "new_name": New name of cookie
+            if you also want to delete the cookie in user's browser, set "old_domain" as well
+
+        Actions taken by middleware:
+            - will delete any cookie with "old_name"
+            - if create a new cookie with "new_name" and set its value to value of "old_name" cookie
+                + it will not modify cookie with "new_name" if it already exists in request.COOKIES
+        """
+
+        # Let students save and manage their annotations
+        # .. toggle_name: COOKIE_NAME_CHANGE_ACTIVATE_EXPAND_PHASE
+        # .. toggle_implementation: SettingToggle
+        # .. toggle_default: False
+        # .. toggle_description: Used to enable CookieNameChange middleware which changes a cookie name in request.COOKIES
+        # .. toggle_warnings: This should be set at the same time you set COOKIE_NAME_CHANGE_EXPAND_INFO setting
+        # .. toggle_use_cases: temporary
+        # .. toggle_creation_date: 2021-08-04
+        # .. toggle_removal_date: 2021-09-01
+        # .. toggle_tickets: TODO
+        if getattr(settings, "COOKIE_NAME_CHANGE_ACTIVATE_EXPAND_PHASE", False):
+
+            old_cookie_in_request = False
+            if (
+                (
+                    expand_settings := getattr(
+                        settings, "COOKIE_NAME_CHANGE_EXPAND_INFO", None
+                    )
+                )
+                is not None
+                and expand_settings.get("new_name", None) is not None
+                and expand_settings.get("old_name", None) is not None
+            ):
+                if expand_settings["old_name"] in request.COOKIES:
+                    old_cookie_in_request = True
+                    old_cookie_value = request.COOKIES[
+                            expand_settings['old_name']
+                        ]
+                    del request.COOKIES[expand_settings['old_name']]
+
+                if expand_settings["new_name"] not in request.COOKIES and old_cookie_in_request:
+                        request.COOKIES[expand_settings["new_name"]] = old_cookie_value
+
+        response = self.get_response(request)
+
+        # This was commented out case the current usecase
+        # does not require deleting old cookies cause of short experation date
+        # if old_cookie_in_request:
+        #     response.delete_cookie(
+        #         expand_settings[old_name], domain=expand_settings["old_domain"])
+        #     )
+
+        return response

--- a/openedx/core/djangoapps/cookie_metadata/middleware.py
+++ b/openedx/core/djangoapps/cookie_metadata/middleware.py
@@ -7,7 +7,6 @@ class CookieNameChange:
 
     def __init__(self, get_response):
         self.get_response = get_response
-        # One-time configuration and initialization.
 
     def __call__(self, request):
         """
@@ -15,7 +14,7 @@ class CookieNameChange:
 
         For this middleware to run:
         - set COOKIE_NAME_CHANGE_ACTIVATE_EXPAND_PHASE =  True
-        - COOKIE_NAME_CHANGE__EXPAND_INFO is a dict and has following info:
+        - COOKIE_NAME_CHANGE_EXPAND_INFO is a dict and has following info:
             "old_name": Previous name of cookie
             "new_name": New name of cookie
             if you also want to delete the cookie in user's browser, set "old_domain" as well
@@ -26,7 +25,6 @@ class CookieNameChange:
                 + it will not modify cookie with "new_name" if it already exists in request.COOKIES
         """
 
-        # Let students save and manage their annotations
         # .. toggle_name: COOKIE_NAME_CHANGE_ACTIVATE_EXPAND_PHASE
         # .. toggle_implementation: SettingToggle
         # .. toggle_default: False
@@ -37,35 +35,25 @@ class CookieNameChange:
         # .. toggle_removal_date: 2021-09-01
         # .. toggle_tickets: TODO
         if getattr(settings, "COOKIE_NAME_CHANGE_ACTIVATE_EXPAND_PHASE", False):
-
             old_cookie_in_request = False
+            expand_settings = getattr(settings, "COOKIE_NAME_CHANGE_EXPAND_INFO", None)
+
             if (
-                (
-                    expand_settings := getattr(
-                        settings, "COOKIE_NAME_CHANGE_EXPAND_INFO", None
-                    )
-                )
-                is not None
-                and expand_settings.get("new_name", None) is not None
-                and expand_settings.get("old_name", None) is not None
+                expand_settings is not None
+                and type(expand_settings) is dict
+                and "new_name" in expand_settings
+                and "old_name" in expand_settings
             ):
                 if expand_settings["old_name"] in request.COOKIES:
                     old_cookie_in_request = True
-                    old_cookie_value = request.COOKIES[
-                            expand_settings['old_name']
-                        ]
-                    del request.COOKIES[expand_settings['old_name']]
+                    old_cookie_value = request.COOKIES[expand_settings["old_name"]]
+                    del request.COOKIES[expand_settings["old_name"]]
 
-                if expand_settings["new_name"] not in request.COOKIES and old_cookie_in_request:
-                        request.COOKIES[expand_settings["new_name"]] = old_cookie_value
+                if (
+                    expand_settings["new_name"] not in request.COOKIES
+                    and old_cookie_in_request
+                ):
+                    request.COOKIES[expand_settings["new_name"]] = old_cookie_value
 
         response = self.get_response(request)
-
-        # This was commented out case the current usecase
-        # does not require deleting old cookies cause of short experation date
-        # if old_cookie_in_request:
-        #     response.delete_cookie(
-        #         expand_settings[old_name], domain=expand_settings["old_domain"])
-        #     )
-
         return response

--- a/openedx/core/djangoapps/cookie_metadata/tests/__init__.py
+++ b/openedx/core/djangoapps/cookie_metadata/tests/__init__.py
@@ -1,0 +1,1 @@
+#!/usr/bin/env python3

--- a/openedx/core/djangoapps/cookie_metadata/tests/__init__.py
+++ b/openedx/core/djangoapps/cookie_metadata/tests/__init__.py
@@ -1,1 +1,0 @@
-#!/usr/bin/env python3

--- a/openedx/core/djangoapps/cookie_metadata/tests/test_cookie_name_change.py
+++ b/openedx/core/djangoapps/cookie_metadata/tests/test_cookie_name_change.py
@@ -14,12 +14,10 @@ class TestCookieNameChange(TestCase):
     Test class for CookieNameChange
     """
 
-
     def setUp(self):
         self.mock_response = Mock()
         self.cookie_name_change_middleware = CookieNameChange(self.mock_response)
         self.mock_request = Mock()
-
 
         self.old_value = "." * 100
         self.old_key = 'a'
@@ -74,7 +72,6 @@ class TestCookieNameChange(TestCase):
 
         self.mock_request.COOKIES = self.old_dict.copy()
 
-
         with self.settings(
             COOKIE_NAME_CHANGE_ACTIVATE_EXPAND_PHASE=True
         ), self.settings(COOKIE_NAME_CHANGE_EXPAND_INFO=self.expand_settings):
@@ -100,7 +97,6 @@ class TestCookieNameChange(TestCase):
         self.old_dict.update(no_change_cookies)
 
         self.mock_request.COOKIES = self.old_dict.copy()
-
 
         with self.settings(
             COOKIE_NAME_CHANGE_ACTIVATE_EXPAND_PHASE=False

--- a/openedx/core/djangoapps/cookie_metadata/tests/test_cookie_name_change.py
+++ b/openedx/core/djangoapps/cookie_metadata/tests/test_cookie_name_change.py
@@ -1,0 +1,136 @@
+"""
+Test Modle to test CookieNameChange class
+"""
+from unittest.mock import Mock
+
+from django.test import TestCase
+
+
+from ..middleware import CookieNameChange
+
+
+class TestCookieNameChange(TestCase):
+    """
+    Test class for CookieNameChange
+    """
+
+    def test_cookie_swap(self):
+        """Check to make sure Middleware correctly swaps keys"""
+
+        mock_response = Mock()
+        middleware = CookieNameChange(mock_response)
+        mock_request = Mock()
+
+        old_value = "." * 100
+        extra_cookies = {
+            "_b": "." * 13,
+            "_c_": "." * 13,
+            "a.b": "." * 10,
+        }
+        old_dict = {
+            "a": old_value,
+        }
+        old_dict.update(extra_cookies)
+
+        mock_request.COOKIES = old_dict.copy()
+        expand_settings = {
+            "old_name": "a",
+            "new_name": "b",
+            "old_domain": "old_domain.com",
+        }
+
+        with self.settings(
+            COOKIE_NAME_CHANGE_ACTIVATE_EXPAND_PHASE=True
+        ), self.settings(COOKIE_NAME_CHANGE_EXPAND_INFO=expand_settings):
+            middleware(mock_request)
+
+        assert expand_settings["old_name"] not in mock_request.COOKIES.keys()
+        assert expand_settings["new_name"] in mock_request.COOKIES.keys()
+        assert mock_request.COOKIES[expand_settings["new_name"]] == old_value
+        test_dict = extra_cookies.copy()
+        test_dict[expand_settings['new_name']] = old_value
+        assert mock_request.COOKIES == test_dict
+
+        # make sure response function is called once
+        mock_response.assert_called_once()
+
+    def test_cookie_no_swap(self):
+        """Make sure middleware does not change cookie if new_name cookie is already present"""
+
+        expand_settings = {
+            "old_name": "a",
+            "new_name": "b",
+            "old_domain": "old_domain.com",
+        }
+
+        mock_response = Mock()
+        middleware = CookieNameChange(mock_response)
+
+        mock_request = Mock()
+
+        old_value = "." * 100
+        new_value = "." * 13
+        no_change_cookies = {
+            expand_settings['new_name']: new_value,
+            "_c_": "." * 13,
+            "a.b": "." * 10,
+        }
+        old_dict = {
+            "a": old_value,
+        }
+        old_dict.update(no_change_cookies)
+
+        mock_request.COOKIES = old_dict.copy()
+
+
+        with self.settings(
+            COOKIE_NAME_CHANGE_ACTIVATE_EXPAND_PHASE=True
+        ), self.settings(COOKIE_NAME_CHANGE_EXPAND_INFO=expand_settings):
+            middleware(mock_request)
+
+        assert expand_settings["old_name"] not in mock_request.COOKIES.keys()
+        assert expand_settings["new_name"] in mock_request.COOKIES.keys()
+        assert mock_request.COOKIES[expand_settings["new_name"]] == new_value
+        assert mock_request.COOKIES == no_change_cookies
+
+        # make sure response function is called once
+        mock_response.assert_called_once()
+
+    def test_does_nothing(self):
+        """Make sure turning off toggle turns off middleware"""
+
+        expand_settings = {
+            "old_name": "a",
+            "new_name": "b",
+            "old_domain": "old_domain.com",
+        }
+
+        mock_response = Mock()
+        middleware = CookieNameChange(mock_response)
+
+        mock_request = Mock()
+
+        old_value = "." * 100
+        new_value = "." * 13
+        no_change_cookies = {
+            expand_settings['new_name']: new_value,
+            "_c_": "." * 13,
+            "a.b": "." * 10,
+        }
+        old_dict = {
+            "a": old_value,
+        }
+        old_dict.update(no_change_cookies)
+
+        mock_request.COOKIES = old_dict.copy()
+
+
+        with self.settings(
+            COOKIE_NAME_CHANGE_ACTIVATE_EXPAND_PHASE=False
+        ), self.settings(COOKIE_NAME_CHANGE_EXPAND_INFO=expand_settings):
+            middleware(mock_request)
+
+        assert mock_request.COOKIES == old_dict
+
+        # make sure response function is called once
+        mock_response.assert_called_once()

--- a/openedx/core/djangoapps/cookie_metadata/tests/test_cookie_name_change.py
+++ b/openedx/core/djangoapps/cookie_metadata/tests/test_cookie_name_change.py
@@ -14,123 +14,100 @@ class TestCookieNameChange(TestCase):
     Test class for CookieNameChange
     """
 
-    def test_cookie_swap(self):
-        """Check to make sure Middleware correctly swaps keys"""
 
-        mock_response = Mock()
-        middleware = CookieNameChange(mock_response)
-        mock_request = Mock()
+    def setUp(self):
+        self.mock_response = Mock()
+        self.cookie_name_change_middleware = CookieNameChange(self.mock_response)
+        self.mock_request = Mock()
 
-        old_value = "." * 100
-        extra_cookies = {
+
+        self.old_value = "." * 100
+        self.old_key = 'a'
+        self.extra_cookies = {
             "_b": "." * 13,
             "_c_": "." * 13,
             "a.b": "." * 10,
         }
-        old_dict = {
-            "a": old_value,
+        self.old_dict = {
+            self.old_key: self.old_value,
         }
-        old_dict.update(extra_cookies)
 
-        mock_request.COOKIES = old_dict.copy()
-        expand_settings = {
-            "old_name": "a",
+        self.expand_settings = {
+            "old_name": self.old_key,
             "new_name": "b",
             "old_domain": "old_domain.com",
         }
 
+    def test_cookie_swap(self):
+        """Check to make sure self.Middleware correctly swaps keys"""
+
+        self.old_dict.update(self.extra_cookies)
+
+        self.mock_request.COOKIES = self.old_dict.copy()
+
         with self.settings(
             COOKIE_NAME_CHANGE_ACTIVATE_EXPAND_PHASE=True
-        ), self.settings(COOKIE_NAME_CHANGE_EXPAND_INFO=expand_settings):
-            middleware(mock_request)
+        ), self.settings(COOKIE_NAME_CHANGE_EXPAND_INFO=self.expand_settings):
+            self.cookie_name_change_middleware(self.mock_request)
 
-        assert expand_settings["old_name"] not in mock_request.COOKIES.keys()
-        assert expand_settings["new_name"] in mock_request.COOKIES.keys()
-        assert mock_request.COOKIES[expand_settings["new_name"]] == old_value
-        test_dict = extra_cookies.copy()
-        test_dict[expand_settings['new_name']] = old_value
-        assert mock_request.COOKIES == test_dict
+        assert self.expand_settings["old_name"] not in self.mock_request.COOKIES.keys()
+        assert self.expand_settings["new_name"] in self.mock_request.COOKIES.keys()
+        assert self.mock_request.COOKIES[self.expand_settings["new_name"]] == self.old_value
+        test_dict = self.extra_cookies.copy()
+        test_dict[self.expand_settings['new_name']] = self.old_value
+        assert self.mock_request.COOKIES == test_dict
 
         # make sure response function is called once
-        mock_response.assert_called_once()
+        self.mock_response.assert_called_once()
 
     def test_cookie_no_swap(self):
-        """Make sure middleware does not change cookie if new_name cookie is already present"""
+        """Make sure self.cookie_name_change_middleware does not change cookie if new_name cookie is already present"""
 
-        expand_settings = {
-            "old_name": "a",
-            "new_name": "b",
-            "old_domain": "old_domain.com",
-        }
-
-        mock_response = Mock()
-        middleware = CookieNameChange(mock_response)
-
-        mock_request = Mock()
-
-        old_value = "." * 100
         new_value = "." * 13
         no_change_cookies = {
-            expand_settings['new_name']: new_value,
+            self.expand_settings['new_name']: new_value,
             "_c_": "." * 13,
             "a.b": "." * 10,
         }
-        old_dict = {
-            "a": old_value,
-        }
-        old_dict.update(no_change_cookies)
 
-        mock_request.COOKIES = old_dict.copy()
+        self.old_dict.update(no_change_cookies)
+
+        self.mock_request.COOKIES = self.old_dict.copy()
 
 
         with self.settings(
             COOKIE_NAME_CHANGE_ACTIVATE_EXPAND_PHASE=True
-        ), self.settings(COOKIE_NAME_CHANGE_EXPAND_INFO=expand_settings):
-            middleware(mock_request)
+        ), self.settings(COOKIE_NAME_CHANGE_EXPAND_INFO=self.expand_settings):
+            self.cookie_name_change_middleware(self.mock_request)
 
-        assert expand_settings["old_name"] not in mock_request.COOKIES.keys()
-        assert expand_settings["new_name"] in mock_request.COOKIES.keys()
-        assert mock_request.COOKIES[expand_settings["new_name"]] == new_value
-        assert mock_request.COOKIES == no_change_cookies
+        assert self.expand_settings["old_name"] not in self.mock_request.COOKIES.keys()
+        assert self.expand_settings["new_name"] in self.mock_request.COOKIES.keys()
+        assert self.mock_request.COOKIES[self.expand_settings["new_name"]] == new_value
+        assert self.mock_request.COOKIES == no_change_cookies
 
         # make sure response function is called once
-        mock_response.assert_called_once()
+        self.mock_response.assert_called_once()
 
     def test_does_nothing(self):
-        """Make sure turning off toggle turns off middleware"""
+        """Make sure turning off toggle turns off self.cookie_name_change_middleware"""
 
-        expand_settings = {
-            "old_name": "a",
-            "new_name": "b",
-            "old_domain": "old_domain.com",
-        }
-
-        mock_response = Mock()
-        middleware = CookieNameChange(mock_response)
-
-        mock_request = Mock()
-
-        old_value = "." * 100
         new_value = "." * 13
         no_change_cookies = {
-            expand_settings['new_name']: new_value,
+            self.expand_settings['new_name']: new_value,
             "_c_": "." * 13,
             "a.b": "." * 10,
         }
-        old_dict = {
-            "a": old_value,
-        }
-        old_dict.update(no_change_cookies)
+        self.old_dict.update(no_change_cookies)
 
-        mock_request.COOKIES = old_dict.copy()
+        self.mock_request.COOKIES = self.old_dict.copy()
 
 
         with self.settings(
             COOKIE_NAME_CHANGE_ACTIVATE_EXPAND_PHASE=False
-        ), self.settings(COOKIE_NAME_CHANGE_EXPAND_INFO=expand_settings):
-            middleware(mock_request)
+        ), self.settings(COOKIE_NAME_CHANGE_EXPAND_INFO=self.expand_settings):
+            self.cookie_name_change_middleware(self.mock_request)
 
-        assert mock_request.COOKIES == old_dict
+        assert self.mock_request.COOKIES == self.old_dict
 
         # make sure response function is called once
-        mock_response.assert_called_once()
+        self.mock_response.assert_called_once()

--- a/openedx/core/djangoapps/cookie_metadata/tests/test_cookie_name_change.py
+++ b/openedx/core/djangoapps/cookie_metadata/tests/test_cookie_name_change.py
@@ -1,5 +1,5 @@
 """
-Test Modle to test CookieNameChange class
+Test Module to test CookieNameChange class
 """
 from unittest.mock import Mock
 
@@ -15,6 +15,7 @@ class TestCookieNameChange(TestCase):
     """
 
     def setUp(self):
+        super().setUp()
         self.mock_response = Mock()
         self.cookie_name_change_middleware = CookieNameChange(self.mock_response)
         self.mock_request = Mock()
@@ -33,7 +34,6 @@ class TestCookieNameChange(TestCase):
         self.expand_settings = {
             "old_name": self.old_key,
             "new_name": "b",
-            "old_domain": "old_domain.com",
         }
 
     def test_cookie_swap(self):


### PR DESCRIPTION
Description: Adds a new middleware to help with cookie name changes. It uses the idea of expand and contract, where after we've changed the name, the middleware allows up to accept either a cookie with new name (given higher priority when both are present) or cookie with old name.

This is also helpful when changing domain of a cookie.

impacts: developers, users(anyone that has cookies)
Change depends on django setting changes. See CookieNameChange middleware for more info.