### PR TITLE
chore: `django-cor-headers` post deployment cleanup.

### DIFF
--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -16,7 +16,6 @@ from corsheaders.defaults import default_headers as corsheaders_default_headers
 from django.core.exceptions import ImproperlyConfigured
 from django.urls import reverse_lazy
 from edx_django_utils.plugins import add_plugins
-from importlib.metadata import version
 from path import Path as path
 
 
@@ -556,12 +555,6 @@ derive_settings(__name__)
 if FEATURES.get('ENABLE_CORS_HEADERS'):
     CORS_ALLOW_CREDENTIALS = True
     CORS_ORIGIN_WHITELIST = ENV_TOKENS.get('CORS_ORIGIN_WHITELIST', ())
-
-    # values are already updated above with default CORS_ORIGIN_WHITELIST values but in
-    # case of new version django_cors_headers they will get override.
-    cors_major_version = int(version('django_cors_headers').split('.')[0])
-    if cors_major_version >= 3 and CORS_ORIGIN_WHITELIST and ENV_TOKENS.get('CORS_ORIGIN_WHITELIST_WITH_SCHEME'):
-        CORS_ORIGIN_WHITELIST = ENV_TOKENS.get('CORS_ORIGIN_WHITELIST_WITH_SCHEME')
 
     CORS_ORIGIN_ALLOW_ALL = ENV_TOKENS.get('CORS_ORIGIN_ALLOW_ALL', False)
     CORS_ALLOW_INSECURE = ENV_TOKENS.get('CORS_ALLOW_INSECURE', False)

--- a/lms/djangoapps/experiments/tests/test_views.py
+++ b/lms/djangoapps/experiments/tests/test_views.py
@@ -13,7 +13,6 @@ from django.core.handlers.wsgi import WSGIRequest
 from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils.timezone import now
-from importlib_metadata import version
 from rest_framework.test import APITestCase
 
 from common.djangoapps.student.tests.factories import UserFactory
@@ -260,11 +259,6 @@ class ExperimentCrossDomainTests(APITestCase):
             data,
             **kwargs
         )
-
-    def test_white_list_contents_with_cors_header_version(self, *args):  # pylint: disable=unused-argument
-        """ Verify that with django-cor-header<3 it loads list with scheme. """
-        assert settings.CORS_ORIGIN_WHITELIST == ['https://sandbox.edx.org']
-        assert int(version('django_cors_headers').split('.')[0]) == 3
 
 
 class ExperimentKeyValueViewSetTests(APITestCase):  # lint-amnesty, pylint: disable=missing-class-docstring

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -25,7 +25,6 @@ import yaml
 from corsheaders.defaults import default_headers as corsheaders_default_headers
 from django.core.exceptions import ImproperlyConfigured
 from edx_django_utils.plugins import add_plugins
-from importlib.metadata import version
 from path import Path as path
 
 from openedx.core.djangoapps.plugins.constants import ProjectType, SettingsType
@@ -357,12 +356,6 @@ CSRF_TRUSTED_ORIGINS = ENV_TOKENS.get('CSRF_TRUSTED_ORIGINS', [])
 if FEATURES.get('ENABLE_CORS_HEADERS') or FEATURES.get('ENABLE_CROSS_DOMAIN_CSRF_COOKIE'):
     CORS_ALLOW_CREDENTIALS = True
     CORS_ORIGIN_WHITELIST = ENV_TOKENS.get('CORS_ORIGIN_WHITELIST', ())
-
-    # values are already updated above with default CORS_ORIGIN_WHITELIST values but in
-    # case of new version of django_cors_headers they will get override.
-    cors_major_version = int(version('django_cors_headers').split('.')[0])
-    if cors_major_version >= 3 and CORS_ORIGIN_WHITELIST and ENV_TOKENS.get('CORS_ORIGIN_WHITELIST_WITH_SCHEME'):
-        CORS_ORIGIN_WHITELIST = ENV_TOKENS.get('CORS_ORIGIN_WHITELIST_WITH_SCHEME')
 
     CORS_ORIGIN_ALLOW_ALL = ENV_TOKENS.get('CORS_ORIGIN_ALLOW_ALL', False)
     CORS_ALLOW_INSECURE = ENV_TOKENS.get('CORS_ALLOW_INSECURE', False)

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -20,7 +20,6 @@ from uuid import uuid4
 import openid.oidutil
 from django.utils.translation import ugettext_lazy
 from edx_django_utils.plugins import add_plugins
-from importlib.metadata import version
 from path import Path as path
 
 from openedx.core.djangoapps.plugins.constants import ProjectType, SettingsType

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -599,11 +599,4 @@ REGISTRATION_RATELIMIT = '5/minute'
 RESET_PASSWORD_TOKEN_VALIDATE_API_RATELIMIT = '2/m'
 RESET_PASSWORD_API_RATELIMIT = '2/m'
 
-CORS_ORIGIN_WHITELIST = ['sandbox.edx.org']
-CORS_ORIGIN_WHITELIST_WITH_SCHEME = ['https://sandbox.edx.org']
-
-# values are already updated above with default CORS_ORIGIN_WHITELIST values but in
-# case of new version django_cors_headers they will get override.
-cors_major_version = int(version('django_cors_headers').split('.')[0])
-if cors_major_version >= 3 and CORS_ORIGIN_WHITELIST and CORS_ORIGIN_WHITELIST_WITH_SCHEME:
-    CORS_ORIGIN_WHITELIST = CORS_ORIGIN_WHITELIST_WITH_SCHEME
+CORS_ORIGIN_WHITELIST = ['https://sandbox.edx.org']


### PR DESCRIPTION
CORS_ORIGIN_WHITELIST configs already updated with schemes so no need for other list.

PRs merged with schemes in `CORS_ORIGIN_WHITELIST`
https://github.com/edx/edx-internal/pull/5469
https://github.com/edx/edge-internal/pull/367
https://github.com/edx/sandbox-internal/pull/191

After this PR we can remove the `CORS_ORIGIN_WHITELIST_WITH_SCHEME` from configs