### PR TITLE
feat: show share feedback button only for discussions MFE when URL is configured [BD-38]

### DIFF
--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -720,6 +720,7 @@ def _discussions_mfe_context(query_params: Dict, course_key: CourseKey, user: Us
         "show_mfe": show_mfe,
         "legacy_url": f"{forum_url}?discussions_experience=legacy",
         "mfe_url": f"{forum_url}?discussions_experience=new",
+        "share_feedback_url": settings.DISCUSSIONS_MFE_FEEDBACK_URL,
         "course_key": course_key,
         "show_banner": show_banner,
         "discussions_mfe_url": mfe_url,

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -4920,3 +4920,5 @@ CUSTOM_PAGES_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-a
 # The expected value is an Integer representing the cutoff point (in months) for inclusion to the message. Example:
 # a value of `3` would include learners who have logged in within the past 3 months.
 BULK_COURSE_EMAIL_LAST_LOGIN_ELIGIBILITY_PERIOD = None
+
+DISCUSSIONS_MFE_FEEDBACK_URL = None

--- a/lms/templates/discussion/_switch_experience_fragment.html
+++ b/lms/templates/discussion/_switch_experience_fragment.html
@@ -16,14 +16,15 @@ from django.utils.translation import ugettext as _
     <a class="btn btn-outline-light mr-2" href="${legacy_url}">
         ${_("View legacy experience")}
     </a>
+    % if share_feedback_url:
+        <a class="btn btn-outline-light" href="${share_feedback_url}">
+            ${_("Share feedback")}
+        </a>
+    % endif
     % else:
     <a class="btn btn-outline-light mr-2" href="${mfe_url}">
         ${_("View the new experience")}
     </a>
     % endif
-
-    <a class="btn btn-outline-light">
-        ${_("Share feedback")}
-    </a>
 </div>
 % endif


### PR DESCRIPTION
## Description
Removes the share feedback button unless a URL is configured, and only shows it for the discussions MFE view.
