### PR TITLE
[MST-1025] Use pending name change in IDV post_save signal

### DIFF
--- a/common/djangoapps/student/models_api.py
+++ b/common/djangoapps/student/models_api.py
@@ -109,6 +109,17 @@ def get_course_access_role(user, org, course_id, role):
     return course_access_role
 
 
+def get_pending_name_change(user):
+    """
+    Return a string representing the user's pending name change, or None if it does not exist.
+    """
+    try:
+        pending_name_change = _PendingNameChange.objects.get(user=user)
+        return pending_name_change.new_name
+    except _PendingNameChange.DoesNotExist:
+        return None
+
+
 def do_name_change_request(user, new_name, rationale):
     """
     Create a name change request. This either updates the user's current PendingNameChange, or creates

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -455,7 +455,7 @@ edx-i18n-tools==0.7.0
     # via ora2
 edx-milestones==0.3.2
     # via -r requirements/edx/base.in
-edx-name-affirmation==0.9.1
+edx-name-affirmation==0.9.2
     # via -r requirements/edx/base.in
 edx-opaque-keys[django]==2.2.2
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -559,7 +559,7 @@ edx-lint==5.1.0
     # via -r requirements/edx/testing.txt
 edx-milestones==0.3.2
     # via -r requirements/edx/testing.txt
-edx-name-affirmation==0.9.1
+edx-name-affirmation==0.9.2
     # via -r requirements/edx/testing.txt
 edx-opaque-keys[django]==2.2.2
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -541,7 +541,7 @@ edx-lint==5.1.0
     # via -r requirements/edx/testing.in
 edx-milestones==0.3.2
     # via -r requirements/edx/base.txt
-edx-name-affirmation==0.9.1
+edx-name-affirmation==0.9.2
     # via -r requirements/edx/base.txt
 edx-opaque-keys[django]==2.2.2
     # via


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Update the `post_save` signal for IDV to emit the user's pending name over their current profile name, if they have one.

## Supporting information

[MST-1025](https://openedx.atlassian.net/browse/MST-1025)