### PR TITLE
feat: only log requests that fail user verification in SafeSessionMiddleware

### DIFF
--- a/openedx/core/djangoapps/safe_sessions/middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/middleware.py
@@ -598,7 +598,7 @@ def track_request_user_changes(request):
                 location = "\n".join("%30s : %s:%d" % (t[3], t[1], t[2]) for t in stack[0:12])
 
                 if not hasattr(self, 'debug_user_changes'):
-                    self.debug_user_changes = [] # pylint: disable=attribute-defined-outside-init
+                    self.debug_user_changes = []  # pylint: disable=attribute-defined-outside-init
 
                 if not hasattr(request, name):
                     original_user = value

--- a/openedx/core/djangoapps/safe_sessions/middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/middleware.py
@@ -411,8 +411,8 @@ class SafeSessionMiddleware(SessionMiddleware, MiddlewareMixin):
         # page is used during an active session.
         #
         # The relevant views set a flag to indicate the exemption.
-       # if getattr(response, 'safe_sessions_expected_user_change', None):
-        #   return
+        if getattr(response, 'safe_sessions_expected_user_change', None):
+            return
 
         if hasattr(request, 'safe_cookie_verified_user_id'):
             if hasattr(request.user, 'real_user'):

--- a/openedx/core/djangoapps/safe_sessions/middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/middleware.py
@@ -589,7 +589,6 @@ def track_request_user_changes(request):
         """
         A wrapper class for the request object.
         """
-        debug_user_changes = []
 
         def __setattr__(self, name, value):
             nonlocal original_user
@@ -597,6 +596,9 @@ def track_request_user_changes(request):
                 stack = inspect.stack()
                 # Written this way in case you need more of the stack for debugging.
                 location = "\n".join("%30s : %s:%d" % (t[3], t[1], t[2]) for t in stack[0:12])
+
+                if not hasattr(self, 'debug_user_changes'):
+                    self.debug_user_changes = []
 
                 if not hasattr(request, name):
                     original_user = value

--- a/openedx/core/djangoapps/safe_sessions/middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/middleware.py
@@ -429,7 +429,8 @@ class SafeSessionMiddleware(SessionMiddleware, MiddlewareMixin):
             if request_user_object_mismatch or session_user_mismatch:
                 # Log accumulated information stored on request for each change of user
                 if hasattr(request, 'debug_user_changes'):
-                    log.info('\n'.join(request.debug_user_changes))
+                    log.warn('An unsafe user transition was found. It either needs to be fixed or exempted.\n'
+                             + '\n'.join(request.debug_user_changes))
 
                 session_id_changed = hasattr(request.session, 'session_key') and\
                     request.safe_cookie_verified_session_id != request.session.session_key
@@ -461,8 +462,8 @@ class SafeSessionMiddleware(SessionMiddleware, MiddlewareMixin):
                 else:
                     log.warning(
                         (
-                            "SafeCookieData user at initial request '{}' does not match user in session: '{}' "
-                            "or user at response time: '{}' for request path '{}'. {}"
+                            "SafeCookieData user at initial request '{}' matches neither user in session: '{}' "
+                            "nor user at response time: '{}' for request path '{}'. {}"
                         ).format(  # pylint: disable=logging-format-interpolation
                             request.safe_cookie_verified_user_id, userid_in_session, request.user.id, request.path,
                             log_suffix

--- a/openedx/core/djangoapps/safe_sessions/middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/middleware.py
@@ -430,7 +430,7 @@ class SafeSessionMiddleware(SessionMiddleware, MiddlewareMixin):
                 # Log accumulated information stored on request for each change of user
                 if hasattr(request, 'debug_user_changes'):
                     log.warning('An unsafe user transition was found. It either needs to be fixed or exempted.\n {}'
-                             .format('\n'.join(request.debug_user_changes)))
+                                .format('\n'.join(request.debug_user_changes)))
 
                 session_id_changed = hasattr(request.session, 'session_key') and\
                     request.safe_cookie_verified_session_id != request.session.session_key

--- a/openedx/core/djangoapps/safe_sessions/middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/middleware.py
@@ -598,7 +598,7 @@ def track_request_user_changes(request):
                 location = "\n".join("%30s : %s:%d" % (t[3], t[1], t[2]) for t in stack[0:12])
 
                 if not hasattr(self, 'debug_user_changes'):
-                    self.debug_user_changes = []
+                    self.debug_user_changes = [] # pylint: disable=attribute-defined-outside-init
 
                 if not hasattr(request, name):
                     original_user = value

--- a/openedx/core/djangoapps/safe_sessions/middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/middleware.py
@@ -432,7 +432,7 @@ class SafeSessionMiddleware(SessionMiddleware, MiddlewareMixin):
                     log.info('\n'.join(request.debug_user_changes))
 
                 session_id_changed = hasattr(request.session, 'session_key') and\
-                                     request.safe_cookie_verified_session_id != request.session.session_key
+                    request.safe_cookie_verified_session_id != request.session.session_key
                 # delete old session id for security
                 del request.safe_cookie_verified_session_id
 

--- a/openedx/core/djangoapps/safe_sessions/middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/middleware.py
@@ -429,8 +429,8 @@ class SafeSessionMiddleware(SessionMiddleware, MiddlewareMixin):
             if request_user_object_mismatch or session_user_mismatch:
                 # Log accumulated information stored on request for each change of user
                 if hasattr(request, 'debug_user_changes'):
-                    log.warn('An unsafe user transition was found. It either needs to be fixed or exempted.\n'
-                             + '\n'.join(request.debug_user_changes))
+                    log.warning('An unsafe user transition was found. It either needs to be fixed or exempted.\n {}'
+                             .format('\n'.join(request.debug_user_changes)))
 
                 session_id_changed = hasattr(request.session, 'session_key') and\
                     request.safe_cookie_verified_session_id != request.session.session_key

--- a/openedx/core/djangoapps/safe_sessions/tests/test_middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/tests/test_middleware.py
@@ -362,7 +362,7 @@ class TestSafeSessionMiddleware(TestSafeSessionsLogMixin, TestCase):
         SafeSessionMiddleware.set_user_id_in_session(self.request, different_user)
         self.request.user = UserFactory.create()
         with self.assert_logged_for_both_mismatch(self.user.id, different_user.id,
-                                                                        self.request.user.id, self.request.path, False):
+                                                  self.request.user.id, self.request.path, False):
             with patch('openedx.core.djangoapps.safe_sessions.middleware.set_custom_attribute') as mock_attr:
                 response = SafeSessionMiddleware().process_response(self.request, self.client.response)
         assert response.status_code == 200

