### PR TITLE
fix: Add back in dummy locales for unit test.

### DIFF
--- a/pavelib/paver_tests/test_extract_and_generate.py
+++ b/pavelib/paver_tests/test_extract_and_generate.py
@@ -77,9 +77,20 @@ class TestGenerate(TestCase):
         .mo files should exist, and be recently created (modified
         after start of test suite)
         """
+        # Change dummy_locales to only contain Esperanto.
+        self.configuration.dummy_locales = ['eo']
 
+        # Clear previous files.
+        for locale in self.configuration.dummy_locales:
+            for filename in ('django', 'djangojs'):
+                mofile = filename + '.mo'
+                path = os.path.join(self.configuration.get_messages_dir(locale), mofile)
+                if os.path.exists(path):
+                    os.remove(path)
+
+        # Regenerate files.
         generate.main(verbosity=0, strict=False)
-        for locale in self.configuration.translated_locales:
+        for locale in self.configuration.dummy_locales:
             for filename in ('django', 'djangojs'):
                 mofile = filename + '.mo'
                 path = os.path.join(self.configuration.get_messages_dir(locale), mofile)


### PR DESCRIPTION
## Description

We broke this test as part of previous work for the Django 3.2 upgrade.

https://openedx.atlassian.net/browse/BOM-2868