### PR TITLE
fix: install django-ratelimit-backend from commit hash

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -323,7 +323,7 @@ django-pyfs==3.1.0
     # via -r requirements/edx/base.in
 django-ratelimit==3.0.1
     # via -r requirements/edx/base.in
-git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a6#egg=django-ratelimit-backend==2.0.1a6
+git+https://github.com/edx/django-ratelimit-backend.git@6e1a0c6ea1d27062c16e9fb94d3c44475146877e#egg=django-ratelimit-backend
     # via -r requirements/edx/github.in
 git+https://github.com/edx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776#egg=django-require==1.0.12
     # via -r requirements/edx/github.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -412,7 +412,7 @@ django-pyfs==3.1.0
     # via -r requirements/edx/testing.txt
 django-ratelimit==3.0.1
     # via -r requirements/edx/testing.txt
-git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a6#egg=django-ratelimit-backend==2.0.1a6
+git+https://github.com/edx/django-ratelimit-backend.git@6e1a0c6ea1d27062c16e9fb94d3c44475146877e#egg=django-ratelimit-backend
     # via -r requirements/edx/testing.txt
 git+https://github.com/edx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776#egg=django-require==1.0.12
     # via -r requirements/edx/testing.txt

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -61,7 +61,7 @@ git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752
 
 # This is a temporary fork until https://github.com/brutasse/django-ratelimit-backend/pull/50 is merged
 # back into the upstream code.
-git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a6#egg=django-ratelimit-backend==2.0.1a6
+git+https://github.com/edx/django-ratelimit-backend.git@6e1a0c6ea1d27062c16e9fb94d3c44475146877e#egg=django-ratelimit-backend
 
 # original repo is not maintained any more.
 git+https://github.com/edx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776#egg=django-require==1.0.12

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -394,7 +394,7 @@ django-pyfs==3.1.0
     # via -r requirements/edx/base.txt
 django-ratelimit==3.0.1
     # via -r requirements/edx/base.txt
-git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a6#egg=django-ratelimit-backend==2.0.1a6
+git+https://github.com/edx/django-ratelimit-backend.git@6e1a0c6ea1d27062c16e9fb94d3c44475146877e#egg=django-ratelimit-backend
     # via -r requirements/edx/base.txt
 git+https://github.com/edx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776#egg=django-require==1.0.12
     # via -r requirements/edx/base.txt


### PR DESCRIPTION

## Description

Previously we're installing with tag but somehow it wasn't bringing the exact version we wanted.

## Testing instructions

Run Django 3.0 python tests on this PR to verify that the change is working fine.
