### PR TITLE
fix: fix issues with LANGUAGE_CODE for legacy UI [BB-4823] [OSPR-6196]

### DIFF
--- a/lms/djangoapps/courseware/context_processor.py
+++ b/lms/djangoapps/courseware/context_processor.py
@@ -10,6 +10,7 @@ from pytz import timezone
 
 from edx_django_utils.cache import TieredCache
 from lms.djangoapps.courseware.models import LastSeenCoursewareTimezone
+from openedx.core.djangoapps.site_configuration.helpers import get_value
 from openedx.core.djangoapps.user_api.errors import UserAPIInternalError, UserNotFound
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preference, get_user_preferences
 from openedx.core.lib.cache_utils import get_cache
@@ -26,6 +27,8 @@ def user_timezone_locale_prefs(request):
     """
     Checks if request has an authenticated user.
     If so, sends set (or none if unset) time_zone and language prefs.
+    If site-wide language is set, that language is used over the language set
+    in user preferences.
 
     This interacts with the DateUtils to either display preferred or attempt to determine
     system/browser set time_zones and languages
@@ -47,6 +50,9 @@ def user_timezone_locale_prefs(request):
                     key: user_preferences.get(pref_name, None)
                     for key, pref_name in RETRIEVABLE_PREFERENCES.items()
                 }
+        site_wide_language = get_value('LANGUAGE_CODE', None)
+        if site_wide_language:
+            user_prefs['user_language'] = site_wide_language
 
         cached_value.update(user_prefs)
     return cached_value

--- a/lms/djangoapps/courseware/tests/test_context_processor.py
+++ b/lms/djangoapps/courseware/tests/test_context_processor.py
@@ -3,7 +3,7 @@ Unit tests for courseware context_processor
 """
 
 from pytz import timezone
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 from django.contrib.auth.models import AnonymousUser
 
 from lms.djangoapps.courseware.context_processor import (
@@ -47,6 +47,13 @@ class UserPrefContextProcessorUnitTest(ModuleStoreTestCase):
         assert context['user_language'] is None
         assert context['user_timezone'] is not None
         assert context['user_timezone'] == 'Asia/Tokyo'
+
+    @patch("lms.djangoapps.courseware.context_processor.get_value")
+    def test_site_wide_language_set(self, mock_get_value):
+        mock_get_value.return_value = 'ar'
+        set_user_preference(self.user, 'pref-lang', 'en')
+        context = user_timezone_locale_prefs(self.request)
+        assert context['user_language'] == 'ar'
 
     def test_get_user_timezone_or_last_seen_timezone_or_utc(self):
         # We default to UTC


### PR DESCRIPTION
<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This PR fixes some of the issues of #28502, which are described [this comment](https://github.com/edx/edx-platform/pull/28502#issuecomment-907841530).

#28502 introduced the change that allows to set `LANGUAGE_CODE` in site configurations, which made it possible to change translation of the entire site for all learners from Django admin panel. However, the implemented solution didn't work in all cases. This PR implements changes to fix the following:
- In legacy UI in some instances (most of the times it would be when a language code would be required to format a date) would use the language which was set in users' preferences, or if none were set, would fallback to English

Before (the date is not in the correct format):
![Screenshot 2021-10-28 at 00-53-08 لوحة المعلومات Your Platform Name Here](https://user-images.githubusercontent.com/30300520/139160847-9b6c0fc9-968a-4e93-b381-2c2145c020ea.png)
After (the date is now in the correct format):
![Screenshot 2021-10-28 at 00-47-41 لوحة المعلومات Your Platform Name Here](https://user-images.githubusercontent.com/30300520/139158441-1a2bf5c9-8e21-4327-908c-6d08a0baad23.png)

## Supporting information

[BB-4823](https://tasks.opencraft.com/browse/BB-4823)
[OSPR-6196](https://openedx.atlassian.net/browse/OSPR-6196)
#28502
#29122

## Testing instructions

- Change/set `LANGUAGE_CODE` site config to `ar` at http://localhost:18000/admin/site_configuration/siteconfiguration/ (it might take some time to take effect because of caching; you can add `SITE_CACHE_TTL = 0` to `lms/envs/private.py` to remove caching)
- Go to http://localhost:18000/dashboard and check that the dates for the courses the user is enrolled in are correctly formatted (see screenshots above)

## Deadline

"None"