### PR TITLE
chore: add repository field to package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "edx",
   "version": "0.1.0",
+  "repository": "https://github.com/edx/edx-platform",
   "dependencies": {
     "@edx/brand-edx.org": "^1.3.3",
     "@edx/edx-bootstrap": "1.0.4",


### PR DESCRIPTION
This is primarily so that tooling (e.g., Paragon usage insights) can properly link to this repository.
