### PR TITLE
feat: add esg submission fetch endpoint

### DIFF
--- a/lms/djangoapps/ora_staff_grader/serializers.py
+++ b/lms/djangoapps/ora_staff_grader/serializers.py
@@ -115,38 +115,38 @@ class InitializeSerializer(serializers.Serializer):
         ]
 
 class UploadedFileSerializer(serializers.Serializer):
-  """ Serializer for a file uploaded as a part of a response """
-  downloadURL = serializers.URLField(source='download_url')
-  description = serializers.CharField()
-  name = serializers.CharField()
+    """ Serializer for a file uploaded as a part of a response """
+    downloadURL = serializers.URLField(source='download_url')
+    description = serializers.CharField()
+    name = serializers.CharField()
 
 
 class ResponseSerializer(serializers.Serializer):
-  """ Serializer for the responseData api construct, which represents the contents of a submitted learner response """
-  files = serializers.ListField(child=UploadedFileSerializer(), allow_empty=True)
-  text = serializers.ListField(child=serializers.CharField(), allow_empty=True)
+    """ Serializer for the responseData api construct, which represents the contents of a submitted learner response """
+    files = serializers.ListField(child=UploadedFileSerializer(), allow_empty=True)
+    text = serializers.ListField(child=serializers.CharField(), allow_empty=True)
 
 
 class AssessmentCriteriaSerializer(serializers.Serializer):
-  """ Serializer for information about a criterion, in the context of a completed assessment """
-  name = serializers.CharField()
-  feedback = serializers.CharField()
-  # to be completed in AU-410
-  # score = serializers.IntegerField()
-  selectedOption = serializers.CharField(source='option')
+    """ Serializer for information about a criterion, in the context of a completed assessment """
+    name = serializers.CharField()
+    feedback = serializers.CharField()
+    # to be completed in AU-410
+    # score = serializers.IntegerField()
+    selectedOption = serializers.CharField(source='option')
 
 
 class GradeDataSerializer(serializers.Serializer):
-  """ Serializer for the `gradeData` api construct, which represents a completed staff assessment """
-  score = ScoreField(required=False)
-  overallFeedback = serializers.CharField(source='feedback', required=False)
-  criteria = serializers.ListField(child=AssessmentCriteriaSerializer(), allow_empty=True, required=False)
+    """ Serializer for the `gradeData` api construct, which represents a completed staff assessment """
+    score = ScoreField(required=False)
+    overallFeedback = serializers.CharField(source='feedback', required=False)
+    criteria = serializers.ListField(child=AssessmentCriteriaSerializer(), allow_empty=True, required=False)
 
 
 class SubmissionDetailResponseSerializer(serializers.Serializer):
-  """ Serializer for the response from the submission """
-  gradeData = GradeDataSerializer(source='assessment')
-  response = ResponseSerializer(source='submission')
-  #  to be completed in AU-387
-  #  gradeStatus = GradeStatusField()
-  #  lockStatus = LockStatusField()
+    """ Serializer for the response from the submission """
+    gradeData = GradeDataSerializer(source='assessment')
+    response = ResponseSerializer(source='submission')
+    #  to be completed in AU-387
+    #  gradeStatus = GradeStatusField()
+    #  lockStatus = LockStatusField()

--- a/lms/djangoapps/ora_staff_grader/serializers.py
+++ b/lms/djangoapps/ora_staff_grader/serializers.py
@@ -59,10 +59,10 @@ class OpenResponseMetadataSerializer(serializers.Serializer):  # pylint: disable
 
 
 class ScoreField(serializers.Field):
-  def to_representation(self, value):
-    if ('pointsEarned' not in value) and ('pointsPossible' not in value):
-      return None
-    return ScoreSerializer(value).data
+    def to_representation(self, value):
+        if ('pointsEarned' not in value) and ('pointsPossible' not in value):
+            return None
+        return ScoreSerializer(value).data
 
 
 class ScoreSerializer(serializers.Serializer):  # pylint: disable=abstract-method
@@ -71,6 +71,7 @@ class ScoreSerializer(serializers.Serializer):  # pylint: disable=abstract-metho
     """
     pointsEarned = serializers.IntegerField(default=0)
     pointsPossible = serializers.IntegerField(default=0)
+
 
 class SubmissionMetadataSerializer(serializers.Serializer):  # pylint: disable=abstract-method
     """
