### PR TITLE
Use latest pip & pip-tools in jenkins_env

### DIFF
--- a/requirements/edx/pip-tools.txt
+++ b/requirements/edx/pip-tools.txt
@@ -10,7 +10,7 @@ click==7.1.2
     #   pip-tools
 pep517==0.11.0
     # via pip-tools
-pip-tools==6.3.0
+pip-tools==6.4.0
     # via -r requirements/edx/pip-tools.in
 tomli==1.2.1
     # via pep517

--- a/scripts/jenkins-common.sh
+++ b/scripts/jenkins-common.sh
@@ -48,8 +48,10 @@ source $VENV_PATH/edx-venv/bin/activate
 # Hack to fix up egg-link files given that the virtualenv is not relocatable
 sed -i "s|^/home/jenkins/shallow-clone|`pwd`|" -- \
     $VENV_PATH/edx-venv/lib/python*/site-packages/*.egg-link
+pip install pip==21.3
 pip install -qr requirements/edx/pip-tools.txt
-pip-sync -q requirements/edx/testing.txt requirements/edx/django.txt
+pip install -qr requirements/edx/testing.txt
+pip install -qr requirements/edx/django.txt
 
 # add the node packages dir to PATH
 PATH=$PATH:node_modules/.bin

--- a/scripts/jenkins-common.sh
+++ b/scripts/jenkins-common.sh
@@ -50,8 +50,7 @@ sed -i "s|^/home/jenkins/shallow-clone|`pwd`|" -- \
     $VENV_PATH/edx-venv/lib/python*/site-packages/*.egg-link
 pip install pip==21.3
 pip install -qr requirements/edx/pip-tools.txt
-pip install -qr requirements/edx/testing.txt
-pip install -qr requirements/edx/django.txt
+pip-sync -q requirements/edx/testing.txt requirements/edx/django.txt
 
 # add the node packages dir to PATH
 PATH=$PATH:node_modules/.bin

--- a/scripts/xdist/setup_worker.sh
+++ b/scripts/xdist/setup_worker.sh
@@ -22,6 +22,7 @@ source $venv/bin/activate
 sed -i "s|\(^/home/jenkins\)/shallow-clone|\1/edx-platform|" -- \
     $venv/lib/python*/site-packages/*.egg-link
 pip install -qr requirements/edx/pip-tools.txt
-pip-sync -q requirements/edx/testing.txt "${DJANGO_REQUIREMENT}"
+pip install -qr requirements/edx/testing.txt
+pip install -qr "${DJANGO_REQUIREMENT}"
 
 mkdir reports

--- a/scripts/xdist/setup_worker.sh
+++ b/scripts/xdist/setup_worker.sh
@@ -22,7 +22,6 @@ source $venv/bin/activate
 sed -i "s|\(^/home/jenkins\)/shallow-clone|\1/edx-platform|" -- \
     $venv/lib/python*/site-packages/*.egg-link
 pip install -qr requirements/edx/pip-tools.txt
-pip install -qr requirements/edx/testing.txt
-pip install -qr "${DJANGO_REQUIREMENT}"
+pip-sync -q requirements/edx/testing.txt "${DJANGO_REQUIREMENT}"
 
 mkdir reports


### PR DESCRIPTION
## Description
- edx-platform Jenkins tests started failing for some reason. To resolve the failure, we used latest pip version i.e. `pip==21.3` which needed `pip-tools==6.4.0` to resolve the [pip-sync](https://github.com/jazzband/pip-tools/issues/1503) issue.