### PR TITLE
move send_activation_email celery task ( Step 1/3)

### DIFF
--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -50,6 +50,7 @@ from openedx.core.djangoapps.programs.models import ProgramsApiConfig  # lint-am
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.theming import helpers as theming_helpers
 from openedx.core.djangoapps.user_api.preferences import api as preferences_api
+from openedx.core.djangoapps.user_authn.tasks import send_activation_email
 from openedx.core.djangoapps.user_authn.toggles import should_redirect_to_authn_microfrontend
 from openedx.core.djangolib.markup import HTML, Text
 from openedx.features.enterprise_support.utils import is_enterprise_learner
@@ -71,7 +72,6 @@ from common.djangoapps.student.models import (  # lint-amnesty, pylint: disable=
     email_exists_or_retired
 )
 from common.djangoapps.student.signals import REFUND_ORDER
-from common.djangoapps.student.tasks import send_activation_email
 from common.djangoapps.util.db import outer_atomic
 from common.djangoapps.util.json_request import JsonResponse
 from xmodule.modulestore.django import modulestore


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

#### Context:
The task `send_activation_email` is currently located within `common/djangoapps/student`; hence, alerts for it go will go to a squad within the Open edX theme. The task more properly belongs with the Engagement-Vanguards Squad, which currently owns the user_authn djangoapp and the authn micro-frontend. This issue was highlighted recently when the T&L squad was alerted for a temporary breakage of the `send_activation_email` task.

#### Development notes:
This is one of the 3 PRs that will be needed to complete this task without dropping any Celery task. Changes in this PR include:
- moved `send_activation_email` to `user_authn` djangoapp
- registered task under both new and old name
- exposed the old name for task invocation

## Supporting information

Ticket: https://openedx.atlassian.net/browse/VAN-417

