### PR TITLE
feat: COPPA - remove `primary/elementary` option from education

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -474,8 +474,15 @@ FEATURES = {
     'ENABLE_V2_CERT_DISPLAY_SETTINGS': False,
 }
 
-# VAN-754 - Year of birth field put behind a flag to make it available for openedX.
-COLLECT_YEAR_OF_BIRTH = True
+# .. toggle_name: ENABLE_COPPA_COMPLIANCE
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: When True, inforces COPPA compliance and removes YOB field from registration form and accounnt
+# .. settings page. Also hide YOB banner from profile page.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2021-10-27
+# .. toggle_tickets: 'https://openedx.atlassian.net/browse/VAN-622'
+ENABLE_COPPA_COMPLIANCE = False
 
 ENABLE_JASMINE = False
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -991,8 +991,15 @@ COURSE_MESSAGE_ALERT_DURATION_IN_DAYS = 14
 
 MARKETING_EMAILS_OPT_IN = False
 
-# VAN-754 - Year of birth field put behind a flag to make it available for OpenedX.
-COLLECT_YEAR_OF_BIRTH = True
+# .. toggle_name: ENABLE_COPPA_COMPLIANCE
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: When True, inforces COPPA compliance and removes YOB field from registration form and accounnt
+# .. settings page. Also hide YOB banner from profile page.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2021-10-27
+# .. toggle_tickets: 'https://openedx.atlassian.net/browse/VAN-622'
+ENABLE_COPPA_COMPLIANCE = False
 
 ############################# SET PATH INFORMATION #############################
 PROJECT_ROOT = path(__file__).abspath().dirname().dirname()  # /edx-platform/lms

--- a/lms/static/js/spec/student_account/account_settings_factory_spec.js
+++ b/lms/static/js/spec/student_account/account_settings_factory_spec.js
@@ -27,7 +27,7 @@ define(['backbone',
                     Helpers.PLATFORM_NAME,
                     Helpers.CONTACT_EMAIL,
                     true,
-                    Helpers.COLLECT_YEAR_OF_BIRTH
+                    Helpers.ENABLE_COPPA_COMPLIANCE
                 );
                 return context.accountSettingsView;
             };
