### PR TITLE
fix: url

### DIFF
--- a/lms/urls.py
+++ b/lms/urls.py
@@ -1020,5 +1020,5 @@ if getattr(settings, 'PROVIDER_STATES_URL', None):
 
 # Enhanced Staff Grader (ESG) URLs
 urlpatterns += [
-    url(r'^api/ora_staff_grader', include('lms.djangoapps.ora_staff_grader.urls', 'ora-staff-grader')),
+    url(r'^api/ora_staff_grader', include(('lms.djangoapps.ora_staff_grader.urls', 'ora-staff-grader'))),
 ]


### PR DESCRIPTION
In the weekly update PR (#29455) several tests are failing on the same error.

 https://github.com/edx/edx-platform/runs/4356442215?check_suite_focus=true 

```
Traceback (most recent call last):
  File "./manage.py", line 106, in <module>
    execute_from_command_line([sys.argv[0]] + django_args)
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/django/core/management/__init__.py", line 419, in execute_from_command_line
    utility.execute()
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/django/core/management/__init__.py", line 413, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/django/core/management/base.py", line 354, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/django/core/management/base.py", line 398, in execute
    output = self.handle(*args, **options)
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/django/core/management/base.py", line 89, in wrapped
    res = handle_func(*args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/django/core/management/commands/migrate.py", line 75, in handle
    self.check(databases=[database])
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/django/core/management/base.py", line 419, in check
    all_issues = checks.run_checks(
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/django/core/checks/registry.py", line 76, in run_checks
    new_errors = check(app_configs=app_configs, databases=databases)
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/django/core/checks/urls.py", line 40, in check_url_namespaces_unique
    all_namespaces = _load_all_namespaces(resolver)
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/django/core/checks/urls.py", line 57, in _load_all_namespaces
    url_patterns = getattr(resolver, 'url_patterns', [])
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/django/utils/functional.py", line 48, in __get__
    res = instance.__dict__[self.name] = self.func(instance)
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/django/urls/resolvers.py", line 598, in url_patterns
    patterns = getattr(self.urlconf_module, "urlpatterns", self.urlconf_module)
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/django/utils/functional.py", line 48, in __get__
    res = instance.__dict__[self.name] = self.func(instance)
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/django/urls/resolvers.py", line 591, in urlconf_module
    return import_module(self.urlconf_name)
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 843, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/runner/work/edx-platform/edx-platform/lms/urls.py", line 1021, in <module>
    url(r'^api/ora_staff_grader', include('lms.djangoapps.ora_staff_grader.urls', 'ora-staff-grader')),
NameError: name 'url' is not defined
```

I can't tell what's up here. `url` is used many times in this file. The only thing I can see is that some calls have an additional set of parens? I don't know how that could be it but I'm gonna give it a shot and see what happens.