### PR TITLE
feat: add flag to create_test_users to ignore when a user already exists

### DIFF
--- a/common/djangoapps/student/management/commands/_create_users.py
+++ b/common/djangoapps/student/management/commands/_create_users.py
@@ -1,10 +1,16 @@
 """ Shared behavior between create_test_users and create_random_users """
+from django.contrib.auth import get_user_model
+from django.core.validators import ValidationError
 from xmodule.modulestore.django import modulestore
+
 
 from lms.djangoapps.instructor.access import allow_access
 from openedx.core.djangoapps.user_authn.views.registration_form import AccountCreationForm
-from common.djangoapps.student.helpers import do_create_account
+from common.djangoapps.student.helpers import do_create_account, AccountValidationError
 from common.djangoapps.student.models import CourseEnrollment
+
+
+User = get_user_model()
 
 
 def create_users(
@@ -12,7 +18,8 @@ def create_users(
     user_data,
     enrollment_mode=None,
     course_staff=False,
-    activate=False
+    activate=False,
+    ignore_user_already_exists=False,
 ):
     """Create users, enrolling them in course_key if it's not None"""
     for single_user_data in user_data:
@@ -21,7 +28,19 @@ def create_users(
             tos_required=False
         )
 
-        (user, _, _) = do_create_account(account_creation_form)
+        user_already_exists = False
+        try:
+            (user, _, _) = do_create_account(account_creation_form)
+        except (ValidationError, AccountValidationError) as e:
+            try:
+                user = User.objects.get(username=single_user_data['username'])
+                if user.email == single_user_data['email'] and ignore_user_already_exists:
+                        user_already_exists = True
+                        print(f'Test user {user.username} already exists. Continuing to attempt to enroll.')
+                else:
+                    raise e
+            except User.DoesNotExist:
+                raise e
 
         if activate:
             user.is_active = True
@@ -33,7 +52,7 @@ def create_users(
                 course = modulestore().get_course(course_key, depth=1)
                 allow_access(course, user, 'staff', send_email=False)
 
-        if course_key and course_staff:
+        if course_key and course_staff and not user_already_exists:
             print(f'Created user {user.username} as course staff')
-        else:
+        elif not user_already_exists:
             print(f'Created user {user.username}')

--- a/common/djangoapps/student/management/commands/_create_users.py
+++ b/common/djangoapps/student/management/commands/_create_users.py
@@ -35,8 +35,8 @@ def create_users(
             try:
                 user = User.objects.get(username=single_user_data['username'])
                 if user.email == single_user_data['email'] and ignore_user_already_exists:
-                        user_already_exists = True
-                        print(f'Test user {user.username} already exists. Continuing to attempt to enroll.')
+                    user_already_exists = True
+                    print(f'Test user {user.username} already exists. Continuing to attempt to enroll.')
                 else:
                     raise e
             except User.DoesNotExist:

--- a/common/djangoapps/student/management/commands/_create_users.py
+++ b/common/djangoapps/student/management/commands/_create_users.py
@@ -47,7 +47,7 @@ def create_users(
                     raise account_creation_error
             except User.DoesNotExist:
                 # If a user with the username doesn't exist the error was probably something else, so reraise
-                raise account_creation_error  #pylint: disable=raise-missing-from 
+                raise account_creation_error  # pylint: disable=raise-missing-from
 
         if activate:
             user.is_active = True

--- a/common/djangoapps/student/management/commands/create_test_users.py
+++ b/common/djangoapps/student/management/commands/create_test_users.py
@@ -64,6 +64,11 @@ class Command(BaseCommand):
             ),
             action='store_true'
         )
+        parser.add_argument(
+            '--ignore_user_already_exists',
+            help="Don't fail if a user already exists. Log the error and attempt to enroll them in the course.",
+            action='store_true'
+        )
 
     def handle(self, *args, **options):
         course_key = options['course']
@@ -78,5 +83,6 @@ class Command(BaseCommand):
             ),
             enrollment_mode=enrollment_mode,
             course_staff=course_staff,
-            activate=True
+            activate=True,
+            ignore_user_already_exists=options['ignore_user_already_exists']
         )

--- a/common/djangoapps/student/management/tests/test_create_test_users.py
+++ b/common/djangoapps/student/management/tests/test_create_test_users.py
@@ -29,10 +29,18 @@ class CreateTestUsersTestCase(SharedModuleStoreTestCase):
         self.user_model = get_user_model()
         self.num_users_start = len(self.user_model.objects.all())
 
-    def call_command(self, users, course=None, mode=None, password=None, domain=None, course_staff=False):
+    def call_command(
+        self,
+        users,
+        course=None,
+        mode=None,
+        password=None,
+        domain=None,
+        course_staff=False,
+        ignore_user_already_exists=False
+    ):
         """ Helper method to call the management command with various arguments """
-        args = ['create_test_users']
-        args.extend(users)
+        args = list(users)
         if course:
             args.extend(['--course', course])
         if mode:
@@ -43,7 +51,10 @@ class CreateTestUsersTestCase(SharedModuleStoreTestCase):
             args.extend(['--domain', domain])
         if course_staff:
             args.append('--course_staff')
-        call_command(*args)
+        if ignore_user_already_exists:
+            args.append('--ignore_user_already_exists')
+
+        call_command('create_test_users', *args)
 
     def test_create_users(self):
         """
@@ -203,3 +214,19 @@ class CreateTestUsersTestCase(SharedModuleStoreTestCase):
         user = self.user_model.objects.get(username=username)
         assert not CourseAccessRole.objects.filter(user=user).exists()
         assert not CourseEnrollment.objects.filter(user=user).exists()
+
+    def test_create_user__ignore_user_already_exists(self):
+        """
+        Test that ignore_user_already_exists will allow us to specify a username
+        that already exists without raising an exception
+        """
+        test_username = 'IgnoreUserAlreadyExistsUser'
+        assert not self.user_model.objects.filter(username=test_username).exists()
+
+        self.call_command([test_username])
+        assert self.user_model.objects.filter(username=test_username).exists()
+
+        with self.assertRaises(ValidationError):
+            self.call_command([test_username], ignore_user_already_exists=False)
+
+        self.call_command([test_username], ignore_user_already_exists=True)


### PR DESCRIPTION
for https://github.com/openedx/edx-ora2/pull/1781

[AU-462](https://openedx.atlassian.net/browse/AU-462)

Add a new parameter to create_test_users, `--ignore_user_already_exists`.
Normally, if a user provided to the command already exists, the command fails.
With this new option, if a user already exists, we ignore the failure to create a user, look them up, and move on to the enrollment step.

Note: I originally also was going to add a flag to ignore if the user was already enrolled, but the way that we're enrolling doesn't throw an error anyways, just logs and continues. 