### PR TITLE
feat: add gradestatus, lockStatus, and points to ESG submission fetch

### DIFF
--- a/lms/djangoapps/ora_staff_grader/serializers.py
+++ b/lms/djangoapps/ora_staff_grader/serializers.py
@@ -141,8 +141,7 @@ class AssessmentCriteriaSerializer(serializers.Serializer):
     """ Serializer for information about a criterion, in the context of a completed assessment """
     name = serializers.CharField()
     feedback = serializers.CharField()
-    # to be completed in AU-410
-    # score = serializers.IntegerField()
+    points = serializers.IntegerField()
     selectedOption = serializers.CharField(source='option')
 
 

--- a/lms/djangoapps/ora_staff_grader/serializers.py
+++ b/lms/djangoapps/ora_staff_grader/serializers.py
@@ -9,8 +9,9 @@ from rest_framework import serializers
 
 class GradeStatusField(serializers.ChoiceField):
     """ Field that can have the values ['graded' 'ungraded'] """
-    def __init__(self):
-        super().__init__(choices=['graded', 'ungraded'])
+    def __init__(self, *args, **kwargs):
+        kwargs['choices'] = ['graded', 'ungraded']
+        super().__init__(*args, **kwargs)
 
 
 class LockStatusField(serializers.ChoiceField):
@@ -154,11 +155,16 @@ class GradeDataSerializer(serializers.Serializer):
 
 class SubmissionDetailResponseSerializer(serializers.Serializer):
     """ Serializer for the response from the submission """
-    gradeData = GradeDataSerializer(source='assessment')
-    response = ResponseSerializer(source='submission')
-    #  to be completed in AU-387
-    #  gradeStatus = GradeStatusField()
-    #  lockStatus = LockStatusField()
+    gradeData = GradeDataSerializer(source='submission_and_assessment_info.assessment')
+    response = ResponseSerializer(source='submission_and_assessment_info.submission')
+    gradeStatus = serializers.SerializerMethodField()
+    lockStatus = LockStatusField(source='lock_info.lock_status')
+
+    def get_gradeStatus(self, obj):
+        if obj.get('submission_and_assessment_info', {}).get('assessment'):
+            return 'graded'
+        else:
+            return 'ungraded'
 
 
 class LockStatusSerializer(serializers.Serializer):

--- a/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
@@ -359,12 +359,13 @@ class TestAssessmentCriteriaSerializer(TestCase):
 
     def test_assessment_criteria_serializer(self):
         """ Base serialization behavior """
-        input = Mock()
+        input = Mock(points=595)
         data = AssessmentCriteriaSerializer(input).data
 
         expected_value = {
             'name': str(input.name),
             'feedback': str(input.feedback),
+            'points': input.points,
             'selectedOption': str(input.option),
         }
         assert data == expected_value
@@ -374,6 +375,7 @@ class TestAssessmentCriteriaSerializer(TestCase):
         input = {
             'name': 'SomeCriterioOn',
             'feedback': 'Pathetic Effort',
+            'points': None,
             'option': None,
         }
         data = AssessmentCriteriaSerializer(input).data
@@ -398,7 +400,7 @@ class TestGradeDataSerializer(TestCase):
         """ Base serialization behavior, with and without criteria """
         input = MagicMock()
         if has_criteria:
-            input.criteria = [Mock(), Mock(), Mock()]
+            input.criteria = [Mock(points=123), Mock(points=11), Mock(points=22)]
         data = GradeDataSerializer(input).data
 
         expected_value = {

--- a/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
@@ -433,7 +433,7 @@ class TestSubmissionDetailResponseSerializer(TestCase):
         }
         mock_get_grade_status.assert_called_once_with(input)
         assert data == expected_value
-        
+
     @ddt.data(True, False)
     def test_get__gradeStatus(self, has_assessment):
         """ Unit test for get_gradeStatus """

--- a/lms/djangoapps/ora_staff_grader/tests/test_views.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_views.py
@@ -176,6 +176,7 @@ class TestFetchSubmissionView(BaseViewTest):
                 {
                     'name': "Criterion 1",
                     'option': "Three",
+                    'points': 3,
                     'feedback': "Feedback 1"
                 },
             ]

--- a/lms/djangoapps/ora_staff_grader/tests/test_views.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_views.py
@@ -196,7 +196,7 @@ class TestFetchSubmissionView(BaseViewTest):
         assert response.data['response'].keys() == set(['files', 'text'])
         expected_assessment_keys = set(['score', 'overallFeedback', 'criteria']) if has_assessment else set()
         assert response.data['gradeData'].keys() == expected_assessment_keys
-        
+
         mock_get_submission_and_assessment_info.assert_called_once()
         mock_get_submission_and_assessment_info_args = mock_get_submission_and_assessment_info.call_args[0]
         assert len(mock_get_submission_and_assessment_info_args) == 3

--- a/lms/djangoapps/ora_staff_grader/views.py
+++ b/lms/djangoapps/ora_staff_grader/views.py
@@ -121,7 +121,7 @@ class SubmissionFetchView(RetrieveAPIView):
     def get(self, request, ora_location, submission_uuid, *args, **kwargs):
         submission_and_assessment_info = self.get_submission_and_assessment_info(request, ora_location, submission_uuid)
         lock_info = self.check_submission_lock(request, ora_location, submission_uuid)
-        
+
         serializer = SubmissionDetailResponseSerializer({
             'submission_and_assessment_info': submission_and_assessment_info,
             'lock_info': lock_info,

--- a/lms/djangoapps/ora_staff_grader/views.py
+++ b/lms/djangoapps/ora_staff_grader/views.py
@@ -120,16 +120,32 @@ class SubmissionFetchView(RetrieveAPIView):
     @require_params(['ora_location', 'submission_uuid'])
     def get(self, request, ora_location, submission_uuid, *args, **kwargs):
         submission_and_assessment_info = self.get_submission_and_assessment_info(request, ora_location, submission_uuid)
-        return Response(SubmissionDetailResponseSerializer(submission_and_assessment_info).data)
+        lock_info = self.check_submission_lock(request, ora_location, submission_uuid)
+        
+        serializer = SubmissionDetailResponseSerializer({
+            'submission_and_assessment_info': submission_and_assessment_info,
+            'lock_info': lock_info,
+        })
+
+        return Response(serializer.data)
 
     def get_submission_and_assessment_info(self, request, usage_id, submission_uuid):
         """
-        Get submission content and assessment data from the ORA's 'get_submission_and_assessment_info' XBlock.json_handler
+        Get submission content and assessment data from ORA 'get_submission_and_assessment_info' XBlock.json_handler
         """
         data = {
             'submission_uuid': submission_uuid
         }
         return call_xblock_json_handler(request, usage_id, 'get_submission_and_assessment_info', data)
+
+    def check_submission_lock(self, request, usage_id, submission_uuid):
+        """
+        Look up lock info for the given submission by calling the ORA's 'check_submission_lock' XBlock.json_handler
+        """
+        data = {
+            'submission_uuid': submission_uuid
+        }
+        return call_xblock_json_handler(request, usage_id, 'check_submission_lock', data)
 
 
 class SubmissionLockView(RetrieveAPIView):


### PR DESCRIPTION
## Description

- add gradeStatus and lockStatus to ESG submission fetch
- add points to assessment criterion in ESG submission fetch

## Supporting information

[AU-387](https://openedx.atlassian.net/browse/AU-387)
[AU-410](https://openedx.atlassian.net/browse/AU-410)