### PR TITLE
fix: Create a better admin UI for PendingNameChange model

### DIFF
--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -552,9 +552,20 @@ class UserCelebrationAdmin(admin.ModelAdmin):
     def has_module_permission(self, request):
         return False
 
+
+@admin.register(PendingNameChange)
+class PendingNameChangeAdmin(admin.ModelAdmin):
+    """Admin interface for the Pending Name Change model"""
+    readonly_fields = ('user', )
+    list_display = ('user', 'new_name', 'rationale')
+    search_fields = ('user', 'new_name')
+
+    class Meta:
+        model = PendingNameChange
+
+
 admin.site.register(UserTestGroup)
 admin.site.register(Registration)
-admin.site.register(PendingNameChange)
 admin.site.register(AccountRecoveryConfiguration, ConfigurationModelAdmin)
 admin.site.register(DashboardConfiguration, ConfigurationModelAdmin)
 admin.site.register(RegistrationCookieConfiguration, ConfigurationModelAdmin)


### PR DESCRIPTION
## Description

[MST-1069](https://openedx.atlassian.net/browse/MST-1069)

The current admin UI for the PendingNameChange model has no useful info and is not performant on edit form. This change make the view and edit of the model easier in Django admin

See before:

![PendingNameChangeAdminOld](https://user-images.githubusercontent.com/16839373/135477820-6222529c-4f37-4369-ac3a-76bc2652ab00.jpg)

After the change:

![PendingNameChangeAdminNew](https://user-images.githubusercontent.com/16839373/135477859-a568c018-1ad8-43cd-89b1-4b4b4bb47d3f.jpeg)


![PendingNameChangeEditForm](https://user-images.githubusercontent.com/16839373/135477906-f45522e8-9673-49c4-8f6d-5c03e35a1149.jpeg)

## Testing instructions

Didn't include any unit tests for this change because the code is just configuring the existing admin form Django already provide.

Should test manually on stage and prod.


@edx/masters-devs-cosmonauts Please review
