### PR TITLE
fix: stop django 3.2 from picking CoursegraphConfig from coursegraph app

### DIFF
--- a/common/djangoapps/util/db.py
+++ b/common/djangoapps/util/db.py
@@ -8,7 +8,7 @@ import random
 # TransactionManagementError used below actually *does* derive from the standard "Exception" class.
 # lint-amnesty, pylint: disable=bad-option-value, nonstandard-exception
 from contextlib import contextmanager
-
+import django
 from django.db import DEFAULT_DB_ALIAS, transaction  # lint-amnesty, pylint: disable=unused-import
 
 from openedx.core.lib.cache_utils import get_cache
@@ -52,10 +52,13 @@ class OuterAtomic(transaction.Atomic):
     """
     ALLOW_NESTED = False
 
-    def __init__(self, using, savepoint, name=None, durable=False,):
+    def __init__(self, using, savepoint, name=None, durable=False):
         self.name = name
         self.durable = durable
-        super().__init__(using, savepoint, durable)
+        if django.VERSION >= (3, 1):
+            super().__init__(using, savepoint, durable)
+        else:
+            super().__init__(using, savepoint)
 
     def __enter__(self):
 

--- a/common/djangoapps/util/db.py
+++ b/common/djangoapps/util/db.py
@@ -55,7 +55,7 @@ class OuterAtomic(transaction.Atomic):
     def __init__(self, using, savepoint, name=None, durable=False):
         self.name = name
         self.durable = durable
-        if django.VERSION >= (3, 1):
+        if django.VERSION >= (3, 2):
             super().__init__(using, savepoint, durable)   # pylint: disable=too-many-function-args
         else:
             super().__init__(using, savepoint)

--- a/common/djangoapps/util/db.py
+++ b/common/djangoapps/util/db.py
@@ -56,7 +56,7 @@ class OuterAtomic(transaction.Atomic):
         self.name = name
         self.durable = durable
         if django.VERSION >= (3, 1):
-            super().__init__(using, savepoint, durable)
+            super().__init__(using, savepoint, durable)  # pylint: disable=too-many-arguments
         else:
             super().__init__(using, savepoint)
 

--- a/common/djangoapps/util/db.py
+++ b/common/djangoapps/util/db.py
@@ -52,9 +52,10 @@ class OuterAtomic(transaction.Atomic):
     """
     ALLOW_NESTED = False
 
-    def __init__(self, using, savepoint, name=None):
+    def __init__(self, using, savepoint, durable=False, name=None):
         self.name = name
-        super().__init__(using, savepoint)
+        self.durable = durable
+        super().__init__(using, savepoint, durable)
 
     def __enter__(self):
 
@@ -84,7 +85,7 @@ class OuterAtomic(transaction.Atomic):
         super().__enter__()
 
 
-def outer_atomic(using=None, savepoint=True, name=None):
+def outer_atomic(using=None, savepoint=True, name=None, durable=False):
     """
     A variant of Django's atomic() which cannot be nested inside another atomic.
 
@@ -120,10 +121,10 @@ def outer_atomic(using=None, savepoint=True, name=None):
         TransactionManagementError: if already inside an atomic block.
     """
     if callable(using):
-        return OuterAtomic(DEFAULT_DB_ALIAS, savepoint)(using)
+        return OuterAtomic(DEFAULT_DB_ALIAS, savepoint, durable)(using)
     # Decorator: @outer_atomic(...) or context manager: with outer_atomic(...): ...
     else:
-        return OuterAtomic(using, savepoint, name)
+        return OuterAtomic(using, savepoint, name, durable)
 
 
 def generate_int_id(minimum=0, maximum=MYSQL_MAX_INT, used_ids=None):

--- a/common/djangoapps/util/db.py
+++ b/common/djangoapps/util/db.py
@@ -56,7 +56,7 @@ class OuterAtomic(transaction.Atomic):
         self.name = name
         self.durable = durable
         if django.VERSION >= (3, 1):
-            super().__init__(using, savepoint, durable)  # pylint: disable=too-many-arguments
+            super().__init__(using, savepoint, durable)   # pylint: disable=too-many-function-args
         else:
             super().__init__(using, savepoint)
 

--- a/common/djangoapps/util/db.py
+++ b/common/djangoapps/util/db.py
@@ -52,7 +52,7 @@ class OuterAtomic(transaction.Atomic):
     """
     ALLOW_NESTED = False
 
-    def __init__(self, using, savepoint, durable=False, name=None):
+    def __init__(self, using, savepoint, name=None, durable=False,):
         self.name = name
         self.durable = durable
         super().__init__(using, savepoint, durable)

--- a/openedx/core/djangoapps/coursegraph/apps.py
+++ b/openedx/core/djangoapps/coursegraph/apps.py
@@ -14,4 +14,10 @@ class CoursegraphConfig(AppConfig):
     """
     name = 'openedx.core.djangoapps.coursegraph'
 
+    # In Django 3.2, app configuration is automatically selected from apps.py
+    # submodule in case of single config class in apps.py module, to disable
+    # this feature we need to set `default = False` in AppConfig of that app
+    # https://docs.djangoproject.com/en/3.2/ref/applications/#configuring-applications
+    default = False
+
     from openedx.core.djangoapps.coursegraph import tasks


### PR DESCRIPTION
In Django 3.2, app configuration is automatically selected from apps.py submodule in case of single config class in apps.py module, to disable this feature we need to set `default = False` in AppConfig of that app

https://docs.djangoproject.com/en/3.2/ref/applications/#configuring-applications