### PR TITLE
feat: Send date override to credentials

### DIFF
--- a/lms/djangoapps/certificates/models.py
+++ b/lms/djangoapps/certificates/models.py
@@ -1239,3 +1239,31 @@ class CertificateDateOverride(TimeStampedModel):
     def __str__(self):
         return "Certificate %s, date overridden to %s by %s on %s." % \
                (self.generated_certificate, self.date, self.overridden_by, self.created)
+
+    def save(self, *args, **kwargs):  # pylint: disable=signature-differs
+        """
+        After the base save() method finishes, fire the COURSE_CERT_CHANGED
+        signal.
+        """
+        super().save(*args, **kwargs)
+        COURSE_CERT_CHANGED.send_robust(
+            sender=self.__class__,
+            user=self.generated_certificate.user,
+            course_key=self.generated_certificate.course_id,
+            mode=self.generated_certificate.mode,
+            status=self.generated_certificate.status,
+        )
+
+    def delete(self, *args, **kwargs):  # pylint: disable=signature-differs
+        """
+        After the base delete() method finishes, fire the COURSE_CERT_CHANGED
+        signal.
+        """
+        super().delete(*args, **kwargs)
+        COURSE_CERT_CHANGED.send_robust(
+            sender=self.__class__,
+            user=self.generated_certificate.user,
+            course_key=self.generated_certificate.course_id,
+            mode=self.generated_certificate.mode,
+            status=self.generated_certificate.status,
+        )


### PR DESCRIPTION
## Description

When sending a `GeneratedCertificate` to Credentials, send the associated
`CertificateDateOverride` (if there is one), or else `None`. This
will be triggered after any save of a `GeneratedCertificate`, and after
any save or deletion of a single `CertificateDateOverride`.

Credentials will eventually store its own copy of this date override, or
edit or remove exiting date overrides.

## Supporting information
Toward [MICROBA-1423](https://openedx.atlassian.net/browse/MICROBA-1423)

## Testing instructions
To test locally: Once the branch is pulled and you have the lms up and running:
- In the devstack directory, run `make dev.attach.lms` to see server activity
- Go to the CertificateDateOverride Django Admin page: http://localhost:18000/admin/certificates/certificatedateoverride/
- Add a CertificateDateOverride
- In the `attach`, you should see a line like: `Task award_course_certificate will award certificate for  course course-[course key here] with a date override of [the date you put]`

## Deadline

None
