### PR TITLE
[SE-5142] Footer sticks to the bottom of the page on Logistration pages

### DIFF
--- a/lms/static/sass/base/_base.scss
+++ b/lms/static/sass/base/_base.scss
@@ -10,7 +10,7 @@ html {
   font-style: normal;
   line-height: 1em;
   background: theme-color("inverse");
-
+  height: 100%;
 }
 
 body {
@@ -19,7 +19,7 @@ body {
   font-size: $font-size-base;
   line-height: 1em;
   background: $body-bg;
-
+  height: 100%;
 }
 
 // removing the outline on any element that we make programmatically focusable
@@ -134,6 +134,8 @@ a:visited:not(.btn) {
   margin: $baseline auto 0 auto;
   max-width: map-get($container-max-widths, xl);
   padding: 0 0 $baseline/2;
+  flex: 1 0 auto;
+  display: flex;
 
   @include media-breakpoint-up(md) {
     padding: 0 $baseline $baseline/2;

--- a/lms/static/sass/base/_layouts.scss
+++ b/lms/static/sass/base/_layouts.scss
@@ -92,6 +92,7 @@ body.view-in-course {
     margin-top: ($baseline*2);
     padding-right: 2%;
     padding-left: 2%;
+    flex-shrink: 0;
 
     footer#footer-openedx { // shame selector to match existing
       min-width: auto;

--- a/lms/static/sass/views/_login-register.scss
+++ b/lms/static/sass/views/_login-register.scss
@@ -53,6 +53,9 @@
 
 .window-wrap {
   background: $body-bg;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 }
 
 .login-register-content {
@@ -954,4 +957,3 @@ ul.fa-ul{
 body.open-modal {
   overflow: hidden;
 }
-


### PR DESCRIPTION
## Description

Changes the footer on the Logistration and Course pages to hug the bottom of the page when no content.

It's annoying to learners when the footer moves up and down to accommodate course content.

## Supporting information

https://tasks.opencraft.com/browse/SE-5142

Before

![Screenshot_20220105_125257](https://user-images.githubusercontent.com/1470652/148206259-b87d80ef-1e7e-4ba0-945e-701815b77465.png)

After:

![Screenshot_20220105_125330](https://user-images.githubusercontent.com/1470652/148206312-4160e9f5-f9a1-435e-b11b-7f92cf780575.png)


## Testing instructions

View any login or course page.

## Deadline

None
