### PR TITLE
docs: pull request template doesn't need Lilac mention anymore

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,8 @@
 <!--
-##
-####         Note: the Lilac master branch has been created.  Please consider whether your change
-    ####     should also be applied to Lilac.  If so, make another pull request against the
-####         open-release/lilac.master branch, or ping @nedbat for help or questions.
-##
 
-Please give the pull request a short but descriptive title.
+Happy Autumn!
+
+Please give your pull request a short but descriptive title.
 Use conventional commits to separate and summarize commits logically:
 https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html
 


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

The pull request template was meant to prompt people about Lilac only while that was still important.  We've since had Koa, and are nearly at Maple....
