### PR TITLE
[SE-4891] feat: add optional but not toggled extra fields

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3437,7 +3437,8 @@ LOGIN_REDIRECT_WHITELIST = []
 #   'terms_of_service': 'hidden', 'city': 'hidden', 'country': 'hidden'}
 # .. setting_description: The signup form may contain extra fields that are presented to every user. For every field, we
 #   can specifiy whether it should be "required": to display the field, and make it mandatory; "optional": to display
-#   the field, and make it non-mandatory; "hidden": to not display the field.
+#   the optional field as part of a toggled input field list; "optional-exposed": to display the optional fields among
+#   the required fields, and make it non-mandatory; "hidden": to not display the field.
 #   When the terms of service are not visible and agreement to the honor code is required (the default), the signup page
 #   includes a paragraph that links to the honor code page (defined my MKTG_URLS["HONOR"]). This page might not be
 #   available for all Open edX platforms. In such cases, the "honor_code" registration field should be "hidden".

--- a/lms/static/js/spec/student_account/register_spec.js
+++ b/lms/static/js/spec/student_account/register_spec.js
@@ -88,7 +88,7 @@
                                 defaultValue: '',
                                 type: 'email',
                                 required: true,
-                                toggled: false,
+                                exposed: true,
                                 instructions: 'Enter your email.',
                                 restrictions: {}
                             },
@@ -99,7 +99,7 @@
                                 defaultValue: '',
                                 type: 'text',
                                 required: true,
-                                toggled: false,
+                                exposed: true,
                                 instructions: 'Enter your email.',
                                 restrictions: {}
                             },
@@ -110,7 +110,7 @@
                                 defaultValue: '',
                                 type: 'text',
                                 required: true,
-                                toggled: false,
+                                exposed: true,
                                 instructions: 'Enter your username.',
                                 restrictions: {}
                             },
@@ -121,7 +121,7 @@
                                 defaultValue: '',
                                 type: 'text',
                                 required: true,
-                                toggled: false,
+                                exposed: true,
                                 instructions: 'Enter your username.',
                                 restrictions: {}
                             },
@@ -132,7 +132,7 @@
                                 defaultValue: '',
                                 type: 'password',
                                 required: true,
-                                toggled: false,
+                                exposed: true,
                                 instructions: 'Enter your password.',
                                 restrictions: {}
                             },
@@ -149,7 +149,7 @@
                                     {value: 'b', name: "Bachelor's degree"}
                                 ],
                                 required: false,
-                                toggled: true,
+                                exposed: false,
                                 instructions: 'Select your education level.',
                                 restrictions: {}
                             },
@@ -166,7 +166,7 @@
                                     {value: 'o', name: 'Other'}
                                 ],
                                 required: false,
-                                toggled: true,
+                                exposed: false,
                                 instructions: 'Select your gender.',
                                 restrictions: {}
                             },
@@ -183,7 +183,7 @@
                                     {value: 2014, name: '2014'}
                                 ],
                                 required: false,
-                                toggled: true,
+                                exposed: false,
                                 instructions: 'Select your year of birth.',
                                 restrictions: {}
                             },
@@ -194,7 +194,7 @@
                                 defaultValue: '',
                                 type: 'textarea',
                                 required: false,
-                                toggled: true,
+                                exposed: false,
                                 instructions: 'Enter your mailing address.',
                                 restrictions: {}
                             },
@@ -205,7 +205,7 @@
                                 defaultValue: '',
                                 type: 'textarea',
                                 required: false,
-                                toggled: true,
+                                exposed: false,
                                 instructions: "If you'd like, tell us why you're interested in edX.",
                                 restrictions: {}
                             },
@@ -216,7 +216,7 @@
                                 defaultValue: '',
                                 type: 'checkbox',
                                 required: true,
-                                toggled: false,
+                                exposed: true,
                                 instructions: '',
                                 restrictions: {},
                                 supplementalLink: '/honor',
