### PR TITLE
feat!: remove misleading JWT monitoring

### DIFF
--- a/openedx/core/djangoapps/oauth_dispatch/jwt.py
+++ b/openedx/core/djangoapps/oauth_dispatch/jwt.py
@@ -5,7 +5,6 @@ import json
 from time import time
 
 from django.conf import settings
-from edx_django_utils.monitoring import set_custom_attribute
 from edx_rbac.utils import create_role_auth_claim_for_user
 from jwkest import jwk
 from jwkest.jws import JWS
@@ -146,7 +145,6 @@ def _compute_time_fields(expires_in):
     """
     now = int(time())
     expires_in = expires_in or settings.JWT_AUTH['JWT_EXPIRATION']
-    set_custom_attribute('jwt_expires_in', expires_in)
     return now, now + expires_in
 
 
@@ -195,7 +193,6 @@ def _attach_profile_claim(payload, user):
 
 def _encode_and_sign(payload, use_asymmetric_key, secret):
     """Encode and sign the provided payload."""
-    set_custom_attribute('jwt_is_asymmetric', use_asymmetric_key)
     keys = jwk.KEYS()
 
     if use_asymmetric_key:


### PR DESCRIPTION
## Description

BREAKING CHANGE: Removed unused and misleading custom attributes
  used for monitoring:
* `jwt_expires_in`: Removed because it is constant for all requests
  and just repeating the setting value. It was also misleading.
* `jwt_is_asymmetric`: Removed because multiple JWTs might be created,
  and only the last would be reported, which is misleading. This was
  meant to help with a future project to get everyone on to asymmetric
  JWTs, but can be added when needed, and probably should ONLY monitor
  deprecated (symmetric) usage that needs to be fixed. That can be left
  for another day.