### PR TITLE
Add new discussions API endpoints to retrieve comments and threads from an user [BD-38] [TNL-8796] [BB-4969]

### DIFF
--- a/lms/djangoapps/discussion/rest_api/forms.py
+++ b/lms/djangoapps/discussion/rest_api/forms.py
@@ -118,8 +118,26 @@ class CommentListGetForm(_PaginationForm):
     A form to validate query parameters in the comment list retrieval endpoint
     """
     thread_id = CharField()
+    flagged = BooleanField(required=False)
     endorsed = ExtendedNullBooleanField(required=False)
     requested_fields = MultiValueField(required=False)
+
+
+class UserCommentListGetForm(_PaginationForm):
+    """
+    A form to validate query parameters in the comment list retrieval endpoint
+    """
+    course_id = CharField()
+    flagged = BooleanField(required=False)
+    requested_fields = MultiValueField(required=False)
+
+    def clean_course_id(self):
+        """Validate course_id"""
+        value = self.cleaned_data["course_id"]
+        try:
+            return CourseLocator.from_string(value)
+        except InvalidKeyError:
+            raise ValidationError(f"'{value}' is not a valid course id")  # lint-amnesty, pylint: disable=raise-missing-from
 
 
 class CommentActionsForm(Form):

--- a/lms/djangoapps/discussion/rest_api/permissions.py
+++ b/lms/djangoapps/discussion/rest_api/permissions.py
@@ -89,8 +89,14 @@ def get_editable_fields(cc_content: Union[Thread, Comment], context: Dict) -> Se
     is_thread = cc_content["type"] == "thread"
     is_comment = cc_content["type"] == "comment"
     is_privileged = context["is_requester_privileged"]
-    # True if we're dealing with a closed thread or a comment in a closed thread
-    is_thread_closed = cc_content["closed"] if is_thread else context["thread"]["closed"]
+
+    if is_thread:
+        is_thread_closed = cc_content["closed"]
+    elif context.get("thread"):
+        is_thread_closed = context["thread"]["closed"]
+    else:
+        # No editable fields when outside thread context
+        return set()
 
     # Map each field to the condition in which it's editable.
     editable_fields = {

--- a/lms/djangoapps/discussion/rest_api/serializers.py
+++ b/lms/djangoapps/discussion/rest_api/serializers.py
@@ -392,7 +392,10 @@ class CommentSerializer(_ContentSerializer):
         """
         Returns the username of the endorsing user, if the information is
         available and would not identify the author of an anonymous thread.
+        This information is unavailable outside the thread context.
         """
+        if not self.context.get("thread"):
+            return None
         endorsement = obj.get("endorsement")
         if endorsement:
             endorser_id = int(endorsement["user_id"])
@@ -408,8 +411,11 @@ class CommentSerializer(_ContentSerializer):
     def get_endorsed_by_label(self, obj):
         """
         Returns the role label (i.e. "Staff" or "Community TA") for the
-        endorsing user
+        endorsing user.
+        This information is unavailable outside the thread context.
         """
+        if not self.context.get("thread"):
+            return None
         endorsement = obj.get("endorsement")
         if endorsement:
             return self._get_user_label(int(endorsement["user_id"]))
@@ -419,7 +425,10 @@ class CommentSerializer(_ContentSerializer):
     def get_endorsed_at(self, obj):
         """
         Returns the timestamp for the endorsement, if available.
