### PR TITLE
feat: add onboarding status wrapper

### DIFF
--- a/lms/djangoapps/support/urls.py
+++ b/lms/djangoapps/support/urls.py
@@ -19,6 +19,7 @@ from .views.program_enrollments import (
     SAMLProvidersWithOrg,
 )
 from .views.sso_records import SsoView
+from .views.onboarding_status import OnboardingView
 
 COURSE_ENTITLEMENTS_VIEW = EntitlementSupportView.as_view()
 
@@ -71,4 +72,8 @@ urlpatterns = [
         name='get_saml_providers'
     ),
     re_path(r'sso_records/(?P<username_or_email>[\w.@+-]+)?$', SsoView.as_view(), name='sso_records'),
+    re_path(
+        r'onboarding_status/(?P<username_or_email>[\w.@+-]+)?$',
+        OnboardingView.as_view(), name='onboarding_status'
+    ),
 ]

--- a/lms/djangoapps/support/views/onboarding_status.py
+++ b/lms/djangoapps/support/views/onboarding_status.py
@@ -1,0 +1,98 @@
+"""
+Views for Onboarding Status.
+"""
+
+from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
+from django.db.models import Q
+from django.utils.decorators import method_decorator
+from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
+from edx_proctoring.views import StudentOnboardingStatusView
+from rest_framework.generics import GenericAPIView
+
+from common.djangoapps.course_modes.models import CourseMode
+from common.djangoapps.util.json_request import JsonResponse
+from lms.djangoapps.support.decorators import require_support_permission
+from openedx.core.djangoapps.enrollments.api import get_enrollments
+
+
+class OnboardingView(GenericAPIView):
+    """
+    Return most recent and originally verified onboarding exam status for a given user.
+    Return 404 is user not found.
+    """
+    @method_decorator(require_support_permission)
+    def get(self, request, username_or_email):
+        """
+        * Example Request:
+            - GET /support/onboarding_status/<username_or_email>
+
+        * Example Response:
+            {
+                "verified_in": {
+                    "onboarding_status": "verified",
+                    "onboarding_link": "/courses/<course_id>/jump_to/<block_id>",
+                    "expiration_date": null,
+                    "onboarding_past_due": false,
+                    "onboarding_release_date": "2016-01-01T00:00:00+00:00",
+                    "review_requirements_url": "",
+                    "course_id": "<course_id>",
+                    "enrollment_date": "2021-12-29T14:30:18.895435Z",
+                    "instructor_dashboard_link": "/courses/<course_id>/instructor#view-special_exams"
+                },
+                "current_status": {
+                    "onboarding_status": "other_course_approved",
+                    "onboarding_link": "/courses/<course_id>/jump_to/<block_id>",
+                    "expiration_date": "2023-12-29T15:52:28.245Z",
+                    "onboarding_past_due": false,
+                    "onboarding_release_date": "2020-01-01T00:00:00+00:00",
+                    "review_requirements_url": "",
+                    "course_id": "<course_id>",
+                    "enrollment_date": "2021-12-29T15:58:29.489916Z",
+                    "instructor_dashboard_link": "/courses/<course_id>/instructor#view-special_exams"
+                }
+            }
+        """
+        # return dict
+        onboarding_status = {
+            'verified_in': None,
+            'current_status': None
+        }
+
+        # make object mutable
+        request.GET = request.GET.copy()
+
+        try:
+            user = User.objects.get(Q(username=username_or_email) | Q(email=username_or_email))
+        except User.DoesNotExist:
+            return JsonResponse(onboarding_status, status=404)
+
+        request.GET['username'] = user.username
+        enrollments = get_enrollments(user.username)
+
+        enrollments = sorted(enrollments, key=lambda enrollment: enrollment['created'], reverse=True)
+        enrollments = filter(
+            lambda enrollment: enrollment['mode'] in [CourseMode.VERIFIED, CourseMode.PROFESSIONAL],
+            enrollments
+        )
+
+        for enrollment in enrollments:
+            request.GET['course_id'] = enrollment['course_details']['course_id']
+
+            status = StudentOnboardingStatusView().get(request).data
+
+            if 'onboarding_status' in status:
+                status['course_id'] = enrollment['course_details']['course_id']
+                status['enrollment_date'] = enrollment['created']
+                status['instructor_dashboard_link'] = \
+                    '/courses/{}/instructor#view-special_exams'.format(status['course_id'])
+
+                # set most recent status only at first iteration
+                if onboarding_status['current_status'] is None:
+                    onboarding_status['current_status'] = status
+
+                # stay in loop to find original verified enrollment. Expensive!
+                if status['onboarding_status'] == ProctoredExamStudentAttemptStatus.verified:
+                    onboarding_status['verified_in'] = status
+                    break
+
+        return JsonResponse(onboarding_status)


### PR DESCRIPTION
## Description
This PR adds a support-only endpoint to fetch students' onboarding status including most recent (current) and originally verified attempt. It loops over all `verified` and `professional` enrollments in descending order of created date.  

## Context
Although there's already an endpoint in [edx-proctoring](https://github.com/edx/edx-proctoring/blob/211ca866ae79e8f99ebab091a7a1abbd4d4ff791/edx_proctoring/views.py#L481) which requires a `course_id` and currently we are using this in [frontend-app-support-tools](https://github.com/openedx/frontend-app-support-tools/blob/1f64e415be2c179de001db21dc76e0724e638d4d/src/users/data/api.js#L245). However, it is a costly operation and not ideal for frontend. It is also not consistent in some cases where most recent paid enrollments do not have onboarding exam.

## Linked Ticket
[PROD-2437](https://openedx.atlassian.net/browse/PROD-2437)

## Testing Instructions:
- Follow [instructions](https://github.com/edx/edx-proctoring/blob/master/docs/developing.rst#using-mockprock-as-a-backend) and setup mockprock locally. Each small step is very important. 
- Add a new course via [Studio](http://localhost:18010/home/) and Enable Proctored Exams in Settings -> Advance Settings
- Make sure that `mockprock` is listed as Proctoring Provider 
- Set start date of course to some past date
- Add section and subsection in course outline. From subsection advanced settings, enable onboarding exam and save.
- Proctoring Settings button will appear. Open and verify if the settings are correct. Replace `host.docker.internal` with `localhost` in url.
- Congratulations if you have made this far! 
- Add `verified` and `audit` course modes via [LMS Admin](http://localhost:18000/admin/course_modes/coursemode/)
- Enroll a `verified` user in the course with an Audit Track via [LMS](http://localhost:18000/) in incognito or private tab.
- Run and use [support-tools](http://localhost:18450) to change user enrollment to `verified` track. 
- Add manual verification for verified user via [LMS Admin](http://localhost:18000/admin/verify_student/manualverification/)
- Open the course in [LMS](http://localhost:18000/) as a `verified` user in private window. Which will redirect to frontend-app-learning automatically. 
- Take onboarding exam. 
- Check [API](http://localhost:18000/support/onboarding_status/verified@example.com) response in browser with staff user 
- Manually change onboarding status via LMS Admin in [Proctored Exam Attempts Model](http://localhost:18000/admin/edx_proctoring/proctoredexamstudentattempt/)
- Verify [API](http://localhost:18000/support/onboarding_status/verified@example.com) response in browser accordingly
- Repeat the steps for multiple courses against same user and verify API response. 

## TODO:

- [ ] Verify on stage after merge