### PR TITLE
feat!: upgrade pyjwt to version 2.1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,8 +91,30 @@ REQ_FILES = \
 	requirements/edx/development \
 	scripts/xblock/requirements
 
+define COMMON_CONSTRAINTS_TEMP_COMMENT
+# This is a temporary solution to override the real common_constraints.txt\n# In edx-lint, until the pyjwt constraint in edx-lint has been removed.\n# See BOM-2721 for more details.\n# Below is the copied and edited version of common_constraints\n
+endef
+
+COMMON_CONSTRAINTS_TXT=requirements/common_constraints.txt
+.PHONY: $(COMMON_CONSTRAINTS_TXT)
+$(COMMON_CONSTRAINTS_TXT):
+	wget -O "$(@)" https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt || touch "$(@)"
+	echo "$(COMMON_CONSTRAINTS_TEMP_COMMENT)" | cat - $(@) > temp && mv temp $(@)
+
 compile-requirements: export CUSTOM_COMPILE_COMMAND=make upgrade
-compile-requirements: ## Re-compile *.in requirements to *.txt
+compile-requirements: $(COMMON_CONSTRAINTS_TXT) ## Re-compile *.in requirements to *.txt
+	# This is a temporary solution to override the real common_constraints.txt
+	# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
+	# See BOM-271 for more details.
+	sed 's/pyjwt\[crypto\]<2.0.0//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
+	mv requirements/common_constraints.tmp requirements/common_constraints.txt
+	sed 's/social-auth-core<4.0.3//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
+	mv requirements/common_constraints.tmp requirements/common_constraints.txt
+	sed 's/edx-drf-extensions<7.0.0//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
+	mv requirements/common_constraints.tmp requirements/common_constraints.txt
+	sed 's/edx-auth-backends<4.0.0//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
+	mv requirements/common_constraints.tmp requirements/common_constraints.txt
+
 	@ export REBUILD='--rebuild'; \
 	for f in $(REQ_FILES); do \
 		echo ; \
@@ -108,7 +130,7 @@ compile-requirements: ## Re-compile *.in requirements to *.txt
 	sed '/^[dD]jango==/d' requirements/edx/testing.txt > requirements/edx/testing.tmp
 	mv requirements/edx/testing.tmp requirements/edx/testing.txt
 
-upgrade: pre-requirements ## update the pip requirements files to use the latest releases satisfying our constraints
+upgrade: pre-requirements  ## update the pip requirements files to use the latest releases satisfying our constraints
 	$(MAKE) compile-requirements COMPILE_OPTS="--upgrade"
 
 check-types: ## run static type-checking tests

--- a/lms/djangoapps/edxnotes/tests.py
+++ b/lms/djangoapps/edxnotes/tests.py
@@ -1077,7 +1077,12 @@ class EdxNotesViewsTest(ModuleStoreTestCase):
         response = self.client.get(self.get_token_url)
         assert response.status_code == 200
         client = Application.objects.get(name='edx-notes')
-        jwt.decode(response.content, client.client_secret, audience=client.client_id)
+        jwt.decode(
+            response.content,
+            client.client_secret,
+            audience=client.client_id,
+            algorithms=[settings.JWT_AUTH['JWT_ALGORITHM']]
+        )
 
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_EDXNOTES": True})
     def test_get_id_token_anonymous(self):

--- a/openedx/core/djangoapps/oauth_dispatch/tests/mixins.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/mixins.py
@@ -46,8 +46,10 @@ class AccessTokenMixin:
                 algorithms=[settings.JWT_AUTH['JWT_ALGORITHM']],
                 audience=audience,
                 issuer=issuer,
-                verify_expiration=verify_expiration,
-                options={'verify_signature': False},
+                options={
+                    'verify_signature': False,
+                    "verify_exp": verify_expiration
+                },
             )
 
         # Note that if we expect the claims to have expired

