### PR TITLE
fix: do not log error for sessions where user is changed to None

### DIFF
--- a/openedx/core/djangoapps/safe_sessions/middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/middleware.py
@@ -421,10 +421,12 @@ class SafeSessionMiddleware(SessionMiddleware, MiddlewareMixin):
                 request.user = request.user.real_user
 
             # determine if the request.user is different now than it was on the initial request
-            request_user_object_mismatch = request.safe_cookie_verified_user_id != request.user.id
+            request_user_object_mismatch = request.safe_cookie_verified_user_id != request.user.id and\
+                request.user.id is not None
 
             # determine if the current session user is different than the user in the initial request
-            session_user_mismatch = request.safe_cookie_verified_user_id != userid_in_session
+            session_user_mismatch = request.safe_cookie_verified_user_id != userid_in_session and\
+                userid_in_session is not None
 
             if request_user_object_mismatch or session_user_mismatch:
                 # Log accumulated information stored on request for each change of user

--- a/openedx/core/djangoapps/safe_sessions/tests/test_middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/tests/test_middleware.py
@@ -203,7 +203,7 @@ class TestSafeSessionProcessResponse(TestSafeSessionsLogMixin, TestCase):
         self.request.safe_cookie_verified_session_id = '1'
         self.request.user = AnonymousUser()
         self.request.session[SESSION_KEY] = self.user.id
-        with self.assert_no_error_logged():
+        with self.assert_no_warning_logged():
             self.assert_response(set_request_user=False, set_session_cookie=True)
 
     def test_update_cookie_data_at_step_3(self):


### PR DESCRIPTION
## Description
When the user has been changed to None (eg after a session timeout), do not issue a SafeSessions warning.