### PR TITLE
[MST-803] Update account API to allow pending name changes

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -924,7 +924,7 @@ class Registration(models.Model):
 
 class PendingNameChange(DeletableByUserValue, models.Model):
     """
-    This model keeps track of pending requested changes to a user's email address.
+    This model keeps track of pending requested changes to a user's name.
 
     .. pii: Contains new_name, retired in LMSAccountRetirementView
     .. pii_types: name

--- a/common/djangoapps/student/models_api.py
+++ b/common/djangoapps/student/models_api.py
@@ -1,7 +1,10 @@
 """
 Provides Python APIs exposed from Student models.
 """
+import datetime
 import logging
+
+from pytz import UTC
 
 from common.djangoapps.student.models import CourseAccessRole as _CourseAccessRole
 from common.djangoapps.student.models import CourseEnrollment as _CourseEnrollment
@@ -16,6 +19,7 @@ from common.djangoapps.student.models import (
     ALLOWEDTOENROLL_TO_UNENROLLED as _ALLOWEDTOENROLL_TO_UNENROLLED,
     DEFAULT_TRANSITION_STATE as _DEFAULT_TRANSITION_STATE,
 )
+from common.djangoapps.student.models import PendingNameChange as _PendingNameChange
 from common.djangoapps.student.models import UserProfile as _UserProfile
 
 # This is done so that if these strings change within the app, we can keep exported constants the same
@@ -103,3 +107,50 @@ def get_course_access_role(user, org, course_id, role):
                       })
         return None
     return course_access_role
+
+
+def do_name_change_request(user, new_name, rationale):
+    """
+    Create a name change request. This either updates the user's current PendingNameChange, or creates
+    a new one if it doesn't exist. Returns the PendingNameChange object and a boolean describing whether
+    or not a new one was created.
+    """
+    user_profile = _UserProfile.objects.get(user=user)
+    if user_profile.name == new_name:
+        log_msg = (
+            'user_id={user_id} requested a name change, but the requested name is the same as'
+            'their current profile name. Not taking any action.'.format(user_id=user.id)
+        )
+        log.warning(log_msg)
+        return None, False
+
+    pending_name_change, created = _PendingNameChange.objects.update_or_create(
+        user=user,
+        defaults={
+            'new_name': new_name,
+            'rationale': rationale
+        }
+    )
+
+    return pending_name_change, created
+
+
+def confirm_name_change(user, pending_name_change):
+    """
+    Confirm a pending name change. This updates the user's profile name and deletes the
+    PendingNameChange object.
+    """
+    user_profile = _UserProfile.objects.get(user=user)
+
+    # Store old name in profile metadata
+    meta = user_profile.get_meta()
+    if 'old_names' not in meta:
+        meta['old_names'] = []
+    meta['old_names'].append(
+        [user_profile.name, pending_name_change.rationale, datetime.datetime.now(UTC).isoformat()]
+    )
+    user_profile.set_meta(meta)
+
+    user_profile.name = pending_name_change.new_name
+    user_profile.save()
+    pending_name_change.delete()

--- a/common/djangoapps/student/signals/receivers.py
+++ b/common/djangoapps/student/signals/receivers.py
@@ -9,10 +9,18 @@ from django.contrib.auth import get_user_model
 from django.db import IntegrityError
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
+from edx_name_affirmation.signals import VERIFIED_NAME_APPROVED
 
 from lms.djangoapps.courseware.toggles import courseware_mfe_progress_milestones_are_active
 from common.djangoapps.student.helpers import EMAIL_EXISTS_MSG_FMT, USERNAME_EXISTS_MSG_FMT, AccountValidationError
-from common.djangoapps.student.models import CourseEnrollment, CourseEnrollmentCelebration, is_email_retired, is_username_retired  # lint-amnesty, pylint: disable=line-too-long
+from common.djangoapps.student.models import (
+    CourseEnrollment,
+    CourseEnrollmentCelebration,
+    PendingNameChange,
+    is_email_retired,
+    is_username_retired
+)
+from common.djangoapps.student.models_api import confirm_name_change
 
 
 @receiver(pre_save, sender=get_user_model())
@@ -69,4 +77,17 @@ def create_course_enrollment_celebration(sender, instance, created, **kwargs):
         )
     except IntegrityError:
         # A celebration object was already created. Shouldn't happen, but ignore it if it does.
+        pass
+
+
+@receiver(VERIFIED_NAME_APPROVED)
+def listen_for_verified_name_approved(sender, user_id, profile_name, **kwargs):
+    """
+    If the user has a pending name change that corresponds to an approved verified name, confirm it.
+    """
+    user = get_user_model().objects.get(id=user_id)
+    try:
+        pending_name_change = PendingNameChange.objects.get(user=user, new_name=profile_name)
+        confirm_name_change(user, pending_name_change)
+    except PendingNameChange.DoesNotExist:
         pass

--- a/common/djangoapps/student/tests/test_receivers.py
+++ b/common/djangoapps/student/tests/test_receivers.py
@@ -1,9 +1,18 @@
 """ Tests for student signal receivers. """
 
+from edx_name_affirmation.signals import VERIFIED_NAME_APPROVED
 from edx_toggles.toggles.testutils import override_waffle_flag
 from lms.djangoapps.courseware.toggles import COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES
-from common.djangoapps.student.models import CourseEnrollmentCelebration
-from common.djangoapps.student.tests.factories import CourseEnrollmentFactory
+from common.djangoapps.student.models import (
+    CourseEnrollmentCelebration,
+    PendingNameChange,
+    UserProfile
+)
+from common.djangoapps.student.tests.factories import (
+    CourseEnrollmentFactory,
+    UserFactory,
+    UserProfileFactory
+)
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 
 
@@ -33,3 +42,23 @@ class ReceiversTest(SharedModuleStoreTestCase):
         """ Test we don't make a celebration if the MFE redirect waffle flag is off """
         CourseEnrollmentFactory()
         assert CourseEnrollmentCelebration.objects.count() == 0
