### PR TITLE
fix: get correct root URL for Track Selection page

### DIFF
--- a/common/djangoapps/course_modes/helpers.py
+++ b/common/djangoapps/course_modes/helpers.py
@@ -138,8 +138,8 @@ def get_verified_track_links(language):
         Dictionary with URL's with verified certificate informational links.
         If not edx.org, returns a dictionary with default URL's.
     """
-    support_url = settings.SUPPORT_SITE_LINK
-    root_url = settings.LMS_ROOT_URL
+    support_root_url = settings.SUPPORT_SITE_LINK
+    marketing_root_url = settings.MKTG_URLS.get('ROOT')
 
     enabled_languages = {
         'en': 'hc/en-us',
@@ -147,10 +147,12 @@ def get_verified_track_links(language):
     }
 
     # Add edX specific links only to edx.org
-    if root_url and 'edx.org' in root_url:
-        track_verified_url = urljoin(root_url, 'verified-certificate')
-        if support_url and 'support.edx.org' in support_url:
+    if marketing_root_url and 'edx.org' in marketing_root_url:
+        track_verified_url = urljoin(marketing_root_url, 'verified-certificate')
+        if support_root_url and 'support.edx.org' in support_root_url:
             support_article_params = '/articles/360013426573-'
+            # Must specify the language in the URL since
+            # support links do not auto detect the language settings
             language_specific_params = {
                 'en': 'What-are-the-differences-between-audit-free-and-verified-paid-courses-',
                 'es-419': ('-Cu%C3%A1les-son-las-diferencias'
@@ -161,7 +163,7 @@ def get_verified_track_links(language):
             else:
                 full_params = enabled_languages['en'] + support_article_params + language_specific_params['en']
             track_comparison_url = urljoin(
-                support_url,
+                support_root_url,
                 full_params
             )
             return {
@@ -170,6 +172,6 @@ def get_verified_track_links(language):
             }
     # Default URL's are used if not edx.org
     return {
-        'verified_certificate': root_url,
-        'learn_more': support_url,
+        'verified_certificate': marketing_root_url,
+        'learn_more': support_root_url,
     }

--- a/common/djangoapps/course_modes/tests/test_views.py
+++ b/common/djangoapps/course_modes/tests/test_views.py
@@ -7,12 +7,14 @@ import decimal
 import unittest
 from datetime import datetime, timedelta
 from unittest.mock import patch
+from urllib.parse import urljoin
 
 import ddt
 import freezegun
 import httpretty
 import pytz
 from django.conf import settings
+from django.test import override_settings
 from django.urls import reverse
 
 from common.djangoapps.course_modes.models import CourseMode, Mode
@@ -542,6 +544,16 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
         self.assertContains(response, 'access to all course activities')
         self.assertContains(response, 'Full access')
 
+        # Check for informational links - verified
+        marketing_root = settings.MKTG_URLS.get('ROOT')
+        marketing_url = urljoin(marketing_root, 'verified-certificate')
+        self.assertContains(response, marketing_url)
+        support_root = settings.SUPPORT_SITE_LINK
+        article_params = ('hc/en-us/articles/360013426573-'
+                          'What-are-the-differences-between-audit-free-and-verified-paid-courses-')
+        support_url = urljoin(support_root, article_params)
+        self.assertContains(response, support_url)
+
         # Check for happy path messaging - audit
         self.assertContains(response, "discussion forums and non-graded assignments")
         self.assertContains(response, "Get temporary access")
@@ -573,6 +585,7 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
         # This string only occurs in lms/templates/course_modes/choose.html
         # and related theme and translation files.
 
+    @override_settings(MKTG_URLS={'ROOT': 'https://www.example.edx.org'})
     @ddt.data(
         # gated_content_on, course_duration_limits_on, waffle_flag_on, expected_page_assertion_function
         (True, True, True, _assert_fbe_page),

--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -121,7 +121,7 @@ class ChooseModeView(View):
         ecommerce_service = EcommerceService()
 
         # We assume that, if 'professional' is one of the modes, it should be the *only* mode.
-        # If there are both modes, default to non-id-professional.
+        # If there are both modes, default to 'no-id-professional'.
         has_enrolled_professional = (CourseMode.is_professional_slug(enrollment_mode) and is_active)
         if CourseMode.has_professional_mode(modes) and not has_enrolled_professional:
             purchase_workflow = request.GET.get("purchase_workflow", "single")

--- a/lms/static/sass/views/_track_selection.scss
+++ b/lms/static/sass/views/_track_selection.scss
@@ -1,5 +1,8 @@
 .track-selection-container {
-    max-width: 946px;
+    .wrapper-register-choose {
+        max-width: 946px;
+        margin: 0 auto;
+    }
 
     .page-header h3 {
         color: #001B1E;
@@ -25,7 +28,7 @@
     }
 
     .track-selection-certificate .choice-bullets li:last-child {
-        margin-bottom: 2rem;
+        margin-bottom: 1.5rem;
     }
 
     .track-selection-audit .choice-bullets li:last-child {

--- a/lms/templates/course_modes/fbe.html
+++ b/lms/templates/course_modes/fbe.html
@@ -59,9 +59,9 @@ from openedx.core.djangolib.markup import HTML, Text
             end_bold=HTML('</b>'),
         )}</li>
         % if audit_access_deadline:
-        <li>${_("Access expires and all progress will be lost on")} ${audit_access_deadline}</li>
+        <li class="font-italic">${_("Access expires and all progress will be lost on")} ${audit_access_deadline}</li>
         % else:
-        <li>${_("Access expires and all progress will be lost")}</li>
+        <li class="font-italic">${_("Access expires and all progress will be lost")}</li>
         % endif
     </ul>
 </div>


### PR DESCRIPTION
[REV-2387](https://openedx.atlassian.net/browse/REV-2387). 

Before we turn on the new experience for Track Selection to all learners, there were some edge cases that needed to be checked, and the URL to be fixed.

Please note that the edge case of having a `credit mode` does not need any special logic as it will display the same messaging (old Track Selection displayed a special message that related to the learner having credit or not).

**Edit:** The commit that has been removed (with a Professional mode commit message) was mistakenly confused by another commit and dropped from this PR. This will be added in another PR, since it allows the upgrade button to redirect to basket.

**This PR:**
- Misc CSS fixes (local vs prod issue). 
- Fixed the "verified certificate" link with the correct base URL.
- Fix on a comment.


<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->
