### PR TITLE
build: use the correct base branch for xsscommitlint

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -24,7 +24,7 @@ jobs:
         fetch-depth: 2
 
     - name: Fetch master for comparison
-      run: git fetch --depth=1 origin master
+      run: git fetch --depth=1 origin ${{ github.base_ref }}
 
     - name: Install Required System Packages
       run: sudo apt-get update && sudo apt-get install libxmlsec1-dev
@@ -65,6 +65,7 @@ jobs:
         SCRIPT_TO_RUN: ./scripts/generic-ci-tests.sh
         SHARD: 4
         PIP_SRC_DIR: ${{ runner.temp }}
+        TARGET_BRANCH: ${{ github.base_ref }}
       run: |
         ./scripts/all-tests.sh
 

--- a/scripts/xss-commit-linter.sh
+++ b/scripts/xss-commit-linter.sh
@@ -34,6 +34,7 @@ show_verbose() {
     echo "Files linted is based on the following:"
     echo "- Current commit: ${current_branch_hash}"
     echo "- Main commit: ${MAIN_COMMIT}"
+    echo "- Target branch: ${TARGET_BRANCH}"
     echo "- Merge base command: ${merge_base_command}"
     echo "- Merge base: ${merge_base}"
     echo "- Diff command: ${diff_command}"


### PR DESCRIPTION
It might not be master!

(cherry picked from commit fc894e1fd8977ac450118887a1914ca248e3571c) on the maple.master branch.


## Description

The xss-commit-lint check would fail on any PR whose base branch was not master.  This makes it work properly.

Here is a maple.master pull request before the change, with a failing check: https://github.com/edx/edx-platform/pull/29034

Here is the change working correctly on maple.master: https://github.com/edx/edx-platform/pull/29037