### PR TITLE
revert: Reverts removal of related programs from resume html template

### DIFF
--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -304,7 +304,7 @@ from lms.djangoapps.experiments.utils import UPSELL_TRACKING_FLAG
                   % endif
 
                 % else:
-                  <%include file="_dashboard_course_resume.html" args="resume_button_url=resume_button_url, course_overview=course_overview, enrollment=enrollment, is_unfulfilled_entitlement=is_unfulfilled_entitlement, course_target=course_target"/>
+                  <%include file="_dashboard_course_resume.html" args="resume_button_url=resume_button_url, course_overview=course_overview, enrollment=enrollment, is_unfulfilled_entitlement=is_unfulfilled_entitlement, course_target=course_target, related_programs=related_programs"/>
                 % endif
               % endif
           </div>

--- a/lms/templates/dashboard/_dashboard_course_resume.html
+++ b/lms/templates/dashboard/_dashboard_course_resume.html
@@ -1,4 +1,4 @@
-<%page args="resume_button_url, course_overview, enrollment, is_unfulfilled_entitlement, course_target" expression_filter="h"/>
+<%page args="resume_button_url, course_overview, enrollment, is_unfulfilled_entitlement, course_target, related_programs" expression_filter="h"/>
 
 <%!
 import six


### PR DESCRIPTION
I believe this caused issues on [e2e tests](https://build.testeng.edx.org/view/e2e-tests/job/edx-e2e-tests/7206/testReport/junit/regression.tests.lms.test_lms_login/LoginTest/test_login/) because although the resume template used in edx-platform was updated, there are other resume templates used for theming that were not properly removed.

Partial revert of https://github.com/edx/edx-platform/pull/28669/

My guess is that the culprit is [this line from the edx theme of the resume template](https://github.com/edx/edx-themes/blob/master/edx-platform/edx.org-next/lms/templates/dashboard/_dashboard_course_resume.html#L1)