--- a/openedx/core/djangoapps/safe_sessions/tests/test_middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/tests/test_middleware.py
@@ -372,14 +372,14 @@ class TestSafeSessionMiddleware(TestSafeSessionsLogMixin, TestCase):
     def test_warn_with_verbose_logging(self):
         self.set_up_for_success()
         self.request.user = UserFactory.create()
-        with self.assert_logged('SafeCookieData: Changing request user. ', log_level='info'):
+        with self.assert_logged('SafeCookieData: Changing request user. ', log_level='warn'):
             SafeSessionMiddleware().process_response(self.request, self.client.response)
 
     @patch("openedx.core.djangoapps.safe_sessions.middleware.LOG_REQUEST_USER_CHANGES", False)
     def test_warn_without_verbose_logging(self):
         self.set_up_for_success()
         self.request.user = UserFactory.create()
-        with self.assert_regex_not_logged('SafeCookieData: Changing request user. ', log_level='info'):
+        with self.assert_regex_not_logged('SafeCookieData: Changing request user. ', log_level='warn'):
             SafeSessionMiddleware().process_response(self.request, self.client.response)
 
     def test_no_warn_on_expected_user_change(self):

--- a/openedx/core/djangoapps/safe_sessions/tests/test_middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/tests/test_middleware.py
@@ -372,14 +372,14 @@ class TestSafeSessionMiddleware(TestSafeSessionsLogMixin, TestCase):
     def test_warn_with_verbose_logging(self):
         self.set_up_for_success()
         self.request.user = UserFactory.create()
-        with self.assert_logged('SafeCookieData: Changing request user. ', log_level='warn'):
+        with self.assert_logged('SafeCookieData: Changing request user. ', log_level='warning'):
             SafeSessionMiddleware().process_response(self.request, self.client.response)
 
     @patch("openedx.core.djangoapps.safe_sessions.middleware.LOG_REQUEST_USER_CHANGES", False)
     def test_warn_without_verbose_logging(self):
         self.set_up_for_success()
         self.request.user = UserFactory.create()
-        with self.assert_regex_not_logged('SafeCookieData: Changing request user. ', log_level='warn'):
+        with self.assert_regex_not_logged('SafeCookieData: Changing request user. ', log_level='warning'):
             SafeSessionMiddleware().process_response(self.request, self.client.response)
 
     def test_no_warn_on_expected_user_change(self):

--- a/openedx/core/djangoapps/safe_sessions/tests/test_utils.py
+++ b/openedx/core/djangoapps/safe_sessions/tests/test_utils.py
@@ -115,34 +115,38 @@ class TestSafeSessionsLogMixin:
             yield
 
     @contextmanager
-    def assert_logged_for_request_user_mismatch(self, user_at_request, user_at_response, log_level, request_path):
+    def assert_logged_for_request_user_mismatch(self, user_at_request, user_at_response, log_level, request_path,
+                                                session_changed):
         """
         Asserts that warning was logged when request.user
         was not equal to user at response
         """
+        session_suffix = 'Session changed.' if session_changed else 'Session did not change.'
         with self.assert_logged_with_message(
             (
-                "SafeCookieData user at request '{}' does not match user at response: '{}' "
-                "for request path '{}'"
+                "SafeCookieData user at initial request '{}' does not match user at response time: '{}' "
+                "for request path '{}'. {}"
             ).format(
-                user_at_request, user_at_response, request_path
+                user_at_request, user_at_response, request_path, session_suffix
             ),
             log_level=log_level,
         ):
             yield
 
     @contextmanager
