### PR TITLE
fix: Incorrect country value not accepted on registration form

### DIFF
--- a/common/djangoapps/student/tests/test_configuration_overrides.py
+++ b/common/djangoapps/student/tests/test_configuration_overrides.py
@@ -68,7 +68,7 @@ class TestSite(TestCase):
             "address1": "foo",
             "city": "foo",
             "state": "foo",
-            "country": "foo",
+            "country": "AU",
             "company": "foo",
             "title": "foo"
         }.items()))

--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -109,6 +109,16 @@ def validate_name(name):
         raise forms.ValidationError(_('Enter a valid name'))
 
 
+def validate_country(country):
+    """
+    Verifies a country is valid, raises a ValidationError otherwise.
+    Args:
+        country (unicode): The country to validate.
+    """
+    if country not in countries:
+        raise forms.ValidationError(_('Enter a valid country name'))
+
+
 class UsernameField(forms.CharField):
     """
     A CharField that validates usernames based on the `ENABLE_UNICODE_USERNAME` feature.
@@ -208,6 +218,26 @@ class AccountCreationForm(forms.Form):
                                 "required": _("To enroll, you must follow the honor code.")
                             }
                         )
+                elif field_name == "country":
+                    required_value = field_value == "required"
+                    error_message = error_message_dict.get(
+                        field_name,
+                        _("You are missing one or more required fields")
+                    )
+                    # country code should only be 2 char long according to ISO Alpha-2 format
+                    min_length = 2
+                    max_length = 2
+                    self.fields[field_name] = forms.CharField(
+                        required=required_value,
+                        min_length=min_length,
+                        max_length=max_length,
+                        validators=[validate_country],
+                        error_messages={
+                            "required": error_message,
+                            "min_length": error_message,
+                            "max_length": error_message,
+                        }
+                    )
                 else:
                     required = field_value == "required"
                     min_length = 1


### PR DESCRIPTION
<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.

- This PR ensure that an incorrect country value is not accepted when provided by any third party IDP. More details are on this ticket: https://openedx.atlassian.net/browse/ENT-4405

Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
