### PR TITLE
feat: Add Program Enrollments API View

### DIFF
--- a/lms/djangoapps/support/urls.py
+++ b/lms/djangoapps/support/urls.py
@@ -12,7 +12,11 @@ from .views.enrollments import EnrollmentSupportListView, EnrollmentSupportView
 from .views.feature_based_enrollments import FeatureBasedEnrollmentsSupportView, FeatureBasedEnrollmentSupportAPIView
 from .views.index import index
 from .views.manage_user import ManageUserDetailView, ManageUserSupportView
-from .views.program_enrollments import LinkProgramEnrollmentSupportView, ProgramEnrollmentsInspectorView
+from .views.program_enrollments import (
+    LinkProgramEnrollmentSupportView,
+    LinkProgramEnrollmentSupportAPIView,
+    ProgramEnrollmentsInspectorView
+)
 from .views.sso_records import SsoView
 
 COURSE_ENTITLEMENTS_VIEW = EntitlementSupportView.as_view()
@@ -45,8 +49,16 @@ urlpatterns = [
         FeatureBasedEnrollmentSupportAPIView.as_view(),
         name="feature_based_enrollment_details"
     ),
-    re_path(r'link_program_enrollments/?$', LinkProgramEnrollmentSupportView.as_view(),
-            name='link_program_enrollments'),
+    re_path(
+        r'link_program_enrollments/?$',
+        LinkProgramEnrollmentSupportView.as_view(),
+        name='link_program_enrollments'
+    ),
+    re_path(
+        r'link_program_enrollments_details/?$',
+        LinkProgramEnrollmentSupportAPIView.as_view(),
+        name='link_program_enrollments_details'
+    ),
     re_path(
         r'program_enrollments_inspector/?$',
         ProgramEnrollmentsInspectorView.as_view(),

--- a/lms/djangoapps/support/views/program_enrollments.py
+++ b/lms/djangoapps/support/views/program_enrollments.py
@@ -2,14 +2,15 @@
 Support tool for changing course enrollments.
 """
 
-
-import csv
-from uuid import UUID
-
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.db.models import Q
 from django.utils.decorators import method_decorator
 from django.views.generic import View
+from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
+from rest_framework.views import APIView
+from rest_framework.authentication import SessionAuthentication
+from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
 from social_django.models import UserSocialAuth
 
 from common.djangoapps.edxmako.shortcuts import render_to_response
@@ -17,7 +18,6 @@ from common.djangoapps.third_party_auth.models import SAMLProviderConfig
 from lms.djangoapps.program_enrollments.api import (
     fetch_program_enrollments_by_student,
     get_users_by_external_keys_and_org_key,
-    link_program_enrollments
 )
 from lms.djangoapps.program_enrollments.exceptions import (
     BadOrganizationShortNameException,
@@ -26,6 +26,7 @@ from lms.djangoapps.program_enrollments.exceptions import (
 from lms.djangoapps.support.decorators import require_support_permission
 from lms.djangoapps.support.serializers import ProgramEnrollmentSerializer, serialize_user_info
 from lms.djangoapps.verify_student.services import IDVerificationService
+from lms.djangoapps.support.views.utils import validate_and_link_program_enrollments
 
 TEMPLATE_PATH = 'support/link_program_enrollments.html'
 DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S'
@@ -60,7 +61,7 @@ class LinkProgramEnrollmentSupportView(View):
         """
         program_uuid = request.POST.get('program_uuid', '').strip()
         text = request.POST.get('text', '')
-        successes, errors = self._validate_and_link(program_uuid, text)
+        successes, errors = validate_and_link_program_enrollments(program_uuid, text)
         return render_to_response(
             TEMPLATE_PATH,
             {
@@ -71,48 +72,48 @@ class LinkProgramEnrollmentSupportView(View):
             }
         )
 
-    @staticmethod
-    def _validate_and_link(program_uuid_string, linkage_text):
-        """
-        Validate arguments, and if valid, call `link_program_enrollments`.
 
-        Returns: (successes, errors)
-            where successes and errors are both list[str]
+class LinkProgramEnrollmentSupportAPIView(APIView):
+    """
+    Support-only API View for linking learner enrollments by support staff.
+    """
+    authentication_classes = (
+        JwtAuthentication, SessionAuthentication
+    )
+    permission_classes = (
+        IsAuthenticated,
+    )
+
+    @method_decorator(require_support_permission)
+    def post(self, request):
         """
-        if not (program_uuid_string and linkage_text):
-            error = (
-                "You must provide both a program uuid "
-                "and a series of lines with the format "
-                "'external_user_key,lms_username'."
-            )
-            return [], [error]
-        try:
-            program_uuid = UUID(program_uuid_string)
-        except ValueError:
-            return [], [
-                f"Supplied program UUID '{program_uuid_string}' is not a valid UUID."
-            ]
-        reader = csv.DictReader(
-            linkage_text.splitlines(), fieldnames=('external_key', 'username')
-        )
-        ext_key_to_username = {
-            (item.get('external_key') or '').strip(): (item['username'] or '').strip()
-            for item in reader
+        Links learner enrollments by support staff
+        * Example Request:
+            - POST / support / link_program_enrollments_details/
+            * Sample Payload
+            {
+                program_uuid: < program_uuid > ,
+                username_pair_text: 'external_user_key,lms_username'
+            }
+        * Example Response:
+            {
+                program_uuid: < program_uuid>,
+                username_pair_text: 'external_user_key,lms_username'
+                successes: 'Success messages if Linkages are created',
+                errors: 'Error messages if there is no linkages'
+            }
+        """
+
+        program_uuid = request.POST.get('program_uuid', '').strip()
+        username_pair_text = request.POST.get('username_pair_text', '')
+        successes, errors = validate_and_link_program_enrollments(program_uuid, username_pair_text)
+        data = {
+            'successes': successes,
+            'errors': errors,
+            'program_uuid': program_uuid,
+            'username_pair_text': username_pair_text,
         }
-        if not (all(ext_key_to_username.keys()) and all(ext_key_to_username.values())):
-            return [], [
-                "All linking lines must be in the format 'external_user_key,lms_username'"
-            ]
-        link_errors = link_program_enrollments(
-            program_uuid, ext_key_to_username
-        )
-        successes = [
-            str(item)
-            for item in ext_key_to_username.items()
-            if item not in link_errors
-        ]
-        errors = list(link_errors.values())
-        return successes, errors
+        return Response(data)
 
 
 class ProgramEnrollmentsInspectorView(View):

--- a/lms/djangoapps/support/views/utils.py
+++ b/lms/djangoapps/support/views/utils.py
@@ -1,6 +1,9 @@
 """
 Various utility methods used by support app views.
 """
+import csv
+from uuid import UUID
+
 from django.core.exceptions import ObjectDoesNotExist
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
@@ -8,6 +11,9 @@ from opaque_keys.edx.keys import CourseKey
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.features.content_type_gating.models import ContentTypeGatingConfig
 from openedx.features.course_duration_limits.models import CourseDurationLimitConfig
+from lms.djangoapps.program_enrollments.api import (
+    link_program_enrollments
+)
 
 
 def get_course_duration_info(course_key):
@@ -42,3 +48,46 @@ def get_course_duration_info(course_key):
 
     except (ObjectDoesNotExist, InvalidKeyError):
         return {}
+
+
+def validate_and_link_program_enrollments(program_uuid_string, linkage_text):
+    """
+    Validate arguments, and if valid, call `link_program_enrollments`.
+
+    Returns: (successes, errors)
+        where successes and errors are both list[str]
+    """
+    if not (program_uuid_string and linkage_text):
+        error = (
+            "You must provide both a program uuid "
+            "and a series of lines with the format "
+            "'external_user_key,lms_username'."
+        )
+        return [], [error]
+    try:
+        program_uuid = UUID(program_uuid_string)
+    except ValueError:
+        return [], [
+            f"Supplied program UUID '{program_uuid_string}' is not a valid UUID."
+        ]
+    reader = csv.DictReader(
+        linkage_text.splitlines(), fieldnames=('external_key', 'username')
+    )
+    ext_key_to_username = {
+        (item.get('external_key') or '').strip(): (item['username'] or '').strip()
+        for item in reader
+    }
+    if not (all(ext_key_to_username.keys()) and all(ext_key_to_username.values())):
+        return [], [
+            "All linking lines must be in the format 'external_user_key,lms_username'"
+        ]
+    link_errors = link_program_enrollments(
+        program_uuid, ext_key_to_username
+    )
+    successes = [
+        str(item)
+        for item in ext_key_to_username.items()
+        if item[0] not in link_errors.keys()
+    ]
+    errors = [message for message in link_errors.values()]  # lint-amnesty, pylint: disable=unnecessary-comprehension
+    return successes, errors


### PR DESCRIPTION
This is a Support upgrade ticket that adds a link program enrollments API view to `lms/djangoapps/support/program_enrollments.py`. The purpose of this PR is to create an API endpoint for the development of the link program enrollment feature in frontend-app-support-tools.

- [ ] Tested with a link.

Link to the ticket: [PROD-2478](https://openedx.atlassian.net/jira/software/c/projects/PROD/boards/507?modal=detail&selectedIssue=PROD-2478)

Testing Methodology:
- Make a program using this document: [How to enable Programs on Devstack](https://openedx.atlassian.net/wiki/spaces/PT/pages/3034218678/How+to+enable+Programs+on+Devstack)
- Go to LMS Admin and [create a program enrollment](http://localhost:18000/admin/program_enrollments/programenrollment/add/) for a current user.
- Go to LMS support tools and [verify if linkages](http://localhost:18000/support/link_program_enrollments) are being created for the program enrollments. (Optional)
- Use a post request according to the [documentation](https://github.com/edx/edx-platform/blob/9debbcafe5dac3785f119e9cc3c6ccff48da079a/lms/djangoapps/support/views/program_enrollments.py#L78) to create an API call to the program enrollment and verify if the program enrollments are being created in the admin.