### PR TITLE
feat: ESG BFF submission/lock endpoint

### DIFF
--- a/lms/djangoapps/ora_staff_grader/errors.py
+++ b/lms/djangoapps/ora_staff_grader/errors.py
@@ -1,0 +1,4 @@
+""" Error codes and exceptions for ESG """
+
+ERR_MISSING_PARAM = "ERR_MISSING_PARAM"
+ERR_BAD_ORA_LOCATION = "ERR_BAD_ORA_LOCATION"

--- a/lms/djangoapps/ora_staff_grader/serializers.py
+++ b/lms/djangoapps/ora_staff_grader/serializers.py
@@ -14,9 +14,9 @@ class GradeStatusField(serializers.ChoiceField):
 
 
 class LockStatusField(serializers.ChoiceField):
-    """ Field that can have the values ['not-locked', 'locked', 'in-progress'] """
-    def __init__(self):
-        super().__init__(choices=['not-locked', 'locked', 'in-progress'])
+    """ Field that can have the values ['unlocked', 'locked', 'in-progress'] """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs, choices=['unlocked', 'locked', 'in-progress'])
 
 
 class CourseMetadataSerializer(serializers.Serializer):  # pylint: disable=abstract-method
@@ -159,3 +159,17 @@ class SubmissionDetailResponseSerializer(serializers.Serializer):
     #  to be completed in AU-387
     #  gradeStatus = GradeStatusField()
     #  lockStatus = LockStatusField()
+
+
+class LockStatusSerializer(serializers.Serializer):
+    """
+    Info about the status of a submission lock, with extra metadata stripped out.
+    """
+    # lockStatus = serializers.CharField(source='lock_status')
+    lockStatus = LockStatusField(source='lock_status')
+
+    class Meta:
+        fields = [
+            'lockStatus'
+        ]
+        read_only_fields = fields

--- a/lms/djangoapps/ora_staff_grader/serializers.py
+++ b/lms/djangoapps/ora_staff_grader/serializers.py
@@ -165,7 +165,6 @@ class LockStatusSerializer(serializers.Serializer):
     """
     Info about the status of a submission lock, with extra metadata stripped out.
     """
-    # lockStatus = serializers.CharField(source='lock_status')
     lockStatus = LockStatusField(source='lock_status')
 
     class Meta:

--- a/lms/djangoapps/ora_staff_grader/serializers.py
+++ b/lms/djangoapps/ora_staff_grader/serializers.py
@@ -19,7 +19,7 @@ class LockStatusField(serializers.ChoiceField):
         super().__init__(*args, **kwargs, choices=['unlocked', 'locked', 'in-progress'])
 
 
-class CourseMetadataSerializer(serializers.Serializer):  # pylint: disable=abstract-method
+class CourseMetadataSerializer(serializers.Serializer):
     """
     Serialize top-level info about a course, used for creating header in ESG
     """
@@ -40,7 +40,7 @@ class CourseMetadataSerializer(serializers.Serializer):  # pylint: disable=abstr
         read_only_fields = fields
 
 
-class OpenResponseMetadataSerializer(serializers.Serializer):  # pylint: disable=abstract-method
+class OpenResponseMetadataSerializer(serializers.Serializer):
     """
     Serialize ORA metadata, used for setting up views in ESG
     """
@@ -67,7 +67,7 @@ class ScoreField(serializers.Field):
         return ScoreSerializer(value).data
 
 
-class ScoreSerializer(serializers.Serializer):  # pylint: disable=abstract-method
+class ScoreSerializer(serializers.Serializer):
     """
     Score (points earned/possible) for use in SubmissionMetadataSerializer
     """
@@ -75,7 +75,7 @@ class ScoreSerializer(serializers.Serializer):  # pylint: disable=abstract-metho
     pointsPossible = serializers.IntegerField(required=False)
 
 
-class SubmissionMetadataSerializer(serializers.Serializer):  # pylint: disable=abstract-method
+class SubmissionMetadataSerializer(serializers.Serializer):
     """
     Submission metadata for displaying submissions table in ESG
     """

--- a/lms/djangoapps/ora_staff_grader/serializers.py
+++ b/lms/djangoapps/ora_staff_grader/serializers.py
@@ -37,6 +37,7 @@ class CourseMetadataSerializer(serializers.Serializer):  # pylint: disable=abstr
             'number',
             'courseId',
         ]
+        read_only_fields = fields
 
 
 class OpenResponseMetadataSerializer(serializers.Serializer):  # pylint: disable=abstract-method
