### PR TITLE
MB-1192: [feat] Add course ended, not passing

### DIFF
--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -786,7 +786,9 @@ def user_has_passing_grade_in_course(enrollment):
     Check to see if a user has passing grade for a course
     """
     try:
-        course_grade = CourseGradeFactory().read(enrollment.user, course=enrollment.course_overview, create_if_needed=False)
+        user = enrollment.user
+        course = enrollment.course_overview
+        course_grade = CourseGradeFactory().read(user, course, create_if_needed=False)
         if course_grade:
             return course_grade.passed
     except AttributeError:

--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -779,3 +779,16 @@ def does_user_profile_exist(user):
         return hasattr(user, 'profile')
     except (ProgrammingError, ObjectDoesNotExist):
         return False
+
+
+def user_has_passing_grade_in_course(enrollment):
+    """
+    Check to see if a user has passing grade for a course
+    """
+    try:
+        course_grade = CourseGradeFactory().read(enrollment.user, course=enrollment.course_overview, create_if_needed=False)
+        if course_grade:
+            return course_grade.passed
+    except AttributeError:
+        pass
+    return False

--- a/lms/templates/dashboard/_dashboard_certificate_information.html
+++ b/lms/templates/dashboard/_dashboard_certificate_information.html
@@ -1,4 +1,4 @@
-<%page expression_filter="h" args="cert_status, course_overview, enrollment, reverify_link" />
+<%page expression_filter="h" args="cert_status, course_ended_not_passing, course_overview, enrollment, reverify_link" />
 
 <%!
 from django.urls import reverse
@@ -8,6 +8,7 @@ from openedx.core.djangolib.markup import HTML, Text
 from common.djangoapps.course_modes.models import CourseMode
 from lms.djangoapps.certificates.data import CertificateStatuses
 from xmodule.data import CertificatesDisplayBehaviors
+from common.djangoapps.student.helpers import user_has_passing_grade_in_course
 %>
 <%namespace name='static' file='../static_content.html'/>
 
@@ -33,7 +34,10 @@ elif cert_status['status'] == CertificateStatuses.notpassing:
 else:
     status_css_class = 'course-status-processing'
 %>
-<% requesting_post_url = reverse('generate_user_cert', args=[str(course_overview.id)]) %>
+<% 
+  requesting_post_url = reverse('generate_user_cert', args=[str(course_overview.id)])
+  progress_page_url = reverse('progress', args=[str(course_overview.id)])
+%>
 
 % if cert_status['status'] != 'processing':
   % if cert_status['status'] == 'certificate_earned_but_not_available':
@@ -161,5 +165,21 @@ else:
 
     </div>
   % endif
+% elif course_ended_not_passing:
+  <div class="message message-status ${status_css_class} d-flex justify-content-between align-items-center">
+    <div class="message-copy">
+      <%
+        container_string = _("You are not eligible for a certificate.")
+      %>
+      <span class="info-date-block localized-datetime" data-language="${user_language}" data-timezone="${user_timezone}" data-string="${container_string}"></span>
+    </div>
+    <ul class="actions actions-primary">
+      <li class="action">
+        <a class="btn btn-primary" rel="noopener" href="${progress_page_url}" target="_blank" title="${_('This link will open the course progress page' )}">
+          ${_("View grades")}
+        </a>
+      </li>
+    </ul>
+  </div>
 % endif
 

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -45,9 +45,9 @@ from lms.djangoapps.experiments.utils import UPSELL_TRACKING_FLAG
 %>
 
 <%
-  is_audit_enrollment = enrollment.mode == "audit" or enrollment.mode == "honor"
+  is_non_certificate_enrollment = enrollment.mode == "audit" or enrollment.mode == "honor"
   is_passing_course = user_has_passing_grade_in_course(enrollment)
-  course_ended_not_passing = course_overview.has_ended() and is_passing_course == False and is_audit_enrollment == False
+  course_ended_not_passing = course_overview.has_ended() and is_passing_course == False and is_non_certificate_enrollment == False
 %>
 
 <%namespace name='static' file='../static_content.html'/>

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -11,6 +11,7 @@ from django.utils.translation import ungettext
 from django.urls import reverse
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.helpers import enrollment_mode_display
+from common.djangoapps.student.helpers import user_has_passing_grade_in_course
 from lms.djangoapps.course_home_api.toggles import course_home_legacy_is_active
 from lms.djangoapps.verify_student.services import IDVerificationService
 from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string
@@ -41,6 +42,12 @@ from lms.djangoapps.experiments.utils import UPSELL_TRACKING_FLAG
     cert_name_long = settings.CERT_NAME_LONG
 
   is_course_expired = hasattr(show_courseware_link, 'error_code') and show_courseware_link.error_code == 'audit_expired'
+%>
+
+<%
+  is_audit_enrollment = enrollment.mode == "audit" or enrollment.mode == "honor"
+  is_passing_course = user_has_passing_grade_in_course(enrollment)
+  course_ended_not_passing = course_overview.has_ended() and is_passing_course == False and is_audit_enrollment == False
 %>
 
 <%namespace name='static' file='../static_content.html'/>
@@ -350,7 +357,7 @@ from lms.djangoapps.experiments.utils import UPSELL_TRACKING_FLAG
       % endif
 
       % if cert_status:
-        <%include file='_dashboard_certificate_information.html' args='cert_status=cert_status,course_overview=course_overview, enrollment=enrollment, reverify_link=reverify_link'/>
+        <%include file='_dashboard_certificate_information.html' args='cert_status=cert_status, course_ended_not_passing=course_ended_not_passing, course_overview=course_overview, enrollment=enrollment, reverify_link=reverify_link'/>
       % endif
 
       % if credit_status is not None:


### PR DESCRIPTION
## Description

If a student has not passed a course, the course has ended, and they have a verified seat, we want to show them a message at a glance on the dashboard. This version no longer requires an edx-themes PR.

## Supporting information

Desktop:
![image](https://user-images.githubusercontent.com/16495365/128916675-ba8d2c80-fe3e-4741-b5c5-f6e0cf69fdaf.png)


## Testing instructions
- Enroll a learner in a course with a verified seat.
- make sure finish the course, but not get a passing grade in the course.
- change the date of the course to a date in the past, and check the dashboard.