### PR TITLE
chore: version bump to 3.28.23

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -30,7 +30,7 @@ django-storages<1.9
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==3.28.22
+edx-enterprise==3.28.23
 
 # Newer versions need a more recent version of python-dateutil
 freezegun==0.3.12

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -442,7 +442,7 @@ edx-drf-extensions==7.0.1
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.28.22
+edx-enterprise==3.28.23
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -542,7 +542,7 @@ edx-drf-extensions==7.0.1
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.28.22
+edx-enterprise==3.28.23
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -522,7 +522,7 @@ edx-drf-extensions==7.0.1
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.28.22
+edx-enterprise==3.28.23
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

-->

## Description

There's a 50 char limit to course keys on the CSOD lms so we need to limit the size of our encoded course keys within the content metadata, was accomplished with a dictionary database table leading longer keys to be associated with a uuid.

Work done as part of ENT-4954