### PR TITLE
support classes decoration in `with_site_configuration`

### DIFF
--- a/openedx/core/djangoapps/site_configuration/tests/test_util.py
+++ b/openedx/core/djangoapps/site_configuration/tests/test_util.py
@@ -22,25 +22,25 @@ def with_site_configuration(domain="test.localhost", configuration=None):
         configuration (dict): configuration to use for the test site.
     """
     # This decorator creates Site and SiteConfiguration instances for given domain
-    def _decorator(func):                       # pylint: disable=missing-docstring
-        @wraps(func)
-        def _decorated(*args, **kwargs):        # pylint: disable=missing-docstring
-            # make a domain name out of directory name
-            site, __ = Site.objects.get_or_create(domain=domain, name=domain)
-            site_configuration, created = SiteConfiguration.objects.get_or_create(
-                site=site,
-                defaults={"enabled": True, "site_values": configuration},
-            )
-            if not created:
-                site_configuration.site_values = configuration
-                site_configuration.save()
+    def _get_site(*args, **kwargs):
+        site, _ = Site.objects.get_or_create(domain=domain, name=domain)
+        return site
 
-            with patch('openedx.core.djangoapps.site_configuration.helpers.get_current_site_configuration',
-                       return_value=site_configuration):
-                with patch('openedx.core.djangoapps.theming.helpers.get_current_site', return_value=site):
-                    with patch('django.contrib.sites.models.SiteManager.get_current', return_value=site):
-                        return func(*args, **kwargs)
-        return _decorated
+    def _get_site_config(*args, **kwargs):
+        site = _get_site()
+        site_configuration, _ = SiteConfiguration.objects.get_or_create(
+            site=site,
+            defaults={"enabled": True},
+        )
+        apply_appsembler_theme_configs(site_configuration, configuration)
+        return site_configuration
+
+    def _decorator(test_class_or_func):
+        config_patcher = patch('openedx.core.djangoapps.site_configuration.helpers.get_current_site_configuration',
+                               Mock(side_effect=_get_site_config))
+        crs_patcher = patch('openedx.core.djangoapps.theming.helpers.get_current_site', Mock(side_effect=_get_site))
+        site_patcher = patch('django.contrib.sites.models.SiteManager.get_current', Mock(side_effect=_get_site))
+        return config_patcher(crs_patcher(site_patcher(test_class_or_func)))
     return _decorator
 
 

--- a/openedx/core/djangoapps/site_configuration/tests/test_util.py
+++ b/openedx/core/djangoapps/site_configuration/tests/test_util.py
@@ -2,11 +2,9 @@
 Test helpers for Site Configuration.
 """
 
-
-from functools import wraps
 import contextlib
 
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 from django.contrib.sites.models import Site
 
@@ -32,7 +30,6 @@ def with_site_configuration(domain="test.localhost", configuration=None):
             site=site,
             defaults={"enabled": True},
         )
-        apply_appsembler_theme_configs(site_configuration, configuration)
         return site_configuration
 
     def _decorator(test_class_or_func):


### PR DESCRIPTION
## Description

This decorator should be nicer to use and allows cleaning up the db test objects. This implementation works with classes as well.

## Testing speed

This adds a minor database impact during tests for cleaning up test objects, but test cases shouldn't share data anyway.

## Testing instructions

Test should pass, this decorator is used tens of times in the platform.

## Deadline

None.
