### PR TITLE
fix: updated cache policy for import_status endpoint

### DIFF
--- a/cms/djangoapps/contentstore/views/import_export.py
+++ b/cms/djangoapps/contentstore/views/import_export.py
@@ -20,6 +20,7 @@ from django.core.files.storage import FileSystemStorage
 from django.db import transaction
 from django.http import Http404, HttpResponse, HttpResponseNotFound, StreamingHttpResponse
 from django.utils.translation import gettext as _
+from django.views.decorators.cache import cache_control
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_GET, require_http_methods
 from edx_django_utils.monitoring import set_custom_attribute, set_custom_attributes_for_course_key
@@ -232,6 +233,7 @@ def _write_chunk(request, courselike_key):  # lint-amnesty, pylint: disable=too-
 @require_GET
 @ensure_csrf_cookie
 @login_required
+@cache_control(no_cache=True, no_store=True, must_revalidate=True)
 @ensure_valid_course_key
 def import_status_handler(request, course_key_string, filename=None):
     """

--- a/cms/djangoapps/contentstore/views/import_export.py
+++ b/cms/djangoapps/contentstore/views/import_export.py
@@ -275,9 +275,7 @@ def import_status_handler(request, course_key_string, filename=None):
             message = artifact.text
     else:
         status = min(task_status.completed_steps + 1, 3)
-    if task_status:
-        logging.info(f'Import Name : {name} task uuid:  {task_status.uuid} task status : {task_status.state} status:'
-                     f'{status}')
+
     return JsonResponse({"ImportStatus": status, "Message": message})
 
 

--- a/cms/djangoapps/contentstore/views/tests/test_import_export.py
+++ b/cms/djangoapps/contentstore/views/tests/test_import_export.py
@@ -675,6 +675,17 @@ class ImportTestCase(CourseTestCase):
         status_response = self.get_import_status(self.course.id, self.good_tar)
         self.assertImportStatusResponse(status_response, self.UpdatingError, import_error.UNKNOWN_ERROR_IN_IMPORT)
 
+    def test_import_status_response_is_not_cached(self):
+        """Helper method to get course import status."""
+        resp = self.client.get(
+            reverse_course_url(
+                'import_status_handler',
+                self.course.id,
+                kwargs={'filename': os.path.split(self.good_tar)[1]}
+            )
+        )
+        self.assertEqual(resp.headers['Cache-Control'], 'no-cache, no-store, must-revalidate')
+
 
 @override_settings(CONTENTSTORE=TEST_DATA_CONTENTSTORE)
 @ddt.ddt

--- a/cms/djangoapps/contentstore/views/tests/test_import_export.py
+++ b/cms/djangoapps/contentstore/views/tests/test_import_export.py
@@ -676,7 +676,7 @@ class ImportTestCase(CourseTestCase):
         self.assertImportStatusResponse(status_response, self.UpdatingError, import_error.UNKNOWN_ERROR_IN_IMPORT)
 
     def test_import_status_response_is_not_cached(self):
-        """Helper method to get course import status."""
+        """To test import_status endpoint response is not cached"""
         resp = self.client.get(
             reverse_course_url(
                 'import_status_handler',

--- a/cms/static/js/features/import/views/import.js
+++ b/cms/static/js/features/import/views/import.js
@@ -28,7 +28,7 @@ define(
         var current = {stage: 0, state: STATE.READY};
         var deferred = null;
         var file = {name: null, url: null};
-        var timeout = {id: null, delay: 1000};
+        var timeout = {id: null, delay: 3000};
         var $dom = {
             stages: $('ol.status-progress').children(),
             successStage: $('.item-progresspoint-success'),


### PR DESCRIPTION
### https://openedx.atlassian.net/browse/TNL-9265

Due to cache policy, the response header contains  max-age= 14400 which causes inconsistency in Import UI because of that UI was not updating as it should be the reason was  that cached response of the request was returened to application.

