### PR TITLE
closed: fix: upgrade py2neo from 3.1.2 to 2021.1.5 

### DIFF
--- a/openedx/core/djangoapps/coursegraph/management/commands/tests/utils.py
+++ b/openedx/core/djangoapps/coursegraph/management/commands/tests/utils.py
@@ -84,17 +84,17 @@ class MockTransaction:
         self.graph.number_rollbacks += 1
 
 
-class MockNodeSelector:
+class MockNodeMatcher:
     """
-    Mocks out py2neo's NodeSelector class. Used to select a node from a graph.
-    py2neo's NodeSelector expects a real graph object to run queries against,
+    Mocks out py2neo's NodeMatcher class. Used to match a node from a graph.
+    py2neo's NodeMatcher expects a real graph object to run queries against,
     so, rather than have to mock out MockGraph to accommodate those queries,
-    it seemed simpler to mock out NodeSelector as well.
+    it seemed simpler to mock out NodeMatcher as well.
     """
     def __init__(self, graph):
         self.graph = graph
 
-    def select(self, label, course_key):
+    def match(self, label, course_key):
         """
         Selects nodes that match a label and course_key
         Args:
@@ -107,13 +107,13 @@ class MockNodeSelector:
         for node in self.graph.nodes:
             if node.has_label(label) and node["course_key"] == course_key:
                 nodes.append(node)
-        return MockNodeSelection(nodes)
+        return MockNodeMatch(nodes)
 
 
-class MockNodeSelection(list):
+class MockNodeMatch(list):
     """
-    Mocks out py2neo's NodeSelection class: this is the type of what
-    MockNodeSelector's `select` method returns.
+    Mocks out py2neo's NodeMatch class: this is the type of what
+    MockNodeMatcher's `match` method returns.
     """
     def first(self):
         """

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -94,3 +94,9 @@ click<8.0.0
 
 # jsonfield2 will be replaced with jsonfield in https://openedx.atlassian.net/browse/BOM-1917.
 jsonfield2<3.1.0        # jsonfield2 3.1.0 drops support for python 3.5
+
+# At the time of writing this comment, we do not know whether py2neo>=2022
+# will support our currently-deployed Neo4j version (3.5).
+# Feel free to loosen this constraint if/when it is confirmed that a later
+# version of py2neo will work with Neo4j 3.5.
+py2neo<2022

--- a/requirements/edx-sandbox/py35.txt
+++ b/requirements/edx-sandbox/py35.txt
@@ -62,7 +62,6 @@ numpy==1.16.5
     #   chem
     #   matplotlib
     #   openedx-calc
-    #   scipy
 openedx-calc==1.0.9
     # via -r requirements/edx-sandbox/py35.in
 pycparser==2.20
@@ -81,7 +80,7 @@ pytz==2021.1
     # via matplotlib
 random2==1.0.1
     # via -r requirements/edx-sandbox/py35.in
-regex==2021.7.6
+regex==2021.8.3
     # via nltk
 scipy==1.2.1
     # via
@@ -103,7 +102,7 @@ sympy==1.6.2
     #   -c requirements/edx-sandbox/py35-constraints.txt
     #   -r requirements/edx-sandbox/py35.in
     #   symmath
-tqdm==4.62.0
+tqdm==4.62.1
     # via nltk
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/edx-sandbox/py38.txt
+++ b/requirements/edx-sandbox/py38.txt
@@ -46,7 +46,7 @@ nltk==3.6.2
     # via
     #   -r requirements/edx-sandbox/py38.in
     #   chem
-numpy==1.21.1
+numpy==1.21.2
     # via
     #   -r requirements/edx-sandbox/py38.in
     #   chem
@@ -71,7 +71,7 @@ python-dateutil==2.4.0
     #   matplotlib
 random2==1.0.1
     # via -r requirements/edx-sandbox/py38.in
-regex==2021.7.6
+regex==2021.8.3
     # via nltk
 scipy==1.7.1
     # via
@@ -88,5 +88,5 @@ sympy==1.6.2
     #   -c requirements/edx-sandbox/../constraints.txt
     #   -r requirements/edx-sandbox/py38.in
     #   symmath
-tqdm==4.62.0
+tqdm==4.62.1
     # via nltk

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -124,6 +124,7 @@ openedx-calc                        # Library supporting mathematical calculatio
 ora2
 piexif                              # Exif image metadata manipulation, used in the profile_images app
 Pillow                              # Image manipulation library; used for course assets, profile images, invoice PDFs, etc.
+py2neo                              # Driver for converting Python modulestore structures to Neo4j's schema (for Coursegraph).
 pycountry
 pycryptodomex
 pygments                            # Used to support colors in paver command output

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -18,8 +18,6 @@
     # via -r requirements/edx/github.in
 -e .
     # via -r requirements/edx/local.in
--e git+https://github.com/technige/py2neo.git@py2neo-3.1.2#egg=py2neo==3.1.2
-    # via -r requirements/edx/github.in
 -e git+https://github.com/edx/RateXBlock.git@2.0.1#egg=rate-xblock
     # via -r requirements/edx/github.in
 -e common/lib/safe_lxml
@@ -48,6 +46,8 @@ aniso8601==9.0.1
     #   tincan
 appdirs==1.4.4
     # via fs
+asgiref==3.4.1
+    # via uvicorn
 async-timeout==3.0.1
     # via aiohttp
 attrs==21.2.0
@@ -66,7 +66,7 @@ beautifulsoup4==4.9.3
     # via pynliner
 billiard==3.6.4.0
     # via celery
-bleach==3.3.1
+bleach==4.0.0
     # via
     #   -r requirements/edx/base.in
     #   django-wiki
@@ -105,6 +105,7 @@ certifi==2021.5.30
     # via
     #   -r requirements/edx/paver.txt
     #   elasticsearch
