### PR TITLE
chore: update edx-proctoring version to latest release

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -474,7 +474,7 @@ edx-opaque-keys[django]==2.2.2
     #   xmodule
 edx-organizations==6.10.0
     # via -r requirements/edx/base.in
-edx-proctoring==3.23.9
+edx-proctoring==3.24.0
     # via
     #   -r requirements/edx/base.in
     #   edx-proctoring-proctortrack

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -579,7 +579,7 @@ edx-opaque-keys[django]==2.2.2
     #   xmodule
 edx-organizations==6.10.0
     # via -r requirements/edx/testing.txt
-edx-proctoring==3.23.9
+edx-proctoring==3.24.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-proctoring-proctortrack

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -561,7 +561,7 @@ edx-opaque-keys[django]==2.2.2
     #   xmodule
 edx-organizations==6.10.0
     # via -r requirements/edx/base.txt
-edx-proctoring==3.23.9
+edx-proctoring==3.24.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring-proctortrack


### PR DESCRIPTION
Update edx-proctoring to version 3.24.0. Release notes for this version can be found here: https://github.com/edx/edx-proctoring/blob/master/CHANGELOG.rst#3240---2021-08-25