### PR TITLE
feat: trigger complete_video event when video is marked for completion

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/video/completion_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/completion_spec.js
@@ -37,8 +37,10 @@
         });
 
         it('calls the completion api when marking an object complete', function() {
+            spyOnEvent(state.el, 'complete');
             state.completionHandler.markCompletion(Date.now());
             expect($.ajax).toHaveBeenCalledWith(completionAjaxCall);
+            expect('complete').toHaveBeenTriggeredOn(state.el);
             expect(state.completionHandler.isComplete).toEqual(true);
         });
 

--- a/common/lib/xmodule/xmodule/js/spec/video/video_events_plugin_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_events_plugin_spec.js
@@ -59,6 +59,16 @@ import '../helper.js'
             expect(state.videoEventsPlugin.emitPlayVideoEvent).toBeTruthy();
         });
 
+        it('can emit "complete_video" event when video is marked as complete', function() {
+            state.el.trigger('complete');
+            expect(Logger.log).toHaveBeenCalledWith('complete_video', {
+                id: 'id',
+                code: this.code,
+                currentTime: 10,
+                duration: this.duration
+            });
+        });
+
         it('can emit "speed_change_video" event', function() {
             state.el.trigger('speedchange', ['2.0', '1.0']);
             expect(Logger.log).toHaveBeenCalledWith('speed_change_video', {
@@ -199,6 +209,7 @@ import '../helper.js'
                 ready: plugin.onReady,
                 play: plugin.onPlay,
                 pause: plugin.onPause,
+                complete: plugin.onComplete,
                 'ended stop': plugin.onEnded,
                 seek: plugin.onSeek,
                 skip: plugin.onSkip,

--- a/common/lib/xmodule/xmodule/js/src/video/09_completion.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_completion.js
@@ -154,6 +154,7 @@
                 var errmsg;
                 this.isComplete = true;
                 this.lastSentTime = currentTime;
+                this.state.el.trigger('complete');
                 if (this.state.config.publishCompletionUrl) {
                     $.ajax({
                         type: 'POST',

--- a/common/lib/xmodule/xmodule/js/src/video/09_events_plugin.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_events_plugin.js
@@ -15,7 +15,7 @@
                 return new EventsPlugin(state, i18n, options);
             }
 
-            _.bindAll(this, 'onReady', 'onPlay', 'onPause', 'onEnded', 'onSeek',
+            _.bindAll(this, 'onReady', 'onPlay', 'onPause', 'onComplete', 'onEnded', 'onSeek',
             'onSpeedChange', 'onAutoAdvanceChange', 'onShowLanguageMenu', 'onHideLanguageMenu',
             'onSkip', 'onShowTranscript', 'onHideTranscript', 'onShowCaptions', 'onHideCaptions',
             'destroy');
@@ -41,6 +41,7 @@
                     ready: this.onReady,
                     play: this.onPlay,
                     pause: this.onPause,
+                    complete: this.onComplete,
                     'ended stop': this.onEnded,
                     seek: this.onSeek,
                     skip: this.onSkip,
@@ -76,6 +77,10 @@
             onPause: function() {
                 this.log('pause_video', {currentTime: this.getCurrentTime()});
                 this.emitPlayVideoEvent = true;
+            },
+
+            onComplete: function() {
+                this.log('complete_video', {currentTime: this.getCurrentTime()});
             },
 
             onEnded: function() {


### PR DESCRIPTION
This PR has changes to trigger `complete_video` event when video is marked for completion.

## Testing instructions
1. After checking out branch run `paver update_assets` commands to update webpack bundle with JS changes
2. Enable completion tool
go to http://localhost:18000/admin/waffle/switch/ (substitute your LMS URL for http://localhost:18000/), and add a new switch with Name completion.enable_completion_tracking and Active selected.
3. Add any video to course and publish it from studio
4. Navigate to the video in course experience as learner and play video
5. `complete_video` should be triggered as soon as video is completed and that event should be moniter both in browsers xHR console as well as standard output of LMS
<img width="1423" alt="Screen Shot 2022-01-12 at 10 57 45 AM" src="https://user-images.githubusercontent.com/434995/149072481-3cf46d57-10f5-49f6-943a-af33b1eb74b0.png">
