### PR TITLE
[VAN-332] Full name validation on registration page.

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -89,6 +89,14 @@ def contains_html(value):
     return bool(regex.search(value))
 
 
+def contains_url(value):
+    """
+    Validator method to check whether full name contains url
+    """
+    regex = re.findall(r'https|http?://(?:[-\w.]|(?:%[\da-fA-F]{2}))+', value)
+    return bool(regex)
+
+
 def validate_name(name):
     """
     Verifies a Full_Name is valid, raises a ValidationError otherwise.
@@ -97,6 +105,8 @@ def validate_name(name):
     """
     if contains_html(name):
         raise forms.ValidationError(_('Full Name cannot contain the following characters: < >'))
+    if contains_url(name):
+        raise forms.ValidationError(_('Enter a valid name'))
 
 
 class UsernameField(forms.CharField):

--- a/openedx/core/djangoapps/user_authn/views/tests/test_register.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_register.py
@@ -237,6 +237,27 @@ class RegistrationViewValidationErrorTest(ThirdPartyAuthTestMixin, UserAPITestCa
             }
         )
 
+    def test_register_fullname_url_validation_error(self):
+        """
+        Test for catching invalid full name errors
+        """
+        response = self.client.post(self.url, {
+            "email": "bob@example.com",
+            "name": "Bob Smith http://test.com",
+            "username": "bob",
+            "password": "password",
+            "honor_code": "true",
+        })
+        assert response.status_code == 400
+        response_json = json.loads(response.content.decode('utf-8'))
+        self.assertDictEqual(
+            response_json,
+            {
+                "name": [{"user_message": 'Enter a valid name'}],
+                "error_code": "validation-error"
+            }
+        )
+
     @override_waffle_flag(REGISTRATION_FAILURE_LOGGING_FLAG, True)
     def test_registration_failure_logging(self):
         # Register a user


### PR DESCRIPTION

## Description

When a user registers for a new account, they can do so for an e-mail address that is not theirs.  In this case, if they put a URL in the full name field, that URL will be part of the subject of a welcome e-mail we send them after the e-mail account holder confirms that they want the account to be created.



## Supporting information

Ticket: [VAN-332](https://openedx.atlassian.net/browse/VAN-332)

## Testing instructions

Added unit test.
