### PR TITLE
feat: Activate Studio SSO for devstack

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -21,6 +21,7 @@ SITE_NAME = 'localhost:8001'
 HTTPS = 'off'
 
 CMS_BASE = 'localhost:18010'
+SESSION_COOKIE_NAME = 'studio_sessionid'
 
 ################################ LOGGERS ######################################
 
@@ -47,6 +48,8 @@ LMS_BASE = 'localhost:18000'
 LMS_ROOT_URL = f'http://{LMS_BASE}'
 FEATURES['PREVIEW_LMS_BASE'] = "preview." + LMS_BASE
 
+# TODO: Remove after Studio OAuth transition is complete. See docs/guides/studio_oauth.rst
+LOGIN_URL = '/login/'
 FRONTEND_LOGIN_URL = LMS_ROOT_URL + '/login'
 FRONTEND_LOGOUT_URL = LMS_ROOT_URL + '/logout'
 FRONTEND_REGISTER_URL = LMS_ROOT_URL + '/register'
@@ -253,3 +256,12 @@ PROCTORING_USER_OBFUSCATION_KEY = '85920908f28904ed733fe576320db18cabd7b6cd'
 
 #################### Webpack Configuration Settings ##############################
 WEBPACK_LOADER['DEFAULT']['TIMEOUT'] = 5
+
+################ Using LMS SSO for login to Studio ################
+SOCIAL_AUTH_EDX_OAUTH2_KEY = 'studio-sso-key'
+SOCIAL_AUTH_EDX_OAUTH2_SECRET = 'studio-sso-secret'  # in stage, prod would be high-entropy secret
+SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT = 'http://edx.devstack.lms:18000'  # routed internally server-to-server
+SOCIAL_AUTH_EDX_OAUTH2_PUBLIC_URL_ROOT = 'http://localhost:18000'  # used in browser redirect
+
+# Don't form the return redirect URL with HTTPS on devstack
+SOCIAL_AUTH_REDIRECT_IS_HTTPS = False

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -30,6 +30,8 @@ LMS_BASE = 'localhost:18000'
 CMS_BASE = 'localhost:18010'
 SITE_NAME = LMS_BASE
 
+SESSION_COOKIE_NAME = 'lms_sessionid'
+
 # By default don't use a worker, execute tasks as if they were local functions
 CELERY_ALWAYS_EAGER = True
 HTTPS = 'off'
@@ -41,6 +43,7 @@ IDA_LOGOUT_URI_LIST = [
     'http://localhost:18130/logout/',  # ecommerce
     'http://localhost:18150/logout/',  # credentials
     'http://localhost:18381/logout/',  # discovery
+    'http://localhost:18010/logout/',  # studio
 ]
 
 ################################ LOGGERS ######################################


### PR DESCRIPTION
This also requires using different session cookie names in devstack for
LMS and Studio so that we can properly use the OAuth flow locally, rather
than just sharing a session cookie on the localhost domain. (Note that
ports are not used for cookie segmentation in browsers.)

- [x] Provisioning PR merged and communicated first: https://github.com/edx/devstack/pull/825

Part of ARCHBOM-1860
