### PR TITLE
move send_activation_email celery task (step 2/3)

### DIFF
--- a/openedx/core/djangoapps/user_authn/tasks.py
+++ b/openedx/core/djangoapps/user_authn/tasks.py
@@ -73,8 +73,8 @@ _NEW_TASK_NAME = 'openedx.core.djangoapps.user_authn.tasks.send_activation_email
 
 
 # Register task under both its old and new names,
-# but expose only the old-named task for invocation.
-# -> Next step: Once we deploy and teach Celery workers the new name,
-#    set `send_activation_email` to the new-named task.
-send_activation_email = shared_task(bind=True, name=_OLD_TASK_NAME)(_send_activation_email)
-shared_task(bind=True, name=_NEW_TASK_NAME)(_send_activation_email)
+# but expose only the new-named task for invocation.
+# -> Next step: Once we deploy and stop using the old task name,
+#    stop registering the task under the old name.
+shared_task(bind=True, name=_OLD_TASK_NAME)(_send_activation_email)
+send_activation_email = shared_task(bind=True, name=_NEW_TASK_NAME)(_send_activation_email)


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

#### Context:
The task `send_activation_email` is currently located within `common/djangoapps/student`; hence, alerts for it go will go to a squad within the Open edX theme. The task more properly belongs with the Engagement-Vanguards Squad, which currently owns the user_authn djangoapp and the authn micro-frontend. This issue was highlighted recently when the T&L squad was alerted for a temporary breakage of the `send_activation_email` task.

#### Development notes:
- This is the second PR needed to complete this task without dropping any Celery task. 
- Switched to using the task of the new name

## Supporting information

Step 1: https://github.com/edx/edx-platform/pull/28666
Step 2: this ticket

Jira ticket: https://openedx.atlassian.net/browse/VAN-417

## Testing instructions

Tested it locally by:
- Moved to the new named task
- Created a new account and checked the activation email log
- Verified that the logs contain the new name `openedx.core.djangoapps.user_authn.tasks.send_activation_email`

## Deadline

None