### PR TITLE
feat: update cert language if integrity signature is enabled

### DIFF
--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -49,6 +49,7 @@ from lms.djangoapps.certificates.utils import (
     get_certificate_url,
     get_preferred_certificate_name
 )
+from openedx.core.djangoapps.agreements.toggles import is_integrity_signature_enabled
 from openedx.core.djangoapps.catalog.api import get_course_run_details
 from openedx.core.djangoapps.content.course_overviews.api import get_course_overview_or_none
 from openedx.core.djangoapps.lang_pref.api import get_closest_released_language
@@ -64,7 +65,7 @@ _ = translation.gettext
 INVALID_CERTIFICATE_TEMPLATE_PATH = 'certificates/invalid.html'
 
 
-def get_certificate_description(mode, certificate_type, platform_name):
+def get_certificate_description(mode, certificate_type, platform_name, course_key):
     """
     :return certificate_type_description on the basis of current mode
     """
@@ -82,10 +83,13 @@ def get_certificate_description(mode, certificate_type, platform_name):
         certificate_type_description = _("A {cert_type} certificate signifies that a "
                                          "learner has agreed to abide by the honor code established by "
                                          "{platform_name} and has completed all of the required tasks for this course "
-                                         "under its guidelines. A {cert_type} certificate also indicates that the "
-                                         "identity of the learner has been checked and "
-                                         "is valid.").format(cert_type=certificate_type,
-                                                             platform_name=platform_name)
+                                         "under its guidelines. ").format(cert_type=certificate_type,
+                                                                          platform_name=platform_name)
+        if not is_integrity_signature_enabled(course_key):
+            certificate_type_description += _("A {cert_type} certificate also indicates that the "
+                                              "identity of the learner has been checked and "
+                                              "is valid.").format(cert_type=certificate_type)
+
     elif mode == 'xseries':
         # Translators:  This text describes the 'XSeries' course certificate type.  An XSeries is a collection of
         # courses related to each other in a meaningful way, such as a specific topic or theme, or even an organization
@@ -146,7 +150,9 @@ def _update_certificate_context(context, course, course_overview, user_certifica
         platform_name=platform_name,
         certificate_type=context.get("certificate_type"))
 
-    certificate_type_description = get_certificate_description(user_certificate.mode, certificate_type, platform_name)
+    certificate_type_description = get_certificate_description(
+        user_certificate.mode, certificate_type, platform_name, course.location.course_key
+    )
     if certificate_type_description:
         context['certificate_type_description'] = certificate_type_description
 
@@ -247,6 +253,7 @@ def _update_course_context(request, context, course, platform_name):
     context['accomplishment_copy_course_name'] = accomplishment_copy_course_name
     course_number = course.display_coursenumber if course.display_coursenumber else course.number
     context['course_number'] = course_number
+    context['is_integrity_signature_enabled_for_course'] = is_integrity_signature_enabled(course.location.course_key)
     if context['organization_long_name']:
         # Translators:  This text represents the description of course
         context['accomplishment_copy_course_description'] = _('a course of study offered by {partner_short_name}, '


### PR DESCRIPTION
## [MST-1190](https://openedx.atlassian.net/browse/MST-1190)

If the integrity signature flag has been enabled for a course, update the verified certificate description. The flag value should also be accessible to cert templates, so it has been added to the context.

