### PR TITLE
chore: replace calls to url with path

### DIFF
--- a/lms/djangoapps/ora_staff_grader/urls.py
+++ b/lms/djangoapps/ora_staff_grader/urls.py
@@ -1,7 +1,7 @@
 """
 URLs for Enhanced Staff Grader (ESG) backend-for-frontend (BFF)
 """
-from django.conf.urls import include, url
+from django.conf.urls import include
 from django.urls.conf import path
 
 
@@ -14,7 +14,7 @@ urlpatterns = []
 app_name = "ora-staff-grader"
 
 urlpatterns += [
-    url('mock/', include('lms.djangoapps.ora_staff_grader.mock.urls')),
+    path('mock/', include('lms.djangoapps.ora_staff_grader.mock.urls')),
     path(
         'initialize/', InitializeView.as_view(), name='initialize'
     ),

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -1020,5 +1020,5 @@ if getattr(settings, 'PROVIDER_STATES_URL', None):
 
 # Enhanced Staff Grader (ESG) URLs
 urlpatterns += [
-    url(r'^api/ora_staff_grader', include('lms.djangoapps.ora_staff_grader.urls', 'ora-staff-grader')),
+    path('api/ora_staff_grader', include('lms.djangoapps.ora_staff_grader.urls', 'ora-staff-grader')),
 ]


### PR DESCRIPTION
When doing the weekly branch update PR I realized that we needed to change this as we've completely switched elsewhere in platform. I was gonna do it in the premerge branch I set up, btu this should probably not be hidden amongst hundreds of other commits, and then we won't even need a premerge.