### PR TITLE
fix: User unretirement django admin template should use static instead of admin_static template library

### DIFF
--- a/lms/templates/admin/user_api/accounts/cancel_retirement_action.html
+++ b/lms/templates/admin/user_api/accounts/cancel_retirement_action.html
@@ -1,5 +1,5 @@
 {% extends "admin/change_form.html" %}
-{% load i18n admin_static admin_modify %}
+{% load i18n static admin_modify %}
 
 {% block content %}
 


### PR DESCRIPTION
## Description

[TNL-8884](https://openedx.atlassian.net/browse/TNL-8884). This change would fix the issue where the undeleting a user results in 500



