### PR TITLE
Flaky assetstore test

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/tests/test_assetstore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_assetstore.py
@@ -115,6 +115,8 @@ class TestMongoAssetMetadataStorage(TestCase):
         So we can use the below date comparison
         """
         for attr in mdata1.ATTRS_ALLOWED_TO_UPDATE:  # lint-amnesty, pylint: disable=redefined-outer-name
+            if attr == "edited_on":
+                continue  # The edited_on gets updated during save, so comparing it makes tests flaky.
             if isinstance(getattr(mdata1, attr), datetime):
                 self._assert_datetimes_equal(getattr(mdata1, attr), getattr(mdata2, attr))
             else:


### PR DESCRIPTION
## Description

While working on https://github.com/edx/edx-platform/pull/29058 I found a flaky `assetstore` test.

The test in question goes like this: create an asset with specific metadata, save the asset into the asset store, then read it out, and assert that all of its metadata is unchanged.

https://github.com/edx/edx-platform/blob/acd83d1c050ef07d456854471f18ccb6ee5c435f/common/lib/xmodule/xmodule/modulestore/tests/test_assetstore.py#L177-L183

However, this test is actually flaky because the metadata _does_ get changed, by this line:

https://github.com/edx/edx-platform/blob/acd83d1c050ef07d456854471f18ccb6ee5c435f/common/lib/xmodule/xmodule/modulestore/__init__.py#L680

If the time between `_make_asset_metadata` and setting the updated `edited_on` is small enough, the test will pass. Otherwise, it will fail.

Adding some sleeps to the code like this guarantees that the test will fail:

https://github.com/edx/edx-platform/blob/77f07de263a0dba79e5b68d34dfbd836397196a3/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py#L2731-L2769

Example of the failing test: 

https://build.testeng.edx.org/job/edx-platform-django-3.2-python-pipeline-pr/757/testReport/junit/xmodule.xmodule.modulestore.tests.test_assetstore/TestMongoAssetMetadataStorage/Run_Tests___commonlib_unit___test_save_one_and_confirm_3/

```
    def _assert_datetimes_equal(self, datetime1, datetime2):
        """
        Don't compare microseconds as mongo doesn't encode below milliseconds
        """
>       assert datetime1.replace(microsecond=0) == datetime2.replace(microsecond=0)
E       AssertionError: assert datetime.datetime(2021, 10, 22, 21, 46, 43, tzinfo=<UTC>) == datetime.datetime(2021, 10, 22, 21, 46, 42, tzinfo=<bson.tz_util.FixedOffset object at 0x7fc00cc49940>)
E         +datetime.datetime(2021, 10, 22, 21, 46, 43, tzinfo=<UTC>)
E         -datetime.datetime(2021, 10, 22, 21, 46, 42, tzinfo=<bson.tz_util.FixedOffset object at 0x7fc00cc49940>)
```

## Testing instructions

View the CI results.

## Deadline

None

## Other information

It seems that the `find_asset_metadata()` method is not longer used outside of test code. Maybe it can be removed altogether?