### PR TITLE
feat: Don't warn about expected user changes in safe-sessions

### DIFF
--- a/lms/djangoapps/courseware/tests/tests.py
+++ b/lms/djangoapps/courseware/tests/tests.py
@@ -38,14 +38,6 @@ class ActivateLoginTest(LoginEnrollmentTestCase):
         """
         self.logout()
 
-    def test_request_attr_on_logout(self):
-        """
-        Test request object after logging out to see whether it
-        has 'is_from_log_out' attribute set to true.
-        """
-        response = self.client.get(reverse('logout'))
-        assert getattr(response.wsgi_request, 'is_from_logout', False)
-
 
 class PageLoaderTestCase(LoginEnrollmentTestCase):
     """

--- a/openedx/core/djangoapps/safe_sessions/tests/test_middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/tests/test_middleware.py
@@ -338,9 +338,7 @@ class TestSafeSessionMiddleware(TestSafeSessionsLogMixin, TestCase):
         # But then user changes unexpectedly
         self.request.user = UserFactory.create()
 
-        with self.assert_logged_with_message(
-            "SafeCookieData user at request '1' does not match user at response: '2' for request path '/'", 'warning'
-        ):
+        with self.assert_logged_for_request_user_mismatch(self.user.id, self.request.user.id, 'warning', '/'):
             with patch('openedx.core.djangoapps.safe_sessions.middleware.set_custom_attribute') as mock_attr:
                 response = SafeSessionMiddleware().process_response(self.request, self.client.response)
         assert response.status_code == 200

--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -41,6 +41,7 @@ from common.djangoapps.track import segment
 from common.djangoapps.util.json_request import JsonResponse
 from common.djangoapps.util.password_policy_validators import normalize_password
 from openedx.core.djangoapps.password_policy import compliance as password_policy_compliance
+from openedx.core.djangoapps.safe_sessions.middleware import mark_user_change_as_expected
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_authn.config.waffle import ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY
 from openedx.core.djangoapps.user_authn.cookies import get_response_with_refreshed_jwt_cookies, set_logged_in_cookies
@@ -593,6 +594,7 @@ def login_user(request, api_version='v1'):
         set_custom_attribute('login_user_auth_failed_error', False)
         set_custom_attribute('login_user_response_status', response.status_code)
         set_custom_attribute('login_user_redirect_url', redirect_url)
+        mark_user_change_as_expected(response, user.id)
         return response
     except AuthFailedError as error:
         response_content = error.get_response()

--- a/openedx/core/djangoapps/user_authn/views/logout.py
+++ b/openedx/core/djangoapps/user_authn/views/logout.py
@@ -69,7 +69,6 @@ class LogoutView(TemplateView):
 
     def dispatch(self, request, *args, **kwargs):
         # We do not log here, because we have a handler registered to perform logging on successful logouts.
-        request.is_from_logout = True
 
         # Get third party auth provider's logout url
         self.tpa_logout_url = tpa_pipeline.get_idp_logout_url_from_running_pipeline(request)

--- a/openedx/core/djangoapps/user_authn/views/logout.py
+++ b/openedx/core/djangoapps/user_authn/views/logout.py
@@ -11,6 +11,7 @@ from django.utils.http import urlencode
 from django.views.generic import TemplateView
 from oauth2_provider.models import Application
 
+from openedx.core.djangoapps.safe_sessions.middleware import mark_user_change_as_expected
 from openedx.core.djangoapps.user_authn.cookies import delete_logged_in_cookies
 from openedx.core.djangoapps.user_authn.utils import is_safe_login_or_logout_redirect
 from common.djangoapps.third_party_auth import pipeline as tpa_pipeline
@@ -80,6 +81,7 @@ class LogoutView(TemplateView):
         # Clear the cookie used by the edx.org marketing site
         delete_logged_in_cookies(response)
 
+        mark_user_change_as_expected(response, None)
         return response
 
     def _build_logout_url(self, url):


### PR DESCRIPTION
## Description

This is intended to silence a rare false positive that seems to happen when someone logs in on a browser that already has an active session for another user. We believe there should be no further positives once this case is handled.

- login and logout views annotate the response to indicate the session user should be changing between the request and response phases
- safe-sessions middleware skips the verify-user check when this annotation is present

Also improve tests and docs and remove an old workaround for the logout case.

## Affected roles

LMS operators.

## Supporting information

Ticket: ARCHBOM-1878

## Testing instructions

- Log out
- Open login page in two tabs
- Log into one account in first tab
- Log into another account in second tab
- Confirm that log messages and custom attributes do not fire

## Deadline

None