### PR TITLE
fix: [REV-2492] remove graded content unfbe bullet

### DIFF
--- a/common/djangoapps/course_modes/tests/test_views.py
+++ b/common/djangoapps/course_modes/tests/test_views.py
@@ -601,11 +601,6 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
         # This string only occurs in lms/templates/course_modes/track_selection.html
         # and related theme and translation files.
 
-        # Check for string unique to unfbe.html.
-        self.assertContains(response, "Some graded content may be locked")
-        # This string only occurs in lms/templates/course_modes/unfbe.html
-        # and related theme and translation files.
-
         # Check min_price was correctly passed in.
         self.assertContains(response, min_price)
 

--- a/lms/templates/course_modes/unfbe.html
+++ b/lms/templates/course_modes/unfbe.html
@@ -32,7 +32,6 @@ from openedx.core.djangolib.markup import HTML, Text
 <div class="choice-bullets track-selection-type-unfbe">
     <ul>
         <li>${_("Get access to the course material, including videos and readings")}</li>
-        <li>${_("Some graded content may be locked")}</li>
     </ul>
 </div>
 </%block>


### PR DESCRIPTION
<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

We've received feedback from our partners that the text bullet "Some graded content may be locked" on our unhappy path track selection page is problematic and undesired. This PR removes this bullet:

![image](https://user-images.githubusercontent.com/3790674/146789503-4cba7f73-028c-46a2-97b4-31edd44f1c5e.png)

## Supporting information

* Jira: [REV-2492](https://openedx.atlassian.net/browse/REV-2492)
* Research: [Confluence](https://openedx.atlassian.net/wiki/spaces/~931919476/pages/3281551415/REV-2492)

## Testing instructions

Checked local devstack to ensure bullet does not appear. Screenshot:

<img width="1552" alt="screenshot-devstack" src="https://user-images.githubusercontent.com/3790674/146790278-93f6003f-5984-4570-ad8f-741dc8ffbcf1.png">

## Deadline

No specific deadline.

## Other information

Background:
* Track selection is the screen which appears after a learner enrolls in a course.
* Track selection has 2 paths: a "happy path" for most courses, and an "unhappy path" for courses that may not have access duration limits or gated content.
* The bullet in question (as well as the request from our partner) only is present in "unhappy path" courses.