### PR TITLE
[SE-4631] add CCX ID to generated filename prefixes (#27028)

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -635,6 +635,17 @@ FEATURES = {
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/7845
     'ENABLE_COURSE_DISCOVERY': False,
 
+    # .. toggle_name: FEATURES['ENABLE_COURSE_FILENAME_CCX_SUFFIX']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: If set to True, CCX ID will be included in the generated filename for CCX courses.
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2021-03-16
+    # .. toggle_target_removal_date: None
+    # .. toggle_tickets: None
+    # .. toggle_warnings: Turning this feature ON will affect all generated filenames which are related to CCX courses.
+    'ENABLE_COURSE_FILENAME_CCX_SUFFIX': False,
+
     # Setting for overriding default filtering facets for Course discovery
     # COURSE_DISCOVERY_FILTERS = ["org", "language", "modes"]
 


### PR DESCRIPTION
This is the backport of https://github.com/edx/edx-platform/pull/27028.

---
This pull requests backport a feature to include CCX course IDs in the generated course filenames used for downloading reports, etc.

The suffix appended to the generated filename prefix is following the  `<separator>_ccx_<ccx id>` pattern, to ensure unique filename generation per ccx - previously all CCX courses were downloaded with the same name.

**Dependencies**: None

**Screenshots**: 
![Screenshot 2021-03-16 at 16 22 12](https://user-images.githubusercontent.com/19173947/111349994-f1c42980-8681-11eb-8fff-d28024899957.png)

**Sandbox URL**: TBD

**Merge deadline**: None

**Testing instructions**:

1. Navigate to https://pr29101.sandbox.opencraft.hosting
2. Login as staff
3. Navigate to https://pr29101.sandbox.opencraft.hosting/courses/ccx-v1:edX+DemoX+Demo_Course+ccx@1/instructor#view-data_download
4. Click "Download profile information as a CSV" button
5. Check that the file name contains CCX