### PR TITLE
[MST-1150] Add integrity signature flag to courseware api

### DIFF
--- a/openedx/core/djangoapps/courseware_api/serializers.py
+++ b/openedx/core/djangoapps/courseware_api/serializers.py
@@ -118,6 +118,7 @@ class CourseInfoSerializer(serializers.Serializer):  # pylint: disable=abstract-
     verify_identity_url = AbsoluteURLField()
     verification_status = serializers.CharField()
     linkedin_add_to_profile_url = serializers.URLField()
+    is_integrity_signature_enabled = serializers.BooleanField()
     user_needs_integrity_signature = serializers.BooleanField()
     username = serializers.CharField()
 

--- a/openedx/core/djangoapps/courseware_api/tests/test_views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/test_views.py
@@ -358,6 +358,8 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
         response = self.client.get(self.url)
         assert response.status_code == 200
         courseware_data = response.json()
+        assert 'is_integrity_signature_enabled' in courseware_data
+        assert courseware_data['is_integrity_signature_enabled'] is True
         assert 'user_needs_integrity_signature' in courseware_data
         assert courseware_data['user_needs_integrity_signature'] == needs_integrity_signature
 

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -45,7 +45,7 @@ from lms.djangoapps.courseware.views.views import get_cert_data
 from lms.djangoapps.grades.api import CourseGradeFactory
 from lms.djangoapps.verify_student.services import IDVerificationService
 from openedx.core.djangoapps.agreements.api import get_integrity_signature
-from openedx.core.djangoapps.agreements.toggles import is_integrity_signature_enabled
+from openedx.core.djangoapps.agreements.toggles import is_integrity_signature_enabled as integrity_signature_toggle
 from openedx.core.djangoapps.courseware_api.utils import get_celebrations_dict
 from openedx.core.djangoapps.programs.utils import ProgramProgressMeter
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
@@ -314,12 +314,19 @@ class CoursewareMeta:
             )
 
     @property
+    def is_integrity_signature_enabled(self):
+        """
+        Course waffle flag for the integrity signature feature.
+        """
+        return integrity_signature_toggle(self.course_key)
+
+    @property
     def user_needs_integrity_signature(self):
         """
         Boolean describing whether the user needs to sign the integrity agreement for a course.
         """
         if (
-            is_integrity_signature_enabled(self.course_key)
+            integrity_signature_toggle(self.course_key)
             and not self.is_staff
             and self.enrollment_object
             and self.enrollment_object.mode in CourseMode.CERTIFICATE_RELEVANT_MODES


### PR DESCRIPTION
<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Pass the `agreements.enable_integrity_signature` flag through courseware API so [frontend-app-learning](https://github.com/edx/frontend-app-learning) can make use of it.

## Supporting information

[MST-1150](https://openedx.atlassian.net/browse/MST-1150)