### PR TITLE
Fix broken link to developer stack in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ recommend that you use a service provider to run the software for you.  They
 have free trials that make it easy to get started:
 https://openedx.org/get-started/
 
-If you will be modifying edx-platform code, the `Open edX Devstack`_ (Developer Stack) is
+If you will be modifying edx-platform code, the `Open edX Developer Stack`_ (Developer Stack) is
 a Docker-based development environment.
 
 If you want to run your own Open edX server and have the technical skills to do


### PR DESCRIPTION
<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description
The link to developer stack is broken. He currently point to [https://github.com/edx/edx-platform#id3](https://github.com/edx/edx-platform#id3) instead of [https://github.com/edx/devstack](https://github.com/edx/devstack)

This fix make match between the text and link definition.

This change will impact new contributors. They have an easier access to the developer stack.

## Supporting information

[Jira ticket](https://openedx.atlassian.net/browse/CRI-245)

## Testing instructions

Click the link !!!

## Deadline

"None"

## Other information

This change does not impact other changes.
