### PR TITLE
[SE-4860] Upgrade Celery to v5.2.1

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -12,14 +12,15 @@
 # This file contains all common constraints for edx-repos
 -c common_constraints.txt
 
-# celert>5.0.0 hasn't been tested yet, so the constraint will be removed after testing latest version
-celery<5.0.0
+# As it is not clarified what exact breaking changes will be introduced as per
+# the next major release, ensure the installed version is within boundaries.
+celery>=5.2.2,<6.0.0
+
+# required for celery>=5.2.0;<5.3.0
+click>=8.0,<9.0
 
 # edx-platform currently only supported for Django 3.2.x
 django<3.3
-
-# Newer versions need celery >= 5.0
-django-celery-results<2.1
 
 # We do not support version django-config-models<1.0.0
 django-config-models>=1.0.0
@@ -79,9 +80,6 @@ python-slugify<5.0.0
 
 # greater version has breaking changes and requires some migration steps.
 django-webpack-loader==0.7.0
-
-# celery requires click<8.0.0 which would be fixed once https://github.com/celery/celery/issues/6753 is done.
-click<8.0.0
 
 # Release 2.1.0 pulls declares `pact-python` as a base requirement, even though it should be
 # a testing requirement. Installing it would cause a bunch of new tool packages to become base

--- a/requirements/edx-sandbox/py38.txt
+++ b/requirements/edx-sandbox/py38.txt
@@ -10,7 +10,7 @@ cffi==1.15.0
     # via cryptography
 chem==1.2.0
     # via -r requirements/edx-sandbox/py38.in
-click==7.1.2
+click==8.0.3
     # via
     #   -c requirements/edx-sandbox/../constraints.txt
     #   nltk

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -135,7 +135,7 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.2.0
     # via celery
-code-annotations==1.2.0
+code-annotations==1.3.0
     # via
     #   edx-enterprise
     #   edx-toggles
@@ -245,7 +245,7 @@ django-appconf==1.0.5
     #   django-statici18n
 django-cache-memoize==0.1.10
     # via edx-enterprise
-django-celery-results==2.0.1
+django-celery-results==2.2.0
     # via -r requirements/edx/base.in
 django-classy-tags==3.0.1
     # via django-sekizai
@@ -749,7 +749,7 @@ pillow==9.0.1
     #   edx-organizations
 polib==1.1.1
     # via edx-i18n-tools
-prompt-toolkit==3.0.24
+prompt-toolkit==3.0.27
     # via click-repl
 psutil==5.9.0
     # via

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -36,7 +36,7 @@ aiohttp==3.8.1
     # via geoip2
 aiosignal==1.2.0
     # via aiohttp
-amqp==2.6.1
+amqp==5.0.9
     # via kombu
 analytics-python==1.4.0
     # via -r requirements/edx/base.in
@@ -91,7 +91,7 @@ botocore==1.8.17
     #   s3transfer
 bridgekeeper==0.9
     # via -r requirements/edx/base.in
-celery==4.4.7
+celery==5.2.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
@@ -119,13 +119,23 @@ charset-normalizer==2.0.12
     #   requests
 chem==1.2.0
     # via -r requirements/edx/base.in
-click==7.1.2
+click==8.0.3
     # via
     #   -c requirements/edx/../constraints.txt
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
     #   code-annotations
     #   nltk
     #   user-util
-code-annotations==1.3.0
+click-didyoumean==0.3.0
+    # via celery
+click-plugins==1.1.1
+    # via celery
+click-repl==0.2.0
+    # via celery
+code-annotations==1.2.0
     # via
     #   edx-enterprise
     #   edx-toggles
@@ -236,9 +246,7 @@ django-appconf==1.0.5
 django-cache-memoize==0.1.10
     # via edx-enterprise
 django-celery-results==2.0.1
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/base.in
+    # via -r requirements/edx/base.in
 django-classy-tags==3.0.1
     # via django-sekizai
 django-config-models==2.3.0
@@ -598,7 +606,7 @@ jsonfield==3.1.0
     #   ora2
 jwcrypto==1.0
     # via pylti1p3
-kombu==4.6.11
+kombu==5.2.3
     # via celery
 laboratory==1.0.2
     # via -r requirements/edx/base.in
@@ -741,6 +749,8 @@ pillow==9.0.1
     #   edx-organizations
 polib==1.1.1
     # via edx-i18n-tools
+prompt-toolkit==3.0.24
+    # via click-repl
 psutil==5.9.0
     # via
     #   -r requirements/edx/paver.txt
