### PR TITLE
feat!: Change the way tabs are ordered [BD-38] [TNL-9174] [BB-5076]

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v0/serializers/tabs.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/serializers/tabs.py
@@ -71,23 +71,7 @@ class CourseTabSerializer(serializers.Serializer):  # pylint: disable=abstract-m
 class TabIDLocatorSerializer(serializers.Serializer):  # pylint: disable=abstract-method
     """Serializer for tab locations, used to identify a tab in a course."""
 
-    tab_id = serializers.CharField(required=False, help_text=_("ID of tab to update"))
-    tab_locator = UsageKeyField(required=False, help_text=_("Location (Usage Key) of tab to update"))
-
-    def validate(self, attrs: Dict) -> Dict:
-        """
-        Validates that either the ``tab_id`` or ``tab_locator`` are specified, but not both.
-
-        Args:
-            attrs (Dict): A dictionary of attributes to validate
-        """
-        has_tab_id = "tab_id" in attrs
-        has_tab_locator = "tab_locator" in attrs
-        if has_tab_locator ^ has_tab_id:
-            return super().validate(attrs)
-        raise serializers.ValidationError(
-            {"non_field_errors": _("Need to supply either a valid tab_id or a tab_location.")}
-        )
+    tab_locator = UsageKeyField(required=True, help_text=_("Location (Usage Key) of tab to update"))
 
 
 class CourseTabUpdateSerializer(serializers.Serializer):  # pylint: disable=abstract-method

--- a/cms/djangoapps/contentstore/rest_api/v0/views/advanced_settings.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/advanced_settings.py
@@ -24,7 +24,7 @@ class AdvancedCourseSettingsView(DeveloperErrorViewMixin, APIView):
 
     class FilterQuery(forms.Form):
         """
-        Form for validating query marameters passed to advanced course settings view
+        Form for validating query parameters passed to advanced course settings view
         to filter the data it returns.
         """
         filter_fields = forms.CharField(strip=True, empty_value=None, required=False)

