### PR TITLE
fix: remove extra slash in course blocks api call for report generation

### DIFF
--- a/common/static/common/js/components/BlockBrowser/data/api/client.js
+++ b/common/static/common/js/components/BlockBrowser/data/api/client.js
@@ -1,7 +1,7 @@
 import Cookies from 'js-cookie';
 import 'whatwg-fetch';
 
-const COURSE_BLOCKS_API = '/api/courses/v1/blocks/';
+const COURSE_BLOCKS_API = '/api/courses/v1/blocks';
 
 const HEADERS = {
   Accept: 'application/json',


### PR DESCRIPTION
<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Related Ticket
https://github.com/mitodl/mitxpro/issues/2332

## Description
It removes the extra `/` in the courses API being called in the `Data Download` section under `Instructor Dashboard`.  The API was working fine until we did Django upgrades in a [PR](https://github.com/edx/edx-platform/pull/28852/files#diff-fcd30e4a6a554f40a4fd8eb2e11a1692fe1c36bc1aca446914a78502bcd400b1R21). So, after replacing `url` with `path` the `//` in any URL wouldn't match as part of regex defined earlier and it would return `404`. 

## How to reproduce:
- Make sure you are on `master`
- Sign in as staff and open the `Instructor Dashboard`
- Now, Open the `Data Download` section and then click `Select a section or problem`, you will see `404` on the API call. e.g. 

```
/api/courses/v1/blocks//?course_id=<YOUR_COURSE_ID>&all_blocks=true&depth=all&requested_fields=name,display_name,block_type,children 404
```

## Testing instructions
- It would be a good idea to go through reproduction steps first. change to this branch and retest. (You might need to regenerate your assets e.g. `paver update_assets` in case you see any cache related issue)

## Additional Information:
- The original reports generation functionality was added in https://github.com/edx/edx-platform/pull/17824
- Django upgrade after this started giving 404 was done in https://github.com/edx/edx-platform/pull/28852 
