### PR TITLE
feat: edx-enterprise 3.33.5 release

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -30,7 +30,7 @@ django-storages<1.9
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==3.33.1
+edx-enterprise==3.33.5
 
 # Newer versions need a more recent version of python-dateutil
 freezegun==0.3.12

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -431,7 +431,7 @@ edx-drf-extensions==8.0.0
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.33.1
+edx-enterprise==3.33.5
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -536,7 +536,7 @@ edx-drf-extensions==8.0.0
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.33.1
+edx-enterprise==3.33.5
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -517,7 +517,7 @@ edx-drf-extensions==8.0.0
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.33.1
+edx-enterprise==3.33.5
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
[3.33.5]
---------
fix: CSOD API session tokens are now saved to the customer's configuration instead of individual transmission audits

[3.33.4]
---------
feat: integrated channels only requests content metadata for courses that need updating

[3.33.3]
---------
feat: Change Bulk Enrollment Assignment Logic for Pending learners

[3.33.2]
---------
fix: no longer notify learners of already existing enrollments

- [ENT-5115](https://openedx.atlassian.net/browse/ENT-5115)
- https://pypi.org/project/edx-enterprise/3.33.5/
