### PR TITLE
fix: update assessment visibility copy in studio

### DIFF
--- a/cms/templates/js/show-correctness-editor.underscore
+++ b/cms/templates/js/show-correctness-editor.underscore
@@ -21,13 +21,19 @@
             <%- gettext('Show assessment results when subsection is past due') %>
         </label>
         <p class='field-message' id='show_correctness_past_due_description'>
+            <%- gettext('Learners do not see whether their answers to assessments were correct or incorrect, nor the score received, until after the due date for the subsection has passed.') %>
             <% if (self_paced) { %>
-                <%- gettext('Learners do not see whether their answers to assessments were correct or incorrect, nor the score received, until after the course end date has passed.') %>
-                <%- gettext('If the course does not have an end date, learners always see their scores when they submit answers to assessments.') %>
-            <% } else { %>
-                <%- gettext('Learners do not see whether their answers to assessments were correct or incorrect, nor the score received, until after the due date for the subsection has passed.') %>
-                <%- gettext('If the subsection does not have a due date, learners always see their scores when they submit answers to assessments.') %>
+                <%= edx.HtmlUtils.interpolateHtml(
+                    gettext(
+                        'In a self paced course, graded subsections are assigned due dates based on each learner\'s {linkStart}Personalized Learner Schedule{linkEnd}.'
+                    ),
+                    {
+                        linkStart: edx.HtmlUtils.HTML('<a href="https://support.edx.org/hc/en-us/articles/206503568-How-do-self-paced-courses-work-" rel="noopener" target="_blank">'),
+                        linkEnd: edx.HtmlUtils.HTML('</a>')
+                    }
+                ) %>
             <% } %>
+            <%- gettext('If the subsection does not have a due date, learners always see their scores when they submit answers to assessments.') %>
         </p>
     </div>
 </div>


### PR DESCRIPTION
## Description

Updating the Assessment Results Visibility copy under Subsection Settings in Studio for self-paced courses to reflect Personalized Learner Schedules. The previous copy was inaccurate because it referred to the **course's end date** as the metric used to determine visibility rather than the **assessment's due date**.

Instructor paced copy (left) vs Self paced copy (right)
<div>
<img width="300" alt="AA-1168_InstructorPacedCopy" src="https://user-images.githubusercontent.com/25124041/149208980-aeaf8f12-2263-4a9c-b7d8-d46d6f300c23.png">
<img width="300" alt="AA-1168_SelfPacedCopy" src="https://user-images.githubusercontent.com/25124041/149209430-ed11e9f0-ff5f-4d8c-a96a-89a9fceaaf83.png">
</div>
