### PR TITLE
Revert "Use new version of edx-when."

### DIFF
--- a/lms/djangoapps/course_api/api.py
+++ b/lms/djangoapps/course_api/api.py
@@ -22,8 +22,6 @@ from lms.djangoapps.courseware.courses import (
     get_permission_for_course_about
 )
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
-from openedx.core.djangoapps.content.learning_sequences.api import get_course_outline
-from openedx.core.djangoapps.content.learning_sequences.data import CourseOutlineData
 from openedx.core.lib.api.view_utils import LazySequence
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
@@ -237,18 +235,9 @@ def get_due_dates(request, course_key, user):
                 url: the deep link to the block
                 date: the due date for the block
     """
-    try:
-        outline = get_course_outline(course_key)
-    except (ValueError, CourseOutlineData.DoesNotExist):
-        # Either this course is Old Mongo-backed or doesn't have a generated course outline.
-        course_version = None
-    else:
-        course_version = outline.published_version
-
     dates = get_dates_for_course(
         course_key,
         user,
-        published_version=course_version
     )
 
     store = modulestore()

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -1559,8 +1559,8 @@ class ProgressPageTests(ProgressPageBaseTests):
 
     @patch.dict(settings.FEATURES, {'ASSUME_ZERO_GRADE_IF_ABSENT_FOR_ALL_TESTS': False})
     @ddt.data(
-        (False, 63, 44),
-        (True, 55, 38)
+        (False, 63, 46),
+        (True, 55, 40)
     )
     @ddt.unpack
     def test_progress_queries(self, enable_waffle, initial, subsequent):

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -2740,9 +2740,7 @@ def reset_due_date(request, course_id):
     unit = find_unit(course, request.POST.get('url'))
     reason = strip_tags(request.POST.get('reason', ''))
 
-    version = getattr(course, 'course_version', None)
-
-    original_due_date = get_date_for_block(course_id, unit.location, published_version=version)
+    original_due_date = get_date_for_block(course_id, unit.location)
 
     set_due_date_extension(course, unit, student, None, request.user, reason=reason)
     if not original_due_date:

--- a/lms/djangoapps/instructor/views/tools.py
+++ b/lms/djangoapps/instructor/views/tools.py
@@ -125,13 +125,11 @@ def get_units_with_due_date(course):
     """
     units = []
 
-    version = getattr(course, 'course_version', None)
-
     # Pass in a schedule here so that we get back any relative dates in the course, but actual value
     # doesn't matter, since we don't care about the dates themselves, just whether they exist.
     # Thus we don't save or care about this temporary schedule object.
     schedule = Schedule(start_date=course.start)
-    course_dates = api.get_dates_for_course(course.id, schedule=schedule, published_version=version)
+    course_dates = api.get_dates_for_course(course.id, schedule=schedule)
 
     def visit(node):
         """
@@ -175,8 +173,7 @@ def set_due_date_extension(course, unit, student, due_date, actor=None, reason='
     # We normally set dates at the subsection level. But technically dates can be anywhere down the tree (and
     # usually are in self paced courses, where the subsection date gets propagated down).
     # So find all children that we need to set the date on, then set those dates.
-    version = getattr(course, 'course_version', None)
-    course_dates = api.get_dates_for_course(course.id, user=student, published_version=version)
+    course_dates = api.get_dates_for_course(course.id, user=student)
     blocks_to_set = {unit}  # always include the requested unit, even if it doesn't appear to have a due date now
 
     def visit(node):
@@ -194,9 +191,8 @@ def set_due_date_extension(course, unit, student, due_date, actor=None, reason='
     for block in blocks_to_set:
         if due_date:
             try:
-                api.set_date_for_block(
-                    course.id, block.location, 'due', due_date, user=student, reason=reason, actor=actor
-                )
+                api.set_date_for_block(course.id, block.location, 'due', due_date, user=student, reason=reason,
+                                       actor=actor)
             except api.MissingDateError as ex:
                 raise DashboardError(_("Unit {0} has no due date to extend.").format(unit.location)) from ex
             except api.InvalidDateError as ex:

--- a/openedx/core/djangoapps/content/learning_sequences/api/outlines.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/outlines.py
@@ -356,7 +356,7 @@ def _get_user_course_outline_and_processors(course_key: CourseKey,  # lint-amnes
         # particular ordering).
         processor = processor_cls(course_key, user, at_time)
         processors[name] = processor
-        processor.load_data(full_course_outline)
+        processor.load_data()
         if not user_can_see_all_content:
             # function_trace lets us see how expensive each processor is being.
             with function_trace(f'learning_sequences.api.outline_processors.{name}'):

--- a/openedx/core/djangoapps/content/learning_sequences/api/processors/base.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/processors/base.py
@@ -8,8 +8,6 @@ from datetime import datetime
 from opaque_keys.edx.keys import CourseKey  # lint-amnesty, pylint: disable=unused-import
 from openedx.core import types
 
-from ...data import CourseOutlineData
-
 log = logging.getLogger(__name__)
 
 
@@ -46,7 +44,7 @@ class OutlineProcessor:
         self.user = user
         self.at_time = at_time
 
-    def load_data(self, full_course_outline: CourseOutlineData):  # pylint: disable=unused-argument
+    def load_data(self):
         """
         Fetch whatever data you need about the course and user here.
 
