### PR TITLE
test: save pytest warning reports to GHA artifacts

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -63,3 +63,47 @@ jobs:
       - name: run tests
         run: |
           python -Wd -m pytest -p no:randomly --ds=${{ env.settings_path }} ${{ env.unit_test_paths }}
+
+      - name: rename warnings json file
+        if: success()
+        run: |
+          cd test_root/log
+          mv pytest_warnings.json pytest_warnings_${{ matrix.shard_name }}.json
+
+      - name: save pytest warnings json file
+        if: success()
+        uses: actions/upload-artifact@v2
+        with:
+          name: pytest-warnings-json
+          path: |
+            test_root/log/pytest_warnings*.json
+
+  compile-warnings-report:
+    runs-on: [ self-hosted ]
+    needs: [ run-tests ]
+    steps:
+      - name: sync directory owner
+        run: sudo chown runner:runner -R .*
+      - uses: actions/checkout@v2
+      - name: collect pytest warnings files
+        uses: actions/download-artifact@v2
+        with:
+          name: pytest-warnings-json
+          path: test_root/log
+
+      - name: display structure of downloaded files
+        run: ls -la test_root/log
+
+      - name: compile warnings report
+        run: |
+          python openedx/core/process_warnings.py --dir-path test_root/log --html-path reports/pytest_warnings/warning_report_all.html
+
+      - name: save warning report
+        if: success()
+        uses: actions/upload-artifact@v2
+        with:
+          name: pytest-warning-report-html
+          path: |
+            reports/pytest_warnings/warning_report_all.html
+
+

--- a/common/lib/conftest.py
+++ b/common/lib/conftest.py
@@ -7,6 +7,9 @@ import pytest
 
 from safe_lxml import defuse_xml_libs
 
+# This import is needed for pytest plugin configuration, so please avoid deleting this during refactoring
+from openedx.core.pytest_hooks import pytest_configure  # pylint: disable=unused-import
+
 defuse_xml_libs()
 
 

--- a/openedx/core/process_warnings.py
+++ b/openedx/core/process_warnings.py
@@ -91,7 +91,7 @@ def read_warning_data(dir_path):
     # TODO(jinder): currently this is hard-coded in, maybe create a constants file with info
     # THINK(jinder): but creating file for one constant seems overkill
     warnings_file_name_regex = (
-        r"pytest_warnings_?\d*\.json"  # noqa pylint: disable=W1401
+        r"pytest_warnings_?[\w-]*\.json"  # noqa pylint: disable=W1401
     )
 
     # iterate through files_in_dir and see if they match our know file name pattern


### PR DESCRIPTION
Saving pytest warnings report (HTML) in Github actions artifacts. File download as zip on local machine.

Context: https://openedx.atlassian.net/browse/BOM-3100

---------------
Click on summary 

<img width="882" alt="Screen Shot 2021-12-16 at 2 07 27 PM" src="https://user-images.githubusercontent.com/445320/146341639-5bfe242e-f6b5-4be8-b193-b312fa0e2c02.png">

