### PR TITLE
chore: update edx-name-affirmation version

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -445,7 +445,7 @@ edx-i18n-tools==0.8.1
     # via ora2
 edx-milestones==0.3.3
     # via -r requirements/edx/base.in
-edx-name-affirmation==2.0.1
+edx-name-affirmation==2.0.2
     # via -r requirements/edx/base.in
 edx-opaque-keys[django]==2.2.2
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -555,7 +555,7 @@ edx-lint==5.2.1
     # via -r requirements/edx/testing.txt
 edx-milestones==0.3.3
     # via -r requirements/edx/testing.txt
-edx-name-affirmation==2.0.1
+edx-name-affirmation==2.0.2
     # via -r requirements/edx/testing.txt
 edx-opaque-keys[django]==2.2.2
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -538,7 +538,7 @@ edx-lint==5.2.1
     # via -r requirements/edx/testing.in
 edx-milestones==0.3.3
     # via -r requirements/edx/base.txt
-edx-name-affirmation==2.0.1
+edx-name-affirmation==2.0.2
     # via -r requirements/edx/base.txt
 edx-opaque-keys[django]==2.2.2
     # via


### PR DESCRIPTION
Update edx-name-affirmation to latest release version. The latest version cuts over to new celery tasks for updating verified names.
