### PR TITLE
test: default to split modulestore in tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -30,6 +30,7 @@ jobs:
             "common-2",
             "common-3",
         ]
+      fail-fast: false
 
 
     name: python-${{ matrix.python-version }},django-${{ matrix.django-version }},${{ matrix.shard_name }}

--- a/common/lib/xmodule/xmodule/modulestore/tests/django_utils.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/django_utils.py
@@ -73,7 +73,7 @@ def mixed_store_config(data_dir, mappings, store_order=None, modulestore_options
             to use in creating courses.
     """
     if store_order is None:
-        store_order = [StoreConstructors.draft, StoreConstructors.split]
+        store_order = [StoreConstructors.split, StoreConstructors.draft]
 
     options = {
         'default_class': 'xmodule.hidden_module.HiddenDescriptor',


### PR DESCRIPTION
Just out of curiosity... how many tests will fail?
______________________
Result: 1406 failures out 16170 total tests. A whopping 608 of the failures are from lms/djangoapps/courseware.
