### PR TITLE
fix: fix issues with LANGUAGE_CODE [BB-4823] [OSPR-6178]

### DIFF
--- a/lms/djangoapps/courseware/context_processor.py
+++ b/lms/djangoapps/courseware/context_processor.py
@@ -7,6 +7,7 @@ to the templates without having to append every view file.
 """
 
 
+from openedx.core.djangoapps.site_configuration.helpers import get_value
 from openedx.core.djangoapps.user_api.errors import UserAPIInternalError, UserNotFound
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preferences
 from openedx.core.lib.cache_utils import get_cache
@@ -22,6 +23,8 @@ def user_timezone_locale_prefs(request):
     """
     Checks if request has an authenticated user.
     If so, sends set (or none if unset) time_zone and language prefs.
+    If site-wide language is set, that language is used over the language set
+    in user preferences.
 
     This interacts with the DateUtils to either display preferred or attempt to determine
     system/browser set time_zones and languages
@@ -43,6 +46,9 @@ def user_timezone_locale_prefs(request):
                     key: user_preferences.get(pref_name, None)
                     for key, pref_name in RETRIEVABLE_PREFERENCES.items()
                 }
+        site_wide_language = get_value('LANGUAGE_CODE', None)
+        if site_wide_language:
+            user_prefs['user_language'] = site_wide_language
 
         cached_value.update(user_prefs)
     return cached_value

--- a/lms/djangoapps/courseware/tests/test_context_processor.py
+++ b/lms/djangoapps/courseware/tests/test_context_processor.py
@@ -3,7 +3,7 @@ Unit tests for courseware context_processor
 """
 
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 from django.contrib.auth.models import AnonymousUser
 
 from lms.djangoapps.courseware.context_processor import user_timezone_locale_prefs
@@ -43,3 +43,10 @@ class UserPrefContextProcessorUnitTest(ModuleStoreTestCase):
         assert context['user_language'] is None
         assert context['user_timezone'] is not None
         assert context['user_timezone'] == 'Asia/Tokyo'
+
+    @patch("lms.djangoapps.courseware.context_processor.get_value")
+    def test_site_wide_language_set(self, mock_get_value):
+        mock_get_value.return_value = 'ar'
+        set_user_preference(self.user, 'pref-lang', 'en')
+        context = user_timezone_locale_prefs(self.request)
+        assert context['user_language'] == 'ar'

--- a/openedx/core/djangoapps/dark_lang/middleware.py
+++ b/openedx/core/djangoapps/dark_lang/middleware.py
@@ -16,7 +16,6 @@ from django.utils.deprecation import MiddlewareMixin
 
 from openedx.core.djangoapps.dark_lang import DARK_LANGUAGE_KEY
 from openedx.core.djangoapps.dark_lang.models import DarkLangConfig
-from openedx.core.djangoapps.site_configuration.helpers import get_value
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preference
 
 # If django 1.7 or higher is used, the right-side can be updated with new-style codes.
@@ -91,16 +90,7 @@ class DarkLangMiddleware(MiddlewareMixin):
             return
 
         self._clean_accept_headers(request)
-        self._set_site_or_microsite_language(request)
         self._activate_preview_language(request)
-
-    def _set_site_or_microsite_language(self, request):
-        """
-        Apply language specified in site configuration.
-        """
-        language = get_value('LANGUAGE_CODE', None)
-        if language:
-            request.session[LANGUAGE_SESSION_KEY] = language
 
     def _fuzzy_match(self, lang_code):
         """Returns a fuzzy match for lang_code"""

--- a/openedx/core/djangoapps/dark_lang/tests.py
+++ b/openedx/core/djangoapps/dark_lang/tests.py
@@ -257,16 +257,6 @@ class DarkLangMiddlewareTests(CacheIsolationTestCase):
         session[LANGUAGE_SESSION_KEY] = session_language
         session.save()
 
-    @with_site_configuration(configuration={'LANGUAGE_CODE': 'rel'})
-    def test_site_configuration_language(self):
-        # `LANGUAGE_CODE` in site configuration should override session lang
-        self._set_client_session_language('notrel')
-        self.client.get('/home')
-        self.assert_session_lang_equals(
-            'rel',
-            self.client.session
-        )
-
     def test_preview_lang_with_released_language(self):
         # Preview lang should always override selection
         self._post_set_preview_lang('rel')

--- a/openedx/core/djangoapps/lang_pref/middleware.py
+++ b/openedx/core/djangoapps/lang_pref/middleware.py
@@ -9,6 +9,7 @@ from django.utils.translation import LANGUAGE_SESSION_KEY
 from django.utils.translation.trans_real import parse_accept_lang_header
 
 from openedx.core.djangoapps.lang_pref import COOKIE_DURATION, LANGUAGE_HEADER, LANGUAGE_KEY
+from openedx.core.djangoapps.site_configuration.helpers import get_value
 from openedx.core.djangoapps.user_api.errors import UserAPIInternalError, UserAPIRequestError
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preference, set_user_preference
 from openedx.core.lib.mobile_utils import is_request_from_mobile_app
@@ -26,63 +27,89 @@ class LanguagePreferenceMiddleware(MiddlewareMixin):
         """
         If a user's UserPreference contains a language preference, use the user's preference.
         Save the current language preference cookie as the user's preferred language.
