### PR TITLE
Add waffle flag for new Track Selection template

### DIFF
--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -27,6 +27,7 @@ from opaque_keys.edx.keys import CourseKey
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.helpers import get_course_final_price
 from common.djangoapps.edxmako.shortcuts import render_to_response
+from edx_toggles.toggles import LegacyWaffleFlag, LegacyWaffleFlagNamespace
 from lms.djangoapps.commerce.utils import EcommerceService
 from lms.djangoapps.experiments.utils import get_experiment_user_metadata_context
 from lms.djangoapps.verify_student.services import IDVerificationService
@@ -42,6 +43,24 @@ from common.djangoapps.util.db import outer_atomic
 from xmodule.modulestore.django import modulestore
 
 LOG = logging.getLogger(__name__)
+
+# Namespace for course_modes waffle flags.
+WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name='course_modes')
+
+# .. toggle_name: course_modes.use_new_track_selection
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: This flag enables the use of the new track selection template for testing purposes before full rollout
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2021-8-23
+# .. toggle_target_removal_date: None
+# .. toggle_tickets: REV-2133
+# .. toggle_warnings: This temporary feature toggle does not have a target removal date.
+VALUE_PROP_TRACK_SELECTION_FLAG = LegacyWaffleFlag(
+    waffle_namespace=WAFFLE_FLAG_NAMESPACE,
+    flag_name='use_new_track_selection',
+    module_name=__name__,
+)
 
 
 class ChooseModeView(View):


### PR DESCRIPTION
[REV-2133](https://openedx.atlassian.net/browse/REV-2133). 
For Value Prop implementation, we're creating a new Track Selection page.

**This PR:**
- The new template and the code to return the new template were merged but the settings for the waffle flag were missing from subtask [REV-2322](https://openedx.atlassian.net/browse/REV-2322), adding them is this PR. 

**Note:**
- Tests will be aded in another PR. This is going out prior to UI tests to expedite UX review.
- The new Track Selection will be merged under a flag for testing purposes and subsequently rolled out to all learners, as well as openedX. Current Track Selection page will be deprecated.

**This ticket will follow the below steps:**
1) Create waffle flag (Done in [REV-2322](https://openedx.atlassian.net/browse/REV-2322)).
2) Add the new template in `edx-platform` (Done, [PR here](https://github.com/edx/edx-platform/pull/28418)). 
3) Add the waffle code in `edx-platform` and hook up the new template (Done, [PR here](https://github.com/edx/edx-platform/pull/28373)). 
4) Turn on the waffle for a set of users (revenue and UX) for testing purposes.
5) Remove the waffle flag and point to just the new file for happy path.
6) Address the non-happy path and other scenarios.
7) Remove the old `edx-themes` and `edx-platform` templates and CSS files.

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

