### PR TITLE
fix: pinning version of the name affirmation plugin used in Maple to versions < 2.x

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -83,7 +83,7 @@ edx-django-utils>=4.0.0            # Utilities for cache, monitoring, and plugin
 edx-drf-extensions
 edx-enterprise
 edx-milestones
-edx-name-affirmation
+edx-name-affirmation<2.0.0
 edx-organizations
 edx-proctoring>=2.0.1
 edx-proctoring-proctortrack==1.0.5  # Intentionally and permanently pinned to ensure code changes are reviewed


### PR DESCRIPTION
## Description

- Pin edx-name-affirmation plugin to <2.0.0. The 2.x versions has a breaking change that does not seem compatible with the current state of the Maple branch.
