### PR TITLE
refactor: changed create_user with UserFactory to avoid errors

### DIFF
--- a/cms/djangoapps/cms_user_tasks/tests.py
+++ b/cms/djangoapps/cms_user_tasks/tests.py
@@ -10,7 +10,6 @@ from uuid import uuid4
 import ddt
 from boto.exception import NoAuthHandlerFound
 from django.conf import settings
-from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.core import mail
 from django.test import override_settings
 from django.urls import reverse
@@ -20,6 +19,7 @@ from user_tasks.models import UserTaskArtifact, UserTaskStatus
 from user_tasks.serializers import ArtifactSerializer, StatusSerializer
 
 from cms.djangoapps.contentstore.toggles import BYPASS_OLX_FAILURE
+from common.djangoapps.student.tests.factories import UserFactory
 
 from .signals import user_task_stopped
 
@@ -78,7 +78,7 @@ class TestUserTasks(APITestCase):
 
     @classmethod
     def setUpTestData(cls):  # lint-amnesty, pylint: disable=super-method-not-called
-        cls.user = User.objects.create_user('test_user', 'test@example.com', 'password')
+        cls.user = UserFactory.create(username='test_user', email='test@example.com', password='password')
         cls.status = UserTaskStatus.objects.create(
             user=cls.user, task_id=str(uuid4()), task_class='test_rest_api.sample_task', name='SampleTask 2',
             total_steps=5)
@@ -152,7 +152,7 @@ class TestUserTaskStopped(APITestCase):
 
     @classmethod
     def setUpTestData(cls):  # lint-amnesty, pylint: disable=super-method-not-called
-        cls.user = User.objects.create_user('test_user', 'test@example.com', 'password')
+        cls.user = UserFactory.create(username='test_user', email='test@example.com', password='password')
         cls.status = UserTaskStatus.objects.create(
             user=cls.user, task_id=str(uuid4()), task_class='test_rest_api.sample_task', name='SampleTask 2',
             total_steps=5)

--- a/cms/djangoapps/contentstore/tests/test_i18n.py
+++ b/cms/djangoapps/contentstore/tests/test_i18n.py
@@ -6,12 +6,12 @@ Tests for validate Internationalization and Module i18n service.
 import gettext
 from unittest import mock, skip
 
-from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.utils import translation
 from django.utils.translation import get_language
 
 from cms.djangoapps.contentstore.tests.utils import AjaxEnabledTestClient
 from cms.djangoapps.contentstore.views.preview import _preview_module_system
+from common.djangoapps.student.tests.factories import UserFactory
 from openedx.core.lib.edx_six import get_gettext
 from xmodule.modulestore.django import ModuleI18nService
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
@@ -192,7 +192,7 @@ class InternationalizationTest(ModuleStoreTestCase):
         self.password = 'foo'
 
         # Create the use so we can log them in.
-        self.user = User.objects.create_user(self.uname, self.email, self.password)
+        self.user = UserFactory.create(username=self.uname, email=self.email, password=self.password)
 
         # Note that we do not actually need to do anything
         # for registration if we directly mark them active.

--- a/cms/djangoapps/contentstore/tests/test_permissions.py
+++ b/cms/djangoapps/contentstore/tests/test_permissions.py
@@ -5,12 +5,11 @@ Test CRUD for authorization.
 
 import copy
 
-from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
-
 from cms.djangoapps.contentstore.tests.utils import AjaxEnabledTestClient
 from cms.djangoapps.contentstore.utils import reverse_course_url, reverse_url
 from common.djangoapps.student import auth
 from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole, OrgInstructorRole, OrgStaffRole
+from common.djangoapps.student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 
 
@@ -52,7 +51,7 @@ class TestCourseAccess(ModuleStoreTestCase):
         for i in range(8):
             username = f"user{i}"
             email = f"test+user{i}@edx.org"
-            user = User.objects.create_user(username, email, 'foo')
+            user = UserFactory.create(username=username, email=email, password='foo')
             user.is_active = True
             user.save()
             users.append(user)

