### PR TITLE
feat: Add two middlewares to the CMS

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -710,6 +710,10 @@ MIDDLEWARE = [
     'edx_django_utils.cache.middleware.RequestCacheMiddleware',
     'edx_django_utils.monitoring.MonitoringMemoryMiddleware',
 
+    # Monitoring and logging middleware
+    'openedx.core.lib.request_utils.ExpectedErrorMiddleware',
+    'edx_django_utils.monitoring.CachedCustomMonitoringMiddleware',
+
     # Cookie monitoring
     'openedx.core.lib.request_utils.CookieMonitoringMiddleware',
 


### PR DESCRIPTION
## Description

feat: Add two middlewares to the CMS:
- middleware that will allow the CMS to ignore certain errors sent to New Relic when considering error rate alerts. With this change, errors to ignore need only to be added to the `EXPECTED_ERRORS` Django setting in order to ignore them against the totals.
- middleware that batch-reports the cached custom attributes to New Relic at the end of a request.

Both these middlewares are already present in the LMS here:
https://github.com/edx/edx-platform/blob/e2bb4d3598d8753723d30ad6322475e4f634e316/lms/envs/common.py#L2019-L2022

The CMS hasn't had an error alert since Jan 15th, 2021. But if an error suddenly becomes the cause of many alerts without being an important error, this middleware addition will allow us to quickly squelch it using the `EXPECTED_ERRORS` setting.

## Supporting information

Slack conversation here:
https://edx-internal.slack.com/archives/CG7FM3BLY/p1629296259151100

## Testing instructions

This change should cause no functional changes. But checking the NR data - particularly the prod-edx-edxapp-cms errors/violations - should be done post-deployment.

## Deadline

None
