### PR TITLE
feat: Add a new user API for discussions [BD-38] [TNL-8795]

### DIFF
--- a/lms/djangoapps/discussion/rest_api/serializers.py
+++ b/lms/djangoapps/discussion/rest_api/serializers.py
@@ -682,13 +682,33 @@ class DiscussionRolesListSerializer(serializers.Serializer):
 
     def create(self, validated_data):
         """
-        Overriden create abstract method
+        Overridden create abstract method
         """
 
     def update(self, instance, validated_data):
         """
-        Overriden update abstract method
+        Overridden update abstract method
         """
+
+
+class UserStatsSerializer(serializers.Serializer):
+    """
+    Serializer for course user stats.
+    """
+    threads = serializers.IntegerField()
+    replies = serializers.IntegerField()
+    responses = serializers.IntegerField()
+    active_flags = serializers.IntegerField()
+    inactive_flags = serializers.IntegerField()
+    username = serializers.CharField()
+
+    def to_representation(self, instance):
+        """Remove flag counts if user is not privileged."""
+        data = super().to_representation(instance)
+        if not self.context.get("is_privileged", False):
+            data["active_flags"] = None
+            data["inactive_flags"] = None
+        return data
 
 
 class BlackoutDateSerializer(serializers.Serializer):

--- a/lms/djangoapps/discussion/rest_api/tests/utils.py
+++ b/lms/djangoapps/discussion/rest_api/tests/utils.py
@@ -277,6 +277,21 @@ class CommentsServiceMockMixin:
             status=200
         )
 
+    def register_course_stats_response(self, course_key, stats, page, num_pages):
+        """Register a mock response for GET on the CS user course stats instance endpoint"""
+        assert httpretty.is_enabled(), 'httpretty must be enabled to mock calls.'
+        httpretty.register_uri(
+            httpretty.GET,
+            f"http://localhost:4567/api/v1/users/{course_key}/stats",
+            body=json.dumps({
+                "user_stats": stats,
+                "page": page,
+                "num_pages": num_pages,
+                "count": len(stats),
+            }),
+            status=200
+        )
+
     def register_subscription_response(self, user):
         """
         Register a mock response for POST and DELETE on the CS user subscription

--- a/lms/djangoapps/discussion/rest_api/urls.py
+++ b/lms/djangoapps/discussion/rest_api/urls.py
@@ -3,13 +3,13 @@
 Discussion API URLs
 """
 
-
 from django.conf import settings
 from django.urls import include, path, re_path
 from rest_framework.routers import SimpleRouter
 
 from lms.djangoapps.discussion.rest_api.views import (
     CommentViewSet,
+    CourseActivityStatsView,
     CourseDiscussionRolesAPIView,
     CourseDiscussionSettingsAPIView,
     CourseTopicsView,
@@ -32,6 +32,11 @@ urlpatterns = [
         ),
         CourseDiscussionSettingsAPIView.as_view(),
         name="discussion_course_settings",
+    ),
+    re_path(
+        fr"^v1/courses/{settings.COURSE_KEY_PATTERN}/activity_stats",
+        CourseActivityStatsView.as_view(),
+        name="discussion_course_activity_stats",
     ),
     re_path(
         fr"^v1/courses/{settings.COURSE_ID_PATTERN}/upload$",

--- a/openedx/core/djangoapps/django_comment_common/comment_client/course.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/course.py
@@ -2,8 +2,9 @@
 """Provides base Commentable model class"""
 from __future__ import annotations
 
-from typing import Dict
+from typing import Dict, Optional
 
+from edx_django_utils.monitoring import function_trace
 from opaque_keys.edx.keys import CourseKey
 
 from openedx.core.djangoapps.django_comment_common.comment_client import settings
@@ -39,3 +40,50 @@ def get_course_commentable_counts(course_key: CourseKey) -> Dict[str, Dict[str, 
         metric_action='commentable_stats.retrieve',
     )
     return response
+
+
+@function_trace("get_course_user_stats")
+def get_course_user_stats(course_key: CourseKey, params: Optional[Dict] = None) -> Dict[str, Dict[str, int]]:
+    """
+    Get stats about a user's participation in a course.
+
+    Args:
+        course_key (str|CourseKey): course key for which stats are needed.
+        params (Optional[Dict]): pagination and sorting query parameters.
+
+    Returns:
+        A mapping of user ids to stats about the user.
+
+        e.g.
+            {
+                "user_stats" [
+                    {
+                        "active_flags": 2,
+                        "inactive_flags": 0,
+                        "replies": 3,
+                        "responses": 2,
+                        "threads": 7,
+                        "username": "edx"
+                    },
+                    ...
+                ],
+                "num_pages": 12,
+                "page": 3,
+                "count": 124
+                ...
+            }
+
+    """
+    if params is None:
+        params = {}
+    url = f"{settings.PREFIX}/users/{course_key}/stats"
+    return perform_request(
+        'get',
+        url,
+        params,
+        metric_action='user.course_stats',
+        metric_tags=[
+            f"course_key:{course_key}",
+            "function:get_course_user_stats",
+        ],
+    )


### PR DESCRIPTION
## Description

Adds a new user API for discussion that returns the discussion stats across the course.

## Supporting information

- https://openedx.atlassian.net/browse/TNL-8795

**Depends on**: https://github.com/edx/cs_comments_service/pull/352

## Testing instructions

- In a course with existing discussions, post as a user. 
- Visit <LMS>/api/discussion/v1/courses/<course_id>activity_stats and check that the user's activity stats are updated.
- Create a new post, visit the API and check that the post count is incremented.
- Add comments, responses and see that the counts are updated.
- Delete comments, responses and posts and see that the counts are updated. 
- Mark a comment/post/response as flagged and see that flagged count is updated.
- Mark a comment/post/response as flagged by multiple users. The flagged count should only go up once, i.e. it should only count if content is flagged, not count how many times it's flagged. 
- Unmark content as flagged. The flagged count should remain the same as long as the content is still flagged by some user. If a post is unflagged by all users the count should go down. 

