### PR TITLE
[feat] Add user_id scope to credentialsApiClient

### DIFF
--- a/openedx/core/djangoapps/credentials/utils.py
+++ b/openedx/core/djangoapps/credentials/utils.py
@@ -34,7 +34,8 @@ def get_credentials_api_client(user, org=None):
         org (str): Optional organization to look up the site config for, rather than the current request
 
     """
-    jwt = create_jwt_for_user(user)
+    scopes = ['email', 'profile', 'user_id']
+    jwt = create_jwt_for_user(user, scopes=scopes)
 
     if org is None:
         url = CredentialsApiConfig.current().internal_api_url  # by current request


### PR DESCRIPTION


## Description

Now that we're actively using the LMS_USER_ID inside credentials to
identify users, we need to make sure that users created by
notify_credentials are including it in the jwt scopes when authenticated
with credentials.

## Supporting information

related credentials PR: https://github.com/edx/credentials/pull/1312

## Testing instructions

If you have a program cached in the LMS:
1. Create a user and enroll them in the program's course
2. manually verify their identity, and set their enrollment to verified
3. Put them on the Allow list and generate a course cert
4. run `notify_credentials` for that user
