### PR TITLE
feat: return user id from login_refresh

### DIFF
--- a/openedx/core/djangoapps/user_authn/cookies.py
+++ b/openedx/core/djangoapps/user_authn/cookies.py
@@ -170,6 +170,7 @@ def get_response_with_refreshed_jwt_cookies(request, user):
     response.content = json.dumps(
         {
             'success': True,
+            'user_id': user.id,
             'response_epoch_seconds': current_time,
             'response_http_date': http_date(current_time),
             'expires': expires_date if expires_date else 'not-found',

--- a/openedx/core/djangoapps/user_authn/tests/test_cookies.py
+++ b/openedx/core/djangoapps/user_authn/tests/test_cookies.py
@@ -153,7 +153,7 @@ class CookieTests(TestCase):
         self._set_use_jwt_cookie_header(self.request)
         response = cookies_api.get_response_with_refreshed_jwt_cookies(self.request, self.user)
         data = json.loads(response.content.decode('utf8').replace("'", '"'))
-        assert data['success'] == True
+        assert data['success'] is True
         assert data['user_id'] == self.user.id
         assert data['expires_epoch_seconds'] > 0
         assert data['expires'] != 'not-found'

--- a/openedx/core/djangoapps/user_authn/tests/test_cookies.py
+++ b/openedx/core/djangoapps/user_authn/tests/test_cookies.py
@@ -153,6 +153,8 @@ class CookieTests(TestCase):
         self._set_use_jwt_cookie_header(self.request)
         response = cookies_api.get_response_with_refreshed_jwt_cookies(self.request, self.user)
         data = json.loads(response.content.decode('utf8').replace("'", '"'))
+        assert data['success'] == True
+        assert data['user_id'] == self.user.id
         assert data['expires_epoch_seconds'] > 0
         assert data['expires'] != 'not-found'
         self._assert_cookies_present(response, cookies_api.JWT_COOKIE_NAMES)


### PR DESCRIPTION
## Description

To enhance monitoring of login_refresh issues that happen
in the frontend, return user id as part of successful
refreshes.

## Supporting information

There have been a variety of login_refresh issues in the MFEs, and if the issue happens to affect otherwise successful logins, this information would help us learn who and how many unique users are affected.