### PR TITLE
fix: django.contrib.staticfiles.storage.CachedStaticFilesStorage is…

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -59,7 +59,6 @@ django-oauth-toolkit                # Provides oAuth2 capabilities for Django
 django-pipeline
 django-pyfs
 django-ratelimit
-django-require
 django-sekizai
 django-ses
 django-simple-history

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -325,7 +325,7 @@ django-ratelimit==3.0.1
     # via -r requirements/edx/base.in
 git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a6#egg=django-ratelimit-backend==2.0.1a6
     # via -r requirements/edx/github.in
-django-require==1.0.11
+git+https://github.com/vtemian/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776#egg=django-require==1.0.12
     # via -r requirements/edx/base.in
 django-sekizai==2.0.0
     # via

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -326,7 +326,7 @@ django-ratelimit==3.0.1
 git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a6#egg=django-ratelimit-backend==2.0.1a6
     # via -r requirements/edx/github.in
 git+https://github.com/edx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776#egg=django-require==1.0.12
-    # via -r requirements/edx/base.in
+    # via -r requirements/edx/github.in
 django-sekizai==2.0.0
     # via
     #   -r requirements/edx/base.in
@@ -1012,7 +1012,7 @@ sympy==1.6.2
     #   symmath
 tableauserverclient==0.16.0
     # via edx-enterprise
-testfixtures==6.18.1
+testfixtures==6.18.2
     # via edx-enterprise
 text-unidecode==1.3
     # via python-slugify

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -325,7 +325,7 @@ django-ratelimit==3.0.1
     # via -r requirements/edx/base.in
 git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a6#egg=django-ratelimit-backend==2.0.1a6
     # via -r requirements/edx/github.in
-git+https://github.com/vtemian/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776#egg=django-require==1.0.12
+git+https://github.com/edx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776#egg=django-require==1.0.12
     # via -r requirements/edx/base.in
 django-sekizai==2.0.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -414,7 +414,7 @@ django-ratelimit==3.0.1
     # via -r requirements/edx/testing.txt
 git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a6#egg=django-ratelimit-backend==2.0.1a6
     # via -r requirements/edx/testing.txt
-git+https://github.com/vtemian/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776#egg=django-require==1.0.12
+git+https://github.com/edx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776#egg=django-require==1.0.12
     # via -r requirements/edx/testing.txt
 django-sekizai==2.0.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1423,7 +1423,7 @@ tableauserverclient==0.16.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
-testfixtures==6.18.1
+testfixtures==6.18.2
     # via
     #   -r requirements/edx/testing.txt
     #   edx-enterprise

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -414,7 +414,7 @@ django-ratelimit==3.0.1
     # via -r requirements/edx/testing.txt
 git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a6#egg=django-ratelimit-backend==2.0.1a6
     # via -r requirements/edx/testing.txt
-django-require==1.0.11
+git+https://github.com/vtemian/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776#egg=django-require==1.0.12
     # via -r requirements/edx/testing.txt
 django-sekizai==2.0.0
     # via

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -63,6 +63,9 @@ git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752
 # back into the upstream code.
 git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a6#egg=django-ratelimit-backend==2.0.1a6
 
+# original repo is not maintained any more.
+git+https://github.com/vtemian/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776#egg=django-require==1.0.12
+
 # Our libraries:
 -e git+https://github.com/edx/codejail.git@3.1.3#egg=codejail==3.1.3
 -e git+https://github.com/edx/RateXBlock.git@2.0.1#egg=rate-xblock

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -64,7 +64,7 @@ git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752
 git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a6#egg=django-ratelimit-backend==2.0.1a6
 
 # original repo is not maintained any more.
-git+https://github.com/vtemian/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776#egg=django-require==1.0.12
+git+https://github.com/edx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776#egg=django-require==1.0.12
 
 # Our libraries:
 -e git+https://github.com/edx/codejail.git@3.1.3#egg=codejail==3.1.3

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -397,7 +397,7 @@ django-ratelimit==3.0.1
     # via -r requirements/edx/base.txt
 git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a6#egg=django-ratelimit-backend==2.0.1a6
     # via -r requirements/edx/base.txt
-django-require==1.0.11
+git+https://github.com/vtemian/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776#egg=django-require==1.0.12
     # via -r requirements/edx/base.txt
 django-sekizai==2.0.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1316,7 +1316,7 @@ tableauserverclient==0.16.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-testfixtures==6.18.1
+testfixtures==6.18.2
     # via
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/testing.in

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -397,7 +397,7 @@ django-ratelimit==3.0.1
     # via -r requirements/edx/base.txt
 git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a6#egg=django-ratelimit-backend==2.0.1a6
     # via -r requirements/edx/base.txt
-git+https://github.com/vtemian/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776#egg=django-require==1.0.12
+git+https://github.com/edx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776#egg=django-require==1.0.12
     # via -r requirements/edx/base.txt
 django-sekizai==2.0.0
     # via


### PR DESCRIPTION
Using this package [django-require](https://github.com/etianen/django-require) in edx/edx-platform. This package was last released in 2016 and it hasn't yet added support for Django3.2.


ManifestStaticFilesStorage file usage
https://github.com/django/django/blob/stable/2.2.x/django/contrib/staticfiles/storage.py#L488

`django.contrib.staticfiles.storage.CachedStaticFilesStorage is removed.`
https://docs.djangoproject.com/en/3.2/releases/3.1/#features-removed-in-3-1

https://github.com/edx/upgrades/issues/64
