### PR TITLE
fix: Change format of date_override post

### DIFF
--- a/openedx/core/djangoapps/programs/tasks.py
+++ b/openedx/core/djangoapps/programs/tasks.py
@@ -33,6 +33,7 @@ MAX_RETRIES = 11
 PROGRAM_CERTIFICATE = 'program'
 COURSE_CERTIFICATE = 'course-run'
 VISIBLE_DATE_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
+DATE_OVERRIDE_FORMAT = '%Y-%m-%d'
 
 
 def get_completed_programs(site, student):
@@ -306,7 +307,7 @@ def post_course_certificate(client, username, certificate, visible_date, date_ov
             'mode': certificate.mode,
             'type': COURSE_CERTIFICATE,
         },
-        'date_override': date_override.strftime(VISIBLE_DATE_FORMAT) if date_override else None,
+        'date_override': {'date': date_override.strftime(DATE_OVERRIDE_FORMAT)} if date_override else None,
         'attributes': [
             {
                 'name': 'visible_date',


### PR DESCRIPTION
## Description
Credentials needs the course certificate date override data in a
slightly different format than we were passing it before. Fix!

## Supporting information
Toward [MICROBA-1455](https://openedx.atlassian.net/browse/MICROBA-1455)

## Deadline
None

## Other information
This is required before https://github.com/edx/credentials/pull/1279 will work.