+    #   py2neo
     #   requests
 cffi==1.14.6
     # via cryptography
@@ -123,7 +124,9 @@ click==7.1.2
     #   -c requirements/edx/../constraints.txt
     #   code-annotations
     #   nltk
+    #   pact-python
     #   user-util
+    #   uvicorn
 code-annotations==1.2.0
     # via
     #   edx-enterprise
@@ -143,6 +146,7 @@ cryptography==3.4.7
     #   -r requirements/edx/base.in
     #   django-fernet-fields
     #   edx-enterprise
+    #   py2neo
     #   pyjwt
     #   social-auth-core
 cssutils==2.3.0
@@ -327,13 +331,14 @@ django-sekizai==2.0.0
     # via
     #   -r requirements/edx/base.in
     #   django-wiki
-django-ses==2.2.0
+django-ses==2.2.1
     # via -r requirements/edx/base.in
 django-simple-history==3.0.0
     # via
     #   -r requirements/edx/base.in
     #   edx-enterprise
     #   edx-organizations
+    #   edx-proctoring
     #   ora2
 django-splash==1.1.0
     # via -r requirements/edx/base.in
@@ -379,6 +384,8 @@ djangorestframework==3.12.4
     #   super-csv
 djangorestframework-xml==2.0.0
     # via edx-enterprise
+docker==5.0.0
+    # via py2neo
 docopt==0.6.2
     # via xmodule
 docutils==0.17.1
@@ -426,6 +433,7 @@ edx-django-utils==4.2.0
     #   super-csv
 edx-drf-extensions==6.6.0
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/edx/base.in
     #   edx-completion
     #   edx-enterprise
@@ -445,7 +453,7 @@ edx-i18n-tools==0.7.0
     # via ora2
 edx-milestones==0.3.2
     # via -r requirements/edx/base.in
-edx-name-affirmation==0.4.0
+edx-name-affirmation==0.6.1
     # via -r requirements/edx/base.in
 edx-opaque-keys[django]==2.2.2
     # via
@@ -465,7 +473,7 @@ edx-opaque-keys[django]==2.2.2
     #   xmodule
 edx-organizations==6.10.0
     # via -r requirements/edx/base.in
-edx-proctoring==3.23.1
+edx-proctoring==3.23.2
     # via
     #   -r requirements/edx/base.in
     #   edx-proctoring-proctortrack
@@ -482,7 +490,7 @@ edx-search==3.1.0
     # via -r requirements/edx/base.in
 edx-sga==0.16.0
     # via -r requirements/edx/base.in
-edx-submissions==3.2.4
+edx-submissions==3.3.1
     # via
     #   -r requirements/edx/base.in
     #   ora2
@@ -502,10 +510,14 @@ edx-when==2.1.0
     # via
     #   -r requirements/edx/base.in
     #   edx-proctoring
-edxval==2.0.3
+edxval==2.1.0
     # via -r requirements/edx/base.in
 elasticsearch==7.13.4
-    # via edx-search
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   edx-search
+english==2020.7.0
+    # via py2neo
 enmerkar==0.7.1
     # via enmerkar-underscore
 enmerkar-underscore==2.1.0
@@ -516,6 +528,8 @@ event-tracking==1.1.0
     #   edx-event-routing-backends
     #   edx-proctoring
     #   edx-search
+fastapi==0.67.0
+    # via pact-python
 fs==2.0.18
     # via
     #   -r requirements/edx/base.in
@@ -538,6 +552,8 @@ glob2==0.7
     # via -r requirements/edx/base.in
 gunicorn==20.1.0
     # via -r requirements/edx/base.in
+h11==0.12.0
+    # via uvicorn
 help-tokens==2.1.0
     # via -r requirements/edx/base.in
 html5lib==1.1
@@ -600,7 +616,7 @@ libsass==0.10.0
     #   ora2
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==3.0.1
+lti-consumer-xblock==3.0.3
     # via -r requirements/edx/base.in
 lxml==4.5.0
     # via
@@ -650,7 +666,9 @@ git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752
 mongoengine==0.23.1
     # via -r requirements/edx/base.in
 monotonic==1.6
-    # via analytics-python
+    # via
+    #   analytics-python
+    #   py2neo
 mpmath==1.2.1
     # via sympy
 multidict==5.1.0
@@ -659,7 +677,9 @@ multidict==5.1.0
     #   yarl
 mysqlclient==2.0.3
     # via -r requirements/edx/base.in
-newrelic==6.6.0.162
+neotime==1.7.4
+    # via py2neo
+newrelic==6.8.0.163
     # via
     #   -r requirements/edx/base.in
     #   edx-django-utils
@@ -669,7 +689,7 @@ nltk==3.6.2
     #   chem
 nodeenv==1.6.0
     # via -r requirements/edx/base.in
-numpy==1.21.1
+numpy==1.21.2
     # via
     #   chem
     #   openedx-calc
@@ -690,6 +710,11 @@ packaging==21.0
     # via
     #   bleach
     #   drf-yasg
+    #   py2neo
+pact-python==1.4.0
+    # via edxval
+pansi==2020.7.3
+    # via py2neo
 path==16.2.0
     # via
     #   -r requirements/edx/paver.txt
@@ -716,10 +741,17 @@ pillow==8.3.1
     #   edx-organizations
 polib==1.1.1
     # via edx-i18n-tools
+prompt-toolkit==3.0.19
+    # via py2neo
 psutil==5.8.0
     # via
     #   -r requirements/edx/paver.txt
     #   edx-django-utils
+    #   pact-python
+py2neo==2021.1.5
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   -r requirements/edx/base.in
 pycountry==20.7.3
     # via -r requirements/edx/base.in
 pycparser==2.20
@@ -730,8 +762,12 @@ pycryptodomex==3.10.1
     #   edx-proctoring
     #   lti-consumer-xblock
     #   pyjwkest
