### PR TITLE
FAL-2367 [LX-2140] Skip broken links in blockstore

### DIFF
--- a/openedx/core/djangoapps/content_libraries/api.py
+++ b/openedx/core/djangoapps/content_libraries/api.py
@@ -109,6 +109,7 @@ from openedx.core.lib.blockstore_api import (
     set_draft_link,
     commit_draft,
     delete_draft,
+    BundleNotFound,
 )
 from openedx.core.djangolib import blockstore_cache
 from openedx.core.djangolib.blockstore_cache import BundleCache
@@ -1003,12 +1004,15 @@ def get_bundle_links(library_key):
             opaque_key = libraries_linked[link_data.bundle_uuid].library_key
         except KeyError:
             opaque_key = None
-        # Append the link information:
+        try:
+            latest_version = blockstore_cache.get_bundle_version_number(link_data.bundle_uuid)
+        except BundleNotFound:
+            latest_version = 0
         results.append(LibraryBundleLink(
             id=link_name,
             bundle_uuid=link_data.bundle_uuid,
             version=link_data.version,
-            latest_version=blockstore_cache.get_bundle_version_number(link_data.bundle_uuid),
+            latest_version=latest_version,
             opaque_key=opaque_key,
         ))
     return results


### PR DESCRIPTION
[FAL-2367](https://tasks.opencraft.com/browse/FAL-2367) | [LX-2140](https://tasks.opencraft.com/browse/LX-2140) | [OSPR-5985](https://openedx.atlassian.net/browse/OSPR-5985)

The aim here is to avoid broken blockstore blocks where the block links to other blocks that have been deleted.

**Test instructions**:

- create three blocks
- link the first and second to the third
- delete the first
- call the links method on the third block
- verify that it returns successfully
- verify that the list of links contains only the second block 

Note to internal reviewers: this can be tested as part of [opencraft/client/LabXchange/labxchange-dev!1488](https://gitlab.com/opencraft/client/LabXchange/labxchange-dev/-/merge_requests/1488).

To run the tests:

- `make testserver` from the blockstore repo
- `make studio-shell` from the edx-platform devstack
- `EDXAPP_RUN_BLOCKSTORE_TESTS=1 pytest openedx/core/djangoapps/content_libraries/tests/`

**Reviewers**:

- [ ] @eLRuLL 
- [x] @pomegranited 
- [ ] @bradenmacdonald 