### PR TITLE
feat: Emit course completion related events

### DIFF
--- a/lms/djangoapps/grades/events.py
+++ b/lms/djangoapps/grades/events.py
@@ -19,6 +19,9 @@ PROBLEM_SUBMITTED_EVENT_TYPE = 'edx.grades.problem.submitted'
 STATE_DELETED_EVENT_TYPE = 'edx.grades.problem.state_deleted'
 SUBSECTION_OVERRIDE_EVENT_TYPE = 'edx.grades.subsection.score_overridden'
 SUBSECTION_GRADE_CALCULATED = 'edx.grades.subsection.grade_calculated'
+COURSE_GRADE_PASSED_FIRST_TIME_EVENT_TYPE = 'edx.course.grade.passed.first_time'
+COURSE_GRADE_NOW_PASSED_EVENT_TYPE = 'edx.course.grade.now_passed'
+COURSE_GRADE_NOW_FAILED_EVENT_TYPE = 'edx.course.grade.now_failed'
 
 
 def grade_updated(**kwargs):
@@ -133,5 +136,63 @@ def course_grade_calculated(course_grade):
                 'event_transaction_id': str(get_event_transaction_id()),
                 'event_transaction_type': str(get_event_transaction_type()),
                 'grading_policy_hash': str(course_grade.grading_policy_hash),
+            }
+        )
+
+
+def course_grade_passed_first_time(user_id, course_id):
+    """
+    Emits an event edx.course.grade.passed.first_time
+    with data from the passed course_grade.
+    """
+    event_name = COURSE_GRADE_PASSED_FIRST_TIME_EVENT_TYPE
+    context = contexts.course_context_from_course_id(course_id)
+    # TODO (AN-6134): remove this context manager
+    with tracker.get_tracker().context(event_name, context):
+        tracker.emit(
+            event_name,
+            {
+                'user_id': str(user_id),
+                'course_id': str(course_id),
+                'event_transaction_id': str(get_event_transaction_id()),
+                'event_transaction_type': str(get_event_transaction_type())
+            }
+        )
+
+
+def course_grade_now_passed(user, course_id):
+    """
+    Emits an edx.course.grade.now_passed event
+    with data from the course and user passed now .
+    """
+    event_name = COURSE_GRADE_NOW_PASSED_EVENT_TYPE
+    context = contexts.course_context_from_course_id(course_id)
+    with tracker.get_tracker().context(event_name, context):
+        tracker.emit(
+            event_name,
+            {
+                'user_id': str(user.id),
+                'course_id': str(course_id),
+                'event_transaction_id': str(get_event_transaction_id()),
+                'event_transaction_type': str(get_event_transaction_type())
+            }
+        )
+
+
+def course_grade_now_failed(user, course_id):
+    """
+    Emits an edx.course.grade.now_failed event
+    with data from the course and user failed now .
+    """
+    event_name = COURSE_GRADE_NOW_FAILED_EVENT_TYPE
+    context = contexts.course_context_from_course_id(course_id)
+    with tracker.get_tracker().context(event_name, context):
+        tracker.emit(
+            event_name,
+            {
+                'user_id': str(user.id),
+                'course_id': str(course_id),
+                'event_transaction_id': str(get_event_transaction_id()),
+                'event_transaction_type': str(get_event_transaction_type())
             }
         )

