### PR TITLE
fix: update test for race condition while saving course overview

### DIFF
--- a/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
+++ b/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
@@ -39,7 +39,7 @@ from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, check_mongo_calls_range
 
-from ..models import CourseOverview, CourseOverviewImageConfig, CourseOverviewImageSet
+from ..models import CourseOverview, CourseOverviewImageConfig, CourseOverviewImageSet, CourseOverviewTab
 from .factories import CourseOverviewFactory
 
 
@@ -396,7 +396,23 @@ class CourseOverviewTestCase(CatalogIntegrationMixin, ModuleStoreTestCase, Cache
             with check_mongo_calls_range(max_finds=max_mongo_calls, min_finds=min_mongo_calls):
                 _course_overview_2 = CourseOverview.get_from_id(course.id)
 
-    def test_course_overview_saving_race_condition(self):
+    # The CourseOverviewTab and CourseOverviewImageSet objects can't be filtered with course overview object as it is
+    # created with `None` as 'id' - We are going to mock this to as this isn't being tested in this test case, instead
+    # we are testing that on the first request course overview is created and stored and for the second request
+    # it gives IntegrityError - It is just to mimic race condition.
+    # Also we are mocking the RequestCache to disable caching as we want to mimic race condition and we want both
+    # requests to be served without involving cache
+    @mock.patch(
+        'openedx.core.djangoapps.content.course_overviews.models.CourseOverviewTab.objects.filter',
+        mock.Mock(return_value=CourseOverviewTab.objects.none())
+    )
+    @mock.patch(
+        'openedx.core.djangoapps.content.course_overviews.models.CourseOverviewImageSet.objects.filter',
+        mock.Mock(return_value=CourseOverviewImageSet.objects.none())
+    )
+    @mock.patch('openedx.core.lib.cache_utils.RequestCache', mock.Mock(return_value=None))
+    @mock.patch('openedx.core.djangoapps.content.course_overviews.models.log')
+    def test_course_overview_saving_race_condition(self, mock_log):
         """
         Tests that the following scenario will not cause an unhandled exception:
         - Multiple concurrent requests are made for the same non-existent CourseOverview.
@@ -444,6 +460,13 @@ class CourseOverviewTestCase(CatalogIntegrationMixin, ModuleStoreTestCase, Cache
                         # including after an IntegrityError exception the 2nd time.
                         for _ in range(2):
                             assert isinstance(CourseOverview.get_from_id(course.id), CourseOverview)
+
+                        # Make sure that tbe second call skips the cache and
+                        # IntegrityError is triggered and handled gracefully
+                        mock_log.info.assert_called_with(
+                            "Multiple CourseOverviews for course %s requested simultaneously; will only save one.",
+                            course.id
+                        )
 
     def test_course_overview_version_update(self):
         """


### PR DESCRIPTION

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This test was failing for Django 3 and during the investigation, it found that it isn't working as expected due to the introduction of caching. So fixed the test case to avoid caching to mimic race condition.

[Failure log for Django 3.0]( https://build.testeng.edx.org/job/edx-platform-django-3.0-python-pipeline-pr/39/testReport/junit/openedx.core.djangoapps.content.course_overviews.tests.test_course_overviews/CourseOverviewTestCase/Run_Tests___lms_unit___test_course_overview_saving_race_condition/)

[BOM-2799](https://openedx.atlassian.net/browse/BOM-2799) (Ticket has some initial findings in the comment)

