### PR TITLE
[AA-1046] feat: Allow updating goals reminder field without providing the days_per_week field

### DIFF
--- a/lms/djangoapps/course_goals/api.py
+++ b/lms/djangoapps/course_goals/api.py
@@ -29,8 +29,7 @@ def add_course_goal_deprecated(user, course_id, goal_key):
     )
 
 
-def add_course_goal(user, course_id, days_per_week,
-                    subscribed_to_reminders):
+def add_course_goal(user, course_id, subscribed_to_reminders, days_per_week=None):
     """
     Add a new course goal for the provided user and course. If the goal
     already exists, simply update and save the goal.
@@ -38,15 +37,17 @@ def add_course_goal(user, course_id, days_per_week,
     Arguments:
         user: The user that is setting the goal
         course_id (string): The id for the course the goal refers to
-        days_per_week (int): number of days learner wants to learn per week
         subscribed_to_reminders (bool): whether the learner wants to receive email reminders about their goal
+        days_per_week (int): (optional) number of days learner wants to learn per week
     """
     course_key = CourseKey.from_string(str(course_id))
+    defaults = {
+        'subscribed_to_reminders': subscribed_to_reminders,
+    }
+    if days_per_week:
+        defaults['days_per_week'] = days_per_week
     CourseGoal.objects.update_or_create(
-        user=user, course_key=course_key, defaults={
-            'days_per_week': days_per_week,
-            'subscribed_to_reminders': subscribed_to_reminders,
-        }
+        user=user, course_key=course_key, defaults=defaults
     )
 
 

--- a/lms/djangoapps/course_home_api/outline/tests/test_goals.py
+++ b/lms/djangoapps/course_home_api/outline/tests/test_goals.py
@@ -116,15 +116,27 @@ class TestCourseGoalsAPI(SharedModuleStoreTestCase):
         assert current_goals[0].days_per_week == 5
         assert current_goals[0].subscribed_to_reminders is False
 
-    def test_add_without_required_arguments(self):
+    def test_add_without_subscribed_to_reminders(self):
         """ Ensures if required arguments are not provided, post does not succeed. """
-        response = self.save_course_goal(None, None)
+        response = self.save_course_goal(1, None)
         assert len(CourseGoal.objects.filter(user=self.user, course_key=self.course.id)) == 0
         self.assertContains(
             response=response,
-            text="'days_per_week' and 'subscribed_to_reminders' are required.",
+            text="'subscribed_to_reminders' is required.",
             status_code=400
         )
+
+    def test_add_without_days_per_week(self):
+        """ Allow unsubscribing without providing the days_per_week argument """
+        response = self.save_course_goal(1, True)
+
+        current_goals = CourseGoal.objects.filter(user=self.user, course_key=self.course.id)
+        assert len(current_goals) == 1
+        assert current_goals[0].subscribed_to_reminders is True
+
+        response = self.save_course_goal(None, False)
+        current_goals = CourseGoal.objects.filter(user=self.user, course_key=self.course.id)
+        assert current_goals[0].subscribed_to_reminders is False
 
     def test_add_invalid_goal(self):
         """ Ensures an incorrectly formatted post does not succeed. """

--- a/lms/djangoapps/course_home_api/outline/views.py
+++ b/lms/djangoapps/course_home_api/outline/views.py
@@ -421,11 +421,11 @@ def save_course_goal(request):
 
     if COURSE_GOALS_NUMBER_OF_DAYS_GOALS.is_enabled():
         # If body doesn't contain the required goals fields, return 400 to client.
-        if days_per_week is None or subscribed_to_reminders is None:
-            raise ParseError("'days_per_week' and 'subscribed_to_reminders' are required.")
+        if subscribed_to_reminders is None:
+            raise ParseError("'subscribed_to_reminders' is required.")
 
         try:
-            add_course_goal(request.user, course_id, days_per_week, subscribed_to_reminders)
+            add_course_goal(request.user, course_id, subscribed_to_reminders, days_per_week)
             return Response({
                 'header': _('Your course goal has been successfully set.'),
                 'message': _('Course goal updated successfully.'),


### PR DESCRIPTION
This PR enables unsubscribing the user from reminders from the course exit page without knowing their goal information (by only providing the user/course and subscribe value)