### PR TITLE
build: keep Makefile comments from appearing while running make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,9 @@ help: ## display this help message
 	@grep '^[a-zA-Z]' $(MAKEFILE_LIST) | sort | awk -F ':.*?## ' 'NF==2 {printf "\033[36m  %-25s\033[0m %s\n", $$1, $$2}'
 
 clean: ## archive and delete most git-ignored files
-	# Remove all the git-ignored stuff, but save and restore things marked
-	# by start-noclean/end-noclean. Include Makefile in the tarball so that
-	# there's always at least one file even if there are no private files.
+	@# Remove all the git-ignored stuff, but save and restore things marked
+	@# by start-noclean/end-noclean. Include Makefile in the tarball so that
+	@# there's always at least one file even if there are no private files.
 	sed -n -e '/start-noclean/,/end-noclean/p' < .gitignore > /tmp/private-files
 	-tar cf $(PRIVATE_FILES) Makefile `git ls-files --exclude-from=/tmp/private-files --ignored --others`
 	-git clean -fdX
@@ -67,8 +67,8 @@ pre-requirements: ## install Python requirements for running pip-tools
 	pip install -qr requirements/edx/pip-tools.txt
 
 requirements: pre-requirements ## install development environment requirements
-	# The "$(wildcard..)" is to include private.txt if it exists, and make no mention
-	# of it if it does not.  Shell wildcarding can't do that with default options.
+	@# The "$(wildcard..)" is to include private.txt if it exists, and make no mention
+	@# of it if it does not.  Shell wildcarding can't do that with default options.
 	pip-sync -q requirements/edx/development.txt $(wildcard requirements/edx/private.txt)
 
 shell: ## launch a bash shell in a Docker container with all edx-platform dependencies installed
@@ -102,9 +102,9 @@ $(COMMON_CONSTRAINTS_TXT):
 
 compile-requirements: export CUSTOM_COMPILE_COMMAND=make upgrade
 compile-requirements: $(COMMON_CONSTRAINTS_TXT) ## Re-compile *.in requirements to *.txt
-	# This is a temporary solution to override the real common_constraints.txt
-	# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
-	# See BOM-2721 for more details.
+	@# This is a temporary solution to override the real common_constraints.txt
+	@# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
+	@# See BOM-2721 for more details.
 	sed 's/Django<2.3//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
 	mv requirements/common_constraints.tmp requirements/common_constraints.txt
 


### PR DESCRIPTION
These comments are meant for the Makefile maintainers to read, not the
user running make.  We can prefix them with @ to keep make from echoing
them while running.

Without the "@", this is what `make requirements` looks like:
```
$ make requirements
pip install -qr requirements/edx/pip-tools.txt
# The "" is to include private.txt if it exists, and make no mention
# of it if it does not.  Shell wildcarding can't do that with default options.
pip-sync -q requirements/edx/development.txt
```
Those comments shouldn't be displayed there.