### PR TITLE
fix: skip automatic reviews for noisy community-engineering paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -40,15 +40,17 @@ openedx/features/course_duration_limits/   @edx/rev-team
 openedx/features/discounts/                @edx/rev-team
 
 # Community Engineering Squad
+# Commented-out sections are officially owned by community-engineering,
+# but reviews aren't expected unless explicitly tagged by users.
 common/djangoapps/edxmako                  @edx/community-engineering
 common/djangoapps/pipeline_mako            @edx/community-engineering
-common/static                              @edx/community-engineering
+# common/static                              @edx/community-engineering
 common/templates                           @edx/community-engineering
 lms/djangoapps/ccx                         @edx/community-engineering
 lms/djangoapps/dashboard                   @edx/community-engineering
 lms/djangoapps/lti_provider                @edx/community-engineering
 lms/djangoapps/static_template_view        @edx/community-engineering
-lms/static                                 @edx/community-engineering
+# lms/static                                 @edx/community-engineering
 lms/templates                              @edx/community-engineering
 openedx/core/djangoapps/ccxcon             @edx/community-engineering
 openedx/core/djangoapps/contentserver      @edx/community-engineering


### PR DESCRIPTION
as we aren't concerned with these and do not intend to actively monitor,
unless tagged explicitly.