### PR TITLE
fix: abstract edX-specific strings

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -1795,6 +1795,7 @@ id=\"course-enrollment-end-time\" value=\"\" placeholder=\"HH:MM\" autocomplete=
         self._verify_editable(self._get_course_details_response(True))
 
     @mock.patch.dict("django.conf.settings.FEATURES", {'ENABLE_PUBLISHER': True})
+    @override_settings(PLATFORM_NAME='edX')
     def test_course_details_with_enabled_setting_non_global_staff(self):
         """
         Test that user enrollment end date is not editable in response.

--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -338,7 +338,7 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url | n, js_escaped_string}'
                 <span class="tip tip-stacked">
                   ${_("Last day students can enroll.")}
                 % if not enrollment_end_editable:
-                  ${_("Contact your edX partner manager to update these settings.")}
+                  ${_("Contact your {platform_name} partner manager to update these settings.").format(platform_name=settings.PLATFORM_NAME)}
                 % endif
                 </span>
               </div>
@@ -359,7 +359,7 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url | n, js_escaped_string}'
                 <input type="text" class="date upgrade-deadline" id="course-upgrade-deadline-date" placeholder="MM/DD/YYYY" autocomplete="off" readonly aria-readonly="true" />
                 <span class="tip tip-stacked">
                   ${_("Last day students can upgrade to a verified enrollment.")}
-                  ${_("Contact your edX partner manager to update these settings.")}
+                  ${_("Contact your {platform_name} partner manager to update these settings.").format(platform_name=settings.PLATFORM_NAME)}
                 </span>
               </div>
 

--- a/common/djangoapps/student/tests/test_verification_status.py
+++ b/common/djangoapps/student/tests/test_verification_status.py
@@ -30,6 +30,7 @@ from xmodule.modulestore.tests.factories import CourseFactory
 
 
 @patch.dict(settings.FEATURES, {'AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING': True})
+@override_settings(PLATFORM_NAME='edX')
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 @ddt.ddt
 class TestCourseVerificationStatus(UrlResetMixin, ModuleStoreTestCase):

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -435,7 +435,9 @@ class CourseFields:  # lint-amnesty, pylint: disable=missing-class-docstring
     )
     video_upload_pipeline = Dict(
         display_name=_("Video Upload Credentials"),
-        help=_("Enter the unique identifier for your course's video files provided by edX."),
+        help=_(
+            "Enter the unique identifier for your course's video files provided by {platform_name}."
+        ).format(platform_name=settings.PLATFORM_NAME),
         scope=Scope.settings
     )
     no_grade = Boolean(
@@ -479,9 +481,10 @@ class CourseFields:  # lint-amnesty, pylint: disable=missing-class-docstring
             # Translators: Custom Courses for edX (CCX) is an edX feature for re-using course content. CCX Coach is
             # a role created by a course Instructor to enable a person (the "Coach") to manage the custom course for
             # his students.
-            "Allow course instructors to assign CCX Coach roles, and allow coaches to manage Custom Courses on edX."
-            " When false, Custom Courses cannot be created, but existing Custom Courses will be preserved."
-        ),
+            "Allow course instructors to assign CCX Coach roles, and allow coaches to manage "
+            "Custom Courses on {platform_name}. When false, Custom Courses cannot be created, "
+            "but existing Custom Courses will be preserved."
+        ).format(platform_name=settings.PLATFORM_NAME),
         default=False,
         scope=Scope.settings
     )

--- a/lms/djangoapps/branding/api.py
+++ b/lms/djangoapps/branding/api.py
@@ -360,6 +360,7 @@ def _footer_business_links(language=settings.LANGUAGE_CODE):
 
     if language == settings.LANGUAGE_CODE:
         links.append(('affiliates', (marketing_link("AFFILIATES"), _("Affiliates"))))
+        # Translators: 'Open edX' is a trademark, please keep this untranslated
         links.append(('openedx', (_footer_openedx_link()["url"], _("Open edX"))))
         links.append(('careers', (marketing_link("CAREERS"), _("Careers"))))
         links.append(("news", (marketing_link("NEWS"), _("News"))))

--- a/lms/djangoapps/course_home_api/outline/views.py
+++ b/lms/djangoapps/course_home_api/outline/views.py
@@ -6,6 +6,7 @@ from lms.djangoapps.grades.course_grade_factory import CourseGradeFactory
 
 from completion.exceptions import UnavailableCompletionData
 from completion.utilities import get_key_to_last_completed_block
+from django.conf import settings
 from django.http.response import Http404
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
@@ -300,8 +301,10 @@ class OutlineTabView(RetrieveAPIView):
         if not show_enrolled:
             if CourseMode.is_masters_only(course_key):
                 enroll_alert['can_enroll'] = False
-                enroll_alert['extra_text'] = _('Please contact your degree administrator or '
-                                               'edX Support if you have questions.')
+                enroll_alert['extra_text'] = _(
+                    'Please contact your degree administrator or '
+                    '{platform_name} Support if you have questions.'
+                ).format(platform_name=settings.PLATFORM_NAME)
             elif course.invitation_only:
                 enroll_alert['can_enroll'] = False
 

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -706,8 +706,10 @@ class CourseTabView(EdxFragmentView):
             if not CourseEnrollment.is_enrolled(request.user, course.id) and not allow_anonymous:
                 # Only show enroll button if course is open for enrollment.
                 if CourseTabView.course_open_for_learner_enrollment(course):
-                    enroll_message = _('You must be enrolled in the course to see course content. \
-                            {enroll_link_start}Enroll now{enroll_link_end}.')
+                    enroll_message = _(
+                        'You must be enrolled in the course to see course content. '
+                        '{enroll_link_start}Enroll now{enroll_link_end}.'
+                    )
                     PageLevelMessages.register_warning_message(
                         request,
                         Text(enroll_message).format(
@@ -2071,9 +2073,9 @@ def financial_assistance_form(request):
                 'placeholder': '',
                 'name': 'mktg-permission',
                 'label': _(
-                    'I allow edX to use the information provided in this application '
-                    '(except for financial information) for edX marketing purposes.'
-                ),
+                    'I allow {platform_name} to use the information provided in this application '
+                    '(except for financial information) for {platform_name} marketing purposes.'
+                ).format(platform_name=settings.PLATFORM_NAME),
                 'defaultValue': '',
                 'type': 'checkbox',
                 'required': False,

--- a/lms/templates/ccx/coach_dashboard.html
+++ b/lms/templates/ccx/coach_dashboard.html
@@ -2,6 +2,7 @@
 <%inherit file="/main.html" />
 <%namespace name='static' file='/static_content.html'/>
 <%!
+from django.conf import settings
 from django.utils.translation import ugettext as _
 from django.urls import reverse
 from openedx.core.djangolib.js_utils import (
@@ -47,7 +48,7 @@ from openedx.core.djangolib.js_utils import (
                   <input name="name" id="ccx_name" placeholder="${_('Name your CCX')}"/><br/>
                 </div>
                 <div class="field">
-                  <button id="create-ccx" type="submit">${_('Create a new Custom Course for edX')}</button>
+                  <button id="create-ccx" type="submit">${_('Create a new Custom Course for {platform_name}').format(platform_name=settings.PLATFORM_NAME)}</button>
                 </div>
               </form>
           </div>

--- a/lms/templates/certificates/valid.html
+++ b/lms/templates/certificates/valid.html
@@ -9,7 +9,7 @@
 
 <%include file="_accomplishment-rendering.html" />
 <div class="wrapper-about">
-    <aside role="complementary" class="about" aria-label=${_("About edX Certificates")}>
+    <aside role="complementary" class="about" aria-label=${_("About {platform_name} Certificates").format(platform_name=settings.PLATFORM_NAME)}>
         <%include file="_about-edx.html" />
         <%include file="_about-accomplishments.html" />
     </aside>

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -394,7 +394,7 @@ from lms.djangoapps.experiments.utils import UPSELL_TRACKING_FLAG
               <h4 class="message-title">${_('Your current verification will expire soon!')}</h4>
               <p class="message-copy">${_('You have submitted your reverification information. You will see a message on your dashboard when the verification process is complete (usually within 5-7 days).')}</p>
             % elif verification_status['status'] == VERIFY_STATUS_APPROVED:
-              <h4 class="message-title">${_('You have successfully verified your ID with edX')}</h4>
+              <h4 class="message-title">${_('You have successfully verified your ID with {platform_name}').format(platform_name=settings.PLATFORM_NAME)}</h4>
               % if verification_status.get('verification_good_until') is not None:
                 <p class="message-copy">${_('Your current verification is effective until {date}.').format(date=verification_status['verification_good_until'])}
               % endif

--- a/lms/templates/dashboard/_dashboard_status_verification.html
+++ b/lms/templates/dashboard/_dashboard_status_verification.html
@@ -1,6 +1,7 @@
 <%page expression_filter="h"/>
 <%namespace name='static' file='../static_content.html'/>
 <%!
+from django.conf import settings
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 from lms.djangoapps.verify_student.services import IDVerificationService
@@ -10,7 +11,7 @@ from lms.djangoapps.verify_student.services import IDVerificationService
     %if verification_status == 'approved':
         <li class="status status-verification is-accepted">
             <span class="title status-title">${_("Current ID Verification Status: Approved")}</span>
-            <p class="status-note">${_("Your edX ID verification has been approved. Your ID verification is effective for two years after submission.")}</p>
+            <p class="status-note">${_("Your {platform_name} ID verification has been approved. Your ID verification is effective for two years after submission.").format(platform_name=settings.PLATFORM_NAME)}</p>
             %if verification_expiry:
                 <p class="status-note"><span><b>${_("Warning")}: </b></span><i>${_("Your photo ID verification expires on {verification_expiry}. Please be aware photo verification can take up to three days once initiated and you will not be able to earn a certificate or take a proctored exam until approved.").format(verification_expiry=verification_expiry)}</i></p>
                 <div class="btn-reverify">
@@ -21,7 +22,7 @@ from lms.djangoapps.verify_student.services import IDVerificationService
     %elif verification_status == 'pending':
         <li class="status status-verification is-pending">
             <span class="title status-title">${_("Current ID Verification Status: Pending")}</span>
-            <p class="status-note">${_("Your edX ID verification is pending. Your ID verification information has been submitted and will be reviewed shortly.")}</p>
+            <p class="status-note">${_("Your {platform_name} ID verification is pending. Your ID verification information has been submitted and will be reviewed shortly.").format(platform_name=settings.PLATFORM_NAME)}</p>
         </li>
     %elif verification_status in ['denied','must_reverify', 'must_retry']:
         <li class="status status-verification is-denied">

--- a/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_body.html
+++ b/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_body.html
@@ -173,7 +173,7 @@
                         <td>
                             &copy; {% now "Y" %} {{ platform_name }}, {% trans "All rights reserved" as tmsg %}{{ tmsg | force_escape }}.<br/>
                             <br/>
-                            {% trans "Our mailing address is" as tmsg %}{{ tmsg | force_escape }}:<br/>
+                            {% trans "Our mailing address is:" as tmsg %}{{ tmsg | force_escape }}<br/>
                             {{ contact_mailing_address }}
                         </td>
                     </tr>

--- a/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_head.html
+++ b/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_head.html
@@ -4,7 +4,7 @@
 {% get_current_language as LANGUAGE_CODE %}
 <title lang="{{ LANGUAGE_CODE|default:"en" }}">
   {% block title %}
-  {% trans "edX Email" as tmsg %}{{ tmsg | force_escape }}
+  {% filter force_escape %}{% blocktrans %}{{ platform_name }} Email{% endblocktrans %}{% endfilter %}
   {% endblock %}
 </title>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>

--- a/openedx/core/djangoapps/content_libraries/models.py
+++ b/openedx/core/djangoapps/content_libraries/models.py
@@ -327,6 +327,7 @@ class LtiProfile(models.Model):
         null=True,
         on_delete=models.CASCADE,
         related_name='contentlibraries_lti_profile',
+        # Translators: 'Open edX' is a trademark, please keep this untranslated
         verbose_name=_('open edx user'),
     )
 

--- a/openedx/core/djangoapps/user_api/accounts/utils.py
+++ b/openedx/core/djangoapps/user_api/accounts/utils.py
@@ -39,9 +39,10 @@ def validate_social_link(platform_name, new_social_link):
     # Ensure that the new link is valid.
     if formatted_social_link is None:
         required_url_stub = settings.SOCIAL_PLATFORMS[platform_name]['url_stub']
-        raise ValueError(_('Make sure that you are providing a valid username or a URL that contains "{url_stub}". '
-                           'To remove the link from your edX profile, '
-                           'leave this field blank.').format(url_stub=required_url_stub))
+        raise ValueError(_(
+            'Make sure that you are providing a valid username or a URL that contains "{url_stub}". '
+            'To remove the link from your {platform_name} profile, leave this field blank.'
+        ).format(url_stub=required_url_stub, platform_name=settings.PLATFORM_NAME))
 
 
 def format_social_link(platform_name, new_social_link):

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -9,6 +9,7 @@ from unittest import mock
 import ddt
 from django.conf import settings
 from django.http import QueryDict
+from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils.http import urlquote_plus
 from django.utils.timezone import now
@@ -613,6 +614,7 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
 
     @override_waffle_flag(COURSE_HOME_USE_LEGACY_FRONTEND, active=True)
     @override_waffle_flag(COURSE_PRE_START_ACCESS_FLAG, active=True)
+    @override_settings(PLATFORM_NAME="edX")
     def test_masters_course_message(self):
         enroll_button_html = "<button class=\"enroll-btn btn-link\">Enroll now</button>"
 

--- a/openedx/features/course_experience/views/course_home_messages.py
+++ b/openedx/features/course_experience/views/course_home_messages.py
@@ -6,6 +6,7 @@ View logic for handling course messages.
 from datetime import datetime
 
 from babel.dates import format_date, format_timedelta
+from django.conf import settings
 from django.contrib import auth
 from django.template.loader import render_to_string
 from django.utils.http import urlquote_plus
@@ -142,8 +143,10 @@ def _register_course_home_messages(request, course, user_access, course_start_da
             # if a course is a Master's only course, we will not offer user ability to self-enroll
             CourseHomeMessages.register_info_message(
                 request,
-                Text(_('You must be enrolled in the course to see course content. '
-                       'Please contact your degree administrator or edX Support if you have questions.')),
+                Text(_(
+                    'You must be enrolled in the course to see course content. '
+                    'Please contact your degree administrator or {platform_name} Support if you have questions.'
+                )).format(platform_name=settings.PLATFORM_NAME),
                 title=title
             )
         elif not course.invitation_only:

--- a/themes/edx.org/lms/templates/certificates/_about-accomplishments.html
+++ b/themes/edx.org/lms/templates/certificates/_about-accomplishments.html
@@ -4,6 +4,12 @@ from django.utils.translation import ugettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
 <div class="accomplishment-metadata-bit accomplishment-metadata-aboutcert">
-    <h3 class="accomplishment-metadata-title">${_("About edX Verified Certificates")}</h3>
-    <p class="accomplishment-metadata-copy">${_("An edX Verified Certificate signifies that the learner has agreed to abide by the edX honor code and completed all of the required tasks of this course under its guidelines, as well as having their photo ID checked to verify their identity.")}</p>
+  <h3 class="accomplishment-metadata-title">
+    ## Translators: This string will not be used in Open edX installations.
+    ${_("About edX Verified Certificates")}
+  </h3>
+  <p class="accomplishment-metadata-copy">
+    ## Translators: This string will not be used in Open edX installations.
+    ${_("An edX Verified Certificate signifies that the learner has agreed to abide by the edX honor code and completed all of the required tasks of this course under its guidelines, as well as having their photo ID checked to verify their identity.")}
+  </p>
 </div>

--- a/themes/edx.org/lms/templates/certificates/_about-edx.html
+++ b/themes/edx.org/lms/templates/certificates/_about-edx.html
@@ -4,8 +4,10 @@ from django.utils.translation import ugettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
 <div class="accomplishment-metadata-bit accomplishment-metadata-aboutedx">
+    ## Translators: This string will not be used in Open edX installations.
     <h3 class="accomplishment-metadata-title">${_("About edX")}</h3>
     <p class="accomplishment-metadata-copy">
+        ## Translators: This string will not be used in Open edX installations.
         ${Text(_("{link_start}edX{link_end} offers interactive online classes and MOOCs from the world's best universities, including MIT, Harvard, Berkeley, University of Texas, and many others. edX is a non-profit online initiative created by founding partners Harvard and MIT.")).format(
             link_start=HTML('<a href="http://www.edx.org">'),
             link_end=HTML('</a>'),

--- a/themes/edx.org/lms/templates/course_modes/choose.html
+++ b/themes/edx.org/lms/templates/course_modes/choose.html
@@ -120,6 +120,7 @@ from openedx.core.djangolib.markup import HTML, Text
                                                                 <li>${Text(_("{b_start}Graded Assignments: {b_end}Build your skills through graded assignments and projects.")).format(**b_tag_kwargs)}</li>
                                                             % endif
                                                             <li>${Text(_("{b_start}Easily Sharable: {b_end}Add the certificate to your CV or resumé, or post it directly on LinkedIn.")).format(**b_tag_kwargs)}</li>
+                                                            ## Translators: This string will not be used in Open edX installations.
                                                             <li>${Text(_("{b_start}Support our Mission: {b_end}EdX, a non-profit, relies on verified certificates to help fund affordable education to everyone globally.")).format(**b_tag_kwargs)}</li>
                                                         </ul>
                                                     % else:


### PR DESCRIPTION
## Description

Many strings throughout edx-platform and beyond use too much edX-specific language. This is a pass at cleaning up strings found in `django.po`.

### Open Questions
- How can we abstract the usage of `edX.org` within the strings? -> this is underway at https://github.com/edx/edx-platform/pull/28638
- Do i18n_tools still work? I would like to test this by generating dummy translations. -> yes
- I'm unsure who would be best suited to review this, will likely lean on CE team.

## Supporting information

This work has spun out of the Transifex working group.

## Testing instructions

1. run `i18n_tool generate`
2. in admin, set `eo` as an option in DarkLangConfig (`en,eo`)
3. in account profile, choose the dummy test lang as your lang pref
4. visit the appropriate pages to see that the strings are internationalized & abstracted

## Deadline

October 8th
