### PR TITLE
Revert "mysqlclient upgrade"

### DIFF
--- a/.github/workflows/pylint-checks.yml
+++ b/.github/workflows/pylint-checks.yml
@@ -58,8 +58,6 @@ jobs:
       run: |
         pip install -r requirements/pip.txt
         pip install -r requirements/edx/development.txt --src ${{ runner.temp }}
-        pip uninstall -y mysqlclient
-        pip install --no-binary mysqlclient mysqlclient
 
     - name: Run Quality Tests
       run: |

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -97,3 +97,5 @@ py2neo<2022
 # Sphinx requires docutils<0.18. This pin can be removed once https://github.com/sphinx-doc/sphinx/issues/9777 is closed.
 docutils<0.18
 
+# mysqlclient==2.1.0 caused NameError in running pylint checks on master
+mysqlclient<2.1.0

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -667,8 +667,10 @@ multidict==5.2.0
     # via
     #   aiohttp
     #   yarl
-mysqlclient==2.1.0
-    # via -r requirements/edx/base.in
+mysqlclient==2.0.3
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   -r requirements/edx/base.in
 newrelic==7.2.4.171
     # via
     #   -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -902,8 +902,10 @@ mypy==0.910
     # via -r requirements/edx/development.in
 mypy-extensions==0.4.3
     # via mypy
-mysqlclient==2.1.0
-    # via -r requirements/edx/testing.txt
+mysqlclient==2.0.3
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   -r requirements/edx/testing.txt
 newrelic==7.2.4.171
     # via
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -851,8 +851,10 @@ multidict==5.2.0
     #   -r requirements/edx/base.txt
     #   aiohttp
     #   yarl
-mysqlclient==2.1.0
-    # via -r requirements/edx/base.txt
+mysqlclient==2.0.3
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   -r requirements/edx/base.txt
 newrelic==7.2.4.171
     # via
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
Reverts edx/edx-platform#29418

In case we need to revert due to pylint issues. Although I have verified it on my fork pylint seems good.