### PR TITLE
fix: textbooks should be enabled if course has any textbooks enabled.

### DIFF
--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -188,13 +188,12 @@ def get_proctored_exam_settings_url(course_locator) -> str:
     proctored_exam_settings_url = ''
     if exam_setting_view_enabled():
         mfe_base_url = get_course_authoring_url(course_locator)
+        course_mfe_url = f'{mfe_base_url}/course/{course_locator}'
         if mfe_base_url:
             if proctoring_settings_modal_view_enabled(course_locator):
-                proctored_exam_settings_url = (
-                    f'{mfe_base_url}/course/{course_locator}/pages-and-resources/proctoring/settings'
-                )
+                proctored_exam_settings_url = f'{course_mfe_url}/pages-and-resources/proctoring/settings'
             else:
-                proctored_exam_settings_url = f'{mfe_base_url}/course/{course_locator}/proctored-exam-settings'
+                proctored_exam_settings_url = f'{course_mfe_url}/proctored-exam-settings'
     return proctored_exam_settings_url
 
 

--- a/lms/djangoapps/courseware/plugins.py
+++ b/lms/djangoapps/courseware/plugins.py
@@ -7,6 +7,8 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.utils.translation import ugettext_noop as _
 from opaque_keys.edx.keys import CourseKey
+
+from openedx.core.djangoapps.course_apps.toggles import proctoring_settings_modal_view_enabled
 from xmodule.modulestore.django import modulestore
 
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
@@ -89,7 +91,7 @@ class TextbooksCourseApp(CourseApp):
         """
         Returns if the textbook app is globally enabled.
         """
-        return TEXTBOOK_ENABLED
+        return len(CourseOverview.get_from_id(course_key).pdf_textbooks) > 0
 
     @classmethod
     def set_enabled(cls, course_key: CourseKey, enabled: bool, user: 'User') -> bool:
@@ -211,7 +213,8 @@ class ProctoringCourseApp(CourseApp):
 
     @staticmethod
     def legacy_link(course_key: CourseKey):
-        return get_proctored_exam_settings_url(course_key)
+        if not proctoring_settings_modal_view_enabled(course_key):
+            return get_proctored_exam_settings_url(course_key)
 
 
 class CustomPagesCourseApp(CourseApp):
@@ -237,9 +240,9 @@ class CustomPagesCourseApp(CourseApp):
     def is_enabled(cls, course_key: CourseKey) -> bool:  # pylint: disable=unused-argument
         """
         Returns if the custom pages app is enabled.
-        For now this feature is enabled without any manual setup
+        For now this feature is disabled without any manual setup
         """
-        return True
+        return False
 
     @classmethod
     def set_enabled(cls, course_key: CourseKey, enabled: bool, user: 'User') -> bool:

--- a/openedx/core/djangoapps/course_apps/rest_api/v1/views.py
+++ b/openedx/core/djangoapps/course_apps/rest_api/v1/views.py
@@ -71,7 +71,8 @@ class CourseAppSerializer(serializers.Serializer):  # pylint: disable=abstract-m
             "documentation_links": instance.documentation_links,
         }
         if hasattr(instance, "legacy_link"):
-            data["legacy_link"] = request.build_absolute_uri(instance.legacy_link(course_key))
+            course_legacy_link = instance.legacy_link(course_key)
+            data["legacy_link"] = request.build_absolute_uri(course_legacy_link) if course_legacy_link else ''
         return data
 
 


### PR DESCRIPTION
fix: proctoring settings to show pop up modal
fix: custom pages to be "disabled" by default
fix: only build legacy link when an app sends any link

[TNL-8701](https://openedx.atlassian.net/browse/TNL-8701)