### PR TITLE
chore: upgrade edx-proctoring to 4.8.4

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -470,7 +470,7 @@ edx-opaque-keys[django]==2.2.2
     #   xmodule
 edx-organizations==6.10.1
     # via -r requirements/edx/base.in
-edx-proctoring==4.8.3
+edx-proctoring==4.8.4
     # via
     #   -r requirements/edx/base.in
     #   edx-proctoring-proctortrack

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -575,7 +575,7 @@ edx-opaque-keys[django]==2.2.2
     #   xmodule
 edx-organizations==6.10.1
     # via -r requirements/edx/testing.txt
-edx-proctoring==4.8.3
+edx-proctoring==4.8.4
     # via
     #   -r requirements/edx/testing.txt
     #   edx-proctoring-proctortrack

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -560,7 +560,7 @@ edx-opaque-keys[django]==2.2.2
     #   xmodule
 edx-organizations==6.10.1
     # via -r requirements/edx/base.txt
-edx-proctoring==4.8.3
+edx-proctoring==4.8.4
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring-proctortrack


### PR DESCRIPTION
Upgrade the edx-proctoring library. With this upgrade, we can handle proctored exam student attempt review result callback from proctoring provider better, when the exam is no longer proctored.

@openedx/masters-devs-cosmonauts Please review
