### PR TITLE
temp: Add a constraint on openedx-calc v2.0.1

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -96,3 +96,6 @@ py2neo<2022
 
 # Sphinx requires docutils<0.18. This pin can be removed once https://github.com/sphinx-doc/sphinx/issues/9777 is closed.
 docutils<0.18
+
+# Temporary constraint on openedx-calc. Latest openedx-calc also contains symmath, which may upend symmath package version
+openedx-calc==2.0.1


### PR DESCRIPTION
`symmath` has been added to `openedx-calc v3.0.0` ([openedx-calc #38](https://github.com/openedx/openedx-calc/pull/38)). 
Prior to removing `symmath` from `edx-platform`, a constraint needs to be
put to use the old version of `openedx-calc` so that everything in
`edx-platform` still plays nicely.