### PR TITLE
feat: put teams app availability behind waffle flag

### DIFF
--- a/lms/djangoapps/teams/plugins.py
+++ b/lms/djangoapps/teams/plugins.py
@@ -9,6 +9,7 @@ from django.utils.translation import ugettext_noop as _
 from opaque_keys.edx.keys import CourseKey
 
 from lms.djangoapps.courseware.tabs import EnrolledTab
+from lms.djangoapps.teams.waffle import ENABLE_TEAMS_APP
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.course_apps.plugins import CourseApp
 from . import is_feature_enabled
@@ -57,6 +58,8 @@ class TeamsCourseApp(CourseApp):
         """
         The teams app is currently available globally based on a feature setting.
         """
+        if not ENABLE_TEAMS_APP.is_enabled():
+            return False
         return settings.FEATURES.get("ENABLE_TEAMS", False)
 
     @classmethod

--- a/lms/djangoapps/teams/waffle.py
+++ b/lms/djangoapps/teams/waffle.py
@@ -1,0 +1,20 @@
+"""
+This module contains various configuration settings via
+waffle switches for the learner_dashboard app.
+"""
+
+from edx_toggles.toggles import WaffleFlag
+
+# .. toggle_name: teams.enable_teams_app
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Waffle flag to enable teams app for a course
+# .. toggle_use_cases: temporary, open_edx
+# .. toggle_creation_date: 2021-10-07
+# .. toggle_target_removal_date: 2021-11-01
+# .. toggle_warnings: When the flag is ON, the teams app will be visible in the new course authoring mfe.
+# .. toggle_tickets: TNL-8816
+ENABLE_TEAMS_APP = WaffleFlag(
+    'teams.enable_teams_app',
+    __name__,
+)

--- a/lms/djangoapps/teams/waffle.py
+++ b/lms/djangoapps/teams/waffle.py
@@ -1,6 +1,6 @@
 """
 This module contains various configuration settings via
-waffle switches for the learner_dashboard app.
+waffle switches for the teams app.
 """
 
 from edx_toggles.toggles import WaffleFlag


### PR DESCRIPTION
[TNL-8816](https://openedx.atlassian.net/browse/TNL-8816)

Put the teams app availability behind a waffle flag. The flag name is "teams.enable_teams_app"