@@ -61,7 +59,7 @@ class OutlineProcessor:
         """
         pass  # lint-amnesty, pylint: disable=unnecessary-pass
 
-    def inaccessible_sequences(self, full_course_outline: CourseOutlineData):  # pylint: disable=unused-argument
+    def inaccessible_sequences(self, full_course_outline):  # lint-amnesty, pylint: disable=unused-argument
         """
         Return a set/frozenset of Sequence UsageKeys that are not accessible.
 
@@ -70,7 +68,7 @@ class OutlineProcessor:
         """
         return frozenset()
 
-    def usage_keys_to_remove(self, full_course_outline: CourseOutlineData):  # pylint: disable=unused-argument
+    def usage_keys_to_remove(self, full_course_outline):  # lint-amnesty, pylint: disable=unused-argument
         """
         Return a set/frozenset of UsageKeys to remove altogether.
 

--- a/openedx/core/djangoapps/content/learning_sequences/api/processors/content_gating.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/processors/content_gating.py
@@ -27,7 +27,7 @@ class ContentGatingOutlineProcessor(OutlineProcessor):
         self.required_content = None
         self.can_skip_entrance_exam = False
 
-    def load_data(self, full_course_outline):
+    def load_data(self):
         """
         Get the required content for the course, and whether
         or not the user can skip the entrance exam.

--- a/openedx/core/djangoapps/content/learning_sequences/api/processors/enrollment_track_partition_groups.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/processors/enrollment_track_partition_groups.py
@@ -1,9 +1,5 @@
 # lint-amnesty, pylint: disable=missing-module-docstring
 import logging
-from datetime import datetime
-
-from opaque_keys.edx.keys import CourseKey
-from openedx.core import types
 
 from xmodule.partitions.enrollment_track_partition_generator import (
     create_enrollment_track_partition_with_course_id
@@ -26,12 +22,12 @@ class EnrollmentTrackPartitionGroupsOutlineProcessor(OutlineProcessor):
     significant limitation. Nonetheless, it is a step towards the goal of
     supporting all partition schemes in the future.
     """
-    def __init__(self, course_key: CourseKey, user: types.User, at_time: datetime):
+    def __init__(self, course_key, user, at_time):
         super().__init__(course_key, user, at_time)
         self.enrollment_track_groups = {}
         self.user_group = None
 
-    def load_data(self, full_course_outline):
+    def load_data(self):
         """
         Pull track groups for this course and which group the user is in.
         """

--- a/openedx/core/djangoapps/content/learning_sequences/api/processors/schedule.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/processors/schedule.py
@@ -42,16 +42,11 @@ class ScheduleOutlineProcessor(OutlineProcessor):
         self._course_end = None
         self._is_beta_tester = False
 
