### PR TITLE
fix: back-port cert generation fix for non-verified modes to maple

### DIFF
--- a/lms/djangoapps/certificates/generation_handler.py
+++ b/lms/djangoapps/certificates/generation_handler.py
@@ -9,6 +9,7 @@ cannot be generated, a message is logged and no further action is taken.
 import logging
 
 from common.djangoapps.course_modes import api as modes_api
+from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.models import CourseEnrollment
 from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.certificates.models import (
@@ -21,6 +22,7 @@ from lms.djangoapps.certificates.utils import has_html_certificates_enabled
 from lms.djangoapps.grades.api import CourseGradeFactory
 from lms.djangoapps.instructor.access import is_beta_tester
 from lms.djangoapps.verify_student.services import IDVerificationService
+from openedx.core.djangoapps.agreements.toggles import is_integrity_signature_enabled
 from openedx.core.djangoapps.content.course_overviews.api import get_course_overview_or_none
 
 log = logging.getLogger(__name__)
@@ -163,14 +165,21 @@ def _can_generate_certificate_common(user, course_key, enrollment_mode):
         log.info(f'{user.id} : {course_key} does not have an enrollment. Certificate cannot be generated.')
         return False
 
-    if not modes_api.is_eligible_for_certificate(enrollment_mode):
+    is_eligible_for_cert = modes_api.is_eligible_for_certificate(enrollment_mode)
+    if not is_eligible_for_cert:
         log.info(f'{user.id} : {course_key} has an enrollment mode of {enrollment_mode}, which is not eligible for a '
                  f'certificate. Certificate cannot be generated.')
         return False
 
-    if not IDVerificationService.user_is_verified(user):
-        log.info(f'{user.id} does not have a verified id. Certificate cannot be generated for {course_key}.')
-        return False
+    # If the IDV check fails we then check if the course-run requires ID verification. Honor and Professional-No-ID
+    # modes do not require IDV for certificate generation.
+    if _required_verification_missing(course_key, user):
+        if enrollment_mode not in CourseMode.NON_VERIFIED_MODES:
+            log.info(f'{user.id} does not have a verified id. Certificate cannot be generated for {course_key}.')
+            return False
+
+        log.info(f'{user.id} : {course_key} is eligible for a certificate without requiring a verified ID. '
+                 'Skipping results of the ID verification check.')
 
     if not _can_generate_certificate_for_status(user, course_key, enrollment_mode):
         return False
@@ -217,7 +226,9 @@ def _set_regular_cert_status(user, course_key, enrollment_mode, course_grade):
     if status is not None:
         return status
 
-    if IDVerificationService.user_is_verified(user) and not _is_passing_grade(course_grade) and cert is not None:
+    if not _required_verification_missing(course_key, user) \
+            and not _is_passing_grade(course_grade) \
+            and cert is not None:
         if cert.status != CertificateStatuses.notpassing:
             course_grade_val = _get_grade_value(course_grade)
             cert.mark_notpassing(mode=enrollment_mode, grade=course_grade_val, source='certificate_generation')
@@ -238,7 +249,7 @@ def _get_cert_status_common(user, course_key, enrollment_mode, course_grade, cer
             cert.invalidate(mode=enrollment_mode, source='certificate_generation')
         return CertificateStatuses.unavailable
 
-    if not IDVerificationService.user_is_verified(user) and _has_passing_grade_or_is_allowlisted(user, course_key,
+    if _required_verification_missing(course_key, user) and _has_passing_grade_or_is_allowlisted(user, course_key,
                                                                                                  course_grade):
         if cert is None:
             _generate_certificate_task(user=user, course_key=course_key, enrollment_mode=enrollment_mode,
@@ -397,3 +408,10 @@ def _is_mode_now_eligible(enrollment_mode, cert):
     if modes_api.is_eligible_for_certificate(enrollment_mode) and not modes_api.is_eligible_for_certificate(cert.mode):
         return True
     return False
+
+
+def _required_verification_missing(course_key, user):
+    """
+    Return true if IDV is required for this course and the user does not have it
+    """
+    return not is_integrity_signature_enabled(course_key) and not IDVerificationService.user_is_verified(user)

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -2082,7 +2082,7 @@ class TestCertificateGeneration(InstructorTaskModuleTestCase):
             'failed': 0,
             'skipped': 2
         }
-        with self.assertNumQueries(71):
+        with self.assertNumQueries(82):
             self.assertCertificatesGenerated(task_input, expected_results)
 
     @ddt.data(


### PR DESCRIPTION
## Description

[MICROBA-1594]
- Cherry picks commit 7e3ef93a63db8c0fb95c67a7dbac4e92fadcf18f
- Cherry picks commit df71aebdcf5f843fa404d43bf204d1ee8162e149

## Supporting information

This backports a fix from edx-platform to the Maple release. We accidentally broke the generation of Certificates in non-verified enrollment modes in our Course Certificate generation refactoring project. 

[MICROBA-1594]: https://openedx.atlassian.net/browse/MICROBA-1594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