### PR TITLE
fix: remove now unnecessary course flag for verified names

### DIFF
--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -140,18 +140,6 @@ COURSEWARE_MICROFRONTEND_PROCTORED_EXAMS = CourseWaffleFlag(
     WAFFLE_FLAG_NAMESPACE, 'mfe_proctored_exams', __name__
 )
 
-# .. toggle_name: courseware.verified_name
-# .. toggle_implementation: CourseWaffleFlag
-# .. toggle_default: False
-# .. toggle_description: Course waffle flag for verified name functionality (see https://github.com/edx/edx-name-affirmation)
-# .. toggle_use_cases: temporary
-# .. toggle_creation_date: 2021-7-14
-# .. toggle_target_removal_date: None
-# .. toggle_warnings: None
-COURSEWARE_VERIFIED_NAME_FLAG = CourseWaffleFlag(
-    WAFFLE_FLAG_NAMESPACE, 'verified_name', __name__
-)
-
 
 def mfe_special_exams_is_active(course_key: CourseKey) -> bool:
     """
@@ -306,10 +294,6 @@ def streak_celebration_is_active(course_key):
         courseware_mfe_progress_milestones_are_active(course_key) and
         COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES_STREAK_CELEBRATION.is_enabled(course_key)
     )
-
-
-def is_verified_name_enabled_for_course(course_key):
-    return COURSEWARE_VERIFIED_NAME_FLAG.is_enabled(course_key)
 
 
 # .. toggle_name: COURSES_INVITE_ONLY

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -66,8 +66,7 @@ from ..module_render import get_module_for_descriptor, toc_for_course
 from ..permissions import MASQUERADE_AS_STUDENT
 from ..toggles import (
     courseware_legacy_is_visible,
-    courseware_mfe_is_advertised,
-    is_verified_name_enabled_for_course
+    courseware_mfe_is_advertised
 )
 from .views import CourseTabView
 
@@ -445,8 +444,7 @@ class CoursewareIndex(View):
             'section_title': None,
             'sequence_title': None,
             'disable_accordion': not DISABLE_COURSE_OUTLINE_PAGE_FLAG.is_enabled(self.course.id),
-            'show_search': show_search,
-            'is_verified_name_enabled': is_verified_name_enabled_for_course(self.course.id),
+            'show_search': show_search
         }
         courseware_context.update(
             get_experiment_user_metadata_context(

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -246,8 +246,7 @@ ${HTML(fragment.foot_html())}
             </div>
         </header>
 
-        <main id="main" tabindex="-1" aria-label="Content"
-        data-is-verified-name-enabled="${is_verified_name_enabled}">
+        <main id="main" tabindex="-1" aria-label="Content">
             % if getattr(course, 'entrance_exam_enabled') and \
                getattr(course, 'entrance_exam_minimum_score_pct') and \
                entrance_exam_current_score is not UNDEFINED:


### PR DESCRIPTION
Instead of being passed via the UI this flag state is now picked up directly from the name affirmation library API.

We haven't actually turned on the courseware.verified_name flag anywhere outside of development yet.

indirectly part of MST-1020
