### PR TITLE
fix: format audit deadline in Track Selection

### DIFF
--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -27,6 +27,7 @@ from opaque_keys.edx.keys import CourseKey
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.helpers import get_course_final_price
 from common.djangoapps.edxmako.shortcuts import render_to_response
+from common.djangoapps.util.date_utils import strftime_localized_html
 from edx_toggles.toggles import WaffleFlag
 from lms.djangoapps.commerce.utils import EcommerceService
 from lms.djangoapps.experiments.utils import get_experiment_user_metadata_context
@@ -249,7 +250,9 @@ class ChooseModeView(View):
 
         duration = get_user_course_duration(request.user, course)
         deadline = duration and get_user_course_expiration_date(request.user, course)
-        context['audit_access_deadline'] = deadline
+        if deadline:
+            formatted_audit_access_date = strftime_localized_html(deadline, 'SHORT_DATE')
+            context['audit_access_deadline'] = formatted_audit_access_date
         fbe_is_on = deadline and gated_content
 
         # REV-2133 TODO Value Prop: remove waffle flag after testing is completed

--- a/lms/static/sass/views/_track_selection.scss
+++ b/lms/static/sass/views/_track_selection.scss
@@ -85,6 +85,7 @@
     background: white;
     position: relative;
     margin-bottom: 1.5rem;
+    margin-top: 80px !important;
 }
 
 #track_selection_audit:hover {

--- a/lms/templates/course_modes/track_selection.html
+++ b/lms/templates/course_modes/track_selection.html
@@ -151,7 +151,7 @@ from openedx.core.djangolib.js_utils import js_escaped_string
                         </div>
                         % endif
                         <div class="track-selection-choice track-selection-audit col-6">
-                            <p class="float-right m-3"><b>${_("FREE")}</b></p>
+                            <p class="float-right m-3 text-uppercase"><b>${_("Free")}</b></p>
                             <div class="choice-title"><h4>${_("Access this course")}</h4></div>
                             <div class="choice-bullets">
                                 <ul>
@@ -164,7 +164,7 @@ from openedx.core.djangolib.js_utils import js_escaped_string
                                         end_bold=HTML('</b>'),
                                     )}</li>
                                     % if audit_access_deadline:
-                                    <li>${_("Access expires and all progress will be lost on")} ${_(audit_access_deadline)}</li>
+                                    <li>${_("Access expires and all progress will be lost on")} ${audit_access_deadline}</li>
                                     % else:
                                     <li>${_("Access expires and all progress will be lost")}</li>
                                     % endif


### PR DESCRIPTION
[REV-2133](https://openedx.atlassian.net/browse/REV-2133).

The new Value Prop Track Selection was not being displayed under the waffle flag because of a date formatting issue with translations.

`File "/tmp/mako_lms/a85e3e96736d0a8e00ea888b22986cb8/course_modes/track_selection.html.py", line 261, in render_content
    __M_writer(filters.html_escape(filters.decode.utf8(_(audit_access_deadline))))`
`File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/translation/__init__.py", line 79, in gettext
    return _trans.gettext(message)`
`File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/translation/trans_real.py", line 351, in gettext
    eol_message = message.replace('\r\n', '\n').replace('\r', '\n')
TypeError: an integer is required (got type str)`

Fix is to add formatting to the `audit_access_deadline` to display HTML and not an integer.

<img width="821" alt="Screen Shot 2021-08-27 at 9 10 36 AM" src="https://user-images.githubusercontent.com/13632680/131132478-b240c165-2764-4ebe-a182-3adde7fbbfed.png">



<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

