### PR TITLE
build: nudge devs about Maple release in github

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,10 @@
 <!--
 
-Happy Autumn!
+🍁🍁
+🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
+    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
+🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
+🍁🍁
 
 Please give your pull request a short but descriptive title.
 Use conventional commits to separate and summarize commits logically:


### PR DESCRIPTION
## Description

Nudge devs, when they open PRs on edx-platform, that they should backport their bug fixes to the Maple master branch.

This is ready for review @nedbat.