### PR TITLE
Update waffle flag for Value Prop Track Selection

### DIFF
--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -261,7 +261,7 @@ class ChooseModeView(View):
 
         # REV-2133 TODO Value Prop: remove waffle flag after testing is completed
         # and happy path version is ready to be rolled out to all users.
-        if waffle.flag_is_active(request, 'course_modes.use_new_track_selection'):
+        if VALUE_PROP_TRACK_SELECTION_FLAG.is_enabled():
             # First iteration of happy path does not handle errors. If there are enrollment errors for a learner that is
             # technically considered happy path, old Track Selection page will be displayed.
             if not error:

--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -27,7 +27,7 @@ from opaque_keys.edx.keys import CourseKey
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.helpers import get_course_final_price
 from common.djangoapps.edxmako.shortcuts import render_to_response
-from edx_toggles.toggles import LegacyWaffleFlag, LegacyWaffleFlagNamespace
+from edx_toggles.toggles import WaffleFlag
 from lms.djangoapps.commerce.utils import EcommerceService
 from lms.djangoapps.experiments.utils import get_experiment_user_metadata_context
 from lms.djangoapps.verify_student.services import IDVerificationService
@@ -44,9 +44,6 @@ from xmodule.modulestore.django import modulestore
 
 LOG = logging.getLogger(__name__)
 
-# Namespace for course_modes waffle flags.
-WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name='course_modes')
-
 # .. toggle_name: course_modes.use_new_track_selection
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
@@ -56,11 +53,7 @@ WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name='course_modes')
 # .. toggle_target_removal_date: None
 # .. toggle_tickets: REV-2133
 # .. toggle_warnings: This temporary feature toggle does not have a target removal date.
-VALUE_PROP_TRACK_SELECTION_FLAG = LegacyWaffleFlag(
-    waffle_namespace=WAFFLE_FLAG_NAMESPACE,
-    flag_name='use_new_track_selection',
-    module_name=__name__,
-)
+VALUE_PROP_TRACK_SELECTION_FLAG = WaffleFlag('course_modes.use_new_track_selection', __name__)
 
 
 class ChooseModeView(View):


### PR DESCRIPTION
[REV-2133](https://openedx.atlassian.net/browse/REV-2133). 
For Value Prop implementation, we're creating a new Track Selection page.

**This PR:**
- Updates the use of `LegacyWaffleFlag` to just `WaffleFlag`
- Update the conditional to use the variable that was set in [this PR](https://github.com/edx/edx-platform/pull/28523). 

**Note:**
- Tests will be aded in another PR. This is going out prior to UI tests to expedite UX review.
- The new Track Selection will be merged under a flag for testing purposes and subsequently rolled out to all learners, as well as openedX. Current Track Selection page will be deprecated.

**This ticket will follow the below steps:**
1) Create waffle flag (Done in [REV-2322](https://openedx.atlassian.net/browse/REV-2322)).
2) Add the new template in `edx-platform` (Done, [PR here](https://github.com/edx/edx-platform/pull/28418)). 
plus add waffle flag settings (Done, [PR here](https://github.com/edx/edx-platform/pull/28523)).
3) Add the waffle code in `edx-platform` and hook up the new template (Done, [PR here](https://github.com/edx/edx-platform/pull/28373)). 
4) Turn on the waffle for a set of users (revenue and UX) for testing purposes.
5) Remove the waffle flag and point to just the new file for happy path.
6) Address the non-happy path and other scenarios.
7) Remove the old `edx-themes` and `edx-platform` templates and CSS files.

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->
