### PR TITLE
(WIP) Emit eventtracking events on successful first and third party auth.

### DIFF
--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -77,6 +77,7 @@ from django.http import HttpResponseBadRequest
 from django.shortcuts import redirect
 from django.urls import reverse
 from edx_django_utils.monitoring import set_custom_attribute
+from eventtracking import tracker
 from social_core.exceptions import AuthException
 from social_core.pipeline import partial
 from social_core.utils import module_member, slugify
@@ -707,9 +708,8 @@ def set_logged_in_cookies(backend=None, user=None, strategy=None, auth_entry=Non
 
 
 @partial.partial
-def login_analytics(strategy, auth_entry, current_partial=None, *args, **kwargs):  # lint-amnesty, pylint: disable=keyword-arg-before-vararg
-    """ Sends login info to Segment """
-
+def login_analytics(strategy=None, backend=None, pipeline_index=None, current_partial=None, auth_entry=None, *args, **kwargs):
+    """ Sends login info to Segment (bi) and event tracking backends."""
     event_name = None
     if auth_entry == AUTH_ENTRY_LOGIN:
         event_name = 'edx.bi.user.account.authenticated'
@@ -720,8 +720,41 @@ def login_analytics(strategy, auth_entry, current_partial=None, *args, **kwargs)
         segment.track(kwargs['user'].id, event_name, {
             'category': "conversion",
             'label': None,
-            'provider': kwargs['backend'].name
+            'provider': backend.name
         })
+
+    # .. pii: Username, possibly any other social login data including fullname, email, profile URLs, 'other' possible PII sent with social auth.  Retirement will depend on configured event-tracking backends.  PII sent to Segment retired directly through Segment API call in Tubular. Tracking logs retained.   # pylint: disable=line-too-long
+    # .. pii_types: name, username, email_address, birth_date, external_service, image, other
+    # .. pii_retirement: retained, third_party
+    user = kwargs['user']
+    track_data = {
+        'user_id': user.id,
+        'username': user.username,
+        'auth_data': {
+            'tpa_auth_entry': auth_entry,
+            'tpa_provider': backend.name,
+        }
+    }
+
+    # re: PII: Of default enabled social auth backends, only SAML, by default, saves all extra_data
+    # to UserSocialAuth.  This can be configured in SAMLConfiguration object by setting
+    # GET_ALL_EXTRA_DATA to False.  Individual extra_data fields can be specified for storage by
+    # overriding other_config_str in SAMLConfiguration.
+    try:
+        user_social_auth = social_django.models.UserSocialAuth.objects.get(user=user)
+        track_data['auth_data'].update({
+            'tpa_social_uid': user_social_auth.uid,
+            'tpa_social_extra_data': user_social_auth.extra_data
+        })
+    except social_django.models.UserSocialAuth.NotFound:
+        pass
+
+    track_event_name = 'edx.user.account.authenticated'
+    user_tpa_context = dict()
+    user_tpa_context.update(tracker.get_tracker().resolve_context())
+
+    with tracker.get_tracker().context(track_event_name, user_tpa_context):
+        tracker.emit(name=track_event_name, data=track_data)
 
 
 @partial.partial

--- a/common/djangoapps/third_party_auth/tests/test_pipeline.py
+++ b/common/djangoapps/third_party_auth/tests/test_pipeline.py
@@ -12,6 +12,7 @@ from common.djangoapps.third_party_auth.tests.specs.base import IntegrationTestM
 from common.djangoapps.third_party_auth.tests.specs.test_testshib import SamlIntegrationTestUtilities
 from common.djangoapps.third_party_auth.tests.testutil import simulate_running_pipeline
 from common.djangoapps.third_party_auth.tests.utils import skip_unless_thirdpartyauth
+from lms.djangoapps.program_enrollments.management.commands.tests.utils import UserSocialAuthFactory
 
 
 @skip_unless_thirdpartyauth()
@@ -98,3 +99,61 @@ class PipelineOverridesTest(SamlIntegrationTestUtilities, IntegrationTestMixin, 
             mock_uuid.return_value = uuid4
             final_username = pipeline.get_username(strategy, details, self.provider.backend_class())
             assert expected_username == final_username['username']
+
+
+@unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, testutil.AUTH_FEATURES_KEY + ' not enabled')
+class PipelineLoginAnalyticsTest(IntegrationTestMixin, testutil.TestCase):
+    """
+    Tests for login_analytics step in the TPA pipeline.
+    """
+
+    def setUp(self):
+        super(PipelineLoginAnalyticsTest, self).setUp()
+        self.provider = self.configure_dummy_provider(
+            enabled=True,
+            name="Test Dummy Provider",
+            slug='test',
+            backend_name='dummy'
+        )
+
+    def test_tpa_login_tracking_event(self):
+        """
+        Test successful third party auth login produces correct tracking log event.
+        """
+        dummy_extra_data = {"foo_extra_1": "something", "foo_extra_2": "something else"}
+        social = UserSocialAuthFactory.create(slug=self.provider.slug)
+        user = social.user
+        uid = social.uid
+        social.extra_data = dummy_extra_data
+        social.save()
+        expected_track_data = {
+            'user_id': user.id,
+            'username': user.username,
+            'auth_data': {
+                'tpa_auth_entry': pipeline.AUTH_ENTRY_LOGIN,
+                'tpa_provider': 'dummy',
+                'tpa_social_uid': uid,
+                'tpa_social_extra_data': dummy_extra_data
+            }
+        }
+        expected_segment_track_props = {
+            'category': "conversion",
+            'label': None,
+            'provider': 'dummy'
+        }
+
+        __, strategy = self.get_request_and_strategy()
+        pipeline_kws = {'uid': social.uid, 'user': user, 'social': social}
+
+        # don't decorate whole test method with these since they can be called creating UserSocialAuth
+        with mock.patch("common.djangoapps.third_party_auth.pipeline.tracker.emit") as mock_tracker_emit:
+            with mock.patch("common.djangoapps.third_party_auth.pipeline.segment.track") as mock_segment_track:
+                pipeline.login_analytics(
+                    strategy=strategy, backend=self.provider.backend_class(),
+                    pipeline_index=0, auth_entry='login', **pipeline_kws
+                )
+                mock_tracker_emit.assert_called_once_with(name='edx.user.account.authenticated', data=expected_track_data)
+                mock_segment_track.assert_called_once_with(
+                    user.id, 'edx.bi.user.account.authenticated',
+                    expected_segment_track_props
+                )

--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -25,6 +25,7 @@ from django.views.decorators.csrf import csrf_exempt, csrf_protect, ensure_csrf_
 from django.views.decorators.debug import sensitive_post_parameters
 from django.views.decorators.http import require_http_methods
 from edx_django_utils.monitoring import set_custom_attribute
+from eventtracking import tracker
 from ratelimit.decorators import ratelimit
 from rest_framework.views import APIView
 
@@ -350,6 +351,22 @@ def _track_user_login(user, request):
             'provider': None
         },
     )
