### PR TITLE
make year of birth compliant with coppa

### DIFF
--- a/lms/static/js/student_account/models/user_account_model.js
+++ b/lms/static/js/student_account/models/user_account_model.js
@@ -56,8 +56,16 @@
             },
 
             isAboveMinimumAge: function() {
-                var yearOfBirth = this.get('year_of_birth');
-                var isBirthDefined = !(_.isUndefined(yearOfBirth) || _.isNull(yearOfBirth));
+                var yearOfBirth = this.get('year_of_birth'),
+                    isBirthDefined = !(_.isUndefined(yearOfBirth) || _.isNull(yearOfBirth)),
+                    minimumAllowedAge = this.get('parental_consent_age_limit'),
+                    enableCoppaCompliance = this.get('enable_coppa_compliance');
+
+                if(enableCoppaCompliance){
+                    var currentYear = new Date().getFullYear(),
+                    isOlderThanMinimum = (currentYear - yearOfBirth) >= minimumAllowedAge;
+                    return isBirthDefined && isOlderThanMinimum && !(this.get('requires_parental_consent'));
+                }
                 return isBirthDefined && !(this.get('requires_parental_consent'));
             }
         });

--- a/openedx/features/learner_profile/static/learner_profile/js/learner_profile_factory.js
+++ b/openedx/features/learner_profile/static/learner_profile/js/learner_profile_factory.js
@@ -28,7 +28,11 @@
             var accountSettingsModel = new AccountSettingsModel(
                 _.extend(
                     options.account_settings_data,
-                    {default_public_account_fields: options.default_public_account_fields}
+                    {
+                    default_public_account_fields: options.default_public_account_fields,
+                    parental_consent_age_limit: options.parental_consent_age_limit,
+                    enable_coppa_compliance: options.enable_coppa_compliance
+                    }
                 ),
                 {parse: true}
             );

--- a/openedx/features/learner_profile/static/learner_profile/js/views/learner_profile_view.js
+++ b/openedx/features/learner_profile/static/learner_profile/js/views/learner_profile_view.js
@@ -107,10 +107,17 @@
                             Backbone.history.start();
                         }
                     } else {
-                        // xss-lint: disable=javascript-jquery-html
-                        $wrapperProfileBioElement.html(this.sectionTwoView.render().el);
+                        if(this.isCoppaCompliant())
+                            // xss-lint: disable=javascript-jquery-html
+                            $wrapperProfileBioElement.html(this.sectionTwoView.render().el);
                     }
                     return this;
+                },
+
+                isCoppaCompliant: function() {
+                   var enableCoppaCompliance = this.options.accountSettingsModel.get('enable_coppa_compliance'),
+                       isAboveAge = this.options.accountSettingsModel.isAboveMinimumAge();
+                   return !enableCoppaCompliance || (enableCoppaCompliance && isAboveAge);
                 },
 
                 renderFields: function() {
@@ -119,7 +126,7 @@
                         imageView,
                         settings;
 
-                    if (this.options.ownProfile) {
+                    if (this.options.ownProfile && this.isCoppaCompliant()) {
                         fieldView = this.options.accountPrivacyFieldView;
                         settings = this.options.accountSettingsModel;
                         fieldView.profileIsPrivate = !settings.get('year_of_birth');

--- a/openedx/features/learner_profile/views/learner_profile.py
+++ b/openedx/features/learner_profile/views/learner_profile.py
@@ -108,6 +108,8 @@ def learner_profile_context(request, profile_username, user_is_staff):
             'backpack_ui_img': staticfiles_storage.url('certificates/images/backpack-ui.png'),
             'platform_name': configuration_helpers.get_value('platform_name', settings.PLATFORM_NAME),
             'social_platforms': settings.SOCIAL_PLATFORMS,
+            'enable_coppa_compliance': settings.ENABLE_COPPA_COMPLIANCE,
+            'parental_consent_age_limit': settings.PARENTAL_CONSENT_AGE_LIMIT
         },
         'show_program_listing': ProgramsApiConfig.is_enabled(),
         'show_dashboard_tabs': True,


### PR DESCRIPTION
## Description
Adds a check to make the UX in compliant with Coppa suggestions. After this change only users older than 13 years are able to cascade between their limited and full profile.

## Supporting information
- [VAN Ticket](https://openedx.atlassian.net/browse/VAN-753)

## Testing instructions

- Profile page would offer the dropdown to switch between limited and full profile only to users older than 13 years.