### PR TITLE
feat: add esg status fetch endpoint

### DIFF
--- a/lms/djangoapps/ora_staff_grader/serializers.py
+++ b/lms/djangoapps/ora_staff_grader/serializers.py
@@ -154,13 +154,13 @@ class GradeDataSerializer(serializers.Serializer):
 
 class SubmissionDetailResponseSerializer(serializers.Serializer):
     """ Serializer for the response from the submission """
-    gradeData = GradeDataSerializer(source='submission_and_assessment_info.assessment')
-    response = ResponseSerializer(source='submission_and_assessment_info.submission')
+    gradeData = GradeDataSerializer(source='assessment_info')
+    response = ResponseSerializer(source='submission_info')
     gradeStatus = serializers.SerializerMethodField()
     lockStatus = LockStatusField(source='lock_info.lock_status')
 
     def get_gradeStatus(self, obj):
-        if obj.get('submission_and_assessment_info', {}).get('assessment'):
+        if obj.get('assessment_info', {}).get('assessment'):
             return 'graded'
         else:
             return 'ungraded'

--- a/lms/djangoapps/ora_staff_grader/serializers.py
+++ b/lms/djangoapps/ora_staff_grader/serializers.py
@@ -151,6 +151,7 @@ class GradeDataSerializer(serializers.Serializer):
     overallFeedback = serializers.CharField(source='feedback', required=False)
     criteria = serializers.ListField(child=AssessmentCriteriaSerializer(), allow_empty=True, required=False)
 
+
 class SubmissionStatusFetchSerializer(serializers.Serializer):
     """ Serializer for the response from the submission status fetch endpoint"""
     gradeData = GradeDataSerializer(source='assessment_info')
@@ -158,10 +159,11 @@ class SubmissionStatusFetchSerializer(serializers.Serializer):
     lockStatus = LockStatusField(source='lock_info.lock_status')
 
     def get_gradeStatus(self, obj):
-        if obj.get('assessment_info', {}).get('assessment'):
+        if not obj.get('assessment_info', {}) == {}:
             return 'graded'
         else:
             return 'ungraded'
