### PR TITLE
Post Django 3.2 Cleanup

### DIFF
--- a/common/djangoapps/student/management/tests/test_bulk_change_enrollment.py
+++ b/common/djangoapps/student/management/tests/test_bulk_change_enrollment.py
@@ -5,7 +5,6 @@ from unittest.mock import call, patch
 
 import ddt
 import pytest
-import django
 from django.core.management import call_command
 from django.core.management.base import CommandError
 
@@ -107,10 +106,7 @@ class BulkChangeEnrollmentTests(SharedModuleStoreTestCase):
                 commit=True,
             )
 
-        if django.VERSION < (3, 0):
-            assert 'Error: one of the arguments -c/--course -o/--org is required' == str(err.value)
-        else:
-            assert 'Error: argument -o/--org: not allowed with argument -c/--course' == str(err.value)
+        assert 'Error: argument -o/--org: not allowed with argument -c/--course' == str(err.value)
 
     @patch('common.djangoapps.student.models.tracker')
     def test_with_org_and_invalid_to_mode(self, mock_tracker):

--- a/common/djangoapps/util/db.py
+++ b/common/djangoapps/util/db.py
@@ -8,7 +8,6 @@ import random
 # TransactionManagementError used below actually *does* derive from the standard "Exception" class.
 # lint-amnesty, pylint: disable=bad-option-value, nonstandard-exception
 from contextlib import contextmanager
-import django
 from django.db import DEFAULT_DB_ALIAS, transaction  # lint-amnesty, pylint: disable=unused-import
 
 from openedx.core.lib.cache_utils import get_cache
@@ -55,10 +54,7 @@ class OuterAtomic(transaction.Atomic):
     def __init__(self, using, savepoint, name=None, durable=False):
         self.name = name
         self.durable = durable
-        if django.VERSION >= (3, 2):
-            super().__init__(using, savepoint, durable)   # pylint: disable=too-many-function-args
-        else:
-            super().__init__(using, savepoint)  # lint-amnesty, pylint: disable=no-value-for-parameter
+        super().__init__(using, savepoint, durable)   # pylint: disable=too-many-function-args
 
     def __enter__(self):
 

--- a/lms/djangoapps/badges/events/course_complete.py
+++ b/lms/djangoapps/badges/events/course_complete.py
@@ -6,7 +6,6 @@ Helper functions for the course complete event that was originally included with
 import hashlib
 import logging
 
-import django
 from django.urls import reverse
 from django.utils.text import slugify
 from django.utils.translation import ugettext_lazy as _
@@ -40,10 +39,7 @@ def course_slug(course_key, mode):
     # slugify() now removes leading and trailing dashes and underscores.
     # Reference: Django 3.2 Release Notes https://docs.djangoproject.com/en/3.2/releases/3.2/#miscellaneous
     # TODO: Remove this condition and make this return as default when platform is upgraded to 3.2
