### PR TITLE
fix: add nested CSS to avoid popover class name override 

### DIFF
--- a/lms/static/sass/views/_track_selection.scss
+++ b/lms/static/sass/views/_track_selection.scss
@@ -1,254 +1,243 @@
-.container-fluid {
+.track-selection-container {
     max-width: 946px;
-}
 
-.page-header h3 {
-    color: #001B1E;
-}
-
-.verification-process h3 {
-    color: #454545;
-    font-size: 1.4rem;
-    text-align: center;
-    font-weight: 700;
-    line-height: 1.8rem;
-}
-
-.track-selection-choice, .verified-note {
-    margin: 0 1rem;
-}
-
-.track-selection-choice li {
-    margin-bottom: 1.25rem;
-}
-
-.track-selection-audit {
-    background-color: white;
-    border: 1px solid #707070;
-    position: relative;
-    float: right;
-}
-
-.track-selection-certificate {
-    float: left;
-}
-
-.track-selection-certificate .choice-bullets li:last-child {
-    margin-bottom: 2rem;
-}
-
-.certificate-container {
-    background-color: #EFF8FA;
-    border: 1px solid #707070;
-    height: auto;
-    position: relative;
-}
-
-.award-icon {
-    padding: 12px;
-    color: #EFF8FA;
-    position: absolute;
-}
-
-.track-selection-button {
-    text-align: center;
-}
-
-.track-selection-button button {
-    width: 90%;
-    font-size: 1rem;
-    box-shadow: none;
-    border-radius: 0px;
-    position: relative;
-    margin-bottom: 1.5rem;
-    padding: 8px;
-}
-
-#track_selection_upgrade {
-    background: #00262B;
-}
-
-#track_selection_upgrade:hover {
-    background: #2D494E;
-    border-color: transparent;
-    color: #fff;
-}
-
-#track_selection_audit {
-    color: #00262B;
-    border-color: #F2F0EF;
-    background: white;
-    position: absolute;
-    bottom: 0;
-    left: 5%;
-}
-
-#track_selection_audit:hover {
-    background: #00262B;
-    border-color: #00262B;
-    color: #fff;
-    border-radius: 0px;
-}
-
-.verified-note {
-    display: grid;
-    grid-template-columns: 5% 95%;
-    order: 1;
-    margin-bottom: 2rem;
-    margin-top: -1px;
-    border: 1px solid #707070;
-    border-top: 0;
-    padding: 1rem;
-}
-
-.note-info {
-    float: right;
-    font-size: 14px;
-    margin-left: 12px;
-    line-height: 1.5rem;
-}
-
-.note-icon {
-    display: grid;
-    place-items: center;
-}
-
-.choice-bullets {
-    padding: 0 3rem 1rem 2rem;
-    line-height: 1.5rem;
-    font-size: 14px;
-}
-
-a:not(.btn), a:visited:not(.btn) {
-    color: #454545;
-}
-
-.choice-bullets li {
-    color: #454545;
-}
-
-.choice-title {
-    width: 100%;
-    display: inline-block;
-}
-
-.choice-title h4 {
-    text-align: center;
-    font-weight: 700;
-    color: #454545;
-    line-height: 28px;
-    font-size: 22px;
-}
-
-.price-display {
-    font-size: 14px;
-    font-style: normal;
-    font-weight: 700;
-    line-height: 1.25rem;
-    float: right;
-    margin: 0.75rem;
-    color: #454545;
-}
-
-.corner-overlay {
-    border-color: #002121 transparent transparent #002121;
-    border-style: solid;
-    border-width: 45px;
-    height: 0;
-    width: 0;
-    position: absolute;
-}
-
-.collapsible {
-    color: #00688d !important;
-    font-weight: 700;
-    font-size: 14px !important;
-}
-
-.collapsible-item {
-    letter-spacing: -0.3px;
-}
-
-.popover-icon {
-    color: #00262B;
-    position: relative;
-}
-
-.popover {
-    visibility: hidden;
-    width: 132px;
-    background-color: #fff;
-    color: #454545;
-    border: 1px solid #B9BABE;
-    border-radius: 6px;
-    text-align: left;
-    padding: 0.8rem 1rem;
-    position: absolute;
-    z-index: 1;
-    top: -22px;
-    left: 178%;
-}
-
-.popover a {
-    text-decoration: underline;
-}
-
-.visible {
-    visibility: visible;
-}
-
-.popover:before {
-    position: absolute;
-    display: inline-block;
-    left: -18px;
-    top: 22px;
-    content: '';
-    border-width: 9px;
-    border-style: solid;
-    border-color: transparent #B9BABE transparent transparent;
-}
-
-.popover:after {
-    position: absolute;
-    display: inline-block;
-    border-width: 7px;
-    border-style: solid;
-    border-color: transparent #fff transparent transparent;
-    left: -14px;
-    top: 1.5rem;
-    content: '';
-}
-
-@media (max-width: map-get($grid-breakpoints, 'sm')) {
-    .choice-bullets {
-        padding: 0 2rem 0 1rem;
+    .page-header h3 {
+        color: #001B1E;
+        font-size: 1.4rem;
+        text-align: center;
+        font-weight: 700;
+        line-height: 1.8rem;
     }
 
-    .collapsible {
-        margin-bottom: 1.3rem;
+    .track-selection-choice, .verified-note {
+        margin: 0 1rem;
     }
 
-    .corner-overlay {
-        border-width: 35px !important;
+    .track-selection-audit {
+        background-color: white;
+        border: 1px solid #707070;
+        position: relative;
+        float: right;
+    }
+
+    .track-selection-certificate {
+        float: left;
+    }
+
+    .track-selection-certificate .choice-bullets li:last-child {
+        margin-bottom: 2rem;
+    }
+
+    .certificate-container {
+        background-color: #EFF8FA;
+        border: 1px solid #707070;
+        height: auto;
+        position: relative;
     }
 
     .award-icon {
-        padding: 6px !important;
+        padding: 12px;
+        color: #EFF8FA;
+        position: absolute;
     }
 
-    .award-icon svg {
-        width: 25px !important;
+    .track-selection-button {
+        text-align: center;
+    }
+
+    .track-selection-button button {
+        width: 90%;
+        font-size: 1rem;
+        box-shadow: none;
+        border-radius: 0px;
+        position: relative;
+        margin-bottom: 1.5rem;
+        padding: 8px;
+    }
+
+    #track_selection_upgrade {
+        background: #00262B;
+    }
+
+    #track_selection_upgrade:hover {
+        background: #2D494E;
+        border-color: transparent;
+        color: #fff;
+    }
+
+    #track_selection_audit {
+        color: #00262B;
+        border-color: #F2F0EF;
+        background: white;
+        position: absolute;
+        bottom: 0;
+        left: 5%;
+    }
+
+    #track_selection_audit:hover {
+        background: #00262B;
+        border-color: #00262B;
+        color: #fff;
+        border-radius: 0px;
+    }
+
+    .verified-note {
+        display: grid;
+        grid-template-columns: 5% 95%;
+        order: 1;
+        margin-bottom: 2rem;
+        margin-top: -1px;
+        border: 1px solid #707070;
+        border-top: 0;
+        padding: 1rem;
+    }
+
+    .note-info {
+        float: right;
+        font-size: 14px;
+        margin-left: 12px;
+        line-height: 1.5rem;
+    }
+
+    .note-icon {
+        display: grid;
+        place-items: center;
+    }
+
+    .choice-bullets {
+        padding: 0 3rem 1rem 2rem;
+        line-height: 1.5rem;
+        font-size: 14px;
+    }
+
+    a:not(.btn), a:visited:not(.btn) {
+        color: #454545;
+    }
+
+    .choice-bullets li {
+        color: #454545;
+    }
+
+    .choice-title {
+        width: 100%;
+        display: inline-block;
+    }
+
+    .choice-title h4 {
+        text-align: center;
+        font-weight: 700;
+        color: #454545;
+        line-height: 28px;
+        font-size: 22px;
     }
 
     .price-display {
         font-size: 14px;
+        font-style: normal;
+        font-weight: 700;
+        line-height: 1.25rem;
+        float: right;
+        margin: 0.75rem;
+        color: #454545;
     }
-}
 
