### PR TITLE
fix: rtl language layout

### DIFF
--- a/lms/static/sass/_header.scss
+++ b/lms/static/sass/_header.scss
@@ -366,7 +366,7 @@
         width: 100%;
         padding: $baseline*0.6 $baseline;
         border-bottom: 1px solid theme-color('light');
-        text-align: left;
+        @include text-align(left);
         cursor: pointer;
 
         &:hover,


### PR DESCRIPTION
# Description

So far, every RTL language style has been overwritten in every theme to cover for the unsupported behavior of RTL languages in the platform. This fix will address that and it'll reduce the overhead to do the same in the themes.

With this fix, we won't need to change any theme because the default will be to support the RTL languages even in the face of the default theme.

# Reproducing

You'll need to run the `devstack`, change the language to some RTL language (e.g. `ar`), and see the style correctly formatted in the default theme and any customized theme that hasn't patched the fix.

# Extra info

This PR is in regard to [this ticket](https://tasks.opencraft.com/browse/BB-4381).

It also is a replacement for [this PR](https://github.com/open-craft/edx-platform/pull/406).

reviewer @shimulch 
