### PR TITLE
[AA-1046] Surface course goals in courseware api

### DIFF
--- a/openedx/core/djangoapps/courseware_api/serializers.py
+++ b/openedx/core/djangoapps/courseware_api/serializers.py
@@ -5,6 +5,7 @@ Course API Serializers.  Representing course catalog data
 from rest_framework import serializers
 
 from lms.djangoapps.course_home_api.progress.serializers import CertificateDataSerializer
+from lms.djangoapps.course_home_api.outline.serializers import CourseGoalsSerializer
 from openedx.core.lib.api.fields import AbsoluteURLField
 
 
@@ -81,6 +82,7 @@ class CourseInfoSerializer(serializers.Serializer):  # pylint: disable=abstract-
     access_expiration = serializers.DictField()
     can_show_upgrade_sock = serializers.BooleanField()
     content_type_gating_enabled = serializers.BooleanField()
+    course_goals = CourseGoalsSerializer()
     effort = serializers.CharField()
     end = serializers.DateTimeField()
     enrollment = serializers.DictField()


### PR DESCRIPTION
I was unsubscribing users from reminders from course exit page, but the course exit page didn't know if goals were enabled.
A one-line fix would be to simply ignore those requests, but it feels cleaner to surface goals in the courseware api and then check if they exist on the learning mfe side