### PR TITLE
fix: default for CertificatesDisplayBehaviors is enum string value, not enum.

### DIFF
--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -563,7 +563,7 @@ class CourseFields:  # lint-amnesty, pylint: disable=missing-class-docstring
             "user can see their certificate for the course"
         ),
         scope=Scope.settings,
-        default=CertificatesDisplayBehaviors.END,
+        default=CertificatesDisplayBehaviors.END.value,
     )
     course_image = String(
         display_name=_("Course About Page Image"),


### PR DESCRIPTION
This should correct a large number of errors encountered when trying
to dump courses to neo4j.

TNL-8386