@@ -513,25 +513,27 @@
                     expect(view.$submitButton).toHaveAttr('disabled');
                 });
 
-                it('shows optional not toggled fields', function() {
+                it('shows optional exposed fields', function() {
                     var formFields = FORM_DESCRIPTION.fields
                     formFields.push({
                         placeholder: '',
-                        name: 'not_toggled_custom_optional_field',
-                        label: 'Not toggled custom optional field.',
+                        name: 'exposed_custom_optional_field',
+                        label: 'Exposed custom optional field.',
                         defaultValue: '',
                         type: 'checkbox',
                         required: false,
-                        toggled: false,
+                        exposed: true,
                         instructions: 'Check this field if you would like to.',
                         restrictions: {}
                     })
 
                     createRegisterView(this, formFields);
-                    var elementClasses = view.$('.not-toggled-optional-fields').attr('class');
-                    // Expect the toggled optional fields container does not have other
+                    var elementClasses = view.$('.exposed-optional-fields').attr('class');
+                    var elementChildren = view.$('.exposed-optional-fields .form-field')
+                    // Expect the exposed optional fields container does not have other
                     // classes assigned, like .hidden
-                    expect(elementClasses).toEqual('not-toggled-optional-fields');
+                    expect(elementClasses).toEqual('exposed-optional-fields');
+                    expect(elementChildren.length).toEqual(1)
                 });
 
                 it('hides optional fields by default', function() {

--- a/lms/static/js/spec/student_account/register_spec.js
+++ b/lms/static/js/spec/student_account/register_spec.js
@@ -88,6 +88,7 @@
                                 defaultValue: '',
                                 type: 'email',
                                 required: true,
+                                toggled: false,
                                 instructions: 'Enter your email.',
                                 restrictions: {}
                             },
@@ -98,6 +99,7 @@
                                 defaultValue: '',
                                 type: 'text',
                                 required: true,
+                                toggled: false,
                                 instructions: 'Enter your email.',
                                 restrictions: {}
                             },
@@ -108,6 +110,7 @@
                                 defaultValue: '',
                                 type: 'text',
                                 required: true,
+                                toggled: false,
                                 instructions: 'Enter your username.',
                                 restrictions: {}
                             },
@@ -118,6 +121,7 @@
                                 defaultValue: '',
                                 type: 'text',
                                 required: true,
+                                toggled: false,
                                 instructions: 'Enter your username.',
                                 restrictions: {}
                             },
@@ -128,6 +132,7 @@
                                 defaultValue: '',
                                 type: 'password',
                                 required: true,
+                                toggled: false,
                                 instructions: 'Enter your password.',
                                 restrictions: {}
                             },
@@ -144,6 +149,7 @@
                                     {value: 'b', name: "Bachelor's degree"}
                                 ],
                                 required: false,
+                                toggled: true,
                                 instructions: 'Select your education level.',
                                 restrictions: {}
                             },
@@ -160,6 +166,7 @@
                                     {value: 'o', name: 'Other'}
                                 ],
                                 required: false,
+                                toggled: true,
                                 instructions: 'Select your gender.',
                                 restrictions: {}
                             },
@@ -176,6 +183,7 @@
                                     {value: 2014, name: '2014'}
                                 ],
                                 required: false,
+                                toggled: true,
                                 instructions: 'Select your year of birth.',
                                 restrictions: {}
                             },
@@ -186,6 +194,7 @@
                                 defaultValue: '',
                                 type: 'textarea',
                                 required: false,
+                                toggled: true,
                                 instructions: 'Enter your mailing address.',
                                 restrictions: {}
                             },
@@ -196,6 +205,7 @@
                                 defaultValue: '',
                                 type: 'textarea',
                                 required: false,
+                                toggled: true,
                                 instructions: "If you'd like, tell us why you're interested in edX.",
                                 restrictions: {}
                             },
@@ -206,11 +216,12 @@
                                 defaultValue: '',
                                 type: 'checkbox',
                                 required: true,
