### PR TITLE
fix: Update Track Selection to support verified only mode

### DIFF
--- a/common/djangoapps/course_modes/tests/test_views.py
+++ b/common/djangoapps/course_modes/tests/test_views.py
@@ -564,6 +564,7 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
         self.assertContains(response, '<span class="award-icon">')
         self.assertContains(response, '<span class="popover-icon">')
         self.assertContains(response, '<span class="note-icon">')
+        self.assertContains(response, '<div class="grid-options">')
 
         # Check for upgrade button ID
         self.assertContains(response, 'track_selection_upgrade')
@@ -608,6 +609,9 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
         # Check min_price was correctly passed in.
         self.assertContains(response, min_price)
 
+        # Check for the HTML element for courses with more than one mode
+        self.assertContains(response, '<div class="grid-options">')
+
     def _assert_legacy_page(self, response, **_):
         """
         Assert choose.html was rendered.
@@ -650,7 +654,11 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
         This test checks that the right template is rendered.
 
         """
-        # The active course mode already exists. Create verified course mode:
+        # Create audit/honor course modes
+        for mode in ('audit', 'honor'):
+            CourseModeFactory.create(mode_slug=mode, course_id=self.course_that_started.id)
+
+        # Create verified course mode:
         verified_mode = CourseModeFactory.create(
             mode_slug='verified',
             course_id=self.course_that_started.id,
@@ -673,6 +681,31 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
                     url = reverse('course_modes_choose', args=[str(self.course_that_started.id)])
                     response = self.client.get(url)
                     expected_page_assertion_function(self, response, min_price=verified_mode.min_price)
+
+    def test_verified_mode_only(self):
+        # Create only the verified mode and enroll the user
+        CourseModeFactory.create(
+            mode_slug='verified',
+            course_id=self.course_that_started.id,
+            min_price=149,
+        )
+        CourseEnrollmentFactory(
+            is_active=True,
+            course_id=self.course_that_started.id,
+            user=self.user
+        )
+
+        # Value Prop TODO (REV-2378): remove waffle flag from tests once the new Track Selection template is rolled out.
+        with override_waffle_flag(VALUE_PROP_TRACK_SELECTION_FLAG, active=True):
+            with patch(GATING_METHOD_NAME, return_value=True):
+                with patch(CDL_METHOD_NAME, return_value=True):
+                    url = reverse('course_modes_choose', args=[str(self.course_that_started.id)])
+                    response = self.client.get(url)
+                    # Check that only the verified option is rendered
+                    self.assertContains(response, "Earn a certificate")
+                    self.assertNotContains(response, "Access this course")
+                    self.assertContains(response, '<div class="grid-single">')
+                    self.assertNotContains(response, '<div class="grid-options">')
 
 
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')

--- a/common/djangoapps/course_modes/tests/test_views.py
+++ b/common/djangoapps/course_modes/tests/test_views.py
@@ -702,6 +702,7 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
                     url = reverse('course_modes_choose', args=[str(self.course_that_started.id)])
                     response = self.client.get(url)
                     # Check that only the verified option is rendered
+                    self.assertNotContains(response, "Choose a path for your course in")
                     self.assertContains(response, "Earn a certificate")
                     self.assertNotContains(response, "Access this course")
                     self.assertContains(response, '<div class="grid-single">')

--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -176,12 +176,15 @@ class ChooseModeView(View):
             user=request.user,
             course_key=course_key
         )
+        is_single_mode = len(modes) == 1
+
         context = {
             "course_modes_choose_url": reverse(
                 "course_modes_choose",
                 kwargs={'course_id': course_id}
             ),
             "modes": modes,
+            "is_single_mode": is_single_mode,
             "has_credit_upsell": has_credit_upsell,
             "course_name": course.display_name_with_default,
             "course_org": course.display_org_with_default,

--- a/lms/static/sass/views/_track_selection.scss
+++ b/lms/static/sass/views/_track_selection.scss
@@ -12,6 +12,12 @@
         line-height: 1.8rem;
     }
 