+
+    # Send a standard event-tracking event
+    # .. pii: Username is sent to any configured event-tracking backend.  PII sent to Segment retired directly through Segment API call in Tubular. Tracking logs retained.   # pylint: disable=line-too-long
+    # .. pii_types: username
+    # .. pii_retirement: retained, third_party
+    track_data = {
+        'user_id': user.id,
+        'username': user.username,
+        'auth_data': {}
+    }
+
+    track_event_name = 'edx.user.account.authenticated'
+    context = tracker.get_tracker().resolve_context()
+
+    with tracker.get_tracker().context(track_event_name, context):
+        tracker.emit(name=track_event_name, data=track_data)
 
 
 def _create_message(site, root_url, allowed_domain):


### PR DESCRIPTION
Previously only an event in the edx.bi namespace was sent to Segment
New event name is 'edx.user.account.authenticated' and is emitted
in tpa.pipeline.login_analytics step and in user_authn.views.login._track_user_login.

TPA pipeline event include social auth UID and extra_data if available.

Include PII annotations for edx.user.account.authenticated events and
PII-related comment in tpa pipeline login_analytics explaining
which provider types share PII in extra_data by default

Add test coverage for tpa.pipeline.login_analytics

Change function signature of login_analytics to one that will work with unit tests using @partial.partial decorator

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

It's useful to have tracking of authentication outside of just Segment integrations.  This can be used for logging and other BI and analytics integrations.  This PR adds code to emit the event `edx.user.account.authenticated` from first and third party auth login workflows.  TPA logins will include an additional event property `auth_data` containing information about the backend/auth provider, social auth data, and social UID.  


Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
