### PR TITLE
chore: bump ora to 3.7.4

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -685,7 +685,7 @@ openedx-calc==2.0.1
     # via -r requirements/edx/base.in
 openedx-events==0.6.0
     # via -r requirements/edx/base.in
-ora2==3.7.3
+ora2==3.7.4
     # via -r requirements/edx/base.in
 packaging==21.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -918,7 +918,7 @@ openedx-calc==2.0.1
     # via -r requirements/edx/testing.txt
 openedx-events==0.6.0
     # via -r requirements/edx/testing.txt
-ora2==3.7.3
+ora2==3.7.4
     # via -r requirements/edx/testing.txt
 packaging==21.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -867,7 +867,7 @@ openedx-calc==2.0.1
     # via -r requirements/edx/base.txt
 openedx-events==0.6.0
     # via -r requirements/edx/base.txt
-ora2==3.7.3
+ora2==3.7.4
     # via -r requirements/edx/base.txt
 packaging==21.0
     # via


### PR DESCRIPTION
## Description

Bump ORA to 3.7.4. This version introduces custom window.confirm-esque prompts, because Chrome and Safari have begun to disallow window.confirm from within cross-origin iframes.