### PR TITLE
fix: Google Analytics tracking in LMS

### DIFF
--- a/lms/djangoapps/branding/tests/test_page.py
+++ b/lms/djangoapps/branding/tests/test_page.py
@@ -108,6 +108,11 @@ class AnonymousIndexPageTest(ModuleStoreTestCase):
         # Location should be "/login".
         assert response._headers.get('location')[1] == '/login'  # pylint: disable=protected-access
 
+    @override_settings(GOOGLE_ANALYTICS_ACCOUNT="UA-1234")
+    def test_google_analytics_account_present(self):
+        response = self.client.get('/')
+        self.assertContains(response, "UA-1234")
+
 
 class PreRequisiteCourseCatalog(ModuleStoreTestCase, LoginEnrollmentTestCase, MilestonesTestCaseMixin):
     """

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -152,7 +152,7 @@ from common.djangoapps.pipeline_mako import render_require_js_path_overrides
 % if ga_acct:
     <script type="text/javascript">
     var _gaq = _gaq || [];
-    _gaq.push(['_setAccount', '${ga_acct | n, js_escaped_string}']);
+    _gaq.push(['_setAccount', '${ga_acct}']);
     _gaq.push(['_trackPageview']);
 
     (function() {


### PR DESCRIPTION
## Description

Google Analytics tracking was broken in the LMS because the `escapejs` function
was replacing the dash "-" by "\u002D" in the account ID. As far as we understand, this issue was
introduced in 2017 by the following change:
https://github.com/edx/edx-platform/commit/7ea3b013ad47eab5b6532e3af602892894781d55#diff-1adbd21958e452c19656801dc282c38d458be2b2afeecad134e77c1de607a74dR117

The solution consists of not escaping the GOOGLE_ANALYTICS_ACCOUNT setting.
Generally speaking, settings and site configuration should be sufficiently
trusted that we don't need to escape them.

## Supporting information

This issue was first reported here: https://discuss.overhang.io/t/utf16-encoding-of-plugin-string-breaking-google-analytics/1756/

## Testing instructions

    pytest lms/djangoapps/branding/tests/test_page.py::AnonymousIndexPageTest::test_google_analytics_account_present

## Deadline

None.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
