### PR TITLE
feat: add JS for upgrade button redirect in Track Selection

### DIFF
--- a/lms/static/sass/views/_track_selection.scss
+++ b/lms/static/sass/views/_track_selection.scss
@@ -240,6 +240,10 @@
         .price-display {
             font-size: 14px;
         }
+
+        .choice-bullets {
+            padding: 0 2rem 1rem 1rem;
+        }
     }
 
     @media (min-width: map-get($grid-breakpoints, 'md')) {

--- a/lms/static/sass/views/_track_selection.scss
+++ b/lms/static/sass/views/_track_selection.scss
@@ -20,7 +20,6 @@
         background-color: white;
         border: 1px solid #707070;
         position: relative;
-        float: right;
     }
 
     .track-selection-certificate {

--- a/lms/templates/course_modes/track_selection.html
+++ b/lms/templates/course_modes/track_selection.html
@@ -16,6 +16,17 @@ from openedx.core.djangolib.js_utils import js_escaped_string
 
 <%block name="js_extra">
     <script type="text/javascript">
+        // upgrade button re-direct to ecommerce basket (which re-directs to Payment MFE)
+        % if use_ecommerce_payment_flow:
+        $(function(){
+            $('button[name=verified_mode]').click(function(e){
+                e.preventDefault();
+                window.location.href = '${ecommerce_payment_page | n, js_escaped_string}?sku=' +
+                encodeURIComponent('${sku | n, js_escaped_string}');
+            });
+        });
+        % endif
+
         // popover icon toggle
         $(function(){
             $('body').click(function (e) {


### PR DESCRIPTION
[REV-2387](https://openedx.atlassian.net/browse/REV-2387).

**This PR:**
- Adds the upgrade button redirect to ecommerce (which redirects to Payment MFE) upon click of the button.
- Decreases padding  of the bullet points on responsive version.
- Removes CSS float (see below note).

**Note:** 
The post method checks the course mode and the `contribution`, and if the mode is `verified` it redirects to ID verification (`IDVerificationService`), code [here](https://github.com/edx/edx-platform/blob/42d79c5ef5ccf516809d0e5a325e4da3f0acdc01/common/djangoapps/course_modes/views.py#L341). However, if `use_ecommerce_payment_flow` is true and added to `context` in views.py, there is JS that needs to run on the click of the upgrade button to redirect to `/basket/add/?sku=` URL instead. This is how current Track Selection is done.

There isn't a clear answer yet why this is done this way instead of on the views.py side, refactor work will soon follow up in [REV-2394](https://openedx.atlassian.net/browse/REV-2394).

**Note on the CSS:**
There has been a margin issue on the audit side, where when it's stacked it floats to the right. On the same screen width, this issue is seen by Phil Shiu locally and in prod in Chrome and Firefox, as well as on his mobile phone.
Diane and I don't see this in prod using Chrome and Firefox, as well as my mobile phone.

Removing the float doesn't look like it breaks the desktop view so I am removing it.


<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->