### PR TITLE
[MST-1105] Prevent name change request if requested name is identical to existing name

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/api.py
+++ b/openedx/core/djangoapps/user_api/accounts/api.py
@@ -243,9 +243,13 @@ def _validate_name_change(user_profile, data, field_errors):
         return None
 
     old_name = user_profile.name
+    new_name = data['name']
+
+    if old_name == new_name:
+        return None
 
     try:
-        validate_name(data['name'])
+        validate_name(new_name)
     except ValidationError as err:
         field_errors["name"] = {
             "developer_message": f"Error thrown from validate_name: '{err.message}'",
@@ -253,7 +257,7 @@ def _validate_name_change(user_profile, data, field_errors):
         }
         return None
 
-    if _does_name_change_require_verification(user_profile, old_name, data['name']):
+    if _does_name_change_require_verification(user_profile, old_name, new_name):
         err_msg = 'This name change requires ID verification.'
         field_errors['name'] = {
             'developer_message': err_msg,


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Fixes a bug where the user would be prompted to complete ID verification without actually changing their name.

## Supporting information

[MST-1105](https://openedx.atlassian.net/browse/MST-1105)