--- a/cms/djangoapps/contentstore/views/tests/test_access.py
+++ b/cms/djangoapps/contentstore/views/tests/test_access.py
@@ -3,13 +3,12 @@ Tests access.py
 """
 
 
-from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.test import TestCase
 from opaque_keys.edx.locator import CourseLocator
 
 from common.djangoapps.student.auth import add_users
 from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole
-from common.djangoapps.student.tests.factories import AdminFactory
+from common.djangoapps.student.tests.factories import AdminFactory, UserFactory
 
 from ..access import get_user_role
 
@@ -23,8 +22,16 @@ class RolesTest(TestCase):
         super().setUp()
 
         self.global_admin = AdminFactory()
-        self.instructor = User.objects.create_user('testinstructor', 'testinstructor+courses@edx.org', 'foo')
-        self.staff = User.objects.create_user('teststaff', 'teststaff+courses@edx.org', 'foo')
+        self.instructor = UserFactory.create(
+            username='testinstructor',
+            email='testinstructor+courses@edx.org',
+            password='foo',
+        )
+        self.staff = UserFactory.create(
+            username='teststaff',
+            email='teststaff+courses@edx.org',
+            password='foo',
+        )
         self.course_key = CourseLocator('mitX', '101', 'test')
 
     def test_get_user_role_instructor(self):

--- a/cms/djangoapps/contentstore/views/tests/test_user.py
+++ b/cms/djangoapps/contentstore/views/tests/test_user.py
@@ -12,18 +12,21 @@ from cms.djangoapps.contentstore.utils import reverse_course_url
 from common.djangoapps.student import auth
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole
+from common.djangoapps.student.tests.factories import UserFactory
 
 
 class UsersTestCase(CourseTestCase):  # lint-amnesty, pylint: disable=missing-class-docstring
     def setUp(self):
         super().setUp()
-        self.ext_user = User.objects.create_user(
-            "joe", "joe@comedycentral.com", "haha")
+        self.ext_user = UserFactory.create(
+            username="joe", email="joe@comedycentral.com", password="haha",
+        )
         self.ext_user.is_active = True
         self.ext_user.is_staff = False
         self.ext_user.save()
-        self.inactive_user = User.objects.create_user(
-            "carl", "carl@comedycentral.com", "haha")
+        self.inactive_user = UserFactory.create(
+            username="carl", email="carl@comedycentral.com", password="haha",
+        )
         self.inactive_user.is_active = False
         self.inactive_user.is_staff = False
         self.inactive_user.save()

--- a/cms/djangoapps/course_creators/tests/test_admin.py
+++ b/cms/djangoapps/course_creators/tests/test_admin.py
@@ -6,7 +6,6 @@ Tests course_creators.admin.py.
 from unittest import mock
 
 from django.contrib.admin.sites import AdminSite
-from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.core import mail
 from django.http import HttpRequest
 from django.test import TestCase
@@ -15,6 +14,7 @@ from cms.djangoapps.course_creators.admin import CourseCreatorAdmin
 from cms.djangoapps.course_creators.models import CourseCreator
 from common.djangoapps.student import auth
 from common.djangoapps.student.roles import CourseCreatorRole
+from common.djangoapps.student.tests.factories import UserFactory
 
 
 def mock_render_to_string(template_name, context):
@@ -30,11 +30,19 @@ class CourseCreatorAdminTest(TestCase):
     def setUp(self):
         """ Test case setup """
         super().setUp()
-        self.user = User.objects.create_user('test_user', 'test_user+courses@edx.org', 'foo')
+        self.user = UserFactory.create(
+            username='test_user',
+            email='test_user+courses@edx.org',
+            password='foo',
+        )
         self.table_entry = CourseCreator(user=self.user)
         self.table_entry.save()
 
-        self.admin = User.objects.create_user('Mark', 'admin+courses@edx.org', 'foo')
+        self.admin = UserFactory.create(
+            username='Mark',
+            email='admin+courses@edx.org',
+            password='foo',
+        )
         self.admin.is_staff = True
 
         self.request = HttpRequest()

--- a/cms/djangoapps/course_creators/tests/test_views.py
+++ b/cms/djangoapps/course_creators/tests/test_views.py
@@ -5,7 +5,6 @@ Tests course_creators.views.py.
 
 from unittest import mock
 
-from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.core.exceptions import PermissionDenied
 from django.test import TestCase
 from django.urls import reverse
@@ -19,6 +18,7 @@ from cms.djangoapps.course_creators.views import (
 )
 from common.djangoapps.student import auth
 from common.djangoapps.student.roles import CourseCreatorRole
+from common.djangoapps.student.tests.factories import UserFactory
 
 
 class CourseCreatorView(TestCase):
@@ -29,8 +29,16 @@ class CourseCreatorView(TestCase):
     def setUp(self):
         """ Test case setup """
         super().setUp()
-        self.user = User.objects.create_user('test_user', 'test_user+courses@edx.org', 'foo')
-        self.admin = User.objects.create_user('Mark', 'admin+courses@edx.org', 'foo')
+        self.user = UserFactory.create(
+            username='test_user',
+            email='test_user+courses@edx.org',
+            password='foo',
+        )
+        self.admin = UserFactory.create(
+            username='Mark',
+            email='admin+courses@edx.org',
+            password='foo',
+        )
         self.admin.is_staff = True
 
     def test_staff_permission_required(self):

--- a/common/djangoapps/student/tests/test_authz.py
+++ b/common/djangoapps/student/tests/test_authz.py
@@ -6,14 +6,14 @@ from unittest import mock
 import pytest
 
 from ccx_keys.locator import CCXLocator
-from django.contrib.auth.models import AnonymousUser, User  # lint-amnesty, pylint: disable=imported-auth-user
+from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import PermissionDenied
 from django.test import TestCase
 from opaque_keys.edx.locator import CourseLocator
 
 from common.djangoapps.student.auth import add_users, has_studio_read_access, has_studio_write_access, remove_users, user_has_role  # lint-amnesty, pylint: disable=line-too-long
 from common.djangoapps.student.roles import CourseCreatorRole, CourseInstructorRole, CourseStaffRole
-from common.djangoapps.student.tests.factories import AdminFactory
+from common.djangoapps.student.tests.factories import AdminFactory, UserFactory
 
 
 class CreatorGroupTest(TestCase):
@@ -24,8 +24,12 @@ class CreatorGroupTest(TestCase):
     def setUp(self):
         """ Test case setup """
         super().setUp()
-        self.user = User.objects.create_user('testuser', 'test+courses@edx.org', 'foo')
-        self.admin = User.objects.create_user('Mark', 'admin+courses@edx.org', 'foo')
+        self.user = UserFactory.create(
+            username='testuser', email='test+courses@edx.org', password='foo',
+        )
+        self.admin = UserFactory.create(
+            username='Mark', email='admin+courses@edx.org', password='foo',
+        )
         self.admin.is_staff = True
 
     def test_creator_group_not_enabled(self):
@@ -51,7 +55,7 @@ class CreatorGroupTest(TestCase):
             assert user_has_role(self.user, CourseCreatorRole())
 
             # check that a user who has not been added to the group still returns false
-            user_not_added = User.objects.create_user('testuser2', 'test+courses2@edx.org', 'foo2')
+            user_not_added = UserFactory.create(username='testuser2', email='test+courses2@edx.org', password='foo2')
             assert not user_has_role(user_not_added, CourseCreatorRole())
 
             # remove first user from the group and verify that CourseCreatorRole().has_user now returns false
@@ -153,7 +157,7 @@ class CCXCourseGroupTest(TestCase):
         """
         super().setUp()
         self.global_admin = AdminFactory()
