### PR TITLE
feat: Add breadcrumbs for textbooks screen

### DIFF
--- a/cms/templates/textbooks.html
+++ b/cms/templates/textbooks.html
@@ -5,7 +5,6 @@
 <%!
 from django.utils.translation import ugettext as _
 from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string
-from openedx.core.djangoapps.discussions.config.waffle import ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND
 from cms.djangoapps.contentstore.utils import get_pages_and_resources_url
 %>
 
@@ -40,8 +39,8 @@ CMS.URL.LMS_BASE = "${settings.LMS_BASE | n, js_escaped_string}"
   <div class="wrapper-mast wrapper">
     % if context_course:
       <%
-        pages_and_resources_mfe_enabled = ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND.is_enabled(context_course.id)
-        course_key = context_course.id
+        pages_and_resources_mfe_url = get_pages_and_resources_url(context_course.id)
+        pages_and_resources_mfe_enabled = bool(pages_and_resources_mfe_url)
       %>
     % endif
 
@@ -55,7 +54,7 @@ CMS.URL.LMS_BASE = "${settings.LMS_BASE | n, js_escaped_string}"
                   <span class="spacer"> &rsaquo;</span>
               </li>
               <li class="nav-item">
-                <a class="title" href="${get_pages_and_resources_url(course_key)}" rel="external">${_("Pages & Resources")}</a>
+                <a class="title" href="${pages_and_resources_mfe_url}" rel="external">${_("Pages & Resources")}</a>
                 <span class="spacer"> &rsaquo;</span>
               </li>
           </ol>

--- a/cms/templates/textbooks.html
+++ b/cms/templates/textbooks.html
@@ -5,6 +5,8 @@
 <%!
 from django.utils.translation import ugettext as _
 from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string
+from openedx.core.djangoapps.discussions.config.waffle import ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND
+from cms.djangoapps.contentstore.utils import get_pages_and_resources_url
 %>
 
 <%block name="title">${_("Textbooks")}</%block>
@@ -36,11 +38,39 @@ CMS.URL.LMS_BASE = "${settings.LMS_BASE | n, js_escaped_string}"
 
 <%block name="content">
   <div class="wrapper-mast wrapper">
+    % if context_course:
+      <%
+        pages_and_resources_mfe_enabled = ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND.is_enabled(context_course.id)
+        course_key = context_course.id
+      %>
+    % endif
+
+    % if pages_and_resources_mfe_enabled:
+    <header class="mast has-actions">
+      <div class="jump-nav">
+        <nav class="nav-dd title ui-left">
+          <ol>
+              <li class="nav-item">
+                  <span class="label">${_("Content")}</span>
+                  <span class="spacer"> &rsaquo;</span>
+              </li>
+              <li class="nav-item">
+                <a class="title" href="${get_pages_and_resources_url(course_key)}" rel="external">${_("Pages & Resources")}</a>
+                <span class="spacer"> &rsaquo;</span>
+              </li>
+          </ol>
+        </nav>
+      </div>
+      <h1 class="page-header">
+        <span class="sr">&gt; </span>${_("Textbooks")}
+      </h1>
+    % else:
     <header class="mast has-actions has-subtitle">
       <h1 class="page-header">
         <small class="subtitle">${_("Content")}</small>
         <span class="sr">&gt; </span>${_("Textbooks")}
       </h1>
+    % endif
 
       <nav class="nav-actions" aria-label="${_('Page Actions')}">
         <h3 class="sr">${_("Page Actions")}</h3>


### PR DESCRIPTION

## Description
Update navigation/ add breadcrumbs for textbooks page. The current update is gated by the `pages_and_resources_mfe` waffle flag. `Pages & Resources` breadcrumb navigates the user to the new Page & resources MFE home page.


## Testing instructions

1. `pages_and_resources_mfe` waffle flag activation triggers the update UI. 
2. Enable the `pages_and_resources_mfe` waffle flag from the studio admin panel.

New UI when the flag is active:
<img width="1367" alt="Screenshot 2021-09-02 at 4 06 44 PM" src="https://user-images.githubusercontent.com/79941147/131834410-c2cc72cb-f78e-4960-94f1-0bba58b86f2f.png">

Old UI when the flag is inactive:
<img width="1399" alt="Screenshot 2021-09-02 at 4 07 05 PM" src="https://user-images.githubusercontent.com/79941147/131834469-6414dde5-5f4b-449c-81c0-513d08ba99b2.png">

