### PR TITLE
fix: remove extra slash in courseblock api call

### DIFF
--- a/common/static/common/js/components/BlockBrowser/data/api/client.js
+++ b/common/static/common/js/components/BlockBrowser/data/api/client.js
@@ -21,7 +21,7 @@ export function buildQueryString(data) {
 }
 
 export const getCourseBlocks = courseId => fetch(
-  `${COURSE_BLOCKS_API}/?${buildQueryString({
+  `${COURSE_BLOCKS_API}?${buildQueryString({
     course_id: courseId,
     all_blocks: true,
     depth: 'all',


### PR DESCRIPTION
## Description
This issue has already been fixed in the master branch. It needs to be backported to maple branch
Backport Report Generation fix openedx#130
[Reference commit](https://github.com/openedx/edx-platform/commit/2ebfe47077a51a5aaba56c0cd39f072d538dbd30)

Useful information to include:
- Which edX user roles will this change impact? (Course Author)
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
Before:
![C1C9FE9E-1DF4-42FC-BA15-245EE506472B](https://user-images.githubusercontent.com/17564158/150986477-46a5d52c-6b7c-46ad-b525-8d8218ce9e3e.png)

After:
![image](https://user-images.githubusercontent.com/17564158/150986358-2a559c00-990e-4157-b82d-729a6db86acb.png)

- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.
NA

## Supporting information

https://github.com/openedx/build-test-release-wg/issues/130

## Testing instructions

1. Setup Devstack Environment with docker

~~~
make dev.pull.lms
make dev.provision.lms
make dev.up.lms
~~~

2.  Access lms page, login in with edx default user,  enroll demo course

3.  Open below page with chrome in developer mode

- http://VM_IP:18000/courses/course-v1:edX+DemoX+Demo_Course/instructor#view-data_download


## Deadline
None

## Other information
NA
