### PR TITLE
Fix wiki app config to make it configurable [BD-38] [BD-4686] [TNL-8702]

### DIFF
--- a/lms/djangoapps/course_wiki/plugins/__init__.py
+++ b/lms/djangoapps/course_wiki/plugins/__init__.py
@@ -63,6 +63,5 @@ class WikiCourseApp(CourseApp):
         return {
             # The wiki cannot be enabled/disabled via the API yet.
             "enable": False,
-            # There is nothing to configure for Wiki yet.
-            "configure": False,
+            "configure": True,
         }


### PR DESCRIPTION
## Description

Currently, the wiki app doesn’t show up as configurable, this PR marks it as configurable in its plugin. 


## Supporting information

[BB-4686](https://tasks.opencraft.com/browse/BB-4868)
[TNL-8702](https://openedx.atlassian.net/browse/TNL-8702)