### PR TITLE
fix: enabling the notes tool using the course authoring will now add the notes tab [BD-38] [TNL-8819]

### DIFF
--- a/lms/djangoapps/edxnotes/plugins.py
+++ b/lms/djangoapps/edxnotes/plugins.py
@@ -13,6 +13,7 @@ from lms.djangoapps.courseware.tabs import EnrolledTab
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.course_apps.plugins import CourseApp
 from openedx.core.lib.courses import get_course_by_id
+from xmodule.tabs import CourseTab, CourseTabList
 
 User = get_user_model()
 
@@ -79,6 +80,12 @@ class EdxNotesCourseApp(CourseApp):
         """
         course = get_course_by_id(course_key)
         course.edxnotes = enabled
+        if enabled:
+            notes_tab = CourseTabList.get_tab_by_id(course.tabs, 'edxnotes')
+            if notes_tab is None:
+                # If the course doesn't already have the notes tab, add it.
+                notes_tab = CourseTab.load("edxnotes")
+                course.tabs.append(notes_tab)
         modulestore().update_item(course, user.id)
         return enabled
 

--- a/openedx/core/djangoapps/course_apps/tests/test_notes_app.py
+++ b/openedx/core/djangoapps/course_apps/tests/test_notes_app.py
@@ -1,0 +1,26 @@
+"""
+Tests for wiki course app.
+"""
+from unittest.mock import patch
+
+from django.conf import settings
+
+from lms.djangoapps.edxnotes.plugins import EdxNotesCourseApp
+from openedx.core.djangoapps.course_apps.tests.utils import TabBasedCourseAppTestMixin
+from openedx.core.djangolib.testing.utils import skip_unless_cms
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+
+
+@skip_unless_cms
+@patch.dict(settings.FEATURES, {'ENABLE_EDXNOTES': True})
+class NotesCourseAppTestCase(TabBasedCourseAppTestMixin, ModuleStoreTestCase):
+    """Test cases for Notes CourseApp."""
+
+    tab_type = 'edxnotes'
+    course_app_class = EdxNotesCourseApp
+
+    def _assert_app_enabled(self, app_tab):
+        assert app_tab.is_enabled(self.course, self.user)
+
+    def _assert_app_disabled(self, app_tab):
+        assert not app_tab.is_enabled(self.course, self.user)

--- a/openedx/core/djangoapps/course_apps/tests/test_wiki_app.py
+++ b/openedx/core/djangoapps/course_apps/tests/test_wiki_app.py
@@ -2,54 +2,21 @@
 Tests for wiki course app.
 """
 
-from common.djangoapps.student.tests.factories import AdminFactory, UserFactory
 from lms.djangoapps.course_wiki.plugins.course_app import WikiCourseApp
+from openedx.core.djangoapps.course_apps.tests.utils import TabBasedCourseAppTestMixin
 from openedx.core.djangolib.testing.utils import skip_unless_cms
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory
 
 
 @skip_unless_cms
-class WikiCourseAppTestCase(ModuleStoreTestCase):
+class WikiCourseAppTestCase(TabBasedCourseAppTestMixin, ModuleStoreTestCase):
     """Test cases for Wiki CourseApp."""
 
-    def setUp(self):
-        super().setUp()
-        self.course = CourseFactory.create()
-        self.instructor = AdminFactory.create()
-        self.user = UserFactory()
+    tab_type = 'wiki'
+    course_app_class = WikiCourseApp
 
-    def get_wiki_tab(self, course_key):
-        """
-        Reload the course and fetch the wiki tab if present.
-        """
-        course = self.store.get_course(course_key)
-        return next((tab for tab in course.tabs if tab.type == 'wiki'), None)
+    def _assert_app_enabled(self, app_tab):
+        assert not app_tab.is_hidden
 
