### PR TITLE
feat!: improve discussion provider listing and configuration [BD-38] [TNL-8622]

### DIFF
--- a/openedx/core/djangoapps/discussions/models.py
+++ b/openedx/core/djangoapps/discussions/models.py
@@ -169,7 +169,6 @@ AVAILABLE_PROVIDER_MAP = {
         'messages': [],
         'has_full_support': True,
         'supports_in_context_discussions': True,
-        'visible': False,
     },
     Provider.ED_DISCUSS: {
         'features': [


### PR DESCRIPTION
## Description

Includes the new discussion provider in the API response under certain circumstance. If the
legacy provider is already in use, the new provider will be hidden. If the new provider is used
then the legacy provider will be hidden. If some other provider is used, then the new or legacy
providers will be visible depending on whether the discussions MFE is enabled.

This also fixes the "group_at_subsection" setting so that it's saved when using the new provider,
and also removes legacy plugin configuration when the legacy or new provider aren't being used.

## Supporting information

- https://openedx.atlassian.net/browse/TNL-8622

## Testing instructions

- Test setting up a course for the first time. The new provider should be hidden. 
- Test setting up a course with the "ENABLE_DISCUSSIONS_MFE" set to try. The new provider should be visible.
- Test an existing course. If it uses the legacy provider that should show up and the new one should be hidden. If it uses the new provider the legacy one should be hidden. 
- When using neither the legacy or new provider, the plugin_configuraiton should not show legacy settings
- When using the new 'openedx' provider,  grouping at subsections should be saved and returned by the API. 
