### PR TITLE
chore: Applied lint-amnesty on openedx/core/djangoapps

### DIFF
--- a/openedx/core/djangoapps/contentserver/middleware.py
+++ b/openedx/core/djangoapps/contentserver/middleware.py
@@ -20,11 +20,11 @@ from opaque_keys.edx.locator import AssetLocator
 
 from openedx.core.djangoapps.header_control import force_header_for_response
 from common.djangoapps.student.models import CourseEnrollment
-from xmodule.assetstore.assetmgr import AssetManager
-from xmodule.contentstore.content import XASSET_LOCATION_TAG, StaticContent
-from xmodule.exceptions import NotFoundError
-from xmodule.modulestore import InvalidLocationError
-from xmodule.modulestore.exceptions import ItemNotFoundError
+from xmodule.assetstore.assetmgr import AssetManager  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.contentstore.content import XASSET_LOCATION_TAG, StaticContent  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.exceptions import NotFoundError  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore import InvalidLocationError  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.exceptions import ItemNotFoundError  # lint-amnesty, pylint: disable=wrong-import-order
 
 from .caching import get_cached_content, set_cached_content
 from .models import CdnUserAgentsConfig, CourseAssetCacheTtlConfig

--- a/openedx/core/djangoapps/course_apps/tests/test_notes_app.py
+++ b/openedx/core/djangoapps/course_apps/tests/test_notes_app.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from lms.djangoapps.edxnotes.plugins import EdxNotesCourseApp
 from openedx.core.djangoapps.course_apps.tests.utils import TabBasedCourseAppTestMixin
 from openedx.core.djangolib.testing.utils import skip_unless_cms
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
 
 
 @skip_unless_cms

--- a/openedx/core/djangoapps/course_apps/tests/test_proctoring_app.py
+++ b/openedx/core/djangoapps/course_apps/tests/test_proctoring_app.py
@@ -8,8 +8,8 @@ from django.conf import settings
 
 from lms.djangoapps.courseware.plugins import ProctoringCourseApp
 from openedx.core.djangolib.testing.utils import skip_unless_cms
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, CourseUserType
-from xmodule.modulestore.tests.factories import CourseFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, CourseUserType  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 
 @skip_unless_cms

--- a/openedx/core/djangoapps/course_apps/tests/test_wiki_app.py
+++ b/openedx/core/djangoapps/course_apps/tests/test_wiki_app.py
@@ -5,7 +5,7 @@ Tests for wiki course app.
 from lms.djangoapps.course_wiki.plugins.course_app import WikiCourseApp
 from openedx.core.djangoapps.course_apps.tests.utils import TabBasedCourseAppTestMixin
 from openedx.core.djangolib.testing.utils import skip_unless_cms
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
 
 
 @skip_unless_cms

--- a/openedx/core/djangoapps/course_apps/tests/utils.py
+++ b/openedx/core/djangoapps/course_apps/tests/utils.py
@@ -8,8 +8,8 @@ from opaque_keys.edx.keys import CourseKey
 from common.djangoapps.student.tests.factories import AdminFactory, CourseEnrollmentFactory, UserFactory
 from openedx.core.djangoapps.course_apps.plugins import CourseApp
 from openedx.core.djangolib.testing.utils import skip_unless_cms
