### PR TITLE
refactor: consider celery imports from common settings plus env tokens

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2693,11 +2693,17 @@ DEBUG_TOOLBAR_PATCH_SETTINGS = False
 
 ################################# CELERY ######################################
 
-CELERY_IMPORTS = (
+CELERY_IMPORTS = [
     # Since xblock-poll is not a Django app, and XBlocks don't get auto-imported
     # by celery workers, its tasks will not get auto-discovered:
     'poll.tasks',
-)
+]
+
+# .. setting_name: CELERY_EXTRA_IMPORTS
+# .. setting_default: []
+# .. setting_description: Adds extra packages that don't get auto-imported (Example: XBlocks).
+#    These packages are added in addition to those added by CELERY_IMPORTS.
+CELERY_EXTRA_IMPORTS = []
 
 # Message configuration
 

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -1068,3 +1068,6 @@ DISCUSSIONS_MFE_FEEDBACK_URL = ENV_TOKENS.get('DISCUSSIONS_MFE_FEEDBACK_URL', DI
 
 ############## DRF overrides ##############
 REST_FRAMEWORK.update(ENV_TOKENS.get('REST_FRAMEWORK', {}))
+
+############################# CELERY ############################
+CELERY_IMPORTS.extend(ENV_TOKENS.get('CELERY_EXTRA_IMPORTS', []))


### PR DESCRIPTION
<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This allows to add extra celery imports from environment variables.

## Other info
For this PR I take the suggestion to change the tuple for a list and to use the name `CELERY_EXTRA_IMPORTS` from [this comment](https://discuss.openedx.org/t/setting-naming-convention-question-for-extending-list-or-tuple/6967/2?u=mafermazu)

For more information: [Discuss Post](https://discuss.openedx.org/t/setting-naming-convention-question-for-extending-list-or-tuple/6967)
Related PR: #30222