### PR TITLE
feat: add response config for ora meta data

### DIFF
--- a/lms/djangoapps/ora_staff_grader/serializers.py
+++ b/lms/djangoapps/ora_staff_grader/serializers.py
@@ -48,6 +48,14 @@ class OpenResponseMetadataSerializer(serializers.Serializer):
     name = serializers.CharField(source='display_name')
     prompts = serializers.ListField()
     type = serializers.SerializerMethodField()
+    textResponseConfig = serializers.SerializerMethodField()
+    fileUploadResponseConfig = serializers.SerializerMethodField()
+
+    def get_textResponseConfig(self, instance):
+        return instance.text_response or 'none'
+
+    def get_fileUploadResponseConfig(self, instance):
+        return instance.file_upload_response or 'none'
 
     def get_type(self, instance):
         return 'team' if instance.teams_enabled else 'individual'
@@ -57,6 +65,8 @@ class OpenResponseMetadataSerializer(serializers.Serializer):
             'name',
             'prompts',
             'type',
+            'textResponseConfig',
+            'fileUploadResponseConfig',
         ]
         read_only_fields = fields
 

--- a/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
@@ -53,6 +53,7 @@ class TestCourseMetadataSerializer(SharedModuleStoreTestCase):
         }
 
 
+@ddt.ddt
 class TestOpenResponseMetadataSerializer(TestCase):
     """
     Tests for OpenResponseMetadataSerializer
@@ -60,7 +61,9 @@ class TestOpenResponseMetadataSerializer(TestCase):
     ora_data = {
         "display_name": "Week 1: Time Travel Paradoxes",
         "prompts": ["<p>In your own words, explain a famous time travel paradox</p>"],
-        "teams_enabled": False
+        "teams_enabled": False,
+        "text_response": None,
+        "file_upload_response": None,
     }
 
     def setUp(self):
@@ -76,6 +79,8 @@ class TestOpenResponseMetadataSerializer(TestCase):
             "name": self.ora_data['display_name'],
             "prompts": self.ora_data['prompts'],
             "type": "individual",
+            "textResponseConfig": "none",
+            "fileUploadResponseConfig": "none",
         }
 
     def test_team_ora(self):
@@ -87,7 +92,29 @@ class TestOpenResponseMetadataSerializer(TestCase):
             "name": self.ora_data['display_name'],
             "prompts": self.ora_data['prompts'],
             "type": "team",
+            "textResponseConfig": "none",
+            "fileUploadResponseConfig": "none",
         }
+
+    @ddt.unpack
+    @ddt.data(('optional', 'optional'), ('required', 'required'))
+    def test_response_config(self, text_response, file_upload_response):
+        self.mock_ora_instance.text_response = text_response
+        self.mock_ora_instance.file_upload_response = file_upload_response
+
+        data = OpenResponseMetadataSerializer(self.mock_ora_instance).data
+
+        assert data['textResponseConfig'] == text_response
+        assert data['fileUploadResponseConfig'] == file_upload_response
+
+    def test_response_config_none(self):
+        self.mock_ora_instance.text_response = None
+        self.mock_ora_instance.file_upload_response = None
+
+        data = OpenResponseMetadataSerializer(self.mock_ora_instance).data
+
+        assert data['textResponseConfig'] == "none"
+        assert data['fileUploadResponseConfig'] == "none"
 
 
 class TestSubmissionMetadataSerializer(TestCase):


### PR DESCRIPTION
add `textResponseConfig` and `fileUploadResponseConfig` to oraMetadata.

Updated the response config to return string for 'none', 'optional', required'