### PR TITLE
feat: Program Inspectors API View

### DIFF
--- a/lms/djangoapps/support/urls.py
+++ b/lms/djangoapps/support/urls.py
@@ -17,6 +17,7 @@ from .views.program_enrollments import (
     LinkProgramEnrollmentSupportAPIView,
     ProgramEnrollmentsInspectorView,
     SAMLProvidersWithOrg,
+    ProgramEnrollmentsInspectorAPIView,
 )
 from .views.sso_records import SsoView
 from .views.onboarding_status import OnboardingView
@@ -70,6 +71,11 @@ urlpatterns = [
         r'get_saml_providers/?$',
         SAMLProvidersWithOrg.as_view(),
         name='get_saml_providers'
+    ),
+    re_path(
+        r'program_enrollments_inspector_details/?$',
+        ProgramEnrollmentsInspectorAPIView.as_view(),
+        name='program_enrollments_inspector_details'
     ),
     re_path(r'sso_records/(?P<username_or_email>[\w.@+-]+)?$', SsoView.as_view(), name='sso_records'),
     re_path(


### PR DESCRIPTION
This is a feature update for Program inspector tools to MFEs. Based on the query string parameters passed through the GET request, it helps search the data store for information about ProgramEnrollment and SSO linkage with the user.

Ticket LInk: [PROG-2479](https://openedx.atlassian.net/browse/PROD-2479?atlOrigin=eyJpIjoiNzZmMWFlOTY0ZDMzNGNkY2IzOWI3ODFlZmQwYjZlNjgiLCJwIjoiaiJ9)

Testing instructions:
Pre - Please follow [Program Enrollment Linkage](https://github.com/openedx/frontend-app-support-tools/pull/200) steps.
1. Make a [verified name for an existing user](http://localhost:18000/admin/edx_name_affirmation/verifiedname) 
2. Create a [ Course Enrollment for Program](http://localhost:18000/admin/program_enrollments/programcourseenrollment)