### PR TITLE
feat: upgrade Django version to 3.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,13 +106,7 @@ compile-requirements: $(COMMON_CONSTRAINTS_TXT) ## Re-compile *.in requirements 
 	# This is a temporary solution to override the real common_constraints.txt
 	# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
 	# See BOM-271 for more details.
-	sed 's/pyjwt\[crypto\]<2.0.0//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
-	mv requirements/common_constraints.tmp requirements/common_constraints.txt
-	sed 's/social-auth-core<4.0.3//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
-	mv requirements/common_constraints.tmp requirements/common_constraints.txt
-	sed 's/edx-drf-extensions<7.0.0//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
-	mv requirements/common_constraints.tmp requirements/common_constraints.txt
-	sed 's/edx-auth-backends<4.0.0//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
+	sed 's/Django<2.3//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
 	mv requirements/common_constraints.tmp requirements/common_constraints.txt
 	sed 's/drf-jwt<1.19.1//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
 	mv requirements/common_constraints.tmp requirements/common_constraints.txt
@@ -130,17 +124,6 @@ compile-requirements: $(COMMON_CONSTRAINTS_TXT) ## Re-compile *.in requirements 
 	# Let tox control the Django version for tests
 	grep -e "^django==" requirements/edx/base.txt > requirements/edx/django.txt
 	sed '/^[dD]jango==/d' requirements/edx/testing.txt > requirements/edx/testing.tmp
-	mv requirements/edx/testing.tmp requirements/edx/testing.txt
-
-	# to avoid multiple entries remove it from django and django30 first and add later.
-	sed -i '/^[dD]jango-cookies-samesite==/d' requirements/edx/django.txt
-	sed -i '/^[dD]jango-cookies-samesite==/d' requirements/edx/django30.txt
-	grep -e "^django-cookies-samesite==" requirements/edx/base.txt >> requirements/edx/django.txt
-	grep -e "^django-cookies-samesite==" requirements/edx/base.txt >> requirements/edx/django30.txt
-
-	# removing django-cookies-samesite from all testing.txt file. It is not require for django32.
-	# at the time of django32 final upgrade job remove this package from base.in
-	sed '/^[dD]jango-cookies-samesite==/d' requirements/edx/testing.txt > requirements/edx/testing.tmp
 	mv requirements/edx/testing.tmp requirements/edx/testing.txt
 
 upgrade: pre-requirements  ## update the pip requirements files to use the latest releases satisfying our constraints

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -18,10 +18,10 @@
 
 
 # using LTS django version
-Django<2.3
+
 
 # latest version is causing e2e failures in edx-platform.
-# See  comment.
+# See pyjwt[crypto]<2.0.0 comment.
 
 
 # elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -16,7 +16,7 @@
 celery<5.0.0
 
 # edx-platform currently only supported for Django 2.2.x
-django<2.3
+django<3.3
 
 # Newer versions need celery >= 5.0
 django-celery-results<2.1

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -43,7 +43,6 @@ defusedxml
 Django                              # Web application framework
 django-appconf
 django-celery-results               # Only used for the CacheBackend for celery results
-django-cookies-samesite             # Middleware which allows SameSite=None flag for session and csrf cookies in Django<3.0.5
 django-config-models                # Configuration models for Django allowing config management with auditing
 django-cors-headers                 # Used to allow to configure CORS headers for cross-domain requests
 django-countries                    # Country data for Django forms and model fields

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -44,6 +44,8 @@ aniso8601==9.0.1
     # via edx-tincan-py35
 appdirs==1.4.4
     # via fs
+asgiref==3.4.1
+    # via django
 async-timeout==3.0.1
     # via aiohttp
 attrs==21.2.0
@@ -161,9 +163,8 @@ defusedxml==0.7.1
     #   social-auth-core
 deprecated==1.2.13
     # via jwcrypto
-django==2.2.24
+django==3.2.8
     # via
-    #   -c requirements/edx/../common_constraints.txt
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   django-appconf
@@ -241,8 +242,6 @@ django-config-models==2.2.0
     #   edx-enterprise
     #   edx-name-affirmation
     #   lti-consumer-xblock
-django-cookies-samesite==0.9.0
-    # via -r requirements/edx/base.in
 django-cors-headers==3.10.0
     # via -r requirements/edx/base.in
 django-countries==7.2.1
@@ -991,8 +990,6 @@ tqdm==4.62.3
     # via nltk
 typing-extensions==3.10.0.2
     # via aiohttp
-ua-parser==0.10.0
-    # via django-cookies-samesite
 unicodecsv==0.14.1
     # via
     #   -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -57,6 +57,7 @@ appdirs==1.4.4
 asgiref==3.4.1
     # via
     #   -r requirements/edx/testing.txt
+    #   django
     #   uvicorn
 astroid==2.6.6
     # via
@@ -238,9 +239,8 @@ distlib==0.3.3
     # via
     #   -r requirements/edx/testing.txt
     #   virtualenv
-django==2.2.24
+django==3.2.8
     # via
-    #   -c requirements/edx/../common_constraints.txt
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   django-appconf
@@ -323,8 +323,6 @@ django-config-models==2.2.0
     #   edx-enterprise
     #   edx-name-affirmation
     #   lti-consumer-xblock
-django-cookies-samesite==0.9.0
-    # via -r requirements/edx/testing.txt
 django-cors-headers==3.10.0
     # via -r requirements/edx/testing.txt
 django-countries==7.2.1
@@ -1438,10 +1436,6 @@ typing-extensions==3.10.0.2
     #   gitpython
     #   mypy
     #   pydantic
-ua-parser==0.10.0
-    # via
-    #   -r requirements/edx/testing.txt
-    #   django-cookies-samesite
 unicodecsv==0.14.1
     # via
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/django.txt
+++ b/requirements/edx/django.txt
@@ -1,2 +1,1 @@
-django==2.2.24
-django-cookies-samesite==0.9.0
+django==3.2.8

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -53,7 +53,10 @@ appdirs==1.4.4
     #   -r requirements/edx/base.txt
     #   fs
 asgiref==3.4.1
-    # via uvicorn
+    # via
+    #   -r requirements/edx/base.txt
+    #   django
+    #   uvicorn
 astroid==2.6.6
     # via
     #   pylint
@@ -226,7 +229,6 @@ diff-cover==4.0.0
 distlib==0.3.3
     # via virtualenv
     # via
-    #   -c requirements/edx/../common_constraints.txt
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   django-appconf
@@ -308,7 +310,6 @@ django-config-models==2.2.0
     #   edx-enterprise
     #   edx-name-affirmation
     #   lti-consumer-xblock
-    # via -r requirements/edx/base.txt
 django-cors-headers==3.10.0
     # via -r requirements/edx/base.txt
 django-countries==7.2.1
@@ -1324,10 +1325,6 @@ typing-extensions==3.10.0.2
     #   aiohttp
     #   gitpython
     #   pydantic
-ua-parser==0.10.0
-    # via
-    #   -r requirements/edx/base.txt
-    #   django-cookies-samesite
 unicodecsv==0.14.1
     # via
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
**Upgrade Django version to 3.2**

**Testing few items:**
- [x] - Sandbox created with this branch https://awais786.sandbox.edx.org/
- [x] - e2e tests pass against sandbox.
- [x] - Purcahsed 1 course.
- [x] - MFE-registration/login working
- [x] - Admin working fine
- [x] - Course creation working in studio.
- [x] - Celery tasks from import/export course worked fine.

**Failed Item**
- [ ] - Failed on apple-id signin. (PR for fix: https://github.com/edx/edx-platform/pull/28993)



