### PR TITLE
chore: Applied lint-amnesty on cms/djangoapps

### DIFF
--- a/cms/djangoapps/api/v1/serializers/course_runs.py
+++ b/cms/djangoapps/api/v1/serializers/course_runs.py
@@ -12,7 +12,7 @@ from cms.djangoapps.contentstore.views.assets import update_course_run_asset
 from cms.djangoapps.contentstore.views.course import create_new_course, get_course_and_check_access, rerun_course
 from common.djangoapps.student.models import CourseAccessRole
 from openedx.core.lib.courses import course_image_url
-from xmodule.modulestore.django import modulestore
+from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 
 IMAGE_TYPES = {
     'image/jpeg': 'jpg',

--- a/cms/djangoapps/api/v1/tests/test_serializers/test_course_runs.py
+++ b/cms/djangoapps/api/v1/tests/test_serializers/test_course_runs.py
@@ -10,8 +10,8 @@ from django.test import RequestFactory
 from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole
 from common.djangoapps.student.tests.factories import UserFactory
 from openedx.core.lib.courses import course_image_url
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 from ...serializers.course_runs import CourseRunSerializer
 from ..utils import serialize_datetime

--- a/cms/djangoapps/api/v1/tests/test_views/test_course_runs.py
+++ b/cms/djangoapps/api/v1/tests/test_views/test_course_runs.py
@@ -16,12 +16,12 @@ from rest_framework.test import APIClient
 from common.djangoapps.student.models import CourseAccessRole
 from common.djangoapps.student.tests.factories import TEST_PASSWORD, AdminFactory, UserFactory
 from openedx.core.lib.courses import course_image_url
-from xmodule.contentstore.content import StaticContent
-from xmodule.contentstore.django import contentstore
-from xmodule.exceptions import NotFoundError
-from xmodule.modulestore.django import modulestore
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ToyCourseFactory
+from xmodule.contentstore.content import StaticContent  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.contentstore.django import contentstore  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.exceptions import NotFoundError  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, ToyCourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 from ...serializers.course_runs import CourseRunSerializer
 from ..utils import serialize_datetime

--- a/cms/djangoapps/maintenance/tests.py
+++ b/cms/djangoapps/maintenance/tests.py
@@ -12,10 +12,10 @@ from django.urls import reverse
 from cms.djangoapps.contentstore.management.commands.utils import get_course_versions
 from common.djangoapps.student.tests.factories import AdminFactory, UserFactory
 from openedx.features.announcements.models import Announcement
-from xmodule.modulestore import ModuleStoreEnum
-from xmodule.modulestore.django import modulestore
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 from .views import COURSE_KEY_ERROR_MESSAGES, MAINTENANCE_VIEWS
 

--- a/cms/djangoapps/maintenance/views.py
+++ b/cms/djangoapps/maintenance/views.py
@@ -22,9 +22,9 @@ from common.djangoapps.util.json_request import JsonResponse
 from common.djangoapps.util.views import require_global_staff
 from openedx.features.announcements.forms import AnnouncementForm
 from openedx.features.announcements.models import Announcement
-from xmodule.modulestore import ModuleStoreEnum
-from xmodule.modulestore.django import modulestore
-from xmodule.modulestore.exceptions import ItemNotFoundError
+from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.exceptions import ItemNotFoundError  # lint-amnesty, pylint: disable=wrong-import-order
 
 log = logging.getLogger(__name__)
 

--- a/cms/djangoapps/models/settings/course_grading.py
+++ b/cms/djangoapps/models/settings/course_grading.py
@@ -12,7 +12,7 @@ from eventtracking import tracker
 from cms.djangoapps.contentstore.signals.signals import GRADING_POLICY_CHANGED
 from cms.djangoapps.models.settings.waffle import material_recompute_only
 from common.djangoapps.track.event_transaction_utils import create_new_event_transaction_id
-from xmodule.modulestore.django import modulestore
+from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 
 log = logging.getLogger(__name__)
 

--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -17,8 +17,8 @@ from common.djangoapps.xblock_django.models import XBlockStudioConfigurationFlag
 from openedx.core.djangoapps.discussions.config.waffle_utils import legacy_discussion_experience_enabled
 from openedx.core.lib.teams_config import TeamsetType
 from openedx.features.course_experience import COURSE_ENABLE_UNENROLLED_ACCESS_FLAG
-from xmodule.modulestore.django import modulestore
-from xmodule.modulestore.exceptions import InvalidProctoringProvider
+from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.exceptions import InvalidProctoringProvider  # lint-amnesty, pylint: disable=wrong-import-order
 
 LOGGER = logging.getLogger(__name__)
 

--- a/cms/djangoapps/models/settings/encoder.py
+++ b/cms/djangoapps/models/settings/encoder.py
@@ -10,7 +10,7 @@ from json.encoder import JSONEncoder
 from opaque_keys.edx.locations import Location
 
 from openedx.core.djangoapps.models.course_details import CourseDetails
-from xmodule.fields import Date
+from xmodule.fields import Date  # lint-amnesty, pylint: disable=wrong-import-order
 
 from .course_grading import CourseGradingModel
 

--- a/cms/djangoapps/xblock_config/apps.py
+++ b/cms/djangoapps/xblock_config/apps.py
@@ -6,7 +6,7 @@ xblock_config Application Configuration
 from django.apps import AppConfig
 
 import cms.lib.xblock.runtime
-import xmodule.x_module
+import xmodule.x_module  # lint-amnesty, pylint: disable=wrong-import-order
 
 
 class XBlockConfig(AppConfig):


### PR DESCRIPTION
Applied lint-amnesty on following cms djangoapps to suppress wrong-import-order warnings:

- api
- maintenance
- models
- xblock_config

JIRA: https://openedx.atlassian.net/browse/BOM-3075