+    .grid-single {
+        margin: auto;
+        width: 450px;
+        margin-bottom: 2rem;
+    }
+
     .track-selection-choice, .verified-note {
         margin: 0 1rem;
     }
@@ -269,10 +275,13 @@
         .choice-bullets {
             padding: 0 2rem 1rem 1rem;
         }
+        .grid-single {
+            width: 100%;
+        }
     }
 
     @media (min-width: map-get($grid-breakpoints, 'md')) {
-        .track-selection-options {
+        .grid-options {
             display: grid;
             grid-template-columns: 50% 50%;
         }

--- a/lms/templates/course_modes/track_selection.html
+++ b/lms/templates/course_modes/track_selection.html
@@ -86,7 +86,11 @@ from openedx.core.djangolib.js_utils import js_escaped_string
                 <article class="register-choose content-main">
                     <header class="page-header">
                         <h3 class="py-md-3">
-                            ${_("Choose a path for your course in")} ${_(course_name)}
+                            % if is_single_mode:
+                                ${_(course_name)}
+                            % else:
+                                ${_("Choose a path for your course in")} ${_(course_name)}
+                            % endif
                         </h3>
                     </header>
 

--- a/lms/templates/course_modes/track_selection.html
+++ b/lms/templates/course_modes/track_selection.html
@@ -92,7 +92,11 @@ from openedx.core.djangolib.js_utils import js_escaped_string
 
                     <form class="form-register-choose mb-4 mt-0" method="post" name="enrollment_mode_form" id="enrollment_mode_form">
                         <div class="row">
-                        <div class="track-selection-options">
+                        % if is_single_mode:
+                        <div class="grid-single">
+                        % else:
+                        <div class="grid-options">
+                        % endif
                             % if "verified" in modes:
                             <div class="track-selection-choice track-selection-certificate mr-md-2">
                                 <div class="certificate-container">
@@ -137,6 +141,7 @@ from openedx.core.djangolib.js_utils import js_escaped_string
                                 )}</div>
                             </div>
                             % endif
+                            % if "audit" in modes:
                             <div class="track-selection-choice track-selection-audit ml-md-3">
                                 <p class="float-right text-uppercase price-display">${_("Free")}</p>
                                 <div class="choice-title"><h4>${_("Access this course")}</h4></div>
@@ -149,6 +154,7 @@ from openedx.core.djangolib.js_utils import js_escaped_string
                                     </li>
                                 </ul>
                             </div>
+                            % endif
                         </div>
                         <input type="hidden" name="csrfmiddlewaretoken" value="${ csrf_token }">
                     </form>


### PR DESCRIPTION
[REV-2450](https://openedx.atlassian.net/browse/REV-2450).

Track Selection does not currently support courses with verified only mode, and it currently displays both options. It should display as the below:

<img width="600" alt="Screen Shot 2021-12-06 at 3 56 23 PM" src="https://user-images.githubusercontent.com/13632680/144921363-63996199-07eb-4d52-a2af-b510d55a7784.png">

**Pls note:**
- This PR also fixes the inverse, audit only courses. The expected behavior in this case is to have the learner skip track selection and be redirected to course home, however if the learner gets to the track selection URL somehow not through the usual path for an audit only course, it would look like:

<img width="600" alt="Screen Shot 2021-12-06 at 3 56 09 PM" src="https://user-images.githubusercontent.com/13632680/144921398-9814ad03-4920-4bca-aeed-67077583e327.png">

**This PR:**
- Fixes the issue with showing an audit option for verified only courses.
- Also checks for courses with only one course mode.
- Updates the CSS to support having only 1 option in the center of the page.
- Adds tests.

**How to test:**
- Checkout my branch `julianajlk/REV-2450/vp-track-selection-verified-only`
- Create a new course other than the Demo course with verified mode onlu, via [Ecommerce Course Admin](http://localhost:18130/courses/).
- Make sure you have the `VALUE_PROP_TRACK_SELECTION_FLAG` enabled or comment out L271 in views.py.
- Enroll in the newly created course. 
- Track Selection should appear after enrolling in the course with only one mode option.

<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->