--- a/openedx/features/discounts/tests/test_views.py
+++ b/openedx/features/discounts/tests/test_views.py
@@ -46,7 +46,7 @@ class TestCourseUserDiscount(ModuleStoreTestCase):
         assert expected_payload['discount_applicable'] == response.data['discount_applicable']
 
         # make sure that the response matches the expected response
-        response_payload = jwt.decode(response.data['jwt'], verify=False)
+        response_payload = jwt.decode(response.data['jwt'], options={"verify_signature": False})
         assert all(item in list(response_payload.items()) for item in expected_payload.items())
 
     def test_course_user_discount_no_user(self):

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -21,27 +21,27 @@
 Django<2.3
 
 # latest version is causing e2e failures in edx-platform.
-# See pyjwt[crypto]<2.0.0 comment.
+# See  comment.
 drf-jwt<1.19.1
 
-# 4.0.0 requires pyjwt[crypto] 2.1.0. See pyjwt[crypto]<2.0.0 comment.
-edx-auth-backends<4.0.0
+# 4.0.0 requires pyjwt[crypto] 2.1.0. See  comment.
 
-# 7.0.0 requires pyjwt[crypto] 2.1.0. See pyjwt[crypto]<2.0.0 comment.
-edx-drf-extensions<7.0.0
+
+# 7.0.0 requires pyjwt[crypto] 2.1.0. See  comment.
+
 
 # PyJWT[crypto] 2.0.0 has a number of breaking changes that we are
 # actively working to fix. A number of the active constraints are all related
 # to this effort. Additionally, your IDA/service may also be affected directly
 # by these changes. You should not upgrade without knowing what you are doing.
-pyjwt[crypto]<2.0.0
+
 
 # 5.0.0+ of social-auth-app-django requires social-auth-core>=4.1.0
 social-auth-app-django<5.0.0
 
 # latest version requires PyJWT>=2.0.0 but drf-jwt requires PyJWT[crypto]<2.0.0,>=1.5.2.
-# See pyjwt[crypto]<2.0.0 comment.
-social-auth-core<4.0.3
+# See  comment.
+
 
 # elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.
 # elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -1,0 +1,48 @@
+# This is a temporary solution to override the real common_constraints.txt
+# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
+# See BOM-2721 for more details.
+# Below is the copied and edited version of common_constraints
+
+# A central location for most common version constraints
+# (across edx repos) for pip-installation.
+#
+# Similar to other constraint files this file doesn't install any packages.
+# It specifies version constraints that will be applied if a package is needed.
+# When pinning something here, please provide an explanation of why it is a good
+# idea to pin this package across all edx repos, Ideally, link to other information
+# that will help people in the future to remove the pin when possible.
+# Writing an issue against the offending project and linking to it here is good.
+#
+# Note: Changes to this file will automatically be used by other repos, referencing
+#  this file from Github directly. It does not require packaging in edx-lint.
+
+
+# using LTS django version
+Django<2.3
+
+# latest version is causing e2e failures in edx-platform.
+# See pyjwt[crypto]<2.0.0 comment.
+drf-jwt<1.19.1
+
+# 4.0.0 requires pyjwt[crypto] 2.1.0. See pyjwt[crypto]<2.0.0 comment.
+edx-auth-backends<4.0.0
+
+# 7.0.0 requires pyjwt[crypto] 2.1.0. See pyjwt[crypto]<2.0.0 comment.
+edx-drf-extensions<7.0.0
+
+# PyJWT[crypto] 2.0.0 has a number of breaking changes that we are
+# actively working to fix. A number of the active constraints are all related
+# to this effort. Additionally, your IDA/service may also be affected directly
+# by these changes. You should not upgrade without knowing what you are doing.
+pyjwt[crypto]<2.0.0
+
+# 5.0.0+ of social-auth-app-django requires social-auth-core>=4.1.0
+social-auth-app-django<5.0.0
+
+# latest version requires PyJWT>=2.0.0 but drf-jwt requires PyJWT[crypto]<2.0.0,>=1.5.2.
+# See pyjwt[crypto]<2.0.0 comment.
+social-auth-core<4.0.3
+
+# elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.
+# elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
+elasticsearch<7.14.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,7 +10,7 @@
 
 
 # This file contains all common constraints for edx-repos
