### PR TITLE
docs: remove outdated reference to courseware_mfe opt-in (#29678)

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -4684,7 +4684,6 @@ PROGRAM_CONSOLE_MICROFRONTEND_URL = None
 # .. setting_name: LEARNING_MICROFRONTEND_URL
 # .. setting_default: None
 # .. setting_description: Base URL of the micro-frontend-based courseware page.
-# .. setting_warning: Also set site's courseware.courseware_mfe waffle flag.
 LEARNING_MICROFRONTEND_URL = None
 
 ############### Settings for the ace_common plugin #################


### PR DESCRIPTION
Backport of #29678 to `maple.master`. This is a clean cherry-pick.

