### PR TITLE
fix: language cookie "samesite" attribute

### DIFF
--- a/openedx/core/djangoapps/dark_lang/middleware.py
+++ b/openedx/core/djangoapps/dark_lang/middleware.py
@@ -16,7 +16,7 @@ from django.utils.deprecation import MiddlewareMixin
 
 from openedx.core.djangoapps.dark_lang import DARK_LANGUAGE_KEY
 from openedx.core.djangoapps.dark_lang.models import DarkLangConfig
-from openedx.core.djangoapps.lang_pref import COOKIE_DURATION
+from openedx.core.djangoapps.lang_pref.helpers import set_language_cookie
 from openedx.core.djangoapps.site_configuration.helpers import get_value
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preference
 
@@ -110,13 +110,7 @@ class DarkLangMiddleware(MiddlewareMixin):
         language = get_value('LANGUAGE_CODE', None)
         if language:
             request.session[LANGUAGE_SESSION_KEY] = language
-            response.set_cookie(
-                settings.LANGUAGE_COOKIE_NAME,
-                value=language,
-                domain=settings.SHARED_COOKIE_DOMAIN,
-                max_age=COOKIE_DURATION,
-                secure=request.is_secure()
-            )
+            set_language_cookie(request, response, language)
 
     def _fuzzy_match(self, lang_code):
         """Returns a fuzzy match for lang_code"""
@@ -174,10 +168,4 @@ class DarkLangMiddleware(MiddlewareMixin):
 
         # Set the session key to the requested preview lang
         request.session[LANGUAGE_SESSION_KEY] = preview_lang
-        response.set_cookie(
-            settings.LANGUAGE_COOKIE_NAME,
-            value=preview_lang,
-            domain=settings.SHARED_COOKIE_DOMAIN,
-            max_age=COOKIE_DURATION,
-            secure=request.is_secure()
-        )
+        set_language_cookie(request, response, preview_lang)

--- a/openedx/core/djangoapps/lang_pref/helpers.py
+++ b/openedx/core/djangoapps/lang_pref/helpers.py
@@ -1,0 +1,36 @@
+"""
+Language preference cookie helper functions
+"""
+from django.conf import settings
+
+from openedx.core.djangoapps.lang_pref import COOKIE_DURATION
+
+
+def get_language_cookie(request, default=None):
+    """
+    Return the language cookie stored in the request object.
+    """
+    return request.COOKIES.get(settings.LANGUAGE_COOKIE_NAME, default)
+
+
+def set_language_cookie(request, response, value):
+    """
+    Set the language cookie in the response object.
+    """
+    response.set_cookie(
+        settings.LANGUAGE_COOKIE_NAME,
+        value=value,
+        domain=settings.SHARED_COOKIE_DOMAIN,
+        max_age=COOKIE_DURATION,
+        secure=request.is_secure(),
+        samesite="None" if request.is_secure() else "Lax",
+    )
+
+
+def unset_language_cookie(response):
+    """
+    Remove the language cookie from the response object.
+    """
+    response.delete_cookie(
+        settings.LANGUAGE_COOKIE_NAME, domain=settings.SHARED_COOKIE_DOMAIN
+    )

--- a/openedx/core/djangoapps/lang_pref/tests/test_middleware.py
+++ b/openedx/core/djangoapps/lang_pref/tests/test_middleware.py
@@ -75,6 +75,7 @@ class TestUserPreferenceMiddleware(CacheIsolationTestCase):
                 domain=settings.SESSION_COOKIE_DOMAIN,
                 max_age=COOKIE_DURATION,
                 secure=self.request.is_secure(),
+                samesite="Lax"
             )
         else:
             response.delete_cookie.assert_called_with(

--- a/openedx/core/djangoapps/lang_pref/views.py
+++ b/openedx/core/djangoapps/lang_pref/views.py
@@ -10,7 +10,8 @@ from django.http import HttpResponse
 from django.utils.translation import LANGUAGE_SESSION_KEY
 from django.views.decorators.csrf import ensure_csrf_cookie
 
-from openedx.core.djangoapps.lang_pref import COOKIE_DURATION, LANGUAGE_KEY
+from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
+from openedx.core.djangoapps.lang_pref.helpers import set_language_cookie
 
 
 @ensure_csrf_cookie
@@ -24,11 +25,5 @@ def update_session_language(request):
         language = data.get(LANGUAGE_KEY, settings.LANGUAGE_CODE)
         if request.session.get(LANGUAGE_SESSION_KEY, None) != language:
             request.session[LANGUAGE_SESSION_KEY] = str(language)
-        response.set_cookie(
-            settings.LANGUAGE_COOKIE_NAME,
-            language,
-            domain=settings.SHARED_COOKIE_DOMAIN,
-            max_age=COOKIE_DURATION,
-            secure=request.is_secure(),
-        )
+        set_language_cookie(request, response, language)
     return response


### PR DESCRIPTION
## Description

The language cookie "samesite" attribute was always set to "None", even in
non-secure environments, such as the devstack. This was causing client-side
warnings in non-https environments, and the language cookie was not properly
set.

## Testing instructions

In the devstack, verify that the openedx-language-preference cookie is correctly set, and there is no warning anymore in the browser console. This should happen for every authenticated request to the lms.

## Deadline

I would like to merge this in time for the Maple release (December 9th).

## Other information

cc @nedbat @pdpinch for later inclusion in the Maple release.