### PR TITLE
fix: redirect behavior to learner-specific progress pages

### DIFF
--- a/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
+++ b/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
@@ -50,7 +50,7 @@ def send_ace_message(goal):
     site = Site.objects.get_current()
     message_context = get_base_template_context(site)
 
-    course_home_url = get_learning_mfe_home_url(course_key=goal.course_key, view_name='home')
+    course_home_url = get_learning_mfe_home_url(course_key=goal.course_key, url_fragment='home')
 
     goals_unsubscribe_url = f'{settings.LEARNING_MICROFRONTEND_URL}/goal-unsubscribe/{goal.unsubscribe_token}'
 

--- a/lms/djangoapps/course_home_api/outline/views.py
+++ b/lms/djangoapps/course_home_api/outline/views.py
@@ -207,7 +207,7 @@ class OutlineTabView(RetrieveAPIView):
         if course_home_legacy_is_active(course.id):
             dates_tab_link = request.build_absolute_uri(reverse('dates', args=[course.id]))
         else:
-            dates_tab_link = get_learning_mfe_home_url(course_key=course.id, view_name='dates')
+            dates_tab_link = get_learning_mfe_home_url(course_key=course.id, url_fragment='dates')
 
         # Set all of the defaults
         access_expiration = None

--- a/lms/djangoapps/courseware/tabs.py
+++ b/lms/djangoapps/courseware/tabs.py
@@ -47,7 +47,7 @@ class CoursewareTab(EnrolledTab):
                 url_func = course_reverse_func_from_name_func(reverse_name_func)
                 return url_func(course, reverse_func)
             else:
-                return get_learning_mfe_home_url(course_key=course.id, view_name='home')
+                return get_learning_mfe_home_url(course_key=course.id, url_fragment='home')
 
         tab_dict['link_func'] = link_func
         super().__init__(tab_dict)
@@ -112,7 +112,7 @@ class ProgressTab(EnrolledTab):
     def __init__(self, tab_dict):
         def link_func(course, reverse_func):
             if course_home_mfe_progress_tab_is_active(course.id):
-                return get_learning_mfe_home_url(course_key=course.id, view_name=self.view_name)
+                return get_learning_mfe_home_url(course_key=course.id, url_fragment=self.view_name)
             else:
                 return reverse_func(self.view_name, args=[str(course.id)])
 
@@ -337,7 +337,7 @@ class DatesTab(EnrolledTab):
             if course_home_legacy_is_active(course.id):
                 return reverse_func(self.view_name, args=[str(course.id)])
             else:
-                return get_learning_mfe_home_url(course_key=course.id, view_name=self.view_name)
+                return get_learning_mfe_home_url(course_key=course.id, url_fragment=self.view_name)
 
         tab_dict['link_func'] = link_func
         super().__init__(tab_dict)

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -606,7 +606,7 @@ class ViewsTestCase(BaseViewsTestCase):
                 'course_id': str(course.id),
             }
         )
-        mfe_url = get_learning_mfe_home_url(course_key=course.id, view_name='home')
+        mfe_url = get_learning_mfe_home_url(course_key=course.id, url_fragment='home')
 
         with _set_course_home_mfe_flag(activate_mfe):
             response = self.client.get(reverse('about_course', args=[str(course.id)]))

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -936,7 +936,7 @@ def course_about(request, course_id):
             if course_home_legacy_is_active(course.id):
                 course_target = reverse(course_home_url_name(course.id), args=[str(course.id)])
             else:
-                course_target = get_learning_mfe_home_url(course_key=course.id, view_name='home')
+                course_target = get_learning_mfe_home_url(course_key=course.id, url_fragment='home')
         else:
             course_target = reverse('about_course', args=[str(course.id)])
 
@@ -1061,7 +1061,7 @@ def dates(request, course_id):
     course_key = CourseKey.from_string(course_id)
     if not (course_home_legacy_is_active(course_key) or request.user.is_staff):
         raise Redirect(get_learning_mfe_home_url(
-            course_key=course_key, view_name=COURSE_DATES_NAME, params=request.GET,
+            course_key=course_key, url_fragment=COURSE_DATES_NAME, params=request.GET,
         ))
 
     # Enable NR tracing for this view based on course
@@ -1133,13 +1133,12 @@ def dates(request, course_id):
 @data_sharing_consent_required
 def progress(request, course_id, student_id=None):
     """ Display the progress page. """
-    from lms.urls import COURSE_PROGRESS_NAME
-
     course_key = CourseKey.from_string(course_id)
 
     if course_home_mfe_progress_tab_is_active(course_key) and not request.user.is_staff:
+        end_of_redirect_url = 'progress' if not student_id else f'progress/{student_id}'
         raise Redirect(get_learning_mfe_home_url(
-            course_key=course_key, view_name=COURSE_PROGRESS_NAME, params=request.GET,
+            course_key=course_key, url_fragment=end_of_redirect_url, params=request.GET,
         ))
 
     with modulestore().bulk_operations(course_key):

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1737,7 +1737,7 @@ def get_student_progress_url(request, course_id):
     user = get_student_from_identifier(request.POST.get('unique_student_identifier'))
 
     if course_home_mfe_progress_tab_is_active(course_id):
