### PR TITLE
feat: put year of birth behind feature flag

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -474,6 +474,9 @@ FEATURES = {
     'ENABLE_V2_CERT_DISPLAY_SETTINGS': False,
 }
 
+# VAN-754 - Year of birth field put behind a flag to make it available for openedX.
+COLLECT_YEAR_OF_BIRTH = True
+
 ENABLE_JASMINE = False
 
 # List of logout URIs for each IDA that the learner should be logged out of when they logout of the LMS. Only applies to

--- a/lms/static/js/student_account/views/AccessView.js
+++ b/lms/static/js/student_account/views/AccessView.js
@@ -82,6 +82,7 @@
                     this.isEnterpriseEnable = options.is_enterprise_enable || false;
                     this.isAccountRecoveryFeatureEnabled = options.is_account_recovery_feature_enabled || false;
                     this.is_require_third_party_auth_enabled = options.is_require_third_party_auth_enabled || false;
+                    this.collect_year_of_birth = options.collect_year_of_birth;
 
                 // The login view listens for 'sync' events from the reset model
                     this.resetModel = new PasswordResetModel({}, {
@@ -207,7 +208,8 @@
                             thirdPartyAuth: this.thirdPartyAuth,
                             platformName: this.platformName,
                             hideAuthWarnings: this.hideAuthWarnings,
-                            is_require_third_party_auth_enabled: this.is_require_third_party_auth_enabled
+                            is_require_third_party_auth_enabled: this.is_require_third_party_auth_enabled,
+                            collectYearOfBirth: this.collect_year_of_birth,
                         });
 
                     // Listen for 'auth-complete' event so we can enroll/redirect the user appropriately.

--- a/lms/static/js/student_account/views/RegisterView.js
+++ b/lms/static/js/student_account/views/RegisterView.js
@@ -64,7 +64,8 @@
                     this.autoRegisterWelcomeMessage = data.thirdPartyAuth.autoRegisterWelcomeMessage || '';
                     this.registerFormSubmitButtonText =
                         data.thirdPartyAuth.registerFormSubmitButtonText || _('Create Account');
-                    this.is_require_third_party_auth_enabled = data.is_require_third_party_auth_enabled || false;
+                    this.is_require_third_party_auth_enabled = data.is_require_third_party_auth_enabled;
+                    this.collectYearOfBirth = data.collectYearOfBirth;
 
                     this.listenTo(this.model, 'sync', this.saveSuccess);
                     this.listenTo(this.model, 'validation', this.renderLiveValidations);
@@ -128,7 +129,9 @@
 
                     html = this.renderFields(requiredFields, 'required-fields');
 
-                    html.push.apply(html, this.renderFields(optionalFields, 'optional-fields'));
+                    html.push.apply(html, this.renderFields(
+                      optionalFields, `optional-fields ${this.collectYearOfBirth ? '' : 'full-length-fields'}`
+                    ));
 
                     this.render(html.join(''));
                 },

--- a/lms/static/sass/views/_login-register.scss
+++ b/lms/static/sass/views/_login-register.scss
@@ -508,6 +508,14 @@ ul.fa-ul{
     /** FROM _accounts.scss - end **/
   }
 
+
+  .optional-fields {
+      &.full-length-fields {
+          .select-gender {
+              width: 100%;
+          }
+      }
+  }
   .input-block {
     width: 100%;
     border-color: $gray;

--- a/openedx/core/djangoapps/user_authn/views/login_form.py
+++ b/openedx/core/djangoapps/user_authn/views/login_form.py
@@ -262,6 +262,7 @@ def login_and_registration_form(request, initial_mode="login"):
             'enterprise_slug_login_url': get_enterprise_slug_login_url(),
             'is_enterprise_enable': enterprise_enabled(),
             'is_require_third_party_auth_enabled': is_require_third_party_auth_enabled(),
+            'collect_year_of_birth': settings.COLLECT_YEAR_OF_BIRTH,
         },
         'login_redirect_url': redirect_to,  # This gets added to the query string of the "Sign In" button in header
         'responsive': True,

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -122,7 +122,7 @@ REAL_IP_KEY = 'openedx.core.djangoapps.util.ratelimit.real_ip'
 
 
 @transaction.non_atomic_requests
