### PR TITLE
BOM-2746: Pin django-ipware and pylint versions

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -103,3 +103,7 @@ edxval<2.1
 # django-ipware==4.0.0 contains a critical change related to ip-handling which needs to be tested on sandbox
 # This constraint will be removed in https://openedx.atlassian.net/browse/BOM-2747
 django-ipware<4.0.0
+
+# pylint>=2.10.0 introduced a lot of new pylint warnings.
+# A separate PR will be needed to remove the pin and fix all the pylint warnings
+pylint<2.10.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -99,3 +99,7 @@ jsonfield2<3.1.0        # jsonfield2 3.1.0 drops support for python 3.5
 # a testing requirement. Installing it would cause a bunch of new tool packages to become base
 # requirements of edx-platform. Pinning temporarily until this is resolved in edx-val.
 edxval<2.1
+
+# django-ipware==4.0.0 contains a critical change related to ip-handling which needs to be tested on sandbox
+# This constraint will be removed in https://openedx.atlassian.net/browse/BOM-2747
+django-ipware<4.0.0

--- a/requirements/edx-sandbox/py35.txt
+++ b/requirements/edx-sandbox/py35.txt
@@ -62,6 +62,7 @@ numpy==1.16.5
     #   chem
     #   matplotlib
     #   openedx-calc
+    #   scipy
 openedx-calc==1.0.9
     # via -r requirements/edx-sandbox/py35.in
 pycparser==2.20
@@ -80,7 +81,7 @@ pytz==2021.1
     # via matplotlib
 random2==1.0.1
     # via -r requirements/edx-sandbox/py35.in
-regex==2021.8.3
+regex==2021.8.21
     # via nltk
 scipy==1.2.1
     # via
@@ -102,7 +103,7 @@ sympy==1.6.2
     #   -c requirements/edx-sandbox/py35-constraints.txt
     #   -r requirements/edx-sandbox/py35.in
     #   symmath
-tqdm==4.62.1
+tqdm==4.62.2
     # via nltk
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/edx-sandbox/py38.txt
+++ b/requirements/edx-sandbox/py38.txt
@@ -71,7 +71,7 @@ python-dateutil==2.4.0
     #   matplotlib
 random2==1.0.1
     # via -r requirements/edx-sandbox/py38.in
-regex==2021.8.3
+regex==2021.8.21
     # via nltk
 scipy==1.7.1
     # via
@@ -88,5 +88,5 @@ sympy==1.6.2
     #   -c requirements/edx-sandbox/../constraints.txt
     #   -r requirements/edx-sandbox/py38.in
     #   symmath
-tqdm==4.62.1
+tqdm==4.62.2
     # via nltk

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -174,7 +174,6 @@ django==2.2.24
     #   django-filter
     #   django-method-override
     #   django-model-utils
-    #   django-mptt
     #   django-multi-email-field
     #   django-mysql
     #   django-oauth-toolkit
@@ -274,6 +273,7 @@ django-filter==2.4.0
     #   lti-consumer-xblock
 django-ipware==3.0.7
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   edx-enterprise
     #   edx-proctoring
@@ -299,7 +299,7 @@ django-model-utils==4.1.1
     #   edxval
     #   ora2
     #   super-csv
-django-mptt==0.12.0
+django-mptt==0.13.1
     # via
     #   -r requirements/edx/base.in
     #   django-wiki
@@ -414,7 +414,7 @@ edx-django-release-util==1.1.0
     # via -r requirements/edx/base.in
 edx-django-sites-extensions==3.1.0
     # via -r requirements/edx/base.in
-edx-django-utils==4.2.0
+edx-django-utils==4.3.0
     # via
     #   -r requirements/edx/base.in
     #   django-config-models
@@ -622,7 +622,7 @@ lxml==4.5.0
     #   xmlsec
 mailsnake==1.6.4
     # via -r requirements/edx/base.in
-mako==1.1.4
+mako==1.1.5
     # via
     #   -r requirements/edx/base.in
     #   acid-xblock
@@ -843,7 +843,7 @@ recommender-xblock==2.0.1
     # via -r requirements/edx/base.in
 redis==3.5.3
     # via -r requirements/edx/base.in
-regex==2021.8.3
+regex==2021.8.21
     # via nltk
 requests==2.26.0
     # via
@@ -874,7 +874,7 @@ rest-condition==1.0.3
     # via
     #   -r requirements/edx/base.in
     #   edx-drf-extensions
-ruamel.yaml==0.17.11
+ruamel.yaml==0.17.13
     # via drf-yasg
 ruamel.yaml.clib==0.2.6
     # via ruamel.yaml
@@ -895,7 +895,7 @@ semantic-version==2.8.5
     # via edx-drf-extensions
 shapely==1.7.1
     # via -r requirements/edx/base.in
-simplejson==3.17.3
+simplejson==3.17.4
     # via
     #   -r requirements/edx/base.in
     #   sailthru-client
@@ -980,13 +980,13 @@ sympy==1.6.2
     #   symmath
 tableauserverclient==0.16.0
     # via edx-enterprise
