### PR TITLE
feat: upgrade django-cors-headers to lateast version.

### DIFF
--- a/lms/djangoapps/experiments/tests/test_views.py
+++ b/lms/djangoapps/experiments/tests/test_views.py
@@ -176,7 +176,7 @@ def cross_domain_config(func):
         'ENABLE_CROSS_DOMAIN_CSRF_COOKIE': True
     })
     settings_decorator = override_settings(
-        CORS_ORIGIN_WHITELIST=['ecommerce.edx.org'],
+        CORS_ORIGIN_WHITELIST=['https://ecommerce.edx.org'],
         CSRF_COOKIE_NAME="prod-edx-csrftoken",
         CROSS_DOMAIN_CSRF_COOKIE_NAME="prod-edx-csrftoken",
         CROSS_DOMAIN_CSRF_COOKIE_DOMAIN=".edx.org"
@@ -262,9 +262,9 @@ class ExperimentCrossDomainTests(APITestCase):
         )
 
     def test_white_list_contents_with_cors_header_version(self, *args):  # pylint: disable=unused-argument
-        """ Verify that with django-cor-header<3 it loads list without scheme. """
-        assert settings.CORS_ORIGIN_WHITELIST == ['sandbox.edx.org']
-        assert int(version('django_cors_headers').split('.')[0]) == 2
+        """ Verify that with django-cor-header<3 it loads list with scheme. """
+        assert settings.CORS_ORIGIN_WHITELIST == ['https://sandbox.edx.org']
+        assert int(version('django_cors_headers').split('.')[0]) == 3
 
 
 class ExperimentKeyValueViewSetTests(APITestCase):  # lint-amnesty, pylint: disable=missing-class-docstring

--- a/openedx/core/djangoapps/cors_csrf/helpers.py
+++ b/openedx/core/djangoapps/cors_csrf/helpers.py
@@ -48,9 +48,14 @@ def is_cross_domain_request_allowed(request):
             log.debug("Referer '%s' must have the scheme 'https'")
             return False
 
+    scheme_with_host = referer
+    # if url is like `https://www.foo.bar/baz/` following check will return `https://www.foo.bar`
+    if referer and referer_parts.scheme and referer_parts.path:
+        scheme_with_host = referer.replace(referer_parts.path, '')
+
     domain_is_whitelisted = (
         getattr(settings, 'CORS_ORIGIN_ALLOW_ALL', False) or
-        referer_hostname in getattr(settings, 'CORS_ORIGIN_WHITELIST', [])
+        scheme_with_host in getattr(settings, 'CORS_ORIGIN_WHITELIST', [])
     )
     if not domain_is_whitelisted:
         if referer_hostname is None:

--- a/openedx/core/djangoapps/cors_csrf/tests/test_authentication.py
+++ b/openedx/core/djangoapps/cors_csrf/tests/test_authentication.py
@@ -40,7 +40,7 @@ class CrossDomainAuthTest(TestCase):
         'ENABLE_CROSS_DOMAIN_CSRF_COOKIE': True
     })
     @override_settings(
-        CORS_ORIGIN_WHITELIST=["www.edx.org"],
+        CORS_ORIGIN_WHITELIST=["https://www.edx.org"],
         CROSS_DOMAIN_CSRF_COOKIE_NAME="prod-edx-csrftoken",
         CROSS_DOMAIN_CSRF_COOKIE_DOMAIN=".edx.org"
     )

--- a/openedx/core/djangoapps/enrollments/tests/test_views.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_views.py
@@ -1260,7 +1260,7 @@ def cross_domain_config(func):
         'ENABLE_CROSS_DOMAIN_CSRF_COOKIE': True
     })
     settings_decorator = override_settings(
-        CORS_ORIGIN_WHITELIST=["www.edx.org"],
+        CORS_ORIGIN_WHITELIST=["https://www.edx.org"],
         CROSS_DOMAIN_CSRF_COOKIE_NAME="prod-edx-csrftoken",
         CROSS_DOMAIN_CSRF_COOKIE_DOMAIN=".edx.org"
     )

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -24,8 +24,8 @@ django-celery-results<2.1
 # We do not support version django-config-models<1.0.0
 django-config-models>=1.0.0
 
-# The CORS_ORIGIN_WHITELIST changes in a backwards incompatible way in 3.0.0, needs matching configuration repo changes
-django-cors-headers<3.0.0
+# greater version has breaking changes `settings have been renamed`. Check https://github.com/adamchainz/django-cors-headers/blob/main/HISTORY.rst#350-2020-08-25
+django-cors-headers==3.2.0
 
 # django-storages version 1.9 drops support for boto storage backend.
 django-storages<1.9

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -248,7 +248,7 @@ django-config-models==2.2.0
     #   lti-consumer-xblock
 django-cookies-samesite==0.9.0
     # via -r requirements/edx/base.in
-django-cors-headers==2.5.3
+django-cors-headers==3.2.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -329,7 +329,7 @@ django-config-models==2.2.0
     #   lti-consumer-xblock
 django-cookies-samesite==0.9.0
     # via -r requirements/edx/testing.txt
-django-cors-headers==2.5.3
+django-cors-headers==3.2.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -314,7 +314,7 @@ django-config-models==2.2.0
     #   lti-consumer-xblock
 django-cookies-samesite==0.9.0
     # via -r requirements/edx/base.txt
-django-cors-headers==2.5.3
+django-cors-headers==3.2.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
**This PR constains major changes.**

Upgrade `django-cor-headers` to [3.2.0](https://github.com/adamchainz/django-cors-headers/blob/main/HISTORY.rst#320-2019-11-15).

**Breaking Changes**
- `CORS_ORIGIN_WHITELIST` now requires URI schemes.
-  Added new list `CORS_ORIGIN_WHITELIST_WITH_SCHEME` which contains all links of `CORS_ORIGIN_WHITELIST` with schemes and load the desired list after checking `django-cors-headers` installed version. It will help to avoid any errors during deployment.
- For more details visit https://github.com/adamchainz/django-cors-headers/blob/main/HISTORY.rst#320-2019-11-15

**Related PRs already merged in internals.**

https://github.com/edx/edx-internal/pull/5369
https://github.com/edx/sandbox-internal/pull/189
Previous PR which added condition in settings (https://github.com/edx/edx-platform/pull/28588):
edge PR https://github.com/edx/edge-internal/pull/366

https://openedx.atlassian.net/browse/BOM-2765

