### PR TITLE
fix: edx-enterprise 3.38.3

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -30,7 +30,7 @@ django-storages<1.9
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==3.38.2
+edx-enterprise==3.38.3
 
 # Newer versions need a more recent version of python-dateutil
 freezegun==0.3.12

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -441,7 +441,7 @@ edx-drf-extensions==8.0.1
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.38.2
+edx-enterprise==3.38.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -542,7 +542,7 @@ edx-drf-extensions==8.0.1
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.38.2
+edx-enterprise==3.38.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -526,7 +526,7 @@ edx-drf-extensions==8.0.1
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.38.2
+edx-enterprise==3.38.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
## Description

- bump edx-enterprise to 3.38.3
- more logging to debug missing completion records

## References

- https://pypi.org/project/edx-enterprise/3.38.3/
- https://github.com/openedx/edx-enterprise/pull/1439
- [ENT-5255](https://openedx.atlassian.net/browse/ENT-5255)
