### PR TITLE
feat: Logging improvement for status code checks in integrated channe…

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -33,7 +33,7 @@ django-storages<1.9
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==3.28.9
+edx-enterprise==3.28.10
 
 # Newer versions need a more recent version of python-dateutil
 freezegun==0.3.12

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -445,7 +445,7 @@ edx-drf-extensions==6.6.0
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.28.9
+edx-enterprise==3.28.10
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -545,7 +545,7 @@ edx-drf-extensions==6.6.0
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.28.9
+edx-enterprise==3.28.10
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -526,7 +526,7 @@ edx-drf-extensions==6.6.0
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.28.9
+edx-enterprise==3.28.10
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
Integrated channels completion routine now logs all response details (as logger.error), when status_code >=400 when calling external LMS systems to report completion. We were previously silently missing those errors. This is important because we still do save audit logs in this case, but with error_message populated, and status_code also populated. but sometimes it's useful to be able to see the error logs to diagnose completion reporting issues using splunk without cracking open the database.

edx-enterprise 3.28.10 upgrade is contained in this change

Details at: https://github.com/edx/edx-enterprise/pull/1351