-        progress_url = get_learning_mfe_home_url(course_id, 'progress')
+        progress_url = get_learning_mfe_home_url(course_id, url_fragment='progress')
         if user is not None:
             progress_url += '/{}/'.format(user.id)
     else:

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -75,7 +75,7 @@ from lms.djangoapps.experiments.utils import UPSELL_TRACKING_FLAG
         % endif
       >
 <article class="course${mode_class}" aria-labelledby="course-title-${enrollment.course_id}" id="course-card-${course_card_index}">
-  <% course_target = reverse(course_home_url_name(course_overview.id), args=[str(course_overview.id)]) if course_home_legacy_is_active(course_overview.id) else get_learning_mfe_home_url(course_key=course_overview.id, view_name="home") %>
+  <% course_target = reverse(course_home_url_name(course_overview.id), args=[str(course_overview.id)]) if course_home_legacy_is_active(course_overview.id) else get_learning_mfe_home_url(course_key=course_overview.id, url_fragment="home") %>
   <section class="details" aria-labelledby="details-heading-${enrollment.course_id}">
       <h2 class="hd hd-2 sr" id="details-heading-${enrollment.course_id}">${_('Course details')}</h2>
     <div class="wrapper-course-image" aria-hidden="true">

--- a/openedx/features/course_experience/api/v1/views.py
+++ b/openedx/features/course_experience/api/v1/views.py
@@ -98,7 +98,7 @@ def reset_course_deadlines(request):
         if course_home_legacy_is_active(course_key):
             body_link = '{}{}'.format(settings.LMS_ROOT_URL, reverse('dates', args=[str(course_key)]))
         else:
-            body_link = get_learning_mfe_home_url(course_key=str(course_key), view_name='dates')
+            body_link = get_learning_mfe_home_url(course_key=str(course_key), url_fragment='dates')
 
         return Response({
             'body': format_html('<a href="{}">{}</a>', body_link, _('View all dates')),

--- a/openedx/features/course_experience/url_helpers.py
+++ b/openedx/features/course_experience/url_helpers.py
@@ -195,7 +195,7 @@ def make_learning_mfe_courseware_url(
 
 def get_learning_mfe_home_url(
         course_key: CourseKey,
-        view_name: Optional[str] = None,
+        url_fragment: Optional[str] = None,
         params: Optional[QueryDict] = None,
 ) -> str:
     """
@@ -206,13 +206,13 @@ def get_learning_mfe_home_url(
     http://localhost:2000/course/course-v1:edX+DemoX+Demo_Course/dates
 
     `course_key` can be either an OpaqueKey or a string.
-    `view_name` is an optional string.
+    `url_fragment` is an optional string.
     `params` is an optional QueryDict object (e.g. request.GET)
     """
     mfe_link = f'{settings.LEARNING_MICROFRONTEND_URL}/course/{course_key}'
 
-    if view_name:
-        mfe_link += f'/{view_name}'
+    if url_fragment:
+        mfe_link += f'/{url_fragment}'
 
     if params:
         mfe_link += f'?{params.urlencode()}'

--- a/openedx/features/course_experience/views/course_dates.py
+++ b/openedx/features/course_experience/views/course_dates.py
@@ -37,7 +37,7 @@ class CourseDatesFragmentView(EdxFragmentView):
         if course_home_legacy_is_active(course_key):
             dates_tab_link = reverse('dates', args=[course.id])
         else:
-            dates_tab_link = get_learning_mfe_home_url(course_key=course.id, view_name='dates')
+            dates_tab_link = get_learning_mfe_home_url(course_key=course.id, url_fragment='dates')
 
         context = {
             'course_date_blocks': [block for block in course_date_blocks if block.title != 'current_datetime'],

--- a/openedx/features/course_experience/views/course_home.py
+++ b/openedx/features/course_experience/views/course_home.py
@@ -70,7 +70,7 @@ class CourseHomeView(CourseTabView):
         if course_home_legacy_is_active(course.id) or request.user.is_staff:
             home_fragment_view = CourseHomeFragmentView()
             return home_fragment_view.render_to_fragment(request, course_id=course_id, **kwargs)
-        microfrontend_url = get_learning_mfe_home_url(course_key=course_id, view_name='home', params=request.GET)
+        microfrontend_url = get_learning_mfe_home_url(course_key=course_id, url_fragment='home', params=request.GET)
         raise Redirect(microfrontend_url)
 
 


### PR DESCRIPTION
## Description

We have progress page links like `/course/<course_key>/progress/<learner_id>` on both the learning micro-frontend and on the preexisting LMS page. These pages allow course team members (and others) to look at how the progress page appears to them. But the redirect didn't preserve the info of which learner's progress page the course team was trying to preview. This fixes that.

## Supporting information

[JIRA:AU-375](https://openedx.atlassian.net/browse/AU-375)