-from xmodule.modulestore.django import modulestore
-from xmodule.modulestore.tests.factories import CourseFactory
+from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 
 def make_test_course_app(

--- a/openedx/core/djangoapps/course_date_signals/handlers.py
+++ b/openedx/core/djangoapps/course_date_signals/handlers.py
@@ -10,9 +10,9 @@ from xblock.fields import Scope
 
 from cms.djangoapps.contentstore.config.waffle import CUSTOM_RELATIVE_DATES
 from openedx.core.lib.graph_traversals import get_children, leaf_filter, traverse_pre_order
-from xmodule.modulestore import ModuleStoreEnum
-from xmodule.modulestore.django import SignalHandler, modulestore
-from xmodule.util.misc import is_xblock_an_assignment
+from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.django import SignalHandler, modulestore  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.util.misc import is_xblock_an_assignment  # lint-amnesty, pylint: disable=wrong-import-order
 
 from .models import SelfPacedRelativeDatesConfig
 from .utils import spaced_out_sections

--- a/openedx/core/djangoapps/course_date_signals/tests.py
+++ b/openedx/core/djangoapps/course_date_signals/tests.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 from unittest.mock import patch  # lint-amnesty, pylint: disable=wrong-import-order
 
 from cms.djangoapps.contentstore.config.waffle import CUSTOM_RELATIVE_DATES
-from edx_toggles.toggles.testutils import override_waffle_flag
+from edx_toggles.toggles.testutils import override_waffle_flag  # lint-amnesty, pylint: disable=wrong-import-order
 from openedx.core.djangoapps.course_date_signals.handlers import (
     _gather_graded_items,
     _get_custom_pacing_children,
@@ -11,8 +11,8 @@ from openedx.core.djangoapps.course_date_signals.handlers import (
     extract_dates_from_course
 )
 from openedx.core.djangoapps.course_date_signals.models import SelfPacedRelativeDatesConfig
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
 from . import utils
 
 

--- a/openedx/core/djangoapps/course_groups/models.py
+++ b/openedx/core/djangoapps/course_groups/models.py
@@ -16,8 +16,8 @@ from opaque_keys.edx.django.models import CourseKeyField
 
 from openedx.core.djangolib.model_mixins import DeletableByUserValue
 
-from openedx_events.learning.data import CohortData, CourseData, UserData, UserPersonalData
-from openedx_events.learning.signals import COHORT_MEMBERSHIP_CHANGED
+from openedx_events.learning.data import CohortData, CourseData, UserData, UserPersonalData  # lint-amnesty, pylint: disable=wrong-import-order
+from openedx_events.learning.signals import COHORT_MEMBERSHIP_CHANGED  # lint-amnesty, pylint: disable=wrong-import-order
 
 log = logging.getLogger(__name__)
 

--- a/openedx/core/djangoapps/course_groups/partition_scheme.py
+++ b/openedx/core/djangoapps/course_groups/partition_scheme.py
@@ -10,7 +10,7 @@ from lms.djangoapps.courseware.masquerade import (
     get_masquerading_user_group,
     is_masquerading_as_specific_student
 )
-from xmodule.partitions.partitions import NoSuchUserPartitionGroupError
+from xmodule.partitions.partitions import NoSuchUserPartitionGroupError  # lint-amnesty, pylint: disable=wrong-import-order
 
 from .cohorts import get_cohort, get_group_info_for_cohort
 

--- a/openedx/core/djangoapps/course_groups/tests/helpers.py
+++ b/openedx/core/djangoapps/course_groups/tests/helpers.py
@@ -10,8 +10,8 @@ from factory.django import DjangoModelFactory
 from opaque_keys.edx.locator import CourseLocator
 
 from openedx.core.djangoapps.django_comment_common.models import CourseDiscussionSettings
-from xmodule.modulestore import ModuleStoreEnum
-from xmodule.modulestore.django import modulestore
+from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 
 from ..cohorts import set_course_cohorted
 from ..models import CohortMembership, CourseCohort, CourseCohortsSettings, CourseUserGroup

--- a/openedx/core/djangoapps/course_groups/tests/test_api_views.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_api_views.py
@@ -12,8 +12,8 @@ from django.urls import reverse
 from openedx.core.djangoapps.oauth_dispatch.tests.factories import ApplicationFactory, AccessTokenFactory
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 from common.djangoapps.student.tests.factories import UserFactory
-from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import ToyCourseFactory
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import ToyCourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 from .. import cohorts
 from .helpers import CohortFactory

--- a/openedx/core/djangoapps/course_groups/tests/test_cohorts.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_cohorts.py
@@ -16,9 +16,9 @@ from openedx_events.tests.utils import OpenEdxEventsTestMixin
 
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import UserFactory
-from xmodule.modulestore.django import modulestore
-from xmodule.modulestore.tests.django_utils import TEST_DATA_MIXED_MODULESTORE, ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import ToyCourseFactory
+from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.django_utils import TEST_DATA_MIXED_MODULESTORE, ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import ToyCourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 from .. import cohorts
 from ..models import CourseCohort, CourseUserGroup, CourseUserGroupPartitionGroup, UnregisteredLearnerCohortAssignments

--- a/openedx/core/djangoapps/course_groups/tests/test_events.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_events.py
@@ -5,11 +5,11 @@ Classes:
     CohortEventTest: Test event sent after cohort membership changes.
 """
 from openedx.core.djangoapps.course_groups.models import CohortMembership
-from unittest.mock import Mock
+from unittest.mock import Mock  # lint-amnesty, pylint: disable=wrong-import-order
 
-from openedx_events.learning.data import CohortData, CourseData, UserData, UserPersonalData
-from openedx_events.learning.signals import COHORT_MEMBERSHIP_CHANGED
-from openedx_events.tests.utils import OpenEdxEventsTestMixin
+from openedx_events.learning.data import CohortData, CourseData, UserData, UserPersonalData  # lint-amnesty, pylint: disable=wrong-import-order
+from openedx_events.learning.signals import COHORT_MEMBERSHIP_CHANGED  # lint-amnesty, pylint: disable=wrong-import-order
+from openedx_events.tests.utils import OpenEdxEventsTestMixin  # lint-amnesty, pylint: disable=wrong-import-order
 
 from common.djangoapps.student.tests.factories import UserFactory
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
@@ -17,7 +17,7 @@ from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 from openedx.core.djangoapps.course_groups.tests.helpers import CohortFactory
 
-from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
 
 
 @skip_unless_lms

--- a/openedx/core/djangoapps/course_groups/tests/test_partition_scheme.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_partition_scheme.py
@@ -11,10 +11,10 @@ from lms.djangoapps.courseware.tests.test_masquerade import StaffMasqueradeTestC
 from openedx.core.djangoapps.user_api.partition_schemes import RandomUserPartitionScheme
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 from common.djangoapps.student.tests.factories import UserFactory
-from xmodule.modulestore.django import modulestore
-from xmodule.modulestore.tests.django_utils import TEST_DATA_MIXED_MODULESTORE, ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import ToyCourseFactory
-from xmodule.partitions.partitions import Group, UserPartition, UserPartitionError
+from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.django_utils import TEST_DATA_MIXED_MODULESTORE, ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import ToyCourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.partitions.partitions import Group, UserPartition, UserPartitionError  # lint-amnesty, pylint: disable=wrong-import-order
 
 from ..cohorts import add_user_to_cohort, get_course_cohorts, remove_user_from_cohort
 from ..models import CourseUserGroupPartitionGroup

--- a/openedx/core/djangoapps/course_groups/tests/test_views.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_views.py
@@ -18,8 +18,8 @@ from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import InstructorFactory
 from common.djangoapps.student.tests.factories import StaffFactory
 from common.djangoapps.student.tests.factories import UserFactory
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 from ..cohorts import DEFAULT_COHORT_NAME, get_cohort, get_cohort_by_id, get_cohort_by_name, get_group_info_for_cohort
 from ..models import CourseCohort, CourseUserGroup


### PR DESCRIPTION
Applied lint amnesty on following openedx djangoapps to suppress wrong-import-order warning:

- contentsever
- course_apps
- course_date_signals
- course_groups

JIRA: https://openedx.atlassian.net/browse/BOM-3080