### PR TITLE
fix: prefer HTML5 video when youtube support is deprecated.

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -218,7 +218,7 @@ class VideoBlock(
         If only either youtube or hls is present then play whichever is present
         """
         yt_present = bool(youtube_streams.strip()) if youtube_streams else False
-        hls_present = any(source for source in html5_sources if source.strip().endswith('.m3u8'))
+        hls_present = any(source for source in html5_sources)
 
         if yt_present and hls_present:
             return self.youtube_deprecated

--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -1150,7 +1150,7 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
             'waffle_enabled': False,
             'youtube': '3_yD_cEKoCk',
             'hls': [],
-            'result': 'false'
+            'result': 'true'
         },
         {
             'course_override': WaffleFlagCourseOverrideModel.ALL_CHOICES.off,


### PR DESCRIPTION
```
﻿In the case where a server/course has both:

* YouTube deprecated (waffle flag: videos.deprecate_youtube = True)
* HLS enabled (ConfigModel: HLSPlaybackEnabledFlag, in video_config)

Prior to this commit, we would prefer the HLS source if one of the
HTML5 video sources specified a .m3u8 file. However it looks like this
file isn't always guaranteed to be produced by the video pipeline.

This fix always prefers HTML5 video sources to YouTube is the
server/course is configured to deprecate YouTube, as long as at least
one non-YouTube source is found. TNL-8594.

Note that this may confuse users because we're essentially bypassing
their Studio-specified preferred primary source with a server-wide
setting.
```
