### PR TITLE
fix: ed-discussion configuration message added

### DIFF
--- a/openedx/core/djangoapps/discussions/models.py
+++ b/openedx/core/djangoapps/discussions/models.py
@@ -151,7 +151,7 @@ AVAILABLE_PROVIDER_MAP = {
             accessibility='',
             contact_email='',
         )._asdict(),
-        'messages': [],
+        'messages': [pii_sharing_required_message('Ed Discussion')],
         'has_full_support': False
     },
     'inscribe': {


### PR DESCRIPTION

## Description
[TNL-9261](https://openedx.atlassian.net/browse/TNL-9261)
discussion configuration message was missing for ed-discussion. it has been added in this PR. supported ticket is attached.

FYI- @marcotuts 
