### PR TITLE
BOM-2715: Pinned numpy>=1.16.0,<1.17.0 in codejail requirements

### DIFF
--- a/requirements/edx-sandbox/py38.in
+++ b/requirements/edx-sandbox/py38.in
@@ -6,12 +6,15 @@ lxml                                # XML parser
 matplotlib                          # 2D plotting library
 networkx                            # Utilities for creating, manipulating, and studying network graphs
 nltk                                # Natural language processing; used by the chem package
-numpy                               # Numeric array processing utilities; used by scipy
 openedx-calc
 pyparsing                           # Python Parsing module
 random2                             # Implementation of random module that works identically under Python 2 and 3
 scipy                               # Math, science, and engineering library
 sympy                               # Symbolic math library
+
+# numpy>=1.17.0 caused failures in importing numpy in code-jail environment.
+# The issue will be investigated and fixed in https://openedx.atlassian.net/browse/BOM-2841.
+numpy>=1.16.0,<1.17.0
 
 # Install these packages from the edx-platform working tree
 # NOTE: if you change code in these packages, you MUST change the version

--- a/requirements/edx-sandbox/py38.txt
+++ b/requirements/edx-sandbox/py38.txt
@@ -46,7 +46,7 @@ nltk==3.6.2
     # via
     #   -r requirements/edx-sandbox/py38.in
     #   chem
-numpy==1.21.2
+numpy==1.16.6
     # via
     #   -r requirements/edx-sandbox/py38.in
     #   chem


### PR DESCRIPTION
**Issue:** [BOM-2715](https://openedx.atlassian.net/browse/BOM-2715)

### Description
- `numpy>=1.17.0` causes issues with `Python 3.8` in code-jail environment.
- Pinned the `numpy>=1.16.0,<1.17.0` in code-jail `Python 3.8` requirements to resolve the `numpy` issue in the code-jail upgrade.