### PR TITLE
fix: remove block browser 404s.

### DIFF
--- a/common/static/common/js/components/BlockBrowser/data/api/client.js
+++ b/common/static/common/js/components/BlockBrowser/data/api/client.js
@@ -21,7 +21,7 @@ export function buildQueryString(data) {
 }
 
 export const getCourseBlocks = courseId => fetch(
-  `${COURSE_BLOCKS_API}/?${buildQueryString({
+  `${COURSE_BLOCKS_API}?${buildQueryString({
     course_id: courseId,
     all_blocks: true,
     depth: 'all',


### PR DESCRIPTION
Instructor dashboard "Select a section or problem" button is unresponsive; instructors are unable to generate problem reports. The issue is that the url it hits for the api call has an extra slash after courses.
`https://courses.edx.org/api/courses/v1/blocks//?course_id=course-v1%3AedX%2BDemoX.1%2B2T2019&all_blocks=true&depth=all&requested_fields=name,display_name,block_type,children
`404s
versus
`https://courses.edx.org/api/courses/v1/blocks/?course_id=course-v1%3AedX%2BDemoX.1%2B2T2019&all_blocks=true&depth=all&requested_fields=name,display_name,block_type,children`

Removing one slash from the blockbrowser js file will fix this issue. This is a CAT-2 so it is affecting many of our instructors ability to generate valuable grading reports.