### PR TITLE
fix: resolve incomplete module import for field overrides

### DIFF
--- a/lms/djangoapps/courseware/field_overrides.py
+++ b/lms/djangoapps/courseware/field_overrides.py
@@ -27,8 +27,8 @@ from xblock.field_data import FieldData
 from xmodule.modulestore.inheritance import InheritanceMixin
 
 NOTSET = object()
-ENABLED_OVERRIDE_PROVIDERS_KEY = 'courseware.field_overrides.enabled_providers.{course_id}'
-ENABLED_MODULESTORE_OVERRIDE_PROVIDERS_KEY = 'courseware.modulestore_field_overrides.enabled_providers.{course_id}'
+ENABLED_OVERRIDE_PROVIDERS_KEY = 'lms.djangoapps.courseware.field_overrides.enabled_providers.{course_id}'
+ENABLED_MODULESTORE_OVERRIDE_PROVIDERS_KEY = 'lms.djangoapps.courseware.modulestore_field_overrides.enabled_providers.{course_id}'
 
 
 def resolve_dotted(name):

--- a/lms/djangoapps/courseware/field_overrides.py
+++ b/lms/djangoapps/courseware/field_overrides.py
@@ -28,7 +28,8 @@ from xmodule.modulestore.inheritance import InheritanceMixin
 
 NOTSET = object()
 ENABLED_OVERRIDE_PROVIDERS_KEY = 'lms.djangoapps.courseware.field_overrides.enabled_providers.{course_id}'
-ENABLED_MODULESTORE_OVERRIDE_PROVIDERS_KEY = 'lms.djangoapps.courseware.modulestore_field_overrides.enabled_providers.{course_id}'
+ENABLED_MODULESTORE_OVERRIDE_PROVIDERS_KEY = 'lms.djangoapps.courseware.modulestore_field_overrides.\
+    enabled_providers.{course_id}'
 
 
 def resolve_dotted(name):

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -750,7 +750,7 @@ if FEATURES.get('CUSTOM_COURSES_EDX'):
 ##### Individual Due Date Extensions #####
 if FEATURES.get('INDIVIDUAL_DUE_DATES'):
     FIELD_OVERRIDE_PROVIDERS += (
-        'courseware.student_field_overrides.IndividualStudentOverrideProvider',
+        'lms.djangoapps.courseware.student_field_overrides.IndividualStudentOverrideProvider',
     )
 
 ##### Show Answer Override for Self-Paced Courses #####


### PR DESCRIPTION
## Description

Fixes this [issue](https://github.com/openedx/build-test-release-wg/issues/112)

The string constant defined for default override providers is missing the fully scoped import namespace which results in errors when attempting to enroll in a course. This adds the full import path to those constants.

## Supporting information

None

## Deadline

None

## Other information

None
