### PR TITLE
Pin mysqlclient<2.1.0

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -96,3 +96,6 @@ py2neo<2022
 
 # Sphinx requires docutils<0.18. This pin can be removed once https://github.com/sphinx-doc/sphinx/issues/9777 is closed.
 docutils<0.18
+
+# mysqlclient==2.1.0 caused NameError in running pylint checks on master
+mysqlclient<2.1.0

--- a/requirements/edx-sandbox/py38.txt
+++ b/requirements/edx-sandbox/py38.txt
@@ -16,7 +16,7 @@ click==7.1.2
     # via
     #   -c requirements/edx-sandbox/../constraints.txt
     #   nltk
-cryptography==35.0.0
+cryptography==36.0.0
     # via -r requirements/edx-sandbox/py38.in
 cycler==0.11.0
     # via matplotlib

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -139,7 +139,7 @@ coreschema==0.0.4
     #   drf-yasg
 crowdsourcehinter-xblock==0.6
     # via -r requirements/edx/base.in
-cryptography==35.0.0
+cryptography==36.0.0
     # via
     #   -r requirements/edx/base.in
     #   django-fernet-fields
@@ -326,7 +326,7 @@ django-sekizai==2.0.0
     # via
     #   -r requirements/edx/base.in
     #   django-wiki
-django-ses==2.3.0
+django-ses==2.3.1
     # via -r requirements/edx/base.in
 django-simple-history==3.0.0
     # via
@@ -483,7 +483,7 @@ edx-search==3.1.0
     # via -r requirements/edx/base.in
 edx-sga==0.17.2
     # via -r requirements/edx/base.in
-edx-submissions==3.4.0
+edx-submissions==3.4.1
     # via
     #   -r requirements/edx/base.in
     #   ora2
@@ -539,7 +539,7 @@ future==0.18.2
     #   edx-celeryutils
     #   edx-enterprise
     #   pyjwkest
-geoip2==4.4.0
+geoip2==4.5.0
     # via -r requirements/edx/base.in
 glob2==0.7
     # via -r requirements/edx/base.in
@@ -558,6 +558,8 @@ idna==3.3
     #   -r requirements/edx/paver.txt
     #   requests
     #   yarl
+importlib-metadata==4.8.2
+    # via markdown
 inflection==0.5.1
     # via drf-yasg
 interchange==2021.0.4
@@ -607,7 +609,7 @@ libsass==0.10.0
     #   ora2
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==3.1.1
+lti-consumer-xblock==3.1.2
     # via -r requirements/edx/base.in
 lxml==4.5.0
     # via
@@ -622,14 +624,14 @@ lxml==4.5.0
     #   xmlsec
 mailsnake==1.6.4
     # via -r requirements/edx/base.in
-mako==1.1.5
+mako==1.1.6
     # via
     #   -r requirements/edx/base.in
     #   acid-xblock
     #   lti-consumer-xblock
     #   xblock-google-drive
     #   xblock-utils
-markdown==3.3.4
+markdown==3.3.6
     # via
     #   -r requirements/edx/base.in
     #   django-wiki
@@ -666,7 +668,9 @@ multidict==5.2.0
     #   aiohttp
     #   yarl
 mysqlclient==2.0.3
-    # via -r requirements/edx/base.in
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   -r requirements/edx/base.in
 newrelic==7.2.4.171
     # via
     #   -r requirements/edx/base.in
@@ -696,7 +700,7 @@ openedx-events==0.6.0
     # via -r requirements/edx/base.in
 ora2==3.7.4
     # via -r requirements/edx/base.in
-packaging==21.2
+packaging==21.3
     # via
     #   bleach
     #   drf-yasg
@@ -716,7 +720,7 @@ path.py==12.5.0
     #   xmodule
 paver==1.3.4
     # via -r requirements/edx/paver.txt
-pbr==5.7.0
+pbr==5.8.0
     # via
     #   -r requirements/edx/paver.txt
     #   stevedore
@@ -781,7 +785,7 @@ pymongo==3.10.1
     #   mongoengine
 pynliner==0.8.0
     # via -r requirements/edx/base.in
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via
     #   chem
     #   openedx-calc
@@ -854,7 +858,7 @@ random2==1.0.1
     # via -r requirements/edx/base.in
 recommender-xblock==2.0.1
     # via -r requirements/edx/base.in