@@ -56,6 +57,7 @@ class OpenResponseMetadataSerializer(serializers.Serializer):  # pylint: disable
             'prompts',
             'type',
         ]
+        read_only_fields = fields
 
 
 class ScoreField(serializers.Field):
@@ -99,6 +101,7 @@ class SubmissionMetadataSerializer(serializers.Serializer):  # pylint: disable=a
             'lockStatus',
             'score'
         ]
+        read_only_fields = fields
 
 
 class InitializeSerializer(serializers.Serializer):
@@ -117,6 +120,7 @@ class InitializeSerializer(serializers.Serializer):
             'submissions',
             'rubricConfig',
         ]
+        read_only_fields = fields
 
 
 class UploadedFileSerializer(serializers.Serializer):

--- a/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
@@ -100,7 +100,7 @@ class TestSubmissionMetadataSerializer(TestCase):
         "dateGraded": "<yyyy-mm-dd HH:MM:SS/None>",
         "gradedBy": "<username/empty>",
         "gradingStatus": "<ungraded/graded>",
-        "lockStatus": "<locked/unlocked/in-progress",
+        "lockStatus": "<locked/unlocked/in-progress>",
         "score": {
             "pointsEarned": <num>,
             "pointsPossible": <num>

--- a/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
@@ -428,12 +428,8 @@ class TestSubmissionDetailResponseSerializer(TestCase):
 
 class TestLockStatusSerializer(SharedModuleStoreTestCase):
     """
-    Tests for CourseMetadataSerializer
+    Tests for LockStatusSerializer
     """
-    lock_contested = {
-        "error": "Submission already locked"
-    }
-
     lock_in_progress = {
         "submission_uuid": "e34ef789-a4b1-48cf-b1bc-b3edacfd4eb2",
         "owner_id": "10ab03f1b75b4f9d9ab13a1fd1dccca1",

--- a/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
@@ -10,6 +10,7 @@ from lms.djangoapps.ora_staff_grader.serializers import (
     CourseMetadataSerializer,
     GradeDataSerializer,
     InitializeSerializer,
+    LockStatusSerializer,
     OpenResponseMetadataSerializer,
     ResponseSerializer,
     ScoreField,
@@ -423,3 +424,47 @@ class TestSubmissionDetailResponseSerializer(TestCase):
             'response': ResponseSerializer(input.submission).data
         }
         assert data == expected_value
+
+
+class TestLockStatusSerializer(SharedModuleStoreTestCase):
+    """
+    Tests for CourseMetadataSerializer
+    """
+    lock_contested = {
+        "error": "Submission already locked"
+    }
+
+    lock_in_progress = {
+        "submission_uuid": "e34ef789-a4b1-48cf-b1bc-b3edacfd4eb2",
+        "owner_id": "10ab03f1b75b4f9d9ab13a1fd1dccca1",
+        "created_at": "2021-09-21T21:54:09.901221Z",
+        "lock_status": "in-progress",
+    }
+
+    lock_in_progress_expected = {
+        "lockStatus": "in-progress"
+    }
+
+    lock_owned_by_other_user = {
+        "submission_uuid": "e34ef789-a4b1-48cf-b1bc-b3edacfd4eb2",
+        "owner_id": "10ab03f1b75b4f9d9ab13a1fd1dccca1",
+        "created_at": "2021-09-21T21:54:09.901221Z",
+        "lock_status": "locked",
+    }
+
+    lock_owned_by_other_user_expected = {
+        "lockStatus": "locked"
+    }
+
+    course_id = "course-v1:Oxford+TT101+2054"
+
+    def setUp(self):
+        super().setUp()
+
+    def test_happy_path(self):
+        """ For simple cases, lock status is passed through directly """
+        data = LockStatusSerializer(self.lock_in_progress).data
+        assert data == self.lock_in_progress_expected
+
+        data = LockStatusSerializer(self.lock_owned_by_other_user).data
+        assert data == self.lock_owned_by_other_user_expected

--- a/lms/djangoapps/ora_staff_grader/tests/test_views.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_views.py
@@ -53,14 +53,14 @@ class TestInitializeView(BaseViewTest):
         response = self.client.get(self.api_url)
 
         assert response.status_code == 400
-        assert response.content.decode() == "Query must contain an ora_location param."
+        assert response.content.decode() == "Query requires the following query params: ora_location"
 
     def test_bad_ora_location(self):
-        """ Bad ORA location should return a 404 and error message """
+        """ Bad ORA location should return a 400 and error message """
         self.client.login(username=self.staff.username, password=self.password)
         response = self.client.get(self.api_url, {'ora_location': 'not_a_real_location'})
 
-        assert response.status_code == 404
+        assert response.status_code == 400
         assert response.content.decode() == "Invalid ora_location."
 
     @patch('lms.djangoapps.ora_staff_grader.views.InitializeView.get_rubric_config')
@@ -112,7 +112,7 @@ class TestFetchSubmissionView(BaseViewTest):
         response = self.client.get(self.api_url)
 
         assert response.status_code == 400
-        assert response.content.decode() == "Query must contain an ora_location param."
+        assert response.content.decode() == "Query requires the following query params: ora_location, submission_uuid"
 
     def test_blank_ora_location(self):
         """ Missing ora_location param should return 400 and error message """
@@ -120,7 +120,7 @@ class TestFetchSubmissionView(BaseViewTest):
         response = self.client.get(self.api_url, {'ora_location': ''})
 
         assert response.status_code == 400
-        assert response.content.decode() == "Query must contain an ora_location param."
+        assert response.content.decode() == "Query requires the following query params: ora_location, submission_uuid"
 
     def test_missing_submission_uuid(self):
         """ Missing submission_uuid param should return 400 and error message """
@@ -128,7 +128,7 @@ class TestFetchSubmissionView(BaseViewTest):
         response = self.client.get(self.api_url, {'ora_location': Mock()})
 
         assert response.status_code == 400
-        assert response.content.decode() == "Query must contain a submission_uuid param."
+        assert response.content.decode() == "Query requires the following query params: ora_location, submission_uuid"
 
     def test_blank_submission_uuid(self):
         """ Blank submission_uuid param should return 400 and error message """
@@ -136,7 +136,7 @@ class TestFetchSubmissionView(BaseViewTest):
         response = self.client.get(self.api_url, {'ora_location': Mock(), 'submission_uuid': ''})
 
         assert response.status_code == 400
-        assert response.content.decode() == "Query must contain a submission_uuid param."
+        assert response.content.decode() == "Query requires the following query params: ora_location, submission_uuid"
 
     @ddt.data(True, False)
     @patch('lms.djangoapps.ora_staff_grader.views.SubmissionFetchView.get_submission_and_assessment_info')

--- a/lms/djangoapps/ora_staff_grader/tests/test_views.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_views.py
@@ -223,7 +223,6 @@ class TestSubmissionLockView(APITestCase):
 
         self.client.login(username=self.staff.username, password=self.password)
 
-
     def url_with_params(self, params):
         """ For DRF client.posts, you can't add query params easily. This helper adds it to the request URL """
         query_dictionary = QueryDict('', mutable=True)
@@ -290,7 +289,6 @@ class TestSubmissionLockView(APITestCase):
         expected_value = {"lockStatus": "unlocked"}
         assert response.status_code == 200
         assert json.loads(response.content) == expected_value
-
 
     @patch('lms.djangoapps.ora_staff_grader.views.call_xblock_json_handler')
     def test_delete_lock_contested(self, mock_xblock_handler):

--- a/lms/djangoapps/ora_staff_grader/tests/test_views.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_views.py
@@ -2,7 +2,13 @@
 Tests for ESG views
 """
 import ddt
+import json
+
+from uuid import uuid4
+from django.http import QueryDict
+from django.http.response import HttpResponse, HttpResponseForbidden
 from django.urls import reverse
+from opaque_keys.edx.keys import CourseKey
 from rest_framework.test import APITestCase
 from unittest.mock import Mock, patch
 
@@ -180,3 +186,122 @@ class TestFetchSubmissionView(BaseViewTest):
         assert response.data['response'].keys() == set(['files', 'text'])
         expected_assessment_keys = set(['score', 'overallFeedback', 'criteria']) if has_assessment else set()
         assert response.data['gradeData'].keys() == expected_assessment_keys
+
+
+class TestSubmissionLockView(APITestCase):
+    """
+    Tests for the /lock view, locking or unlocking a submission for grading
+    """
+    view_name = 'ora-staff-grader:lock'
+    api_url = reverse(view_name)
+
+    test_submission_uuid = str(uuid4())
+    test_anon_user_id = 'anon-user-id'
+    test_timestamp = '2020-08-29T02:14:00-04:00'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.course_key = CourseKey.from_string('course-v1:edX+ToyX+Toy_Course')
+        cls.test_ora_location = 'block-v1:edX+ToyX+Toy_Course+type@openassessment+block@f00'
+        cls.password = 'password'
+        cls.staff = StaffFactory(course_key=cls.course_key, password=cls.password)
+
+    def setUp(self):
+        super().setUp()
+
+        # Request to claim a lock must include ora_location, submissionID, and value=True
+        self.test_claim_lock_params = {
+            "ora_location": self.test_ora_location,
+            "submissionId": self.test_submission_uuid,
+            "value": True
+        }
+
+        # Request to claim a lock must include ora_location, submissionID, and value=False
+        self.test_delete_lock_params = self.test_claim_lock_params.copy()
+        self.test_delete_lock_params['value'] = False
+
+        self.client.login(username=self.staff.username, password=self.password)
+
+
+    def url_with_params(self, params):
+        """ For DRF client.posts, you can't add query params easily. This helper adds it to the request URL """
+        query_dictionary = QueryDict('', mutable=True)
+        query_dictionary.update(params)
+
+        return '{base_url}?{querystring}'.format(
+            base_url=reverse(self.view_name),
+            querystring=query_dictionary.urlencode()
+        )
+
+    def test_invalid_ora(self):
+        """ An invalid ORA returns a 404 """
+        self.test_claim_lock_params['ora_location'] = 'not_a_real_location'
+
+        response = self.client.post(self.url_with_params(self.test_claim_lock_params))
+
+        assert response.status_code == 400
+        assert response.content.decode() == "Invalid ora_location."
+
+    @patch('lms.djangoapps.ora_staff_grader.views.call_xblock_json_handler')
+    def test_claim_lock(self, mock_xblock_handler):
+        """ Passing value=True indicates to claim a submission lock. Success returns lock status 'in-progress'. """
+        mock_return_data = {
+            "submission_uuid": self.test_submission_uuid,
+            "owner_id": self.test_anon_user_id,
+            "created_at": self.test_timestamp,
+            "lock_status": "in-progress"
+        }
+        mock_xblock_handler.return_value = HttpResponse(json.dumps(mock_return_data), content_type="application/json")
+
+        response = self.client.post(self.url_with_params(self.test_claim_lock_params))
+
+        expected_value = {"lockStatus": "in-progress"}
+        assert response.status_code == 200
+        assert json.loads(response.content) == expected_value
+
+    @patch('lms.djangoapps.ora_staff_grader.views.call_xblock_json_handler')
+    def test_claim_lock_contested(self, mock_xblock_handler):
+        """ Attempting to claim a lock owned by another user returns a 403 - forbidden and passes error code. """
+        mock_return_data = {
+            "error": "ERR_LOCK_CONTESTED"
+        }
+        mock_xblock_handler.return_value = HttpResponseForbidden(json.dumps(mock_return_data), content_type="application/json")
+
+        response = self.client.post(self.url_with_params(self.test_claim_lock_params))
+
+        expected_value = mock_return_data
+        assert response.status_code == 403
+        assert json.loads(response.content) == expected_value
+
+    @patch('lms.djangoapps.ora_staff_grader.views.call_xblock_json_handler')
+    def test_delete_lock(self, mock_xblock_handler):
+        """ Passing value=False indicates to delete a submission lock. Success returns lock status 'unlocked'. """
+        mock_return_data = {
+            "submission_uuid": "",
+            "owner_id": "",
+            "created_at": "",
+            "lock_status": "unlocked"
+        }
+        mock_xblock_handler.return_value = HttpResponse(json.dumps(mock_return_data), content_type="application/json")
+
+        response = self.client.post(self.url_with_params(self.test_delete_lock_params))
+
+        expected_value = {"lockStatus": "unlocked"}
+        assert response.status_code == 200
+        assert json.loads(response.content) == expected_value
+
+
+    @patch('lms.djangoapps.ora_staff_grader.views.call_xblock_json_handler')
+    def test_delete_lock_contested(self, mock_xblock_handler):
+        """ Attempting to delete a lock owned by another user returns a 403 - forbidden and passes error code. """
+        mock_return_data = {
+            "error": "ERR_LOCK_CONTESTED"
+        }
+        mock_xblock_handler.return_value = HttpResponseForbidden(json.dumps(mock_return_data), content_type="application/json")
+
+        response = self.client.post(self.url_with_params(self.test_delete_lock_params))
+
+        expected_value = mock_return_data
+        assert response.status_code == 403
+        assert json.loads(response.content) == expected_value

--- a/lms/djangoapps/ora_staff_grader/tests/test_views.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_views.py
@@ -13,6 +13,7 @@ from rest_framework.test import APITestCase
 from unittest.mock import Mock, patch
 
 from common.djangoapps.student.tests.factories import StaffFactory
+from lms.djangoapps.ora_staff_grader.errors import ERR_BAD_ORA_LOCATION, ERR_MISSING_PARAM
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
@@ -59,7 +60,7 @@ class TestInitializeView(BaseViewTest):
         response = self.client.get(self.api_url)
 
         assert response.status_code == 400
-        assert response.content.decode() == "Query requires the following query params: ora_location"
+        assert response.content.decode() == ERR_MISSING_PARAM
 
     def test_bad_ora_location(self):
         """ Bad ORA location should return a 400 and error message """
@@ -67,7 +68,7 @@ class TestInitializeView(BaseViewTest):
         response = self.client.get(self.api_url, {'ora_location': 'not_a_real_location'})
 
         assert response.status_code == 400
-        assert response.content.decode() == "Invalid ora_location."
+        assert response.content.decode() == ERR_BAD_ORA_LOCATION
 
     @patch('lms.djangoapps.ora_staff_grader.views.InitializeView.get_rubric_config')
     @patch('lms.djangoapps.ora_staff_grader.views.InitializeView.get_submissions')
@@ -239,13 +240,13 @@ class TestSubmissionLockView(APITestCase):
     # Tests for claiming a lock (POST)
 
     def test_claim_lock_invalid_ora(self):
-        """ An invalid ORA returns a 404 """
+        """ An invalid ORA returns a 400 """
         self.test_lock_params['ora_location'] = 'not_a_real_location'
 
         response = self.claim_lock(self.test_lock_params)
 
         assert response.status_code == 400
-        assert response.content.decode() == "Invalid ora_location."
+        assert response.content.decode() == ERR_BAD_ORA_LOCATION
 
     @patch('lms.djangoapps.ora_staff_grader.views.call_xblock_json_handler')
     def test_claim_lock(self, mock_xblock_handler):

--- a/lms/djangoapps/ora_staff_grader/tests/test_views.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_views.py
@@ -119,7 +119,7 @@ class TestFetchSubmissionView(BaseViewTest):
         response = self.client.get(self.api_url)
 
         assert response.status_code == 400
-        assert response.content.decode() == "Query requires the following query params: ora_location, submission_uuid"
+        assert response.content.decode() == ERR_MISSING_PARAM
 
     def test_blank_ora_location(self):
         """ Missing ora_location param should return 400 and error message """
@@ -127,7 +127,7 @@ class TestFetchSubmissionView(BaseViewTest):
         response = self.client.get(self.api_url, {'ora_location': ''})
 
         assert response.status_code == 400
-        assert response.content.decode() == "Query requires the following query params: ora_location, submission_uuid"
+        assert response.content.decode() == ERR_MISSING_PARAM
 
     def test_missing_submission_uuid(self):
         """ Missing submission_uuid param should return 400 and error message """
@@ -135,7 +135,7 @@ class TestFetchSubmissionView(BaseViewTest):
         response = self.client.get(self.api_url, {'ora_location': Mock()})
 
         assert response.status_code == 400
-        assert response.content.decode() == "Query requires the following query params: ora_location, submission_uuid"
+        assert response.content.decode() == ERR_MISSING_PARAM
 
     def test_blank_submission_uuid(self):
         """ Blank submission_uuid param should return 400 and error message """
@@ -143,7 +143,7 @@ class TestFetchSubmissionView(BaseViewTest):
         response = self.client.get(self.api_url, {'ora_location': Mock(), 'submission_uuid': ''})
 
         assert response.status_code == 400
-        assert response.content.decode() == "Query requires the following query params: ora_location, submission_uuid"
+        assert response.content.decode() == ERR_MISSING_PARAM
 
     @ddt.data(True, False)
     @patch('lms.djangoapps.ora_staff_grader.views.SubmissionFetchView.get_submission_and_assessment_info')

--- a/lms/djangoapps/ora_staff_grader/urls.py
+++ b/lms/djangoapps/ora_staff_grader/urls.py
@@ -4,7 +4,8 @@ URLs for Enhanced Staff Grader (ESG) backend-for-frontend (BFF)
 
 from django.urls.conf import path
 
-from lms.djangoapps.ora_staff_grader.views import InitializeView, SubmissionFetchView
+
+from lms.djangoapps.ora_staff_grader.views import InitializeView, SubmissionFetchView, SubmissionLockView
 
 
 urlpatterns = []
@@ -15,5 +16,8 @@ urlpatterns += [
     ),
     path(
         'submission', SubmissionFetchView.as_view(), name='fetch-submission'
-    )
+    ),
+    path(
+        'submission/lock', SubmissionLockView.as_view(), name='lock'
+    ),
 ]

