### PR TITLE
Remove event routing backends from edx-platform

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1477,9 +1477,6 @@ INSTALLED_APPS = [
     'common.djangoapps.track',
     'eventtracking.django.apps.EventTrackingConfig',
 
-    # Backends for receiving edX LMS events
-    'event_routing_backends.apps.EventRoutingBackendsConfig',
-
     # For asset pipelining
     'common.djangoapps.edxmako.apps.EdxMakoConfig',
     'pipeline',

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3141,9 +3141,6 @@ INSTALLED_APPS = [
 
     'ratelimitbackend',
 
-    # Backends for receiving edX LMS events
-    'event_routing_backends.apps.EventRoutingBackendsConfig',
-
     # Database-backed Organizations App (http://github.com/edx/edx-organizations)
     'organizations',
 

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -84,7 +84,6 @@ edx-django-sites-extensions
 edx-django-utils>=4.0.0            # Utilities for cache, monitoring, and plugins
 edx-drf-extensions
 edx-enterprise
-edx-event-routing-backends
 edx-milestones
 edx-name-affirmation
 edx-organizations


### PR DESCRIPTION
Removing event-routing-backend as core dependency of edx-platform. we are going to add it as optional dependency [here](https://github.com/edx/configuration/blob/b185437d1210f440ea9bc5d03c1590f443cc7cf4/playbooks/roles/edxapp/defaults/main.yml#L538)
