### PR TITLE
fix: fix contract mismatches in ESG BFF

### DIFF
--- a/lms/djangoapps/ora_staff_grader/serializers.py
+++ b/lms/djangoapps/ora_staff_grader/serializers.py
@@ -52,7 +52,7 @@ class RubricCriterionOptionsSerializer(serializers.Serializer):
 class RubricCriterionSerializer(serializers.Serializer):
     label = serializers.CharField()
     prompt = serializers.CharField()
-    feedback = serializers.ChoiceField(choices=["optional", "disabled", "required"])
+    feedback = serializers.ChoiceField(required=False, choices=["optional", "disabled", "required"], default="disabled")
     name = serializers.CharField()
     orderNum = serializers.IntegerField(source="order_num")
     options = serializers.ListField(child=RubricCriterionOptionsSerializer())

--- a/lms/djangoapps/ora_staff_grader/serializers.py
+++ b/lms/djangoapps/ora_staff_grader/serializers.py
@@ -90,7 +90,7 @@ class SubmissionMetadataSerializer(serializers.Serializer):
     """
     Submission metadata for displaying submissions table in ESG
     """
-    submissionUuid = serializers.CharField()
+    submissionUUID = serializers.CharField(source='submissionUuid')
     username = serializers.CharField(allow_null=True)
     teamName = serializers.CharField(allow_null=True)
     dateSubmitted = serializers.DateTimeField()
