### PR TITLE
LEARNER-8639: Enable upgrade banner for ios requests having 3172 as app version

### DIFF
--- a/lms/djangoapps/mobile_api/mobile_platform.py
+++ b/lms/djangoapps/mobile_api/mobile_platform.py
@@ -58,6 +58,29 @@ class IOS(MobilePlatform):
                         r'\(Build [0-9a-zA-Z]*\)\)')
     NAME = "iOS"
 
+    @classmethod
+    def get_user_app_platform(cls, user_agent, user_agent_regex):
+        """
+        Replaces build number(3172) with app version(2.26.3) and
+        Returns platform instance if user_agent matches with USER_AGENT_REGEX
+
+        Arguments:
+            user_agent (str): user-agent for mobile app making the request.
+            user_agent_regex (regex str): Regex for user-agent valid for any type pf mobile platform.
+
+        Returns:
+           An instance of class passed (which would be one of the supported mobile platform
+           classes i.e. PLATFORM_CLASSES) if user_agent matches regex of that class else returns None
+        """
+
+        # Replace Build number 3172 with app version number 2.26.3
+        # so that we can enable upgrade banner and compare this version with other versions
+        # For details visit the ticket https://openedx.atlassian.net/browse/LEARNER-8639
+        sub_regex = r'(3172)(; OS Version [0-9.]+ \(Build [0-9a-zA-Z]*\)\))'
+        user_agent = re.sub(sub_regex, r'2.26.3\2', user_agent)
+
+        return super(IOS, cls).get_user_app_platform(user_agent, user_agent_regex)
+
 
 class Android(MobilePlatform):
     """ Android platform """

--- a/lms/djangoapps/mobile_api/tests/test_mobile_platform.py
+++ b/lms/djangoapps/mobile_api/tests/test_mobile_platform.py
@@ -22,6 +22,8 @@ class TestMobilePlatform(TestCase):
         ("edX/org.edx.mobile (3.3.3; OS Version 9.2 (Build 13C75))", "iOS", "3.3.3"),
         ("edX/org.edx.mobile (3.3.3.test; OS Version 9.2 (Build 13C75))", "iOS", "3.3.3.test"),
         ("edX/org.test-domain.mobile (0.1.5; OS Version 9.2 (Build 13C75))", "iOS", "0.1.5"),
+        ("edX/org.test-domain.mobile (3172; OS Version 9.2 (Build 13C75))", "iOS", "2.26.3"),
+        ("edX/org.test-domain.mobile (2.26.3; OS Version 9.2 (Build 13C75))", "iOS", "2.26.3"),
         ("Dalvik/2.1.0 (Linux; U; Android 5.1; Nexus 5 Build/LMY47I) edX/org.edx.mobile/1.1.1", "Android", "1.1.1"),
         ("Dalvik/2.1.0 (Linux; U; Android 5.1; Nexus 5 Build/LMY47I) edX/org.edx.mobile/3.3.3.X", "Android", "3.3.3.X"),
         ("Dalvik/2.1.0 (Linux; U; Android 9; MI 6 MIUI/V11.0.3.0.PCAMIXM) edX/org.edx.mobile/2.17.1", "Android", "2.17.1"),  # lint-amnesty, pylint: disable=line-too-long


### PR DESCRIPTION
Enable upgrade banner for ios requests having 3172 as app version in header

LEARNER-8639

## Description

Replaces 3172(build number) with app number(2.26.3) in header which marks request as ios 2.26.3

## Supporting information

https://openedx.atlassian.net/browse/LEARNER-8639

## Testing instructions
We have setup a sandbox(https://jawad-khan.sandbox.edx.org) to test this. Test using edX/org.edx.mobile (2.26.3; OS Version 15.0 (Build 19A339)) as user agent.
