### PR TITLE
fix: Mark user change as expected in LTIToolLaunchView.post

### DIFF
--- a/openedx/core/djangoapps/content_libraries/views.py
+++ b/openedx/core/djangoapps/content_libraries/views.py
@@ -70,6 +70,7 @@ from openedx.core.djangoapps.content_libraries.serializers import (
 )
 import openedx.core.djangoapps.site_configuration.helpers as configuration_helpers
 from openedx.core.lib.api.view_utils import view_auth_classes
+from openedx.core.djangoapps.safe_sessions.middleware import mark_user_change_as_expected
 from openedx.core.djangoapps.xblock import api as xblock_api
 
 from .models import ContentLibrary
@@ -924,7 +925,6 @@ class LtiToolLaunchView(TemplateResponseMixin, LtiToolView):
             sub=self.launch_data['sub'])
 
         if edx_user is not None:
-
             login(self.request, edx_user)
             perms = api.get_library_user_permissions(
                 usage_key.lib_key,
@@ -1005,7 +1005,8 @@ class LtiToolLaunchView(TemplateResponseMixin, LtiToolView):
 
         # Authenticate the launch and setup LTI profiles.
 
-        if not self._authenticate_and_login(usage_key):
+        edx_user = self._authenticate_and_login(usage_key)
+        if not edx_user:
             return self._bad_request_response()
 
         # Get the block.
@@ -1020,7 +1021,9 @@ class LtiToolLaunchView(TemplateResponseMixin, LtiToolView):
 
         # Render context and response.
         context = self.get_context_data()
-        return self.render_to_response(context)
+        response = self.render_to_response(context)
+        mark_user_change_as_expected(response, edx_user.id)
+        return response
 
     def handle_ags(self):
         """


### PR DESCRIPTION
The lti user gets authenticated and logged in as a part of the LTI View
Post.  This results in the request user changing during the request.  We
mark it here so that it does not produce a false alarm in our
SafeSessions middleware.
