### PR TITLE
fix: Trying to measure block lengths on empty structures

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/mongo_connection.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/mongo_connection.py
@@ -148,7 +148,11 @@ def structure_from_mongo(structure, course_context=None):
             for the course that this data is being processed for.
     """
     with TIMER.timer('structure_from_mongo', course_context) as tagger:
-        tagger.measure('blocks', len(structure['blocks']))
+        if structure and structure.get('blocks'):
+            block_length = len(structure['blocks'])
+        else:
+            block_length = 0
+        tagger.measure("blocks", block_length)
 
         structure['root'] = BlockKey(*structure['root'])
         new_blocks = {}


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

In some situations the `blocks` object retrieved from Mongo is empty. There is a line of code that is generating metrics from that `blocks` object which throws an error for that empty structure, even though there is no functional requirement for the object to be non-null. This adds a conditional check to determine if the object has any value and records a length of 0 otherwise.

## Supporting information

[issue#272](https://github.com/mitodl/edx-platform/issues/272)