-pygments==2.9.0
-    # via -r requirements/edx/base.in
+pydantic==1.8.2
+    # via fastapi
+pygments==2.10.0
+    # via
+    #   -r requirements/edx/base.in
+    #   py2neo
 pyjwkest==1.4.2
     # via
     #   -r requirements/edx/base.in
@@ -818,8 +854,10 @@ pytz==2021.1
     #   event-tracking
     #   fs
     #   icalendar
+    #   neotime
     #   olxcleaner
     #   ora2
+    #   py2neo
     #   tincan
     #   xblock
 pyuca==1.2
@@ -837,7 +875,7 @@ recommender-xblock==2.0.1
     # via -r requirements/edx/base.in
 redis==3.5.3
     # via -r requirements/edx/base.in
-regex==2021.7.6
+regex==2021.8.3
     # via nltk
 requests==2.26.0
     # via
@@ -845,6 +883,7 @@ requests==2.26.0
     #   analytics-python
     #   coreapi
     #   django-oauth-toolkit
+    #   docker
     #   edx-analytics-data-api-client
     #   edx-bulk-grades
     #   edx-drf-extensions
@@ -853,6 +892,7 @@ requests==2.26.0
     #   edx-rest-api-client
     #   geoip2
     #   mailsnake
+    #   pact-python
     #   pyjwkest
     #   python-swiftclient
     #   requests-oauthlib
@@ -913,13 +953,18 @@ six==1.16.0
     #   edx-i18n-tools
     #   edx-milestones
     #   edx-rbac
+    #   english
     #   event-tracking
     #   fs
     #   fs-s3fs
     #   html5lib
     #   isodate
     #   libsass
+    #   neotime
+    #   pact-python
+    #   pansi
     #   paver
+    #   py2neo
     #   pyjwkest
     #   python-dateutil
     #   python-memcached
@@ -932,9 +977,12 @@ slumber==0.7.1
     #   edx-enterprise
     #   edx-rest-api-client
 social-auth-app-django==4.0.0
-    # via -r requirements/edx/base.in
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -r requirements/edx/base.in
 social-auth-core==3.4.0
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   social-auth-app-django
@@ -952,6 +1000,8 @@ sqlparse==0.4.1
     #   django
 staff-graded-xblock==1.5.1
     # via -r requirements/edx/base.in
+starlette==0.14.2
+    # via fastapi
 stevedore==3.3.0
     # via
     #   -r requirements/edx/base.in
@@ -977,10 +1027,12 @@ text-unidecode==1.3
     # via python-slugify
 tincan==1.0.0
     # via edx-event-routing-backends
-tqdm==4.62.0
+tqdm==4.62.1
     # via nltk
 typing-extensions==3.10.0.0
-    # via aiohttp
+    # via
+    #   aiohttp
+    #   pydantic
 ua-parser==0.10.0
     # via django-cookies-samesite
 unicodecsv==0.14.1
@@ -996,9 +1048,13 @@ urllib3==1.26.6
     #   -r requirements/edx/paver.txt
     #   elasticsearch
     #   geoip2
+    #   pact-python
+    #   py2neo
     #   requests
 user-util==1.0.0
     # via -r requirements/edx/base.in
+uvicorn==0.14.0
+    # via pact-python
 vine==1.3.0
     # via
     #   amqp
@@ -1007,6 +1063,8 @@ voluptuous==0.12.1
     # via ora2
 watchdog==2.1.3
     # via -r requirements/edx/paver.txt
+wcwidth==0.2.5
+    # via prompt-toolkit
 web-fragments==1.1.0
     # via
     #   -r requirements/edx/base.in
@@ -1023,6 +1081,8 @@ webob==1.8.7
     # via
     #   xblock
     #   xmodule
+websocket-client==1.2.1
+    # via docker
 wrapt==1.11.2
     # via
     #   -c requirements/edx/../constraints.txt
@@ -1050,7 +1110,7 @@ git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.3.5#egg=xblock-d
     # via -r requirements/edx/github.in
 git+https://github.com/open-craft/xblock-poll@922cd36fb1c3cfe00b4ce03b19a13185d136447d#egg=xblock-poll==1.10.2
     # via -r requirements/edx/github.in
-xblock-utils==2.1.3
+xblock-utils==2.2.0
     # via
     #   -r requirements/edx/base.in
     #   edx-sga

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -22,5 +22,5 @@ markupsafe==2.0.1
     # via jinja2
 pluggy==0.13.1
     # via diff-cover
-pygments==2.9.0
+pygments==2.10.0
     # via diff-cover

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -18,8 +18,6 @@
     # via -r requirements/edx/testing.txt
 -e .
     # via -r requirements/edx/testing.txt
--e git+https://github.com/technige/py2neo.git@py2neo-3.1.2#egg=py2neo==3.1.2
-    # via -r requirements/edx/testing.txt
 -e git+https://github.com/edx/RateXBlock.git@2.0.1#egg=rate-xblock
     # via -r requirements/edx/testing.txt
 -e common/lib/safe_lxml
@@ -57,7 +55,11 @@ appdirs==1.4.4
     # via
     #   -r requirements/edx/testing.txt
     #   fs
-astroid==2.6.5
+asgiref==3.4.1
+    # via
+    #   -r requirements/edx/testing.txt
+    #   uvicorn
+astroid==2.6.6
     # via
     #   -r requirements/edx/testing.txt
     #   pylint
@@ -95,7 +97,7 @@ billiard==3.6.4.0
     # via
     #   -r requirements/edx/testing.txt
     #   celery
-bleach==3.3.1
+bleach==4.0.0
     # via
     #   -r requirements/edx/testing.txt
     #   django-wiki
@@ -136,6 +138,7 @@ certifi==2021.5.30
     # via
     #   -r requirements/edx/testing.txt
     #   elasticsearch
+    #   py2neo
     #   requests
 cffi==1.14.6
     # via
