### PR TITLE
[MST-998] Search by external_user_key is now case insensitive

### DIFF
--- a/lms/djangoapps/support/tests/test_views.py
+++ b/lms/djangoapps/support/tests/test_views.py
@@ -1069,6 +1069,38 @@ class ProgramEnrollmentsInspectorViewTests(SupportViewTestCase):
         render_call_dict = mocked_render.call_args[0][1]
         assert expected_error == render_call_dict['error']
 
+    @patch_render
+    def test_search_external_user_case_insensitive(self, mocked_render):
+        external_user_key = 'AbCdEf123'
+        requested_external_user_key = 'aBcDeF123'
+
+        created_user, expected_user_info = self._construct_user(
+            'test_user_connected',
+            self.org_key_list[0],
+            external_user_key
+        )
+
+        expected_enrollments = self._construct_enrollments(
+            [self.program_uuid],
+            [self.course.id],
+            external_user_key,
+            created_user
+        )
+        id_verified = self._construct_id_verification(created_user)
+
+        self.client.get(self.url, data={
+            'external_user_key': requested_external_user_key,
+            'org_key': self.org_key_list[0]
+        })
+        expected_info = {
+            'user': expected_user_info,
+            'enrollments': expected_enrollments,
+            'id_verification': id_verified,
+        }
+
+        render_call_dict = mocked_render.call_args[0][1]
+        assert expected_info == render_call_dict['learner_program_enrollments']
+
 
 class SsoRecordsTests(SupportViewTestCase):  # lint-amnesty, pylint: disable=missing-class-docstring
 

--- a/lms/djangoapps/support/views/program_enrollments.py
+++ b/lms/djangoapps/support/views/program_enrollments.py
@@ -224,7 +224,9 @@ class ProgramEnrollmentsInspectorView(View):
                 [external_user_key],
                 org_key
             )
-            found_user = users_by_key.get(external_user_key)
+            # Remove entries with no corresponding user and convert keys to lowercase
+            users_by_key_lower = {key.lower(): value for key, value in users_by_key.items() if value}
+            found_user = users_by_key_lower.get(external_user_key.lower())
         except (
             BadOrganizationShortNameException,
             ProviderDoesNotExistException


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Supporting information

[MST-998](https://openedx.atlassian.net/browse/MST-998)