### PR TITLE
fix: course discovery dates localization after user logout

### DIFF
--- a/lms/djangoapps/courseware/context_processor.py
+++ b/lms/djangoapps/courseware/context_processor.py
@@ -5,7 +5,7 @@ This is meant to simplify the process of sending user preferences (espec. time_z
 to the templates without having to append every view file.
 
 """
-
+from django.utils.translation import get_language
 from pytz import timezone
 
 from edx_django_utils.cache import TieredCache
@@ -38,7 +38,7 @@ def user_timezone_locale_prefs(request):
     if not cached_value:
         user_prefs = {
             'user_timezone': None,
-            'user_language': None,
+            'user_language': get_language(),
         }
         if hasattr(request, 'user') and request.user.is_authenticated:
             try:

--- a/lms/djangoapps/courseware/tests/test_context_processor.py
+++ b/lms/djangoapps/courseware/tests/test_context_processor.py
@@ -4,6 +4,7 @@ Unit tests for courseware context_processor
 
 from pytz import timezone
 from unittest.mock import Mock, patch  # lint-amnesty, pylint: disable=wrong-import-order
+from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 
 from lms.djangoapps.courseware.context_processor import (
@@ -32,7 +33,7 @@ class UserPrefContextProcessorUnitTest(ModuleStoreTestCase):
         self.request.user = AnonymousUser()
         context = user_timezone_locale_prefs(self.request)
         assert context['user_timezone'] is None
-        assert context['user_language'] is None
+        assert context['user_language'] == settings.LANGUAGE_CODE
 
     def test_no_timezone_preference(self):
         set_user_preference(self.user, 'pref-lang', 'en')


### PR DESCRIPTION
Preconditions:
- course discovery enabled

STR:
- log in
- choose any language with a different date format (e.g. Ukrainian)
- check date format changed on the /courses page
- logout and go to /courses again

AR:
- date format is English on /courses, but stays the same as for the logged in
user on the main page

ER:
- date format stays the same as for logged in user

Related PR to the open-release/maple.master branch:
- https://github.com/openedx/edx-platform/pull/29773