### PR TITLE
feat: upgrade lti-consumer-xblock library to include the OSPR-6283

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -614,7 +614,7 @@ libsass==0.10.0
     #   ora2
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==3.1.2
+lti-consumer-xblock==3.2.0
     # via -r requirements/edx/base.in
 lxml==4.5.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -826,7 +826,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/testing.txt
     #   ora2
-lti-consumer-xblock==3.1.2
+lti-consumer-xblock==3.2.0
     # via -r requirements/edx/testing.txt
 lxml==4.5.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -785,7 +785,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==3.1.2
+lti-consumer-xblock==3.2.0
     # via -r requirements/edx/base.txt
 lxml==4.5.0
     # via


### PR DESCRIPTION
The lti-consumer-xblock library now have custom parameters template substitution capability. See the [corresponding OSPR](https://github.com/openedx/xblock-lti-consumer/pull/215) for details

@openedx/masters-devs-cosmonauts Please help review.