### PR TITLE
LOGOUT_REDIRECT_URL to be used for logout redirection

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1363,6 +1363,12 @@ USERNAME_REGEX_PARTIAL = r'[\w .@_+-]+'
 USERNAME_PATTERN = fr'(?P<username>{USERNAME_REGEX_PARTIAL})'
 
 
+# .. setting_name: LOGOUT_REDIRECT_URL
+# .. setting_default: None
+# .. setting_description: The user is by default redirected to edX's dashboard, if redirect_url is not specified
+#  in the logout URL. LOGOUT_REDIRECT_URL can be used as default redirection-url instead of dashboard.
+LOGOUT_REDIRECT_URL = None
+
 ############################## EVENT TRACKING #################################
 LMS_SEGMENT_KEY = None
 

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -1042,3 +1042,9 @@ COURSE_OLX_VALIDATION_IGNORE_LIST = ENV_TOKENS.get(
 
 ################# show account activate cta after register ########################
 SHOW_ACCOUNT_ACTIVATION_CTA = ENV_TOKENS.get('SHOW_ACCOUNT_ACTIVATION_CTA', SHOW_ACCOUNT_ACTIVATION_CTA)
+
+# New variable named LOGOUT_REDIRECT_URL which can be used as default redirection-url instead of dashboard.
+LOGOUT_REDIRECT_URL = ENV_TOKENS.get(
+    'LOGOUT_REDIRECT_URL',
+    None
+)

--- a/openedx/core/djangoapps/user_authn/views/logout.py
+++ b/openedx/core/djangoapps/user_authn/views/logout.py
@@ -60,6 +60,11 @@ class LogoutView(TemplateView):
         if target_url:
             target_url = parse.unquote(parse.quote_plus(target_url))
 
+        # In case no target-url is specified in request,
+        # LOGOUT_REDIRECT_URL will be used instead.
+        if not target_url and settings.LOGOUT_REDIRECT_URL:
+            target_url = settings.LOGOUT_REDIRECT_URL
+
         use_target_url = target_url and is_safe_login_or_logout_redirect(
             redirect_to=target_url,
             request_host=self.request.get_host(),

--- a/openedx/core/djangoapps/user_authn/views/tests/test_logout.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_logout.py
@@ -193,3 +193,18 @@ class LogoutTests(TestCase):
                 'show_tpa_logout_link': True,
             }
             self.assertDictContainsSubset(expected, response.context_data)
+
+    @mock.patch('openedx.core.djangoapps.user_authn.views.logout.is_safe_login_or_logout_redirect')
+    @override_settings(LOGOUT_REDIRECT_URL='http://test-mock.com/logout')
+    def test_logout_redirect_url_settings(self, mock_is_safe_login_or_logout_redirect):
+        mock_is_safe_login_or_logout_redirect.return_value = True
+        redirect_url = ''
+        url = '{logout_path}?redirect_url={redirect_url}'.format(
+            logout_path=reverse('logout'),
+            redirect_url=redirect_url
+        )
+        response = self.client.get(url, HTTP_HOST='testserver')
+        expected = {
+            'target': urllib.parse.unquote(settings.LOGOUT_REDIRECT_URL),
+        }
+        self.assertDictContainsSubset(expected, response.context_data)


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

If redirect_url is not specified in the logout URL (/logout) then the user is by default redirected to edX's dashboard (/dashboard). Introduced a new variable named `LOGOUT_REDIRECT_URL` which can be used as default redirection-url instead of dashboard.

## Supporting information

[issue-271](https://github.com/mitodl/edx-platform/issues/271)

## Deadline

Aim to get this merged before October 9