### PR TITLE
[MST-1312] Exclude Master's enrollments from Honor Code check

### DIFF
--- a/openedx/core/djangoapps/courseware_api/tests/test_views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/test_views.py
@@ -356,7 +356,7 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
     @ddt.data(
         (None, False, False, False),
         ('verified', False, False, True),
-        ('masters', False, False, True),
+        ('masters', False, False, False),
         ('audit', False, False, False),
         ('verified', False, True, False),
         ('masters', False, True, False),

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -328,14 +328,15 @@ class CoursewareMeta:
         """
         Boolean describing whether the user needs to sign the integrity agreement for a course.
         """
-        enrollment_is_cert_relavant = (
+        integrity_signature_required = (
             self.enrollment_object
-            and self.enrollment_object.mode in CourseMode.CERTIFICATE_RELEVANT_MODES
+            # Master's enrollments are excluded here as honor code is handled separately
+            and self.enrollment_object.mode in CourseMode.CREDIT_MODES + CourseMode.CREDIT_ELIGIBLE_MODES
         )
 
-        if not enrollment_is_cert_relavant:
+        if not integrity_signature_required:
             # Check masquerading as a non-audit enrollment
-            enrollment_is_cert_relavant = is_masquerading_as_non_audit_enrollment(
+            integrity_signature_required = is_masquerading_as_non_audit_enrollment(
                 self.effective_user,
                 self.course_key,
                 self.course_masquerade
@@ -343,7 +344,7 @@ class CoursewareMeta:
 
         if (
             integrity_signature_toggle(self.course_key)
-            and enrollment_is_cert_relavant
+            and integrity_signature_required
         ):
             signature = get_integrity_signature(self.effective_user.username, str(self.course_key))
             if not signature:


### PR DESCRIPTION
<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This change prevents Master's learners from encountering the Honor Code within a course.

Note that this does not change masquerade behavior yet - staff masquerading as a Master's learner will still see the Honor Code.

## Supporting information

https://openedx.atlassian.net/browse/MST-1312