### PR TITLE
fix: [AA-950] Change coupon flag from WaffleFlag to CourseWaffleFlag

### DIFF
--- a/lms/djangoapps/course_home_api/course_metadata/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/course_metadata/tests/test_views.py
@@ -16,7 +16,7 @@ from lms.djangoapps.courseware.toggles import (
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.course_home_api.tests.utils import BaseCourseHomeTests
-from lms.djangoapps.experiments.utils import STREAK_DISCOUNT_FLAG
+from lms.djangoapps.courseware.toggles import COURSEWARE_MFE_MILESTONES_STREAK_DISCOUNT
 
 
 @ddt.ddt
@@ -85,7 +85,7 @@ class CourseHomeMetadataTests(BaseCourseHomeTests):
     def test_streak_data_in_response(self):
         """ Test that metadata endpoint returns data for the streak celebration """
         CourseEnrollment.enroll(self.user, self.course.id, 'audit')
-        with override_waffle_flag(STREAK_DISCOUNT_FLAG, active=True):
+        with override_waffle_flag(COURSEWARE_MFE_MILESTONES_STREAK_DISCOUNT, active=True):
             with mock.patch('common.djangoapps.student.models.UserCelebration.perform_streak_updates', return_value=3):
                 response = self.client.get(self.url, content_type='application/json')
                 celebrations = response.json()['celebrations']

--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -85,6 +85,21 @@ COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES_STREAK_CELEBRATION = CourseWaffleFl
     WAFFLE_FLAG_NAMESPACE, 'mfe_progress_milestones_streak_celebration', __name__
 )
 
+# .. toggle_name: courseware.mfe_progress_milestones_streak_discount_enabled
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: This flag enables an engagement discount incentive message.
+# .. toggle_warnings: This flag depends on the streak celebration feature being enabled
+# .. toggle_use_cases: opt_out, open_edx
+# .. toggle_creation_date: 2021-08-26
+# .. toggle_target_removal_date: None
+# .. toggle_tickets: https://openedx.atlassian.net/browse/AA-950
+COURSEWARE_MFE_MILESTONES_STREAK_DISCOUNT = CourseWaffleFlag(
+    WAFFLE_FLAG_NAMESPACE, 'streak_discount_enabled',
+    __name__,
+)
+
+
 # .. toggle_name: courseware.optimized_render_xblock
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False

--- a/lms/djangoapps/experiments/utils.py
+++ b/lms/djangoapps/experiments/utils.py
@@ -69,20 +69,6 @@ UPSELL_TRACKING_FLAG = WaffleFlag(
 )
 # TODO END: Clean up as part of REV-1205 (End)
 
-# .. toggle_name: streak_celebration.streak_discount_enabled
-# .. toggle_implementation: WaffleFlag
-# .. toggle_default: False
-# .. toggle_description: This flag enables an engagement discount incentive message.
-# .. toggle_warnings: This flag depends on the streak celebration feature being enabled
-# .. toggle_use_cases: opt_out, open_edx
-# .. toggle_creation_date: 2021-08-26
-# .. toggle_target_removal_date: None
-# .. toggle_tickets: https://openedx.atlassian.net/browse/AA-950
-STREAK_DISCOUNT_FLAG = WaffleFlag(
-    'streak_celebration.streak_discount_enabled',
-    __name__,
-)
-
 
 def check_and_get_upgrade_link_and_date(user, enrollment=None, course=None):
     """

--- a/openedx/core/djangoapps/courseware_api/tests/test_views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/test_views.py
@@ -29,7 +29,7 @@ from lms.djangoapps.courseware.toggles import (
     COURSEWARE_MICROFRONTEND_SPECIAL_EXAMS,
     COURSEWARE_MICROFRONTEND_PROCTORED_EXAMS,
 )
-from lms.djangoapps.experiments.utils import STREAK_DISCOUNT_FLAG
+from lms.djangoapps.courseware.toggles import COURSEWARE_MFE_MILESTONES_STREAK_DISCOUNT
 from lms.djangoapps.verify_student.services import IDVerificationService
 from common.djangoapps.student.models import (
     CourseEnrollment, CourseEnrollmentCelebration
@@ -301,7 +301,7 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
     def test_streak_data_in_response(self):
         """ Test that metadata endpoint returns data for the streak celebration """
         CourseEnrollment.enroll(self.user, self.course.id, 'audit')
-        with override_waffle_flag(STREAK_DISCOUNT_FLAG, active=True):
+        with override_waffle_flag(COURSEWARE_MFE_MILESTONES_STREAK_DISCOUNT, active=True):
             with mock.patch('common.djangoapps.student.models.UserCelebration.perform_streak_updates', return_value=3):
                 response = self.client.get(self.url, content_type='application/json')
                 celebrations = response.json()['celebrations']

--- a/openedx/core/djangoapps/courseware_api/utils.py
+++ b/openedx/core/djangoapps/courseware_api/utils.py
@@ -7,7 +7,7 @@ from babel.numbers import get_currency_symbol
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.models import CourseEnrollmentCelebration, UserCelebration
 from lms.djangoapps.courseware.utils import can_show_verified_upgrade, verified_upgrade_deadline_link
-from lms.djangoapps.experiments.utils import STREAK_DISCOUNT_FLAG
+from lms.djangoapps.courseware.toggles import COURSEWARE_MFE_MILESTONES_STREAK_DISCOUNT
 from openedx.features.course_duration_limits.access import get_user_course_expiration_date
 from openedx.features.discounts.applicability import can_show_streak_discount_coupon
 from common.djangoapps.track import segment
@@ -37,7 +37,7 @@ def get_celebrations_dict(user, enrollment, course, browser_timezone):
         # We only want to offer the streak discount
         # if the course has not ended, is upgradeable and the user is not an enterprise learner
         if can_show_streak_discount_coupon(user, course):
-            celebrations['streak_discount_enabled'] = STREAK_DISCOUNT_FLAG.is_enabled()
+            celebrations['streak_discount_enabled'] = COURSEWARE_MFE_MILESTONES_STREAK_DISCOUNT.is_enabled()
 
             # Send course streak coupon event
             course_key = str(course.id)


### PR DESCRIPTION
Replacing the streak_celebration.discount_experiment_AA759 Waffle flag with
courseware.streak_discount_enabled CourseWaffleFlag

https://openedx.atlassian.net/browse/AA-950
