### PR TITLE
removed non-profit language in base open edx templates

### DIFF
--- a/themes/edx.org/lms/templates/certificates/_about-edx.html
+++ b/themes/edx.org/lms/templates/certificates/_about-edx.html
@@ -8,7 +8,7 @@ from openedx.core.djangolib.markup import HTML, Text
     <h3 class="accomplishment-metadata-title">${_("About edX")}</h3>
     <p class="accomplishment-metadata-copy">
         ## Translators: This string will not be used in Open edX installations.
-        ${Text(_("{link_start}edX{link_end} offers interactive online classes and MOOCs from the world's best universities, including MIT, Harvard, Berkeley, University of Texas, and many others. edX is a non-profit online initiative created by founding partners Harvard and MIT.")).format(
+        ${Text(_("{link_start}edX{link_end} offers interactive online classes and MOOCs from the world's best universities, including MIT, Harvard, Berkeley, University of Texas, and many others. edX is an online initiative created by founding partners Harvard and MIT.")).format(
             link_start=HTML('<a href="http://www.edx.org">'),
             link_end=HTML('</a>'),
         )}

--- a/themes/edx.org/lms/templates/course_modes/choose.html
+++ b/themes/edx.org/lms/templates/course_modes/choose.html
@@ -121,7 +121,7 @@ from openedx.core.djangolib.markup import HTML, Text
                                                             % endif
                                                             <li>${Text(_("{b_start}Easily Sharable: {b_end}Add the certificate to your CV or resumé, or post it directly on LinkedIn.")).format(**b_tag_kwargs)}</li>
                                                             ## Translators: This string will not be used in Open edX installations.
-                                                            <li>${Text(_("{b_start}Support our Mission: {b_end}EdX, a non-profit, relies on verified certificates to help fund affordable education to everyone globally.")).format(**b_tag_kwargs)}</li>
+                                                            <li>${Text(_("{b_start}Support our Mission: {b_end}EdX relies on verified certificates to help fund affordable education to everyone globally.")).format(**b_tag_kwargs)}</li>
                                                         </ul>
                                                     % else:
                                                         <h4>${_("Benefits of a Verified Certificate")}</h4>
@@ -161,7 +161,7 @@ from openedx.core.djangolib.markup import HTML, Text
                                                                 <li>${Text(_("{b_start}Graded Assignments: {b_end}Build your skills through graded assignments and projects.")).format(**b_tag_kwargs)}</li>
                                                             % endif
                                                             <li>${Text(_("{b_start}Easily Sharable: {b_end}Add the certificate to your CV or resumé, or post it directly on LinkedIn.")).format(**b_tag_kwargs)}</li>
-                                                            <li>${Text(_("{b_start}Support our Mission: {b_end}EdX, a non-profit, relies on verified certificates to help fund affordable education to everyone globally.")).format(**b_tag_kwargs)}</li>
+                                                            <li>${Text(_("{b_start}Support our Mission: {b_end}EdX relies on verified certificates to help fund affordable education to everyone globally.")).format(**b_tag_kwargs)}</li>
                                                         </ul>
                                                     % else:
                                                         <h4>${_("Benefits of a Verified Certificate")}</h4>


### PR DESCRIPTION
## Description

Minor changes from 2 templates that remove reference to edx's status as a non-profit.