--c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+-c common_constraints.txt
 
 # celert>5.0.0 hasn't been tested yet, so the constraint will be removed after testing latest version
 celery<5.0.0
@@ -82,10 +82,6 @@ python-slugify<5.0.0
 
 # greater version has breaking changes and requires some migration steps.
 django-webpack-loader==0.7.0
-
-# edx-proctoring==3.11.4 (latest) requires PyJWT<2.0.0
-PyJWT[crypto]<2.0.0
-social-auth-core<4.0.0  # social-auth-core>=4.0.0 requires PYJWT>=2.0.0
 
 # celery requires click<8.0.0 which would be fixed once https://github.com/celery/celery/issues/6753 is done.
 click<8.0.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -109,7 +109,3 @@ py2neo<2022
 # as of right now (Sep 8 2021), we need to not use the latest edx-when
 # version which might be causing issues with course publishing
 edx-when==2.1.0
-
-# pinning edx-proctoring<4.0.0 and will be unpinned in following PR
-# https://github.com/edx/edx-platform/pull/28475
-edx-proctoring<4.0.0

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -165,7 +165,7 @@ deprecated==1.2.13
     # via jwcrypto
 django==2.2.24
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/edx/../common_constraints.txt
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   django-appconf
@@ -392,7 +392,7 @@ done-xblock==2.0.4
     # via -r requirements/edx/base.in
 drf-jwt==1.19.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/edx/../common_constraints.txt
     #   edx-drf-extensions
 drf-yasg==1.20.0
     # via edx-api-doc-tools
@@ -402,10 +402,8 @@ edx-analytics-data-api-client==0.17.0
     # via -r requirements/edx/base.in
 edx-api-doc-tools==1.5.0
     # via -r requirements/edx/base.in
-edx-auth-backends==3.4.0
-    # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -r requirements/edx/base.in
+edx-auth-backends==4.0.0
+    # via -r requirements/edx/base.in
 edx-bulk-grades==0.9.2
     # via
     #   -r requirements/edx/base.in
@@ -433,9 +431,8 @@ edx-django-utils==4.4.0
     #   edx-when
     #   ora2
     #   super-csv
-edx-drf-extensions==6.6.0
+edx-drf-extensions==7.0.1
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/edx/base.in
     #   edx-completion
     #   edx-enterprise
@@ -476,9 +473,8 @@ edx-opaque-keys[django]==2.2.2
     #   xmodule
 edx-organizations==6.10.0
     # via -r requirements/edx/base.in
-edx-proctoring==3.24.6
+edx-proctoring==4.0.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   edx-proctoring-proctortrack
 edx-proctoring-proctortrack==1.0.5
@@ -521,7 +517,7 @@ edxval==2.0.3
     #   -r requirements/edx/base.in
 elasticsearch==7.13.4
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/edx/../common_constraints.txt
     #   edx-search
 enmerkar==0.7.1
     # via enmerkar-underscore
@@ -682,7 +678,7 @@ multidict==5.1.0
     #   yarl
 mysqlclient==2.0.3
     # via -r requirements/edx/base.in
-newrelic==6.8.1.164
+newrelic==6.10.0.165
     # via
     #   -r requirements/edx/base.in
     #   edx-django-utils
@@ -771,13 +767,12 @@ pyjwkest==1.4.2
     #   -r requirements/edx/base.in
     #   edx-drf-extensions
     #   lti-consumer-xblock
-pyjwt[crypto]==1.7.1
+pyjwt[crypto]==2.1.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   drf-jwt
     #   edx-auth-backends
