### PR TITLE
feat: add API endpoint for change email settings

### DIFF
--- a/common/djangoapps/student/urls.py
+++ b/common/djangoapps/student/urls.py
@@ -17,7 +17,7 @@ urlpatterns = [
     path('accounts/disable_account_ajax', views.disable_account_ajax, name="disable_account_ajax"),
     path('accounts/manage_user_standing', views.manage_user_standing, name='manage_user_standing'),
 
-    path('change_email_settings', views.change_email_settings, name='change_email_settings'),
+    path('api/change_email_settings', views.change_email_settings, name='change_email_settings'),
 
     re_path(fr'^course_run/{settings.COURSE_ID_PATTERN}/refund_status$',
             views.course_run_refund_status,
@@ -28,5 +28,4 @@ urlpatterns = [
         views.activate_secondary_email,
         name='activate_secondary_email'
     ),
-
 ]


### PR DESCRIPTION
<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

feat: add API endpoint for change email settings

We need to introduce the API for changing email settings to opt-in / out for receiving course emails so that it could be used in other platforms.

## Supporting information

https://github.com/mitodl/mitxonline/issues/288

## Testing instructions

You could test the API at that endpoint 
```
URL: http://edx.odl.local:18000/api/change_email_settings

Params: course_id, receive_emails
```

## Deadline

None

## Other information

None