@@ -162,8 +165,10 @@ click==7.1.2
     #   code-annotations
     #   edx-lint
     #   nltk
+    #   pact-python
     #   pip-tools
     #   user-util
+    #   uvicorn
 click-log==0.3.2
     # via
     #   -r requirements/edx/testing.txt
@@ -196,6 +201,7 @@ cryptography==3.4.7
     #   -r requirements/edx/testing.txt
     #   django-fernet-fields
     #   edx-enterprise
+    #   py2neo
     #   pyjwt
     #   social-auth-core
 cssselect==1.1.0
@@ -335,7 +341,7 @@ django-crum==0.7.9
     #   edx-rbac
     #   edx-toggles
     #   super-csv
-django-debug-toolbar==3.2.1
+django-debug-toolbar==3.2.2
     # via -r requirements/edx/development.in
 django-fernet-fields==0.6
     # via
@@ -409,13 +415,14 @@ django-sekizai==2.0.0
     # via
     #   -r requirements/edx/testing.txt
     #   django-wiki
-django-ses==2.2.0
+django-ses==2.2.1
     # via -r requirements/edx/testing.txt
 django-simple-history==3.0.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
     #   edx-organizations
+    #   edx-proctoring
     #   ora2
 django-splash==1.1.0
     # via -r requirements/edx/testing.txt
@@ -463,6 +470,10 @@ djangorestframework-xml==2.0.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
+docker==5.0.0
+    # via
+    #   -r requirements/edx/testing.txt
+    #   py2neo
 docopt==0.6.2
     # via
     #   -r requirements/edx/testing.txt
@@ -519,6 +530,7 @@ edx-django-utils==4.2.0
     #   super-csv
 edx-drf-extensions==6.6.0
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/edx/testing.txt
     #   edx-completion
     #   edx-enterprise
@@ -542,7 +554,7 @@ edx-lint==5.0.0
     # via -r requirements/edx/testing.txt
 edx-milestones==0.3.2
     # via -r requirements/edx/testing.txt
-edx-name-affirmation==0.4.0
+edx-name-affirmation==0.6.1
     # via -r requirements/edx/testing.txt
 edx-opaque-keys[django]==2.2.2
     # via
@@ -562,7 +574,7 @@ edx-opaque-keys[django]==2.2.2
     #   xmodule
 edx-organizations==6.10.0
     # via -r requirements/edx/testing.txt
-edx-proctoring==3.23.1
+edx-proctoring==3.23.2
     # via
     #   -r requirements/edx/testing.txt
     #   edx-proctoring-proctortrack
@@ -583,7 +595,7 @@ edx-sga==0.16.0
     # via -r requirements/edx/testing.txt
 edx-sphinx-theme==3.0.0
     # via -r requirements/edx/development.in
-edx-submissions==3.2.4
+edx-submissions==3.3.1
     # via
     #   -r requirements/edx/testing.txt
     #   ora2
@@ -605,12 +617,17 @@ edx-when==2.1.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-proctoring
-edxval==2.0.3
+edxval==2.1.0
     # via -r requirements/edx/testing.txt
 elasticsearch==7.13.4
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/edx/testing.txt
     #   edx-search
+english==2020.7.0
+    # via
+    #   -r requirements/edx/testing.txt
+    #   py2neo
 enmerkar==0.7.1
     # via
     #   -r requirements/edx/testing.txt
@@ -629,10 +646,14 @@ execnet==1.9.0
     #   pytest-xdist
 factory-boy==3.2.0
     # via -r requirements/edx/testing.txt
-faker==8.10.3
+faker==8.11.0
     # via
     #   -r requirements/edx/testing.txt
     #   factory-boy
+fastapi==0.67.0
+    # via
+    #   -r requirements/edx/testing.txt
+    #   pact-python
 filelock==3.0.12
     # via
     #   -r requirements/edx/testing.txt
@@ -665,7 +686,7 @@ gitdb==4.0.7
     # via
     #   -r requirements/edx/testing.txt
     #   gitpython
-gitpython==3.1.18
+gitpython==3.1.20
     # via
     #   -r requirements/edx/testing.txt
     #   transifex-client
@@ -673,6 +694,10 @@ glob2==0.7
     # via -r requirements/edx/testing.txt
 gunicorn==20.1.0
     # via -r requirements/edx/testing.txt
+h11==0.12.0
+    # via
+    #   -r requirements/edx/testing.txt
+    #   uvicorn
 help-tokens==2.1.0
     # via -r requirements/edx/testing.txt
 html5lib==1.1
@@ -692,7 +717,7 @@ idna==3.2
     #   yarl
 imagesize==1.2.0
     # via sphinx
-importlib-metadata==4.6.3
+importlib-metadata==4.6.4
     # via
     #   -r requirements/edx/testing.txt
     #   pytest-randomly
@@ -786,7 +811,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/testing.txt
     #   ora2
-lti-consumer-xblock==3.0.1
+lti-consumer-xblock==3.0.3
     # via -r requirements/edx/testing.txt
 lxml==4.5.0
     # via
@@ -852,6 +877,7 @@ monotonic==1.6
     # via
     #   -r requirements/edx/testing.txt
     #   analytics-python
+    #   py2neo
 mpmath==1.2.1
     # via
     #   -r requirements/edx/testing.txt
@@ -867,7 +893,11 @@ mypy-extensions==0.4.3
     # via mypy
 mysqlclient==2.0.3
     # via -r requirements/edx/testing.txt
-newrelic==6.6.0.162
+neotime==1.7.4
+    # via
+    #   -r requirements/edx/testing.txt
+    #   py2neo
+newrelic==6.8.0.163
     # via
     #   -r requirements/edx/testing.txt
     #   edx-django-utils
@@ -877,7 +907,7 @@ nltk==3.6.2
     #   chem
 nodeenv==1.6.0
     # via -r requirements/edx/testing.txt
