### PR TITLE
fix: relax load in instructor dashboard page.

### DIFF
--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -119,7 +119,7 @@ def instructor_dashboard_2(request, course_id):  # lint-amnesty, pylint: disable
         log.error("Unable to find course with course key %s while loading the Instructor Dashboard.", course_id)
         return HttpResponseServerError()
 
-    course = get_course_by_id(course_key, depth=0)
+    course = get_course_by_id(course_key, depth=None)
 
     access = {
         'admin': request.user.is_staff,


### PR DESCRIPTION
# Fix: Relax load when Bringing all the course children when fetching a course in the instructor dashboard page.

<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description
This PR aims to solve the following issue:


When loading the Instructor dashboard, the course is fetched with 
https://github.com/edx/edx-platform/blob/3cbc5b9cdcbebb74b6f03957fcc7eb3749846add/lms/djangoapps/instructor/views/instructor_dashboard.py#L122

 Please note that the parameter **depth** is zero, so the course is fetched with no children (sections, subsections, sequentials, etc). In a subsequent part of the code, the extensions tab is loaded, specifically in :  

https://github.com/edx/edx-platform/blob/3cbc5b9cdcbebb74b6f03957fcc7eb3749846add/lms/djangoapps/instructor/views/instructor_dashboard.py#L585

Which eventually call the method **get_units_with_due_date** 

https://github.com/edx/edx-platform/blob/3cbc5b9cdcbebb74b6f03957fcc7eb3749846add/lms/djangoapps/instructor/views/tools.py#L121

. This method iterates over the course and its children to find blocks with due dates. This iteration was taking too long unless the course is fetched with **depth** None, which brings all the children of the course, reason why this PR is created.

This was already tested in stage, where instructor dashboard load times were significantly improved.

#### Useful information to include:
- This PR impacts the student's users when they want to inspect the dashboard page of a course when a course is big and has many due dates.

## Supporting information

Edunext integration PRs: 
- https://github.com/eduNEXT/edunext-platform/pull/501
- https://github.com/eduNEXT/edunext-platform/pull/605

## Testing instructions

 it was necessary to find a big course thinking that the Jhony PR https://github.com/eduNEXT/edunext-platform/pull/519 says that the problem is searching with the block or subsections with a due date. For that reason, I made a mongo query in mongo shell to find the course structure with more due dates. 

```mongo 
use edxapp

db.modulestore.structures.aggregate([
    {"$match":{"root.0":"course"}},
    { "$project": {
      "dueBlocks": {
        "$size": {
          "$filter": {
            "input": "$blocks",
            "as": "bot",
            "cond": { "$gt": ["$$bot.fields.due", null] }
            }
          }
        }
      }
    },
    {"$sort": { "dueBlocks": -1 }},
    {"$limit": 5}
  ])
```
This returns the id structure and the quantity of due blocks.

```
{ _id: ObjectId("61b8d306545ca25b9e3ddcc1"), dueBlocks: 232 }
{ _id: ObjectId("61b9b944012990ee9ba10eea"), dueBlocks: 232 }
```
Then in `edxapp.modulestore.active_versions` continue and find the course of the id structure. 
`{"versions.published-branch": ObjectId('61b9b944012990ee9ba10eea')}`

With the course, I tested the time response as a client of the page `/instructor#view-course_info` before and after the change. This change increases the performance of response from 13s to 3s of time.

**before**:
![bracu-13s](https://user-images.githubusercontent.com/51926076/147491595-092c9d75-2f3d-4ba5-9137-78fa88b2ca44.png)

**after**

![bracu-3s](https://user-images.githubusercontent.com/51926076/147491604-ce3f77be-022f-4bc3-aa5b-20fc5b26a010.png)


## Other information

**note**: Probably it wasn't necessarily a course with a lot of due dates, but with a lot of subsections or children in order to test the lag.