+
+    def test_listen_for_verified_name_approved(self):
+        """
+        Test that profile name is updated when a pending name change is approved
+        """
+        user = UserFactory(email='email@test.com', username='jdoe')
+        UserProfileFactory(user=user)
+
+        new_name = 'John Doe'
+        PendingNameChange.objects.create(user=user, new_name=new_name)
+        assert PendingNameChange.objects.count() == 1
+
+        # Send a VERIFIED_NAME_APPROVED signal where the profile name matches the name
+        # change request
+        VERIFIED_NAME_APPROVED.send(sender=None, user_id=user.id, profile_name=new_name)
+
+        # Assert that the pending name change was deleted and the profile name was updated
+        assert PendingNameChange.objects.count() == 0
+        profile = UserProfile.objects.get(user=user)
+        assert profile.name == new_name

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3998,6 +3998,7 @@ ACCOUNT_VISIBILITY_CONFIGURATION["admin_fields"] = (
         "year_of_birth",
         "phone_number",
         "activation_key",
+        "pending_name_change",
         "is_verified_name_enabled",
     ]
 )

--- a/openedx/core/djangoapps/user_api/urls.py
+++ b/openedx/core/djangoapps/user_api/urls.py
@@ -16,6 +16,7 @@ from .accounts.views import (
     AccountViewSet,
     DeactivateLogoutView,
     LMSAccountRetirementView,
+    NameChangeView,
     UsernameReplacementView
 )
 from . import views as user_api_views
@@ -116,6 +117,11 @@ urlpatterns = [
         r'^v1/accounts/deactivate_logout/$',
         DeactivateLogoutView.as_view(),
         name='deactivate_logout'
+    ),
+    url(
+        r'^v1/accounts/name_change/$',
+        NameChangeView.as_view(),
+        name='name_change'
     ),
     url(
         fr'^v1/accounts/{settings.USERNAME_PATTERN}/verification_status/$',


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

- If the verified name waffle flag is turned on and a user requires verification when changing their name, do not allow them to update their profile name through `AccountViewSet`. Include information in the response that will allow the frontend to handle this accordingly.
- Create an endpoint that allows the user to create a `PendingNameChange`.
- Add a signal to the students app that listens for a `VerifiedName` to update its status to "approved"; if the `profile_name` attribute on said `VerifiedName` matches the user's pending name change, approve the name change.
- Update `AccountViewSet` to return a `pending_name_change` value if the user has an active name change request.

https://github.com/edx/edx-name-affirmation/pull/43 must be merged first.

## Supporting information

[MST-803](https://openedx.atlassian.net/browse/MST-803)