### PR TITLE
fix: fixed build errors blocking django 3.1 and 3.2 tests

### DIFF
--- a/openedx/core/djangoapps/coursegraph/tasks.py
+++ b/openedx/core/djangoapps/coursegraph/tasks.py
@@ -11,7 +11,16 @@ from django.utils import timezone
 from edx_django_utils.cache import RequestCache
 from edx_django_utils.monitoring import set_code_owner_attribute
 from opaque_keys.edx.keys import CourseKey
-from py2neo import Graph, Node, Relationship, NodeMatcher
+
+import py2neo  # pylint: disable=unused-import
+from py2neo import Graph, Node, Relationship
+
+try:
+    from py2neo.matching import NodeMatcher
+except ImportError:
+    from py2neo import NodeMatcher
+else:
+    pass
 
 
 log = logging.getLogger(__name__)

--- a/scripts/xdist/prepare_xdist_nodes.sh
+++ b/scripts/xdist/prepare_xdist_nodes.sh
@@ -15,6 +15,10 @@ if [[ -z ${TOXENV+x} ]] || [[ ${TOXENV} == 'null' ]]; then
     DJANGO_REQUIREMENT="requirements/edx/django.txt"
 elif [[ ${TOXENV} == *'django30'* ]]; then
     DJANGO_REQUIREMENT="requirements/edx/django30.txt"
+elif [[ ${TOXENV} == *'django31'* ]]; then
+    DJANGO_REQUIREMENT="requirements/edx/django31.txt"
+elif [[ ${TOXENV} == *'django32'* ]]; then
+    DJANGO_REQUIREMENT="requirements/edx/django32.txt"
 fi
 
 ip_list=$(<pytest_worker_ips.txt)


### PR DESCRIPTION
we were facing import errors with Django 3.1 and 3.2 workers, there seems to be an inconsistency in `py2neo` packages itself regarding this, ref: https://github.com/py2neo-org/py2neo/blob/59d2961d7b14e31318d703b954fd4f43748dd1e5/py2neo/__init__.py#L74