### PR TITLE
feat: AA-1127: Overrides Braze Frequency Cap for dynamic pacing emails

### DIFF
--- a/openedx/core/djangoapps/schedules/message_types.py
+++ b/openedx/core/djangoapps/schedules/message_types.py
@@ -12,6 +12,7 @@ class ScheduleMessageType(BaseMessageType):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.log_level = logging.DEBUG if DEBUG_MESSAGE_WAFFLE_FLAG.is_enabled() else None
+        self.options['override_frequency_capping'] = True
 
 
 class RecurringNudge(ScheduleMessageType):

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -388,7 +388,7 @@ drf-jwt==1.19.1
     # via edx-drf-extensions
 drf-yasg==1.20.0
     # via edx-api-doc-tools
-edx-ace==1.4.0
+edx-ace==1.4.1
     # via -r requirements/edx/base.in
 edx-api-doc-tools==1.5.0
     # via -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -494,7 +494,7 @@ drf-yasg==1.20.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-api-doc-tools
-edx-ace==1.4.0
+edx-ace==1.4.1
     # via -r requirements/edx/testing.txt
 edx-api-doc-tools==1.5.0
     # via -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -476,7 +476,7 @@ drf-yasg==1.20.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-api-doc-tools
-edx-ace==1.4.0
+edx-ace==1.4.1
     # via -r requirements/edx/base.txt
 edx-api-doc-tools==1.5.0
     # via -r requirements/edx/base.txt


### PR DESCRIPTION
edx-ace version 1.4.1 introduces the ability to override braze
email frequency caps.

Dependent on https://github.com/edx/edx-ace/pull/123

https://openedx.atlassian.net/browse/AA-1127
