### PR TITLE
feat: Display date override on certificate

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ recommend that you use a service provider to run the software for you.  They
 have free trials that make it easy to get started:
 https://openedx.org/get-started/
 
-If you will be modifying edx-platform code, the `Open edX Developer Stack`_ is
+If you will be modifying edx-platform code, the `Open edX Devstack`_ (Developer Stack) is
 a Docker-based development environment.
 
 If you want to run your own Open edX server and have the technical skills to do

--- a/lms/djangoapps/certificates/tests/factories.py
+++ b/lms/djangoapps/certificates/tests/factories.py
@@ -2,7 +2,7 @@
 Certificates factories
 """
 
-
+import datetime
 from uuid import uuid4
 
 from factory.django import DjangoModelFactory
@@ -10,6 +10,7 @@ from factory.django import DjangoModelFactory
 from common.djangoapps.student.models import LinkedInAddToProfileConfiguration
 from lms.djangoapps.certificates.models import (
     CertificateAllowlist,
+    CertificateDateOverride,
     CertificateHtmlViewConfiguration,
     CertificateInvalidation,
     CertificateStatuses,
@@ -104,3 +105,14 @@ class LinkedInAddToProfileConfigurationFactory(DjangoModelFactory):
 
     enabled = True
     company_identifier = "1337"
+
+
+class CertificateDateOverrideFactory(DjangoModelFactory):
+    """
+    CertificateDateOverride factory
+    """
+    class Meta:
+        model = CertificateDateOverride
+
+    date = datetime.datetime(2021, 5, 11)
+    reason = "Learner really wanted this on their birthday"

--- a/lms/djangoapps/certificates/tests/test_api.py
+++ b/lms/djangoapps/certificates/tests/test_api.py
@@ -1131,12 +1131,18 @@ class MockGeneratedCertificate:
         self.status = status
         self.created_date = datetime.now(pytz.UTC)
         self.modified_date = datetime.now(pytz.UTC)
+        self.date_override = None
 
     def is_valid(self):
         """
         Return True if certificate is valid else return False.
         """
         return self.status == CertificateStatuses.downloadable
+
+
+class MockCertificateDateOverride:
+    def __init__(self, date=None):
+        self.date = date or datetime.now(pytz.UTC)
 
 
 @contextmanager
@@ -1220,6 +1226,12 @@ class CertificatesApiTestCase(TestCase):
             maybe_avail = self.course.certificate_available_date if uses_avail_date else self.certificate.modified_date
             assert maybe_avail == available_date_for_certificate(self.course, self.certificate)
             assert self.certificate.modified_date == display_date_for_certificate(self.course, self.certificate)
+
+            # With a certificate date override, display date returns the override, available date ignores it
+            self.certificate.date_override = MockCertificateDateOverride()
+            date = self.certificate.date_override.date
+            assert date == display_date_for_certificate(self.course, self.certificate)
+            assert maybe_avail == available_date_for_certificate(self.course, self.certificate)
 
 
 @ddt.ddt


### PR DESCRIPTION
## Description

If the certificate has an associated `CertificateDateOverride`, display
that date on the certificate instead of any other date.

## Supporting information

[MICROBA-1422](https://openedx.atlassian.net/browse/MICROBA-1422)

(Originally opened this as https://github.com/edx/edx-platform/pull/28428 but my branches got messed up.)

## Testing instructions

To test locally: 
1. Add a `CertificateDateOverride` to a certificate in the Django Admin: http://localhost:18000/admin/certificates/certificatedateoverride/
2. View the certificate; you should see the date you added in the override as the "Issued On" date.

## Deadline

None

## Other information
Related to:
- https://github.com/edx/edx-platform/pull/28258
- https://github.com/edx/edx-platform/pull/28394
