### PR TITLE
fix: update goal reminder email urls

### DIFF
--- a/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
+++ b/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
@@ -3,7 +3,6 @@ Command to trigger sending reminder emails for learners to achieve their Course 
 """
 from datetime import date, datetime, timedelta
 import logging
-import six
 
 from django.conf import settings
 from django.contrib.sites.models import Site
@@ -26,7 +25,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preference
 from openedx.core.lib.celery.task_utils import emulate_http_request
 from openedx.features.course_duration_limits.access import get_user_course_expiration_date
-from openedx.features.course_experience import course_home_url_name
+from openedx.features.course_experience.url_helpers import get_learning_mfe_home_url
 
 log = logging.getLogger(__name__)
 
@@ -52,11 +51,9 @@ def send_ace_message(goal):
     site = Site.objects.get_current()
     message_context = get_base_template_context(site)
 
-    course_home_url = reverse(course_home_url_name(course.id), args=[str(course.id)])
-    course_home_absolute_url_parts = ("https", site.name, course_home_url, '', '', '')
-    course_home_absolute_url = six.moves.urllib.parse.urlunparse(course_home_absolute_url_parts)
+    course_home_url = get_learning_mfe_home_url(course_key=goal.course_key)
 
-    goals_unsubscribe_url = reverse(
+    goals_unsubscribe_url = settings.LEARNING_MICROFRONTEND_URL + reverse(
         'course-home:unsubscribe-from-course-goal',
         kwargs={'token': goal.unsubscribe_token}
     )
@@ -66,7 +63,7 @@ def send_ace_message(goal):
         'platform_name': configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME),
         'course_name': course_name,
         'days_per_week': goal.days_per_week,
-        'course_url': course_home_absolute_url,
+        'course_url': course_home_url,
         'goals_unsubscribe_url': goals_unsubscribe_url,
         'unsubscribe_url': None,  # We don't want to include the default unsubscribe link
     })


### PR DESCRIPTION
course url now links to the MFE and unsubscribe link was missing the domain 