### PR TITLE
TEMP Iamsobanjaved/test regis change

### DIFF
--- a/openedx/core/djangoapps/dark_lang/middleware.py
+++ b/openedx/core/djangoapps/dark_lang/middleware.py
@@ -16,7 +16,7 @@ from django.utils.deprecation import MiddlewareMixin
 
 from openedx.core.djangoapps.dark_lang import DARK_LANGUAGE_KEY
 from openedx.core.djangoapps.dark_lang.models import DarkLangConfig
-from openedx.core.djangoapps.lang_pref import COOKIE_DURATION
+from openedx.core.djangoapps.lang_pref.helpers import set_language_cookie
 from openedx.core.djangoapps.site_configuration.helpers import get_value
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preference
 
@@ -110,13 +110,7 @@ class DarkLangMiddleware(MiddlewareMixin):
         language = get_value('LANGUAGE_CODE', None)
         if language:
             request.session[LANGUAGE_SESSION_KEY] = language
-            response.set_cookie(
-                settings.LANGUAGE_COOKIE_NAME,
-                value=language,
-                domain=settings.SHARED_COOKIE_DOMAIN,
-                max_age=COOKIE_DURATION,
-                secure=request.is_secure()
-            )
+            set_language_cookie(request, response, language)
 
     def _fuzzy_match(self, lang_code):
         """Returns a fuzzy match for lang_code"""
@@ -174,10 +168,4 @@ class DarkLangMiddleware(MiddlewareMixin):
 
         # Set the session key to the requested preview lang
         request.session[LANGUAGE_SESSION_KEY] = preview_lang
-        response.set_cookie(
-            settings.LANGUAGE_COOKIE_NAME,
-            value=preview_lang,
-            domain=settings.SHARED_COOKIE_DOMAIN,
-            max_age=COOKIE_DURATION,
-            secure=request.is_secure()
-        )
+        set_language_cookie(request, response, preview_lang)

--- a/openedx/core/djangoapps/lang_pref/helpers.py
+++ b/openedx/core/djangoapps/lang_pref/helpers.py
@@ -1,0 +1,36 @@
+"""
+Language preference cookie helper functions
+"""
+from django.conf import settings
+
+from openedx.core.djangoapps.lang_pref import COOKIE_DURATION
+
+
+def get_language_cookie(request, default=None):
+    """
+    Return the language cookie stored in the request object.
+    """
+    return request.COOKIES.get(settings.LANGUAGE_COOKIE_NAME, default)
+
+
+def set_language_cookie(request, response, value):
+    """
+    Set the language cookie in the response object.
+    """
+    response.set_cookie(
+        settings.LANGUAGE_COOKIE_NAME,
+        value=value,
+        domain=settings.SHARED_COOKIE_DOMAIN,
+        max_age=COOKIE_DURATION,
+        secure=request.is_secure(),
+        samesite="None" if request.is_secure() else "Lax",
+    )
+
+
+def unset_language_cookie(response):
+    """
+    Remove the language cookie from the response object.
+    """
+    response.delete_cookie(
+        settings.LANGUAGE_COOKIE_NAME, domain=settings.SHARED_COOKIE_DOMAIN
+    )

--- a/openedx/core/djangoapps/lang_pref/tests/test_middleware.py
+++ b/openedx/core/djangoapps/lang_pref/tests/test_middleware.py
@@ -75,6 +75,7 @@ class TestUserPreferenceMiddleware(CacheIsolationTestCase):
                 domain=settings.SESSION_COOKIE_DOMAIN,
                 max_age=COOKIE_DURATION,
                 secure=self.request.is_secure(),
+                samesite="Lax"
             )
         else:
             response.delete_cookie.assert_called_with(

--- a/openedx/core/djangoapps/lang_pref/views.py
+++ b/openedx/core/djangoapps/lang_pref/views.py
@@ -10,7 +10,8 @@ from django.http import HttpResponse
 from django.utils.translation import LANGUAGE_SESSION_KEY
 from django.views.decorators.csrf import ensure_csrf_cookie
 
-from openedx.core.djangoapps.lang_pref import COOKIE_DURATION, LANGUAGE_KEY
+from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
+from openedx.core.djangoapps.lang_pref.helpers import set_language_cookie
 
 
 @ensure_csrf_cookie
@@ -24,11 +25,5 @@ def update_session_language(request):
         language = data.get(LANGUAGE_KEY, settings.LANGUAGE_CODE)
         if request.session.get(LANGUAGE_SESSION_KEY, None) != language:
             request.session[LANGUAGE_SESSION_KEY] = str(language)
-        response.set_cookie(
-            settings.LANGUAGE_COOKIE_NAME,
-            language,
-            domain=settings.SHARED_COOKIE_DOMAIN,
-            max_age=COOKIE_DURATION,
-            secure=request.is_secure(),
-        )
+        set_language_cookie(request, response, language)
     return response


### PR DESCRIPTION
Trying to find the root cause temp PR.

The language cookie "samesite" attribute was always set to "None", even in
non-secure environments, such as the devstack. This was causing client-side
warnings in non-https environments, and the language cookie was not properly
set.

<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
