### PR TITLE
fix: consider course end date in visible_date

### DIFF
--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -874,6 +874,17 @@ def _course_uses_available_date(course):
     )
 
 
+def _course_uses_end_date(course):
+    """Returns if the course end date should be used"""
+    display_behavior_is_valid = course.certificates_display_behavior == CertificatesDisplayBehaviors.END
+
+    return (
+        _enabled_and_instructor_paced(course)
+        and course.end
+        and display_behavior_is_valid
+    )
+
+
 def available_date_for_certificate(course, certificate, certificate_available_date=None):
     """
     Returns the available date to use with a certificate
@@ -885,6 +896,8 @@ def available_date_for_certificate(course, certificate, certificate_available_da
     """
     if _course_uses_available_date(course):
         return certificate_available_date or course.certificate_available_date
+    if _course_uses_end_date(course):
+        return course.end
     return certificate.modified_date
 
 


### PR DESCRIPTION
## Description

We send a visible_date from Platform to Credentials so that credentials
knows what date to display on the learner record (also used in some
other places, like calculating program cert date). If the course is
instructor-paced and the certificate display behavior is set to "end",
we need to send the course end date as the visible date.

Related to MICROBA-1554.

## Supporting information

[MICROBA-1554](https://openedx.atlassian.net/browse/MICROBA-1554)
And the original CR: [CR-4166](https://openedx.atlassian.net/browse/CR-4166)

## Testing instructions

1. Identify or make a course in a program.
2. In Studio, set the end date of the course to something in the future, and set the Certificates Display Behavior to "end date of course".
3. As a learner, earn a passing grade in the course.
4. Check your Program Record page for the program this course is part of. Even though you have earned a passing grade, the row for this course in the Program Record should show "not earned" until the course end date lapses.

## Deadline

None
