### PR TITLE
[BD-13] refactor: deprecates ModuleSystem properties related to code sandboxing

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_preview.py
+++ b/cms/djangoapps/contentstore/views/tests/test_preview.py
@@ -8,17 +8,19 @@ from unittest import mock
 
 import ddt
 from django.test.client import Client, RequestFactory
+from django.test.utils import override_settings
 from web_fragments.fragment import Fragment
 from xblock.core import XBlock, XBlockAside
 
+from xmodule.contentstore.django import contentstore
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.django import modulestore
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, upload_file_to_course
+from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.test_asides import AsideTestType
 from cms.djangoapps.contentstore.utils import reverse_usage_url
 from cms.djangoapps.xblock_config.models import StudioConfig
 from common.djangoapps.student.tests.factories import UserFactory
-from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.test_asides import AsideTestType  # lint-amnesty, pylint: disable=wrong-import-order
 
 from ..preview import _preview_module_system, get_preview_fragment
 
@@ -220,22 +222,28 @@ class CmsModuleSystemShimTest(ModuleStoreTestCase):
     """
     Tests that the deprecated attributes in the Module System (XBlock Runtime) return the expected values.
     """
+    COURSE_ID = 'edX/CmsModuleShimTest/2021_Fall'
+    PYTHON_LIB_FILENAME = 'test_python_lib.zip'
+    PYTHON_LIB_SOURCE_FILE = './common/test/data/uploads/python_lib.zip'
+
     def setUp(self):
         """
-        Set up the user and other fields that will be used to instantiate the runtime.
+        Set up the user, course and other fields that will be used to instantiate the runtime.
         """
         super().setUp()
-        self.course = CourseFactory.create()
+        org, number, run = self.COURSE_ID.split('/')
+        self.course = CourseFactory.create(org=org, number=number, run=run)
         self.user = UserFactory()
         self.request = RequestFactory().get('/dummy-url')
         self.request.user = self.user
         self.request.session = {}
         self.descriptor = ItemFactory(category="video", parent=self.course)
         self.field_data = mock.Mock()
+        self.contentstore = contentstore()
         self.runtime = _preview_module_system(
             self.request,
-            self.descriptor,
-            self.field_data,
+            descriptor=ItemFactory(category="problem", parent=self.course),
+            field_data=mock.Mock(),
         )
 
     def test_get_user_role(self):
@@ -247,12 +255,32 @@ class CmsModuleSystemShimTest(ModuleStoreTestCase):
         html = get_preview_fragment(self.request, descriptor, {'element_id': 142}).content
         assert '<div id="142" ns="main">Testing the MakoService</div>' in html
 
