### PR TITLE
feat: only show verification deadline if integrity signature is not enabled

### DIFF
--- a/lms/djangoapps/courseware/date_summary.py
+++ b/lms/djangoapps/courseware/date_summary.py
@@ -24,6 +24,7 @@ from lms.djangoapps.certificates.api import get_active_web_certificate, can_show
 from lms.djangoapps.courseware.utils import verified_upgrade_deadline_link, can_show_verified_upgrade
 from lms.djangoapps.verify_student.models import VerificationDeadline
 from lms.djangoapps.verify_student.services import IDVerificationService
+from openedx.core.djangoapps.agreements.toggles import is_integrity_signature_enabled
 from openedx.core.djangolib.markup import HTML, Text
 from openedx.features.course_duration_limits.access import get_user_course_expiration_date
 from openedx.features.course_experience import RELATIVE_DATES_FLAG, UPGRADE_DEADLINE_MESSAGE, CourseHomeMessages
@@ -719,7 +720,8 @@ class VerificationDeadlineDate(DateSummary):
         return (
             is_active and
             mode == 'verified' and
-            self.verification_status in ('expired', 'none', 'must_reverify')
+            self.verification_status in ('expired', 'none', 'must_reverify') and
+            not is_integrity_signature_enabled(self.course_id)
         )
 
     @lazy

--- a/lms/djangoapps/courseware/tests/test_date_summary.py
+++ b/lms/djangoapps/courseware/tests/test_date_summary.py
@@ -37,6 +37,7 @@ from lms.djangoapps.courseware.models import (
 from lms.djangoapps.verify_student.models import VerificationDeadline
 from lms.djangoapps.verify_student.services import IDVerificationService
 from lms.djangoapps.verify_student.tests.factories import SoftwareSecurePhotoVerificationFactory
+from openedx.core.djangoapps.agreements.toggles import ENABLE_INTEGRITY_SIGNATURE
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
@@ -654,6 +655,14 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
         course = create_course_run(days_till_start=-1)
         user = create_user()
         CourseEnrollmentFactory(course_id=course.id, user=user, mode=CourseMode.AUDIT)
+        block = VerificationDeadlineDate(course, user)
+        assert not block.is_allowed
+
+    @override_waffle_flag(ENABLE_INTEGRITY_SIGNATURE, active=True)
+    def test_verification_deadline_with_integrity_signature(self):
+        course = create_course_run(days_till_start=-1)
+        user = create_user()
+        CourseEnrollmentFactory(course_id=course.id, user=user, mode=CourseMode.VERIFIED)
         block = VerificationDeadlineDate(course, user)
         assert not block.is_allowed
 


### PR DESCRIPTION
## [MST-1189](https://openedx.atlassian.net/browse/MST-1189)

The verification deadline should only show on the dates outline if the integrity signature is not enabled for that course. If the integrity signature flag is enabled, this date should be hidden.