### PR TITLE
fix: fixed user permissions in self-hosted runners

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -31,6 +31,8 @@ jobs:
 
     name: python ${{ matrix.python-version }},django ${{ matrix.django-version }} ${{ matrix.test_module }}
     steps:
+      - name: sync directory owner
+        run: sudo chown runner:runner -R .*
       - uses: actions/checkout@v2
       - name: start mongodb service
         run: |


### PR DESCRIPTION
after we merged the workflow for unit tests, I've been monitoring the performance of self-hosted runners and autoscaling capability, on some PRs the actions started failing (e.g https://github.com/edx/edx-platform/actions/runs/1477945174/attempts/1) because the checkout action couldn't clean up the workspace, the reason for this could be `runner` user not having enough permissions remove items in runner container, I've added this change to give `runner` user appropriate permissions which seem to have fixed the issue.