### PR TITLE
chore: Applied lint-amnesty on openedx/core/djangoapps

### DIFF
--- a/openedx/core/djangoapps/site_configuration/context_processors.py
+++ b/openedx/core/djangoapps/site_configuration/context_processors.py
@@ -4,7 +4,7 @@ Django template context processors.
 
 
 from django.conf import settings
-from urllib.parse import quote_plus
+from urllib.parse import quote_plus  # lint-amnesty, pylint: disable=wrong-import-order
 
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
@@ -74,8 +74,8 @@ from common.djangoapps.student.tests.factories import (
     SuperuserFactory,
     UserFactory
 )
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 from ...tests.factories import UserOrgTagFactory
 from ..views import USER_PROFILE_PII, AccountRetirementView

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_utils.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_utils.py
@@ -11,8 +11,8 @@ from openedx.core.djangoapps.user_api.accounts.utils import retrieve_last_sitewi
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import UserFactory
-from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 from ..utils import format_social_link, validate_social_link
 

--- a/openedx/core/djangoapps/user_api/accounts/utils.py
+++ b/openedx/core/djangoapps/user_api/accounts/utils.py
@@ -17,8 +17,8 @@ from common.djangoapps.student.models import AccountRecovery, Registration, get_
 from openedx.core.djangolib.oauth2_retirement_utils import retire_dot_oauth2_models
 from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
 from openedx.core.djangoapps.theming.helpers import get_config_value_from_site_or_settings, get_current_site
-from xmodule.modulestore.django import modulestore
-from xmodule.modulestore.exceptions import ItemNotFoundError
+from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.exceptions import ItemNotFoundError  # lint-amnesty, pylint: disable=wrong-import-order
 
 from ..models import UserRetirementStatus
 

--- a/openedx/core/djangoapps/user_api/management/commands/cancel_user_retirement_request.py
+++ b/openedx/core/djangoapps/user_api/management/commands/cancel_user_retirement_request.py
@@ -11,7 +11,7 @@ from django.core.management.base import BaseCommand, CommandError
 
 from openedx.core.djangoapps.user_api.models import UserRetirementStatus
 
-from edx_django_utils.user import generate_password
+from edx_django_utils.user import generate_password  # lint-amnesty, pylint: disable=wrong-import-order
 
 LOGGER = logging.getLogger(__name__)
 

--- a/openedx/core/djangoapps/user_api/management/tests/test_email_opt_in_list.py
+++ b/openedx/core/djangoapps/user_api/management/tests/test_email_opt_in_list.py
@@ -18,8 +18,8 @@ from openedx.core.djangoapps.user_api.preferences.api import update_email_opt_in
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 
 @ddt.ddt

--- a/openedx/core/djangoapps/user_api/partition_schemes.py
+++ b/openedx/core/djangoapps/user_api/partition_schemes.py
@@ -9,7 +9,7 @@ import random
 from eventtracking import tracker
 
 import openedx.core.djangoapps.user_api.course_tag.api as course_tag_api
-from xmodule.partitions.partitions import NoSuchUserPartitionGroupError, UserPartitionError
+from xmodule.partitions.partitions import NoSuchUserPartitionGroupError, UserPartitionError  # lint-amnesty, pylint: disable=wrong-import-order
 
 log = logging.getLogger(__name__)
 

