### PR TITLE
pin edx-when to 2.1.0 for testing

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -1,4 +1,4 @@
-# Version constraints for pip-installation.
+https://imgur.com/gallery/rjiMxVD# Version constraints for pip-installation.
 #
 # This file doesn't install any packages. It specifies version constraints
 # that will be applied if a package is needed.
@@ -109,3 +109,7 @@ pylint<2.10.0
 # Feel free to loosen this constraint if/when it is confirmed that a later
 # version of py2neo will work with Neo4j 3.5.
 py2neo<2022
+
+# as of right now (Sep 8 2021), we need to not use the latest edx-when
+# version which might be causing issues with course publishing
+edx-when==2.1.0


### PR DESCRIPTION
We had to revert edx-when from 2.2.0 to 2.1.0 here: https://github.com/edx/edx-platform/pull/28684

This was caused by an issue where the start dates for chapters/sections were being returned as `None` (or possibly not being returned at all?), causing the Learning Sequences API to not properly calculate the dates for sequences, which in turn caused errors in proctoring. Reverting the version bump of edx-when fixed the issue momentarily. This pinning is here until we can fix the root bug.