-redis==4.0.0
+redis==4.0.2
     # via -r requirements/edx/base.in
 regex==2021.11.10
     # via nltk
@@ -903,7 +907,7 @@ semantic-version==2.8.5
     # via edx-drf-extensions
 shapely==1.8.0
     # via -r requirements/edx/base.in
-simplejson==3.17.5
+simplejson==3.17.6
     # via
     #   -r requirements/edx/base.in
     #   sailthru-client
@@ -1079,6 +1083,8 @@ xss-utils==0.3.0
     # via -r requirements/edx/base.in
 yarl==1.7.2
     # via aiohttp
+zipp==3.6.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -54,7 +54,7 @@ aniso8601==9.0.1
     # via
     #   -r requirements/edx/testing.txt
     #   edx-tincan-py35
-anyio==3.3.4
+anyio==3.4.0
     # via
     #   -r requirements/edx/testing.txt
     #   starlette
@@ -67,7 +67,7 @@ asgiref==3.4.1
     #   -r requirements/edx/testing.txt
     #   django
     #   uvicorn
-astroid==2.8.5
+astroid==2.8.6
     # via
     #   -r requirements/edx/testing.txt
     #   pylint
@@ -205,7 +205,7 @@ coverage[toml]==6.1.2
     #   pytest-cov
 crowdsourcehinter-xblock==0.6
     # via -r requirements/edx/testing.txt
-cryptography==35.0.0
+cryptography==36.0.0
     # via
     #   -r requirements/edx/testing.txt
     #   django-fernet-fields
@@ -421,7 +421,7 @@ django-sekizai==2.0.0
     # via
     #   -r requirements/edx/testing.txt
     #   django-wiki
-django-ses==2.3.0
+django-ses==2.3.1
     # via -r requirements/edx/testing.txt
 django-simple-history==3.0.0
     # via
@@ -597,7 +597,7 @@ edx-sga==0.17.2
     # via -r requirements/edx/testing.txt
 edx-sphinx-theme==3.0.0
     # via -r requirements/edx/development.in
-edx-submissions==3.4.0
+edx-submissions==3.4.1
     # via
     #   -r requirements/edx/testing.txt
     #   ora2
@@ -644,7 +644,7 @@ execnet==1.9.0
     #   pytest-xdist
 factory-boy==3.2.1
     # via -r requirements/edx/testing.txt
-faker==9.8.2
+faker==9.8.3
     # via
     #   -r requirements/edx/testing.txt
     #   factory-boy
@@ -652,7 +652,7 @@ fastapi==0.70.0
     # via
     #   -r requirements/edx/testing.txt
     #   pact-python
-filelock==3.3.2
+filelock==3.4.0
     # via
     #   -r requirements/edx/testing.txt
     #   tox
@@ -683,7 +683,7 @@ future==0.18.2
     #   edx-celeryutils
     #   edx-enterprise
     #   pyjwkest
-geoip2==4.4.0
+geoip2==4.5.0
     # via -r requirements/edx/testing.txt
 gitdb==4.0.9
     # via
@@ -724,6 +724,7 @@ imagesize==1.3.0
 importlib-metadata==4.8.2
     # via
     #   -r requirements/edx/testing.txt
+    #   markdown
     #   pytest-randomly
 importlib-resources==5.4.0
     # via jsonschema
@@ -822,7 +823,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/testing.txt
     #   ora2
-lti-consumer-xblock==3.1.1
+lti-consumer-xblock==3.1.2
     # via -r requirements/edx/testing.txt
 lxml==4.5.0
     # via
@@ -840,14 +841,14 @@ m2r==0.2.1
     # via sphinxcontrib-openapi
 mailsnake==1.6.4
     # via -r requirements/edx/testing.txt
-mako==1.1.5
+mako==1.1.6
     # via
     #   -r requirements/edx/testing.txt
     #   acid-xblock
     #   lti-consumer-xblock
     #   xblock-google-drive
     #   xblock-utils
-markdown==3.3.4
+markdown==3.3.6
     # via
     #   -r requirements/edx/testing.txt
     #   django-wiki
@@ -902,7 +903,9 @@ mypy==0.910
 mypy-extensions==0.4.3
     # via mypy
 mysqlclient==2.0.3
