### PR TITLE
chore: bump edx-ace to 1.3.1

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -391,7 +391,7 @@ drf-jwt==1.19.0
     #   edx-drf-extensions
 drf-yasg==1.20.0
     # via edx-api-doc-tools
-edx-ace==1.2.0
+edx-ace==1.3.1
     # via -r requirements/edx/base.in
 edx-analytics-data-api-client==0.17.0
     # via -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -484,7 +484,7 @@ drf-yasg==1.20.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-api-doc-tools
-edx-ace==1.2.0
+edx-ace==1.3.1
     # via -r requirements/edx/testing.txt
 edx-analytics-data-api-client==0.17.0
     # via -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -467,7 +467,7 @@ drf-yasg==1.20.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-api-doc-tools
-edx-ace==1.2.0
+edx-ace==1.3.1
     # via -r requirements/edx/base.txt
 edx-analytics-data-api-client==0.17.0
     # via -r requirements/edx/base.txt


### PR DESCRIPTION
This allows us to force specific transactional emails to go through the default channel instead.

AA-951