### PR TITLE
fix: Replaced '&#39' with '&#x27' to prevent tests from failing on Django 3

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
@@ -9,6 +9,7 @@ import unittest
 from datetime import datetime, timedelta
 from unittest.mock import Mock, patch
 import ddt
+import django
 from django.conf import settings
 from django.contrib.auth.hashers import UNUSABLE_PASSWORD_PREFIX, make_password
 from django.contrib.auth.models import AnonymousUser, User  # lint-amnesty, pylint: disable=imported-auth-user
@@ -282,6 +283,9 @@ class ResetPasswordTests(EventTestMixin, CacheIsolationTestCase):
         }
 
         body = bodies[body_type]
+
+        if django.VERSION >= (3, 0):
+            expected_output = "You&#x27;re receiving this e-mail because you requested a password reset"
 
         assert 'Password reset' in sent_message.subject
         assert expected_output in body


### PR DESCRIPTION
django.utils.html.escape() now uses html.escape() to escape HTML: edx-platform django3.0 so this test failed with django3.0
`openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py::ResetPasswordTests::test_reset_password_email_2___html____You__39_re_receiving_this_e_mail_because_you_requested_a_password_reset__`

[Django 3 release notes](https://docs.djangoproject.com/en/3.0/releases/3.0/)

JIRA: https://openedx.atlassian.net/browse/BOM-2773