### PR TITLE
fix: correct typo, content is locked, not lost

### DIFF
--- a/common/djangoapps/course_modes/tests/test_views.py
+++ b/common/djangoapps/course_modes/tests/test_views.py
@@ -569,7 +569,7 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
         # and related theme and translation files.
 
         # Check for string unique to unfbe.html.
-        self.assertContains(response, "Some graded content may be lost")
+        self.assertContains(response, "Some graded content may be locked")
         # This string only occurs in lms/templates/course_modes/unfbe.html
         # and related theme and translation files.
 

--- a/lms/templates/course_modes/unfbe.html
+++ b/lms/templates/course_modes/unfbe.html
@@ -32,7 +32,7 @@ from openedx.core.djangolib.markup import HTML, Text
 <div class="choice-bullets track-selection-type-unfbe">
     <ul>
         <li>${_("Get access to the course material, including videos and readings")}</li>
-        <li>${_("Some graded content may be lost")}</li>
+        <li>${_("Some graded content may be locked")}</li>
     </ul>
 </div>
 </%block>


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

The text on the partial-based FBE page should say "Some graded content may be locked", no "lost".

Current page:

![image](https://user-images.githubusercontent.com/3790674/134063630-667d8670-cfcd-4bca-9b32-5ed3299c38dd.png)

Desired page:

![image](https://user-images.githubusercontent.com/3790674/134063567-0a1df564-77c5-4a09-997d-ce5e03c692c0.png)

## Supporting information

Closes: https://openedx.atlassian.net/browse/REV-2325

## Testing instructions

1.  Browse to a course that has either gated content or course duration limits or both turned off.
2. Enroll in the course.
3. The track selection page should have a bullet that says "Some graded content may be locked".

## Deadline

None.

## Other information

N/A.