### PR TITLE
[AA-1089] fix: don't introduce integrity errors when updating LastSeenCoursewareTimezone

### DIFF
--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -485,7 +485,7 @@ class CoursewareInformation(RetrieveAPIView):
                 TieredCache.set_all_tiers(cache_key, str(browser_timezone), 86400)  # Refresh the cache daily
                 LastSeenCoursewareTimezone.objects.update_or_create(
                     user=user,
-                    last_seen_courseware_timezone=browser_timezone,
+                    defaults={'last_seen_courseware_timezone': browser_timezone},
                 )
 
     def get_object(self):


### PR DESCRIPTION
The update_or_create was previously incorrectly using the last_seen_courseware_timezone kwarg when it should have been used as part of the defaults