### PR TITLE
fix: errors with anonymous user

### DIFF
--- a/openedx/core/djangoapps/user_api/course_tag/api.py
+++ b/openedx/core/djangoapps/user_api/course_tag/api.py
@@ -69,6 +69,9 @@ def get_course_tag(user, course_id, key):
     Returns:
         string value, or None if there is no value saved
     """
+    if user.is_anonymous:
+        return None
+
     if BulkCourseTags.is_prefetched(course_id):
         try:
             return BulkCourseTags.get_course_tag(user.id, course_id, key)

--- a/openedx/core/djangoapps/user_api/course_tag/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/course_tag/tests/test_api.py
@@ -2,7 +2,7 @@
 Test the user course tag API.
 """
 
-
+from django.contrib.auth.models import AnonymousUser
 from django.test import TestCase
 from opaque_keys.edx.locator import CourseLocator
 
@@ -20,6 +20,10 @@ class TestCourseTagAPI(TestCase):
         self.user = UserFactory.create()
         self.course_id = CourseLocator('test_org', 'test_course_number', 'test_run')
         self.test_key = 'test_key'
+
+    def test_get_course_tag_for_anonymous_user(self):
+        tag = course_tag_api.get_course_tag(AnonymousUser(), self.course_id, self.test_key)
+        assert tag is None
 
     def test_get_set_course_tag(self):
         # get a tag that doesn't exist


### PR DESCRIPTION
## Description

There are several errors that appear in monitoring when calls
are made with an anonymous user. This resolves one (or more).

## Testing

The new unit test works with this change, and fails without this change.

## Additional Notes

Here is an edx link for New Relic to a related error: https://onenr.io/0BoQD3nZZjy

And stacktrace information:
```
builtins:TypeError
Error message:
Field 'id' expected a number but got <django.contrib.auth.models.AnonymousUser object at 0x7f81c0528850>.
Traceback (most recent call last):
...
File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/courseware_api/views.py", line 591, in get
File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/seq_module.py", line 396, in get_metadata
File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/seq_module.py", line 573, in _get_render_metadata
File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/seq_module.py", line 775, in _render_student_view_for_items
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/edx_django_utils/plugins/pluggable_override.py", line 77, in wrapper
File "/edx/app/edxapp/edx-platform/openedx/core/lib/xblock_utils/__init__.py", line 563, in get_icon
File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/vertical_block.py", line 192, in get_icon_class
File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/vertical_block.py", line 192, in <setcomp>
File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/split_test_module.py", line 418, in get_icon_class
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/functional.py", line 48, in __get__
File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/split_test_module.py", line 195, in child
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/functional.py", line 48, in __get__
File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/split_test_module.py", line 185, in child_descriptor
File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/split_test_module.py", line 235, in get_child_descriptors
File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/split_test_module.py", line 264, in get_group_id
File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/partitions/partitions_service.py", line 150, in get_user_group_id_for_partition
File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/partitions/partitions_service.py", line 174, in get_group
File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/user_api/partition_schemes.py", line 59, in get_group_for_user
File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/user_api/course_tag/api.py", line 78, in get_course_tag
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/manager.py", line 85, in manager_method
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/query.py", line 424, in get
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/query.py", line 941, in filter
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/query.py", line 961, in _filter_or_exclude
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/query.py", line 968, in _filter_or_exclude_inplace
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/sql/query.py", line 1393, in add_q
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/sql/query.py", line 1412, in _add_q
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/sql/query.py", line 1347, in build_filter
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/sql/query.py", line 1193, in build_lookup
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/lookups.py", line 25, in __init__
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/fields/related_lookups.py", line 117, in get_prep_lookup
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/fields/__init__.py", line 1825, in get_prep_value
```