### PR TITLE
fix: Stop showing course certificate buttons to beta testers

### DIFF
--- a/lms/djangoapps/certificates/generation_handler.py
+++ b/lms/djangoapps/certificates/generation_handler.py
@@ -19,7 +19,7 @@ from lms.djangoapps.certificates.models import (
 from lms.djangoapps.certificates.tasks import CERTIFICATE_DELAY_SECONDS, generate_certificate
 from lms.djangoapps.certificates.utils import has_html_certificates_enabled
 from lms.djangoapps.grades.api import CourseGradeFactory
-from lms.djangoapps.instructor.access import list_with_level
+from lms.djangoapps.instructor.access import is_beta_tester
 from lms.djangoapps.verify_student.services import IDVerificationService
 from openedx.core.djangoapps.content.course_overviews.api import get_course_overview_or_none
 
@@ -131,7 +131,7 @@ def _can_generate_regular_certificate(user, course_key, enrollment_mode, course_
         log.info(f'{course_key} is a CCX course. Certificate cannot be generated for {user.id}.')
         return False
 
-    if _is_beta_tester(user, course_key):
+    if is_beta_tester(user, course_key):
         log.info(f'{user.id} is a beta tester in {course_key}. Certificate cannot be generated.')
         return False
 
@@ -268,7 +268,7 @@ def _can_set_regular_cert_status(user, course_key, enrollment_mode):
     if _is_ccx_course(course_key):
         return False
 
-    if _is_beta_tester(user, course_key):
+    if is_beta_tester(user, course_key):
         return False
 
     return _can_set_cert_status_common(user, course_key, enrollment_mode)
@@ -322,14 +322,6 @@ def _can_generate_certificate_for_status(user, course_key, enrollment_mode):
     log.info(f'Certificate with status {cert.status} already exists for {user.id} : {course_key}, and is eligible for '
              f'generation. The current enrollment mode is {enrollment_mode} and the existing cert mode is {cert.mode}')
     return True
-
-
-def _is_beta_tester(user, course_key):
-    """
-    Check if the user is a beta tester in this course run
-    """
-    beta_testers_queryset = list_with_level(course_key, 'beta')
-    return beta_testers_queryset.filter(username=user.username).exists()
 
 
 def _is_ccx_course(course_key):

--- a/lms/djangoapps/certificates/tests/test_generation_handler.py
+++ b/lms/djangoapps/certificates/tests/test_generation_handler.py
@@ -32,7 +32,7 @@ from xmodule.modulestore.tests.factories import CourseFactory
 
 log = logging.getLogger(__name__)
 
-BETA_TESTER_METHOD = 'lms.djangoapps.certificates.generation_handler._is_beta_tester'
+BETA_TESTER_METHOD = 'lms.djangoapps.certificates.generation_handler.is_beta_tester'
 COURSE_OVERVIEW_METHOD = 'lms.djangoapps.certificates.generation_handler.get_course_overview_or_none'
 CCX_COURSE_METHOD = 'lms.djangoapps.certificates.generation_handler._is_ccx_course'
 GET_GRADE_METHOD = 'lms.djangoapps.certificates.generation_handler._get_course_grade'

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -1545,8 +1545,8 @@ class ProgressPageTests(ProgressPageBaseTests):
             self.assertContains(resp, "Download Your Certificate")
 
     @ddt.data(
-        (True, 54),
-        (False, 54),
+        (True, 55),
+        (False, 55),
     )
     @ddt.unpack
     def test_progress_queries_paced_courses(self, self_paced, query_count):
@@ -1559,8 +1559,8 @@ class ProgressPageTests(ProgressPageBaseTests):
 
     @patch.dict(settings.FEATURES, {'ASSUME_ZERO_GRADE_IF_ABSENT_FOR_ALL_TESTS': False})
     @ddt.data(
-        (False, 62, 45),
-        (True, 54, 39)
+        (False, 63, 46),
+        (True, 55, 40)
     )
     @ddt.unpack
     def test_progress_queries(self, enable_waffle, initial, subsequent):

--- a/lms/djangoapps/instructor/access.py
+++ b/lms/djangoapps/instructor/access.py
@@ -112,3 +112,11 @@ def update_forum_role(course_id, user, rolename, action):
         role.users.remove(user)
     else:
         raise ValueError(f"unrecognized action '{action}'")
+
+
+def is_beta_tester(user, course_id):
+    """
+    Returns True if the user is a beta tester in this course, and False if not
+    """
+    beta_testers_queryset = list_with_level(course_id, 'beta')
+    return beta_testers_queryset.filter(username=user.username).exists()

--- a/lms/djangoapps/instructor/tests/test_access.py
+++ b/lms/djangoapps/instructor/tests/test_access.py
@@ -10,6 +10,7 @@ from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.instructor.access import (
     allow_access,
     list_with_level,
+    is_beta_tester,
     revoke_access,
     update_forum_role
 )
@@ -46,6 +47,12 @@ class TestInstructorAccessList(SharedModuleStoreTestCase):
         beta_testers_alternative = list_with_level(self.course.id, 'beta')
         assert set(beta_testers) == set(self.beta_testers)
         assert set(beta_testers_alternative) == set(self.beta_testers)
+
+    def test_is_beta(self):
+        beta_tester = self.beta_testers[0]
+        user = UserFactory.create()
+        assert is_beta_tester(beta_tester, self.course.id)
+        assert not is_beta_tester(user, self.course.id)
 
 
 class TestInstructorAccessAllow(EmailTemplateTagMixin, SharedModuleStoreTestCase):


### PR DESCRIPTION
Stop showing course certificate buttons to beta testers

Beta testers can’t earn course certificates (in the course for which they're a beta tester), so they should not see a “Request Certificate” button or other info describing how they can earn a cert.

MICROBA-992