### PR TITLE
Use new version of edx-when.

### DIFF
--- a/lms/djangoapps/course_api/api.py
+++ b/lms/djangoapps/course_api/api.py
@@ -22,6 +22,8 @@ from lms.djangoapps.courseware.courses import (
     get_permission_for_course_about
 )
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from openedx.core.djangoapps.content.learning_sequences.api import get_course_outline
+from openedx.core.djangoapps.content.learning_sequences.data import CourseOutlineData
 from openedx.core.lib.api.view_utils import LazySequence
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
@@ -227,9 +229,18 @@ def get_due_dates(request, course_key, user):
                 url: the deep link to the block
                 date: the due date for the block
     """
+    try:
+        outline = get_course_outline(course_key)
+    except (ValueError, CourseOutlineData.DoesNotExist):
+        # Either this course is Old Mongo-backed or doesn't have a generated course outline.
+        course_version = None
+    else:
+        course_version = outline.published_version
+
     dates = get_dates_for_course(
         course_key,
         user,
+        published_version=course_version
     )
 
     store = modulestore()

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -1559,8 +1559,8 @@ class ProgressPageTests(ProgressPageBaseTests):
 
     @patch.dict(settings.FEATURES, {'ASSUME_ZERO_GRADE_IF_ABSENT_FOR_ALL_TESTS': False})
     @ddt.data(
-        (False, 63, 46),
-        (True, 55, 40)
+        (False, 63, 44),
+        (True, 55, 38)
     )
     @ddt.unpack
     def test_progress_queries(self, enable_waffle, initial, subsequent):

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -2740,7 +2740,9 @@ def reset_due_date(request, course_id):
     unit = find_unit(course, request.POST.get('url'))
     reason = strip_tags(request.POST.get('reason', ''))
 
-    original_due_date = get_date_for_block(course_id, unit.location)
+    version = getattr(course, 'course_version', None)
+
+    original_due_date = get_date_for_block(course_id, unit.location, published_version=version)
 
     set_due_date_extension(course, unit, student, None, request.user, reason=reason)
     if not original_due_date:

--- a/openedx/core/djangoapps/content/learning_sequences/api/outlines.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/outlines.py
@@ -356,7 +356,7 @@ def _get_user_course_outline_and_processors(course_key: CourseKey,  # lint-amnes
         # particular ordering).
         processor = processor_cls(course_key, user, at_time)
         processors[name] = processor
-        processor.load_data()
+        processor.load_data(full_course_outline)
         if not user_can_see_all_content:
             # function_trace lets us see how expensive each processor is being.
             with function_trace(f'learning_sequences.api.outline_processors.{name}'):

--- a/openedx/core/djangoapps/content/learning_sequences/api/processors/base.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/processors/base.py
@@ -8,6 +8,8 @@ from datetime import datetime
 from opaque_keys.edx.keys import CourseKey  # lint-amnesty, pylint: disable=unused-import
 from openedx.core import types
 
+from ...data import CourseOutlineData
+
 log = logging.getLogger(__name__)
 
 
@@ -44,7 +46,7 @@ class OutlineProcessor:
         self.user = user
         self.at_time = at_time
 
-    def load_data(self):
+    def load_data(self, full_course_outline: CourseOutlineData):  # pylint: disable=unused-argument
         """
         Fetch whatever data you need about the course and user here.
 
@@ -59,7 +61,7 @@ class OutlineProcessor:
         """
         pass  # lint-amnesty, pylint: disable=unnecessary-pass
 
-    def inaccessible_sequences(self, full_course_outline):  # lint-amnesty, pylint: disable=unused-argument
+    def inaccessible_sequences(self, full_course_outline: CourseOutlineData):  # pylint: disable=unused-argument
         """
         Return a set/frozenset of Sequence UsageKeys that are not accessible.
 
@@ -68,7 +70,7 @@ class OutlineProcessor:
         """
         return frozenset()
 
-    def usage_keys_to_remove(self, full_course_outline):  # lint-amnesty, pylint: disable=unused-argument
+    def usage_keys_to_remove(self, full_course_outline: CourseOutlineData):  # pylint: disable=unused-argument
         """
         Return a set/frozenset of UsageKeys to remove altogether.
 

--- a/openedx/core/djangoapps/content/learning_sequences/api/processors/content_gating.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/processors/content_gating.py
@@ -27,7 +27,7 @@ class ContentGatingOutlineProcessor(OutlineProcessor):
         self.required_content = None
         self.can_skip_entrance_exam = False
 
-    def load_data(self):
+    def load_data(self, full_course_outline):
         """
         Get the required content for the course, and whether
         or not the user can skip the entrance exam.

--- a/openedx/core/djangoapps/content/learning_sequences/api/processors/enrollment_track_partition_groups.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/processors/enrollment_track_partition_groups.py
@@ -1,5 +1,9 @@
 # lint-amnesty, pylint: disable=missing-module-docstring
 import logging
+from datetime import datetime
+
+from opaque_keys.edx.keys import CourseKey
+from openedx.core import types
 
 from xmodule.partitions.enrollment_track_partition_generator import (
     create_enrollment_track_partition_with_course_id
@@ -22,12 +26,12 @@ class EnrollmentTrackPartitionGroupsOutlineProcessor(OutlineProcessor):
     significant limitation. Nonetheless, it is a step towards the goal of
     supporting all partition schemes in the future.
     """
-    def __init__(self, course_key, user, at_time):
+    def __init__(self, course_key: CourseKey, user: types.User, at_time: datetime):
         super().__init__(course_key, user, at_time)
         self.enrollment_track_groups = {}
         self.user_group = None
 
-    def load_data(self):
+    def load_data(self, full_course_outline):
         """
         Pull track groups for this course and which group the user is in.
         """

