### PR TITLE
chore: update name-affirmation to 1.0.1

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -454,7 +454,7 @@ edx-i18n-tools==0.7.0
     # via ora2
 edx-milestones==0.3.2
     # via -r requirements/edx/base.in
-edx-name-affirmation==1.0.0
+edx-name-affirmation==1.0.1
     # via -r requirements/edx/base.in
 edx-opaque-keys[django]==2.2.2
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -558,7 +558,7 @@ edx-lint==5.2.0
     # via -r requirements/edx/testing.txt
 edx-milestones==0.3.2
     # via -r requirements/edx/testing.txt
-edx-name-affirmation==1.0.0
+edx-name-affirmation==1.0.1
     # via -r requirements/edx/testing.txt
 edx-opaque-keys[django]==2.2.2
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -539,7 +539,7 @@ edx-lint==5.2.0
     # via -r requirements/edx/testing.in
 edx-milestones==0.3.2
     # via -r requirements/edx/base.txt
-edx-name-affirmation==1.0.0
+edx-name-affirmation==1.0.1
     # via -r requirements/edx/base.txt
 edx-opaque-keys[django]==2.2.2
     # via


### PR DESCRIPTION
fixes a bug where a task checked a flag

MST-1063
