### PR TITLE
build: name github action workflows, not jobs

### DIFF
--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Test JavaScript
 
 on:
   pull_request:
@@ -10,7 +10,6 @@ on:
 
 jobs:
   run_tests:
-    name: JS
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/migrations-check.yml
+++ b/.github/workflows/migrations-check.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Check Migrations
 
 on:
   workflow_dispatch:
@@ -9,7 +9,6 @@ on:
 
 jobs:
   run_tests:
-    name: Migrations Test
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/unit-tests-check.yml
+++ b/.github/workflows/unit-tests-check.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Collect Unit Tests
 
 on:
   pull_request:
@@ -7,7 +7,6 @@ on:
 
 jobs:
   run_tests:
-    name: Ensure Unit Tests Running
     runs-on: ubuntu-20.04
     strategy:
       matrix:


### PR DESCRIPTION
## Description
Under a PR's "Checks", GitHub displays the names of
GitHub Action (GHA) workflows, not the names of the
jobs within the workflows.

Since all the workflows were named "CI", GitHub
is showing that PRs have three checks, all named "CI".

This commit removes the job names, and instead adds
unique workflow names.

## Deadline

None

## Other information
...