### PR TITLE
Remove or contextualize references to `edX.org` in translated strings

### DIFF
--- a/lms/djangoapps/branding/api.py
+++ b/lms/djangoapps/branding/api.py
@@ -112,6 +112,8 @@ def get_footer(is_secure=True, language=settings.LANGUAGE_CODE):
                    "&utm_source=opensource-partner"
                    "&utm_content=open-edx-partner-footer-link"
                    "&utm_campaign=open-edx-footer",
+            # Translators: This string is used across Open edX installations
+            # as a callback to edX. Please do not translate `edX.org`
             "text": _("Take free online courses at edX.org"),
         },
     }

--- a/lms/djangoapps/bulk_email/tests/test_course_optout.py
+++ b/lms/djangoapps/bulk_email/tests/test_course_optout.py
@@ -88,7 +88,7 @@ class TestOptoutCourseEmails(ModuleStoreTestCase):
 
     def test_optout_using_unsubscribe_link_in_email(self):
         """
-        Make sure email is't sent to learner after opt out.
+        Make sure email isn't sent to learner after opt out.
         """
         self.client.logout()
 

--- a/lms/templates/bulk_email/unsubscribe_success.html
+++ b/lms/templates/bulk_email/unsubscribe_success.html
@@ -1,6 +1,7 @@
 <%page expression_filter="h"/>
 <%!
 from openedx.core.djangolib.markup import HTML, Text
+from django.conf import settings
 from django.utils.translation import ugettext as _
 
 %>
@@ -34,8 +35,9 @@ from django.utils.translation import ugettext as _
 
             %endif
             <br><br>
-            ${Text(_("{link_start}Return to edX.org{link_end}")).format(
-            link_start=HTML("<u> <a href='https://www.edx.org/'>"),
+            ${Text(_("{link_start}Return to {platform_name}{link_end}")).format(
+            link_start=HTML("<u> <a href={lms_route_url}>").format(lms_route_url=settings.LMS_ROOT_URL),
+            platform_name=settings.PLATFORM_NAME,
             link_end=HTML("</a> </u> "),
             )}
 

--- a/lms/templates/financial-assistance/financial-assistance.html
+++ b/lms/templates/financial-assistance/financial-assistance.html
@@ -18,12 +18,24 @@ from common.djangoapps.edxmako.shortcuts import marketing_link
 
   <div class="financial-assistance financial-assistance-body">
     <h2>${_("A Note to Learners")}</h2>
+    ## Translators: This string will not be used in Open edX installations.
     <p>${_("Dear edX Learner,")}</p>
+
+    ## Translators: This string will not be used in Open edX installations.
     <p>${_("EdX Financial Assistance is a program we created to give learners in all financial circumstances a chance to earn a Verified Certificate upon successful completion of an edX course.")}</p>
+
+    ## Translators: This string will not be used in Open edX installations.
     <p>${_("If you are interested in working toward a Verified Certificate, but cannot afford to pay the fee, please apply now. Please note that financial assistance is limited and may not be awarded to all eligible candidates.")}</p>
+
+    ## Translators: This string will not be used in Open edX installations.
     <p>${_("In order to be eligible for edX Financial Assistance, you must demonstrate that paying the Verified Certificate fee would cause you economic hardship. To apply, you will be asked to answer a few questions about why you are applying and how the Verified Certificate will benefit you.")}</p>
+
+    ## Translators: This string will not be used in Open edX installations.
     <p>${_("If your application is approved, we'll give you instructions for verifying your identity on edx.org so you can start working toward completing your edX course.")}</p>
+
+    ## Translators: This string will not be used in Open edX installations.
     <p>${_("EdX is committed to making it possible for you to take high quality courses from leading institutions regardless of your financial situation, earn a Verified Certificate, and share your success with others.")}</p>
+    ## Translators: This string will not be used in Open edX installations. Do not translate the name "Anant".
     <p class="signature">${_("Sincerely, Anant")}</p>
   </div>
 

--- a/themes/red-theme/lms/templates/schedules/edx_ace/recurringnudge_day3/email/body.txt
+++ b/themes/red-theme/lms/templates/schedules/edx_ace/recurringnudge_day3/email/body.txt
@@ -4,14 +4,14 @@
 This is the RED theme!
 {% if course_ids|length > 1 %}
 {% blocktrans trimmed %}
-    Remember when you enrolled in {{ course_name }}, and other courses on edX.org? We do, and we’re glad
+    Remember when you enrolled in {{ course_name }}, and other courses on {{ platform_name }}? We do, and we’re glad
     to have you! Come see what everyone is learning.
 {% endblocktrans %}
 
 {% trans "Start learning now" %} <{% with_link_tracking dashboard_url %}>
 {% else %}
 {% blocktrans trimmed %}
-    Remember when you enrolled in {{ course_name }} on edX.org? We do, and we’re glad
+    Remember when you enrolled in {{ course_name }} on {{ platform_name }}? We do, and we’re glad
     to have you! Come see what everyone is learning.
 {% endblocktrans %}
 


### PR DESCRIPTION
## Description

In order to properly internationalize all strings for Open edX, remove references to `edX.org` that is hardcoded in strings so that Open edX installations to not contain references back to the edX main site.

Additionally, add some translators comments for strings we ONLY use on edX.org, so Open edX site operators working on translations understand why the strings are not abstracted, and contextualize one string that references edX.org that should appear on Open edX installations.

## Supporting information

Brought up by Pierre in Transifex Working Group. Doing this work on behalf of them

## Testing instructions

Need to test by figuring out how to manually pull up the template `lms/templates/bulk_email/unsubscribe_success.html` to make sure variables are inserted properly.

## Deadline

Oct 8 (Maple)
