### PR TITLE
feat: Hide discussion block in studio if non-legacy discussion provider is configured for course [BD-38] [TNL-8699] [BB-4928]

### DIFF
--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -25,6 +25,7 @@ from common.djangoapps.student.auth import has_course_author_access
 from common.djangoapps.xblock_django.api import authorable_xblocks, disabled_xblocks
 from common.djangoapps.xblock_django.models import XBlockStudioConfigurationFlag
 from openedx.core.lib.xblock_utils import get_aside_from_xblock, is_xblock_aside
+from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
 
@@ -294,6 +295,9 @@ def get_component_templates(courselike, library=False):  # lint-amnesty, pylint:
 
     component_types = _filter_disabled_blocks(component_types)
 
+    # Filter out discussion component from component_types if non-legacy discussion provider is configured for course
+    component_types = _filter_discussion_for_non_legacy_provider(component_types, courselike.location.course_key)
+
     # Content Libraries currently don't allow opting in to unsupported xblocks/problem types.
     allow_unsupported = getattr(courselike, "allow_unsupported_xblocks", False)
 
@@ -436,6 +440,20 @@ def get_component_templates(courselike, library=False):  # lint-amnesty, pylint:
         component_templates.insert(0, advanced_component_templates)
 
     return component_templates
+
+
+def _filter_discussion_for_non_legacy_provider(all_components, course_key):
+    """
+    Filter out Discussion component if non-legacy discussion provider is configured for course key
+    """
+    discussion_provider = DiscussionsConfiguration.get(context_key=course_key).provider_type
+
+    if discussion_provider != 'legacy':
+        filtered_components = [component for component in all_components if component != 'discussion']
+    else:
+        filtered_components = all_components
+
+    return filtered_components
 
 
 def _filter_disabled_blocks(all_blocks):


### PR DESCRIPTION
<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

A number of components are available in the 'Add New Component' section to course authors in the Studio UI. One such component is the 'Discussion' component.
This PR removes the 'Discussion' button from the 'Add New Component' section, if a non-legacy discussion provider is configured for the course for which the new component is being added.

Course Author user role is impacted by this change


## Supporting information

[TNL-8699](https://openedx.atlassian.net/browse/TNL-8699)

## Testing instructions

1. Use the 'Pages & Resources' page in 'frontend-app-course-authoring' [MFE](https://github.com/edx/frontend-app-course-authoring/)
2. Select Discussion Settings and select any provider other than 'edX'.
3. Add any mandatory key, secret, etc. as required for the provider and save changes.
4. From the studio UI, select the course, add new unit or select existing unit.
5. Check 'Discussion' button missing from the 'Add New Component' section.

## Deadline

"None"
