### PR TITLE
[BB-4649] fix: Duplicate Arabic month

### DIFF
--- a/lms/static/js/spec/dateutil_factory_spec.js
+++ b/lms/static/js/spec/dateutil_factory_spec.js
@@ -25,7 +25,7 @@ define(['../dateutil_factory.js'], function(DateUtilIterator) {
                 var testLangs = {
                     en: 'Due Oct 14, 2016 08:00 UTC',
                     ru: 'Due 14 окт. 2016 г. 08:00 UTC',
-                    ar: 'Due ١٤ تشرين الأول أكتوبر ٢٠١٦ ٠٨:٠٠ UTC',
+                    ar: 'Due ١٤ أكتوبر ٢٠١٦ ٠٨:٠٠ UTC',
                     fr: 'Due 14 oct. 2016 08:00 UTC'
                 };
                 $form = $(

--- a/package-lock.json
+++ b/package-lock.json
@@ -18636,9 +18636,9 @@
       }
     },
     "moment": {
-      "version": "2.19.3",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.3.tgz",
-      "integrity": "sha1-vbmdJw1tf9p4zA+6zoVeJ/59pp8="
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "moment-timezone": {
       "version": "0.5.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18636,9 +18636,9 @@
       }
     },
     "moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
+      "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
     },
     "moment-timezone": {
       "version": "0.5.14",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "jquery.scrollto": "2.1.2",
     "js-cookie": "2.2.0",
     "jwt-decode": "^2.2.0",
-    "moment": "2.29.1",
+    "moment": "2.20.1",
     "moment-timezone": "0.5.14",
     "node-sass": "4.12.0",
     "picturefill": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "jquery.scrollto": "2.1.2",
     "js-cookie": "2.2.0",
     "jwt-decode": "^2.2.0",
-    "moment": "2.19.3",
+    "moment": "2.29.1",
     "moment-timezone": "0.5.14",
     "node-sass": "4.12.0",
     "picturefill": "3.0.2",


### PR DESCRIPTION
## Description

Arabic months are being shown in duplicates. The issue is from moment js. This issue has been [reported](https://github.com/moment/moment/issues/4270) and [solved](https://github.com/moment/moment/pull/4359) back in 2017. But unfortunately, Open edX [depending](https://github.com/edx/edx-platform/blob/master/package.json#L42) on a version before that. 

**Before this PR**
<img width="354" alt="Screenshot 2021-08-18 at 3 59 23 PM" src="https://user-images.githubusercontent.com/1010244/129882938-1d2616ff-732b-48e3-8533-9c918ca7230c.png">

**After this PR**
<img width="341" alt="Screenshot 2021-08-18 at 4 11 43 PM" src="https://user-images.githubusercontent.com/1010244/129882969-66df7967-9fcb-49dd-806d-684c344cd509.png">

## Testing instructions

1. Clone this PR in your local devstack.
2. Run lms - `make dev.up.lms`.
3. Change language to Arabic from - `http://localhost:18000/update_lang/`.
4. Visit - `http://localhost:18000/courses`.
5. Make sure that Arabic months are correct in the course start date.

## Deadline

None

## Other information

**Reviewers**
- [ ] @alfredchavez 