### PR TITLE
fix: Add the devstack domain white list to the account MFE

### DIFF
--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -264,6 +264,7 @@ LOGIN_REDIRECT_WHITELIST.extend([
     #   BASE_URL=http://localhost:$PORT
     # as opposed to:
     #   BASE_URL=localhost:$PORT
+    'localhost:1997',  # frontend-app-account
     'localhost:1976',  # frontend-app-program-console
     'localhost:1994',  # frontend-app-gradebook
     'localhost:2000',  # frontend-app-learning


### PR DESCRIPTION
## Description

This is to enhance the devstack addition of the account MFE. See the [devstack PR here](https://github.com/edx/devstack/pull/822). By adding this localhost domain to whitelist, it helps a more seamless between local LMS and account MFE.

@edx/masters-devs-cosmonauts FYI
