### PR TITLE
fix: release edx-enterprise 3.33.10

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -30,7 +30,7 @@ django-storages<1.9
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==3.33.9
+edx-enterprise==3.33.10
 
 # Newer versions need a more recent version of python-dateutil
 freezegun==0.3.12

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -434,7 +434,7 @@ edx-drf-extensions==8.0.1
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.33.9
+edx-enterprise==3.33.10
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -541,7 +541,7 @@ edx-drf-extensions==8.0.1
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.33.9
+edx-enterprise==3.33.10
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -523,7 +523,7 @@ edx-drf-extensions==8.0.1
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.33.9
+edx-enterprise==3.33.10
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
[3.33.10]
---------
fix: incorrectly skipping completion transmissions

- https://pypi.org/project/edx-enterprise/3.33.10/
- [ENT-5095](https://openedx.atlassian.net/browse/ENT-5095)
- https://github.com/edx/edx-enterprise/pull/1405
