### PR TITLE
feat: return user roles and privilege information in course metadata [BD-38] [TNL-9218] [BB-5097]

### DIFF
--- a/lms/djangoapps/discussion/django_comment_client/utils.py
+++ b/lms/djangoapps/discussion/django_comment_client/utils.py
@@ -1,6 +1,8 @@
 # pylint: skip-file
 import json
 import logging
+from typing import Set
+
 import regex
 from collections import defaultdict
 from datetime import datetime
@@ -83,6 +85,26 @@ def get_role_ids(course_id):
     """
     roles = Role.objects.filter(course_id=course_id).exclude(name=FORUM_ROLE_STUDENT)
     return {role.name: list(role.users.values_list('id', flat=True)) for role in roles}
+
+
+def get_user_role_names(user: User, course_key: CourseKey) -> Set[str]:
+    """
+    Get a set of discussion roles a user has for the specified course.
+
+    Args:
+        user (User): a user
+        course_key (CourseKey): a course key
+
+    Returns:
+        (Set[str]) a set of role names that the user has.
+
+    """
+    return set(
+        Role.objects.filter(
+            users=user,
+            course_id=course_key,
+        ).values_list('name', flat=True).distinct()
+    )
 
 
 def has_discussion_privileges(user, course_id):

--- a/lms/djangoapps/discussion/rest_api/serializers.py
+++ b/lms/djangoapps/discussion/rest_api/serializers.py
@@ -18,7 +18,6 @@ from lms.djangoapps.discussion.django_comment_client.utils import (
     get_group_name,
     is_comment_too_deep,
 )
-from openedx.core.djangoapps.discussions.utils import get_group_names_by_id
 from lms.djangoapps.discussion.rest_api.permissions import (
     NON_UPDATABLE_COMMENT_FIELDS,
     NON_UPDATABLE_THREAD_FIELDS,
@@ -26,6 +25,7 @@ from lms.djangoapps.discussion.rest_api.permissions import (
     get_editable_fields,
 )
 from lms.djangoapps.discussion.rest_api.render import render_body
+from openedx.core.djangoapps.discussions.utils import get_group_names_by_id
 from openedx.core.djangoapps.django_comment_common.comment_client.comment import Comment
 from openedx.core.djangoapps.django_comment_common.comment_client.thread import Thread
 from openedx.core.djangoapps.django_comment_common.comment_client.user import User as CommentClientUser
@@ -37,6 +37,7 @@ from openedx.core.djangoapps.django_comment_common.models import (
     FORUM_ROLE_MODERATOR,
     Role,
 )
+from openedx.core.lib.api.serializers import CourseKeyField
 
 User = get_user_model()
 
@@ -631,3 +632,43 @@ class DiscussionRolesListSerializer(serializers.Serializer):
         Overriden update abstract method
         """
         pass  # lint-amnesty, pylint: disable=unnecessary-pass
+
+
+class BlackoutDateSerializer(serializers.Serializer):
+    """
+    Serializer for blackout dates.
+    """
+    start = serializers.DateTimeField(help_text="The ISO 8601 timestamp for the start of the blackout period")
+    end = serializers.DateTimeField(help_text="The ISO 8601 timestamp for the end of the blackout period")
+
+
+class CourseMetadataSerailizer(serializers.Serializer):
+    """
+    Serializer for course metadata.
+    """
+    id = CourseKeyField(help_text="The identifier of the course")
+    blackouts = serializers.ListField(
+        child=BlackoutDateSerializer(),
+        help_text="A list of objects representing blackout periods "
+                  "(during which discussions are read-only except for privileged users)."
+    )
+    thread_list_url = serializers.URLField(
+        help_text="The URL of the list of all threads in the course.",
+    )
+    following_thread_list_url = serializers.URLField(
+        help_text="thread_list_url with parameter following=True",
+    )
+    topics_url = serializers.URLField(help_text="The URL of the topic listing for the course.")
+    allow_anonymous = serializers.BooleanField(
+        help_text="A boolean which indicating whether anonymous posts are allowed or not.",
+    )
+    allow_anonymous_to_peers = serializers.BooleanField(
+        help_text="A boolean which indicating whether posts anonymous to peers are allowed or not.",
+    )
+    user_roles = serializers.ListField(
+        child=serializers.CharField(),
+        help_text="A list of all the roles the requesting user has for this course.",
+    )
+    user_is_privileged = serializers.BooleanField(
+        help_text="A boolean indicating if the current user has a privileged role",
+    )

--- a/lms/djangoapps/discussion/rest_api/tests/test_views.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views.py
@@ -315,6 +315,8 @@ class CourseViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
                 "topics_url": "http://testserver/api/discussion/v1/course_topics/x/y/z",
                 "allow_anonymous": True,
                 "allow_anonymous_to_peers": False,
+                'user_is_privileged': False,
+                'user_roles': ['Student'],
             }
         )
 


### PR DESCRIPTION
## Description

The frontends need to be aware of a user's privileges in order to know what operations are supported. This adds the user roles and privilege information to the discussion metadata API.

## Supporting information

- https://openedx.atlassian.net/browse/TNL-9218

## Testing instructions

- Check the course metadata api at: http://localhost:18000/api/discussion/v1/courses/course-v1:edX+DemoX+Demo_Course
- It should have a new field called "user_roles" that returns a user's discussion roles in the course. 
- It should have a new field called "user_is_privileged" that returns whether the user is privilged for that course. 

## Other information

This might not be the best place for this data, however, it seemed like an overkill to add a whole new API just to return it. It is in the end course-specific, so I felt it OK to include here. 

There is another API (`/api/enrollment/v1/roles/`) that returns all of a user's roles however it doesn't include discussion roles, and it's a bit complicated to make it work with discussion roles since they are implemented differently and stored in a different model. 