### PR TITLE
refactor: move course location util to common djangoapp instead of xm…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ extract_translations: ## extract localizable strings from sources
 push_translations: ## push source strings to Transifex for translation
 	i18n_tool transifex push
 
-pull_translations: requirements  ## pull translations from Transifex
+pull_translations:  ## pull translations from Transifex
 	git clean -fdX conf/locale
 	i18n_tool transifex pull
 	i18n_tool extract

--- a/common/djangoapps/util/course.py
+++ b/common/djangoapps/util/course.py
@@ -7,6 +7,7 @@ import logging
 from urllib.parse import urlencode
 
 from django.conf import settings
+from opaque_keys.edx.keys import CourseKey, UsageKey
 
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
@@ -70,3 +71,12 @@ def has_certificates_enabled(course):
     if not settings.FEATURES.get('CERTIFICATES_HTML_VIEW', False):
         return False
     return course.cert_html_view_enabled
+
+
+def course_location_from_key(course_key: CourseKey) -> UsageKey:
+    """Creates a usage key for the toplevel course item, handling differences between mongo and newer keys"""
+    if getattr(course_key, 'deprecated', False):
+        block_id = course_key.run
+    else:
+        block_id = 'course'
+    return course_key.make_usage_key('course', block_id)

--- a/common/lib/xmodule/xmodule/contentstore/utils.py
+++ b/common/lib/xmodule/xmodule/contentstore/utils.py
@@ -1,6 +1,5 @@
 # lint-amnesty, pylint: disable=missing-module-docstring
 
-from opaque_keys.edx.keys import CourseKey, UsageKey
 from xmodule.contentstore.content import StaticContent
 
 from .django import contentstore
@@ -46,12 +45,3 @@ def restore_asset_from_trashcan(location):
             store.save(thumbnail_content)
         except Exception:  # lint-amnesty, pylint: disable=broad-except
             pass  # OK if this is left dangling
-
-
-def course_location_from_key(course_key: CourseKey) -> UsageKey:
-    """Creates a usage key for the toplevel course item, handling differences between mongo and newer keys"""
-    if getattr(course_key, 'deprecated', False):
-        block_id = course_key.run
-    else:
-        block_id = 'course'
-    return course_key.make_usage_key('course', block_id)

--- a/common/test/acceptance/fixtures/course.py
+++ b/common/test/acceptance/fixtures/course.py
@@ -14,7 +14,7 @@ from path import Path
 
 from common.test.acceptance.fixtures import STUDIO_BASE_URL
 from common.test.acceptance.fixtures.base import FixtureError, XBlockContainerFixture
-from xmodule.contentstore.utils import course_location_from_key
+from common.djangoapps.util.course import course_location_from_key
 
 
 class XBlockFixtureDesc:

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -124,10 +124,10 @@ from openedx.features.course_experience.waffle import waffle as course_experienc
 from openedx.features.enterprise_support.api import data_sharing_consent_required
 from common.djangoapps.student.models import CourseEnrollment, UserTestGroup
 from common.djangoapps.util.cache import cache, cache_if_anonymous
+from common.djangoapps.util.course import course_location_from_key
 from common.djangoapps.util.db import outer_atomic
 from common.djangoapps.util.milestones_helpers import get_prerequisite_courses_display
 from common.djangoapps.util.views import ensure_valid_course_key, ensure_valid_usage_key
-from xmodule.contentstore.utils import course_location_from_key
 from xmodule.course_module import COURSE_VISIBILITY_PUBLIC, COURSE_VISIBILITY_PUBLIC_OUTLINE
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError, NoPathToItem


### PR DESCRIPTION
### [PROD-2447](https://openedx.atlassian.net/browse/PROD-2447)

### Description
This PR moves the util method `course_location_from_key` in xmodule utils to common djangoapps utils(added previously in https://github.com/edx/edx-platform/pull/28050). This refactoring is needed because the inclusion of util in xmodule is causing issues with paver initialization(which utilizes fixture from https://github.com/edx/edx-platform/blob/master/common/test/acceptance/fixtures/course.py#L17) and fails pull translation jobs. The job was temporarily fixed by running requirements before starting the job. That change has been reverted. paver automatically installs the requirements via prereqs command after initialization.