### PR TITLE
BOM-2850: Upgrade django-cors-headers to 3.5.0

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -24,8 +24,9 @@ django-celery-results<2.1
 # We do not support version django-config-models<1.0.0
 django-config-models>=1.0.0
 
-# greater version has breaking changes `settings have been renamed`. Check https://github.com/adamchainz/django-cors-headers/blob/main/HISTORY.rst#350-2020-08-25
-django-cors-headers==3.2.0
+# This version has `rename settings` but old names are preserved as aliases for backward compatibility.
+# stilling not supporting django32. Greater version has the support. Will update in next PR.
+django-cors-headers==3.5.0
 
 # django-storages version 1.9 drops support for boto storage backend.
 django-storages<1.9

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -248,7 +248,7 @@ django-config-models==2.2.0
     #   lti-consumer-xblock
 django-cookies-samesite==0.9.0
     # via -r requirements/edx/base.in
-django-cors-headers==3.2.0
+django-cors-headers==3.5.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
@@ -413,6 +413,7 @@ edx-ccx-keys==1.2.1
 edx-celeryutils==1.1.0
     # via
     #   -r requirements/edx/base.in
+    #   edx-name-affirmation
     #   super-csv
 edx-completion==4.1.0
     # via -r requirements/edx/base.in
@@ -426,6 +427,7 @@ edx-django-utils==4.4.0
     #   django-config-models
     #   edx-drf-extensions
     #   edx-enterprise
+    #   edx-name-affirmation
     #   edx-rest-api-client
     #   edx-toggles
     #   edx-when
@@ -678,7 +680,7 @@ multidict==5.1.0
     #   yarl
 mysqlclient==2.0.3
     # via -r requirements/edx/base.in
-newrelic==6.10.0.165
+newrelic==7.0.0.166
     # via
     #   -r requirements/edx/base.in
     #   edx-django-utils
@@ -1032,7 +1034,7 @@ uritemplate==3.0.1
     # via
     #   coreapi
     #   drf-yasg
-urllib3==1.26.6
+urllib3==1.26.7
     # via
     #   -r requirements/edx/paver.txt
     #   elasticsearch
@@ -1045,7 +1047,7 @@ vine==1.3.0
     # via
     #   amqp
     #   celery
-voluptuous==0.12.1
+voluptuous==0.12.2
     # via ora2
 watchdog==2.1.5
     # via -r requirements/edx/paver.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -235,7 +235,7 @@ diff-cover==4.0.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
-distlib==0.3.2
+distlib==0.3.3
     # via
     #   -r requirements/edx/testing.txt
     #   virtualenv
@@ -329,7 +329,7 @@ django-config-models==2.2.0
     #   lti-consumer-xblock
 django-cookies-samesite==0.9.0
     # via -r requirements/edx/testing.txt
-django-cors-headers==3.2.0
+django-cors-headers==3.5.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
@@ -513,6 +513,7 @@ edx-ccx-keys==1.2.1
 edx-celeryutils==1.1.0
     # via
     #   -r requirements/edx/testing.txt
+    #   edx-name-affirmation
     #   super-csv
 edx-completion==4.1.0
     # via -r requirements/edx/testing.txt
@@ -526,6 +527,7 @@ edx-django-utils==4.4.0
     #   django-config-models
     #   edx-drf-extensions
     #   edx-enterprise
+    #   edx-name-affirmation
     #   edx-rest-api-client
     #   edx-toggles
     #   edx-when
@@ -903,7 +905,7 @@ mypy-extensions==0.4.3
     # via mypy
 mysqlclient==2.0.3
     # via -r requirements/edx/testing.txt
-newrelic==6.10.0.165
+newrelic==7.0.0.166
     # via
     #   -r requirements/edx/testing.txt
     #   edx-django-utils
@@ -977,7 +979,7 @@ pillow==8.3.2
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
     #   edx-organizations
-pip-tools==6.2.0
+pip-tools==6.3.0
     # via -r requirements/edx/pip-tools.txt
 platformdirs==2.3.0
     # via
@@ -1132,7 +1134,7 @@ pytest-metadata==1.8.0
     #   pytest-json-report
 pytest-randomly==3.10.1
     # via -r requirements/edx/testing.txt
-pytest-xdist[psutil]==2.3.0
+pytest-xdist[psutil]==2.4.0
     # via -r requirements/edx/testing.txt
 python-dateutil==2.4.0
     # via
@@ -1381,7 +1383,7 @@ sphinxcontrib-devhelp==1.0.2
     # via sphinx
 sphinxcontrib-htmlhelp==2.0.0
     # via sphinx
-sphinxcontrib-httpdomain==1.7.0
+sphinxcontrib-httpdomain==1.8.0
     # via sphinxcontrib-openapi
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
@@ -1483,7 +1485,7 @@ uritemplate==3.0.1
     #   -r requirements/edx/testing.txt
     #   coreapi
     #   drf-yasg
