### PR TITLE
build: use unique names for workflows

### DIFF
--- a/.github/workflows/ci-static-analysis.yml
+++ b/.github/workflows/ci-static-analysis.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Static analysis
 
 on: pull_request
 

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Javascript tests
 
 on:
   pull_request:

--- a/.github/workflows/migrations-check.yml
+++ b/.github/workflows/migrations-check.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Migrations check
 
 on:
   workflow_dispatch:

--- a/.github/workflows/pylint-checks.yml
+++ b/.github/workflows/pylint-checks.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Pylint checks
 
 on:
   pull_request:

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Quality checks
 
 on:
   pull_request:

--- a/.github/workflows/unit-tests-check.yml
+++ b/.github/workflows/unit-tests-check.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Unit tests
 
 on:
   pull_request:


### PR DESCRIPTION
It's confusing to have six different checks, all called "CI".  This
gives them unique names to help devs navigate the checks.

