### PR TITLE
fix: Fixing test due to the change in django32.

### DIFF
--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -373,15 +373,16 @@ class TeamAPITestCase(APITestCase, SharedModuleStoreTestCase):
                 teams_configuration=teams_configuration_2
             )
 
+            cls.users = {
+                'staff': AdminFactory.create(password=cls.test_password),
+                'course_staff': StaffFactory.create(course_key=cls.test_course_1.id, password=cls.test_password),
+                'admin': AdminFactory.create(password=cls.test_password)
+            }
+
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
         cls.topics_count = 6
-        cls.users = {
-            'staff': AdminFactory.create(password=cls.test_password),
-            'course_staff': StaffFactory.create(course_key=cls.test_course_1.id, password=cls.test_password),
-            'admin': AdminFactory.create(password=cls.test_password)
-        }
         cls.create_and_enroll_student(username='student_enrolled')
         cls.create_and_enroll_student(username='student_on_team_1_private_set_1', mode=CourseMode.MASTERS)
         cls.create_and_enroll_student(username='student_on_team_2_private_set_1', mode=CourseMode.MASTERS)


### PR DESCRIPTION
Objects assigned to class attributes in TestCase.setUpTestData() are now isolated for each test method.

https://docs.djangoproject.com/en/3.2/releases/3.2/#tests

BOM-2866
