### PR TITLE
BOM-2782: Use DeploymentMonitoringMiddleware in settings

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -719,6 +719,7 @@ MIDDLEWARE = [
 
     'crum.CurrentRequestUserMiddleware',
 
+    'edx_django_utils.monitoring.DeploymentMonitoringMiddleware',
     # A newer and safer request cache.
     'edx_django_utils.cache.middleware.RequestCacheMiddleware',
     'edx_django_utils.monitoring.MonitoringMemoryMiddleware',

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2015,6 +2015,7 @@ MIDDLEWARE = [
 
     'crum.CurrentRequestUserMiddleware',
 
+    'edx_django_utils.monitoring.DeploymentMonitoringMiddleware',
     # A newer and safer request cache.
     'edx_django_utils.cache.middleware.RequestCacheMiddleware',
 


### PR DESCRIPTION
**Issue:** [BOM-2782](https://openedx.atlassian.net/browse/BOM-2782)

### Description
- Added the `DeploymentMonitroringMiddleware` to record `Django` and `Python` versions in the `NewRelic`.