-    if django.VERSION >= (3, 2):
-        return f'{base_slug}_{digest}'
-
-    return base_slug + digest
+    return f'{base_slug}_{digest}'
 
 
 def badge_description(course, mode):

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2036,10 +2036,6 @@ CREDIT_NOTIFICATION_CACHE_TIMEOUT = 5 * 60 * 60
 MIDDLEWARE = [
     'openedx.core.lib.x_forwarded_for.middleware.XForwardedForMiddleware',
 
-    # Avoid issue with https://blog.heroku.com/chrome-changes-samesite-cookie
-    # Override was found here https://github.com/django/django/pull/11894
-    'django_cookies_samesite.middleware.CookiesSameSite',
-
     'crum.CurrentRequestUserMiddleware',
 
     'edx_django_utils.monitoring.DeploymentMonitoringMiddleware',
@@ -2152,13 +2148,6 @@ MIDDLEWARE = [
     # This must be last
     'openedx.core.djangoapps.site_configuration.middleware.SessionCookieDomainOverrideMiddleware',
 ]
-
-if django.VERSION >= (3, 1):
-    # Avoid issue with https://blog.heroku.com/chrome-changes-samesite-cookie
-    # Override was found here https://github.com/django/django/pull/11894
-    MIDDLEWARE.remove(
-        'django_cookies_samesite.middleware.CookiesSameSite'
-    )
 
 # Clickjacking protection can be disbaled by setting this to 'ALLOW'
 X_FRAME_OPTIONS = 'DENY'

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -160,8 +160,7 @@ DCS_SESSION_COOKIE_SAMESITE_FORCE_ALL = ENV_TOKENS.get('DCS_SESSION_COOKIE_SAMES
 # As django-cookies-samesite package is set to be removed from base requirements when we upgrade to Django 3.2,
 # we should follow the settings name provided by Django.
 # https://docs.djangoproject.com/en/3.2/ref/settings/#session-cookie-samesite
-if django.VERSION >= (3, 1):
-    SESSION_COOKIE_SAMESITE = DCS_SESSION_COOKIE_SAMESITE
+SESSION_COOKIE_SAMESITE = DCS_SESSION_COOKIE_SAMESITE
 
 AWS_SES_REGION_NAME = ENV_TOKENS.get('AWS_SES_REGION_NAME', 'us-east-1')
 AWS_SES_REGION_ENDPOINT = ENV_TOKENS.get('AWS_SES_REGION_ENDPOINT', 'email.us-east-1.amazonaws.com')

--- a/openedx/core/djangoapps/api_admin/tests/test_forms.py
+++ b/openedx/core/djangoapps/api_admin/tests/test_forms.py
@@ -1,6 +1,5 @@
 #pylint: disable=missing-docstring
 
-import django
 import ddt
 from django.test import TestCase
 
@@ -35,8 +34,6 @@ class ViewersWidgetTest(TestCase):
         dummy_string_value = 'staff, verified'
         input_field_name = 'viewers'
         extra_formating = ''
-        if django.VERSION < (2, 1):
-            extra_formating = ' /'
         expected_widget_html = '<input type="text" name="{input_field_name}" value="{serialized_value}"{extra_formating}>'.format(  # lint-amnesty, pylint: disable=line-too-long
             input_field_name=input_field_name,
             serialized_value=dummy_string_value,

--- a/openedx/core/djangoapps/credentials/management/commands/tests/test_notify_credentials.py
+++ b/openedx/core/djangoapps/credentials/management/commands/tests/test_notify_credentials.py
@@ -2,8 +2,6 @@
 Tests the ``notify_credentials`` management command.
 """
 
-
-import django
 from datetime import datetime
 from unittest import mock
 
@@ -287,10 +285,7 @@ class TestNotifyCredentials(TestCase):
 
         # Told to use it, and enabled. Should use config in preference of command line
         self.expected_options['start_date'] = '2017-03-01T00:00:00Z'
-        if django.VERSION >= (3, 0):
-            self.expected_options['skip_checks'] = False
-        else:
-            del self.expected_options['skip_checks']
+        self.expected_options['skip_checks'] = False
         call_command(Command(), '--start-date', '2017-01-01', '--args-from-database')
         assert mock_task.called
         assert mock_task.call_args[0][0] == self.expected_options

--- a/openedx/core/djangoapps/oauth_dispatch/migrations/0006_drop_application_id_constraints.py
+++ b/openedx/core/djangoapps/oauth_dispatch/migrations/0006_drop_application_id_constraints.py
@@ -10,12 +10,7 @@ DEPENDENCIES = [
     ('oauth_dispatch', '0005_applicationaccess_type'),
 ]
 RUN_BEFORE = []
-if django.VERSION >= (2, 0):
-    # Using django-oauth-toolkit 1.3.2+, which squashed and deleted the original 6 migrations
-    DEPENDENCIES.append(('oauth2_provider', '0001_initial'))
-else:
-    # Using django-oauth-toolkit 1.1.3 or earlier, before the migrations squashing
-    RUN_BEFORE.append(('oauth2_provider', '0005_auto_20170514_1141'))
+DEPENDENCIES.append(('oauth2_provider', '0001_initial'))
 
 
 class Migration(migrations.Migration):

--- a/openedx/core/djangoapps/oauth_dispatch/migrations/0007_restore_application_id_constraints.py
+++ b/openedx/core/djangoapps/oauth_dispatch/migrations/0007_restore_application_id_constraints.py
@@ -6,10 +6,7 @@ import django.db.models.deletion
 from django.conf import settings
 from django.db import migrations, models
 
-if django.VERSION >= (2, 0):
-    dot_migration = '0001_initial'
-else:
-    dot_migration = '0006_auto_20171214_2232'
+dot_migration = '0001_initial'
 
 
 class Migration(migrations.Migration):

--- a/openedx/core/djangoapps/site_configuration/middleware.py
+++ b/openedx/core/djangoapps/site_configuration/middleware.py
@@ -1,8 +1,6 @@
 """
 This file contains Django middleware related to the site_configuration app.
 """
-
-import django
 from django.conf import settings
 from django.utils.deprecation import MiddlewareMixin
 
@@ -45,10 +43,8 @@ class SessionCookieDomainOverrideMiddleware(MiddlewareMixin):
                     'domain': domain,
                     'secure': secure,
                     'httponly': httponly,
+                    'samesite': samesite
                 }
-                # samesite flag was added in django 2.1, so only pass it in for django 2.1 or higher
-                if django.VERSION >= (2, 1):
-                    kwargs['samesite'] = samesite
 
                 # then call down into the normal Django set_cookie method
                 return response.set_cookie_wrapped_func(key, value, **kwargs)

--- a/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
@@ -9,7 +9,6 @@ import unittest
 from datetime import datetime, timedelta
 from unittest.mock import Mock, patch
 import ddt
-import django
 from django.conf import settings
 from django.contrib.auth.hashers import UNUSABLE_PASSWORD_PREFIX, make_password
 from django.contrib.auth.models import AnonymousUser, User  # lint-amnesty, pylint: disable=imported-auth-user
@@ -284,7 +283,7 @@ class ResetPasswordTests(EventTestMixin, CacheIsolationTestCase):
 
         body = bodies[body_type]
 
-        if django.VERSION >= (3, 0) and body_type == 'html':
+        if body_type == 'html':
             expected_output = "You&#x27;re receiving this e-mail because you requested a password reset"
 
         assert 'Password reset' in sent_message.subject

--- a/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
@@ -255,7 +255,7 @@ class ResetPasswordTests(EventTestMixin, CacheIsolationTestCase):
 
     @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', "Test only valid in LMS")
     @ddt.data(('plain_text', "You're receiving this e-mail because you requested a password reset"),
-              ('html', "You&#39;re receiving this e-mail because you requested a password reset"))
+              ('html', "You&#x27;re receiving this e-mail because you requested a password reset"))
     @ddt.unpack
     def test_reset_password_email(self, body_type, expected_output):
         """Tests contents of reset password email, and that user is not active"""
@@ -282,9 +282,6 @@ class ResetPasswordTests(EventTestMixin, CacheIsolationTestCase):
         }
 
         body = bodies[body_type]
-
-        if body_type == 'html':
-            expected_output = "You&#x27;re receiving this e-mail because you requested a password reset"
 
         assert 'Password reset' in sent_message.subject
         assert expected_output in body


### PR DESCRIPTION
Since the platform is upgraded to Django 3.2, we can now remove all the conditions that were put there to run the code against multiple Django versions.