### PR TITLE
fix: update key name for save/program/ api

### DIFF
--- a/lms/djangoapps/save_for_later/api/v1/tests/test_views.py
+++ b/lms/djangoapps/save_for_later/api/v1/tests/test_views.py
@@ -125,7 +125,7 @@ class ProgramSaveForLaterApiViewTest(ThirdPartyAuthTestMixin, APITestCase):
         mock_get_programs.return_value = self.program
         request_payload = {
             'email': self.email,
-            'uuid': self.uuid,
+            'program_uuid': self.uuid,
         }
         response = self.client.post(self.api_url, data=request_payload)
         assert response.status_code == 200
@@ -144,7 +144,7 @@ class ProgramSaveForLaterApiViewTest(ThirdPartyAuthTestMixin, APITestCase):
         """
         request_payload = {
             'email': self.email,
-            'uuid': self.uuid,
+            'program_uuid': self.uuid,
         }
         for _ in range(int(settings.SAVE_FOR_LATER_EMAIL_RATE_LIMIT.split('/')[0])):
             response = self.client.post(self.api_url, data=request_payload)
@@ -167,6 +167,6 @@ class ProgramSaveForLaterApiViewTest(ThirdPartyAuthTestMixin, APITestCase):
         """
         Test email validation
         """
-        request_payload = {'email': self.invalid_email, 'uuid': self.uuid}
+        request_payload = {'email': self.invalid_email, 'program_uuid': self.uuid}
         response = self.client.post(self.api_url, data=request_payload)
         assert response.status_code == 400

--- a/lms/djangoapps/save_for_later/api/v1/views.py
+++ b/lms/djangoapps/save_for_later/api/v1/views.py
@@ -118,7 +118,7 @@ class ProgramSaveForLaterApiView(APIView):
         """
         user = request.user
         data = request.data
-        program_uuid = data.get('uuid')
+        program_uuid = data.get('program_uuid')
         email = data.get('email')
 
         if getattr(request, 'limited', False):


### PR DESCRIPTION
update key name from uuid to program_uuid for save/program/ api.

<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