-testfixtures==6.18.0
+testfixtures==6.18.1
     # via edx-enterprise
 text-unidecode==1.3
     # via python-slugify
 tincan==1.0.0
     # via edx-event-routing-backends
-tqdm==4.62.1
+tqdm==4.62.2
     # via nltk
 typing-extensions==3.10.0.0
     # via aiohttp
@@ -1014,7 +1014,7 @@ vine==1.3.0
     #   celery
 voluptuous==0.12.1
     # via ora2
-watchdog==2.1.3
+watchdog==2.1.5
     # via -r requirements/edx/paver.txt
 web-fragments==1.1.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -243,7 +243,6 @@ django==2.2.24
     #   django-filter
     #   django-method-override
     #   django-model-utils
-    #   django-mptt
     #   django-multi-email-field
     #   django-mysql
     #   django-oauth-toolkit
@@ -350,6 +349,7 @@ django-filter==2.4.0
     #   lti-consumer-xblock
 django-ipware==3.0.7
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
     #   edx-proctoring
@@ -377,7 +377,7 @@ django-model-utils==4.1.1
     #   edxval
     #   ora2
     #   super-csv
-django-mptt==0.12.0
+django-mptt==0.13.1
     # via
     #   -r requirements/edx/testing.txt
     #   django-wiki
@@ -507,7 +507,7 @@ edx-django-release-util==1.1.0
     # via -r requirements/edx/testing.txt
 edx-django-sites-extensions==3.1.0
     # via -r requirements/edx/testing.txt
-edx-django-utils==4.2.0
+edx-django-utils==4.3.0
     # via
     #   -r requirements/edx/testing.txt
     #   django-config-models
@@ -634,7 +634,7 @@ execnet==1.9.0
     #   pytest-xdist
 factory-boy==3.2.0
     # via -r requirements/edx/testing.txt
-faker==8.11.0
+faker==8.12.0
     # via
     #   -r requirements/edx/testing.txt
     #   factory-boy
@@ -670,7 +670,7 @@ gitdb==4.0.7
     # via
     #   -r requirements/edx/testing.txt
     #   gitpython
-gitpython==3.1.20
+gitpython==3.1.18
     # via
     #   -r requirements/edx/testing.txt
     #   transifex-client
@@ -810,7 +810,7 @@ m2r==0.2.1
     # via sphinxcontrib-openapi
 mailsnake==1.6.4
     # via -r requirements/edx/testing.txt
-mako==1.1.4
+mako==1.1.5
     # via
     #   -r requirements/edx/testing.txt
     #   acid-xblock
@@ -1003,6 +1003,7 @@ pylatexenc==2.10
     #   olxcleaner
 pylint==2.9.6
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   edx-lint
     #   pylint-celery
@@ -1158,7 +1159,7 @@ recommender-xblock==2.0.1
     # via -r requirements/edx/testing.txt
 redis==3.5.3
     # via -r requirements/edx/testing.txt
-regex==2021.8.3
+regex==2021.8.21
     # via
     #   -r requirements/edx/testing.txt
     #   nltk
@@ -1193,7 +1194,7 @@ rest-condition==1.0.3
     # via
     #   -r requirements/edx/testing.txt
     #   edx-drf-extensions
-ruamel.yaml==0.17.11
+ruamel.yaml==0.17.13
     # via
     #   -r requirements/edx/testing.txt
     #   drf-yasg
@@ -1229,7 +1230,7 @@ semantic-version==2.8.5
     #   edx-drf-extensions
 shapely==1.7.1
     # via -r requirements/edx/testing.txt
-simplejson==3.17.3
+simplejson==3.17.4
     # via
     #   -r requirements/edx/testing.txt
     #   sailthru-client
@@ -1358,7 +1359,7 @@ tableauserverclient==0.16.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
-testfixtures==6.18.0
+testfixtures==6.18.1
     # via
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
@@ -1384,13 +1385,13 @@ tomli==1.2.1
     # via
     #   -r requirements/edx/pip-tools.txt
     #   pep517
-tox==3.24.2
+tox==3.24.3
     # via
     #   -r requirements/edx/testing.txt
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/edx/testing.txt
-tqdm==4.62.1
+tqdm==4.62.2
     # via
     #   -r requirements/edx/testing.txt
     #   nltk
@@ -1400,7 +1401,6 @@ typing-extensions==3.10.0.0
     # via
     #   -r requirements/edx/testing.txt
     #   aiohttp
-    #   gitpython
     #   mypy
 ua-parser==0.10.0
     # via
@@ -1442,7 +1442,7 @@ voluptuous==0.12.1
     #   ora2
 vulture==2.3
     # via -r requirements/edx/development.in
-watchdog==2.1.3
+watchdog==2.1.5
     # via -r requirements/edx/testing.txt
 web-fragments==1.1.0
     # via

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -24,7 +24,7 @@ edx-sphinx-theme==3.0.0
     # via -r requirements/edx/doc.in
 gitdb==4.0.7
     # via gitpython
-gitpython==3.1.20
+gitpython==3.1.18
     # via -r requirements/edx/doc.in
 idna==3.2
     # via requests
