### PR TITLE
fix: Transifex fix for local requirements during paver setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ extract_translations: ## extract localizable strings from sources
 push_translations: ## push source strings to Transifex for translation
 	i18n_tool transifex push
 
-pull_translations: ## pull translations from Transifex
+pull_translations: requirements  ## pull translations from Transifex
 	git clean -fdX conf/locale
 	i18n_tool transifex pull
 	i18n_tool extract


### PR DESCRIPTION
Pull Translations has been broken in edx-platform for a number of months
partially in part because of an import issue with local packages during
paver setup. This solves that problem by running make requirements as part
of the pull_translations make target.

Note: This should not be the default behavior. This is only a patch so the
translation job works again. The paver job being run (i18n_compilejs) does
the same install before it runs so we are doubling up there which is not
great.

PROD-2455