### PR TITLE
feat: time-based logging for userid mismatches

### DIFF
--- a/openedx/core/djangoapps/safe_sessions/middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/middleware.py
@@ -446,7 +446,7 @@ class SafeSessionMiddleware(SessionMiddleware, MiddlewareMixin):
                 if is_request_response_mismatch and not is_request_session_mismatch:
                     log.warning(
                         (
-                            "SafeCookieData user at request '{}' does not match user in response: '{}' "
+                            "SafeCookieData user in initial request '{}' does not match user at response time: '{}' "
                             "for request path '{}'. {}"
                         ).format(  # pylint: disable=logging-format-interpolation
                             request.safe_cookie_verified_user_id, request.user.id, request.path,
@@ -457,7 +457,7 @@ class SafeSessionMiddleware(SessionMiddleware, MiddlewareMixin):
                 elif is_request_session_mismatch and not is_request_response_mismatch:
                     log.warning(
                         (
-                            "SafeCookieData user at request '{}' does not match user in session: '{}' "
+                            "SafeCookieData user in initial request '{}' does not match user in session: '{}' "
                             "for request path '{}'. {}"
                         ).format(  # pylint: disable=logging-format-interpolation
                             request.safe_cookie_verified_user_id, userid_in_session, request.path,
@@ -469,8 +469,8 @@ class SafeSessionMiddleware(SessionMiddleware, MiddlewareMixin):
                     # both session user and user in response are different than user in request
                     log.warning(
                         (
-                            "SafeCookieData user at request '{}' does not match user in session: '{}' "
-                            "or user in response: {} for request path '{}'. {}"
+                            "SafeCookieData user in initial request '{}' does not match user in session: '{}' "
+                            "or user at response time: {} for request path '{}'. {}"
                         ).format(  # pylint: disable=logging-format-interpolation
                             request.safe_cookie_verified_user_id, userid_in_session, request.user.id, request.path,
                             log_session_suffix

--- a/openedx/core/djangoapps/safe_sessions/tests/test_middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/tests/test_middleware.py
@@ -220,15 +220,15 @@ class TestSafeSessionProcessResponse(TestSafeSessionsLogMixin, CacheIsolationTes
     @patch("django.core.cache.cache.set")
     @ddt.unpack
     @ddt.data(
-        {'change_response_user': True, 'change_session_user': False, 'mismatch_location': 'response',
+        {'change_response_user': True, 'change_session_user': False, 'mismatch_location': 'at response time',
          'change_session': True},
-        {'change_response_user': False, 'change_session_user': True, 'mismatch_location': 'session',
+        {'change_response_user': False, 'change_session_user': True, 'mismatch_location': 'in session',
          'change_session': True},
         {'change_response_user': True, 'change_session_user': True, 'mismatch_location': 'both',
          'change_session': True},
-        {'change_response_user': True, 'change_session_user': False, 'mismatch_location': 'response',
+        {'change_response_user': True, 'change_session_user': False, 'mismatch_location': 'at response time',
          'change_session': False},
-        {'change_response_user': False, 'change_session_user': True, 'mismatch_location': 'session',
+        {'change_response_user': False, 'change_session_user': True, 'mismatch_location': 'in session',
          'change_session': False},
         {'change_response_user': True, 'change_session_user': True, 'mismatch_location': 'both',
          'change_session': False},
@@ -254,7 +254,7 @@ class TestSafeSessionProcessResponse(TestSafeSessionsLogMixin, CacheIsolationTes
             if not mismatch_location == 'both':
                 with self.assert_logged_with_message(
                     (
-                        "SafeCookieData user at request '{}' does not match user in {}: '{}' "
+                        "SafeCookieData user in initial request '{}' does not match user {}: '{}' "
                         "for request path '{}'. {}"
                     ).format(
                         self.MOCK_USER.id, mismatch_location, new_user.id, self.request.path, log_session_suffix
@@ -266,8 +266,8 @@ class TestSafeSessionProcessResponse(TestSafeSessionsLogMixin, CacheIsolationTes
             else:
                 with self.assert_logged_with_message(
                     (
-                        "SafeCookieData user at request '{}' does not match user in session: '{}' "
-                        "or user in response: {} for request path '{}'. {}"
+                        "SafeCookieData user in initial request '{}' does not match user in session: '{}' "
+                        "or user at response time: {} for request path '{}'. {}"
                     ).format(
                         self.MOCK_USER.id, new_user.id, new_user.id, self.request.path, log_session_suffix
                     ),
@@ -412,7 +412,7 @@ class TestSafeSessionMiddleware(TestSafeSessionsLogMixin, TestCase):
 
         with self.assert_logged_with_message(
             (
-                "SafeCookieData user at request '{}' does not match user in response: '{}' "
+                "SafeCookieData user in initial request '{}' does not match user at response time: '{}' "
                 "for request path '{}'. Session id has not changed"
             ).format(
                 self.user.id, self.request.user.id, self.request.path

--- a/openedx/core/djangoapps/safe_sessions/tests/test_utils.py
+++ b/openedx/core/djangoapps/safe_sessions/tests/test_utils.py
@@ -113,37 +113,3 @@ class TestSafeSessionsLogMixin:
         """
         with self.assert_logged('SafeCookieData not created due to invalid value for session_id'):
             yield
-
-    @contextmanager
-    def assert_logged_for_request_user_mismatch(self, user_at_request, user_at_response, log_level, request_path):
-        """
-        Asserts that warning was logged when request.user
-        was not equal to user at response
-        """
-        with self.assert_logged_with_message(
-            (
-                "SafeCookieData user at request '{}' does not match user at response: '{}' "
-                "for request path '{}'"
-            ).format(
-                user_at_request, user_at_response, request_path
-            ),
-            log_level=log_level,
-        ):
-            yield
-
-    @contextmanager
-    def assert_logged_for_session_user_mismatch(self, user_at_request, user_in_session, request_path):
-        """
-        Asserts that warning was logged when request.user
-        was not equal to user at session
-        """
-        with self.assert_logged_with_message(
-            (
-                "SafeCookieData user at request '{}' does not match user in session: '{}' "
-                "for request path '{}'"
-            ).format(
-                user_at_request, user_in_session, request_path
-            ),
-            log_level='warning',
-        ):
-            yield


### PR DESCRIPTION
## Description

Modify LOG_REQUEST_USER_CHANGES toggle with a memcache key that is set to True after the SafeSession middleware finds a userid mismatch, expiring after 300s. 

## Supporting information

https://openedx.atlassian.net/browse/ARCHBOM-1876

## Deadline
None
