### PR TITLE
BOM-2849: Upgrade django-cors-headers to 3.9.0

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -24,10 +24,6 @@ django-celery-results<2.1
 # We do not support version django-config-models<1.0.0
 django-config-models>=1.0.0
 
-# This version has `rename settings` but old names are preserved as aliases for backward compatibility.
-# stilling not supporting django32. Greater version has the support. Will update in next PR.
-django-cors-headers==3.5.0
-
 # django-storages version 1.9 drops support for boto storage backend.
 django-storages<1.9
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -248,10 +248,8 @@ django-config-models==2.2.0
     #   lti-consumer-xblock
 django-cookies-samesite==0.9.0
     # via -r requirements/edx/base.in
-django-cors-headers==3.5.0
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/base.in
+django-cors-headers==3.9.0
+    # via -r requirements/edx/base.in
 django-countries==7.2.1
     # via
     #   -r requirements/edx/base.in
@@ -309,7 +307,7 @@ django-mptt==0.13.4
     #   django-wiki
 django-multi-email-field==0.6.2
     # via edx-enterprise
-django-mysql==4.0.0
+django-mysql==4.1.0
     # via -r requirements/edx/base.in
 django-oauth-toolkit==1.3.2
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -329,10 +329,8 @@ django-config-models==2.2.0
     #   lti-consumer-xblock
 django-cookies-samesite==0.9.0
     # via -r requirements/edx/testing.txt
-django-cors-headers==3.5.0
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/testing.txt
+django-cors-headers==3.9.0
+    # via -r requirements/edx/testing.txt
 django-countries==7.2.1
     # via
     #   -r requirements/edx/testing.txt
@@ -396,7 +394,7 @@ django-multi-email-field==0.6.2
     # via
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
-django-mysql==4.0.0
+django-mysql==4.1.0
     # via -r requirements/edx/testing.txt
 django-oauth-toolkit==1.3.2
     # via
@@ -1585,7 +1583,7 @@ yarl==1.6.3
     # via
     #   -r requirements/edx/testing.txt
     #   aiohttp
-zipp==3.5.0
+zipp==3.5.1
     # via
     #   -r requirements/edx/testing.txt
     #   importlib-metadata

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -313,10 +313,8 @@ django-config-models==2.2.0
     #   edx-name-affirmation
     #   lti-consumer-xblock
     # via -r requirements/edx/base.txt
-django-cors-headers==3.5.0
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/base.txt
+django-cors-headers==3.9.0
+    # via -r requirements/edx/base.txt
 django-countries==7.2.1
     # via
     #   -r requirements/edx/base.txt
@@ -378,7 +376,7 @@ django-multi-email-field==0.6.2
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-django-mysql==4.0.0
+django-mysql==4.1.0
     # via -r requirements/edx/base.txt
 django-oauth-toolkit==1.3.2
     # via
@@ -1460,7 +1458,7 @@ yarl==1.6.3
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
-zipp==3.5.0
+zipp==3.5.1
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
Relevant JIRA : https://openedx.atlassian.net/browse/BOM-2849

Following is the [changelog](https://github.com/adamchainz/django-cors-headers/blob/main/HISTORY.rst#390-2021-09-28) for django-cors-headers post v3.5.0, It seems that we are good to go to the latest version.

<img width="1043" alt="image" src="https://user-images.githubusercontent.com/41958659/135599905-846164eb-d3e2-4949-91e5-2db569bb79cf.png">