+
 
 class SubmissionFetchSerializer(SubmissionStatusFetchSerializer):
     """

--- a/lms/djangoapps/ora_staff_grader/serializers.py
+++ b/lms/djangoapps/ora_staff_grader/serializers.py
@@ -151,11 +151,9 @@ class GradeDataSerializer(serializers.Serializer):
     overallFeedback = serializers.CharField(source='feedback', required=False)
     criteria = serializers.ListField(child=AssessmentCriteriaSerializer(), allow_empty=True, required=False)
 
-
-class SubmissionDetailResponseSerializer(serializers.Serializer):
-    """ Serializer for the response from the submission """
+class SubmissionStatusFetchSerializer(serializers.Serializer):
+    """ Serializer for the response from the submission status fetch endpoint"""
     gradeData = GradeDataSerializer(source='assessment_info')
-    response = ResponseSerializer(source='submission_info')
     gradeStatus = serializers.SerializerMethodField()
     lockStatus = LockStatusField(source='lock_info.lock_status')
 
@@ -164,6 +162,13 @@ class SubmissionDetailResponseSerializer(serializers.Serializer):
             return 'graded'
         else:
             return 'ungraded'
+
+class SubmissionFetchSerializer(SubmissionStatusFetchSerializer):
+    """
+    Serializer for the response from the submission fetch endpoint
+    Same as the SubmissionStatusFetchSerializer with an added submission_info field
+    """
+    response = ResponseSerializer(source='submission_info')
 
 
 class LockStatusSerializer(serializers.Serializer):

--- a/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
@@ -426,8 +426,8 @@ class TestSubmissionDetailResponseSerializer(TestCase):
             data = serializer.data
 
         expected_value = {
-            'gradeData': GradeDataSerializer(input.submission_and_assessment_info.assessment).data,
-            'response': ResponseSerializer(input.submission_and_assessment_info.submission).data,
+            'gradeData': GradeDataSerializer(input.assessment_info).data,
+            'response': ResponseSerializer(input.submission_info).data,
             'gradeStatus': mock_get_grade_status.return_value,
             'lockStatus': LockStatusField().to_representation(input.lock_info.lock_status)
         }
@@ -438,7 +438,7 @@ class TestSubmissionDetailResponseSerializer(TestCase):
     def test_get__gradeStatus(self, has_assessment):
         """ Unit test for get_gradeStatus """
         assessment = {'somekey': 'somevalue'} if has_assessment else {}
-        input = {'submission_and_assessment_info': {'assessment': assessment}}
+        input = {'assessment_info': {'assessment': assessment}}
         value = SubmissionDetailResponseSerializer().get_gradeStatus(input)
         expected = 'graded' if has_assessment else 'ungraded'
         assert value == expected

--- a/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
@@ -438,13 +438,15 @@ class TestSubmissionStatusFetchSerializer(TestCase):
     def test_get__gradeStatus(self, has_assessment):
         """ Unit test for get_gradeStatus """
         assessment = {'somekey': 'somevalue'} if has_assessment else {}
-        input = {'assessment_info': {'assessment': assessment}}
+        input = {'assessment_info': assessment}
         value = SubmissionStatusFetchSerializer().get_gradeStatus(input)
         expected = 'graded' if has_assessment else 'ungraded'
         assert value == expected
 
 
 class TestSubmissionFetchSerializer(TestCase):
+    """ Tests for the SubmissionFetchSerializer """
+
     def test_submission_fetch_serializer(self):
         """ Base serialization behavior """
         input = MagicMock()

--- a/lms/djangoapps/ora_staff_grader/tests/test_views.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_views.py
@@ -217,7 +217,7 @@ class TestFetchSubmissionStatusView(BaseViewTest):
     def test_blank_ora_location(self):
         """ Missing ora_location param should return 400 and error message """
         self.log_in()
-        response = self.client.get(self.api_url, {'ora_location': ''})
+        response = self.client.get(self.api_url, {'oraLocation': ''})
 
         assert response.status_code == 400
         assert response.content.decode() == ERR_MISSING_PARAM
@@ -225,7 +225,7 @@ class TestFetchSubmissionStatusView(BaseViewTest):
     def test_missing_submission_uuid(self):
         """ Missing submission_uuid param should return 400 and error message """
         self.log_in()
-        response = self.client.get(self.api_url, {'ora_location': Mock()})
+        response = self.client.get(self.api_url, {'oraLocation': Mock()})
 
         assert response.status_code == 400
         assert response.content.decode() == ERR_MISSING_PARAM
@@ -233,7 +233,7 @@ class TestFetchSubmissionStatusView(BaseViewTest):
     def test_blank_submission_uuid(self):
         """ Blank submission_uuid param should return 400 and error message """
         self.log_in()
-        response = self.client.get(self.api_url, {'ora_location': Mock(), 'submission_uuid': ''})
+        response = self.client.get(self.api_url, {'oraLocation': Mock(), 'submissionUuid': ''})
 
         assert response.status_code == 400
         assert response.content.decode() == ERR_MISSING_PARAM
@@ -269,7 +269,7 @@ class TestFetchSubmissionStatusView(BaseViewTest):
 
         self.log_in()
         ora_location, submission_uuid = Mock(), Mock()
-        response = self.client.get(self.api_url, {'ora_location': ora_location, 'submission_uuid': submission_uuid})
+        response = self.client.get(self.api_url, {'oraLocation': ora_location, 'submissionUuid': submission_uuid})
 
         assert response.status_code == 200
         actual = response.json()

--- a/lms/djangoapps/ora_staff_grader/urls.py
+++ b/lms/djangoapps/ora_staff_grader/urls.py
@@ -5,7 +5,9 @@ URLs for Enhanced Staff Grader (ESG) backend-for-frontend (BFF)
 from django.urls.conf import path
 
 
-from lms.djangoapps.ora_staff_grader.views import InitializeView, SubmissionFetchView, SubmissionLockView
+from lms.djangoapps.ora_staff_grader.views import (
+    InitializeView, SubmissionFetchView, SubmissionLockView, SubmissionStatusFetchView,
+)
 
 
 urlpatterns = []
@@ -16,6 +18,9 @@ urlpatterns += [
     ),
     path(
         'submission', SubmissionFetchView.as_view(), name='fetch-submission'
+    ),
+    path(
+        'submission/status', SubmissionStatusFetchView.as_view(), name='fetch-submission-status'
     ),
     path(
         'submission/lock', SubmissionLockView.as_view(), name='lock'

--- a/lms/djangoapps/ora_staff_grader/views.py
+++ b/lms/djangoapps/ora_staff_grader/views.py
@@ -15,7 +15,7 @@ from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
 
 from lms.djangoapps.ora_staff_grader.errors import ERR_BAD_ORA_LOCATION
-from lms.djangoapps.ora_staff_grader.serializers import InitializeSerializer, LockStatusSerializer, SubmissionDetailResponseSerializer
+from lms.djangoapps.ora_staff_grader.serializers import InitializeSerializer, LockStatusSerializer, SubmissionFetchSerializer
 from lms.djangoapps.ora_staff_grader.utils import call_xblock_json_handler, require_params
 from openedx.core.djangoapps.content.course_overviews.api import get_course_overview_or_none
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
@@ -124,7 +124,7 @@ class SubmissionFetchView(RetrieveAPIView):
         assessment_info = self.get_assessment_info(request, ora_location, submission_uuid)
         lock_info = self.check_submission_lock(request, ora_location, submission_uuid)
 
-        serializer = SubmissionDetailResponseSerializer({
+        serializer = SubmissionFetchSerializer({
             'submission_info': submission_info,
             'assessment_info': assessment_info,
             'lock_info': lock_info,

--- a/lms/djangoapps/ora_staff_grader/views.py
+++ b/lms/djangoapps/ora_staff_grader/views.py
@@ -190,7 +190,7 @@ class SubmissionStatusFetchView(RetrieveAPIView):
     )
     permission_classes = (IsAuthenticated,)
 
-    @require_params(['ora_location', 'submission_uuid'])
+    @require_params(['oraLocation', 'submissionUuid'])
     def get(self, request, ora_location, submission_uuid, *args, **kwargs):
         assessment_info = self.get_assessment_info(request, ora_location, submission_uuid)
         lock_info = self.check_submission_lock(request, ora_location, submission_uuid)

--- a/lms/djangoapps/ora_staff_grader/views.py
+++ b/lms/djangoapps/ora_staff_grader/views.py
@@ -3,7 +3,6 @@ Views for Enhanced Staff Grader
 """
 import json
 from django.http.response import HttpResponseBadRequest
