### PR TITLE
feat: upgrade Django version to 3.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,8 @@ compile-requirements: $(COMMON_CONSTRAINTS_TXT) ## Re-compile *.in requirements 
 	# This is a temporary solution to override the real common_constraints.txt
 	# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
 	# See BOM-2721 for more details.
+	sed 's/Django<2.3//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
+	mv requirements/common_constraints.tmp requirements/common_constraints.txt
 
 	@ export REBUILD='--rebuild'; \
 	for f in $(REQ_FILES); do \
@@ -120,17 +122,6 @@ compile-requirements: $(COMMON_CONSTRAINTS_TXT) ## Re-compile *.in requirements 
 	# Let tox control the Django version for tests
 	grep -e "^django==" requirements/edx/base.txt > requirements/edx/django.txt
 	sed '/^[dD]jango==/d' requirements/edx/testing.txt > requirements/edx/testing.tmp
-	mv requirements/edx/testing.tmp requirements/edx/testing.txt
-
-	# to avoid multiple entries remove it from django and django30 first and add later.
-	sed -i '/^[dD]jango-cookies-samesite==/d' requirements/edx/django.txt
-	sed -i '/^[dD]jango-cookies-samesite==/d' requirements/edx/django30.txt
-	grep -e "^django-cookies-samesite==" requirements/edx/base.txt >> requirements/edx/django.txt
-	grep -e "^django-cookies-samesite==" requirements/edx/base.txt >> requirements/edx/django30.txt
-
-	# removing django-cookies-samesite from all testing.txt file. It is not require for django32.
-	# at the time of django32 final upgrade job remove this package from base.in
-	sed '/^[dD]jango-cookies-samesite==/d' requirements/edx/testing.txt > requirements/edx/testing.tmp
 	mv requirements/edx/testing.tmp requirements/edx/testing.txt
 
 upgrade: pre-requirements  ## update the pip requirements files to use the latest releases satisfying our constraints

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -18,7 +18,7 @@
 
 
 # using LTS django version
-Django<2.3
+
 
 # elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.
 # elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -15,8 +15,8 @@
 # celert>5.0.0 hasn't been tested yet, so the constraint will be removed after testing latest version
 celery<5.0.0
 
-# edx-platform currently only supported for Django 2.2.x
-django<2.3
+# edx-platform currently only supported for Django 3.2.x
+django<3.3
 
 # Newer versions need celery >= 5.0
 django-celery-results<2.1

--- a/requirements/edx-sandbox/py35.txt
+++ b/requirements/edx-sandbox/py35.txt
@@ -8,7 +8,7 @@ common/lib/sandbox-packages
     # via -r requirements/edx-sandbox/py35.in
 common/lib/symmath
     # via -r requirements/edx-sandbox/py35.in
-cffi==1.14.6
+cffi==1.15.0
     # via cryptography
 chem==1.2.0
     # via -r requirements/edx-sandbox/py35.in

--- a/requirements/edx-sandbox/py38.txt
+++ b/requirements/edx-sandbox/py38.txt
@@ -8,7 +8,7 @@ common/lib/sandbox-packages
     # via -r requirements/edx-sandbox/py38.in
 common/lib/symmath
     # via -r requirements/edx-sandbox/py38.in
-cffi==1.14.6
+cffi==1.15.0
     # via cryptography
 chem==1.2.0
     # via -r requirements/edx-sandbox/py38.in

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -43,7 +43,6 @@ defusedxml
 Django                              # Web application framework
 django-appconf
 django-celery-results               # Only used for the CacheBackend for celery results
-django-cookies-samesite             # Middleware which allows SameSite=None flag for session and csrf cookies in Django<3.0.5
 django-config-models                # Configuration models for Django allowing config management with auditing
 django-cors-headers                 # Used to allow to configure CORS headers for cross-domain requests
 django-countries                    # Country data for Django forms and model fields

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -44,6 +44,8 @@ aniso8601==9.0.1
     # via edx-tincan-py35
 appdirs==1.4.4
     # via fs
+asgiref==3.4.1
+    # via django
 async-timeout==3.0.1
     # via aiohttp
 attrs==21.2.0
