### PR TITLE
chore: Removed django.contrib.staticfiles.templatetags.staticfiles

### DIFF
--- a/openedx/core/djangoapps/schedules/resolvers.py
+++ b/openedx/core/djangoapps/schedules/resolvers.py
@@ -7,7 +7,7 @@ from itertools import groupby
 import attr
 from django.conf import settings
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
-from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.templatetags.static import static
 from django.db.models import Exists, F, OuterRef, Q
 from django.urls import reverse
 from edx_ace.recipient import Recipient


### PR DESCRIPTION
Removed django.contrib.staticfiles.templatetags.staticfiles as Django 3 doesn't support it.

[Django 3.0 Release Notes](https://docs.djangoproject.com/en/3.0/releases/3.0/)

JIRA:[BOM-2768]( https://openedx.atlassian.net/browse/BOM-2768)