### PR TITLE
feat: update min grade cutoff from 97 to 99

### DIFF
--- a/cms/static/js/views/settings/grading.js
+++ b/cms/static/js/views/settings/grading.js
@@ -214,10 +214,13 @@ define(['js/views/validation',
                 var widthPerPoint = cachethis.gradeBarWidth / 100;
                 return function(event, ui) {
                     var barIndex = ui.element.index();
-            // min and max represent limits not labels (note, can's make smaller than 3 points wide)
-                    var min = (barIndex < cachethis.descendingCutoffs.length ? cachethis.descendingCutoffs[barIndex].cutoff + 3 : 3);
+                    var offset = 1;
+            // min and max represent limits not labels
+                    var min = (barIndex < cachethis.descendingCutoffs.length
+                      ? cachethis.descendingCutoffs[barIndex].cutoff + offset
+                      : offset);
             // minus 2 b/c minus 1 is the element we're effecting. It's max is just shy of the next one above it
-                    var max = (barIndex >= 2 ? cachethis.descendingCutoffs[barIndex - 2].cutoff - 3 : 97);
+                    var max = (barIndex >= 2 ? cachethis.descendingCutoffs[barIndex - 2].cutoff - offset : 99);
                     ui.element.resizable('option', {minWidth: min * widthPerPoint, maxWidth: max * widthPerPoint});
                 };
             },
@@ -227,10 +230,13 @@ define(['js/views/validation',
                 var cachethis = this;
                 return function(event, ui) {
                     var barIndex = ui.element.index();
+                    var offset = 1;
             // min and max represent limits not labels (note, can's make smaller than 3 points wide)
-                    var min = (barIndex < cachethis.descendingCutoffs.length ? cachethis.descendingCutoffs[barIndex].cutoff + 3 : 3);
+                    var min = (barIndex < cachethis.descendingCutoffs.length
+                      ? cachethis.descendingCutoffs[barIndex].cutoff + offset
+                      : offset);
             // minus 2 b/c minus 1 is the element we're effecting. It's max is just shy of the next one above it
-                    var max = (barIndex >= 2 ? cachethis.descendingCutoffs[barIndex - 2].cutoff - 3 : 100);
+                    var max = (barIndex >= 2 ? cachethis.descendingCutoffs[barIndex - 2].cutoff - offset : 100);
                     var percentage = Math.min(Math.max(ui.size.width / cachethis.gradeBarWidth * 100, min), max);
                     cachethis.descendingCutoffs[barIndex - 1].cutoff = Math.round(percentage);
                     cachethis.renderGradeRanges();


### PR DESCRIPTION
## Description

Updates the studio grade configuration min grade cutoff from 97% to 99%

## Supporting information

JIRA: [AU-292](https://openedx.atlassian.net/browse/AU-292)

## Testing instructions

Navigate to studio for a course and load the grading settings menu item.  Drag the cuttoff on the table up to the right-hand edge of the interface.  The limit should now be 99%