-    def test_xqueue_is_not_available_in_studio(self):
-        descriptor = ItemFactory(category="problem", parent=self.course)
-        runtime = _preview_module_system(
-            self.request,
-            descriptor=descriptor,
-            field_data=mock.Mock(),
+    @override_settings(COURSES_WITH_UNSAFE_CODE=[COURSE_ID])
+    def test_can_execute_unsafe_code(self):
+        assert self.runtime.can_execute_unsafe_code()
+
+    def test_cannot_execute_unsafe_code(self):
+        assert not self.runtime.can_execute_unsafe_code()
+
+    @override_settings(PYTHON_LIB_FILENAME=PYTHON_LIB_FILENAME)
+    def test_get_python_lib_zip(self):
+        zipfile = upload_file_to_course(
+            course_key=self.course.id,
+            contentstore=self.contentstore,
+            source_file=self.PYTHON_LIB_SOURCE_FILE,
+            target_filename=self.PYTHON_LIB_FILENAME,
         )
-        assert runtime.xqueue is None
-        assert runtime.service(descriptor, 'xqueue') is None
+        assert self.runtime.get_python_lib_zip() == zipfile
+
+    def test_no_get_python_lib_zip(self):
+        zipfile = upload_file_to_course(
+            course_key=self.course.id,
+            contentstore=self.contentstore,
+            source_file=self.PYTHON_LIB_SOURCE_FILE,
+            target_filename=self.PYTHON_LIB_FILENAME,
+        )
+        assert self.runtime.get_python_lib_zip() is None
+
+    def test_cache(self):
+        assert hasattr(self.runtime.cache, 'get')
+        assert hasattr(self.runtime.cache, 'set')

--- a/common/djangoapps/util/tests/test_sandboxing.py
+++ b/common/djangoapps/util/tests/test_sandboxing.py
@@ -3,12 +3,15 @@ Tests for sandboxing.py in util app
 """
 
 
+import ddt
 from django.test import TestCase
 from django.test.utils import override_settings
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import CourseLocator, LibraryLocator
 
-from xmodule.util.sandboxing import can_execute_unsafe_code
+from xmodule.contentstore.django import contentstore
+from xmodule.modulestore.tests.django_utils import upload_file_to_course
+from xmodule.util.sandboxing import can_execute_unsafe_code, SandboxService
 
 
 class SandboxingTest(TestCase):
@@ -39,3 +42,75 @@ class SandboxingTest(TestCase):
         assert not can_execute_unsafe_code(CourseLocator('edX', 'full', '2012_Fall'))
         assert not can_execute_unsafe_code(CourseLocator('edX', 'full', '2013_Spring'))
         assert not can_execute_unsafe_code(LibraryLocator('edX', 'test_bank'))
+
+
+@ddt.ddt
+class SandboxServiceTest(TestCase):
+    """
+    Test SandboxService methods.
+    """
+    PYTHON_LIB_FILENAME = 'test_python_lib.zip'
+    PYTHON_LIB_SOURCE_FILE = './common/test/data/uploads/python_lib.zip'
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Upload the python lib file to the test course.
+        """
+        super().setUpClass()
+
+        course_key = CourseLocator('test', 'sandbox_test', '2021_01')
+        cls.sandbox_service = SandboxService(course_id=course_key, contentstore=contentstore)
+        cls.zipfile = upload_file_to_course(
+            course_key=course_key,
+            contentstore=cls.sandbox_service.contentstore(),
+            source_file=cls.PYTHON_LIB_SOURCE_FILE,
+            target_filename=cls.PYTHON_LIB_FILENAME,
+        )
+
+    @staticmethod
+    def validate_can_execute_unsafe_code(context_key, expected_result):
+        sandbox_service = SandboxService(course_id=context_key, contentstore=None)
+        assert expected_result == sandbox_service.can_execute_unsafe_code()
+
+    @ddt.data(
+        CourseLocator('edX', 'notful', 'empty'),
+        LibraryLocator('edY', 'test_bank'),
+    )
+    @override_settings(COURSES_WITH_UNSAFE_CODE=['edX/full/.*', 'library:v1-edX+.*'])
+    def test_sandbox_exclusion(self, context_key):
+        """
+        Test to make sure that a non-match returns false
+        """
+        self.validate_can_execute_unsafe_code(context_key, False)
+
+    @ddt.data(
+        CourseKey.from_string('edX/full/2012_Fall'),
+        CourseKey.from_string('edX/full/2013_Spring'),
+    )
+    @override_settings(COURSES_WITH_UNSAFE_CODE=['edX/full/.*'])
+    def test_sandbox_inclusion(self, context_key):
+        """
+        Test to make sure that a match works across course runs
+        """
+        self.validate_can_execute_unsafe_code(context_key, True)
+        self.validate_can_execute_unsafe_code(LibraryLocator('edX', 'test_bank'), False)
+
+    @ddt.data(
+        CourseLocator('edX', 'full', '2012_Fall'),
+        CourseLocator('edX', 'full', '2013_Spring'),
+        LibraryLocator('edX', 'test_bank'),
+    )
+    def test_courselikes_with_unsafe_code_default(self, context_key):
+        """
+        Test that the default setting for COURSES_WITH_UNSAFE_CODE is an empty setting,
+        i.e., we don't use @override_settings in these tests
+        """
+        self.validate_can_execute_unsafe_code(context_key, False)
+
+    @override_settings(PYTHON_LIB_FILENAME=PYTHON_LIB_FILENAME)
+    def test_get_python_lib_zip(self):
+        assert self.sandbox_service.get_python_lib_zip() == self.zipfile
+
+    def test_no_python_lib_zip(self):
+        assert self.sandbox_service.get_python_lib_zip() is None

--- a/common/lib/xmodule/xmodule/capa_module.py
+++ b/common/lib/xmodule/xmodule/capa_module.py
@@ -31,12 +31,6 @@ from capa.capa_problem import LoncapaProblem, LoncapaSystem
 from capa.inputtypes import Status
 from capa.responsetypes import LoncapaProblemError, ResponseError, StudentInputError
 from capa.util import convert_files_to_filenames, get_inner_html_from_xpath
-from common.djangoapps.xblock_django.constants import (
-    ATTR_KEY_ANONYMOUS_USER_ID,
-    ATTR_KEY_USER_IS_STAFF,
-    ATTR_KEY_USER_ID,
-)
-from openedx.core.djangolib.markup import HTML, Text
 from xmodule.contentstore.django import contentstore
 from xmodule.editing_module import EditingMixin
 from xmodule.exceptions import NotFoundError, ProcessingError
@@ -53,6 +47,12 @@ from xmodule.x_module import (
     shim_xmodule_js
 )
 from xmodule.xml_module import XmlMixin
+from common.djangoapps.xblock_django.constants import (
+    ATTR_KEY_ANONYMOUS_USER_ID,
+    ATTR_KEY_USER_IS_STAFF,
+    ATTR_KEY_USER_ID,
+)
+from openedx.core.djangolib.markup import HTML, Text
 
 from .fields import Date, ScoreField, Timedelta
 from .progress import Progress
@@ -121,6 +121,8 @@ class Randomization(String):
 @XBlock.needs('user')
 @XBlock.needs('i18n')
 @XBlock.needs('mako')
+@XBlock.needs('cache')
+@XBlock.needs('sandbox')
 # Studio doesn't provide XQueueService, but the LMS does.
 @XBlock.wants('xqueue')
 @XBlock.wants('call_to_action')
@@ -814,12 +816,15 @@ class ProblemBlock(
         anonymous_student_id = user_service.get_current_user().opt_attrs.get(ATTR_KEY_ANONYMOUS_USER_ID)
         seed = user_service.get_current_user().opt_attrs.get(ATTR_KEY_USER_ID) or 0
 
+        sandbox_service = self.runtime.service(self, 'sandbox')
+        cache_service = self.runtime.service(self, 'cache')
+
         capa_system = LoncapaSystem(
             ajax_url=self.ajax_url,
             anonymous_student_id=anonymous_student_id,
-            cache=self.runtime.cache,
-            can_execute_unsafe_code=self.runtime.can_execute_unsafe_code,
-            get_python_lib_zip=self.runtime.get_python_lib_zip,
+            cache=cache_service,
+            can_execute_unsafe_code=sandbox_service.can_execute_unsafe_code,
+            get_python_lib_zip=sandbox_service.get_python_lib_zip,
             DEBUG=self.runtime.DEBUG,
             filestore=self.runtime.filestore,
             i18n=self.runtime.service(self, "i18n"),

--- a/common/lib/xmodule/xmodule/modulestore/tests/django_utils.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/django_utils.py
@@ -8,6 +8,7 @@ import functools
 import os
 from contextlib import contextmanager
 from enum import Enum
+from mimetypes import guess_type
 from unittest.mock import patch
 
 from django.conf import settings
@@ -16,6 +17,12 @@ from django.db import connections, transaction
 from django.test import TestCase
 from django.test.utils import override_settings
 
+from xmodule.contentstore.content import StaticContent
+from xmodule.contentstore.django import _CONTENTSTORE
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.django import SignalHandler, clear_existing_modulestores, modulestore
+from xmodule.modulestore.tests.factories import XMODULE_FACTORY_LOCK
+from xmodule.modulestore.tests.mongo_connection import MONGO_HOST, MONGO_PORT_NUM
 from lms.djangoapps.courseware.field_overrides import OverrideFieldData
 from openedx.core.djangolib.testing.utils import CacheIsolationMixin, CacheIsolationTestCase, FilteredQueryCountMixin
 from openedx.core.lib.tempdir import mkdtemp_clean
@@ -23,11 +30,6 @@ from common.djangoapps.split_modulestore_django.models import SplitModulestoreCo
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import AdminFactory, UserFactory, InstructorFactory
 from common.djangoapps.student.tests.factories import StaffFactory
-from xmodule.contentstore.django import _CONTENTSTORE
-from xmodule.modulestore import ModuleStoreEnum
-from xmodule.modulestore.django import SignalHandler, clear_existing_modulestores, modulestore
-from xmodule.modulestore.tests.factories import XMODULE_FACTORY_LOCK
-from xmodule.modulestore.tests.mongo_connection import MONGO_HOST, MONGO_PORT_NUM
 
 
 class CourseUserType(Enum):
@@ -604,3 +606,16 @@ class ModuleStoreTestCase(
             self.store.update_item(course, user_id)
         updated_course = self.store.get_course(course.id)
         return updated_course
+
+
+def upload_file_to_course(course_key, contentstore, source_file, target_filename):
+    '''
+    Uploads the given source file to the given course, and returns the content of the file.
+    '''
+    asset_key = course_key.make_asset_key('asset', target_filename)
+    with open(source_file, "rb") as f:
+        file_contents = f.read()
+    mimetype = guess_type(source_file)[0]
+    content = StaticContent(asset_key, target_filename, mimetype, file_contents, locked=False)
+    contentstore.save(content)
+    return file_contents

--- a/common/lib/xmodule/xmodule/tests/__init__.py
+++ b/common/lib/xmodule/xmodule/tests/__init__.py
@@ -28,6 +28,7 @@ from xblock.fields import Reference, ReferenceList, ReferenceValueDict, ScopeIds
 
 from capa.xqueue_interface import XQueueService
 from xmodule.assetstore import AssetMetadata
+from xmodule.contentstore.django import contentstore
 from xmodule.error_module import ErrorBlock
 from xmodule.mako_module import MakoDescriptorSystem
 from xmodule.modulestore import ModuleStoreEnum
@@ -35,7 +36,9 @@ from xmodule.modulestore.draft_and_published import ModuleStoreDraftAndPublished
 from xmodule.modulestore.inheritance import InheritanceMixin
 from xmodule.modulestore.xml import CourseLocationManager
 from xmodule.tests.helpers import mock_render_template, StubMakoService, StubUserService
-from xmodule.x_module import ModuleSystem, XModuleDescriptor, XModuleMixin
+from xmodule.util.sandboxing import SandboxService
+from xmodule.x_module import DoNothingCache, ModuleSystem, XModuleDescriptor, XModuleMixin
+from openedx.core.lib.cache_utils import CacheService
 
 
 MODULE_DIR = path(__file__).dirname()
@@ -49,10 +52,16 @@ class TestModuleSystem(ModuleSystem):  # pylint: disable=abstract-method
     ModuleSystem for testing
     """
     def __init__(self, **kwargs):
-        id_manager = CourseLocationManager(kwargs['course_id'])
+        course_id = kwargs['course_id']
+        id_manager = CourseLocationManager(course_id)
         kwargs.setdefault('id_reader', id_manager)
         kwargs.setdefault('id_generator', id_manager)
-        kwargs.setdefault('services', {}).setdefault('field-data', DictFieldData({}))
+
+        services = kwargs.get('services', {})
+        services.setdefault('cache', CacheService(DoNothingCache()))
+        services.setdefault('field-data', DictFieldData({}))
+        services.setdefault('sandbox', SandboxService(contentstore, course_id))
+        kwargs['services'] = services
         super().__init__(**kwargs)
 
     def handler_url(self, block, handler, suffix='', query='', thirdparty=False):  # lint-amnesty, pylint: disable=arguments-differ

--- a/common/lib/xmodule/xmodule/util/sandboxing.py
+++ b/common/lib/xmodule/xmodule/util/sandboxing.py
@@ -41,3 +41,29 @@ def get_python_lib_zip(contentstore, course_id):
         return zip_lib.data
     else:
         return None
+
+
+class SandboxService:
+    """
+    A service which provides utilities for executing sandboxed Python code, for example, inside custom Python questions.
+
+    Args:
+        contentstore(function): function which creates an instance of xmodule.content.ContentStore
+        course_id(string or CourseLocator): identifier for the course
+    """
+    def __init__(self, contentstore, course_id, **kwargs):
+        super().__init__(**kwargs)
+        self.contentstore = contentstore
+        self.course_id = course_id
+
+    def can_execute_unsafe_code(self):
+        """
+        Returns a boolean, true if the course can run outside the sandbox.
+        """
+        return can_execute_unsafe_code(self.course_id)
+
+    def get_python_lib_zip(self):
+        """
+        Return the bytes of the course code library file, if it exists.
+        """
+        return get_python_lib_zip(self.contentstore, self.course_id)

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -34,13 +34,13 @@ from xblock.fields import (
 )
 from xblock.runtime import IdGenerator, IdReader, Runtime
 
-from openedx.core.djangolib.markup import HTML
 from xmodule import block_metadata_utils
 from xmodule.errortracker import exc_info_to_str
 from xmodule.exceptions import UndefinedContext
 from xmodule.fields import RelativeTime
 from xmodule.modulestore.exceptions import ItemNotFoundError
 from xmodule.util.xmodule_django import add_webpack_to_fragment
+from openedx.core.djangolib.markup import HTML
 
 from common.djangoapps.xblock_django.constants import (
     ATTR_KEY_ANONYMOUS_USER_ID,
@@ -1906,6 +1906,59 @@ class ModuleSystemShim:
             }
         return None
 
+    @property
+    def can_execute_unsafe_code(self):
+        """
+        Returns a function which returns a boolean, indicating whether or not to allow the execution of unsafe,
+        unsandboxed code.
+
+        Deprecated in favor of the sandbox service.
+        """
+        warnings.warn(
+            'runtime.can_execute_unsafe_code is deprecated. Please use the sandbox service instead.',
+            DeprecationWarning, stacklevel=3,
+        )
+        sandbox_service = self._services.get('sandbox')
+        if sandbox_service:
+            return sandbox_service.can_execute_unsafe_code
+        # Default to saying "no unsafe code".
+        return lambda: False
+
+    @property
+    def get_python_lib_zip(self):
+        """
+        Returns a function returning a bytestring or None.
+
+        The bytestring is the contents of a zip file that should be importable by other Python code running in the
+        module.
+
+        Deprecated in favor of the sandbox service.
+        """
+        warnings.warn(
+            'runtime.get_python_lib_zip is deprecated. Please use the sandbox service instead.',
+            DeprecationWarning, stacklevel=3,
+        )
+        sandbox_service = self._services.get('sandbox')
+        if sandbox_service:
+            return sandbox_service.get_python_lib_zip
+        # Default to saying "no lib data"
+        return lambda: None
+
+    @property
+    def cache(self):
+        """
+        Returns a cache object with two methods:
+        * .get(key) returns an object from the cache or None.
+        * .set(key, value, timeout_secs=None) stores a value in the cache with a timeout.
+
+        Deprecated in favor of the cache service.
+        """
+        warnings.warn(
+            'runtime.cache is deprecated. Please use the cache service instead.',
+            DeprecationWarning, stacklevel=3,
+        )
+        return self._services.get('cache') or DoNothingCache()
+
 
 class ModuleSystem(MetricsMixin, ConfigurableFragmentWrapper, ModuleSystemShim, Runtime):
     """
@@ -1925,10 +1978,10 @@ class ModuleSystem(MetricsMixin, ConfigurableFragmentWrapper, ModuleSystemShim, 
             replace_urls, descriptor_runtime, filestore=None,
             debug=False, hostname="", publish=None, node_path="",
             course_id=None,
-            cache=None, can_execute_unsafe_code=None, replace_course_urls=None,
+            replace_course_urls=None,
             replace_jump_to_id_urls=None, error_descriptor_class=None,
             field_data=None, rebind_noauth_module_to_user=None,
-            get_python_lib_zip=None, **kwargs):
+            **kwargs):
         """
         Create a closure around the system environment.
 
@@ -1956,17 +2009,6 @@ class ModuleSystem(MetricsMixin, ConfigurableFragmentWrapper, ModuleSystemShim, 
 
         publish(event) - A function that allows XModules to publish events (such as grade changes)
 
-        cache - A cache object with two methods:
-            .get(key) returns an object from the cache or None.
-            .set(key, value, timeout_secs=None) stores a value in the cache with a timeout.
-
-        can_execute_unsafe_code - A function returning a boolean, whether or
-            not to allow the execution of unsafe, unsandboxed code.
-
-        get_python_lib_zip - A function returning a bytestring or None.  The
-            bytestring is the contents of a zip file that should be importable
-            by other Python code running in the module.
-
         error_descriptor_class - The class to use to render XModules with errors
 
         field_data - the `FieldData` to use for backing XBlock storage.
@@ -1993,10 +2035,6 @@ class ModuleSystem(MetricsMixin, ConfigurableFragmentWrapper, ModuleSystemShim, 
 
         if publish:
             self.publish = publish
-
-        self.cache = cache or DoNothingCache()
-        self.can_execute_unsafe_code = can_execute_unsafe_code or (lambda: False)
-        self.get_python_lib_zip = get_python_lib_zip or (lambda: None)
         self.replace_course_urls = replace_course_urls
         self.replace_jump_to_id_urls = replace_jump_to_id_urls
         self.error_descriptor_class = error_descriptor_class

--- a/openedx/core/lib/cache_utils.py
+++ b/openedx/core/lib/cache_utils.py
@@ -223,3 +223,27 @@ def get_cache(name):
     """
     assert name is not None
     return RequestCache(name).data
+
+
+class CacheService:
+    """
+    An XBlock service which provides a cache.
+
+    Args:
+        cache(object): provides get/set functions for retrieving/storing key/value pairs.
+    """
+    def __init__(self, cache, **kwargs):
+        super().__init__(**kwargs)
+        self._cache = cache
+
+    def get(self, key, *args, **kwargs):
+        """
+        Returns the value cached against the given key, or None.
+        """
+        return self._cache.get(key, *args, **kwargs)
+
+    def set(self, key, value, *args, **kwargs):
+        """
+        Caches the value against the given key.
+        """
+        return self._cache.set(key, value, *args, **kwargs)


### PR DESCRIPTION
## Description

Builds on the shim added by https://github.com/edx/edx-platform/pull/29190 to deprecate the following `ModuleSystem` attributes which are only used by CAPA problems:
* `cache`: deprecated in favour of the added CacheService
* `can_execute_unsafe_code`, `get_python_lib_zip`: deprecated in favour of the added SandboxService

Also fixes the [`safe_exec.tests.TestSafeOrNot.test_cant_do_something_forbidden`](https://github.com/edx/edx-platform/blob/78799f25ee6f0015c5288174602c29eea6de706a/common/lib/capa/capa/safe_exec/tests/test_safe_exec.py#L84) test , which was failing on my devstack with latest master. But since Jenkins and the github CI don't run in a virtualenv, this test is skipped, so this issue had gone unnoticed.

This change is only a refactoring, and should not affect Learners, Course Authors, or anyone else using edx-platform.

## Supporting information

* [Content Core Platform Simplication project](https://openedx.atlassian.net/wiki/spaces/AC/pages/3091629503/Content+Core+Platform+Simplification)
* [BLENDED-113](https://openedx.atlassian.net/browse/BLENDED-113) (edX internal ticket)
* [FAL-2209](https://tasks.opencraft.com/browse/FAL-2209) (OpenCraft internal ticket)

## Testing instructions

* LMS: https://pr29260.sandbox.opencraft.hosting/
* Studio: https://studio.pr29260.sandbox.opencraft.hosting/

LMS:
1. Login as a demo learner (`honor@example.com` / `edx`)
1. Enrol in the [BD-13 test course](https://pr29260.sandbox.opencraft.hosting/courses/course-v1:OpenCraft+BD-13+2021_1/about)
1. Navigate to the [Complex Blocks > Custom python problem](https://discovery.pr29260.sandbox.opencraft.hosting/learning/course/course-v1:OpenCraft+BD-13+2021_1/block-v1:OpenCraft+BD-13+2021_1+type@sequential+block@862667c509144a4c83381589185f9072/block-v1:OpenCraft+BD-13+2021_1+type@vertical+block@0edf5722fa1240ef82228ece3e68adcc). Ensure that you can answer the question correctly (this tests the python code sandboxing).
1. Switch to the Legacy Course Experience and ensure you can still answer this problem.

Regression testing: 

1. Browse around the Demo course, paying particular attention to the CAPA problems.
1. Check that you can submit answers to problems, and save changes to blocks. (This tests that these changes haven't broken anything else with CAPA problems.)
1. Switch to the Legacy Course Experience and ensure you can submit answers to problems there too.

Studio:
1. Login as a demo staff (`staff@example.com` / `edx`)
2. Navigate to the Demo course and browse through the blocks, paying particular attention to the CAPA problem blocks. Ensure they render and edit as expected.
3. Check that you can submit answers to problems, and save changes to blocks.
4. Preview unpublished changes and ensure they render as expected.
4. Publish changes, and ensure they render in the LMS as expected.

safe_exec:

In your devstack's `lms-shell`, run the following command, and ensure all tests pass.

```bash
pytest common/lib/capa/capa/safe_exec/tests/test_safe_exec.py
```

## Deadline

None