### PR TITLE
chore: Removed django.utils.lru_cache

### DIFF
--- a/openedx/core/djangoapps/content_libraries/library_bundle.py
+++ b/openedx/core/djangoapps/content_libraries/library_bundle.py
@@ -5,7 +5,7 @@ Helper code for working with Blockstore bundles that contain OLX
 import dateutil.parser
 import logging  # lint-amnesty, pylint: disable=wrong-import-order
 
-from django.utils.lru_cache import lru_cache
+from functools import lru_cache
 from opaque_keys.edx.locator import BundleDefinitionLocator, LibraryUsageLocatorV2
 from xblock.core import XBlock
 from xblock.plugin import PluginMissingError

--- a/openedx/core/djangoapps/xblock/runtime/runtime.py
+++ b/openedx/core/djangoapps/xblock/runtime/runtime.py
@@ -11,7 +11,7 @@ from completion.models import BlockCompletion
 from completion.services import CompletionService
 from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied
-from django.utils.lru_cache import lru_cache
+from functools import lru_cache
 from eventtracking import tracker
 from web_fragments.fragment import Fragment
 from xblock.exceptions import NoSuchServiceError

--- a/openedx/core/storage.py
+++ b/openedx/core/storage.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.contrib.staticfiles.storage import StaticFilesStorage
 from django.core.files.storage import get_storage_class, FileSystemStorage
 from django.utils.deconstruct import deconstructible
-from django.utils.lru_cache import lru_cache
+from functools import lru_cache
 from pipeline.storage import NonPackagingMixin
 from require.storage import OptimizedFilesMixin
 from storages.backends.s3boto3 import S3Boto3Storage


### PR DESCRIPTION
Removed django.utils.lru_cache as Django 3 doesn't support it.

[Django 3 release notes](https://docs.djangoproject.com/en/3.0/releases/3.0/)

JIRA: [BOM-2767](https://openedx.atlassian.net/browse/BOM-2767)