### PR TITLE
fix: remove fake2 language from django settings

### DIFF
--- a/conf/locale/config.yaml
+++ b/conf/locale/config.yaml
@@ -94,7 +94,6 @@ locales:
 # The locales used for fake-accented English, for testing.
 dummy_locales:
     - eo
-    - fake2
     - rtl  # Fake testing language for Arabic
 
 # Directories we don't search for strings.

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1715,7 +1715,6 @@ LANGUAGES = [
     ('en', 'English'),
     ('rtl', 'Right-to-Left Test Language'),
     ('eo', 'Dummy Language (Esperanto)'),  # Dummy languaged used for testing
-    ('fake2', 'Fake translations'),        # Another dummy language for testing (not pushed to prod)
 
     ('am', 'አማርኛ'),  # Amharic
     ('ar', 'العربية'),  # Arabic

--- a/pavelib/paver_tests/test_extract_and_generate.py
+++ b/pavelib/paver_tests/test_extract_and_generate.py
@@ -77,8 +77,6 @@ class TestGenerate(TestCase):
         .mo files should exist, and be recently created (modified
         after start of test suite)
         """
-        # Change dummy_locales to not have Esperanto present.
-        self.configuration.dummy_locales = ['fake2']
 
         generate.main(verbosity=0, strict=False)
         for locale in self.configuration.translated_locales:


### PR DESCRIPTION


## Description

This was causing issue with Django 3.2, as Django has restricted to only use language from the pre-defined set of languages provided by Django.

> Only languages listed in the LANGUAGES setting can be selected. If you want to restrict the language selection to a subset of provided languages (because your application doesn't provide all those languages), set LANGUAGES to a list of languages.
https://docs.djangoproject.com/en/3.2/topics/i18n/translation/#how-django-discovers-language-preference

Languages provided by Django: https://github.com/django/django/blob/d400b08a8baa697905daadd47a6ba12336e93336/django/conf/global_settings.py#L56


Failure Log:
>SystemCheckError: System check identified some issues:
>
>ERRORS:
>?: (translation.E002) You have provided an invalid language code in the LANGUAGES setting: 'fake2'.

[BOM-2870](https://openedx.atlassian.net/browse/BOM-2870)
