### PR TITLE
fix: add some whitespace fixes for goal reminder email on apple mobile mail

### DIFF
--- a/lms/djangoapps/course_goals/templates/course_goals/edx_ace/goalreminder/email/body.html
+++ b/lms/djangoapps/course_goals/templates/course_goals/edx_ace/goalreminder/email/body.html
@@ -8,6 +8,7 @@
         font-size: 1em;
         line-height: 1.5;
         max-width: 600px;
+        border: 10px solid white;
     "
 {% endblock %}
 {% block main_style %}
@@ -38,8 +39,8 @@
                         line-height: 1.75rem;
                         text-align: left;
                         color: black;
-                        margin-top: 0;
-                        margin-bottom: 0;
+                        margin-top: 20px;
+                        margin-bottom: 20px;
                         ">
                         {% filter force_escape %}{% blocktrans %}
                             There’s still time to reach your goal


### PR DESCRIPTION
In Apple Mail

before
<img src="https://user-images.githubusercontent.com/5958221/148118208-ee41e13f-8842-44b0-a38f-f4ab0ee5b1b4.PNG" height="40%" width="40%">
after
<img src="https://user-images.githubusercontent.com/5958221/148118210-9074e076-f561-4bcc-ac03-ed4b7bbb77bc.PNG" height="40%" width="40%">

New Version in Mobile Gmail (doesn't seem to have any major regressions)
<img src="https://user-images.githubusercontent.com/5958221/148118757-c4f93172-2f69-4c3b-8ac8-2638fa9599cd.png" height="40%" width="40%">
