### PR TITLE
fix: update discussions MFE path [BD-38] [TNL-9347]

### DIFF
--- a/lms/djangoapps/courseware/tests/test_discussion_xblock.py
+++ b/lms/djangoapps/courseware/tests/test_discussion_xblock.py
@@ -330,7 +330,7 @@ class TestXBlockInCourse(SharedModuleStoreTestCase):
             <iframe
                 id='discussions-mfe-tab-embed'
                 title='Discussions'
-                src='http://test.url/discussions/edX/toy/2012_Fall/topics/test_discussion_xblock_id'
+                src='http://test.url/edX/toy/2012_Fall/topics/test_discussion_xblock_id'
             />
             """,
             html,

--- a/lms/djangoapps/discussion/django_comment_client/tests/test_utils.py
+++ b/lms/djangoapps/discussion/django_comment_client/tests/test_utils.py
@@ -1236,7 +1236,7 @@ class DiscussionTabTestCase(ModuleStoreTestCase):
 
     @override_settings(DISCUSSIONS_MICROFRONTEND_URL="http://test.url")
     @ddt.data(
-        (True, 'http://test.url/discussions/{}/'),
+        (True, 'http://test.url/{}/'),
         (False, '/courses/{}/discussion/forum/'),
     )
     @ddt.unpack

--- a/openedx/core/djangoapps/discussions/tests/test_transformer.py
+++ b/openedx/core/djangoapps/discussions/tests/test_transformer.py
@@ -59,7 +59,7 @@ class DiscussionsTopicLinkTransformerTestCase(TransformerRegistryTestMixin, Modu
             self.discussable_unit.location,
             self.TRANSFORMER_CLASS_TO_TEST.EMBED_URL,
         )
-        assert embed_url == f"http://discussions-mfe/discussions/{self.course.id}/topics/{self.test_topic_id}"
+        assert embed_url == f"http://discussions-mfe/{self.course.id}/topics/{self.test_topic_id}"
 
         external_id = block_structure.get_xblock_field(
             self.discussable_unit.location,

--- a/openedx/core/djangoapps/discussions/url_helpers.py
+++ b/openedx/core/djangoapps/discussions/url_helpers.py
@@ -16,7 +16,7 @@ def get_discussions_mfe_url(course_key: CourseKey) -> str:
         (str) URL link for MFE. Empty if the base url isn't configured
     """
     if settings.DISCUSSIONS_MICROFRONTEND_URL is not None:
-        return f"{settings.DISCUSSIONS_MICROFRONTEND_URL}/discussions/{course_key}/"
+        return f"{settings.DISCUSSIONS_MICROFRONTEND_URL}/{course_key}/"
     return ''
 
 
@@ -26,6 +26,7 @@ def get_discussions_mfe_topic_url(course_key: CourseKey, topic_id: str) -> str:
 
     Args:
         course_key (CourseKey): course key of course for which to get url
+        topic_id (str): topic id for which to generate URL
 
     Returns:
         (str) URL link for MFE. Empty if the base url isn't configured

--- a/openedx/core/lib/xblock_builtin/xblock_discussion/xblock_discussion/__init__.py
+++ b/openedx/core/lib/xblock_builtin/xblock_discussion/xblock_discussion/__init__.py
@@ -5,10 +5,10 @@ Discussion XBlock
 import logging
 import urllib
 
-from django.conf import settings
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.urls import reverse
 from django.utils.translation import get_language_bidi
+from openedx.core.djangoapps.discussions.url_helpers import get_discussions_mfe_topic_url
 from web_fragments.fragment import Fragment
 from xblock.completable import XBlockCompletionMode
 from xblock.core import XBlock
@@ -170,11 +170,11 @@ class DiscussionXBlock(XBlock, StudioEditableXBlockMixin, XmlParserMixin):  # li
         Renders student view for LMS.
         """
         fragment = Fragment()
-        if ENABLE_DISCUSSIONS_MFE.is_enabled(self.course_key) and settings.DISCUSSIONS_MICROFRONTEND_URL:
-            url = f"{settings.DISCUSSIONS_MICROFRONTEND_URL}/discussions/{self.course_key}/topics/{self.discussion_id}"
+        mfe_url = get_discussions_mfe_topic_url(self.course_key, self.discussion_id)
+        if ENABLE_DISCUSSIONS_MFE.is_enabled(self.course_key) and mfe_url:
             fragment.add_content(HTML(
                 "<iframe id='discussions-mfe-tab-embed' src='{src}' title='{title}'></iframe>"
-            ).format(src=url, title=_("Discussions")))
+            ).format(src=mfe_url, title=_("Discussions")))
             fragment.add_css(
                 """
                 #discussions-mfe-tab-embed {


### PR DESCRIPTION
## Description

Remove the redundant /discussions from the start of the discussions MFE path. 

## Supporting information

Ticket: https://openedx.atlassian.net/browse/TNL-9347
