### PR TITLE
[BD-13] deprecates runtime.xqueue in favor of the XQueueService

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_preview.py
+++ b/cms/djangoapps/contentstore/views/tests/test_preview.py
@@ -236,3 +236,13 @@ class CmsModuleSystemShimTest(ModuleStoreTestCase):
         descriptor = ItemFactory(category="pure", parent=self.course)
         html = get_preview_fragment(self.request, descriptor, {'element_id': 142}).content
         assert '<div id="142" ns="main">Testing the MakoService</div>' in html
+
+    def test_xqueue_is_not_available_in_studio(self):
+        descriptor = ItemFactory(category="problem", parent=self.course)
+        runtime = _preview_module_system(
+            self.request,
+            descriptor=descriptor,
+            field_data=mock.Mock(),
+        )
+        assert runtime.xqueue is None
+        assert runtime.service(descriptor, 'xqueue') is None

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -725,6 +725,7 @@ CROSS_DOMAIN_CSRF_COOKIE_NAME = ''
 CSRF_TRUSTED_ORIGINS = []
 
 #################### CAPA External Code Evaluation #############################
+XQUEUE_WAITTIME_BETWEEN_REQUESTS = 5  # seconds
 XQUEUE_INTERFACE = {
     'url': 'http://localhost:18040',
     'basic_auth': ['edx', 'edx'],

--- a/common/lib/capa/capa/inputtypes.py
+++ b/common/lib/capa/capa/inputtypes.py
@@ -994,9 +994,9 @@ class MatlabInput(CodeInput):
         response = data['submission']
 
         # construct xqueue headers
-        qinterface = self.capa_system.xqueue['interface']
+        qinterface = self.capa_system.xqueue.interface
         qtime = datetime.utcnow().strftime(xqueue_interface.dateformat)
-        callback_url = self.capa_system.xqueue['construct_callback']('ungraded_response')
+        callback_url = self.capa_system.xqueue.construct_callback('ungraded_response')
         anonymous_student_id = self.capa_system.anonymous_student_id
         # TODO: Why is this using self.capa_system.seed when we have self.seed???
         queuekey = xqueue_interface.make_hashkey(str(self.capa_system.seed) + qtime +

--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -2586,14 +2586,14 @@ class CodeResponse(LoncapaResponse):
     """
     Grade student code using an external queueing server, called 'xqueue'.
 
-    Expects 'xqueue' dict in LoncapaSystem with the following keys that are
+    Expects 'xqueue' dict in LoncapaSystem with the following properties that are
     needed by CodeResponse::
 
-        capa_system.xqueue = {
-            'interface': XQueueInterface object.
-            'construct_callback': Per-StudentModule callback URL constructor,
+        capa_system.xqueue = object with properties:
+            interface: XQueueInterface object.
+            construct_callback: Per-StudentModule callback URL constructor,
                 defaults to using 'score_update' as the correct dispatch (function).
-            'default_queuename': Default queue name to submit request (string).
+            default_queuename: Default queue name to submit request (string).
         }
 
     External requests are only submitted for student submission grading, not
@@ -2623,7 +2623,7 @@ class CodeResponse(LoncapaResponse):
 
         # We do not support xqueue within Studio.
         if self.capa_system.xqueue is not None:
-            default_queuename = self.capa_system.xqueue['default_queuename']
+            default_queuename = self.capa_system.xqueue.default_queuename
         else:
             default_queuename = None
         self.queue_name = xml.get('queuename', default_queuename)
@@ -2684,7 +2684,7 @@ class CodeResponse(LoncapaResponse):
         # Prepare xqueue request
         #------------------------------------------------------------
 
-        qinterface = self.capa_system.xqueue['interface']
+        qinterface = self.capa_system.xqueue.interface
         qtime = datetime.strftime(datetime.now(UTC), xqueue_interface.dateformat)
 
         anonymous_student_id = self.capa_system.anonymous_student_id
@@ -2693,7 +2693,7 @@ class CodeResponse(LoncapaResponse):
         queuekey = xqueue_interface.make_hashkey(
             str(self.capa_system.seed) + qtime + anonymous_student_id + self.answer_id
         )
-        callback_url = self.capa_system.xqueue['construct_callback']()
+        callback_url = self.capa_system.xqueue.construct_callback()
         xheader = xqueue_interface.make_xheader(
             lms_callback_url=callback_url,
             lms_key=queuekey,

--- a/common/lib/capa/capa/tests/helpers.py
+++ b/common/lib/capa/capa/tests/helpers.py
@@ -44,12 +44,19 @@ def tst_render_template(template, context):  # pylint: disable=unused-argument
     return '<div>{0}</div>'.format(saxutils.escape(repr(context)))
 
 
-def calledback_url(dispatch='score_update'):
-    """A callback url method to use in tests."""
-    return dispatch
+class StubXQueueService:
+    """
+    Stubs out the XQueueService for Capa problem tests.
+    """
+    def __init__(self):
+        self.interface = MagicMock()
+        self.interface.send_to_queue.return_value = (0, 'Success!')
+        self.default_queuename = 'testqueue'
+        self.waittime = 10
 
-xqueue_interface = MagicMock()  # pylint: disable=invalid-name
-xqueue_interface.send_to_queue.return_value = (0, 'Success!')
+    def construct_callback(self, dispatch='score_update'):
+        """A callback url method to use in tests."""
+        return dispatch
 
 
 def test_capa_system(render_template=None):
@@ -72,12 +79,7 @@ def test_capa_system(render_template=None):
         seed=0,
         STATIC_URL='/dummy-static/',
         STATUS_CLASS=Status,
-        xqueue={
-            'interface': xqueue_interface,
-            'construct_callback': calledback_url,
-            'default_queuename': 'testqueue',
-            'waittime': 10
-        },
+        xqueue=StubXQueueService(),
     )
     return the_system
 

--- a/common/lib/capa/capa/tests/test_inputtypes.py
+++ b/common/lib/capa/capa/tests/test_inputtypes.py
@@ -643,9 +643,7 @@ class MatlabTest(unittest.TestCase):
     def test_plot_data(self):
         data = {'submission': 'x = 1234;'}
         response = self.the_input.handle_ajax("plot", data)
-
-        test_capa_system().xqueue['interface'].send_to_queue.assert_called_with(header=ANY, body=ANY)
-
+        self.the_input.capa_system.xqueue.interface.send_to_queue.assert_called_with(header=ANY, body=ANY)
         assert response['success']
         assert self.the_input.input_state['queuekey'] is not None
         assert self.the_input.input_state['queuestate'] == 'queued'
@@ -653,7 +651,7 @@ class MatlabTest(unittest.TestCase):
     def test_plot_data_failure(self):
         data = {'submission': 'x = 1234;'}
         error_message = 'Error message!'
-        test_capa_system().xqueue['interface'].send_to_queue.return_value = (1, error_message)
+        self.the_input.capa_system.xqueue.interface.send_to_queue.return_value = (1, error_message)
         response = self.the_input.handle_ajax("plot", data)
         assert not response['success']
         assert response['message'] == error_message
@@ -740,7 +738,7 @@ class MatlabTest(unittest.TestCase):
         data = {'submission': 'x = 1234;'}
         response = the_input.handle_ajax("plot", data)  # lint-amnesty, pylint: disable=unused-variable
 
-        body = system.xqueue['interface'].send_to_queue.call_args[1]['body']
+        body = system.xqueue.interface.send_to_queue.call_args[1]['body']
         payload = json.loads(body)
         assert 'test_api_key' == payload['token']
         assert '2' == payload['endpoint_version']

--- a/common/lib/capa/capa/tests/test_xqueue_interface.py
+++ b/common/lib/capa/capa/tests/test_xqueue_interface.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""
+Tests the xqueue service interface.
+"""
+
+from unittest import TestCase
+from django.conf import settings
+
+from capa.xqueue_interface import XQueueInterface, XQueueService
+
+
+class XQueueServiceTest(TestCase):
+    """
+    Tests the XQueue service methods.
+    """
+    @staticmethod
+    def construct_callback(*args, **kwargs):
+        return 'https://lms.url/callback'
+
+    def setUp(self):
+        super().setUp()
+        self.service = XQueueService(
+            url=settings.XQUEUE_INTERFACE['url'],
+            django_auth=settings.XQUEUE_INTERFACE['django_auth'],
+            basic_auth=settings.XQUEUE_INTERFACE['basic_auth'],
+            construct_callback=self.construct_callback,
+            default_queuename='my-very-own-queue',
+            waittime=settings.XQUEUE_WAITTIME_BETWEEN_REQUESTS,
+        )
+
+    def test_interface(self):
+        assert isinstance(self.service.interface, XQueueInterface)
+
+    def test_construct_callback(self):
+        assert self.service.construct_callback() == 'https://lms.url/callback'
+
+    def test_default_queuename(self):
+        assert self.service.default_queuename == 'my-very-own-queue'
+
+    def test_waittime(self):
+        assert self.service.waittime == 5

--- a/common/lib/capa/capa/xqueue_interface.py
+++ b/common/lib/capa/capa/xqueue_interface.py
@@ -1,7 +1,6 @@
-# lint-amnesty, pylint: disable=missing-module-docstring
-#  LMS Interface to external queueing system (xqueue)
-#
-
+"""
+LMS Interface to external queueing system (xqueue)
+"""
 
 import hashlib
 import json
@@ -149,3 +148,53 @@ class XQueueInterface(object):
             return 1, 'unexpected HTTP status code [%d]' % response.status_code
 
         return parse_xreply(response.text)
+
+
+class XQueueService:
+    """
+    XBlock service providing an interface to the XQueue service.
+
+    Args:
+        construct_callback(callable): function which constructs a fully-qualified callback URL to make xqueue requests.
+        default_queuename(string): course-specific queue name.
+        waittime(int): number of seconds to wait between xqueue requests
+        url(string): base URL for the XQueue service.
+        django_auth(dict): username and password for the XQueue service.
+        basic_auth(array or None): basic authentication credentials, if needed.
+    """
+    def __init__(self, construct_callback, default_queuename, waittime, url, django_auth, basic_auth=None):
+
+        requests_auth = requests.auth.HTTPBasicAuth(*basic_auth) if basic_auth else None
+        self._interface = XQueueInterface(url, django_auth, requests_auth)
+
+        self._construct_callback = construct_callback
+        self._default_queuename = default_queuename.replace(' ', '_')
+        self._waittime = waittime
+
+    @property
+    def interface(self):
+        """
+        Returns the XQueueInterface instance.
+        """
+        return self._interface
+
+    @property
+    def construct_callback(self):
+        """
+        Returns the function to construct the XQueue callback.
+        """
+        return self._construct_callback
+
+    @property
+    def default_queuename(self):
+        """
+        Returns the default queue name for the current course.
+        """
+        return self._default_queuename
+
+    @property
+    def waittime(self):
+        """
+        Returns the number of seconds to wait in between calls to XQueue.
+        """
+        return self._waittime

--- a/common/lib/xmodule/xmodule/capa_module.py
+++ b/common/lib/xmodule/xmodule/capa_module.py
@@ -827,7 +827,7 @@ class ProblemBlock(
             render_template=self.runtime.service(self, 'mako').render_template,
             seed=seed,  # Why do we do this if we have self.seed?
             STATIC_URL=self.runtime.STATIC_URL,
-            xqueue=self.runtime.xqueue,
+            xqueue=self.runtime.service(self, 'xqueue'),
             matlab_api_key=self.matlab_api_key
         )
 
@@ -1746,7 +1746,8 @@ class ProblemBlock(
         if self.lcp.is_queued():
             prev_submit_time = self.lcp.get_recentmost_queuetime()
 
-            waittime_between_requests = self.runtime.xqueue['waittime']
+            xqueue_service = self.runtime.service(self, 'xqueue')
+            waittime_between_requests = xqueue_service.waittime if xqueue_service else 0
             if (current_time - prev_submit_time).total_seconds() < waittime_between_requests:
                 msg = _("You must wait at least {wait} seconds between submissions.").format(
                     wait=waittime_between_requests)

--- a/common/lib/xmodule/xmodule/capa_module.py
+++ b/common/lib/xmodule/xmodule/capa_module.py
@@ -121,6 +121,8 @@ class Randomization(String):
 @XBlock.needs('user')
 @XBlock.needs('i18n')
 @XBlock.needs('mako')
+# Studio doesn't provide XQueueService, but the LMS does.
+@XBlock.wants('xqueue')
 @XBlock.wants('call_to_action')
 class ProblemBlock(
     ScorableXBlockMixin,

--- a/common/lib/xmodule/xmodule/tests/__init__.py
+++ b/common/lib/xmodule/xmodule/tests/__init__.py
@@ -26,6 +26,7 @@ from xblock.core import XBlock
 from xblock.field_data import DictFieldData
 from xblock.fields import Reference, ReferenceList, ReferenceValueDict, ScopeIds
 
+from capa.xqueue_interface import XQueueService
 from xmodule.assetstore import AssetMetadata
 from xmodule.error_module import ErrorBlock
 from xmodule.mako_module import MakoDescriptorSystem
@@ -140,13 +141,14 @@ def get_test_system(
         services={
             'user': user_service,
             'mako': mako_service,
-        },
-        xqueue={
-            'interface': None,
-            'callback_url': '/',
-            'default_queuename': 'testqueue',
-            'waittime': 10,
-            'construct_callback': Mock(name='get_test_system.xqueue.construct_callback', side_effect="/"),
+            'xqueue': XQueueService(
+                url='http://xqueue.url',
+                django_auth={},
+                basic_auth=[],
+                default_queuename='testqueue',
+                waittime=10,
+                construct_callback=Mock(name='get_test_system.xqueue.construct_callback', side_effect="/"),
+            ),
         },
         node_path=os.environ.get("NODE_PATH", "/usr/local/lib/node_modules"),
         course_id=course_id,

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -817,7 +817,8 @@ class ProblemBlockTest(unittest.TestCase):  # lint-amnesty, pylint: disable=miss
         # Expect that the number of attempts is NOT incremented
         assert module.attempts == 1
 
-    def test_submit_problem_with_files(self):
+    @patch.object(XQueueInterface, '_http_post')
+    def test_submit_problem_with_files(self, mock_xqueue_post):
         # Check a problem with uploaded files, using the submit_problem API.
         # pylint: disable=protected-access
 
@@ -830,10 +831,8 @@ class ProblemBlockTest(unittest.TestCase):  # lint-amnesty, pylint: disable=miss
 
         module = CapaFactoryWithFiles.create()
 
-        # Mock the XQueueInterface.
-        xqueue_interface = XQueueInterface("http://example.com/xqueue", Mock())
-        xqueue_interface._http_post = Mock(return_value=(0, "ok"))
-        module.system.xqueue['interface'] = xqueue_interface
+        # Mock the XQueueInterface post method
+        mock_xqueue_post.return_value = (0, "ok")
 
         # Create a request dictionary for submit_problem.
         get_request_dict = {
@@ -862,13 +861,14 @@ class ProblemBlockTest(unittest.TestCase):  # lint-amnesty, pylint: disable=miss
         #   )
         # pylint: enable=line-too-long
 
-        assert xqueue_interface._http_post.call_count == 1
-        _, kwargs = xqueue_interface._http_post.call_args
+        assert mock_xqueue_post.call_count == 1
+        _, kwargs = mock_xqueue_post.call_args
         self.assertCountEqual(fpaths, list(kwargs['files'].keys()))
         for fpath, fileobj in kwargs['files'].items():
             assert fpath == fileobj.name
 
-    def test_submit_problem_with_files_as_xblock(self):
+    @patch.object(XQueueInterface, '_http_post')
+    def test_submit_problem_with_files_as_xblock(self, mock_xqueue_post):
         # Check a problem with uploaded files, using the XBlock API.
         # pylint: disable=protected-access
 
@@ -881,10 +881,8 @@ class ProblemBlockTest(unittest.TestCase):  # lint-amnesty, pylint: disable=miss
 
         module = CapaFactoryWithFiles.create()
 
-        # Mock the XQueueInterface.
-        xqueue_interface = XQueueInterface("http://example.com/xqueue", Mock())
-        xqueue_interface._http_post = Mock(return_value=(0, "ok"))
-        module.system.xqueue['interface'] = xqueue_interface
+        # Mock the XQueueInterface post method
+        mock_xqueue_post.return_value = (0, "ok")
 
         # Create a webob Request with the files uploaded.
         post_data = []
@@ -895,8 +893,8 @@ class ProblemBlockTest(unittest.TestCase):  # lint-amnesty, pylint: disable=miss
 
         module.handle('xmodule_handler', request, 'problem_check')
 
-        assert xqueue_interface._http_post.call_count == 1
-        _, kwargs = xqueue_interface._http_post.call_args
+        assert mock_xqueue_post.call_count == 1
+        _, kwargs = mock_xqueue_post.call_args
         self.assertCountEqual(fnames, list(kwargs['files'].keys()))
         for fpath, fileobj in kwargs['files'].items():
             assert fpath == fileobj.name
@@ -3101,7 +3099,8 @@ class ProblemCheckTrackingTest(unittest.TestCase):
                                         'group_label': '',
                                         'variant': module.seed}}
 
-    def test_file_inputs(self):
+    @patch.object(XQueueInterface, '_http_post')
+    def test_file_inputs(self, mock_xqueue_post):
         fnames = ["prog1.py", "prog2.py", "prog3.py"]
         fpaths = [os.path.join(DATA_DIR, "capa", fname) for fname in fnames]
         fileobjs = [open(fpath) for fpath in fpaths]
@@ -3111,10 +3110,8 @@ class ProblemCheckTrackingTest(unittest.TestCase):
         factory = CapaFactoryWithFiles
         module = factory.create()
 
-        # Mock the XQueueInterface.
-        xqueue_interface = XQueueInterface("http://example.com/xqueue", Mock())
-        xqueue_interface._http_post = Mock(return_value=(0, "ok"))  # pylint: disable=protected-access
-        module.system.xqueue['interface'] = xqueue_interface
+        # Mock the XQueueInterface post method
+        mock_xqueue_post.return_value = (0, "ok")
 
         answer_input_dict = {
             CapaFactoryWithFiles.input_key(response_num=2): fileobjs,

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -1826,6 +1826,31 @@ class ModuleSystemShim:
             return render_service.render_template
         return None
 
+    @property
+    def xqueue(self):
+        """
+        Returns a dict containing the XQueueInterface object, as well as parameters for the specific StudentModule:
+        * interface: XQueueInterface object
+        * construct_callback: function to construct the fully-qualified LMS callback URL.
+        * default_queuename: default queue name for the course in XQueue
+        * waittime: number of seconds to wait in between calls to XQueue
+
+        Deprecated in favor of the xqueue service.
+        """
+        warnings.warn(
+            'runtime.xqueue is deprecated. Please use the xqueue service instead.',
+            DeprecationWarning, stacklevel=3,
+        )
+        xqueue_service = self._services.get('xqueue')
+        if xqueue_service:
+            return {
+                'interface': xqueue_service.interface,
+                'construct_callback': xqueue_service.construct_callback,
+                'default_queuename': xqueue_service.default_queuename,
+                'waittime': xqueue_service.waittime,
+            }
+        return None
+
 
 class ModuleSystem(MetricsMixin, ConfigurableFragmentWrapper, ModuleSystemShim, Runtime):
     """
@@ -1843,7 +1868,7 @@ class ModuleSystem(MetricsMixin, ConfigurableFragmentWrapper, ModuleSystemShim, 
     def __init__(
             self, static_url, track_function, get_module,
             replace_urls, descriptor_runtime, filestore=None,
-            debug=False, hostname="", xqueue=None, publish=None, node_path="",
+            debug=False, hostname="", publish=None, node_path="",
             course_id=None,
             cache=None, can_execute_unsafe_code=None, replace_course_urls=None,
             replace_jump_to_id_urls=None, error_descriptor_class=None, get_real_user=None,
@@ -1865,12 +1890,6 @@ class ModuleSystem(MetricsMixin, ConfigurableFragmentWrapper, ModuleSystemShim, 
 
         filestore - A filestore ojbect.  Defaults to an instance of OSFS based
                          at settings.DATA_DIR.
-
-        xqueue - Dict containing XqueueInterface object, as well as parameters
-                    for the specific StudentModule:
-                    xqueue = {'interface': XQueueInterface object,
-                              'callback_url': Callback into the LMS,
-                              'queue_name': Target queuename in Xqueue}
 
         replace_urls - TEMPORARY - A function like static_replace.replace_urls
                          that capa_module can use to fix up the static urls in
@@ -1914,7 +1933,6 @@ class ModuleSystem(MetricsMixin, ConfigurableFragmentWrapper, ModuleSystemShim, 
         super().__init__(field_data=field_data, **kwargs)
 
         self.STATIC_URL = static_url
-        self.xqueue = xqueue
         self.track_function = track_function
         self.filestore = filestore
         self.get_module = get_module

--- a/lms/djangoapps/courseware/tests/test_discussion_xblock.py
+++ b/lms/djangoapps/courseware/tests/test_discussion_xblock.py
@@ -300,7 +300,6 @@ class TestXBlockInCourse(SharedModuleStoreTestCase):
             student_data=mock.Mock(name='student_data'),
             course_id=self.course.id,
             track_function=mock.Mock(name='track_function'),
-            xqueue_callback_url_prefix=mock.Mock(name='xqueue_callback_url_prefix'),
             request_token='request_token',
         )
 
@@ -321,7 +320,6 @@ class TestXBlockInCourse(SharedModuleStoreTestCase):
             student_data=mock.Mock(name='student_data'),
             course_id=self.course.id,
             track_function=mock.Mock(name='track_function'),
-            xqueue_callback_url_prefix=mock.Mock(name='xqueue_callback_url_prefix'),
             request_token='request_token',
         )
 
@@ -375,7 +373,6 @@ class TestXBlockInCourse(SharedModuleStoreTestCase):
                 student_data=mock.Mock(name='student_data'),
                 course_id=self.course.id,
                 track_function=mock.Mock(name='track_function'),
-                xqueue_callback_url_prefix=mock.Mock(name='xqueue_callback_url_prefix'),
                 request_token='request_token',
             )
 
@@ -447,7 +444,6 @@ class TestXBlockQueryLoad(SharedModuleStoreTestCase):
                 student_data=mock.Mock(name='student_data'),
                 course_id=course.id,
                 track_function=mock.Mock(name='track_function'),
-                xqueue_callback_url_prefix=mock.Mock(name='xqueue_callback_url_prefix'),
                 request_token='request_token',
             )
             with self.assertNumQueries(num_queries):

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -41,6 +41,7 @@ from xblock.runtime import DictKeyValueStore, KvsFieldData, Runtime  # lint-amne
 from xblock.test.tools import TestRuntime  # lint-amnesty, pylint: disable=wrong-import-order
 
 from capa.tests.response_xml_factory import OptionResponseXMLFactory  # lint-amnesty, pylint: disable=reimported
+from capa.xqueue_interface import XQueueInterface
 from common.djangoapps.course_modes.models import CourseMode  # lint-amnesty, pylint: disable=reimported
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from common.djangoapps.student.tests.factories import RequestFactoryNoCsrf
@@ -2567,6 +2568,7 @@ class LmsModuleSystemShimTest(SharedModuleStoreTestCase):
     """
     Tests that the deprecated attributes in the LMS Module System (XBlock Runtime) return the expected values.
     """
+    COURSE_ID = 'edX/LmsModuleShimTest/2021_Fall'
 
     @classmethod
     def setUpClass(cls):
@@ -2574,7 +2576,8 @@ class LmsModuleSystemShimTest(SharedModuleStoreTestCase):
         Set up the course and descriptor used to instantiate the runtime.
         """
         super().setUpClass()
-        cls.course = CourseFactory.create()
+        org, number, run = cls.COURSE_ID.split('/')
+        cls.course = CourseFactory.create(org=org, number=number, run=run)
         cls.descriptor = ItemFactory(category="vertical", parent=cls.course)
         cls.problem_descriptor = ItemFactory(category="problem", parent=cls.course)
 
@@ -2586,7 +2589,7 @@ class LmsModuleSystemShimTest(SharedModuleStoreTestCase):
         self.user = UserFactory(id=232)
         self.student_data = Mock()
         self.track_function = Mock()
-        self.xqueue_callback_url_prefix = Mock()
+        self.xqueue_callback_url_prefix = 'https://lms.url'
         self.request_token = Mock()
 
     @ddt.data(
@@ -2701,3 +2704,22 @@ class LmsModuleSystemShimTest(SharedModuleStoreTestCase):
         )
         rendered = runtime.render_template('templates/edxmako.html', {'element_id': 'hi'})  # pylint: disable=not-callable
         assert rendered == '<div id="hi" ns="main">Testing the MakoService</div>\n'
+
+    def test_xqueue(self):
+        runtime, _ = render.get_module_system_for_user(
+            self.user,
+            self.student_data,
+            self.descriptor,
+            self.course.id,
+            self.track_function,
+            self.xqueue_callback_url_prefix,
+            self.request_token,
+            course=self.course,
+        )
+        xqueue = runtime.xqueue
+        assert isinstance(xqueue['interface'], XQueueInterface)
+        assert xqueue['default_queuename'] == 'edX-LmsModuleShimTest'
+        assert xqueue['waittime'] == 5
+        callback_url = f'https://lms.url/courses/edX/LmsModuleShimTest/2021_Fall/xqueue/232/{self.descriptor.location}'
+        assert xqueue['construct_callback']() == f'{callback_url}/score_update'
+        assert xqueue['construct_callback']('mock_dispatch') == f'{callback_url}/mock_dispatch'

--- a/lms/djangoapps/instructor_task/api_helper.py
+++ b/lms/djangoapps/instructor_task/api_helper.py
@@ -17,7 +17,6 @@ from opaque_keys.edx.keys import UsageKey
 
 from common.djangoapps.util.db import outer_atomic
 from lms.djangoapps.courseware.courses import get_problems_in_section
-from lms.djangoapps.courseware.module_render import get_xqueue_callback_url_prefix
 from lms.djangoapps.instructor_task.models import PROGRESS, InstructorTask
 from xmodule.modulestore.django import modulestore
 
@@ -131,8 +130,7 @@ def _get_xmodule_instance_args(request, task_id):
     Calculate parameters needed for instantiating xmodule instances.
 
     The `request_info` will be passed to a tracking log function, to provide information
-    about the source of the task request.   The `xqueue_callback_url_prefix` is used to
-    permit old-style xqueue callbacks directly to the appropriate module in the LMS.
+    about the source of the task request.
     The `task_id` is also passed to the tracking log function.
     """
     request_info = {'username': request.user.username,
@@ -142,8 +140,7 @@ def _get_xmodule_instance_args(request, task_id):
                     'host': request.META['SERVER_NAME'],
                     }
 
-    xmodule_instance_args = {'xqueue_callback_url_prefix': get_xqueue_callback_url_prefix(request),
-                             'request_info': request_info,
+    xmodule_instance_args = {'request_info': request_info,
                              'task_id': task_id,
                              }
     return xmodule_instance_args

--- a/lms/djangoapps/instructor_task/tasks_helper/module_state.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/module_state.py
@@ -357,16 +357,12 @@ def _get_module_instance_for_task(course_id, student, module_descriptor, xmodule
         '''
         return lambda event_type, event: task_track(request_info, task_info, event_type, event, page='x_module_task')
 
-    xqueue_callback_url_prefix = xmodule_instance_args.get('xqueue_callback_url_prefix', '') \
-        if xmodule_instance_args is not None else ''
-
     return get_module_for_descriptor_internal(
         user=student,
         descriptor=module_descriptor,
         student_data=student_data,
         course_id=course_id,
         track_function=make_track_function(),
-        xqueue_callback_url_prefix=xqueue_callback_url_prefix,
         grade_bucket_type=grade_bucket_type,
         # This module isn't being used for front-end rendering
         request_token=None,

--- a/lms/djangoapps/instructor_task/tests/test_tasks.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks.py
@@ -83,7 +83,6 @@ class TestInstructorTasks(InstructorTaskModuleTestCase):
         Calculate dummy values for parameters needed for instantiating xmodule instances.
         """
         return {
-            'xqueue_callback_url_prefix': 'dummy_value',
             'request_info': {
                 'username': 'dummy_username',
                 'user_id': 'dummy_id',


### PR DESCRIPTION
## Description

Builds on the shim added by https://github.com/edx/edx-platform/pull/29190 to deprecate the `ModuleSystem.xqueue` property, which is only used by CAPA problems.

This change is only a refactoring, and should not affect Learners, Course Authors, or anyone else using edx-platform.

## Supporting information

* [Content Core Platform Simplication project](https://openedx.atlassian.net/wiki/spaces/AC/pages/3091629503/Content+Core+Platform+Simplification)
* [BLENDED-113](https://openedx.atlassian.net/browse/BLENDED-113) (edX internal ticket)
* [FAL-2209](https://tasks.opencraft.com/browse/FAL-2209) (OpenCraft internal ticket)

## Testing instructions

* LMS: https://pr29312.sandbox.opencraft.hosting/
* Studio: https://studio.pr29312.sandbox.opencraft.hosting/

LMS:
1. Login as a demo learner (`honor@example.com` / `edx`)
2. Enroll in the BD-13 test course
3. Navigate to [Complex blocks > External grader](https://discovery.pr29312.sandbox.opencraft.hosting/learning/course/course-v1:OpenCraft+BD-13+2021_1/block-v1:OpenCraft+BD-13+2021_1+type@sequential+block@862667c509144a4c83381589185f9072/block-v1:OpenCraft+BD-13+2021_1+type@vertical+block@b7e89f99b71d44f9b88dd1775628f539)
4. Ensure that you can submit answers to the externally graded problem.

    ⚠️ Note: the grader is dumb, and so always returns "correct", so it doesn't matter what you submit.
5. Repeat this test in the legacy course experience.

Studio:
1. Login as a demo staff (`staff@example.com` / `edx`)
2. Navigate to the [BD-13 test course > Complex blocks > External grader](https://studio.pr29312.sandbox.opencraft.hosting/container/block-v1:OpenCraft+BD-13+2021_1+type@vertical+block@b7e89f99b71d44f9b88dd1775628f539)
3. Try submitting answers to the problem.

    You'll get a message that reads "Error: No grader has been set up for this problem. " because externally graded problems can only be graded in preview / LMS mode.

     You can verify this behaviour on the sandbox created for https://github.com/edx/edx-platform/pull/29260.
4. View the problem in Preview mode, and ensure you can submit answers to the problem as you can in the LMS.

**Regression testing:**

LMS:
1. Login as a demo learner (`honor@example.com` / `edx`)
2. Browse around the Demo course, paying particular attention to the CAPA problems.
3. Check that you can submit answers to problems, and save changes to blocks.
3. Switch to the Legacy Course Experience and ensure you can submit answers to problems there too.

Studio:
1. Login as a demo staff (`staff@example.com` / `edx`)
2. Navigate to the Demo course and browse through the blocks, paying particular attention to the CAPA problem blocks. Ensure they render and edit as expected.
3. Check that you can submit answers to problems, and save changes to blocks.
4. Preview unpublished changes and ensure they render as expected.
4. Publish changes, and ensure they render in the LMS as expected.

## Deadline

None

## Author Notes & Concerns

1. See [this comment](https://github.com/edx/edx-platform/pull/29312#pullrequestreview-814434914) for question about `xqueue_callback_url_prefix`.

Notes for <strike>hacking</strike> setting up the dummy external grader:

```bash
# on the sandbox appserver:
sudo mkdir /edx/app/grader
sudo chown pomegranited: /edx/app/grader
cd /edx/app/grader

# set up virtualenv
sudo apt install python3.8-venv
python3 -m venv venv/grader

# check out my dummy grader branch
git clone https://github.com/open-craft/xqueue-watcher/
cd xqueue-watcher
git checkout jill/bd-13-dummy-grader

# Run the grader in a screen session
screen -S grader
source /edx/app/grader/venv/grader/bin/activate
make requirements  # had to run this twice to get around some error with building a wheel for dogstatsd-python
python -m xqueue_watcher -d .
# suspend screen session
```