### PR TITLE
chore: update edx-proctoring version

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -461,7 +461,7 @@ edx-opaque-keys[django]==2.2.2
     #   xmodule
 edx-organizations==6.10.0
     # via -r requirements/edx/base.in
-edx-proctoring==4.1.2
+edx-proctoring==4.1.3
     # via
     #   -r requirements/edx/base.in
     #   edx-proctoring-proctortrack

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -570,7 +570,7 @@ edx-opaque-keys[django]==2.2.2
     #   xmodule
 edx-organizations==6.10.0
     # via -r requirements/edx/testing.txt
-edx-proctoring==4.1.2
+edx-proctoring==4.1.3
     # via
     #   -r requirements/edx/testing.txt
     #   edx-proctoring-proctortrack

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -553,7 +553,7 @@ edx-opaque-keys[django]==2.2.2
     #   xmodule
 edx-organizations==6.10.0
     # via -r requirements/edx/base.txt
-edx-proctoring==4.1.2
+edx-proctoring==4.1.3
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring-proctortrack


### PR DESCRIPTION
Bump edx-proctoring to latest release. This version contains a fix that allows any status update to a practice exam to trigger updates for grades, credit, and certificates.

@edx/masters-devs-cosmonauts 