### PR TITLE
fix: loading of profile images in devstack

### DIFF
--- a/lms/urls.py
+++ b/lms/urls.py
@@ -922,11 +922,12 @@ urlpatterns += [
 
 if settings.DEBUG:
     urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
-    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+    # profile image urls must come before the media url to work
     urlpatterns += static(
         settings.PROFILE_IMAGE_BACKEND['options']['base_url'],
         document_root=settings.PROFILE_IMAGE_BACKEND['options']['location']
     )
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 # UX reference templates
 urlpatterns += [


### PR DESCRIPTION
## Description

Profile images don't load in the devstack since the path for media files is broader than the path for profile images, reorderig them fixes this.

## Testing instructions

1. Upload a profile image for a user in the lms running in the devstack
2. The image will throw a 404 on the devstack
3. Switch to this branch and restart
4. The image should now start showing up

## Deadline

"None"