### PR TITLE
revert: fix: default for CertificatesDisplayBehaviors is enum string value, not enum.

### DIFF
--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -573,7 +573,7 @@ class CourseFields:  # lint-amnesty, pylint: disable=missing-class-docstring
             "user can see their certificate for the course"
         ),
         scope=Scope.settings,
-        default=CertificatesDisplayBehaviors.END.value,
+        default=CertificatesDisplayBehaviors.END,
     )
     course_image = String(
         display_name=_("Course About Page Image"),


### PR DESCRIPTION
This is a cautionary revert of edx/edx-platform#29138 in case it may be related to a recent learner certificates regression: [CR-4216 (edX internal)](https://openedx.atlassian.net/browse/CR-4216). I'm opening it now just to get tests going. If it turns out not to be the culprit, I'll close this PR.

ping @staubina , who is investigating the linked CR.