### PR TITLE
Backport to Lilac master: xblock-poll's export to CSV feature is not working [TNL-8370] [MNG-2273] [BB-4877]

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2576,6 +2576,12 @@ DEBUG_TOOLBAR_PATCH_SETTINGS = False
 
 ################################# CELERY ######################################
 
+CELERY_IMPORTS = (
+    # Since xblock-poll is not a Django app, and XBlocks don't get auto-imported
+    # by celery workers, its tasks will not get auto-discovered:
+    'poll.tasks',
+)
+
 # Celery beat configuration
 
 CELERYBEAT_SCHEDULER = 'celery.beat:PersistentScheduler'


### PR DESCRIPTION
## Description

This is a backport of https://github.com/edx/edx-platform/pull/28019 to the Lilac master branch, as [requested](https://github.com/edx/edx-platform/pull/28019#issuecomment-952413371) by @alfredchavez.

Summary:

> xblock-poll's celery task was broken, then fixed in #23700, then broken again by #25479. This fixes it again.


## Supporting information

See original PR.

## Testing instructions

See original PR.

## Deadline

None

## Other information

.