--- a/lms/djangoapps/ora_staff_grader/utils.py
+++ b/lms/djangoapps/ora_staff_grader/utils.py
@@ -39,7 +39,7 @@ def require_params(param_names):
     return decorator
 
 
-def call_xblock_json_handler(request, usage_id, handler_name, data):
+def call_xblock_json_handler(request, usage_id, handler_name, data, decode=True):
     """
     Create an internally-routed XBlock.json_handler request.
     The internal auth code/param unpacking requires a POST request with payload in the body.
@@ -49,6 +49,9 @@ def call_xblock_json_handler(request, usage_id, handler_name, data):
         usage_id (str): Usage ID of the XBlock for running the handler
         handler_name (str): the name of the XBlock handler method
         data (dict): Data to be encoded and sent as the body of the POST request
+        decode (Boolean): Whether to return just the decoded body (True, default) or the original HttpReponse (False)
+    returns:
+        content (Dict) or response (HttpResponse): depending on whether decode is True (Dict) or False (HttpResponse)
     """
     # XBlock.json_handler operates through a POST request
     proxy_request = clone_request(request, "POST")
@@ -61,6 +64,11 @@ def call_xblock_json_handler(request, usage_id, handler_name, data):
     usage_key = UsageKey.from_string(usage_id)
     course_id = str(usage_key.course_key)
 
