### PR TITLE
Fix: remove the created flag for user profile creation

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -837,7 +837,7 @@ def user_post_save_callback(sender, **kwargs):
 
     # Ensure the user has a profile when run via management command
     _called_by_management_command = getattr(user, '_called_by_management_command', None)
-    if _called_by_management_command and kwargs['created']:
+    if _called_by_management_command:
         try:
             __ = user.profile
         except UserProfile.DoesNotExist:


### PR DESCRIPTION
### Description

- Sandbox creation is failing at user profile creation step right now. After the management command has been updated, now the `created` flag isn't needed anymore so removing the flag.
- Sandbox created successfully: https://userprofilecreation.sandbox.edx.org