--- a/openedx/core/djangoapps/content/learning_sequences/api/processors/schedule.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/processors/schedule.py
@@ -42,11 +42,16 @@ class ScheduleOutlineProcessor(OutlineProcessor):
         self._course_end = None
         self._is_beta_tester = False
 
-    def load_data(self):
-        """Pull dates information from edx-when."""
-        # (usage_key, 'due'): datetime.datetime(2019, 12, 11, 15, 0, tzinfo=<UTC>)
-        # TODO: Merge https://github.com/edx/edx-when/pull/48 and add `outline_only=True`
-        self.dates = get_dates_for_course(self.course_key, self.user)
+    def load_data(self, full_course_outline):
+        """
+        Pull dates information from edx-when.
+
+        Return data format: (usage_key, 'due'): datetime.datetime(2019, 12, 11, 15, 0, tzinfo=<UTC>)
+        """
+        self.dates = get_dates_for_course(
+            self.course_key, self.user, subsection_and_higher_only=True,
+            published_version=full_course_outline.published_version
+        )
 
         for (usage_key, field_name), date in self.dates.items():
             self.keys_to_schedule_fields[usage_key][field_name] = date

--- a/openedx/core/djangoapps/content/learning_sequences/api/processors/special_exams.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/processors/special_exams.py
@@ -28,7 +28,7 @@ class SpecialExamsOutlineProcessor(OutlineProcessor):
     """
     Responsible for applying all outline processing related to special exams.
     """
-    def load_data(self):
+    def load_data(self, full_course_outline):
         """
         Check if special exams are enabled
         """

--- a/openedx/core/djangoapps/content/learning_sequences/api/tests/test_outlines.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/tests/test_outlines.py
@@ -1737,8 +1737,10 @@ class EnrollmentTrackPartitionGroupsTestCase(OutlineProcessorTestCase):  # lint-
 
         check_date = datetime(2021, 3, 27, tzinfo=timezone.utc)
         for learner_to_verify in learners_to_verify:
-            processor = EnrollmentTrackPartitionGroupsOutlineProcessor(self.course_key, learner_to_verify, check_date)
-            processor.load_data()
+            processor = EnrollmentTrackPartitionGroupsOutlineProcessor(
+                self.course_key, learner_to_verify, check_date
+            )
+            processor.load_data(full_outline)
             removed_usage_keys = processor.usage_keys_to_remove(full_outline)
             assert len(removed_usage_keys) == expected_values_dict[learner_to_verify.username]
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -507,7 +507,7 @@ edx-toggles==4.2.0
     #   ora2
 edx-user-state-client==1.3.2
     # via -r requirements/edx/base.in
-edx-when==2.1.0
+edx-when==2.2.0
     # via
     #   -r requirements/edx/base.in
     #   edx-proctoring

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -618,7 +618,7 @@ edx-toggles==4.2.0
     #   ora2
 edx-user-state-client==1.3.2
     # via -r requirements/edx/testing.txt
-edx-when==2.1.0
+edx-when==2.2.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-proctoring

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -598,7 +598,7 @@ edx-toggles==4.2.0
     #   ora2
 edx-user-state-client==1.3.2
     # via -r requirements/edx/base.txt
-edx-when==2.1.0
+edx-when==2.2.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

- Uses the newest (2.2.0) version of edx-when to optimize the querying of course block dates when querying dates for use in a course outline, which don't need block dates below the subsection level of a course.
- Passes the course's published version to all the appropriate places where edx-when's API is called - to allow edx-when to more efficiently cache queried/processed results.

## Supporting information
The edx-when diff:
https://github.com/edx/edx-when/compare/2.1.0...2.2.0

The ticket:
https://openedx.atlassian.net/browse/TNL-8061

## Testing instructions

- Pre-deploy testing on devstack or a sandbox:
  -  No noticeable functional difference should be seen - particularly when viewing course outlines in the courseware. Those outlines should render more quickly for large, non-self-paced courses but might not be noticeable.
  - Upon course change/publish, course structural changes should show up in the course outline.
  - The change is being deployed to this sandbox: https://edx-when.sandbox.edx.org/ - in order to test normal operation.
- Post-deploy:
  - Courseware home (and elsewhere) course outlines work fine with no errors.
  - Upon course change/publish, course structural changes should show up in the course outline.
  - The average response time numbers for `get_user_course_outline()` should improve greatly here:
    - https://onenr.io/0oqQarNKJw1

## Deadline

None

## Other information

A migration will be performed during the deployment - this SQL will be executed:
```
BEGIN;
--
-- Add field block_type to contentdate
--
ALTER TABLE `edx_when_contentdate` ADD COLUMN `block_type` varchar(255) NULL;
--
-- Create index edx_when_course_block_type_idx on field(s) course_id, block_type of model contentdate
--
CREATE INDEX `edx_when_course_block_type_idx` ON `edx_when_contentdate` (`course_id`, `block_type`);
COMMIT;
```
The edx_when_contentdate field has ~2 million rows - but the table should *not* be locked on field addition due to AWS Aurora's ability to add NULL-able columns without a table lock.

---

To actually get course block dates (for a self-paced course) to be created and queried by edx-when, I had to:
- Enable this [waffle flag](https://studio-edx-when.sandbox.edx.org/admin/waffle/flag/): course_experience.relative_dates
- Add a single "enable-for-all" row in this model:
  - https://studio-edx-when.sandbox.edx.org/admin/course_date_signals/selfpacedrelativedatesconfig/
- Change the course start and/or end dates.
- Edit the course to cause a publish (i.e. add a unit, etc.) and publish it.
- Enable course outlines via the `learning_sequences.use_for_outlines` waffle flag.
- Visit the course home page, which will now call the `get_user_course_outline()` method to retrieve the course outline.