### PR TITLE
feat: add a file upload endpoint to the discussions REST API. [BD-38] [TNL-8779] [BB-4961]

### DIFF
--- a/lms/djangoapps/discussion/rest_api/urls.py
+++ b/lms/djangoapps/discussion/rest_api/urls.py
@@ -16,7 +16,8 @@ from lms.djangoapps.discussion.rest_api.views import (
     CourseView,
     ReplaceUsernamesView,
     RetireUserView,
-    ThreadViewSet
+    ThreadViewSet,
+    UploadFileView,
 )
 
 ROUTER = SimpleRouter()
@@ -30,6 +31,11 @@ urlpatterns = [
         ),
         CourseDiscussionSettingsAPIView.as_view(),
         name="discussion_course_settings",
+    ),
+    url(
+        fr"^v1/courses/{settings.COURSE_ID_PATTERN}/upload$",
+        UploadFileView.as_view(),
+        name="upload_file",
     ),
     url(
         r"^v1/courses/{}/roles/(?P<rolename>[A-Za-z0-9+ _-]+)/?$".format(


### PR DESCRIPTION
## Description

Adds a file upload endpoint to the Discussions app REST API, in order to support uploading images in threads and comments for [TNL-8779](https://openedx.atlassian.net/browse/TNL-8779).

## Testing instructions

A POST request from an authenticated user to `/api/discussions/v1/upload_file/`, containing a `multipart/form-data` body with one image file attached, should result in the file being uploaded to the default storage engine, and a JSON response containing a `location` field with the file URL should be returned. The returned URL should retrieve the uploaded file.