### PR TITLE
Staff Grader initialize tests

### DIFF
--- a/lms/djangoapps/ora_staff_grader/serializers.py
+++ b/lms/djangoapps/ora_staff_grader/serializers.py
@@ -46,13 +46,58 @@ class OpenResponseMetadataSerializer(serializers.Serializer):  # pylint: disable
         ]
 
 
+class ScoreSerializer(serializers.Serializer):  # pylint: disable=abstract-method
+    """
+    Score (points earned/possible) for use in SubmissionMetadataSerializer
+    """
+    pointsEarned = serializers.IntegerField(default=0)
+    pointsPossible = serializers.IntegerField(default=0)
+
+    class Meta:
+        fields = ['pointsEarned', 'pointsPossible']
+
+    def to_representation(self, instance):
+        """ An empty dict should return None instead """
+        if ('pointsEarned' not in instance) and ('pointsPossible' not in instance):
+            return None
+        return super().to_representation(instance)
+
+
+class SubmissionMetadataSerializer(serializers.Serializer):  # pylint: disable=abstract-method
+    """
+    Submission metadata for displaying submissions table in ESG
+    """
+    submissionUuid = serializers.CharField()
+    username = serializers.CharField(allow_null=True)
+    teamName = serializers.CharField(allow_null=True)
+    dateSubmitted = serializers.DateTimeField()
+    dateGraded = serializers.DateTimeField(allow_null=True)
+    gradedBy = serializers.CharField(allow_null=True)
+    gradingStatus = serializers.CharField()
+    lockStatus = serializers.CharField()
+    score = ScoreSerializer(allow_null=True)
+
+    class Meta:
+        fields = [
+            'submissionUuid',
+            'username',
+            'teamName',
+            'dateSubmitted',
+            'dateGraded',
+            'gradedBy',
+            'gradingStatus',
+            'lockStatus',
+            'score'
+        ]
+
+
 class InitializeSerializer(serializers.Serializer):
     """
     Serialize info for the initialize call. Packages ORA, course, submission, and rubric data.
     """
     courseMetadata = CourseMetadataSerializer()
     oraMetadata = OpenResponseMetadataSerializer()
-    submissions = serializers.DictField()
+    submissions = serializers.DictField(child=SubmissionMetadataSerializer())
     rubricConfig = serializers.DictField()
 
     class Meta:
@@ -62,30 +107,3 @@ class InitializeSerializer(serializers.Serializer):
             'submissions',
             'rubricConfig',
         ]
-
-    @staticmethod
-    def transform_submission(submission):
-        """ Basic data transforms for submissions """
-
-        # Add teamName if omitted, this is allowed for individual responses
-        if 'teamName' not in submission:
-            submission['teamName'] = None
-
-        # Add username if omitted, this is allowed for team responses
-        if 'username' not in submission:
-            submission['username'] = None
-
-        # An empty score dict should be transformed to None
-        if not submission['score']:
-            submission['score'] = None
-
-        return submission
-
-    def to_representation(self, instance):
-        representation = super().to_representation(instance)
-
-        # Some basic transforms/cleanup for Submissions
-        for (submission_id, submission) in representation['submissions'].items():
-            representation['submissions'][submission_id] = self.transform_submission(submission)
-
-        return representation

--- a/lms/djangoapps/ora_staff_grader/serializers.py
+++ b/lms/djangoapps/ora_staff_grader/serializers.py
@@ -48,11 +48,17 @@ class ScoreSerializer(serializers.Serializer):  # pylint: disable=abstract-metho
     """
     Score (points earned/possible) for use in SubmissionMetadataSerializer
     """
-    pointsEarned = serializers.IntegerField()
-    pointsPossible = serializers.IntegerField()
+    pointsEarned = serializers.IntegerField(default=0)
+    pointsPossible = serializers.IntegerField(default=0)
 
     class Meta:
         fields = ['pointsEarned', 'pointsPossible']