-urllib3==1.26.6
+urllib3==1.26.7
     # via
     #   -r requirements/edx/testing.txt
     #   elasticsearch
@@ -1508,7 +1510,7 @@ virtualenv==20.8.0
     # via
     #   -r requirements/edx/testing.txt
     #   tox
-voluptuous==0.12.1
+voluptuous==0.12.2
     # via
     #   -r requirements/edx/testing.txt
     #   ora2

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -82,7 +82,7 @@ text-unidecode==1.3
     # via python-slugify
 typing-extensions==3.10.0.2
     # via gitpython
-urllib3==1.26.6
+urllib3==1.26.7
     # via requests
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -46,7 +46,7 @@ stevedore==3.4.0
     # via
     #   -r requirements/edx/paver.in
     #   edx-opaque-keys
-urllib3==1.26.6
+urllib3==1.26.7
     # via requests
 watchdog==2.1.5
     # via -r requirements/edx/paver.in

--- a/requirements/edx/pip-tools.txt
+++ b/requirements/edx/pip-tools.txt
@@ -10,7 +10,7 @@ click==7.1.2
     #   pip-tools
 pep517==0.11.0
     # via pip-tools
-pip-tools==6.2.0
+pip-tools==6.3.0
     # via -r requirements/edx/pip-tools.in
 tomli==1.2.1
     # via pep517

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -224,7 +224,7 @@ diff-cover==4.0.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/coverage.txt
-distlib==0.3.2
+distlib==0.3.3
     # via virtualenv
     # via
     #   -c requirements/edx/../common_constraints.txt
@@ -313,7 +313,7 @@ django-config-models==2.2.0
     #   edx-name-affirmation
     #   lti-consumer-xblock
     # via -r requirements/edx/base.txt
-django-cors-headers==3.2.0
+django-cors-headers==3.5.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
@@ -493,6 +493,7 @@ edx-ccx-keys==1.2.1
 edx-celeryutils==1.1.0
     # via
     #   -r requirements/edx/base.txt
+    #   edx-name-affirmation
     #   super-csv
 edx-completion==4.1.0
     # via -r requirements/edx/base.txt
@@ -506,6 +507,7 @@ edx-django-utils==4.4.0
     #   django-config-models
     #   edx-drf-extensions
     #   edx-enterprise
+    #   edx-name-affirmation
     #   edx-rest-api-client
     #   edx-toggles
     #   edx-when
@@ -850,7 +852,7 @@ multidict==5.1.0
     #   yarl
 mysqlclient==2.0.3
     # via -r requirements/edx/base.txt
-newrelic==6.10.0.165
+newrelic==7.0.0.166
     # via
     #   -r requirements/edx/base.txt
     #   edx-django-utils
@@ -1058,7 +1060,7 @@ pytest-metadata==1.8.0
     #   pytest-json-report
 pytest-randomly==3.10.1
     # via -r requirements/edx/testing.in
-pytest-xdist[psutil]==2.3.0
+pytest-xdist[psutil]==2.4.0
     # via -r requirements/edx/testing.in
 python-dateutil==2.4.0
     # via
@@ -1368,7 +1370,7 @@ uritemplate==3.0.1
     #   -r requirements/edx/base.txt
     #   coreapi
     #   drf-yasg
-urllib3==1.26.6
+urllib3==1.26.7
     # via
     #   -r requirements/edx/base.txt
     #   elasticsearch
@@ -1389,7 +1391,7 @@ vine==1.3.0
     #   celery
 virtualenv==20.8.0
     # via tox
-voluptuous==0.12.1
+voluptuous==0.12.2
     # via
     #   -r requirements/edx/base.txt
     #   ora2

--- a/scripts/xblock/requirements.txt
+++ b/scripts/xblock/requirements.txt
@@ -12,5 +12,5 @@ idna==3.2
     # via requests
 requests==2.26.0
     # via -r scripts/xblock/requirements.in
-urllib3==1.26.6
+urllib3==1.26.7
     # via requests


### PR DESCRIPTION
JIRA : https://openedx.atlassian.net/browse/BOM-2850

https://github.com/adamchainz/django-cors-headers/blob/main/HISTORY.rst#370-2021-01-25

```
Following Django’s example in Ticket #31670 for replacing the term “whitelist”, plus an aim to make the setting names more comprehensible, the following settings have been renamed:

CORS_ORIGIN_WHITELIST -> CORS_ALLOWED_ORIGINS
CORS_ORIGIN_REGEX_WHITELIST -> CORS_ALLOWED_ORIGIN_REGEXES
CORS_ORIGIN_ALLOW_ALL -> CORS_ALLOW_ALL_ORIGINS
The old names will continue to work as aliases, with the new ones taking precedence.
```

Next PR with 3.7.0 wil be django32 compatible.
