### PR TITLE
chore: Update version of edx-name-affirmation library from 0.6.4 to 0.7.0.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -454,7 +454,7 @@ edx-i18n-tools==0.7.0
     # via ora2
 edx-milestones==0.3.2
     # via -r requirements/edx/base.in
-edx-name-affirmation==0.6.4
+edx-name-affirmation==0.7.0
     # via -r requirements/edx/base.in
 edx-opaque-keys[django]==2.2.2
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -559,7 +559,7 @@ edx-lint==5.0.0
     # via -r requirements/edx/testing.txt
 edx-milestones==0.3.2
     # via -r requirements/edx/testing.txt
-edx-name-affirmation==0.6.4
+edx-name-affirmation==0.7.0
     # via -r requirements/edx/testing.txt
 edx-opaque-keys[django]==2.2.2
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -541,7 +541,7 @@ edx-lint==5.0.0
     # via -r requirements/edx/testing.in
 edx-milestones==0.3.2
     # via -r requirements/edx/base.txt
-edx-name-affirmation==0.6.4
+edx-name-affirmation==0.7.0
     # via -r requirements/edx/base.txt
 edx-opaque-keys[django]==2.2.2
     # via


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This package includes a change that adds two key fields to the VerifiedNameHistoryView, verified_name_enabled and use_verified_name_for_certs.

MST-954 (https://openedx.atlassian.net/browse/MST-954)

## Testing instructions

Query the VerifiedNameHistoryView at `{LMS_BASE}/api/edx_name_affirmation/v1/verified_name/history`.