### PR TITLE
feat: leave IDV out of proctoring requirements mail if honorcode

### DIFF
--- a/common/djangoapps/student/email_helpers.py
+++ b/common/djangoapps/student/email_helpers.py
@@ -9,6 +9,7 @@ from django.conf import settings
 
 from lms.djangoapps.verify_student.services import IDVerificationService
 from openedx.core.djangoapps.ace_common.template_context import get_base_template_context
+from openedx.core.djangoapps.agreements.toggles import is_integrity_signature_enabled
 from openedx.core.djangoapps.enrollments.api import is_enrollment_valid_for_proctoring
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from xmodule.modulestore.django import modulestore
@@ -55,6 +56,7 @@ def generate_proctoring_requirements_email_context(user, course_id):
         'course_name': course_module.display_name,
         'proctoring_provider': capwords(course_module.proctoring_provider.replace('_', ' ')),
         'proctoring_requirements_url': settings.PROCTORING_SETTINGS.get('LINK_URLS', {}).get('faq', ''),
+        'idv_required': not is_integrity_signature_enabled(course_id),
         'id_verification_url': IDVerificationService.get_verify_location(),
     }
 

--- a/common/djangoapps/student/tests/test_email.py
+++ b/common/djangoapps/student/tests/test_email.py
@@ -15,6 +15,7 @@ from django.test import TransactionTestCase, override_settings
 from django.test.client import RequestFactory
 from django.urls import reverse
 from django.utils.html import escape
+from edx_toggles.toggles.testutils import override_waffle_flag
 
 from common.djangoapps.edxmako.shortcuts import marketing_link
 from common.djangoapps.student.email_helpers import generate_proctoring_requirements_email_context
@@ -31,6 +32,7 @@ from common.djangoapps.third_party_auth.views import inactive_user_view
 from common.djangoapps.util.testing import EventTestMixin
 from lms.djangoapps.verify_student.services import IDVerificationService
 from openedx.core.djangoapps.ace_common.tests.mixins import EmailTemplateTagMixin
+from openedx.core.djangoapps.agreements.toggles import ENABLE_INTEGRITY_SIGNATURE, is_integrity_signature_enabled
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.theming.tests.test_util import with_comprehensive_theme
 from openedx.core.djangolib.testing.utils import CacheIsolationMixin, CacheIsolationTestCase
