### PR TITLE
test: fix skip-checks in a test for django 30

### DIFF
--- a/openedx/core/djangoapps/credentials/management/commands/tests/test_notify_credentials.py
+++ b/openedx/core/djangoapps/credentials/management/commands/tests/test_notify_credentials.py
@@ -3,6 +3,7 @@ Tests the ``notify_credentials`` management command.
 """
 
 
+import django
 from datetime import datetime
 from unittest import mock
 
@@ -286,7 +287,10 @@ class TestNotifyCredentials(TestCase):
 
         # Told to use it, and enabled. Should use config in preference of command line
         self.expected_options['start_date'] = '2017-03-01T00:00:00Z'
-        del self.expected_options['skip_checks']
+        if django.VERSION >= (3, 0):
+            self.expected_options['skip_checks'] = False
+        else:
+            del self.expected_options['skip_checks']
         call_command(Command(), '--start-date', '2017-01-01', '--args-from-database')
         assert mock_task.called
         assert mock_task.call_args[0][0] == self.expected_options


### PR DESCRIPTION
> The new --skip-checks option skips running system checks prior to running the command.

https://docs.djangoproject.com/en/3.2/releases/3.0/#management-commands