### PR TITLE
fix: batch fixes for ESG integration

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1816,6 +1816,7 @@ OPTIONAL_APPS = (
     ('openassessment', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
     ('openassessment.assessment', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
     ('openassessment.fileupload', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
+    ('openassessment.staffgrader', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
     ('openassessment.workflow', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
     ('openassessment.xblock', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
 

--- a/lms/djangoapps/ora_staff_grader/utils.py
+++ b/lms/djangoapps/ora_staff_grader/utils.py
@@ -9,7 +9,7 @@ from lms.djangoapps.ora_staff_grader.errors import MissingParamResponse
 from opaque_keys.edx.keys import UsageKey
 from rest_framework.request import clone_request
 
-from lms.djangoapps.courseware.module_render import handle_xblock_callback
+from lms.djangoapps.courseware.module_render import handle_xblock_callback_noauth
 
 
 def require_params(param_names):
@@ -67,4 +67,4 @@ def call_xblock_json_handler(request, usage_id, handler_name, data):
     course_id = str(usage_key.course_key)
 
     # Send the request and return the HTTP response from the XBlock
-    return handle_xblock_callback(proxy_request, course_id, usage_id, handler_name)
+    return handle_xblock_callback_noauth(proxy_request, course_id, usage_id, handler_name)

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3880,6 +3880,7 @@ OPTIONAL_APPS = [
     ('openassessment', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
     ('openassessment.assessment', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
     ('openassessment.fileupload', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
+    ('openassessment.staffgrader', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
     ('openassessment.workflow', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
     ('openassessment.xblock', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
 


### PR DESCRIPTION
## Description

- Change internal xblock handler to `noauth` version
- Add `openassessment.staffgrader` app for migrations

FYI @openedx/masters-devs-gta 