### PR TITLE
feat: only show IDV panel until honor code replaces it

### DIFF
--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -29,6 +29,7 @@ from lms.djangoapps.commerce.utils import EcommerceService
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.experiments.utils import get_dashboard_course_info, get_experiment_user_metadata_context
 from lms.djangoapps.verify_student.services import IDVerificationService
+from openedx.core.djangoapps.agreements.toggles import is_integrity_signature_enabled
 from openedx.core.djangoapps.catalog.utils import (
     get_programs,
     get_pseudo_session_for_entitlement,
@@ -748,8 +749,17 @@ def student_dashboard(request):  # lint-amnesty, pylint: disable=too-many-statem
     else:
         redirect_message = ''
 
+    all_integrity_enabled = True
+    if not course_enrollments:
+        all_integrity_enabled = is_integrity_signature_enabled(None)
+    for enrollment in course_enrollments:
+        if not is_integrity_signature_enabled(enrollment.course_id):
+            all_integrity_enabled = False
+            break
+
     valid_verification_statuses = ['approved', 'must_reverify', 'pending', 'expired']
-    display_sidebar_on_dashboard = verification_status['status'] in valid_verification_statuses and \
+    display_sidebar_on_dashboard = not all_integrity_enabled and \
+        verification_status['status'] in valid_verification_statuses and \
         verification_status['should_display']
 
     # Filter out any course enrollment course cards that are associated with fulfilled entitlements


### PR DESCRIPTION
The integrity flag is a course waffle flag so until it's on for everyone this will not be triggered - that's OK and expected

Tested locally by setting up an in-progress IDV and then toggling the flag.

MST-1153

This code change is several templates away from the template pointed to in the ticket, it turns out to be entirely wrapped in a section using this variable.