### PR TITLE
temp: Add logs for CourseMode selection errors

### DIFF
--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -236,6 +236,7 @@ class ChooseModeView(View):
                 context["sku"] = verified_mode.sku
                 context["bulk_sku"] = verified_mode.bulk_sku
 
+        # REV-2415 TODO: remove [Track Selection Check] logs introduced by REV-2355 for error handling check
         context['currency_data'] = []
         if waffle.switch_is_active('local_currency'):
             if 'edx-price-l10n' not in request.COOKIES:


### PR DESCRIPTION
[REV-2355](https://openedx.atlassian.net/browse/REV-2355).

Adding logs to determine usability of certain parts of the code in the `post` method for CourseMode selection (track selection). This is part of the error handling work for Value Prop.

This PR will be followed by https://github.com/edx/edx-platform/pull/28941
The logs will be removed once Value Prop work is wrapped up, in [REV-2415](https://openedx.atlassian.net/browse/REV-2415). 

<!--

Happy Autumn!

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

