### PR TITLE
feat: allow bulk email templates to be deleted

### DIFF
--- a/lms/djangoapps/bulk_email/admin.py
+++ b/lms/djangoapps/bulk_email/admin.py
@@ -57,18 +57,10 @@ unsupported tags will cause email sending to fail.
 '''
         }),
     )
-    # Turn off the action bar (we have no bulk actions)
-    actions = None
 
     def has_add_permission(self, request):
         """Enable the ability to add new templates, as we want to be able to define multiple templates."""
         return True
-
-    def has_delete_permission(self, request, obj=None):
-        """
-        Disables the ability to remove existing templates, as we'd like to make sure we don't have dangling references.
-        """
-        return False
 
 
 class CourseAuthorizationAdmin(admin.ModelAdmin):


### PR DESCRIPTION
## Description

There are some old bulk email templates in the database that we don’t
need anymore. We need to make this change in order to delete them. After
removing the templates we want to remove, we’ll leave in the ability to
delete.

[MICROBA-1573]

## Supporting information

https://openedx.atlassian.net/browse/MICROBA-1573

## Testing instructions

- Open the bulk_email admin: https://internal.courses.edx.org/admin/bulk_email/courseemailtemplate/ (you may need permission)
- In the "list" view, you should see checkboxes on the left side of each row and the ability to delete in action dropdown at the top
- If you click into any template, you should see a "delete" button.

## Deadline

None.


[MICROBA-1573]: https://openedx.atlassian.net/browse/MICROBA-1573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