-@media (min-width: map-get($grid-breakpoints, 'md')) {
-    .track-selection-container {
-        display: grid;
-        grid-template-columns: 50% 50%;
+    .corner-overlay {
+        border-color: #002121 transparent transparent #002121;
+        border-style: solid;
+        border-width: 45px;
+        height: 0;
+        width: 0;
+        position: absolute;
     }
-}
-  
+
+    .collapsible {
+        color: #00688d !important;
+        font-weight: 700;
+        font-size: 14px !important;
+        display: none;
+        text-decoration: underline;
+    }
+
+    .collapsible-item {
+        letter-spacing: -0.3px;
+    }
+
+    .popover-icon {
+        color: #00262B;
+        position: relative;
+    }
+
+    .popover {
+        visibility: hidden;
+        width: 132px;
+        background-color: #fff;
+        color: #454545;
+        border: 1px solid #B9BABE;
+        border-radius: 6px;
+        text-align: left;
+        padding: 0.8rem 1rem;
+        position: absolute;
+        z-index: 1;
+        top: -22px;
+        left: 178%;
+    }
+
+    .popover a {
+        text-decoration: underline;
+    }
+
+    .visible {
+        visibility: visible;
+    }
+
+    .popover:before {
+        position: absolute;
+        display: inline-block;
+        left: -18px;
+        top: 22px;
+        content: '';
+        border-width: 9px;
+        border-style: solid;
+        border-color: transparent #B9BABE transparent transparent;
+    }
+
+    .popover:after {
+        position: absolute;
+        display: inline-block;
+        border-width: 7px;
+        border-style: solid;
+        border-color: transparent #fff transparent transparent;
+        left: -14px;
+        top: 1.5rem;
+        content: '';
+    }
+
+    @media (max-width: map-get($grid-breakpoints, 'sm')) {
+        .collapsible {
+            margin-bottom: 1.3rem;
+        }
+
+        .corner-overlay {
+            border-width: 35px !important;
+        }
+
+        .award-icon {
+            padding: 6px !important;
+        }
+
+        .award-icon svg {
+            width: 25px !important;
+        }
+
+        .price-display {
+            font-size: 14px;
+        }
+    }
+
+    @media (min-width: map-get($grid-breakpoints, 'md')) {
+        .track-selection-options {
+            display: grid;
+            grid-template-columns: 50% 50%;
+        }
+    }
+}    

