### PR TITLE
[MST-916] Set runtime service for Name Affirmation

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3098,6 +3098,7 @@ INSTALLED_APPS = [
     'openedx.features.content_type_gating',
     'openedx.features.discounts',
     'openedx.features.effort_estimation',
+    'openedx.features.name_affirmation_api.apps.NameAffirmationApiConfig',
 
     'lms.djangoapps.experiments',
 

--- a/openedx/features/name_affirmation_api/README.rst
+++ b/openedx/features/name_affirmation_api/README.rst
@@ -1,0 +1,6 @@
+Name Affirmation API
+--------------------
+
+This directory contains a passthrough for the edx-name-affirmation plugin,
+in order to enable support in other plugins/packages such as edx-proctoring.
+See here: `https://github.com/edx/edx-name-affirmation`_.

--- a/openedx/features/name_affirmation_api/apps.py
+++ b/openedx/features/name_affirmation_api/apps.py
@@ -1,0 +1,23 @@
+"""
+Name Affirmation API App Configuration
+"""
+
+
+from django.apps import AppConfig
+from django.conf import settings
+from edx_proctoring.runtime import set_runtime_service
+
+
+class NameAffirmationApiConfig(AppConfig):
+    """
+    Application Configuration for Misc Services.
+    """
+    name = 'openedx.features.name_affirmation_api'
+
+    def ready(self):
+        """
+        Connect services.
+        """
+        if settings.FEATURES.get('ENABLE_SPECIAL_EXAMS'):
+            from edx_name_affirmation.services import NameAffirmationService
+            set_runtime_service('name_affirmation', NameAffirmationService())

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -445,7 +445,7 @@ edx-i18n-tools==0.7.0
     # via ora2
 edx-milestones==0.3.2
     # via -r requirements/edx/base.in
-edx-name-affirmation==0.3.1
+edx-name-affirmation==0.4.0
     # via -r requirements/edx/base.in
 edx-opaque-keys[django]==2.2.2
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -542,7 +542,7 @@ edx-lint==5.0.0
     # via -r requirements/edx/testing.txt
 edx-milestones==0.3.2
     # via -r requirements/edx/testing.txt
-edx-name-affirmation==0.3.1
+edx-name-affirmation==0.4.0
     # via -r requirements/edx/testing.txt
 edx-opaque-keys[django]==2.2.2
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -526,7 +526,7 @@ edx-lint==5.0.0
     # via -r requirements/edx/testing.in
 edx-milestones==0.3.2
     # via -r requirements/edx/base.txt
-edx-name-affirmation==0.3.1
+edx-name-affirmation==0.4.0
     # via -r requirements/edx/base.txt
 edx-opaque-keys[django]==2.2.2
     # via


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

If special exams are enabled, set a runtime service for Name Affirmation in order to enable it for use in proctored exam attempts.

## Supporting information

[MST-916](https://openedx.atlassian.net/browse/MST-916)