-        self.staff = User.objects.create_user('teststaff', 'teststaff+courses@edx.org', 'foo')
+        self.staff = UserFactory.create(username='teststaff', email='teststaff+courses@edx.org', password='foo')
         self.ccx_course_key = CCXLocator.from_string('ccx-v1:edX+DemoX+Demo_Course+ccx@1')
         add_users(self.global_admin, CourseStaffRole(self.ccx_course_key), self.staff)
 
@@ -191,8 +195,12 @@ class CourseGroupTest(TestCase):
         """ Test case setup """
         super().setUp()
         self.global_admin = AdminFactory()
-        self.creator = User.objects.create_user('testcreator', 'testcreator+courses@edx.org', 'foo')
-        self.staff = User.objects.create_user('teststaff', 'teststaff+courses@edx.org', 'foo')
+        self.creator = UserFactory.create(
+            username='testcreator', email='testcreator+courses@edx.org', password='foo',
+        )
+        self.staff = UserFactory.create(
+            username='teststaff', email='teststaff+courses@edx.org', password='foo',
+        )
         self.course_key = CourseLocator('mitX', '101', 'test')
 
     def test_add_user_to_course_group(self):
@@ -240,7 +248,9 @@ class CourseGroupTest(TestCase):
         Verifies PermissionDenied if caller of remove_user_from_course_group is not instructor role.
         """
         add_users(self.global_admin, CourseInstructorRole(self.course_key), self.creator)
-        another_staff = User.objects.create_user('another', 'teststaff+anothercourses@edx.org', 'foo')
+        another_staff = UserFactory.create(
+            username='another', email='teststaff+anothercourses@edx.org', password='foo',
+        )
         add_users(self.global_admin, CourseStaffRole(self.course_key), self.creator, self.staff, another_staff)
         with pytest.raises(PermissionDenied):
             remove_users(self.staff, CourseStaffRole(self.course_key), another_staff)

--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -715,7 +715,7 @@ class EnrollInCourseTest(EnrollmentEventTestMixin, CacheIsolationTestCase):
 
     @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
     def test_enrollment(self):
-        user = User.objects.create_user("joe", "joe@joe.com", "password")
+        user = UserFactory.create(username="joe", email="joe@joe.com", password="password")
         course_id = CourseKey.from_string("edX/Test101/2013")
         course_id_partial = CourseKey.from_string("edX/Test101/")
         course = CourseOverviewFactory.create(id=course_id)

--- a/common/djangoapps/third_party_auth/saml_configuration/tests/test_saml_configuration.py
+++ b/common/djangoapps/third_party_auth/saml_configuration/tests/test_saml_configuration.py
@@ -3,10 +3,10 @@ Tests for SAMLConfiguration endpoints
 """
 from django.urls import reverse
 from django.contrib.sites.models import Site
