### PR TITLE
fix: Decorate celery task to set code owner attribute.

### DIFF
--- a/openedx/core/djangoapps/user_authn/tasks.py
+++ b/openedx/core/djangoapps/user_authn/tasks.py
@@ -44,6 +44,7 @@ def get_pwned_properties(pwned_response, password):
 
 
 @shared_task
+@set_code_owner_attribute
 def check_pwned_password_and_send_track_event(user_id, password, internal_user=False):
     """
     Check the Pwned Databases and send its event to Segment


### PR DESCRIPTION
See https://edx.readthedocs.io/projects/edx-django-utils/en/latest/monitoring/how_tos/add_code_owner_custom_attribute_to_an_ida.html\#handling-celery-tasks fo more details.

Not relevant to Maple.

@uzairr FYI.