### PR TITLE
test: removing test as not needed anymore

### DIFF
--- a/lms/djangoapps/tests/test_utils.py
+++ b/lms/djangoapps/tests/test_utils.py
@@ -3,13 +3,9 @@ Unit Tests for Utils Class
 """
 
 
-import importlib
-from importlib.metadata import version
 from unittest import TestCase
 
 import ddt
-import django
-from django.conf import settings
 from opaque_keys.edx.keys import CourseKey, UsageKey
 
 from lms.djangoapps.utils import _get_key
@@ -31,19 +27,3 @@ class UtilsTests(TestCase):  # lint-amnesty, pylint: disable=missing-class-docst
     @ddt.unpack
     def test_get_key(self, input_key, output_key, key_cls):
         assert _get_key(input_key, key_cls) == output_key
-
-    def test_same_site_cookie_version(self):
-        """
-        Make sure with django (2.2 or 3.0) django_cookies_samesite settings enabled.
-        For greater version django_cookies_samesite not required.
-        """
-        self.assertTrue(hasattr(settings, 'DCS_SESSION_COOKIE_SAMESITE_FORCE_ALL'))
-        self.assertTrue(hasattr(settings, 'DCS_SESSION_COOKIE_SAMESITE'))
-
-        if django.VERSION >= (3, 1):
-            self.assertNotIn('django_cookies_samesite.middleware.CookiesSameSite', settings.MIDDLEWARE)
-            with self.assertRaises(importlib.metadata.PackageNotFoundError):
-                version('django-cookies-samesite')
-        else:
-            self.assertTrue(version('django-cookies-samesite'))
-            self.assertIn('django_cookies_samesite.middleware.CookiesSameSite', settings.MIDDLEWARE)


### PR DESCRIPTION
## Description

This test case was added to make sure that `django-cookies-samesite` is installed with Django up till 3.0 but as now we are moving to Django 3.2, this isn't needed anymore
