### PR TITLE
Update PII annotations and fix annotation linting issues

### DIFF
--- a/.annotation_safe_list.yml
+++ b/.annotation_safe_list.yml
@@ -82,8 +82,6 @@ workflow.AssessmentWorkflowStep:
 # Via edx-celeryutils
 celery_utils.ChordData:
   ".. no_pii:": "No PII"
-celery_utils.FailedTask:
-  ".. no_pii:": "No PII"
 
 # Via completion XBlock
 completion.BlockCompletion:

--- a/.pii_annotations.yml
+++ b/.pii_annotations.yml
@@ -28,10 +28,12 @@ annotations:
               - other
         - ".. pii_retirement:":
             choices:
-              - retained
-              - local_api
-              - consumer_api
-              - third_party
+              - retained          # Intentionally kept for legal reasons
+              - local_api         # An API exists in this repository for retiring this information
+              - consumer_api      # The data's consumer must implement an API for retiring this information
+              - third_party       # A third party API exists to retire this data
+              - to_be_implemented # Retirement tooling not yet implemented
+
 extensions:
     python:
         - py

--- a/.pii_annotations.yml
+++ b/.pii_annotations.yml
@@ -1,7 +1,7 @@
 source_path: ./
 report_path: pii_report
 safelist_path: .annotation_safe_list.yml
-coverage_target: 94.5
+coverage_target: 88.6
 # See OEP-30 for more information on these values and what they mean:
 # https://open-edx-proposals.readthedocs.io/en/latest/oep-0030-arch-pii-markup-and-auditing.html#docstring-annotations
 annotations:

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -3032,9 +3032,11 @@ class RegistrationCookieConfiguration(ConfigurationModel):
         )
 
 
