### PR TITLE
chore: bump name affirmation to complete column removal

### DIFF
--- a/common/djangoapps/util/tests/test_db.py
+++ b/common/djangoapps/util/tests/test_db.py
@@ -197,9 +197,6 @@ class MigrationTests(TestCase):
     """
 
     @override_settings(MIGRATION_MODULES={})
-    @unittest.skip(
-        "Temporary skip for MST-969 while the is_verified column is removed from the verified_name table"
-    )
     def test_migrations_are_in_sync(self):
         """
         Tests that the migration files are in sync with the models.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -445,7 +445,7 @@ edx-i18n-tools==0.7.0
     # via ora2
 edx-milestones==0.3.2
     # via -r requirements/edx/base.in
-edx-name-affirmation==0.6.3
+edx-name-affirmation==0.6.4
     # via -r requirements/edx/base.in
 edx-opaque-keys[django]==2.2.2
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -542,7 +542,7 @@ edx-lint==5.0.0
     # via -r requirements/edx/testing.txt
 edx-milestones==0.3.2
     # via -r requirements/edx/testing.txt
-edx-name-affirmation==0.6.3
+edx-name-affirmation==0.6.4
     # via -r requirements/edx/testing.txt
 edx-opaque-keys[django]==2.2.2
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -526,7 +526,7 @@ edx-lint==5.0.0
     # via -r requirements/edx/testing.in
 edx-milestones==0.3.2
     # via -r requirements/edx/base.txt
-edx-name-affirmation==0.6.3
+edx-name-affirmation==0.6.4
     # via -r requirements/edx/base.txt
 edx-opaque-keys[django]==2.2.2
     # via


### PR DESCRIPTION
This is the last PR removing verified name is_verified,
so we can bring back the test.

MST-969