### PR TITLE
fix: add is_configured property

### DIFF
--- a/lms/djangoapps/learner_dashboard/tests/test_views.py
+++ b/lms/djangoapps/learner_dashboard/tests/test_views.py
@@ -54,7 +54,7 @@ class TestProgramDiscussionIframeView(SharedModuleStoreTestCase, ProgramCacheMix
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         expected_data = {
-            'enabled': True,
+            'tab_view_enabled': True,
             'discussion': {
                 'iframe': "",
                 'configured': False
@@ -69,6 +69,29 @@ class TestProgramDiscussionIframeView(SharedModuleStoreTestCase, ProgramCacheMix
         self.client.logout()
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 401)
+
+    def test_program_discussion_disabled(self):
+        """
+        Tests that API does not return discussion iframe when discussion
+        configuration is disabled.
+        """
+        __ = ProgramDiscussionsConfiguration.objects.create(
+            program_uuid=self.program_uuid,
+            enabled=False,
+            provider_type="piazza",
+        )
+        expected_data = {
+            'tab_view_enabled': True,
+            'discussion': {
+                'iframe': "",
+                'configured': False
+            }
+        }
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, expected_data)
 
     def test_api_returns_discussions_iframe(self):
         """

--- a/lms/djangoapps/learner_dashboard/views.py
+++ b/lms/djangoapps/learner_dashboard/views.py
@@ -86,7 +86,7 @@ class ProgramDiscussionIframeView(APIView, ProgramSpecificViewMixin):
     **Example**
 
         {
-            'enabled_for_masters': True,
+            'tab_view_enabled': True,
             'discussion': {
                 "iframe": "
                             <iframe
@@ -96,10 +96,9 @@ class ProgramDiscussionIframeView(APIView, ProgramSpecificViewMixin):
                              >
                             </iframe>
                             ",
-                "enabled": false
+                "configured": false
             }
         }
-
 
     """
     authentication_classes = (BearerAuthentication, SessionAuthentication)
@@ -108,14 +107,11 @@ class ProgramDiscussionIframeView(APIView, ProgramSpecificViewMixin):
     def get(self, request, program_uuid):
         """ GET handler """
         program_discussion_lti = ProgramDiscussionLTI(program_uuid, request)
-        return Response(
-
-            {
-                'enabled': masters_program_tab_view_is_enabled(),
-                'discussion': {
-                    'iframe': program_discussion_lti.render_iframe(),
-                    'configured': bool(program_discussion_lti.configuration),
-                }
-            },
-            status=status.HTTP_200_OK
-        )
+        response_data = {
+            'tab_view_enabled': masters_program_tab_view_is_enabled(),
+            'discussion': {
+                'iframe': program_discussion_lti.render_iframe(),
+                'configured': program_discussion_lti.is_configured,
+            }
+        }
+        return Response(response_data, status=status.HTTP_200_OK)

--- a/openedx/core/djangoapps/discussions/models.py
+++ b/openedx/core/djangoapps/discussions/models.py
@@ -552,17 +552,13 @@ class ProgramDiscussionsConfiguration(TimeStampedModel):
         return f"Configuration(uuid='{self.program_uuid}', provider='{self.provider_type}', enabled={self.enabled})"
 
     @classmethod
-    def is_enabled(cls, program_uuid) -> bool:
+    def get(cls, program_uuid):
         """
-        Check if there is an active configuration for a given program uuid
-
-        Default to False, if no configuration exists
+        Lookup a program discussion configuration by program uuid.
         """
-        try:
-            configuration = cls.objects.get(program_uuid=program_uuid)
-            return configuration.enabled
-        except cls.DoesNotExist:
-            return False
+        return ProgramDiscussionsConfiguration.objects.filter(
+            program_uuid=program_uuid
+        ).first()
 
 
 class DiscussionTopicLink(models.Model):


### PR DESCRIPTION
Add `is_configured` property in `ProgramDiscussionLTI`. This fixes a bug when a program discussion configuration is disabled it still renders the discussion tab. 

FYI - @mehaknasir 