### PR TITLE
fix: privacy banner close button issue in Track Selection

### DIFF
--- a/lms/templates/course_modes/track_selection.html
+++ b/lms/templates/course_modes/track_selection.html
@@ -30,7 +30,6 @@ from openedx.core.djangolib.js_utils import js_escaped_string
         // popover icon toggle
         $(function(){
             $('body').click(function (e) {
-                e.stopPropagation();
                 $('.popover').css({"visibility": "hidden", "opacity": 0});
             });
             $('.popover-icon').click(function(e){


### PR DESCRIPTION
[REV-2387](https://openedx.atlassian.net/browse/REV-2387).

The privacy banner at the top of the page was not closing, this fixes the issue.
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->