### PR TITLE
chore: remove usages of rest_condition 

### DIFF
--- a/common/djangoapps/third_party_auth/api/permissions.py
+++ b/common/djangoapps/third_party_auth/api/permissions.py
@@ -12,7 +12,6 @@ from edx_rest_framework_extensions.permissions import (
     JwtRestrictedApplication,
     NotJwtRestrictedApplication
 )
-from rest_condition import C
 from rest_framework.permissions import BasePermission
 
 from openedx.core.lib.api.permissions import ApiKeyHeaderPermission
@@ -51,11 +50,11 @@ class JwtHasTpaProviderFilterForRequestedProvider(BasePermission):
 
 # TODO: Remove ApiKeyHeaderPermission. Check deprecated_api_key_header custom attribute for active usage.
 _NOT_JWT_RESTRICTED_TPA_PERMISSIONS = (
-    C(NotJwtRestrictedApplication) &
-    (C(IsSuperuser) | ApiKeyHeaderPermission | C(IsStaff))  # pylint: disable=unsupported-binary-operation
+    NotJwtRestrictedApplication &
+    (IsSuperuser | ApiKeyHeaderPermission | IsStaff)  # pylint: disable=unsupported-binary-operation
 )
 _JWT_RESTRICTED_TPA_PERMISSIONS = (
-    C(JwtRestrictedApplication) &
+    JwtRestrictedApplication &
     JwtHasScope &
     JwtHasTpaProviderFilterForRequestedProvider
 )

--- a/lms/djangoapps/certificates/apis/v0/views.py
+++ b/lms/djangoapps/certificates/apis/v0/views.py
@@ -10,7 +10,6 @@ from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthenticat
 from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
-from rest_condition import C
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -156,16 +155,17 @@ class CertificatesListView(APIView):
         BearerAuthenticationAllowInactiveUser,
         SessionAuthenticationAllowInactiveUser,
     )
