### PR TITLE
fix: include pii sharing values in the API

### DIFF
--- a/openedx/core/djangoapps/discussions/serializers.py
+++ b/openedx/core/djangoapps/discussions/serializers.py
@@ -17,6 +17,8 @@ class LtiSerializer(serializers.ModelSerializer):
     """
     Serialize LtiConfiguration responses
     """
+    pii_share_email = serializers.BooleanField(required=False)
+    pii_share_username = serializers.BooleanField(required=False)
 
     class Meta:
         model = LtiConfiguration
@@ -42,6 +44,9 @@ class LtiSerializer(serializers.ModelSerializer):
         return payload
 
     def to_representation(self, instance):
+        """
+        Serialize object into a primitive data types.
+        """
         representation = super().to_representation(instance)
         if not self.context.get('pii_sharing_allowed'):
             representation.pop('pii_share_username')
@@ -214,6 +219,7 @@ class DiscussionsConfigurationSerializer(serializers.ModelSerializer):
         """
         course_key = instance.context_key
         payload = super().to_representation(instance)
+
         lti_configuration = LtiSerializer(
             instance.lti_configuration,
             context={'pii_sharing_allowed': get_lti_pii_sharing_state_for_course(course_key)}

--- a/openedx/core/djangoapps/discussions/tests/test_views.py
+++ b/openedx/core/djangoapps/discussions/tests/test_views.py
@@ -51,7 +51,9 @@ DEFAULT_LTI_CONFIGURATION = {
     'lti_1p1_client_key': '',
     'lti_1p1_client_secret': '',
     'lti_1p1_launch_url': '',
-    'version': None
+    'version': None,
+    'pii_share_email': False,
+    'pii_share_username': False,
 }
 
 DATA_LTI_CONFIGURATION = {


### PR DESCRIPTION
[TNL-9318](https://openedx.atlassian.net/browse/TNL-9318)


The PR fixes an issue that when switching from `legacy` to LTI provider PII fields were excluded from the backend. 