### PR TITLE
fix: some visual fixes the goal reminder email for outlook

### DIFF
--- a/lms/djangoapps/course_goals/templates/course_goals/edx_ace/goalreminder/email/body.html
+++ b/lms/djangoapps/course_goals/templates/course_goals/edx_ace/goalreminder/email/body.html
@@ -24,23 +24,31 @@
     <tr>
         <td>
             {% include "goal_reminder_banner.html" %}
-            <div class="goal-reminder-body-wrapper" style="width:inherit; font-size: 14px; font-size: 0.875rem; padding: 0 20px 0 5%; margin: 36px 20px 0 17px; margin: 2.25rem 1.25rem 0 1.0625rem;">
-                <h3 style="
-                    font-size: 25px;
-                    font-size: 1.563rem;
-                    font-style: normal;
-                    font-weight: 700;
-                    line-height: 28px;
-                    line-height: 1.75rem;
-                    text-align: left;
-                    color: black;
-                    ">
-                    {% filter force_escape %}{% blocktrans %}
-                        There’s still time to reach your goal
-                    {% endblocktrans %}{% endfilter %}
-                </h3>
+            <tr>
+              <td height="36" align="center" valign="middle" style="margin: 0; font-size: 0px; line-height: 0px;">&nbsp;</td>
+            </tr>
+            <table class="goal-reminder-body-wrapper" style="width:inherit; font-size: 14px; font-size: 0.875rem; padding: 0 20px 0 5%; margin: 0 20px 0 17px; margin: 0 1.25rem 0 1.0625rem;">
+                <tr>
+                    <h3 style="
+                        font-size: 25px;
+                        font-size: 1.563rem;
+                        font-style: normal;
+                        font-weight: 700;
+                        line-height: 28px;
+                        line-height: 1.75rem;
+                        text-align: left;
+                        color: black;
+                        margin-top: 0;
+                        margin-bottom: 0;
+                        ">
+                        {% filter force_escape %}{% blocktrans %}
+                            There’s still time to reach your goal
+                        {% endblocktrans %}{% endfilter %}
+                    </h3>
+                </tr>
 
-                <p style="color: rgba(0,0,0,.75); font-size: 16px; font-size: 1rem;">
+                <tr>
+                <p style="color: rgba(0,0,0,.75); font-size: 16px; font-size: 1rem; margin: 0; padding-top: 20px; padding-bottom: 14px">
                     {% filter force_escape %}
                         {% blocktrans count count=days_per_week asvar goal_text %}
                             You set a goal of learning {start_bold}{{days_per_week}} time a week in {{course_name}}{end_bold}. You’re not quite there, but there's still time to reach that goal!
@@ -49,41 +57,51 @@
                         {% endblocktrans %}
                     {% endfilter %}
                     {% interpolate_html goal_text start_bold='<b>'|safe end_bold='</b>'|safe %}
-                    <br />
                  </p>
+                </tr>
 
-                <a style="color: white; text-decoration: none; display: inline-block;"
-                    href="{{course_url}}" target="_blank">
-                    <div style="
-                        padding: 8px 12px;
-                        padding: 0.5rem 0.75rem;
+                <tr style="padding-top: 16px;">
+                    <a href="{{course_url}}" target="_blank" style="
+                        display: inline-block;
+                        text-decoration:none !important; text-decoration:none;
+                        color: white;
+                        border-color: #D23228;
+                        border-style: solid;
+                        border-width: 8px 12px;
+                        border-width: 0.5rem 0.75rem;
                         background: #D23228;
-                        margin-bottom: 16px;
-                        margin-bottom: 1rem;
                         font-size: 16px;
                         font-size: 1rem;
                         ">
+                            <p style="margin: 0;">
+                            {% filter force_escape %}{% blocktrans %}
+                                Jump back in
+                            {% endblocktrans %}{% endfilter %}
+                            </p>
+                    </a>
+                </tr>
+
+                <tr>
+                    <p style="margin-top: 0; margin-bottom: 0; color: rgba(0,0,0,.75); font-size: 16px; font-size: 1rem; padding-top: 16px; padding-bottom: 14px">
+                        <br>
                         {% filter force_escape %}{% blocktrans %}
-                            Jump back in
+                            Remember, you can always change your learning goal. The best goal is one that you can stick to.
                         {% endblocktrans %}{% endfilter %}
-                    </div>                
-                </a>
+                    </p>
+                </tr>
 
-                <p style="color: rgba(0,0,0,.75); font-size: 16px; font-size: 1rem;">
-                    {% filter force_escape %}{% blocktrans %}
-                        Remember, you can always change your learning goal. The best goal is one that you can stick to.
-                    {% endblocktrans %}{% endfilter %}
-                    <br />
-                </p>
-
-                <a style="color: #D23228; text-decoration: none; display: inline-block; border: 0.0625rem solid #F2F0EF;"
+                <tr>
+                <a style="text-decoration: none; display: inline-block; border: 10px solid #F2F0EF; border: 0.0625rem solid #F2F0EF;"
                    href="{{course_url}}" target="_blank">
                     <div style="
-                        padding: 8px 12px;
-                        padding: 0.5rem 0.75rem;
+                        border-color: white;
+                        border-style: solid;
+                        border-width: 6px 12px;
+                        border-width: 0.5rem 0.75rem;
                         background: white;
                         font-size: 16px;
                         font-size: 1rem;
+                        color: #D23228;
                         ">
                         {% filter force_escape %}{% blocktrans %}
                             Adjust my goal
@@ -110,7 +128,8 @@
                         {% endblocktrans %}{% endfilter %}
                     </a>
                 </center>
-            </div>
+                </tr>
+            </table>
         </td>
     </tr>
 </table>


### PR DESCRIPTION
Outlook was having issues formatting the email when it was forwarded, but also when received directly. It still looks pretty weird when forwarded, but now looks normal when received directly, so I won't attempt to fix the forwarded email issue.

I recommend hiding whitespace when reviewing this PR

Original Screenshot when forwarding the email:
<img width="617" alt="Screen Shot 2021-11-16 at 1 55 42 PM" src="https://user-images.githubusercontent.com/5958221/142048300-e2dc1740-a69e-49a9-a554-b82d953f7634.png">

New Screenshot when email is received directly:
<img width="446" alt="Screen Shot 2021-11-16 at 1 45 19 PM" src="https://user-images.githubusercontent.com/5958221/142048382-2a87f755-f406-4d43-bbff-1d2ad0c4fd73.png">

No major regressions on gmail:
<img width="416" alt="Screen Shot 2021-11-16 at 1 48 45 PM" src="https://user-images.githubusercontent.com/5958221/142048413-da45e5da-730b-46c6-b244-00dcef8e16df.png">

