### PR TITLE
fix: added type annotations to fix mypy failure in CI

### DIFF
--- a/common/lib/xmodule/xmodule/partitions/partitions_service.py
+++ b/common/lib/xmodule/xmodule/partitions/partitions_service.py
@@ -6,12 +6,18 @@ persist the assignments.
 
 
 import logging
-from django.conf import settings
+from typing import Dict
 
+from django.conf import settings
+from django.contrib.auth import get_user_model
 from openedx.core.lib.cache_utils import request_cached
 from openedx.core.lib.dynamic_partitions_generators import DynamicPartitionGeneratorsPluginManager
+
 from xmodule.modulestore.django import modulestore
 from xmodule.partitions.partitions import get_partition_from_id
+from .partitions import Group
+
+User = get_user_model()
 
 log = logging.getLogger(__name__)
 
@@ -38,7 +44,8 @@ def get_all_partitions_for_course(course, active_only=False):
     return all_partitions
 
 
-def get_user_partition_groups(course_key, user_partitions, user, partition_dict_key='name'):
+def get_user_partition_groups(course_key: str, user_partitions: list, user: User,
+                              partition_dict_key: str = 'name') -> Dict[str, Group]:
     """
     Collect group ID for each partition in this course for this user.
      Arguments:

--- a/openedx/core/djangoapps/content/learning_sequences/api/processors/enrollment_track_partition_groups.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/processors/enrollment_track_partition_groups.py
@@ -1,6 +1,7 @@
 # lint-amnesty, pylint: disable=missing-module-docstring
 import logging
 from datetime import datetime
+from typing import Dict
 
 from opaque_keys.edx.keys import CourseKey
 from openedx.core import types
@@ -12,6 +13,7 @@ from xmodule.partitions.partitions import (
     ENROLLMENT_TRACK_PARTITION_ID,
 )
 from xmodule.partitions.partitions_service import get_user_partition_groups
+from xmodule.partitions.partitions import Group
 
 from .base import OutlineProcessor
 
@@ -28,10 +30,10 @@ class EnrollmentTrackPartitionGroupsOutlineProcessor(OutlineProcessor):
     """
     def __init__(self, course_key: CourseKey, user: types.User, at_time: datetime):
         super().__init__(course_key, user, at_time)
-        self.enrollment_track_groups = {}
+        self.enrollment_track_groups: Dict[str, Group] = {}
         self.user_group = None
 
-    def load_data(self, full_course_outline):
+    def load_data(self, full_course_outline) -> None:
         """
         Pull track groups for this course and which group the user is in.
         """


### PR DESCRIPTION
we've recently introduced static analysis in our CI checks to warn authors when they're not adding type annotations to their code, after the check integrated and PR merged it was failing on all PRs because of missing annotation, this PR fixed that error and adds required annotation.