### PR TITLE
fix: update hover state for textbooks breadcrumbs

### DIFF
--- a/cms/static/sass/elements/_navigation.scss
+++ b/cms/static/sass/elements/_navigation.scss
@@ -218,6 +218,15 @@ nav {
       }
     }
 
+    .hyperlink {
+      color: $gray-d2;
+
+      &:hover,
+      &:active {
+        color: theme-color("primary");
+      }
+    }
+
     .spacer {
       margin-right: 20px;
       margin-left: 20px;

--- a/cms/templates/textbooks.html
+++ b/cms/templates/textbooks.html
@@ -54,7 +54,7 @@ CMS.URL.LMS_BASE = "${settings.LMS_BASE | n, js_escaped_string}"
                   <span class="spacer"> &rsaquo;</span>
               </li>
               <li class="nav-item">
-                <a class="title" href="${pages_and_resources_mfe_url}" rel="external">${_("Pages & Resources")}</a>
+                <a class="hyperlink" href="${pages_and_resources_mfe_url}" rel="external">${_("Pages & Resources")}</a>
                 <span class="spacer"> &rsaquo;</span>
               </li>
           </ol>


### PR DESCRIPTION
[TNL-8606](https://openedx.atlassian.net/browse/TNL-8606)
- Update textbooks breadcrumbs color and hover state color

Normal text color: 
<img width="317" alt="Screenshot 2021-09-09 at 1 26 31 AM" src="https://user-images.githubusercontent.com/79941147/132580689-80e2eaac-957e-4ad0-b678-a939c5da9f69.png">

Hover text color:
<img width="337" alt="Screenshot 2021-09-09 at 1 26 41 AM" src="https://user-images.githubusercontent.com/79941147/132580730-b79f72d5-8628-48c8-b2ed-29758fd5ea00.png">
 