@@ -116,6 +117,7 @@ class InitializeSerializer(serializers.Serializer):
             'submissions',
             'rubricConfig',
         ]
+
 
 class UploadedFileSerializer(serializers.Serializer):
     """ Serializer for a file uploaded as a part of a response """

--- a/lms/djangoapps/ora_staff_grader/serializers.py
+++ b/lms/djangoapps/ora_staff_grader/serializers.py
@@ -77,7 +77,7 @@ class SubmissionMetadataSerializer(serializers.Serializer):  # pylint: disable=a
     """
     Submission metadata for displaying submissions table in ESG
     """
-    submissionUuid = serializers.UUIDField()
+    submissionUuid = serializers.CharField()
     username = serializers.CharField(allow_null=True)
     teamName = serializers.CharField(allow_null=True)
     dateSubmitted = serializers.DateTimeField()
@@ -121,7 +121,7 @@ class InitializeSerializer(serializers.Serializer):
 
 class UploadedFileSerializer(serializers.Serializer):
     """ Serializer for a file uploaded as a part of a response """
-    downloadURL = serializers.URLField(source='download_url')
+    downloadUrl = serializers.URLField(source='download_url')
     description = serializers.CharField()
     name = serializers.CharField()
 

--- a/lms/djangoapps/ora_staff_grader/serializers.py
+++ b/lms/djangoapps/ora_staff_grader/serializers.py
@@ -69,8 +69,8 @@ class ScoreSerializer(serializers.Serializer):  # pylint: disable=abstract-metho
     """
     Score (points earned/possible) for use in SubmissionMetadataSerializer
     """
-    pointsEarned = serializers.IntegerField(default=0)
-    pointsPossible = serializers.IntegerField(default=0)
+    pointsEarned = serializers.IntegerField(required=False)
+    pointsPossible = serializers.IntegerField(required=False)
 
 
 class SubmissionMetadataSerializer(serializers.Serializer):  # pylint: disable=abstract-method

--- a/lms/djangoapps/ora_staff_grader/serializers.py
+++ b/lms/djangoapps/ora_staff_grader/serializers.py
@@ -8,13 +8,16 @@ from rest_framework import serializers
 
 
 class GradeStatusField(serializers.ChoiceField):
-  def __init__(self):
-    super().__init__(choices=['graded', 'ungraded'])
+    """ Field that can have the values ['graded' 'ungraded'] """
+    def __init__(self):
+        super().__init__(choices=['graded', 'ungraded'])
 
 
 class LockStatusField(serializers.ChoiceField):
-  def __init__(self):
-    super().__init__(choices=['not-locked', 'locked', 'in-progress'])
+    """ Field that can have the values ['not-locked', 'locked', 'in-progress'] """
+    def __init__(self):
+        super().__init__(choices=['not-locked', 'locked', 'in-progress'])
+
 
 class CourseMetadataSerializer(serializers.Serializer):  # pylint: disable=abstract-method
     """

--- a/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
@@ -2,7 +2,6 @@
 Tests for ESG Serializers
 """
 import ddt
-from unittest.case import expectedFailure
 from django.test import TestCase
 from unittest.mock import Mock, MagicMock
 

--- a/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
@@ -297,7 +297,7 @@ class TestScoreFieldAndSerializer(TestCase):
     def test_serializer_no_values(self):
         """ Passing the ScoreSerializer an empty dict should result in two zeroes for the field """
         data = ScoreSerializer({}).data
-        assert data ==  {'pointsEarned': 0, 'pointsPossible': 0}
+        assert data == {'pointsEarned': 0, 'pointsPossible': 0}
 
     def test_serialier(self):
         """ Base serialization behavior for ScoreSerializer """

--- a/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
@@ -269,8 +269,8 @@ class TestInitializeSerializer(TestCase):
 class TestScoreFieldAndSerializer(TestCase):
 
     def test_field_no_values(self):
-        assert ScoreField().to_representation({}) == None
-    
+        assert ScoreField().to_representation({}) is None
+
     @ddt.data('pointsEarned', 'pointsPossible')
     def test_field_missing(self, missing_field):
         value = {'pointsEarned': 30, 'pointsPossible': 50}
@@ -292,15 +292,13 @@ class TestScoreFieldAndSerializer(TestCase):
 
     def test_serializer_no_values(self):
         data = ScoreSerializer({}).data
-        
         assert data ==  {'pointsEarned': 0, 'pointsPossible': 0}
