### PR TITLE
revert: "fix: give proper status code for invalid sequence metadata r…

### DIFF
--- a/openedx/core/djangoapps/courseware_api/tests/test_views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/test_views.py
@@ -384,11 +384,6 @@ class SequenceApiTestViews(MasqueradeMixin, BaseCoursewareTests):
         assert response.data['display_name'] == 'sequence'
         assert len(response.data['items']) == 1
 
-    def test_unit_error(self):
-        """Verify that we return a proper error when passed a non-sequence"""
-        response = self.client.get(f'/api/courseware/sequence/{self.unit.location}')
-        assert response.status_code == 422
-
     @ddt.data(
         (False, None, False, False),
         (True, None, True, False),

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -11,7 +11,6 @@ from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthenticat
 from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, UsageKey
-from rest_framework import status
 from rest_framework.exceptions import NotFound
 from rest_framework.generics import RetrieveAPIView
 from rest_framework.permissions import IsAuthenticated
@@ -553,8 +552,7 @@ class SequenceMetadata(DeveloperErrorViewMixin, APIView):
         * 400 if an invalid parameter was sent.
         * 403 if a user who does not have permission to masquerade as
           another user specifies a username other than their own.
-        * 404 if the course/usage_key is not available or cannot be seen.
-        * 422 if the usage key is valid but does not have sequence metadata (like a unit or a problem)
+        * 404 if the course is not available or cannot be seen.
     """
 
     authentication_classes = (
@@ -584,10 +582,6 @@ class SequenceMetadata(DeveloperErrorViewMixin, APIView):
             str(usage_key),
             disable_staff_debug_info=True,
             will_recheck_access=True)
-
-        if not hasattr(sequence, 'get_metadata'):
-            # Looks like we were asked for metadata on something that is not a sequence (or section).
-            return Response(status=status.HTTP_422_UNPROCESSABLE_ENTITY)
 
         view = STUDENT_VIEW
         if request.user.is_anonymous:


### PR DESCRIPTION
…equests (#29741)"

## Description

This reverts commit a76a79f973ca05f3921fa2a3428fa7052868a725.

it was a backport of #29741 but it was breaking unit tests

I'm going to try to open a PR to fix the unit tests, but I don't know how long that might take. 

## Testing instructions

Do the github actions pass?

## Deadline

We need to fix open-release/maple.master asap, one way or another