+    #   edx-drf-extensions
     #   edx-proctoring
     #   edx-rest-api-client
     #   pylti1p3
@@ -969,7 +964,6 @@ six==1.16.0
     #   python-memcached
     #   python-swiftclient
     #   social-auth-app-django
-    #   social-auth-core
 slumber==0.7.1
     # via
     #   edx-bulk-grades
@@ -977,13 +971,11 @@ slumber==0.7.1
     #   edx-rest-api-client
 social-auth-app-django==4.0.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/edx/../common_constraints.txt
     #   -r requirements/edx/base.in
     #   edx-auth-backends
-social-auth-core==3.4.0
+social-auth-core==4.1.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   edx-auth-backends
     #   social-auth-app-django

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -241,7 +241,7 @@ distlib==0.3.2
     #   virtualenv
 django==2.2.24
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/edx/../common_constraints.txt
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   django-appconf
@@ -489,7 +489,7 @@ done-xblock==2.0.4
     # via -r requirements/edx/testing.txt
 drf-jwt==1.19.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/edx/../common_constraints.txt
     #   -r requirements/edx/testing.txt
     #   edx-drf-extensions
 drf-yasg==1.20.0
@@ -502,10 +502,8 @@ edx-analytics-data-api-client==0.17.0
     # via -r requirements/edx/testing.txt
 edx-api-doc-tools==1.5.0
     # via -r requirements/edx/testing.txt
-edx-auth-backends==3.4.0
-    # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -r requirements/edx/testing.txt
+edx-auth-backends==4.0.0
+    # via -r requirements/edx/testing.txt
 edx-bulk-grades==0.9.2
     # via
     #   -r requirements/edx/testing.txt
@@ -533,9 +531,8 @@ edx-django-utils==4.4.0
     #   edx-when
     #   ora2
     #   super-csv
-edx-drf-extensions==6.6.0
+edx-drf-extensions==7.0.1
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/edx/testing.txt
     #   edx-completion
     #   edx-enterprise
@@ -580,9 +577,8 @@ edx-opaque-keys[django]==2.2.2
     #   xmodule
 edx-organizations==6.10.0
     # via -r requirements/edx/testing.txt
-edx-proctoring==3.24.6
+edx-proctoring==4.0.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   edx-proctoring-proctortrack
 edx-proctoring-proctortrack==1.0.5
@@ -631,7 +627,7 @@ edxval==2.0.3
     #   -r requirements/edx/testing.txt
 elasticsearch==7.13.4
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/edx/../common_constraints.txt
     #   -r requirements/edx/testing.txt
     #   edx-search
 enmerkar==0.7.1
@@ -907,7 +903,7 @@ mypy-extensions==0.4.3
     # via mypy
 mysqlclient==2.0.3
     # via -r requirements/edx/testing.txt
-newrelic==6.8.1.164
+newrelic==6.10.0.165
     # via
     #   -r requirements/edx/testing.txt
     #   edx-django-utils
@@ -1042,13 +1038,12 @@ pyjwkest==1.4.2
     #   -r requirements/edx/testing.txt
     #   edx-drf-extensions
     #   lti-consumer-xblock
-pyjwt[crypto]==1.7.1
+pyjwt[crypto]==2.1.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   drf-jwt
     #   edx-auth-backends
+    #   edx-drf-extensions
     #   edx-proctoring
     #   edx-rest-api-client
     #   pylti1p3
@@ -1340,7 +1335,6 @@ six==1.16.0
     #   python-swiftclient
     #   singledispatch
     #   social-auth-app-django
-    #   social-auth-core
     #   sphinxcontrib-httpdomain
     #   tox
     #   transifex-client
@@ -1359,13 +1353,11 @@ snowballstemmer==2.1.0
     # via sphinx
 social-auth-app-django==4.0.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/edx/../common_constraints.txt
     #   -r requirements/edx/testing.txt
     #   edx-auth-backends