--- a/cms/djangoapps/contentstore/rest_api/v0/views/tabs.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/tabs.py
@@ -177,7 +177,7 @@ class CourseTabReorderView(DeveloperErrorViewMixin, APIView):
         return super().handle_exception(exc)
 
     @apidocs.schema(
-        body=[TabIDLocatorSerializer],
+        body=TabIDLocatorSerializer(many=True),
         parameters=[
             apidocs.string_parameter("course_id", apidocs.ParameterLocation.PATH, description="Course ID"),
         ],
@@ -199,23 +199,11 @@ class CourseTabReorderView(DeveloperErrorViewMixin, APIView):
 
             POST /api/contentstore/v0/tabs/{course_id}/reorder [
                 {
-                    "tab_id": "info"
-                },
-                {
-                    "tab_id": "courseware"
-                },
-                {
                     "tab_locator": "block-v1:TstX+DemoX+Demo+type@static_tab+block@d26fcb0e93824fbfa5c9e5f100e2511a"
                 },
                 {
-                    "tab_id": "wiki"
+                    "tab_locator": "block-v1:TstX+DemoX+Demo+type@static_tab+block@a011f1bd05af4578ae397ed8cabccf62"
                 },
-                {
-                    "tab_id": "discussion"
-                },
-                {
-                    "tab_id": "progress"
-                }
             ]
 
 
@@ -233,7 +221,7 @@ class CourseTabReorderView(DeveloperErrorViewMixin, APIView):
         tab_id_locators.is_valid(raise_exception=True)
         reorder_tabs_handler(
             course_module,
-            {"tabs": tab_id_locators.validated_data},
+            tab_id_locators.validated_data,
             request.user,
         )
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/cms/djangoapps/contentstore/views/tabs.py
+++ b/cms/djangoapps/contentstore/views/tabs.py
@@ -110,7 +110,7 @@ def update_tabs_handler(course_item: CourseBlock, tabs_data: Dict, user: User) -
     """
 
     if "tabs" in tabs_data:
-        reorder_tabs_handler(course_item, tabs_data, user)
+        reorder_tabs_handler(course_item, tabs_data["tabs"], user)
     elif "tab_id_locator" in tabs_data:
         edit_tab_handler(course_item, tabs_data, user)
     else:
@@ -126,34 +126,17 @@ def reorder_tabs_handler(course_item, tabs_data, user):
     # The locators are used to identify static tabs since they are xmodules.
     # Although all tabs have tab_ids, newly created static tabs do not know
     # their tab_ids since the xmodule editor uses only locators to identify new objects.
-    requested_tab_id_locators = tabs_data["tabs"]
 
-    #get original tab list of only static tabs with their original index(position) in the full course tabs list
-    old_tab_dict = {}
-    for idx, tab in enumerate(course_item.tabs):
-        if isinstance(tab, StaticTab):
-            old_tab_dict[tab] = idx
-    old_tab_list = list(old_tab_dict.keys())
-
-    new_tab_list = create_new_list(requested_tab_id_locators, old_tab_list)
-
-    # Creates a full new course tab list of both default and static course tabs
-    # by looping through the new tab list of static only tabs and
-    # putting them in their new position in the list of course item tabs
-    # original_idx gives the list of positions of all static tabs in course tabs originally
-    full_new_tab_list = course_item.tabs
-    original_idx = list(old_tab_dict.values())
-    for i in range(len(new_tab_list)):
-        full_new_tab_list[original_idx[i]] = new_tab_list[i]
+    new_tab_list = create_new_list(tabs_data, course_item.tabs)
 
     # validate the tabs to make sure everything is Ok (e.g., did the client try to reorder unmovable tabs?)
     try:
-        CourseTabList.validate_tabs(full_new_tab_list)
+        CourseTabList.validate_tabs(new_tab_list)
     except InvalidTabsException as exception:
         raise ValidationError({"error": f"New list of tabs is not valid: {str(exception)}."}) from exception
 
     # persist the new order of the tabs
-    course_item.tabs = full_new_tab_list
+    course_item.tabs = new_tab_list
     modulestore().update_item(course_item, user.id)
 
 
@@ -173,7 +156,7 @@ def create_new_list(requested_tab_id_locators, old_tab_list):
     # global or course settings.  so add those to the end of the list.
     non_displayed_tabs = set(old_tab_list) - set(new_tab_list)
     new_tab_list.extend(non_displayed_tabs)
-    return new_tab_list
+    return sorted(new_tab_list, key=lambda item: item.priority or float('inf'))
 
 
 def edit_tab_handler(course_item: CourseBlock, tabs_data: Dict, user: User):

--- a/cms/djangoapps/contentstore/views/tests/test_tabs.py
+++ b/cms/djangoapps/contentstore/views/tests/test_tabs.py
@@ -1,6 +1,7 @@
 """ Tests for tab functions (just primitive). """
 
 import json
+from random import random
 
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
 from cms.djangoapps.contentstore.utils import reverse_course_url
@@ -38,9 +39,9 @@ class TabsPageTests(CourseTestCase):
     def check_invalid_tab_id_response(self, resp):
         """Verify response is an error listing the invalid_tab_id"""
 
-        self.assertEqual(resp.status_code, 400)
+        assert resp.status_code == 400
         resp_content = json.loads(resp.content.decode('utf-8'))
-        self.assertIn("error", resp_content)
+        assert "error" in resp_content
 
     def test_not_implemented(self):
         """Verify not implemented errors"""
@@ -75,34 +76,38 @@ class TabsPageTests(CourseTestCase):
     def test_reorder_tabs(self):
         """Test re-ordering of tabs"""
 
-        # get the original tab ids
-        orig_tab_ids = [tab.tab_id for tab in self.course.tabs]
-        tab_ids = list(orig_tab_ids)
-        num_orig_tabs = len(orig_tab_ids)
+        # get the original tabs
+        tabs = list(self.course.tabs)
+        num_orig_tabs = len(self.course.tabs)
 
         # make sure we have enough tabs to play around with
-        self.assertGreaterEqual(num_orig_tabs, 5)
+        assert num_orig_tabs >= 5
 
-        # reorder the last two tabs
-        tab_ids[num_orig_tabs - 1], tab_ids[num_orig_tabs - 2] = tab_ids[num_orig_tabs - 2], tab_ids[num_orig_tabs - 1]
+        # Randomise the order of static tabs, leave the rest intact
+        tabs.sort(key=lambda tab: (100+random()) if tab.type == 'static_tab' else tab.priority)
 
-        # remove the third to the last tab, the removed tab has to be a static tab
-        # (the code needs to handle the case where tabs requested for re-ordering is a subset of the tabs in the course)
-        removed_tab = tab_ids.pop(num_orig_tabs - 3)
-        self.assertEqual(len(tab_ids), num_orig_tabs - 1)
+        tabs_data = [
+            {'tab_locator': str(self.course.id.make_usage_key("static_tab", tab.url_slug))}
+            for tab in tabs
+            if tab.type == 'static_tab'
+        ]
+        # Remove one tab randomly. This shouldn't delete the tab.
+        tabs_data.pop()
 
         # post the request with the reordered static tabs only
         resp = self.client.ajax_post(
             self.url,
-            data={'tabs': [{'tab_id': tab_id} for tab_id in tab_ids if 'static' in tab_id]},
+            data={
+                'tabs': tabs_data
+            },
         )
-        self.assertEqual(resp.status_code, 204)
+        assert resp.status_code == 204
 
         # reload the course and verify the new tab order
         self.reload_course()
+        reordered_tab_ids = [tab.tab_id for tab in tabs]
         new_tab_ids = [tab.tab_id for tab in self.course.tabs]
-        self.assertEqual(new_tab_ids, tab_ids + [removed_tab])
-        self.assertNotEqual(new_tab_ids, orig_tab_ids)
+        assert new_tab_ids == reordered_tab_ids
 
     def test_reorder_tabs_invalid_list(self):
         """Test re-ordering of tabs with invalid tab list"""
@@ -118,9 +123,9 @@ class TabsPageTests(CourseTestCase):
             self.url,
             data={'tabs': [{'tab_id': tab_id} for tab_id in tab_ids]},
         )
-        self.assertEqual(resp.status_code, 400)
+        assert resp.status_code == 400
         resp_content = json.loads(resp.content.decode('utf-8'))
-        self.assertIn("error", resp_content)
+        assert "error" in resp_content
 
     def test_reorder_tabs_invalid_tab(self):
         """Test re-ordering of tabs with invalid tab"""
@@ -141,7 +146,7 @@ class TabsPageTests(CourseTestCase):
         old_tab = CourseTabList.get_tab_by_type(self.course.tabs, tab_type)
 
         # visibility should be different from new setting
-        self.assertNotEqual(old_tab.is_hidden, new_is_hidden_setting)
+        assert old_tab.is_hidden != new_is_hidden_setting
 
         # post the request
         resp = self.client.ajax_post(
@@ -151,12 +156,12 @@ class TabsPageTests(CourseTestCase):
                 'is_hidden': new_is_hidden_setting,
             }),
         )
-        self.assertEqual(resp.status_code, 204)
+        assert resp.status_code == 204
 
         # reload the course and verify the new visibility setting
         self.reload_course()
         new_tab = CourseTabList.get_tab_by_type(self.course.tabs, tab_type)
-        self.assertEqual(new_tab.is_hidden, new_is_hidden_setting)
+        assert new_tab.is_hidden == new_is_hidden_setting
 
     def test_toggle_tab_visibility(self):
         """Test toggling of tab visibility"""
@@ -182,15 +187,15 @@ class TabsPageTests(CourseTestCase):
         preview_url = f'/xblock/{self.test_tabs[0].location}/{STUDENT_VIEW}'
 
         resp = self.client.get(preview_url, HTTP_ACCEPT='application/json')
-        self.assertEqual(resp.status_code, 200)
+        assert resp.status_code == 200
         resp_content = json.loads(resp.content.decode('utf-8'))
         html = resp_content['html']
 
         # Verify that the HTML contains the expected elements
-        self.assertIn('<span class="action-button-text">Edit</span>', html)
-        self.assertIn('<span class="sr">Duplicate this component</span>', html)
-        self.assertIn('<span class="sr">Delete this component</span>', html)
-        self.assertIn('<span data-tooltip="Drag to reorder" class="drag-handle action"></span>', html)
+        assert '<span class="action-button-text">Edit</span>' in html
+        assert '<span class="sr">Duplicate this component</span>' in html
+        assert '<span class="sr">Delete this component</span>' in html
+        assert '<span data-tooltip="Drag to reorder" class="drag-handle action"></span>' in html
 
 
 class PrimitiveTabEdit(ModuleStoreTestCase):
@@ -206,15 +211,15 @@ class PrimitiveTabEdit(ModuleStoreTestCase):
         with self.assertRaises(IndexError):
             tabs.primitive_delete(course, 7)
         tabs.primitive_delete(course, 2)
-        self.assertNotIn({'type': 'textbooks'}, course.tabs)
+        assert {'type': 'textbooks'} not in course.tabs
         # Check that discussion has shifted up
-        self.assertEqual(course.tabs[2], {'type': 'discussion', 'name': 'Discussion'})
+        assert course.tabs[2] == {'type': 'discussion', 'name': 'Discussion'}
 
     def test_insert(self):
         """Test primitive tab insertion."""
         course = CourseFactory.create()
         tabs.primitive_insert(course, 2, 'pdf_textbooks', 'aname')
-        self.assertEqual(course.tabs[2], {'type': 'pdf_textbooks', 'name': 'aname'})
+        assert course.tabs[2] == {'type': 'pdf_textbooks', 'name': 'aname'}
         with self.assertRaises(ValueError):
             tabs.primitive_insert(course, 0, 'pdf_textbooks', 'aname')
         with self.assertRaises(ValueError):
@@ -225,4 +230,4 @@ class PrimitiveTabEdit(ModuleStoreTestCase):
         course = CourseFactory.create()
         tabs.primitive_insert(course, 3, 'pdf_textbooks', 'aname')
         course2 = modulestore().get_course(course.id)
-        self.assertEqual(course2.tabs[3], {'type': 'pdf_textbooks', 'name': 'aname'})
+        assert course2.tabs[3] == {'type': 'pdf_textbooks', 'name': 'aname'}

--- a/cms/templates/edit-tabs.html
+++ b/cms/templates/edit-tabs.html
@@ -9,7 +9,7 @@
   from openedx.core.djangolib.js_utils import js_escaped_string
   from cms.djangoapps.contentstore.utils import get_pages_and_resources_url
 %>
-<%block name="title">${_("Pages")}</%block>
+<%block name="title">${_("Custom pages")}</%block>
 <%block name="bodyclass">is-signedin course view-static-pages</%block>
 
 <%block name="header_extras">
@@ -52,14 +52,14 @@
       </nav>
     </div>
     <h1 class="page-header">
-      <span class="sr">&gt; </span>${_("Custom Pages")}
+      <span class="sr">&gt; </span>${_("Custom pages")}
     </h1>
   % else:
   <header class="mast has-actions has-subtitle">
     <h1 class="page-header">
       <small class="subtitle">${_("Content")}</small>
       ## Translators: Custom Pages refer to the tabs that appear in the top navigation of each course.
-      <span class="sr"> > </span>${_("Custom Pages")}
+      <span class="sr"> > </span>${_("Custom pages")}
     </h1>
   % endif
 

--- a/common/lib/xmodule/xmodule/tabs.py
+++ b/common/lib/xmodule/xmodule/tabs.py
@@ -302,6 +302,7 @@ class StaticTab(CourseTab):
     type = 'static_tab'
     is_default = False  # A static tab is never added to a course by default
     allow_multiple = True
+    priority = 100
 
     def __init__(self, tab_dict=None, name=None, url_slug=None):
         def link_func(course, reverse_func):
@@ -406,6 +407,7 @@ class CourseTabList(List):
             CourseTab.load('wiki'),
             CourseTab.load('progress'),
         ])
+        course.tabs.sort(key=lambda tab: tab.priority or float('inf'))
 
     @staticmethod
     def get_discussion(course):

--- a/lms/djangoapps/ccx/plugins.py
+++ b/lms/djangoapps/ccx/plugins.py
@@ -18,6 +18,7 @@ class CcxCourseTab(CourseTab):
     """
 
     type = "ccx_coach"
+    priority = 310
     title = gettext_noop("CCX Coach")
     view_name = "ccx_coach_dashboard"
     is_dynamic = True    # The CCX view is dynamically added to the set of tabs when it is enabled

--- a/lms/djangoapps/course_wiki/tab.py
+++ b/lms/djangoapps/course_wiki/tab.py
@@ -20,6 +20,7 @@ class WikiTab(EnrolledTab):
     view_name = "course_wiki"
     is_hideable = True
     is_default = False
+    priority = 70
 
     def __init__(self, tab_dict):
         # Default to hidden

--- a/lms/djangoapps/courseware/tabs.py
+++ b/lms/djangoapps/courseware/tabs.py
@@ -5,8 +5,8 @@ perform some LMS-specific tab display gymnastics for the Entrance Exams feature
 
 
 from django.conf import settings
-from django.utils.translation import ugettext as _
-from django.utils.translation import ugettext_noop
+from django.utils.translation import gettext as _
+from django.utils.translation import gettext_noop
 
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.entrance_exams import user_can_skip_entrance_exam
@@ -33,8 +33,8 @@ class CoursewareTab(EnrolledTab):
     The main courseware view.
     """
     type = 'courseware'
-    title = ugettext_noop('Course')
-    priority = 10
+    title = gettext_noop('Course')
+    priority = 11
     view_name = 'courseware'
     is_movable = False
     is_default = False
@@ -68,8 +68,8 @@ class CourseInfoTab(CourseTab):
     The course info view.
     """
     type = 'course_info'
-    title = ugettext_noop('Home')
-    priority = 20
+    title = gettext_noop('Home')
+    priority = 10
     view_name = 'info'
     tab_id = 'info'
     is_movable = False
@@ -85,8 +85,8 @@ class SyllabusTab(EnrolledTab):
     A tab for the course syllabus.
     """
     type = 'syllabus'
-    title = ugettext_noop('Syllabus')
-    priority = 30
+    title = gettext_noop('Syllabus')
+    priority = 80
     view_name = 'syllabus'
     allow_multiple = True
     is_default = False
@@ -103,8 +103,8 @@ class ProgressTab(EnrolledTab):
     The course progress view.
     """
     type = 'progress'
-    title = ugettext_noop('Progress')
-    priority = 40
+    title = gettext_noop('Progress')
+    priority = 20
     view_name = 'progress'
     is_hideable = True
     is_default = False
@@ -131,7 +131,7 @@ class TextbookTabsBase(CourseTab):
     Abstract class for textbook collection tabs classes.
     """
     # Translators: 'Textbooks' refers to the tab in the course that leads to the course' textbooks
-    title = ugettext_noop("Textbooks")
+    title = gettext_noop("Textbooks")
     is_collection = True
     is_default = False
 
@@ -153,7 +153,7 @@ class TextbookTabs(TextbookTabsBase):
     A tab representing the collection of all textbook tabs.
     """
     type = 'textbooks'
-    priority = None
+    priority = 200
     view_name = 'book'
 
     @classmethod
@@ -177,7 +177,7 @@ class PDFTextbookTabs(TextbookTabsBase):
     A tab representing the collection of all PDF textbook tabs.
     """
     type = 'pdf_textbooks'
-    priority = None
+    priority = 201
     view_name = 'pdf_book'
 
     @classmethod
@@ -196,7 +196,7 @@ class HtmlTextbookTabs(TextbookTabsBase):
     A tab representing the collection of all Html textbook tabs.
     """
     type = 'html_textbooks'
-    priority = None
+    priority = 201
     view_name = 'html_book'
 
     @classmethod
@@ -263,7 +263,7 @@ class ExternalDiscussionCourseTab(LinkTab):
 
     type = 'external_discussion'
     # Translators: 'Discussion' refers to the tab in the courseware that leads to the discussion forums
-    title = ugettext_noop('Discussion')
+    title = gettext_noop('Discussion')
     priority = None
     is_default = False
 
@@ -285,7 +285,7 @@ class ExternalLinkCourseTab(LinkTab):
     A course tab containing an external link.
     """
     type = 'external_link'
-    priority = None
+    priority = 110
     is_default = False    # An external link tab is not added to a course by default
     allow_multiple = True
 
@@ -326,9 +326,9 @@ class DatesTab(EnrolledTab):
     A tab representing the relevant dates for a course.
     """
     type = "dates"
-    title = ugettext_noop(
-        "Dates")  # We don't have the user in this context, so we don't want to translate it at this level.
-    priority = 50
+    # We don't have the user in this context, so we don't want to translate it at this level.
+    title = gettext_noop("Dates")
+    priority = 30
     view_name = "dates"
     is_dynamic = True
 

--- a/lms/djangoapps/discussion/plugins.py
+++ b/lms/djangoapps/discussion/plugins.py
@@ -19,7 +19,7 @@ class DiscussionTab(TabFragmentViewMixin, EnrolledTab):
 
     type = 'discussion'
     title = ugettext_noop('Discussion')
-    priority = None
+    priority = 40
     view_name = 'forum_form_discussion'
     fragment_view_name = 'lms.djangoapps.discussion.views.DiscussionBoardFragmentView'
     is_hideable = settings.FEATURES.get('ALLOW_HIDING_DISCUSSION_TAB', False)

--- a/lms/djangoapps/edxnotes/plugins.py
+++ b/lms/djangoapps/edxnotes/plugins.py
@@ -26,6 +26,7 @@ class EdxNotesTab(EnrolledTab):
     type = "edxnotes"
     title = _("Notes")
     view_name = "edxnotes"
+    priority = 50
 
     @classmethod
     def is_enabled(cls, course, user=None):

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -81,6 +81,7 @@ class InstructorDashboardTab(CourseTab):
     title = ugettext_noop('Instructor')
     view_name = "instructor_dashboard"
     is_dynamic = True    # The "Instructor" tab is instead dynamically added when it is enabled
+    priority = 300
 
     @classmethod
     def is_enabled(cls, course, user=None):

--- a/lms/djangoapps/teams/plugins.py
+++ b/lms/djangoapps/teams/plugins.py
@@ -28,6 +28,7 @@ class TeamsTab(EnrolledTab):
     type = "teams"
     title = _("Teams")
     view_name = "teams_dashboard"
+    priority = 60
 
     @classmethod
     def is_enabled(cls, course, user=None):

--- a/openedx/features/lti_course_tab/tab.py
+++ b/openedx/features/lti_course_tab/tab.py
@@ -195,6 +195,7 @@ class LtiCourseTab(LtiCourseLaunchMixin, EnrolledTab):
     A tab to add custom LTI components to a course in a tab.
     """
     type = 'lti_tab'
+    priority = 120
     is_default = False
     allow_multiple = True
 
@@ -266,6 +267,7 @@ class DiscussionLtiCourseTab(LtiCourseLaunchMixin, TabFragmentViewMixin, Enrolle
     Course tab that loads the associated LTI-based discussion provider in a tab.
     """
     type = 'lti_discussion'
+    priority = 41
     allow_multiple = False
     is_dynamic = True
     title = gettext_lazy("Discussion")


### PR DESCRIPTION
## Description
The change imposes a new ordering for tabs based on their new priority. When reordering tabs, this ordering will be maintained.

For course authors this means that any time they change the ordering of static tabs, the new ordering will be enforced. Tabs that previously didn't have a priority now have a priority set, so courses these will now have a more uniform location across courses. 

## Supporting information

- https://openedx.atlassian.net/browse/TNL-9174

## Testing instructions

This PR shouldn't have any changes for courses where tabs are already ordered in the new priority. However, for courses where the ordering is different, the new ordering should not be enforced, which is as follows:

- courseware
- course_info
- progress
- dates
- discussion
- external_discussion
- lti_discussion
- edxnotes
- teams
- wiki
- syllabus
- static_tab
- external_link
- lti_tab
- textbooks
- html_textbooks
- pdf_textbooks
- instructor
- ccx
