### PR TITLE
Link on course about page should link to the learning MFE

### DIFF
--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -933,7 +933,10 @@ def course_about(request, course_id):
         studio_url = get_studio_url(course, 'settings/details')
 
         if request.user.has_perm(VIEW_COURSE_HOME, course):
-            course_target = reverse(course_home_url_name(course.id), args=[str(course.id)])
+            if course_home_legacy_is_active(course.id):
+                course_target = reverse(course_home_url_name(course.id), args=[str(course.id)])
+            else:
+                course_target = get_learning_mfe_home_url(course_key=course.id, view_name='home')
         else:
             course_target = reverse('about_course', args=[str(course.id)])
 


### PR DESCRIPTION
## Description

This fixes a bug where the "View Course" link on the course about page  would link to the legacy courseware view, even through the waffle flag that enables the legacy view was not turned on.

<img width="1704" alt="Screenshot 2021-09-13 at 09 03 28" src="https://user-images.githubusercontent.com/32585/133038529-213a1864-2b6e-43ec-854f-b84007db8c11.png">

## Sandbox:

- https://mfeplayground-master.opencraft.hosting/

## Testing instructions

1. Log into the LMS.
2. Enroll into the Demo course.
3. View the course about page (you can navigate to the course about page from the "Discover New" link in the header).
4. Verify that the "View Course" link points to the courseware MFE instead of the legacy view.
5. Create/enable the `course_home.course_home_use_legacy_frontend` waffle flag.
6. Verify that the "View Course" link now points to the legacy view.

## Deadline

None
