### PR TITLE
[MST-859] Update proctored exam settings URL

### DIFF
--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -18,6 +18,7 @@ from cms.djangoapps.contentstore.toggles import exam_setting_view_enabled
 from common.djangoapps.student import auth
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole
+from openedx.core.djangoapps.course_apps.toggles import proctoring_settings_modal_view_enabled
 from openedx.core.djangoapps.discussions.config.waffle import ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND
 from openedx.core.djangoapps.django_comment_common.models import assign_default_role
 from openedx.core.djangoapps.django_comment_common.utils import seed_permissions_roles
@@ -188,7 +189,12 @@ def get_proctored_exam_settings_url(course_locator) -> str:
     if exam_setting_view_enabled():
         mfe_base_url = get_course_authoring_url(course_locator)
         if mfe_base_url:
-            proctored_exam_settings_url = f'{mfe_base_url}/course/{course_locator}/proctored-exam-settings'
+            if proctoring_settings_modal_view_enabled(course_locator):
+                proctored_exam_settings_url = (
+                    f'{mfe_base_url}/course/{course_locator}/pages-and-resources/proctoring/settings'
+                )
+            else:
+                proctored_exam_settings_url = f'{mfe_base_url}/course/{course_locator}/proctored-exam-settings'
     return proctored_exam_settings_url
 
 

--- a/lms/djangoapps/courseware/plugins.py
+++ b/lms/djangoapps/courseware/plugins.py
@@ -172,6 +172,11 @@ class ProctoringCourseApp(CourseApp):
     app_id = "proctoring"
     name = _("Proctoring")
     description = _("Maintain exam integrity by enabling a proctoring solution for your course")
+    documentation_links = {
+        "learn_more_configuration": settings.PROCTORING_SETTINGS.get(
+            'LINK_URLS', {}
+        ).get('course_authoring_faq', ''),
+    }
 
     @classmethod
     def is_available(cls, course_key: CourseKey) -> bool:
@@ -192,7 +197,7 @@ class ProctoringCourseApp(CourseApp):
         """
         Don't allow proctored exam settings to be enabled from the card
         """
-        raise ValueError("Teams cannot be enabled/disabled via this API.")
+        raise ValueError("Proctoring cannot be enabled/disabled via this API.")
 
     @classmethod
     def get_allowed_operations(cls, course_key: CourseKey, user: Optional[User] = None) -> Dict[str, bool]:
@@ -201,8 +206,7 @@ class ProctoringCourseApp(CourseApp):
         """
         return {
             "enable": False,
-            # There is nothing to configure for proctored exams yet.
-            "configure": False,
+            "configure": True,
         }
 
     @staticmethod

--- a/openedx/core/djangoapps/course_apps/toggles.py
+++ b/openedx/core/djangoapps/course_apps/toggles.py
@@ -3,5 +3,27 @@ Toggles for course apps.
 """
 from edx_toggles.toggles import LegacyWaffleSwitchNamespace
 
+from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
+
 #: Namespace for use by course apps for creating availability toggles
 COURSE_APPS_WAFFLE_NAMESPACE = LegacyWaffleSwitchNamespace("course_apps")
+
+# .. toggle_name: course_apps.proctoring_settings_modal_view
+# .. toggle_use_cases: temporary
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: When enabled, users will be directed to a new proctoring settings
+#    modal on the Pages and Resources view when accessing proctored exam settings.
+# .. toggle_warnings: None
+# .. toggle_creation_date: 2021-08-17
+# .. toggle_target_removal_date: None
+PROCTORING_SETTINGS_MODAL_VIEW = CourseWaffleFlag(
+    COURSE_APPS_WAFFLE_NAMESPACE, 'proctoring_settings_modal_view', module_name=__name__,
+)
+
+
+def proctoring_settings_modal_view_enabled(course_key):
+    """
+    Returns a boolean if proctoring settings modal view is enabled for a course.
+    """
+    return PROCTORING_SETTINGS_MODAL_VIEW.is_enabled(course_key)


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

If `course_apps.proctoring_settings_modal_view` course waffle flag is enabled, the proctored exam settings link directs to a new modal view, rather than the old exam settings page.

This depends on https://github.com/edx/frontend-app-course-authoring/pull/182

## Supporting information

[MST-859](https://openedx.atlassian.net/browse/MST-859)