@@ -931,6 +941,7 @@ six==1.16.0
     #   analytics-python
     #   bleach
     #   chem
+    #   click-repl
     #   codejail
     #   crowdsourcehinter-xblock
     #   edx-ace
@@ -1026,14 +1037,17 @@ urllib3==1.26.8
     #   requests
 user-util==1.0.0
     # via -r requirements/edx/base.in
-vine==1.3.0
+vine==5.0.0
     # via
     #   amqp
     #   celery
+    #   kombu
 voluptuous==0.12.2
     # via ora2
 watchdog==2.1.6
     # via -r requirements/edx/paver.txt
+wcwidth==0.2.5
+    # via prompt-toolkit
 web-fragments==2.0.0
     # via
     #   -r requirements/edx/base.in
@@ -1076,7 +1090,7 @@ xblock==1.6.1
     #   xblock-utils
 xblock-drag-and-drop-v2 @ git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.3.5
     # via -r requirements/edx/github.in
-xblock-poll @ git+https://github.com/open-craft/xblock-poll@922cd36fb1c3cfe00b4ce03b19a13185d136447d
+xblock-poll @ git+https://github.com/open-craft/xblock-poll@v1.12.0
     # via -r requirements/edx/github.in
 xblock-utils==3.0.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -42,7 +42,7 @@ aiosignal==1.2.0
     #   aiohttp
 alabaster==0.7.12
     # via sphinx
-amqp==2.6.1
+amqp==5.0.9
     # via
     #   -r requirements/edx/testing.txt
     #   kombu
@@ -128,7 +128,7 @@ botocore==1.8.17
     #   s3transfer
 bridgekeeper==0.9
     # via -r requirements/edx/testing.txt
-celery==4.4.7
+celery==5.2.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
@@ -159,13 +159,17 @@ charset-normalizer==2.0.12
     #   requests
 chem==1.2.0
     # via -r requirements/edx/testing.txt
-click==7.1.2
+click==8.0.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/development.in
     #   -r requirements/edx/pip-tools.txt
     #   -r requirements/edx/testing.txt
+    #   celery
+    #   click-didyoumean
     #   click-log
+    #   click-plugins
+    #   click-repl
     #   code-annotations
     #   edx-lint
     #   nltk
@@ -173,11 +177,23 @@ click==7.1.2
     #   pip-tools
     #   user-util
     #   uvicorn
+click-didyoumean==0.3.0
+    # via
+    #   -r requirements/edx/testing.txt
+    #   celery
 click-log==0.3.2
     # via
     #   -r requirements/edx/testing.txt
     #   edx-lint
-code-annotations==1.3.0
+click-plugins==1.1.1
+    # via
+    #   -r requirements/edx/testing.txt
+    #   celery
+click-repl==0.2.0
+    # via
+    #   -r requirements/edx/testing.txt
+    #   celery
+code-annotations==1.2.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
@@ -316,9 +332,7 @@ django-cache-memoize==0.1.10
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
 django-celery-results==2.0.1
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/testing.txt
+    # via -r requirements/edx/testing.txt
 django-classy-tags==3.0.1
     # via
     #   -r requirements/edx/testing.txt
@@ -801,7 +815,7 @@ jwcrypto==1.0
     # via
     #   -r requirements/edx/testing.txt
     #   pylti1p3
-kombu==4.6.11
+kombu==5.2.3
     # via
     #   -r requirements/edx/testing.txt
     #   celery
@@ -1005,6 +1019,10 @@ polib==1.1.1
     # via
     #   -r requirements/edx/testing.txt
     #   edx-i18n-tools
+prompt-toolkit==3.0.24
+    # via
+    #   -r requirements/edx/testing.txt
+    #   click-repl
 psutil==5.9.0
     # via
     #   -r requirements/edx/testing.txt
@@ -1305,6 +1323,7 @@ six==1.16.0
     #   bleach
     #   bok-choy
     #   chem
+    #   click-repl
     #   codejail
     #   crowdsourcehinter-xblock
     #   edx-ace
@@ -1494,7 +1513,7 @@ uvicorn==0.17.5
     # via
     #   -r requirements/edx/testing.txt
     #   pact-python
-vine==1.3.0
+vine==5.0.0
     # via
     #   -r requirements/edx/testing.txt
     #   amqp
@@ -1511,6 +1530,10 @@ vulture==2.3
     # via -r requirements/edx/development.in
 watchdog==2.1.6
     # via -r requirements/edx/testing.txt
