### PR TITLE
feat: add activation link to registration event

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -245,7 +245,7 @@ def create_account_with_params(request, params):
         except Exception:  # pylint: disable=broad-except
             log.exception(f"Enable discussion notifications failed for user {user.id}.")
 
-    _track_user_registration(user, profile, params, third_party_provider)
+    _track_user_registration(user, profile, params, third_party_provider, registration)
 
     # Announce registration
     REGISTER_USER.send(sender=None, user=user, registration=registration)
@@ -321,7 +321,7 @@ def _link_user_to_third_party_provider(
     return third_party_provider, running_pipeline
 
 
-def _track_user_registration(user, profile, params, third_party_provider):
+def _track_user_registration(user, profile, params, third_party_provider, registration):
     """ Track the user's registration. """
     if hasattr(settings, 'LMS_SEGMENT_KEY') and settings.LMS_SEGMENT_KEY:
         identity_args = [
@@ -354,6 +354,7 @@ def _track_user_registration(user, profile, params, third_party_provider):
             'is_education_selected': bool(profile.level_of_education_display),
             'is_goal_set': bool(profile.goals),
             'total_registration_time': round(float(params.get('totalRegistrationTime', '0'))),
+            'activation_key': registration.activation_key if registration else None,
         }
         # DENG-803: For segment events forwarded along to Hubspot, duplicate the `properties` section of
         # the event payload into the `traits` section so that they can be received. This is a temporary


### PR DESCRIPTION

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Added activation key to the registration event to be used by braze. 
Currently in our activation reminder emails we are not sending activation link, by sending activation key we can add the link in the emails that are send via braze.

Current Email:
![Screen Shot 2021-05-26 at 10 54 48 AM](https://user-images.githubusercontent.com/40633976/130455529-1c273236-78e5-498d-9ecf-4fd40ef2967d.png)


## Supporting information

Ticket: https://openedx.atlassian.net/browse/VAN-693

