### PR TITLE
feat: make use of more reasonable timezone when recording user activity

### DIFF
--- a/lms/djangoapps/course_goals/models.py
+++ b/lms/djangoapps/course_goals/models.py
@@ -4,7 +4,6 @@ Course Goals Models
 
 import uuid
 import logging
-import pytz
 from datetime import datetime, timedelta
 
 from django.contrib.auth import get_user_model
@@ -18,7 +17,7 @@ from simple_history.models import HistoricalRecords
 
 from lms.djangoapps.courseware.masquerade import is_masquerading
 from lms.djangoapps.course_goals.toggles import COURSE_GOALS_NUMBER_OF_DAYS_GOALS
-from openedx.core.djangoapps.user_api.preferences.api import get_user_preferences
+from lms.djangoapps.courseware.context_processor import get_user_timezone_or_last_seen_timezone_or_utc
 from openedx.core.lib.mobile_utils import is_request_from_mobile_app
 
 # Each goal is represented by a goal key and a string description.
@@ -139,8 +138,7 @@ class UserActivity(models.Model):
         if is_masquerading(user, course_key):
             return None
 
-        user_preferences = get_user_preferences(user)
-        timezone = pytz.timezone(user_preferences.get('time_zone', 'UTC'))
+        timezone = get_user_timezone_or_last_seen_timezone_or_utc(user)
         now = datetime.now(timezone)
         date = now.date()
 


### PR DESCRIPTION
The get_user_timezone_or_last_seen_timezone_or_utc helper method was added to make use of a last seen timezone that we have for the user (set in the learning mfe) to email users in their morning as part of the goal reminder email management command
I think we can reasonably start making use of this when recording user activity to improve the accuracy of that data

If someone only uses the mobile app or only accesses the non-learning-mfe frontends, the last seen timezone won't be set, but for those cases it will then be equivalent to what we have already - and in most cases, the data should be better

(but this fallback can be further improved in follow on work)