-    # via -r requirements/edx/testing.txt
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   -r requirements/edx/testing.txt
 newrelic==7.2.4.171
     # via
     #   -r requirements/edx/testing.txt
@@ -933,7 +936,7 @@ openedx-events==0.6.0
     # via -r requirements/edx/testing.txt
 ora2==3.7.4
     # via -r requirements/edx/testing.txt
-packaging==21.2
+packaging==21.3
     # via
     #   -r requirements/edx/testing.txt
     #   bleach
@@ -962,7 +965,7 @@ path.py==12.5.0
     #   xmodule
 paver==1.3.4
     # via -r requirements/edx/testing.txt
-pbr==5.7.0
+pbr==5.8.0
     # via
     #   -r requirements/edx/testing.txt
     #   stevedore
@@ -1088,7 +1091,7 @@ pymongo==3.10.1
     #   mongoengine
 pynliner==0.8.0
     # via -r requirements/edx/testing.txt
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via
     #   -r requirements/edx/testing.txt
     #   chem
@@ -1207,7 +1210,7 @@ random2==1.0.1
     # via -r requirements/edx/testing.txt
 recommender-xblock==2.0.1
     # via -r requirements/edx/testing.txt
-redis==4.0.0
+redis==4.0.2
     # via -r requirements/edx/testing.txt
 regex==2021.11.10
     # via
@@ -1276,7 +1279,7 @@ semantic-version==2.8.5
     #   edx-drf-extensions
 shapely==1.8.0
     # via -r requirements/edx/testing.txt
-simplejson==3.17.5
+simplejson==3.17.6
     # via
     #   -r requirements/edx/testing.txt
     #   sailthru-client
@@ -1340,7 +1343,7 @@ sniffio==1.2.0
     # via
     #   -r requirements/edx/testing.txt
     #   anyio
-snowballstemmer==2.1.0
+snowballstemmer==2.2.0
     # via sphinx
 social-auth-app-django==5.0.0
     # via

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -38,13 +38,13 @@ jinja2==3.0.3
     #   sphinx
 markupsafe==2.0.1
     # via jinja2
-packaging==21.2
+packaging==21.3
     # via sphinx
-pbr==5.7.0
+pbr==5.8.0
     # via stevedore
 pygments==2.10.0
     # via sphinx
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via packaging
 python-slugify==4.0.1
     # via
@@ -60,7 +60,7 @@ six==1.16.0
     # via edx-sphinx-theme
 smmap==5.0.0
     # via gitdb
-snowballstemmer==2.1.0
+snowballstemmer==2.2.0
     # via sphinx
 sphinx==4.3.0
     # via

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -24,7 +24,7 @@ path==16.2.0
     # via -r requirements/edx/paver.in
 paver==1.3.4
     # via -r requirements/edx/paver.in
-pbr==5.7.0
+pbr==5.8.0
     # via stevedore
 psutil==5.8.0
     # via -r requirements/edx/paver.in

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -52,7 +52,7 @@ aniso8601==9.0.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-tincan-py35
-anyio==3.3.4
+anyio==3.4.0
     # via starlette
 appdirs==1.4.4
     # via
@@ -63,7 +63,7 @@ asgiref==3.4.1
     #   -r requirements/edx/base.txt
     #   django
     #   uvicorn
-astroid==2.8.5
+astroid==2.8.6
     # via
     #   pylint
     #   pylint-celery
@@ -194,7 +194,7 @@ coverage[toml]==6.1.2
     #   pytest-cov
 crowdsourcehinter-xblock==0.6
     # via -r requirements/edx/base.txt
-cryptography==35.0.0
+cryptography==36.0.0
     # via
     #   -r requirements/edx/base.txt
     #   django-fernet-fields
@@ -405,7 +405,7 @@ django-sekizai==2.0.0
     # via
     #   -r requirements/edx/base.txt
     #   django-wiki
-django-ses==2.3.0
+django-ses==2.3.1
     # via -r requirements/edx/base.txt
 django-simple-history==3.0.0
     # via
@@ -578,7 +578,7 @@ edx-search==3.1.0
     # via -r requirements/edx/base.txt
 edx-sga==0.17.2
     # via -r requirements/edx/base.txt