-    def test_app_disabled_by_default(self):
-        """
-        Test that the wiki tab is disabled by default.
-        """
-        assert not WikiCourseApp.is_enabled(self.course.id)
-
-    def test_app_enabling(self):
-        """
-        Test that enabling and disable the app enabled/disables the tab.
-        """
-        WikiCourseApp.set_enabled(self.course.id, True, self.instructor)
-        wiki_tab = self.get_wiki_tab(self.course.id)
-        assert not wiki_tab.is_hidden
-        WikiCourseApp.set_enabled(self.course.id, False, self.instructor)
-        wiki_tab = self.get_wiki_tab(self.course.id)
-        assert wiki_tab.is_hidden
-
-    def test_app_adds_wiki(self):
-        """
-        Test that enabling the app for a course that doesn't have the wiki tab
-        adds the wiki tab.
-        """
-        self.course.tabs = [tab for tab in self.course.tabs if tab.type != 'wiki']
-        self.store.update_item(self.course, self.instructor.id)
-        assert self.get_wiki_tab(self.course.id) is None
-        WikiCourseApp.set_enabled(self.course.id, True, self.instructor)
-        assert self.get_wiki_tab(self.course.id) is not None
+    def _assert_app_disabled(self, app_tab):
+        assert app_tab.is_hidden

--- a/openedx/core/djangoapps/course_apps/tests/utils.py
+++ b/openedx/core/djangoapps/course_apps/tests/utils.py
@@ -5,7 +5,11 @@ from typing import Type
 
 from opaque_keys.edx.keys import CourseKey
 
+from common.djangoapps.student.tests.factories import AdminFactory, CourseEnrollmentFactory, UserFactory
 from openedx.core.djangoapps.course_apps.plugins import CourseApp
+from openedx.core.djangolib.testing.utils import skip_unless_cms
+from xmodule.modulestore.django import modulestore
+from xmodule.modulestore.tests.factories import CourseFactory
 
 
 def make_test_course_app(
@@ -55,3 +59,57 @@ def make_test_course_app(
     TestCourseApp.name = name
     TestCourseApp.description = description
     return TestCourseApp
+
+
+@skip_unless_cms
+class TabBasedCourseAppTestMixin:
+    """Test cases a course app adding/removing tabs CourseApp."""
+
+    tab_type = None
+    course_app_class = None
+
+    def setUp(self):
+        super().setUp()
+        self.course = CourseFactory.create()
+        self.instructor = AdminFactory.create()
+        self.user = UserFactory()
+        CourseEnrollmentFactory.create(user=self.user, course_id=self.course.id)
+
+    def reload_course(self):
+        self.course = modulestore().get_course(self.course.id)
+
+    def get_app_tab(self, course_key):
+        """
+        Reload the course and fetch the app tab if present.
+        """
+        course = self.store.get_course(course_key)
+        return next((tab for tab in course.tabs if tab.type == self.tab_type), None)
+
+    def test_app_disabled_by_default(self):
+        """
+        Test that the app tab is disabled by default.
+        """
+        assert not self.course_app_class.is_enabled(self.course.id)
+
+    def test_app_enabling(self):
+        """
+        Test that enabling and disable the app enabled/disables the tab.
+        """
+        self.course_app_class.set_enabled(self.course.id, True, self.instructor)
+        self.reload_course()
+        app_tab = self.get_app_tab(self.course.id)
+        self._assert_app_enabled(app_tab)
+        self.course_app_class.set_enabled(self.course.id, False, self.instructor)
+        self.reload_course()
+        app_tab = self.get_app_tab(self.course.id)
+        self._assert_app_disabled(app_tab)
+
+    def test_app_adds_tab(self):
+        """
+        Test that enabling the app for a course that doesn't have the app tab adds the tab.
+        """
+        self.course.tabs = [tab for tab in self.course.tabs if tab.type != self.tab_type]
+        self.store.update_item(self.course, self.instructor.id)
+        assert self.get_app_tab(self.course.id) is None
+        self.course_app_class.set_enabled(self.course.id, True, self.instructor)
+        assert self.get_app_tab(self.course.id) is not None


### PR DESCRIPTION
## Description
If an existing course doesn't already have the notes tab, enabling notes will not make it show up. This change fixes this by adding the tab in case it isn't already in the course.

## Supporting information
- https://openedx.atlassian.net/browse/TNL-8819

## Testing instructions

1. Try enabling/disabling the notes tool here: http://localhost:2001/course/course-v1:edX+DemoX+Demo_Course/pages-and-resources
2. The notes tool should get enabled/disabled (i.e. the notes tab will show up and you'll be able to take notes in the course)
3. Disable the notes tool, and manually remove the notes tab from a course (you can export the course, remove the tab, and import  it). 
4. Now try importing the notes tool. Without this PR, notes will be enabled but the tab won't show up. With this PR, the notes tab will be added to the course automatically 
