### PR TITLE
feat: add support-only endpoint to get FBE details

### DIFF
--- a/lms/djangoapps/support/urls.py
+++ b/lms/djangoapps/support/urls.py
@@ -2,14 +2,14 @@
 URLs for the student support app.
 """
 
-
+from django.conf import settings
 from django.conf.urls import url
 
 from .views.certificate import CertificatesSupportView
 from .views.contact_us import ContactUsView
 from .views.course_entitlements import EntitlementSupportView
 from .views.enrollments import EnrollmentSupportListView, EnrollmentSupportView
-from .views.feature_based_enrollments import FeatureBasedEnrollmentsSupportView
+from .views.feature_based_enrollments import FeatureBasedEnrollmentsSupportView, FeatureBasedEnrollmentSupportAPIView
 from .views.index import index
 from .views.manage_user import ManageUserDetailView, ManageUserSupportView
 from .views.program_enrollments import LinkProgramEnrollmentSupportView, ProgramEnrollmentsInspectorView
@@ -39,6 +39,11 @@ urlpatterns = [
         r'^feature_based_enrollments/?$',
         FeatureBasedEnrollmentsSupportView.as_view(),
         name="feature_based_enrollments"
+    ),
+    url(
+        fr'^feature_based_enrollment_details/{settings.COURSE_ID_PATTERN}$',
+        FeatureBasedEnrollmentSupportAPIView.as_view(),
+        name="feature_based_enrollment_details"
     ),
     url(r'link_program_enrollments/?$', LinkProgramEnrollmentSupportView.as_view(), name='link_program_enrollments'),
     url(

--- a/lms/djangoapps/support/views/utils.py
+++ b/lms/djangoapps/support/views/utils.py
@@ -1,0 +1,44 @@
+"""
+Various utility methods used by support app views.
+"""
+from django.core.exceptions import ObjectDoesNotExist
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import CourseKey
+
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from openedx.features.content_type_gating.models import ContentTypeGatingConfig
+from openedx.features.course_duration_limits.models import CourseDurationLimitConfig
+
+
+def get_course_duration_info(course_key):
+    """
+    Fetch course duration information from database.
+    """
+    try:
+        key = CourseKey.from_string(course_key)
+        course = CourseOverview.objects.values('display_name').get(id=key)
+        duration_config = CourseDurationLimitConfig.current(course_key=key)
+        gating_config = ContentTypeGatingConfig.current(course_key=key)
+        duration_enabled = CourseDurationLimitConfig.enabled_for_course(course_key=key)
+        gating_enabled = ContentTypeGatingConfig.enabled_for_course(course_key=key)
+
+        gating_dict = {
+            'enabled': gating_enabled,
+            'enabled_as_of': str(gating_config.enabled_as_of) if gating_config.enabled_as_of else 'N/A',
+            'reason': gating_config.provenances['enabled'].value
+        }
+        duration_dict = {
+            'enabled': duration_enabled,
+            'enabled_as_of': str(duration_config.enabled_as_of) if duration_config.enabled_as_of else 'N/A',
+            'reason': duration_config.provenances['enabled'].value
+        }
+
+        return {
+            'course_id': course_key,
+            'course_name': course.get('display_name'),
+            'gating_config': gating_dict,
+            'duration_config': duration_dict,
+        }
+
+    except (ObjectDoesNotExist, InvalidKeyError):
+        return {}


### PR DESCRIPTION
### [PROD-2477](https://openedx.atlassian.net/browse/PROD-2477)

## Description
This PR adds a support-only api endpoint in LMS support application that returns feature based enrollment configuration details for a course id. This API endpoint is equivalent of support/feature_based_enrollments view which uses Django templates to render the page. This endpoint is needed in order to create a new FBE component in support Tools MFE.

## Testing instructions

Note: admin urls use LMS as base.

- Create a new course in Studio and set its start date in past.
- Add a verified and audit mode against the course in `admin/course_modes/coursemode/`
- Add a new configuration at `admin/content_type_gating/contenttypegatingconfig/`. Set Enabled to True, enabled as of date to past, and point course run to newly created course.
- Repeat the previous step for `admin/course_duration_limits/coursedurationlimitconfig/`
- After the configurations, visit `http://localhost:18000/support/feature_based_enrollment_details/<course_id>`
- If all is enabled, you will response similar to example response. If not, an empty dict will be returned.

Example Response:

```
{
              "course_id": <course_id>,
              "course_name": "FBE course",
              "gating_config": {
                "enabled": true,
                "enabled_as_of": "2030-01-01 00:00:00+00:00",
                "reason": "Site"
              },
              "duration_config": {
                "enabled": true,
                "enabled_as_of": "2030-01-01 00:00:00+00:00",
                "reason": "Site"
              }
            }
```