+                                toggled: false,
                                 instructions: '',
                                 restrictions: {},
                                 supplementalLink: '/honor',
                                 supplementalText: 'Review the Terms of Service and Honor Code'
-                            }
+                            },
                         ]
                     };
                 var createRegisterView = function(that, formFields) {
@@ -500,6 +511,27 @@
 
                 // Form button should be disabled on success.
                     expect(view.$submitButton).toHaveAttr('disabled');
+                });
+
+                it('shows optional not toggled fields', function() {
+                    var formFields = FORM_DESCRIPTION.fields
+                    formFields.push({
+                        placeholder: '',
+                        name: 'not_toggled_custom_optional_field',
+                        label: 'Not toggled custom optional field.',
+                        defaultValue: '',
+                        type: 'checkbox',
+                        required: false,
+                        toggled: false,
+                        instructions: 'Check this field if you would like to.',
+                        restrictions: {}
+                    })
+
+                    createRegisterView(this, formFields);
+                    var elementClasses = view.$('.not-toggled-optional-fields').attr('class');
+                    // Expect the toggled optional fields container does not have other
+                    // classes assigned, like .hidden
+                    expect(elementClasses).toEqual('not-toggled-optional-fields');
                 });
 
                 it('hides optional fields by default', function() {

--- a/lms/static/js/student_account/views/RegisterView.js
+++ b/lms/static/js/student_account/views/RegisterView.js
@@ -101,7 +101,8 @@
                         field,
                         len = data.length,
                         requiredFields = [],
-                        optionalFields = [];
+                        optionalFields = [],
+                        notToggledOptionalFields = [];
 
                     this.fields = data;
 
@@ -123,12 +124,18 @@
                                 // input elements that are visible on the page.
                                 this.hasOptionalFields = true;
                             }
-                            optionalFields.push(field);
+
+                            if (field.toggled) {
+                                optionalFields.push(field);
+                            } else {
+                                notToggledOptionalFields.push(field);
+                            }
                         }
                     }
 
                     html = this.renderFields(requiredFields, 'required-fields');
 
+                    html.push.apply(html, this.renderFields(notToggledOptionalFields, 'not-toggled-optional-fields'));
                     html.push.apply(html, this.renderFields(
                       optionalFields, `optional-fields ${!this.enableCoppaCompliance ? '' : 'full-length-fields'}`
                     ));
@@ -250,6 +257,14 @@
                         window.analytics.track('edx.bi.user.register.optional_fields_selected');
                         $('.optional-fields').toggleClass('hidden');
                     });
+
+                    // Since the honor TOS text has a composed css selector, it is more future proof
+                    // to insert the not toggled optional fields before .honor_tos_combined's parent
+                    // that is the container for the honor TOS text and checkbox.
+                    // xss-lint: disable=javascript-jquery-insert-into-target
+                    $('.not-toggled-optional-fields').insertBefore(
+                        $('.honor_tos_combined').parent()
+                    );
 
                     // We are swapping the order of these elements here because the honor code agreement
                     // is a required checkbox field and the optional fields toggle is a cosmetic

--- a/lms/static/js/student_account/views/RegisterView.js
+++ b/lms/static/js/student_account/views/RegisterView.js
@@ -102,7 +102,7 @@
                         len = data.length,
                         requiredFields = [],
                         optionalFields = [],
-                        notToggledOptionalFields = [];
+                        exposedOptionalFields = [];
 
                     this.fields = data;
 
@@ -125,17 +125,17 @@
                                 this.hasOptionalFields = true;
                             }
 
-                            if (field.toggled) {
-                                optionalFields.push(field);
+                            if (field.exposed) {
+                                exposedOptionalFields.push(field);
                             } else {
-                                notToggledOptionalFields.push(field);
+                                optionalFields.push(field);
                             }
                         }
                     }
 
                     html = this.renderFields(requiredFields, 'required-fields');
 
