### PR TITLE
docs: remove outdated reference to courseware_mfe opt-in

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -4695,7 +4695,6 @@ PROGRAM_CONSOLE_MICROFRONTEND_URL = None
 # .. setting_name: LEARNING_MICROFRONTEND_URL
 # .. setting_default: None
 # .. setting_description: Base URL of the micro-frontend-based courseware page.
-# .. setting_warning: Also set site's courseware.courseware_mfe waffle flag.
 LEARNING_MICROFRONTEND_URL = None
 # .. setting_name: DISCUSSIONS_MICROFRONTEND_URL
 # .. setting_default: None


### PR DESCRIPTION
## Description

See commit message.

## Supporting information

@fghaas pointed out the mistake in this Discourse post: https://discuss.openedx.org/t/disabling-the-learning-mfe-in-maple-slightly-misleading-documentation/6320

## Testing instructions

N/A

## Deadline

ASAP

## Other information

I will backport this to `open-release/maple.master` so that the correction will be reflected in `open-release/maple.2`.