-class BulkUnenrollConfiguration(ConfigurationModel):  # lint-amnesty, pylint: disable=empty-docstring
+class BulkUnenrollConfiguration(ConfigurationModel):
     """
+    Config model for the bulk_unenroll command
 
+    .. no_pii:
     """
     csv_file = models.FileField(
         validators=[FileExtensionValidator(allowed_extensions=['csv'])],
@@ -3046,7 +3048,9 @@ class BulkUnenrollConfiguration(ConfigurationModel):  # lint-amnesty, pylint: di
 
 class BulkChangeEnrollmentConfiguration(ConfigurationModel):
     """
-    config model for the bulk_change_enrollment_csv command
+    Config model for the bulk_change_enrollment_csv command
+
+    .. no_pii:
     """
     csv_file = models.FileField(
         validators=[FileExtensionValidator(allowed_extensions=['csv'])],
@@ -3191,7 +3195,9 @@ class AllowedAuthUser(TimeStampedModel):
 
 class AccountRecoveryConfiguration(ConfigurationModel):
     """
-    configuration model for recover account management command
+    Configuration model for recover account management command
+
+    .. no_pii:
     """
     csv_file = models.FileField(
         validators=[FileExtensionValidator(allowed_extensions=['csv'])],

--- a/lms/djangoapps/course_home_api/models.py
+++ b/lms/djangoapps/course_home_api/models.py
@@ -11,6 +11,8 @@ from openedx.core.djangoapps.config_model_utils.models import StackedConfigurati
 class DisableProgressPageStackedConfig(StackedConfigurationModel):
     """
     Stacked Config Model for disabling the frontend-app-learning progress page
+
+    .. no_pii:
     """
 
     STACKABLE_FIELDS = ('disabled',)

--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -1173,8 +1173,10 @@ class VerificationDeadline(TimeStampedModel):
 
 class SSPVerificationRetryConfig(ConfigurationModel):  # pylint: disable=model-missing-unicode, useless-suppression
     """
-        SSPVerificationRetryConfig used to inject arguments
-        to retry_failed_photo_verifications management command
+    SSPVerificationRetryConfig used to inject arguments
+    to retry_failed_photo_verifications management command
+
+    .. no_pii:
     """
 
     class Meta:

--- a/openedx/core/djangoapps/content/learning_sequences/models.py
+++ b/openedx/core/djangoapps/content/learning_sequences/models.py
@@ -53,6 +53,8 @@ class LearningContext(TimeStampedModel):
     because this table can contain things that are not courses.
 
     It is okay to make a foreign key against this table.
+
+    .. no_pii:
     """
     id = models.BigAutoField(primary_key=True)
     context_key = LearningContextKeyField(
@@ -74,6 +76,8 @@ class LearningContext(TimeStampedModel):
 class CourseContext(TimeStampedModel):
     """
     A model containing course specific information e.g course_visibility
+
+    .. no_pii:
     """
     learning_context = models.OneToOneField(
         LearningContext, on_delete=models.CASCADE, primary_key=True, related_name="course_context"
@@ -106,6 +110,8 @@ class LearningSequence(TimeStampedModel):
     CourseSectionSequence.
 
     It is okay to make a foreign key against this table.
+
+    .. no_pii:
     """
     id = models.BigAutoField(primary_key=True)
     learning_context = models.ForeignKey(
@@ -131,6 +137,8 @@ class CourseContentVisibilityMixin(models.Model):
 
     We keep the XBlock field names here, even if they're somewhat misleading.
     Please read the comments carefully for each field.
+
+    .. no_pii:
     """
     # This is an obscure, OLX-only flag (there is no UI for it in Studio) that
     # lets you define a Sequence that is reachable by direct URL but not shown
@@ -174,6 +182,8 @@ class UserPartitionGroup(models.Model):
     UserPartitionGroups are not associated with LearningSequence directly
     because User Partitions often carry course-level assumptions (e.g.
     Enrollment Track) that don't make sense outside of a Course.
+
+    .. no_pii:
     """
     id = models.BigAutoField(primary_key=True)
     partition_id = models.BigIntegerField(null=False)
@@ -191,6 +201,8 @@ class UserPartitionGroup(models.Model):
 class CourseSection(CourseContentVisibilityMixin, TimeStampedModel):
     """
     Course Section data, mapping to the 'chapter' block type.
+
+    .. no_pii:
     """
     id = models.BigAutoField(primary_key=True)
     course_context = models.ForeignKey(
@@ -225,6 +237,8 @@ class SectionPartitionGroup(models.Model):
     Used for the user_partition_groups ManyToManyField field in the CourseSection model above.
     Adds a cascading delete which will delete these many-to-many relations
     whenever a UserPartitionGroup or CourseSection object is deleted.
+
+    .. no_pii:
     """
     class Meta:
         unique_together = [
@@ -249,6 +263,8 @@ class CourseSectionSequence(CourseContentVisibilityMixin, TimeStampedModel):
 
     Do NOT make a foreign key against this table, as the values are deleted and
     re-created on course publish.
+
+    .. no_pii:
     """
     id = models.BigAutoField(primary_key=True)
     course_context = models.ForeignKey(
@@ -289,6 +305,8 @@ class SectionSequencePartitionGroup(models.Model):
     Used for the user_partition_groups ManyToManyField field in the CourseSectionSequence model above.
     Adds a cascading delete which will delete these many-to-many relations
     whenever a UserPartitionGroup or CourseSectionSequence object is deleted.
+
+    .. no_pii:
     """
     class Meta:
         unique_together = [
@@ -303,6 +321,8 @@ class CourseSequenceExam(TimeStampedModel):
     """
     This model stores XBlock information that affects outline level information
     pertaining to special exams
+
+    .. no_pii:
     """
     course_section_sequence = models.OneToOneField(CourseSectionSequence, on_delete=models.CASCADE, related_name='exam')
 
@@ -318,6 +338,8 @@ class PublishReport(models.Model):
     All these fields could be derived with aggregate SQL functions, but it would
     be slower and make the admin code more complex. Since we only write at
     publish time, keeping things in sync is less of a concern.
+
+    .. no_pii:
     """
     learning_context = models.OneToOneField(
         LearningContext, on_delete=models.CASCADE, related_name='publish_report'
@@ -350,6 +372,8 @@ class ContentError(models.Model):
     freeform messages. It is quite possible that at some point we will come up
     with a more comprehensive taxonomy of error messages, at which point we
     could do a backfill to regenerate this data in a more normalized way.
+
+    .. no_pii:
     """
     id = models.BigAutoField(primary_key=True)
     publish_report = models.ForeignKey(

--- a/openedx/core/djangoapps/content_libraries/models.py
+++ b/openedx/core/djangoapps/content_libraries/models.py
@@ -37,6 +37,8 @@ class ContentLibrary(models.Model):
     re-imported on another Open edX instance should be kept in Blockstore. This
     model in the LMS should only be used to track settings specific to this Open
     edX instance, like who has permission to edit this content library.
+
+    .. no_pii:
     """
     objects = ContentLibraryManager()
 
@@ -89,6 +91,8 @@ class ContentLibrary(models.Model):
 class ContentLibraryPermission(models.Model):
     """
     Row recording permissions for a content library
+
+    .. no_pii:
     """
     library = models.ForeignKey(ContentLibrary, on_delete=models.CASCADE, related_name="permission_grants")
     # One of the following must be set (but not both):

--- a/openedx/core/djangoapps/discussions/models.py
+++ b/openedx/core/djangoapps/discussions/models.py
@@ -237,6 +237,8 @@ def get_supported_providers() -> list[str]:
 class ProviderFilter(StackedConfigurationModel):
     """
     Associate allow/deny-lists of discussions providers with courses/orgs
+
+    .. no_pii:
     """
 
     allow = ListCharField(
@@ -322,6 +324,8 @@ class ProviderFilter(StackedConfigurationModel):
 class DiscussionsConfiguration(TimeStampedModel):
     """
     Associates a learning context with discussion provider and configuration
+
+    .. no_pii:
     """
 
     context_key = LearningContextKeyField(

--- a/openedx/core/djangoapps/video_config/models.py
+++ b/openedx/core/djangoapps/video_config/models.py
@@ -98,7 +98,8 @@ class CourseYoutubeBlockedFlag(ConfigurationModel):
     Disables the playback of youtube videos for a given course.
     If the flag is present for the course, and set to "enabled",
     then youtube is disabled for that course.
-    .. no_pii
+
+    .. no_pii:
     """
     KEY_FIELDS = ('course_id',)
 

--- a/openedx/features/announcements/models.py
+++ b/openedx/features/announcements/models.py
@@ -7,7 +7,11 @@ from django.db import models
 
 
 class Announcement(models.Model):
-    """Site-wide announcements to be displayed on the dashboard"""
+    """
+    Site-wide announcements to be displayed on the dashboard
+
+    .. no_pii:
+    """
     class Meta:
         app_label = 'announcements'
 

--- a/openedx/features/discounts/models.py
+++ b/openedx/features/discounts/models.py
@@ -15,6 +15,8 @@ from openedx.core.djangoapps.config_model_utils.models import StackedConfigurati
 class DiscountRestrictionConfig(StackedConfigurationModel):
     """
     A ConfigurationModel used to manage restrictons for lms-controlled discounts
+
+    .. no_pii:
     """
 
     STACKABLE_FIELDS = ('disabled',)
@@ -43,6 +45,8 @@ class DiscountRestrictionConfig(StackedConfigurationModel):
 class DiscountPercentageConfig(StackedConfigurationModel):
     """
     A ConfigurationModel to configure the discount percentage for the first purchase discount
+
+    .. no_pii:
     """
     STACKABLE_FIELDS = ('percentage',)
     percentage = models.PositiveIntegerField()


### PR DESCRIPTION
## Description

The OEP-30 checker has not been running in edx-platform CI for some time. The number of models lacking PII annotations has gone up quite a bit in that time, with coverage dropping from 94.5% to 82.9% in the Devstack environment, and some annotation linting issues have been introduced along the way. Locally these commits brought the coverage back up to 88.6%, with the majority of remaining issues being historical models that we'd normally just drop the coverage % for anyway.

This PR is a collection of fixes that represent some of the output of my 8/2021 hackathon project:

- Fix linting issues
- Add "no pii" annotations to models which clearly have no PII in them

Additional notes and output from this hackathon project will be here: https://openedx.atlassian.net/wiki/spaces/~bmesick/pages/3102998898/8+2021+Doc+Hackation+PII+Annotations+Output

## Testing instructions

- Make sure your requirements are up to date
- Make sure you have applied migrations
- Shell into LMS Devstack and run: 
- `export DJANGO_SETTINGS_MODULE=lms.envs.devstack_docker`
- `code_annotations django_find_annotations --config_file .pii_annotations.yml --lint` to check for linting violations, there should be none
- `code_annotations django_find_annotations --config_file .pii_annotations.yml --coverage` to check the coverage percentage. This can vary based on your configuration, but my run on edx-platform master yielded 88.6%.


## Deadline

None
