### PR TITLE
feat: adds CELERY_BROKER_TRANSPORT_OPTIONS

### DIFF
--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -391,10 +391,14 @@ BROKER_URL = "{}://{}:{}@{}/{}".format(CELERY_BROKER_TRANSPORT,
                                        CELERY_BROKER_VHOST)
 BROKER_USE_SSL = ENV_TOKENS.get('CELERY_BROKER_USE_SSL', False)
 
-BROKER_TRANSPORT_OPTIONS = {
-    'fanout_patterns': True,
-    'fanout_prefix': True,
-}
+try:
+    BROKER_TRANSPORT_OPTIONS = {
+        'fanout_patterns': True,
+        'fanout_prefix': True,
+        **ENV_TOKENS.get('CELERY_BROKER_TRANSPORT_OPTIONS', {})
+    }
+except TypeError as exc:
+    raise ImproperlyConfigured('CELERY_BROKER_TRANSPORT_OPTIONS must be a dict') from exc
 
 # Message expiry time in seconds
 CELERY_EVENT_QUEUE_TTL = ENV_TOKENS.get('CELERY_EVENT_QUEUE_TTL', None)

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -506,10 +506,14 @@ BROKER_URL = "{}://{}:{}@{}/{}".format(CELERY_BROKER_TRANSPORT,
                                        CELERY_BROKER_VHOST)
 BROKER_USE_SSL = ENV_TOKENS.get('CELERY_BROKER_USE_SSL', False)
 
-BROKER_TRANSPORT_OPTIONS = {
-    'fanout_patterns': True,
-    'fanout_prefix': True,
-}
+try:
+    BROKER_TRANSPORT_OPTIONS = {
+        'fanout_patterns': True,
+        'fanout_prefix': True,
+        **ENV_TOKENS.get('CELERY_BROKER_TRANSPORT_OPTIONS', {})
+    }
+except TypeError as exc:
+    raise ImproperlyConfigured('CELERY_BROKER_TRANSPORT_OPTIONS must be a dict') from exc
 
 # Block Structures
 


### PR DESCRIPTION
## Description

Cherry-pick of https://github.com/edx/edx-platform/pull/28849

The release of Redis 6 introduced the ability to share this service among multiple accounts, securing the access to specific keys using a username/password and ACLs. Celery uses kombu to provide Redis brokering for the message queues, but kombu was missing a couple of key enhancements to support multi-tenant redis.

This PR allows to configure the broker transport options to enjoy the benefits of the above-mentioned updates.

## Supporting information

OpenCraft wants to use multi-tenant Redis for their shared hosting service, so we can stop maintaining RabbitMQ.

## Deadline

None

## Other information

The initial PR that partially contained these changes: https://github.com/edx/edx-platform/pull/28020

## Reviewers

- [ ] @pomegranited 
- [ ] @Agrendalath 