### PR TITLE
fix: fetch commons.js from the correct URL [SE-4785]

### DIFF
--- a/cms/templates/content_libraries/xblock_iframe.html
+++ b/cms/templates/content_libraries/xblock_iframe.html
@@ -66,7 +66,7 @@
        files (defined in webpack.common.config.js) to get that entry point and all
        of its dependencies.
     -->
-  <script type="text/javascript" src="{{ lms_root_url }}/static/xmodule_js/common_static/bundles/commons.js"></script>
+  <script type="text/javascript" src="{{ lms_root_url }}/static/bundles/commons.js"></script>
   <!-- The video XBlock (and perhaps others?) expect this global: -->
   <script>
     window.onTouchBasedDevice = function() { return navigator.userAgent.match(/iPhone|iPod|iPad|Android/i); };


### PR DESCRIPTION
## Description

This mirrors a fix in [frontend-app-library-authoring](https://github.com/edx/frontend-app-library-authoring/pull/25/files#diff-4102b1726b612b7813106191ef87849273f5d89da904f5ab69fb1974a31987d5R307), enabling standard xblocks such as HTML, problem, and video, to work via LTI in a production setup.  (The previous URL would work only in a devstack.)

## Testing instructions

Setup is exactly as instructed in https://github.com/edx/edx-platform/pull/27411 - this is a direct follow-up.

## Deadline

None.