### PR TITLE
fix: remove hardcoded edx user info cookie name

### DIFF
--- a/lms/static/js/spec/student_account/utils_spec.js
+++ b/lms/static/js/spec/student_account/utils_spec.js
@@ -2,22 +2,20 @@ define(['jquery', 'js/student_account/utils'],
     function($, Utils) {
         'use strict';
         describe('edxUserCookie', function() {
-            var userInfo, user;
-
-            userInfo = {
-                version: 1,
-                username: 'local-test-user'
-            };
+            var user,
+                edxUserInfoCookieName = 'edx-user-info', 
+                userInfo = {
+                    version: 1,
+                    username: 'local-test-user'
+                };
 
             beforeEach(function() {
-                document.cookie = 'edx-user-info="' +
+                document.cookie = edxUserInfoCookieName + '="' +
                   '{\"version\": 1, \"username\": \"local-test-user\"}";'; // eslint-disable-line no-useless-escape
             });
 
             it('returns correct user information from cookie', function() {
-                spyOn(Utils, 'getHostname').and.returnValue('localhost');
-
-                user = Utils.userFromEdxUserCookie();
+                user = Utils.userFromEdxUserCookie(edxUserInfoCookieName);
                 expect(user).toEqual(userInfo);
             });
         });

--- a/lms/static/js/student_account/multiple_enterprise.js
+++ b/lms/static/js/student_account/multiple_enterprise.js
@@ -19,10 +19,10 @@
              * @param  {string} nextUrl The URL to redirect to after multiple enterprise selection or incase
              * the selection page is bypassed e.g. when dealing with direct enrolment urls.
              */
-            check: function(nextUrl) {
+            check: function(nextUrl, edxUserInfoCookieName) {
                 var view = this;
                 var selectionPageUrl = this.urls.multipleEnterpriseUrl + encodeURIComponent(nextUrl);
-                var username = Utils.userFromEdxUserCookie().username;
+                var username = Utils.userFromEdxUserCookie(edxUserInfoCookieName).username;
                 var next = nextUrl || '/';
                 var enterpriseInUrl = this.getEnterpriseFromUrl(nextUrl);
                 var userInEnterprise = false;

--- a/lms/static/js/student_account/utils.js
+++ b/lms/static/js/student_account/utils.js
@@ -2,30 +2,11 @@
     'use strict';
     define(['jquery'], function($) {
         var edxUserCookieUtils = {
-            getHostname: function() {
-                return window.location.hostname;
-            },
+            userFromEdxUserCookie: function(edxUserInfoCookieName) {
+                var cookie, user, userCookie;
 
-            userFromEdxUserCookie: function() {
-                var hostname = this.getHostname();
-                var isLocalhost = hostname.indexOf('localhost') >= 0;
-                var isSandbox = hostname.indexOf('sandbox') >=0;
-                var isStage = hostname.indexOf('stage') >= 0;
-                var isEdge = hostname.indexOf('edge') >= 0;
-                var cookie, edxUserCookie, prefix, user, userCookie;
-
-                if (isLocalhost || isSandbox) {
-                    // localhost doesn't have prefixes
-                    edxUserCookie = 'edx-user-info';
-                } else {
-                    // does not take sandboxes into account
-                    prefix = isStage ? 'stage' : 'prod';
-                    prefix = isEdge ? 'edge' : prefix;
-                    edxUserCookie = prefix + '-edx-user-info';
-                }
-
-                cookie = document.cookie.match('(^|;)\\s*' + edxUserCookie + '\\s*=\\s*([^;]+)');
-                userCookie = cookie ? cookie.pop() : $.cookie(edxUserCookie);
+                cookie = document.cookie.match('(^|;)\\s*' + edxUserInfoCookieName + '\\s*=\\s*([^;]+)');
+                userCookie = cookie ? cookie.pop() : $.cookie(edxUserInfoCookieName);
 
                 // returns the user object from cookie. Replaces '054' with ',' and removes '\'
                 user = userCookie.replace(/\\/g, '').replace(/054/g, ',');

--- a/lms/static/js/student_account/views/AccessView.js
+++ b/lms/static/js/student_account/views/AccessView.js
@@ -55,6 +55,7 @@
                     };
 
                     this.thirdPartyAuthHint = options.third_party_auth_hint || null;
+                    this.edxUserInfoCookieName = options.edx_user_info_cookie_name || 'edx-user-info';
 
                     // Account activation messages
                     this.accountActivationMessages = options.account_activation_messages || [];
@@ -320,10 +321,13 @@
              */
                 loginComplete: function() {
                     if (this.thirdPartyAuth && this.thirdPartyAuth.finishAuthUrl) {
-                        multipleEnterpriseInterface.check(this.thirdPartyAuth.finishAuthUrl);
+                        multipleEnterpriseInterface.check(
+                            this.thirdPartyAuth.finishAuthUrl,
+                            this.edxUserInfoCookieName
+                        );
                     // Note: the third party auth URL likely contains another redirect URL embedded inside
                     } else {
-                        multipleEnterpriseInterface.check(this.nextUrl);
+                        multipleEnterpriseInterface.check(this.nextUrl, this.edxUserInfoCookieName);
                     }
                 },
 

--- a/openedx/core/djangoapps/user_authn/views/login_form.py
+++ b/openedx/core/djangoapps/user_authn/views/login_form.py
@@ -273,6 +273,7 @@ def login_and_registration_form(request, initial_mode="login"):
             'ENABLE_COMBINED_LOGIN_REGISTRATION_FOOTER',
             settings.FEATURES['ENABLE_COMBINED_LOGIN_REGISTRATION_FOOTER']
         ),
+        'edx_user_info_cookie_name': settings.EDXMKTG_USER_INFO_COOKIE_NAME,
     }
 
     update_logistration_context_for_enterprise(request, context, enterprise_customer)


### PR DESCRIPTION
## Description
Removed hardcoded edx user info cookie name and used settings variable.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
