### PR TITLE
feat: external plugin integration in instructor dashboard

### DIFF
--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -545,15 +545,15 @@ SYSTEM_WIDE_ROLE_CLASSES = ENV_TOKENS.get('SYSTEM_WIDE_ROLE_CLASSES') or SYSTEM_
 ######################## Setting for content libraries ########################
 MAX_BLOCKS_PER_CONTENT_LIBRARY = ENV_TOKENS.get('MAX_BLOCKS_PER_CONTENT_LIBRARY', MAX_BLOCKS_PER_CONTENT_LIBRARY)
 
+########################## Derive Any Derived Settings  #######################
+
+derive_settings(__name__)
+
 ####################### Plugin Settings ##########################
 
 # This is at the bottom because it is going to load more settings after base settings are loaded
 
 add_plugins(__name__, ProjectType.CMS, SettingsType.PRODUCTION)
-
-########################## Derive Any Derived Settings  #######################
-
-derive_settings(__name__)
 
 ############# CORS headers for cross-domain requests #################
 if FEATURES.get('ENABLE_CORS_HEADERS'):

--- a/lms/djangoapps/instructor/constants.py
+++ b/lms/djangoapps/instructor/constants.py
@@ -1,0 +1,9 @@
+"""
+Constants used by Instructor.
+"""
+
+# this is the UserPreference key for the user's recipient invoice copy
+INVOICE_KEY = 'pref-invoice-copy'
+
+# external plugins (if any) will use this constant to return context to instructor dashboard
+INSTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME = 'instructor_dashboard'

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -12,6 +12,7 @@ from django.contrib.sites.models import Site
 from django.test.utils import override_settings
 from django.urls import reverse
 from edx_toggles.toggles.testutils import override_waffle_flag
+from edx_django_utils.plugins import get_plugins_view_context
 from pyquery import PyQuery as pq
 from pytz import UTC
 
@@ -27,6 +28,7 @@ from lms.djangoapps.courseware.tabs import get_course_tab_list
 from lms.djangoapps.courseware.tests.factories import StudentModuleFactory
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from lms.djangoapps.grades.config.waffle import WRITABLE_GRADEBOOK, waffle_flags
+from lms.djangoapps.instructor.constants import INSTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME
 from lms.djangoapps.instructor.toggles import DATA_DOWNLOAD_V2
 from lms.djangoapps.instructor.views.gradebook_api import calculate_page_info
 from openedx.core.djangoapps.course_groups.cohorts import set_course_cohorted
@@ -34,6 +36,7 @@ from openedx.core.djangoapps.discussions.config.waffle import (
     ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND,
     OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG
 )
+from openedx.core.djangoapps.plugins.constants import ProjectType
 from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, ModuleStoreTestCase
@@ -581,6 +584,15 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         response = self.client.get(self.url)
         # assert we don't get a 500 error
         assert 200 == response.status_code
+
+    def test_plugin_context(self):
+       
+        context_from_plugins = get_plugins_view_context(
+            ProjectType.LMS,
+            INSTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME
+        )
+
+        assert 'plugins' in context_from_plugins
 
 
 @ddt.ddt

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -586,7 +586,9 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         assert 200 == response.status_code
 
     def test_plugin_context(self):
