### PR TITLE
fix: RegexPattern, used by re_path(), no longer returns keyword argum…

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -114,7 +114,7 @@ def _is_library_component_limit_reached(usage_key):
 @require_http_methods(("DELETE", "GET", "PUT", "POST", "PATCH"))
 @login_required
 @expect_json
-def xblock_handler(request, usage_key_string):
+def xblock_handler(request, usage_key_string=None):
     """
     The restful handler for xblock requests.
 


### PR DESCRIPTION
Django30: RegexPattern, used by re_path(), no longer returns keyword arguments with None values to be passed to the view for the optional named groups that are missing.

Release notes: https://docs.djangoproject.com/en/3.2/releases/3.0/#miscellaneous

https://docs.djangoproject.com/en/3.2/ref/urls/#re-path
```
When a match is made, captured groups from the regular expression are passed to the view – as 
named arguments if the groups are named, and as positional arguments otherwise. 
The values are passed as strings, without any type conversion.
```

Django [PR](https://github.com/django/django/pull/11477) where this issue got fixed.

https://openedx.atlassian.net/browse/BOM-2793

sandbox https://awais786.sandbox.edx.org/