-    def load_data(self, full_course_outline):
-        """
-        Pull dates information from edx-when.
-
-        Return data format: (usage_key, 'due'): datetime.datetime(2019, 12, 11, 15, 0, tzinfo=<UTC>)
-        """
-        self.dates = get_dates_for_course(
-            self.course_key, self.user, subsection_and_higher_only=True,
-            published_version=full_course_outline.published_version
-        )
+    def load_data(self):
+        """Pull dates information from edx-when."""
+        # (usage_key, 'due'): datetime.datetime(2019, 12, 11, 15, 0, tzinfo=<UTC>)
+        # TODO: Merge https://github.com/edx/edx-when/pull/48 and add `outline_only=True`
+        self.dates = get_dates_for_course(self.course_key, self.user)
 
         for (usage_key, field_name), date in self.dates.items():
             self.keys_to_schedule_fields[usage_key][field_name] = date

--- a/openedx/core/djangoapps/content/learning_sequences/api/processors/special_exams.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/processors/special_exams.py
@@ -28,7 +28,7 @@ class SpecialExamsOutlineProcessor(OutlineProcessor):
     """
     Responsible for applying all outline processing related to special exams.
     """
-    def load_data(self, full_course_outline):
+    def load_data(self):
         """
         Check if special exams are enabled
         """

--- a/openedx/core/djangoapps/content/learning_sequences/api/tests/test_outlines.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/tests/test_outlines.py
@@ -1737,10 +1737,8 @@ class EnrollmentTrackPartitionGroupsTestCase(OutlineProcessorTestCase):  # lint-
 
         check_date = datetime(2021, 3, 27, tzinfo=timezone.utc)
         for learner_to_verify in learners_to_verify:
-            processor = EnrollmentTrackPartitionGroupsOutlineProcessor(
-                self.course_key, learner_to_verify, check_date
-            )
-            processor.load_data(full_outline)
+            processor = EnrollmentTrackPartitionGroupsOutlineProcessor(self.course_key, learner_to_verify, check_date)
+            processor.load_data()
             removed_usage_keys = processor.usage_keys_to_remove(full_outline)
             assert len(removed_usage_keys) == expected_values_dict[learner_to_verify.username]
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -509,7 +509,7 @@ edx-toggles==4.2.0
     #   ora2
 edx-user-state-client==1.3.2
     # via -r requirements/edx/base.in
-edx-when==2.2.0
+edx-when==2.1.0
     # via
     #   -r requirements/edx/base.in
     #   edx-proctoring

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -619,7 +619,7 @@ edx-toggles==4.2.0
     #   ora2
 edx-user-state-client==1.3.2
     # via -r requirements/edx/testing.txt
-edx-when==2.2.0
+edx-when==2.1.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-proctoring

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -599,7 +599,7 @@ edx-toggles==4.2.0
     #   ora2
 edx-user-state-client==1.3.2
     # via -r requirements/edx/base.txt
-edx-when==2.2.0
+edx-when==2.1.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring


### PR DESCRIPTION
Reverts edx/edx-platform#28551 because of errors seen with proctoring.
The error from splunk:
```
Sep  8 13:57:27 ip-10-2-10-179 [service_variant=lms][django.request][env:prod-edx-edxapp] ERROR [ip-10-2-10-179  6705] [user 23059362] [ip 103.43.155.249] [log.py:222] - Internal Server Error: /api/edx_proctoring/v1/user_onboarding/status
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/base.py", line 115, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/base.py", line 113, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/lib/python3.8/contextlib.py", line 75, in inner
    return func(*args, **kwds)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/newrelic/hooks/framework_django.py", line 562, in wrapper
    return wrapped(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/views/generic/base.py", line 71, in view
    return self.dispatch(request, *args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/newrelic/hooks/component_djangorestframework.py", line 60, in _nr_wrapper_APIView_dispatch_
    return wrapped(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/rest_framework/views.py", line 509, in dispatch
    response = self.handle_exception(exc)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/newrelic/hooks/component_djangorestframework.py", line 67, in _handle_exception_wrapper
    return wrapped(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/edx_proctoring/views.py", line 189, in handle_exception
    resp = super().handle_exception(exc)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/rest_framework/views.py", line 469, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
    raise exc
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/edx_proctoring/views.py", line 590, in get
    data['onboarding_release_date'] = effective_start.isoformat()
AttributeError: 'NoneType' object has no attribute 'isoformat'
```