### PR TITLE
fix: add integer check for lms_user_id

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -325,6 +325,8 @@ class AccountViewSet(ViewSet):
                 user = User.objects.get(id=lms_user_id)
             except (UserNotFound, User.DoesNotExist):
                 return Response(status=status.HTTP_404_NOT_FOUND)
+            except ValueError:
+                return Response(status=status.HTTP_400_BAD_REQUEST)
             search_usernames = [user.username]
         try:
             account_settings = get_account_settings(


### PR DESCRIPTION
[PROD-2598](https://openedx.atlassian.net/browse/PROD-2598)
Fixing Minor validation bug causing error 500 on non-integer lms user id.

This PR also fixes some tests.