-    # Send and decode the request
+    # Send the request
     response = handle_xblock_callback(proxy_request, course_id, usage_id, handler_name)
-    return json.loads(response.content)
+
+    # And decode if requested
+    if decode:
+        return json.loads(response.content)
+    else:
+        return response

--- a/lms/djangoapps/ora_staff_grader/utils.py
+++ b/lms/djangoapps/ora_staff_grader/utils.py
@@ -5,6 +5,7 @@ from functools import wraps
 import json
 
 from django.http.response import HttpResponseBadRequest
+from lms.djangoapps.ora_staff_grader.errors import ERR_MISSING_PARAM
 
 from opaque_keys.edx.keys import UsageKey
 from rest_framework.request import clone_request
@@ -31,7 +32,7 @@ def require_params(param_names):
                 param = request.query_params.get(param_name)
 
                 if not param:
-                    return HttpResponseBadRequest(f"Query requires the following query params: {', '.join(param_names)}")
+                    return HttpResponseBadRequest(ERR_MISSING_PARAM)
 
                 passed_parameters.append(param)
             return function(self, request, *passed_parameters, *args, **kwargs)

--- a/lms/djangoapps/ora_staff_grader/views.py
+++ b/lms/djangoapps/ora_staff_grader/views.py
@@ -155,7 +155,7 @@ class SubmissionLockView(RetrieveAPIView):
     permission_classes = (IsAuthenticated,)
 
     @require_params(['ora_location', 'submissionId', 'value'])
