### PR TITLE
feat: allow get account info on lms user id

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/permissions.py
+++ b/openedx/core/djangoapps/user_api/accounts/permissions.py
@@ -2,7 +2,6 @@
 Permissions classes for User accounts API views.
 """
 
-
 from django.conf import settings
 from rest_framework import permissions
 
@@ -12,6 +11,7 @@ class CanDeactivateUser(permissions.BasePermission):
     Grants access to AccountDeactivationView if the requesting user is a superuser
     or has the explicit permission to deactivate a User account.
     """
+
     def has_permission(self, request, view):
         return request.user.has_perm('student.can_deactivate_users')
 
@@ -22,6 +22,7 @@ class CanRetireUser(permissions.BasePermission):
     a superuser, the RETIREMENT_SERVICE_USERNAME, or has the explicit permission to
     retire a User account.
     """
+
     def has_permission(self, request, view):
         return request.user.has_perm('accounts.can_retire_user')
 
@@ -30,5 +31,18 @@ class CanReplaceUsername(permissions.BasePermission):
     """
     Grants access to the Username Replacement API for the service user.
     """
+
     def has_permission(self, request, view):
         return request.user.username == getattr(settings, "USERNAME_REPLACEMENT_WORKER", False)
+
+
+class CanGetAccountInfoUsingId(permissions.BasePermission):
+    """
+    Grants access to AccountViewSet if the requesting user is a superuser/staff
+    and reqesting to get account info based on LMS User id
+    """
+
+    def has_permission(self, request, view):
+        return request.GET.get('lms_user_id') is None or (
+            request.GET.get('lms_user_id') and (request.user.is_staff or request.user.is_superuser)
+        )

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -5,15 +5,12 @@ For additional information and historical context, see:
 https://openedx.atlassian.net/wiki/display/TNL/User+API
 """
 
-
 import datetime
 import logging
 import uuid
 from functools import wraps
 
 import pytz
-from rest_framework.exceptions import UnsupportedMediaType
-
 from consent.models import DataSharingConsent
 from django.apps import apps
 from django.conf import settings
@@ -31,6 +28,7 @@ from integrated_channels.degreed.models import DegreedLearnerDataTransmissionAud
 from integrated_channels.sap_success_factors.models import SapSuccessFactorsLearnerDataTransmissionAudit
 from rest_framework import permissions, status
 from rest_framework.authentication import SessionAuthentication
+from rest_framework.exceptions import UnsupportedMediaType
 from rest_framework.parsers import JSONParser
 from rest_framework.response import Response
 from rest_framework.serializers import ValidationError
