### PR TITLE
feat: Add a new way to enable/disable teams [BD-38] [TNL-9175] [BB-5066]

### DIFF
--- a/common/lib/xmodule/xmodule/tests/test_course_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_course_module.py
@@ -278,12 +278,14 @@ class TeamsConfigurationTestCase(unittest.TestCase):
         self.course.teams_configuration = TeamsConfig(None)
         self.count = itertools.count()
 
-    def add_team_configuration(self, max_team_size=3, topics=None):
+    def add_team_configuration(self, max_team_size=3, topics=None, enabled=None):
         """ Add a team configuration to the course. """
         teams_config_data = {}
         teams_config_data["topics"] = [] if topics is None else topics
         if max_team_size is not None:
             teams_config_data["max_team_size"] = max_team_size
+        if enabled is not None:
+            teams_config_data["enabled"] = enabled
         self.course.teams_configuration = TeamsConfig(teams_config_data)
 
     def make_topic(self):
@@ -301,42 +303,84 @@ class TeamsConfigurationTestCase(unittest.TestCase):
         }
 
     def test_teams_enabled_new_course(self):
+        """
+        Tests that teams are not enabled by default as no teamsets exist.
+        """
         # Make sure we can detect when no teams exist.
         assert not self.course.teams_enabled
+        assert not self.course.teams_configuration.is_enabled
 
-        # add topics
+    def test_teams_enabled_with_default(self):
+        """
+        Test that teams are automatically enabled if a teamset is added, but it can be disabled via the `enabled` field.
+        """
+        # Test that teams is enabled if topic are created
         self.add_team_configuration(max_team_size=4, topics=[self.make_topic()])
         assert self.course.teams_enabled
+        assert self.course.teams_configuration.is_enabled
 
-        # remove them again
-        self.add_team_configuration(max_team_size=4, topics=[])
+        # Test that teams are disabled if topic exists, but enabled is False
+        self.add_team_configuration(max_team_size=4, topics=[self.make_topic()], enabled=False)
         assert not self.course.teams_enabled
+        assert not self.course.teams_configuration.is_enabled
+
+    def test_teams_disabled_no_teamsets(self):
+        """
+        Test that teams is disabled if there are no teamsets whether enabled is set to true or false
+        """
+        self.add_team_configuration(max_team_size=4, topics=[], enabled=True)
+        assert not self.course.teams_enabled
+        assert not self.course.teams_configuration.is_enabled
+        self.add_team_configuration(max_team_size=4, topics=[], enabled=False)
+        assert not self.course.teams_enabled
+        assert not self.course.teams_configuration.is_enabled
 
     def test_teams_enabled_max_size_only(self):
+        """
+        Test that teams isn't enabled if only a max team size is configured.
+        """
         self.add_team_configuration(max_team_size=4)
         assert not self.course.teams_enabled
 
     def test_teams_enabled_no_max_size(self):
+        """
+        Test that teams is enabled if a max team size is missing but teamsets are created.s
+        """
         self.add_team_configuration(max_team_size=None, topics=[self.make_topic()])
         assert self.course.teams_enabled
 
     def test_teams_max_size_no_teams_configuration(self):
+        """
+        Test that the default maximum team size matches the configured maximum
+        """
         assert self.course.teams_configuration.default_max_team_size == DEFAULT_COURSE_RUN_MAX_TEAM_SIZE
 
     def test_teams_max_size_with_teams_configured(self):
+        """
+        Test that if you provide a custom global max_team_size, it reflects in the config.
+        """
         size = 4
         self.add_team_configuration(max_team_size=size, topics=[self.make_topic(), self.make_topic()])
         assert self.course.teams_enabled
         assert size == self.course.teams_configuration.default_max_team_size
 
     def test_teamsets_no_config(self):
+        """
+        Tests that no teamsets are configured by default.
+        """
         assert self.course.teamsets == []
 
     def test_teamsets_empty(self):
+        """
+        Test that if only the max team size is configured then there are no teamsets
+        """
         self.add_team_configuration(max_team_size=4)
         assert self.course.teamsets == []
 
     def test_teamsets_present(self):
+        """
+        Tests that if valid teamsets are added they show up in the config
+        """
         topics = [self.make_topic(), self.make_topic()]
         self.add_team_configuration(max_team_size=4, topics=topics)
         assert self.course.teams_enabled
