### PR TITLE
fix: enterprise user check fails for courses without verified track

### DIFF
--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -260,7 +260,7 @@ class ChooseModeView(View):
         # and happy path version is ready to be rolled out to all users.
         if VALUE_PROP_TRACK_SELECTION_FLAG.is_enabled():
             if not error:  # TODO: Remove by executing REV-2355
-                if not enterprise_customer:  # TODO: Remove by executing REV-2342
+                if not enterprise_customer_for_request(request):  # TODO: Remove by executing REV-2342
                     if fbe_is_on:
                         return render_to_response("course_modes/fbe.html", context)
                     else:


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

The [`track_selection`](https://github.com/edx/edx-platform/blob/3827f4c90d7c85f24e83e4b98e7682b324a660d9/lms/templates/course_modes/track_selection.html) page is shown when a learner enrolls in a course. We are rebuilding the track selection page and are currently redirecting enterprise users to the old track selection page [`choose.html`](https://github.com/edx/edx-platform/blob/master/lms/templates/course_modes/choose.html).

Bug: some learners enrolling in a course without a verified mode receive an error page. This is because we check the variable `enterprise_user` to see if the user should see the new track selection page, and the variable `enterprise_user` is only set when the course has a verified mode.

## Supporting information

Bug in implementation of [REV-2325](https://openedx.atlassian.net/browse/REV-2325?focusedCommentId=569300).

## Testing instructions

1.  Identify a course with no verified track.
2. Check a learner can enroll in that course.

## Deadline

ASAP. This is causing errors in Production.

## Other information

N/A.
