### PR TITLE
feat: [VAN-751] Put user's year of birth behind the feature flag

### DIFF
--- a/lms/static/js/spec/student_account/account_settings_factory_spec.js
+++ b/lms/static/js/spec/student_account/account_settings_factory_spec.js
@@ -26,7 +26,8 @@ define(['backbone',
                     1,
                     Helpers.PLATFORM_NAME,
                     Helpers.CONTACT_EMAIL,
-                    true
+                    true,
+                    Helpers.COLLECT_YEAR_OF_BIRTH
                 );
                 return context.accountSettingsView;
             };
@@ -164,6 +165,7 @@ define(['backbone',
                     Helpers.PLATFORM_NAME,
                     Helpers.CONTACT_EMAIL,
                     true,
+                    Helpers.COLLECT_YEAR_OF_BIRTH,
                     '',
 
                     Helpers.SYNC_LEARNER_PROFILE_DATA,

--- a/lms/static/js/spec/student_account/helpers.js
+++ b/lms/static/js/spec/student_account/helpers.js
@@ -10,6 +10,7 @@ define(['underscore'], function(_) {
     var PASSWORD_RESET_SUPPORT_LINK = 'https://support.edx.org/hc/en-us/articles/206212088-What-if-I-did-not-receive-a-password-reset-message-'; // eslint-disable-line max-len
     var PLATFORM_NAME = 'edX';
     var CONTACT_EMAIL = 'info@example.com';
+    var COLLECT_YEAR_OF_BIRTH = true;
 
     var SYNC_LEARNER_PROFILE_DATA = true;
     var ENTERPRISE_NAME = 'Test Enterprise';
@@ -221,6 +222,7 @@ define(['underscore'], function(_) {
         PASSWORD_RESET_SUPPORT_LINK: PASSWORD_RESET_SUPPORT_LINK,
         PLATFORM_NAME: PLATFORM_NAME,
         CONTACT_EMAIL: CONTACT_EMAIL,
+        COLLECT_YEAR_OF_BIRTH: COLLECT_YEAR_OF_BIRTH,
 
         SYNC_LEARNER_PROFILE_DATA: SYNC_LEARNER_PROFILE_DATA,
         ENTERPRISE_NAME: ENTERPRISE_NAME,

--- a/lms/static/js/student_account/views/account_settings_factory.js
+++ b/lms/static/js/student_account/views/account_settings_factory.js
@@ -22,6 +22,7 @@
             platformName,
             contactEmail,
             allowEmailChange,
+            collectYearOfBirth,
             socialPlatforms,
             syncLearnerProfileData,
             enterpriseName,
@@ -38,7 +39,7 @@
                 emailFieldView, secondaryEmailFieldView, socialFields, accountDeletionFields, platformData,
                 aboutSectionMessageType, aboutSectionMessage, fullnameFieldView, countryFieldView,
                 fullNameFieldData, emailFieldData, secondaryEmailFieldData, countryFieldData, additionalFields,
-                fieldItem, emailFieldViewIndex, focusId,
+                fieldItem, emailFieldViewIndex, focusId, yearOfBirthViewIndex,
                 tabIndex = 0;
 
             $accountSettingsElement = $('.wrapper-account-settings');
@@ -245,6 +246,13 @@
                     ]
                 }
             ];
+
+            if (!collectYearOfBirth){
+              yearOfBirthViewIndex = aboutSectionsData[1]['fields'].findIndex(function (field) {
+	              return field['view']['options']['valueAttribute']=== 'year_of_birth';
+                });
+              aboutSectionsData[1]['fields'].splice(yearOfBirthViewIndex,1)
+}
 
 			// Secondary email address
             if (isSecondaryEmailFeatureEnabled) {

--- a/lms/templates/student_account/account_settings.html
+++ b/lms/templates/student_account/account_settings.html
@@ -48,6 +48,7 @@ from openedx.core.djangoapps.user_api.accounts.utils import is_secondary_email_f
         extendedProfileFields = ${ extended_profile_fields | n, dump_js_escaped_json },
         displayAccountDeletion = ${ enable_account_deletion | n, dump_js_escaped_json};
         isSecondaryEmailFeatureEnabled = ${ bool(is_secondary_email_feature_enabled()) | n, dump_js_escaped_json },
+        collectYearOfBirth = ${ bool(collect_year_of_birth) | n, dump_js_escaped_json },
 
     AccountSettingsFactory(
         fieldsData,
@@ -61,6 +62,7 @@ from openedx.core.djangoapps.user_api.accounts.utils import is_secondary_email_f
         platformName,
         contactEmail,
         allowEmailChange,
+        collectYearOfBirth,
         socialPlatforms,
 
         syncLearnerProfileData,

--- a/openedx/core/djangoapps/user_api/accounts/settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/settings_views.py
@@ -144,6 +144,7 @@ def account_settings_context(request):
         ),
         'extended_profile_fields': _get_extended_profile_fields(),
         'beta_language': beta_language,
+        'collect_year_of_birth': settings.COLLECT_YEAR_OF_BIRTH,
     }
 
     enterprise_customer = enterprise_customer_for_request(request)


### PR DESCRIPTION
<!--

Happy Autumn!

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Remove the ‘year of birth’ field from the Accounts page on monolith FE if server-side CAPTURE_YEAR_OF_BIRTH feature flag is disabled.


## Supporting information

Ticket: https://openedx.atlassian.net/browse/VAN-751

## Testing instructions

Fixed unit test