-    def post(self, request, ora_location, submission_uuid, value,  *args, **kwargs):
+    def post(self, request, ora_location, submission_uuid, value, *args, **kwargs):
         # Validate ORA location
         try:
             UsageKey.from_string(ora_location)

--- a/lms/djangoapps/ora_staff_grader/views.py
+++ b/lms/djangoapps/ora_staff_grader/views.py
@@ -1,7 +1,8 @@
 """
 Views for Enhanced Staff Grader
 """
-from django.http.response import HttpResponseBadRequest, HttpResponseNotFound
+import json
+from django.http.response import HttpResponseBadRequest
 from django.utils.translation import ugettext as _
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
@@ -13,7 +14,7 @@ from rest_framework.response import Response
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
 
-from lms.djangoapps.ora_staff_grader.serializers import InitializeSerializer, SubmissionDetailResponseSerializer
+from lms.djangoapps.ora_staff_grader.serializers import InitializeSerializer, LockStatusSerializer, SubmissionDetailResponseSerializer
 from lms.djangoapps.ora_staff_grader.utils import call_xblock_json_handler, require_params
 from openedx.core.djangoapps.content.course_overviews.api import get_course_overview_or_none
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
@@ -128,3 +129,80 @@ class SubmissionFetchView(RetrieveAPIView):
             'submission_uuid': submission_uuid
         }
         return call_xblock_json_handler(request, usage_id, 'get_submission_and_assessment_info', data)
