### PR TITLE
chore: lti-consumer-xblock version update

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -598,7 +598,7 @@ libsass==0.10.0
     #   ora2
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==3.1.0
+lti-consumer-xblock==3.1.1
     # via -r requirements/edx/base.in
 lxml==4.5.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -809,7 +809,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/testing.txt
     #   ora2
-lti-consumer-xblock==3.1.0
+lti-consumer-xblock==3.1.1
     # via -r requirements/edx/testing.txt
 lxml==4.5.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -767,7 +767,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==3.1.0
+lti-consumer-xblock==3.1.1
     # via -r requirements/edx/base.txt
 lxml==4.5.0
     # via


### PR DESCRIPTION
## Description

Version update of **lti-consumer-xblock**, from **3.1.0** to **3.1.1**

## Supporting information

https://github.com/openedx/build-test-release-wg/issues/122
https://github.com/mitodl/mitxpro/issues/2327