+wcwidth==0.2.5
+    # via
+    #   -r requirements/edx/testing.txt
+    #   prompt-toolkit
 web-fragments==2.0.0
     # via
     #   -r requirements/edx/testing.txt
@@ -1560,7 +1583,7 @@ xblock==1.6.1
     #   xblock-utils
 xblock-drag-and-drop-v2 @ git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.3.5
     # via -r requirements/edx/testing.txt
-xblock-poll @ git+https://github.com/open-craft/xblock-poll@922cd36fb1c3cfe00b4ce03b19a13185d136447d
+xblock-poll @ git+https://github.com/open-craft/xblock-poll@v1.12.0
     # via -r requirements/edx/testing.txt
 xblock-utils==3.0.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -193,7 +193,7 @@ click-repl==0.2.0
     # via
     #   -r requirements/edx/testing.txt
     #   celery
-code-annotations==1.2.0
+code-annotations==1.3.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
@@ -331,7 +331,7 @@ django-cache-memoize==0.1.10
     # via
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
-django-celery-results==2.0.1
+django-celery-results==2.2.0
     # via -r requirements/edx/testing.txt
 django-classy-tags==3.0.1
     # via
@@ -1019,7 +1019,7 @@ polib==1.1.1
     # via
     #   -r requirements/edx/testing.txt
     #   edx-i18n-tools
-prompt-toolkit==3.0.24
+prompt-toolkit==3.0.27
     # via
     #   -r requirements/edx/testing.txt
     #   click-repl
@@ -1518,6 +1518,7 @@ vine==5.0.0
     #   -r requirements/edx/testing.txt
     #   amqp
     #   celery
+    #   kombu
 virtualenv==20.13.3
     # via
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -12,7 +12,7 @@ certifi==2021.10.8
     # via requests
 charset-normalizer==2.0.12
     # via requests
-click==7.1.2
+click==8.0.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   code-annotations

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -73,5 +73,5 @@ git+https://github.com/edx/django-require.git@0c54adb167142383b26ea6b3edecc32118
 
 # Third Party XBlocks
 
-git+https://github.com/open-craft/xblock-poll@922cd36fb1c3cfe00b4ce03b19a13185d136447d#egg=xblock-poll==1.10.2
+git+https://github.com/open-craft/xblock-poll@v1.12.0#egg=xblock-poll==1.12.0
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.3.5#egg=xblock-drag-and-drop-v2==2.3.5

--- a/requirements/edx/pip-tools.txt
+++ b/requirements/edx/pip-tools.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-click==7.1.2
+click==8.0.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   pip-tools

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -182,7 +182,7 @@ click-repl==0.2.0
     # via
     #   -r requirements/edx/base.txt
     #   celery
-code-annotations==1.2.0
+code-annotations==1.3.0
     # via
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/testing.in
@@ -318,7 +318,7 @@ django-cache-memoize==0.1.10
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-django-celery-results==2.0.1
+django-celery-results==2.2.0
     # via -r requirements/edx/base.txt
 django-classy-tags==3.0.1
     # via
@@ -959,7 +959,7 @@ polib==1.1.1
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/testing.in
     #   edx-i18n-tools
-prompt-toolkit==3.0.24
+prompt-toolkit==3.0.27
     # via
     #   -r requirements/edx/base.txt
     #   click-repl
@@ -1402,6 +1402,7 @@ vine==5.0.0
     #   -r requirements/edx/base.txt
     #   amqp
     #   celery
+    #   kombu
 virtualenv==20.13.3
     # via tox
 voluptuous==0.12.2

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -40,7 +40,7 @@ aiosignal==1.2.0
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
-amqp==2.6.1
+amqp==5.0.9
     # via
     #   -r requirements/edx/base.txt
     #   kombu
@@ -75,7 +75,6 @@ attrs==21.4.0
     #   aiohttp
     #   edx-ace
     #   openedx-events
-    #   outcome
     #   pytest
 babel==2.9.1
     # via
@@ -123,7 +122,7 @@ botocore==1.8.17
     #   s3transfer
 bridgekeeper==0.9
     # via -r requirements/edx/base.txt
-celery==4.4.7
+celery==5.2.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
@@ -154,20 +153,36 @@ charset-normalizer==2.0.12
     #   requests
 chem==1.2.0
     # via -r requirements/edx/base.txt
-click==7.1.2
+click==8.0.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
+    #   celery
+    #   click-didyoumean
     #   click-log