@@ -165,7 +165,7 @@ define(['backbone',
                     Helpers.PLATFORM_NAME,
                     Helpers.CONTACT_EMAIL,
                     true,
-                    Helpers.COLLECT_YEAR_OF_BIRTH,
+                    Helpers.ENABLE_COPPA_COMPLIANCE,
                     '',
 
                     Helpers.SYNC_LEARNER_PROFILE_DATA,

--- a/lms/static/js/spec/student_account/helpers.js
+++ b/lms/static/js/spec/student_account/helpers.js
@@ -10,7 +10,7 @@ define(['underscore'], function(_) {
     var PASSWORD_RESET_SUPPORT_LINK = 'https://support.edx.org/hc/en-us/articles/206212088-What-if-I-did-not-receive-a-password-reset-message-'; // eslint-disable-line max-len
     var PLATFORM_NAME = 'edX';
     var CONTACT_EMAIL = 'info@example.com';
-    var COLLECT_YEAR_OF_BIRTH = true;
+    var ENABLE_COPPA_COMPLIANCE = false;
 
     var SYNC_LEARNER_PROFILE_DATA = true;
     var ENTERPRISE_NAME = 'Test Enterprise';
@@ -222,7 +222,7 @@ define(['underscore'], function(_) {
         PASSWORD_RESET_SUPPORT_LINK: PASSWORD_RESET_SUPPORT_LINK,
         PLATFORM_NAME: PLATFORM_NAME,
         CONTACT_EMAIL: CONTACT_EMAIL,
-        COLLECT_YEAR_OF_BIRTH: COLLECT_YEAR_OF_BIRTH,
+        ENABLE_COPPA_COMPLIANCE: ENABLE_COPPA_COMPLIANCE,
 
         SYNC_LEARNER_PROFILE_DATA: SYNC_LEARNER_PROFILE_DATA,
         ENTERPRISE_NAME: ENTERPRISE_NAME,

--- a/lms/static/js/student_account/views/AccessView.js
+++ b/lms/static/js/student_account/views/AccessView.js
@@ -82,7 +82,7 @@
                     this.isEnterpriseEnable = options.is_enterprise_enable || false;
                     this.isAccountRecoveryFeatureEnabled = options.is_account_recovery_feature_enabled || false;
                     this.is_require_third_party_auth_enabled = options.is_require_third_party_auth_enabled || false;
-                    this.collect_year_of_birth = options.collect_year_of_birth;
+                    this.enable_coppa_compliance = options.enable_coppa_compliance;
 
                 // The login view listens for 'sync' events from the reset model
                     this.resetModel = new PasswordResetModel({}, {
@@ -209,7 +209,7 @@
                             platformName: this.platformName,
                             hideAuthWarnings: this.hideAuthWarnings,
                             is_require_third_party_auth_enabled: this.is_require_third_party_auth_enabled,
-                            collectYearOfBirth: this.collect_year_of_birth,
+                            enableCoppaCompliance: this.enable_coppa_compliance,
                         });
 
                     // Listen for 'auth-complete' event so we can enroll/redirect the user appropriately.

--- a/lms/static/js/student_account/views/RegisterView.js
+++ b/lms/static/js/student_account/views/RegisterView.js
@@ -65,7 +65,7 @@
                     this.registerFormSubmitButtonText =
                         data.thirdPartyAuth.registerFormSubmitButtonText || _('Create Account');
                     this.is_require_third_party_auth_enabled = data.is_require_third_party_auth_enabled;
-                    this.collectYearOfBirth = data.collectYearOfBirth;
+                    this.enableCoppaCompliance = data.enableCoppaCompliance;
 
                     this.listenTo(this.model, 'sync', this.saveSuccess);
                     this.listenTo(this.model, 'validation', this.renderLiveValidations);
@@ -130,7 +130,7 @@
                     html = this.renderFields(requiredFields, 'required-fields');
 
                     html.push.apply(html, this.renderFields(
-                      optionalFields, `optional-fields ${this.collectYearOfBirth ? '' : 'full-length-fields'}`
+                      optionalFields, `optional-fields ${!this.enableCoppaCompliance ? '' : 'full-length-fields'}`
                     ));
 
                     this.render(html.join(''));

--- a/lms/static/js/student_account/views/account_settings_factory.js
+++ b/lms/static/js/student_account/views/account_settings_factory.js
@@ -22,7 +22,7 @@
             platformName,
             contactEmail,
             allowEmailChange,
-            collectYearOfBirth,
+            enableCoppaCompliance,
             socialPlatforms,
             syncLearnerProfileData,
             enterpriseName,
@@ -39,7 +39,7 @@
                 emailFieldView, secondaryEmailFieldView, socialFields, accountDeletionFields, platformData,
                 aboutSectionMessageType, aboutSectionMessage, fullnameFieldView, countryFieldView,
                 fullNameFieldData, emailFieldData, secondaryEmailFieldData, countryFieldData, additionalFields,
-                fieldItem, emailFieldViewIndex, focusId, yearOfBirthViewIndex,
+                fieldItem, emailFieldViewIndex, focusId, yearOfBirthViewIndex, levelOfEducationFieldData,
                 tabIndex = 0;
 
             $accountSettingsElement = $('.wrapper-account-settings');
@@ -135,6 +135,11 @@
                 };
             }
 
+            levelOfEducationFieldData = fieldsData.level_of_education.options;
+            if (enableCoppaCompliance) {
+                levelOfEducationFieldData = levelOfEducationFieldData.filter(option => option[0] !== 'el');
+            }
+
             aboutSectionsData = [
                 {
                     title: gettext('Basic Account Information'),
@@ -212,7 +217,7 @@
                                 model: userAccountModel,
                                 title: gettext('Education Completed'),
                                 valueAttribute: 'level_of_education',
-                                options: fieldsData.level_of_education.options,
+                                options: levelOfEducationFieldData,
                                 persistChanges: true
                             })
                         },
@@ -247,7 +252,7 @@
                 }
             ];
 
-            if (!collectYearOfBirth){
+            if (enableCoppaCompliance){
               yearOfBirthViewIndex = aboutSectionsData[1]['fields'].findIndex(function (field) {
 	              return field['view']['options']['valueAttribute']=== 'year_of_birth';
                 });

--- a/lms/templates/student_account/account_settings.html
+++ b/lms/templates/student_account/account_settings.html
@@ -48,7 +48,7 @@ from openedx.core.djangoapps.user_api.accounts.utils import is_secondary_email_f
         extendedProfileFields = ${ extended_profile_fields | n, dump_js_escaped_json },
         displayAccountDeletion = ${ enable_account_deletion | n, dump_js_escaped_json};
         isSecondaryEmailFeatureEnabled = ${ bool(is_secondary_email_feature_enabled()) | n, dump_js_escaped_json },
-        collectYearOfBirth = ${ bool(collect_year_of_birth) | n, dump_js_escaped_json },
+        enableCoppaCompliance = ${ bool(enable_coppa_compliance) | n, dump_js_escaped_json },
 
     AccountSettingsFactory(
         fieldsData,
@@ -62,7 +62,7 @@ from openedx.core.djangoapps.user_api.accounts.utils import is_secondary_email_f
         platformName,
         contactEmail,
         allowEmailChange,
-        collectYearOfBirth,
+        enableCoppaCompliance,
         socialPlatforms,
 
         syncLearnerProfileData,

--- a/openedx/core/djangoapps/user_api/accounts/settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/settings_views.py
@@ -144,7 +144,7 @@ def account_settings_context(request):
         ),
         'extended_profile_fields': _get_extended_profile_fields(),
         'beta_language': beta_language,
-        'collect_year_of_birth': settings.COLLECT_YEAR_OF_BIRTH,
+        'enable_coppa_compliance': settings.ENABLE_COPPA_COMPLIANCE,
     }
 
     enterprise_customer = enterprise_customer_for_request(request)

--- a/openedx/core/djangoapps/user_authn/views/login_form.py
+++ b/openedx/core/djangoapps/user_authn/views/login_form.py
@@ -262,7 +262,7 @@ def login_and_registration_form(request, initial_mode="login"):
             'enterprise_slug_login_url': get_enterprise_slug_login_url(),
             'is_enterprise_enable': enterprise_enabled(),
             'is_require_third_party_auth_enabled': is_require_third_party_auth_enabled(),
-            'collect_year_of_birth': settings.COLLECT_YEAR_OF_BIRTH,
+            'enable_coppa_compliance': settings.ENABLE_COPPA_COMPLIANCE,
         },
         'login_redirect_url': redirect_to,  # This gets added to the query string of the "Sign In" button in header
         'responsive': True,

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -170,7 +170,7 @@ def create_account_with_params(request, params):  # pylint: disable=too-many-sta
         if 'confirm_email' in extra_fields:
             del extra_fields['confirm_email']
 
-    if not settings.COLLECT_YEAR_OF_BIRTH and 'year_of_birth' in params:
+    if settings.ENABLE_COPPA_COMPLIANCE and 'year_of_birth' in params:
         params['year_of_birth'] = ''
 
     # registration via third party (Google, Facebook) using mobile application

--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -336,7 +336,7 @@ class RegistrationFormFactory:
 
     def __init__(self):
 
-        if not settings.COLLECT_YEAR_OF_BIRTH and 'year_of_birth' in self.EXTRA_FIELDS:
+        if settings.ENABLE_COPPA_COMPLIANCE and 'year_of_birth' in self.EXTRA_FIELDS:
             self.EXTRA_FIELDS.remove('year_of_birth')
 
         # Backwards compatibility: Honor code is required by default, unless

--- a/openedx/core/djangoapps/user_authn/views/tests/test_register.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_register.py
@@ -2062,7 +2062,7 @@ class RegistrationViewTestV2(RegistrationViewTestV1):
         ]
 
     @override_settings(
-        COLLECT_YEAR_OF_BIRTH=False,
+        ENABLE_COPPA_COMPLIANCE=True,
         REGISTRATION_EXTRA_FIELDS={
             "level_of_education": "optional",
             "gender": "optional",
@@ -2080,8 +2080,8 @@ class RegistrationViewTestV2(RegistrationViewTestV1):
     )
     def test_year_of_birth_field_with_feature_flag(self):
         """
-        Test that year of birth is not returned when COLLECT_YEAR_OF_BIRTH is
-        set to False.
+        Test that year of birth is not returned when ENABLE_COPPA_COMPLIANCE is
+        set to True.
         """
         response = self.client.get(self.url)
         self.assertHttpOK(response)


### PR DESCRIPTION
## Description
Remove `primary/elementary` option from the education field if COPPA compliance feature flag is enabled. Also, renamed the flag.

VAN-762

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
