### PR TITLE
[MST-866] Use course overviews instead of modulestore in enrollments service

### DIFF
--- a/openedx/core/djangoapps/enrollments/services.py
+++ b/openedx/core/djangoapps/enrollments/services.py
@@ -10,7 +10,7 @@ from django.db.models import Q
 from opaque_keys.edx.keys import CourseKey
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.models import CourseEnrollment
-from xmodule.modulestore.django import modulestore
+from openedx.core.djangoapps.content.course_overviews.api import get_course_overview_or_none
 
 
 class EnrollmentsService:
@@ -68,12 +68,12 @@ class EnrollmentsService:
         * text_search: the string against which to do a match on users' username or email; optional
         """
         course_id_coursekey = CourseKey.from_string(course_id)
-        course_module = modulestore().get_course(course_id_coursekey)
-        if not course_module or not course_module.enable_proctored_exams:
+        course_overview = get_course_overview_or_none(course_id_coursekey)
+        if not course_overview or not course_overview.enable_proctored_exams:
             return None
 
         allow_honor_mode = settings.PROCTORING_BACKENDS.get(
-            course_module.proctoring_provider, {}
+            course_overview.proctoring_provider, {}
         ).get('allow_honor_mode', False)
         enrollments = self._get_enrollments_for_course_proctoring_eligible_modes(course_id, allow_honor_mode)
 

--- a/openedx/core/djangoapps/enrollments/tests/test_services.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_services.py
@@ -7,9 +7,9 @@ from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import UserFactory
+from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from openedx.core.djangoapps.enrollments.services import EnrollmentsService
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory
 
 
 @ddt.ddt
@@ -28,7 +28,7 @@ class EnrollmentsServiceTests(ModuleStoreTestCase):
             CourseMode.PROFESSIONAL,
             CourseMode.VERIFIED
         ]
-        self.course = CourseFactory.create(enable_proctored_exams=True)
+        self.course = CourseOverviewFactory.create(enable_proctored_exams=True)
 
         for index in range(len(self.course_modes)):
             course_mode = self.course_modes[index]
@@ -74,7 +74,7 @@ class EnrollmentsServiceTests(ModuleStoreTestCase):
         """
         Test that an empty list is returned if a course has no enrollments
         """
-        course = CourseFactory.create(enable_proctored_exams=True)
+        course = CourseOverviewFactory.create(enable_proctored_exams=True)
 
         enrollments = self.service.get_enrollments_can_take_proctored_exams(str(course.id))  # pylint: disable=no-member
 
@@ -82,7 +82,7 @@ class EnrollmentsServiceTests(ModuleStoreTestCase):
 
     def test_get_enrollments_can_take_proctored_exams_allow_honor(self):
         self.course.proctoring_provider = 'test'
-        self.store.update_item(self.course, self.user.id)
+        self.course.save()
 
         mock_proctoring_backend = {
             'test': {
@@ -104,7 +104,7 @@ class EnrollmentsServiceTests(ModuleStoreTestCase):
 
     def test_get_enrollments_can_take_proctored_exams_not_enable_proctored_exams(self):
         self.course.enable_proctored_exams = False
-        self.store.update_item(self.course, self.user.id)
+        self.course.save()
 
         enrollments = self.service.get_enrollments_can_take_proctored_exams(str(self.course.id))
 
@@ -170,7 +170,7 @@ class EnrollmentsServicePerformanceTests(ModuleStoreTestCase):
     def setUp(self):
         super().setUp()
         self.service = EnrollmentsService()
-        self.course = CourseFactory.create(enable_proctored_exams=True)
+        self.course = CourseOverviewFactory.create(enable_proctored_exams=True)
         self.course_modes = [
             CourseMode.AUDIT,
             CourseMode.EXECUTIVE_EDUCATION,


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Following the changes in https://github.com/edx/edx-platform/pull/28085, this updates the Enrollments service to utilize the newly added proctoring fields on the CourseOverview model, rather than using modulestore.

## Supporting information

[MST-866](https://openedx.atlassian.net/browse/MST-866)