@@ -104,7 +106,7 @@ certifi==2021.10.8
     #   elasticsearch
     #   py2neo
     #   requests
-cffi==1.14.6
+cffi==1.15.0
     # via cryptography
 chardet==4.0.0
     # via
@@ -161,9 +163,8 @@ defusedxml==0.7.1
     #   social-auth-core
 deprecated==1.2.13
     # via jwcrypto
-django==2.2.24
+django==3.2.8
     # via
-    #   -c requirements/edx/../common_constraints.txt
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   django-appconf
@@ -241,8 +242,6 @@ django-config-models==2.2.0
     #   edx-enterprise
     #   edx-name-affirmation
     #   lti-consumer-xblock
-django-cookies-samesite==0.9.0
-    # via -r requirements/edx/base.in
 django-cors-headers==3.10.0
     # via -r requirements/edx/base.in
 django-countries==7.2.1
@@ -277,7 +276,7 @@ django-js-asset==1.2.2
     # via django-mptt
 django-method-override==1.0.4
     # via -r requirements/edx/base.in
-django-model-utils==4.1.1
+django-model-utils==4.2.0
     # via
     #   -r requirements/edx/base.in
     #   django-user-tasks
@@ -552,7 +551,7 @@ idna==3.3
     #   yarl
 inflection==0.5.1
     # via drf-yasg
-interchange==2021.0.3
+interchange==2021.0.4
     # via py2neo
 ipaddress==1.0.23
     # via -r requirements/edx/base.in
@@ -725,7 +724,7 @@ psutil==5.8.0
     # via
     #   -r requirements/edx/paver.txt
     #   edx-django-utils
-py2neo==2021.2.1
+py2neo==2021.2.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
@@ -835,7 +834,7 @@ pytz==2021.3
     #   xblock
 pyuca==1.2
     # via -r requirements/edx/base.in
-pyyaml==5.4.1
+pyyaml==6.0
     # via
     #   -r requirements/edx/base.in
     #   code-annotations
@@ -989,8 +988,6 @@ tqdm==4.62.3
     # via nltk
 typing-extensions==3.10.0.2
     # via aiohttp
-ua-parser==0.10.0
-    # via django-cookies-samesite
 unicodecsv==0.14.1
     # via
     #   -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -61,6 +61,7 @@ appdirs==1.4.4
 asgiref==3.4.1
     # via
     #   -r requirements/edx/testing.txt
+    #   django
     #   uvicorn
 astroid==2.6.6
     # via
@@ -144,7 +145,7 @@ certifi==2021.10.8
     #   elasticsearch
     #   py2neo
     #   requests
-cffi==1.14.6
+cffi==1.15.0
     # via
     #   -r requirements/edx/testing.txt
     #   cryptography
@@ -242,9 +243,8 @@ distlib==0.3.3
     # via
     #   -r requirements/edx/testing.txt
     #   virtualenv
-django==2.2.24
+django==3.2.8
     # via
-    #   -c requirements/edx/../common_constraints.txt
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   django-appconf
@@ -327,8 +327,6 @@ django-config-models==2.2.0
     #   edx-enterprise
     #   edx-name-affirmation
     #   lti-consumer-xblock
-django-cookies-samesite==0.9.0
-    # via -r requirements/edx/testing.txt
 django-cors-headers==3.10.0
     # via -r requirements/edx/testing.txt
 django-countries==7.2.1
@@ -367,7 +365,7 @@ django-js-asset==1.2.2
     #   django-mptt
 django-method-override==1.0.4
     # via -r requirements/edx/testing.txt
-django-model-utils==4.1.1
+django-model-utils==4.2.0
     # via
     #   -r requirements/edx/testing.txt
     #   django-user-tasks
@@ -728,7 +726,7 @@ iniconfig==1.1.1
     # via
     #   -r requirements/edx/testing.txt
     #   pytest
-interchange==2021.0.3
+interchange==2021.0.4
     # via
     #   -r requirements/edx/testing.txt
     #   py2neo
@@ -994,7 +992,7 @@ py==1.10.0
     #   pytest
     #   pytest-forked
     #   tox
