### PR TITLE
fix: update course URL match pattern to also match learning MFE [BD-38] [TNL-8820] 

### DIFF
--- a/openedx/core/lib/request_utils.py
+++ b/openedx/core/lib/request_utils.py
@@ -18,7 +18,7 @@ from rest_framework.views import exception_handler
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 # accommodates course api urls, excluding any course api routes that do not fall under v*/courses, such as v1/blocks.
-COURSE_REGEX = re.compile(fr'^(.*?/courses/)(?!v[0-9]+/[^/]+){settings.COURSE_ID_PATTERN}')
+COURSE_REGEX = re.compile(fr'^(.*?/course(s)?/)(?!v[0-9]+/[^/]+){settings.COURSE_ID_PATTERN}')
 
 # .. toggle_name: request_utils.capture_cookie_sizes
 # .. toggle_implementation: WaffleFlag

--- a/openedx/core/lib/tests/test_request_utils.py
+++ b/openedx/core/lib/tests/test_request_utils.py
@@ -73,7 +73,6 @@ class RequestUtilTestCase(unittest.TestCase):
         """ Test course_id_from_url(). """
 
         assert course_id_from_url('/login') is None
-        assert course_id_from_url('/course/edX/maths/2020') is None
         assert course_id_from_url('/courses/edX/maths/') is None
         assert course_id_from_url('/api/courses/v1/blocks/edX/maths/2020') is None
         assert course_id_from_url('/api/courses/v1/blocks/course-v1:incidental+courseid+formatting') is None
@@ -82,8 +81,14 @@ class RequestUtilTestCase(unittest.TestCase):
         course_id = course_id_from_url('/courses/course-v1:edX+maths+2020')
         self.assertCourseIdFieldsMatch(course_id=course_id, org="edX", course='maths', run='2020')
 
+        course_id = course_id_from_url('/course/course-v1:edX+maths+2020')
+        self.assertCourseIdFieldsMatch(course_id=course_id, org="edX", course='maths', run='2020')
+
         course_id = course_id_from_url('/courses/edX/maths/2020')
         self.assertCourseIdFieldsMatch(course_id=course_id, org='edX', course='maths', run='2020')
+
+        course_id = course_id_from_url('/course/edX/maths/2020')
+        self.assertCourseIdFieldsMatch(course_id=course_id, org="edX", course='maths', run='2020')
 
         course_id = course_id_from_url('/api/courses/v1/courses/course-v1:edX+maths+2020')
         self.assertCourseIdFieldsMatch(course_id=course_id, org='edX', course='maths', run='2020')


### PR DESCRIPTION
## Description

The learning MFE paths include /course/{course_id} which doesn't match /courses/{course_id} which is what the regex expects. This causes issues with the Wiki  when accessed from the learning MFE doesn't detect that course it's related to in the middleware.

## Supporting information

[TNL-8820](https://openedx.atlassian.net/browse/TNL-8820)

## Testing instructions

- Click on the wiki tab in the learning MFE **without** this PR. The wiki page will load without any visible course UI such as course tabs etc. 
- Click on the wiki tab in the learning MFE **with** this PR. The wiki page will load normally, the way it would if you'd lick the wiki tab on the legacy experience. 


## Deadline

"None" 
