### PR TITLE
fix: cast course_id to CourseKey when loading CourseOverview

### DIFF
--- a/common/djangoapps/course_modes/rest_api/serializers.py
+++ b/common/djangoapps/course_modes/rest_api/serializers.py
@@ -4,6 +4,7 @@ Course modes API serializers.
 
 
 from rest_framework import serializers
+from opaque_keys.edx.keys import CourseKey
 
 from common.djangoapps.course_modes.models import CourseMode
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
@@ -39,7 +40,8 @@ class CourseModeSerializer(serializers.Serializer):
         ListCreateAPIView.
         """
         if 'course_id' in validated_data:
-            course_overview = CourseOverview.get_from_id(validated_data['course_id'])
+            course_id = CourseKey.from_string(validated_data['course_id'])
+            course_overview = CourseOverview.get_from_id(course_id)
             del validated_data['course_id']
             validated_data['course'] = course_overview
 


### PR DESCRIPTION
<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

When creating a course mode using the API for a course which course overview object version is less than the CourseOverview class version, an assertion error is raised.

```
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/mongodb_proxy.py", line 55, in wrapper
    return func(*args, **kwargs)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/mongo/base.py", line 1128, in has_course
    assert isinstance(course_key, CourseKey)
AssertionError
```
This happens because the API serializer calls CourseOverview.get_from_id ([here](https://github.com/edx/edx-platform/blob/aba0bf6a486b679739484438b5b5a6aa8a0f2a00/common/djangoapps/course_modes/rest_api/serializers.py#L42)) with a bare string, and then loads the course overview from the modulestore if the version condition is met ([here](https://github.com/edx/edx-platform/blob/aba0bf6a486b679739484438b5b5a6aa8a0f2a00/openedx/core/djangoapps/content/course_overviews/models.py#L391)). When the method tries to load the object with the string as an identifier, raises the assertion error([here](https://github.com/edx/edx-platform/blob/aba0bf6a486b679739484438b5b5a6aa8a0f2a00/openedx/core/djangoapps/content/course_overviews/models.py#L284)).

## Supporting information

The course modes API was created based on this [Jira](https://openedx.atlassian.net/browse/EDUCATOR-4190) issue

## Testing instructions

With a course that meets the requirement `instance.version < CourseOverview.version` make the following call
```
curl -X POST "https://<domain>/api/course_modes/v1/courses/course-v1%3Atesting-site%2BTS%2B00/" -H  "accept: application/json" -H  "Content-Type: application/json" -H  "X-CSRFToken: 5lillyFTelMhHy9ne4i8HJ7IbU7SQe4mpAsRr0OZBoWZrqYqNWhxEmP2BHHClYYd" -d "{  \"course_id\": \"course-v1:testing-site+TS+00\",  \"mode_slug\": \"honor\",  \"mode_display_name\": \"Honor\",  \"currency\": \"usd\"}"
```
That results in:
```
2021-12-27 19:52:55,381 INFO 2870331 [openedx.core.djangoapps.content.course_overviews.models] [user 261689] [ip 201.234.236.10] models.py:260 - Attempting to load CourseOverview for course course-v1:testing-site+TS+00 from modulestore.
2021-12-27 19:52:55,661 ERROR 2870331 [root] [user None] [ip None] signals.py:22 - Uncaught exception from None
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/base.py", line 115, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/base.py", line 113, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/lib/python3.8/contextlib.py", line 75, in inner
    return func(*args, **kwds)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/views/generic/base.py", line 71, in view
    return self.dispatch(request, *args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/rest_framework/views.py", line 509, in dispatch
    response = self.handle_exception(exc)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/rest_framework/views.py", line 469, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
    raise exc
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/rest_framework/generics.py", line 242, in post
    return self.create(request, *args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/rest_framework/mixins.py", line 19, in create
    self.perform_create(serializer)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/rest_framework/mixins.py", line 24, in perform_create
    serializer.save()
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/rest_framework/serializers.py", line 205, in save
    self.instance = self.create(validated_data)
  File "/edx/app/edxapp/edx-platform/common/djangoapps/course_modes/rest_api/serializers.py", line 44, in create
    course_overview = CourseOverview.get_from_id(validated_data['course_id'])
  File "/edx/app/edxapp/edx-platform/openedx/core/lib/cache_utils.py", line 74, in decorator
    result = wrapped(*args, **kwargs)
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/content/course_overviews/models.py", line 373, in get_from_id
    course_overview = cls.load_from_module_store(course_id)
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/content/course_overviews/models.py", line 265, in load_from_module_store
    with store.bulk_operations(course_id):
  File "/usr/lib/python3.8/contextlib.py", line 113, in __enter__
    return next(self.gen)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/ccx/modulestore.py", line 305, in bulk_operations
    with self._modulestore.bulk_operations(course_id, emit_signals=emit_signals, ignore_case=ignore_case):
  File "/usr/lib/python3.8/contextlib.py", line 113, in __enter__
    return next(self.gen)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/mixed.py", line 1046, in bulk_operations
    store = self._get_modulestore_for_courselike(course_id)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/mixed.py", line 217, in _get_modulestore_for_courselike
    if has_locator(store):
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/mixed.py", line 215, in <lambda>
    has_locator = lambda store: store.has_course(locator)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/mongodb_proxy.py", line 55, in wrapper
    return func(*args, **kwargs)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/mongo/base.py", line 1128, in has_course
    assert isinstance(course_key, CourseKey)
AssertionError
2021-12-27 19:52:56,423 ERROR 2870331 [django.request] [user 261689] [ip 201.234.236.10] log.py:222 - Internal Server Error: /api/course_modes/v1/courses/course-v1:testing-site+TS+00/
```
Then make the change, and you'll be able to create the course mode.

## Other information

We found this error in our Lilac staging version while creating course modes through [this](https://github.com/edx/edx-platform/pull/28114) new feature with course overviews taken from juniper DB backups.