### PR TITLE
BOM-2747: Remove django-ipware constraint

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -100,10 +100,6 @@ jsonfield2<3.1.0        # jsonfield2 3.1.0 drops support for python 3.5
 # requirements of edx-platform. Pinning temporarily until this is resolved in edx-val.
 edxval<2.1
 
-# django-ipware==4.0.0 contains a critical change related to ip-handling which needs to be tested on sandbox
-# This constraint will be removed in https://openedx.atlassian.net/browse/BOM-2747
-django-ipware<4.0.0
-
 # pylint>=2.10.0 introduced a lot of new pylint warnings.
 # A separate PR will be needed to remove the pin and fix all the pylint warnings
 pylint<2.10.0

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -271,9 +271,8 @@ django-filter==2.4.0
     #   -r requirements/edx/base.in
     #   edx-enterprise
     #   lti-consumer-xblock
-django-ipware==3.0.7
+django-ipware==4.0.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   edx-enterprise
     #   edx-proctoring
@@ -305,7 +304,7 @@ django-mptt==0.13.1
     #   django-wiki
 django-multi-email-field==0.6.2
     # via edx-enterprise
-django-mysql==3.12.0
+django-mysql==4.0.0
     # via -r requirements/edx/base.in
 django-oauth-toolkit==1.3.2
     # via
@@ -895,7 +894,7 @@ semantic-version==2.8.5
     # via edx-drf-extensions
 shapely==1.7.1
     # via -r requirements/edx/base.in
-simplejson==3.17.4
+simplejson==3.17.5
     # via
     #   -r requirements/edx/base.in
     #   sailthru-client

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -347,9 +347,8 @@ django-filter==2.4.0
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
     #   lti-consumer-xblock
-django-ipware==3.0.7
+django-ipware==4.0.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
     #   edx-proctoring
@@ -385,7 +384,7 @@ django-multi-email-field==0.6.2
     # via
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
-django-mysql==3.12.0
+django-mysql==4.0.0
     # via -r requirements/edx/testing.txt
 django-oauth-toolkit==1.3.2
     # via
@@ -1230,7 +1229,7 @@ semantic-version==2.8.5
     #   edx-drf-extensions
 shapely==1.7.1
     # via -r requirements/edx/testing.txt
-simplejson==3.17.4
+simplejson==3.17.5
     # via
     #   -r requirements/edx/testing.txt
     #   sailthru-client

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -332,9 +332,8 @@ django-filter==2.4.0
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   lti-consumer-xblock
-django-ipware==3.0.7
+django-ipware==4.0.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   edx-proctoring
@@ -370,7 +369,7 @@ django-multi-email-field==0.6.2
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-django-mysql==3.12.0
+django-mysql==4.0.0
     # via -r requirements/edx/base.txt
 django-oauth-toolkit==1.3.2
     # via
@@ -1161,7 +1160,7 @@ semantic-version==2.8.5
     #   edx-drf-extensions
 shapely==1.7.1
     # via -r requirements/edx/base.txt
-simplejson==3.17.4
+simplejson==3.17.5
     # via
     #   -r requirements/edx/base.txt
     #   sailthru-client


### PR DESCRIPTION
**Issue:** [BOM-2747](https://openedx.atlassian.net/browse/BOM-2747)

### Description
- Removed the `django-ipware` constraint to test the latest version for breaking changes.

### Testing
- Sandbox created successfully: https://djangoipwaretest.sandbox.edx.org/
- Account creation worked successfully.