@@ -80,8 +80,6 @@ stevedore==3.4.0
     # via code-annotations
 text-unidecode==1.3
     # via python-slugify
-typing-extensions==3.10.0.0
-    # via gitpython
 urllib3==1.26.6
     # via requests
 

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -48,7 +48,7 @@ stevedore==3.4.0
     #   edx-opaque-keys
 urllib3==1.26.6
     # via requests
-watchdog==2.1.3
+watchdog==2.1.5
     # via -r requirements/edx/paver.in
 wrapt==1.11.2
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -230,7 +230,6 @@ distlib==0.3.2
     #   django-filter
     #   django-method-override
     #   django-model-utils
-    #   django-mptt
     #   django-multi-email-field
     #   django-mysql
     #   django-oauth-toolkit
@@ -335,6 +334,7 @@ django-filter==2.4.0
     #   lti-consumer-xblock
 django-ipware==3.0.7
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   edx-proctoring
@@ -362,7 +362,7 @@ django-model-utils==4.1.1
     #   edxval
     #   ora2
     #   super-csv
-django-mptt==0.12.0
+django-mptt==0.13.1
     # via
     #   -r requirements/edx/base.txt
     #   django-wiki
@@ -490,7 +490,7 @@ edx-django-release-util==1.1.0
     # via -r requirements/edx/base.txt
 edx-django-sites-extensions==3.1.0
     # via -r requirements/edx/base.txt
-edx-django-utils==4.2.0
+edx-django-utils==4.3.0
     # via
     #   -r requirements/edx/base.txt
     #   django-config-models
@@ -614,7 +614,7 @@ execnet==1.9.0
     # via pytest-xdist
 factory-boy==3.2.0
     # via -r requirements/edx/testing.in
-faker==8.11.0
+faker==8.12.0
     # via factory-boy
 filelock==3.0.12
     # via
@@ -645,7 +645,7 @@ geoip2==4.2.0
     # via -r requirements/edx/base.txt
 gitdb==4.0.7
     # via gitpython
-gitpython==3.1.20
+gitpython==3.1.18
     # via transifex-client
 glob2==0.7
     # via -r requirements/edx/base.txt
@@ -771,7 +771,7 @@ lxml==4.5.0
     #   xmlsec
 mailsnake==1.6.4
     # via -r requirements/edx/base.txt
-mako==1.1.4
+mako==1.1.5
     # via
     #   -r requirements/edx/base.txt
     #   acid-xblock
@@ -948,6 +948,7 @@ pylatexenc==2.10
     #   olxcleaner
 pylint==2.9.6
     # via
+    #   -c requirements/edx/../constraints.txt
     #   edx-lint
     #   pylint-celery
     #   pylint-django
@@ -1090,7 +1091,7 @@ recommender-xblock==2.0.1
     # via -r requirements/edx/base.txt
 redis==3.5.3
     # via -r requirements/edx/base.txt
-regex==2021.8.3
+regex==2021.8.21
     # via
     #   -r requirements/edx/base.txt
     #   nltk
@@ -1124,7 +1125,7 @@ rest-condition==1.0.3
     # via
     #   -r requirements/edx/base.txt
     #   edx-drf-extensions
-ruamel.yaml==0.17.11
+ruamel.yaml==0.17.13
     # via
     #   -r requirements/edx/base.txt
     #   drf-yasg
@@ -1160,7 +1161,7 @@ semantic-version==2.8.5
     #   edx-drf-extensions
 shapely==1.7.1
     # via -r requirements/edx/base.txt
-simplejson==3.17.3
+simplejson==3.17.4
     # via
     #   -r requirements/edx/base.txt
     #   sailthru-client
@@ -1261,7 +1262,7 @@ tableauserverclient==0.16.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-testfixtures==6.18.0
+testfixtures==6.18.1
     # via
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/testing.in
@@ -1281,13 +1282,13 @@ toml==0.10.2
     #   pytest
     #   pytest-cov
     #   tox
-tox==3.24.2
+tox==3.24.3
     # via
     #   -r requirements/edx/testing.in
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/edx/testing.in
-tqdm==4.62.1
+tqdm==4.62.2
     # via
     #   -r requirements/edx/base.txt
     #   nltk
@@ -1297,7 +1298,6 @@ typing-extensions==3.10.0.0
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
-    #   gitpython
 ua-parser==0.10.0
     # via
     #   -r requirements/edx/base.txt
@@ -1334,7 +1334,7 @@ voluptuous==0.12.1
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-watchdog==2.1.3
+watchdog==2.1.5
     # via -r requirements/edx/base.txt
 web-fragments==1.1.0
     # via


### PR DESCRIPTION
**Issue:** [BOM-2746](https://openedx.atlassian.net/browse/BOM-2746)

### Description
- `django-ipware==4.0.0` contains a critical change related to ip handling so pin the version in constraints and create a separate PR to upgrade the version after testing on sandbox. This'll be fixed in https://openedx.atlassian.net/browse/BOM-2747.
- `pylint>=2.10.0` introduced a lot of new pylint warnings. A separate PR will be needed to remove the pin and fix all the pylint warnings. This'll be fixed in https://openedx.atlassian.net/browse/BOM-2748.
