### PR TITLE
[OSPR-5888] fix: change buttons in wiki modal to anchor tags

### DIFF
--- a/lms/templates/wiki/history.html
+++ b/lms/templates/wiki/history.html
@@ -215,15 +215,15 @@
         {% trans "Back to history view" as tmsg %}{{tmsg|force_escape}}
       </a>
       {% if article|can_write:user %}
-        <button type="button" class="btn btn-large btn-primary switch-to-revision">
+        <a class="btn btn-large btn-primary switch-to-revision">
           <span class="icon fa fa-flag" aria-hidden="true"></span>
           {% trans "Switch to this version" as tmsg %}{{tmsg|force_escape}}
-        </button>
+        </a>
       {% else %}
-        <button type="button" class="btn btn-large btn-primary disabled">
+        <a class="btn btn-large btn-primary disabled">
           <span class="icon fa fa-lock" aria-hidden="true"></span>
           {% trans "Switch to this version" as tmsg%}{{tmsg|force_escape}}
-        </button>
+        </a>
       {% endif %}
       </div>
     </div>
@@ -250,15 +250,15 @@
           {% trans "Back to history view" as tmsg%}{{tmsg|force_escape}}
         </a>
         {% if article|can_write:user %}
-        <button type="button" class="btn btn-large btn-primary merge-revision-commit">
+        <a class="btn btn-large btn-primary merge-revision-commit">
           <span class="icon fa fa-file" aria-hidden="true"></span>
           {% trans "Create new merged version" as tmsg%}{{tmsg|force_escape}}
-        </button>
+        </a>
         {% else %}
-          <button type="button" class="btn btn-large btn-primary disabled">
+          <a type="button" class="btn btn-large btn-primary disabled">
             <span class="icon fa fa-lock" aria-hidden="true"></span>
             {% trans "Create new merged version" as tmsg%}{{tmsg|force_escape}}
-          </button>
+          </a>
         {% endif %}
       </div>
     </div>


### PR DESCRIPTION
## Description

**Cherry-pick PR for already merged https://github.com/edx/edx-platform/pull/28049**

This exists in `master` but not in `lilac.master`.

The action buttons in wiki modal have href attribute
but do not have an event listener for click.
This PR changes the buttons to anchor tags so that they
work as expected when clicked.

## Supporting information

https://openedx.atlassian.net/browse/OSPR-5888

https://github.com/edx/edx-platform/pull/28049

## Testing instructions

https://github.com/edx/edx-platform/pull/28049
