### PR TITLE
feat: Add custom attribute for cookie header size

### DIFF
--- a/openedx/core/lib/request_utils.py
+++ b/openedx/core/lib/request_utils.py
@@ -146,8 +146,8 @@ class CookieMonitoringMiddleware(MiddlewareMixin):
 
         """
 
-        if request.META.get('HTTP_COOKIE', None):
-            set_custom_attribute('cookies.header.size', len(request.META['HTTP_COOKIE'].encode('utf-8')))
+        raw_header_cookie = request.META.get('HTTP_COOKIE', '')
+        set_custom_attribute('cookies.header.size', len(raw_header_cookie.encode('utf-8')))
 
         if not CAPTURE_COOKIE_SIZES.is_enabled():
             return

--- a/openedx/core/lib/request_utils.py
+++ b/openedx/core/lib/request_utils.py
@@ -24,8 +24,8 @@ COURSE_REGEX = re.compile(fr'^(.*?/courses/)(?!v[0-9]+/[^/]+){settings.COURSE_ID
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Enables more detailed capturing of cookie sizes for monitoring purposes. This can be useful for tracking
-#       down large cookies if requests are nearing limits on the total size of cookies. See the CookieMonitoringMiddleware
-#       docstring for details on the monitoring custom attributes that will be set.
+#       down large cookies if requests are nearing limits on the total size of cookies. See the
+#       CookieMonitoringMiddleware docstring for details on the monitoring custom attributes that will be set.
 # .. toggle_warnings: Enabling this flag will add a number of custom attributes, and could adversely affect other
 #       monitoring. Only enable temporarily, or lower TOP_N_COOKIES_CAPTURED and TOP_N_COOKIE_GROUPS_CAPTURED django
 #       settings to capture less data.

--- a/openedx/core/lib/request_utils.py
+++ b/openedx/core/lib/request_utils.py
@@ -23,8 +23,8 @@ COURSE_REGEX = re.compile(fr'^(.*?/courses/)(?!v[0-9]+/[^/]+){settings.COURSE_ID
 # .. toggle_name: request_utils.capture_cookie_sizes
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
-# .. toggle_description: Enables capturing of cookie sizes for monitoring purposes. This can be useful for tracking
-#       down large cookies and avoiding hitting limits on the total size of cookies. See the CookieMonitoringMiddleware
+# .. toggle_description: Enables detailed capturing of cookie sizes for monitoring purposes. This can be useful for tracking
+#       down large cookies if requests are nearing limits on the total size of cookies. See the CookieMonitoringMiddleware
 #       docstring for details on the monitoring custom attributes that will be set.
 # .. toggle_warnings: Enabling this flag will add a number of custom attributes, and could adversely affect other
 #       monitoring. Only enable temporarily, or lower TOP_N_COOKIES_CAPTURED and TOP_N_COOKIE_GROUPS_CAPTURED django
@@ -123,6 +123,10 @@ class CookieMonitoringMiddleware(MiddlewareMixin):
 
         Attributes that are added by this middleware:
 
+        cookies.header.size: The total size in bytes of the cookie header
+
+        If CAPTURE_COOKIE_SIZES is enabled, additional attributes will be added:
+
         cookies.<N>.name: The name of the Nth largest cookie
         cookies.<N>.size: The size of the Nth largest cookie
         cookies..group.<N>.name: The name of the Nth largest cookie.
@@ -141,6 +145,11 @@ class CookieMonitoringMiddleware(MiddlewareMixin):
         - TOP_N_COOKIE_GROUPS_CAPTURED
 
         """
+
+        if (request.META.get('HTTP_COOKIE', None)):
+            set_custom_attribute('cookies.header.size', len(request.META['HTTP_COOKIE'].encode('utf-8')))
+
+
         if not CAPTURE_COOKIE_SIZES.is_enabled():
             return
 

