### PR TITLE
fix: remove ProctoredExamSoftwareSecureReview.video_url from proctoring library

### DIFF
--- a/common/djangoapps/util/tests/test_db.py
+++ b/common/djangoapps/util/tests/test_db.py
@@ -1,6 +1,7 @@
 """Tests for util.db module."""
 
 
+import unittest
 from io import StringIO
 
 import ddt
@@ -122,6 +123,9 @@ class MigrationTests(TestCase):
     """
 
     @override_settings(MIGRATION_MODULES={})
+    @unittest.skip(
+        "Temporary skip for MST-1100 while video_url columns are removed from ProctoredExamSoftwareSecureReview"
+    )
     def test_migrations_are_in_sync(self):
         """
         Tests that the migration files are in sync with the models.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -462,7 +462,7 @@ edx-opaque-keys[django]==2.2.2
     #   xmodule
 edx-organizations==6.10.0
     # via -r requirements/edx/base.in
-edx-proctoring==4.3.1
+edx-proctoring==4.3.2
     # via
     #   -r requirements/edx/base.in
     #   edx-proctoring-proctortrack

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -571,7 +571,7 @@ edx-opaque-keys[django]==2.2.2
     #   xmodule
 edx-organizations==6.10.0
     # via -r requirements/edx/testing.txt
-edx-proctoring==4.3.1
+edx-proctoring==4.3.2
     # via
     #   -r requirements/edx/testing.txt
     #   edx-proctoring-proctortrack

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -553,7 +553,7 @@ edx-opaque-keys[django]==2.2.2
     #   xmodule
 edx-organizations==6.10.0
     # via -r requirements/edx/base.txt
-edx-proctoring==4.3.1
+edx-proctoring==4.3.2
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring-proctortrack


### PR DESCRIPTION
## Description

As part of [MST-1100](https://openedx.atlassian.net/browse/MST-1100), update the edx-proctoring library to version 4.3.2 to remove code reference of ProctoredExamSoftwareSecureReview.video_url field. This is second step of a column drop.
