### PR TITLE
Update ace email header to match braze email header

### DIFF
--- a/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
+++ b/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
@@ -78,6 +78,8 @@ def send_ace_message(goal):
         'image_url': image_url,
         'unsubscribe_url': None,  # We don't want to include the default unsubscribe link
         'omit_unsubscribe_link': True,
+        'courses_url': getattr(settings, 'ACE_EMAIL_COURSES_URL', None),
+        'programs_url': getattr(settings, 'ACE_EMAIL_PROGRAMS_URL', None),
     })
 
     msg = Message(

--- a/lms/djangoapps/course_goals/templates/course_goals/edx_ace/goalreminder/email/head.html
+++ b/lms/djangoapps/course_goals/templates/course_goals/edx_ace/goalreminder/email/head.html
@@ -2,13 +2,10 @@
 {% block additional_styles %}
 <style type="text/css">
     @media only screen and (max-width: 456px) {
-        .goals-banner-div {
-            background-image: url('{{image_url}}goalreminder-mobile-hero.png') !important;
-            height: 185px !important;
-            padding-top: 0 !important;
-        }
         .goal-reminder-body-wrapper {
-            margin: 0 .8rem 0 .3rem !important;
+            margin: 5px 12.8px 0 4.8px !important;
+            margin: .5rem .8rem 0 .3rem !important;
+            padding-left: 3% !important;
         }
         h3 {
             margin-top: 0;

--- a/lms/templates/goal_reminder_banner.html
+++ b/lms/templates/goal_reminder_banner.html
@@ -1,11 +1,10 @@
 {# email client support for style sheets is pretty spotty, so we have to inline all of these styles #}
 {% if image_url %}
-<div class="goals-banner-div" style="
-    width: 100%;
-    height: 0;
-    padding-top: 42%;
-    background-image: url('{{image_url}}goalreminder-desktop-hero.png');
-    background-size: contain;
-    background-repeat: no-repeat;">
-</div>
+<table cellpadding="0" cellspacing="0">
+  <tr>
+    <td align="left" valign="top">
+      <img src="{{image_url}}goalreminder-desktop-hero.png" width="600" border="0" style="display:block;height:auto" class="mobile_img" />
+    </td>
+  </tr>
+</table>
 {% endif %}

--- a/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_body.html
+++ b/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_body.html
@@ -11,203 +11,246 @@
 {# email itself. #}
 
 <div lang="{{ LANGUAGE_CODE|default:"en" }}" style="
-    display:none;
-    font-size:1px;
-    line-height:1px;
-    max-height:0px;
-    max-width:0px;
-    opacity:0;
-    overflow:hidden;
-    visibility:hidden;
-">
-    {% block preview_text %}{% endblock %}
+  display:none;
+  font-size:1px;
+  line-height:1px;
+  max-height:0px;
+  max-width:0px;
+  opacity:0;
+  overflow:hidden;
+  visibility:hidden;
+  ">
+  {% block preview_text %}{% endblock %}
 </div>
 
 {% for image_src in channel.tracker_image_sources %}
-    <img src="{image_src}" alt="" role="presentation" aria-hidden="true" />
+  <img src="{image_src}" alt="" role="presentation" aria-hidden="true" />
 {% endfor %}
 
 {% google_analytics_tracking_pixel %}
 
 <div bgcolor="#f5f5f5" lang="{{ LANGUAGE_CODE|default:"en" }}" dir="{{ LANGUAGE_BIDI|yesno:"rtl,ltr" }}" style="
-    margin: 0;
-    padding: 0;
-    min-width: 100%;
-    background-color: #f5f5f5;
-">
-    <!-- Hack for outlook 2010, which wants to render everything in Times New Roman -->
-    <!--[if mso]>
-    <style type="text/css">
-    body, table, td {font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif !important;}
-    </style>
-    <![endif]-->
+  margin: 0;
+  padding: 0;
+  min-width: 100%;
+  background-color: #f5f5f5;
+  ">
+  <!-- Hack for outlook 2010, which wants to render everything in Times New Roman -->
+  <!--[if mso]>
+  <style type="text/css">
+  body, table, td {font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif !important;}
+  </style>
+  <![endif]-->
 
-    <!--[if (gte mso 9)|(IE)]>
-    <table role="presentation" width="600" align="center" cellpadding="0" cellspacing="0" border="0">
-    <tr>
-    <td>
-    <![endif]-->
+  <!--[if (gte mso 9)|(IE)]>
+  <table role="presentation" width="600" align="center" cellpadding="0" cellspacing="0" border="0">
+  <tr>
+  <td>
+  <![endif]-->
 
-    <!-- CONTENT -->
-    <table class="content" role="presentation" align="center" cellpadding="0" cellspacing="0" border="0" bgcolor="#fbfaf9" width="100%"
+  <!-- CONTENT -->
+  <table class="content" role="presentation" align="center" cellpadding="0" cellspacing="0" border="0" bgcolor="#fbfaf9" width="100%"
     {% block table_style %}
-        style="
-            font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-            font-size: 1em;
-            line-height: 1.5;
-            max-width: 600px;
-            padding: 0 20px 0 20px;
-        "
+      style="
+      font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+      font-size: 1em;
+      line-height: 1.5;
+      max-width: 600px;
+      padding: 0 20px 0 20px;
+      "
     {% endblock %}
-    >
-        <tr>
-            <!-- HEADER -->
-            <td class="header" style="
-                padding: 20px;
-                background-color: #f5f5f5;
-            ">
-                {% block header %}
-                <table role="presentation" width="100%" align="left" border="0" cellpadding="0" cellspacing="0">
-                    <tr>
-                        <td width="70">
-                            <a href="{% with_link_tracking homepage_url %}"><img
-                                    src="{{ logo_url }}"
-                                    height="30" alt="{% filter force_escape %}{% blocktrans %}Go to {{ platform_name }} Home Page{% endblocktrans %}{% endfilter %}"/></a>
+  >
+    {% block header %}
+      <td class="header" style="background-color: #f5f5f5;">
+        <table width="100%" border="0" cellspacing="0" cellpadding="0" align="center" bgcolor="#F5F5F5">
+          <tr>
+            <td valign="top" align="center">
+              <table width="600" cellpadding="0" cellspacing="0" align="center" class="width_100percent">
+                <tr>
+                  <td valign="top" align="center" style="min-width:600px;" class="min_width">
+                    <table width="100%" cellpadding="0" cellspacing="0" bgcolor="#F5F5F5">
+                      <tr><td height="10" style="line-height:1px;">&nbsp;</td></tr>
+                      <tr>
+                        <td align="left" valign="top" style="padding:0 60px;" class="padding_none">
+                          <table cellpadding="0" cellspacing="0" align="left" class="width_100percent">
+                            <tr>
+                              <td align="center" valign="top">
+                                <table cellpadding="0" cellspacing="0">
+                                  <tr>
+                                    <td align="left" valign="top">
+                                      <a href="{% with_link_tracking homepage_url %}">
+                                        <img src="{{ logo_url }}" style="max-height: 65px;" height="auto" alt="{% filter force_escape %}{% blocktrans %}Go to {{ platform_name }} Home Page{% endblocktrans %}{% endfilter %}"/></a>
+                                    </td>
+                                  </tr>
+                                </table>
+                              </td>
+                            </tr>
+                          </table>
+                          <table height="66" cellpadding="0" cellspacing="0" align="right" class="width_100percent height_0">
+                            <tr>
+                              <td align="center" valign="middle" class="paddingtop_10">
+                                <table cellpadding="0" cellspacing="0">
+                                  <tr>
+                                    <td align="left" valign="top" style="color: #d23228;">
+                                      {% if courses_url %}
+                                        <a href="{% with_link_tracking courses_url %}" target="_blank" style="font-family:'Inter',Helvetica,Arial,sans-serif;font-size:15px;line-height:20px;text-decoration:none;color:#000001;font-weight:bold;">
+                                          {% trans "Courses" as tmsg %}{{ tmsg | force_escape }}
+                                        </a>
+                                        &nbsp; / &nbsp;
+                                      {% endif %}
+                                      {% if programs_url %}
+                                        <a href="{% with_link_tracking programs_url %}" target="_blank" style="font-family:'Inter',Helvetica,Arial,sans-serif;font-size:15px;line-height:20px;text-decoration:none;color:#000001;font-weight:bold;">
+                                          {% trans "Programs" as tmsg %}{{ tmsg | force_escape }}
+                                        </a>
+                                        &nbsp; / &nbsp;
+                                      {% endif %}
+                                      <a href="{% with_link_tracking dashboard_url %}" target="_blank" style="font-family:'Inter',Helvetica,Arial,sans-serif;font-size:15px;line-height:20px;text-decoration:none;color:#000001;font-weight:bold;">
+                                        {% trans "My Account" as tmsg %}{{ tmsg | force_escape }}
+                                      </a>
+                                    </td>
+                                  </tr>
+                                </table>
+                              </td>
+                            </tr>
+                          </table>
                         </td>
-                        <td align="right" style="text-align: {{ LANGUAGE_BIDI|yesno:"left,right" }};">
-                            <a class="login" href="{% with_link_tracking dashboard_url %}" style="color: #005686;">{%  trans "Sign In" %}</a>
-                        </td>
-                    </tr>
-                </table>
-                {% endblock %}
+                      </tr>
+                      <tr><td height="10" style="line-height:1px;font-size:1px;">&nbsp;</td></tr>
+                    </table>
+                  </td>
+                </tr>
+              </table>
             </td>
-        </tr>
+          </tr>
+        </table>
+    {% endblock %}
+  </td>
+</tr>
+<tr>
+  <!-- MAIN -->
+  <td class="main" bgcolor="#ffffff"
+    {% block main_style %}
+      style="
+      padding: 15px 20px 30px 20px;
+      box-shadow: 0 1px 5px rgba(0,0,0,0.25);
+      "
+    {% endblock %}
+  >
+    {% block content %}{% endblock %}
+  </td>
+</tr>
 
+<tr>
+  <!-- FOOTER -->
+  <td class="footer" style="padding: 20px; background-color: #f5f5f5;">
+    <table role="presentation" width="100%" align="left" border="0" cellpadding="0" cellspacing="0">
+      <tr>
+        <td style="padding-bottom: 20px;">
+          <!-- SOCIAL -->
+          <table role="presentation" align="{{ LANGUAGE_BIDI|yesno:"right,left" }}" border="0" border="0" cellpadding="0" cellspacing="0" width="210">
+            <tr>
+              {% if social_media_urls.linkedin %}
+                <td height="32" width="42">
+                  <a href="{{ social_media_urls.linkedin|safe }}">
+                    <img src="https://media.sailthru.com/595/1k1/8/o/599f354ec70cb.png"
+                      width="32" height="32" alt="{% filter force_escape %}{% blocktrans %}{{ platform_name }} on LinkedIn{% endblocktrans %}{% endfilter %}"/>
+                  </a>
+                </td>
+              {% endif %}
+              {% if social_media_urls.twitter %}
+                <td height="32" width="42">
+                  <a href="{{ social_media_urls.twitter|safe }}">
+                    <img src="https://media.sailthru.com/595/1k1/8/o/599f354d9c26e.png"
+                      width="32" height="32" alt="{% filter force_escape %}{% blocktrans %}{{ platform_name }} on Twitter{% endblocktrans %}{% endfilter %}"/>
+                  </a>
+                </td>
+              {% endif %}
+              {% if social_media_urls.facebook %}
+                <td height="32" width="42">
+                  <a href="{{ social_media_urls.facebook|safe }}">
+                    <img src="https://media.sailthru.com/595/1k1/8/o/599f355052c8e.png"
+                      width="32" height="32" alt="{% filter force_escape %}{% blocktrans %}{{ platform_name }} on Facebook{% endblocktrans %}{% endfilter %}"/>
+                  </a>
+                </td>
+              {% endif %}
+              {% if social_media_urls.google_plus %}
+                <td height="32" width="42">
+                  <a href="{{ social_media_urls.google_plus|safe }}">
+                    <img src="https://media.sailthru.com/595/1k1/8/o/599f354fc554a.png"
+                      width="32" height="32" alt="{% filter force_escape %}{% blocktrans %}{{ platform_name }} on Google Plus{% endblocktrans %}{% endfilter %}"/>
+                  </a>
+                </td>
+              {% endif %}
+              {% if social_media_urls.reddit %}
+                <td height="32" width="42">
+                  <a href="{{ social_media_urls.reddit|safe }}">
+                    <img src="https://media.sailthru.com/595/1k1/8/o/599f354e326b9.png"
+                      width="32" height="32" alt="{% filter force_escape %}{% blocktrans %}{{ platform_name }} on Reddit{% endblocktrans %}{% endfilter %}"/>
+                  </a>
+                </td>
+              {% endif %}
+            </tr>
+          </table>
+        </td>
+      </tr>
+      <tr>
+        <!-- APP BUTTONS -->
+        <td style="padding-bottom: 20px;">
+          {% if mobile_store_urls.apple %}
+            <a href="{{ mobile_store_urls.apple|safe }}" style="text-decoration: none">
+              <img src="https://media.sailthru.com/595/1k1/6/2/5931cfbba391b.png"
+                alt="{% trans "Download the iOS app on the Apple Store" as tmsg %}{{ tmsg | force_escape }}"
+                width="136" height="50" style="margin-{{ LANGUAGE_BIDI|yesno:"left,right" }}: 10px"/>
+            </a>
+          {% endif %}
+          {% if mobile_store_urls.google %}
+            <a href="{{ mobile_store_urls.google|safe }}" style="text-decoration: none">
+              <img src="https://media.sailthru.com/595/1k1/6/2/5931cf879a033.png"
+                alt="{% trans "Download the Android app on the Google Play Store" as tmsg %}{{ tmsg | force_escape }}"
+                width="136" height="50"/>
+            </a>
+          {% endif %}
+        </td>
+      </tr>
+      <tr>
+        <!-- Actions -->
+        <td style="padding-bottom: 20px; background-color: #f5f5f5;">
+          {% get_action_links channel omit_unsubscribe_link=omit_unsubscribe_link as action_links %}
+          {% for action_link_url, action_link_text in action_links %}
+            <p>
+              <a href="{{ action_link_url }}" style="color: #005686">
+                <font color="#005686"><b>{{ action_link_text }}</b></font>
+              </a>
+            </p>
+          {% endfor %}
+        </td>
+      </tr>
+      <tr>
+        <!-- COPYRIGHT -->
+        <td>
+          &copy; {% now "Y" %} {{ platform_name }}, {% trans "All rights reserved" as tmsg %}{{ tmsg | force_escape }}.<br/>
+          <br/>
+          {% trans "Our mailing address is:" as tmsg %}{{ tmsg | force_escape }}<br/>
+          {{ contact_mailing_address }}
+        </td>
+      </tr>
+      {% if unsubscribe_url %}
         <tr>
-            <!-- MAIN -->
-            <td class="main" bgcolor="#ffffff"
-                {% block main_style %}
-                    style="
-                        padding: 15px 20px 30px 20px;
-                        box-shadow: 0 1px 5px rgba(0,0,0,0.25);
-                    "
-                {% endblock %}
-            >
-                {% block content %}{% endblock %}
-            </td>
+          <td>
+            <a href="{% with_link_tracking unsubscribe_url %}">{% trans "Unsubscribe from these emails." as tmsg %}{{ tmsg | force_escape }}</a>
+          </td>
         </tr>
-
-        <tr>
-            <!-- FOOTER -->
-            <td class="footer" style="padding: 20px; background-color: #f5f5f5;">
-                <table role="presentation" width="100%" align="left" border="0" cellpadding="0" cellspacing="0">
-                    <tr>
-                        <td style="padding-bottom: 20px;">
-                            <!-- SOCIAL -->
-                            <table role="presentation" align="{{ LANGUAGE_BIDI|yesno:"right,left" }}" border="0" border="0" cellpadding="0" cellspacing="0" width="210">
-                                <tr>
-                                    {% if social_media_urls.linkedin %}
-                                        <td height="32" width="42">
-                                            <a href="{{ social_media_urls.linkedin|safe }}">
-                                                <img src="https://media.sailthru.com/595/1k1/8/o/599f354ec70cb.png"
-                                                     width="32" height="32" alt="{% filter force_escape %}{% blocktrans %}{{ platform_name }} on LinkedIn{% endblocktrans %}{% endfilter %}"/>
-                                            </a>
-                                        </td>
-                                    {% endif %}
-                                    {% if social_media_urls.twitter %}
-                                        <td height="32" width="42">
-                                            <a href="{{ social_media_urls.twitter|safe }}">
-                                                <img src="https://media.sailthru.com/595/1k1/8/o/599f354d9c26e.png"
-                                                     width="32" height="32" alt="{% filter force_escape %}{% blocktrans %}{{ platform_name }} on Twitter{% endblocktrans %}{% endfilter %}"/>
-                                            </a>
-                                        </td>
-                                    {% endif %}
-                                    {% if social_media_urls.facebook %}
-                                        <td height="32" width="42">
-                                            <a href="{{ social_media_urls.facebook|safe }}">
-                                                <img src="https://media.sailthru.com/595/1k1/8/o/599f355052c8e.png"
-                                                     width="32" height="32" alt="{% filter force_escape %}{% blocktrans %}{{ platform_name }} on Facebook{% endblocktrans %}{% endfilter %}"/>
-                                            </a>
-                                        </td>
-                                    {% endif %}
-                                    {% if social_media_urls.google_plus %}
-                                        <td height="32" width="42">
-                                            <a href="{{ social_media_urls.google_plus|safe }}">
-                                                <img src="https://media.sailthru.com/595/1k1/8/o/599f354fc554a.png"
-                                                     width="32" height="32" alt="{% filter force_escape %}{% blocktrans %}{{ platform_name }} on Google Plus{% endblocktrans %}{% endfilter %}"/>
-                                            </a>
-                                        </td>
-                                    {% endif %}
-                                    {% if social_media_urls.reddit %}
-                                        <td height="32" width="42">
-                                            <a href="{{ social_media_urls.reddit|safe }}">
-                                                <img src="https://media.sailthru.com/595/1k1/8/o/599f354e326b9.png"
-                                                     width="32" height="32" alt="{% filter force_escape %}{% blocktrans %}{{ platform_name }} on Reddit{% endblocktrans %}{% endfilter %}"/>
-                                            </a>
-                                        </td>
-                                    {% endif %}
-                                </tr>
-                            </table>
-                        </td>
-                    </tr>
-                    <tr>
-                        <!-- APP BUTTONS -->
-                        <td style="padding-bottom: 20px;">
-                            {% if mobile_store_urls.apple %}
-                                <a href="{{ mobile_store_urls.apple|safe }}" style="text-decoration: none">
-                                    <img src="https://media.sailthru.com/595/1k1/6/2/5931cfbba391b.png"
-                                         alt="{% trans "Download the iOS app on the Apple Store" as tmsg %}{{ tmsg | force_escape }}"
-                                         width="136" height="50" style="margin-{{ LANGUAGE_BIDI|yesno:"left,right" }}: 10px"/>
-                                </a>
-                            {% endif %}
-                            {% if mobile_store_urls.google %}
-                                <a href="{{ mobile_store_urls.google|safe }}" style="text-decoration: none">
-                                    <img src="https://media.sailthru.com/595/1k1/6/2/5931cf879a033.png"
-                                         alt="{% trans "Download the Android app on the Google Play Store" as tmsg %}{{ tmsg | force_escape }}"
-                                         width="136" height="50"/>
-                                </a>
-                            {% endif %}
-                        </td>
-                    </tr>
-                    <tr>
-                        <!-- Actions -->
-                        <td style="padding-bottom: 20px; background-color: #f5f5f5;">
-                            {% get_action_links channel omit_unsubscribe_link=omit_unsubscribe_link as action_links %}
-                            {% for action_link_url, action_link_text in action_links %}
-                                <p>
-                                    <a href="{{ action_link_url }}" style="color: #005686">
-                                        <font color="#005686"><b>{{ action_link_text }}</b></font>
-                                    </a>
-                                </p>
-                            {% endfor %}
-                        </td>
-                    </tr>
-                    <tr>
-                        <!-- COPYRIGHT -->
-                        <td>
-                            &copy; {% now "Y" %} {{ platform_name }}, {% trans "All rights reserved" as tmsg %}{{ tmsg | force_escape }}.<br/>
-                            <br/>
-                            {% trans "Our mailing address is:" as tmsg %}{{ tmsg | force_escape }}<br/>
-                            {{ contact_mailing_address }}
-                        </td>
-                    </tr>
-                    {% if unsubscribe_url %}
-                        <tr>
-                            <td>
-                                <a href="{% with_link_tracking unsubscribe_url %}">{% trans "Unsubscribe from these emails." as tmsg %}{{ tmsg | force_escape }}</a>
-                            </td>
-                        </tr>
-                    {% endif %}
-                </table>
-            </td>
-        </tr>
+      {% endif %}
     </table>
+  </td>
+</tr>
+</table>
 
-    <!--[if (gte mso 9)|(IE)]>
-    </td>
-    </tr>
-    </table>
-    <![endif]-->
+<!--[if (gte mso 9)|(IE)]>
+  </td>
+  </tr>
+  </table>
+  <![endif]-->
 
 </div>
 

--- a/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_head.html
+++ b/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_head.html
@@ -33,5 +33,22 @@
         padding-bottom: 20px;
       }
     }
+    * {margin-top:0px;margin-bottom:0px;padding:0px;border:none;outline:none;list-style:none;-webkit-text-size-adjust: none;}
+    body {margin:0 !important;padding:0 !important;width: 100% !important;-webkit-text-size-adjust: 100% !important;-ms-text-size-adjust: 100% !important;-webkit-font-smoothing: antialiased !important;}
+    img {border:0 !important;display: block !important;outline: none !important;}
+    table {border-collapse: collapse;mso-table-lspace:0px;mso-table-rspace: 0px;}
+    td {border-collapse:collapse;mso-line-height-rule:exactly;}
+
+    @media only screen and (max-width:480px){
+      .width_100percent {width: 100% !important;}
+      .min_width {min-width: 320px !important;}
+      .mobile_img {width: 100% !important; height: auto !important;}
+      .background_none {background: none !important;}
+      .display_block {display: block !important;}
+
+      .height_0 {height: 0 !important;}
+      .padding_none {padding-left: 0 !important; padding-right: 0 !important;}
+      .paddingtop_10 {padding-top: 10px !important;}
+    }
 </style>
 {% block additional_styles %}{% endblock %}


### PR DESCRIPTION
A lot of the changes to base_body.html are changing indentation so if you want to hide the whitespace changes use this link
https://github.com/edx/edx-platform/pull/29310/files?diff=unified&w=1

Please also review the internal PR here https://github.com/edx/edx-internal/pull/5712 that sets the url for the courses and programs links (which go to the marketing site)

Existing header in Braze:
<img width="656" alt="Screen Shot 2021-11-12 at 5 54 01 PM" src="https://user-images.githubusercontent.com/5958221/141583388-915effbc-5841-4bd7-a2ef-bef6d6c60948.png">

New header in Ace desktop:
<img width="714" alt="Screen Shot 2021-11-13 at 11 52 22 AM" src="https://user-images.githubusercontent.com/5958221/141652098-e0e52f4f-4bad-44ba-91ef-990f790c5a5d.png">

New header in Ace mobile:
![img](https://user-images.githubusercontent.com/5958221/141652686-822f0671-b391-49ed-a8cb-f3743cc3af1d.png)

