### PR TITLE
fix: avoid onresize height loop [SE-4876]

### DIFF
--- a/cms/templates/content_libraries/xblock_iframe.html
+++ b/cms/templates/content_libraries/xblock_iframe.html
@@ -125,7 +125,10 @@
   <!-- fragment head -->
   {{ fragment.head_html | safe }}
 </head>
-<body>
+<!-- The default stylesheet will set the body min-height to 100% (a common strategy to allow for background
+  images to fill the viewport), but this has the undesireable side-effect of causing an infinite loop via the onResize
+  event listeners below, in certain situations.  Resetting it to the default "auto" skirts the problem.-->
+<body style="min-height: auto">
   <!-- fragment body -->
   {{ fragment.body_html | safe }}
   <!-- fragment foot -->


### PR DESCRIPTION
### Description 

We set a global `min-height: 100%` for the body element (a common strategy to allow for background images to fill the viewport), but this is undesirable for iframes where the `window.onresize` is used to programmatically adjust the iframe height.  Because `onresize` will fire when the body adjusts itself as per its `min-height: 100%`, in certain situations this will lead to an infinite resizing loop.  This is notably visible when:

* Rendering the video block when using Firefox: this causes the iframe  size to jiggle indefinitely.
* Rendering the HTML block when there are empty block elements (such as   `<p></p>`) that have a vertical margin set (which happens to be the  default to HTML blocks): this will cause the iframe to increase in  height infinitely.

By adding an inline `min-height: auto` on the wrapping body element, this overrides the Studio-served CSS, and thus fixes the problem.

### Test instructions

This fix is a mirror of the one in https://github.com/edx/frontend-app-library-authoring/pull/26, and subject to the same conditions (infinite iframe resize loop).  Following the test instructions in that PR is a more self-contained way to test this one; otherwise, a full LTI setup would be required.