### PR TITLE
fix: (MICROBA-1594) fix certificate generation logic for enrollment modes that don't require IDV but are cert eligible

### DIFF
--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -2081,7 +2081,7 @@ class TestCertificateGeneration(InstructorTaskModuleTestCase):
             'failed': 0,
             'skipped': 2
         }
-        with self.assertNumQueries(77):
+        with self.assertNumQueries(82):
             self.assertCertificatesGenerated(task_input, expected_results)
 
     @ddt.data(


### PR DESCRIPTION
## Description

[MICROBA-1594]

* Update course certificate generation logic when ID verification fails to check if the enrollment mode requires IDV.

This change fixes an issue where Honor certificates could not be generated in an Open edX installation unless a manual IDV override was added for the student.## Supporting information.

[MICROBA-1594]: https://openedx.atlassian.net/browse/MICROBA-1594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