### PR TITLE
Upload artifacts even when quality job fails

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -70,6 +70,7 @@ jobs:
         ./scripts/all-tests.sh
 
     - name: Save Job Artifacts
+      if: always()
       uses: actions/upload-artifact@v2
       with:
         name: Build-Artifacts


### PR DESCRIPTION
When quality jobs fails, the step to upload artifacts is also skipped which could come in handy while debugging quality failures. So allowing the artifacts step to always run regardless of the outcome of the job.