### PR TITLE
feat: notify MFE when a sequence is hidden-after-due

### DIFF
--- a/common/lib/xmodule/xmodule/tests/test_sequence.py
+++ b/common/lib/xmodule/xmodule/tests/test_sequence.py
@@ -110,6 +110,11 @@ class SequenceBlockTestCase(XModuleXmlImportTest):
         module_system.descriptor_runtime = block._runtime  # pylint: disable=protected-access
         block.xmodule_runtime = module_system
 
+        # The render operation will ask modulestore for the current course to get some data. As these tests were
+        # originally not written to be compatible with a real modulestore, we've mocked out the relevant return values.
+        module_system.modulestore = Mock()
+        module_system.modulestore.get_course.return_value = self.course
+
     def _get_rendered_view(self,
                            sequence,
                            requested_child=None,
@@ -124,12 +129,8 @@ class SequenceBlockTestCase(XModuleXmlImportTest):
         if extra_context:
             context.update(extra_context)
 
-        # The render operation will ask modulestore for the current course to get some data. As these tests were
-        # originally not written to be compatible with a real modulestore, we've mocked out the relevant return values.
-        with patch.object(SequenceBlock, '_get_course') as mock_course:
-            self.course.self_paced = self_paced
-            mock_course.return_value = self.course
-            return sequence.xmodule_runtime.render(sequence, view, context).content
+        self.course.self_paced = self_paced
+        return sequence.xmodule_runtime.render(sequence, view, context).content
 
     def _assert_view_at_position(self, rendered_html, expected_position):
         """

--- a/openedx/core/djangoapps/courseware_api/tests/test_views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/test_views.py
@@ -373,7 +373,8 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
                 assert courseware_data['is_mfe_proctored_exams_enabled'] == (is_globally_enabled and is_waffle_enabled)
 
 
-class SequenceApiTestViews(BaseCoursewareTests):
+@ddt.ddt
+class SequenceApiTestViews(MasqueradeMixin, BaseCoursewareTests):
     """
     Tests for the sequence REST API
     """
@@ -392,6 +393,32 @@ class SequenceApiTestViews(BaseCoursewareTests):
         assert response.status_code == 200
         assert response.data['display_name'] == 'sequence'
         assert len(response.data['items']) == 1
+
+    @ddt.data(
+        (False, None, False, False),
+        (True, None, True, False),
+        (True, {'username': 'student'}, False, True),
+        # Masquerading as a limited-access learner here, but specific partition/group doesn't matter.
+        # We just want to test that masquerading as a non-specific learner has a different outcome.
+        (True, {'user_partition_id': 51, 'group_id': 1}, True, False),
+    )
+    @ddt.unpack
+    def test_hidden_after_due(self, is_past_due, masquerade_config, expected_hidden, expected_banner):
+        """Validate the metadata when hide-after-due is set for a sequence"""
+        due = datetime.now() + timedelta(days=-1 if is_past_due else 1)
+        sequence = ItemFactory(parent=self.chapter, category='sequential', hide_after_due=True, due=due)
+
+        CourseEnrollment.enroll(self.user, self.course.id)
+
+        user = self.instructor if masquerade_config else self.user
+        self.client.login(username=user.username, password='foo')
+        if masquerade_config:
+            self.update_masquerade(**masquerade_config)
+
+        response = self.client.get(f'/api/courseware/sequence/{sequence.location}')
+        assert response.status_code == 200
+        assert response.data['is_hidden_after_due'] == expected_hidden
+        assert bool(response.data['banner_text']) == expected_banner
 
 
 class ResumeApiTestViews(BaseCoursewareTests, CompletionWaffleTestMixin):

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -29,7 +29,7 @@ from lms.djangoapps.courseware.access_response import (
 )
 from lms.djangoapps.courseware.context_processor import user_timezone_locale_prefs
 from lms.djangoapps.courseware.courses import check_course_access
-from lms.djangoapps.courseware.masquerade import setup_masquerade
+from lms.djangoapps.courseware.masquerade import is_masquerading_as_specific_student, setup_masquerade
 from lms.djangoapps.courseware.module_render import get_module_by_usage_id
 from lms.djangoapps.courseware.tabs import get_course_tab_list
 from lms.djangoapps.courseware.toggles import (
@@ -545,7 +545,8 @@ class SequenceMetadata(DeveloperErrorViewMixin, APIView):
         if request.user.is_anonymous:
             view = PUBLIC_VIEW
 
-        return Response(sequence.get_metadata(view=view))
+        context = {'specific_masquerade': is_masquerading_as_specific_student(request.user, usage_key.course_key)}
+        return Response(sequence.get_metadata(view=view, context=context))
 
 
 class Resume(DeveloperErrorViewMixin, APIView):


### PR DESCRIPTION
Currently, if a learner manually loads a sequence page that would normally be skipped for them because it is hidden-after-due, the sequence renders anyway.

This commit tells the frontend when it should not show a sequence because it's hidden.

MFE side: https://github.com/edx/frontend-app-learning/pull/636

https://openedx.atlassian.net/browse/AA-1000