-                    html.push.apply(html, this.renderFields(notToggledOptionalFields, 'not-toggled-optional-fields'));
+                    html.push.apply(html, this.renderFields(exposedOptionalFields, 'exposed-optional-fields'));
                     html.push.apply(html, this.renderFields(
                       optionalFields, `optional-fields ${!this.enableCoppaCompliance ? '' : 'full-length-fields'}`
                     ));
@@ -262,7 +262,7 @@
                     // to insert the not toggled optional fields before .honor_tos_combined's parent
                     // that is the container for the honor TOS text and checkbox.
                     // xss-lint: disable=javascript-jquery-insert-into-target
-                    $('.not-toggled-optional-fields').insertBefore(
+                    $('.exposed-optional-fields').insertBefore(
                         $('.honor_tos_combined').parent()
                     );
 

--- a/openedx/core/djangoapps/user_api/helpers.py
+++ b/openedx/core/djangoapps/user_api/helpers.py
@@ -135,7 +135,7 @@ class FormDescription:
 
     def add_field(
             self, name, label="", field_type="text", default="",
-            placeholder="", instructions="", required=True, restrictions=None,
+            placeholder="", instructions="", toggled=None, required=True, restrictions=None,
             options=None, include_default_option=False, error_messages=None,
             supplementalLink="", supplementalText=""
     ):
@@ -158,6 +158,10 @@ class FormDescription:
 
             instructions (unicode): Short instructions for using the field
                 (e.g. "This is the email address you used when you registered.")
+
+            toggled (boolean): Whether the field is optional and conditionally shown.
+                In case the field is not set, the field will be treated as toggled
+                if not set to required.
 
             required (boolean): Whether the field is required or optional.
 
@@ -202,6 +206,7 @@ class FormDescription:
             "defaultValue": default,
             "placeholder": placeholder,
             "instructions": instructions,
+            "toggled": toggled if toggled is not None else not required,
             "required": required,
             "restrictions": {},
             "errorMessages": {},
@@ -268,6 +273,7 @@ class FormDescription:
                     "label": "Cheese or Wine?",
                     "defaultValue": "cheese",
                     "type": "select",
+                    "toggled": False,
                     "required": True,
                     "placeholder": "",
                     "instructions": "",
@@ -283,6 +289,7 @@ class FormDescription:
                     "label": "comments",
                     "defaultValue": "",
                     "type": "text",
+                    "toggled": True,
                     "required": False,
                     "placeholder": "Any comments?",
                     "instructions": "Please enter additional comments here."

--- a/openedx/core/djangoapps/user_api/helpers.py
+++ b/openedx/core/djangoapps/user_api/helpers.py
@@ -159,9 +159,8 @@ class FormDescription:
             instructions (unicode): Short instructions for using the field
                 (e.g. "This is the email address you used when you registered.")
 
-            exposed (boolean): Whether the field is optional and conditionally shown.
-                In case the field is not set, the field will be treated as toggled
-                if not set to required.
+            exposed (boolean): Whether the field is shown if not required.
+                If the field is not set, the field will be visible if it's required.
 
             required (boolean): Whether the field is required or optional.
 
@@ -198,6 +197,9 @@ class FormDescription:
                 allowed=", ".join(self.ALLOWED_TYPES)
             )
             raise InvalidFieldError(msg)
