### PR TITLE
feat: Add feature to display a global maintenance banner

### DIFF
--- a/openedx/core/djangoapps/util/tests/test_user_messages.py
+++ b/openedx/core/djangoapps/util/tests/test_user_messages.py
@@ -3,6 +3,8 @@ Unit tests for user messages.
 """
 
 
+import warnings
+
 import ddt
 from django.contrib.messages.middleware import MessageMiddleware
 from django.test import RequestFactory, TestCase
@@ -76,3 +78,59 @@ class UserMessagesTestCase(TestCase):
         messages = list(PageLevelMessages.user_messages(self.request))
         assert len(messages) == 1
         assert messages[0].type == expected_message_type
+
+    def global_message_count(self):
+        """
+        Count the number of times the global message appears in the user messages.
+        """
+        expected_html = """<div class="message-content">I &lt;3 HTML-escaping</div>"""
+        messages = list(PageLevelMessages.user_messages(self.request))
+        return len(list(msg for msg in messages if expected_html in msg.message_html))
+
+    def test_global_message_off_by_default(self):
+        """Verifies feature toggle."""
+        with self.settings(
+            GLOBAL_NOTICE_ENABLED=False,
+            GLOBAL_NOTICE_MESSAGE="I <3 HTML-escaping",
+            GLOBAL_NOTICE_TYPE='WARNING'
+        ):
+            # Missing when feature disabled
+            assert self.global_message_count() == 0
+
+    def test_global_message_persistent(self):
+        """Verifies global message is always included, when enabled."""
+        with self.settings(
+            GLOBAL_NOTICE_ENABLED=True,
+            GLOBAL_NOTICE_MESSAGE="I <3 HTML-escaping",
+            GLOBAL_NOTICE_TYPE='WARNING'
+        ):
+            # Present with no other setup
+            assert self.global_message_count() == 1
+
+            # Present when other messages are present
+            PageLevelMessages.register_user_message(self.request, UserMessageType.INFO, "something else")
+            assert self.global_message_count() == 1
+
+    def test_global_message_error_isolation(self):
+        """Verifies that any setting errors don't break the page, or other messages."""
+        with self.settings(
+            GLOBAL_NOTICE_ENABLED=True,
+            GLOBAL_NOTICE_MESSAGE=ThrowingMarkup(),  # force an error
+            GLOBAL_NOTICE_TYPE='invalid'
+        ):
+            PageLevelMessages.register_user_message(self.request, UserMessageType.WARNING, "something else")
+            # Doesn't throw, or even interfere with other messages,
+            # when given invalid settings
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter('always')
+                messages = list(PageLevelMessages.user_messages(self.request))
+                assert len(w) == 1
+                assert str(w[0].message) == "Could not register global notice: Exception('Some random error')"
+            assert len(messages) == 1
+            assert "something else" in messages[0].message_html
+
+
+class ThrowingMarkup:
+    """Class that raises an exception if markupsafe tries to get HTML from it."""
+    def __html__(self):
+        raise Exception("Some random error")

--- a/openedx/core/djangoapps/util/user_messages.py
+++ b/openedx/core/djangoapps/util/user_messages.py
@@ -17,10 +17,13 @@ There are two common use cases:
 
 from abc import abstractmethod
 from enum import Enum
+import warnings
 
+from django.conf import settings
 from django.contrib import messages
 from django.utils.translation import ugettext as _
 
+from edx_toggles.toggles import SettingToggle
 from openedx.core.djangolib.markup import HTML, Text
 
 
@@ -181,11 +184,45 @@ class UserMessageCollection():
         return (_create_user_message(message) for message in django_messages if self.get_namespace() in message.tags)
 
 
+# .. toggle_name: GLOBAL_NOTICE_ENABLED
+# .. toggle_implementation: SettingToggle
+# .. toggle_default: False
+# .. toggle_description: When enabled, show the contents of GLOBAL_NOTICE_MESSAGE as a message on every page. This is intended to be used as a way of communicating an upcoming or currently active maintenance window or to warn of known site issues. HTML is not supported for the message content. Message styling can be controlled with GLOBAL_NOTICE_TYPE, set to one of INFO, SUCCESS, WARNING, or ERROR (defaulting to INFO). Also see openedx.core.djangoapps.util.maintenance_banner.add_maintenance_banner for a variation that only shows a message on specific views.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2021-09-07
+GLOBAL_NOTICE_ENABLED = SettingToggle('GLOBAL_NOTICE_ENABLED', default=False)
+
+
 class PageLevelMessages(UserMessageCollection):
     """
     This set of messages appears as top page level messages.
     """
     NAMESPACE = 'page_level_messages'
+
+    @classmethod
+    def user_messages(cls, request):
+        """
+        Returns outstanding user messages, along with any persistent site-wide messages.
+        """
+        # If there is a global notice, add it to the messages just
+        # prior to retrieval. (Kind of a hack, but this ensures both
+        # code reuse and only-once-per-page display.)
+        try:
+            if GLOBAL_NOTICE_ENABLED.is_enabled():
+                # FIXME: user_messages calls the messages "body_html"
+                # internally but the messages appear to be
+                # HTML-encoded or tag-stripped in practice. Until that
+                # ambiguity is resolved, best bet is to use plaintext
+                # that would be safe either as text or HTML.
+                if notice_message := getattr(settings, 'GLOBAL_NOTICE_MESSAGE', None):
+                    notice_type_str = getattr(settings, 'GLOBAL_NOTICE_TYPE', None)
+                    notice_type = getattr(UserMessageType, notice_type_str, UserMessageType.INFO)
+
+                cls.register_user_message(request, notice_type, notice_message)
+        except BaseException as e:
+            warnings.warn(f"Could not register global notice: {e!r}", UserWarning)
+
+        return super().user_messages(request)
 
     @classmethod
     def get_message_html(cls, body_html, title=None, dismissable=False, **kwargs):


### PR DESCRIPTION
This is intended for use in the Studio OAuth transition (ARCHBOM-1887) but may be useful in the future as well.

![image](https://user-images.githubusercontent.com/59623490/132401815-dabeef94-1652-4463-bfb5-2f7d35f548af.png)

Example usage:
```
GLOBAL_NOTICE_ENABLED = True
GLOBAL_NOTICE_MESSAGE = """Studio users may experience some interruptions on September 8, 2021, between 9 AM and 10 AM Eastern Daylight Time (UTC-4)."""
GLOBAL_NOTICE_TYPE = 'WARNING'
```

## Deadline

End of day 2021-09-07 since we want this for 9/8 (but not critical).