### PR TITLE
Jsb/ha10 style fix

### DIFF
--- a/cms/static/sass/elements/_header.scss
+++ b/cms/static/sass/elements/_header.scss
@@ -1,6 +1,15 @@
 // studio - elements - global header
 // ====================
 
+@supports (-moz-appearance: none) {
+ .wrapper.wrapper-l {
+   width: 74% !important;
+ }
+ .wrapper.wrapper-r {
+   width: 26% !important;
+ }
+}
+
 .wrapper-header {
   @extend %ui-depth3;
 


### PR DESCRIPTION
**Background:**
This change is a fix for issue: ha-10. The styles in firefox appear broken into the header for any reason that I disown. I propose this changes to resolve this. If you think in another way to fix this you are welcome to advise anything.

**Before:**
![error](https://user-images.githubusercontent.com/18581590/140945775-5ba38562-5db5-4617-9525-2d6ea6e63023.png)

**After:**
![Screenshot from 2021-11-08 16-00-02](https://user-images.githubusercontent.com/18581590/140817318-136d388a-6507-4edd-a082-f93de8d0df79.png)