### PR TITLE
fix: course discovery dates localization after user logout

### DIFF
--- a/lms/djangoapps/bulk_user_retirement/tests/test_views.py
+++ b/lms/djangoapps/bulk_user_retirement/tests/test_views.py
@@ -85,7 +85,7 @@ class BulkUserRetirementViewTests(APITestCase):
                 "usernames": f'{self.user3.username},{self.user4.username}'
             })
             assert response.status_code == 200
-            assert response.data == expected_response
+            assert sorted(response.data['successful_user_retirements']) == sorted(expected_response['successful_user_retirements'])  # pylint: disable=line-too-long
 
             retirement_status_1 = UserRetirementStatus.objects.get(user__username=self.user3.username)
             assert retirement_status_1.current_state == self.pending_state
@@ -107,7 +107,7 @@ class BulkUserRetirementViewTests(APITestCase):
                 )
             })
             assert response.status_code == 200
-            assert response.data == expected_response
+            assert sorted(response.data['successful_user_retirements']) == sorted(expected_response['successful_user_retirements'])  # pylint: disable=line-too-long
 
             retirement_status_1 = UserRetirementStatus.objects.get(user__username=self.user3.username)
             assert retirement_status_1.current_state == self.pending_state

--- a/lms/djangoapps/courseware/context_processor.py
+++ b/lms/djangoapps/courseware/context_processor.py
@@ -5,7 +5,7 @@ This is meant to simplify the process of sending user preferences (espec. time_z
 to the templates without having to append every view file.
 
 """
-
+from django.utils.translation import get_language
 from pytz import timezone
 
 from edx_django_utils.cache import TieredCache
@@ -35,7 +35,7 @@ def user_timezone_locale_prefs(request):
     if not cached_value:
         user_prefs = {
             'user_timezone': None,
-            'user_language': None,
+            'user_language': get_language(),
         }
         if hasattr(request, 'user') and request.user.is_authenticated:
             try:

--- a/lms/djangoapps/courseware/tests/test_context_processor.py
+++ b/lms/djangoapps/courseware/tests/test_context_processor.py
@@ -4,6 +4,7 @@ Unit tests for courseware context_processor
 
 from pytz import timezone
 from unittest.mock import Mock
+from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 
 from lms.djangoapps.courseware.context_processor import (
@@ -32,7 +33,7 @@ class UserPrefContextProcessorUnitTest(ModuleStoreTestCase):
         self.request.user = AnonymousUser()
         context = user_timezone_locale_prefs(self.request)
         assert context['user_timezone'] is None
-        assert context['user_language'] is None
+        assert context['user_language'] == settings.LANGUAGE_CODE
 
     def test_no_timezone_preference(self):
         set_user_preference(self.user, 'pref-lang', 'en')


### PR DESCRIPTION
Preconditions:
- course discovery enabled

STR:
- log in
- choose any language with a different date format (e.g. Ukrainian)
- check date format changed on the /courses page
- logout and go to /courses again

AR:
- date format is English on /courses, but stays the same as for logged in
user on the main page

ER:
- date format stays the same as for logged in user

Related PR to the master branch:
- https://github.com/openedx/edx-platform/pull/29772