### PR TITLE
feat: created custom pages course app plugin [BD-38] [TNL-8543] [BB-4738]

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2470,3 +2470,4 @@ PROGRESS_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-r
 TEAMS_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_features/teams/teams_setup.html"
 TEXTBOOKS_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_assets/textbooks.html"
 WIKI_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_assets/course_wiki.html"
+CUSTOM_PAGES_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_assets/pages.html#adding-custom-pages"

--- a/lms/djangoapps/courseware/plugins.py
+++ b/lms/djangoapps/courseware/plugins.py
@@ -212,3 +212,55 @@ class ProctoringCourseApp(CourseApp):
     @staticmethod
     def legacy_link(course_key: CourseKey):
         return get_proctored_exam_settings_url(course_key)
+
+
+class CustomPagesCourseApp(CourseApp):
+    """
+    Course app config for custom pages app.
+    """
+
+    app_id = "custom_pages"
+    name = _("Custom pages")
+    description = _("Provide additional course content and resources with custom pages")
+    documentation_links = {
+        "learn_more_configuration": settings.CUSTOM_PAGES_HELP_URL,
+    }
+
+    @classmethod
+    def is_available(cls, course_key: CourseKey) -> bool:  # pylint: disable=unused-argument
+        """
+        The custom pages app is available for all courses.
+        """
+        return True
+
+    @classmethod
+    def is_enabled(cls, course_key: CourseKey) -> bool:  # pylint: disable=unused-argument
+        """
+        Returns if the custom pages app is enabled.
+        For now this feature is enabled without any manual setup
+        """
+        return True
+
+    @classmethod
+    def set_enabled(cls, course_key: CourseKey, enabled: bool, user: 'User') -> bool:
+        """
+        The custom pages app can be globally enabled/disabled.
+
+        Currently, it isn't possible to enable/disable this app on a per-course basis.
+        """
+        raise ValueError("The custom pages app can not be enabled/disabled for a single course.")
+
+    @classmethod
+    def get_allowed_operations(cls, course_key: CourseKey, user: Optional[User] = None) -> Dict[str, bool]:
+        """
+        Returns the allowed operations for the app.
+        """
+        return {
+            # Either the app is available and configurable or not. You cannot disable it from the API yet.
+            "enable": False,
+            "configure": True,
+        }
+
+    @staticmethod
+    def legacy_link(course_key: CourseKey):
+        return urls.reverse('tabs_handler', kwargs={'course_key_string': course_key})

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -4798,3 +4798,4 @@ PROGRESS_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-r
 TEAMS_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_features/teams/teams_setup.html"
 TEXTBOOKS_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_assets/textbooks.html"
 WIKI_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_assets/course_wiki.html"
+CUSTOM_PAGES_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_assets/pages.html#adding-custom-pages"

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
             "teams = lms.djangoapps.teams.plugins:TeamsCourseApp",
             "textbooks = lms.djangoapps.courseware.plugins:TextbooksCourseApp",
             "wiki = lms.djangoapps.course_wiki.plugins:WikiCourseApp",
+            "custom_pages = lms.djangoapps.courseware.plugins:CustomPagesCourseApp",
         ],
         "openedx.course_tool": [
             "calendar_sync_toggle = openedx.features.calendar_sync.plugins:CalendarSyncToggleTool",


### PR DESCRIPTION
## Description:

This pull request creates a new custom pages course app plugin that will automatically show up in the list of course apps.

## Supporting information:
[BB-4738](https://tasks.opencraft.com/browse/BB-4738)

## Testing instructions:

- Checkout to this branch in the `edx-platform` repository
- Spin up the master version of devstack
- Sign in to the studio platform
- Confirm that "custom pages" is included in the list of course apps from this API: http://localhost:18010/api/course_apps/v1/apps/course-v1:edX+DemoX+Demo_Course

## Reviewer:

@xitij2000 