-       
+        """
+        Tests that whether context from plugins is being returned
+        """
         context_from_plugins = get_plugins_view_context(
             ProjectType.LMS,
             INSTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME

--- a/lms/djangoapps/instructor/views/__init__.py
+++ b/lms/djangoapps/instructor/views/__init__.py
@@ -1,4 +1,0 @@
-"""
-This is the UserPreference key for the user's recipient invoice copy
-"""
-INVOICE_KEY = 'pref-invoice-copy'

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -87,6 +87,7 @@ from lms.djangoapps.discussion.django_comment_client.utils import (
 )
 from lms.djangoapps.instructor import enrollment
 from lms.djangoapps.instructor.access import ROLES, allow_access, list_with_level, revoke_access, update_forum_role
+from lms.djangoapps.instructor.constants import INVOICE_KEY
 from lms.djangoapps.instructor.enrollment import (
     enroll_email,
     get_email_params,
@@ -95,7 +96,6 @@ from lms.djangoapps.instructor.enrollment import (
     send_mail_to_student,
     unenroll_email,
 )
-from lms.djangoapps.instructor.views import INVOICE_KEY
 from lms.djangoapps.instructor.views.instructor_task_helpers import extract_email_features, extract_task_features
 from lms.djangoapps.instructor_analytics import basic as instructor_analytics_basic, csvs as instructor_analytics_csvs
 from lms.djangoapps.instructor_task import api as task_api
@@ -139,10 +139,6 @@ TASK_SUBMISSION_OK = 'created'
 
 SUCCESS_MESSAGE_TEMPLATE = _("The {report_type} report is being created. "
                              "To view the status of the report, see Pending Tasks below.")
-
-# Please avoid changing value of this constant
-# as this is also being used inside external plugins
-INSTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME = "instructor_dashboard"
 
 
 def common_exceptions_400(func):

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -140,6 +140,8 @@ TASK_SUBMISSION_OK = 'created'
 SUCCESS_MESSAGE_TEMPLATE = _("The {report_type} report is being created. "
                              "To view the status of the report, see Pending Tasks below.")
 
+# Please avoid changing value of this constant
+# as this is also being used inside external plugins
 INCTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME = "instructor"
 
 

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -140,6 +140,8 @@ TASK_SUBMISSION_OK = 'created'
 SUCCESS_MESSAGE_TEMPLATE = _("The {report_type} report is being created. "
                              "To view the status of the report, see Pending Tasks below.")
 
+INCTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME = "instructor"
+
 
 def common_exceptions_400(func):
     """

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -142,7 +142,7 @@ SUCCESS_MESSAGE_TEMPLATE = _("The {report_type} report is being created. "
 
 # Please avoid changing value of this constant
 # as this is also being used inside external plugins
-INCTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME = "instructor"
+INSTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME = "instructor_dashboard"
 
 
 def common_exceptions_400(func):

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -257,7 +257,8 @@ def instructor_dashboard_2(request, course_id):  # lint-amnesty, pylint: disable
         'xqa_server': settings.FEATURES.get('XQA_SERVER', "http://your_xqa_server.com"),
     }
 
-    # this import has been done inline to avoid failing a test: TestCourseTabApi
+    # this import has been done inline to avoid circular import 
+    # due to which a test fails: TestCourseTabApi
     from lms.djangoapps.instructor.views.api import INCTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME
 
     context_from_plugins = get_plugins_view_context(

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -53,7 +53,6 @@ from lms.djangoapps.courseware.courses import get_studio_url
 from lms.djangoapps.courseware.module_render import get_module_by_usage_id
 from lms.djangoapps.discussion.django_comment_client.utils import has_forum_access
 from lms.djangoapps.grades.api import is_writable_gradebook_enabled
-from lms.djangoapps.instructor.views.api import INCTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME
 from openedx.core.djangoapps.course_groups.cohorts import DEFAULT_COHORT_NAME, get_course_cohorts, is_course_cohorted
 from openedx.core.djangoapps.discussions.config.waffle_utils import legacy_discussion_experience_enabled
 from openedx.core.djangoapps.discussions.utils import available_division_schemes
@@ -256,6 +255,8 @@ def instructor_dashboard_2(request, course_id):  # lint-amnesty, pylint: disable
         'certificate_invalidation_view_url': certificate_invalidation_view_url,
         'xqa_server': settings.FEATURES.get('XQA_SERVER', "http://your_xqa_server.com"),
     }
+
+    from lms.djangoapps.instructor.views.api import INCTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME
 
     # lms.djangoapp is passed to get_plugins_view_context instead of ProjectType.LMS
     # to avoid cyclic import issue

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -72,7 +72,7 @@ from .. import permissions
 from ..toggles import data_download_v2_is_enabled
 from .tools import get_units_with_due_date, title_or_url
 
-# this import has been done here, at the last, to avoid failing a test: TestCourseTabApi  
+# this import has been done here, at the last, to avoid failing a test: TestCourseTabApi
 from lms.djangoapps.instructor.views.api import INCTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME
 
 log = logging.getLogger(__name__)

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -57,6 +57,7 @@ from openedx.core.djangoapps.course_groups.cohorts import DEFAULT_COHORT_NAME, g
 from openedx.core.djangoapps.discussions.config.waffle_utils import legacy_discussion_experience_enabled
 from openedx.core.djangoapps.discussions.utils import available_division_schemes
 from openedx.core.djangoapps.django_comment_common.models import FORUM_ROLE_ADMINISTRATOR, CourseDiscussionSettings
+from openedx.core.djangoapps.plugins.constants import ProjectType
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.verified_track_content.models import VerifiedTrackCohortedCourse
 from openedx.core.djangolib.markup import HTML, Text
@@ -70,6 +71,9 @@ from xmodule.tabs import CourseTab
 from .. import permissions
 from ..toggles import data_download_v2_is_enabled
 from .tools import get_units_with_due_date, title_or_url
+
+# this import has been done here, at the last to avoid an error/exception
+from lms.djangoapps.instructor.views.api import INCTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME
 
 log = logging.getLogger(__name__)
 
@@ -256,12 +260,8 @@ def instructor_dashboard_2(request, course_id):  # lint-amnesty, pylint: disable
         'xqa_server': settings.FEATURES.get('XQA_SERVER', "http://your_xqa_server.com"),
     }
 
-    from lms.djangoapps.instructor.views.api import INCTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME
-
-    # lms.djangoapp is passed to get_plugins_view_context instead of ProjectType.LMS
-    # to avoid cyclic import issue
     context_from_plugins = get_plugins_view_context(
-        'lms.djangoapp',
+        ProjectType.LMS,
         INCTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME,
         context
     )

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -72,7 +72,7 @@ from .. import permissions
 from ..toggles import data_download_v2_is_enabled
 from .tools import get_units_with_due_date, title_or_url
 
-# this import has been done here, at the last to avoid an error/exception
+# this import has been done here, at the last, to avoid failing a test: TestCourseTabApi  
 from lms.djangoapps.instructor.views.api import INCTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME
 
 log = logging.getLogger(__name__)

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -257,7 +257,7 @@ def instructor_dashboard_2(request, course_id):  # lint-amnesty, pylint: disable
         'xqa_server': settings.FEATURES.get('XQA_SERVER', "http://your_xqa_server.com"),
     }
 
-    # this import has been done inline to avoid circular import 
+    # this import has been done inline to avoid circular import
     # due to which a test fails: TestCourseTabApi
     from lms.djangoapps.instructor.views.api import INCTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME
 

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -53,6 +53,7 @@ from lms.djangoapps.courseware.courses import get_studio_url
 from lms.djangoapps.courseware.module_render import get_module_by_usage_id
 from lms.djangoapps.discussion.django_comment_client.utils import has_forum_access
 from lms.djangoapps.grades.api import is_writable_gradebook_enabled
+from lms.djangoapps.instructor.constants import INSTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME
 from openedx.core.djangoapps.course_groups.cohorts import DEFAULT_COHORT_NAME, get_course_cohorts, is_course_cohorted
 from openedx.core.djangoapps.discussions.config.waffle_utils import legacy_discussion_experience_enabled
 from openedx.core.djangoapps.discussions.utils import available_division_schemes
@@ -256,10 +257,6 @@ def instructor_dashboard_2(request, course_id):  # lint-amnesty, pylint: disable
         'certificate_invalidation_view_url': certificate_invalidation_view_url,
         'xqa_server': settings.FEATURES.get('XQA_SERVER', "http://your_xqa_server.com"),
     }
-
-    # this import has been done inline to avoid circular import
-    # due to which a test fails: TestCourseTabApi
-    from lms.djangoapps.instructor.views.api import INSTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME
 
     context_from_plugins = get_plugins_view_context(
         ProjectType.LMS,

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -72,9 +72,6 @@ from .. import permissions
 from ..toggles import data_download_v2_is_enabled
 from .tools import get_units_with_due_date, title_or_url
 
-# this import has been done here, at the last, to avoid failing a test: TestCourseTabApi
-from lms.djangoapps.instructor.views.api import INCTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME
-
 log = logging.getLogger(__name__)
 
 
@@ -259,6 +256,9 @@ def instructor_dashboard_2(request, course_id):  # lint-amnesty, pylint: disable
         'certificate_invalidation_view_url': certificate_invalidation_view_url,
         'xqa_server': settings.FEATURES.get('XQA_SERVER', "http://your_xqa_server.com"),
     }
+
+    # this import has been done inline to avoid failing a test: TestCourseTabApi
+    from lms.djangoapps.instructor.views.api import INCTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME
 
     context_from_plugins = get_plugins_view_context(
         ProjectType.LMS,

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -259,13 +259,14 @@ def instructor_dashboard_2(request, course_id):  # lint-amnesty, pylint: disable
 
     # this import has been done inline to avoid circular import
     # due to which a test fails: TestCourseTabApi
-    from lms.djangoapps.instructor.views.api import INCTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME
+    from lms.djangoapps.instructor.views.api import INSTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME
 
     context_from_plugins = get_plugins_view_context(
         ProjectType.LMS,
-        INCTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME,
+        INSTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME,
         context
     )
+
     context.update(context_from_plugins)
 
     return render_to_response('instructor/instructor_dashboard_2/instructor_dashboard_2.html', context)

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -22,6 +22,7 @@ from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_POST
 from edx_proctoring.api import does_backend_support_onboarding
 from edx_when.api import is_enabled_for_course
+from edx_django_utils.plugins import get_plugins_view_context
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from xblock.field_data import DictFieldData
@@ -52,6 +53,7 @@ from lms.djangoapps.courseware.courses import get_studio_url
 from lms.djangoapps.courseware.module_render import get_module_by_usage_id
 from lms.djangoapps.discussion.django_comment_client.utils import has_forum_access
 from lms.djangoapps.grades.api import is_writable_gradebook_enabled
+from lms.djangoapps.instructor.views.api import INCTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME
 from openedx.core.djangoapps.course_groups.cohorts import DEFAULT_COHORT_NAME, get_course_cohorts, is_course_cohorted
 from openedx.core.djangoapps.discussions.config.waffle_utils import legacy_discussion_experience_enabled
 from openedx.core.djangoapps.discussions.utils import available_division_schemes
@@ -254,6 +256,15 @@ def instructor_dashboard_2(request, course_id):  # lint-amnesty, pylint: disable
         'certificate_invalidation_view_url': certificate_invalidation_view_url,
         'xqa_server': settings.FEATURES.get('XQA_SERVER', "http://your_xqa_server.com"),
     }
+
+    # lms.djangoapp is passed to get_plugins_view_context instead of ProjectType.LMS
+    # to avoid cyclic import issue
+    context_from_plugins = get_plugins_view_context(
+        'lms.djangoapp',
+        INCTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME,
+        context
+    )
+    context.update(context_from_plugins)
 
     return render_to_response('instructor/instructor_dashboard_2/instructor_dashboard_2.html', context)
 

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -953,16 +953,16 @@ DASHBOARD_COURSE_LIMIT = ENV_TOKENS.get('DASHBOARD_COURSE_LIMIT', None)
 ######################## Setting for content libraries ########################
 MAX_BLOCKS_PER_CONTENT_LIBRARY = ENV_TOKENS.get('MAX_BLOCKS_PER_CONTENT_LIBRARY', MAX_BLOCKS_PER_CONTENT_LIBRARY)
 
+########################## Derive Any Derived Settings  #######################
+
+derive_settings(__name__)
+
 ############################### Plugin Settings ###############################
 
 # This is at the bottom because it is going to load more settings after base settings are loaded
 
 # Load production.py in plugins
 add_plugins(__name__, ProjectType.LMS, SettingsType.PRODUCTION)
-
-########################## Derive Any Derived Settings  #######################
-
-derive_settings(__name__)
 
 ############## Settings for Completion API #########################
 

--- a/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
+++ b/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
@@ -130,7 +130,7 @@ from openedx.core.djangolib.markup import HTML
           <% is_hidden = section_data.get('is_hidden', False) %>
           <section id="${ section_data['section_key'] }" class="idash-section${' hidden' if hidden else ''}" aria-labelledby="header-${section_data['section_key']}">
               <h3 class="hd hd-3" id="header-${ section_data['section_key'] }">${ section_data['section_display_name'] }</h3>
-              <%include file="${ section_data['section_key'] }.html" args="section_data=section_data" />
+              <%include file="${ section_data.get('template_path_prefix', '') }${ section_data['section_key'] }.html" args="section_data=section_data" />
           </section>
           % endfor
         </section>


### PR DESCRIPTION
## Description

There are plugins which return context which is then embedded/used accordingly. So in instructor dashboard we need a flow/function which get/fetches the context from external plugins and updates the existing context with the context returned from external plugins. This has been done via a function **get_plugins_view_context** of **edx_django_utils.plugins**. A separate constant file has been created in instructor which consist of a constant: **INSTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME**. Any external plugin which uses this constant, will return context to instructor dashboard.

While installing an external plugin, all the settings should be derived first and **add_plugins** function should be called afterwards in **lms -> envs -> production.py** but currently **add_plugins** function is being called before **derive_settings** function, hence their order has been switched. Same goes for **cms -> envs -> production.py**

In **lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html**, we include the html files of sections from relative path, but in case of plugin, we need to give absolute path, as plugin's html file is inside plugin so in order to give absolute path we need to add a prefix **"/"**.

## Supporting information

None

## Testing instructions

- Any external plugin which uses the constant **INSTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME** to return any context,  will be received in instructor dashboard.
- If we call the **add_plugins** function before **derive_settings** function, then an exception can be seen while adding plugin's template in app_dirs.
- If we call the **add_plugins** function after **derive_settings** function, then plugin's template is successfully added in app_dirs.
- If we don't place a prefix **"/"** while including a html file from some other directory/app then an exception can be seen as it automatically adds relative path to it while including and the file can not be found on this path because plugin's html file is inside plugin templates.
- If we place a prefix **"/"** while including a html file from some other directory/app then it includes the file successfully as now absolute path is provided by appending this prefix.  

## Deadline

None

## Other information

None
