### PR TITLE
fix: edx provider data in the api

### DIFF
--- a/openedx/core/djangoapps/discussions/models.py
+++ b/openedx/core/djangoapps/discussions/models.py
@@ -27,7 +27,8 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 
 log = logging.getLogger(__name__)
 
-DEFAULT_PROVIDER_TYPE = 'legacy'
+EDX_PROVIDER = 'legacy'
+DEFAULT_PROVIDER_TYPE = EDX_PROVIDER
 DEFAULT_CONFIG_ENABLED = True
 
 ProviderExternalLinks = namedtuple(

--- a/openedx/core/djangoapps/discussions/models.py
+++ b/openedx/core/djangoapps/discussions/models.py
@@ -35,7 +35,7 @@ ProviderExternalLinks = namedtuple(
 
 class Provider:
     """
-    Discussion providers data.
+    List of Discussion providers.
     """
     LEGACY = 'legacy'
     ED_DISCUSS = 'ed-discuss'

--- a/openedx/core/djangoapps/discussions/models.py
+++ b/openedx/core/djangoapps/discussions/models.py
@@ -27,14 +27,26 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 
 log = logging.getLogger(__name__)
 
-EDX_PROVIDER = 'legacy'
-DEFAULT_PROVIDER_TYPE = EDX_PROVIDER
-DEFAULT_CONFIG_ENABLED = True
-
 ProviderExternalLinks = namedtuple(
     'ProviderExternalLinks',
     ['learn_more', 'configuration', 'general', 'accessibility', 'contact_email']
 )
+
+
+class Provider:
+    """
+    Discussion providers data.
+    """
+    LEGACY = 'legacy'
+    ED_DISCUSS = 'ed-discuss'
+    INSCRIBE = 'inscribe'
+    PIAZZA = 'piazza'
+    YELLOWDIG = 'yellowdig'
+    OPEN_EDX = 'openedx'
+
+
+DEFAULT_PROVIDER_TYPE = Provider.LEGACY
+DEFAULT_CONFIG_ENABLED = True
 
 
 class Features(Enum):
@@ -105,7 +117,7 @@ def pii_sharing_required_message(provider_name):
 
 
 AVAILABLE_PROVIDER_MAP = {
-    'legacy': {
+    Provider.LEGACY: {
         'features': [
             Features.BASIC_CONFIGURATION.value,
             Features.PRIMARY_DISCUSSION_APP_EXPERIENCE.value,
@@ -131,7 +143,7 @@ AVAILABLE_PROVIDER_MAP = {
         'messages': [],
         'has_full_support': True
     },
-    'openedx': {
+    Provider.OPEN_EDX: {
         'features': [
             Features.BASIC_CONFIGURATION.value,
             Features.PRIMARY_DISCUSSION_APP_EXPERIENCE.value,
@@ -159,7 +171,7 @@ AVAILABLE_PROVIDER_MAP = {
         'supports_in_context_discussions': True,
         'visible': False,
     },
-    'ed-discuss': {
+    Provider.ED_DISCUSS: {
         'features': [
             Features.PRIMARY_DISCUSSION_APP_EXPERIENCE.value,
             Features.BASIC_CONFIGURATION.value,
@@ -186,7 +198,7 @@ AVAILABLE_PROVIDER_MAP = {
         'messages': [pii_sharing_required_message('Ed Discussion')],
         'has_full_support': False
     },
-    'inscribe': {
+    Provider.INSCRIBE: {
         'features': [
             Features.PRIMARY_DISCUSSION_APP_EXPERIENCE.value,
             Features.BASIC_CONFIGURATION.value,
@@ -214,7 +226,7 @@ AVAILABLE_PROVIDER_MAP = {
         'messages': [pii_sharing_required_message('InScribe')],
         'has_full_support': False
     },
-    'piazza': {
+    Provider.PIAZZA: {
         'features': [
             Features.PRIMARY_DISCUSSION_APP_EXPERIENCE.value,
             Features.BASIC_CONFIGURATION.value,
@@ -238,7 +250,7 @@ AVAILABLE_PROVIDER_MAP = {
         'messages': [],
         'has_full_support': False
     },
-    'yellowdig': {
+    Provider.YELLOWDIG: {
         'features': [
             Features.PRIMARY_DISCUSSION_APP_EXPERIENCE.value,
             Features.BASIC_CONFIGURATION.value,

--- a/openedx/core/djangoapps/discussions/serializers.py
+++ b/openedx/core/djangoapps/discussions/serializers.py
@@ -17,6 +17,9 @@ class LtiSerializer(serializers.ModelSerializer):
     """
     Serialize LtiConfiguration responses
     """
+    # pii_share_username = serializers.BooleanField(read_only=False,)
+    # pii_share_email = serializers.BooleanField(read_only=False,)
+
     class Meta:
         model = LtiConfiguration
         fields = [
@@ -212,22 +215,27 @@ class DiscussionsConfigurationSerializer(serializers.ModelSerializer):
         """
         course_key = instance.context_key
         payload = super().to_representation(instance)
-        lti_configuration_data = {}
-        if instance.supports_lti():
-            lti_configuration = LtiSerializer(instance.lti_configuration, context={
-                'pii_sharing_allowed': get_lti_pii_sharing_state_for_course(course_key),
-            })
-            lti_configuration_data = lti_configuration.data
-        provider_type = instance.provider_type or DEFAULT_PROVIDER_TYPE
+        # breakpoint()
+        # lti_configuration_data = {}
+        # if instance.supports_lti():
+        # pi = DiscussionsConfiguration.objects.all()[0]
+        lti_configuration = LtiSerializer(
+            instance.lti_configuration,
+            context={'pii_sharing_allowed': get_lti_pii_sharing_state_for_course(course_key)}
+        )
+        lti_configuration_data = lti_configuration.data
+
+        # lti_configuration_data = lti_configuration.data
+        provider_type = instance.provider_type
         plugin_configuration = instance.plugin_configuration
-        if provider_type == 'legacy':
-            course = get_course_by_id(course_key)
-            legacy_settings = LegacySettingsSerializer(
-                course,
-                data=plugin_configuration,
-            )
-            if legacy_settings.is_valid(raise_exception=True):
-                plugin_configuration = legacy_settings.data
+        # if provider_type == 'legacy':
+        course = get_course_by_id(course_key)
+        legacy_settings = LegacySettingsSerializer(
+            course,
+            data=plugin_configuration,
+        )
+        if legacy_settings.is_valid(raise_exception=True):
+            plugin_configuration = legacy_settings.data
         features_list = [
             {'id': feature.value, 'feature_support_type': feature.feature_support_type}
             for feature in Features

--- a/openedx/core/djangoapps/discussions/serializers.py
+++ b/openedx/core/djangoapps/discussions/serializers.py
@@ -9,7 +9,7 @@ from rest_framework import serializers
 from openedx.core.djangoapps.django_comment_common.models import CourseDiscussionSettings
 from openedx.core.lib.courses import get_course_by_id
 from xmodule.modulestore.django import modulestore
-from .models import AVAILABLE_PROVIDER_MAP, DEFAULT_PROVIDER_TYPE, DiscussionsConfiguration, Features
+from .models import AVAILABLE_PROVIDER_MAP, DEFAULT_PROVIDER_TYPE, DiscussionsConfiguration, Features, Provider
 from .utils import available_division_schemes, get_divided_discussions
 
 
@@ -304,10 +304,8 @@ class DiscussionsConfigurationSerializer(serializers.ModelSerializer):
         """
         plugin_configuration = validated_data.pop('plugin_configuration', {})
         updated_provider_type = validated_data.get('provider_type') or instance.provider_type
-        will_support_legacy = bool(
-            updated_provider_type == 'legacy'
-        )
-        if will_support_legacy:
+
+        if updated_provider_type == Provider.LEGACY:
             legacy_settings = LegacySettingsSerializer(
                 self._get_course(),
                 context={

--- a/openedx/core/djangoapps/discussions/serializers.py
+++ b/openedx/core/djangoapps/discussions/serializers.py
@@ -180,8 +180,8 @@ class DiscussionsConfigurationSerializer(serializers.ModelSerializer):
             'unit_level_visibility',
         ]
         fields = [
-                     'enabled',
-                 ] + course_fields
+            'enabled',
+        ] + course_fields
 
     def _get_course(self):
         """

--- a/openedx/core/djangoapps/discussions/serializers.py
+++ b/openedx/core/djangoapps/discussions/serializers.py
@@ -17,8 +17,6 @@ class LtiSerializer(serializers.ModelSerializer):
     """
     Serialize LtiConfiguration responses
     """
-    # pii_share_username = serializers.BooleanField(read_only=False,)
-    # pii_share_email = serializers.BooleanField(read_only=False,)
 
     class Meta:
         model = LtiConfiguration
@@ -73,6 +71,7 @@ class LegacySettingsSerializer(serializers.BaseSerializer):
     """
     Serialize legacy discussions settings
     """
+
     class Meta:
         fields = [
             'allow_anonymous',
@@ -181,8 +180,8 @@ class DiscussionsConfigurationSerializer(serializers.ModelSerializer):
             'unit_level_visibility',
         ]
         fields = [
-            'enabled',
-        ] + course_fields
+                     'enabled',
+                 ] + course_fields
 
     def _get_course(self):
         """
@@ -215,20 +214,15 @@ class DiscussionsConfigurationSerializer(serializers.ModelSerializer):
         """
         course_key = instance.context_key
         payload = super().to_representation(instance)
-        # breakpoint()
-        # lti_configuration_data = {}
-        # if instance.supports_lti():
-        # pi = DiscussionsConfiguration.objects.all()[0]
         lti_configuration = LtiSerializer(
             instance.lti_configuration,
             context={'pii_sharing_allowed': get_lti_pii_sharing_state_for_course(course_key)}
         )
         lti_configuration_data = lti_configuration.data
 
-        # lti_configuration_data = lti_configuration.data
         provider_type = instance.provider_type
         plugin_configuration = instance.plugin_configuration
-        # if provider_type == 'legacy':
+
         course = get_course_by_id(course_key)
         legacy_settings = LegacySettingsSerializer(
             course,

--- a/openedx/core/djangoapps/discussions/tests/test_models.py
+++ b/openedx/core/djangoapps/discussions/tests/test_models.py
@@ -9,7 +9,7 @@ from django.test import TestCase
 from opaque_keys.edx.keys import CourseKey
 from organizations.models import Organization
 
-from ..models import DEFAULT_CONFIG_ENABLED, DEFAULT_PROVIDER_TYPE
+from ..models import DEFAULT_CONFIG_ENABLED, DEFAULT_PROVIDER_TYPE, Provider
 from ..models import DiscussionsConfiguration
 from ..models import ProviderFilter
 
@@ -137,7 +137,7 @@ class DiscussionsConfigurationModelTest(TestCase):
         self.configuration_with_values = DiscussionsConfiguration(
             context_key=self.course_key_with_values,
             enabled=False,
-            provider_type='legacy',
+            provider_type=Provider.LEGACY,
             plugin_configuration={
                 'url': 'http://localhost',
             },
@@ -162,7 +162,7 @@ class DiscussionsConfigurationModelTest(TestCase):
         assert configuration.enabled  # by default
         assert configuration.lti_configuration is None
         assert len(configuration.plugin_configuration.keys()) == 0
-        assert configuration.provider_type == 'legacy'
+        assert configuration.provider_type == DEFAULT_PROVIDER_TYPE
 
     def test_get_with_values(self):
         """


### PR DESCRIPTION
BE: Update Discussion Provider API to always include legacy provider info
-
This PR resolves an issue where when the user switches to edX provider and it shows no information for that provider. The API will always include legacy and LTI data if available data in the GET request.

Example endpoint
--
https://studio.stage.edx.org/api/discussions/v0/course-v1:UBCx+Water201x_2+2T2015

[TNL-9293](https://openedx.atlassian.net/browse/TNL-9293)