### PR TITLE
feat: notify_credentials of changed overrides

### DIFF
--- a/openedx/core/djangoapps/credentials/tasks/v1/tasks.py
+++ b/openedx/core/djangoapps/credentials/tasks/v1/tasks.py
@@ -95,6 +95,8 @@ def handle_notify_credentials(options, course_keys):
         logger.exception('No site configuration found for site %s', options['site'])
         return
 
+    # If a start_date or end_date are passed, this will include certificates
+    # with a CertificateDateOverride modified within the time range
     certs = get_recently_modified_certificates(
         course_keys, options['start_date'], options['end_date'], options['user_ids']
     )


### PR DESCRIPTION
We use the `notify_credentials` management command to keep certificate-
related data in the LMS and Credentials service in sync. We can run it
with specific arguments (user_ids, course_keys, etc.) when we notice a
data discrepancy; and it is run regularly by a Jenkins job with the
`--auto` flag every ~4 hours to keep things up-to-date.

Because we probably never want to notify credentials of of ALL the
GeneratedCertificates, the celery task must be given some arguments
to filter down to the relevant certificates. Running the management
command with the `--auto` flag (as the Jenkins job does) adds
`start_date` and `end_date` arguments of 4 hours ago and now,
respectively.

The handle_notify_credentials celery task then takes those arguments and
looks for any GeneratedCertificates that have been modified within the
given time range by checking the GeneratedCertificate modified_date.
It will send the current data for those certificates to credentials.

However, we also want to notify credentials about certificates that have
an associated CertificateDateOverride that has changed within that time
range: added, updated, or deleted. But changes to a
CertificateDateOverride won’t affect the GeneratedCertificate’s modified
date, and therefore wouldn’t be included in the list of certs cent to
credentials.

This commit adds a check for changed CertificateDateOverrides and
includes their associated GeneratedCertificates in the list of certs. We
use the CertificateDateOverride’s history model for this check so that
we can include certificates whose override was deleted.

## Supporting information

[MICROBA-1489](https://openedx.atlassian.net/browse/MICROBA-1489)

## Deadline

None