@@ -102,7 +102,7 @@ class SubmissionMetadataSerializer(serializers.Serializer):
 
     class Meta:
         fields = [
-            'submissionUuid',
+            'submissionUUID',
             'username',
             'teamName',
             'dateSubmitted',

--- a/lms/djangoapps/ora_staff_grader/serializers.py
+++ b/lms/djangoapps/ora_staff_grader/serializers.py
@@ -144,14 +144,18 @@ class InitializeSerializer(serializers.Serializer):
     courseMetadata = CourseMetadataSerializer()
     oraMetadata = OpenResponseMetadataSerializer()
     submissions = serializers.DictField(child=SubmissionMetadataSerializer())
-    rubricConfig = RubricConfigSerializer()
+
+    def to_representation(self, instance):
+        """ Move rubric config inside of ORA metadata """
+        representation = super().to_representation(instance)
+        representation['oraMetadata']['rubricConfig'] = RubricConfigSerializer(instance['rubricConfig']).data
+        return representation
 
     class Meta:
         fields = [
             'courseMetadata',
             'oraMetadata',
             'submissions',
-            'rubricConfig',
         ]
         read_only_fields = fields
 

--- a/lms/djangoapps/ora_staff_grader/serializers.py
+++ b/lms/djangoapps/ora_staff_grader/serializers.py
@@ -147,7 +147,6 @@ class InitializeSerializer(serializers.Serializer):
     oraMetadata = OpenResponseMetadataSerializer()
     submissions = serializers.DictField(child=SubmissionMetadataSerializer())
 
-
     class Meta:
         fields = [
             'courseMetadata',

--- a/lms/djangoapps/ora_staff_grader/tests/test_data.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_data.py
@@ -53,10 +53,62 @@ example_rubric_options = [
     }
 ]
 
+example_rubric_options_serialized = [
+    {
+        "orderNum": 0,
+        "name": "troll",
+        "label": "Troll",
+        "explanation": "Failing grade",
+        "points": 0
+    },
+    {
+        "orderNum": 1,
+        "name": "dreadful",
+        "label": "Dreadful",
+        "explanation": "Failing grade",
+        "points": 1
+    },
+    {
+        "orderNum": 2,
+        "name": "poor",
+        "label": "Poor",
+        "explanation": "Failing grade (may repeat)",
+        "points": 2
+    },
+    {
+        "orderNum": 3,
+        "name": "poor",
+        "label": "Poor",
+        "explanation": "Failing grade (may repeat)",
+        "points": 3
+    },
+    {
+        "orderNum": 4,
+        "name": "acceptable",
+        "label": "Acceptable",
+        "explanation": "Passing grade (may continue to N.E.W.T)",
+        "points": 4
+    },
+    {
+        "orderNum": 5,
+        "name": "exceeds_expectations",
+        "label": "Exceeds Expectations",
+        "explanation": "Passing grade (may continue to N.E.W.T)",
+        "points": 5
+    },
+    {
+        "orderNum": 6,
+        "name": "outstanding",
+        "label": "Outstanding",
+        "explanation": "Passing grade (will continue to N.E.W.T)",
+        "points": 6
+    }
+]
+
 example_rubric = {
-    "feedback_prompt": "How did this student do?",
-    "feedback_default_text": "For the O.W.L exams, this student...",
-    "criteria": [
+    "rubric_feedback_prompt": "How did this student do?",
+    "rubric_feedback_default_text": "For the O.W.L exams, this student...",
+    "rubric_criteria": [
         {
             "order_num": 0,
             "name": "potions",
@@ -70,7 +122,6 @@ example_rubric = {
             "name": "charms",
             "label": "Charms",
             "prompt": "How did this student perform in the Charms exam",
-            "feedback": "required",
             "options": example_rubric_options
         }
     ]

--- a/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
@@ -29,6 +29,7 @@ from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from lms.djangoapps.ora_staff_grader.errors import ERR_UNKNOWN, ErrorSerializer
 from lms.djangoapps.ora_staff_grader.tests import test_data
 
+
 class TestErrorSerializer(TestCase):
     """ Tests for error serialization """
 

--- a/lms/djangoapps/ora_staff_grader/views.py
+++ b/lms/djangoapps/ora_staff_grader/views.py
@@ -8,7 +8,6 @@ from lms.djangoapps.ora_staff_grader.ora_api import (
     claim_submission_lock,
     delete_submission_lock,
     get_assessment_info,
-    get_rubric_config,
     get_submission_info,
     get_submissions,
     submit_grade
@@ -64,7 +63,6 @@ class InitializeView(StaffGraderBaseView):
         courseMetadata
         oraMetadata
         submissions
-        rubricConfig
     }
 
     Errors:
@@ -78,10 +76,9 @@ class InitializeView(StaffGraderBaseView):
         try:
             init_data = {}
 
-            # Get ORA block and rubric
+            # Get ORA block and config (incl. rubric)
             ora_usage_key = UsageKey.from_string(ora_location)
             init_data['oraMetadata'] = modulestore().get_item(ora_usage_key)
-            init_data['rubricConfig'] = get_rubric_config(request, ora_location)
 
             # Get course metadata
             course_id = str(ora_usage_key.course_key)

--- a/lms/djangoapps/ora_staff_grader/views.py
+++ b/lms/djangoapps/ora_staff_grader/views.py
@@ -76,23 +76,21 @@ class InitializeView(StaffGraderBaseView):
     @require_params([PARAM_ORA_LOCATION])
     def get(self, request, ora_location, *args, **kwargs):
         try:
-            response_data = {}
+            init_data = {}
 
-            # Get ORA block
+            # Get ORA block and rubric
             ora_usage_key = UsageKey.from_string(ora_location)
-            response_data['oraMetadata'] = modulestore().get_item(ora_usage_key)
+            init_data['oraMetadata'] = modulestore().get_item(ora_usage_key)
+            init_data['rubricConfig'] = get_rubric_config(request, ora_location)
 
             # Get course metadata
             course_id = str(ora_usage_key.course_key)
-            response_data['courseMetadata'] = get_course_overview_or_none(course_id)
+            init_data['courseMetadata'] = get_course_overview_or_none(course_id)
 
             # Get list of submissions for this ORA
-            response_data['submissions'] = get_submissions(request, ora_location)
+            init_data['submissions'] = get_submissions(request, ora_location)
 
-            # Get the rubric config for this ORA
-            response_data['rubricConfig'] = get_rubric_config(request, ora_location)
-
-            return Response(InitializeSerializer(response_data).data)
+            return Response(InitializeSerializer(init_data).data)
 
         # Catch bad ORA location
         except (InvalidKeyError, ItemNotFoundError):


### PR DESCRIPTION
## Description

- Change `submissionUuid` to `submissionUUID` in `initialize` call to match contract
- Move `rubricConfig` inside of `oraMetadata` to match contract
- Refactor how we get rubric info, pull from ORA block directly instead of using rubric reuse API
- Many, many test updates

FYI @openedx/masters-devs-gta 

## Testing instructions

Do it work tho?