-numpy==1.21.1
+numpy==1.21.2
     # via
     #   -r requirements/edx/testing.txt
     #   chem
@@ -900,9 +930,18 @@ packaging==21.0
     #   -r requirements/edx/testing.txt
     #   bleach
     #   drf-yasg
+    #   py2neo
     #   pytest
     #   sphinx
     #   tox
+pact-python==1.4.0
+    # via
+    #   -r requirements/edx/testing.txt
+    #   edxval
+pansi==2020.7.3
+    # via
+    #   -r requirements/edx/testing.txt
+    #   py2neo
 path==16.2.0
     # via
     #   -r requirements/edx/testing.txt
@@ -948,10 +987,15 @@ polib==1.1.1
     # via
     #   -r requirements/edx/testing.txt
     #   edx-i18n-tools
+prompt-toolkit==3.0.19
+    # via
+    #   -r requirements/edx/testing.txt
+    #   py2neo
 psutil==5.8.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-django-utils
+    #   pact-python
     #   pytest-xdist
 py==1.10.0
     # via
@@ -959,6 +1003,10 @@ py==1.10.0
     #   pytest
     #   pytest-forked
     #   tox
+py2neo==2021.1.5
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   -r requirements/edx/testing.txt
 pycodestyle==2.7.0
     # via -r requirements/edx/testing.txt
 pycountry==20.7.3
@@ -973,10 +1021,15 @@ pycryptodomex==3.10.1
     #   edx-proctoring
     #   lti-consumer-xblock
     #   pyjwkest
-pygments==2.9.0
+pydantic==1.8.2
+    # via
+    #   -r requirements/edx/testing.txt
+    #   fastapi
+pygments==2.10.0
     # via
     #   -r requirements/edx/testing.txt
     #   diff-cover
+    #   py2neo
     #   sphinx
 pyjwkest==1.4.2
     # via
@@ -1071,7 +1124,7 @@ pytest-metadata==1.8.0
     # via
     #   -r requirements/edx/testing.txt
     #   pytest-json-report
-pytest-randomly==3.8.0
+pytest-randomly==3.10.1
     # via -r requirements/edx/testing.txt
 pytest-xdist[psutil]==2.3.0
     # via -r requirements/edx/testing.txt
@@ -1131,8 +1184,10 @@ pytz==2021.1
     #   event-tracking
     #   fs
     #   icalendar
+    #   neotime
     #   olxcleaner
     #   ora2
+    #   py2neo
     #   tincan
     #   xblock
 pyuca==1.2
@@ -1153,7 +1208,7 @@ recommender-xblock==2.0.1
     # via -r requirements/edx/testing.txt
 redis==3.5.3
     # via -r requirements/edx/testing.txt
-regex==2021.7.6
+regex==2021.8.3
     # via
     #   -r requirements/edx/testing.txt
     #   nltk
@@ -1163,6 +1218,7 @@ requests==2.26.0
     #   analytics-python
     #   coreapi
     #   django-oauth-toolkit
+    #   docker
     #   edx-analytics-data-api-client
     #   edx-bulk-grades
     #   edx-drf-extensions
@@ -1171,6 +1227,7 @@ requests==2.26.0
     #   edx-rest-api-client
     #   geoip2
     #   mailsnake
+    #   pact-python
     #   pyjwkest
     #   python-swiftclient
     #   requests-oauthlib
@@ -1230,7 +1287,7 @@ simplejson==3.17.3
     #   sailthru-client
     #   super-csv
     #   xblock-utils
-singledispatch==3.6.2
+singledispatch==3.7.0
     # via -r requirements/edx/testing.txt
 six==1.16.0
     # via
@@ -1252,6 +1309,7 @@ six==1.16.0
     #   edx-milestones
     #   edx-rbac
     #   edx-sphinx-theme
+    #   english
     #   event-tracking
     #   freezegun
     #   fs
@@ -1261,7 +1319,11 @@ six==1.16.0
     #   isodate
     #   jsonschema
     #   libsass
+    #   neotime
+    #   pact-python
+    #   pansi
     #   paver
+    #   py2neo
     #   pyjwkest
     #   python-dateutil
     #   python-memcached
@@ -1286,9 +1348,12 @@ smmap==4.0.0
 snowballstemmer==2.1.0
     # via sphinx
 social-auth-app-django==4.0.0
-    # via -r requirements/edx/testing.txt
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -r requirements/edx/testing.txt
 social-auth-core==3.4.0
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   social-auth-app-django
@@ -1329,6 +1394,10 @@ sqlparse==0.4.1
     #   django-debug-toolbar
 staff-graded-xblock==1.5.1
     # via -r requirements/edx/testing.txt
+starlette==0.14.2
+    # via
+    #   -r requirements/edx/testing.txt
+    #   fastapi
 stevedore==3.3.0
     # via
     #   -r requirements/edx/testing.txt
@@ -1372,7 +1441,7 @@ toml==0.10.2
     #   pytest-cov
     #   tox
     #   vulture
-tomli==1.2.0
+tomli==1.2.1
     # via
     #   -r requirements/edx/pip-tools.txt
     #   pep517
@@ -1382,7 +1451,7 @@ tox==3.24.1
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/edx/testing.txt
-tqdm==4.62.0
+tqdm==4.62.1
     # via
     #   -r requirements/edx/testing.txt
     #   nltk
@@ -1392,7 +1461,9 @@ typing-extensions==3.10.0.0
     # via
     #   -r requirements/edx/testing.txt
     #   aiohttp
+    #   gitpython
     #   mypy
+    #   pydantic
 ua-parser==0.10.0
     # via
     #   -r requirements/edx/testing.txt
@@ -1401,7 +1472,7 @@ unicodecsv==0.14.1
     # via
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
-unidiff==0.6.0
+unidiff==0.7.0
     # via -r requirements/edx/testing.txt
 uritemplate==3.0.1
     # via
