### PR TITLE
docs: comments about how pytest finds settings

### DIFF
--- a/cms/pytest.ini
+++ b/cms/pytest.ini
@@ -1,4 +1,8 @@
 [pytest]
+# Note: The first file of settings found is used, there is no combining, so
+# this file is used for the tests in the cms tree, and setup.cfg is ignored.
+# Details at https://docs.pytest.org/en/latest/reference/customize.html
+
 DJANGO_SETTINGS_MODULE = cms.envs.test
 addopts = --nomigrations --reuse-db --durations=20 -p no:randomly --json-report --json-report-omit keywords streams collectors log traceback tests --json-report-file=none
 # Enable default handling for all warnings, including those that are ignored by default;

--- a/common/lib/pytest.ini
+++ b/common/lib/pytest.ini
@@ -1,4 +1,8 @@
 [pytest]
+# Note: The first file of settings found is used, there is no combining, so
+# this file is used for the tests in the common/lib tree, and setup.cfg is ignored.
+# Details at https://docs.pytest.org/en/latest/reference/customize.html
+
 # Use the LMS settings for these tests; should work with CMS just as well though:
 DJANGO_SETTINGS_MODULE = lms.envs.test
 addopts = --nomigrations --reuse-db --durations=20 --json-report --json-report-omit keywords streams collectors log traceback tests --json-report-file=none

--- a/common/test/pytest.ini
+++ b/common/test/pytest.ini
@@ -1,4 +1,8 @@
 [pytest]
+# Note: The first file of settings found is used, there is no combining, so
+# this file is used for the tests in the common/test tree, and setup.cfg is ignored.
+# Details at https://docs.pytest.org/en/latest/reference/customize.html
+
 addopts = -p no:randomly --durations=20 --json-report --json-report-omit keywords streams collectors log traceback tests --json-report-file=none
 # Enable default handling for all warnings, including those that are ignored by default;
 # but hide rate-limit warnings (because we deliberately don't throttle test user logins)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,8 @@
 [tool:pytest]
+# Note: The first file of settings found is used, there is no combining, so
+# this file is only used for tests that don't find a pytest.ini file first.
+# Details at https://docs.pytest.org/en/latest/reference/customize.html
+
 DJANGO_SETTINGS_MODULE = lms.envs.test
 addopts = --nomigrations --reuse-db --durations=20 --json-report --json-report-omit keywords streams collectors log traceback tests --json-report-file=none
 # Enable default handling for all warnings, including those that are ignored by default;


### PR DESCRIPTION
It took a while for me to understand why my setup.cfg setting was only
applying to some tests.  Hopefully these comments will save someone else
some confusion.

