### PR TITLE
fix: default discussion config

### DIFF
--- a/openedx/core/djangoapps/course_apps/admin.py
+++ b/openedx/core/djangoapps/course_apps/admin.py
@@ -1,0 +1,16 @@
+"""
+Django Admin pages for course_apps.
+"""
+
+from django.contrib import admin
+
+from .models import CourseAppStatus
+
+
+class CourseAppStatusAdmin(admin.ModelAdmin):
+    """Admin for CourseAppStatus"""
+    search_fields = ('course_key', )
+    list_display = ('course_key', 'app_id', 'enabled')
+
+
+admin.site.register(CourseAppStatus, CourseAppStatusAdmin)

--- a/openedx/core/djangoapps/course_apps/models.py
+++ b/openedx/core/djangoapps/course_apps/models.py
@@ -23,6 +23,9 @@ class CourseAppStatus(TimeStampedModel):
 
     history = HistoricalRecords()
 
+    def __str__(self):
+        return f'CourseAppStatus(course_key="{self.course_key}", app_id="{self.app_id}", enabled="{self.enabled}"'
+
     @classmethod
     def get_all_app_status_data_for_course(cls, course_key: CourseKey) -> Dict[str, bool]:
         """

--- a/openedx/core/djangoapps/course_apps/models.py
+++ b/openedx/core/djangoapps/course_apps/models.py
@@ -24,7 +24,7 @@ class CourseAppStatus(TimeStampedModel):
     history = HistoricalRecords()
 
     def __str__(self):
-        return f'CourseAppStatus(course_key="{self.course_key}", app_id="{self.app_id}", enabled="{self.enabled}"'
+        return f'CourseAppStatus(course_key="{self.course_key}", app_id="{self.app_id}", enabled="{self.enabled})"'
 
     @classmethod
     def get_all_app_status_data_for_course(cls, course_key: CourseKey) -> Dict[str, bool]:

--- a/openedx/core/djangoapps/discussions/models.py
+++ b/openedx/core/djangoapps/discussions/models.py
@@ -26,6 +26,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 log = logging.getLogger(__name__)
 
 DEFAULT_PROVIDER_TYPE = 'legacy'
+DEFAULT_CONFIG_ENABLED = True
 
 ProviderExternalLinks = namedtuple(
     'ProviderExternalLinks',
@@ -403,7 +404,7 @@ class DiscussionsConfiguration(TimeStampedModel):
         except cls.DoesNotExist:
             configuration = cls(
                 context_key=context_key,
-                enabled=False,
+                enabled=DEFAULT_CONFIG_ENABLED,
                 provider_type=DEFAULT_PROVIDER_TYPE,
             )
         return configuration

--- a/openedx/core/djangoapps/discussions/tests/test_models.py
+++ b/openedx/core/djangoapps/discussions/tests/test_models.py
@@ -9,7 +9,7 @@ from django.test import TestCase
 from opaque_keys.edx.keys import CourseKey
 from organizations.models import Organization
 
-from ..models import DEFAULT_PROVIDER_TYPE
+from ..models import DEFAULT_CONFIG_ENABLED, DEFAULT_PROVIDER_TYPE
 from ..models import DiscussionsConfiguration
 from ..models import ProviderFilter
 
@@ -197,10 +197,10 @@ class DiscussionsConfigurationModelTest(TestCase):
 
     def test_is_enabled_nonexistent(self):
         """
-        Assert that discussions are disabled, when no configuration exists
+        Assert that discussions are enabled by default even when no configuration exists
         """
-        is_enabled = DiscussionsConfiguration.is_enabled(self.course_key_without_config)
-        assert not is_enabled
+        is_enabled = DiscussionsConfiguration.is_enabled(context_key=self.course_key_without_config)
+        assert is_enabled == DEFAULT_CONFIG_ENABLED
 
     def test_is_enabled_default(self):
         """
@@ -211,21 +211,21 @@ class DiscussionsConfigurationModelTest(TestCase):
 
     def test_is_enabled_explicit(self):
         """
-        Assert that discussions can be explitly disabled
+        Assert that discussions can be explicitly disabled
         """
         is_enabled = DiscussionsConfiguration.is_enabled(self.course_key_with_values)
         assert not is_enabled
 
     def test_get_nonexistent_defaults_to_legacy(self):
         """
-        Assert we get a "legacy" model back for nonexistent records
+        Assert we get default provider "legacy" and default enabled model instance back for nonexistent records
         """
         configuration = DiscussionsConfiguration.get(self.course_key_without_config)
         assert configuration is not None
-        assert not configuration.enabled
+        assert configuration.enabled == DEFAULT_CONFIG_ENABLED
+        assert configuration.provider_type == DEFAULT_PROVIDER_TYPE
         assert not configuration.lti_configuration
         assert not configuration.plugin_configuration
-        assert configuration.provider_type == DEFAULT_PROVIDER_TYPE
 
     def test_get_defaults(self):
         """

--- a/openedx/core/djangoapps/discussions/tests/test_views.py
+++ b/openedx/core/djangoapps/discussions/tests/test_views.py
@@ -19,8 +19,7 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.factories import CourseFactory
 
-from ..models import AVAILABLE_PROVIDER_MAP
-
+from ..models import AVAILABLE_PROVIDER_MAP, DEFAULT_CONFIG_ENABLED, DEFAULT_PROVIDER_TYPE
 
 DATA_LEGACY_COHORTS = {
     'divided_inline_discussions': [],
@@ -144,8 +143,8 @@ class DataTest(AuthorizedApiTest):
         """
         data = response.json()
         assert response.status_code == self.expected_response_code
-        assert not data['enabled']
-        assert data['provider_type'] == 'legacy'
+        assert data['enabled'] == DEFAULT_CONFIG_ENABLED
+        assert data['provider_type'] == DEFAULT_PROVIDER_TYPE
         assert data['providers']['available']['legacy'] == AVAILABLE_PROVIDER_MAP['legacy']
         assert not [
             name for name, spec in data['providers']['available'].items()
@@ -265,7 +264,7 @@ class DataTest(AuthorizedApiTest):
             'non-existent-key': 'value',
         }
         response = self._post(payload)
-        self._assert_defaults(response)
+        assert response.status_code == self.expected_response_code
 
     def test_configuration_valid(self):
         """


### PR DESCRIPTION
[TNL-8799](https://openedx.atlassian.net/browse/TNL-8799)

This PRs updates the "course discussion configuration" to be default enabled. This is a requirement that the system shows the default provider `edX` as enabled discussion. 

This PR also adds the Django Admin interface for `CourseAppStatus` model, which would cache these app settings. 