-    def assert_logged_for_session_user_mismatch(self, user_at_request, user_in_session, request_path):
+    def assert_logged_for_session_user_mismatch(self, user_at_request, user_in_session, request_path, session_changed):
         """
         Asserts that warning was logged when request.user
         was not equal to user at session
         """
+        session_suffix = 'Session changed.' if session_changed else 'Session did not change.'
+
         with self.assert_logged_with_message(
             (
-                "SafeCookieData user at request '{}' does not match user in session: '{}' "
-                "for request path '{}'"
+                "SafeCookieData user at initial request '{}' does not match user in session: '{}' "
+                "for request path '{}'. {}"
             ).format(
-                user_at_request, user_in_session, request_path
+                user_at_request, user_in_session, request_path, session_suffix
             ),
             log_level='warning',
         ):

--- a/openedx/core/djangoapps/safe_sessions/tests/test_utils.py
+++ b/openedx/core/djangoapps/safe_sessions/tests/test_utils.py
@@ -1,8 +1,7 @@
 """
 Shared test utilities for Safe Sessions tests
 """
-
-
+import pytest
 from contextlib import contextmanager
 from unittest.mock import patch
 
@@ -22,6 +21,16 @@ class TestSafeSessionsLogMixin:
             yield
             assert mock_log.called
             self.assertRegex(mock_log.call_args_list[0][0][0], log_string)
+
+    @contextmanager
+    def assert_regex_not_logged(self, log_string, log_level='error'):
+        """
+        Asserts that the logger was called with the given
+        log_level and with a regex of the given string.
+        """
+        with pytest.raises(AssertionError):
+            with self.assert_logged(log_string, log_level=log_level):
+                yield
 
     @contextmanager
     def assert_logged_with_message(self, log_string, log_level='error'):
@@ -147,6 +156,26 @@ class TestSafeSessionsLogMixin:
                 "for request path '{}'. {}"
             ).format(
                 user_at_request, user_in_session, request_path, session_suffix
+            ),
+            log_level='warning',
+        ):
+            yield
+
+    @contextmanager
+    def assert_logged_for_both_mismatch(self, user_at_request, user_in_session, user_at_response, request_path,
+                                        session_changed):
+        """
+        Asserts that warning was logged when request.user
+        was not equal to user at session
+        """
+        session_suffix = 'Session changed.' if session_changed else 'Session did not change.'
+
+        with self.assert_logged_with_message(
+            (
+                "SafeCookieData user at initial request '{}' does not match user in session: '{}' "
+                "or user at response time: '{}' for request path '{}'. {}"
+            ).format(
+                user_at_request, user_in_session, user_at_response, request_path, session_suffix
             ),
             log_level='warning',
         ):

--- a/openedx/core/djangoapps/safe_sessions/tests/test_utils.py
+++ b/openedx/core/djangoapps/safe_sessions/tests/test_utils.py
@@ -23,9 +23,9 @@ class TestSafeSessionsLogMixin:
             self.assertRegex(mock_log.call_args_list[0][0][0], log_string)
 
     @contextmanager
-    def assert_regex_not_logged(self, log_string, log_level='error'):
+    def assert_regex_not_logged(self, log_string, log_level):
         """
-        Asserts that the logger was called with the given
+        Asserts that the logger was not called with the given
         log_level and with a regex of the given string.
         """
         with pytest.raises(AssertionError):
@@ -172,8 +172,8 @@ class TestSafeSessionsLogMixin:
 
         with self.assert_logged_with_message(
             (
-                "SafeCookieData user at initial request '{}' does not match user in session: '{}' "
-                "or user at response time: '{}' for request path '{}'. {}"
+                "SafeCookieData user at initial request '{}' matches neither user in session: '{}' "
+                "nor user at response time: '{}' for request path '{}'. {}"
             ).format(
                 user_at_request, user_in_session, user_at_response, request_path, session_suffix
             ),


### PR DESCRIPTION
## Description
Update the LOG_REQUEST_USER_CHANGES toggle to have it determine whether or not we will save information about all changes to the user in a request rather than logging it immediately. We will only log this information if the request fails the subsequent verify_user check in the response.
This will only affect Developers.

## Supporting information
https://openedx.atlassian.net/browse/ARCHBOM-1923

## Testing instructions

This guy is hard to test outside a development environment. Inside a development environment, you can test by enabling the LOG_REQUEST_USER_CHANGES toggle and disabling the ```        if getattr(response, 'safe_sessions_expected_user_change', None):
            return``` check inside SafeSessionMiddleware.process_response. 
Then:
1. while logged out, open two login windows
2. log in to one of them (keeping the other window open)
3. in the other window, log in using a different user
In the logs, you should see a message `SafeCookieData user at initial request does not match user at response time` and information about how the SafeCookieData user has changed over the life of the request.

## Deadline

None