### PR TITLE
fix: Correctly create origin from URL in CORS CSRF middleware

### DIFF
--- a/openedx/core/djangoapps/cors_csrf/tests/test_middleware.py
+++ b/openedx/core/djangoapps/cors_csrf/tests/test_middleware.py
@@ -69,6 +69,7 @@ class TestCorsMiddlewareProcessRequest(TestCase):
         'https://foo.com', 'https://www.foo.com', 'https://learning.edge.foo.bar']
     )
     @ddt.data(
+        'https://foo.com', 'https://foo.com/',
         'https://foo.com/bar/', 'https://foo.com/bar/baz/', 'https://www.foo.com/bar/baz/',
         'https://learning.edge.foo.bar', 'https://learning.edge.foo.bar/foo'
     )


### PR DESCRIPTION
Deleting all instances of the path from the URL meant that URLs like
`https://learning.edx.org/` were turned into `https:learning.edx.org`. The
solution here is to use `urlunparse` to put the URL back together, but only
with the desired components (scheme and authority/netloc).


This relates to our previous upgrade to django-cors-headers 3.x, which
changed to use origins instead of domains in its whitelist setting:

https://github.com/edx/edx-platform/commit/36df86d829fdc32935b97d9959fd399fe2fa0f0d#diff-811d60a3e1d60ff694eace0242e77d6b810d8e9c63c36d7b3c2591a08ebbb94bR58

Also:

- Replace word "domain" with "origin" in few places to use the correct
  term. (We should probably change this more broadly in names and comments
  in this module as some point.)
- Simplify logging to just output what we know, and not try to recapitulate
  the logic too much.

ref: BOM-2961

- [x] Decide whether this needs to be backported to Maple
- [x] Add unit tests, maybe
