### PR TITLE
feat: associate name to username in saml config

### DIFF
--- a/common/djangoapps/third_party_auth/samlproviderconfig/serializers.py
+++ b/common/djangoapps/third_party_auth/samlproviderconfig/serializers.py
@@ -22,7 +22,8 @@ class SAMLProviderConfigSerializer(serializers.ModelSerializer):  # lint-amnesty
             saml_configuration = SAMLConfiguration.objects.current_set().get(id=validated_data['saml_config_id'])
             del validated_data['saml_config_id']
             validated_data['saml_configuration'] = saml_configuration
-
+        if validated_data.get('attr_first_name'):
+            validated_data['attr_username'] = validated_data['attr_first_name']
         return SAMLProviderConfig.objects.create(**validated_data)
 
     def update(self, instance, validated_data):

--- a/common/djangoapps/third_party_auth/samlproviderconfig/tests/test_samlproviderconfig.py
+++ b/common/djangoapps/third_party_auth/samlproviderconfig/tests/test_samlproviderconfig.py
@@ -25,6 +25,8 @@ SINGLE_PROVIDER_CONFIG = {
     'enabled': 'true',
     'slug': 'test-slug',
     'country': 'https://example.customer.com/countrycode',
+    'attr_first_name': 'jon',
+    'attr_last_name': 'snow',
 }
 
 SINGLE_PROVIDER_CONFIG_2 = copy.copy(SINGLE_PROVIDER_CONFIG)
@@ -144,6 +146,7 @@ class SAMLProviderConfigTests(APITestCase):
         provider_config = SAMLProviderConfig.objects.get(slug=SINGLE_PROVIDER_CONFIG_2['slug'])
         assert provider_config.name == 'name-of-config-2'
         assert provider_config.country == SINGLE_PROVIDER_CONFIG_2['country']
+        assert provider_config.attr_username == SINGLE_PROVIDER_CONFIG['attr_first_name']
 
         # check association has also been created
         assert EnterpriseCustomerIdentityProvider.objects.filter(


### PR DESCRIPTION
## Description

Associate a first name entered in the saml config to be the user's username hint attribute

## Supporting information

https://openedx.atlassian.net/browse/ENT-4287

<!--

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
