### PR TITLE
fix: course creation notice visibility and admin search

### DIFF
--- a/cms/djangoapps/course_creators/admin.py
+++ b/cms/djangoapps/course_creators/admin.py
@@ -82,7 +82,7 @@ class CourseCreatorAdmin(admin.ModelAdmin):
     # Fields that filtering support
     list_filter = ['state', 'state_changed']
     # Fields that search supports.
-    search_fields = ['user__username', 'user__email', 'state', 'note', 'organizations']
+    search_fields = ['user__username', 'user__email', 'state', 'note']
     # Turn off the action bar (we have no bulk actions)
     actions = None
     form = CourseCreatorForm

--- a/cms/static/js/index.js
+++ b/cms/static/js/index.js
@@ -168,7 +168,7 @@ define(['domReady', 'jquery', 'underscore', 'js/utils/cancel_on_escape', 'js/vie
                 $('.libraries-tab').toggleClass('active', tab === 'libraries-tab');
 
             // Also toggle this course-related notice shown below the course tab, if it is present:
-                $('.wrapper-creationrights').toggleClass('is-hidden', tab !== 'courses');
+                $('.wrapper-creationrights').toggleClass('is-hidden', tab !== 'courses-tab');
             };
         };
 


### PR DESCRIPTION
## Description

This PR includes two bugfixes. They are separate, but related in that they touch the "course_creators" CMS app. 

The second commit (admin search) fixes a bug introduced by this community PR: https://github.com/edx/edx-platform/pull/26616. The first commit (creation rights notice) fixes a bug that was reported right around the same time, although I cannot find any code-level evidence that it is related to the community PR.

### fix: show creation rights notice on studio "courses" tab

There was a JS bug that made it so the course creation rights
notice (the thing that invites new studio users to request
access to create content) disappeared if the user selected
the "Courses" or "Libraries" tab.

This is because it was incorrectly comparing the #courses-tab
URL frament against the string "courses" instead of "courses-tab".

Home page (with or without fix):
![image](https://user-images.githubusercontent.com/3628148/133292040-8f18d3af-d430-41d7-b494-ebcf2f1d40ff.png)


After clicking "Courses" tab (without fix):
![image](https://user-images.githubusercontent.com/3628148/133292132-7e13cd15-7768-4490-b333-ddd0c16fa99b.png)

After clicking "Courses" tab (with fix):
![image](https://user-images.githubusercontent.com/3628148/133300741-e27db6f1-bb2c-4a57-9454-108902574c45.png)

### fix: repair search of course creator statuses in django admin

It was broken because "organizations" was erronously included
in the `search_fields` admin option. Many-to-many fields
may not be used for search.


## Supporting information

Bug tix: 
* Creation notice visibility: https://openedx.atlassian.net/browse/TNL-8718
* Admin search: https://openedx.atlassian.net/browse/TNL-8722

## Testing instructions

### Creation notice visibility:
Repro bug:
* Check out master.
* Start CMS in devstack.
* Go to localhost:18010 and log in with a non-global-staff account.
* Notice that "Become a course creator" expandable section is visible.
* Click on the "Courses" tab, noticing that it adds `#courses-tab` to the URL.
* Notice the bug: the "Become a course creator" section has become invisible.

Confirm fix:
* Check out this branch.
* If necessary -- Clear your browser's cache for localhost:18010 (or all sites)
* Go to localhost:18010 and log in with a non-global-staff account.
* Notice that "Become a course creator" expandable section is visible.
* Click on the "Courses" tab, noticing that it adds `#courses-tab` to the URL.
* Notice the fix: the "Become a course creator" section is still visible.
* Click "Libraries" tab. Notice should disappear.
* Click "Courses" tab. Notice should reappear.

### Admin search:
Repro bug:
* Check out master.
* Start CMS in devstack.
* Go to http://localhost:18010/admin/course_creators/coursecreator/ logged in as global staff.
* Search anything.
* Notice that it 500s.

Confirm fix:
* Check out this branch.
* Restart CMS.
* Go to http://localhost:18010/admin/course_creators/coursecreator/ logged in as global staff.
* Search anything.
* You should results instead of a 500.

## Deadline

For partner support's sake, would be good to have this in by end-of-week (2021-09-17).

## Other information

None
