### PR TITLE
fix: Ensure edX staff user can also see Honor Code modal dialog

### DIFF
--- a/openedx/core/djangoapps/courseware_api/tests/test_views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/test_views.py
@@ -42,6 +42,7 @@ from xmodule.data import CertificatesDisplayBehaviors
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import ItemFactory, ToyCourseFactory
+from xmodule.partitions.partitions import ENROLLMENT_TRACK_PARTITION_ID
 
 
 User = get_user_model()
@@ -338,7 +339,8 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
         ('audit', False, False, False),
         ('verified', False, True, False),
         ('masters', False, True, False),
-        ('verified', True, False, False),
+        ('verified', True, False, True),
+        ('audit', True, False, False),
     )
     @ddt.unpack
     @override_waffle_flag(ENABLE_INTEGRITY_SIGNATURE, True)
@@ -370,6 +372,31 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
         TieredCache.dangerous_clear_all_tiers()
         self.client.get(self.url, {'browser_timezone': 'Asia/Tokyo'})
         assert len(LastSeenCoursewareTimezone.objects.filter()) == 1
+
+    @ddt.data(
+        (1, False),
+        (2, True),
+        (3, True),
+    )
+    @ddt.unpack
+    @override_waffle_flag(ENABLE_INTEGRITY_SIGNATURE, True)
+    def test_course_staff_masquerade(self, masquerade_group_id, needs_signature):
+        self.user.is_staff = True
+        self.user.save()
+        CourseEnrollment.enroll(self.user, self.course.id, 'audit')
+        masquerade_config = {
+            'role': 'student',
+            'user_partition_id': ENROLLMENT_TRACK_PARTITION_ID,
+            'group_id': masquerade_group_id
+        }
+        self.update_masquerade(**masquerade_config)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        courseware_data = response.json()
+        assert 'is_integrity_signature_enabled' in courseware_data
+        assert courseware_data['is_integrity_signature_enabled'] is True
+        assert 'user_needs_integrity_signature' in courseware_data
+        assert courseware_data['user_needs_integrity_signature'] == needs_signature
 
 
 @ddt.ddt

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -1,7 +1,6 @@
 """
 Course API Views
 """
-
 from completion.exceptions import UnavailableCompletionData
 from completion.utilities import get_key_to_last_completed_block
 from django.urls import reverse
@@ -32,7 +31,11 @@ from lms.djangoapps.courseware.access_response import (
 )
 from lms.djangoapps.courseware.context_processor import user_timezone_locale_prefs
 from lms.djangoapps.courseware.courses import check_course_access
-from lms.djangoapps.courseware.masquerade import is_masquerading_as_specific_student, setup_masquerade
+from lms.djangoapps.courseware.masquerade import (
+    is_masquerading_as_specific_student,
+    setup_masquerade,
+    is_masquerading_as_non_audit_enrollment,
+)
 from lms.djangoapps.courseware.models import LastSeenCoursewareTimezone
 from lms.djangoapps.courseware.module_render import get_module_by_usage_id
 from lms.djangoapps.courseware.tabs import get_course_tab_list
@@ -325,11 +328,22 @@ class CoursewareMeta:
         """
         Boolean describing whether the user needs to sign the integrity agreement for a course.
         """
+        enrollment_is_cert_relavant = (
+            self.enrollment_object
+            and self.enrollment_object.mode in CourseMode.CERTIFICATE_RELEVANT_MODES
+        )
+
+        if not enrollment_is_cert_relavant:
+            # Check masquerading as a non-audit enrollment
+            enrollment_is_cert_relavant = is_masquerading_as_non_audit_enrollment(
+                self.effective_user,
+                self.course_key,
+                self.course_masquerade
+            )
+
         if (
             integrity_signature_toggle(self.course_key)
-            and not self.is_staff
-            and self.enrollment_object
-            and self.enrollment_object.mode in CourseMode.CERTIFICATE_RELEVANT_MODES
+            and enrollment_is_cert_relavant
         ):
             signature = get_integrity_signature(self.effective_user.username, str(self.course_key))
             if not signature:


### PR DESCRIPTION
## Description

[MST-1109](https://openedx.atlassian.net/browse/MST-1109)
Add the ability for masqueraded staff user to also see honor code signature modal in the courseware