### PR TITLE
test: don't run xss-commit-linter post-merge

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         fetch-depth: 2
 
-    - name: Fetch master for comparison
+    - name: Fetch base branch for comparison
       run: git fetch --depth=1 origin ${{ github.base_ref }}
 
     - name: Install Required System Packages

--- a/pavelib/quality.py
+++ b/pavelib/quality.py
@@ -518,7 +518,7 @@ def run_xsscommitlint():
     _prepare_report_dir(xsscommitlint_report_dir)
 
     sh(
-        "{repo_root}/scripts/{xsscommitlint_script} | tee {xsscommitlint_report}".format(
+        "{repo_root}/scripts/{xsscommitlint_script} -v | tee {xsscommitlint_report}".format(
             repo_root=Env.REPO_ROOT,
             xsscommitlint_script=xsscommitlint_script,
             xsscommitlint_report=xsscommitlint_report,

--- a/scripts/generic-ci-tests.sh
+++ b/scripts/generic-ci-tests.sh
@@ -134,8 +134,12 @@ case "$TEST_SUITE" in
                 run_paver_quality run_stylelint -l $STYLELINT_THRESHOLD || { EXIT=1; }
                 echo "Running xss linter report."
                 run_paver_quality run_xsslint -t $XSSLINT_THRESHOLDS || { EXIT=1; }
-                echo "Running safe commit linter report."
-                run_paver_quality run_xsscommitlint || { EXIT=1; }
+                if [[ ! -z "$TARGET_BRANCH" ]]; then
+                    echo "Running safe commit linter report."
+                    run_paver_quality run_xsscommitlint || { EXIT=1; }
+                else
+                    echo "Skipping safe commit linter report."
+                fi
                 echo "Running PII checker on all Django models..."
                 run_paver_quality run_pii_check || { EXIT=1; }
                 echo "Running reserved keyword checker on all Django models..."

--- a/scripts/xss-commit-linter.sh
+++ b/scripts/xss-commit-linter.sh
@@ -48,7 +48,7 @@ for i in "$@"; do
             shift # past argument=value
             ;;
         -v|--verbose)
-            VERBOSE=true
+            show_verbose
             ;;
         -h|--help|*)
             # help or unknown option
@@ -85,9 +85,6 @@ if [ "$diff_files" = "" ]; then
     echo ""
     echo "No files linted."
 else
-    if [ ${VERBOSE} ] ; then
-        show_verbose
-    fi
     for f in $diff_files; do
         echo ""
         echo "Linting $f:"


### PR DESCRIPTION
<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

The xss-commit-linter quality step was running after a merge, but it would fail: it's designed to check the commits in a pull request, and post-merge, it couldn't find the commits to check because there was no target branch.  But there's no need to run it post-merge anyway, so skip it in that case.
