### PR TITLE
[BD-38] [TNL-8842] [BB-5251] Add API support for reason codes

### DIFF
--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -971,7 +971,7 @@ def _do_extra_actions(api_content, cc_content, request_fields, actions_form, con
     update that require a separate comments service request.
     """
     for field, form_value in actions_form.cleaned_data.items():
-        if field in request_fields and form_value != api_content[field]:
+        if field in request_fields and field in api_content and form_value != api_content[field]:
             api_content[field] = form_value
             if field == "following":
                 _handle_following_field(form_value, context["cc_requester"], cc_content)

--- a/lms/djangoapps/discussion/rest_api/permissions.py
+++ b/lms/djangoapps/discussion/rest_api/permissions.py
@@ -102,6 +102,7 @@ def get_editable_fields(cc_content: Union[Thread, Comment], context: Dict) -> Se
     editable_fields = {
         "abuse_flagged": True,
         "closed": is_thread and is_privileged,
+        "close_reason_code": is_thread and is_privileged,
         "pinned": is_thread and is_privileged,
         "read": is_thread,
     }
@@ -114,6 +115,7 @@ def get_editable_fields(cc_content: Union[Thread, Comment], context: Dict) -> Se
     editable_fields.update({
         "voted": True,
         "raw_body": is_privileged or is_author,
+        "edit_reason_code": is_privileged,
         "following": is_thread,
         "topic_id": is_thread and (is_author or is_privileged),
         "type": is_thread and (is_author or is_privileged),

--- a/lms/djangoapps/discussion/rest_api/tests/test_permissions.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_permissions.py
@@ -66,7 +66,7 @@ class GetInitializableFieldsTest(ModuleStoreTestCase):
             "abuse_flagged", "course_id", "following", "raw_body", "read", "title", "topic_id", "type", "voted"
         }
         if is_privileged:
-            expected |= {"closed", "pinned"}
+            expected |= {"closed", "pinned", "close_reason_code", "edit_reason_code"}
         if is_privileged and is_cohorted:
             expected |= {"group_id"}
         if allow_anonymous:
@@ -87,6 +87,8 @@ class GetInitializableFieldsTest(ModuleStoreTestCase):
         expected = {
             "anonymous", "abuse_flagged", "parent_id", "raw_body", "thread_id", "voted"
         }
+        if is_privileged:
+            expected |= {"edit_reason_code"}
         if (is_thread_author and thread_type == "question") or is_privileged:
             expected |= {"endorsed"}
         assert actual == expected
@@ -116,7 +118,7 @@ class GetEditableFieldsTest(ModuleStoreTestCase):
         actual = get_editable_fields(thread, context)
         expected = {"abuse_flagged", "following", "read", "voted"}
         if is_privileged:
-            expected |= {"closed", "pinned"}
+            expected |= {"closed", "pinned", "close_reason_code", "edit_reason_code"}
         if is_author or is_privileged:
             expected |= {"topic_id", "type", "title", "raw_body"}
         if is_privileged and is_cohorted:
@@ -148,6 +150,8 @@ class GetEditableFieldsTest(ModuleStoreTestCase):
         )
         actual = get_editable_fields(comment, context)
         expected = {"abuse_flagged", "voted"}
+        if is_privileged:
+            expected |= {"edit_reason_code"}
         if is_author or is_privileged:
             expected |= {"raw_body"}
         if (is_thread_author and thread_type == "question") or is_privileged:

--- a/lms/djangoapps/discussion/rest_api/tests/test_serializers.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_serializers.py
@@ -317,6 +317,7 @@ class CommentSerializerTest(SerializerTestMixin, SharedModuleStoreTestCase):
             "editable_fields": ["abuse_flagged", "voted"],
             "child_count": 0,
             "can_delete": False,
+            "last_edit": None,
         }
 
         assert self.serialize(comment) == expected

--- a/lms/djangoapps/discussion/rest_api/tests/test_views.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views.py
@@ -1509,6 +1509,7 @@ class CommentViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase, Pr
             "can_delete": True,
             "anonymous": False,
             "anonymous_to_peers": False,
+            "last_edit": None,
         }
         response_data.update(overrides or {})
         return response_data
@@ -1901,6 +1902,7 @@ class CommentViewSetCreateTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
             "can_delete": True,
             "anonymous": False,
             "anonymous_to_peers": False,
+            "last_edit": None,
         }
         response = self.client.post(
             self.url,
@@ -1991,6 +1993,7 @@ class CommentViewSetPartialUpdateTest(DiscussionAPIViewTestMixin, ModuleStoreTes
             "can_delete": True,
             "anonymous": False,
             "anonymous_to_peers": False,
+            "last_edit": None,
         }
         response_data.update(overrides or {})
         return response_data
@@ -2178,6 +2181,7 @@ class CommentViewSetRetrieveTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase
             "can_delete": True,
             "anonymous": False,
             "anonymous_to_peers": False,
+            "last_edit": None,
         }
 
         response = self.client.get(self.url)

--- a/lms/djangoapps/discussion/rest_api/tests/utils.py
+++ b/lms/djangoapps/discussion/rest_api/tests/utils.py
@@ -31,10 +31,19 @@ def _get_thread_callback(thread_data):
         additional required fields.
         """
         response_data = make_minimal_cs_thread(thread_data)
+        original_data = response_data.copy()
         for key, val_list in parsed_body(request).items():
             val = val_list[0]
             if key in ["anonymous", "anonymous_to_peers", "closed", "pinned"]:
                 response_data[key] = val == "True"
+            elif key == "edit_reason_code":
+                response_data["edit_history"] = [
+                    {
+                        "original_body": original_data["body"],
+                        "author": thread_data.get('username'),
+                        "reason_code": val,
+                    },
+                ]
             else:
                 response_data[key] = val
         return (200, headers, json.dumps(response_data))
@@ -53,6 +62,7 @@ def _get_comment_callback(comment_data, thread_id, parent_id):
         Simulate the comment creation or update endpoint as described above.
         """
         response_data = make_minimal_cs_comment(comment_data)
+        original_data = response_data.copy()
         # thread_id and parent_id are not included in request payload but
         # are returned by the comments service
         response_data["thread_id"] = thread_id
@@ -61,6 +71,14 @@ def _get_comment_callback(comment_data, thread_id, parent_id):
             val = val_list[0]
             if key in ["anonymous", "anonymous_to_peers", "endorsed"]:
                 response_data[key] = val == "True"
+            elif key == "edit_reason_code":
+                response_data["edit_history"] = [
+                    {
+                        "original_body": original_data["body"],
+                        "author": comment_data.get('username'),
+                        "reason_code": val,
+                    },
+                ]
             else:
                 response_data[key] = val
         return (200, headers, json.dumps(response_data))
@@ -438,8 +456,15 @@ class CommentsServiceMockMixin:
             "voted": False,
             "vote_count": 0,
             "editable_fields": [
-                "abuse_flagged", "anonymous", "following", "raw_body", "read",
-                "title", "topic_id", "type", "voted"
+                "abuse_flagged",
+                "anonymous",
+                "following",
+                "raw_body",
+                "read",
+                "title",
+                "topic_id",
+                "type",
+                "voted",
             ],
             "course_id": str(self.course.id),
             "topic_id": "test_topic",
@@ -460,6 +485,9 @@ class CommentsServiceMockMixin:
             "id": "test_thread",
             "type": "discussion",
             "response_count": 0,
+            "last_edit": None,
+            "closed_by": None,
+            "close_reason_code": None,
         }
         response_data.update(overrides or {})
         return response_data
@@ -497,6 +525,8 @@ def make_minimal_cs_thread(overrides=None):
         "read": False,
         "endorsed": False,
         "resp_total": 0,
+        "closed_by": None,
+        "close_reason_code": None,
     }
     ret.update(overrides or {})
     return ret

--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -401,6 +401,14 @@ class ThreadViewSet(DeveloperErrorViewMixin, ViewSet):
 
         * read (optional): A boolean to mark thread as read
 
+        * closed (optional, privileged): A boolean to mark thread as closed.
+
+        * edit_reason_code (optional, privileged): A string containing a reason
+        code for editing the thread's body.
+
+        * close_reason_code (optional, privileged): A string containing a reason
+        code for closing the thread.
+
         * topic_id, type, title, raw_body, anonymous, and anonymous_to_peers
         are accepted with the same meaning as in a POST request
 
@@ -629,6 +637,9 @@ class CommentViewSet(DeveloperErrorViewMixin, ViewSet):
 
         * raw_body, anonymous and anonymous_to_peers are accepted with the same
         meaning as in a POST request
+
+        * edit_reason_code (optional, privileged): A string containing a reason
+        code for a moderator to edit the comment.
 
         If "application/merge-patch+json" is not the specified content type,
         a 415 error is returned.

--- a/openedx/core/djangoapps/django_comment_common/comment_client/comment.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/comment.py
@@ -14,12 +14,12 @@ class Comment(models.Model):
         'endorsed', 'parent_id', 'thread_id', 'username', 'votes', 'user_id',
         'closed', 'created_at', 'updated_at', 'depth', 'at_position_list',
         'type', 'commentable_id', 'abuse_flaggers', 'endorsement',
-        'child_count',
+        'child_count', 'edit_history',
     ]
 
     updatable_fields = [
         'body', 'anonymous', 'anonymous_to_peers', 'course_id', 'closed',
-        'user_id', 'endorsed', 'endorsement_user_id',
+        'user_id', 'endorsed', 'endorsement_user_id', 'edit_reason_code',
     ]
 
     initializable_fields = updatable_fields

--- a/openedx/core/djangoapps/django_comment_common/comment_client/thread.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/thread.py
@@ -21,19 +21,20 @@ class Thread(models.Model):
         'highlighted_body', 'endorsed', 'read', 'group_id', 'group_name', 'pinned',
         'abuse_flaggers', 'resp_skip', 'resp_limit', 'resp_total', 'thread_type',
         'endorsed_responses', 'non_endorsed_responses', 'non_endorsed_resp_total',
-        'context', 'last_activity_at',
+        'context', 'last_activity_at', 'closed_by', 'close_reason_code', 'edit_history',
     ]
 
     # updateable_fields are sent in PUT requests
     updatable_fields = [
         'title', 'body', 'anonymous', 'anonymous_to_peers', 'course_id', 'read',
-        'closed', 'user_id', 'commentable_id', 'group_id', 'group_name', 'pinned', 'thread_type'
+        'closed', 'user_id', 'commentable_id', 'group_id', 'group_name', 'pinned', 'thread_type',
+        'close_reason_code', 'edit_reason_code',
     ]
 
     # metric_tag_fields are used by Datadog to record metrics about the model
     metric_tag_fields = [
         'course_id', 'group_id', 'pinned', 'closed', 'anonymous', 'anonymous_to_peers',
-        'endorsed', 'read'
+        'endorsed', 'read',
     ]
 
     # initializable_fields are sent in POST requests


### PR DESCRIPTION
## Description

Add API support for submitting reason codes when editing a comment or a thread, or when closing a thread.

## Supporting information

[Issue TNL-8842](https://openedx.atlassian.net/browse/TNL-8842)

## Testing instructions

1. Have a working `master` devstack setup.
2. Have 2 sample users, one of which has a moderator role.
3. Sign-in as the non-moderator user and create a post using either the discussions MFE or the old discussions UI.
4. Note down the created thread id.
4. Switch to the moderator user, and, while on the LMS page (http://localhost:18000), open the browser's javascript console
5. Test the API by issuing the following statements, replacing the thread id where appropriate:
```javascript
await $.get('http://localhost:18000/api/discussion/v1/threads/THREAD_ID/')
// verify that the returned object has `last_edit = null`, indicating that the post wasn't edited yet.
await $.ajax({ type: 'PATCH', url: 'http://localhost:18000/api/discussion/v1/threads/THREAD_ID/', contentType: 'application/merge-patch+json', data: '{"raw_body": "some edit", "edit_reason_code": "some-reason"}' })
// verify that `last_edit` now contains the previous body, as well as the specified reason code.
``` 

## Deadline

None

## Other information

* ~~Depends on corresponding support in `cs_comments_service`, which is being implemented by [this PR](https://github.com/edx/cs_comments_service/pull/356). (already merged)~~ (PR reverted)
* Depends on corresponding support in `cs_comments_service`, implemented in [this PR](https://github.com/openedx/cs_comments_service/pull/366)
* Followed up by [TNL-9479](https://openedx.atlassian.net/browse/TNL-9479), implemented in [this PR](https://github.com/openedx/edx-platform/pull/29831), adding a new API for fetching predefined reason codes from `edx-platform`'s settings, and validating them.
