### PR TITLE
feat: Added support for enterprise id in course_grade_passed_first_time event

### DIFF
--- a/lms/djangoapps/grades/events.py
+++ b/lms/djangoapps/grades/events.py
@@ -12,6 +12,8 @@ from common.djangoapps.track.event_transaction_utils import (
     set_event_transaction_type
 )
 
+from openedx.features.enterprise_support.context import get_enterprise_event_context
+
 COURSE_GRADE_CALCULATED = 'edx.grades.course.grade_calculated'
 GRADES_OVERRIDE_EVENT_TYPE = 'edx.grades.problem.score_overridden'
 GRADES_RESCORE_EVENT_TYPE = 'edx.grades.problem.rescored'
@@ -147,6 +149,8 @@ def course_grade_passed_first_time(user_id, course_id):
     """
     event_name = COURSE_GRADE_PASSED_FIRST_TIME_EVENT_TYPE
     context = contexts.course_context_from_course_id(course_id)
+    context_enterprise = get_enterprise_event_context(user_id, course_id)
+    context.update(context_enterprise)
     # TODO (AN-6134): remove this context manager
     with tracker.get_tracker().context(event_name, context):
         tracker.emit(

--- a/openedx/features/enterprise_support/context.py
+++ b/openedx/features/enterprise_support/context.py
@@ -1,0 +1,35 @@
+"""
+APIs providing enterprise context for events.
+"""
+try:
+    from enterprise.models import EnterpriseCourseEnrollment
+except ImportError:  # pragma: no cover
+    pass
+
+
+def get_enterprise_event_context(user_id, course_id):
+    """
+    Creates an enterprise context from a `course_id` anf `user_id`.
+
+    Example Returned Context::
+
+        {
+            'enterprise_uuid': '1a0fbcbe-49e5-42f1-8e83-4cddfa592f22'
+        }
+
+    Arguments:
+        user_id: id of user object.
+        course_id: id of course object.
+
+    Returns:
+        dict: A dictionary representing the enterprise uuid.
+    """
+    # Prevent a circular import.
+    from openedx.features.enterprise_support.api import enterprise_enabled
+    from openedx.features.enterprise_support.utils import is_enterprise_learner
+    context = {}
+    if enterprise_enabled() and is_enterprise_learner(user_id):
+        uuids = EnterpriseCourseEnrollment.get_enterprise_uuids_with_user_and_course(str(user_id), str(course_id))
+        if uuids:
+            context.update({"enterprise_uuid": str(uuids[0])})
+    return context

--- a/openedx/features/enterprise_support/tests/test_context.py
+++ b/openedx/features/enterprise_support/tests/test_context.py
@@ -1,0 +1,44 @@
+"""
+Test the enterprise support APIs.
+"""
+from django.conf import settings
+from django.test.utils import override_settings
+
+from common.djangoapps.student.tests.factories import UserFactory, CourseEnrollmentFactory
+from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_unless_lms
+from openedx.features.enterprise_support.context import get_enterprise_event_context
+from openedx.features.enterprise_support.tests import FEATURES_WITH_ENTERPRISE_ENABLED
+from openedx.features.enterprise_support.tests.factories import (
+    EnterpriseCustomerUserFactory,
+    EnterpriseCourseEnrollmentFactory
+)
+from openedx.features.enterprise_support.tests.mixins.enterprise import EnterpriseServiceMockMixin
+
+
+@override_settings(FEATURES=FEATURES_WITH_ENTERPRISE_ENABLED)
+@skip_unless_lms
+class TestEnterpriseContext(EnterpriseServiceMockMixin, CacheIsolationTestCase):
+    """
+    Test enterprise event context APIs.
+    """
+    ENABLED_CACHES = ['default']
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory.create(
+            username=settings.ENTERPRISE_SERVICE_WORKER_USERNAME,
+            email='ent_worker@example.com',
+            password='password123',
+        )
+        super().setUpTestData()
+
+    def test_get_enterprise_event_context(self):
+        course_enrollment = CourseEnrollmentFactory(user=self.user)
+        course = course_enrollment.course
+        enterprise_customer_user = EnterpriseCustomerUserFactory(user_id=self.user.id)
+        EnterpriseCourseEnrollmentFactory(
+            enterprise_customer_user=enterprise_customer_user,
+            course_id=course.id
+        )
+        assert get_enterprise_event_context(course_id=course.id, user_id=self.user.id) == \
+               {'enterprise_uuid': str(enterprise_customer_user.enterprise_customer_id)}

--- a/openedx/features/enterprise_support/utils.py
+++ b/openedx/features/enterprise_support/utils.py
@@ -7,7 +7,7 @@ import json
 
 from crum import get_current_request
 from django.conf import settings
-from django.contrib.auth import get_backends, login
+from django.contrib.auth import get_backends, login, get_user_model
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.core.cache import cache
 from django.http import HttpRequest
@@ -415,16 +415,17 @@ def is_enterprise_learner(user):
     Check if the given user belongs to an enterprise. Cache the value if an enterprise learner is found.
 
     Arguments:
-        user (User): Django User object.
+        user (User): Django User object or Django User object id.
 
     Returns:
         (bool): True if given user is an enterprise learner.
     """
-    cached_is_enterprise_key = get_is_enterprise_cache_key(user.id)
+    user_id = user.id if isinstance(user, get_user_model()) else user
+    cached_is_enterprise_key = get_is_enterprise_cache_key(user_id)
     if cache.get(cached_is_enterprise_key):
         return True
 
-    if EnterpriseCustomerUser.objects.filter(user_id=user.id).exists():
+    if EnterpriseCustomerUser.objects.filter(user_id=user_id).exists():
         # Cache the enterprise user for one hour.
         cache.set(cached_is_enterprise_key, True, 3600)
         return True


### PR DESCRIPTION
This PR has changes to added edx enterprise context(which is enterprise UUID of the learner for now) to `course_grade_passed_first_time` event.