-    
+
     def test_serialier(self):
         input = {'pointsEarned': 10, 'pointsPossible': 200}
         data = ScoreSerializer(input).data
-
         assert data == input
-    
+
     @ddt.data('pointsEarned', 'pointsPossible')
     def test_serializer_missing_field(self, missing_field):
         value = {'pointsEarned': 30, 'pointsPossible': 50}
@@ -318,7 +316,7 @@ class TestUploadedFileSerializer(TestCase):
     def test_uploaded_file_serializer(self):
         input = MagicMock()
         data = UploadedFileSerializer(input).data
-        
+
         expected_value = {
             'downloadURL': str(input.download_url),
             'description': str(input.description),
@@ -333,7 +331,7 @@ class TestResponseSerializer(TestCase):
     def test_response_serializer__empty(self):
         input = {'files': [], 'text': []}
         assert ResponseSerializer(input).data == input
-    
+
     @ddt.unpack
     @ddt.data((True, True), (True, False), (False, True), (False, False))
     def test_response_serializer(self, has_text, has_files):
@@ -342,13 +340,13 @@ class TestResponseSerializer(TestCase):
             input.files = [Mock(), Mock(), Mock()]
         if has_text:
             input.text = [Mock(), Mock(), Mock()]
-        
+
         data = ResponseSerializer(input).data
         expected_value = {
             'files': [UploadedFileSerializer(mock_file).data for mock_file in input.files] if has_files else [],
             'text': [str(mock_text) for mock_text in input.text] if has_text else [],
         }
-        assert data == expected_value    
+        assert data == expected_value
 
 
 class TestAssessmentCriteriaSerializer(TestCase):
@@ -378,11 +376,12 @@ class TestAssessmentCriteriaSerializer(TestCase):
 
         assert data == expected_value
 
+
 @ddt.ddt
 class TestGradeDataSerializer(TestCase):
 
     def test_grade_data_serializer__no_assessment(self):
-        assert GradeDataSerializer({}).data == {} 
+        assert GradeDataSerializer({}).data == {}
 
     @ddt.data(True, False)
     def test_grade_data_serializer__assessment(self, has_criteria):

--- a/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
@@ -327,7 +327,7 @@ class TestUploadedFileSerializer(TestCase):
         data = UploadedFileSerializer(input).data
 
         expected_value = {
-            'downloadURL': str(input.download_url),
+            'downloadUrl': str(input.download_url),
             'description': str(input.description),
             'name': str(input.name),
         }

--- a/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
@@ -275,15 +275,11 @@ class TestScoreFieldAndSerializer(TestCase):
 
     @ddt.data('pointsEarned', 'pointsPossible')
     def test_field_missing(self, missing_field):
-        """ One missing field should result in the field defaulting to 0 """
+        """ Missing fields should just be ignored """
         value = {'pointsEarned': 30, 'pointsPossible': 50}
         del value[missing_field]
 
-        expectedValue = dict(value)
-        expectedValue[missing_field] = 0
-
-        actualValue = ScoreField().to_representation(value)
-        assert expectedValue == actualValue
+        assert ScoreField().to_representation(value) == value
 
     def test_field(self):
         """ Base serialization behavior for ScoreField """
@@ -295,9 +291,8 @@ class TestScoreFieldAndSerializer(TestCase):
         assert representation == data
 
     def test_serializer_no_values(self):
-        """ Passing the ScoreSerializer an empty dict should result in two zeroes for the field """
-        data = ScoreSerializer({}).data
-        assert data == {'pointsEarned': 0, 'pointsPossible': 0}
+        """ Passing the ScoreSerializer an empty dict should result in an empty serializer """
+        assert ScoreSerializer({}).data == {}
 
     def test_serialier(self):
         """ Base serialization behavior for ScoreSerializer """
@@ -307,15 +302,11 @@ class TestScoreFieldAndSerializer(TestCase):
 
     @ddt.data('pointsEarned', 'pointsPossible')
     def test_serializer_missing_field(self, missing_field):
-        """ One missing field should result in the field defaulting to 0 """
+        """ Missing fields should just be ignored """
         value = {'pointsEarned': 30, 'pointsPossible': 50}
         del value[missing_field]
 
-        expectedValue = dict(value)
-        expectedValue[missing_field] = 0
-
-        actualValue = ScoreSerializer(value).data
-        assert expectedValue == actualValue
+        assert ScoreSerializer(value).data == value
 
 
 class TestUploadedFileSerializer(TestCase):

--- a/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
@@ -267,12 +267,15 @@ class TestInitializeSerializer(TestCase):
 
 @ddt.ddt
 class TestScoreFieldAndSerializer(TestCase):
+    """ Tests for ScoreField and ScoreSerializer """
 
     def test_field_no_values(self):
+        """ An empty dict passed to the field should return None """
         assert ScoreField().to_representation({}) is None
 
     @ddt.data('pointsEarned', 'pointsPossible')
     def test_field_missing(self, missing_field):
+        """ One missing field should result in the field defaulting to 0 """
         value = {'pointsEarned': 30, 'pointsPossible': 50}
         del value[missing_field]
 
@@ -283,6 +286,7 @@ class TestScoreFieldAndSerializer(TestCase):
         assert expectedValue == actualValue
 
     def test_field(self):
+        """ Base serialization behavior for ScoreField """
         data = {
             'pointsEarned': 20,
             'pointsPossible': 40
@@ -291,16 +295,19 @@ class TestScoreFieldAndSerializer(TestCase):
         assert representation == data
 
     def test_serializer_no_values(self):
+        """ Passing the ScoreSerializer an empty dict should result in two zeroes for the field """
         data = ScoreSerializer({}).data
         assert data ==  {'pointsEarned': 0, 'pointsPossible': 0}
 
     def test_serialier(self):
+        """ Base serialization behavior for ScoreSerializer """
         input = {'pointsEarned': 10, 'pointsPossible': 200}
         data = ScoreSerializer(input).data
         assert data == input
 
     @ddt.data('pointsEarned', 'pointsPossible')
     def test_serializer_missing_field(self, missing_field):
+        """ One missing field should result in the field defaulting to 0 """
         value = {'pointsEarned': 30, 'pointsPossible': 50}
         del value[missing_field]
 
@@ -312,8 +319,10 @@ class TestScoreFieldAndSerializer(TestCase):
 
 
 class TestUploadedFileSerializer(TestCase):
+    """ Tests for UploadedFileSerializer """
 
     def test_uploaded_file_serializer(self):
+        """ Base serialization behavior """
         input = MagicMock()
         data = UploadedFileSerializer(input).data
 
@@ -327,14 +336,17 @@ class TestUploadedFileSerializer(TestCase):
 
 @ddt.ddt
 class TestResponseSerializer(TestCase):
+    """ Tests for ResponseSerializer """
 
     def test_response_serializer__empty(self):
+        """ Empty fields should be allowed """
         input = {'files': [], 'text': []}
         assert ResponseSerializer(input).data == input
 
     @ddt.unpack
     @ddt.data((True, True), (True, False), (False, True), (False, False))
     def test_response_serializer(self, has_text, has_files):
+        """ Base serialization behavior """
         input = MagicMock()
         if has_files:
             input.files = [Mock(), Mock(), Mock()]
@@ -350,8 +362,10 @@ class TestResponseSerializer(TestCase):
 
 
 class TestAssessmentCriteriaSerializer(TestCase):
+    """ Tests for AssessmentCriteriaSerializer """
 
     def test_assessment_criteria_serializer(self):
+        """ Base serialization behavior """
         input = Mock()
         data = AssessmentCriteriaSerializer(input).data
 
@@ -363,6 +377,7 @@ class TestAssessmentCriteriaSerializer(TestCase):
         assert data == expected_value
 
     def test_assessment_criteria_serializer__feedback_only(self):
+        """ Test for serialization behavior of a feedback-only criterion """
         input = {
             'name': 'SomeCriterioOn',
             'feedback': 'Pathetic Effort',
@@ -379,12 +394,15 @@ class TestAssessmentCriteriaSerializer(TestCase):
 
 @ddt.ddt
 class TestGradeDataSerializer(TestCase):
+    """ Tests for GradeDataSerializer """
 
     def test_grade_data_serializer__no_assessment(self):
+        """ Passing an empty dict should result in an empty dict """
         assert GradeDataSerializer({}).data == {}
 
     @ddt.data(True, False)
     def test_grade_data_serializer__assessment(self, has_criteria):
+        """ Base serialization behavior, with and without criteria """
         input = MagicMock()
         if has_criteria:
             input.criteria = [Mock(), Mock(), Mock()]
@@ -402,8 +420,10 @@ class TestGradeDataSerializer(TestCase):
 
 
 class TestSubmissionDetailResponseSerializer(TestCase):
+    """ Tests for SubmissionDetailResponseSerializer """
 
     def test_submission_detail_response_serializer(self):
+        """ Base serialization behavior """
         input = MagicMock()
         data = SubmissionDetailResponseSerializer(input).data
 

--- a/lms/djangoapps/ora_staff_grader/tests/test_views.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_views.py
@@ -14,7 +14,7 @@ from xmodule.modulestore.tests.factories import ItemFactory
 
 
 class BaseViewTest(SharedModuleStoreTestCase, APITestCase):
-
+    """ Base class for shared test utils and setup """
     MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
 
     @classmethod

--- a/lms/djangoapps/ora_staff_grader/tests/test_views.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_views.py
@@ -41,7 +41,6 @@ class BaseViewTest(SharedModuleStoreTestCase, APITestCase):
         self.client.login(username=self.staff.username, password=self.password)
 
 
-
 class TestInitializeView(BaseViewTest):
     """
     Tests for the /initialize view, creating setup data for ESG
@@ -168,7 +167,7 @@ class TestFetchSubmissionView(BaseViewTest):
                 },
             ]
         }
-        mock_get_submission_and_assessment_info.return_value =  {
+        mock_get_submission_and_assessment_info.return_value = {
             'submission': mock_submission,
             'assessment': mock_assessment,
         }
@@ -179,5 +178,5 @@ class TestFetchSubmissionView(BaseViewTest):
         assert response.status_code == 200
         assert response.data.keys() == set(['gradeData', 'response'])
         assert response.data['response'].keys() == set(['files', 'text'])
-        expected_assessment_keys = set(['score', 'overallFeedback', 'criteria']) if has_assessment else set()          
+        expected_assessment_keys = set(['score', 'overallFeedback', 'criteria']) if has_assessment else set()
         assert response.data['gradeData'].keys() == expected_assessment_keys

--- a/lms/djangoapps/ora_staff_grader/tests/test_views.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_views.py
@@ -1,9 +1,10 @@
 """
 Tests for ESG views
 """
+import ddt
 from django.urls import reverse
 from rest_framework.test import APITestCase
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from common.djangoapps.student.tests.factories import StaffFactory
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
@@ -12,18 +13,15 @@ from xmodule.modulestore.tests.factories import CourseFactory
 from xmodule.modulestore.tests.factories import ItemFactory
 
 
-class TestInitializeView(SharedModuleStoreTestCase, APITestCase):
-    """
-    Tests for the /initialize view, creating setup data for ESG
-    """
-    view_name = 'ora-staff-grader:initialize'
-    api_url = reverse(view_name)
+class BaseViewTest(SharedModuleStoreTestCase, APITestCase):
 
     MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+
+        cls.api_url = reverse(cls.view_name)
 
         cls.course = CourseFactory.create()
         cls.course_key = cls.course.location.course_key
@@ -41,6 +39,14 @@ class TestInitializeView(SharedModuleStoreTestCase, APITestCase):
     def log_in(self):
         """ Log in as staff """
         self.client.login(username=self.staff.username, password=self.password)
+
+
+
+class TestInitializeView(BaseViewTest):
+    """
+    Tests for the /initialize view, creating setup data for ESG
+    """
+    view_name = 'ora-staff-grader:initialize'
 
     def test_missing_ora_location(self):
         """ Missing ora_location param should return 400 and error message """
@@ -92,3 +98,86 @@ class TestInitializeView(SharedModuleStoreTestCase, APITestCase):
         expected_keys = set(['courseMetadata', 'oraMetadata', 'submissions', 'rubricConfig'])
         assert response.status_code == 200
         assert response.data.keys() == expected_keys
+
+
+@ddt.ddt
+class TestFetchSubmissionView(BaseViewTest):
+    """
+    Tests for the submission fetch view
+    """
+    view_name = 'ora-staff-grader:fetch-submission'
+
+    def test_missing_ora_location(self):
+        """ Missing ora_location param should return 400 and error message """
+        self.log_in()
+        response = self.client.get(self.api_url)
+
+        assert response.status_code == 400
+        assert response.content.decode() == "Query must contain an ora_location param."
+
+    def test_blank_ora_location(self):
+        """ Missing ora_location param should return 400 and error message """
+        self.log_in()
+        response = self.client.get(self.api_url, {'ora_location': ''})
+
+        assert response.status_code == 400
+        assert response.content.decode() == "Query must contain an ora_location param."
+
+    def test_missing_submission_uuid(self):
+        """ Missing submission_uuid param should return 400 and error message """
+        self.log_in()
+        response = self.client.get(self.api_url, {'ora_location': Mock()})
+
+        assert response.status_code == 400
+        assert response.content.decode() == "Query must contain a submission_uuid param."
+
+    def test_blank_submission_uuid(self):
+        """ Blank submission_uuid param should return 400 and error message """
+        self.log_in()
+        response = self.client.get(self.api_url, {'ora_location': Mock(), 'submission_uuid': ''})
+
+        assert response.status_code == 400
+        assert response.content.decode() == "Query must contain a submission_uuid param."
+
+    @ddt.data(True, False)
+    @patch('lms.djangoapps.ora_staff_grader.views.SubmissionFetchView.get_submission_and_assessment_info')
+    def test_fetch_submission(self, has_assessment, mock_get_submission_and_assessment_info):
+        """ """
+        mock_submission = {
+            'text': ['This is the answer'],
+            'files': [
+                {
+                    'name': 'name_0',
+                    'description': 'description_0',
+                    'download_url': 'www.file_url.com/key_0'
+                }
+            ]
+        }
+
+        mock_assessment = {} if not has_assessment else {
+            'feedback': "Base Assessment Feedback",
+            'score': {
+                'pointsEarned': 5,
+                'pointsPossible': 6,
+            },
+            'criteria': [
+                {
+                    'name': "Criterion 1",
+                    'option': "Three",
+                    'feedback': "Feedback 1"
+                },
+            ]
+        }
+        mock_get_submission_and_assessment_info.return_value =  {
+            'submission': mock_submission,
+            'assessment': mock_assessment,
+        }
+
+        self.log_in()
+        response = self.client.get(self.api_url, {'ora_location': Mock(), 'submission_uuid': Mock()})
+
+        assert response.status_code == 200
+        assert response.data.keys() == set(['gradeData', 'response'])
+        assert response.data['response'].keys() == set(['files', 'text'])
+        expected_assessment_keys = set(['score', 'overallFeedback', 'criteria']) if has_assessment else set()          
+        assert response.data['gradeData'].keys() == expected_assessment_keys

--- a/lms/djangoapps/ora_staff_grader/urls.py
+++ b/lms/djangoapps/ora_staff_grader/urls.py
@@ -14,6 +14,6 @@ urlpatterns += [
         'initialize', InitializeView.as_view(), name='initialize'
     ),
     path(
-        'fetch-submission', SubmissionFetchView.as_view(), name='fetch-submission'
+        'submission', SubmissionFetchView.as_view(), name='fetch-submission'
     )
 ]

--- a/lms/djangoapps/ora_staff_grader/urls.py
+++ b/lms/djangoapps/ora_staff_grader/urls.py
@@ -4,7 +4,7 @@ URLs for Enhanced Staff Grader (ESG) backend-for-frontend (BFF)
 
 from django.urls.conf import path
 
-from lms.djangoapps.ora_staff_grader.views import InitializeView
+from lms.djangoapps.ora_staff_grader.views import InitializeView, SubmissionFetchView
 
 
 urlpatterns = []
@@ -13,4 +13,7 @@ urlpatterns += [
     path(
         'initialize', InitializeView.as_view(), name='initialize'
     ),
+    path(
+        'fetch-submission', SubmissionFetchView.as_view(), name='fetch-submission'
+    )
 ]

--- a/lms/djangoapps/ora_staff_grader/views.py
+++ b/lms/djangoapps/ora_staff_grader/views.py
@@ -106,7 +106,7 @@ class SubmissionFetchView(RetrieveAPIView):
         response: {
             text: (list of string), [the html content of text responses]
             files: (list of dict) [{
-                downloadURL: (string) file download url
+                downloadUrl: (string) file download url
                 description: (string) file description
                 name: (string) filename
             }]

--- a/lms/djangoapps/ora_staff_grader/views.py
+++ b/lms/djangoapps/ora_staff_grader/views.py
@@ -13,7 +13,7 @@ from rest_framework.response import Response
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
 
-from lms.djangoapps.ora_staff_grader.serializers import InitializeSerializer
+from lms.djangoapps.ora_staff_grader.serializers import InitializeSerializer, SubmissionDetailResponseSerializer
 from lms.djangoapps.ora_staff_grader.utils import call_xblock_json_handler
 from openedx.core.djangoapps.content.course_overviews.api import get_course_overview_or_none
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
@@ -84,3 +84,47 @@ class InitializeView(RetrieveAPIView):
             'target_rubric_block_id': usage_id
         }
         return call_xblock_json_handler(request, usage_id, 'get_rubric', data)
+
+
+class SubmissionFetchView(RetrieveAPIView):
+    """
+    GET submission contents and assessment info, if any
+
+    Response: {
+        
+    }
+
+    Returns:
+        200
+        400
+        403
+        404
+        405
+    """
+    authentication_classes = (
+        JwtAuthentication,
+        BearerAuthenticationAllowInactiveUser,
+        SessionAuthenticationAllowInactiveUser,
+    )
+    permission_classes = (IsAuthenticated,)
+
+    def get(self, request, *args, **kwargs):
+        ora_location = request.query_params.get('ora_location')
+        if not ora_location:
+            return HttpResponseBadRequest(_("Query must contain an ora_location param."))
+        
+        submission_uuid = request.query_params.get('submission_uuid')
+        if not submission_uuid:
+            return HttpResponseBadRequest(_("Query must contain a submission_uuid param."))
+
+        submission_and_assessment_info = self.get_submission_and_assessment_info(ora_location, submission_uuid)
+        return Response(SubmissionDetailResponseSerializer(submission_and_assessment_info).data)
+
+    def get_submission_and_assessment_info(self, request, usage_id, submission_uuid):
+        """
+        Get submission content and assessment data from the ORA's 'get_submission_and_assessment_info' XBlock.json_handler
+        """
+        data = {
+            'submission_uuid': submission_uuid
+        }
+        return call_xblock_json_handler(request, usage_id, 'get_submission_and_assessment_info', data)

--- a/lms/djangoapps/ora_staff_grader/views.py
+++ b/lms/djangoapps/ora_staff_grader/views.py
@@ -91,15 +91,27 @@ class SubmissionFetchView(RetrieveAPIView):
     GET submission contents and assessment info, if any
 
     Response: {
-
+        gradeData: {
+            score: (dict or None) {
+                pointsEarned: (int) earned points
+                pointsPossible: (int) possible points
+            }
+            overallFeedback: (string) overall feedback
+            criteria: (list of dict) [{
+                name: (str) name of criterion
+                feedback: (str) feedback for criterion
+                selectedOption: (str) name of selected option or None if feedback-only criterion
+            }]
+        }
+        response: {
+            text: (list of string), [the html content of text responses]
+            files: (list of dict) [{
+                downloadURL: (string) file download url
+                description: (string) file description
+                name: (string) filename
+            }]
+        }
     }
-
-    Returns:
-        200
-        400
-        403
-        404
-        405
     """
     authentication_classes = (
         JwtAuthentication,

--- a/lms/djangoapps/ora_staff_grader/views.py
+++ b/lms/djangoapps/ora_staff_grader/views.py
@@ -91,7 +91,7 @@ class SubmissionFetchView(RetrieveAPIView):
     GET submission contents and assessment info, if any
 
     Response: {
-        
+
     }
 
     Returns:
@@ -112,7 +112,7 @@ class SubmissionFetchView(RetrieveAPIView):
         ora_location = request.query_params.get('ora_location')
         if not ora_location:
             return HttpResponseBadRequest(_("Query must contain an ora_location param."))
-        
+
         submission_uuid = request.query_params.get('submission_uuid')
         if not submission_uuid:
             return HttpResponseBadRequest(_("Query must contain a submission_uuid param."))


### PR DESCRIPTION
## Description

- Add BFF Endpoint for submission fetch
- Also `score` serialization to be able to return None

## Supporting information

[AU-364](https://openedx.atlassian.net/browse/AU-364)

https://openedx.atlassian.net/wiki/spaces/PT/pages/3154542730/Enhanced+Staff+Grader+Data+Flow+Design#fetch-submission

Due to a misunderstanding when doing the backend ORA work for this, the endpoint doesn't return `gradeStatus` or `lockStatus`. That will be done in [AU-387](https://openedx.atlassian.net/browse/AU-387)

@edx/masters-devs-gta 
