### PR TITLE
fix: add a couple guards for anonymous users

### DIFF
--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -498,6 +498,9 @@ class CoursewareInformation(RetrieveAPIView):
         The timezone in the user's account is frequently not set.
         This method sets a user's recent timezone that can be used as a fallback
         """
+        if not user.id:
+            return
+
         cache_key = 'browser_timezone_{}'.format(str(user.id))
         browser_timezone = self.request.query_params.get('browser_timezone', None)
         cached_value = TieredCache.get_cached_response(cache_key)

--- a/openedx/core/djangoapps/user_api/course_tag/api.py
+++ b/openedx/core/djangoapps/user_api/course_tag/api.py
@@ -107,6 +107,9 @@ def set_course_tag(user, course_id, key, value):
     # simultaneous calls from many processes. Handle by retrying after
     # a short delay?
 
+    if not user.id:
+        return
+
     record, _ = UserCourseTag.objects.get_or_create(
         user=user,
         course_id=course_id,


### PR DESCRIPTION
This fixes a couple places (LastSeenCoursewareTimezone and UserCourseTag) where we were saving an entry for a user, but not making sure we ignored anonymous users.

No obvious terrible UX, but I saw the user course tag error in splunk, and the timezone error in devstack. Figured it was an easy fix.