### PR TITLE
fix: use the same logo in ace emails as we use in our braze emails

### DIFF
--- a/lms/djangoapps/branding/api.py
+++ b/lms/djangoapps/branding/api.py
@@ -651,4 +651,6 @@ def get_logo_url_for_email():
     Returns the url for the branded logo image for embedding in email templates.
     """
     default_logo_url = getattr(settings, 'DEFAULT_EMAIL_LOGO_URL', None)
-    return getattr(settings, 'LOGO_URL_PNG', None) or default_logo_url
+    # The LOGO_URL_PNG might be reused in the future for other things, so including an email specific png logo
+    return (getattr(settings, 'LOGO_URL_PNG_FOR_EMAIL', None) or
+            getattr(settings, 'LOGO_URL_PNG', None) or default_logo_url)


### PR DESCRIPTION
Our existing logo in ace emails isn't readable in dark mode

I also need a review of the related [edx-internal PR](https://github.com/edx/edx-internal/pull/5795)

Braze Email Header Dark Mode Mobile Gmail
![Image from iOS (2)](https://user-images.githubusercontent.com/5958221/144310472-c5504cd6-9cbd-4cd6-92ef-2f403cfe7183.jpg)

Before Ace Email Header Dark Mode Mobile Gmail
![Image from iOS](https://user-images.githubusercontent.com/5958221/144310470-fa6d823e-32a9-41b2-9d43-0d312ff4583a.jpg)

After Ace Email Header Dark Mode Mobile Gmail
![Image from iOS (1)](https://user-images.githubusercontent.com/5958221/144310474-c099ef0b-c1fa-44e0-86c2-3e18d2d14fed.jpg)

(there is also a separate lower priority issue of the logo not stacking in the header like it does on mobile, but that can be fixed separately)