### PR TITLE
docs: COURSEGRAPH_JOB_QUEUE is a setting, not a toggle

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2195,13 +2195,10 @@ POLICY_CHANGE_TASK_RATE_LIMIT = '300/h'
 
 ############## Settings for CourseGraph ############################
 
-# .. toggle_name: COURSEGRAPH_JOB_QUEUE
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: value of LOW_PRIORITY_QUEUE
-# .. toggle_description: The name of the Celery queue to which CourseGraph refresh
+# .. setting_name: COURSEGRAPH_JOB_QUEUE
+# .. setting_default: value of LOW_PRIORITY_QUEUE
+# .. setting_description: The name of the Celery queue to which CourseGraph refresh
 #      tasks will be sent
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2021-10-01
 COURSEGRAPH_JOB_QUEUE = LOW_PRIORITY_QUEUE
 
 ########## Settings for video transcript migration tasks ############


### PR DESCRIPTION
## Description

This will fix a pylint failure that currently exists
because toggle_default is expected to be 'True' or 'False'.

## Testing instructions

```
~/openedx/devstack$ make lms-up-without-deps-shell
root@lms /edx/app/edxapp/edx-platform$ pylint cms/envs/common.py  # Should pass.
```

## Deadline

ASAP - master build is broken

## Other information

I [pushed directly to master](https://github.com/openedx/edx-platform/commit/06d2f1463411bb12a9cc693c8eebf4f7fde8fcfe) to see if branch protection rules would stop me -- they didn't. In the process, I introduced a CMS pylint violation. Oops.
