### PR TITLE
fix: remove check for default values for video component when exporting.

### DIFF
--- a/common/lib/xmodule/xmodule/tests/test_video.py
+++ b/common/lib/xmodule/xmodule/tests/test_video.py
@@ -744,7 +744,7 @@ class VideoExportTestCase(VideoBlockTestBase):
 
         xml = self.descriptor.definition_to_xml(self.file_system)
         parser = etree.XMLParser(remove_blank_text=True)
-        xml_string = '<video url_name="SampleProblem"/>'
+        xml_string = '<video youtube="1.00:3_yD_cEKoCk" url_name="SampleProblem"/>'
         expected = etree.XML(xml_string, parser=parser)
         self.assertXmlEqual(expected, xml)
 
@@ -784,7 +784,7 @@ class VideoExportTestCase(VideoBlockTestBase):
         """
         xml = self.descriptor.definition_to_xml(self.file_system)
         # Check that download_video field is also set to default (False) in xml for backward compatibility
-        expected = '<video url_name="SampleProblem"/>\n'
+        expected = '<video youtube="1.00:3_yD_cEKoCk" url_name="SampleProblem"/>\n'
         assert expected == etree.tostring(xml, pretty_print=True).decode('utf-8')
 
     @patch('xmodule.video_module.video_module.edxval_api', None)
@@ -794,7 +794,7 @@ class VideoExportTestCase(VideoBlockTestBase):
         """
         self.descriptor.transcripts = None
         xml = self.descriptor.definition_to_xml(self.file_system)
-        expected = b'<video url_name="SampleProblem"/>\n'
+        expected = b'<video youtube="1.00:3_yD_cEKoCk" url_name="SampleProblem"/>\n'
         assert expected == etree.tostring(xml, pretty_print=True)
 
     @patch('xmodule.video_module.video_module.edxval_api', None)

--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -673,9 +673,7 @@ class VideoBlock(
         """
         xml = etree.Element('video')
         youtube_string = create_youtube_string(self)
-        # Mild workaround to ensure that tests pass -- if a field
-        # is set to its default value, we don't need to write it out.
-        if youtube_string and youtube_string != '1.00:3_yD_cEKoCk':
+        if youtube_string:
             xml.set('youtube', str(youtube_string))
         xml.set('url_name', self.url_name)
         attrs = [

--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -1671,7 +1671,7 @@ class VideoBlockTest(TestCase, VideoBlockTestBase):
 
         actual = self.descriptor.definition_to_xml(resource_fs=self.file_system)
         expected_str = """
-            <video url_name="SampleProblem" transcripts='{transcripts}'>
+            <video youtube="1.00:3_yD_cEKoCk" url_name="SampleProblem" transcripts='{transcripts}'>
                 <video_asset client_video_id="test_client_video_id" duration="111.0" image="">
                     <encoded_video profile="mobile" url="http://example.com/video" file_size="222" bitrate="333"/>
                     <transcripts>
@@ -1765,7 +1765,7 @@ class VideoBlockTest(TestCase, VideoBlockTestBase):
         """
         self.descriptor.edx_video_id = 'nonexistent'
         actual = self.descriptor.definition_to_xml(resource_fs=self.file_system)
-        expected_str = """<video url_name="SampleProblem"/>"""
+        expected_str = """<video youtube="1.00:3_yD_cEKoCk" url_name="SampleProblem"/>"""
         parser = etree.XMLParser(remove_blank_text=True)
         expected = etree.XML(expected_str, parser=parser)
         self.assertXmlEqual(expected, actual)
@@ -1778,7 +1778,7 @@ class VideoBlockTest(TestCase, VideoBlockTestBase):
         mock_get_video_ids_info.return_value = True, []
 
         actual = self.descriptor.definition_to_xml(resource_fs=self.file_system)
-        expected_str = '<video url_name="SampleProblem"></video>'
+        expected_str = '<video youtube="1.00:3_yD_cEKoCk" url_name="SampleProblem"></video>'
 
         parser = etree.XMLParser(remove_blank_text=True)
         expected = etree.XML(expected_str, parser=parser)


### PR DESCRIPTION
## [TNL-9372](https://openedx.atlassian.net/browse/TNL-9372)


### Description

Course import with a unit containing default video content fails to import. This gives us a SelfPointer exception on the video XML and prevents course import from successfully completing.

The fix is to remove an old temporary workaround fix to bypass the tests where the default video URL is checked and then bypassed.

### Testing Instructions

- Add a video component to a unit in Studio.
- Don't change any of the information in the video component, especially not the youtube or edX video ID
- Export the course and download the tarball
- Import the course from the downloaded tarball

#### Expected behavior:
Course imports successfully.

#### Actual behavior:
Course import fails.
```Course olx validation failed. Please check your email.```

```Errors:  (1)
1.  ERROR SelfPointer (video/a1e136d956a64b398d1bd0bea84fd881.xml): The tag <video url_name='a1e136d956a64b398d1bd0bea84fd881'> tag appears to be pointing to itself
```
#### After fix behavior:
Course imports successfully.

