### PR TITLE
feat: add reset option to the Randomized Content Block

### DIFF
--- a/common/lib/xmodule/xmodule/assets/library_content/public/js/library_content_reset.js
+++ b/common/lib/xmodule/xmodule/assets/library_content/public/js/library_content_reset.js
@@ -1,0 +1,18 @@
+/* JavaScript for reset option that can be done on a randomized LibraryContentBlock */
+function LibraryContentReset(runtime, element) {
+  $('.problem-reset-btn', element).click((e) => {
+    e.preventDefault();
+    $.post({
+      url: runtime.handlerUrl(element, 'reset_selected_children'),
+      success(data) {
+        edx.HtmlUtils.setHtml(element, edx.HtmlUtils.HTML(data));
+        // Rebind the reset button for the block
+        XBlock.initializeBlock(element);
+        // Render the new set of problems (XBlocks)
+        $(".xblock", element).each(function(i, child) {
+          XBlock.initializeBlock(child);
+        });
+      },
+    });
+  });
+}

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -8,6 +8,7 @@ import logging
 import random
 from copy import copy
 from gettext import ngettext
+from rest_framework import status
 
 import bleach
 from django.conf import settings
@@ -21,7 +22,7 @@ from web_fragments.fragment import Fragment
 from webob import Response
 from xblock.completable import XBlockCompletionMode
 from xblock.core import XBlock
-from xblock.fields import Integer, List, Scope, String
+from xblock.fields import Integer, List, Scope, String, Boolean
 
 from capa.responsetypes import registry
 from xmodule.mako_module import MakoTemplateBlockBase
@@ -175,6 +176,14 @@ class LibraryContentBlock(
         # which random/first set of matching blocks was selected per user
         default=[],
         scope=Scope.user_state,
+    )
+    # This cannot be called `show_reset_button`, because children blocks inherit this as a default value.
+    allow_resetting_children = Boolean(
+        display_name=_("Show Reset Button"),
+        help=_("Determines whether a 'Reset Problems' button is shown, so users may reset their answers and reshuffle "
+               "selected items."),
+        scope=Scope.settings,
+        default=False
     )
 
     @property
@@ -346,6 +355,27 @@ class LibraryContentBlock(
 
         return self.selected
 
+    @XBlock.handler
+    def reset_selected_children(self, _, __):
+        """
+        Resets the XBlock's state for a user.
+
+        This resets the state of all `selected` children and then clears the `selected` field
+        so that the new blocks are randomly chosen for this user.
+        """
+        if not self.allow_resetting_children:
+            return Response('"Resetting selected children" is not allowed for this XBlock',
+                            status=status.HTTP_400_BAD_REQUEST)
+
+        for block_type, block_id in self.selected_children():
+            block = self.runtime.get_block(self.location.course_key.make_usage_key(block_type, block_id))
+            if hasattr(block, 'reset_problem'):
+                block.reset_problem(None)
+                block.save()
+
+        self.selected = []
+        return Response(json.dumps(self.student_view({}).content))
+
     def _get_selected_child_blocks(self):
         """
         Generator returning XBlock instances of the children selected for the
@@ -383,7 +413,11 @@ class LibraryContentBlock(
             'show_bookmark_button': False,
             'watched_completable_blocks': set(),
             'completion_delay_ms': None,
+            'reset_button': self.allow_resetting_children,
         }))
+
+        fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/library_content_reset.js'))
+        fragment.initialize_js('LibraryContentReset')
         return fragment
 
     def author_view(self, context):

--- a/lms/static/sass/course/courseware/_courseware.scss
+++ b/lms/static/sass/course/courseware/_courseware.scss
@@ -635,6 +635,17 @@ html.video-fullscreen {
         border-bottom: 1px solid #ddd;
         margin-bottom: ($baseline*0.75);
         padding: 0 0 15px;
+
+        .problem-reset-btn-wrapper {
+          position: relative;
+          .problem-reset-btn {
+            &:hover,
+            &:focus,
+            &:active {
+              color: $primary;
+            }
+          }
+        }
       }
 
       .vert > .xblock-student_view.is-hidden,

--- a/lms/templates/vert_module.html
+++ b/lms/templates/vert_module.html
@@ -69,6 +69,12 @@ from openedx.core.djangolib.markup import HTML
 % endfor
 </div>
 
+% if reset_button:
+  <div class="problem-reset-btn-wrapper">
+    <button type="button" class="problem-reset-btn btn-link" data-value="${_('Reset Problems')}"><span aria-hidden="true">${_('Reset Problems')}</span><span class="sr">${_("Reset Problems")}</span></button>
+  </div>
+% endif
+
 <%static:require_module_async module_name="js/dateutil_factory" class_name="DateUtilFactory">
     DateUtilFactory.transform('.localized-datetime');
 </%static:require_module_async>


### PR DESCRIPTION
<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This PR supersedes the previous one at #28624 

This adds a reset option to the randomized content block. This way students can prepare themselves for exams by answering a series of questions at random from a pre-determined set (something similar to flashcards).

We have been doing it with Python scripts within the CAPA blocks - questions and answers were included directly in the script and the reset button was changing the seed used for determining the question set. This PR introduces a similar functionality by using built-in Open edX features, thus making it more user-friendly and available for less technical course authoring teams.


## Supporting information

- [BB-4659](https://tasks.opencraft.com/browse/BB-4659)
- [BB-5258](https://tasks.opencraft.com/browse/BB-5258)
- [Video demo](https://www.loom.com/share/91b7224cb8a74cf2891a240b6e4fb8c6)

## Testing instructions

* Check out to this branch `tecoholic/add_reset_to_randomized_content_block` on `edx-platform`.
* In Studio, create a Randomized Content Block and set the `Show Reset Button` option to `True`.
* View the live version of the new block and click on the `Reset Problems` button on the bottom left part of the Randomized Content Block.
* Verify that the contents of the block are reloaded, answers are reset and the questions are changed.

## Deadline

None

## Other information

This feature is created with the use-case of using the Randomized Content Block as a Flash Card system for students to cycle through a prepared set of questions/problems.