-py2neo==2021.2.1
+py2neo==2021.2.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
@@ -1184,7 +1182,7 @@ pyuca==1.2
     # via -r requirements/edx/testing.txt
 pywatchman==1.4.1
     # via -r requirements/edx/development.in
-pyyaml==5.4.1
+pyyaml==6.0
     # via
     #   -r requirements/edx/testing.txt
     #   code-annotations
@@ -1445,10 +1443,6 @@ typing-extensions==3.10.0.2
     #   gitpython
     #   mypy
     #   pydantic
-ua-parser==0.10.0
-    # via
-    #   -r requirements/edx/testing.txt
-    #   django-cookies-samesite
 unicodecsv==0.14.1
     # via
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/django.txt
+++ b/requirements/edx/django.txt
@@ -1,2 +1,1 @@
-django==2.2.24
-django-cookies-samesite==0.9.0
+django==3.2.8

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -50,7 +50,7 @@ python-slugify==4.0.1
     #   code-annotations
 pytz==2021.3
     # via babel
-pyyaml==5.4.1
+pyyaml==6.0
     # via code-annotations
 requests==2.26.0
     # via sphinx

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -55,7 +55,10 @@ appdirs==1.4.4
     #   -r requirements/edx/base.txt
     #   fs
 asgiref==3.4.1
-    # via uvicorn
+    # via
+    #   -r requirements/edx/base.txt
+    #   django
+    #   uvicorn
 astroid==2.6.6
     # via
     #   pylint
@@ -135,7 +138,7 @@ certifi==2021.10.8
     #   elasticsearch
     #   py2neo
     #   requests
-cffi==1.14.6
+cffi==1.15.0
     # via
     #   -r requirements/edx/base.txt
     #   cryptography
@@ -229,7 +232,6 @@ diff-cover==4.0.0
 distlib==0.3.3
     # via virtualenv
     # via
-    #   -c requirements/edx/../common_constraints.txt
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   django-appconf
@@ -311,7 +313,6 @@ django-config-models==2.2.0
     #   edx-enterprise
     #   edx-name-affirmation
     #   lti-consumer-xblock
-    # via -r requirements/edx/base.txt
 django-cors-headers==3.10.0
     # via -r requirements/edx/base.txt
 django-countries==7.2.1
@@ -348,7 +349,7 @@ django-js-asset==1.2.2
     #   django-mptt
 django-method-override==1.0.4
     # via -r requirements/edx/base.txt
-django-model-utils==4.1.1
+django-model-utils==4.2.0
     # via
     #   -r requirements/edx/base.txt
     #   django-user-tasks
@@ -687,7 +688,7 @@ inflection==0.5.1
     #   drf-yasg
 iniconfig==1.1.1
     # via pytest
-interchange==2021.0.3
+interchange==2021.0.4
     # via
     #   -r requirements/edx/base.txt
     #   py2neo
@@ -931,7 +932,7 @@ py==1.10.0
     #   pytest
     #   pytest-forked
     #   tox
-py2neo==2021.2.1
+py2neo==2021.2.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
@@ -1107,7 +1108,7 @@ pytz==2021.3
     #   xblock
 pyuca==1.2
     # via -r requirements/edx/base.txt
-pyyaml==5.4.1
+pyyaml==6.0
     # via
     #   -r requirements/edx/base.txt
     #   code-annotations
@@ -1328,10 +1329,6 @@ typing-extensions==3.10.0.2
     #   aiohttp
     #   gitpython
     #   pydantic
-ua-parser==0.10.0
-    # via
-    #   -r requirements/edx/base.txt
-    #   django-cookies-samesite
 unicodecsv==0.14.1
     # via
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
Upgrade Django version to 3.2

Previous PR which got reverted: https://github.com/edx/edx-platform/pull/28885

**Testing checklist (on sandbox):**
- [x] - Sandbox created with this branch https://awais786.sandbox.edx.org/
- [x] - e2e tests pass against sandbox.
- [x] - Course purchase worflow.
- [x] - MFE-registration/login working
- [x] - Django admin working fine
- [x] - Course creation working in studio.
- [x] - Celery tasks from import/export course worked fine.
- [x] - Third party sign in (Apple-id sign)