### PR TITLE
Revert "fix: Remove django-admin default login."

### DIFF
--- a/cms/djangoapps/contentstore/views/public.py
+++ b/cms/djangoapps/contentstore/views/public.py
@@ -12,10 +12,7 @@ from common.djangoapps.edxmako.shortcuts import render_to_response
 
 from ..config import waffle
 
-__all__ = [
-    'register_redirect_to_lms', 'login_redirect_to_lms', 'howitworks', 'accessibility',
-    'redirect_to_lms_login_for_admin'
-]
+__all__ = ['register_redirect_to_lms', 'login_redirect_to_lms', 'howitworks', 'accessibility']
 
 
 def register_redirect_to_lms(request):
@@ -40,13 +37,6 @@ def login_redirect_to_lms(request):
         params=_build_next_param(request),
     )
     return redirect(login_url)
-
-
-def redirect_to_lms_login_for_admin(request):
-    """
-    This view redirect the admin/login url to the site's login page.
-    """
-    return redirect('/login?next=/admin')
 
 
 def _build_next_param(request):

--- a/cms/djangoapps/course_creators/tests/test_admin.py
+++ b/cms/djangoapps/course_creators/tests/test_admin.py
@@ -176,3 +176,18 @@ class CourseCreatorAdminTest(TestCase):
 
         self.request.user = self.user
         self.assertFalse(self.creator_admin.has_change_permission(self.request))
+
+    def test_rate_limit_login(self):
+        with mock.patch.dict('django.conf.settings.FEATURES', {'ENABLE_CREATOR_GROUP': True}):
+            post_params = {'username': self.user.username, 'password': 'wrong_password'}
+            # try logging in 30 times, the default limit in the number of failed
+            # login attempts in one 5 minute period before the rate gets limited
+            for _ in range(30):
+                response = self.client.post('/admin/login/', post_params)
+                self.assertEqual(response.status_code, 200)
+
+            response = self.client.post('/admin/login/', post_params)
+            # Since we are using the default rate limit behavior, we are
+            # expecting this to return a 403 error to indicate that there have
+            # been too many attempts
+            self.assertEqual(response.status_code, 403)

--- a/cms/templates/admin/base_site.html
+++ b/cms/templates/admin/base_site.html
@@ -15,5 +15,5 @@
             <a href="{{ docsroot }}">{% trans 'Documentation' as tmsg %} {{tmsg|force_escape}}</a> /
         {% endif %}
     {% endif %}
-    <a href="/logout/">{% trans 'Log out' as tmsg %} {{tmsg|force_escape}}</a>
+    <a href="{% url 'admin:logout' %}">{% trans 'Log out' as tmsg %} {{tmsg|force_escape}}</a>
 {% endblock %}

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -230,12 +230,6 @@ if settings.FEATURES.get('ENABLE_SERVICE_STATUS'):
 if not settings.FEATURES.get('ENABLE_CHANGE_USER_PASSWORD_ADMIN'):
     urlpatterns.append(re_path(r'^admin/auth/user/\d+/password/$', handler404))
 urlpatterns.append(path('admin/password_change/', handler404))
-urlpatterns.append(
-    path(
-        r'^admin/login/', contentstore_views.redirect_to_lms_login_for_admin,
-        name='redirect_to_lms_login_for_admin'
-    )
-)
 urlpatterns.append(path('admin/', admin.site.urls))
 
 # enable entrance exams

--- a/lms/templates/admin/base_site.html
+++ b/lms/templates/admin/base_site.html
@@ -15,5 +15,5 @@
             <a href="{{ docsroot }}">{% trans 'Documentation' as tmsg%}{{tmsg|force_escape}}</a> /
         {% endif %}
     {% endif %}
-    <a href="{% url 'logout' %}">{% trans 'Log out' as tmsg%}{{tmsg|force_escape}}</a>
+    <a href="{% url 'admin:logout' %}">{% trans 'Log out' as tmsg%}{{tmsg|force_escape}}</a>
 {% endblock %}

--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -11,6 +11,7 @@ import re
 import urllib
 
 from django.conf import settings
+from django.contrib import admin
 from django.contrib.auth import authenticate, get_user_model
 from django.contrib.auth import login as django_login
 from django.contrib.auth.decorators import login_required
@@ -643,9 +644,13 @@ def login_refresh(request):  # lint-amnesty, pylint: disable=missing-function-do
 
 def redirect_to_lms_login(request):
     """
-    This view redirect the admin/login url to the site's login page.
+    This view redirect the admin/login url to the site's login page if
+    waffle switch is on otherwise returns the admin site's login view.
     """
-    return redirect('/login?next=/admin')
+    if ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY.is_enabled():
+        return redirect('/login?next=/admin')
+    else:
+        return admin.site.login(request)
 
 
 class LoginSessionView(APIView):

--- a/openedx/core/tests/test_admin_view.py
+++ b/openedx/core/tests/test_admin_view.py
@@ -6,7 +6,10 @@ This is not inside a django app because it is a global property of the system.
 
 from django.test import Client, TestCase
 from django.urls import reverse
+from edx_toggles.toggles.testutils import override_waffle_switch
 from common.djangoapps.student.tests.factories import UserFactory, TEST_PASSWORD
+
+from openedx.core.djangoapps.user_authn.views.login import ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY
 
 
 class TestAdminView(TestCase):
@@ -36,7 +39,10 @@ class TestAdminView(TestCase):
         assert response.status_code == 302
 
     def test_admin_login_redirect(self):
-        """Admin login will redirect towards the site login page."""
-        response = self.client.get(reverse('admin:login'))
-        assert response.url == '/login?next=/admin'
-        assert response.status_code == 302
+        with override_waffle_switch(ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY, True):
+            response = self.client.get(reverse('admin:login'))
+            assert response.url == '/login?next=/admin'
+            assert response.status_code == 302
+        with override_waffle_switch(ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY, False):
+            response = self.client.get(reverse('admin:login'))
+            assert response.template_name == ['admin/login.html']


### PR DESCRIPTION
Reverts openedx/edx-platform#29416

## Description 
During the testing on stage, we found that it needs to redirect the learners back to internal.courses.edx.org/admin  instead of courses.edx.org/admin after the login from LMS side which was missed from the PR.