+    # pylint: disable=unsupported-binary-operation
     permission_classes = (
-        C(IsAuthenticated) & (
-            C(permissions.NotJwtRestrictedApplication) |
+        IsAuthenticated & (
+            permissions.NotJwtRestrictedApplication |
             (
-                C(permissions.JwtRestrictedApplication) &
+                permissions.JwtRestrictedApplication &
                 permissions.JwtHasScope &
                 permissions.JwtHasUserFilterForRequestedUser
             )
         ),
-        (C(permissions.IsStaff) | IsOwnerOrPublicCertificates),  # pylint: disable=unsupported-binary-operation
+        permissions.IsStaff | IsOwnerOrPublicCertificates,
     )
 
     required_scopes = ['certificates:read']

--- a/openedx/core/lib/api/permissions.py
+++ b/openedx/core/lib/api/permissions.py
@@ -8,7 +8,6 @@ from django.http import Http404
 from edx_django_utils.monitoring import set_custom_attribute
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
-from rest_condition import C
 from rest_framework import permissions
 
 from edx_rest_framework_extensions.permissions import IsStaff, IsUserInUrl
@@ -103,7 +102,7 @@ class IsMasterCourseStaffInstructor(permissions.BasePermission):
 
 class IsUserInUrlOrStaff(permissions.BasePermission):
     def has_permission(self, request, view):
-        return C(IsStaff) | IsUserInUrl
+        return IsStaff | IsUserInUrl
 
 
 class IsStaffOrReadOnly(permissions.BasePermission):

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -3,6 +3,16 @@
 # See BOM-2721 for more details.
 # Below is the copied and edited version of common_constraints
 
+# This is a temporary solution to override the real common_constraints.txt
+# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
+# See BOM-2721 for more details.
+# Below is the copied and edited version of common_constraints
+
+# This is a temporary solution to override the real common_constraints.txt
+# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
+# See BOM-2721 for more details.
+# Below is the copied and edited version of common_constraints
+
 # A central location for most common version constraints
 # (across edx repos) for pip-installation.
 #

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -102,9 +102,3 @@ pylint<2.10.0
 # Feel free to loosen this constraint if/when it is confirmed that a later
 # version of py2neo will work with Neo4j 3.5.
 py2neo<2022
-
-# The next major release of edx-drf-extensions removes support for
-# rest_condition, and this is being handled in
-# https://github.com/edx/edx-platform/pull/28663
-# Till that PR is merged, keep to a version below 8 to avoid breaking things.
-edx-drf-extensions<8.0.0

--- a/requirements/edx-sandbox/py35.txt
+++ b/requirements/edx-sandbox/py35.txt
@@ -51,7 +51,7 @@ networkx==2.2
     # via
     #   -c requirements/edx-sandbox/../constraints.txt
     #   -r requirements/edx-sandbox/py35.in
-nltk==3.6.3
+nltk==3.6.4
     # via
     #   -r requirements/edx-sandbox/py35.in
     #   chem
@@ -62,7 +62,6 @@ numpy==1.16.5
     #   chem
     #   matplotlib
     #   openedx-calc
-    #   scipy
 openedx-calc==1.0.9
     # via -r requirements/edx-sandbox/py35.in
 pycparser==2.20
@@ -77,11 +76,11 @@ python-dateutil==2.4.0
     # via
     #   -c requirements/edx-sandbox/../constraints.txt
     #   matplotlib
-pytz==2021.1
+pytz==2021.3
     # via matplotlib
 random2==1.0.1
     # via -r requirements/edx-sandbox/py35.in
-regex==2021.9.24
+regex==2021.9.30
     # via nltk
 scipy==1.2.1
     # via

--- a/requirements/edx-sandbox/py38.txt
+++ b/requirements/edx-sandbox/py38.txt
@@ -16,7 +16,7 @@ click==7.1.2
     # via
     #   -c requirements/edx-sandbox/../constraints.txt
     #   nltk
-cryptography==3.4.8
+cryptography==35.0.0
     # via -r requirements/edx-sandbox/py38.in
 cycler==0.10.0
     # via matplotlib
@@ -42,7 +42,7 @@ networkx==2.5.1
     # via
     #   -c requirements/edx-sandbox/../constraints.txt
     #   -r requirements/edx-sandbox/py38.in
-nltk==3.6.3
+nltk==3.6.4
     # via
     #   -r requirements/edx-sandbox/py38.in
     #   chem
@@ -71,7 +71,7 @@ python-dateutil==2.4.0
     #   matplotlib
 random2==1.0.1
     # via -r requirements/edx-sandbox/py38.in
-regex==2021.9.24
+regex==2021.9.30
     # via nltk
 scipy==1.7.1
     # via

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -141,7 +141,6 @@ python3-openid ; python_version>='3'
 python3-saml
 pyuca                               # For more accurate sorting of translated country names in django-countries
 recommender-xblock                  # https://github.com/edx/RecommenderXBlock
-rest-condition                      # DRF's recommendation for supporting complex permissions
 social-auth-core
 pysrt                               # Support for SubRip subtitle files, used in the video XModule
 pytz                                # Time zone information database

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -41,9 +41,7 @@ amqp==2.6.1
 analytics-python==1.4.0
     # via -r requirements/edx/base.in
 aniso8601==9.0.1
-    # via
-    #   edx-tincan-py35
-    #   tincan
+    # via edx-tincan-py35
 appdirs==1.4.4
     # via fs
 async-timeout==3.0.1
@@ -203,7 +201,6 @@ django==2.2.24
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-enterprise
-    #   edx-event-routing-backends
     #   edx-i18n-tools
     #   edx-milestones
     #   edx-name-affirmation
@@ -223,7 +220,6 @@ django==2.2.24
     #   lti-consumer-xblock
     #   openedx-events
     #   ora2
-    #   rest-condition
     #   super-csv
     #   xss-utils
 django-appconf==1.0.5
@@ -243,7 +239,6 @@ django-config-models==2.2.0
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   edx-enterprise
-    #   edx-event-routing-backends
     #   edx-name-affirmation
     #   lti-consumer-xblock
 django-cookies-samesite==0.9.0
@@ -267,7 +262,6 @@ django-fernet-fields==0.6
     # via
     #   -r requirements/edx/base.in
     #   edx-enterprise
-    #   edx-event-routing-backends
     #   edxval
 django-filter==21.1
     # via
@@ -378,7 +372,6 @@ djangorestframework==3.12.4
     #   edx-proctoring
     #   edx-submissions
     #   ora2
-    #   rest-condition
     #   super-csv
 djangorestframework-xml==2.0.0
     # via edx-enterprise
@@ -431,7 +424,7 @@ edx-django-utils==4.4.0
     #   edx-when
     #   ora2
     #   super-csv
-edx-drf-extensions==7.0.1
+edx-drf-extensions==8.0.0
     # via
     #   -r requirements/edx/base.in
     #   edx-completion
@@ -446,8 +439,6 @@ edx-enterprise==3.28.22
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
-edx-event-routing-backends==4.1.0
-    # via -r requirements/edx/base.in
 edx-i18n-tools==0.7.0
     # via ora2
 edx-milestones==0.3.2
@@ -500,7 +491,6 @@ edx-toggles==4.2.0
     # via
     #   -r requirements/edx/base.in
     #   edx-completion
-    #   edx-event-routing-backends
     #   edx-name-affirmation
     #   edxval
     #   ora2
@@ -508,7 +498,6 @@ edx-user-state-client==1.3.2
     # via -r requirements/edx/base.in
 edx-when==2.2.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   edx-proctoring
 edxval==2.0.3
@@ -526,7 +515,6 @@ enmerkar-underscore==2.1.0
 event-tracking==1.1.1
     # via
     #   -r requirements/edx/base.in
-    #   edx-event-routing-backends
     #   edx-proctoring
     #   edx-search
 fs==2.0.18
@@ -571,9 +559,7 @@ interchange==2021.0.3
 ipaddress==1.0.23
     # via -r requirements/edx/base.in
 isodate==0.6.0
-    # via
-    #   edx-event-routing-backends
-    #   python3-saml
+    # via python3-saml
 itypes==1.2.0
     # via coreapi
 jinja2==3.0.1
@@ -594,7 +580,6 @@ jsonfield2==3.0.3
     #   -r requirements/edx/base.in
     #   edx-celeryutils
     #   edx-enterprise
-    #   edx-event-routing-backends
     #   edx-proctoring
     #   edx-submissions
     #   lti-consumer-xblock
@@ -672,7 +657,7 @@ monotonic==1.6
     #   py2neo
 mpmath==1.2.1
     # via sympy
-multidict==5.1.0
+multidict==5.2.0
     # via
     #   aiohttp
     #   yarl
@@ -682,7 +667,7 @@ newrelic==7.0.0.166
     # via
     #   -r requirements/edx/base.in
     #   edx-django-utils
-nltk==3.6.3
+nltk==3.6.4
     # via
     #   -r requirements/edx/base.in
     #   chem
@@ -810,7 +795,6 @@ python-dateutil==2.4.0
     #   edx-ace
     #   edx-drf-extensions
     #   edx-enterprise
-    #   edx-event-routing-backends
     #   edx-proctoring
     #   icalendar
     #   olxcleaner
@@ -834,7 +818,7 @@ python3-saml==1.9.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
-pytz==2021.1
+pytz==2021.3
     # via
     #   -r requirements/edx/base.in
     #   babel
@@ -844,7 +828,6 @@ pytz==2021.1
     #   django-ses
     #   edx-completion
     #   edx-enterprise
-    #   edx-event-routing-backends
     #   edx-proctoring
     #   edx-submissions
     #   edx-tincan-py35
@@ -854,7 +837,6 @@ pytz==2021.1
     #   interchange
     #   olxcleaner
     #   ora2
-    #   tincan
     #   xblock
 pyuca==1.2
     # via -r requirements/edx/base.in
@@ -871,7 +853,7 @@ recommender-xblock==2.0.1
     # via -r requirements/edx/base.in
 redis==3.5.3
     # via -r requirements/edx/base.in
-regex==2021.9.24
+regex==2021.9.30
     # via nltk
 requests==2.26.0
     # via
@@ -883,7 +865,6 @@ requests==2.26.0
     #   edx-bulk-grades
     #   edx-drf-extensions
     #   edx-enterprise
-    #   edx-event-routing-backends
     #   edx-rest-api-client
     #   geoip2
     #   mailsnake
@@ -899,10 +880,6 @@ requests-oauthlib==1.3.0
     # via
     #   -r requirements/edx/base.in
     #   social-auth-core
-rest-condition==1.0.3
-    # via
-    #   -r requirements/edx/base.in
-    #   edx-drf-extensions
 ruamel.yaml==0.17.16
     # via drf-yasg
 ruamel.yaml.clib==0.2.6
@@ -1010,12 +987,10 @@ sympy==1.6.2
     #   symmath
 tableauserverclient==0.16.0
     # via edx-enterprise
-testfixtures==6.18.2
+testfixtures==6.18.3
     # via edx-enterprise
 text-unidecode==1.3
     # via python-slugify
-tincan==1.0.0
-    # via edx-event-routing-backends
 tqdm==4.62.3
     # via nltk
 typing-extensions==3.10.0.2
@@ -1045,7 +1020,7 @@ vine==1.3.0
     #   celery
 voluptuous==0.12.2
     # via ora2
-watchdog==2.1.5
+watchdog==2.1.6
     # via -r requirements/edx/paver.txt
 web-fragments==1.1.0
     # via

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-coverage==5.5
+coverage==6.0
     # via -r requirements/edx/coverage.in
 diff-cover==4.0.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -50,7 +50,6 @@ aniso8601==9.0.1
     # via
     #   -r requirements/edx/testing.txt
     #   edx-tincan-py35
-    #   tincan
 appdirs==1.4.4
     # via
     #   -r requirements/edx/testing.txt
@@ -191,7 +190,7 @@ coreschema==0.0.4
     #   -r requirements/edx/testing.txt
     #   coreapi
     #   drf-yasg
-coverage==5.5
+coverage[toml]==6.0
     # via
     #   -r requirements/edx/testing.txt
     #   pytest-cov
@@ -280,7 +279,6 @@ django==2.2.24
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-enterprise
-    #   edx-event-routing-backends
     #   edx-i18n-tools
     #   edx-milestones
     #   edx-name-affirmation
@@ -300,7 +298,6 @@ django==2.2.24
     #   lti-consumer-xblock
     #   openedx-events
     #   ora2
-    #   rest-condition
     #   super-csv
     #   xss-utils
 django-appconf==1.0.5
@@ -324,7 +321,6 @@ django-config-models==2.2.0
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
-    #   edx-event-routing-backends
     #   edx-name-affirmation
     #   lti-consumer-xblock
 django-cookies-samesite==0.9.0
@@ -350,7 +346,6 @@ django-fernet-fields==0.6
     # via
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
-    #   edx-event-routing-backends
     #   edxval
 django-filter==21.1
     # via
@@ -467,7 +462,6 @@ djangorestframework==3.12.4
     #   edx-proctoring
     #   edx-submissions
     #   ora2
-    #   rest-condition
     #   super-csv
 djangorestframework-xml==2.0.0
     # via
@@ -531,7 +525,7 @@ edx-django-utils==4.4.0
     #   edx-when
     #   ora2
     #   super-csv
-edx-drf-extensions==7.0.1
+edx-drf-extensions==8.0.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-completion
@@ -546,8 +540,6 @@ edx-enterprise==3.28.22
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
-edx-event-routing-backends==4.1.0
-    # via -r requirements/edx/testing.txt
 edx-i18n-tools==0.7.0
     # via
     #   -r requirements/edx/testing.txt
@@ -610,7 +602,6 @@ edx-toggles==4.2.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-completion
-    #   edx-event-routing-backends
     #   edx-name-affirmation
     #   edxval
     #   ora2
@@ -618,7 +609,6 @@ edx-user-state-client==1.3.2
     # via -r requirements/edx/testing.txt
 edx-when==2.2.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   edx-proctoring
 edxval==2.0.3
@@ -639,7 +629,6 @@ enmerkar-underscore==2.1.0
 event-tracking==1.1.1
     # via
     #   -r requirements/edx/testing.txt
-    #   edx-event-routing-backends
     #   edx-proctoring
     #   edx-search
 execnet==1.9.0
@@ -648,7 +637,7 @@ execnet==1.9.0
     #   pytest-xdist
 factory-boy==3.2.0
     # via -r requirements/edx/testing.txt
-faker==8.14.0
+faker==8.16.0
     # via
     #   -r requirements/edx/testing.txt
     #   factory-boy
@@ -656,7 +645,7 @@ fastapi==0.68.1
     # via
     #   -r requirements/edx/testing.txt
     #   pact-python
-filelock==3.1.0
+filelock==3.3.0
     # via
     #   -r requirements/edx/testing.txt
     #   tox
@@ -744,7 +733,6 @@ ipaddress==1.0.23
 isodate==0.6.0
     # via
     #   -r requirements/edx/testing.txt
-    #   edx-event-routing-backends
     #   python3-saml
 isort==5.9.3
     # via
@@ -785,12 +773,11 @@ jsonfield2==3.0.3
     #   -r requirements/edx/testing.txt
     #   edx-celeryutils
     #   edx-enterprise
-    #   edx-event-routing-backends
     #   edx-proctoring
     #   edx-submissions
     #   lti-consumer-xblock
     #   ora2
-jsonschema==3.2.0
+jsonschema==4.0.1
     # via sphinxcontrib-openapi
 jwcrypto==1.0
     # via
@@ -892,7 +879,7 @@ mpmath==1.2.1
     # via
     #   -r requirements/edx/testing.txt
     #   sympy
-multidict==5.1.0
+multidict==5.2.0
     # via
     #   -r requirements/edx/testing.txt
     #   aiohttp
@@ -907,7 +894,7 @@ newrelic==7.0.0.166
     # via
     #   -r requirements/edx/testing.txt
     #   edx-django-utils
-nltk==3.6.3
+nltk==3.6.4
     # via
     #   -r requirements/edx/testing.txt
     #   chem
@@ -942,7 +929,7 @@ packaging==21.0
     #   pytest
     #   sphinx
     #   tox
-pact-python==1.4.3
+pact-python==1.4.4
     # via -r requirements/edx/testing.txt
 pansi==2020.7.3
     # via
@@ -1116,7 +1103,7 @@ pytest==6.2.5
     #   pytest-xdist
 pytest-attrib==0.1.3
     # via -r requirements/edx/testing.txt
-pytest-cov==2.12.1
+pytest-cov==3.0.0
     # via -r requirements/edx/testing.txt
 pytest-django==4.4.0
     # via -r requirements/edx/testing.txt
@@ -1143,7 +1130,6 @@ python-dateutil==2.4.0
     #   edx-ace
     #   edx-drf-extensions
     #   edx-enterprise
-    #   edx-event-routing-backends
     #   edx-proctoring
     #   faker
     #   freezegun
@@ -1173,7 +1159,7 @@ python3-saml==1.9.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
-pytz==2021.1
+pytz==2021.3
     # via
     #   -r requirements/edx/testing.txt
     #   babel
@@ -1183,7 +1169,6 @@ pytz==2021.1
     #   django-ses
     #   edx-completion
     #   edx-enterprise
-    #   edx-event-routing-backends
     #   edx-proctoring
     #   edx-submissions
     #   edx-tincan-py35
@@ -1193,7 +1178,6 @@ pytz==2021.1
     #   interchange
     #   olxcleaner
     #   ora2
-    #   tincan
     #   xblock
 pyuca==1.2
     # via -r requirements/edx/testing.txt
@@ -1213,7 +1197,7 @@ recommender-xblock==2.0.1
     # via -r requirements/edx/testing.txt
 redis==3.5.3
     # via -r requirements/edx/testing.txt
-regex==2021.9.24
+regex==2021.9.30
     # via
     #   -r requirements/edx/testing.txt
     #   nltk
@@ -1227,7 +1211,6 @@ requests==2.26.0
     #   edx-bulk-grades
     #   edx-drf-extensions
     #   edx-enterprise
-    #   edx-event-routing-backends
     #   edx-rest-api-client
     #   geoip2
     #   mailsnake
@@ -1246,10 +1229,6 @@ requests-oauthlib==1.3.0
     # via
     #   -r requirements/edx/testing.txt
     #   social-auth-core
-rest-condition==1.0.3
-    # via
-    #   -r requirements/edx/testing.txt
-    #   edx-drf-extensions
 ruamel.yaml==0.17.16
     # via
     #   -r requirements/edx/testing.txt
@@ -1323,7 +1302,6 @@ six==1.16.0
     #   httpretty
     #   interchange
     #   isodate
-    #   jsonschema
     #   libsass
     #   pact-python
     #   pansi
@@ -1421,7 +1399,7 @@ tableauserverclient==0.16.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
-testfixtures==6.18.2
+testfixtures==6.18.3
     # via
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
@@ -1430,22 +1408,19 @@ text-unidecode==1.3
     #   -r requirements/edx/testing.txt
     #   faker
     #   python-slugify
-tincan==1.0.0
-    # via
-    #   -r requirements/edx/testing.txt
-    #   edx-event-routing-backends
 toml==0.10.2
     # via
     #   -r requirements/edx/testing.txt
     #   mypy
     #   pylint
     #   pytest
-    #   pytest-cov
     #   tox
     #   vulture
 tomli==1.2.1
     # via
     #   -r requirements/edx/pip-tools.txt
+    #   -r requirements/edx/testing.txt
+    #   coverage
     #   pep517
 tox==3.24.4
     # via
@@ -1512,7 +1487,7 @@ voluptuous==0.12.2
     #   ora2
 vulture==2.3
     # via -r requirements/edx/development.in
-watchdog==2.1.5
+watchdog==2.1.6
     # via -r requirements/edx/testing.txt
 web-fragments==1.1.0
     # via
@@ -1583,7 +1558,7 @@ yarl==1.6.3
     # via
     #   -r requirements/edx/testing.txt
     #   aiohttp
-zipp==3.5.1
+zipp==3.6.0
     # via
     #   -r requirements/edx/testing.txt
     #   importlib-metadata

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -48,7 +48,7 @@ python-slugify==4.0.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   code-annotations
-pytz==2021.1
+pytz==2021.3
     # via babel
 pyyaml==5.4.1
     # via code-annotations

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -48,7 +48,7 @@ stevedore==3.4.0
     #   edx-opaque-keys
 urllib3==1.26.7
     # via requests
-watchdog==2.1.5
+watchdog==2.1.6
     # via -r requirements/edx/paver.in
 wrapt==1.11.2
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -48,7 +48,6 @@ aniso8601==9.0.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-tincan-py35
-    #   tincan
 appdirs==1.4.4
     # via
     #   -r requirements/edx/base.txt
@@ -179,7 +178,7 @@ coreschema==0.0.4
     #   -r requirements/edx/base.txt
     #   coreapi
     #   drf-yasg
-coverage==5.5
+coverage[toml]==6.0
     # via
     #   -r requirements/edx/coverage.txt
     #   pytest-cov
@@ -265,7 +264,6 @@ distlib==0.3.3
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-enterprise
-    #   edx-event-routing-backends
     #   edx-i18n-tools
     #   edx-milestones
     #   edx-name-affirmation
@@ -285,7 +283,6 @@ distlib==0.3.3
     #   lti-consumer-xblock
     #   openedx-events
     #   ora2
-    #   rest-condition
     #   super-csv
     #   xss-utils
 django-appconf==1.0.5
@@ -309,7 +306,6 @@ django-config-models==2.2.0
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-    #   edx-event-routing-backends
     #   edx-name-affirmation
     #   lti-consumer-xblock
     # via -r requirements/edx/base.txt
@@ -332,7 +328,6 @@ django-fernet-fields==0.6
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-    #   edx-event-routing-backends
     #   edxval
 django-filter==21.1
     # via
@@ -449,7 +444,6 @@ djangorestframework==3.12.4
     #   edx-proctoring
     #   edx-submissions
     #   ora2
-    #   rest-condition
     #   super-csv
 djangorestframework-xml==2.0.0
     # via
@@ -511,7 +505,7 @@ edx-django-utils==4.4.0
     #   edx-when
     #   ora2
     #   super-csv
-edx-drf-extensions==7.0.1
+edx-drf-extensions==8.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-completion
@@ -526,8 +520,6 @@ edx-enterprise==3.28.22
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
-edx-event-routing-backends==4.1.0
-    # via -r requirements/edx/base.txt
 edx-i18n-tools==0.7.0
     # via
     #   -r requirements/edx/base.txt
@@ -589,7 +581,6 @@ edx-toggles==4.2.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-completion
-    #   edx-event-routing-backends
     #   edx-name-affirmation
     #   edxval
     #   ora2
@@ -597,7 +588,6 @@ edx-user-state-client==1.3.2
     # via -r requirements/edx/base.txt
 edx-when==2.2.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-proctoring
 edxval==2.0.3
@@ -618,18 +608,17 @@ enmerkar-underscore==2.1.0
 event-tracking==1.1.1
     # via
     #   -r requirements/edx/base.txt
-    #   edx-event-routing-backends
     #   edx-proctoring
     #   edx-search
 execnet==1.9.0
     # via pytest-xdist
 factory-boy==3.2.0
     # via -r requirements/edx/testing.in
-faker==8.14.0
+faker==8.16.0
     # via factory-boy
 fastapi==0.68.1
     # via pact-python
-filelock==3.1.0
+filelock==3.3.0
     # via
     #   tox
     #   virtualenv
@@ -704,7 +693,6 @@ ipaddress==1.0.23
 isodate==0.6.0
     # via
     #   -r requirements/edx/base.txt
-    #   edx-event-routing-backends
     #   python3-saml
 isort==5.9.3
     # via
@@ -745,7 +733,6 @@ jsonfield2==3.0.3
     #   -r requirements/edx/base.txt
     #   edx-celeryutils
     #   edx-enterprise
-    #   edx-event-routing-backends
     #   edx-proctoring
     #   edx-submissions
     #   lti-consumer-xblock
@@ -843,7 +830,7 @@ mpmath==1.2.1
     # via
     #   -r requirements/edx/base.txt
     #   sympy
-multidict==5.1.0
+multidict==5.2.0
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
@@ -854,7 +841,7 @@ newrelic==7.0.0.166
     # via
     #   -r requirements/edx/base.txt
     #   edx-django-utils
-nltk==3.6.3
+nltk==3.6.4
     # via
     #   -r requirements/edx/base.txt
     #   chem
@@ -888,7 +875,7 @@ packaging==21.0
     #   py2neo
     #   pytest
     #   tox
-pact-python==1.4.3
+pact-python==1.4.4
     # via -r requirements/edx/testing.in
 pansi==2020.7.3
     # via
@@ -1044,7 +1031,7 @@ pytest==6.2.5
     #   pytest-xdist
 pytest-attrib==0.1.3
     # via -r requirements/edx/testing.in
-pytest-cov==2.12.1
+pytest-cov==3.0.0
     # via -r requirements/edx/testing.in
 pytest-django==4.4.0
     # via -r requirements/edx/testing.in
@@ -1069,7 +1056,6 @@ python-dateutil==2.4.0
     #   edx-ace
     #   edx-drf-extensions
     #   edx-enterprise
-    #   edx-event-routing-backends
     #   edx-proctoring
     #   faker
     #   freezegun
@@ -1099,7 +1085,7 @@ python3-saml==1.9.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
-pytz==2021.1
+pytz==2021.3
     # via
     #   -r requirements/edx/base.txt
     #   babel
@@ -1109,7 +1095,6 @@ pytz==2021.1
     #   django-ses
     #   edx-completion
     #   edx-enterprise
-    #   edx-event-routing-backends
     #   edx-proctoring
     #   edx-submissions
     #   edx-tincan-py35
@@ -1119,7 +1104,6 @@ pytz==2021.1
     #   interchange
     #   olxcleaner
     #   ora2
-    #   tincan
     #   xblock
 pyuca==1.2
     # via -r requirements/edx/base.txt
@@ -1136,7 +1120,7 @@ recommender-xblock==2.0.1
     # via -r requirements/edx/base.txt
 redis==3.5.3
     # via -r requirements/edx/base.txt
-regex==2021.9.24
+regex==2021.9.30
     # via
     #   -r requirements/edx/base.txt
     #   nltk
@@ -1150,7 +1134,6 @@ requests==2.26.0
     #   edx-bulk-grades
     #   edx-drf-extensions
     #   edx-enterprise
-    #   edx-event-routing-backends
     #   edx-rest-api-client
     #   geoip2
     #   mailsnake
@@ -1168,10 +1151,6 @@ requests-oauthlib==1.3.0
     # via
     #   -r requirements/edx/base.txt
     #   social-auth-core
-rest-condition==1.0.3
-    # via
-    #   -r requirements/edx/base.txt
-    #   edx-drf-extensions
 ruamel.yaml==0.17.16
     # via
     #   -r requirements/edx/base.txt
@@ -1313,7 +1292,7 @@ tableauserverclient==0.16.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-testfixtures==6.18.2
+testfixtures==6.18.3
     # via
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/testing.in
@@ -1323,16 +1302,13 @@ text-unidecode==1.3
     #   -r requirements/edx/base.txt
     #   faker
     #   python-slugify
-tincan==1.0.0
-    # via
-    #   -r requirements/edx/base.txt
-    #   edx-event-routing-backends
 toml==0.10.2
     # via
     #   pylint
     #   pytest
-    #   pytest-cov
     #   tox
+tomli==1.2.1
+    # via coverage
 tox==3.24.4
     # via
     #   -r requirements/edx/testing.in
@@ -1391,7 +1367,7 @@ voluptuous==0.12.2
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-watchdog==2.1.5
+watchdog==2.1.6
     # via -r requirements/edx/base.txt
 web-fragments==1.1.0
     # via
@@ -1458,7 +1434,7 @@ yarl==1.6.3
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
-zipp==3.5.1
+zipp==3.6.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
## Description

The rest_condition library hasn't been updated in a while. Meanwhile DRF now supports what it provides directly as of v3.9.

This PR removes usages of rest_condition, however to do that we need to also update https://github.com/edx/edx-drf-extensions/ to support DRF-style combined permission classes. 

## Supporting information

https://github.com/edx/upgrades/issues/2

## Testing instructions

This should not change anything for end-users, and shouldn't break existing tests

## Deadline

This is part of the Django 3.2 upgrade.

## Other information

Depends on: https://github.com/edx/edx-drf-extensions/pull/202
edx-drf-extensions is upgraded to a version of pyjwt that is currently unsupported, so this builds on https://github.com/edx/edx-platform/pull/28475