--- a/openedx/core/djangoapps/user_api/preferences/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/preferences/tests/test_api.py
@@ -17,8 +17,8 @@ from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_un
 from openedx.core.lib.time_zone_utils import get_display_time_zone
 from common.djangoapps.student.models import UserProfile
 from common.djangoapps.student.tests.factories import UserFactory
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 from ...errors import (  # lint-amnesty, pylint: disable=unused-import
     CountryCodeError,

--- a/openedx/core/djangoapps/user_api/tests/test_models.py
+++ b/openedx/core/djangoapps/user_api/tests/test_models.py
@@ -8,8 +8,8 @@ from django.test import TestCase
 
 from common.djangoapps.student.tests.factories import UserFactory
 from common.djangoapps.student.tests.tests import UserSettingsEventTestMixin
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 from ..models import UserOrgTag, UserPreference
 from ..preferences.api import set_user_preference

--- a/openedx/core/djangoapps/user_api/tests/test_partition_schemes.py
+++ b/openedx/core/djangoapps/user_api/tests/test_partition_schemes.py
@@ -11,8 +11,8 @@ from django.test import TestCase
 
 from openedx.core.djangoapps.user_api.partition_schemes import RandomUserPartitionScheme, UserPartitionError
 from common.djangoapps.student.tests.factories import UserFactory
-from xmodule.partitions.partitions import Group, UserPartition
-from xmodule.partitions.tests.test_partitions import PartitionTestCase
+from xmodule.partitions.partitions import Group, UserPartition  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.partitions.tests.test_partitions import PartitionTestCase  # lint-amnesty, pylint: disable=wrong-import-order
 
 
 class MemoryCourseTagAPI:

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -12,8 +12,8 @@ from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_un
 from openedx.core.lib.api.test_utils import TEST_API_KEY, ApiTestCase
 from openedx.core.lib.time_zone_utils import get_display_time_zone
 from common.djangoapps.student.tests.factories import UserFactory
-from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 from ..accounts.tests.retirement_helpers import (  # pylint: disable=unused-import
     RetirementTestCase,

--- a/openedx/core/djangoapps/user_authn/tests/test_tasks.py
+++ b/openedx/core/djangoapps/user_authn/tests/test_tasks.py
@@ -6,7 +6,7 @@ Tests for the Sending activation email celery tasks
 from django.conf import settings
 from django.test import TestCase
 from edx_ace.errors import ChannelError, RecoverableChannelDeliveryError
-from unittest import mock
+from unittest import mock  # lint-amnesty, pylint: disable=wrong-import-order
 
 from common.djangoapps.student.models import Registration
 from common.djangoapps.student.views.management import compose_activation_email, compose_and_send_activation_email

--- a/openedx/core/djangoapps/user_authn/views/auto_auth.py
+++ b/openedx/core/djangoapps/user_authn/views/auto_auth.py
@@ -36,7 +36,7 @@ from common.djangoapps.student.models import (
 )
 from common.djangoapps.util.json_request import JsonResponse
 
-from edx_django_utils.user import generate_password
+from edx_django_utils.user import generate_password  # lint-amnesty, pylint: disable=wrong-import-order
 
 
 def auto_auth(request):  # pylint: disable=too-many-statements

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -84,7 +84,7 @@ from common.djangoapps.track import segment
 from common.djangoapps.util.db import outer_atomic
 from common.djangoapps.util.json_request import JsonResponse
 
-from edx_django_utils.user import generate_password
+from edx_django_utils.user import generate_password  # lint-amnesty, pylint: disable=wrong-import-order
 
 log = logging.getLogger("edx.student")
 AUDIT_LOG = logging.getLogger("audit")

--- a/openedx/core/djangoapps/user_authn/views/tests/test_auto_auth.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_auto_auth.py
@@ -20,7 +20,7 @@ from openedx.core.djangoapps.django_comment_common.models import (
     Role
 )
 from openedx.core.djangoapps.django_comment_common.utils import seed_permissions_roles
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
 
 
 class AutoAuthTestCase(UrlResetMixin, TestCase):

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -21,7 +21,7 @@ from django.urls import NoReverseMatch, reverse
 from edx_toggles.toggles.testutils import override_waffle_flag, override_waffle_switch
 from freezegun import freeze_time
 from common.djangoapps.student.tests.factories import RegistrationFactory, UserFactory, UserProfileFactory
-from openedx_events.tests.utils import OpenEdxEventsTestMixin
+from openedx_events.tests.utils import OpenEdxEventsTestMixin  # lint-amnesty, pylint: disable=wrong-import-order
 
 from openedx.core.djangoapps.password_policy.compliance import (
     NonCompliantPasswordException,

--- a/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
@@ -35,7 +35,7 @@ from openedx.core.djangolib.markup import HTML, Text
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 from common.djangoapps.third_party_auth.tests.testutil import ThirdPartyAuthTestMixin, simulate_running_pipeline
 from common.djangoapps.util.testing import UrlResetMixin
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
 
 
 @skip_unless_lms

--- a/openedx/core/djangoapps/util/testing.py
+++ b/openedx/core/djangoapps/util/testing.py
@@ -12,9 +12,9 @@ from openedx.core.djangoapps.django_comment_common.utils import seed_permissions
 from openedx.core.djangoapps.user_api.tests.factories import UserCourseTagFactory
 from openedx.core.lib.teams_config import TeamsConfig
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
-from xmodule.partitions.partitions import Group, UserPartition
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.partitions.partitions import Group, UserPartition  # lint-amnesty, pylint: disable=wrong-import-order
 
 
 class ContentGroupTestCase(ModuleStoreTestCase):


### PR DESCRIPTION
Applied lint amnesty on following openedx djangoapps to suppress wrong-import-order warning:

- site_configuration
- user_api
- user_authn
- util

JIRA: https://openedx.atlassian.net/browse/BOM-3084