-social-auth-core==3.4.0
+social-auth-core==4.1.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   edx-auth-backends
     #   social-auth-app-django

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -227,7 +227,7 @@ diff-cover==4.0.0
 distlib==0.3.2
     # via virtualenv
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/edx/../common_constraints.txt
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   django-appconf
@@ -470,7 +470,7 @@ done-xblock==2.0.4
     # via -r requirements/edx/base.txt
 drf-jwt==1.19.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/edx/../common_constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-drf-extensions
 drf-yasg==1.20.0
@@ -483,10 +483,8 @@ edx-analytics-data-api-client==0.17.0
     # via -r requirements/edx/base.txt
 edx-api-doc-tools==1.5.0
     # via -r requirements/edx/base.txt
-edx-auth-backends==3.4.0
-    # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -r requirements/edx/base.txt
+edx-auth-backends==4.0.0
+    # via -r requirements/edx/base.txt
 edx-bulk-grades==0.9.2
     # via
     #   -r requirements/edx/base.txt
@@ -514,9 +512,8 @@ edx-django-utils==4.4.0
     #   edx-when
     #   ora2
     #   super-csv
-edx-drf-extensions==6.6.0
+edx-drf-extensions==7.0.1
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-completion
     #   edx-enterprise
@@ -562,9 +559,8 @@ edx-opaque-keys[django]==2.2.2
     #   xmodule
 edx-organizations==6.10.0
     # via -r requirements/edx/base.txt
-edx-proctoring==3.24.6
+edx-proctoring==4.0.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-proctoring-proctortrack
 edx-proctoring-proctortrack==1.0.5
@@ -611,7 +607,7 @@ edxval==2.0.3
     #   -r requirements/edx/base.txt
 elasticsearch==7.13.4
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/edx/../common_constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-search
 enmerkar==0.7.1
@@ -855,7 +851,7 @@ multidict==5.1.0
     #   yarl
 mysqlclient==2.0.3
     # via -r requirements/edx/base.txt
-newrelic==6.8.1.164
+newrelic==6.10.0.165
     # via
     #   -r requirements/edx/base.txt
     #   edx-django-utils
@@ -979,13 +975,12 @@ pyjwkest==1.4.2
     #   -r requirements/edx/base.txt
     #   edx-drf-extensions
     #   lti-consumer-xblock
-pyjwt[crypto]==1.7.1
+pyjwt[crypto]==2.1.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   drf-jwt
     #   edx-auth-backends
+    #   edx-drf-extensions
     #   edx-proctoring
     #   edx-rest-api-client
     #   pylti1p3
@@ -1261,7 +1256,6 @@ six==1.16.0
     #   python-swiftclient
     #   singledispatch
     #   social-auth-app-django
-    #   social-auth-core
     #   tox
     #   transifex-client
     #   virtualenv
@@ -1275,13 +1269,11 @@ smmap==4.0.0
     # via gitdb
 social-auth-app-django==4.0.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/edx/../common_constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-auth-backends
-social-auth-core==3.4.0
+social-auth-core==4.1.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-auth-backends
     #   social-auth-app-django


### PR DESCRIPTION

## Description

This PR contains BREAKING CHANGES

- Upgrading `pyjwt` to the latest version (i.e. 2.1.0). It has some breaking changes so updated the codebase accordingly.
- Upgraded `edx-drf-extensions` to the latest version which is compatible with `pyjwt`'s latest version.
- Upgraded `edx-auth-backends` to the latest version which is compatible with `pyjwt`'s latest version.

## Supporting information

- https://pyjwt.readthedocs.io/en/stable/changelog.html#v2-0-0

## Testing instructions

We have tested this change on the sandbox. I tested this by updating the accounts settings which use JWT Authentication. (https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/user_api/accounts/views.py#L292)

URL: https://pyjwt.sandbox.edx.org/account/settings

## Deadline

Need this to go out before Django 3.2 upgrade.

