### PR TITLE
refactor: update account verification messages

### DIFF
--- a/common/djangoapps/student/tests/test_activate_account.py
+++ b/common/djangoapps/student/tests/test_activate_account.py
@@ -166,6 +166,22 @@ class TestActivateAccount(TestCase):
         self.assertRedirects(response, login_page_url)
         self.assertContains(response, 'Your account could not be activated')
 
+    @override_settings(MARKETING_EMAILS_OPT_IN=True)
+    def test_email_confirmation_notification_on_logistration(self):
+        """
+        Verify that logistration page displays success/error/info messages
+        about email confirmation instead of activation when MARKETING_EMAILS_OPT_IN
+        is set to True.
+        """
+        response = self.client.get(reverse('activate', args=[self.registration.activation_key]), follow=True)
+        self.assertContains(response, 'Success! You have confirmed your email.')
+
+        response = self.client.get(reverse('activate', args=[self.registration.activation_key]), follow=True)
+        self.assertContains(response, 'This email has already been confirmed.')
+
+        response = self.client.get(reverse('activate', args=[uuid4().hex]), follow=True)
+        self.assertContains(response, 'Your email could not be confirmed')
+
     @override_settings(LOGIN_REDIRECT_WHITELIST=['localhost:1991'])
     @override_settings(FEATURES={**FEATURES_WITH_AUTHN_MFE_ENABLED, 'ENABLE_ENTERPRISE_INTEGRATION': True})
     @override_waffle_flag(REDIRECT_TO_AUTHN_MICROFRONTEND, active=True)

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -516,10 +516,15 @@ def activate_account(request, key):
     monitoring_utils.set_custom_attribute('student_activate_account', 'lms')
     activation_message_type = None
 
+    activated_or_confirmed = 'confirmed' if settings.MARKETING_EMAILS_OPT_IN else 'activated'
+    account_or_email = 'email' if settings.MARKETING_EMAILS_OPT_IN else 'account'
+
     invalid_message = HTML(_(
-        '{html_start}Your account could not be activated{html_end}'
+        '{html_start}Your {account_or_email} could not be {activated_or_confirmed}{html_end}'
         'Something went wrong, please <a href="{support_url}">contact support</a> to resolve this issue.'
     )).format(
+        account_or_email=account_or_email,
+        activated_or_confirmed=activated_or_confirmed,
         support_url=configuration_helpers.get_value(
             'ACTIVATION_EMAIL_SUPPORT_LINK', settings.ACTIVATION_EMAIL_SUPPORT_LINK
         ) or settings.SUPPORT_SITE_LINK,
@@ -549,7 +554,9 @@ def activate_account(request, key):
             activation_message_type = 'info'
             messages.info(
                 request,
-                HTML(_('{html_start}This account has already been activated.{html_end}')).format(
+                HTML(_('{html_start}This {account_or_email} has already been {activated_or_confirmed}.{html_end}')).format(
+                    account_or_email=account_or_email,
+                    activated_or_confirmed=activated_or_confirmed,
                     html_start=HTML('<p class="message-title">'),
                     html_end=HTML('</p>'),
                 ),
@@ -558,7 +565,7 @@ def activate_account(request, key):
         else:
             registration.activate()
             # Success message for logged in users.
-            message = _('{html_start}Success{html_end} You have activated your account.')
+            message = _('{html_start}Success{html_end} You have {activated_or_confirmed} your {account_or_email}.')
 
             tracker.emit(
                 USER_ACCOUNT_ACTIVATED,
@@ -571,7 +578,7 @@ def activate_account(request, key):
             if not request.user.is_authenticated:
                 # Success message for logged out users
                 message = _(
-                    '{html_start}Success! You have activated your account.{html_end}'
+                    '{html_start}Success! You have {activated_or_confirmed} your {account_or_email}.{html_end}'
                     'You will now receive email updates and alerts from us related to'
                     ' the courses you are enrolled in. Sign In to continue.'
                 )
@@ -581,6 +588,8 @@ def activate_account(request, key):
             messages.success(
                 request,
                 HTML(message).format(
+                    account_or_email=account_or_email,
+                    activated_or_confirmed=activated_or_confirmed,
                     html_start=HTML('<p class="message-title">'),
                     html_end=HTML('</p>'),
                 ),

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -554,7 +554,9 @@ def activate_account(request, key):
             activation_message_type = 'info'
             messages.info(
                 request,
-                HTML(_('{html_start}This {account_or_email} has already been {activated_or_confirmed}.{html_end}')).format(
+                HTML(_(
+                    '{html_start}This {account_or_email} has already been {activated_or_confirmed}.{html_end}'
+                )).format(
                     account_or_email=account_or_email,
                     activated_or_confirmed=activated_or_confirmed,
                     html_start=HTML('<p class="message-title">'),


### PR DESCRIPTION
<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

As part of removing account activation step, we have repurposed the account activation email to account verification email. Following PR updates the success, error and information messages once the link has been clicked given in the email.

||Success|Info|Error|
|----|----|----|----|
Authenticated | <img width="1222" alt="Screenshot 2021-11-16 at 4 00 20 PM" src="https://user-images.githubusercontent.com/40633976/141974417-6d9d2bad-ad9f-4033-9cf5-cc0881431625.png">| <img width="1222" alt="Screenshot 2021-11-16 at 3 59 32 PM" src="https://user-images.githubusercontent.com/40633976/141974414-0922625a-59ee-434a-8dec-45fae3ad480c.png"> | <img width="1222" alt="Screenshot 2021-11-16 at 3 59 24 PM" src="https://user-images.githubusercontent.com/40633976/141974407-655f0ad7-1d1a-4d72-bd22-854909e9ae26.png">
| Unauthenticated | <img width="545" alt="Screenshot 2021-11-16 at 4 03 30 PM" src="https://user-images.githubusercontent.com/40633976/141974422-2d8bbef9-708b-4e1d-888b-47294d61841c.png"> | <img width="562" alt="Screenshot 2021-11-16 at 3 59 14 PM" src="https://user-images.githubusercontent.com/40633976/141974400-6ccd5c01-b6a1-4203-aa59-538e0a42a03a.png"> | <img width="562" alt="Screenshot 2021-11-16 at 3 59 07 PM" src="https://user-images.githubusercontent.com/40633976/141974396-067e55f3-aca8-484c-9f78-b241c9bcaa67.png">

## Supporting information

Ticket: https://openedx.atlassian.net/browse/VAN-767

### EDIT
These screenshot depict the original design that contained the word "verified". This was later updated to "confirmed" by design team