### PR TITLE
fix: LANGUAGE_CODE in settings.py should be in the form ll or ll-cc.

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1715,7 +1715,7 @@ LANGUAGES = [
     ('en', 'English'),
     ('rtl', 'Right-to-Left Test Language'),
     ('eo', 'Dummy Language (Esperanto)'),  # Dummy languaged used for testing
-    ('fake2', 'Fake translations'),        # Another dummy language for testing (not pushed to prod)
+    ('fa-ke2', 'Fake translations'),        # Another dummy language for testing (not pushed to prod)
 
     ('am', 'አማርኛ'),  # Amharic
     ('ar', 'العربية'),  # Arabic


### PR DESCRIPTION
LANGUAGE_CODE in settings.py should be in the form ll or ll-cc
where ll is the language and cc is the country.

https://github.com/django/django/commit/5db8d617c0a5b16fabe16d1d52b2f9db519d8bb6#diff-a9cf3889460f406f1d1a6cefcb504347012a445a7da97ad614f61e5e73f7f9acR24