### PR TITLE
fix: account activation email site logo is not themed

### DIFF
--- a/common/djangoapps/student/email_helpers.py
+++ b/common/djangoapps/student/email_helpers.py
@@ -11,6 +11,7 @@ from lms.djangoapps.verify_student.services import IDVerificationService
 from openedx.core.djangoapps.ace_common.template_context import get_base_template_context
 from openedx.core.djangoapps.enrollments.api import is_enrollment_valid_for_proctoring
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from openedx.core.djangoapps.theming import helpers as theming_helpers
 from xmodule.modulestore.django import modulestore
 
 
@@ -22,7 +23,8 @@ def generate_activation_email_context(user, registration):
         user (User): Currently logged-in user
         registration (Registration): Registration object for the currently logged-in user
     """
-    context = get_base_template_context(None)
+    site = theming_helpers.get_current_site()
+    context = get_base_template_context(site)
     context.update({
         'name': user.profile.name,
         'key': registration.activation_key,


### PR DESCRIPTION
Fix the issue when the email sent from the microsite with its own theme
has the logo from the main site.

Preconditions:
- microsite with its own theme is up and running

STR:
- Create a new account on the microsite;
- Check your email inbox.

Related PR to the master branch:
- https://github.com/openedx/edx-platform/pull/29764