### PR TITLE
fix: backport cert generation fix for non verified modes to maple 

### DIFF
--- a/lms/djangoapps/certificates/generation_handler.py
+++ b/lms/djangoapps/certificates/generation_handler.py
@@ -9,6 +9,7 @@ cannot be generated, a message is logged and no further action is taken.
 import logging
 
 from common.djangoapps.course_modes import api as modes_api
+from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.models import CourseEnrollment
 from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.certificates.models import (
@@ -164,14 +165,20 @@ def _can_generate_certificate_common(user, course_key, enrollment_mode):
         log.info(f'{user.id} : {course_key} does not have an enrollment. Certificate cannot be generated.')
         return False
 
-    if not modes_api.is_eligible_for_certificate(enrollment_mode):
+    is_eligible_for_cert = modes_api.is_eligible_for_certificate(enrollment_mode)
+    if not is_eligible_for_cert:
         log.info(f'{user.id} : {course_key} has an enrollment mode of {enrollment_mode}, which is not eligible for a '
                  f'certificate. Certificate cannot be generated.')
         return False
 
     if _required_verification_missing(course_key, user):
-        log.info(f'{user.id} does not have a verified id. Certificate cannot be generated for {course_key}.')
-        return False
+        # Honor courses can be eligible for certificates and don't require a valid approved IDV
+        if is_eligible_for_cert and enrollment_mode in CourseMode.NON_VERIFIED_MODES:
+            log.info(f'{user.id} : {course_key} is eligible for a certificate without requiring a verified id. '
+                     'Skipping result of the ID verification check.')
+        else:
+            log.info(f'{user.id} does not have a verified id. Certificate cannot be generated for {course_key}.')
+            return False
 
     if not _can_generate_certificate_for_status(user, course_key, enrollment_mode):
         return False

--- a/lms/djangoapps/certificates/tests/test_generation_handler.py
+++ b/lms/djangoapps/certificates/tests/test_generation_handler.py
@@ -36,11 +36,13 @@ BETA_TESTER_METHOD = 'lms.djangoapps.certificates.generation_handler.is_beta_tes
 COURSE_OVERVIEW_METHOD = 'lms.djangoapps.certificates.generation_handler.get_course_overview_or_none'
 CCX_COURSE_METHOD = 'lms.djangoapps.certificates.generation_handler._is_ccx_course'
 GET_GRADE_METHOD = 'lms.djangoapps.certificates.generation_handler._get_course_grade'
+INTEGRITY_ENABLED_METHOD = 'lms.djangoapps.certificates.generation_handler.is_integrity_signature_enabled'
 ID_VERIFIED_METHOD = 'lms.djangoapps.verify_student.services.IDVerificationService.user_is_verified'
 PASSING_GRADE_METHOD = 'lms.djangoapps.certificates.generation_handler._is_passing_grade'
 WEB_CERTS_METHOD = 'lms.djangoapps.certificates.generation_handler.has_html_certificates_enabled'
 
 
+@mock.patch(INTEGRITY_ENABLED_METHOD, mock.Mock(return_value=False))
 @mock.patch(ID_VERIFIED_METHOD, mock.Mock(return_value=True))
 @mock.patch(WEB_CERTS_METHOD, mock.Mock(return_value=True))
 @ddt.ddt
@@ -199,14 +201,19 @@ class AllowlistTests(ModuleStoreTestCase):
         """
         assert generate_certificate_task(self.user, self.course_run_key)
 
-    def test_can_generate_not_verified(self):
+    @ddt.data(False, True)
+    def test_can_generate_not_verified(self, idv_retired):
         """
         Test handling when the user's id is not verified
         """
-        with mock.patch(ID_VERIFIED_METHOD, return_value=False):
-            assert not _can_generate_allowlist_certificate(self.user, self.course_run_key, self.enrollment_mode)
-            assert _set_allowlist_cert_status(self.user, self.course_run_key, self.enrollment_mode, self.grade) == \
-                   CertificateStatuses.unverified
+        with mock.patch(ID_VERIFIED_METHOD, return_value=False), \
+                mock.patch(INTEGRITY_ENABLED_METHOD, return_value=idv_retired):
+            self.assertEqual(idv_retired,
+                             _can_generate_allowlist_certificate(self.user, self.course_run_key, self.enrollment_mode))
+            self.assertIsNot(idv_retired,
+                             _set_allowlist_cert_status(
+                                 self.user, self.course_run_key,
+                                 self.enrollment_mode, self.grade) == CertificateStatuses.unverified)
 
     def test_can_generate_not_enrolled(self):
         """
@@ -324,6 +331,7 @@ class AllowlistTests(ModuleStoreTestCase):
         assert _set_allowlist_cert_status(u, key, self.enrollment_mode, self.grade) is None
 
 
+@mock.patch(INTEGRITY_ENABLED_METHOD, mock.Mock(return_value=False))
 @mock.patch(ID_VERIFIED_METHOD, mock.Mock(return_value=True))
 @mock.patch(CCX_COURSE_METHOD, mock.Mock(return_value=False))
 @mock.patch(PASSING_GRADE_METHOD, mock.Mock(return_value=True))
@@ -480,7 +488,8 @@ class CertificateTests(ModuleStoreTestCase):
         """
         assert _can_generate_certificate_for_status(None, None, None)
 
-    def test_can_generate_not_verified_cert(self):
+    @ddt.data(False, True)
+    def test_can_generate_not_verified_cert(self, idv_retired):
         """
         Test handling when the user's id is not verified and they have a cert
         """
@@ -498,12 +507,15 @@ class CertificateTests(ModuleStoreTestCase):
             status=CertificateStatuses.generating
         )
 
-        with mock.patch(ID_VERIFIED_METHOD, return_value=False):
-            assert not _can_generate_regular_certificate(u, self.course_run_key, self.enrollment_mode, self.grade)
-            assert _set_regular_cert_status(u, self.course_run_key, self.enrollment_mode,
-                                            self.grade) == CertificateStatuses.unverified
+        with mock.patch(ID_VERIFIED_METHOD, return_value=False), \
+                mock.patch(INTEGRITY_ENABLED_METHOD, return_value=idv_retired):
+            self.assertEqual(idv_retired, _can_generate_regular_certificate(u, self.course_run_key,
+                                                                            self.enrollment_mode, self.grade))
+            self.assertIsNot(idv_retired, _set_regular_cert_status(u, self.course_run_key, self.enrollment_mode,
+                                                                   self.grade) == CertificateStatuses.unverified)
 
-    def test_can_generate_not_verified_no_cert(self):
+    @ddt.data(False, True)
+    def test_can_generate_not_verified_no_cert(self, idv_retired):
         """
         Test handling when the user's id is not verified and they don't have a cert
         """
@@ -515,12 +527,15 @@ class CertificateTests(ModuleStoreTestCase):
             mode=CourseMode.VERIFIED,
         )
 
-        with mock.patch(ID_VERIFIED_METHOD, return_value=False):
-            assert not _can_generate_regular_certificate(u, self.course_run_key, self.enrollment_mode, self.grade)
-            assert _set_regular_cert_status(u, self.course_run_key, self.enrollment_mode,
-                                            self.grade) == CertificateStatuses.unverified
+        with mock.patch(ID_VERIFIED_METHOD, return_value=False), \
+                mock.patch(INTEGRITY_ENABLED_METHOD, return_value=idv_retired):
+            self.assertEqual(idv_retired, _can_generate_regular_certificate(u, self.course_run_key,
+                                                                            self.enrollment_mode, self.grade))
+            self.assertIsNot(idv_retired, _set_regular_cert_status(u, self.course_run_key, self.enrollment_mode,
+                                                                   self.grade) == CertificateStatuses.unverified)
 
-    def test_can_generate_not_verified_not_passing(self):
+    @ddt.data(False, True)
+    def test_can_generate_not_verified_not_passing(self, idv_retired):
         """
         Test handling when the user's id is not verified and the user is not passing
         """
@@ -538,12 +553,18 @@ class CertificateTests(ModuleStoreTestCase):
             status=CertificateStatuses.generating
         )
 
-        with mock.patch(ID_VERIFIED_METHOD, return_value=False):
-            with mock.patch(PASSING_GRADE_METHOD, return_value=False):
-                assert not _can_generate_regular_certificate(u, self.course_run_key, self.enrollment_mode, self.grade)
+        with mock.patch(ID_VERIFIED_METHOD, return_value=False), \
+                mock.patch(INTEGRITY_ENABLED_METHOD, return_value=idv_retired), \
+                mock.patch(PASSING_GRADE_METHOD, return_value=False):
+            assert not _can_generate_regular_certificate(u, self.course_run_key, self.enrollment_mode, self.grade)
+            if idv_retired:
+                assert _set_regular_cert_status(u, self.course_run_key, self.enrollment_mode, self.grade) \
+                       == CertificateStatuses.notpassing
+            else:
                 assert _set_regular_cert_status(u, self.course_run_key, self.enrollment_mode, self.grade) is None
 
-    def test_can_generate_not_verified_not_passing_allowlist(self):
+    @ddt.data(False, True)
+    def test_can_generate_not_verified_not_passing_allowlist(self, idv_retired):
         """
         Test handling when the user's id is not verified and the user is not passing but is on the allowlist
         """
@@ -562,9 +583,14 @@ class CertificateTests(ModuleStoreTestCase):
         )
         CertificateAllowlistFactory(course_id=self.course_run_key, user=u)
 
-        with mock.patch(ID_VERIFIED_METHOD, return_value=False):
-            with mock.patch(PASSING_GRADE_METHOD, return_value=False):
-                assert not _can_generate_regular_certificate(u, self.course_run_key, self.enrollment_mode, self.grade)
+        with mock.patch(ID_VERIFIED_METHOD, return_value=False), \
+                mock.patch(INTEGRITY_ENABLED_METHOD, return_value=idv_retired), \
+                mock.patch(PASSING_GRADE_METHOD, return_value=False):
+            assert not _can_generate_regular_certificate(u, self.course_run_key, self.enrollment_mode, self.grade)
+            if idv_retired:
+                assert _set_regular_cert_status(u, self.course_run_key, self.enrollment_mode,
+                                                self.grade) == CertificateStatuses.notpassing
+            else:
                 assert _set_regular_cert_status(u, self.course_run_key, self.enrollment_mode,
                                                 self.grade) == CertificateStatuses.unverified
 

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -2082,7 +2082,7 @@ class TestCertificateGeneration(InstructorTaskModuleTestCase):
             'failed': 0,
             'skipped': 2
         }
-        with self.assertNumQueries(71):
+        with self.assertNumQueries(77):
             self.assertCertificatesGenerated(task_input, expected_results)
 
     @ddt.data(

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -2082,7 +2082,7 @@ class TestCertificateGeneration(InstructorTaskModuleTestCase):
             'failed': 0,
             'skipped': 2
         }
-        with self.assertNumQueries(77):
+        with self.assertNumQueries(82):
             self.assertCertificatesGenerated(task_input, expected_results)
 
     @ddt.data(


### PR DESCRIPTION
## Description

[MICROBA-1594]
- Cherry-pick commit 7e3ef93a63db8c0fb95c67a7dbac4e92fadcf18f
- Cherry-pick commit bb28fc6cbf65edfe7dbf3f6f288decd761b9937d


## Supporting information

Fixes an issue the community helped discover with the generation of certificates in non verified modes (Honor, Prof No Id). If the IDV check fails then check if the enrollment mode of the course is eligible for a certificate AND if the enrollment mode is a non-verified mode. If so, skip the result of the IDV check and continue on with certificate generation.


[MICROBA-1594]: https://openedx.atlassian.net/browse/MICROBA-1594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