### PR TITLE
Leangseu edx/au 70

### DIFF
--- a/lms/djangoapps/grades/tasks.py
+++ b/lms/djangoapps/grades/tasks.py
@@ -271,7 +271,6 @@ def _has_db_updated_with_new_score(self, scored_block_usage_key, **kwargs):
                 "student_id": kwargs['anonymous_user_id'],
                 "course_id": str(scored_block_usage_key.course_key),
                 "item_id": str(scored_block_usage_key),
-                "item_type": scored_block_usage_key.block_type,
             }
         )
         found_modified_time = score['created_at'] if score is not None else None


### PR DESCRIPTION
## Description
Grading from Staff Graded Assignment xblocks are not successfully being passed because `edx-sga` has different `item_type` than `xblock_type`. This fix is only to to remove item type filtering because `item_id`/`usage_key` should be enough to identify the block.

[AU-70](https://openedx.atlassian.net/browse/AU-70)

### Useful information to include:
- Step to reproduce was included within the ticket
