### PR TITLE
chore: Update organizations repo URL (moved to openedx org)

### DIFF
--- a/lms/djangoapps/monitoring/scripts/generate_code_owner_mappings.py
+++ b/lms/djangoapps/monitoring/scripts/generate_code_owner_mappings.py
@@ -36,7 +36,7 @@ EDX_REPO_APPS = {
     'integrated_channels': 'https://github.com/edx/edx-enterprise',
     'lti_consumer': 'https://github.com/edx/xblock-lti-consumer',
     'notices': 'https://github.com/edx/platform-plugin-notices',
-    'organizations': 'https://github.com/edx/edx-organizations',
+    'organizations': 'https://github.com/openedx/edx-organizations',
     'search': 'https://github.com/edx/edx-search',
     'super_csv': 'https://github.com/edx/super-csv',
     'wiki': 'https://github.com/edx/django-wiki',


### PR DESCRIPTION
Fixing this should restore the proper code owner mapping on next run.