-from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 
 from rest_framework import status
 from rest_framework.test import APITestCase
+from common.djangoapps.student.tests.factories import UserFactory
 from common.djangoapps.third_party_auth.models import SAMLConfiguration
 from common.djangoapps.third_party_auth.tests.utils import skip_unless_thirdpartyauth
 SAML_CONFIGURATIONS = [
@@ -52,7 +52,7 @@ class SAMLConfigurationTests(APITestCase):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
-        cls.user = User.objects.create_user(username='testuser', password=TEST_PASSWORD)
+        cls.user = UserFactory.create(username='testuser', password=TEST_PASSWORD)
         cls.site, _ = Site.objects.get_or_create(domain='example.com')
         for config in SAML_CONFIGURATIONS:
             cls.samlconfiguration = SAMLConfiguration.objects.get_or_create(

--- a/common/djangoapps/third_party_auth/samlproviderconfig/tests/test_samlproviderconfig.py
+++ b/common/djangoapps/third_party_auth/samlproviderconfig/tests/test_samlproviderconfig.py
@@ -12,6 +12,7 @@ from rest_framework.test import APITestCase
 
 from enterprise.models import EnterpriseCustomerIdentityProvider, EnterpriseCustomer
 from enterprise.constants import ENTERPRISE_ADMIN_ROLE, ENTERPRISE_LEARNER_ROLE
+from common.djangoapps.student.tests.factories import UserFactory
 from common.djangoapps.third_party_auth.tests.samlutils import set_jwt_cookie
 from common.djangoapps.third_party_auth.models import SAMLProviderConfig, SAMLConfiguration
 from common.djangoapps.third_party_auth.tests.utils import skip_unless_thirdpartyauth
@@ -49,7 +50,7 @@ class SAMLProviderConfigTests(APITestCase):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
-        cls.user = User.objects.create_user(username='testuser', password='testpwd')
+        cls.user = UserFactory.create(username='testuser', password='testpwd')
         cls.site, _ = Site.objects.get_or_create(domain='example.com')
         cls.enterprise_customer = EnterpriseCustomer.objects.create(
             uuid=ENTERPRISE_ID,

--- a/common/djangoapps/third_party_auth/samlproviderdata/tests/test_samlproviderdata.py
+++ b/common/djangoapps/third_party_auth/samlproviderdata/tests/test_samlproviderdata.py
@@ -11,6 +11,7 @@ from rest_framework.test import APITestCase
 
 from enterprise.models import EnterpriseCustomer, EnterpriseCustomerIdentityProvider
 from enterprise.constants import ENTERPRISE_ADMIN_ROLE, ENTERPRISE_LEARNER_ROLE
+from common.djangoapps.student.tests.factories import UserFactory
 from common.djangoapps.third_party_auth.models import SAMLProviderData, SAMLProviderConfig
 from common.djangoapps.third_party_auth.tests.samlutils import set_jwt_cookie
 from common.djangoapps.third_party_auth.tests.utils import skip_unless_thirdpartyauth
@@ -49,7 +50,7 @@ class SAMLProviderDataTests(APITestCase):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
-        cls.user = User.objects.create_user(username='testuser', password='testpwd')
+        cls.user = UserFactory.create(username='testuser', password='testpwd')
         cls.site, _ = Site.objects.get_or_create(domain='example.com')
         cls.enterprise_customer = EnterpriseCustomer.objects.create(
             uuid=ENTERPRISE_ID,

--- a/lms/djangoapps/ccx/api/v0/tests/test_views.py
+++ b/lms/djangoapps/ccx/api/v0/tests/test_views.py
@@ -13,7 +13,6 @@ import pytest
 import ddt
 from ccx_keys.locator import CCXLocator
 from django.conf import settings
-from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.urls import Resolver404, resolve, reverse
 from django.utils.timezone import now
 from oauth2_provider import models as dot_models
@@ -760,7 +759,9 @@ class CcxDetailTest(CcxRestApiTest):
         Check authorization for staff users logged in without oauth
         """
         # create a staff user
-        staff_user = User.objects.create_user('test_staff_user', 'test_staff_user@openedx.org', 'test')
+        staff_user = UserFactory.create(
+            username='test_staff_user', email='test_staff_user@openedx.org', password='test',
+        )
         # add staff role to the staff user
         CourseStaffRole(self.master_course_key).add_users(staff_user)
 
@@ -777,7 +778,9 @@ class CcxDetailTest(CcxRestApiTest):
         Check authorization for users logged in without oauth
         """
         # create an instructor user
-        instructor_user = User.objects.create_user('test_instructor_user', 'test_instructor_user@openedx.org', 'test')
+        instructor_user = UserFactory.create(
+            username='test_instructor_user', email='test_instructor_user@openedx.org', password='test',
+        )
         # add instructor role to the instructor user
         CourseInstructorRole(self.master_course_key).add_users(instructor_user)
 
@@ -794,7 +797,9 @@ class CcxDetailTest(CcxRestApiTest):
         Check authorization for other coach users logged in without oauth
         """
         # create an coach user
-        coach_user = User.objects.create_user('test_coach_user', 'test_coach_user@openedx.org', 'test')
+        coach_user = UserFactory.create(
+            username='test_coach_user', email='test_coach_user@openedx.org', password='test',
+        )
         # add coach role to the coach user
         CourseCcxCoachRole(self.master_course_key).add_users(coach_user)
 

--- a/lms/djangoapps/course_goals/tests/test_api.py
+++ b/lms/djangoapps/course_goals/tests/test_api.py
@@ -11,6 +11,7 @@ from django.urls import reverse
 from rest_framework.test import APIClient
 
 from common.djangoapps.student.models import CourseEnrollment
+from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.course_goals.models import CourseGoal
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
@@ -31,7 +32,7 @@ class TestCourseGoalsAPI(SharedModuleStoreTestCase):
         super().setUp()
         self.course = CourseFactory.create(emit_signals=True)
 
-        self.user = User.objects.create_user('john', 'lennon@thebeatles.com', 'password')
+        self.user = UserFactory.create(username='john', email='lennon@thebeatles.com', password='password')
         CourseEnrollment.enroll(self.user, self.course.id)
 
         self.client = APIClient(enforce_csrf_checks=True)

--- a/lms/djangoapps/course_home_api/outline/tests/test_goals.py
+++ b/lms/djangoapps/course_home_api/outline/tests/test_goals.py
@@ -39,7 +39,9 @@ class TestCourseGoalsAPI(SharedModuleStoreTestCase):
         super().setUp()
         self.course = CourseFactory.create(emit_signals=True)
 
-        self.user = User.objects.create_user('john', 'lennon@thebeatles.com', 'password')
+        self.user = UserFactory.create(
+            username='john', email='lennon@thebeatles.com', password='password',
+        )
         CourseEnrollment.enroll(self.user, self.course.id)
 
         self.client = APIClient(enforce_csrf_checks=True)

--- a/lms/djangoapps/discussion/django_comment_client/base/tests.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/tests.py
@@ -241,7 +241,7 @@ class ViewsTestCaseMixin:
             self.password = 'test'
 
             # Create the user and make them active so we can log them in.
-            self.student = User.objects.create_user(uname, email, self.password)
+            self.student = UserFactory.create(username=uname, email=email, password=self.password)
             self.student.is_active = True
             self.student.save()
 
@@ -464,7 +464,7 @@ class ViewsTestCase(
             self.password = 'test'
 
             # Create the user and make them active so we can log them in.
-            self.student = User.objects.create_user(uname, email, self.password)
+            self.student = UserFactory.create(username=uname, email=email, password=self.password)
             self.student.is_active = True
             self.student.save()
 

--- a/lms/djangoapps/program_enrollments/rest_api/v1/tests/test_views.py
+++ b/lms/djangoapps/program_enrollments/rest_api/v1/tests/test_views.py
@@ -10,7 +10,6 @@ from uuid import UUID, uuid4
 
 import ddt
 from django.conf import settings
-from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.core.cache import cache
 from django.test import override_settings
 from django.urls import reverse
@@ -499,7 +498,7 @@ class ProgramEnrollmentsPostTests(ProgramEnrollmentsWriteMixin, APITestCase):
                 'curriculum_uuid': str(self.curriculum_uuid)
             }
         ]
-        user = User.objects.create_user('test_user', 'test@example.com', 'password')
+        user = UserFactory.create(username='test_user', email='test@example.com', password='password')
         url = self.get_url()
         with mock.patch(
                 _get_users_patch_path,

--- a/lms/djangoapps/survey/tests/test_models.py
+++ b/lms/djangoapps/survey/tests/test_models.py
@@ -7,11 +7,11 @@ from collections import OrderedDict
 
 import ddt
 import pytest
-from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.test.client import Client
 
+from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.survey.exceptions import SurveyFormNameAlreadyExists, SurveyFormNotFound
 from lms.djangoapps.survey.models import SurveyAnswer, SurveyForm
 
@@ -31,8 +31,12 @@ class SurveyModelsTests(TestCase):
 
         # Create two accounts
         self.password = 'abc'
-        self.student = User.objects.create_user('student', 'student@test.com', self.password)
-        self.student2 = User.objects.create_user('student2', 'student2@test.com', self.password)
+        self.student = UserFactory.create(
+            username='student', email='student@test.com', password=self.password,
+        )
+        self.student2 = UserFactory.create(
+            username='student2', email='student2@test.com', password=self.password,
+        )
 
         self.test_survey_name = 'TestForm'
         self.test_form = '<li><input name="field1" /></li><li><input name="field2" /></li><li><select name="ddl"><option>1</option></select></li>'  # lint-amnesty, pylint: disable=line-too-long

--- a/lms/djangoapps/survey/tests/test_utils.py
+++ b/lms/djangoapps/survey/tests/test_utils.py
@@ -5,9 +5,9 @@ Python tests for the Survey models
 
 from collections import OrderedDict
 
-from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.test.client import Client
 
+from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.survey.models import SurveyForm
 from lms.djangoapps.survey.utils import check_survey_required_and_unanswered, is_survey_required_for_course
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
@@ -29,10 +29,16 @@ class SurveyModelsTests(ModuleStoreTestCase):
 
         # Create two accounts
         self.password = 'abc'
-        self.student = User.objects.create_user('student', 'student@test.com', self.password)
-        self.student2 = User.objects.create_user('student2', 'student2@test.com', self.password)
+        self.student = UserFactory.create(
+            username='student', email='student@test.com', password=self.password,
+        )
+        self.student2 = UserFactory.create(
+            username='student2', email='student2@test.com', password=self.password,
+        )
 
-        self.staff = User.objects.create_user('staff', 'staff@test.com', self.password)
+        self.staff = UserFactory.create(
+            username='staff', email='staff@test.com', password=self.password,
+        )
         self.staff.is_staff = True
         self.staff.save()
 

--- a/openedx/core/djangoapps/content/learning_sequences/api/tests/test_outlines.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/tests/test_outlines.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import unittest
 
 from django.conf import settings
-from django.contrib.auth.models import AnonymousUser, User  # lint-amnesty, pylint: disable=imported-auth-user
+from django.contrib.auth.models import AnonymousUser
 from django.db.models import signals
 from edx_proctoring.exceptions import ProctoredExamNotFoundException
 from edx_toggles.toggles.testutils import override_waffle_flag
@@ -25,7 +25,7 @@ from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.signals import update_masters_access_course
 from common.djangoapps.student.auth import user_has_role
 from common.djangoapps.student.roles import CourseBetaTesterRole
-from common.djangoapps.student.tests.factories import BetaTesterFactory
+from common.djangoapps.student.tests.factories import BetaTesterFactory, UserFactory
 from xmodule.partitions.partitions import (
     ENROLLMENT_TRACK_PARTITION_ID,
 )
@@ -90,11 +90,11 @@ class PublicApiAvailableTestCase(django.test.TestCase):
         )
         replace_course_outline(cls.course_outline)
 
-        cls.global_staff = User.objects.create_user(
-            'global_staff', email='gstaff@example.com', is_staff=True
+        cls.global_staff = UserFactory.create(
+            username='global_staff', email='gstaff@example.com', is_staff=True
         )
-        cls.student = User.objects.create_user(
-            'student', email='student@example.com', is_staff=False
+        cls.student = UserFactory.create(
+            username='student', email='student@example.com', is_staff=False
         )
         cls.fake_course_1 = CourseKey.from_string("course-v1:Not+Really+Here")
         cls.fake_course_2 = CourseKey.from_string("Also/Not/Here")
@@ -213,11 +213,11 @@ class UserCourseOutlineTestCase(CacheIsolationTestCase):
     def setUpTestData(cls):  # lint-amnesty, pylint: disable=super-method-not-called
         course_key = CourseKey.from_string("course-v1:OpenEdX+Outline+T1")
         # Users...
-        cls.global_staff = User.objects.create_user(
-            'global_staff', email='gstaff@example.com', is_staff=True
+        cls.global_staff = UserFactory.create(
+            username='global_staff', email='gstaff@example.com', is_staff=True
         )
-        cls.student = User.objects.create_user(
-            'student', email='student@example.com', is_staff=False
+        cls.student = UserFactory.create(
+            username='student', email='student@example.com', is_staff=False
         )
         cls.beta_tester = BetaTesterFactory(course_key=course_key)
         cls.anonymous_user = AnonymousUser()
@@ -280,11 +280,11 @@ class OutlineProcessorTestCase(CacheIsolationTestCase):  # lint-amnesty, pylint:
         cls.course_key = CourseKey.from_string("course-v1:OpenEdX+Outline+T1")
 
         # Users...
-        cls.global_staff = User.objects.create_user(
-            'global_staff', email='gstaff@example.com', is_staff=True
+        cls.global_staff = UserFactory.create(
+            username='global_staff', email='gstaff@example.com', is_staff=True
         )
-        cls.student = User.objects.create_user(
-            'student', email='student@example.com', is_staff=False
+        cls.student = UserFactory.create(
+            username='student', email='student@example.com', is_staff=False
         )
         cls.beta_tester = BetaTesterFactory(course_key=cls.course_key)
         cls.anonymous_user = AnonymousUser()
@@ -1237,9 +1237,11 @@ class SequentialVisibilityTestCase(CacheIsolationTestCase):
     def setUpTestData(cls):
         super().setUpTestData()
 
-        cls.global_staff = User.objects.create_user('global_staff', email='gstaff@example.com', is_staff=True)
-        cls.student = User.objects.create_user('student', email='student@example.com', is_staff=False)
-        cls.unenrolled_student = User.objects.create_user('unenrolled', email='unenrolled@example.com', is_staff=False)
+        cls.global_staff = UserFactory.create(username='global_staff', email='gstaff@example.com', is_staff=True)
+        cls.student = UserFactory.create(username='student', email='student@example.com', is_staff=False)
+        cls.unenrolled_student = UserFactory.create(
+            username='unenrolled', email='unenrolled@example.com', is_staff=False,
+        )
         cls.anonymous_user = AnonymousUser()
 
         # Handy variable as we almost always need to test with all types of users
@@ -1386,8 +1388,8 @@ class EnrollmentTrackPartitionGroupsTestCase(OutlineProcessorTestCase):  # lint-
         mode.
         Returns created learner
         """
-        learner = User.objects.create_user(
-            username, email='{}@example.com'.format(username), is_staff=is_staff
+        learner = UserFactory.create(
+            username=username, email='{}@example.com'.format(username), is_staff=is_staff
         )
         learner.courseenrollment_set.create(course_id=self.course_key, is_active=True, mode=mode)
         return learner

--- a/openedx/core/djangoapps/django_comment_common/tests.py
+++ b/openedx/core/djangoapps/django_comment_common/tests.py
@@ -7,7 +7,8 @@ from opaque_keys.edx.locator import CourseLocator
 
 from openedx.core.djangoapps.course_groups.cohorts import CourseCohortsSettings
 from openedx.core.djangoapps.django_comment_common.models import CourseDiscussionSettings, Role
-from common.djangoapps.student.models import CourseEnrollment, User
+from common.djangoapps.student.models import CourseEnrollment
+from common.djangoapps.student.tests.factories import UserFactory
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
@@ -23,15 +24,15 @@ class RoleAssignmentTest(TestCase):
     def setUp(self):
         super().setUp()
         # Check a staff account because those used to get the Moderator role
-        self.staff_user = User.objects.create_user(
-            "patty",
-            "patty@fake.edx.org",
+        self.staff_user = UserFactory.create(
+            username="patty",
+            email="patty@fake.edx.org",
         )
         self.staff_user.is_staff = True
 
-        self.student_user = User.objects.create_user(
-            "hacky",
-            "hacky@fake.edx.org"
+        self.student_user = UserFactory.create(
+            username="hacky",
+            email="hacky@fake.edx.org",
         )
         self.course_key = CourseLocator("edX", "Fake101", "2012")
         CourseEnrollment.enroll(self.staff_user, self.course_key)

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_dot_overrides.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_dot_overrides.py
@@ -9,7 +9,6 @@ import datetime
 import unittest
 
 from django.conf import settings
-from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.test import RequestFactory, TestCase
 from django.utils import timezone
 
@@ -33,7 +32,7 @@ class AuthenticateTestCase(TestCase):
 
     def setUp(self):
         super().setUp()
-        self.user = User.objects.create_user(
+        self.user = UserFactory.create(
             username='darkhelmet',
             password='12345',
             email='darkhelmet@spaceball_one.org',
@@ -58,7 +57,7 @@ class CustomValidationTestCase(TestCase):
     """
     def setUp(self):
         super().setUp()
-        self.user = User.objects.create_user(
+        self.user = UserFactory.create(
             username='darkhelmet',
             password='12345',
             email='darkhelmet@spaceball_one.org',

--- a/openedx/core/djangoapps/user_authn/views/tests/test_register.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_register.py
@@ -2324,7 +2324,7 @@ class RegistrationValidationViewTests(test_utils.ApiTestCase):
         Test if username '{0}' and email '{1}' have conflicts with
         username 'user' and email 'user@email.com'.
         """
-        user = User.objects.create_user(username='user', email='user@email.com')
+        user = UserFactory.create(username='user', email='user@email.com')
         self.assertValidationDecision(
             {
                 'username': username,
@@ -2460,7 +2460,7 @@ class RegistrationValidationViewTests(test_utils.ApiTestCase):
         Test that if `is_authn_mfe` is provided in request along with form_field_key, only
         error message for that field is returned.
         """
-        User.objects.create_user(username='user', email='user@email.com')
+        UserFactory.create(username='user', email='user@email.com')
         # using username and email that have conflicts but sending form_field_key will return
         # validation for only email
         self.assertValidationDecision(

--- a/openedx/core/lib/api/tests/test_authentication.py
+++ b/openedx/core/lib/api/tests/test_authentication.py
@@ -12,7 +12,6 @@ from datetime import timedelta
 import ddt
 from django.conf import settings
 from django.conf.urls import url
-from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.http import HttpResponse
 from django.test import TestCase
 from django.test.utils import override_settings
@@ -24,6 +23,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.test import APIClient, APIRequestFactory
 from rest_framework.views import APIView
 
+from common.djangoapps.student.tests.factories import UserFactory
 from openedx.core.djangoapps.oauth_dispatch import adapters
 from openedx.core.lib.api import authentication
 
@@ -68,7 +68,7 @@ class OAuth2AllowInActiveUsersTests(TestCase):  # lint-amnesty, pylint: disable=
         self.username = 'john'
         self.email = 'lennon@thebeatles.com'
         self.password = 'password'
-        self.user = User.objects.create_user(self.username, self.email, self.password)
+        self.user = UserFactory.create(username=self.username, email=self.email, password=self.password)
 
         self.dot_oauth2_client = self.dot_adapter.create_public_client(
             name='example',


### PR DESCRIPTION
## Description

This PR replaces `User.objects.create_user` references with `UserProfile.create`, to automatically create the user's profile avoiding tests errors.

## Supporting information

This was discussed -[here](https://github.com/edx/edx-platform/pull/28266#discussion_r692468197)- after we encountered some errors while using the user's profile in some tests. For example here:
https://build.testeng.edx.org/job/edx-platform-python-pipeline-pr/33620/#showFailuresLink
More in detail: 
https://build.testeng.edx.org/job/edx-platform-python-pipeline-pr/33620/testReport/junit/lms.djangoapps.course_goals.tests.test_goals/TestCourseGoalsAPI/Run_Tests___lms_unit___test_add_goal/

## Testing instructions

Run edxapp tests:

1. Run specific tests: 
`pytest lms/djangoapps/course_goals/tests/test_goals.py::TestCourseGoalsAPI::test_add_goal `
2. Run specific test suit: `paver test_js_run -s <lms|cms>`

## Deadline

"None"

## Other information

This PR just improves tests by adding missing data.
