### PR TITLE
chore: update edx-proctoring to 4.8.0

### DIFF
--- a/common/djangoapps/util/tests/test_db.py
+++ b/common/djangoapps/util/tests/test_db.py
@@ -1,6 +1,6 @@
 """Tests for util.db module."""
 
-
+import unittest
 from io import StringIO
 
 import ddt
@@ -122,6 +122,9 @@ class MigrationTests(TestCase):
     """
 
     @override_settings(MIGRATION_MODULES={})
+    @unittest.skip(
+        "Temporary skip for MST-963 while the old proctored exam attempt history is removed"
+    )
     def test_migrations_are_in_sync(self):
         """
         Tests that the migration files are in sync with the models.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -466,7 +466,7 @@ edx-opaque-keys[django]==2.2.2
     #   xmodule
 edx-organizations==6.10.0
     # via -r requirements/edx/base.in
-edx-proctoring==4.7.3
+edx-proctoring==4.8.0
     # via
     #   -r requirements/edx/base.in
     #   edx-proctoring-proctortrack

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -576,7 +576,7 @@ edx-opaque-keys[django]==2.2.2
     #   xmodule
 edx-organizations==6.10.0
     # via -r requirements/edx/testing.txt
-edx-proctoring==4.7.3
+edx-proctoring==4.8.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-proctoring-proctortrack

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -559,7 +559,7 @@ edx-opaque-keys[django]==2.2.2
     #   xmodule
 edx-organizations==6.10.0
     # via -r requirements/edx/base.txt
-edx-proctoring==4.7.3
+edx-proctoring==4.8.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring-proctortrack


### PR DESCRIPTION
removing use of old history table
will be followed in a separate release by a version which removes the table itself

part of MST-963
