### PR TITLE
feat: theme-agnostic view to fetch theme assets

### DIFF
--- a/openedx/core/djangoapps/theming/tests/test_views.py
+++ b/openedx/core/djangoapps/theming/tests/test_views.py
@@ -1,16 +1,15 @@
 """
     Tests for comprehensive them
 """
-
+from unittest.mock import patch
 
 from django.conf import settings
-from django.contrib.messages.middleware import MessageMiddleware
 from django.contrib.sites.models import Site
-from django.test import TestCase
+from django.test import TestCase, override_settings
+from django.urls import reverse
 
-from common.djangoapps.student.tests.factories import GlobalStaffFactory
-from openedx.core.djangoapps.theming.middleware import CurrentSiteThemeMiddleware
-from common.djangoapps.student.tests.factories import UserFactory
+from common.djangoapps.student.tests.factories import GlobalStaffFactory, UserFactory
+from openedx.core.djangoapps.theming.models import SiteTheme
 
 THEMING_ADMIN_URL = '/theming/admin'
 TEST_THEME_NAME = 'test-theme'
@@ -21,23 +20,6 @@ class TestThemingViews(TestCase):
     """
     Test theming views.
     """
-    def setUp(self):
-        """
-        Initialize middleware and related objects
-        """
-        super().setUp()
-
-        self.site_theme_middleware = CurrentSiteThemeMiddleware()
-        self.user = UserFactory.create()
-
-    def initialize_mock_request(self, request):
-        """
-        Initialize a test request.
-        """
-        request.user = self.user
-        request.site, __ = Site.objects.get_or_create(domain='test', name='test')
-        request.session = {}
-        MessageMiddleware().process_request(request)
 
     def test_preview_theme_access(self):
         """
@@ -57,7 +39,8 @@ class TestThemingViews(TestCase):
         )
 
         # Logged in non-global staff get a 404
-        self.client.login(username=self.user.username, password=TEST_PASSWORD)
+        non_global_staff_user = UserFactory.create()
+        self.client.login(username=non_global_staff_user.username, password=TEST_PASSWORD)
         response = self.client.get(THEMING_ADMIN_URL)
         assert response.status_code == 404
 
@@ -108,3 +91,23 @@ class TestThemingViews(TestCase):
             response,
             f'<option value="{TEST_THEME_NAME}">'
         )
+
+    def test_asset_no_theme(self):
+        """
+        Fetch theme asset when no theme is set.
+        """
+        response = self.client.get(reverse("theming:openedx.theming.asset", kwargs={"path": "images/logo.png"}))
+        assert response.status_code == 302
+        assert response.url == "/static/images/logo.png"
+
+    @override_settings(STATICFILES_STORAGE="openedx.core.storage.DevelopmentStorage")
+    def test_asset_with_theme(self):
+        """
+        Fetch theme asset when a theme is set.
+        """
+        SiteTheme.objects.create(site=Site.objects.get(), theme_dir_name="red-theme")
+        with patch("openedx.core.storage.DevelopmentStorage.themed") as mock_is_themed:
+            response = self.client.get(reverse("theming:openedx.theming.asset", kwargs={"path": "images/logo.png"}))
+            mock_is_themed.assert_called_once_with("images/logo.png", "red-theme")
+        assert response.status_code == 302
+        assert response.url == "/static/red-theme/images/logo.png"

--- a/openedx/core/djangoapps/theming/urls.py
+++ b/openedx/core/djangoapps/theming/urls.py
@@ -4,19 +4,26 @@ Defines URLs for theming views.
 
 
 from django.conf.urls import url
+from django.urls import path
 
-from .helpers import is_comprehensive_theming_enabled
-from .views import ThemingAdministrationFragmentView
+from . import helpers
+from . import views
 
-app_name = 'openedx.core.djangoapps.theming'
+app_name = "openedx.core.djangoapps.theming"
 
-if is_comprehensive_theming_enabled():
-    urlpatterns = [
+urlpatterns = [
+    path(
+        "asset/<path:path>",
+        views.themed_asset,
+        name="openedx.theming.asset",
+    ),
+]
+
+if helpers.is_comprehensive_theming_enabled():
+    urlpatterns += [
         url(
-            r'^admin',
-            ThemingAdministrationFragmentView.as_view(),
-            name='openedx.theming.update_theme_fragment_view',
+            r"^admin",
+            views.ThemingAdministrationFragmentView.as_view(),
+            name="openedx.theming.update_theme_fragment_view",
         ),
     ]
-else:
-    urlpatterns = []

--- a/openedx/core/djangoapps/theming/views.py
+++ b/openedx/core/djangoapps/theming/views.py
@@ -22,6 +22,7 @@ from openedx.core.djangoapps.util.user_messages import PageLevelMessages
 from common.djangoapps.student.roles import GlobalStaff
 
 from .helpers import theme_exists
+from .helpers_static import get_static_file_url
 from .models import SiteTheme
 
 PREVIEW_SITE_THEME_PREFERENCE_KEY = 'preview-site-theme'
@@ -135,3 +136,18 @@ class ThemingAdministrationFragmentView(EdxFragmentView):
         Returns the page title for the standalone update page.
         """
         return _('Theming Administration')
+
+
+def themed_asset(request, path):
+    """
+    Redirect to themed asset.
+
+    This view makes it easy to link to theme assets without knowing what is the
+    currently enabled theme. For instance, applications outside of the LMS may
+    want to link to the LMS logo.
+
+    Note that the redirect is not permanent because the theme may change from
+    one run to the next.
+    """
+    themed_url = get_static_file_url(path)
+    return redirect(themed_url, permanent=False)


### PR DESCRIPTION
It is possible to set custom logos in microfrontends, for instance with the
LOGO_URL setting. Ideally, we would like that MFEs share the same logos as the
LMS. But this is made difficult when comprehensive theming is enabled, and the
logo is overridden by a custom theme. In that scenario, the logo url becomes
/static/mytheme/images/logo.png. But the MFEs do no know that the "mytheme"
theme is enabled. To resolve this issue, we introduce here a view, at the
"/theming/asset/<path>" url, that redirects to the corresponding asset in the
theme that is currently enabled. Thus, MFEs only have to set
`LOGO_URL=http://lmshost/theming/asset/images/logo.png` to point to the themed
logo.

Related issue: https://github.com/overhangio/tutor-mfe/issues/25

This is a cherry-pick of the following PR: https://github.com/edx/edx-platform/pull/29461