+
+    def to_representation(self, instance):
+        """ An empty dict should return None instead """
+        if ('pointsEarned' not in instance) and ('pointsPossible' not in instance):
+            return None
+        return super().to_representation(instance)
 
 
 class SubmissionMetadataSerializer(serializers.Serializer):  # pylint: disable=abstract-method

--- a/lms/djangoapps/ora_staff_grader/serializers.py
+++ b/lms/djangoapps/ora_staff_grader/serializers.py
@@ -1,6 +1,8 @@
 """
 Serializers for Enhanced Staff Grader (ESG)
 """
+# pylint: disable=abstract-method
+
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from rest_framework import serializers
 

--- a/lms/djangoapps/ora_staff_grader/serializers.py
+++ b/lms/djangoapps/ora_staff_grader/serializers.py
@@ -45,6 +45,9 @@ class OpenResponseMetadataSerializer(serializers.Serializer):  # pylint: disable
 
 
 class InitializeSerializer(serializers.Serializer):
+    """
+    Serialize info for the initialize call. Packages ORA, course, submission, and rubric data.
+    """
     courseMetadata = CourseMetadataSerializer()
     oraMetadata = OpenResponseMetadataSerializer()
     submissions = serializers.DictField()

--- a/lms/djangoapps/ora_staff_grader/serializers.py
+++ b/lms/djangoapps/ora_staff_grader/serializers.py
@@ -66,14 +66,14 @@ class SubmissionMetadataSerializer(serializers.Serializer):  # pylint: disable=a
     Submission metadata for displaying submissions table in ESG
     """
     submissionUuid = serializers.CharField()
-    username = serializers.CharField()
-    teamName = serializers.CharField()
+    username = serializers.CharField(allow_null=True)
+    teamName = serializers.CharField(allow_null=True)
     dateSubmitted = serializers.DateTimeField()
-    dateGraded = serializers.DateTimeField()
-    gradedBy = serializers.CharField()
+    dateGraded = serializers.DateTimeField(allow_null=True)
+    gradedBy = serializers.CharField(allow_null=True)
     gradingStatus = serializers.CharField()
     lockStatus = serializers.CharField()
-    score = ScoreSerializer()
+    score = ScoreSerializer(allow_null=True)
 
     class Meta:
         fields = [

--- a/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
@@ -1,8 +1,10 @@
 """
 Tests for ESG Serializers
 """
-from lms.djangoapps.ora_staff_grader.serializers import CourseMetadataSerializer
-from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from django.test import TestCase
+from unittest.mock import Mock
+
+from lms.djangoapps.ora_staff_grader.serializers import CourseMetadataSerializer, OpenResponseMetadataSerializer
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 
@@ -33,4 +35,42 @@ class TestCourseMetadataSerializer(SharedModuleStoreTestCase):
             "org": self.course_org,
             "number": self.course_number,
             "courseId": self.course_id,
+        }
+
+
+class TestOpenResponseMetadataSerializer(TestCase):
+    """
+    Tests for OpenResponseMetadataSerializer
+    """
+    display_name = "Week 1: Time Travel Paradoxes"
+    prompts = ["<p>In your own words, explain a famous time travel paradox</p>"]
+    teams_enabled = False
+
+    mock_ora_instance = None
+
+    def setUp(self):
+        self.mock_ora_instance = Mock(name='openassessment-block')
+        self.mock_ora_instance.display_name = self.display_name
+        self.mock_ora_instance.prompts = self.prompts
+        self.mock_ora_instance.teams_enabled = self.teams_enabled
+
+    def test_individual_ora(self):
+        # An ORA with teams disabled should have type "individual"
+        data = OpenResponseMetadataSerializer(self.mock_ora_instance).data
+
+        assert data == {
+            "name": self.display_name,
+            "prompts": self.prompts,
+            "type": "individual"
+        }
+
+    def test_team_ora(self):
+        # An ORA with teams enabled should have type "team"
+        self.mock_ora_instance.teams_enabled = True
+        data = OpenResponseMetadataSerializer(self.mock_ora_instance).data
+
+        assert data == {
+            "name": self.display_name,
+            "prompts": self.prompts,
+            "type": "team"
         }

--- a/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
@@ -1,0 +1,36 @@
+"""
+Tests for ESG Serializers
+"""
+from lms.djangoapps.ora_staff_grader.serializers import CourseMetadataSerializer
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
+
+
+class TestCourseMetadataSerializer(SharedModuleStoreTestCase):
+    """
+    Tests for CourseMetadataSerializer
+    """
+    course_org = "Oxford"
+    course_name = "Introduction to Time Travel"
+    course_number = "TT101"
+    course_run = "2054"
+    course_id = "course-v1:Oxford+TT101+2054"
+
+    def setUp(self):
+        self.course_overview = CourseOverviewFactory.create(
+            org=self.course_org,
+            display_name=self.course_name,
+            display_number_with_default=self.course_number,
+            run=self.course_run,
+        )
+
+    def test_course_serialize(self):
+        data = CourseMetadataSerializer(self.course_overview).data
+
+        assert data == {
+            "title": self.course_name,
+            "org": self.course_org,
+            "number": self.course_number,
+            "courseId": self.course_id,
+        }

--- a/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
@@ -144,6 +144,7 @@ class TestSubmissionMetadataSerializer(TestCase):
             }
         }
     }
+
     def test_submission_serialize(self):
         for submission_id, submission_data in self.submission_data.items():
             data = SubmissionMetadataSerializer(submission_data).data
@@ -155,7 +156,7 @@ class TestSubmissionMetadataSerializer(TestCase):
         """
         An empty score dict should be serialized as None
         """
-        submission =  {
+        submission = {
             "submissionUuid": "empty-score",
             "username": "WOPR",
             "dateSubmitted": "1983-06-03 00:00:00",
@@ -166,7 +167,7 @@ class TestSubmissionMetadataSerializer(TestCase):
             "score": {}
         }
 
-        expected_output =  {
+        expected_output = {
             "submissionUuid": "empty-score",
             "username": "WOPR",
             "teamName": None,

--- a/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
@@ -17,29 +17,27 @@ class TestCourseMetadataSerializer(SharedModuleStoreTestCase):
     """
     Tests for CourseMetadataSerializer
     """
-    course_org = "Oxford"
-    course_name = "Introduction to Time Travel"
-    course_number = "TT101"
-    course_run = "2054"
+    course_data = {
+        "org": "Oxford",
+        "display_name": "Introduction to Time Travel",
+        "display_number_with_default": "TT101",
+        "run": "2054",
+    }
+
     course_id = "course-v1:Oxford+TT101+2054"
 
     def setUp(self):
         super().setUp()
 
-        self.course_overview = CourseOverviewFactory.create(
-            org=self.course_org,
-            display_name=self.course_name,
-            display_number_with_default=self.course_number,
-            run=self.course_run,
-        )
+        self.course_overview = CourseOverviewFactory.create(**self.course_data)
 
     def test_course_serialize(self):
         data = CourseMetadataSerializer(self.course_overview).data
 
         assert data == {
-            "title": self.course_name,
-            "org": self.course_org,
-            "number": self.course_number,
+            "title": self.course_data["display_name"],
+            "org": self.course_data["org"],
+            "number": self.course_data["display_number_with_default"],
             "courseId": self.course_id,
         }
 
@@ -48,28 +46,25 @@ class TestOpenResponseMetadataSerializer(TestCase):
     """
     Tests for OpenResponseMetadataSerializer
     """
-    display_name = "Week 1: Time Travel Paradoxes"
-    prompts = ["<p>In your own words, explain a famous time travel paradox</p>"]
-    teams_enabled = False
-
-    mock_ora_instance = None
+    ora_data = {
+        "display_name": "Week 1: Time Travel Paradoxes",
+        "prompts": ["<p>In your own words, explain a famous time travel paradox</p>"],
+        "teams_enabled": False
+    }
 
     def setUp(self):
         super().setUp()
 
-        self.mock_ora_instance = Mock(name='openassessment-block')
-        self.mock_ora_instance.display_name = self.display_name
-        self.mock_ora_instance.prompts = self.prompts
-        self.mock_ora_instance.teams_enabled = self.teams_enabled
+        self.mock_ora_instance = Mock(name='openassessment-block', **self.ora_data)
 
     def test_individual_ora(self):
         # An ORA with teams disabled should have type "individual"
         data = OpenResponseMetadataSerializer(self.mock_ora_instance).data
 
         assert data == {
-            "name": self.display_name,
-            "prompts": self.prompts,
-            "type": "individual"
+            "name": self.ora_data['display_name'],
+            "prompts": self.ora_data['prompts'],
+            "type": "individual",
         }
 
     def test_team_ora(self):
@@ -78,9 +73,9 @@ class TestOpenResponseMetadataSerializer(TestCase):
         data = OpenResponseMetadataSerializer(self.mock_ora_instance).data
 
         assert data == {
-            "name": self.display_name,
-            "prompts": self.prompts,
-            "type": "team"
+            "name": self.ora_data['display_name'],
+            "prompts": self.ora_data['prompts'],
+            "type": "team",
         }
 
 

--- a/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
@@ -158,3 +158,34 @@ class TestSubmissionMetadataSerializer(TestCase):
 
             # For each submission, data is just passed through
             assert self.submission_data[submission_id] == data
+
+    def test_empty_score(self):
+        """
+        An empty score dict should be serialized as None
+        """
+        submission =  {
+            "submissionUuid": "empty-score",
+            "username": "WOPR",
+            "dateSubmitted": "1983-06-03 00:00:00",
+            "dateGraded": None,
+            "gradedBy": None,
+            "gradingStatus": "ungraded",
+            "lockStatus": "unlocked",
+            "score": {}
+        }
+
+        expected_output =  {
+            "submissionUuid": "empty-score",
+            "username": "WOPR",
+            "teamName": None,
+            "dateSubmitted": "1983-06-03 00:00:00",
+            "dateGraded": None,
+            "gradedBy": None,
+            "gradingStatus": "ungraded",
+            "lockStatus": "unlocked",
+            "score": None
+        }
+
+        data = SubmissionMetadataSerializer(submission).data
+
+        assert data == expected_output

--- a/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
@@ -24,6 +24,8 @@ class TestCourseMetadataSerializer(SharedModuleStoreTestCase):
     course_id = "course-v1:Oxford+TT101+2054"
 
     def setUp(self):
+        super().setUp()
+
         self.course_overview = CourseOverviewFactory.create(
             org=self.course_org,
             display_name=self.course_name,
@@ -53,6 +55,8 @@ class TestOpenResponseMetadataSerializer(TestCase):
     mock_ora_instance = None
 
     def setUp(self):
+        super().setUp()
+
         self.mock_ora_instance = Mock(name='openassessment-block')
         self.mock_ora_instance.display_name = self.display_name
         self.mock_ora_instance.prompts = self.prompts

--- a/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
@@ -108,13 +108,13 @@ class TestSubmissionMetadataSerializer(TestCase):
     Right now, this is just passed through without any transforms.
     """
     submission_data = {
-        "a": {
-            "submissionUuid": "a",
+        "ungraded": {
+            "submissionUuid": "ungraded",
             "username": "foo",
-            "teamName": "",
+            "teamName": None,
             "dateSubmitted": "1969-07-16 13:32:00",
-            "dateGraded": "None",
-            "gradedBy": "",
+            "dateGraded": None,
+            "gradedBy": None,
             "gradingStatus": "ungraded",
             "lockStatus": "unlocked",
             "score": {
@@ -122,24 +122,10 @@ class TestSubmissionMetadataSerializer(TestCase):
                 "pointsPossible": 10
             }
         },
-        "b": {
-            "submissionUuid": "b",
-            "username": "",
-            "teamName": "bar",
-            "dateSubmitted": "1969-07-20 20:17:40",
-            "dateGraded": "None",
-            "gradedBy": "",
-            "gradingStatus": "ungraded",
-            "lockStatus": "in-progress",
-            "score": {
-                "pointsEarned": 0,
-                "pointsPossible": 10
-            }
-        },
-        "c": {
-            "submissionUuid": "c",
+        "graded": {
+            "submissionUuid": "graded",
             "username": "baz",
-            "teamName": "",
+            "teamName": None,
             "dateSubmitted": "1969-07-21 21:35:00",
             "dateGraded": "1969-07-24 16:44:00",
             "gradedBy": "buz",
@@ -158,6 +144,44 @@ class TestSubmissionMetadataSerializer(TestCase):
 
             # For each submission, data is just passed through
             assert self.submission_data[submission_id] == data
+
+    def test_missing_team_name(self):
+        """
+        Individual submissions may have a missing or emtpy "teamName".
+        The field should be added to serialized output with null value.
+        """
+        submission =  {
+            "submissionUuid": "individual",
+            "username": "Buzz",
+            "dateSubmitted": "1969-07-21 21:35:00",
+            "dateGraded": "1969-07-24 16:44:00",
+            "gradedBy": "Houston",
+            "gradingStatus": "ungraded",
+            "lockStatus": "unlocked",
+            "score": {
+                "pointsEarned": 10,
+                "pointsPossible": 10
+            }
+        }
+
+        expected_output = {
+            "submissionUuid": "individual",
+            "username": "Buzz",
+            "teamName": None,
+            "dateSubmitted": "1969-07-21 21:35:00",
+            "dateGraded": "1969-07-24 16:44:00",
+            "gradedBy": "Houston",
+            "gradingStatus": "ungraded",
+            "lockStatus": "unlocked",
+            "score": {
+                "pointsEarned": 10,
+                "pointsPossible": 10
+            }
+        }
+
+        data = SubmissionMetadataSerializer(submission).data
+
+        assert data == expected_output
 
     def test_empty_score(self):
         """

--- a/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
@@ -148,7 +148,7 @@ class TestSubmissionMetadataSerializer(TestCase):
         Individual submissions may have a missing or emtpy "teamName".
         The field should be added to serialized output with null value.
         """
-        submission =  {
+        submission = {
             "submissionUuid": "individual",
             "username": "Buzz",
             "dateSubmitted": "1969-07-21 21:35:00",
@@ -185,7 +185,7 @@ class TestSubmissionMetadataSerializer(TestCase):
         """
         An empty score dict should be serialized as None
         """
-        submission =  {
+        submission = {
             "submissionUuid": "empty-score",
             "username": "WOPR",
             "dateSubmitted": "1983-06-03 00:00:00",
@@ -196,7 +196,7 @@ class TestSubmissionMetadataSerializer(TestCase):
             "score": {}
         }
 
-        expected_output =  {
+        expected_output = {
             "submissionUuid": "empty-score",
             "username": "WOPR",
             "teamName": None,

--- a/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
@@ -91,21 +91,19 @@ class TestSubmissionMetadataSerializer(TestCase):
     SubmissionMetadata comes from the ORA list_staff_workflows XBlock.json_handler and has the shape:
 
     "<submission_uuid>": {
-        "submissionUuid": "<submission_uuid>",
-        "username": "<username/empty>",
-        "teamName": "<team_name/empty>",
-        "dateSubmitted": "<yyyy-mm-dd HH:MM:SS>",
-        "dateGraded": "<yyyy-mm-dd HH:MM:SS/None>",
-        "gradedBy": "<username/empty>",
-        "gradingStatus": "<ungraded/graded>",
-        "lockStatus": "<locked/unlocked/in-progress",
-        "score": {
-            "pointsEarned": <num>,
-            "pointsPossible": <num>
+        "submissionUuid": uuid,
+        "username": string or None,
+        "teamName": string orNone,
+        "dateSubmitted": string(yyyy-mm-dd HH:MM:SS),
+        "dateGraded": string(yyyy-mm-dd HH:MM:SS) or None,
+        "gradedBy": string or None,
+        "gradingStatus": "ungraded" or "graded",
+        "lockStatus": "locked", "unlocked", or "in-progress",
+        "score": {} or {
+            "pointsEarned": int,
+            "pointsPossible": int,
         }
     }
-
-    Right now, this is just passed through without any transforms.
     """
     submission_data = {
         "ungraded": {

--- a/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
@@ -94,11 +94,11 @@ class TestInitializeSerializer(TestCase):
         return Mock(name='openassessment-block', **ora_data)
 
     def set_up_course_metadata(self):
+        """ Create mock course metadata for serialization """
         course_org = "Oxford"
         course_name = "Introduction to Time Travel"
         course_number = "TT101"
         course_run = "2054"
-        course_id = "course-v1:Oxford+TT101+2054"
 
         return CourseOverviewFactory.create(
             org=course_org,
@@ -134,19 +134,6 @@ class TestInitializeSerializer(TestCase):
 
         # Rubric data is passed through without transforms, we can create a toy response
         self.mock_rubric_data = {"foo": "bar"}
-
-    def test_serializer_shape(self):
-        """ Simplest test, is the structure correct? """
-        input_data = {
-            "courseMetadata": self.mock_course_metadata,
-            "oraMetadata": self.mock_ora_instance,
-            "submissions": self.mock_submissions_data,
-            "rubricConfig": self.mock_rubric_data,
-        }
-
-        output_data = InitializeSerializer(input_data).data
-
-        assert output_data.keys() == input_data.keys()
 
     def test_serializer_output(self):
         input_data = {

--- a/lms/djangoapps/ora_staff_grader/tests/test_views.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_views.py
@@ -1,0 +1,45 @@
+"""
+Tests for ESG views
+"""
+from django.urls import reverse
+from opaque_keys.edx.keys import CourseKey
+from rest_framework.test import APITestCase
+
+from common.djangoapps.student.tests.factories import StaffFactory
+from openedx.core.djangoapps.catalog.tests.factories import CourseFactory
+
+
+class TestInitializeView(APITestCase):
+    """
+    Tests for the /initialize view, creating setup data for ESG
+    """
+    view_name = 'ora-staff-grader:initialize'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.course_key_str = 'course-v1:Hogwarts+Potions101+S1'
+        cls.course_key = CourseKey.from_string(cls.course_key_str)
+        cls.course = CourseFactory(key=cls.course_key_str)
+
+        cls.password = 'password'
+        cls.staff = StaffFactory(course_key=cls.course_key, password=cls.password)
+
+    def log_in(self):
+        """ Log in as staff """
+        self.client.login(username=self.staff.username, password=self.password)
+
+    def api_url(self, ora_location):
+        """ Create the request URL for hitting /initialize """
+        kwargs = {}
+        if ora_location:
+            kwargs['ora_location'] = ora_location
+        return reverse(self.view_name, kwargs=kwargs)
+
+    def test_missing_ora_location(self):
+        """ Missing ora_location param should return 400 and error message """
+        self.client.login(username=self.staff.username, password=self.password)
+        response = self.client.get(self.api_url(None))
+
+        assert response.status_code == 400
+        assert response.content.decode() == "Query must contain an ora_location param."

--- a/lms/djangoapps/ora_staff_grader/tests/test_views.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_views.py
@@ -85,7 +85,7 @@ class TestInitializeView(SharedModuleStoreTestCase, APITestCase):
         }
 
         # Rubric data is passed through directly, so we can use a toy data payload
-        mock_get_rubric_config.return_value = { "foo": "bar" }
+        mock_get_rubric_config.return_value = {"foo": "bar"}
 
         self.client.login(username=self.staff.username, password=self.password)
         response = self.client.get(self.api_url, {'ora_location': self.ora_usage_key})

--- a/lms/djangoapps/ora_staff_grader/tests/test_views.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_views.py
@@ -2,7 +2,6 @@
 Tests for ESG views
 """
 from django.urls import reverse
-from opaque_keys.edx.keys import CourseKey
 from rest_framework.test import APITestCase
 from unittest.mock import patch
 

--- a/lms/djangoapps/ora_staff_grader/tests/test_views.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_views.py
@@ -4,24 +4,37 @@ Tests for ESG views
 from django.urls import reverse
 from opaque_keys.edx.keys import CourseKey
 from rest_framework.test import APITestCase
+from unittest.mock import patch
 
 from common.djangoapps.student.tests.factories import StaffFactory
-from openedx.core.djangoapps.catalog.tests.factories import CourseFactory
+from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
+from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, SharedModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
+from xmodule.modulestore.tests.factories import ItemFactory
 
 
-class TestInitializeView(APITestCase):
+class TestInitializeView(SharedModuleStoreTestCase, APITestCase):
     """
     Tests for the /initialize view, creating setup data for ESG
     """
     view_name = 'ora-staff-grader:initialize'
     api_url = reverse(view_name)
 
+    MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.course_key_str = 'course-v1:Hogwarts+Potions101+S1'
-        cls.course_key = CourseKey.from_string(cls.course_key_str)
-        cls.course = CourseFactory(key=cls.course_key_str)
+
+        cls.course = CourseFactory.create()
+        cls.course_key = cls.course.location.course_key
+
+        cls.ora_block = ItemFactory.create(
+            category='openassessment',
+            parent_location=cls.course.location,
+            display_name='test',
+        )
+        cls.ora_usage_key = str(cls.ora_block.location)
 
         cls.password = 'password'
         cls.staff = StaffFactory(course_key=cls.course_key, password=cls.password)
@@ -45,3 +58,38 @@ class TestInitializeView(APITestCase):
 
         assert response.status_code == 404
         assert response.content.decode() == "Invalid ora_location."
+
+    @patch('lms.djangoapps.ora_staff_grader.views.InitializeView.get_rubric_config')
+    @patch('lms.djangoapps.ora_staff_grader.views.InitializeView.get_submissions')
+    @patch('lms.djangoapps.ora_staff_grader.views.get_course_overview_or_none')
+    def test_init(self, mock_get_course_overview, mock_get_submissions, mock_get_rubric_config):
+        """ A successful call should return course, ORA, submissions, and rubric data """
+        mock_course_overview = CourseOverviewFactory.create()
+        mock_get_course_overview.return_value = mock_course_overview
+
+        mock_get_submissions.return_value = {
+            "a": {
+                "submissionUuid": "a",
+                "username": "foo",
+                "teamName": "",
+                "dateSubmitted": "1969-07-16 13:32:00",
+                "dateGraded": "None",
+                "gradedBy": "",
+                "gradingStatus": "ungraded",
+                "lockStatus": "unlocked",
+                "score": {
+                    "pointsEarned": 0,
+                    "pointsPossible": 10
+                }
+            }
+        }
+
+        # Rubric data is passed through directly, so we can use a toy data payload
+        mock_get_rubric_config.return_value = { "foo": "bar" }
+
+        self.client.login(username=self.staff.username, password=self.password)
+        response = self.client.get(self.api_url, {'ora_location': self.ora_usage_key})
+
+        expected_keys = set(['courseMetadata', 'oraMetadata', 'submissions', 'rubricConfig'])
+        assert response.status_code == 200
+        assert response.data.keys() == expected_keys

--- a/lms/djangoapps/ora_staff_grader/tests/test_views.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_views.py
@@ -70,10 +70,10 @@ class TestInitializeView(SharedModuleStoreTestCase, APITestCase):
             "a": {
                 "submissionUuid": "a",
                 "username": "foo",
-                "teamName": "",
+                "teamName": None,
                 "dateSubmitted": "1969-07-16 13:32:00",
-                "dateGraded": "None",
-                "gradedBy": "",
+                "dateGraded": None,
+                "gradedBy": None,
                 "gradingStatus": "ungraded",
                 "lockStatus": "unlocked",
                 "score": {

--- a/lms/djangoapps/ora_staff_grader/tests/test_views.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_views.py
@@ -14,6 +14,7 @@ class TestInitializeView(APITestCase):
     Tests for the /initialize view, creating setup data for ESG
     """
     view_name = 'ora-staff-grader:initialize'
+    api_url = reverse(view_name)
 
     @classmethod
     def setUpClass(cls):
@@ -29,17 +30,18 @@ class TestInitializeView(APITestCase):
         """ Log in as staff """
         self.client.login(username=self.staff.username, password=self.password)
 
-    def api_url(self, ora_location):
-        """ Create the request URL for hitting /initialize """
-        kwargs = {}
-        if ora_location:
-            kwargs['ora_location'] = ora_location
-        return reverse(self.view_name, kwargs=kwargs)
-
     def test_missing_ora_location(self):
         """ Missing ora_location param should return 400 and error message """
         self.client.login(username=self.staff.username, password=self.password)
-        response = self.client.get(self.api_url(None))
+        response = self.client.get(self.api_url)
 
         assert response.status_code == 400
         assert response.content.decode() == "Query must contain an ora_location param."
+
+    def test_bad_ora_location(self):
+        """ Bad ORA location should return a 404 and error message """
+        self.client.login(username=self.staff.username, password=self.password)
+        response = self.client.get(self.api_url, {'ora_location': 'not_a_real_location'})
+
+        assert response.status_code == 404
+        assert response.content.decode() == "Invalid ora_location."

--- a/lms/djangoapps/ora_staff_grader/views.py
+++ b/lms/djangoapps/ora_staff_grader/views.py
@@ -1,6 +1,8 @@
 """
 Views for Enhanced Staff Grader
 """
+from django.http.response import HttpResponseBadRequest
+from django.utils.translation import ugettext as _
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
 from opaque_keys.edx.keys import UsageKey
@@ -44,7 +46,10 @@ class InitializeView(RetrieveAPIView):
     permission_classes = (IsAuthenticated,)
 
     def get(self, request, *args, **kwargs):
-        ora_location = request.query_params['ora_location']
+        ora_location = request.query_params.get('ora_location')
+
+        if not ora_location:
+            return HttpResponseBadRequest(_("Query must contain an ora_location param."))
 
         # Get ORA block
         ora_usage_key = UsageKey.from_string(ora_location)

--- a/openedx/core/djangoapps/content/course_overviews/tests/factories.py
+++ b/openedx/core/djangoapps/content/course_overviews/tests/factories.py
@@ -20,6 +20,7 @@ class CourseOverviewFactory(DjangoModelFactory):  # lint-amnesty, pylint: disabl
     version = CourseOverview.VERSION
     pre_requisite_courses = []
     org = 'edX'
+    display_number_with_default = 'toy'
     run = factory.Sequence('2012_Fall_{}'.format)
 
     @factory.lazy_attribute
@@ -32,7 +33,11 @@ class CourseOverviewFactory(DjangoModelFactory):  # lint-amnesty, pylint: disabl
 
     @factory.lazy_attribute
     def id(self):
-        return CourseLocator(self.org, 'toy', self.run)
+        return CourseLocator(self.org, self.display_number_with_default, self.run)
+
+    @factory.lazy_attribute
+    def display_org_with_default(self):
+        return self.org
 
     @factory.lazy_attribute
     def display_name(self):


### PR DESCRIPTION
## Description

- Add tests for Enhanced Staff Grader (ESG) backend for frontend (BFF) initialize call.
- Add tests for supporting serializers.
- Added additional error paths for bad request handling.
- Extend some testing utilities to support tests.

## Supporting information

JIRA: [AU-349](https://openedx.atlassian.net/browse/AU-349)
FYI: @edx/masters-devs-gta 

## Testing instructions

Test suites should pass.