+
+
+class SubmissionLockView(RetrieveAPIView):
+    """
+    POST lock a submission for grading course metadata
+
+    Params:
+    - submissionId (UUID): A submission to lock/unlock
+    - value (bool): Whether to add (True, default) or remove (False) a lock from this submission
+
+    Response: {
+        lockStatus
+    }
+
+    Raises:
+    - 400 for bad request or missing query params
+    - 403 for bad auth or contested lock with payload { 'error': '<error-code>'}
+    """
+    authentication_classes = (
+        JwtAuthentication,
+        BearerAuthenticationAllowInactiveUser,
+        SessionAuthenticationAllowInactiveUser,
+    )
+    permission_classes = (IsAuthenticated,)
+
+    @require_params(['ora_location', 'submissionId', 'value'])
+    def post(self, request, ora_location, submission_uuid, value,  *args, **kwargs):
+        # Validate ORA location
+        try:
+            UsageKey.from_string(ora_location)
+        except (InvalidKeyError, ItemNotFoundError):
+            return HttpResponseBadRequest("Invalid ora_location.")
+
+        # Bool-ify the value param
+        value = True if value.lower() == 'true' else False
+
+        # Determine if we want to claim a submission lock (value=True) or delete it (value=False)
+        if value:
+            response = self.claim_submission_lock(request, ora_location, submission_uuid)
+        else:
+            response = self.delete_submission_lock(request, ora_location, submission_uuid)
+
+        # In the case of an error, pass through the error response code directly
+        if response.status_code != 200:
+            return response
+
+        # Success should return serialized lock info
+        response_data = json.loads(response.content)
+        return Response(LockStatusSerializer(response_data).data)
+
+    def claim_submission_lock(self, request, usage_id, submission_uuid):
+        """
+        Attempt to claim a submission lock for grading.
+
+        Returns:
+        - lockStatus (string) - One of ['not-locked', 'locked', 'in-progress']
+        """
+        body = {
+            "submission_id": submission_uuid
+        }
+
+        # running with decode=False to preserve HTTP status codes for failure states
+        return call_xblock_json_handler(request, usage_id, 'claim_submission_lock', body, decode=False)
+
+    def delete_submission_lock(self, request, usage_id, submission_uuid):
+        """
+        Attempt to claim a submission lock for grading.
+
+        Returns:
+        - lockStatus (string) - One of ['not-locked', 'locked', 'in-progress']
+        """
+        body = {
+            "submission_id": submission_uuid
+        }
+
+        # running with decode=False to preserve HTTP status codes for failure states
+        return call_xblock_json_handler(request, usage_id, 'delete_submission_lock', body, decode=False)