@@ -41,13 +39,11 @@ from wiki.models.pluginbase import RevisionPluginRevision
 
 from common.djangoapps.entitlements.models import CourseEntitlement
 from common.djangoapps.student.models import (  # lint-amnesty, pylint: disable=unused-import
-    AccountRecovery,
     CourseEnrollmentAllowed,
     LoginFailures,
     ManualEnrollmentAudit,
     PendingEmailChange,
     PendingNameChange,
-    Registration,
     User,
     UserProfile,
     get_potentially_retired_user_by_username,
@@ -78,7 +74,7 @@ from ..models import (
     UserRetirementStatus
 )
 from .api import get_account_settings, update_account_settings
-from .permissions import CanDeactivateUser, CanReplaceUsername, CanRetireUser
+from .permissions import CanDeactivateUser, CanGetAccountInfoUsingId, CanReplaceUsername, CanRetireUser
 from .serializers import (
     PendingNameChangeSerializer,
     UserRetirementPartnerReportSerializer,
@@ -114,6 +110,7 @@ def request_requires_username(function):
     Requires that a ``username`` key containing a truthy value exists in
     the ``request.data`` attribute of the decorated function.
     """
+
     @wraps(function)
     def wrapper(self, request):  # pylint: disable=missing-docstring
         username = request.data.get('username', None)
@@ -123,6 +120,7 @@ def request_requires_username(function):
                 data={'message': 'The user was not specified.'}
             )
         return function(self, request)
+
     return wrapper
 
 
@@ -293,7 +291,7 @@ class AccountViewSet(ViewSet):
     authentication_classes = (
         JwtAuthentication, BearerAuthenticationAllowInactiveUser, SessionAuthenticationAllowInactiveUser
     )
-    permission_classes = (permissions.IsAuthenticated,)
+    permission_classes = (permissions.IsAuthenticated, CanGetAccountInfoUsingId)
     parser_classes = (JSONParser, MergePatchParser,)
 
     def get(self, request):
@@ -306,9 +304,11 @@ class AccountViewSet(ViewSet):
         """
         GET /api/user/v1/accounts?username={username1,username2}
         GET /api/user/v1/accounts?email={user_email}
+        GET /api/user/v1/accounts?lms_user_id={lms_user_id} (Staff Only)
         """
         usernames = request.GET.get('username')
         user_email = request.GET.get('email')
+        lms_user_id = request.GET.get('lms_user_id')
         search_usernames = []
 
         if usernames:
@@ -320,9 +320,16 @@ class AccountViewSet(ViewSet):
             except (UserNotFound, User.DoesNotExist):
                 return Response(status=status.HTTP_404_NOT_FOUND)
             search_usernames = [user.username]
+        elif lms_user_id:
+            try:
+                user = User.objects.get(id=lms_user_id)
+            except (UserNotFound, User.DoesNotExist):
+                return Response(status=status.HTTP_404_NOT_FOUND)
+            search_usernames = [user.username]
         try:
             account_settings = get_account_settings(
-                request, search_usernames, view=request.query_params.get('view'))
+                request, search_usernames, view=request.query_params.get('view')
+            )
         except UserNotFound:
             return Response(status=status.HTTP_404_NOT_FOUND)
 
@@ -459,7 +466,7 @@ class AccountDeactivationView(APIView):
     Account deactivation viewset. Currently only supports POST requests.
     Only admins can deactivate accounts.
     """
-    authentication_classes = (JwtAuthentication, )
+    authentication_classes = (JwtAuthentication,)
     permission_classes = (permissions.IsAuthenticated, CanDeactivateUser)
 
     def post(self, request, username):
@@ -505,8 +512,8 @@ class DeactivateLogoutView(APIView):
     -  Log the user out
     - Create a row in the retirement table for that user
     """
-    authentication_classes = (JwtAuthentication, SessionAuthentication, )
-    permission_classes = (permissions.IsAuthenticated, )
+    authentication_classes = (JwtAuthentication, SessionAuthentication,)
+    permission_classes = (permissions.IsAuthenticated,)
 
     def post(self, request):
         """
@@ -1208,7 +1215,7 @@ class UsernameReplacementView(APIView):
     This API will be called first, before calling the APIs in other services as this
     one handles the checks on the usernames provided.
     """
-    authentication_classes = (JwtAuthentication, )
+    authentication_classes = (JwtAuthentication,)
     permission_classes = (permissions.IsAuthenticated, CanReplaceUsername)
 
     def post(self, request):


### PR DESCRIPTION
## Description

[PROD-2590](https://openedx.atlassian.net/browse/PROD-2590) Adds an LMS user id based account info search. Only staff and superusers are allowed to perform this task. LMS user id is the immutable id for a learner that can help in uniquely identifying a learner. The aim of adding the LMS id based filtering is to allow IDAs to fetch learner information given LMS user id. Ideally, no learner data except LMS id should be stored in IDA to avoid PII exposure. So, if IDA needs any learner info, they should be able to get so using LMS id.

To avoid this possible exposure, LMS user-id based filtering should be restricted to Staff only users. This staff is Django level staff(is_staff or is_superuser). This will allow IDAs, who use staff accounts to fetch learner information against LMS id and avoid risking any data exposure by learners.

## Testing instructions

Test all the following url patterns against your local devstack and see everything is working as expected (in both logged in and logged out cases):
1. /api/user/v1/accounts?username=edx
2. /api/user/v1/accounts?email=edx@example.com
3. /api/user/v1/accounts?lms_user_id=3
