### PR TITLE
Exempt multiple safe session user mismatches

### DIFF
--- a/openedx/core/djangoapps/auth_exchange/views.py
+++ b/openedx/core/djangoapps/auth_exchange/views.py
@@ -23,6 +23,7 @@ from rest_framework.views import APIView
 from openedx.core.djangoapps.auth_exchange.forms import AccessTokenExchangeForm
 from openedx.core.djangoapps.oauth_dispatch import adapters
 from openedx.core.djangoapps.oauth_dispatch.api import create_dot_access_token
+from openedx.core.djangoapps.safe_sessions.middleware import mark_user_change_as_expected
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 
 
@@ -151,4 +152,6 @@ class LoginWithAccessTokenView(APIView):
             })
 
         login(request, request.user)  # login generates and stores the user's cookies in the session
-        return HttpResponse(status=204)  # cookies stored in the session are returned with the response
+        response = HttpResponse(status=204)  # cookies stored in the session are returned with the response
+        mark_user_change_as_expected(response, request.user.id)
+        return response

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -39,6 +39,7 @@ from common.djangoapps import third_party_auth
 from common.djangoapps.student.helpers import get_next_url_for_login_page, get_redirect_url_with_host
 from lms.djangoapps.discussion.notification_prefs.views import enable_notifications
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
+from openedx.core.djangoapps.safe_sessions.middleware import mark_user_change_as_expected
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_api import accounts as accounts_settings
 from openedx.core.djangoapps.user_api.accounts.api import (
@@ -586,6 +587,7 @@ class RegistrationView(APIView):
                 path='/',
                 secure=request.is_secure()
             )  # setting the cookie to show account activation dialogue in platform and learning MFE
+        mark_user_change_as_expected(response, user.id)
         return response
 
     def _handle_duplicate_email_username(self, request, data):


### PR DESCRIPTION
## Description

Mark two user changes as expected so it doesn't trigger our Safe Session validation.
1. Register
2. Access Token Login

## Supporting information

https://openedx.atlassian.net/browse/ARCHBOM-1813