### PR TITLE
feat: add support for metadata files that have more than one key

### DIFF
--- a/common/djangoapps/third_party_auth/tasks.py
+++ b/common/djangoapps/third_party_auth/tasks.py
@@ -172,6 +172,16 @@ def _parse_metadata_xml(xml, entity_id):
     public_key = sso_desc.findtext("./{}//{}".format(
         etree.QName(SAML_XML_NS, "KeyDescriptor"), "{http://www.w3.org/2000/09/xmldsig#}X509Certificate"
     ))
+
+    signing_public_key = sso_desc.findtext("./{}{}//{}".format(
+        etree.QName(SAML_XML_NS, "KeyDescriptor"),
+        "[@use='signing']",
+        "{http://www.w3.org/2000/09/xmldsig#}X509Certificate",
+    ))
+
+    if signing_public_key and public_key != signing_public_key:
+        public_key = signing_public_key
+
     if not public_key:
         raise MetadataParseError("Public Key missing. Expected an <X509Certificate>")
     public_key = public_key.replace(" ", "")


### PR DESCRIPTION
<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This PR adds support for this metadata files that have more than one key, resolves that there are times when a specific key exists to be the "signing_key".

Web example: https://blog.samlsecurity.com/2012/02/saml-metadata.html
An example with a large public entity of the Danish government: https://idp.dlbr.dk/federationmetadata/2007-06/federationmetadata.xml

## Other information

The eduNext fork has used this change for a long time and has no negative consequences. ADFS is an example of a system that uses this.

Lilac: https://github.com/eduNEXT/edunext-platform/pull/568 
Juniper: https://github.com/eduNEXT/edunext-platform/pull/414
Ironwood: https://github.com/eduNEXT/edunext-platform/pull/308
Hawthorn: https://github.com/eduNEXT/edunext-platform/pull/227
Ginkgo: https://github.com/eduNEXT/edunext-platform/pull/191

@bradenmacdonald @saleem-latif @MatthewPiatetsky 