+
+        if exposed is None:
+            exposed = required
 
         field_dict = {
             "name": name,

--- a/openedx/core/djangoapps/user_api/helpers.py
+++ b/openedx/core/djangoapps/user_api/helpers.py
@@ -135,7 +135,7 @@ class FormDescription:
 
     def add_field(
             self, name, label="", field_type="text", default="",
-            placeholder="", instructions="", toggled=None, required=True, restrictions=None,
+            placeholder="", instructions="", exposed=None, required=True, restrictions=None,
             options=None, include_default_option=False, error_messages=None,
             supplementalLink="", supplementalText=""
     ):
@@ -159,7 +159,7 @@ class FormDescription:
             instructions (unicode): Short instructions for using the field
                 (e.g. "This is the email address you used when you registered.")
 
-            toggled (boolean): Whether the field is optional and conditionally shown.
+            exposed (boolean): Whether the field is optional and conditionally shown.
                 In case the field is not set, the field will be treated as toggled
                 if not set to required.
 
@@ -206,7 +206,7 @@ class FormDescription:
             "defaultValue": default,
             "placeholder": placeholder,
             "instructions": instructions,
-            "toggled": toggled if toggled is not None else not required,
+            "exposed": exposed,
             "required": required,
             "restrictions": {},
             "errorMessages": {},
@@ -273,7 +273,7 @@ class FormDescription:
                     "label": "Cheese or Wine?",
                     "defaultValue": "cheese",
                     "type": "select",
-                    "toggled": False,
+                    "exposed": True,
                     "required": True,
                     "placeholder": "",
                     "instructions": "",
@@ -289,7 +289,7 @@ class FormDescription:
                     "label": "comments",
                     "defaultValue": "",
                     "type": "text",
-                    "toggled": True,
+                    "exposed": False,
                     "required": False,
                     "placeholder": "Any comments?",
                     "instructions": "Please enter additional comments here."

--- a/openedx/core/djangoapps/user_api/tests/test_helpers.py
+++ b/openedx/core/djangoapps/user_api/tests/test_helpers.py
@@ -95,6 +95,7 @@ class FormDescriptionTest(TestCase):
             placeholder="placeholder",
             instructions="instructions",
             required=True,
+            toggled=False,
             restrictions={
                 "min_length": 2,
                 "max_length": 10
@@ -110,8 +111,8 @@ class FormDescriptionTest(TestCase):
                json.dumps({'method': 'post',
                            'submit_url': '/submit',
                            'fields': [{'name': 'name', 'label': 'label', 'type': 'text', 'defaultValue': 'default',
-                                       'placeholder': 'placeholder', 'instructions': 'instructions', 'required': True,
-                                       'restrictions': {'min_length': 2, 'max_length': 10},
+                                       'placeholder': 'placeholder', 'instructions': 'instructions', 'toggled': False,
+                                       'required': True, 'restrictions': {'min_length': 2, 'max_length': 10},
                                        'errorMessages': {'required': 'You must provide a value!'},
                                        'supplementalLink': '', 'supplementalText': '',
                                        'loginIssueSupportLink': 'https://support.example.com/login-issue-help.html'}]})

--- a/openedx/core/djangoapps/user_api/tests/test_helpers.py
+++ b/openedx/core/djangoapps/user_api/tests/test_helpers.py
@@ -95,7 +95,7 @@ class FormDescriptionTest(TestCase):
             placeholder="placeholder",
             instructions="instructions",
             required=True,
-            toggled=False,
+            exposed=True,
             restrictions={
                 "min_length": 2,
                 "max_length": 10
@@ -111,7 +111,7 @@ class FormDescriptionTest(TestCase):
                json.dumps({'method': 'post',
                            'submit_url': '/submit',
                            'fields': [{'name': 'name', 'label': 'label', 'type': 'text', 'defaultValue': 'default',
-                                       'placeholder': 'placeholder', 'instructions': 'instructions', 'toggled': False,
+                                       'placeholder': 'placeholder', 'instructions': 'instructions', 'exposed': True,
                                        'required': True, 'restrictions': {'min_length': 2, 'max_length': 10},
                                        'errorMessages': {'required': 'You must provide a value!'},
                                        'supplementalLink': '', 'supplementalText': '',

--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -328,11 +328,15 @@ class RegistrationFormFactory:
 
     def _is_field_visible(self, field_name):
         """Check whether a field is visible based on Django settings. """
-        return self._extra_fields_setting.get(field_name) in ["required", "optional"]
+        return self._extra_fields_setting.get(field_name) in ["required", "optional", "optional-not-toggled"]
 
     def _is_field_required(self, field_name):
         """Check whether a field is required based on Django settings. """
         return self._extra_fields_setting.get(field_name) == "required"
+
+    def _is_field_toggled(self, field_name):
+        """Check whether a field is optional and should be toggled. """
+        return self._extra_fields_setting.get(field_name) == "optional"
 
     def __init__(self):
 
@@ -441,6 +445,7 @@ class RegistrationFormFactory:
                                     FormDescription.FIELD_TYPE_MAP.get(field.__class__)),
                                 placeholder=field.initial,
                                 instructions=field.help_text,
+                                toggled=self._is_field_toggled(field_name),
                                 required=(self._is_field_required(field_name) or field.required),
                                 restrictions=restrictions,
                                 options=getattr(field, 'choices', None), error_messages=field.error_messages,

--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -328,15 +328,15 @@ class RegistrationFormFactory:
 
     def _is_field_visible(self, field_name):
         """Check whether a field is visible based on Django settings. """
-        return self._extra_fields_setting.get(field_name) in ["required", "optional", "optional-not-toggled"]
+        return self._extra_fields_setting.get(field_name) in ["required", "optional", "optional-exposed"]
 
     def _is_field_required(self, field_name):
         """Check whether a field is required based on Django settings. """
         return self._extra_fields_setting.get(field_name) == "required"
 
-    def _is_field_toggled(self, field_name):
+    def _is_field_exposed(self, field_name):
         """Check whether a field is optional and should be toggled. """
-        return self._extra_fields_setting.get(field_name) == "optional"
+        return self._extra_fields_setting.get(field_name) in ["required", "optional-exposed"]
 
     def __init__(self):
 
@@ -445,7 +445,7 @@ class RegistrationFormFactory:
                                     FormDescription.FIELD_TYPE_MAP.get(field.__class__)),
                                 placeholder=field.initial,
                                 instructions=field.help_text,
-                                toggled=self._is_field_toggled(field_name),
+                                exposed=self._is_field_exposed(field_name),
                                 required=(self._is_field_required(field_name) or field.required),
                                 restrictions=restrictions,
                                 options=getattr(field, 'choices', None), error_messages=field.error_messages,

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -1020,7 +1020,7 @@ class LoginSessionViewTest(ApiTestCase, OpenEdxEventsTestMixin):
         form_desc = json.loads(response.content.decode('utf-8'))
         assert form_desc['method'] == 'post'
         assert form_desc['submit_url'] == reverse('user_api_login_session', kwargs={'api_version': 'v1'})
-        assert form_desc['fields'] == [{'name': 'email', 'defaultValue': '', 'type': 'email', 'toggled': False,
+        assert form_desc['fields'] == [{'name': 'email', 'defaultValue': '', 'type': 'email', 'exposed': True,
                                         'required': True, 'label': 'Email', 'placeholder': '',
                                         'instructions': 'The email address you used to register with {platform_name}'
                                         .format(platform_name=settings.PLATFORM_NAME),
@@ -1033,7 +1033,7 @@ class LoginSessionViewTest(ApiTestCase, OpenEdxEventsTestMixin):
                                        {'name': 'password',
                                         'defaultValue': '',
                                         'type': 'password',
-                                        'toggled': False,
+                                        'exposed': True,
                                         'required': True,
                                         'label': 'Password',
                                         'placeholder': '',

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -1020,8 +1020,8 @@ class LoginSessionViewTest(ApiTestCase, OpenEdxEventsTestMixin):
         form_desc = json.loads(response.content.decode('utf-8'))
         assert form_desc['method'] == 'post'
         assert form_desc['submit_url'] == reverse('user_api_login_session', kwargs={'api_version': 'v1'})
-        assert form_desc['fields'] == [{'name': 'email', 'defaultValue': '', 'type': 'email', 'required': True,
-                                        'label': 'Email', 'placeholder': '',
+        assert form_desc['fields'] == [{'name': 'email', 'defaultValue': '', 'type': 'email', 'toggled': False,
+                                        'required': True, 'label': 'Email', 'placeholder': '',
                                         'instructions': 'The email address you used to register with {platform_name}'
                                         .format(platform_name=settings.PLATFORM_NAME),
                                         'restrictions': {'min_length': EMAIL_MIN_LENGTH,
@@ -1033,6 +1033,7 @@ class LoginSessionViewTest(ApiTestCase, OpenEdxEventsTestMixin):
                                        {'name': 'password',
                                         'defaultValue': '',
                                         'type': 'password',
+                                        'toggled': False,
                                         'required': True,
                                         'label': 'Password',
                                         'placeholder': '',

--- a/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
@@ -710,7 +710,7 @@ class PasswordResetViewTest(UserAPITestCase):
         assert form_desc['method'] == 'post'
         assert form_desc['submit_url'] == reverse('password_change_request')
         assert form_desc['fields'] ==\
-               [{'name': 'email', 'defaultValue': '', 'type': 'email', 'toggled': False,
+               [{'name': 'email', 'defaultValue': '', 'type': 'email', 'exposed': True,
                  'required': True, 'label': 'Email', 'placeholder': 'username@domain.com',
                  'instructions': 'The email address you used to register with {platform_name}'
                 .format(platform_name=settings.PLATFORM_NAME),

--- a/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
@@ -710,8 +710,8 @@ class PasswordResetViewTest(UserAPITestCase):
         assert form_desc['method'] == 'post'
         assert form_desc['submit_url'] == reverse('password_change_request')
         assert form_desc['fields'] ==\
-               [{'name': 'email', 'defaultValue': '', 'type': 'email', 'required': True,
-                 'label': 'Email', 'placeholder': 'username@domain.com',
+               [{'name': 'email', 'defaultValue': '', 'type': 'email', 'toggled': False,
+                 'required': True, 'label': 'Email', 'placeholder': 'username@domain.com',
                  'instructions': 'The email address you used to register with {platform_name}'
                 .format(platform_name=settings.PLATFORM_NAME),
                  'restrictions': {'min_length': EMAIL_MIN_LENGTH,


### PR DESCRIPTION
## Description

This pull request adds capabilities to define optional but not toggled fields through custom registration forms.

## Supporting information

As part of previous PRs, the field ordering of custom registration form apps was fixed, though this does not mean that the optional fields can be moved out from the toggled/initially hidden optional fields.

**Before**
![Screenshot 2021-10-18 at 09-01-16 Sign in or Register Your Platform Name Here](https://user-images.githubusercontent.com/19173947/137685746-c9a7422c-34dd-4d7b-86ec-eac3da99e278.png)

**After**
![Screenshot 2021-10-18 at 09-08-28 Sign in or Register Your Platform Name Here](https://user-images.githubusercontent.com/19173947/137685755-ac899be4-c296-4ebf-b85f-e8db6899a441.png)


## Testing instructions

1. Navigate to [the sandbox](https://pr29047.sandbox.opencraft.hosting)
2. Click on "register"
3. Validate the **optional** "I hereby confirm receiving updates on new courses, content and new learning initiatives (optional)" checkbox appears right below the password field 

**Example config**

```yaml
REGISTRATION_EXTENSION_FORM: custom_reg_form.forms.ExtraInfoForm
REGISTRATION_EXTRA_FIELDS:
  gender: optional
  year_of_birth: optional
  level_of_education: optional
  goals: optional
  allow_marketing_emails: optional
REGISTRATION_FIELD_ORDER:
  - name
  - username
  - email
  - password
  - country
  - allow_marketing_emails
  - gender
  - year_of_birth
  - level_of_education
  - goals
```

## Deadline

None

## Other information

The naming of the optional fields that are not toggled may not the best, so I'm opened to any naming suggestions.