@@ -1413,17 +1484,23 @@ urllib3==1.26.6
     #   -r requirements/edx/testing.txt
     #   elasticsearch
     #   geoip2
+    #   pact-python
+    #   py2neo
     #   requests
     #   selenium
     #   transifex-client
 user-util==1.0.0
     # via -r requirements/edx/testing.txt
+uvicorn==0.14.0
+    # via
+    #   -r requirements/edx/testing.txt
+    #   pact-python
 vine==1.3.0
     # via
     #   -r requirements/edx/testing.txt
     #   amqp
     #   celery
-virtualenv==20.7.0
+virtualenv==20.7.2
     # via
     #   -r requirements/edx/testing.txt
     #   tox
@@ -1435,6 +1512,10 @@ vulture==2.3
     # via -r requirements/edx/development.in
 watchdog==2.1.3
     # via -r requirements/edx/testing.txt
+wcwidth==0.2.5
+    # via
+    #   -r requirements/edx/testing.txt
+    #   prompt-toolkit
 web-fragments==1.1.0
     # via
     #   -r requirements/edx/testing.txt
@@ -1453,7 +1534,11 @@ webob==1.8.7
     #   -r requirements/edx/testing.txt
     #   xblock
     #   xmodule
-wheel==0.36.2
+websocket-client==1.2.1
+    # via
+    #   -r requirements/edx/testing.txt
+    #   docker
+wheel==0.37.0
     # via
     #   -r requirements/edx/pip-tools.txt
     #   pip-tools
@@ -1485,7 +1570,7 @@ git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.3.5#egg=xblock-d
     # via -r requirements/edx/testing.txt
 git+https://github.com/open-craft/xblock-poll@922cd36fb1c3cfe00b4ce03b19a13185d136447d#egg=xblock-poll==1.10.2
     # via -r requirements/edx/testing.txt
-xblock-utils==2.1.3
+xblock-utils==2.2.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-sga

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -24,7 +24,7 @@ edx-sphinx-theme==3.0.0
     # via -r requirements/edx/doc.in
 gitdb==4.0.7
     # via gitpython
-gitpython==3.1.18
+gitpython==3.1.20
     # via -r requirements/edx/doc.in
 idna==3.2
     # via requests
@@ -40,7 +40,7 @@ packaging==21.0
     # via sphinx
 pbr==5.6.0
     # via stevedore
-pygments==2.9.0
+pygments==2.10.0
     # via sphinx
 pyparsing==2.4.7
     # via packaging
@@ -80,6 +80,8 @@ stevedore==3.3.0
     # via code-annotations
 text-unidecode==1.3
     # via python-slugify
+typing-extensions==3.10.0.0
+    # via gitpython
 urllib3==1.26.6
     # via requests
 

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -58,7 +58,6 @@
 -e git+https://github.com/openedx/olxcleaner.git@2f0d6c7f126cbd69c9724b7b57a0b2565330a297#egg=olxcleaner
 git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
--e git+https://github.com/technige/py2neo.git@py2neo-3.1.2#egg=py2neo==3.1.2
 
 # This is a temporary fork until https://github.com/brutasse/django-ratelimit-backend/pull/50 is merged
 # back into the upstream code.

--- a/requirements/edx/pip-tools.txt
+++ b/requirements/edx/pip-tools.txt
@@ -12,9 +12,9 @@ pep517==0.11.0
     # via pip-tools
 pip-tools==6.2.0
     # via -r requirements/edx/pip-tools.in
-tomli==1.2.0
+tomli==1.2.1
     # via pep517
-wheel==0.36.2
+wheel==0.37.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -18,8 +18,6 @@
     # via -r requirements/edx/base.txt
 -e .
     # via -r requirements/edx/base.txt
--e git+https://github.com/technige/py2neo.git@py2neo-3.1.2#egg=py2neo==3.1.2
-    # via -r requirements/edx/base.txt
 -e git+https://github.com/edx/RateXBlock.git@2.0.1#egg=rate-xblock
     # via -r requirements/edx/base.txt
 -e common/lib/safe_lxml
@@ -55,7 +53,11 @@ appdirs==1.4.4
     # via
     #   -r requirements/edx/base.txt
     #   fs
-astroid==2.6.5
+asgiref==3.4.1
+    # via
+    #   -r requirements/edx/base.txt
+    #   uvicorn
+astroid==2.6.6
     # via
     #   pylint
     #   pylint-celery
@@ -89,7 +91,7 @@ billiard==3.6.4.0
     # via
     #   -r requirements/edx/base.txt
     #   celery
-bleach==3.3.1
+bleach==4.0.0
     # via
     #   -r requirements/edx/base.txt
     #   django-wiki
@@ -130,6 +132,7 @@ certifi==2021.5.30
     # via
     #   -r requirements/edx/base.txt
     #   elasticsearch
+    #   py2neo
     #   requests
 cffi==1.14.6
     # via
@@ -154,7 +157,9 @@ click==7.1.2
     #   code-annotations
     #   edx-lint
     #   nltk
+    #   pact-python
     #   user-util
+    #   uvicorn
 click-log==0.3.2
     # via edx-lint
 code-annotations==1.2.0
@@ -186,6 +191,7 @@ cryptography==3.4.7
     #   -r requirements/edx/base.txt
     #   django-fernet-fields
     #   edx-enterprise
+    #   py2neo
     #   pyjwt
     #   social-auth-core
 cssselect==1.1.0
@@ -394,13 +400,14 @@ django-sekizai==2.0.0
     # via
     #   -r requirements/edx/base.txt
     #   django-wiki
-django-ses==2.2.0
+django-ses==2.2.1
     # via -r requirements/edx/base.txt
 django-simple-history==3.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   edx-organizations
+    #   edx-proctoring
     #   ora2
 django-splash==1.1.0
     # via -r requirements/edx/base.txt
