### PR TITLE
feat: Add SAMLProvidersWithOrg for Support View MFEs

### DIFF
--- a/lms/djangoapps/support/tests/test_views.py
+++ b/lms/djangoapps/support/tests/test_views.py
@@ -1369,3 +1369,33 @@ class LinkProgramEnrollmentSupportAPIViewTests(SupportViewTestCase):
         response_data = json.loads(response.content.decode('utf-8'))
         error = "All linking lines must be in the format 'external_user_key,lms_username'"
         assert response_data['errors'] == [error]
+
+
+class SAMLProvidersWithOrgTests(SupportViewTestCase):
+    """
+    Tests for the get_saml_providers API View
+    """
+    _url = reverse("support:get_saml_providers")
+
+    def setUp(self):
+        """
+        Make the user support staff.
+        """
+        super().setUp()
+        SupportStaffRole().add_users(self.user)
+
+        self.org_key_list = ['test_org', 'donut_org', 'tri_org']
+        for org_key in self.org_key_list:
+            lms_org = OrganizationFactory(
+                short_name=org_key
+            )
+            SAMLProviderConfigFactory(
+                organization=lms_org,
+                slug=org_key,
+                enabled=True,
+            )
+
+    def test_returning_saml_providers(self):
+        response = self.client.get(self._url)
+        response_data = json.loads(response.content.decode('utf-8'))
+        assert response_data == self.org_key_list

--- a/lms/djangoapps/support/urls.py
+++ b/lms/djangoapps/support/urls.py
@@ -15,7 +15,8 @@ from .views.manage_user import ManageUserDetailView, ManageUserSupportView
 from .views.program_enrollments import (
     LinkProgramEnrollmentSupportView,
     LinkProgramEnrollmentSupportAPIView,
-    ProgramEnrollmentsInspectorView
+    ProgramEnrollmentsInspectorView,
+    SAMLProvidersWithOrg,
 )
 from .views.sso_records import SsoView
 
@@ -63,6 +64,11 @@ urlpatterns = [
         r'program_enrollments_inspector/?$',
         ProgramEnrollmentsInspectorView.as_view(),
         name='program_enrollments_inspector'
+    ),
+    re_path(
+        r'get_saml_providers/?$',
+        SAMLProvidersWithOrg.as_view(),
+        name='get_saml_providers'
     ),
     re_path(r'sso_records/(?P<username_or_email>[\w.@+-]+)?$', SsoView.as_view(), name='sso_records'),
 ]


### PR DESCRIPTION
This is a Support upgrade ticket that provides a list of SAMLProviders for further usage in program inspector tools to lms/djangoapps/support/program_enrollments.py. The purpose of this PR is to create an API endpoint for the development of the SAMLProviders data in frontend-app-support-tools.

Link to the ticket: [PROD-2479](https://openedx.atlassian.net/browse/PROD-2479?atlOrigin=eyJpIjoiZGU4ZDNlN2JjM2VjNDNjMDkyMDQzZWJjNjkzOGJjNzYiLCJwIjoiaiJ9)

Testing Methodology:
- Go to LMS admin and [create an organization](http://localhost:18000/admin/organizations/organization/add/).
- Now create a [SAML idP Provider Configuration](http://localhost:18000/admin/third_party_auth/samlproviderconfig/add/)
- Now test the API by making a [GET request](http://localhost:18000/support/get_saml_providers_with_org_key).