### PR TITLE
Remove waffle flag for bulk allowance

### DIFF
--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -125,16 +125,6 @@ COURSEWARE_MICROFRONTEND_PROCTORED_EXAMS = CourseWaffleFlag(
     WAFFLE_FLAG_NAMESPACE, 'mfe_proctored_exams', __name__
 )
 
-# .. toggle_name: courseware.enable_bulk_allowance_modal
-# .. toggle_implementation: WaffleFlag
-# .. toggle_default: False
-# .. toggle_description: Enable new bulk allowance modal
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2021-07-14
-BULK_ALLOWANCE_MODAL = CourseWaffleFlag(
-    WAFFLE_FLAG_NAMESPACE, 'enable_bulk_allowance', __name__,
-)
-
 # .. toggle_name: courseware.verified_name
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -49,7 +49,6 @@ from lms.djangoapps.certificates.models import (
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.courses import get_studio_url
 from lms.djangoapps.courseware.module_render import get_module_by_usage_id
-from lms.djangoapps.courseware.toggles import BULK_ALLOWANCE_MODAL
 from lms.djangoapps.discussion.django_comment_client.utils import available_division_schemes, has_forum_access
 from lms.djangoapps.grades.api import is_writable_gradebook_enabled
 from openedx.core.djangoapps.course_groups.cohorts import DEFAULT_COHORT_NAME, get_course_cohorts, is_course_cohorted
@@ -283,7 +282,6 @@ def _section_special_exams(course, access):
         'escalation_email': escalation_email,
         'show_dashboard': is_backend_dashboard_available(course_key),
         'show_onboarding': does_backend_support_onboarding(course.proctoring_provider),
-        'enable_bulk_allowance': BULK_ALLOWANCE_MODAL.is_enabled(course.id),
     }
     return section_data
 

--- a/lms/templates/instructor/instructor_dashboard_2/special_exams.html
+++ b/lms/templates/instructor/instructor_dashboard_2/special_exams.html
@@ -11,7 +11,7 @@ import pytz
   <div id="proctoring-accordion">
     <div class="wrap">
       <h3 class="hd hd-3 special-exam-header">${_('Allowance Section')}</h3>
-      <div class="special-allowance-container" data-course-id="${ section_data['course_id'] }"data-enable-bulk-allowance="${ section_data['enable_bulk_allowance'] }"></div>
+      <div class="special-allowance-container" data-course-id="${ section_data['course_id'] }"></div>
     </div>
     % if section_data['show_onboarding']:
     <div class="wrap">


### PR DESCRIPTION
## Description

Remove the bulk allowance waffle flag so the bulk allowance feature can entirely replace the old modal and be the standard modal along with replacing the old allowance display with the grouped allowance display.
