### PR TITLE
Fix certificate generation without persistent grades

### DIFF
--- a/lms/djangoapps/certificates/generation_handler.py
+++ b/lms/djangoapps/certificates/generation_handler.py
@@ -50,7 +50,7 @@ def generate_allowlist_certificate_task(user, course_key, generation_mode=None):
     Create a task to generate an allowlist certificate for this user in this course run.
     """
     enrollment_mode = _get_enrollment_mode(user, course_key)
-    course_grade = _get_course_grade(user, course_key)
+    course_grade = _get_course_grade(user, course_key, send_grade_signals=False)
     if _can_generate_allowlist_certificate(user, course_key, enrollment_mode):
         return _generate_certificate_task(user=user, course_key=course_key, enrollment_mode=enrollment_mode,
                                           course_grade=course_grade, generation_mode=generation_mode)
@@ -371,9 +371,12 @@ def _get_grade_value(course_grade):
     return ''
 
 
-def _get_course_grade(user, course_key, send_grade_signals=False):
+def _get_course_grade(user, course_key, send_grade_signals=True):
     """
     Get the user's course grade in this course run. Note that this may be None.
+
+    Use send_grade_signals=False to avoid firing the course grade signals recursively.
+    See details in lms/djangoapps/grades/course_grade_factory.py _update method.
     """
     return CourseGradeFactory().read(user, course_key=course_key, send_grade_signals=send_grade_signals)
 

--- a/lms/djangoapps/certificates/generation_handler.py
+++ b/lms/djangoapps/certificates/generation_handler.py
@@ -68,7 +68,7 @@ def _generate_regular_certificate_task(user, course_key, generation_mode=None):
     eligible and a certificate can be generated.
     """
     enrollment_mode = _get_enrollment_mode(user, course_key)
-    course_grade = _get_course_grade(user, course_key)
+    course_grade = _get_course_grade(user, course_key, send_grade_signals=False)
     if _can_generate_regular_certificate(user, course_key, enrollment_mode, course_grade):
         return _generate_certificate_task(user=user, course_key=course_key, enrollment_mode=enrollment_mode,
                                           course_grade=course_grade, generation_mode=generation_mode)
@@ -371,11 +371,11 @@ def _get_grade_value(course_grade):
     return ''
 
 
-def _get_course_grade(user, course_key):
+def _get_course_grade(user, course_key, send_grade_signals=False):
     """
     Get the user's course grade in this course run. Note that this may be None.
     """
-    return CourseGradeFactory().read(user, course_key=course_key)
+    return CourseGradeFactory().read(user, course_key=course_key, send_grade_signals=send_grade_signals)
 
 
 def _get_enrollment_mode(user, course_key):

--- a/lms/djangoapps/grades/tests/test_course_grade_factory.py
+++ b/lms/djangoapps/grades/tests/test_course_grade_factory.py
@@ -2,18 +2,21 @@
 Tests for the CourseGradeFactory class.
 """
 import itertools
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 import ddt
 from django.conf import settings
 from edx_toggles.toggles.testutils import override_waffle_switch
+import pytest
 
 from common.djangoapps.student.tests.factories import UserFactory
+from lms.djangoapps.certificates.config import AUTO_CERTIFICATE_GENERATION
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.grades.config.tests.utils import persistent_grades_feature_flags
 from openedx.core.djangoapps.content.block_structure.factory import BlockStructureFactory
-from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory
+from openedx.core.djangoapps.signals.signals import COURSE_GRADE_NOW_PASSED
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 from ..config.waffle import ASSUME_ZERO_GRADE_IF_ABSENT, waffle_switch
 from ..course_grade import CourseGrade, ZeroCourseGrade
@@ -72,6 +75,35 @@ class TestCourseGradeFactory(GradeTestBase):
             with patch('lms.djangoapps.grades.models.PersistentCourseGrade.read') as mock_read_grade:
                 grade_factory.read(self.request.user, self.course)
         assert mock_read_grade.called == (feature_flag and course_setting)
+
+    @patch.dict(settings.FEATURES, {'PERSISTENT_GRADES_ENABLED_FOR_ALL_TESTS': False})
+    def test_no_recursion_without_persistent_grades(self):
+        """
+        Course grade signals should not be fired recursively when persistent grades are disabled.
+        """
+        self.mock_process_signal = Mock()  # pylint: disable=attribute-defined-outside-init
+
+        def handler(**kwargs):
+            """
+            Mock signal receiver.
+            """
+            self.mock_process_signal()
+
+        with persistent_grades_feature_flags(
+            global_flag=False,
+            enabled_for_all_courses=False,
+            course_id=self.course.id,
+            enabled_for_course=False
+        ):
+            with override_waffle_switch(AUTO_CERTIFICATE_GENERATION, active=True), mock_get_score(2, 2):
+                COURSE_GRADE_NOW_PASSED.connect(handler)
+                try:
+                    CourseGradeFactory().update(self.request.user, self.course)
+                except RecursionError:
+                    pytest.fail("The COURSE_GRADE_NOW_PASSED signal fired recursively.")
+
+        self.mock_process_signal.assert_called_once()
+        COURSE_GRADE_NOW_PASSED.disconnect(handler)
 
     def test_read_and_update(self):
         grade_factory = CourseGradeFactory()


### PR DESCRIPTION
## Description

Fix for an error related to endless recursion

Dev Notes:
The student gets the passing grade
-> CourseGradeFactory sends the `COURSE_GRADE_NOW_PASSED` signal after the grade calculation
-> `listen_for_passing_grade` receives the signal and calls `generate_certificate_task`
-> `generate_certificate_task` calls `_generate_regular_certificate_task`
-> `_generate_regular_certificate_task` trying to get grade by calling the `_get_course_grade`
-> `_get_course_grade` calls `CourseGradeFactory().read()` but I have persistent grades off, so actually that ends with `CourseGradeFactory().update()`
-> `CourseGradeFactory().update()` sends the `COURSE_GRADE_NOW_PASSED`
And so on

Related PR to master:
- https://github.com/openedx/edx-platform/pull/29792