### PR TITLE
feat: Add Track Selection error handling

### DIFF
--- a/common/djangoapps/course_modes/tests/test_views.py
+++ b/common/djangoapps/course_modes/tests/test_views.py
@@ -545,6 +545,12 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
             if has_perm:
                 self.assertContains(response, error_msg)
                 self.assertContains(response, 'Sorry, we were unable to enroll you')
+
+                # Check for CTA button on error page
+                marketing_root = settings.MKTG_URLS.get('ROOT')
+                search_courses_url = urljoin(marketing_root, '/search?tab=course')
+                self.assertContains(response, search_courses_url)
+                self.assertContains(response, '<span>Explore all courses</span>')
             else:
                 self.assertTrue(CourseEnrollment.is_enrollment_closed(self.user, self.course))
 

--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -11,6 +11,7 @@ import six
 import waffle  # lint-amnesty, pylint: disable=invalid-django-waffle-import
 from babel.dates import format_datetime
 from babel.numbers import get_currency_symbol
+from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.db import transaction
 from django.http import HttpResponse, HttpResponseBadRequest
@@ -23,6 +24,7 @@ from django.views.generic.base import View
 from edx_django_utils.monitoring.utils import increment
 from ipware.ip import get_client_ip
 from opaque_keys.edx.keys import CourseKey
+from urllib.parse import urljoin
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.helpers import get_course_final_price, get_verified_track_links
@@ -133,7 +135,6 @@ class ChooseModeView(View):
                 if purchase_workflow == "bulk" and professional_mode.bulk_sku:
                     redirect_url = ecommerce_service.get_checkout_page_url(professional_mode.bulk_sku)
             return redirect(redirect_url)
-
         course = modulestore().get_course(course_key)
 
         # If there isn't a verified mode available, then there's nothing
@@ -191,6 +192,7 @@ class ChooseModeView(View):
             "nav_hidden": True,
             "content_gating_enabled": gated_content,
             "course_duration_limit_enabled": CourseDurationLimitConfig.enabled_for_enrollment(request.user, course),