+        This information is unavailable outside the thread context.
         """
+        if not self.context.get("thread"):
+            return None
         endorsement = obj.get("endorsement")
         return endorsement["time"] if endorsement else None
 

--- a/lms/djangoapps/discussion/rest_api/tests/test_api.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api.py
@@ -7,10 +7,12 @@ import itertools
 from datetime import datetime, timedelta
 from unittest import mock
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+from opaque_keys.edx.keys import CourseKey
 
 import ddt
 import httpretty
 import pytest
+from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.test.client import RequestFactory
 from opaque_keys.edx.locator import CourseLocator
@@ -42,6 +44,7 @@ from lms.djangoapps.discussion.rest_api.api import (
     get_course_topics,
     get_thread,
     get_thread_list,
+    get_user_comments,
     update_comment,
     update_thread,
 )
@@ -67,6 +70,8 @@ from openedx.core.djangoapps.django_comment_common.models import (
     Role,
 )
 from openedx.core.lib.exceptions import CourseNotFoundError, PageNotFoundError
+
+User = get_user_model()
 
 
 def _remove_discussion_tab(course, user_id):
@@ -1585,6 +1590,119 @@ class GetCommentListTest(ForumsEnableMixin, CommentsServiceMockMixin, SharedModu
         # Page past the end
         with pytest.raises(PageNotFoundError):
             self.get_comment_list(thread, endorsed=True, page=2, page_size=10)
+
+
+@ddt.ddt
+@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+class GetUserCommentsTest(ForumsEnableMixin, CommentsServiceMockMixin, SharedModuleStoreTestCase):
+    """
+    Tests for get_user_comments.
+    """
+
+    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    def setUp(self):
+        super().setUp()
+
+        httpretty.reset()
+        httpretty.enable()
+        self.addCleanup(httpretty.reset)
+        self.addCleanup(httpretty.disable)
+
+        self.course = CourseFactory.create()
+
+        # create staff user so that we don't need to worry about
+        # permissions here
+        self.user = UserFactory.create(is_staff=True)
+        self.register_get_user_response(self.user)
+
+        self.request = RequestFactory().get(f'/api/discussion/v1/users/{self.user.username}/{self.course.id}')
+        self.request.user = self.user
+
+    def test_call_with_single_results_page(self):
+        """
+        Assert that a minimal call with valid inputs, and single result,
+        returns the expected response structure.
+        """
+        self.register_get_comments_response(
+            [make_minimal_cs_comment()],
+            page=1,
+            num_pages=1,
+        )
+        response = get_user_comments(
+            request=self.request,
+            author=self.user,
+            course_key=self.course.id,
+        )
+        assert "results" in response.data
+        assert "pagination" in response.data
+        assert response.data["pagination"]["count"] == 1
+        assert response.data["pagination"]["num_pages"] == 1
+        assert response.data["pagination"]["next"] is None
+        assert response.data["pagination"]["previous"] is None
+
+    @ddt.data(1, 2, 3)
+    def test_call_with_paginated_results(self, page):
+        """
+        Assert that paginated results return the correct pagination
+        information at the pagination boundaries.
+        """
+        self.register_get_comments_response(
+            [make_minimal_cs_comment() for _ in range(30)],
+            page=page,
+            num_pages=3,
+        )
+        response = get_user_comments(
+            request=self.request,
+            author=self.user,
+            course_key=self.course.id,
+            page=page,
+        )
+        assert "pagination" in response.data
+        assert response.data["pagination"]["count"] == 30
+        assert response.data["pagination"]["num_pages"] == 3
+
+        if page in (1, 2):
+            assert response.data["pagination"]["next"] is not None
+            assert f"page={page+1}" in response.data["pagination"]["next"]
+        if page in (2, 3):
+            assert response.data["pagination"]["previous"] is not None
+            assert f"page={page-1}" in response.data["pagination"]["previous"]
+        if page == 1:
+            assert response.data["pagination"]["previous"] is None
+        if page == 3:
+            assert response.data["pagination"]["next"] is None
+
+    def test_call_with_invalid_page(self):
+        """
+        Assert that calls for pages that exceed the existing number of
+        results pages raise PageNotFoundError.
+        """
+        self.register_get_comments_response([], page=2, num_pages=1)
+        with pytest.raises(PageNotFoundError):
+            get_user_comments(
+                request=self.request,
+                author=self.user,
+                course_key=self.course.id,
+                page=2,
+            )
+
+    def test_call_with_non_existent_course(self):
+        """
+        Assert that calls for comments in a course that doesn't exist
+        result in a CourseNotFoundError error.
+        """
+        self.register_get_comments_response(
+            [make_minimal_cs_comment()],
+            page=1,
+            num_pages=1,
+        )
+        with pytest.raises(CourseNotFoundError):
+            get_user_comments(
+                request=self.request,
+                author=self.user,
+                course_key=CourseKey.from_string("x/y/z"),
+                page=2,
+            )
 
 
 @ddt.ddt

--- a/lms/djangoapps/discussion/rest_api/tests/test_views.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views.py
@@ -6,7 +6,7 @@ Tests for Discussion API views
 import json
 from datetime import datetime
 from unittest import mock
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlencode
 
 import ddt
 import httpretty
@@ -58,6 +58,7 @@ class DiscussionAPIViewTestMixin(ForumsEnableMixin, CommentsServiceMockMixin, Ur
     in the test client, utility functions, and a test case for unauthenticated
     requests. Subclasses must set self.url in their setUp methods.
     """
+
     client_class = APIClient
 
     @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
