### PR TITLE
feat: add ora-grading url to devstack and env

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -4683,6 +4683,13 @@ PROGRAM_CONSOLE_MICROFRONTEND_URL = None
 # .. setting_description: Base URL of the micro-frontend-based courseware page.
 # .. setting_warning: Also set site's courseware.courseware_mfe waffle flag.
 LEARNING_MICROFRONTEND_URL = None
+# .. setting_name: ORA_GRADING_MICROFRONTEND_URL
+# .. setting_default: None
+# .. setting_description: Base URL of the micro-frontend-based openassessment grading page.
+#     This is will be show in the open response tab list data.
+# .. setting_warning: Also set site's openresponseassessment.enhanced_staff_grader
+#     waffle flag.
+ORA_GRADING_MICROFRONTEND_URL = None
 
 ############### Settings for the ace_common plugin #################
 ACE_ENABLED_CHANNELS = ['django_email']

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -277,6 +277,7 @@ LOGIN_REDIRECT_WHITELIST.extend([
     'localhost:2001',  # frontend-app-course-authoring
     'localhost:3001',  # frontend-app-library-authoring
     'localhost:18400',  # frontend-app-publisher
+    'localhost:1993',  # frontend-app-ora-grading
     ENTERPRISE_LEARNER_PORTAL_NETLOC,  # frontend-app-learner-portal-enterprise
     ENTERPRISE_ADMIN_PORTAL_NETLOC,  # frontend-app-admin-portal
 ])


### PR DESCRIPTION
## Description

TLDR; I added ora-grading url to the env and devstack. It will be utilize by the openassessment to redirect to ora-grading

[AU-307](https://openedx.atlassian.net/browse/AU-307)

Related PR: [edx-ora2](https://github.com/edx/edx-ora2/pull/1704)

Useful information to include:
- This will be use in openassessment when openresponseassessment.enhanced_staff_grader flag enable.
- This change will be use in [ORA pull request](https://github.com/edx/edx-ora2/pull/1704)

### Test

- Add `ORA_GRADING_MICROFRONTEND_URL = 'http://localhost:1993'` to `edx-platform/lms/envs/private.py` or change `ORA_GRADING_MICROFRONTEND_URL` in `edx-platform/lms/envs/common.py` directly.
 
I will have to discuss to make sure with the team about the port number.
