### PR TITLE
fix: fix video xblock error with installed google tag manager

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
+++ b/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
@@ -169,6 +169,10 @@ function(VideoPlayer, i18n, moment, _) {
                     _oldOnYouTubeIframeAPIReady = window.onYouTubeIframeAPIReady || undefined;
 
                     window.onYouTubeIframeAPIReady = function() {
+                        if (!window.onYouTubeIframeAPIReady.resolve) {
+                            window.onYouTubeIframeAPIReady.resolve = _youtubeApiDeferred.resolve;
+                        }
+
                         window.onYouTubeIframeAPIReady.resolve();
                     };
 


### PR DESCRIPTION
## Description

The issue causes when we use GTM (Google Tag Manager) with Video XBlock.

**Forum discussion:** https://discuss.openedx.org/t/first-video-on-lesson-dont-work/3836/2

![image](https://user-images.githubusercontent.com/17108583/149921599-43c8fe73-1a02-4f60-9363-211ef9431507.png)

