### PR TITLE
fix: do not remove comments from XML during course import

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_import_export.py
+++ b/cms/djangoapps/contentstore/views/tests/test_import_export.py
@@ -1256,7 +1256,25 @@ class TestCourseExportImportProblem(CourseTestCase):
 
             '<problem>\n  <pre>\n    <code>x=10 print("hello \n")</code>\n  </pre>\n  '
             '<multiplechoiceresponse/>\n</problem>\n'
-        ]
+        ],
+        [
+            '<!-- Comment outside of the root (will be deleted). -->'
+            '<problem>'
+            '<!-- Valid comment -->'
+            '<p>'
+            '"<!-- String with non-XML structure: >< -->"'
+            'Text'
+            '</p>'
+            '</problem>',
+
+            '<problem>\n  '
+            '<!-- Valid comment -->\n  '
+            '<p>'
+            '"<!-- String with non-XML structure: >< -->"'
+            'Text'
+            '</p>\n'
+            '</problem>\n'
+        ],
     )
     @ddt.unpack
     def test_problem_content_on_course_export_import(self, problem_data, expected_problem_content):

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -12,6 +12,7 @@ from gettext import ngettext
 import bleach
 from lazy import lazy
 from lxml import etree
+from lxml.etree import XMLSyntaxError
 from opaque_keys.edx.locator import LibraryLocator
 from pkg_resources import resource_string
 from web_fragments.fragment import Fragment
@@ -666,10 +667,20 @@ class LibraryContentBlock(
 
     @classmethod
     def definition_from_xml(cls, xml_object, system):
-        children = [
-            system.process_xml(etree.tostring(child)).scope_ids.usage_id
-            for child in xml_object.getchildren()
-        ]
+        children = []
+
+        for child in xml_object.getchildren():
+            try:
+                children.append(system.process_xml(etree.tostring(child)).scope_ids.usage_id)
+            except (XMLSyntaxError, AttributeError):
+                msg = (
+                    "Unable to load child when parsing Library Content Block. "
+                    "This can happen when a comment is manually added to the course export."
+                )
+                logger.error(msg)
+                if system.error_tracker is not None:
+                    system.error_tracker(msg)
+
         definition = {
             attr_name: json.loads(attr_value)
             for attr_name, attr_value in xml_object.attrib.items()

--- a/common/lib/xmodule/xmodule/modulestore/xml.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml.py
@@ -39,8 +39,7 @@ from xmodule.x_module import (  # lint-amnesty, pylint: disable=unused-import
 from .exceptions import ItemNotFoundError
 from .inheritance import InheritanceKeyValueStore, compute_inherited_metadata, inheriting_field_data
 
-edx_xml_parser = etree.XMLParser(dtd_validation=False, load_dtd=False,
-                                 remove_comments=True, remove_blank_text=True)
+edx_xml_parser = etree.XMLParser(dtd_validation=False, load_dtd=False, remove_blank_text=True)
 
 etree.set_default_parser(edx_xml_parser)
 

--- a/common/lib/xmodule/xmodule/xml_module.py
+++ b/common/lib/xmodule/xmodule/xml_module.py
@@ -18,9 +18,7 @@ from xmodule.x_module import XModuleDescriptor  # lint-amnesty, pylint: disable=
 log = logging.getLogger(__name__)
 
 # assume all XML files are persisted as utf-8.
-EDX_XML_PARSER = XMLParser(dtd_validation=False, load_dtd=False,
-                           remove_comments=True, remove_blank_text=True,
-                           encoding='utf-8')
+EDX_XML_PARSER = XMLParser(dtd_validation=False, load_dtd=False, remove_blank_text=True, encoding='utf-8')
 
 
 def name_to_pathname(name):


### PR DESCRIPTION
This is a follow-up to edx#1087, which reverted this change.

According to the PR comments, parsing strings with XML comments inside them was causing errors. This does not seem to be the case anymore - these strings are just hidden when the block is rendered, but they are not breaking XBlocks.

## Jira

[OSPR-5996](https://openedx.atlassian.net/browse/OSPR-5996)
[BB-3827](https://tasks.opencraft.com/browse/BB-3827)

## Sandbox

https://pr28557.sandbox.opencraft.hosting/ (provisioning)


## Testing instructions
1. Create a new course with the following `Blank Advanced Problem`:
   ```xml
    <problem display_name="Checkboxes" markdown="null">
      <choiceresponse>
        <!-- This information is essential for the course authoring team. -->
        <p>
          Select a correct answer.
          <!-- Comment. -->
        </p>
        <checkboxgroup>
          <choice correct="true">a correct answer</choice>
          <choice correct="false">an incorrect answer</choice>
          <choice correct="false">an incorrect answer</choice>
        </checkboxgroup>
      </choiceresponse>
    </problem>
   ```

1. Export the course.
1. Import the exported course.
1. Check that the comments were retained in the XBlock.

## Deadline

None.

## Reviewers

- [x] @xitij2000 / @kaizoku 
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
```
