### PR TITLE
feat: check if profile name changes are valid for name affirmation.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -455,7 +455,7 @@ edx-i18n-tools==0.7.0
     # via ora2
 edx-milestones==0.3.2
     # via -r requirements/edx/base.in
-edx-name-affirmation==0.9.2
+edx-name-affirmation==0.11.0
     # via -r requirements/edx/base.in
 edx-opaque-keys[django]==2.2.2
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -559,7 +559,7 @@ edx-lint==5.1.0
     # via -r requirements/edx/testing.txt
 edx-milestones==0.3.2
     # via -r requirements/edx/testing.txt
-edx-name-affirmation==0.9.2
+edx-name-affirmation==0.11.0
     # via -r requirements/edx/testing.txt
 edx-opaque-keys[django]==2.2.2
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -541,7 +541,7 @@ edx-lint==5.1.0
     # via -r requirements/edx/testing.in
 edx-milestones==0.3.2
     # via -r requirements/edx/base.txt
-edx-name-affirmation==0.9.2
+edx-name-affirmation==0.11.0
     # via -r requirements/edx/base.txt
 edx-opaque-keys[django]==2.2.2
     # via


### PR DESCRIPTION
## [MST-970](https://openedx.atlassian.net/browse/MST-970)

If name affirmation is enabled, a user should only be allowed to make limited edits to their profile name before they are required to go through IDV. Right now, the allowable edits are limited to:

* add/delete/replace one character (including one space on either side)

Edits that are not allowed, and therefore require IDV include:

* changing 2 or more characters
* changing their name 3 or more times

The logic for determining if edits are valid is contained here: https://github.com/edx/edx-name-affirmation/pull/53

This behavior will not be enabled until name affirmation is fully rolled out, so there should be no noticeable difference in account settings behavior at the time this is merged.