-edx-submissions==3.4.0
+edx-submissions==3.4.1
     # via
     #   -r requirements/edx/base.txt
     #   ora2
@@ -623,11 +623,11 @@ execnet==1.9.0
     # via pytest-xdist
 factory-boy==3.2.1
     # via -r requirements/edx/testing.in
-faker==9.8.2
+faker==9.8.3
     # via factory-boy
 fastapi==0.70.0
     # via pact-python
-filelock==3.3.2
+filelock==3.4.0
     # via
     #   tox
     #   virtualenv
@@ -657,7 +657,7 @@ future==0.18.2
     #   edx-celeryutils
     #   edx-enterprise
     #   pyjwkest
-geoip2==4.4.0
+geoip2==4.5.0
     # via -r requirements/edx/base.txt
 gitdb==4.0.9
     # via gitpython
@@ -688,7 +688,10 @@ idna==3.3
     #   requests
     #   yarl
 importlib-metadata==4.8.2
-    # via pytest-randomly
+    # via
+    #   -r requirements/edx/base.txt
+    #   markdown
+    #   pytest-randomly
 inflect==5.3.0
     # via
     #   -r requirements/edx/coverage.txt
@@ -778,7 +781,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==3.1.1
+lti-consumer-xblock==3.1.2
     # via -r requirements/edx/base.txt
 lxml==4.5.0
     # via
@@ -794,14 +797,14 @@ lxml==4.5.0
     #   xmlsec
 mailsnake==1.6.4
     # via -r requirements/edx/base.txt
-mako==1.1.5
+mako==1.1.6
     # via
     #   -r requirements/edx/base.txt
     #   acid-xblock
     #   lti-consumer-xblock
     #   xblock-google-drive
     #   xblock-utils
-markdown==3.3.4
+markdown==3.3.6
     # via
     #   -r requirements/edx/base.txt
     #   django-wiki
@@ -849,7 +852,9 @@ multidict==5.2.0
     #   aiohttp
     #   yarl
 mysqlclient==2.0.3
-    # via -r requirements/edx/base.txt
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   -r requirements/edx/base.txt
 newrelic==7.2.4.171
     # via
     #   -r requirements/edx/base.txt
@@ -880,7 +885,7 @@ openedx-events==0.6.0
     # via -r requirements/edx/base.txt
 ora2==3.7.4
     # via -r requirements/edx/base.txt
-packaging==21.2
+packaging==21.3
     # via
     #   -r requirements/edx/base.txt
     #   bleach
@@ -908,7 +913,7 @@ path.py==12.5.0
     #   xmodule
 paver==1.3.4
     # via -r requirements/edx/base.txt
-pbr==5.7.0
+pbr==5.8.0
     # via
     #   -r requirements/edx/base.txt
     #   stevedore
@@ -1019,7 +1024,7 @@ pymongo==3.10.1
     #   mongoengine
 pynliner==0.8.0
     # via -r requirements/edx/base.txt
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via
     #   -r requirements/edx/base.txt
     #   chem
@@ -1131,7 +1136,7 @@ random2==1.0.1
     # via -r requirements/edx/base.txt
 recommender-xblock==2.0.1
     # via -r requirements/edx/base.txt
-redis==4.0.0
+redis==4.0.2
     # via -r requirements/edx/base.txt
 regex==2021.11.10
     # via
@@ -1199,7 +1204,7 @@ semantic-version==2.8.5
     #   edx-drf-extensions
 shapely==1.8.0
     # via -r requirements/edx/base.txt
-simplejson==3.17.5
+simplejson==3.17.6
     # via
     #   -r requirements/edx/base.txt
     #   sailthru-client
@@ -1446,7 +1451,9 @@ yarl==1.7.2
     #   -r requirements/edx/base.txt
     #   aiohttp
 zipp==3.6.0
-    # via importlib-metadata
+    # via
+    #   -r requirements/edx/base.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
## Description
- `mysqlclient==2.1.0` caused [NameError](https://github.com/edx/edx-platform/runs/4300661682?check_suite_focus=true) in running pylint checks on master and on all the PRs. Package upgrade was reverted in  https://github.com/edx/edx-platform/pull/29404.
- Now pinning `mysqlclient<2.1.0` so it doesn't get upgraded again without proper testing and fix for the failure.