### PR TITLE
BOM-2859: Update static file path in tests

### DIFF
--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -1589,7 +1589,6 @@ class TestHtmlModifiers(ModuleStoreTestCase):
         self.course.static_asset_path = ""
 
     @override_settings(DEFAULT_COURSE_ABOUT_IMAGE_URL='test.png')
-    @override_settings(STATIC_URL='static/')
     @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
     def test_course_image_for_split_course(self, store):
         """
@@ -1600,7 +1599,7 @@ class TestHtmlModifiers(ModuleStoreTestCase):
         self.course.course_image = ''
 
         url = course_image_url(self.course)
-        assert 'static/test.png' == url
+        assert '/static/test.png' == url
 
     def test_get_course_info_section(self):
         self.course.static_asset_path = "toy_course_dir"

--- a/openedx/core/lib/tests/test_courses.py
+++ b/openedx/core/lib/tests/test_courses.py
@@ -52,7 +52,6 @@ class CourseImageTestCase(ModuleStoreTestCase):
         )
 
     @override_settings(DEFAULT_COURSE_ABOUT_IMAGE_URL='test.png')
-    @override_settings(STATIC_URL='static/')
     @ddt.data(ModuleStoreEnum.Type.split, ModuleStoreEnum.Type.mongo)
     def test_empty_image_name(self, default_store):
         """
@@ -60,7 +59,7 @@ class CourseImageTestCase(ModuleStoreTestCase):
         `DEFAULT_COURSE_ABOUT_IMAGE_URL` defined in the settings.
         """
         course = CourseFactory.create(course_image='', default_store=default_store)
-        assert 'static/test.png' == course_image_url(course)
+        assert '/static/test.png' == course_image_url(course)
 
     def test_get_banner_image_url(self):
         """Test banner image URL formatting."""


### PR DESCRIPTION
**Issue:** [BOM-2859](https://openedx.atlassian.net/browse/BOM-2859)

### Description
- This fixes following test failures in `Django 3.2`. 

> - `lms/djangoapps/courseware/tests/test_module_render.py::TestHtmlModifiers::test_course_image_for_split_course_1_mongo`
> - `lms/djangoapps/courseware/tests/test_module_render.py::TestHtmlModifiers::test_course_image_for_split_course_2_split`
> - `openedx/core/lib/tests/test_courses.py::CourseImageTestCase::test_empty_image_name_1_split`
> - `openedx/core/lib/tests/test_courses.py::CourseImageTestCase::test_empty_image_name_2_mongo`