### PR TITLE
build: use the reusable pr-automerge-open-release workflow

### DIFF
--- a/.github/workflows/pr-automerge-open-release.yml
+++ b/.github/workflows/pr-automerge-open-release.yml
@@ -1,67 +1,29 @@
-# For non-draft changes to Named Release branches:
-# - Check if the user belongs to a maintainers team.
+# For non-draft changes to named release branches:
+# - Check if the user is a maintainer (listed in the MERGERS env var in the
+#     .github/workflows/pr-automerge-open-release.yml workflow).
 # - If so, approve the pull request.
-#   - Tag community-engineering (for now) and the maintainers team.
-#   - Merge the PR when the author comments `@edx-community-bot merge`.
+#   - Merge the PR when the author comments `@openedx-community-bot merge`.
+#
 # Required organization secrets
-# - CC_GITHUB_TOKEN=...
-# - CC_TEAM_CHAMPIONS=org/team-name
-# - CC_TEAM_CONTRIBUTORS_ORG=org
-# - CC_TEAM_CONTRIBUTORS_TEAM=team-name
----
-name: automerge BTR open-release PRs
+# - CC_GITHUB_TOKEN or GITHUB_TOKEN
+
+name: Automerge BTR open-release PRs
+
 on:
   issue_comment:
     branches:
-    - open-release/*
+      - open-release/*
     types:
-    - created
-    - edited
+      - created
+      - edited
   pull_request_target:
     branches:
-    - open-release/*
+      - open-release/*
     types:
-    - opened
-    - edited
-    - ready_for_review
+      - opened
+      - edited
+      - ready_for_review
+
 jobs:
   automerge:
-    if: ${{ (github.event.issue.pull_request && !github.event.issue.pull_request.draft) || (github.event.pull_request && !github.event.pull_request.draft) }}
-    runs-on: ubuntu-latest
-    steps:
-    - name: lookup teams
-      id: teams
-      uses: tspascoal/get-user-teams-membership@v1
-      with:
-        username: "${{ github.actor }}"
-        organization: ${{ secrets.CC_TEAM_CONTRIBUTORS_ORG }}
-        team: ${{ secrets.CC_TEAM_CONTRIBUTORS_TEAM }}
-        GITHUB_TOKEN: "${{ secrets.CC_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}"
-    - name: approve PR
-      if: ${{ steps.teams.outputs.isTeamMember == 'true' && (github.event.action == 'opened' || github.event.action == 'ready_for_review') }}
-      uses: andrewmusgrave/automatic-pull-request-review@0.0.5
-      with:
-        repo-token: ${{ secrets.CC_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
-        event: APPROVE
-        body: |
-          :+1:
-
-          When you're ready to merge, add a comment that says
-          > @edx-community-bot merge
-
-          and we'll handle the rest!
-          CC: @${{ secrets.CC_TEAM_CHAMPIONS }} @${{ secrets.CC_TEAM_CONTRIBUTORS_ORG }}/${{ secrets.CC_TEAM_CONTRIBUTORS_TEAM }}
-    - name: label PR as auto-mergeable
-      if: ${{ steps.teams.outputs.isTeamMember == 'true' && contains(github.event.comment.body, '@edx-community-bot merge') }}
-      uses: andymckay/labeler@978f846c4ca6299fd136f465b42c5e87aca28cac
-      with:
-        add-labels: 'automerge'
-        repo-token: ${{ secrets.CC_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
-    - name: automerge
-      uses: "pascalgn/automerge-action@v0.13.1"
-      env:
-        GITHUB_TOKEN: "${{ secrets.CC_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}"
-        MERGE_COMMIT_MESSAGE: |
-          merge(#{pullRequest.number}): {pullRequest.title}
-
-          {pullRequest.body}
+    uses: openedx/.github/.github/workflows/pr-automerge-open-release.yml@master


### PR DESCRIPTION
## Description

The pr-automerge-open-release workflow was copied into each repo when it was created, because that was the only option.  Now we have reusable workflows.  We had to update the action as part of decoupling, so we took the opportunity to convert it to a reusable workflow at the same time.