### PR TITLE
feat: Added pages&resources url to missing pages 

### DIFF
--- a/cms/djangoapps/contentstore/views/certificates.py
+++ b/cms/djangoapps/contentstore/views/certificates.py
@@ -49,7 +49,6 @@ from xmodule.modulestore.django import modulestore
 from ..exceptions import AssetNotFoundException
 from ..utils import (
     get_lms_link_for_certificate_web_view,
-    get_pages_and_resources_url,
     get_proctored_exam_settings_url,
     reverse_course_url
 )
@@ -430,7 +429,6 @@ def certificates_list_handler(request, course_key_string):
                 'is_global_staff': GlobalStaff().has_user(request.user),
                 'certificate_activation_handler_url': activation_handler_url,
                 'mfe_proctored_exam_settings_url': get_proctored_exam_settings_url(course.id),
-                'pages_and_resources_mfe_link': get_pages_and_resources_url(course.id),
             })
         elif "application/json" in request.META.get('HTTP_ACCEPT'):
             # Retrieve the list of certificates for the specified course

--- a/cms/djangoapps/contentstore/views/checklists.py
+++ b/cms/djangoapps/contentstore/views/checklists.py
@@ -6,7 +6,7 @@ from opaque_keys.edx.keys import CourseKey
 
 from common.djangoapps.edxmako.shortcuts import render_to_response
 from common.djangoapps.student.auth import has_course_author_access
-from cms.djangoapps.contentstore.utils import  get_proctored_exam_settings_url
+from cms.djangoapps.contentstore.utils import get_proctored_exam_settings_url
 from xmodule.modulestore.django import modulestore
 
 __all__ = ['checklists_handler']

--- a/cms/djangoapps/contentstore/views/checklists.py
+++ b/cms/djangoapps/contentstore/views/checklists.py
@@ -6,7 +6,7 @@ from opaque_keys.edx.keys import CourseKey
 
 from common.djangoapps.edxmako.shortcuts import render_to_response
 from common.djangoapps.student.auth import has_course_author_access
-from cms.djangoapps.contentstore.utils import get_pages_and_resources_url, get_proctored_exam_settings_url
+from cms.djangoapps.contentstore.utils import  get_proctored_exam_settings_url
 from xmodule.modulestore.django import modulestore
 
 __all__ = ['checklists_handler']
@@ -32,5 +32,4 @@ def checklists_handler(request, course_key_string=None):
         'language_code': request.LANGUAGE_CODE,
         'context_course': course_module,
         'mfe_proctored_exam_settings_url': get_proctored_exam_settings_url(course_module.id),
-        'pages_and_resources_mfe_link': get_pages_and_resources_url(course_module.id),
     })

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -96,7 +96,6 @@ from ..toggles import split_library_view_on_dashboard
 from ..utils import (
     add_instructor,
     get_lms_link_for_item,
-    get_pages_and_resources_url,
     get_proctored_exam_settings_url,
     initialize_permissions,
     remove_all_instructors,
@@ -728,7 +727,6 @@ def course_index(request, course_key):
             'mfe_proctored_exam_settings_url': get_proctored_exam_settings_url(course_module.id),
             'advance_settings_url': reverse_course_url('advanced_settings_handler', course_module.id),
             'proctoring_errors': proctoring_errors,
-            'pages_and_resources_mfe_link': get_pages_and_resources_url(course_module.id),
         })
 
 
@@ -1165,7 +1163,6 @@ def settings_handler(request, course_key_string):  # lint-amnesty, pylint: disab
                 'enable_extended_course_details': enable_extended_course_details,
                 'upgrade_deadline': upgrade_deadline,
                 'mfe_proctored_exam_settings_url': get_proctored_exam_settings_url(course_module.id),
-                'pages_and_resources_mfe_link': get_pages_and_resources_url(course_module.id),
             }
             if is_prerequisite_courses_enabled():
                 courses, in_process_course_actions = get_courses_accessible_to_user(request)
@@ -1286,7 +1283,6 @@ def grading_handler(request, course_key_string, grader_index=None):
                 'grading_url': reverse_course_url('grading_handler', course_key),
                 'is_credit_course': is_credit_course(course_key),
                 'mfe_proctored_exam_settings_url': get_proctored_exam_settings_url(course_module.id),
-                'pages_and_resources_mfe_link': get_pages_and_resources_url(course_module.id),
             })
         elif 'application/json' in request.META.get('HTTP_ACCEPT', ''):
             if request.method == 'GET':
@@ -1392,7 +1388,6 @@ def advanced_settings_handler(request, course_key_string):
                 'advanced_settings_url': reverse_course_url('advanced_settings_handler', course_key),
                 'publisher_enabled': publisher_enabled,
                 'mfe_proctored_exam_settings_url': get_proctored_exam_settings_url(course_module.id),
-                'pages_and_resources_mfe_link': get_pages_and_resources_url(course_module.id),
                 'proctoring_errors': proctoring_errors,
             })
         elif 'application/json' in request.META.get('HTTP_ACCEPT', ''):
@@ -1745,7 +1740,6 @@ def group_configurations_list_handler(request, course_key_string):
                 'all_group_configurations': displayable_partitions,
                 'should_show_enrollment_track': should_show_enrollment_track,
                 'mfe_proctored_exam_settings_url': get_proctored_exam_settings_url(course.id),
-                'pages_and_resources_mfe_link': get_pages_and_resources_url(course.id),
             })
         elif "application/json" in request.META.get('HTTP_ACCEPT'):
             if request.method == 'POST':

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -43,7 +43,7 @@
             if settings.FEATURES.get("CERTIFICATES_HTML_VIEW") and context_course.cert_html_view_enabled:
                 certificates_url = reverse('certificates_list_handler', kwargs={'course_key_string': six.text_type(course_key)})
             checklists_url = reverse('checklists_handler', kwargs={'course_key_string': six.text_type(course_key)})
