### PR TITLE
feat: update verified upgrade deadline

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2429,6 +2429,8 @@ VERIFY_STUDENT = {
     "EXPIRING_SOON_WINDOW": 28,
 }
 
+PUBLISHER_UPGRADE_DEADLINE_DAYS = 10
+
 ######################## Organizations ########################
 
 # .. toggle_name: ORGANIZATIONS_AUTOCREATE

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -988,6 +988,8 @@ RETRY_CALENDAR_SYNC_EMAIL_MAX_ATTEMPTS = 5
 # Deadline message configurations
 COURSE_MESSAGE_ALERT_DURATION_IN_DAYS = 14
 
+PUBLISHER_UPGRADE_DEADLINE_DAYS = 10
+
 ############################# SET PATH INFORMATION #############################
 PROJECT_ROOT = path(__file__).abspath().dirname().dirname()  # /edx-platform/lms
 REPO_ROOT = PROJECT_ROOT.dirname()

--- a/openedx/core/djangoapps/models/utils.py
+++ b/openedx/core/djangoapps/models/utils.py
@@ -1,0 +1,11 @@
+"""
+Util methods
+"""
+import datetime
+from pytz import UTC
+
+
+def subtract_deadline_delta(end, delta):
+    deadline = end - datetime.timedelta(days=delta)
+    deadline = deadline.replace(hour=23, minute=59, second=59, tzinfo=UTC)
+    return deadline


### PR DESCRIPTION
## Description

#### Context
Automatically updating VUD on extending course end date using the same approach as it’s being used while creating course end date. Whenever the end date is pulled to the discovery, VUD will be as well.

One caveat, the upgrade deadline doesn't change on the frontend of studio unless you refresh the details page. This is because `CourseDetails.fetch` doesn't have upgrade deadline as a attribute and doesn't send this updated information to frontend.

## Supporting information

Ticket: https://openedx.atlassian.net/browse/DISCO-1762

## Testing instructions

Added a unit test