@@ -448,6 +455,10 @@ djangorestframework-xml==2.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
+docker==5.0.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   py2neo
 docopt==0.6.2
     # via
     #   -r requirements/edx/base.txt
@@ -502,6 +513,7 @@ edx-django-utils==4.2.0
     #   super-csv
 edx-drf-extensions==6.6.0
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-completion
     #   edx-enterprise
@@ -526,7 +538,7 @@ edx-lint==5.0.0
     # via -r requirements/edx/testing.in
 edx-milestones==0.3.2
     # via -r requirements/edx/base.txt
-edx-name-affirmation==0.4.0
+edx-name-affirmation==0.6.1
     # via -r requirements/edx/base.txt
 edx-opaque-keys[django]==2.2.2
     # via
@@ -546,7 +558,7 @@ edx-opaque-keys[django]==2.2.2
     #   xmodule
 edx-organizations==6.10.0
     # via -r requirements/edx/base.txt
-edx-proctoring==3.23.1
+edx-proctoring==3.23.2
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring-proctortrack
@@ -565,7 +577,7 @@ edx-search==3.1.0
     # via -r requirements/edx/base.txt
 edx-sga==0.16.0
     # via -r requirements/edx/base.txt
-edx-submissions==3.2.4
+edx-submissions==3.3.1
     # via
     #   -r requirements/edx/base.txt
     #   ora2
@@ -587,12 +599,17 @@ edx-when==2.1.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring
-edxval==2.0.3
+edxval==2.1.0
     # via -r requirements/edx/base.txt
 elasticsearch==7.13.4
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-search
+english==2020.7.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   py2neo
 enmerkar==0.7.1
     # via
     #   -r requirements/edx/base.txt
@@ -609,8 +626,12 @@ execnet==1.9.0
     # via pytest-xdist
 factory-boy==3.2.0
     # via -r requirements/edx/testing.in
-faker==8.10.3
+faker==8.11.0
     # via factory-boy
+fastapi==0.67.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   pact-python
 filelock==3.0.12
     # via
     #   tox
@@ -640,12 +661,16 @@ geoip2==4.2.0
     # via -r requirements/edx/base.txt
 gitdb==4.0.7
     # via gitpython
-gitpython==3.1.18
+gitpython==3.1.20
     # via transifex-client
 glob2==0.7
     # via -r requirements/edx/base.txt
 gunicorn==20.1.0
     # via -r requirements/edx/base.txt
+h11==0.12.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   uvicorn
 help-tokens==2.1.0
     # via -r requirements/edx/base.txt
 html5lib==1.1
@@ -663,7 +688,7 @@ idna==3.2
     #   -r requirements/edx/base.txt
     #   requests
     #   yarl
-importlib-metadata==4.6.3
+importlib-metadata==4.6.4
     # via pytest-randomly
 inflect==5.3.0
     # via
@@ -749,7 +774,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==3.0.1
+lti-consumer-xblock==3.0.3
     # via -r requirements/edx/base.txt
 lxml==4.5.0
     # via
@@ -810,6 +835,7 @@ monotonic==1.6
     # via
     #   -r requirements/edx/base.txt
     #   analytics-python
+    #   py2neo
 mpmath==1.2.1
     # via
     #   -r requirements/edx/base.txt
@@ -821,7 +847,11 @@ multidict==5.1.0
     #   yarl
 mysqlclient==2.0.3
     # via -r requirements/edx/base.txt
-newrelic==6.6.0.162
+neotime==1.7.4
+    # via
+    #   -r requirements/edx/base.txt
+    #   py2neo
+newrelic==6.8.0.163
     # via
     #   -r requirements/edx/base.txt
     #   edx-django-utils
@@ -831,7 +861,7 @@ nltk==3.6.2
     #   chem
 nodeenv==1.6.0
     # via -r requirements/edx/base.txt
-numpy==1.21.1
+numpy==1.21.2
     # via
     #   -r requirements/edx/base.txt
     #   chem
@@ -854,8 +884,17 @@ packaging==21.0
     #   -r requirements/edx/base.txt
     #   bleach
     #   drf-yasg
+    #   py2neo
     #   pytest
     #   tox
+pact-python==1.4.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   edxval
+pansi==2020.7.3
+    # via
+    #   -r requirements/edx/base.txt
+    #   py2neo
 path==16.2.0
     # via
     #   -r requirements/edx/base.txt
@@ -894,16 +933,25 @@ polib==1.1.1
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/testing.in
     #   edx-i18n-tools
+prompt-toolkit==3.0.19
+    # via
+    #   -r requirements/edx/base.txt
+    #   py2neo
 psutil==5.8.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-django-utils
+    #   pact-python
     #   pytest-xdist
 py==1.10.0
     # via
     #   pytest
     #   pytest-forked
     #   tox
+py2neo==2021.1.5
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   -r requirements/edx/base.txt
 pycodestyle==2.7.0
     # via -r requirements/edx/testing.in
 pycountry==20.7.3
@@ -918,11 +966,16 @@ pycryptodomex==3.10.1
     #   edx-proctoring
     #   lti-consumer-xblock
     #   pyjwkest
-pygments==2.9.0
+pydantic==1.8.2
+    # via
+    #   -r requirements/edx/base.txt
+    #   fastapi
+pygments==2.10.0
     # via
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/coverage.txt
     #   diff-cover
+    #   py2neo
 pyjwkest==1.4.2
     # via
     #   -r requirements/edx/base.txt
@@ -1006,7 +1059,7 @@ pytest-metadata==1.8.0
     # via
     #   -r requirements/edx/testing.in
     #   pytest-json-report
-pytest-randomly==3.8.0
+pytest-randomly==3.10.1
     # via -r requirements/edx/testing.in
 pytest-xdist[psutil]==2.3.0
     # via -r requirements/edx/testing.in