-def create_account_with_params(request, params):
+def create_account_with_params(request, params):  # pylint: disable=too-many-statements
     """
     Given a request and a dict of parameters (which may or may not have come
     from the request), create an account for the requesting user, including
@@ -168,6 +168,9 @@ def create_account_with_params(request, params):
     if is_registration_api_v1(request):
         if 'confirm_email' in extra_fields:
             del extra_fields['confirm_email']
+
+    if not settings.COLLECT_YEAR_OF_BIRTH and 'year_of_birth' in params:
+        params['year_of_birth'] = ''
 
     # registration via third party (Google, Facebook) using mobile application
     # doesn't use social auth pipeline (no redirect uri(s) etc involved).

--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -336,6 +336,9 @@ class RegistrationFormFactory:
 
     def __init__(self):
 
+        if not settings.COLLECT_YEAR_OF_BIRTH and 'year_of_birth' in self.EXTRA_FIELDS:
+            self.EXTRA_FIELDS.remove('year_of_birth')
+
         # Backwards compatibility: Honor code is required by default, unless
         # explicitly set to "optional" in Django settings.
         self._extra_fields_setting = copy.deepcopy(configuration_helpers.get_value('REGISTRATION_EXTRA_FIELDS'))

--- a/openedx/core/djangoapps/user_authn/views/tests/test_register.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_register.py
@@ -1894,7 +1894,6 @@ class RegistrationViewTestV1(
 class RegistrationViewTestV2(RegistrationViewTestV1):
     """
     Test for registration api V2
-
     """
 
     # pylint: disable=test-inherits-tests
@@ -2055,6 +2054,51 @@ class RegistrationViewTestV2(RegistrationViewTestV1):
             "country",
             "gender",
             "year_of_birth",
+            "level_of_education",
+            "mailing_address",
+            "goals",
+            "honor_code",
+            "favorite_movie",
+        ]
+
+    @override_settings(
+        COLLECT_YEAR_OF_BIRTH=False,
+        REGISTRATION_EXTRA_FIELDS={
+            "level_of_education": "optional",
+            "gender": "optional",
+            "year_of_birth": "optional",
+            "mailing_address": "optional",
+            "goals": "optional",
+            "city": "optional",
+            "state": "optional",
+            "country": "required",
+            "honor_code": "required",
+            "confirm_email": "required",
+        },
+        REGISTRATION_FIELD_ORDER=None,
+        REGISTRATION_EXTENSION_FORM='openedx.core.djangoapps.user_api.tests.test_helpers.TestCaseForm',
+    )
+    def test_year_of_birth_field_with_feature_flag(self):
+        """
+        Test that year of birth is not returned when COLLECT_YEAR_OF_BIRTH is
+        set to False.
+        """
+        response = self.client.get(self.url)
+        self.assertHttpOK(response)
+
+        # Verify that all fields render in the correct order
+        form_desc = json.loads(response.content.decode('utf-8'))
+        field_names = [field["name"] for field in form_desc["fields"]]
+        assert field_names == [
+            "email",
+            "name",
+            "username",
+            "password",
+            "confirm_email",
+            "city",
+            "state",
+            "country",
+            "gender",
             "level_of_education",
             "mailing_address",
             "goals",


### PR DESCRIPTION
<!--

Happy Autumn!

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

All webapp B2C users land on a monolith Logistration FE where the year of birth information is asked on the Register page.

**Acceptance Criteria**
For all new B2B webapp users; edX platform should not ask for the year of birth information from users during the onboarding step.

## Supporting information

Ticket: https://openedx.atlassian.net/browse/VAN-749

## Testing instructions

Added unit test


