### PR TITLE
BOM-2770: Remove deprecated django.utils.decorator.available_attrs

### DIFF
--- a/common/djangoapps/third_party_auth/decorators.py
+++ b/common/djangoapps/third_party_auth/decorators.py
@@ -6,7 +6,6 @@ Decorators that can be used to interact with third_party_auth.
 from functools import wraps
 
 from django.conf import settings
-from django.utils.decorators import available_attrs
 from six.moves.urllib.parse import urlparse  # lint-amnesty, pylint: disable=unused-import
 
 from common.djangoapps.third_party_auth.models import LTIProviderConfig
@@ -31,4 +30,4 @@ def xframe_allow_whitelisted(view_func):
                     x_frame_option = 'ALLOW'
         resp['X-Frame-Options'] = x_frame_option
         return resp
-    return wraps(view_func, assigned=available_attrs(view_func))(wrapped_view)
+    return wraps(view_func)(wrapped_view)


### PR DESCRIPTION
**Issue:** [BOM-2770](https://openedx.atlassian.net/browse/BOM-2770)

### Description
- Django 3.0 removed some deprecated [Python 2 compatibility APIs](https://docs.djangoproject.com/en/3.2/releases/3.0/#removed-private-python-2-compatibility-apis) which also included `django.utils.decorators.available_attrs` in it. 
- Removed the `assigned` parameter from the `wraps` decorator because `wraps` has the [default value](https://docs.python.org/3/library/functools.html#functools.wraps) of `assigned=WRAPPER_ASSIGNMENTS` and the function `decorators.available_attrs` also returned the same `functools.WRAPPER_ASSIGNMENTS` so this parameter isn't needed anymore.