### PR TITLE
Install codejail from pypi

### DIFF
--- a/requirements/edx-sandbox/py38.txt
+++ b/requirements/edx-sandbox/py38.txt
@@ -73,7 +73,7 @@ random2==1.0.1
     # via -r requirements/edx-sandbox/py38.in
 regex==2021.11.10
     # via nltk
-scipy==1.7.2
+scipy==1.7.3
     # via
     #   -r requirements/edx-sandbox/py38.in
     #   chem

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -164,3 +164,4 @@ XBlock                              # Courseware component architecture
 xblock-utils                        # Provides utilities used by the Discussion XBlock
 xss-utils                           # https://github.com/edx/edx-platform/pull/20633 Fix XSS via Translations
 enmerkar-underscore                 # Implements a underscore extractor for django-babel.
+edx-codejail

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -8,8 +8,6 @@
     # via
     #   -r requirements/edx/local.in
     #   xmodule
--e git+https://github.com/edx/codejail.git@3.1.3#egg=codejail==3.1.3
-    # via -r requirements/edx/github.in
 -e git+https://github.com/edx/django-wiki.git@1.0.2#egg=django-wiki
     # via -r requirements/edx/github.in
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
@@ -112,7 +110,7 @@ cffi==1.15.0
     # via cryptography
 chardet==4.0.0
     # via pysrt
-charset-normalizer==2.0.7
+charset-normalizer==2.0.8
     # via
     #   -r requirements/edx/paver.txt
     #   aiohttp
@@ -407,6 +405,8 @@ edx-celeryutils==1.1.1
     #   -r requirements/edx/base.in
     #   edx-name-affirmation
     #   super-csv
+edx-codejail==3.1.5
+    # via -r requirements/edx/base.in
 edx-completion==4.1.0
     # via -r requirements/edx/base.in
 edx-django-release-util==1.1.0
@@ -816,7 +816,7 @@ python-slugify==4.0.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   code-annotations
-python-swiftclient==3.12.0
+python-swiftclient==3.13.0
     # via ora2
 python3-openid==3.2.0 ; python_version >= "3"
     # via
@@ -899,7 +899,7 @@ s3transfer==0.1.13
     # via boto3
 sailthru-client==2.2.3
     # via edx-ace
-scipy==1.7.2
+scipy==1.7.3
     # via
     #   chem
     #   openedx-calc
@@ -920,12 +920,12 @@ six==1.16.0
     #   analytics-python
     #   bleach
     #   chem
-    #   codejail
     #   crowdsourcehinter-xblock
     #   edx-ace
     #   edx-auth-backends
     #   edx-bulk-grades
     #   edx-ccx-keys
+    #   edx-codejail
     #   edx-django-release-util
     #   edx-drf-extensions
     #   edx-enterprise

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-coverage==6.1.2
+coverage==6.2
     # via -r requirements/edx/coverage.in
 diff-cover==4.0.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -8,8 +8,6 @@
     # via
     #   -r requirements/edx/testing.txt
     #   xmodule
--e git+https://github.com/edx/codejail.git@3.1.3#egg=codejail==3.1.3
-    # via -r requirements/edx/testing.txt
 -e git+https://github.com/edx/django-wiki.git@1.0.2#egg=django-wiki
     # via -r requirements/edx/testing.txt
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
@@ -67,7 +65,7 @@ asgiref==3.4.1
     #   -r requirements/edx/testing.txt
     #   django
     #   uvicorn
-astroid==2.8.6
+astroid==2.9.0
     # via
     #   -r requirements/edx/testing.txt
     #   pylint
@@ -157,7 +155,7 @@ chardet==4.0.0
     # via
     #   -r requirements/edx/testing.txt
     #   pysrt
-charset-normalizer==2.0.7
+charset-normalizer==2.0.8
     # via
     #   -r requirements/edx/testing.txt
     #   aiohttp
@@ -199,7 +197,7 @@ coreschema==0.0.4
     #   -r requirements/edx/testing.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==6.1.2
+coverage[toml]==6.2
     # via
     #   -r requirements/edx/testing.txt
     #   pytest-cov
@@ -513,6 +511,8 @@ edx-celeryutils==1.1.1
     #   -r requirements/edx/testing.txt
     #   edx-name-affirmation
     #   super-csv
+edx-codejail==3.1.5
+    # via -r requirements/edx/testing.txt
 edx-completion==4.1.0
     # via -r requirements/edx/testing.txt
 edx-django-release-util==1.1.0
@@ -1056,7 +1056,7 @@ pylatexenc==2.10
     # via
     #   -r requirements/edx/testing.txt
     #   olxcleaner
-pylint==2.11.1
+pylint==2.12.1
     # via
     #   -r requirements/edx/testing.txt
     #   edx-lint
@@ -1163,7 +1163,7 @@ python-slugify==4.0.1
     #   -r requirements/edx/testing.txt
     #   code-annotations
     #   transifex-client
-python-swiftclient==3.12.0
+python-swiftclient==3.13.0
     # via
     #   -r requirements/edx/testing.txt
     #   ora2
@@ -1264,7 +1264,7 @@ sailthru-client==2.2.3
     # via
     #   -r requirements/edx/testing.txt
     #   edx-ace