--- a/lms/djangoapps/grades/models.py
+++ b/lms/djangoapps/grades/models.py
@@ -8,7 +8,6 @@ a student's score or the course grading policy changes. As they are
 persisted, course grades are also immune to changes in course content.
 """
 
-
 import json
 import logging
 from base64 import b64encode
@@ -28,6 +27,7 @@ from simple_history.models import HistoricalRecords
 from lms.djangoapps.courseware.fields import UnsignedBigIntAutoField
 from lms.djangoapps.grades import events  # lint-amnesty, pylint: disable=unused-import
 from openedx.core.lib.cache_utils import get_cache
+from lms.djangoapps.grades.signals.signals import COURSE_GRADE_PASSED_FIRST_TIME
 
 log = logging.getLogger(__name__)
 
@@ -645,6 +645,11 @@ class PersistentCourseGrade(TimeStampedModel):
             defaults=kwargs
         )
         if passed and not grade.passed_timestamp:
+            COURSE_GRADE_PASSED_FIRST_TIME.send(
+                sender=None,
+                course_id=course_id,
+                user_id=user_id
+            )
             grade.passed_timestamp = now()
             grade.save()
 

--- a/lms/djangoapps/grades/signals/handlers.py
+++ b/lms/djangoapps/grades/signals/handlers.py
@@ -33,7 +33,12 @@ from .signals import (
     PROBLEM_WEIGHTED_SCORE_CHANGED,
     SCORE_PUBLISHED,
     SUBSECTION_OVERRIDE_CHANGED,
-    SUBSECTION_SCORE_CHANGED
+    SUBSECTION_SCORE_CHANGED,
+    COURSE_GRADE_PASSED_FIRST_TIME
+)
+from openedx.core.djangoapps.signals.signals import (
+    COURSE_GRADE_NOW_FAILED,
+    COURSE_GRADE_NOW_PASSED
 )
 
 log = getLogger(__name__)
@@ -264,3 +269,33 @@ def recalculate_course_and_subsection_grades(sender, user, course_key, countdown
             course_key=str(course_key)
         )
     )
+
+
+@receiver(COURSE_GRADE_NOW_PASSED)
+def listen_for_passing_grade(sender, user, course_id, **kwargs):  # pylint: disable=unused-argument
+    """
+    Listen for a signal indicating that the user has passed a course run.
+
+    Emits an edx.course.grade.now_passed event
+    """
+    events.course_grade_now_passed(user, course_id)
+
+
+@receiver(COURSE_GRADE_NOW_FAILED)
+def listen_for_failing_grade(sender, user, course_id, **kwargs):  # pylint: disable=unused-argument
+    """
+    Listen for a signal indicating that the user has failed a course run.
+
+    Emits an edx.course.grade.now_failed event
+    """
+    events.course_grade_now_failed(user, course_id)
+
+
+@receiver(COURSE_GRADE_PASSED_FIRST_TIME)
+def listen_for_course_grade_passed_first_time(sender, user_id, course_id, **kwargs):  # pylint: disable=unused-argument
+    """
+    Listen for a signal indicating that the user has passed course grade first time.
+
+    Emits an event edx.course.grade.passed.first_time
+    """
+    events.course_grade_passed_first_time(user_id, course_id)

--- a/lms/djangoapps/grades/signals/signals.py
+++ b/lms/djangoapps/grades/signals/signals.py
@@ -106,3 +106,14 @@ SUBSECTION_OVERRIDE_CHANGED = Signal(
                            # score that was created.
     ]
 )
+
+
+# This Signal indicates that the user has received a passing grade in the course for the first time.
+# Any subsequent grade changes that may vary the passing/failing status will not re-trigger this event.
+# Emits course grade passed first time event
+COURSE_GRADE_PASSED_FIRST_TIME = Signal(
+    providing_args=[
+        'course_id',  # Course object id
+        'user_id',  # User object id
+    ]
+)

--- a/lms/djangoapps/grades/tests/integration/test_events.py
+++ b/lms/djangoapps/grades/tests/integration/test_events.py
@@ -135,20 +135,33 @@ class GradesEventIntegrationTest(ProblemSubmissionTestMixin, SharedModuleStoreTe
                 'event_transaction_type': events.STATE_DELETED_EVENT_TYPE,
             }
         )
-
-        events_tracker.emit.assert_called_with(
-            events.COURSE_GRADE_CALCULATED,
-            {
-                'percent_grade': 0.0,
-                'grading_policy_hash': 'ChVp0lHGQGCevD0t4njna/C44zQ=',
-                'user_id': str(self.student.id),
-                'letter_grade': '',
-                'event_transaction_id': event_transaction_id,
-                'event_transaction_type': events.STATE_DELETED_EVENT_TYPE,
-                'course_id': str(self.course.id),
-                'course_edited_timestamp': str(course.subtree_edited_on),
-                'course_version': str(course.course_version),
-            }
+        events_tracker.emit.assert_has_calls(
+            [
+                mock_call(
+                    events.COURSE_GRADE_CALCULATED,
+                    {
+                        'percent_grade': 0.0,
+                        'grading_policy_hash': 'ChVp0lHGQGCevD0t4njna/C44zQ=',
+                        'user_id': str(self.student.id),
+                        'letter_grade': '',
+                        'event_transaction_id': event_transaction_id,
+                        'event_transaction_type': events.STATE_DELETED_EVENT_TYPE,
+                        'course_id': str(self.course.id),
+                        'course_edited_timestamp': str(course.subtree_edited_on),
+                        'course_version': str(course.course_version),
+                    }
+                ),
+                mock_call(
+                    events.COURSE_GRADE_NOW_FAILED_EVENT_TYPE,
+                    {
+                        'user_id': str(self.student.id),
+                        'event_transaction_id': event_transaction_id,
+                        'event_transaction_type': events.STATE_DELETED_EVENT_TYPE,
+                        'course_id': str(self.course.id),
+                    }
+                ),
+            ],
+            any_order=True,
         )
 
     def test_rescoring_events(self):

--- a/lms/djangoapps/grades/tests/test_models.py
+++ b/lms/djangoapps/grades/tests/test_models.py
@@ -425,10 +425,12 @@ class PersistentCourseGradesTest(GradesModelTestCase):
         assert grade.letter_grade == ''
         assert grade.passed_timestamp == passed_timestamp
 
-    def test_passed_timestamp_is_now(self):
+    @patch('lms.djangoapps.grades.signals.signals.COURSE_GRADE_PASSED_FIRST_TIME.send')
+    def test_passed_timestamp_is_now(self, mock):
         with freeze_time(now()):
             grade = PersistentCourseGrade.update_or_create(**self.params)
             assert now() == grade.passed_timestamp
+            self.assertEqual(mock.call_count, 1)
 
     def test_create_and_read_grade(self):
         created_grade = PersistentCourseGrade.update_or_create(**self.params)


### PR DESCRIPTION
Emit following events:1. edx.course.grade.now_passed event from lms/djangoapps/certificates/signals.py on COURSE_GRADE_NOW_PASSED receiver in listen_for_passing_grade function2. edx.course.grade.now_failed event from lms/djangoapps/certificates/signals.py on COURSE_GRADE_NOW_FAILED receiver in _listen_for_failing_grade function3. edx.course.completed event fromedx-platform/lms/djangoapps/grades/models.py on passed_timestamp save in update_or_create function

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Here is the ADR for this implemetation https://github.com/edx/edx-platform/pull/28424/files

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