--- a/lms/djangoapps/ora_staff_grader/views.py
+++ b/lms/djangoapps/ora_staff_grader/views.py
@@ -14,6 +14,7 @@ from rest_framework.response import Response
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
 
+from lms.djangoapps.ora_staff_grader.errors import ERR_BAD_ORA_LOCATION
 from lms.djangoapps.ora_staff_grader.serializers import InitializeSerializer, LockStatusSerializer, SubmissionDetailResponseSerializer
 from lms.djangoapps.ora_staff_grader.utils import call_xblock_json_handler, require_params
 from openedx.core.djangoapps.content.course_overviews.api import get_course_overview_or_none
@@ -52,7 +53,7 @@ class InitializeView(RetrieveAPIView):
             ora_usage_key = UsageKey.from_string(ora_location)
             response_data['oraMetadata'] = modulestore().get_item(ora_usage_key)
         except (InvalidKeyError, ItemNotFoundError):
-            return HttpResponseBadRequest(_("Invalid ora_location."))
+            return HttpResponseBadRequest(ERR_BAD_ORA_LOCATION)
 
         # Get course metadata
         course_id = str(ora_usage_key.course_key)
@@ -162,7 +163,7 @@ class SubmissionLockView(RetrieveAPIView):
         try:
             UsageKey.from_string(ora_location)
         except (InvalidKeyError, ItemNotFoundError):
-            return HttpResponseBadRequest("Invalid ora_location.")
+            return HttpResponseBadRequest(ERR_BAD_ORA_LOCATION)
 
         response = self.claim_submission_lock(request, ora_location, submission_uuid)
 
@@ -181,7 +182,7 @@ class SubmissionLockView(RetrieveAPIView):
         try:
             UsageKey.from_string(ora_location)
         except (InvalidKeyError, ItemNotFoundError):
-            return HttpResponseBadRequest("Invalid ora_location.")
+            return HttpResponseBadRequest(ERR_BAD_ORA_LOCATION)
 
         response = self.delete_submission_lock(request, ora_location, submission_uuid)
 

--- a/lms/djangoapps/ora_staff_grader/views.py
+++ b/lms/djangoapps/ora_staff_grader/views.py
@@ -14,7 +14,7 @@ from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
 
 from lms.djangoapps.ora_staff_grader.serializers import InitializeSerializer, SubmissionDetailResponseSerializer
