### PR TITLE
feat: add referrer url when submitting Zendesk support ticket

### DIFF
--- a/lms/djangoapps/support/static/support/jsx/single_support_form.jsx
+++ b/lms/djangoapps/support/static/support/jsx/single_support_form.jsx
@@ -142,10 +142,16 @@ class RenderForm extends React.Component {
           body: formData.message,
         },
         subject: formData.subject, // Zendesk API requires 'subject'
-        custom_fields: [{
+        custom_fields: [
+        {
           id: this.props.context.customFields.course_id,
           value: formData.course,
-        }],
+        },
+        {
+          id: this.props.context.customFields.referrer,
+          value: document.referrer ? document.referrer : "Direct Contact Us Page Request",
+        }
+        ],
         tags: this.props.context.tags,
       };
     request.open('POST', url, true);

--- a/openedx/core/djangoapps/zendesk_proxy/tests/test_v1_views.py
+++ b/openedx/core/djangoapps/zendesk_proxy/tests/test_v1_views.py
@@ -17,7 +17,8 @@ from openedx.core.lib.api.test_utils import ApiTestCase
 @ddt.ddt
 @override_settings(
     ZENDESK_URL="https://www.superrealurlsthataredefinitelynotfake.com",
-    ZENDESK_OAUTH_ACCESS_TOKEN="abcdefghijklmnopqrstuvwxyz1234567890"
+    ZENDESK_OAUTH_ACCESS_TOKEN="abcdefghijklmnopqrstuvwxyz1234567890",
+    ZENDESK_CUSTOM_FIELDS={'referrer': '002'}
 )
 class ZendeskProxyTestCase(ApiTestCase):
     """Tests for zendesk_proxy views."""
@@ -40,6 +41,10 @@ class ZendeskProxyTestCase(ApiTestCase):
                 {
                     'id': '001',
                     'value': 'demo-course'
+                },
+                {
+                    'id': '002',
+                    'value': 'https://www.example.com'
                 }
             ],
         }
@@ -74,7 +79,10 @@ class ZendeskProxyTestCase(ApiTestCase):
                     'comment': {
                         'body': "Help! I'm trapped in a unit test factory and I can't get out!", 'uploads': None
                     },
-                    'custom_fields': [{'id': '001', 'value': 'demo-course'}],
+                    'custom_fields': [
+                        {'id': '001', 'value': 'demo-course'},
+                        {'id': '002', 'value': 'https://www.example.com'},
+                    ],
                     'requester': {'email': self.user.email, 'name': self.user.username},
                     'subject': 'Python Unit Test Help Request', 'tags': ['python_unit_test']
                 }

--- a/openedx/core/djangoapps/zendesk_proxy/tests/test_v1_views.py
+++ b/openedx/core/djangoapps/zendesk_proxy/tests/test_v1_views.py
@@ -17,8 +17,7 @@ from openedx.core.lib.api.test_utils import ApiTestCase
 @ddt.ddt
 @override_settings(
     ZENDESK_URL="https://www.superrealurlsthataredefinitelynotfake.com",
-    ZENDESK_OAUTH_ACCESS_TOKEN="abcdefghijklmnopqrstuvwxyz1234567890",
-    ZENDESK_CUSTOM_FIELDS={'referrer': '002'}
+    ZENDESK_OAUTH_ACCESS_TOKEN="abcdefghijklmnopqrstuvwxyz1234567890"
 )
 class ZendeskProxyTestCase(ApiTestCase):
     """Tests for zendesk_proxy views."""


### PR DESCRIPTION
### [PROD-2570](https://openedx.atlassian.net/browse/PROD-2570)

### Description
Use Zendesk custom fields to add referrer information to the support ticket created from contact_us page. The PR depends upon the config updates in https://github.com/edx/edx-internal/pull/5781 to successfully add the referrer against the custom field.

Since Zendesk is not configured locally, you won't be able to test ticket submission. The thing you can verify is that the referrer value is populated correctly when visiting contact us page from another page or loading the page directly.

- https://developer.zendesk.com/api-reference/ticketing/tickets/tickets/#json-format