--- a/lms/templates/course_modes/track_selection.html
+++ b/lms/templates/course_modes/track_selection.html
@@ -69,7 +69,7 @@ from openedx.core.djangolib.js_utils import js_escaped_string
 <%block name="content">
     <div id="currency_data" value="${currency_data}"></div>
 
-    <div class="container-md container-fluid mx-auto">
+    <div class="track-selection-container container-md container-fluid mx-auto">
         <section class="wrapper m-4 mb-5 m-md-0">
             <div class="wrapper-register-choose wrapper-content-main">
                 <article class="register-choose content-main">
@@ -81,7 +81,7 @@ from openedx.core.djangolib.js_utils import js_escaped_string
 
                     <form class="form-register-choose mb-4 mt-0" method="post" name="enrollment_mode_form" id="enrollment_mode_form">
                         <div class="row">
-                        <div class="track-selection-container">
+                        <div class="track-selection-options">
                             % if "verified" in modes:
                             <div class="track-selection-choice track-selection-certificate mr-md-2">
                                 <div class="certificate-container">
@@ -155,7 +155,7 @@ from openedx.core.djangolib.js_utils import js_escaped_string
                             </div>
                             % endif
                             <div class="track-selection-choice track-selection-audit ml-md-3">
-                                <p class="float-right m-3 text-uppercase price-display">${_("Free")}</p>
+                                <p class="float-right text-uppercase price-display">${_("Free")}</p>
                                 <div class="choice-title"><h4>${_("Access this course")}</h4></div>
                                 <div class="choice-bullets">
                                     <ul>


### PR DESCRIPTION
[REV-2329](https://openedx.atlassian.net/browse/REV-2379). 
[CR-4030](https://openedx.atlassian.net/browse/CR-4030).

A bug has been filed by support in the learner dashboard, in programs when the user has an entitlement. The `popover` element was invisible, not allowing the user to click on "ok" and fire the event. 

This is due to the class use of `popover` in `_track_selection.scss` file, which seems to override the dashboard CSS with ` visibility: hidden;`.

Looks like `edx-platform` CSS is compiled and applied as a whole across the repo.
- Instead of renaming the `popover` to a unique class, this PR nests all of the CSS under `track-selection-container` class, which was added at the same level as `container-fluid`.
- `verification-process` is shared between current track selection page and new value prop page, so I will not make any changes to that.
- This PR also removes CSS that were either unused with this change or causing a visual bug to the new template.

<img width="1095" alt="Screen Shot 2021-09-08 at 4 40 31 PM" src="https://user-images.githubusercontent.com/13632680/132880540-96b1e548-989f-460a-88bc-00121d12715a.png">


<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->
