### PR TITLE
Add a data migration to copy all course index data into MySQL (Take 2)

### DIFF
--- a/common/djangoapps/split_modulestore_django/migrations/0002_data_migration.py
+++ b/common/djangoapps/split_modulestore_django/migrations/0002_data_migration.py
@@ -1,0 +1,80 @@
+import logging
+from django.db import migrations, models
+from django.db.utils import IntegrityError
+
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.django import modulestore
+
+from ..models import SplitModulestoreCourseIndex as SplitModulestoreCourseIndex_Real
+
+log = logging.getLogger(__name__)
+
+
+def forwards_func(apps, schema_editor):
+    """
+    Copy all course index data from MongoDB to MySQL, unless it's already present in MySQL.
+
+    This migration is used as part of an upgrade path from storing course indexes in MongoDB to storing them in MySQL.
+    On edX.org, we began writing to MySQL+MongoDB before we deployed this migration, so some courses are already in
+    MySQL. But any courses that haven't been modified recently would only be in MongoDB and need to be copied over to
+    MySQL before we can switch reading course indexes to MySQL.
+    """
+    db_alias = schema_editor.connection.alias
+    SplitModulestoreCourseIndex = apps.get_model("split_modulestore_django", "SplitModulestoreCourseIndex")
+    split_modulestore = modulestore()._get_modulestore_by_type(ModuleStoreEnum.Type.split)
+
+    for course_index in split_modulestore.db_connection.find_matching_course_indexes(force_mongo=True):
+        data = SplitModulestoreCourseIndex_Real.fields_from_v1_schema(course_index)
+        course_id = data["course_id"]
+
+        try:
+            mysql_entry = SplitModulestoreCourseIndex.objects.get(course_id=course_id)
+            # This course index ("active version") already exists in MySQL.
+            # Let's just make sure it's the latest version. If the MongoDB somehow contains a newer version, something
+            # has gone wrong and we should investigate to ensure we're not losing any data.
+            if mysql_entry.edited_on < data["edited_on"]:
+                log.error(
+                    "Possible data issue found during data migration of course indexes from MongoDB to MySQL: \n"
+                    f"Course {course_id} already exists in MySQL but the MongoDB version is newer. "
+                    "That's unexpected because since the course index table was added to MySQL, there has never been a "
+                    "time when we would write course_indexes updates only to MongoDB without also writing to MySQL. "
+                    "\nMongo data: "
+                    f"edited_on: {data['edited_on']}, "
+                    f"last_update: {data['last_update']}, "
+                    f"published_version: {data['published_version']}"
+                    "\nMySQL data: "
+                    f"edited_on: {mysql_entry.edited_on}, "
+                    f"last_update: {mysql_entry.last_update}, "
+                    f"published_version: {mysql_entry.published_version}"
+                    "\nThe MySQL version will be overwritten and the MongoDB version used."
+                )
+                for key in (
+                    "edited_on", "edited_by_id", "last_update",
+                    "draft_version", "published_version", "library_version"
+                ):
+                    if key in data:  # library_version is probably not in data, that's OK
+                        setattr(mysql_entry, key, data[key])
+                mysql_entry.save(using=db_alias)
+        except SplitModulestoreCourseIndex.DoesNotExist:
+            # This course exists in MongoDB but hasn't yet been migrated to MySQL. Do that now.
+            SplitModulestoreCourseIndex(**data).save(using=db_alias)
+
+def reverse_func(apps, schema_editor):
+    """
+    Reversing the data migration is a no-op, because edX.org used a migration path path that started with writing to
+    both MySQL+MongoDB while still reading from MongoDB, then later executed this data migration, then later cut over to
+    reading from MySQL only. If we reversed this by deleting all entries, it would undo any writes that took place
+    before this data migration, which are unrelated.
+    """
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('split_modulestore_django', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards_func, reverse_func),
+    ]


### PR DESCRIPTION
## Description

This PR is a repeat of https://github.com/edx/edx-platform/pull/29144 which [had to be reverted](https://github.com/edx/edx-platform/pull/29212).

This version has similar code but when encountering unexpected data, it will just log it and proceed rather than throwing an error. [See this discussion](https://github.com/edx/edx-platform/pull/29212#issuecomment-959780731).

If the error occurs again, the log output will look like this:

```
2021-11-10 03:19:06,653 ERROR 449 [common.djangoapps.split_modulestore_django.migrations.0002_data_migration] [user None] [ip None] 0002_data_migration.py:36 - Possible data issue found during data migration of course indexes from MongoDB to MySQL: 
Course course-v1:edX+DemoX+Demo_Course already exists in MySQL but the MongoDB version is newer. That's unexpected because since the course index table was added to MySQL, there has never been a time when we would write course_indexes updates only to MongoDB without also writing to MySQL. 
Mongo data: edited_on: 2021-11-03 22:23:48.989000+00:00, last_update: 2021-11-03 22:24:14.439000+00:00, published_version: 61830c0dca80abc00d1b233f
MySQL data: edited_on: 2021-10-01 11:38:42.219000+00:00, last_update: 2021-10-01 11:38:42.219000+00:00, published_version: bc00d1b233f61830c0dca80a
The MySQL version will be overwritten and the MongoDB version used.
```

## Supporting information

See previous PRs.

## Testing instructions

1. Check out a master devstack. Make some changes to a course or two (maybe a library too).
1. At http://localhost:18000/admin/split_modulestore_django/splitmodulestorecourseindex/ verify that any courses that you've modified are already copied into MySQL. Keep this tab open.
1. Check out this PR and run LMS migrations
1. Open http://localhost:18000/admin/split_modulestore_django/splitmodulestorecourseindex/ in a new tab, and compare to the prior version. Courses that were already present in MySQL should be unchanged, and all remaining courses from your devstack should now be listed there.

## Deadline

None