### PR TITLE
fix: drop segment call for streak discount

### DIFF
--- a/openedx/core/djangoapps/courseware_api/serializers.py
+++ b/openedx/core/djangoapps/courseware_api/serializers.py
@@ -119,6 +119,7 @@ class CourseInfoSerializer(serializers.Serializer):  # pylint: disable=abstract-
     verification_status = serializers.CharField()
     linkedin_add_to_profile_url = serializers.URLField()
     user_needs_integrity_signature = serializers.BooleanField()
+    username = serializers.CharField()
 
     def __init__(self, *args, **kwargs):
         """

--- a/openedx/core/djangoapps/courseware_api/tests/test_views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/test_views.py
@@ -303,6 +303,7 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
             response = self.client.get(self.url)
 
         assert response.status_code == 200
+        assert response.data['username'] == masquerade_role or username
         if expect_course_access:
             assert response.data['course_access']['has_access']
         else:
@@ -313,24 +314,20 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
         CourseEnrollment.enroll(self.user, self.course.id, 'audit')
         with override_waffle_flag(COURSEWARE_MFE_MILESTONES_STREAK_DISCOUNT, active=True):
             with mock.patch('common.djangoapps.student.models.UserCelebration.perform_streak_updates', return_value=3):
-                with mock.patch('common.djangoapps.track.segment.track') as mock_segment_track:
-                    response = self.client.get(self.url, content_type='application/json')
-                    celebrations = response.json()['celebrations']
-                    assert celebrations['streak_length_to_celebrate'] == 3
-                    assert celebrations['streak_discount_enabled'] is True
-                    mock_segment_track.assert_called_once()
+                response = self.client.get(self.url, content_type='application/json')
+                celebrations = response.json()['celebrations']
+                assert celebrations['streak_length_to_celebrate'] == 3
+                assert celebrations['streak_discount_enabled'] is True
 
     def test_streak_segment_suppressed_for_unverified(self):
         """ Test that metadata endpoint does not return a discount and signal is not sent if flag is not set """
         CourseEnrollment.enroll(self.user, self.course.id, 'audit')
         with override_waffle_flag(COURSEWARE_MFE_MILESTONES_STREAK_DISCOUNT, active=False):
             with mock.patch('common.djangoapps.student.models.UserCelebration.perform_streak_updates', return_value=3):
-                with mock.patch('common.djangoapps.track.segment.track') as mock_segment_track:
-                    response = self.client.get(self.url, content_type='application/json')
-                    celebrations = response.json()['celebrations']
-                    assert celebrations['streak_length_to_celebrate'] == 3
-                    assert celebrations['streak_discount_enabled'] is False
-                    mock_segment_track.assert_not_called()
+                response = self.client.get(self.url, content_type='application/json')
+                celebrations = response.json()['celebrations']
+                assert celebrations['streak_length_to_celebrate'] == 3
+                assert celebrations['streak_discount_enabled'] is False
 
     @ddt.data(
         (None, False, False, False),

--- a/openedx/core/djangoapps/courseware_api/utils.py
+++ b/openedx/core/djangoapps/courseware_api/utils.py
@@ -9,7 +9,6 @@ from common.djangoapps.student.models import CourseEnrollmentCelebration, UserCe
 from lms.djangoapps.courseware.utils import can_show_verified_upgrade, verified_upgrade_deadline_link
 from openedx.features.course_duration_limits.access import get_user_course_expiration_date
 from openedx.features.discounts.applicability import can_show_streak_discount_coupon
-from common.djangoapps.track import segment
 
 
 def get_celebrations_dict(user, enrollment, course, browser_timezone):
@@ -43,14 +42,6 @@ def get_celebrations_dict(user, enrollment, course, browser_timezone):
             verified_mode = modes_dict.get('verified', None)
             if verified_mode:
                 celebrations['streak_discount_enabled'] = True
-                segment.track(
-                    user_id=user.id,
-                    event_name='edx.bi.course.streak_discount_enabled',
-                    properties={
-                        'course_id': str(course_key),
-                        'sku': verified_mode.sku,
-                    }
-                )
 
     return celebrations
 

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -159,6 +159,10 @@ class CoursewareMeta:
         return self.course.license
 
     @property
+    def username(self):
+        return self.effective_user.username
+
+    @property
     def course_access(self) -> dict:
         """
         Can the user load this course in the learning micro-frontend?


### PR DESCRIPTION
It's being moved to the frontend, to better control when it's emitted (we want to only emit it if the voucher has not yet been claimed, which the frontend will ask ecommerce about).

**NOTE:** To deploy the backend and frontend change for this, without having a gap in segment calls (or worse, a double count), I think you'd need to add a new event to the frontend, have that deploy. Then switch the canvas to pay attention to just the new signal. Then land this backend PR. But that's a lot of work, so maybe just deploy the frontend as soon as the backend hits prod, like Indiana Jones grabbing an idol? And there'd be a few minutes gap, but that doesn't seem so bad?

https://openedx.atlassian.net/browse/AA-1012