### PR TITLE
docs: remove link to edX.org-internal coursegraph queries

### DIFF
--- a/openedx/core/djangoapps/coursegraph/README.rst
+++ b/openedx/core/djangoapps/coursegraph/README.rst
@@ -97,11 +97,3 @@ In a given course, which units contain problems with custom Python grading code?
       c.course_key = '<course_key>'
   RETURN
       u.location
-
-
-Query Archive
-*************
-
-edX currently maintains a running archive `Coursegraph queries we have found useful`_ which may serve as a helpful reference.
-
-.. _Coursegraph queries we have found useful: https://openedx.atlassian.net/wiki/spaces/SUST/pages/135102646/CourseGraph+Queries


### PR DESCRIPTION
I had thought this wiki page was publicly accessible, but it
turns out that it is restricted to edX employees. Making the
page publicly visible would involve editing some queries
to remove edX.org-specific information, which is doable but
not something I can commit to right now.
