### PR TITLE
feat: AA-940 Remove split_test from Masquerade dropdown

### DIFF
--- a/lms/djangoapps/courseware/masquerade.py
+++ b/lms/djangoapps/courseware/masquerade.py
@@ -142,7 +142,9 @@ class MasqueradeView(View):
             'user_name': course.user_name or '',
         })
         for partition in partitions:
-            if partition.active:
+            # "random" scheme implies a split_test content group, not a cohort
+            # for AA-940 remove split_test partition groups from dropdown
+            if partition.active and partition.scheme.name != "random":
                 data['available'].extend([
                     {
                         'group_id': group.id,

--- a/lms/djangoapps/courseware/masquerade.py
+++ b/lms/djangoapps/courseware/masquerade.py
@@ -143,7 +143,7 @@ class MasqueradeView(View):
         })
         for partition in partitions:
             # "random" scheme implies a split_test content group, not a cohort
-            # for AA-940 remove split_test partition groups from dropdown
+            # and masquerading only cares about user cohorts
             if partition.active and partition.scheme.name != "random":
                 data['available'].extend([
                     {

--- a/lms/djangoapps/courseware/tests/test_masquerade.py
+++ b/lms/djangoapps/courseware/tests/test_masquerade.py
@@ -25,6 +25,7 @@ from lms.djangoapps.courseware.masquerade import (
     get_masquerading_user_group,
     setup_masquerade,
 )
+
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase, MasqueradeMixin, masquerade_as_group_member
 from lms.djangoapps.courseware.tests.test_submitting_problems import ProblemSubmissionTestMixin
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
@@ -241,6 +242,36 @@ class TestMasqueradeLearnerOptions(StaffMasqueradeTestCase):
             response = self.get_available_masquerade_identities()
             is_learner_available = 'Learner' in map(itemgetter('name'), response.json()['available'])
             assert partitions_enabled != is_learner_available
+
+
+@ddt.ddt
+class TestMasqueradeOptionsNoContentGroups(StaffMasqueradeTestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        self.user_partition = UserPartition(
+            0, 'Test User Partition', '',
+            [Group(0, 'Cohort Group 1'), Group(1, 'Cohort Group 2')],
+            scheme_id='cohort'
+        )
+        self.course.user_partitions.append(self.user_partition)
+        self.user_partition = UserPartition(
+            0, 'Test User Partition 2', '',
+            [Group(0, 'Content Group 1'), Group(1, 'Content Group 2')],
+            scheme_id='random'
+        )
+        self.course.user_partitions.append(self.user_partition)
+
+        modulestore().update_item(self.course, self.test_user.id)
+
+    @ddt.data(['Cohort Group 1', True], ['Content Group 1', False])
+    @ddt.unpack
+    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_MASQUERADE': True})
+    def testMasqueradeCohortAvailable(self, target, expected):
+        response = self.get_available_masquerade_identities()
+        is_target_available = target in map(itemgetter('name'), response.json()['available'])
+        assert is_target_available == expected
 
 
 class TestStaffMasqueradeAsStudent(StaffMasqueradeTestCase):

--- a/lms/djangoapps/courseware/tests/test_masquerade.py
+++ b/lms/djangoapps/courseware/tests/test_masquerade.py
@@ -246,6 +246,10 @@ class TestMasqueradeLearnerOptions(StaffMasqueradeTestCase):
 
 @ddt.ddt
 class TestMasqueradeOptionsNoContentGroups(StaffMasqueradeTestCase):
+    """
+    Test that split_test content groups (which are the partitions with a "random" scheme),
+    do not show up in the masquerade options popup, but cohort groups do appear.
+    """
 
     def setUp(self):
         super().setUp()
@@ -269,6 +273,11 @@ class TestMasqueradeOptionsNoContentGroups(StaffMasqueradeTestCase):
     @ddt.unpack
     @patch.dict('django.conf.settings.FEATURES', {'ENABLE_MASQUERADE': True})
     def testMasqueradeCohortAvailable(self, target, expected):
+        """
+        Args:
+            target: The partition to check for in masquerade options
+            expected: Whether to partition should be in the list
+        """
         response = self.get_available_masquerade_identities()
         is_target_available = target in map(itemgetter('name'), response.json()['available'])
         assert is_target_available == expected


### PR DESCRIPTION
Filter content groups that are not part of a cohort from the selection
available to the select in the Masquerade bar.

Refs AA-940
