### PR TITLE
BOM-2772: Remove django-ratelimit-backend from requirements

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -178,7 +178,6 @@ django==2.2.24
     #   django-mysql
     #   django-oauth-toolkit
     #   django-pyfs
-    #   django-ratelimit-backend
     #   django-sekizai
     #   django-ses
     #   django-splash
@@ -320,8 +319,6 @@ django-pyfs==3.1.0
     # via -r requirements/edx/base.in
 django-ratelimit==3.0.1
     # via -r requirements/edx/base.in
-git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a5#egg=django-ratelimit-backend==2.0.1a5
-    # via -r requirements/edx/github.in
 django-require==1.0.11
     # via -r requirements/edx/base.in
 django-sekizai==2.0.0

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -253,7 +253,6 @@ django==2.2.24
     #   django-mysql
     #   django-oauth-toolkit
     #   django-pyfs
-    #   django-ratelimit-backend
     #   django-sekizai
     #   django-ses
     #   django-splash
@@ -407,8 +406,6 @@ django-pipeline==2.0.6
 django-pyfs==3.1.0
     # via -r requirements/edx/testing.txt
 django-ratelimit==3.0.1
-    # via -r requirements/edx/testing.txt
-git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a5#egg=django-ratelimit-backend==2.0.1a5
     # via -r requirements/edx/testing.txt
 django-require==1.0.11
     # via -r requirements/edx/testing.txt

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -59,10 +59,6 @@
 git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
 
-# This is a temporary fork until https://github.com/brutasse/django-ratelimit-backend/pull/50 is merged
-# back into the upstream code.
-git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a5#egg=django-ratelimit-backend==2.0.1a5
-
 # Our libraries:
 -e git+https://github.com/edx/codejail.git@3.1.3#egg=codejail==3.1.3
 -e git+https://github.com/edx/RateXBlock.git@2.0.1#egg=rate-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -238,7 +238,6 @@ distlib==0.3.2
     #   django-mysql
     #   django-oauth-toolkit
     #   django-pyfs
-    #   django-ratelimit-backend
     #   django-sekizai
     #   django-ses
     #   django-splash
@@ -390,8 +389,6 @@ django-pipeline==2.0.6
 django-pyfs==3.1.0
     # via -r requirements/edx/base.txt
 django-ratelimit==3.0.1
-    # via -r requirements/edx/base.txt
-git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a5#egg=django-ratelimit-backend==2.0.1a5
     # via -r requirements/edx/base.txt
 django-require==1.0.11
     # via -r requirements/edx/base.txt


### PR DESCRIPTION
**Issue:** [BOM-2772](https://openedx.atlassian.net/browse/BOM-2772)

### Description
- As per Jeremy's discussion on https://github.com/brutasse/django-ratelimit-backend/issues/53 and mentioned in the https://github.com/edx/edx-platform/blob/master/docs/decisions/0009_simplify_ratelimiting.rst, we've stopped the usage of this fork. 
- https://github.com/edx/edx-platform/pull/26487 removed the usage of `django-ratelimit-backend` fork from `edx-platform` and now we only have `django-ratelimit-backend` fork commit included in the requirements files. 
- So now this PR is removing the unused requirement of `django-ratelimit-backend` from `edx-platform.`