### PR TITLE
refactor: replace User.objects.create_user for UserFactory p2

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_entrance_exam.py
+++ b/cms/djangoapps/contentstore/views/tests/test_entrance_exam.py
@@ -7,7 +7,6 @@ import json
 from unittest.mock import patch
 
 from django.conf import settings
-from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.test.client import RequestFactory
 from milestones.tests.utils import MilestonesTestCaseMixin
 from opaque_keys.edx.keys import UsageKey
@@ -173,7 +172,7 @@ class EntranceExamHandlerTests(CourseTestCase, MilestonesTestCaseMixin):
         resp = self.client.get(self.exam_url)
         self.assertEqual(resp.status_code, 404)
 
-        user = User.objects.create(
+        user = UserFactory.create(
             username='test_user',
             email='test_user@edx.org',
             is_active=True,
@@ -287,7 +286,7 @@ class EntranceExamHandlerTests(CourseTestCase, MilestonesTestCaseMixin):
         """
         Unit Test: test_contentstore_views_entrance_exam_get_invalid_user
         """
-        user = User.objects.create(
+        user = UserFactory.create(
             username='test_user',
             email='test_user@edx.org',
             is_active=True,

--- a/common/djangoapps/student/management/tests/test_change_enterprise_user_username.py
+++ b/common/djangoapps/student/management/tests/test_change_enterprise_user_username.py
@@ -12,6 +12,8 @@ from django.test import TestCase
 from enterprise.models import EnterpriseCustomer, EnterpriseCustomerUser
 from pytest import mark
 
+from common.djangoapps.student.tests.factories import UserFactory
+
 
 @mark.django_db
 class ChangeEnterpriseUserUsernameCommandTests(TestCase):
@@ -25,7 +27,7 @@ class ChangeEnterpriseUserUsernameCommandTests(TestCase):
         """
         Test that the command does not update a user's username if it is not linked to an Enterprise.
         """
-        user = User.objects.create(is_active=True, username='old_username', email='test@example.com')
+        user = UserFactory.create(is_active=True, username='old_username', email='test@example.com')
         new_username = 'new_username'
 
         post_save_handler = mock.MagicMock()
@@ -41,7 +43,7 @@ class ChangeEnterpriseUserUsernameCommandTests(TestCase):
         """
         Test that the command updates the user's username when the user is linked to an Enterprise.
         """
-        user = User.objects.create(is_active=True, username='old_username', email='test@example.com')
+        user = UserFactory.create(is_active=True, username='old_username', email='test@example.com')
         site, _ = Site.objects.get_or_create(domain='example.com')
         enterprise_customer = EnterpriseCustomer.objects.create(
             name='Test EnterpriseCustomer',

--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -763,7 +763,7 @@ class EnrollInCourseTest(EnrollmentEventTestMixin, CacheIsolationTestCase):
 
     def test_enrollment_non_existent_user(self):
         # Testing enrollment of newly unsaved user (i.e. no database entry)
-        user = User(username="rusty", email="rusty@fake.edx.org")
+        user = UserFactory(username="rusty", email="rusty@fake.edx.org")
         course_id = CourseLocator("edX", "Test101", "2013")
         course = CourseOverviewFactory.create(id=course_id)
 
@@ -781,7 +781,7 @@ class EnrollInCourseTest(EnrollmentEventTestMixin, CacheIsolationTestCase):
 
     @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
     def test_enrollment_by_email(self):
-        user = User.objects.create(username="jack", email="jack@fake.edx.org")
+        user = UserFactory.create(username="jack", email="jack@fake.edx.org")
         course_id = CourseLocator("edX", "Test101", "2013")
         course = CourseOverviewFactory.create(id=course_id)
 
@@ -818,7 +818,7 @@ class EnrollInCourseTest(EnrollmentEventTestMixin, CacheIsolationTestCase):
 
     @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
     def test_enrollment_multiple_classes(self):
-        user = User(username="rusty", email="rusty@fake.edx.org")
+        user = UserFactory(username="rusty", email="rusty@fake.edx.org")
         course_id1 = CourseLocator("edX", "Test101", "2013")
         course_id2 = CourseLocator("MITx", "6.003z", "2012")
         course1 = CourseOverviewFactory.create(id=course_id1)
@@ -843,7 +843,7 @@ class EnrollInCourseTest(EnrollmentEventTestMixin, CacheIsolationTestCase):
 
     @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
     def test_activation(self):
-        user = User.objects.create(username="jack", email="jack@fake.edx.org")
+        user = UserFactory.create(username="jack", email="jack@fake.edx.org")
         course_id = CourseLocator("edX", "Test101", "2013")
         course = CourseOverviewFactory.create(id=course_id)
         assert not CourseEnrollment.is_enrolled(user, course_id)
@@ -881,7 +881,7 @@ class EnrollInCourseTest(EnrollmentEventTestMixin, CacheIsolationTestCase):
         self.assert_enrollment_event_was_emitted(user, course_id, course, enrollment)
 
     def test_change_enrollment_modes(self):
-        user = User.objects.create(username="justin", email="jh@fake.edx.org")
+        user = UserFactory.create(username="justin", email="jh@fake.edx.org")
         course_id = CourseLocator("edX", "Test101", "2013")
         course = CourseOverviewFactory.create(id=course_id)
 

--- a/common/lib/xmodule/xmodule/modulestore/tests/django_utils.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/django_utils.py
@@ -11,7 +11,7 @@ from enum import Enum
 from unittest.mock import patch
 
 from django.conf import settings
-from django.contrib.auth.models import AnonymousUser, User  # lint-amnesty, pylint: disable=imported-auth-user
+from django.contrib.auth.models import AnonymousUser
 from django.db import connections
 from django.test import TestCase
 from django.test.utils import override_settings
@@ -525,7 +525,7 @@ class ModuleStoreTestCase(
 
         if self.CREATE_USER:
             # Create the user so we can log them in.
-            self.user = User.objects.create_user(uname, email, self.user_password)
+            self.user = UserFactory.create(username=uname, email=email, password=self.user_password)
 
             # Note that we do not actually need to do anything
             # for registration if we directly mark them active.
@@ -542,7 +542,7 @@ class ModuleStoreTestCase(
         """
         uname = 'teststudent'
         password = 'foo'
-        nonstaff_user = User.objects.create_user(uname, 'test+student@edx.org', password)
+        nonstaff_user = UserFactory.create(username=uname, email='test+student@edx.org', password=password)
 
         # Note that we do not actually need to do anything
         # for registration if we directly mark them active.

--- a/lms/djangoapps/grades/management/commands/tests/test_compute_grades.py
+++ b/lms/djangoapps/grades/management/commands/tests/test_compute_grades.py
@@ -7,9 +7,9 @@ from unittest.mock import ANY, patch
 
 import ddt
 import pytest
-from django.contrib.auth import get_user_model
 from django.core.management import CommandError, call_command
 
+from common.djangoapps.student.tests.factories import UserFactory
 from common.djangoapps.student.models import CourseEnrollment
 from lms.djangoapps.grades.config.models import ComputeGradesSetting
 from lms.djangoapps.grades.management.commands import compute_grades
@@ -32,7 +32,7 @@ class TestComputeGrades(SharedModuleStoreTestCase):
 
         cls.courses = [CourseFactory.create() for _ in range(cls.num_courses)]
         cls.course_keys = [str(course.id) for course in cls.courses]
-        cls.users = [get_user_model().objects.create(username=f'user{idx}') for idx in range(cls.num_users)]
+        cls.users = [UserFactory.create(username=f'user{idx}') for idx in range(cls.num_users)]
 
         for user in cls.users:
             for course in cls.courses:

--- a/openedx/core/djangoapps/credit/tests/test_services.py
+++ b/openedx/core/djangoapps/credit/tests/test_services.py
@@ -26,7 +26,8 @@ class CreditServiceTests(ModuleStoreTestCase):
         self.service = CreditService()
         self.course = CourseFactory.create(org='edX', number='DemoX', display_name='Demo_Course')
         self.credit_course = CreditCourse.objects.create(course_key=self.course.id, enabled=True)
-        self.profile = UserProfile.objects.create(user_id=self.user.id, name='Foo Bar')
+        self.user.profile.name = 'Foo Bar'
+        self.user.profile.save()
 
     def enroll(self, course_id=None, mode=CourseMode.VERIFIED):
         """

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -70,7 +70,7 @@ class LoginTest(SiteMixin, CacheIsolationTestCase):
         self.url = reverse('login_api')
 
     def _create_user(self, username, user_email):
-        user = UserFactory.build(username=username, email=user_email)
+        user = UserFactory.create(username=username, email=user_email)
         user.set_password(self.password)
         user.save()
         return user


### PR DESCRIPTION
This change is done, so the profile is automatically created for tests users. PR continuation of [PR 28525](https://github.com/edx/edx-platform/pull/28525)

## Supporting information

This was discussed -[here](https://github.com/edx/edx-platform/pull/28266#discussion_r692468197)- after we encountered some errors while using the user's profile in some tests. For example, here:
https://build.testeng.edx.org/job/edx-platform-python-pipeline-pr/33777/
More in detail: 
https://build.testeng.edx.org/job/edx-platform-python-pipeline-pr/33777/testReport/junit/cms.djangoapps.contentstore.management.commands.tests.test_create_course/TestCreateCourse/Run_Tests___cms_unit___test_duplicate_course/

## Testing instructions

Run edxapp tests:

1. Run specific tests: 
`pytest lms/djangoapps/course_goals/tests/test_goals.py::TestCourseGoalsAPI::test_add_goal `
2. Run specific test suit: `paver test_js_run -s <lms|cms>`

## Deadline

"None"

## Other information

This PR just improves tests by adding missing data. This time there are no more references to `User.objects.create_user` in tests, just where is required.