### PR TITLE
fix: avoid raising error when auth_entry is None

### DIFF
--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -480,7 +480,7 @@ def parse_query_params(strategy, response, *args, **kwargs):
     """Reads whitelisted query params, transforms them into pipeline args."""
     # If auth_entry is not in the session, we got here by a non-standard workflow.
     # We simply assume 'login' in that case.
-    auth_entry = strategy.request.session.get(AUTH_ENTRY_KEY, AUTH_ENTRY_LOGIN)
+    auth_entry = strategy.request.session.get(AUTH_ENTRY_KEY) or AUTH_ENTRY_LOGIN
     if auth_entry not in _AUTH_ENTRY_CHOICES:
         raise AuthEntryError(strategy.request.backend, 'auth_entry invalid')
 

--- a/common/djangoapps/third_party_auth/tests/test_pipeline_integration.py
+++ b/common/djangoapps/third_party_auth/tests/test_pipeline_integration.py
@@ -594,3 +594,64 @@ class SetIDVerificationStatusTestCase(TestCase):
 
         # Ensure a verification signal was sent
         assert mock_signal.call_count == 1
+
+
+class ParseQueryParamsPipelineTestCase(TestCase):
+    """Tests to ensure reading queryparams from the auth/login URL works as expected."""
+
+    def setUp(self):
+        super().setUp()
+        self.strategy = mock.MagicMock()
+        self.response = mock.MagicMock()
+
+    def test_login_url_with_auth_entry(self):
+        """
+        Parsing query params with auth entry results in dictionary with the auth entry.
+        """
+        expected_query_params = {
+            "auth_entry": "login",
+        }
+        self.strategy.request.session = expected_query_params
+
+        query_params = pipeline.parse_query_params(self.strategy, self.response)
+
+        self.assertDictEqual(expected_query_params, query_params)
+
+    def test_login_url_with_auth_entry_none(self):
+        """
+        Parsing query params with auth entry equals to None results in dictionary with default auth entry.
+        """
+        expected_query_params = {
+            "auth_entry": "login",
+        }
+        self.strategy.request.session = {
+            "auth_entry": None,
+        }
+
+        query_params = pipeline.parse_query_params(self.strategy, self.response)
+
+        self.assertDictEqual(expected_query_params, query_params)
+
+    def test_login_url_without_auth_entry(self):
+        """
+        Parsing query params without auth entry results in dictionary with default auth entry.
+        """
+        expected_query_params = {
+            "auth_entry": "login",
+        }
+        self.strategy.request.session = {}
+
+        query_params = pipeline.parse_query_params(self.strategy, self.response)
+
+        self.assertDictEqual(expected_query_params, query_params)
+
+    def test_login_url_invalid_auth_entry(self):
+        """
+        Parsing query params with invalid auth entry results in AuthEntryError.
+        """
+        self.strategy.request.session = {
+            "auth_entry": "not-valid",
+        }
+
+        with self.assertRaises(pipeline.AuthEntryError):
+            pipeline.parse_query_params(self.strategy, self.response)


### PR DESCRIPTION
<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This PR avoids raising AuthEntryError when auth_entry is `None`. At some point of the authentication flow, when the auth_entry is missing from the auth URL (eg. `auth/login/tpa-saml/?idp=idp`), the request session stores `auth_entry: None` causing this line to fail which avoids the login to complete. 

## Testing instructions

1. Create a SAML IDP Configuration with slug `idp`
2. GET `/auth/login/tpa-saml/?next=%2F%3Ftpa_hint%3DTrue&idp=idp`
Continue flow until failure

## Deadline

None

## Other information

Have you ever experienced this problem before? We found it testing against the Lilac release.