-scipy==1.7.2
+scipy==1.7.3
     # via
     #   -r requirements/edx/testing.txt
     #   chem
@@ -1294,12 +1294,12 @@ six==1.16.0
     #   bleach
     #   bok-choy
     #   chem
-    #   codejail
     #   crowdsourcehinter-xblock
     #   edx-ace
     #   edx-auth-backends
     #   edx-bulk-grades
     #   edx-ccx-keys
+    #   edx-codejail
     #   edx-django-release-util
     #   edx-drf-extensions
     #   edx-enterprise
@@ -1364,7 +1364,7 @@ soupsieve==2.3.1
     # via
     #   -r requirements/edx/testing.txt
     #   beautifulsoup4
-sphinx==4.3.0
+sphinx==4.3.1
     # via
     #   edx-sphinx-theme
     #   sphinxcontrib-httpdomain

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -10,7 +10,7 @@ babel==2.9.1
     # via sphinx
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.7
+charset-normalizer==2.0.8
     # via requests
 click==7.1.2
     # via
@@ -62,7 +62,7 @@ smmap==5.0.0
     # via gitdb
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==4.3.0
+sphinx==4.3.1
     # via
     #   -r requirements/edx/doc.in
     #   edx-sphinx-theme

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -67,7 +67,6 @@ git+https://github.com/edx/django-ratelimit-backend.git@6e1a0c6ea1d27062c16e9fb9
 git+https://github.com/edx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776#egg=django-require==1.0.12
 
 # Our libraries:
--e git+https://github.com/edx/codejail.git@3.1.3#egg=codejail==3.1.3
 -e git+https://github.com/edx/RateXBlock.git@2.0.1#egg=rate-xblock
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive
 

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -6,7 +6,7 @@
 #
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.7
+charset-normalizer==2.0.8
     # via requests
 edx-opaque-keys==2.2.2
     # via -r requirements/edx/paver.in

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -8,8 +8,6 @@
     # via
     #   -r requirements/edx/base.txt
     #   xmodule
--e git+https://github.com/edx/codejail.git@3.1.3#egg=codejail==3.1.3
-    # via -r requirements/edx/base.txt
 -e git+https://github.com/edx/django-wiki.git@1.0.2#egg=django-wiki
     # via -r requirements/edx/base.txt
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
@@ -63,7 +61,7 @@ asgiref==3.4.1
     #   -r requirements/edx/base.txt
     #   django
     #   uvicorn
-astroid==2.8.6
+astroid==2.9.0
     # via
     #   pylint
     #   pylint-celery
@@ -150,7 +148,7 @@ chardet==4.0.0
     # via
     #   -r requirements/edx/base.txt
     #   pysrt
-charset-normalizer==2.0.7
+charset-normalizer==2.0.8
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
@@ -188,7 +186,7 @@ coreschema==0.0.4
     #   -r requirements/edx/base.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==6.1.2
+coverage[toml]==6.2
     # via
     #   -r requirements/edx/coverage.txt
     #   pytest-cov
@@ -495,6 +493,8 @@ edx-celeryutils==1.1.1
     #   -r requirements/edx/base.txt
     #   edx-name-affirmation
     #   super-csv
+edx-codejail==3.1.5
+    # via -r requirements/edx/base.txt
 edx-completion==4.1.0
     # via -r requirements/edx/base.txt
 edx-django-release-util==1.1.0
@@ -995,7 +995,7 @@ pylatexenc==2.10
     # via
     #   -r requirements/edx/base.txt
     #   olxcleaner
-pylint==2.11.1
+pylint==2.12.1
     # via
     #   edx-lint
     #   pylint-celery
@@ -1092,7 +1092,7 @@ python-slugify==4.0.1
     #   -r requirements/edx/base.txt
     #   code-annotations
     #   transifex-client
-python-swiftclient==3.12.0
+python-swiftclient==3.13.0
     # via
     #   -r requirements/edx/base.txt
     #   ora2
@@ -1189,7 +1189,7 @@ sailthru-client==2.2.3
     # via
     #   -r requirements/edx/base.txt
     #   edx-ace
-scipy==1.7.2
+scipy==1.7.3
     # via
     #   -r requirements/edx/base.txt
     #   chem
@@ -1219,12 +1219,12 @@ six==1.16.0
     #   bleach
     #   bok-choy
     #   chem
-    #   codejail
     #   crowdsourcehinter-xblock
     #   edx-ace
     #   edx-auth-backends
     #   edx-bulk-grades
     #   edx-ccx-keys
+    #   edx-codejail
     #   edx-django-release-util
     #   edx-drf-extensions
     #   edx-enterprise

--- a/scripts/xblock/requirements.txt
+++ b/scripts/xblock/requirements.txt
@@ -6,7 +6,7 @@
 #
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.7
+charset-normalizer==2.0.8
     # via requests
 idna==3.3
     # via requests


### PR DESCRIPTION
Issue: [BOM-2481](https://openedx.atlassian.net/browse/BOM-2481)

Description: 
Previously codejail was being installed from github commit but now as codejail has been released on PyPI so this PR installs it from there