### PR TITLE
feat: Display date override on certificate

### DIFF
--- a/openedx/core/djangoapps/certificates/api.py
+++ b/openedx/core/djangoapps/certificates/api.py
@@ -92,11 +92,16 @@ def display_date_for_certificate(course, certificate):
 
     Arguments:
         course (CourseOverview or course descriptor): The course we're getting the date for
+        certificate (GeneratedCertificate): The certificate we're getting the date for
     Returns:
         datetime.date
     """
+    if certificate.date_override:
+        return certificate.date_override.date
+
     if _course_uses_available_date(course) and course.certificate_available_date < datetime.now(UTC):
         return course.certificate_available_date
+
     return certificate.modified_date
 
 

--- a/openedx/core/djangoapps/certificates/api.py
+++ b/openedx/core/djangoapps/certificates/api.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from pytz import UTC
 
 from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist
 
 from lms.djangoapps.certificates import api as certs_api
 from lms.djangoapps.certificates.data import CertificateStatuses
@@ -96,8 +97,11 @@ def display_date_for_certificate(course, certificate):
     Returns:
         datetime.date
     """
-    if certificate.date_override:
-        return certificate.date_override.date
+    try:
+        if certificate.date_override:
+            return certificate.date_override.date
+    except ObjectDoesNotExist:
+        pass
 
     if _course_uses_available_date(course) and course.certificate_available_date < datetime.now(UTC):
         return course.certificate_available_date

--- a/openedx/core/djangoapps/certificates/tests/test_api.py
+++ b/openedx/core/djangoapps/certificates/tests/test_api.py
@@ -65,6 +65,10 @@ class MockGeneratedCertificate:
         """
         return self.status == CertificateStatuses.downloadable
 
+class MockCertificateDateOverride:
+    def __init__(self, date=None):
+        self.date = date or datetime.now(pytz.UTC)
+
 
 @contextmanager
 def configure_waffle_namespace(feature_enabled):
@@ -181,6 +185,6 @@ class CertificatesApiTestCase(TestCase):
             assert self.certificate.modified_date == api.display_date_for_certificate(self.course, self.certificate)
 
             # With a certificate date override, display date returns the override, available date ignores it
-            self.certificate.date_override = { date: datetime(2021, 5, 11) }
+            self.certificate.date_override = MockCertificateDateOverride()
             assert self.certificate.date_override.date == api.display_date_for_certificate(self.course, self.certificate)
             assert maybe_avail == api.available_date_for_certificate(self.course, self.certificate)

--- a/openedx/core/djangoapps/certificates/tests/test_api.py
+++ b/openedx/core/djangoapps/certificates/tests/test_api.py
@@ -57,6 +57,7 @@ class MockGeneratedCertificate:
         self.status = status
         self.created_date = datetime.now(pytz.UTC)
         self.modified_date = datetime.now(pytz.UTC)
+        self.date_override = None
 
     def is_valid(self):
         """
@@ -178,3 +179,8 @@ class CertificatesApiTestCase(TestCase):
             maybe_avail = self.course.certificate_available_date if uses_avail_date else self.certificate.modified_date
             assert maybe_avail == api.available_date_for_certificate(self.course, self.certificate)
             assert self.certificate.modified_date == api.display_date_for_certificate(self.course, self.certificate)
+
+            # With a certificate date override, display date returns the override, available date ignores it
+            self.certificate.date_override = { date: datetime(2021, 5, 11) }
+            assert self.certificate.date_override.date == api.display_date_for_certificate(self.course, self.certificate)
+            assert maybe_avail == api.available_date_for_certificate(self.course, self.certificate)


### PR DESCRIPTION
## Description

If the certificate has an associated `CertificateDateOverride`, display
that date on the certificate instead of any other date.

## Supporting information

[MICROBA-1422](https://openedx.atlassian.net/browse/MICROBA-1422)

## Testing instructions

To test locally: 
1. Add a `CertificateDateOverride` to a certificate in the Django Admin: http://localhost:18000/admin/certificates/certificatedateoverride/
2. View the certificate; you should see the date you added in the override as the "Issued On" date.

## Deadline

None

## Other information
Related to:
- https://github.com/edx/edx-platform/pull/28258
- https://github.com/edx/edx-platform/pull/28394
