### PR TITLE
fix: consistent error response on name change

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -450,7 +450,7 @@ class NameChangeView(APIView):
                 return Response(status=status.HTTP_201_CREATED)
             else:
                 return Response(
-                    'The name given was identical to the current name.',
+                    {'new_name': 'The profile name given was identical to the current name.'},
                     status=status.HTTP_400_BAD_REQUEST
                 )
 


### PR DESCRIPTION
@edx/masters-devs-cosmonauts 

[MST-1068](https://openedx.atlassian.net/browse/MST-1068)

Errors returned by the serializer return as key value pairs but this error was just a string causing inconsistencies displaying in the UI.

This fixes the immediate "broken" issue but I notice some confusing UX with how this works. When I submit a name change this error message shows up under the verified name input even though it is really referring to the profile name. This is a bit misleading so I altered the text a bit but maybe this should be validated before the modal opens? I'll just file another ticket for this it isn't necessarily a bug. See [MST-1089](https://openedx.atlassian.net/browse/MST-1089)