-from django.utils.translation import ugettext as _
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
 from opaque_keys import InvalidKeyError
@@ -15,7 +14,9 @@ from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
 
 from lms.djangoapps.ora_staff_grader.errors import ERR_BAD_ORA_LOCATION
-from lms.djangoapps.ora_staff_grader.serializers import InitializeSerializer, LockStatusSerializer, SubmissionFetchSerializer
+from lms.djangoapps.ora_staff_grader.serializers import (
+    InitializeSerializer, LockStatusSerializer, SubmissionFetchSerializer, SubmissionStatusFetchSerializer
+)
 from lms.djangoapps.ora_staff_grader.utils import call_xblock_json_handler, require_params
 from openedx.core.djangoapps.content.course_overviews.api import get_course_overview_or_none
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
@@ -140,6 +141,66 @@ class SubmissionFetchView(RetrieveAPIView):
             'submission_uuid': submission_uuid
         }
         return call_xblock_json_handler(request, usage_id, 'get_submission_info', data)
+
+    def get_assessment_info(self, request, usage_id, submission_uuid):
+        """
+        Get assessment data from ORA 'get_assessment_info' XBlock.json_handler
+        """
+        data = {
+            'submission_uuid': submission_uuid
+        }
+        return call_xblock_json_handler(request, usage_id, 'get_assessment_info', data)
+
+    def check_submission_lock(self, request, usage_id, submission_uuid):
+        """
+        Look up lock info for the given submission by calling the ORA's 'check_submission_lock' XBlock.json_handler
+        """
+        data = {
+            'submission_uuid': submission_uuid
+        }
+        return call_xblock_json_handler(request, usage_id, 'check_submission_lock', data)
+
+
+class SubmissionStatusFetchView(RetrieveAPIView):
+    """
+    GET submission grade status, lock status, and grade data
+
+    Response: {
+        gradeStatus: (str) one of [graded, ungraded]
+        lockStatus: (str) one of [locked, unlocked, in-progress]
+        gradeData: {
+            score: (dict or None) {
+                pointsEarned: (int) earned points
+                pointsPossible: (int) possible points
+            }
+            overallFeedback: (string) overall feedback
+            criteria: (list of dict) [{
+                name: (str) name of criterion
+                feedback: (str) feedback for criterion
+                points: (int) points of selected option or None if feedback-only criterion
+                selectedOption: (str) name of selected option or None if feedback-only criterion
+            }]
+        }
+    }
+    """
+    authentication_classes = (
+        JwtAuthentication,
+        BearerAuthenticationAllowInactiveUser,
+        SessionAuthenticationAllowInactiveUser,
+    )
+    permission_classes = (IsAuthenticated,)
+
+    @require_params(['ora_location', 'submission_uuid'])
+    def get(self, request, ora_location, submission_uuid, *args, **kwargs):
+        assessment_info = self.get_assessment_info(request, ora_location, submission_uuid)
+        lock_info = self.check_submission_lock(request, ora_location, submission_uuid)
+
+        serializer = SubmissionStatusFetchSerializer({
+            'assessment_info': assessment_info,
+            'lock_info': lock_info,
+        })
+
+        return Response(serializer.data)
 
     def get_assessment_info(self, request, usage_id, submission_uuid):
         """

--- a/lms/djangoapps/ora_staff_grader/views.py
+++ b/lms/djangoapps/ora_staff_grader/views.py
@@ -97,6 +97,7 @@ class SubmissionFetchView(RetrieveAPIView):
             criteria: (list of dict) [{
                 name: (str) name of criterion
                 feedback: (str) feedback for criterion
+                points: (int) points of selected option or None if feedback-only criterion
                 selectedOption: (str) name of selected option or None if feedback-only criterion
             }]
         }
@@ -119,24 +120,35 @@ class SubmissionFetchView(RetrieveAPIView):
 
     @require_params(['ora_location', 'submission_uuid'])
     def get(self, request, ora_location, submission_uuid, *args, **kwargs):
-        submission_and_assessment_info = self.get_submission_and_assessment_info(request, ora_location, submission_uuid)
+        submission_info = self.get_submission_info(request, ora_location, submission_uuid)
+        assessment_info = self.get_assessment_info(request, ora_location, submission_uuid)
         lock_info = self.check_submission_lock(request, ora_location, submission_uuid)
 
         serializer = SubmissionDetailResponseSerializer({
-            'submission_and_assessment_info': submission_and_assessment_info,
+            'submission_info': submission_info,
+            'assessment_info': assessment_info,
             'lock_info': lock_info,
         })
 
         return Response(serializer.data)
 
-    def get_submission_and_assessment_info(self, request, usage_id, submission_uuid):
+    def get_submission_info(self, request, usage_id, submission_uuid):
         """