-from lms.djangoapps.ora_staff_grader.utils import call_xblock_json_handler
+from lms.djangoapps.ora_staff_grader.utils import call_xblock_json_handler, require_params
 from openedx.core.djangoapps.content.course_overviews.api import get_course_overview_or_none
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 
@@ -27,14 +27,13 @@ class InitializeView(RetrieveAPIView):
         courseMetadata
         oraMetadata
         submissions
+        rubricConfig
     }
 
     Returns:
-        200
-        400
-        403
-        404
-        405
+    - 200 on success
+    - 400 for invalid/missing ora_location
+    - 403 for invalid access/credentials
     """
     authentication_classes = (
         JwtAuthentication,
@@ -43,12 +42,8 @@ class InitializeView(RetrieveAPIView):
     )
     permission_classes = (IsAuthenticated,)
 
-    def get(self, request, *args, **kwargs):
-        ora_location = request.query_params.get('ora_location')
-
-        if not ora_location:
-            return HttpResponseBadRequest(_("Query must contain an ora_location param."))
-
+    @require_params(['ora_location'])
+    def get(self, request, ora_location, *args, **kwargs):
         response_data = {}
 
         # Get ORA block
@@ -56,7 +51,7 @@ class InitializeView(RetrieveAPIView):
             ora_usage_key = UsageKey.from_string(ora_location)
             response_data['oraMetadata'] = modulestore().get_item(ora_usage_key)
         except (InvalidKeyError, ItemNotFoundError):
-            return HttpResponseNotFound(_("Invalid ora_location."))
+            return HttpResponseBadRequest(_("Invalid ora_location."))
 
         # Get course metadata
         course_id = str(ora_usage_key.course_key)
@@ -120,16 +115,9 @@ class SubmissionFetchView(RetrieveAPIView):
     )
     permission_classes = (IsAuthenticated,)
 
-    def get(self, request, *args, **kwargs):
-        ora_location = request.query_params.get('ora_location')
-        if not ora_location:
-            return HttpResponseBadRequest(_("Query must contain an ora_location param."))
-
-        submission_uuid = request.query_params.get('submission_uuid')
-        if not submission_uuid:
-            return HttpResponseBadRequest(_("Query must contain a submission_uuid param."))
-
-        submission_and_assessment_info = self.get_submission_and_assessment_info(ora_location, submission_uuid)
+    @require_params(['ora_location', 'submission_uuid'])
+    def get(self, request, ora_location, submission_uuid, *args, **kwargs):
+        submission_and_assessment_info = self.get_submission_and_assessment_info(request, ora_location, submission_uuid)
         return Response(SubmissionDetailResponseSerializer(submission_and_assessment_info).data)
 
     def get_submission_and_assessment_info(self, request, usage_id, submission_uuid):


### PR DESCRIPTION
## Description

Add the `submission/lock` endpoint in support of enhanced staff grader (ESG).

JIRA: [AU-366](https://openedx.atlassian.net/browse/AU-366)
Prerequisite PR: https://github.com/edx/edx-ora2/pull/1741

FYI @edx/masters-devs-gta 

## Testing instructions

- [ ] Test suites pass

After pulling prerequisite work from above PR, exercise the following endpoint:

```
POST {{protocol}}://{{lms_url}}/api/ora_staff_grader/submission/lock?submissionId={{submission_id}}&value={{true/false}}&ora_location={{block_id_encoded}}
```
- [ ] Missing query params returns a `400`
- [ ] Bad ORA location returns a `400`

**Note:** testing requires presence of valid `X-CSRFToken` header.

Operating with `value=true` param instructs the endpoint to try to **claim a submission lock**. Verify the following:
- [ ] Attempting to claim a lock for a submission without a current lock returns successfully `200 - {'lockStatus': 'in-progress'}`
- [ ] Attempting to claim a lock for a submission where you own the current lock (within the past 8 hours) returns successfully `200 - {'lockStatus': 'in-progress'}`
- [ ] Attempting to claim a lock for a submission recently locked by another user returns an error `403 - {'error_code': 'ERR_LOCK_CONTESTED'}`

Operating with `value=false` param instructs the endpoint to try to **delete a submission lock**. Verify the following:
- [ ] Attempting to delete a lock for a submission without a current lock (which is a no-op but) returns successfully `200 - {'lockStatus': 'unlocked'}`
- [ ] Attempting to delete a lock for a submission where you own the current lock (within the past 8 hours) returns successfully `200 - {'lockStatus': 'unlocked'}`
- [ ] Attempting to delete a lock for a submission recently locked by another user returns an error `403 - {'error_code': 'ERR_LOCK_CONTESTED'}`