@@ -281,6 +282,198 @@ class UploadFileViewTest(ForumsEnableMixin, CommentsServiceMockMixin, UrlResetMi
         self.enroll_user_in_course()
         response = self.client.post(self.url, data={})
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@ddt.ddt
+@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+class CommentViewSetListByUserTest(
+    ForumsEnableMixin,
+    CommentsServiceMockMixin,
+    UrlResetMixin,
+    ModuleStoreTestCase,
+):
+    """
+    Common test cases for views retrieving user-published content.
+    """
+
+    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    def setUp(self):
+        super().setUp()
+
+        httpretty.reset()
+        httpretty.enable()
+        self.addCleanup(httpretty.reset)
+        self.addCleanup(httpretty.disable)
+
+        self.user = UserFactory.create(password="password")
+        self.register_get_user_response(self.user)
+
+        self.other_user = UserFactory.create(password="password")
+        self.register_get_user_response(self.other_user)
+
+        self.course = CourseFactory.create(org="a", course="b", run="c", start=datetime.now(UTC))
+        CourseEnrollmentFactory.create(user=self.user, course_id=self.course.id)
+
+        self.url = self.build_url(self.user.username, self.course.id)
+
+    def register_mock_endpoints(self):
+        """
+        Register cs_comments_service mocks for sample threads and comments.
+        """
+        self.register_get_threads_response(
+            threads=[
+                make_minimal_cs_thread({
+                    "id": f"test_thread_{index}",
+                    "course_id": str(self.course.id),
+                    "commentable_id": f"test_topic_{index}",
+                    "username": self.user.username,
+                    "user_id": str(self.user.id),
+                    "thread_type": "discussion",
+                    "title": f"Test Title #{index}",
+                    "body": f"Test body #{index}",
+                })
+                for index in range(30)
+            ],
+            page=1,
+            num_pages=1,
+        )
+        self.register_get_comments_response(
+            comments=[
+                make_minimal_cs_comment({
+                    "id": f"test_comment_{index}",
+                    "thread_id": "test_thread",
+                    "user_id": str(self.user.id),
+                    "username": self.user.username,
+                    "created_at": "2015-05-11T00:00:00Z",
+                    "updated_at": "2015-05-11T11:11:11Z",
+                    "body": f"Test body #{index}",
+                    "votes": {"up_count": 4},
+                })
+                for index in range(30)
+            ],
+            page=1,
+            num_pages=1,
+        )
+
+    def build_url(self, username, course_id, **kwargs):
+        """
+        Builds an URL to access content from an user on a specific course.
+        """
+        base = reverse("comment-list")
+        query = urlencode({
+            "username": username,
+            "course_id": str(course_id),
+            **kwargs,
+        })
+        return f"{base}?{query}"
+
+    def assert_successful_response(self, response):
+        """
+        Check that the response was successful and contains the expected fields.
+        """
+        assert response.status_code == status.HTTP_200_OK
+        response_data = json.loads(response.content)
+        assert "results" in response_data
+        assert "pagination" in response_data
+
+    def test_request_by_unauthenticated_user(self):
+        """
+        Unauthenticated users are not allowed to request users content.
+        """
+        self.register_mock_endpoints()
+        response = self.client.get(self.url)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_request_by_unauthorized_user(self):
+        """
+        Users are not allowed to request content from courses in which
+        they're not either enrolled or staff members.
+        """
+        self.register_mock_endpoints()
+        self.client.login(username=self.other_user.username, password="password")
+        response = self.client.get(self.url)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert json.loads(response.content)["developer_message"] == "Course not found."
+
+    def test_request_by_enrolled_user(self):
+        """
+        Users that are enrolled in a course are allowed to get users'
+        comments in that course.
+        """
+        self.register_mock_endpoints()
+        self.client.login(username=self.other_user.username, password="password")
+        CourseEnrollmentFactory.create(user=self.other_user, course_id=self.course.id)
+        self.assert_successful_response(self.client.get(self.url))
+
+    def test_request_by_global_staff(self):
+        """
+        Staff users are allowed to get any user's comments.
+        """
+        self.register_mock_endpoints()
+        self.client.login(username=self.other_user.username, password="password")
+        GlobalStaff().add_users(self.other_user)
+        self.assert_successful_response(self.client.get(self.url))
+
+    @ddt.data(CourseStaffRole, CourseInstructorRole)
+    def test_request_by_course_staff(self, role):
+        """
+        Course staff users are allowed to get an user's comments in that
+        course.
+        """
+        self.register_mock_endpoints()
+        self.client.login(username=self.other_user.username, password="password")
+        role(course_key=self.course.id).add_users(self.other_user)
+        self.assert_successful_response(self.client.get(self.url))
+
+    def test_request_with_non_existent_user(self):
+        """
+        Requests for users that don't exist result in a 404 response.
+        """
+        self.register_mock_endpoints()
+        self.client.login(username=self.other_user.username, password="password")
+        GlobalStaff().add_users(self.other_user)
+        url = self.build_url("non_existent", self.course.id)
+        response = self.client.get(url)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_request_with_non_existent_course(self):
+        """
+        Requests for courses that don't exist result in a 404 response.
+        """
+        self.register_mock_endpoints()
+        self.client.login(username=self.other_user.username, password="password")
+        GlobalStaff().add_users(self.other_user)
+        url = self.build_url(self.user.username, "x/y/z")
+        response = self.client.get(url)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_request_with_invalid_course_id(self):
+        """
+        Requests with invalid course ID should fail form validation.
+        """
+        self.register_mock_endpoints()
+        self.client.login(username=self.other_user.username, password="password")
+        GlobalStaff().add_users(self.other_user)
+        url = self.build_url(self.user.username, "an invalid course")
+        response = self.client.get(url)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        parsed_response = json.loads(response.content)
+        assert parsed_response["field_errors"]["course_id"]["developer_message"] == \
+            "'an invalid course' is not a valid course id"
+
+    def test_request_with_empty_results_page(self):
+        """
+        Requests for pages that exceed the available number of pages
+        result in a 404 response.
+        """
+        self.register_get_threads_response(threads=[], page=1, num_pages=1)
+        self.register_get_comments_response(comments=[], page=1, num_pages=1)
+
+        self.client.login(username=self.other_user.username, password="password")
+        GlobalStaff().add_users(self.other_user)
+        url = self.build_url(self.user.username, self.course.id, page=2)
+        response = self.client.get(url)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})