@@ -1066,8 +1119,10 @@ pytz==2021.1
     #   event-tracking
     #   fs
     #   icalendar
+    #   neotime
     #   olxcleaner
     #   ora2
+    #   py2neo
     #   tincan
     #   xblock
 pyuca==1.2
@@ -1085,7 +1140,7 @@ recommender-xblock==2.0.1
     # via -r requirements/edx/base.txt
 redis==3.5.3
     # via -r requirements/edx/base.txt
-regex==2021.7.6
+regex==2021.8.3
     # via
     #   -r requirements/edx/base.txt
     #   nltk
@@ -1095,6 +1150,7 @@ requests==2.26.0
     #   analytics-python
     #   coreapi
     #   django-oauth-toolkit
+    #   docker
     #   edx-analytics-data-api-client
     #   edx-bulk-grades
     #   edx-drf-extensions
@@ -1103,6 +1159,7 @@ requests==2.26.0
     #   edx-rest-api-client
     #   geoip2
     #   mailsnake
+    #   pact-python
     #   pyjwkest
     #   python-swiftclient
     #   requests-oauthlib
@@ -1161,7 +1218,7 @@ simplejson==3.17.3
     #   sailthru-client
     #   super-csv
     #   xblock-utils
-singledispatch==3.6.2
+singledispatch==3.7.0
     # via -r requirements/edx/testing.in
 six==1.16.0
     # via
@@ -1182,6 +1239,7 @@ six==1.16.0
     #   edx-lint
     #   edx-milestones
     #   edx-rbac
+    #   english
     #   event-tracking
     #   freezegun
     #   fs
@@ -1190,7 +1248,11 @@ six==1.16.0
     #   httpretty
     #   isodate
     #   libsass
+    #   neotime
+    #   pact-python
+    #   pansi
     #   paver
+    #   py2neo
     #   pyjwkest
     #   python-dateutil
     #   python-memcached
@@ -1210,9 +1272,12 @@ slumber==0.7.1
 smmap==4.0.0
     # via gitdb
 social-auth-app-django==4.0.0
-    # via -r requirements/edx/base.txt
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -r requirements/edx/base.txt
 social-auth-core==3.4.0
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   social-auth-app-django
@@ -1232,6 +1297,10 @@ sqlparse==0.4.1
     #   django
 staff-graded-xblock==1.5.1
     # via -r requirements/edx/base.txt
+starlette==0.14.2
+    # via
+    #   -r requirements/edx/base.txt
+    #   fastapi
 stevedore==3.3.0
     # via
     #   -r requirements/edx/base.txt
@@ -1279,7 +1348,7 @@ tox==3.24.1
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/edx/testing.in
-tqdm==4.62.0
+tqdm==4.62.1
     # via
     #   -r requirements/edx/base.txt
     #   nltk
@@ -1289,6 +1358,8 @@ typing-extensions==3.10.0.0
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
+    #   gitpython
+    #   pydantic
 ua-parser==0.10.0
     # via
     #   -r requirements/edx/base.txt
@@ -1297,7 +1368,7 @@ unicodecsv==0.14.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-unidiff==0.6.0
+unidiff==0.7.0
     # via -r requirements/edx/testing.in
 uritemplate==3.0.1
     # via
@@ -1309,17 +1380,23 @@ urllib3==1.26.6
     #   -r requirements/edx/base.txt
     #   elasticsearch
     #   geoip2
+    #   pact-python
+    #   py2neo
     #   requests
     #   selenium
     #   transifex-client
 user-util==1.0.0
     # via -r requirements/edx/base.txt
+uvicorn==0.14.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   pact-python
 vine==1.3.0
     # via
     #   -r requirements/edx/base.txt
     #   amqp
     #   celery
-virtualenv==20.7.0
+virtualenv==20.7.2
     # via tox
 voluptuous==0.12.1
     # via
@@ -1327,6 +1404,10 @@ voluptuous==0.12.1
     #   ora2
 watchdog==2.1.3
     # via -r requirements/edx/base.txt
+wcwidth==0.2.5
+    # via
+    #   -r requirements/edx/base.txt
+    #   prompt-toolkit
 web-fragments==1.1.0
     # via
     #   -r requirements/edx/base.txt
@@ -1345,6 +1426,10 @@ webob==1.8.7
     #   -r requirements/edx/base.txt
     #   xblock
     #   xmodule
+websocket-client==1.2.1
+    # via
+    #   -r requirements/edx/base.txt
+    #   docker
 wrapt==1.11.2
     # via
     #   -c requirements/edx/../constraints.txt
@@ -1373,7 +1458,7 @@ git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.3.5#egg=xblock-d
     # via -r requirements/edx/base.txt
 git+https://github.com/open-craft/xblock-poll@922cd36fb1c3cfe00b4ce03b19a13185d136447d#egg=xblock-poll==1.10.2
     # via -r requirements/edx/base.txt
-xblock-utils==2.1.3
+xblock-utils==2.2.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-sga


### PR DESCRIPTION
**Closed in favor of https://github.com/edx/edx-platform/pull/28480**
______________________
## Description

The dump_to_neo4j management command has not been working
since the upgrade to python 3.8. The latest version of
python that py2neo 3.1.2 states support for is python 3.5,
so this isn't surprising.

The earliest non-prerelease version of py2neo that supports
python 3.8 is 2020.x (skipping the 4.x and 5.x series). Since
we're going as far as a 2020.x, we may as well upgrade all the
way to the newest series, 2021.x.

This will require an upgrade of Coursegraph's Neo4j
version from 3.2.x to 3.5.x.

## Supporting information

https://openedx.atlassian.net/browse/TNL-8386

## Testing instructions

...

## Deadline
...

## Other information

This configuration PR bumps the version of neo4j that is installed onto the Coursegraph box: https://github.com/edx/configuration/pull/6502