+            "search_courses_url": urljoin(settings.MKTG_URLS.get('ROOT'), '/search?tab=course'),
         }
         context.update(
             get_experiment_user_metadata_context(

--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -152,6 +152,10 @@ class ChooseModeView(View):
             locale = to_locale(get_language())
             enrollment_end_date = format_datetime(course.enrollment_end, 'short', locale=locale)
             params = six.moves.urllib.parse.urlencode({'course_closed': enrollment_end_date})
+            LOG.info(
+                '[Track Selection Check] Enrollment is closed redirect for course [%s], user [%s]',
+                course_id, request.user.username
+            )
             return redirect('{}?{}'.format(reverse('dashboard'), params))
 
         # When a credit mode is available, students will be given the option
@@ -296,7 +300,10 @@ class ChooseModeView(View):
         course = modulestore().get_course(course_key)
         if not user.has_perm(ENROLL_IN_COURSE, course):
             error_msg = _("Enrollment is closed")
-            LOG.info('[Track Selection Check] Error: [%s], for course [%s]', error_msg, course_id)
+            LOG.info(
+                '[Track Selection Check] Error: [%s], for course [%s], user [%s]',
+                error_msg, course_id, request.user.username
+            )
             return self.get(request, course_id, error=error_msg)
 
         requested_mode = self._get_requested_mode(request.POST)

--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -14,7 +14,7 @@ from babel.numbers import get_currency_symbol
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.db import transaction
-from django.http import HttpResponse, HttpResponseBadRequest
+from django.http import HttpResponse
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.decorators import method_decorator
@@ -288,9 +288,10 @@ class ChooseModeView(View):
             course_id (unicode): The slash-separated course key.
 
         Returns:
-            Status code 400 when the requested mode is unsupported. When the honor mode
-            is selected, redirects to the dashboard. When the verified mode is selected,
-            returns error messages if the indicated contribution amount is invalid or
+            When the requested mode is unsupported, returns error message.
+            When the honor mode is selected, redirects to the dashboard.
+            When the verified mode is selected, returns error messages
+            if the indicated contribution amount is invalid or
             below the minimum, otherwise redirects to the verification flow.
 
         """
@@ -316,7 +317,8 @@ class ChooseModeView(View):
                 '[Track Selection Check] Error: requested enrollment mode [%s] is not supported for course [%s]',
                 requested_mode, course_id
             )
-            return HttpResponseBadRequest(_("Enrollment mode not supported"))
+            error_msg = _("Enrollment mode not supported")
+            return self.get(request, course_id, error=error_msg)
 
         if requested_mode == 'audit':
             # If the learner has arrived at this screen via the traditional enrollment workflow,

--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -258,17 +258,17 @@ class ChooseModeView(View):
         fbe_is_on = deadline and gated_content
 
         # Route to correct Track Selection page.
-        # REV-2133 TODO Value Prop: remove waffle flag after testing is completed
-        # and happy path version is ready to be rolled out to all users.
+        # REV-2378 TODO Value Prop: remove waffle flag after all edge cases for track selection are completed.
         if VALUE_PROP_TRACK_SELECTION_FLAG.is_enabled():
-            if not error:  # TODO: Remove by executing REV-2355
-                if not enterprise_customer_for_request(request):  # TODO: Remove by executing REV-2342
-                    if fbe_is_on:
-                        return render_to_response("course_modes/fbe.html", context)
-                    else:
-                        return render_to_response("course_modes/unfbe.html", context)
+            if not enterprise_customer_for_request(request):  # TODO: Remove by executing REV-2342
+                if error:
+                    return render_to_response("course_modes/error.html", context)
+                if fbe_is_on:
+                    return render_to_response("course_modes/fbe.html", context)
+                else:
+                    return render_to_response("course_modes/unfbe.html", context)
 
-        # If error or enterprise_customer, failover to old choose.html page
+        # If enterprise_customer, failover to old choose.html page
         return render_to_response("course_modes/choose.html", context)
 
     @method_decorator(transaction.non_atomic_requests)

--- a/lms/static/sass/views/_track_selection.scss
+++ b/lms/static/sass/views/_track_selection.scss
@@ -224,7 +224,7 @@
     }
 
     .error-button {
-        margin-top: 3rem;
+        margin-top: 2.8rem;
         margin-bottom: 1.5rem;
         padding: 10px 16px;
         box-shadow: none;
@@ -235,6 +235,14 @@
     .error-button span {
         font-weight: 500;
         font-size: 18px;
+        color: #fff;
+    }
+
+    .error-button:hover {
+        background: #2D494E;
+        border-color: transparent;
+        color: #fff;
+        text-decoration: none;
     }
 
     @media (max-width: map-get($grid-breakpoints, 'sm')) {

--- a/lms/static/sass/views/_track_selection.scss
+++ b/lms/static/sass/views/_track_selection.scss
@@ -219,6 +219,24 @@
         content: '';
     }
 
+    section.error-container {
+        height: 42rem;
+    }
+
+    .error-button {
+        margin-top: 3rem;
+        margin-bottom: 1.5rem;
+        padding: 10px 16px;
+        box-shadow: none;
+        border-radius: 0px;
+        position: relative;
+    }
+
+    .error-button span {
+        font-weight: 500;
+        font-size: 18px;
+    }
+
     @media (max-width: map-get($grid-breakpoints, 'sm')) {
         .collapsible {
             margin-bottom: 1.3rem;

--- a/lms/templates/course_modes/error.html
+++ b/lms/templates/course_modes/error.html
@@ -1,6 +1,5 @@
 <%page expression_filter="h"/>
 <%inherit file="../main.html" />
-<%namespace name='static' file='/static_content.html'/>
 <%!
 from django.utils.translation import ugettext as _
 from openedx.core.djangolib.markup import HTML, Text

--- a/lms/templates/course_modes/error.html
+++ b/lms/templates/course_modes/error.html
@@ -21,7 +21,7 @@ from openedx.core.djangolib.js_utils import js_escaped_string
     <div class="track-selection-container mx-auto">
         <section class="wrapper m-4 error-container">
             <header class="page-header mt-5">
-                <h3>${_("Sorry, we were unable to enroll you in the")} ${_(course_name)}</h3>
+                <h3>${_("Sorry, we were unable to enroll you in")} ${_(course_name)}</h3>
             </header>
             <p class="text-center p-1">${_("Error:")} ${_(error)} </p>
             <div class="text-center">

--- a/lms/templates/course_modes/error.html
+++ b/lms/templates/course_modes/error.html
@@ -21,14 +21,16 @@ from openedx.core.djangolib.js_utils import js_escaped_string
     <div class="track-selection-container mx-auto">
         <section class="wrapper m-4 error-container">
             <header class="page-header mt-5">
-                <h3>${_("Sorry, we were unable to enroll you in")} ${_(course_name)}</h3>
+                <h3>${_("Sorry, we were unable to enroll you in")} ${_(course_name)}.</h3>
             </header>
-            <p class="text-center p-1">${_("Error:")} ${_(error)} </p>
-            <div class="text-center">
-                <button type="submit" name="return_course_detail" class="error-button">
-                    <span>${_('Return to course detail')}</span>
-                </buton>
-            </div>
+            <p class="text-center p-1">${_("Error:")} ${_(error)}</p>
+            <ul class="list-actions">
+                <li class="text-center">
+                    <a href="${search_courses_url}" class="button error-button" title="${_('Explore all courses on edX')}">
+                        <span>${_("Explore all courses")}</span>
+                    </a>
+                </li>
+            </ul>
         </section>
     </div>
 </%block>

--- a/lms/templates/course_modes/error.html
+++ b/lms/templates/course_modes/error.html
@@ -1,0 +1,35 @@
+<%page expression_filter="h"/>
+<%inherit file="../main.html" />
+<%namespace name='static' file='/static_content.html'/>
+<%!
+from django.utils.translation import ugettext as _
+from openedx.core.djangolib.markup import HTML, Text
+from django.urls import reverse
+from openedx.core.djangolib.js_utils import js_escaped_string
+%>
+
+<%namespace name='static' file='/static_content.html'/>
+<%block name="bodyclass">step-select-track verification-process</%block>
+<%block name="pagetitle">
+    ${_("Unable to enroll in {course_name}").format(course_name=course_name)}
+</%block>
+
+<%block name="header_extras">
+    <link rel="stylesheet" type="text/css" href="${static.url('paragon/static/paragon.min.css')}" />
+</%block>
+
+<%block name="content">
+    <div class="track-selection-container mx-auto">
+        <section class="wrapper m-4 error-container">
+            <header class="page-header mt-5">
+                <h3>${_("Sorry, we were unable to enroll you in the")} ${_(course_name)}</h3>
+            </header>
+            <p class="text-center p-1">${_("Error:")} ${_(error)} </p>
+            <div class="text-center">
+                <button type="submit" name="return_course_detail" class="error-button">
+                    <span>${_('Return to course detail')}</span>
+                </buton>
+            </div>
+        </section>
+    </div>
+</%block>

--- a/lms/templates/course_modes/track_selection.html
+++ b/lms/templates/course_modes/track_selection.html
@@ -1,6 +1,5 @@
 <%page expression_filter="h"/>
 <%inherit file="../main.html" />
-<%namespace name='static' file='/static_content.html'/>
 <%!
 from django.utils.translation import ugettext as _
 from openedx.core.djangolib.markup import HTML, Text


### PR DESCRIPTION
[REV-2355](https://openedx.atlassian.net/browse/REV-2355).

Value Prop Track Selection has a different view when there's an error, which does not display the course mode options, but just the error message and a call to action button.

**This PR:**
- Adds the template for the error page and CSS
- Updates logic side to display the new error template if there's an error
- Adds unit tests for errors
- Removes duplicate static import from HTML files
- Adds logic and styling for the CTA button on error page

**Before:**
<img width="1266" alt="Screen Shot 2021-10-19 at 8 36 32 AM" src="https://user-images.githubusercontent.com/13632680/137910547-d928c212-84cb-48c3-a5cd-3d4f9725384a.png">

**After:** 
**_Edit_** We've changed the button to link to the search courses page instead, with the text to be `"Explore all courses"` instead of `"Return to course details"`. _Discussion on the reason is on the above ticket, but the TLDR is that in order to get the URL slug that the `Prospectus` course about page has, we would require a database migration because `edx-platform` does not have this saved in the `course` object, as it no longer uses the `course_key`/about._ URL convention for course about pages pre-Prospectus.
Note that this error template will be hit at about 1% of times the track selection is shown to learners.

![localhost_18000_course_modes_choose_course-v1_edX+DemoX+Demo_Course__site_theme=edx org-next (2)](https://user-images.githubusercontent.com/13632680/139101262-5e55e7ff-8cfc-4745-b971-06f87f6423a6.png)


<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

