### PR TITLE
fix: updated the workflow to build and push CI runner docker image on…

### DIFF
--- a/.github/workflows/publish-ci-docker-image.yml
+++ b/.github/workflows/publish-ci-docker-image.yml
@@ -1,6 +1,10 @@
 name: Push CI Runner Docker Image
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 1 * * 3"
+
 jobs:
   push:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
I've updated the workflow to trigger every Wednesday, to build and push updated docker image so it installs latest edx-platform requirements, so self-hosted runners that are run from this image have up to date requirements installed and take relatively less time to during workflow runs