### PR TITLE
fix: do not index solutions in CAPA blocks

### DIFF
--- a/common/lib/xmodule/xmodule/capa_module.py
+++ b/common/lib/xmodule/xmodule/capa_module.py
@@ -552,14 +552,22 @@ class ProblemBlock(
         # Make optioninput's options index friendly by replacing the actual tag with the values
         capa_content = re.sub(r'<optioninput options="\(([^"]+)\)".*?>\s*|\S*<\/optioninput>', r'\1', self.data)
 
-        # Removing solutions and hints, as well as script and style
+        # Remove the following tags with content that can leak hints or solutions:
+        # - `solution` (with optional attributes) and `solutionset`.
+        # - `targetedfeedback` (with optional attributes) and `targetedfeedbackset`.
+        # - `answer` (with optional attributes).
+        # - `script` (with optional attributes).
+        # - `style` (with optional attributes).
+        # - various types of hints (with optional attributes) and `hintpart`.
         capa_content = re.sub(
             re.compile(
                 r"""
-                    <solution>.*?</solution> |
-                    <script>.*?</script> |
-                    <style>.*?</style> |
-                    <[a-z]*hint.*?>.*?</[a-z]*hint>
+                    <solution.*?>.*?</solution.*?> |
+                    <targetedfeedback.*?>.*?</targetedfeedback.*?> |
+                    <answer.*?>.*?</answer> |
+                    <script.*?>.*?</script> |
+                    <style.*?>.*?</style> |
+                    <[a-z]*hint.*?>.*?</[a-z]*hint.*?>
                 """,
                 re.DOTALL |
                 re.VERBOSE),

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -2562,25 +2562,32 @@ class ProblemBlockXMLTest(unittest.TestCase):  # lint-amnesty, pylint: disable=m
     def test_solutions_not_indexed(self):
         xml = textwrap.dedent("""
             <problem>
-                <solution>
-                <div class="detailed-solution">
-                <p>Explanation</p>
+                <solution>Test solution.</solution>
+                <solution explanation-id="solution0">Test solution with attribute.</solution>
+                <solutionset>
+                    Test solutionset.
+                    <solution explanation-id="solution1">Test solution within solutionset.</solution>
+                </solutionset>
 
-                <p>This is what the 1st solution.</p>
+                <targetedfeedback>Test feedback.</targetedfeedback>
+                <targetedfeedback explanation-id="feedback0">Test feedback with attribute.</targetedfeedback>
+                <targetedfeedbackset>
+                    Test FeedbackSet.
+                    <targetedfeedback explanation-id="feedback1">Test feedback within feedbackset.</targetedfeedback>
+                </targetedfeedbackset>
 
-                </div>
-                </solution>
+                <answer>Test answer.</answer>
+                <answer type="loncapa/python">Test answer with attribute.</answer>
 
-                <solution>
-                <div class="detailed-solution">
-                <p>Explanation</p>
+                <script>Test script.</script>
+                <script type="loncapa/python">Test script with attribute.</script>
 
-                <p>This is the 2nd solution.</p>
+                <style>Test style.</style>
+                <style media="all and (max-width: 1920px)">Test style with attribute.</style>
 
-                </div>
-                </solution>
-
-
+                <choicehint>Test choicehint.</choicehint>
+                <hint>Test hint.</hint>
+                <hintpart>Test hintpart.</hintpart>
             </problem>
         """)
         name = "Blank Common Capa Problem"
@@ -2695,7 +2702,7 @@ class ProblemBlockXMLTest(unittest.TestCase):  # lint-amnesty, pylint: disable=m
         """)
         name = "Non latin Input"
         descriptor = self._create_descriptor(sample_text_input_problem_xml, name=name)
-        capa_content = " FX1_VAL='Καλημέρα' Δοκιμή με μεταβλητές με Ελληνικούς χαρακτήρες μέσα σε python: $FX1_VAL "
+        capa_content = " Δοκιμή με μεταβλητές με Ελληνικούς χαρακτήρες μέσα σε python: $FX1_VAL "
 
         descriptor_dict = descriptor.index_dictionary()
         assert descriptor_dict['content']['capa_content'] == smart_str(capa_content)


### PR DESCRIPTION
<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

There are some tags in the Problem XBlock that can contain solutions or hints. Most of them are already being removed, but the current regex does not include the case when the tags have attributes. This decreases the possibility of indexing solutions by expanding the regex.

## Supporting information

OSPR ticket: [OSPR-6173](https://openedx.atlassian.net/browse/OSPR-6173)
OpenCraft Jira ticket: [BB-4994](https://tasks.opencraft.com/browse/BB-4994)


## Known issues
The ElasticSearch connection was not working for me with the most recent devstack version. I had to add this to `lms/envs/private.py` and `cms/envs/private.py`:
```python
ELASTIC_SEARCH_CONFIG = [
    {
        'use_ssl': False,
        'host': 'edx.devstack.elasticsearch710',
        'port': 9200
    }
]
```

## Testing instructions

1. Enable `FEATURES['ENABLE_COURSEWARE_SEARCH']` in LMS.
1. Enable `FEATURES['ENABLE_COURSEWARE_INDEX']` in Studio.
1. Create a Blank Advanced Problem XBlock with the following content (it will not render correctly, but don't worry about it):
   ```xml
    <problem>
      You should not
      <solution>Test solution.</solution>
      <solution explanation-id="solution0">Test solution with attribute.</solution>
      <solutionset>
        Test solutionset.
      <solution explanation-id="solution1">Test solution within solutionset.</solution>
      </solutionset>
      <targetedfeedback>Test feedback.</targetedfeedback>
      <targetedfeedback explanation-id="feedback0">Test feedback with attribute.</targetedfeedback>
      <targetedfeedbackset>
        Test FeedbackSet.
        <targetedfeedback explanation-id="feedback1">Test feedback within feedbackset.</targetedfeedback>
      </targetedfeedbackset>
      <answer>Test answer.</answer>
      <answer type="loncapa/python">Test answer with attribute.</answer>
      <script>Test script.</script>
      <script type="loncapa/python">Test script with attribute.</script>
      <style>Test style.</style>
      <style media="all and (max-width: 1920px)">Test style with attribute.</style>
      <choicehint>Test choicehint.</choicehint>
      <hint>Test hint.</hint>
      <hintpart>Test hintpart.</hintpart>
      see anything else.
    </problem>
   ```
1. Click the "Reindex" button on the Course Outline page in Studio (just in case).
1. Go to your [dashboard](http://localhost:18000/dashboard) in LMS and search for `"anything else"`. You should see the following result: "You should not see anything else.".

## Deadline

"None"

## Reviewers
- [x] @alfredchavez 
- [ ] edX reviewer (TBD)


**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_COURSEWARE_SEARCH: true
  ENABLE_COURSEWARE_INDEX: true
```