### PR TITLE
fix: save for later urls

### DIFF
--- a/lms/djangoapps/save_for_later/api/v1/urls.py
+++ b/lms/djangoapps/save_for_later/api/v1/urls.py
@@ -7,5 +7,5 @@ from django.urls import path
 from lms.djangoapps.save_for_later.api.v1.views import SaveForLaterApiView
 
 urlpatterns = [
-    path(r'^save/course/', SaveForLaterApiView.as_view(), name='save_course'),
+    path('save/course/', SaveForLaterApiView.as_view(), name='save_course'),
 ]

--- a/lms/djangoapps/save_for_later/urls.py
+++ b/lms/djangoapps/save_for_later/urls.py
@@ -4,5 +4,5 @@ from django.conf.urls import include
 from django.urls import path
 
 urlpatterns = [
-    path(r'^api/', include(('lms.djangoapps.save_for_later.api.urls', 'api'), namespace='api')),
+    path('api/', include(('lms.djangoapps.save_for_later.api.urls', 'api'), namespace='api')),
 ]


### PR DESCRIPTION
Fixing a bug that resulted in a 404 for the endpoint introduced in this PR https://github.com/edx/edx-platform/pull/29588. Regular expressions are meant to be used with `re_path()`.