### PR TITLE
BOM-2772: Bump the git tag of edx/django-ratelimit-backend

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -320,7 +320,7 @@ django-pyfs==3.1.0
     # via -r requirements/edx/base.in
 django-ratelimit==3.0.1
     # via -r requirements/edx/base.in
-git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a5#egg=django-ratelimit-backend==2.0.1a5
+git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a6#egg=django-ratelimit-backend==2.0.1a6
     # via -r requirements/edx/github.in
 django-require==1.0.11
     # via -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -408,7 +408,7 @@ django-pyfs==3.1.0
     # via -r requirements/edx/testing.txt
 django-ratelimit==3.0.1
     # via -r requirements/edx/testing.txt
-git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a5#egg=django-ratelimit-backend==2.0.1a5
+git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a6#egg=django-ratelimit-backend==2.0.1a6
     # via -r requirements/edx/testing.txt
 django-require==1.0.11
     # via -r requirements/edx/testing.txt

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -61,7 +61,7 @@ git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752
 
 # This is a temporary fork until https://github.com/brutasse/django-ratelimit-backend/pull/50 is merged
 # back into the upstream code.
-git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a5#egg=django-ratelimit-backend==2.0.1a5
+git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a6#egg=django-ratelimit-backend==2.0.1a6
 
 # Our libraries:
 -e git+https://github.com/edx/codejail.git@3.1.3#egg=codejail==3.1.3

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -391,7 +391,7 @@ django-pyfs==3.1.0
     # via -r requirements/edx/base.txt
 django-ratelimit==3.0.1
     # via -r requirements/edx/base.txt
-git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a5#egg=django-ratelimit-backend==2.0.1a5
+git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a6#egg=django-ratelimit-backend==2.0.1a6
     # via -r requirements/edx/base.txt
 django-require==1.0.11
     # via -r requirements/edx/base.txt


### PR DESCRIPTION
**Issue:** [BOM-2772](https://openedx.atlassian.net/browse/BOM-2772)

### Description
- Bumped the tag version of `edx/django-ratelimit-backend` to include the fix for test failure occuring due to package `django.utils.six` which has been removed in `Django30`. 
- A new tag `v2.0.1a6` was created in edx/django-ratelimit-backend to [fix](https://github.com/edx/django-ratelimit-backend/commit/6e1a0c6ea1d27062c16e9fb94d3c44475146877e) this issue.