### PR TITLE
fix: Improve studio /settings/details page.

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_listing.py
+++ b/cms/djangoapps/contentstore/tests/test_course_listing.py
@@ -315,30 +315,41 @@ class TestCourseListing(ModuleStoreTestCase):
         all of them.
         """
         org_course_one = self.store.make_course_key('AwesomeOrg', 'Course1', 'RunBabyRun')
-        CourseFactory.create(
+        course_1 = CourseFactory.create(
             org=org_course_one.org,
             number=org_course_one.course,
             run=org_course_one.run
         )
+        CourseOverviewFactory.create(id=course_1.id, org='AwesomeOrg')
 
         org_course_two = self.store.make_course_key('AwesomeOrg', 'Course2', 'RunBabyRun')
-        CourseFactory.create(
+        course_2 = CourseFactory.create(
             org=org_course_two.org,
             number=org_course_two.course,
             run=org_course_two.run
         )
+        CourseOverviewFactory.create(id=course_2.id, org='AwesomeOrg')
 
         # Two types of org-wide roles have edit permissions: staff and instructor.  We test both
         role.add_users(self.user)
 
-        with self.assertRaises(AccessListFallback):
-            _accessible_courses_list_from_groups(self.request)
         courses_list, __ = get_courses_accessible_to_user(self.request)
 
         # Verify fetched accessible courses list is a list of CourseSummery instances and test expacted
         # course count is returned
         self.assertEqual(len(list(courses_list)), 2)
         self.assertTrue(all(isinstance(course, CourseOverview) for course in courses_list))
+
+    @ddt.data(OrgStaffRole(), OrgInstructorRole())
+    def test_course_listing_org_permissions_exception(self, role):
+        """
+        Create roles with no course_id neither org to make sure AccessListFallback is raised for
+        platform-wide permissions
+        """
+        role.add_users(self.user)
+
+        with self.assertRaises(AccessListFallback):
+            _accessible_courses_list_from_groups(self.request)
 
     def test_course_listing_with_actions_in_progress(self):
         sourse_course_key = CourseLocator('source-Org', 'source-Course', 'source-Run')

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -483,10 +483,20 @@ def _accessible_courses_list_from_groups(request):
     courses_list = []
     course_keys = {}
 
+    user_global_orgs = set()
     for course_access in all_courses:
-        if course_access.course_id is None:
+        if course_access.course_id is not None:
+            course_keys[course_access.course_id] = course_access.course_id
+        elif course_access.org:
+            user_global_orgs.add(course_access.org)
+        else:
             raise AccessListFallback
-        course_keys[course_access.course_id] = course_access.course_id
+
+    if user_global_orgs:
+        # Getting courses from user global orgs
+        overviews = CourseOverview.get_all_courses(orgs=list(user_global_orgs))
+        overviews_course_keys = {overview.id: overview.id for overview in overviews}
+        course_keys.update(overviews_course_keys)
 
     course_keys = list(course_keys.values())
 


### PR DESCRIPTION
# Fix: Improving Studio homepage performance for users with course access role with no course_id

## Description
The studio performance is degraded in /home and /settings/details/<course_id> pages when a user with a global instructor or staff permissions over an organization (which maps to a Corse Access Role record with a defined role and org, but not course_id) tries to access them. This is because when getting the courses for a user in
https://github.com/edx/edx-platform/blob/3cbc5b9cdcbebb74b6f03957fcc7eb3749846add/cms/djangoapps/contentstore/views/course.py#L470


, if a Course Access Role with no course_id is found, the platform rises an exception in

https://github.com/edx/edx-platform/blob/3cbc5b9cdcbebb74b6f03957fcc7eb3749846add/cms/djangoapps/contentstore/views/course.py#L486

which fallback to a method that also gets courses for the user but causes more overhead over the mongo database.

https://github.com/edx/edx-platform/blob/3cbc5b9cdcbebb74b6f03957fcc7eb3749846add/cms/djangoapps/contentstore/views/course.py#L386

This solution consists of not raising the exception when a Course Access Role does not have a course_id and just pulling all courses from organizations the user has access to globally. The CourseOverview model is used for that purpose. The exception AccessListFallback will only be raised if a Course Access Role record contains neither course_id nor org fields.



<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Supporting information

Edunext integration PRs:
- https://github.com/eduNEXT/edunext-platform/pull/501
- https://github.com/eduNEXT/edunext-platform/pull/604


## Testing Instructions

Jhony PR: 

**_accessible_courses_list_from_groups**
This PR attempts to improve the performance of a global instructor or staff-admin permission, but in this part with this kind of user, the flow always uses the slower function and not the improvement calling `_accessible_courses_summary_iter`. 

https://github.com/eduNEXT/edx-platform/blob/e1f1fe6682b15837deab7daecd16c937064fac8a/cms/djangoapps/contentstore/views/course.py#L758-L768

Otherwise for local or staff instructors of a specific org should be fixed calling `_accessible_courses_list_from_groups`.
![course-staff-local-role](https://user-images.githubusercontent.com/51926076/147507906-fbe5d821-9b5e-4b66-aa38-451dc766e37d.png)


 Even a course doesn't have an id so  adding the id if possible:
https://github.com/eduNEXT/edx-platform/blob/e1f1fe6682b15837deab7daecd16c937064fac8a/cms/djangoapps/contentstore/views/course.py#L485-L491

 In that way not raising immediately the assertion ` AccessListFallback` calling the slower one   `_accessible_courses_summary_iter`.

In this case, the PR helps to improve the performance avoiding the slower method of searching a particular org. In this case, passing from 12s to 3 s.

**before:**
![staff-without-change](https://user-images.githubusercontent.com/51926076/147507997-3c5f6e02-acda-41a1-929b-c5124456ccad.png)

**After**
![after-staff-local](https://user-images.githubusercontent.com/51926076/147508009-b9239d16-4240-4120-b8df-14ce79131f27.png)




## Other information

This PR https://github.com/eduNEXT/edunext-platform/pull/604 discusses the way to improve the studio home page using waffle switch with admin or staff user across many orgs.