### PR TITLE
Update bulk_user_org_email_optout.py

### DIFF
--- a/openedx/core/djangoapps/user_api/management/commands/bulk_user_org_email_optout.py
+++ b/openedx/core/djangoapps/user_api/management/commands/bulk_user_org_email_optout.py
@@ -138,8 +138,8 @@ class Command(BaseCommand):
                 else:
                     cursor.execute('COMMIT;')
                     log.info("Committed opt-out for rows (%s, %s) through (%s, %s).",
-                             optout_rows[start_idx][0], optout_rows[start_idx][1],
-                             optout_rows[end_idx][0], optout_rows[end_idx][1])
+                             *optout_rows[start_idx][0:2:1],
+                             *optout_rows[end_idx][0:2:1])
                 log.info("Sleeping %s seconds...", sleep_between)
                 time.sleep(sleep_between)
             curr_row_idx += chunk_size


### PR DESCRIPTION
refactoring code with var unpack which is more pythonic, concise, readable and efficient; how do think this change which has practical value？

<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
