### PR TITLE
fix: "Uncaught TypeError: n is null" during login to LMS

### DIFF
--- a/lms/static/js/spec/student_account/utils_spec.js
+++ b/lms/static/js/spec/student_account/utils_spec.js
@@ -21,5 +21,19 @@ define(['jquery', 'js/student_account/utils'],
                 expect(user).toEqual(userInfo);
             });
         });
+
+        describe('userFromEdxUserCookie', function() {
+            var user;
+
+            beforeEach(function() {
+                $.cookie('edx-user-info', null);
+            });
+
+            it('returns empty user information when cookie is absent', function() {
+                spyOn($, 'cookie').and.returnValue(null);
+                user = Utils.userFromEdxUserCookie();
+                expect(user).toEqual({});
+            });
+        });
     }
 );

--- a/lms/static/js/student_account/utils.js
+++ b/lms/static/js/student_account/utils.js
@@ -27,6 +27,10 @@
                 cookie = document.cookie.match('(^|;)\\s*' + edxUserCookie + '\\s*=\\s*([^;]+)');
                 userCookie = cookie ? cookie.pop() : $.cookie(edxUserCookie);
 
+                if (!userCookie) {
+                    return {};
+                }
+
                 // returns the user object from cookie. Replaces '054' with ',' and removes '\'
                 user = userCookie.replace(/\\/g, '').replace(/054/g, ',');
                 user = user.substring(1, user.length - 1);


### PR DESCRIPTION
When signing in from the LMS, the authentication request succeeds but
the user was never redirected to the dashboard. This is because of a
js error:

    Uncaught TypeError: userCookie is null
        userFromEdxUserCookie
        http://maple.openedx.overhang.io:8000/static/js/student_account/utils.js:32

The error comes from the fact that the util.js code ignores the
EDXAPP_EDXMKTG_USER_INFO_COOKIE_NAME setting name. Instead the cookie
name is abritrarily prefixed by "stage-" or "prod-" depending on the
hostname. This seems to be primarily motivated by the definition of
edX.org staging/prod environment hostnames :-(

To resolve this issue, we decided that the actual cookie name was not so
important. Instead, the js code needs to not crash even when the cookie
is absent.

This issue was first reported here:
https://github.com/edx/edx-platform/pull/28170#issuecomment-890449885

Close https://github.com/openedx/build-test-release-wg/issues/104


This is a backport of the following PR: https://github.com/edx/edx-platform/pull/29192