### PR TITLE
feat: update certificate generation command

### DIFF
--- a/lms/djangoapps/certificates/management/commands/regenerate_noidv_cert.py
+++ b/lms/djangoapps/certificates/management/commands/regenerate_noidv_cert.py
@@ -29,7 +29,16 @@ class Command(BaseCommand):
             '-c', '--course-keys',
             nargs='+',
             dest='course_keys',
-            help='course run key or space separated list of course run keys'
+            default='',
+            help='Course run key or space separated list of course run keys. If no '
+                 'key is provided, all unverified certs will be regenerated.'
+        )
+        parser.add_argument(
+            '--excluded-keys',
+            nargs='+',
+            dest='excluded_keys',
+            default='',
+            help='Course run key or space separated list of course run keys to exclude from regenerating'
         )
         parser.add_argument(
             '--batch_size',
@@ -50,25 +59,45 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         courses_str = options['course_keys']
+        excluded_str = options['excluded_keys']
+        if courses_str and excluded_str:
+            raise CommandError('You may not specify both course keys and excluded course keys.')
         if not courses_str:
-            raise CommandError('You must specify a course-key or keys')
+            log.info(
+                'No course keys provided. Will regenerate all '
+                'unverified certs for courses not specified by an excluded key'
+            )
 
         batch_size = options['batch_size']
         sleep_seconds = options['sleep_seconds']
-        course_keys = []
-        for course_id in courses_str:
-            # Parse the serialized course key into a CourseKey
-            try:
-                course_key = CourseKey.from_string(course_id)
-            except InvalidKeyError as e:
-                raise CommandError(f'{course_id} is not a valid course-key') from e
-            course_keys.append(course_key)
+
+        course_keys = _convert_to_course_key(courses_str)
+        excluded_keys = _convert_to_course_key(excluded_str)
 
         count = 0
-        for key in course_keys:
-            #rolling count to maintain batch_size across courses
-            count = _handle_course(key, batch_size, sleep_seconds, count)
+        if len(course_keys) > 0:
+            for key in course_keys:
+                # rolling count to maintain batch_size across courses
+                count = _handle_course(key, batch_size, sleep_seconds, count)
+        else:
+            # regenerate unverified certs for all courses with the exception of excluded keys
+            count = _handle_all_courses(batch_size, sleep_seconds, excluded_keys)
         return f'{count}'
+
+
+def _convert_to_course_key(course_id_strings):
+    """
+    Takes in a list of course id strings and returns list of course key object
+    """
+    key_object_list = []
+    for course_id in course_id_strings:
+        # Parse the serialized course key into a CourseKey
+        try:
+            course_key = CourseKey.from_string(course_id)
+        except InvalidKeyError as e:
+            raise CommandError(f'{course_id} is not a valid course-key') from e
+        key_object_list.append(course_key)
+    return key_object_list
 
 
 def _handle_course(course_key, batch_size, sleep_seconds, count):
@@ -88,10 +117,37 @@ def _handle_course(course_key, batch_size, sleep_seconds, count):
 
     log.info(f'Regenerating {len(certs)} unverified certificates for {course_key}')
 
+    return _regenerate_certs(certs, batch_size, sleep_seconds, count, False)
+
+
+def _handle_all_courses(batch_size, sleep_seconds, excluded_keys):
+    """
+    Regenerates unverified status certificates for all courses except for those designated by the excluded keys with
+    delay seconds between certs. Returns how many certs were originally unverified and regenerated.
+    """
+    certs = GeneratedCertificate.objects\
+        .filter(status=CertificateStatuses.unverified)\
+        .exclude(course_id__in=excluded_keys)
+    log.info(f'Regenerating {len(certs)} unverified certificates in all courses except for excluded keys')
+
+    return _regenerate_certs(certs, batch_size, sleep_seconds, 0, True)
+
+
+def _regenerate_certs(certs, batch_size, sleep_seconds, count, check_integrity_signature_flag):
+    """
+    Triggers generate certificate task for a given set of certificates
+    """
     for cert in certs:
-        user = User.objects.get(id=cert.user_id)
-        generate_certificate_task(user, course_key, generation_mode='batch', delay_seconds=0)
-        count += 1
-        if count % batch_size == 0:
-            time.sleep(sleep_seconds)
+        # not ideal to replicate this check, but we have to in the case that we are regenerating certs for all courses.
+        if check_integrity_signature_flag and not is_integrity_signature_enabled(cert.course_id):
+            log.warning(
+                f'Skipping regenerating cert_id={cert.id} because {cert.course_id} does not have honor code enabled'
+            )
+        else:
+            user = User.objects.get(id=cert.user_id)
+            generate_certificate_task(user, cert.course_id, generation_mode='batch', delay_seconds=0)
+            count += 1
+            if count % batch_size == 0:
+                log.info(f'Regenerated {count} unverified certificates. Sleeping for {sleep_seconds} seconds.')
+                time.sleep(sleep_seconds)
     return count


### PR DESCRIPTION
## [MST-1161](https://openedx.atlassian.net/browse/MST-1161)

The regeneration command for unverified certs has to be used to regenerate all unverified certs after the release of the honor code feature on January 19th. Because of this, the command is now updated to regenerate all unverified certificates if no specific course keys are provided. I've also included an option to include excluded keys, so that all unverified certs, except for those in an excluded course key, can be regenerated.