--- a/lms/djangoapps/discussion/rest_api/tests/utils.py
+++ b/lms/djangoapps/discussion/rest_api/tests/utils.py
@@ -155,6 +155,22 @@ class CommentsServiceMockMixin:
             status=200
         )
 
+    def register_get_comments_response(self, comments, page, num_pages):
+        """Register a mock response for GET on the CS comments list endpoint"""
+        assert httpretty.is_enabled(), 'httpretty must be enabled to mock calls.'
+
+        httpretty.register_uri(
+            httpretty.GET,
+            "http://localhost:4567/api/v1/comments",
+            body=json.dumps({
+                "collection": comments,
+                "page": page,
+                "num_pages": num_pages,
+                "comment_count": len(comments),
+            }),
+            status=200
+        )
+
     def register_post_comment_response(self, comment_data, thread_id, parent_id=None):
         """
         Register a mock response for POST on the CS comments endpoint for the

--- a/openedx/core/djangoapps/django_comment_common/comment_client/models.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/models.py
@@ -102,6 +102,15 @@ class Model:
 
     @classmethod
     def retrieve_all(cls, params=None):
+        """
+        Performs a GET request against the resource's listing endpoint.
+
+        Arguments:
+            params: A dictionary of parameters to be passed as the request's query string.
+
+        Returns:
+            The parsed JSON response from the backend.
+        """
         return perform_request(
             'get',
             cls.url(action='get_all'),

--- a/openedx/core/djangoapps/django_comment_common/comment_client/models.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/models.py
@@ -100,6 +100,16 @@ class Model:
     def find(cls, id):  # pylint: disable=redefined-builtin
         return cls(id=id)
 
+    @classmethod
+    def retrieve_all(cls, params=None):
+        return perform_request(
+            'get',
+            cls.url(action='get_all'),
+            params,
+            metric_tags=[f'model_class:{cls.__name__}'],
+            metric_action='model.retrieve_all',
+        )
+
     def _update_from_response(self, response_data):
         for k, v in response_data.items():
             if k in self.accessible_fields:


### PR DESCRIPTION
## Description
Backend: Get User Comments in Course API
Modifies the comments API endpoint to allow retrieving a user's comments in a specific course.

## Depends on
* [cs_comments_service#351](https://github.com/edx/cs_comments_service/pull/351)


## Testing Instructions
1. Setup a master devstack
2. Checkout this branch.
3. Post a few threads and comments with a test user via the Discussions UI
4. Login with a user that has access to the test course
5. Using the browser's developer's tools console, test the endpoints.
6. Example requests:
```javascript
await fetch('/api/discussion/v1/comments?course_id=course-v1%3AedX%2BDemoX%2BDemo_Course&username=edx').then(r => r.json());
await fetch('/api/discussion/v1/comments?course_id=course-v1%3AedX%2BDemoX%2BDemo_Course?username=edx&flagged=true').then(r => r.json());
```