### PR TITLE
fix: log a single line warning in case of video_transcrip NotFound in…

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/video_handlers.py
+++ b/common/lib/xmodule/xmodule/video_module/video_handlers.py
@@ -347,8 +347,13 @@ class VideoStudentViewHandlers:
                     mimetype,
                     add_attachment_header=False
                 )
-            except NotFoundError:
-                log.exception('[Translation Dispatch] %s', self.location)
+            except NotFoundError as exc:
+                edx_video_id = clean_video_id(self.edx_video_id)
+                log.warning(
+                    '[Translation Dispatch] %s: %s',
+                    self.location,
+                    exc if is_bumper else f'Transcript not found for {edx_video_id}, lang: {self.transcript_language}',
+                )
                 response = self.get_static_transcript(request, transcripts)
 
         elif dispatch == 'download':


### PR DESCRIPTION
…stead of long detailed exception (#28552)

this cherry-picks commit 4efa9b5590c6d340ede6dd28a8b4dcffabbf0760

Reviewer:
@arbrandes 
