### PR TITLE
chore: Applied lint-amnesty on cms

### DIFF
--- a/cms/conftest.py
+++ b/cms/conftest.py
@@ -16,7 +16,7 @@ import pytest
 from openedx.core.pytest_hooks import DeferPlugin
 
 # Patch the xml libs before anything else.
-from safe_lxml import defuse_xml_libs  # isort:skip
+from safe_lxml import defuse_xml_libs  # isort:skip  # lint-amnesty, pylint: disable=wrong-import-order
 defuse_xml_libs()
 
 

--- a/cms/envs/bok_choy.py
+++ b/cms/envs/bok_choy.py
@@ -19,7 +19,7 @@ from django.utils.translation import gettext_lazy
 from path import Path as path
 
 from openedx.core.release import RELEASE_LINE
-from xmodule.modulestore.modulestore_settings import update_module_store_settings
+from xmodule.modulestore.modulestore_settings import update_module_store_settings  # lint-amnesty, pylint: disable=wrong-import-order
 
 ########################## Prod-like settings ###################################
 # These should be as close as possible to the settings we use in production.

--- a/cms/lib/xblock/tagging/tagging.py
+++ b/cms/lib/xblock/tagging/tagging.py
@@ -8,8 +8,8 @@ from xblock.core import XBlock, XBlockAside
 from xblock.fields import Dict, Scope
 
 from common.djangoapps.edxmako.shortcuts import render_to_string
-from xmodule.capa_module import ProblemBlock
-from xmodule.x_module import AUTHOR_VIEW
+from xmodule.capa_module import ProblemBlock  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.x_module import AUTHOR_VIEW  # lint-amnesty, pylint: disable=wrong-import-order
 
 _ = lambda text: text
 

--- a/cms/lib/xblock/tagging/test.py
+++ b/cms/lib/xblock/tagging/test.py
@@ -23,10 +23,10 @@ from cms.djangoapps.xblock_config.models import StudioConfig
 from cms.lib.xblock.tagging import StructuredTagsAside
 from cms.lib.xblock.tagging.models import TagAvailableValues, TagCategories
 from common.djangoapps.student.tests.factories import UserFactory
-from xmodule.modulestore import ModuleStoreEnum
-from xmodule.modulestore.django import modulestore
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 
 @ddt.ddt

--- a/cms/lib/xblock/test/test_authoring_mixin.py
+++ b/cms/lib/xblock/test/test_authoring_mixin.py
@@ -9,9 +9,9 @@ from xblock.core import XBlock
 
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
 from common.lib.xmodule.xmodule.tests.test_export import PureXBlock
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
-from xmodule.partitions.partitions import (
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.partitions.partitions import (  # lint-amnesty, pylint: disable=wrong-import-order
     ENROLLMENT_TRACK_PARTITION_ID,
     MINIMUM_STATIC_PARTITION_ID,
     Group,


### PR DESCRIPTION
Applied lint-amnesty on cms/{envs, lib, contest.py} to suppress wrong-import-order warnings

JIRA: https://openedx.atlassian.net/browse/BOM-3077