### PR TITLE
[SE-4650] OEP-15 - add support for course-wide custom resources

### DIFF
--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -998,6 +998,19 @@ class CourseFields:  # lint-amnesty, pylint: disable=missing-class-docstring
         ),
         scope=Scope.settings, default=False
     )
+
+    course_wide_js = List(
+        display_name=_("Course-wide Custom JS"),
+        help=_('Enter Javascript resource URLs you want to be loaded globally throughout the course pages.'),
+        scope=Scope.settings,
+    )
+
+    course_wide_css = List(
+        display_name=_("Course-wide Custom CSS"),
+        help=_('Enter CSS resource URLs you want to be loaded globally throughout the course pages.'),
+        scope=Scope.settings,
+    )
+
     other_course_settings = Dict(
         display_name=_("Other Course Settings"),
         help=_(

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -6,6 +6,7 @@ Tests courseware views.py
 import html
 import itertools
 import json
+import re
 from datetime import datetime, timedelta
 from uuid import uuid4
 
@@ -65,6 +66,7 @@ from lms.djangoapps.courseware.toggles import (
 from lms.djangoapps.courseware.user_state_client import DjangoXBlockUserStateClient
 from lms.djangoapps.grades.config.waffle import ASSUME_ZERO_GRADE_IF_ABSENT
 from lms.djangoapps.grades.config.waffle import waffle_switch as grades_waffle_switch
+from lms.djangoapps.instructor.access import allow_access
 from lms.djangoapps.verify_student.models import VerificationDeadline
 from lms.djangoapps.verify_student.services import IDVerificationService
 from openedx.core.djangoapps.catalog.tests.factories import CourseFactory as CatalogCourseFactory
@@ -3743,3 +3745,64 @@ class ContentOptimizationTestCase(ModuleStoreTestCase):
         response = self.client.get(url)
         assert response.status_code == 200
         assert b"MathJax.Hub.Config" in response.content
+
+
+@ddt.ddt
+class TestCourseWideResources(ModuleStoreTestCase):
+    """
+    Tests that custom course-wide resources are rendered in course pages
+    """
+
+    @ddt.data(
+        ('courseware', 'course_id', False, True),
+        ('dates', 'course_id', False, False),
+        ('progress', 'course_id', False, False),
+        ('instructor_dashboard', 'course_id', True, False),
+        ('forum_form_discussion', 'course_id', False, False),
+        ('render_xblock', 'usage_key_string', False, True),
+    )
+    @ddt.unpack
+    def test_course_wide_resources(self, url_name, param, is_instructor, is_rendered):
+        """
+        Tests that the <script> and <link> tags are created for course-wide custom resources.
+        Also, test that the order which the resources are added match the given order.
+        """
+        user = UserFactory()
+
+        js = ['/test.js', 'https://testcdn.com/js/lib.min.js', '//testcdn.com/js/lib2.js']
+        css = ['https://testcdn.com/css/lib.min.css', '//testcdn.com/css/lib2.css', '/test.css']
+
+        course = CourseFactory.create(course_wide_js=js, course_wide_css=css)
+        chapter = ItemFactory.create(parent=course, category='chapter')
+        sequence = ItemFactory.create(parent=chapter, category='sequential', display_name='Sequence')
+
+        CourseOverview.load_from_module_store(course.id)
+        CourseEnrollmentFactory(user=user, course_id=course.id)
+        if is_instructor:
+            allow_access(course, user, 'instructor')
+        assert self.client.login(username=user.username, password='test')
+
+        kwargs = None
+        if param == 'course_id':
+            kwargs = {'course_id': str(course.id)}
+        elif param == 'usage_key_string':
+            kwargs = {'usage_key_string': str(sequence.location)}
+        response = self.client.get(reverse(url_name, kwargs=kwargs))
+
+        content = response.content.decode('utf-8')
+        js_match = [re.search(f'<script .*src=[\'"]{j}[\'"].*>', content) for j in js]
+        css_match = [re.search(f'<link .*href=[\'"]{c}[\'"].*>', content) for c in css]
+
+        # custom resources are included
+        if is_rendered:
+            assert None not in js_match
+            assert None not in css_match
+
+            # custom resources are added in order
+            for i in range(len(js) - 1):
+                assert js_match[i].start() < js_match[i + 1].start()
+            for i in range(len(css) - 1):
+                assert css_match[i].start() < css_match[i + 1].start()
+        else:
+            assert js_match == [None, None, None]
+            assert css_match == [None, None, None]

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -444,7 +444,8 @@ class CoursewareIndex(View):
             'section_title': None,
             'sequence_title': None,
             'disable_accordion': not DISABLE_COURSE_OUTLINE_PAGE_FLAG.is_enabled(self.course.id),
-            'show_search': show_search
+            'show_search': show_search,
+            'render_course_wide_assets': True,
         }
         courseware_context.update(
             get_experiment_user_metadata_context(

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1806,6 +1806,7 @@ def render_xblock(request, usage_key_string, check_if_enrolled=True):
             'is_learning_mfe': is_learning_mfe,
             'is_mobile_app': is_request_from_mobile_app(request),
             'reset_deadlines_url': reverse(RESET_COURSE_DEADLINES_NAME),
+            'render_course_wide_assets': True,
 
             **optimization_flags,
         }

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -171,6 +171,11 @@ from common.djangoapps.pipeline_mako import render_require_js_path_overrides
     </script>
 % endif
 
+  % if course and course is not UNDEFINED and render_course_wide_assets:
+  % for css in course.course_wide_css:
+    <link rel="stylesheet" href="${css}" type="text/css">
+  % endfor
+  % endif
 </head>
 
 <body class="${static.dir_rtl()} <%block name='bodyclass'/> lang_${LANGUAGE_CODE}">
@@ -215,6 +220,12 @@ from common.djangoapps.pipeline_mako import render_require_js_path_overrides
   <%static:optional_include_mako file="body-extra.html" is_theming_enabled="True" />
   <script type="text/javascript" src="${static.url('js/src/jquery_extend_patch.js')}"></script>
   <div id="lean_overlay"></div>
+
+  % if course and course is not UNDEFINED and render_course_wide_assets:
+  % for js in course.course_wide_js:
+  <script type="text/javascript" src="${js}"></script>
+  % endfor
+  % endif
 </body>
 </html>
 

--- a/lms/templates/main_django.html
+++ b/lms/templates/main_django.html
@@ -20,6 +20,12 @@
   {% block headextra %}{% endblock %}
   {% render_block "css" %}
 
+  {% if request.course and request.render_course_wide_assets %}
+  {% for css in request.course.course_wide_css %}
+  <link rel="stylesheet" href="{{css}}" type="text/css">
+  {% endfor %}
+  {% endif %}
+
   {% optional_include "head-extra.html"|microsite_template_path %}
 
   <meta name="path_prefix" content="{{EDX_ROOT_URL}}">
@@ -46,6 +52,12 @@
     {% javascript 'base_application' %}
 
     {% render_block "js" %}
+
+    {% if request.course and request.render_course_wide_assets %}
+    {% for js in request.course.course_wide_js %}
+    <script type="text/javascript" src="{{js}}"></script>
+    {% endfor %}
+    {% endif %}
 </body>
 </html>
 


### PR DESCRIPTION
## Description

#### Intention
This PR implements [OEP-15](https://open-edx-proposals.readthedocs.io/en/latest/oep-0015-arch-course-wide-js.html#oep-15-course-wide-custom-javascript), i.e., enabling the user to add global course-wide scripts rather than having to define them separately for every XBlock. Having such a feature allow us to integrate third-party libraries such as [ReadSpeaker](https://www.readspeaker.com/) and [Gamalon](https://gamalon.com/) which have been requested by our clients.

#### Approach

As suggested in the [OEP](https://open-edx-proposals.readthedocs.io/en/latest/oep-0015-arch-course-wide-js.html#specification), two [new fields are added to  _Advanced Settings_](https://github.com/edx/edx-platform/pull/28411/commits/4fbb1a86f0819d9d1d1e9a38ff5b5728756499d4#diff-5e5a9a90f02439d6bcd1f65bc96da133eedae87338ba248f7bd49a4752fbbaf7R999)  allowing the staff to specify a list of JS and CSS resources which they want to be included in all pages of the course.

These resources are [rendered in the base templates](https://github.com/edx/edx-platform/pull/28411/commits/4fbb1a86f0819d9d1d1e9a38ff5b5728756499d4#diff-1adbd21958e452c19656801dc282c38d458be2b2afeecad134e77c1de607a74dR174), which will allow them to be included in all course pages.

However, for the micro-frontend React UI things will need to be a little different. There are two main things  consider here:
- In the React UI, units (and all XBocks inside) are rendered in an `iframe`. This means scripts and styles added to the parent frame won't work for the XBlocks rendered inside the `iframe` and vice verca. And so if we want the scripts/styles to be available in both contexts we will have to add them to both.
- Since the React UI is not rendered with Django templates, it will need to be able to fetch the custom resource URLs via an API call and include them in the page dynamically.

The custom JS/CSS resources  [are included](https://github.com/edx/edx-platform/pull/28411/commits/4fbb1a86f0819d9d1d1e9a38ff5b5728756499d4#diff-5cb8e342b5bc31e8e6fe96225069cfe7cf7b313d8d586e5471c0deb254ffbea5R122) in the `CourseInfoSerializer` and will be available to the React UI when it is fetching the course metadata via the API. A future PR on the frontend code will use this and add the resources to the page.
As for the content inside the `iframe`s, they are rendered using templates in django and the changes made for the legacy UI will also work for them.

The changes required for the frontend are available in [frontend-app-learning#581](https://github.com/edx/frontend-app-learning/pull/581)

#### Points of possible debate

* The OEP only mentions adding support for course-wide scripts (JS) and not styles (CSS). I've decided to also allow adding CSS here since a it's quite common for third-party Javascript libraries to have accompanying stylesheets which also need to be added to the page.
* I've used the names _Course-wide JS_ and _Course-wide CSS_ for these fields. I personally preferred it over the term _global_, let me know if you think otherwise or if you have other suggestions.
* For the React UI, including the scripts/styles twice (once in the parent frame and once in the iframe) is obviously not ideal performance-wise. However, I think the purpose of this OEP was to enable a wide variety of scripts to run and these could be targeting either XBlock content or the course page itself depending on the use-case (correct me if I'm wrong), which will mean the scripts need to be included in both places. Another possible solution could be to have three separate options available for the user:
    * Scripts/Styles to be used in the legacy UI
    * Scripts/Styles to be used in the parent frame of the React UI
    * Scripts/Styles to be used in the iframe's of the React UI

   I feel like it's not worth the extra complexity though

## Testing Instructors

**Sandbox Link**: [LMS](https://pr28411.sandbox.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/course/)  /  [Studio](https://studio.pr28411.sandbox.opencraft.hosting/)

1. Login to the studio (**user**: staff@example.com **pass**: edx) and open the [Advanced Settings](https://studio.pr28411.sandbox.opencraft.hosting/settings/advanced/course-v1:edX+DemoX+Demo_Course) for the demo course.
2. Find the _Course-wide Custom JS_ and _Course-wide Custom CSS_ fields and add sample resources to test with. These could be external URLs or files added in the [Files and Uploads](https://studio.pr28411.sandbox.opencraft.hosting/assets/course-v1:edX+DemoX+Demo_Course/) page.
3. Visit the any course page (e.g., courseware, discussions, progress, etc. ) and these scripts should be working

(You can skip steps 1 and 2 and use the scripts I've already added. The script will show you a toast message on the upper left corner of the page.)

## Reviewers
- [ ] @nizarmah 
- [ ] @bradenmacdonald 