-        Get submission content and assessment data from ORA 'get_submission_and_assessment_info' XBlock.json_handler
+        Get submission content from ORA 'get_submission_info' XBlock.json_handler
         """
         data = {
             'submission_uuid': submission_uuid
         }
-        return call_xblock_json_handler(request, usage_id, 'get_submission_and_assessment_info', data)
+        return call_xblock_json_handler(request, usage_id, 'get_submission_info', data)
+
+    def get_assessment_info(self, request, usage_id, submission_uuid):
+        """
+        Get assessment data from ORA 'get_assessment_info' XBlock.json_handler
+        """
+        data = {
+            'submission_uuid': submission_uuid
+        }
+        return call_xblock_json_handler(request, usage_id, 'get_assessment_info', data)
 
     def check_submission_lock(self, request, usage_id, submission_uuid):
         """


### PR DESCRIPTION
## Description

Add an endpoint for ORA Staff Grader for checking the status of a submission.
[AU-365](https://openedx.atlassian.net/browse/AU-365)


returns
```
 {
  gradeStatus: [graded, ungraded]
  lockStatus: [locked, unlocked, in-progress]
  gradeData: {
            score: (dict or None) {
                pointsEarned: (int) earned points
                pointsPossible: (int) possible points
            }
            overallFeedback: (string) overall feedback
            criteria: (list of dict) [{
                name: (str) name of criterion
                feedback: (str) feedback for criterion
                points: (int) points of selected option or None if feedback-only criterion
                selectedOption: (str) name of selected option or None if feedback-only criterion
            }]
        }
   }
}
```
