### PR TITLE
fix: remove edX support URL from login page

### DIFF
--- a/lms/static/js/student_account/views/LoginView.js
+++ b/lms/static/js/student_account/views/LoginView.js
@@ -225,14 +225,13 @@
                         {
                             email: error.responseJSON.email,
                             platform_name: this.platform_name,
-                            support_url: 'https://support.edx.org/',
                             line_break: HtmlUtils.HTML('<br/>'),
                             strong_start: HtmlUtils.HTML('<strong>'),
                             strong_end: HtmlUtils.HTML('</strong>'),
                             anchorStart: HtmlUtils.HTML(
                                 StringUtils.interpolate(
                                     '<a href="{SupportUrl}">', {
-                                        SupportUrl: 'https://support.edx.org/'
+                                        SupportUrl: this.supportURL,
                                     }
                                 )
                             ),

--- a/openedx/core/djangoapps/site_configuration/helpers.py
+++ b/openedx/core/djangoapps/site_configuration/helpers.py
@@ -134,18 +134,21 @@ def get_value(val_name, default=None, **kwargs):  # lint-amnesty, pylint: disabl
     else:
         configuration_value = default
 
-    # Attempt to perform a dictionary update using the provided default
-    # This will fail if the default value is not a dictionary
-    try:
-        value = dict(default)
-        value.update(configuration_value)
-
-    # If the dictionary update fails, just use the configuration value
-    # TypeError: default is not iterable (simple value or None)
-    # ValueError: default is iterable but not a dict (list, not dict)
-    # AttributeError: default does not have an 'update' method
-    except (TypeError, ValueError, AttributeError):
+    if default == '':
         value = configuration_value
+    else:
+        # Attempt to perform a dictionary update using the provided default
+        # This will fail if the default value is not a dictionary
+        try:
+            value = dict(default)
+            value.update(configuration_value)
+
+        # If the dictionary update fails, just use the configuration value
+        # TypeError: default is not iterable (simple value or None)
+        # ValueError: default is iterable but not a dict (list, not dict)
+        # AttributeError: default does not have an 'update' method
+        except (TypeError, ValueError, AttributeError):
+            value = configuration_value
 
     # Return the end result to the caller
     return value

--- a/openedx/core/djangoapps/site_configuration/tests/test_helpers.py
+++ b/openedx/core/djangoapps/site_configuration/tests/test_helpers.py
@@ -67,6 +67,10 @@ class TestHelpers(TestCase):
         # Test that the default value is returned if the value for the given key is not found in the configuration
         assert configuration_helpers.get_value('non_existent_name', 'dummy-default-value') == 'dummy-default-value'
 
+        # Test that correct default value is returned
+        assert configuration_helpers.get_value('non_existent_name', '') == ''
+        assert configuration_helpers.get_value('non_existent_name', None) is None
+
     @with_site_configuration(configuration=test_config)
     def test_get_dict(self):
         """


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This line: https://github.com/edx/edx-platform/blob/master/lms/static/js/student_account/views/LoginView.js#L235 is a link to the edX support site.  This appears on any Open edX site, sending learners from those sites to edX's support channels, where they cannot get help. 

- Removed the hardcoded value of edX's support URL from login page.
- Also fixed a bug with site configuration helper method `get_value`. The expectation from these lines in the function is that it should throw an exception if default is not a dictionary:
```python
    value = dict(default)
    value.update(configuration_value)
```
This however doesn't work for empty strings, instead running `dict()` on default with empty string value returns `{}`. Empty dictionary is then returned from the function which is the expected value.

## Supporting information

Ticket: https://openedx.atlassian.net/browse/VAN-710

## Testing instructions

Tested locally by setting support url
Edit: Added a unit test for `get_value()` method
