### PR TITLE
chore: Removed django.utils.six as not supported in Django3

### DIFF
--- a/common/djangoapps/third_party_auth/management/commands/tests/test_saml.py
+++ b/common/djangoapps/third_party_auth/management/commands/tests/test_saml.py
@@ -6,12 +6,12 @@ existing data accordingly.
 
 import os
 import unittest
+from io import StringIO
 
 from unittest import mock
 from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import CommandError
-from django.utils.six import StringIO
 from requests import exceptions
 from requests.models import Response
 


### PR DESCRIPTION
JIRA: https://openedx.atlassian.net/browse/BOM-2766