### PR TITLE
[CRI-236] Fix course discovery search sidebar filters.

### DIFF
--- a/lms/static/js/discovery/collection.js
+++ b/lms/static/js/discovery/collection.js
@@ -73,8 +73,8 @@
                 var results = response.results || [];
                 this.latestModelsCount = results.length;
                 this.totalCount = response.total;
-                if (typeof response.facets !== 'undefined') {
-                    this.facets = response.facets;
+                if (typeof response.aggs !== 'undefined') {
+                    this.facets = response.aggs;
                 } else {
                     this.facets = [];
                 }

--- a/lms/static/js/discovery/models/course_discovery.js
+++ b/lms/static/js/discovery/models/course_discovery.js
@@ -23,7 +23,7 @@
 
             parse: function(response) {
                 var courses = response.results || [];
-                var facets = response.facets || {};
+                var facets = response.aggs || {};
                 this.courseCards.add(_.pluck(courses, 'data'));
 
                 this.set({

--- a/lms/static/js/spec/discovery/discovery_factory_spec.js
+++ b/lms/static/js/spec/discovery/discovery_factory_spec.js
@@ -51,7 +51,7 @@ define([
                 }
             }
         ],
-        facets: {
+        aggs: {
             org: {
                 total: 26,
                 terms: {

--- a/lms/static/js/spec/discovery/models/course_directory_spec.js
+++ b/lms/static/js/spec/discovery/models/course_directory_spec.js
@@ -27,7 +27,7 @@ define([
                 }
             }
         ],
-        facets: {
+        aggs: {
             org: {
                 total: 26,
                 terms: {


### PR DESCRIPTION
## Description

Elasticsearch7 returns `aggs` instead of `facets`,
fixed elasticsearch response parsing on the FrontEnd.

## STR

1. Set up a Lilac system with `COURSE_DISCOVERY_ENABLED` set to true
2. Go to `/courses` on your platform
3. See that the sidebar is empty
4. If you inspect the traffic, you can see that the call to `/search/course_discovery` contains a field `aggs`, and no field `facets`.

## JIRA ticket

https://openedx.atlassian.net/browse/CRI-236