### PR TITLE
fix: Added the condition on body_type in test_reset_password

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
@@ -284,7 +284,7 @@ class ResetPasswordTests(EventTestMixin, CacheIsolationTestCase):
 
         body = bodies[body_type]
 
-        if django.VERSION >= (3, 0):
+        if django.VERSION >= (3, 0) and body_type=='html':
             expected_output = "You&#x27;re receiving this e-mail because you requested a password reset"
 
         assert 'Password reset' in sent_message.subject

--- a/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
@@ -284,7 +284,7 @@ class ResetPasswordTests(EventTestMixin, CacheIsolationTestCase):
 
         body = bodies[body_type]
 
-        if django.VERSION >= (3, 0) and body_type=='html':
+        if django.VERSION >= (3, 0) and body_type == 'html':
             expected_output = "You&#x27;re receiving this e-mail because you requested a password reset"
 
         assert 'Password reset' in sent_message.subject


### PR DESCRIPTION
Updated the condition in test_reset_password to check the body_type before changing the decimal escape code in expected output for the test

> django.utils.html.escape() now uses html.escape() to escape HTML. This converts ' to `&#x27`; instead of the previous equivalent decimal code `&#39;`.

https://docs.djangoproject.com/en/3.2/releases/3.0/#miscellaneous