### PR TITLE
chore: update proctoring version

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -461,7 +461,7 @@ edx-opaque-keys[django]==2.2.2
     #   xmodule
 edx-organizations==6.10.0
     # via -r requirements/edx/base.in
-edx-proctoring==4.1.3
+edx-proctoring==4.2.0
     # via
     #   -r requirements/edx/base.in
     #   edx-proctoring-proctortrack

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -570,7 +570,7 @@ edx-opaque-keys[django]==2.2.2
     #   xmodule
 edx-organizations==6.10.0
     # via -r requirements/edx/testing.txt
-edx-proctoring==4.1.3
+edx-proctoring==4.2.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-proctoring-proctortrack

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -553,7 +553,7 @@ edx-opaque-keys[django]==2.2.2
     #   xmodule
 edx-organizations==6.10.0
     # via -r requirements/edx/base.txt
-edx-proctoring==4.1.3
+edx-proctoring==4.2.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring-proctortrack


### PR DESCRIPTION
Latest version of edx-proctoring allows timed exams to be visible after the course end date. This is so visibility behavior is consistent across self-paced and instructor-paced courses, and within self-paced courses with personalized schedules. 