### PR TITLE
fix: [AA-950] Add unit test to verify segment called correctly

### DIFF
--- a/openedx/core/djangoapps/courseware_api/tests/test_views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/test_views.py
@@ -311,7 +311,7 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
                     mock_segment_track.assert_called_once()
 
     def test_streak_segment_suppressed_for_unverified(self):
-        """ Test that metadata endpoint does not return a discount for unverified and signal is not sent """
+        """ Test that metadata endpoint does not return a discount and signal is not sent if flag is not set """
         CourseEnrollment.enroll(self.user, self.course.id, 'audit')
         with override_waffle_flag(COURSEWARE_MFE_MILESTONES_STREAK_DISCOUNT, active=False):
             with mock.patch('common.djangoapps.student.models.UserCelebration.perform_streak_updates', return_value=3):

--- a/openedx/core/djangoapps/courseware_api/utils.py
+++ b/openedx/core/djangoapps/courseware_api/utils.py
@@ -7,7 +7,6 @@ from babel.numbers import get_currency_symbol
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.models import CourseEnrollmentCelebration, UserCelebration
 from lms.djangoapps.courseware.utils import can_show_verified_upgrade, verified_upgrade_deadline_link
-from lms.djangoapps.courseware.toggles import COURSEWARE_MFE_MILESTONES_STREAK_DISCOUNT
 from openedx.features.course_duration_limits.access import get_user_course_expiration_date
 from openedx.features.discounts.applicability import can_show_streak_discount_coupon
 from common.djangoapps.track import segment
@@ -36,15 +35,14 @@ def get_celebrations_dict(user, enrollment, course, browser_timezone):
     if streak_length_to_celebrate:
         # We only want to offer the streak discount
         # if the course has not ended, is upgradeable and the user is not an enterprise learner
-        discount_enabled = COURSEWARE_MFE_MILESTONES_STREAK_DISCOUNT.is_enabled()
 
-        if can_show_streak_discount_coupon(user, course) and discount_enabled:
+        if can_show_streak_discount_coupon(user, course):
             # Send course streak coupon event
             course_key = str(course.id)
             modes_dict = CourseMode.modes_for_course_dict(course_id=course_key, include_expired=False)
             verified_mode = modes_dict.get('verified', None)
             if verified_mode:
-                celebrations['streak_discount_enabled'] = discount_enabled
+                celebrations['streak_discount_enabled'] = True
                 segment.track(
                     user_id=user.id,
                     event_name='edx.bi.course.streak_discount_enabled',

--- a/openedx/features/discounts/applicability.py
+++ b/openedx/features/discounts/applicability.py
@@ -20,11 +20,13 @@ from edx_toggles.toggles import LegacyWaffleFlag, LegacyWaffleFlagNamespace
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.entitlements.models import CourseEntitlement
 from lms.djangoapps.courseware.utils import is_mode_upsellable
+from lms.djangoapps.courseware.toggles import COURSEWARE_MFE_MILESTONES_STREAK_DISCOUNT
 from lms.djangoapps.experiments.models import ExperimentData
 from lms.djangoapps.experiments.stable_bucketing import stable_bucketing_hash_group
 from openedx.features.discounts.models import DiscountPercentageConfig, DiscountRestrictionConfig
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.track import segment
+
 
 # .. toggle_name: discounts.enable_discounting
 # .. toggle_implementation: WaffleFlag
@@ -88,6 +90,11 @@ def can_show_streak_discount_coupon(user, course):
     Check whether this combination of user and course
     can receive the streak discount.
     """
+
+    # Feature needs to be enabled
+    if not COURSEWARE_MFE_MILESTONES_STREAK_DISCOUNT.is_enabled():
+        return False
+
     # Course end date needs to be in the future
     if course.has_ended():
         return False


### PR DESCRIPTION
Add positive and negative test
Moved flag update to same block as segment
Moved WaffleFlag check to can_show_streak_discount_coupon for consistency