@@ -237,6 +239,16 @@ class ProctoringRequirementsEmailTests(EmailTemplateTagMixin, ModuleStoreTestCas
         send_proctoring_requirements_email(context)
         self._assert_email()
 
+    @override_waffle_flag(ENABLE_INTEGRITY_SIGNATURE, active=True)
+    def test_send_proctoring_requirements_email_honor(self):
+        self.course = CourseFactory(
+            display_name='honor code on course',
+            enable_proctored_exams=True
+        )
+        context = generate_proctoring_requirements_email_context(self.user, self.course.id)
+        send_proctoring_requirements_email(context)
+        self._assert_email()
+
     def _assert_email(self):
         """
         Verify that the email was sent.
@@ -249,15 +261,22 @@ class ProctoringRequirementsEmailTests(EmailTemplateTagMixin, ModuleStoreTestCas
 
         assert message.subject == f"Proctoring requirements for {self.course.display_name}"
 
-        for fragment in self._get_fragments():
-            assert fragment in text
-            assert fragment in html
+        appears, does_not_appear = self._get_fragments()
+        for fragment in appears:
+            self.assertIn(fragment, text)
+            self.assertIn(fragment, html)
+        for fragment in does_not_appear:
+            self.assertNotIn(fragment, text)
+            self.assertNotIn(fragment, html)
 
     def _get_fragments(self):
+        """
+        Provide a tuple of string[]s that should be (in, not_in) the email
+        """
         course_module = modulestore().get_course(self.course.id)
         proctoring_provider = capwords(course_module.proctoring_provider.replace('_', ' '))
         id_verification_url = IDVerificationService.get_verify_location()
-        return [
+        fragments = [
             (
                 "You are enrolled in {} at {}. This course contains proctored exams.".format(
                     self.course.display_name,
@@ -274,9 +293,15 @@ class ProctoringRequirementsEmailTests(EmailTemplateTagMixin, ModuleStoreTestCas
                 "exam in order to ensure that you are prepared."
             ),
             settings.PROCTORING_SETTINGS.get('LINK_URLS', {}).get('faq', ''),
-            escape("Before taking a graded proctored exam, you must have approved ID verification photos."),
-            id_verification_url
         ]
+        idv_fragments = [
+            escape("Before taking a graded proctored exam, you must have approved ID verification photos."),
+            id_verification_url,
+        ]
+        if not is_integrity_signature_enabled(self.course.id):
+            fragments.extend(idv_fragments)
+            return (fragments, [])
+        return (fragments, idv_fragments)
 
 
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', "Test only valid in LMS")

--- a/common/templates/student/edx_ace/proctoringrequirements/email/body.html
+++ b/common/templates/student/edx_ace/proctoringrequirements/email/body.html
@@ -56,10 +56,11 @@
             {% endfilter %}
             {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=proctoring_requirements_url %}
 
+            {% if idv_required %}
             <p style="color: rgba(0,0,0,.75);">
                 {% filter force_escape %}
                 {% blocktrans %}
-                    Before taking a graded proctored exam, you must have approved ID verification photos. 
+                    Before taking a graded proctored exam, you must have approved ID verification photos.
                 {% endblocktrans %}
                 {% endfilter %}
                 <a href="{{ id_verification_url }}">
@@ -70,6 +71,7 @@
                     {% endfilter %}
                 </a>
             </p>
+            {% endif %}
 
             <p>
                 {% trans "Thank you," as tmsg %}{{ tmsg | force_escape }}

--- a/common/templates/student/edx_ace/proctoringrequirements/email/body.txt
+++ b/common/templates/student/edx_ace/proctoringrequirements/email/body.txt
@@ -8,7 +8,9 @@
 
 {% blocktrans %}To view proctoring instructions and requirements, please visit: {{ proctoring_requirements_url }}{% endblocktrans %}
 
+{% if idv_required %}
 {% blocktrans %}Before taking a graded proctored exam, you must have approved ID verification photos. You can submit ID verification photos here: {{ id_verification_url }}{% endblocktrans %}
+{% endif %}
 
 {% trans "Thank you," %}
 {% blocktrans %}The {{ platform_name }} Team {% endblocktrans %}


### PR DESCRIPTION

## Description

https://openedx.atlassian.net/browse/MST-853

If a course has the honor code flag, don't recommend users to go to IDV in the proctoring requirements email. Basically just adding an if to the two templates and then a bunch of test changes to validate.

## Local Tests

Hacked the code a bit to allow this email to go out immediately on signing up for audit (ordinarily it only goes out on mode change and to verified modes and all that was too much yak shaving for my test). Result emails emitted in the log from A (honor code waffled on) and B (no such override). I don't have a proctoring backend set up so the please visit: (blank) is I think expected.

------- EMAIL -------

To: ashultz+2@edx.org

From: Your Platform Name Here

Subject: Proctoring requirements for Proctored Course A

Body:

Hello a s


You are enrolled in Proctored Course A at Your Platform Name Here. This course contains proctored exams.


Proctored exams are timed exams that you take while proctoring software monitors your computer's desktop, webcam video, and audio. Your course uses Null software for proctoring.


Carefully review the system requirements as well as the steps to take a proctored exam in order to ensure that you are prepared.


To view proctoring instructions and requirements, please visit: 



Thank you,

The Your Platform Name Here Team 


This email was automatically sent from Your Platform Name Here to a s.

-------  END  -------


------- EMAIL -------

To: ashultz+2@edx.org

From: Your Platform Name Here

Subject: Proctoring requirements for Proctored Course B

Body:

Hello a s


You are enrolled in Proctored Course B at Your Platform Name Here. This course contains proctored exams.


Proctored exams are timed exams that you take while proctoring software monitors your computer's desktop, webcam video, and audio. Your course uses Null software for proctoring.


Carefully review the system requirements as well as the steps to take a proctored exam in order to ensure that you are prepared.


To view proctoring instructions and requirements, please visit: 



Before taking a graded proctored exam, you must have approved ID verification photos. You can submit ID verification photos here: http://localhost:1997/id-verification



Thank you,

The Your Platform Name Here Team 


This email was automatically sent from Your Platform Name Here to a s.

-------  END  -------


