### PR TITLE
feat: add courserun_key property to GA event transformer.

### DIFF
--- a/common/djangoapps/track/shim.py
+++ b/common/djangoapps/track/shim.py
@@ -3,6 +3,9 @@
 
 import json
 
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import CourseKey
+
 from .transformers import EventTransformerRegistry
 
 CONTEXT_FIELDS_TO_INCLUDE = [
@@ -85,6 +88,15 @@ class GoogleAnalyticsProcessor:
         copied_event = event.copy()
         if course_id is not None:
             copied_event['label'] = course_id
+            # The value stored as course_id is not always a courserun_key.
+            # It may, for example, be a library instead.  So we parse it first to be sure.
+            # We add a str() call to the input so that sentinel values don't cause
+            # CourseKey to spit up with a different error.
+            try:
+                courserun_key = CourseKey.from_string(str(course_id))
+                copied_event['courserun_key'] = str(courserun_key)
+            except InvalidKeyError:
+                pass
 
         copied_event['nonInteraction'] = 1
 

--- a/common/djangoapps/track/tests/test_shim.py
+++ b/common/djangoapps/track/tests/test_shim.py
@@ -8,10 +8,12 @@ import ddt
 from django.test.utils import override_settings
 
 from openedx.core.lib.tests.assertions.events import assert_events_equal
+from opaque_keys.edx.locator import CourseLocator
 
 from .. import transformers
 from ..shim import PrefixedEventProcessor
 from . import FROZEN_TIME, EventTrackingTestCase
+
 
 LEGACY_SHIM_PROCESSOR = [
     {
@@ -150,6 +152,33 @@ class GoogleAnalyticsProcessorTestCase(EventTrackingTestCase):
         expected_event = {
             'context': context,
             'data': data,
+            'name': sentinel.name,
+            'nonInteraction': 1,
+            'timestamp': FROZEN_TIME,
+        }
+        assert_events_equal(expected_event, emitted_event)
+
+    def test_valid_course_id(self):
+        """ Test that a courserun_key is added if course_id is a valid course key. """
+        data = {sentinel.key: sentinel.value}
+        courserun_key = str(CourseLocator(org='testx', course='test_course', run='test_run'))
+
+        context = {
+            'path': sentinel.path,
+            'user_id': sentinel.user_id,
+            'client_id': sentinel.client_id,
+            'course_id': courserun_key,
+        }
+        with self.tracker.context('test', context):
+            self.tracker.emit(sentinel.name, data)
+
+        emitted_event = self.get_event()
+
+        expected_event = {
+            'context': context,
+            'data': data,
+            'label': courserun_key,
+            'courserun_key': courserun_key,
             'name': sentinel.name,
             'nonInteraction': 1,
             'timestamp': FROZEN_TIME,


### PR DESCRIPTION
The GA transformer adds the context.course_id property of a tracking
log event to the event transmitted automatically to Segment in the
"label" property, so GA can use it.  This adds it also to the
"courserun_key" property, so that regular users of Segment events can
also query it in a more consistently-named property.

For DENG-997.