@@ -347,6 +391,9 @@ class TeamsConfigurationTestCase(unittest.TestCase):
         assert expected_teamsets_data == topics
 
     def test_teams_conf_cached_by_xblock_field(self):
+        """
+        Test that the teamsets are cached in the field so repeated queries don't perform re-computation
+        """
         self.add_team_configuration(max_team_size=5, topics=[self.make_topic()])
         cold_cache_conf = self.course.teams_configuration
         warm_cache_conf = self.course.teams_configuration

--- a/lms/djangoapps/teams/plugins.py
+++ b/lms/djangoapps/teams/plugins.py
@@ -12,6 +12,8 @@ from lms.djangoapps.courseware.tabs import EnrolledTab
 from lms.djangoapps.teams.waffle import ENABLE_TEAMS_APP
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.course_apps.plugins import CourseApp
+from openedx.core.lib.courses import get_course_by_id
+from xmodule.modulestore.django import modulestore
 from . import is_feature_enabled
 
 
@@ -64,11 +66,30 @@ class TeamsCourseApp(CourseApp):
 
     @classmethod
     def is_enabled(cls, course_key: CourseKey) -> bool:
+        """
+        Returns the enabled status of teams.
+
+        Args:
+            course_key (CourseKey): The course for which to fetch the status of teams
+        """
         return CourseOverview.get_from_id(course_key).teams_enabled
 
     @classmethod
     def set_enabled(cls, course_key: CourseKey, enabled: bool, user: User) -> bool:
-        raise ValueError("Teams cannot be enabled/disabled via this API.")
+        """
+        Returns the enabled status of teams.
+        Args:
+            course_key (CourseKey): The course for which to set the status of teams
+            enabled (bool): The new satus for the app.
+            user (User): The user performing the operation
+
+        Returns:
+            (bool): the new status of the app
+        """
+        course = get_course_by_id(course_key)
+        course.teams_configuration.is_enabled = enabled
+        modulestore().update_item(course, user.id)
+        return enabled
 
     @classmethod
     def get_allowed_operations(cls, course_key: CourseKey, user: Optional[User] = None) -> Dict[str, bool]:
@@ -76,6 +97,6 @@ class TeamsCourseApp(CourseApp):
         Return allowed operations for teams app.
         """
         return {
-            "enable": False,
+            "enable": True,
             "configure": True,
         }

--- a/openedx/core/lib/teams_config.py
+++ b/openedx/core/lib/teams_config.py
@@ -30,25 +30,18 @@ class TeamsConfig:
     def __str__(self):
         """
         Return user-friendly string.
