### PR TITLE
Do Not Prevent Learner From Changing Name if Learner Is Not Enrolled in Verified Mode or Learner Has Non-Passable Certificate

### DIFF
--- a/openedx/core/djangoapps/enrollments/api.py
+++ b/openedx/core/djangoapps/enrollments/api.py
@@ -21,6 +21,59 @@ log = logging.getLogger(__name__)
 DEFAULT_DATA_API = 'openedx.core.djangoapps.enrollments.data'
 
 
+def get_verified_enrollments(username, include_inactive=False):
+    """Retrieves all the courses in which user is enrolled in a verified mode.
+
+    Takes a user and retrieves all relative enrollments in which the learner is enrolled in a verified mode.
+    Includes information regarding how the user is enrolled
+    in the the course.
+
+    Args:
+        username: The username of the user we want to retrieve course enrollment information for.
+        include_inactive (bool): Determines whether inactive enrollments will be included
+
+    Returns:
+        A list of enrollment information for the given user.
+
+    Examples:
+        >>> get_verified_enrollments("Bob")
+        [
+            {
+                "created": "2014-10-25T20:18:00Z",
+                "mode": "verified",
+                "is_active": True,
+                "user": "Bob",
+                "course_details": {
+                    "course_id": "edX/edX-Insider/2014T2",
+                    "course_name": "edX Insider Course",
+                    "enrollment_end": "2014-12-20T20:18:00Z",
+                    "enrollment_start": "2014-10-15T20:18:00Z",
+                    "course_start": "2015-02-03T00:00:00Z",
+                    "course_end": "2015-05-06T00:00:00Z",
+                    "course_modes": [
+                        {
+                            "slug": "honor",
+                            "name": "Honor Code Certificate",
+                            "min_price": 0,
+                            "suggested_prices": "",
+                            "currency": "usd",
+                            "expiration_datetime": null,
+                            "description": null,
+                            "sku": null,
+                            "bulk_sku": null
+                        }
+                    ],
+                    "invite_only": True
+                }
+            }
+        ]
+
+    """
+    enrollments = get_enrollments(username, include_inactive)
+    enrollments = filter(lambda enrollment: CourseMode.is_verified_slug(enrollment['mode']), enrollments)
+    return list(enrollments)
+
+
 def get_enrollments(username, include_inactive=False):
     """Retrieves all the courses a user is enrolled in.
 

--- a/openedx/core/djangoapps/enrollments/tests/test_api.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_api.py
@@ -165,6 +165,31 @@ class EnrollmentTest(CacheIsolationTestCase):
         for result_enrollment in result:
             assert result_enrollment['course']['course_id'] in [enrollment['course_id'] for enrollment in enrollments]
 
+    @ddt.data(
+        # Simple test of honor and verified.
+        ([
+            {'course_id': 'the/first/course', 'course_modes': [], 'mode': 'honor'},
+            {'course_id': 'the/second/course', 'course_modes': ['honor', 'verified'], 'mode': 'verified'}
+        ], 1),
+
+        # No enrollments
+        ([], 0),
+
+        # One Enrollment
+        ([
+            {'course_id': 'the/third/course', 'course_modes': ['honor', 'verified', 'audit'], 'mode': 'audit'}
+        ], 0),
+    )
+    @ddt.unpack
+    def test_get_verified_enrollments(self, enrollments, num_verified_enrollments):
+        for enrollment in enrollments:
+            fake_data_api.add_course(enrollment['course_id'], course_modes=enrollment['course_modes'])
+            api.add_enrollment(self.USERNAME, enrollment['course_id'], enrollment['mode'])
+        result = api.get_verified_enrollments(self.USERNAME)
+        assert num_verified_enrollments == len(result)
+        for result_enrollment in result:
+            assert result_enrollment['course']['course_id'] in [enrollment['course_id'] for enrollment in enrollments]
+
     def test_update_enrollment(self):
         # Add fake course enrollment information to the fake data API
         fake_data_api.add_course(self.COURSE_ID, course_modes=['honor', 'verified', 'audit'])


### PR DESCRIPTION
<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Do Not Prevent Learner From Changing Name if Learner Is Not Enrolled in Verified Mode or Learner Has Non-Passable Certificate

The _does_name_change_require_verification(user_profile, old_name, new_name) method of the accounts user_api determines whether a learner can change their name from old_name to new_name. Originally, it delegated solely to the NameChangeValidator class of the edx-name-affirmation API, which ran a set of checks against the name change. One of said checks was asserting that learners with one or more certificates could not change their name without completing IDV.

This pull request changes this behavior.

Learners may have certificates that are not in a passable status (e.g. "unverified"). We only want to require IDV for name changes for learners that have passing statuses. The existing code prevented learners from changing their name if they had any certificates at all, irrespective of the certificate status. This change only considers certificates in a passable status.

Additionally, learners may have certificates and also not be enrolled in any "verified" seats. For example, despite edX no longer offering "honor" seats, learners may have enrollments in "honor" modes, which grant certificates but are not considered "verified" enrollment modes. IDV requires that a learner be enrolled in a "verified" seat in order to complete IDV. Prior to this change, learners that were navigated to IDV to validate a name change were unable to complete IDV. This change introduce a check that a learner is in a "verified" mode in addition to using the NameChangeValidator. This prevents the account MFE from navigating an IDV-ineligible learner to IDV.

## Supporting information

MST-1254: https://openedx.atlassian.net/browse/MST-1254

## Testing instructions

* Create a user.
* Enroll user in a course in an honor mode.
* Earn a certificate in a non-passable state. Alternatively, earn a certificate and change the status to a non-passable state.
* Go to Account Settings page.
* Confirm that you can change your name without requiring IDV.
