### PR TITLE
feat: added program discussions admin view

### DIFF
--- a/lms/djangoapps/learner_dashboard/programs.py
+++ b/lms/djangoapps/learner_dashboard/programs.py
@@ -12,6 +12,7 @@ from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _  # lint-amnesty, pylint: disable=unused-import
 from web_fragments.fragment import Fragment
 
+from common.djangoapps.student.roles import GlobalStaff
 from lms.djangoapps.commerce.utils import EcommerceService
 from lms.djangoapps.learner_dashboard.utils import FAKE_COURSE_KEY, strip_course_id, program_discussions_is_enabled
 from lti_consumer.lti_1p1.contrib.django import lti_embed
@@ -75,6 +76,7 @@ class ProgramDetailsFragmentView(EdxFragmentView):
     Render the program details fragment.
     """
     DEFAULT_ROLE = 'student'
+    ADMIN_ROLE = 'Administrator'
 
     @staticmethod
     def get_program_discussion_configuration(program_uuid):
@@ -91,6 +93,14 @@ class ProgramDetailsFragmentView(EdxFragmentView):
     def _get_result_sourcedid(context_id, resource_link_id, user_id) -> str:
         return f'{context_id}:{resource_link_id}:{user_id}'
 
+    def get_user_roles(self, user):
+        """
+        Returns the Administrator role if the user is Global staff else returns the Student role
+        """
+        if GlobalStaff().has_user(user):
+            return self.ADMIN_ROLE
+        return self.DEFAULT_ROLE
+
     def _get_lti_embed_code(self, program_discussions_configuration, request) -> str:
         """
         Returns the LTI embed code for embedding in the program discussions tab
@@ -105,8 +115,7 @@ class ProgramDetailsFragmentView(EdxFragmentView):
         user_id = str(request.user.id)
         context_id = program_uuid
         resource_link_id = self._get_resource_link_id(program_uuid, request)
-        # TODO: Add support for multiple roles
-        roles = self.DEFAULT_ROLE
+        roles = self.get_user_roles(request.user)
         context_title = program_uuid
         result_sourcedid = self._get_result_sourcedid(context_id, resource_link_id, user_id)
 

--- a/lms/djangoapps/learner_dashboard/programs.py
+++ b/lms/djangoapps/learner_dashboard/programs.py
@@ -95,7 +95,7 @@ class ProgramDetailsFragmentView(EdxFragmentView):
 
     def get_user_roles(self, user):
         """
-        Returns the Administrator role if the user is Global staff else returns the Student role
+        Returns the given user's roles
         """
         if GlobalStaff().has_user(user):
             return self.ADMIN_ROLE

--- a/lms/djangoapps/learner_dashboard/programs.py
+++ b/lms/djangoapps/learner_dashboard/programs.py
@@ -75,7 +75,7 @@ class ProgramDetailsFragmentView(EdxFragmentView):
     """
     Render the program details fragment.
     """
-    DEFAULT_ROLE = 'student'
+    DEFAULT_ROLE = 'Student'
     ADMIN_ROLE = 'Administrator'
 
     @staticmethod


### PR DESCRIPTION
[TNL-9219](https://openedx.atlassian.net/browse/TNL-9219)

Launch the program discussions LTI as an admin if the logged in user is Global staff. This is required to configure the discussion provider. 

Piazza launch as admin
<img width="1396" alt="Screenshot 2021-11-09 at 6 23 11 PM" src="https://user-images.githubusercontent.com/10988308/140936448-444b28f7-1216-4de4-8d99-fa15aec923d9.png">


YellowDig launch as admin
<img width="1433" alt="Screenshot 2021-11-09 at 6 14 56 PM" src="https://user-images.githubusercontent.com/10988308/140936518-5b441f9a-5c50-40bb-a370-56013501da75.png">

