### PR TITLE
feat: LEARNER-8493 Remove upgrade banner from mobile upgrade banner

### DIFF
--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -3213,6 +3213,46 @@ class TestRenderXBlock(RenderXBlockTestMixin, ModuleStoreTestCase, CompletionWaf
             response = self.get_response(usage_key=block.location)
             assert response.status_code == 200
 
+    def test_render_xblock_with_course_duration_limits(self):
+        """
+        Verify that expired banner message appears on xblock page, if learner is enrolled
+        in audit mode.
+        """
+        self.setup_course(ModuleStoreEnum.Type.split)
+        self.setup_user(admin=False, login=True)
+
+        CourseDurationLimitConfig.objects.create(enabled=True, enabled_as_of=datetime(2018, 1, 1))
+        add_course_mode(self.course, mode_slug=CourseMode.AUDIT)
+        add_course_mode(self.course)
+        CourseEnrollmentFactory(user=self.user, course_id=self.course.id, mode=CourseMode.AUDIT)
+
+        response = self.get_response(usage_key=self.vertical_block.location)
+        assert response.status_code == 200
+
+        banner_text = get_expiration_banner_text(self.user, self.course)
+        self.assertContains(response, banner_text, html=True)
+
+    @patch('openedx.core.lib.mobile_utils.is_request_from_mobile_app')
+    def test_render_xblock_with_course_duration_limits_in_mobile_browser(self, mock_is_request_from_mobile_app):
+        """
+        Verify that expired banner message doesn't appear on xblock page in a mobile browser, if learner is enrolled
+        in audit mode.
+        """
+        mock_is_request_from_mobile_app.return_value = True
+        self.setup_course(ModuleStoreEnum.Type.split)
+        self.setup_user(admin=False, login=True)
+
+        CourseDurationLimitConfig.objects.create(enabled=True, enabled_as_of=datetime(2018, 1, 1))
+        add_course_mode(self.course, mode_slug=CourseMode.AUDIT)
+        add_course_mode(self.course)
+        CourseEnrollmentFactory(user=self.user, course_id=self.course.id, mode=CourseMode.AUDIT)
+
+        response = self.get_response(usage_key=self.vertical_block.location)
+        assert response.status_code == 200
+
+        banner_text = get_expiration_banner_text(self.user, self.course)
+        self.assertNotContains(response, banner_text, html=True)
+
 
 class TestRenderXBlockSelfPaced(TestRenderXBlock):  # lint-amnesty, pylint: disable=test-inherits-tests
     """

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -3232,7 +3232,7 @@ class TestRenderXBlock(RenderXBlockTestMixin, ModuleStoreTestCase, CompletionWaf
         banner_text = get_expiration_banner_text(self.user, self.course)
         self.assertContains(response, banner_text, html=True)
 
-    @patch('openedx.core.lib.mobile_utils.is_request_from_mobile_app')
+    @patch('lms.djangoapps.courseware.views.views.is_request_from_mobile_app')
     def test_render_xblock_with_course_duration_limits_in_mobile_browser(self, mock_is_request_from_mobile_app):
         """
         Verify that expired banner message doesn't appear on xblock page in a mobile browser, if learner is enrolled

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1758,6 +1758,8 @@ def render_xblock(request, usage_key_string, check_if_enrolled=True):
         # If other use cases appear, consider removing the is_learning_mfe check or switching this
         # to be its own query parameter that can toggle the behavior.
         student_view_context['hide_access_error_blocks'] = is_learning_mfe and recheck_access
+        is_mobile_app = is_request_from_mobile_app(request)
+        student_view_context['is_mobile_app'] = is_mobile_app
 
         enable_completion_on_view_service = False
         completion_service = block.runtime.service(block, 'completion')
@@ -1807,7 +1809,7 @@ def render_xblock(request, usage_key_string, check_if_enrolled=True):
             'on_courseware_page': True,
             'verified_upgrade_link': verified_upgrade_deadline_link(request.user, course=course),
             'is_learning_mfe': is_learning_mfe,
-            'is_mobile_app': is_request_from_mobile_app(request),
+            'is_mobile_app': is_mobile_app,
             'reset_deadlines_url': reverse(RESET_COURSE_DEADLINES_NAME),
             'render_course_wide_assets': True,
 

--- a/openedx/features/course_duration_limits/access.py
+++ b/openedx/features/course_duration_limits/access.py
@@ -242,6 +242,9 @@ def course_expiration_wrapper(user, block, view, frag, context):  # pylint: disa
     An XBlock wrapper that prepends a message to the beginning of a vertical if
     a user's course is about to expire.
     """
+    if context['is_mobile_app']:
+        return frag
+
     if block.category != 'vertical':
         return frag
 

--- a/openedx/features/course_duration_limits/access.py
+++ b/openedx/features/course_duration_limits/access.py
@@ -242,7 +242,7 @@ def course_expiration_wrapper(user, block, view, frag, context):  # pylint: disa
     An XBlock wrapper that prepends a message to the beginning of a vertical if
     a user's course is about to expire.
     """
-    if context['is_mobile_app']:
+    if context.get('is_mobile_app'):
         return frag
 
     if block.category != 'vertical':


### PR DESCRIPTION
## Description

After investigating the best way to keep a user logged in, and solve rendering issues, we decided to show the unit page in a full webview within the app. However, in order to comply with app store guidelines, we need to remove the upgrade banner from this page.

[Jira Ticket: LEARNER-8493](https://openedx.atlassian.net/browse/LEARNER-8493)

Useful information to include:
- This change will effect only mobile users.


## Testing instructions

This branch is deployed on [sandbox](https://iap.sandbox.edx.org).
For testing:
Visit [web page](https://iap.sandbox.edx.org/xblock/block-v1:1+1+1+type@vertical+block@572d9e1b23b44f299ce3baf3608a7b34) where you can see upgrade banner.

An apk has been built on this sandbox so that you can test it on your android. Github didn't allow me to attach apk here so it can be sent on slack or email. When you visit the same module through mobile app upgrade banner doesn't appear.

 