### PR TITLE
MST-980: Hide proctored exams after due by default

### DIFF
--- a/cms/templates/js/timed-examination-preference-editor.underscore
+++ b/cms/templates/js/timed-examination-preference-editor.underscore
@@ -38,7 +38,7 @@
                     />
                     <%- gettext('Proctored') %>
                 </label>
-                <p class='field-message' id='proctored-exam-description'> <%- gettext('Proctored exams are timed and they record video of each learner taking the exam. The videos are then reviewed to ensure that learners follow all examination rules.') %> </p>
+                <p class='field-message' id='proctored-exam-description'> <%- gettext('Proctored exams are timed and they record video of each learner taking the exam. The videos are then reviewed to ensure that learners follow all examination rules. Please note that setting this exam as proctored will change the visibility settings to "Hide content after due date."') %> </p>
 
                 <% var supports_onboarding = xblockInfo.get('supports_onboarding'); %>
                 <% if (supports_onboarding) { %>


### PR DESCRIPTION
<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

When setting an exam type to proctored, `hide_after_due` will be set to True by default. This also updates the help text on exam type selection to reflect this change.

![Screen Shot 2021-11-01 at 10 48 09 AM](https://user-images.githubusercontent.com/10442143/139694889-9c8120b3-1413-4b5d-9342-8ac204905601.png)

## Supporting information

[MST-980](https://openedx.atlassian.net/browse/MST-980)