-
-        TODO move this code to __str__ after Py3 upgrade.
         """
         return f"Teams configuration for {len(self.teamsets)} team-sets"
-
-    def __str__(self):
-        """
-        Return user-friendly string.
-        """
-        return "Teams configuration for {} team-sets".format(len(self.teamsets))
 
     def __repr__(self):
         """
         Return developer-helpful string.
         """
-        return "<{} default_max_team_size={} teamsets=[{}]>".format(
+        return "<{} default_max_team_size={} teamsets=[{}] enabled={}>".format(
             self.__class__.__name__,
             self.default_max_team_size,
             ", ".join(repr(teamset) for teamset in self.teamsets),
+            self.is_enabled,
         )
 
     def __eq__(self, other):
@@ -77,6 +70,7 @@ class TeamsConfig:
         JSON-friendly dictionary containing cleaned data from this TeamsConfig.
         """
         return {
+            'enabled': self.is_enabled,
             'max_team_size': self.default_max_team_size,
             'team_sets': [
                 teamset.cleaned_data for teamset in self.teamsets
@@ -88,7 +82,16 @@ class TeamsConfig:
         """
         Whether the Course Teams feature is enabled for this course run.
         """
-        return bool(self.teamsets)
+        # Check if the enabled field is set, and teamsets are defined
+        has_teamsets = bool(self.teamsets)
+        return self._data.get('enabled', True) and has_teamsets
+
+    @is_enabled.setter
+    def is_enabled(self, value):
+        """
+        Setter to set value of enabled value
+        """
+        self._data['enabled'] = value
 
     @cached_property
     def teamsets(self):

--- a/openedx/core/lib/tests/test_teams_config.py
+++ b/openedx/core/lib/tests/test_teams_config.py
@@ -58,6 +58,7 @@ class TeamsConfigTests(TestCase):
     }
 
     OUTPUT_DATA_1 = {
+        "enabled": True,
         "max_team_size": 5,
         "team_sets": [
             {
@@ -111,6 +112,7 @@ class TeamsConfigTests(TestCase):
     }
 
     OUTPUT_DATA_2 = {
+        "enabled": True,
         "max_team_size": DEFAULT_COURSE_RUN_MAX_TEAM_SIZE,
         "team_sets": [
             {
@@ -122,10 +124,29 @@ class TeamsConfigTests(TestCase):
             },
         ],
     }
+    INPUT_DATA_3 = {
+        # For a blank config, "enabled" should be automatically added and set to False since no teamsets exist.
+    }
+    OUTPUT_DATA_3 = {
+        "enabled": False,
+        "max_team_size": DEFAULT_COURSE_RUN_MAX_TEAM_SIZE,
+        "team_sets": [],
+    }
+    INPUT_DATA_4 = {
+        # If teamsets are provided, "enabled" should be automatically added and set to True.
+        "team_sets": [dict(id="test-teamset", name="test", description="test")]
+    }
+    OUTPUT_DATA_4 = {
+        "enabled": True,
+        "max_team_size": DEFAULT_COURSE_RUN_MAX_TEAM_SIZE,
+        "team_sets": [dict(id="test-teamset", name="test", description="test", type="open", max_team_size=None)],
+    }
 
     @ddt.data(
         (INPUT_DATA_1, OUTPUT_DATA_1),
         (INPUT_DATA_2, OUTPUT_DATA_2),
+        (INPUT_DATA_3, OUTPUT_DATA_3),
+        (INPUT_DATA_4, OUTPUT_DATA_4),
     )
     @ddt.unpack
     def test_teams_config_round_trip(self, input_data, expected_output_data):

--- a/openedx/core/lib/tests/test_teams_config.py
+++ b/openedx/core/lib/tests/test_teams_config.py
@@ -124,19 +124,20 @@ class TeamsConfigTests(TestCase):
             },
         ],
     }
-    INPUT_DATA_3 = {
-        # For a blank config, "enabled" should be automatically added and set to False since no teamsets exist.
-    }
+    INPUT_DATA_3 = {}
     OUTPUT_DATA_3 = {
+        # When starting with a default blank config, there are no teamsets configured, and as such, teamsets is
+        # disabled, so after processing the config the "enabled" field should be set to False.
         "enabled": False,
         "max_team_size": DEFAULT_COURSE_RUN_MAX_TEAM_SIZE,
         "team_sets": [],
     }
     INPUT_DATA_4 = {
-        # If teamsets are provided, "enabled" should be automatically added and set to True.
         "team_sets": [dict(id="test-teamset", name="test", description="test")]
     }
     OUTPUT_DATA_4 = {
+        # If teamsets are provided, but a value for "enabled" isn't, then the presence of teamsets indicates that
+        # teams should be considered enabled, and the "enabled" field should be set to True.
         "enabled": True,
         "max_team_size": DEFAULT_COURSE_RUN_MAX_TEAM_SIZE,
         "team_sets": [dict(id="test-teamset", name="test", description="test", type="open", max_team_size=None)],


### PR DESCRIPTION
## Description
Adds a new mechanism for enabling/disabling the team feature in a course using an 'enabled' field to the teams config.
If this field is set to true, teams is enabled (team sets/groups) still need to be defined. If this is set to false then teams is disabled whether or not team sets are defined.

## Supporting information
- [TNL Ticket](https://openedx.atlassian.net/browse/TNL-9175)
- https://github.com/edx/edx-platform/pull/28891

## Testing instructions

- Set up a new course or edit the demo course
- [Add a few team-sets to the teams configuration](https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/course_features/teams/teams_setup.html#enable-and-configure-teams)
- Check that teams is enabled in the UI and shows up as new course tab
- In the teams configuration, add a new boolean field called "enabled" and set it to false.
- The teams tab should disappear.
- Now set the field to enabled again. 
- Check that teams show up again
- Now remove all team sets. 
- Check that the tab is hidden even though enabled is true.