### PR TITLE
fix: correct path for dump_course_to_neo4j task, so it goes to correct celery queue.

### DIFF
--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -587,7 +587,7 @@ EXPLICIT_QUEUES = {
         'queue': POLICY_CHANGE_GRADES_ROUTING_KEY},
     'cms.djangoapps.contentstore.tasks.update_search_index': {
         'queue': UPDATE_SEARCH_INDEX_JOB_QUEUE},
-    'openedx.core.djangoapps.coursegraph.dump_course_to_neo4j': {
+    'openedx.core.djangoapps.coursegraph.tasks.dump_course_to_neo4j': {
         'queue': COURSEGRAPH_JOB_QUEUE},
 }
 


### PR DESCRIPTION
fix: correct path for dump_course_to_neo4j task, so it goes to correct celery queue.

TNL-8386