### PR TITLE
feat: InvalidKeyError message changed to NotFound 404 message

### DIFF
--- a/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
@@ -888,7 +888,10 @@ class ContentLibraryXBlockValidationTest(APITestCase):
             endpoint.format(**endpoint_parameters),
         )
         self.assertEqual(response.status_code, 404)
-        self.assertEqual(response.json(), {'detail': "Invalid XBlock key"})
+        msg = f"XBlock {endpoint_parameters.get('block_key')} does not exist, or you don't have permission to view it."
+        self.assertEqual(response.json(), {
+            'detail': msg,
+        })
 
     def test_xblock_handler_invalid_key(self):
         """This endpoint is tested separately from the previous ones as it's not a DRF endpoint."""

--- a/openedx/core/djangoapps/xblock/rest_api/views.py
+++ b/openedx/core/djangoapps/xblock/rest_api/views.py
@@ -36,8 +36,7 @@ LX_BLOCK_TYPES_OVERRIDE = {
 }
 
 
-class InvalidNotFound(NotFound):
-    default_detail = "Invalid XBlock key"
+invalid_not_found_fmt = "XBlock {usage_key} does not exist, or you don't have permission to view it."
 
 
 def _block_type_overrides(request_args):
@@ -71,7 +70,7 @@ def block_metadata(request, usage_key_str):
     try:
         usage_key = UsageKey.from_string(usage_key_str)
     except InvalidKeyError as e:
-        raise InvalidNotFound from e
+        raise NotFound(invalid_not_found_fmt.format(usage_key=usage_key_str)) from e
 
     block = load_block(usage_key, request.user, block_type_overrides=_block_type_overrides(request.GET))
     includes = request.GET.get("include", "").split(",")
@@ -97,7 +96,7 @@ def render_block_view(request, usage_key_str, view_name):
     try:
         usage_key = UsageKey.from_string(usage_key_str)
     except InvalidKeyError as e:
-        raise InvalidNotFound from e
+        raise NotFound(invalid_not_found_fmt.format(usage_key=usage_key_str)) from e
 
     block = load_block(usage_key, request.user, block_type_overrides=_block_type_overrides(request.GET))
     fragment = _render_block_view(block, view_name, request.user)
@@ -122,7 +121,7 @@ def get_handler_url(request, usage_key_str, handler_name):
     try:
         usage_key = UsageKey.from_string(usage_key_str)
     except InvalidKeyError as e:
-        raise InvalidNotFound from e
+        raise NotFound(invalid_not_found_fmt.format(usage_key=usage_key_str)) from e
 
     handler_url = _get_handler_url(usage_key, handler_name, request.user, request.GET)
     return Response({"handler_url": handler_url})


### PR DESCRIPTION
<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

In LabXchange, when a user enters a URL with invalid key blocks, when getting the block an `Invalid XBlock key` error is raised.  I changed this to be a NotFound 404 message.

## Testing instructions

You can use this example to test the error: http://localhost:18000/api/xblock/v2/xblocks/lb:LabXchange:9548bee3:lx_unknown_ty/view/student_view/

With the change you must to see this output:

```
{
    "detail": "XBlock lb:LabXchange:9548bee3:lx_unknown_ty does not exist, or you don't have permission to view it."
}
```

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.
