### PR TITLE
Fixing dj32 setuptestdata tests

### DIFF
--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -13,7 +13,7 @@ import ddt
 import pytz
 from dateutil import parser
 from django.conf import settings
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db.models.signals import post_save
 from django.urls import reverse

--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -379,7 +379,6 @@ class TeamAPITestCase(APITestCase, SharedModuleStoreTestCase):
                 'admin': AdminFactory.create(password=cls.test_password)
             }
 
-
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()

--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -373,15 +373,17 @@ class TeamAPITestCase(APITestCase, SharedModuleStoreTestCase):
                 teams_configuration=teams_configuration_2
             )
 
+            cls.users = {
+                'staff': AdminFactory.create(password=cls.test_password),
+                'course_staff': StaffFactory.create(course_key=cls.test_course_1.id, password=cls.test_password),
+                'admin': AdminFactory.create(password=cls.test_password)
+            }
+
+
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
         cls.topics_count = 6
-        cls.users = {
-            'staff': AdminFactory.create(password=cls.test_password),
-            'course_staff': StaffFactory.create(course_key=cls.test_course_1.id, password=cls.test_password),
-            'admin': AdminFactory.create(password=cls.test_password)
-        }
         cls.create_and_enroll_student(username='student_enrolled')
         cls.create_and_enroll_student(username='student_on_team_1_private_set_1', mode=CourseMode.MASTERS)
         cls.create_and_enroll_student(username='student_on_team_2_private_set_1', mode=CourseMode.MASTERS)

--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -1057,6 +1057,10 @@ class TestListTeamsAPI(EventTestMixin, TeamAPITestCase):
         yet_another_student_username = 'yet_another_student'
         self.create_and_enroll_student(username=another_student_username)
         self.create_and_enroll_student(username=yet_another_student_username)
+
+        self._add_missing_user(another_student_username)
+        self._add_missing_user(yet_another_student_username)
+
         self.solar_team.add_user(self.users[another_student_username])
         self.solar_team.add_user(self.users[yet_another_student_username])
 
@@ -1069,6 +1073,15 @@ class TestListTeamsAPI(EventTestMixin, TeamAPITestCase):
         team_names = [team['name'] for team in teams['results']]
         team_names.sort()
         assert team_names == [self.solar_team.name, self.masters_only_team.name]
+
+    def _add_missing_user(self, missing_user):
+        """
+        django32 TestCase.setUpTestData() are now isolated for each test method.
+        In case of missing user adding this to list.
+        """
+        if missing_user not in self.users:
+            missing_user = User.objects.get(username=missing_user)
+            self.users[missing_user.username] = missing_user
 
 
 @ddt.ddt


### PR DESCRIPTION
## Description

Objects assigned to class attributes in TestCase.setUpTestData() are now isolated for each test method.

https://docs.djangoproject.com/en/3.2/releases/3.2/#tests

It will fix test failures in following issues: 
- [BOM-2866](https://openedx.atlassian.net/browse/BOM-2866)
- [BOM-2865](https://openedx.atlassian.net/browse/BOM-2865)