### PR TITLE
Feature: Add permissions filter to courses API [SE-4588]

### DIFF
--- a/lms/djangoapps/course_api/api.py
+++ b/lms/djangoapps/course_api/api.py
@@ -108,7 +108,12 @@ def _filter_by_search(course_queryset, search_term):
     )
 
 
-def list_courses(request, username, org=None, filter_=None, search_term=None):
+def list_courses(request,
+                 username,
+                 org=None,
+                 filter_=None,
+                 search_term=None,
+                 permissions=None):
     """
     Yield all available courses.
 
@@ -134,12 +139,15 @@ def list_courses(request, username, org=None, filter_=None, search_term=None):
             by the given key-value pairs.
         search_term (string):
             Search term to filter courses (used by ElasticSearch).
+        permissions (list[str]):
+            If specified, it filters visible `CourseOverview` objects by
+            checking if each permission specified is granted for the username.
 
     Return value:
         Yield `CourseOverview` objects representing the collection of courses.
     """
     user = get_effective_user(request.user, username)
-    course_qs = get_courses(user, org=org, filter_=filter_)
+    course_qs = get_courses(user, org=org, filter_=filter_, permissions=permissions)
     course_qs = _filter_by_search(course_qs, search_term)
     return course_qs
 

--- a/lms/djangoapps/course_api/forms.py
+++ b/lms/djangoapps/course_api/forms.py
@@ -10,7 +10,10 @@ from django.forms import CharField, Form
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 
-from openedx.core.djangoapps.util.forms import ExtendedNullBooleanField
+from openedx.core.djangoapps.util.forms import (
+    ExtendedNullBooleanField,
+    MultiValueField
+)
 
 
 class UsernameValidatorMixin:
@@ -59,6 +62,7 @@ class CourseListGetForm(UsernameValidatorMixin, Form):
         filter_type(param_name='mobile', field_name='mobile_available'),
     ]
     mobile = ExtendedNullBooleanField(required=False)
+    permissions = MultiValueField(required=False)
 
     def clean(self):
         """

--- a/lms/djangoapps/course_api/tests/test_forms.py
+++ b/lms/djangoapps/course_api/tests/test_forms.py
@@ -69,6 +69,7 @@ class TestCourseListGetForm(FormTestMixin, UsernameTestMixin, SharedModuleStoreT
             'mobile': None,
             'search_term': '',
             'filter_': None,
+            'permissions': set(),
         }
 
     def test_basic(self):

--- a/lms/djangoapps/course_api/views.py
+++ b/lms/djangoapps/course_api/views.py
@@ -271,6 +271,12 @@ class CourseListView(DeveloperErrorViewMixin, ListAPIView):
             provided org code (e.g., "HarvardX") are returned.
             Case-insensitive.
 
+        permissions (optional):
+            If specified, it filters visible `CourseOverview` objects by
+            checking if each permission specified is granted for the username.
+            Notice that Staff users are always granted permission to list any
+            course.
+
     **Returns**
 
         * 200 on success, with a list of course discovery objects as returned
@@ -321,13 +327,13 @@ class CourseListView(DeveloperErrorViewMixin, ListAPIView):
         form = CourseListGetForm(self.request.query_params, initial={'requesting_user': self.request.user})
         if not form.is_valid():
             raise ValidationError(form.errors)
-
         return list_courses(
             self.request,
             form.cleaned_data['username'],
             org=form.cleaned_data['org'],
             filter_=form.cleaned_data['filter_'],
-            search_term=form.cleaned_data['search_term']
+            search_term=form.cleaned_data['search_term'],
+            permissions=form.cleaned_data['permissions']
         )
 
 


### PR DESCRIPTION
## Description

Add an additional `permissions` parameter to `/api/v1/courses/` to filter courses by checking the user against permissions. The parameter accepts a list of permissions which should be all checked and confirmed to the user on the course for the course to be listed in the return value.

There is not additional design decision documented other then the API docstring itself.

- *Which edX user roles will this change impact?* API consumers, in particular, the Content Libraries MFE, which will use the above API to filter courses that are "importable", that is, user is either instructor or staff, on top of filtering by organization and text search.

## Supporting information

This change will support https://github.com/edx/frontend-app-library-authoring/pull/24 to provide a generic and re-usable way to filter courses that are considered "importable".

## Testing instructions

UTs are covering the API functionality. For manual tests, consider the following:

1. Setup a devstack.
2. Login with staff user (e.g. `edx`).
3. Create a course.
4. Add a user (e.g. `audit`) as an Admin of the course team.
5. Go to http://localhost:18000/api/courses/v1/courses/?org=OC&&username=audit&permissions=instructor
6. Verify that only the new course created at (3.) was returned in the result.
7. Remove the permission granted at (4.), `audit` should not be an Admin.
5. Go to http://localhost:18000/api/courses/v1/courses/?org=OC&&username=audit&permissions=instructor
6. Verify no course is returned.

## Deadline

The PR blocks https://github.com/edx/frontend-app-library-authoring/pull/24.

## Other information

N/A
