### PR TITLE
Set default ES version to 7.10 for devstack testing

### DIFF
--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -263,7 +263,7 @@ ENABLE_ELASTICSEARCH_FOR_TESTS = os.environ.get(
 
 TEST_ELASTICSEARCH_USE_SSL = os.environ.get(
     'EDXAPP_TEST_ELASTICSEARCH_USE_SSL', 'no').lower() in ('true', 'yes', '1')
-TEST_ELASTICSEARCH_HOST = os.environ.get('EDXAPP_TEST_ELASTICSEARCH_HOST', 'edx.devstack.elasticsearch')
+TEST_ELASTICSEARCH_HOST = os.environ.get('EDXAPP_TEST_ELASTICSEARCH_HOST', 'edx.devstack.elasticsearch710')
 TEST_ELASTICSEARCH_PORT = int(os.environ.get('EDXAPP_TEST_ELASTICSEARCH_PORT', '9200'))
 
 ########################## AUTHOR PERMISSION #######################

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -436,7 +436,7 @@ ENABLE_ELASTICSEARCH_FOR_TESTS = os.environ.get(
 
 TEST_ELASTICSEARCH_USE_SSL = os.environ.get(
     'EDXAPP_TEST_ELASTICSEARCH_USE_SSL', 'no').lower() in ('true', 'yes', '1')
-TEST_ELASTICSEARCH_HOST = os.environ.get('EDXAPP_TEST_ELASTICSEARCH_HOST', 'edx.devstack.elasticsearch')
+TEST_ELASTICSEARCH_HOST = os.environ.get('EDXAPP_TEST_ELASTICSEARCH_HOST', 'edx.devstack.elasticsearch710')
 TEST_ELASTICSEARCH_PORT = int(os.environ.get('EDXAPP_TEST_ELASTICSEARCH_PORT', '9200'))
 
 ######### custom courses #########


### PR DESCRIPTION
## Description

fix: ES 7.10 is now the default ES version for devstack, so change the default address for testing ES using integration tests in devstack.

https://openedx.atlassian.net/browse/TNL-8485

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Testing instructions

Run the blockstore integration tests in devstack using these instructions:
https://github.com/edx/blockstore#running-integration-tests
