### PR TITLE
[MST-1195] Hide course upgrade on dashboard if there is no SKU

### DIFF
--- a/common/djangoapps/student/tests/test_views.py
+++ b/common/djangoapps/student/tests/test_views.py
@@ -7,10 +7,11 @@ import itertools
 import json
 import re
 import unittest
-from datetime import timedelta  # lint-amnesty, pylint: disable=unused-import
+from datetime import datetime, timedelta  # lint-amnesty, pylint: disable=unused-import
 from unittest.mock import patch
 
 import ddt
+import pytz
 from completion.test_utils import CompletionWaffleTestMixin, submit_completions_for_testing
 from django.conf import settings
 from django.test.utils import override_settings
@@ -22,6 +23,7 @@ from opaque_keys.edx.keys import CourseKey
 from pyquery import PyQuery as pq
 
 from common.djangoapps.course_modes.models import CourseMode
+from common.djangoapps.course_modes.tests.factories import CourseModeFactory
 from common.djangoapps.entitlements.tests.factories import CourseEntitlementFactory
 from common.djangoapps.student.helpers import DISABLE_UNENROLL_CERT_STATES
 from common.djangoapps.student.models import CourseEnrollment, UserProfile
@@ -36,6 +38,7 @@ from common.djangoapps.util.milestones_helpers import (
 from common.djangoapps.util.testing import UrlResetMixin  # lint-amnesty, pylint: disable=unused-import
 from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
 from lms.djangoapps.certificates.data import CertificateStatuses
+from lms.djangoapps.commerce.utils import EcommerceService
 from openedx.core.djangoapps.catalog.tests.factories import ProgramFactory
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
@@ -907,6 +910,55 @@ class StudentDashboardTests(SharedModuleStoreTestCase, MilestonesTestCaseMixin, 
 
             assert expected_button in dashboard_html
             assert unexpected_button not in dashboard_html
+
+    @ddt.data(
+        # Ecommerce is not enabled
+        (False, True, False, 'abcdef', False),
+        # No verified mode
+        (True, False, False, 'abcdef', False),
+        # User has an entitlement
+        (True, True, True, 'abcdef', False),
+        # No SKU
+        (True, True, False, None, False),
+        (True, True, False, 'abcdef', True)
+    )
+    @ddt.unpack
+    def test_course_upgrade_notification(
+        self, ecommerce_enabled, has_verified_mode, has_entitlement, sku, should_display
+    ):
+        """
+        Upgrade notification for a course should appear if:
+            - Ecommerce service is enabled
+            - The course has a paid/verified mode
+            - The user doesn't have an entitlement for the course
+            - The course has an associated SKU
+        """
+        with patch.object(EcommerceService, 'is_enabled', return_value=ecommerce_enabled):
+            course = CourseFactory.create()
+
+            if has_verified_mode:
+                CourseModeFactory.create(
+                    course_id=course.id,
+                    mode_slug='verified',
+                    mode_display_name='Verified',
+                    expiration_datetime=datetime.now(pytz.UTC) + timedelta(days=1),
+                    sku=sku
+                )
+
+            enrollment = CourseEnrollmentFactory(
+                user=self.user,
+                course_id=course.id
+            )
+
+            if has_entitlement:
+                CourseEntitlementFactory(user=self.user, enrollment_course_run=enrollment)
+
+            response = self.client.get(reverse('dashboard'))
+            html_fragment = '<div class="message message-upsell has-actions is-shown">'
+            if should_display:
+                self.assertContains(response, html_fragment)
+            else:
+                self.assertNotContains(response, html_fragment)
 
 
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Tests only valid for the LMS')

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -42,6 +42,14 @@ from lms.djangoapps.experiments.utils import UPSELL_TRACKING_FLAG
     cert_name_long = settings.CERT_NAME_LONG
 
   is_course_expired = hasattr(show_courseware_link, 'error_code') and show_courseware_link.error_code == 'audit_expired'
+
+  display_course_upgrade = (
+      use_ecommerce_payment_flow
+      and course_mode_info
+      and course_mode_info['show_upsell']
+      and not entitlement
+      and course_mode_info['verified_sku']
+  )
 %>
 
 <%
@@ -413,7 +421,7 @@ from lms.djangoapps.experiments.utils import UPSELL_TRACKING_FLAG
           </div>
         % endif
 
-        % if course_mode_info and course_mode_info['show_upsell'] and not entitlement:
+        % if display_course_upgrade:
           <div class="message message-upsell has-actions is-shown">
             <div class="wrapper-extended">
               <div class="wrapper-icon-message">
@@ -434,11 +442,7 @@ from lms.djangoapps.experiments.utils import UPSELL_TRACKING_FLAG
                 </div>
               </div>
               <div class="action-upgrade-container">
-                % if use_ecommerce_payment_flow and course_mode_info['verified_sku']:
-                  <a class="action action-upgrade track_course_dashboard_green_button" href="${ecommerce_payment_page}?sku=${course_mode_info['verified_sku']}">
-                % else:
-                  <a class="action action-upgrade track_course_dashboard_green_button" href="${IDVerificationService.get_verify_location(course_id=course_overview.id)}" data-course-id="${course_overview.id}" data-user="${user.username}">
-                % endif
+                <a class="action action-upgrade track_course_dashboard_green_button" href="${ecommerce_payment_page}?sku=${course_mode_info['verified_sku']}">
                   <span class="wrapper-copy">
                     <span class="copy" id="upgrade-to-verified">${_("Upgrade")}</span>
                       <span class="sr">&nbsp;${_(course_overview.display_name_with_default)}</span>


### PR DESCRIPTION
<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

![Screen Shot 2021-12-09 at 6 13 37 PM](https://user-images.githubusercontent.com/10442143/145490494-895e53a3-1847-4da9-98a1-5eb04f71f3ac.png)

If ecommerce is not enabled or there is no SKU for the course, the course listing would still display an "upgrade" alert on the dashboard. However, this would link to the IDV flow instead of checkout, which doesn't actually upgrade the learner's seat in the course on its own - they would still be auditing the course after completing IDV if they cannot purchase a verified seat.

Due to this, the course upgrade notification, shown above, should not display at all if there is no way to purchase an upgrade.

## Supporting information

[MST-1195](https://openedx.atlassian.net/browse/MST-1195)