+
+        If site-wide language is set, don't use the language from user's
+        preferences and don't set the value from the cookies as the user's
+        preffered language.
+        Instead use the value set as a site-wide language.
         """
+        site_wide_language = get_value('LANGUAGE_CODE', None)
+        if site_wide_language:
+            request.session[LANGUAGE_SESSION_KEY] = site_wide_language
+            self.update_accept_language(request, site_wide_language)
+            return
+
         cookie_lang = request.COOKIES.get(settings.LANGUAGE_COOKIE, None)
-        if cookie_lang:
-            if request.user.is_authenticated:
-                set_user_preference(request.user, LANGUAGE_KEY, cookie_lang)
-            else:
-                request._anonymous_user_cookie_lang = cookie_lang  # lint-amnesty, pylint: disable=protected-access
+        if not cookie_lang:
+            return
 
-            accept_header = request.META.get(LANGUAGE_HEADER, None)
-            if accept_header:
-                current_langs = parse_accept_lang_header(accept_header)
-                # Promote the cookie_lang over any language currently in the accept header
-                current_langs = [(lang, qvalue) for (lang, qvalue) in current_langs if lang != cookie_lang]
-                current_langs.insert(0, (cookie_lang, 1))
-                accept_header = ",".join(f"{lang};q={qvalue}" for (lang, qvalue) in current_langs)
-            else:
-                accept_header = cookie_lang
-            request.META[LANGUAGE_HEADER] = accept_header
+        if request.user.is_authenticated:
+            set_user_preference(request.user, LANGUAGE_KEY, cookie_lang)
+        else:
+            request._anonymous_user_cookie_lang = cookie_lang  # lint-amnesty, pylint: disable=protected-access
 
-            # Allow the new cookie setting to update the language in the user's session
-            if LANGUAGE_SESSION_KEY in request.session and request.session[LANGUAGE_SESSION_KEY] != cookie_lang:
-                del request.session[LANGUAGE_SESSION_KEY]
+        self.update_accept_language(request, cookie_lang)
+
+        # Allow the new cookie setting to update the language in the user's session
+        if LANGUAGE_SESSION_KEY in request.session and request.session[LANGUAGE_SESSION_KEY] != cookie_lang:
+            del request.session[LANGUAGE_SESSION_KEY]
 
     def process_response(self, request, response):  # lint-amnesty, pylint: disable=missing-function-docstring
-        # If the user is logged in, check for their language preference. Also check for real user
-        # if current user is a masquerading user,
-        user_pref = None
-        current_user = None
-        if hasattr(request, 'user'):
-            current_user = getattr(request.user, 'real_user', request.user)
+        site_wide_language = get_value('LANGUAGE_CODE', None)
+        if site_wide_language:
+            response.set_cookie(
+                settings.LANGUAGE_COOKIE,
+                value=site_wide_language,
+                domain=settings.SESSION_COOKIE_DOMAIN,
+                max_age=COOKIE_DURATION,
+                secure=request.is_secure()
+            )
+        else:
+            # If the user is logged in, check for their language preference. Also check for real user
+            # if current user is a masquerading user,
+            user_pref = None
+            current_user = None
+            if hasattr(request, 'user'):
+                current_user = getattr(request.user, 'real_user', request.user)
 
-        if current_user and current_user.is_authenticated:
-            anonymous_cookie_lang = getattr(request, '_anonymous_user_cookie_lang', None)
-            if anonymous_cookie_lang:
-                user_pref = anonymous_cookie_lang
-                set_user_preference(current_user, LANGUAGE_KEY, anonymous_cookie_lang)
-            else:
-                # Get the user's language preference
-                try:
-                    user_pref = get_user_preference(current_user, LANGUAGE_KEY)
-                except (UserAPIRequestError, UserAPIInternalError):
-                    # If we can't find the user preferences, then don't modify the cookie
-                    pass
+            if current_user and current_user.is_authenticated:
+                anonymous_cookie_lang = getattr(request, '_anonymous_user_cookie_lang', None)
+                if anonymous_cookie_lang:
+                    user_pref = anonymous_cookie_lang
+                    set_user_preference(current_user, LANGUAGE_KEY, anonymous_cookie_lang)
+                else:
+                    # Get the user's language preference
+                    try:
+                        user_pref = get_user_preference(current_user, LANGUAGE_KEY)
+                    except (UserAPIRequestError, UserAPIInternalError):
+                        # If we can't find the user preferences, then don't modify the cookie
+                        pass
 
-            # If set, set the user_pref in the LANGUAGE_COOKIE
-            if user_pref and not is_request_from_mobile_app(request):
-                response.set_cookie(
-                    settings.LANGUAGE_COOKIE,
-                    value=user_pref,
-                    domain=settings.SESSION_COOKIE_DOMAIN,
-                    max_age=COOKIE_DURATION,
-                    secure=request.is_secure()
-                )
-            else:
-                response.delete_cookie(
-                    settings.LANGUAGE_COOKIE,
-                    domain=settings.SESSION_COOKIE_DOMAIN
-                )
+                # If set, set the user_pref in the LANGUAGE_COOKIE
+                if user_pref and not is_request_from_mobile_app(request):
+                    response.set_cookie(
+                        settings.LANGUAGE_COOKIE,
+                        value=user_pref,
+                        domain=settings.SESSION_COOKIE_DOMAIN,
+                        max_age=COOKIE_DURATION,
+                        secure=request.is_secure()
+                    )
+                else:
+                    response.delete_cookie(
+                        settings.LANGUAGE_COOKIE,
+                        domain=settings.SESSION_COOKIE_DOMAIN
+                    )
 
         return response
+
+    def update_accept_language(self, request, new_lang):
+        accept_header = request.META.get(LANGUAGE_HEADER, None)
+        if accept_header:
+            current_langs = parse_accept_lang_header(accept_header)
+            # Promote the new_lang over any language currently in the accept header
+            current_langs = [(lang, qvalue) for (lang, qvalue) in current_langs if lang != new_lang]
+            current_langs.insert(0, (new_lang, 1))
+            accept_header = ",".join(f"{lang};q={qvalue}" for (lang, qvalue) in current_langs)
+        else:
+            accept_header = new_lang
+        request.META[LANGUAGE_HEADER] = accept_header


### PR DESCRIPTION
<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This PR fixes the issues of #28502, which are described [this comment](https://github.com/edx/edx-platform/pull/28502#issuecomment-907841530).

#28502 introduced the change that allows to set `LANGUAGE_CODE` in site configurations, which made it possible to change translation of the entire site for all learners from Django admin panel. However, the implemented solution didn't work in all cases:
- In legacy UI in some instances (most of the times it would be when a language code would be required to format a date) would use the language which was set in users' preferences, or if none were set, would fallback to English
- MFEs would also use the language which was selected in users' preferences, because it would read the values that were set in cookies, and the original solution only modified the values in a session

Before (the date is not in the correct format):
![Screenshot 2021-10-28 at 00-53-08 لوحة المعلومات Your Platform Name Here](https://user-images.githubusercontent.com/30300520/139160847-9b6c0fc9-968a-4e93-b381-2c2145c020ea.png)
After (the date is now in the correct format):
![Screenshot 2021-10-28 at 00-47-41 لوحة المعلومات Your Platform Name Here](https://user-images.githubusercontent.com/30300520/139158441-1a2bf5c9-8e21-4327-908c-6d08a0baad23.png)

## Supporting information

[BB-4823](https://tasks.opencraft.com/browse/BB-4823)
[OSPR-6178](https://openedx.atlassian.net/browse/OSPR-6178)
#28502 

## Testing instructions

- Change/set `LANGUAGE_CODE` site config to `ar` at http://localhost:18000/admin/site_configuration/siteconfiguration/ (it might take some time to take effect because of caching; you can add `SITE_CACHE_TTL = 0` to `lms/envs/private.py` to remove caching)
- Go to http://localhost:18000/dashboard and check that the dates for the courses the user is enrolled in are correctly formatted (see screenshots above)
- Go to http://localhost:1997 (`frontend-app-account`) and check that it's displayed in Arabic; check that setting the language (second dropdown from the bottom) to English doesn't change the language

## Deadline

"None"

## Concerns

After setting `LANGUAGE_CODE` for a site, users who visited that site will have language cookies with the same value as `LANGUAGE_CODE` in site configuration, which might create the following problems:
- If `LANGUAGE_CODE` is removed after, the middleware will use the values from cookies to update users' preferences, which might end up messing up preferences for users that don't want that language be saved to their preferences.
- If cookies that store value for language have domain set to a value which allows subdomains or other domains have access to it, on those domains (if other sites don't have `LANGUAGE_CODE` set) the language in users' preferences will be overwritten. Since [edX Sites are normally hosted on different domains](https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/sites/index.html) and default value for `SESSION_COOKIE_DOMAIN` settings is an empty string, this shouldn't be a problem, but in certain situations it can cause problems.
