### PR TITLE
fix: Fixing test csrf tests failures in django32.

### DIFF
--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -573,6 +573,8 @@ class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCas
         csrf_token = get_token(request)
         request._post = {'csrfmiddlewaretoken': f'{csrf_token}-dummy'}  # pylint: disable=protected-access
         request.user = self.mock_user
+        request.COOKIES[settings.CSRF_COOKIE_NAME] = csrf_token
+
         response = render.handle_xblock_callback(
             request,
             str(self.course_key),
@@ -590,6 +592,8 @@ class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCas
         csrf_token = get_token(request)
         request._post = {'csrfmiddlewaretoken': csrf_token}  # pylint: disable=protected-access
         request.user = self.mock_user
+        request.COOKIES[settings.CSRF_COOKIE_NAME] = csrf_token
+
         response = render.handle_xblock_callback(
             request,
             str(self.course_key),


### PR DESCRIPTION
This test is failing due to change in csrfmiddleware. This related [PR](https://github.com/django/django/pull/12402) from django. ( It is changed in 3.1 )

In django2.2 It is picking value from [CSRF_COOKIE](https://github.com/django/django/blob/2.2.24/django/middleware/csrf.py#L284) but in django3.2 the value is coming from [CSRF_COOKIE_NAME](https://github.com/django/django/blob/3.2/django/middleware/csrf.py#L170)

https://openedx.atlassian.net/browse/BOM-2864

Also fixed the `invalid` scenario it was failing due to some other error now giving proper desired failure.