--- a/openedx/core/lib/request_utils.py
+++ b/openedx/core/lib/request_utils.py
@@ -23,7 +23,7 @@ COURSE_REGEX = re.compile(fr'^(.*?/courses/)(?!v[0-9]+/[^/]+){settings.COURSE_ID
 # .. toggle_name: request_utils.capture_cookie_sizes
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
-# .. toggle_description: Enables detailed capturing of cookie sizes for monitoring purposes. This can be useful for tracking
+# .. toggle_description: Enables more detailed capturing of cookie sizes for monitoring purposes. This can be useful for tracking
 #       down large cookies if requests are nearing limits on the total size of cookies. See the CookieMonitoringMiddleware
 #       docstring for details on the monitoring custom attributes that will be set.
 # .. toggle_warnings: Enabling this flag will add a number of custom attributes, and could adversely affect other
@@ -146,9 +146,8 @@ class CookieMonitoringMiddleware(MiddlewareMixin):
 
         """
 
-        if (request.META.get('HTTP_COOKIE', None)):
+        if request.META.get('HTTP_COOKIE', None):
             set_custom_attribute('cookies.header.size', len(request.META['HTTP_COOKIE'].encode('utf-8')))
-
 
         if not CAPTURE_COOKIE_SIZES.is_enabled():
             return

--- a/openedx/core/lib/tests/test_request_utils.py
+++ b/openedx/core/lib/tests/test_request_utils.py
@@ -99,13 +99,30 @@ class RequestUtilTestCase(unittest.TestCase):
 
     @patch("openedx.core.lib.request_utils.CAPTURE_COOKIE_SIZES")
     @patch("openedx.core.lib.request_utils.set_custom_attribute")
+    def test_basic_cookie_monitoring(self, mock_set_custom_attribute, mock_capture_cookie_sizes):
+        mock_capture_cookie_sizes.is_enabled.return_value = False
+        middleware = CookieMonitoringMiddleware()
+
+        cookies_dict = {'a':'b'}
+
+        factory = RequestFactory()
+        for name, value in cookies_dict.items():
+            factory.cookies[name] = value
+
+        mock_request = factory.request()
+
+        middleware.process_request(mock_request)
+
+        mock_set_custom_attribute.assert_called_once_with('cookies.header.size', 3)
+
+    @patch("openedx.core.lib.request_utils.CAPTURE_COOKIE_SIZES")
+    @patch("openedx.core.lib.request_utils.set_custom_attribute")
     def test_cookie_monitoring(self, mock_set_custom_attribute, mock_capture_cookie_sizes):
 
         mock_capture_cookie_sizes.is_enabled.return_value = True
         middleware = CookieMonitoringMiddleware()
 
-        mock_request = Mock()
-        mock_request.COOKIES = {
+        cookies_dict = {
             "a": "." * 100,
             "_b": "." * 13,
             "_c_": "." * 13,
@@ -116,6 +133,12 @@ class RequestUtilTestCase(unittest.TestCase):
             "b_c": "." * 15,
             "d": "." * 3,
         }
+
+        factory = RequestFactory()
+        for name, value in cookies_dict.items():
+            factory.cookies[name] = value
+
+        mock_request = factory.request()
 
         middleware.process_request(mock_request)
 
@@ -147,6 +170,7 @@ class RequestUtilTestCase(unittest.TestCase):
             call('cookies_total_size', 192),
             call('cookies_unaccounted_size', 3),
             call('cookies_total_num', 9),
+            call('cookies.header.size', 238)
         ], any_order=True)
 
     @patch("openedx.core.lib.request_utils.CAPTURE_COOKIE_SIZES")
@@ -156,12 +180,17 @@ class RequestUtilTestCase(unittest.TestCase):
         mock_capture_cookie_sizes.is_enabled.return_value = True
         middleware = CookieMonitoringMiddleware()
 
-        mock_request = Mock()
-        mock_request.COOKIES = {
+        cookies_dict = {
             "a": "." * 10,
             "b_a": "." * 15,
             "b_c": "." * 20,
         }
+
+        factory = RequestFactory()
+        for name, value in cookies_dict.items():
+            factory.cookies[name] = value
+
+        mock_request = factory.request()
 
         middleware.process_request(mock_request)
 
@@ -188,12 +217,20 @@ class RequestUtilTestCase(unittest.TestCase):
         mock_capture_cookie_sizes.is_enabled.return_value = True
         middleware = CookieMonitoringMiddleware()
 
-        mock_request = Mock()
-        mock_request.COOKIES = {}
+        cookies_dict = {}
+
+        factory = RequestFactory()
+        for name, value in cookies_dict.items():
+            factory.cookies[name] = value
+
+        mock_request = factory.request()
 
         middleware.process_request(mock_request)
 
-        mock_set_custom_attribute.assert_has_calls([call('cookies_total_size', 0)], any_order=True)
+        mock_set_custom_attribute.assert_has_calls([
+            call('cookies_total_size', 0),
+            call('cookies.header.size', 0)
+        ], any_order=True)
 
     @patch("openedx.core.lib.request_utils.CAPTURE_COOKIE_SIZES")
     @patch("openedx.core.lib.request_utils.set_custom_attribute")
@@ -202,11 +239,16 @@ class RequestUtilTestCase(unittest.TestCase):
         mock_capture_cookie_sizes.is_enabled.return_value = True
         middleware = CookieMonitoringMiddleware()
 
-        mock_request = Mock()
-        mock_request.COOKIES = {
+        cookies_dict = {
             "a": "." * 10,
             "b": "." * 15,
         }
+
+        factory = RequestFactory()
+        for name, value in cookies_dict.items():
+            factory.cookies[name] = value
+
+        mock_request = factory.request()
 
         middleware.process_request(mock_request)
 

--- a/openedx/core/lib/tests/test_request_utils.py
+++ b/openedx/core/lib/tests/test_request_utils.py
@@ -103,7 +103,7 @@ class RequestUtilTestCase(unittest.TestCase):
         mock_capture_cookie_sizes.is_enabled.return_value = False
         middleware = CookieMonitoringMiddleware()
 
-        cookies_dict = {'a':'b'}
+        cookies_dict = {'a': 'b'}
 
         factory = RequestFactory()
         for name, value in cookies_dict.items():


### PR DESCRIPTION
## Description

Report the total size of request cookie headers as a custom attribute to New Relic to provide observability into when cookie headers are reaching size limits. Calculated by getting the byte size of request.META['HTTP_COOKIE'], which is the raw string that eventually gets parsed into request.COOKIES (see https://github.com/django/django/blob/2fcafd169b5fcf4bb6711ca8aa4d59d80225ec7a/django/core/handlers/wsgi.py#L135)

The total size ends up being about ~100B more than just adding all the names and values in request.COOKIES, which makes sense considering the string representation has extra semi colons and quotation marks and other delineators.

Update description of CAPTURE_COOKIE_SIZE toggle to specify that it enables more detailed reporting than just the total size

## Deadline

None