### PR TITLE
chore: upgrade to edx-proctoring to 4.6.0

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -460,7 +460,7 @@ edx-opaque-keys[django]==2.2.2
     #   xmodule
 edx-organizations==6.10.0
     # via -r requirements/edx/base.in
-edx-proctoring==4.5.0
+edx-proctoring==4.6.0
     # via
     #   -r requirements/edx/base.in
     #   edx-proctoring-proctortrack

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -569,7 +569,7 @@ edx-opaque-keys[django]==2.2.2
     #   xmodule
 edx-organizations==6.10.0
     # via -r requirements/edx/testing.txt
-edx-proctoring==4.5.0
+edx-proctoring==4.6.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-proctoring-proctortrack

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -551,7 +551,7 @@ edx-opaque-keys[django]==2.2.2
     #   xmodule
 edx-organizations==6.10.0
     # via -r requirements/edx/base.txt
-edx-proctoring==4.5.0
+edx-proctoring==4.6.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring-proctortrack


### PR DESCRIPTION
<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Removes references to the unused "ready_to_resume" and "resumed" statuses on proctored exam attempts.

https://github.com/edx/edx-proctoring/blob/master/CHANGELOG.rst#460---2021-11-03

## Supporting information

[MST-1138](https://openedx.atlassian.net/browse/MST-1138)