+    #   click-plugins
+    #   click-repl
     #   code-annotations
     #   edx-lint
     #   nltk
     #   pact-python
     #   user-util
     #   uvicorn
+click-didyoumean==0.3.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   celery
 click-log==0.3.2
     # via edx-lint
-code-annotations==1.3.0
+click-plugins==1.1.1
+    # via
+    #   -r requirements/edx/base.txt
+    #   celery
+click-repl==0.2.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   celery
+code-annotations==1.2.0
     # via
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/testing.in
@@ -304,9 +319,7 @@ django-cache-memoize==0.1.10
     #   -r requirements/edx/base.txt
     #   edx-enterprise
 django-celery-results==2.0.1
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/base.txt
+    # via -r requirements/edx/base.txt
 django-classy-tags==3.0.1
     # via
     #   -r requirements/edx/base.txt
@@ -762,7 +775,7 @@ jwcrypto==1.0
     # via
     #   -r requirements/edx/base.txt
     #   pylti1p3
-kombu==4.6.11
+kombu==5.2.3
     # via
     #   -r requirements/edx/base.txt
     #   celery
@@ -946,6 +959,10 @@ polib==1.1.1
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/testing.in
     #   edx-i18n-tools
+prompt-toolkit==3.0.24
+    # via
+    #   -r requirements/edx/base.txt
+    #   click-repl
 psutil==5.9.0
     # via
     #   -r requirements/edx/base.txt
@@ -1229,6 +1246,7 @@ six==1.16.0
     #   bleach
     #   bok-choy
     #   chem
+    #   click-repl
     #   codejail
     #   crowdsourcehinter-xblock
     #   edx-ace
@@ -1379,7 +1397,7 @@ user-util==1.0.0
     # via -r requirements/edx/base.txt
 uvicorn==0.17.5
     # via pact-python
-vine==1.3.0
+vine==5.0.0
     # via
     #   -r requirements/edx/base.txt
     #   amqp
@@ -1392,6 +1410,10 @@ voluptuous==0.12.2
     #   ora2
 watchdog==2.1.6
     # via -r requirements/edx/base.txt
+wcwidth==0.2.5
+    # via
+    #   -r requirements/edx/base.txt
+    #   prompt-toolkit
 web-fragments==2.0.0
     # via
     #   -r requirements/edx/base.txt
@@ -1437,7 +1459,7 @@ xblock==1.6.1
     #   xblock-utils
 xblock-drag-and-drop-v2 @ git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.3.5
     # via -r requirements/edx/base.txt
-xblock-poll @ git+https://github.com/open-craft/xblock-poll@922cd36fb1c3cfe00b4ce03b19a13185d136447d
+xblock-poll @ git+https://github.com/open-craft/xblock-poll@v1.12.0
     # via -r requirements/edx/base.txt
 xblock-utils==3.0.0
     # via


### PR DESCRIPTION
## Description

Upgrade Celery to the latest version and bump its dependencies.

## Supporting information

The release of Redis 6 introduced the ability to share this service among multiple accounts, securing access to specific keys using a  username/password and ACLs.

Celery uses `kombu` to provide Redis brokering for the message queues, but `kombu` was missing a couple of key enhancements to support multi-tenant Redis:

- [Add support for setting Redis username celery/kombu#1351](https://github.com/celery/kombu/pull/1351)
- [Add global key prefix for keys set by Redis transporter celery/kombu#1349](https://github.com/celery/kombu/pull/1349)

As [edX have identified](https://github.com/edx/edx-platform/pull/28020#issuecomment-917187564) that the best way to bring our kombu fixes from the [original PR](https://github.com/edx/edx-platform/pull/28020) into edx-platform is to remove the constraints keeping celery < 5.0 and upgrade celery.

[OpenCraft wants to use multi-tenant redis](https://forum.opencraft.com/t/clustered-redis-is-coming-to-ocim/1011/1) for their [shared hosting service](https://opencraft.com/hosting/), so we can stop maintaining RabbitMQ.

The celery upgrade also requires a newer version of `xblock-poll`.

## Dependencies

- https://github.com/edx/configuration/pull/6586

## Testing instructions

The extended heartbeat check for celery is sufficient to test that these changes don't disrupt the functionality on the sandbox as configured below.

1. Visit https://pr29046.sandbox.opencraft.hosting/heartbeat?extended
2. Ensure that the `celery` check passes.

## Deadline

None

## Other information

N/A

## Reviewers

**Settings**
```yaml
DEMO_CREATE_STAFF_USER: true
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
```