-
+            pages_and_resources_mfe_enabled = ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND.is_enabled(context_course.id)
       %>
       <h2 class="info-course">
         <span class="sr">${_("Current Course:")}</span>
@@ -68,12 +68,12 @@
                   <li class="nav-item nav-course-courseware-updates">
                     <a href="${course_info_url}">${_("Updates")}</a>
                   </li>
-                  % if not ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND.is_enabled(context_course.id):
+                  % if not pages_and_resources_mfe_enabled:
                   <li class="nav-item nav-course-courseware-pages">
                     <a href="${tabs_url}">${_("Pages")}</a>
                   </li>
                   % endif
-                  % if ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND.is_enabled(context_course.id):
+                  % if pages_and_resources_mfe_enabled:
                   <li class="nav-item nav-course-courseware-pages-resources">
                     <a href="${get_pages_and_resources_url(course_key)}" rel="external">${_("Pages & Resources")}</a>
                   </li>
@@ -81,7 +81,7 @@
                   <li class="nav-item nav-course-courseware-uploads">
                     <a href="${assets_url}">${_("Files & Uploads")}</a>
                   </li>
-                  % if not ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND.is_enabled(context_course.id):
+                  % if not pages_and_resources_mfe_enabled:
                   <li class="nav-item nav-course-courseware-textbooks">
                     <a href="${textbooks_url}">${_("Textbooks")}</a>
                   </li>

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -67,23 +67,27 @@
                   <li class="nav-item nav-course-courseware-updates">
                     <a href="${course_info_url}">${_("Updates")}</a>
                   </li>
+                  % if not pages_and_resources_mfe_link:
                   <li class="nav-item nav-course-courseware-pages">
                     <a href="${tabs_url}">${_("Pages")}</a>
-                  </li>
-                  <li class="nav-item nav-course-courseware-uploads">
-                    <a href="${assets_url}">${_("Files & Uploads")}</a>
-                  </li>
-                  <li class="nav-item nav-course-courseware-textbooks">
-                    <a href="${textbooks_url}">${_("Textbooks")}</a>
-                  </li>
-                  % if context_course.video_pipeline_configured:
-                  <li class="nav-item nav-course-courseware-videos">
-                    <a href="${videos_url}">${_("Video Uploads")}</a>
                   </li>
                   % endif
                   % if pages_and_resources_mfe_link:
                   <li class="nav-item nav-course-courseware-pages-resources">
                     <a href="${pages_and_resources_mfe_link}" rel="external">${_("Pages & Resources")}</a>
+                  </li>
+                  % endif
+                  <li class="nav-item nav-course-courseware-uploads">
+                    <a href="${assets_url}">${_("Files & Uploads")}</a>
+                  </li>
+                  % if not pages_and_resources_mfe_link:
+                  <li class="nav-item nav-course-courseware-textbooks">
+                    <a href="${textbooks_url}">${_("Textbooks")}</a>
+                  </li>
+                  % endif
+                  % if context_course.video_pipeline_configured:
+                  <li class="nav-item nav-course-courseware-videos">
+                    <a href="${videos_url}">${_("Video Uploads")}</a>
                   </li>
                   % endif
                 </ul>

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -7,11 +7,12 @@
   from django.urls import reverse
   from django.utils.translation import ugettext as _
   from cms.djangoapps.contentstore import toggles
+  from cms.djangoapps.contentstore.utils import get_pages_and_resources_url
+  from openedx.core.djangoapps.discussions.config.waffle import ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND
   from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_enabled, released_languages
 %>
 <div class="wrapper-header wrapper" id="view-top">
   <header class="primary" role="banner">
-
     <div class="wrapper wrapper-l">
       <h1 class="branding">
         <a class="brand-link" href="/">
@@ -67,20 +68,20 @@
                   <li class="nav-item nav-course-courseware-updates">
                     <a href="${course_info_url}">${_("Updates")}</a>
                   </li>
-                  % if not pages_and_resources_mfe_link:
+                  % if not ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND.is_enabled(context_course.id):
                   <li class="nav-item nav-course-courseware-pages">
                     <a href="${tabs_url}">${_("Pages")}</a>
                   </li>
                   % endif
-                  % if pages_and_resources_mfe_link:
+                  % if ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND.is_enabled(context_course.id):
                   <li class="nav-item nav-course-courseware-pages-resources">
-                    <a href="${pages_and_resources_mfe_link}" rel="external">${_("Pages & Resources")}</a>
+                    <a href="${get_pages_and_resources_url(course_key)}" rel="external">${_("Pages & Resources")}</a>
                   </li>
                   % endif
                   <li class="nav-item nav-course-courseware-uploads">
                     <a href="${assets_url}">${_("Files & Uploads")}</a>
                   </li>
-                  % if not pages_and_resources_mfe_link:
+                  % if not ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND.is_enabled(context_course.id):
                   <li class="nav-item nav-course-courseware-textbooks">
                     <a href="${textbooks_url}">${_("Textbooks")}</a>
                   </li>


### PR DESCRIPTION
### [TNL-8604](https://openedx.atlassian.net/browse/TNL-8604)

Added pages&resources url to missing pages dropdown. moved context from view file to template so that template directly get mfe url and its state

Removed `pages` and `textbook` link from studio using waffle flag `discussions.pages_and_resources_mfe` and repositioned pages & resources link.


Sandbox: https://studio-pages.sandbox.edx.org
Use Staff credentials to login and observe that pages & resources button exists in the content dropdown, you can disable it by switching off `discussions.pages_and_resources_mfe`  by using Admin credentials