### PR TITLE
fix: check enterprise_enabled in is_enterprise_learner

### DIFF
--- a/common/djangoapps/student/tests/test_activate_account.py
+++ b/common/djangoapps/student/tests/test_activate_account.py
@@ -167,7 +167,7 @@ class TestActivateAccount(TestCase):
         self.assertContains(response, 'Your account could not be activated')
 
     @override_settings(LOGIN_REDIRECT_WHITELIST=['localhost:1991'])
-    @override_settings(FEATURES=FEATURES_WITH_AUTHN_MFE_ENABLED)
+    @override_settings(FEATURES={**FEATURES_WITH_AUTHN_MFE_ENABLED, 'ENABLE_ENTERPRISE_INTEGRATION': True})
     @override_waffle_flag(REDIRECT_TO_AUTHN_MICROFRONTEND, active=True)
     def test_authenticated_account_activation_with_valid_next_url(self):
         """

--- a/openedx/features/enterprise_support/context.py
+++ b/openedx/features/enterprise_support/context.py
@@ -21,10 +21,9 @@ def get_enterprise_event_context(user_id, course_id):
         dict: A dictionary representing the enterprise uuid.
     """
     # Prevent a circular import.
-    from openedx.features.enterprise_support.api import enterprise_enabled
     from openedx.features.enterprise_support.utils import is_enterprise_learner
     context = {}
-    if enterprise_enabled() and is_enterprise_learner(user_id):
+    if is_enterprise_learner(user_id):
         uuids = EnterpriseCourseEnrollment.get_enterprise_uuids_with_user_and_course(str(user_id), str(course_id))
         if uuids:
             context.update({"enterprise_uuid": str(uuids[0])})

--- a/openedx/features/enterprise_support/signals.py
+++ b/openedx/features/enterprise_support/signals.py
@@ -18,7 +18,6 @@ from slumber.exceptions import HttpClientError
 
 from openedx.core.djangoapps.commerce.utils import ecommerce_api_client
 from openedx.core.djangoapps.signals.signals import COURSE_GRADE_NOW_PASSED, COURSE_ASSESSMENT_GRADE_CHANGED
-from openedx.features.enterprise_support.api import enterprise_enabled
 from openedx.features.enterprise_support.tasks import clear_enterprise_customer_data_consent_share_cache
 from openedx.features.enterprise_support.utils import clear_data_consent_share_cache, is_enterprise_learner
 from common.djangoapps.student.signals import UNENROLL_DONE
@@ -62,7 +61,7 @@ def handle_enterprise_learner_passing_grade(sender, user, course_id, **kwargs): 
     """
     Listen for a learner passing a course, transmit data to relevant integrated channel
     """
-    if enterprise_enabled() and is_enterprise_learner(user):
+    if is_enterprise_learner(user):
         kwargs = {
             'username': str(user.username),
             'course_run_id': str(course_id)
@@ -76,7 +75,7 @@ def handle_enterprise_learner_subsection(sender, user, course_id, subsection_id,
     """
     Listen for an enterprise learner completing a subsection, transmit data to relevant integrated channel.
     """
-    if enterprise_enabled() and is_enterprise_learner(user):
+    if is_enterprise_learner(user):
         kwargs = {
             'username': str(user.username),
             'course_run_id': str(course_id),

--- a/openedx/features/enterprise_support/tests/test_utils.py
+++ b/openedx/features/enterprise_support/tests/test_utils.py
@@ -481,6 +481,15 @@ class TestEnterpriseUtils(TestCase):
 
         assert not mock_cache_set.called
 
+    @mock.patch('django.core.cache.cache.set')
+    @mock.patch('django.core.cache.cache.get')
+    @mock.patch('openedx.features.enterprise_support.api.enterprise_enabled', return_value=False)
+    def test_is_enterprise_learner_enterprise_disabled(self, _, mock_cache_get, mock_cache_set):
+        assert not is_enterprise_learner(self.user)
+        assert not is_enterprise_learner(self.user.id)
+        assert not mock_cache_get.called
+        assert not mock_cache_set.called
+
     @mock.patch('openedx.features.enterprise_support.utils.reverse')
     def test_get_enterprise_slug_login_url_no_reverse_match(self, mock_reverse):
         mock_reverse.side_effect = NoReverseMatch

--- a/openedx/features/enterprise_support/utils.py
+++ b/openedx/features/enterprise_support/utils.py
@@ -420,6 +420,12 @@ def is_enterprise_learner(user):
     Returns:
         (bool): True if given user is an enterprise learner.
     """
+    # Prevent a circular import.
+    from openedx.features.enterprise_support.api import enterprise_enabled
+
+    if not enterprise_enabled():
+        return False
+
     try:
         user_id = int(user)
     except TypeError:
@@ -432,6 +438,7 @@ def is_enterprise_learner(user):
         # Cache the enterprise user for one hour.
         cache.set(cached_is_enterprise_key, True, 3600)
         return True
+
     return False
 
 


### PR DESCRIPTION
<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

https://openedx.atlassian.net/browse/ENT-4934

Check that enterprise is enabled in is_enterprise_learner so that errors don't get thrown when used in edge. 

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
