### PR TITLE
update session on password change

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/password_reset.py
+++ b/openedx/core/djangoapps/user_authn/views/password_reset.py
@@ -4,6 +4,7 @@ import logging
 from django import forms
 from django.conf import settings
 from django.contrib import messages
+from django.contrib.auth import update_session_auth_hash
 from django.contrib.auth.forms import PasswordResetForm, SetPasswordForm
 from django.contrib.auth.hashers import UNUSABLE_PASSWORD_PREFIX
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
@@ -509,6 +510,7 @@ class PasswordResetConfirmWrapper(PasswordResetConfirmView):
         if LoginFailures.is_feature_enabled():
             LoginFailures.clear_lockout_counter(updated_user)
 
+        update_session_auth_hash(request, updated_user)
         send_password_reset_success_email(updated_user, request)
         return response
 
@@ -773,6 +775,7 @@ class LogistrationPasswordResetView(APIView):  # lint-amnesty, pylint: disable=m
                     LoginFailures.clear_lockout_counter(user)
 
                 send_password_reset_success_email(user, request)
+                update_session_auth_hash(request, user)
         except ValidationError as err:
             AUDIT_LOG.exception("Password validation failed")
             error_status = {


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This change will ensure that after changing the password from Profile page the current session should be updated so that the user will remain logged in and all other devices/browser sessions of the same user must be flushed.

VAN-301