### PR TITLE
[MST-938] Remove special exam MFE flags

### DIFF
--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -114,64 +114,6 @@ COURSEWARE_OPTIMIZED_RENDER_XBLOCK = CourseWaffleFlag(
     WAFFLE_FLAG_NAMESPACE, 'optimized_render_xblock', __name__
 )
 
-# .. toggle_name: courseware.mfe_special_exams
-# .. toggle_implementation: CourseWaffleFlag
-# .. toggle_default: False
-# .. toggle_description: Waffle flag to enable special exams experience without
-#   redirecting students to LMS.
-# .. toggle_use_cases: temporary
-# .. toggle_creation_date: 2021-4-29
-# .. toggle_target_removal_date: 2021-6-30
-# .. toggle_warnings: None
-COURSEWARE_MICROFRONTEND_SPECIAL_EXAMS = CourseWaffleFlag(
-    WAFFLE_FLAG_NAMESPACE, 'mfe_special_exams', __name__
-)
-
-# .. toggle_name: courseware.mfe_proctored_exams
-# .. toggle_implementation: CourseWaffleFlag
-# .. toggle_default: False
-# .. toggle_description: Waffle flag to enable proctored exams experience without
-#   redirecting students to LMS.
-# .. toggle_use_cases: temporary
-# .. toggle_creation_date: 2021-5-24
-# .. toggle_target_removal_date: 2021-6-30
-# .. toggle_warnings: None
-COURSEWARE_MICROFRONTEND_PROCTORED_EXAMS = CourseWaffleFlag(
-    WAFFLE_FLAG_NAMESPACE, 'mfe_proctored_exams', __name__
-)
-
-
-def mfe_special_exams_is_active(course_key: CourseKey) -> bool:
-    """
-    Can we see a course special exams in the Learning MFE?
-    """
-    #Avoid circular imports.
-    from lms.djangoapps.courseware.access_utils import in_preview_mode
-    # DENY: Old Mongo courses don't work in the MFE.
-    if course_key.deprecated:
-        return False
-    # DENY: Course preview doesn't work in the MFE
-    if in_preview_mode():
-        return False
-    # OTHERWISE: Defer to value of waffle flag for this course run and user.
-    return COURSEWARE_MICROFRONTEND_SPECIAL_EXAMS.is_enabled(course_key)
-
-
-def mfe_proctored_exams_is_active(course_key: CourseKey) -> bool:
-    """
-    Can we see a course special exams in the Learning MFE?
-    """
-    #Avoid circular imports.
-    from lms.djangoapps.courseware.access_utils import in_preview_mode
-    # DENY: Old Mongo courses don't work in the MFE.
-    if course_key.deprecated:
-        return False
-    # DENY: Course preview doesn't work in the MFE
-    if in_preview_mode():
-        return False
-    # OTHERWISE: Defer to value of waffle flag for this course run and user.
-    return COURSEWARE_MICROFRONTEND_PROCTORED_EXAMS.is_enabled(course_key)
-
 
 def courseware_mfe_is_active(course_key: CourseKey) -> bool:
     """

--- a/openedx/core/djangoapps/courseware_api/serializers.py
+++ b/openedx/core/djangoapps/courseware_api/serializers.py
@@ -116,8 +116,6 @@ class CourseInfoSerializer(serializers.Serializer):  # pylint: disable=abstract-
     verify_identity_url = AbsoluteURLField()
     verification_status = serializers.CharField()
     linkedin_add_to_profile_url = serializers.URLField()
-    is_mfe_special_exams_enabled = serializers.BooleanField()
-    is_mfe_proctored_exams_enabled = serializers.BooleanField()
     user_needs_integrity_signature = serializers.BooleanField()
 
     def __init__(self, *args, **kwargs):

--- a/openedx/core/djangoapps/courseware_api/tests/pacts/api-courseware-contract.json
+++ b/openedx/core/djangoapps/courseware_api/tests/pacts/api-courseware-contract.json
@@ -101,8 +101,6 @@
           "verify_identity_url": null,
           "verification_status": "none",
           "linkedin_add_to_profile_url": null,
-          "is_mfe_special_exams_enabled": false,
-          "is_mfe_proctored_exams_enabled": false,
           "user_needs_integrity_signature": false
         },
         "matchingRules": {
@@ -236,12 +234,6 @@
             "match": "type"
           },
           "$.body.verification_status": {
-            "match": "type"
-          },
-          "$.body.is_mfe_special_exams_enabled": {
-            "match": "type"
-          },
-          "$.body.is_mfe_proctored_exams_enabled": {
             "match": "type"
           },
           "$.body.user_needs_integrity_signature": {

--- a/openedx/core/djangoapps/courseware_api/tests/test_views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/test_views.py
@@ -26,8 +26,6 @@ from lms.djangoapps.courseware.tests.helpers import MasqueradeMixin
 from lms.djangoapps.courseware.toggles import (
     COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES,
     COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES_STREAK_CELEBRATION,
-    COURSEWARE_MICROFRONTEND_SPECIAL_EXAMS,
-    COURSEWARE_MICROFRONTEND_PROCTORED_EXAMS,
 )
 from lms.djangoapps.courseware.toggles import COURSEWARE_MFE_MILESTONES_STREAK_DISCOUNT
 from lms.djangoapps.verify_student.services import IDVerificationService
@@ -323,23 +321,6 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
                     mock_segment_track.assert_not_called()
 
     @ddt.data(
-        (False, False),
-        (False, True),
-        (True, False),
-        (True, True),
-    )
-    @ddt.unpack
-    def test_special_exams_enabled_for_course(self, is_globally_enabled, is_waffle_enabled):
-        """ Ensure that special exams flag present in courseware meta data with expected value """
-        with mock.patch.dict('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': is_globally_enabled}):
-            with override_waffle_flag(COURSEWARE_MICROFRONTEND_SPECIAL_EXAMS, active=is_waffle_enabled):
-                response = self.client.get(self.url)
-                assert response.status_code == 200
-                courseware_data = response.json()
-                assert 'is_mfe_special_exams_enabled' in courseware_data
-                assert courseware_data['is_mfe_special_exams_enabled'] == (is_globally_enabled and is_waffle_enabled)
-
-    @ddt.data(
         (None, False, False, False),
         ('verified', False, False, True),
         ('masters', False, False, True),
@@ -368,23 +349,6 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
         courseware_data = response.json()
         assert 'user_needs_integrity_signature' in courseware_data
         assert courseware_data['user_needs_integrity_signature'] == needs_integrity_signature
-
-    @ddt.data(
-        (False, False),
-        (False, True),
-        (True, False),
-        (True, True),
-    )
-    @ddt.unpack
-    def test_proctored_exams_enabled_for_course(self, is_globally_enabled, is_waffle_enabled):
-        """ Ensure that proctored exams flag present in courseware meta data with expected value """
-        with mock.patch.dict('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': is_globally_enabled}):
-            with override_waffle_flag(COURSEWARE_MICROFRONTEND_PROCTORED_EXAMS, active=is_waffle_enabled):
-                response = self.client.get(self.url)
-                assert response.status_code == 200
-                courseware_data = response.json()
-                assert 'is_mfe_proctored_exams_enabled' in courseware_data
-                assert courseware_data['is_mfe_proctored_exams_enabled'] == (is_globally_enabled and is_waffle_enabled)
 
 
 @ddt.ddt

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -4,7 +4,6 @@ Course API Views
 
 from completion.exceptions import UnavailableCompletionData
 from completion.utilities import get_key_to_last_completed_block
-from django.conf import settings
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
@@ -38,8 +37,6 @@ from lms.djangoapps.courseware.toggles import (
     courseware_legacy_is_visible,
     courseware_mfe_is_visible,
     course_exit_page_is_active,
-    mfe_special_exams_is_active,
-    mfe_proctored_exams_is_active,
 )
 from lms.djangoapps.courseware.views.views import get_cert_data
 from lms.djangoapps.grades.api import CourseGradeFactory
@@ -120,14 +117,6 @@ class CoursewareMeta:
             is_global_staff=self.original_user_is_global_staff,
             is_course_staff=self.original_user_is_staff
         )
-
-    @property
-    def is_mfe_special_exams_enabled(self):
-        return settings.FEATURES.get('ENABLE_SPECIAL_EXAMS', False) and mfe_special_exams_is_active(self.course_key)
-
-    @property
-    def is_mfe_proctored_exams_enabled(self):
-        return settings.FEATURES.get('ENABLE_SPECIAL_EXAMS', False) and mfe_proctored_exams_is_active(self.course_key)
 
     @property
     def enrollment(self):


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Removes `courseware.mfe_special_exams` and `courseware.mfe_proctored_exams`, as the special exams MFE should now be enabled by default if the learning MFE is enabled. Dependent on https://github.com/edx/frontend-app-learning/pull/648

## Supporting information

[MST-938](https://openedx.atlassian.net/browse/MST-938)