### PR TITLE
build: suppress Django deprecation warnings

### DIFF
--- a/cms/pytest.ini
+++ b/cms/pytest.ini
@@ -8,6 +8,8 @@ filterwarnings =
     default
     ignore:No request passed to the backend, unable to rate-limit:UserWarning
     ignore::xblock.exceptions.FieldDataDeprecationWarning
+    ignore::django.utils.deprecation.RemovedInDjango40Warning
+    ignore::django.utils.deprecation.RemovedInDjango41Warning
 norecursedirs = envs
 python_classes =
 python_files = test.py tests.py test_*.py *_tests.py

--- a/common/lib/pytest.ini
+++ b/common/lib/pytest.ini
@@ -9,6 +9,8 @@ filterwarnings =
     default
     ignore:No request passed to the backend, unable to rate-limit:UserWarning
     ignore::xblock.exceptions.FieldDataDeprecationWarning
+    ignore::django.utils.deprecation.RemovedInDjango40Warning
+    ignore::django.utils.deprecation.RemovedInDjango41Warning
 markers =
     mongo
 norecursedirs = .cache

--- a/common/test/pytest.ini
+++ b/common/test/pytest.ini
@@ -7,4 +7,6 @@ filterwarnings =
     default
     ignore:No request passed to the backend, unable to rate-limit:UserWarning
     ignore::xblock.exceptions.FieldDataDeprecationWarning
+    ignore::django.utils.deprecation.RemovedInDjango40Warning
+    ignore::django.utils.deprecation.RemovedInDjango41Warning
 norecursedirs = .cache

--- a/openedx/core/lib/logsettings.py
+++ b/openedx/core/lib/logsettings.py
@@ -129,9 +129,9 @@ def log_python_warnings():
     try:
         # There are far too many of these deprecation warnings in startup to output for every management command;
         # suppress them until we've fixed at least the most common ones as reported by the test suite
-        from django.utils.deprecation import RemovedInDjango20Warning, RemovedInDjango21Warning
-        warnings.simplefilter('ignore', RemovedInDjango20Warning)
-        warnings.simplefilter('ignore', RemovedInDjango21Warning)
+        from django.utils.deprecation import RemovedInDjango40Warning, RemovedInDjango41Warning
+        warnings.simplefilter('ignore', RemovedInDjango40Warning)
+        warnings.simplefilter('ignore', RemovedInDjango41Warning)
     except ImportError:
         pass
     logging.captureWarnings(True)

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,8 @@ filterwarnings =
     default
     ignore:No request passed to the backend, unable to rate-limit:UserWarning
     ignore::xblock.exceptions.FieldDataDeprecationWarning
+    ignore::django.utils.deprecation.RemovedInDjango40Warning
+    ignore::django.utils.deprecation.RemovedInDjango41Warning
 junit_family = xunit2
 norecursedirs = .* *.egg build conf dist node_modules test_root cms/envs lms/envs
 python_classes =


### PR DESCRIPTION
<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

There are hundreds of not thousands of Django deprecation warnings when we run the test suite.  The volume of these makes it impossible to see other warnings.  Most engineers should not be concerned with Django deprecation, since that work is done as part of a formal migration to the next Django version.

This pull request silences those warnings in the tests.

If there's a way to disable those warnings and also disable them when running the code in devstack or production, it would be great to combine them.  This pull request only changes the tests. https://github.com/edx/edx-platform/pull/28913 suppresses the warnings while running.