### PR TITLE
refactor: Studio OAuth cleanup, part 1

### DIFF
--- a/cms/djangoapps/contentstore/tests/tests.py
+++ b/cms/djangoapps/contentstore/tests/tests.py
@@ -181,7 +181,7 @@ class AuthTestCase(ContentStoreTestCase):
             )
             self.assertContains(
                 response,
-                '<a class="action action-signin" href="/signin_redirect_to_lms?next=http%3A%2F%2Ftestserver%2F">'
+                '<a class="action action-signin" href="/login/?next=http%3A%2F%2Ftestserver%2F">'
                 'Sign In</a>'
             )
 

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -647,11 +647,8 @@ LMS_INTERNAL_ROOT_URL = LMS_ROOT_URL
 # Use LMS SSO for login, once enabled by setting LOGIN_URL (see docs/guides/studio_oauth.rst)
 SOCIAL_AUTH_STRATEGY = 'auth_backends.strategies.EdxDjangoStrategy'
 LOGIN_REDIRECT_URL = EDX_ROOT_URL + '/home/'
-# TODO: Set LOGIN_URL to '/login/' after Studio OAuth transition is complete, and
-# finish ARCH-1253 cleanup. See docs/guides/studio_oauth.rst
-LOGIN_URL = reverse_lazy('login_redirect_to_lms')
-FRONTEND_LOGIN_URL = lambda settings: settings.LMS_ROOT_URL + '/login'
-derived('FRONTEND_LOGIN_URL')
+LOGIN_URL = '/login/'
+FRONTEND_LOGIN_URL = LOGIN_URL
 # Warning: Must have trailing slash to activate correct logout view
 # (auth_backends, not LMS user_authn)
 FRONTEND_LOGOUT_URL = '/logout/'

--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -48,9 +48,6 @@ LMS_BASE = 'localhost:18000'
 LMS_ROOT_URL = f'http://{LMS_BASE}'
 FEATURES['PREVIEW_LMS_BASE'] = "preview." + LMS_BASE
 
-# TODO: Remove after Studio OAuth transition is complete. See docs/guides/studio_oauth.rst
-LOGIN_URL = '/login/'
-FRONTEND_LOGIN_URL = LMS_ROOT_URL + '/login'
 FRONTEND_REGISTER_URL = LMS_ROOT_URL + '/register'
 ########################### PIPELINE #################################
 

--- a/docs/guides/studio_oauth.rst
+++ b/docs/guides/studio_oauth.rst
@@ -28,7 +28,7 @@ For each deployed environment (stage, production, etc.):
      - Go to ``/admin/oauth2_provider/application/add/`` in LMS admin
      - Copy the prepopulated client ID and secret to a secure place
      - Leave the user field empty
-     - Set redirect URLs to ``<STUDIO_ROOT_URL>/complete/edx-oauth2/``
+     - Set redirect URLs to ``<STUDIO_ROOT_URL>/complete/edx-oauth2/`` (as well as for any additional domains, such as internally routed domains)
      - Set client type to ``Confidential``
      - Set authorization grant type to ``Authorization code``
      - Set the name to ``studio-sso``
@@ -52,7 +52,6 @@ For each deployed environment (stage, production, etc.):
 #. Configure Studio to initiative OAuth flow and use a separate session cookie::
 
     LOGIN_URL: /login/  # to activate OAuth functionality
-    SESSION_COOKIE_DOMAIN: <studio domain>  # since no longer using root domain to share with LMS
     SESSION_COOKIE_NAME: studio_sessionid
 
 Cleanup
@@ -63,8 +62,7 @@ Config and code changes to be performed after all environments are using OAuth f
 - Set ``LOGIN_URL`` to ``'/login/'`` in ``cms/envs/common.py``
 - Deploy
 - Remove ``LOGIN_URL`` overrides from all environments (devstack and others)
-- Remove remaining ``ARCH-1253`` detritus (login redirect)
-- Remove this doc!
+- Remove doc (convert to migration instructions for next release)
 
 Declining the migration
 -----------------------
@@ -72,4 +70,5 @@ Declining the migration
 Untested instructions for continuing to keep the shared sessions:
 
 - Override ``FRONTEND_LOGOUT_URL`` for Studio to be ``<LMS base>/logout``
+- Override ``FRONTEND_LOGIN_URL`` for Studio to be ``<LMS base>/login``
 - Override ``LOGIN_URL`` for Studio to be ``<LMS base>/login``


### PR DESCRIPTION
- Update migration instructions
    - Changes regarding redirect URLs and cookie domain are to permit the
      site to run on multiple domains.
- Set LOGIN_URL in common so that it can be unset in environment overrides

This bypasses the "redirect to LMS" login/signup code, but does not yet
remove it; removal is covered by DEPR-166 so that this remains a
configuration-only change for now.

This should have no user-visible effect.

ref: ARCHBOM-1890

## Testing instructions

Tested manually in devstack -- various Studio login scenarios.

## Other information

Once this is complete, some edx.org environmental overrides can be removed.