### PR TITLE
chore: Update logo url.

### DIFF
--- a/cms/templates/widgets/footer.html
+++ b/cms/templates/widgets/footer.html
@@ -56,7 +56,7 @@ from openedx.core.djangolib.markup import HTML, Text
 
       <div class="footer-about-openedx">
         <a href="https://open.edx.org" title="${_("Powered by Open edX")}">
-          <img alt="${_("Powered by Open edX")}" src="https://files.edx.org/openedx-logos/open-edx-logo-tag.png">
+          <img alt="${_("Powered by Open edX")}" src="https://logos.openedx.org/open-edx-logo-tag.png">
         </a>
       </div>
     </div>

--- a/lms/djangoapps/branding/tests/test_api.py
+++ b/lms/djangoapps/branding/tests/test_api.py
@@ -158,7 +158,7 @@ class TestFooter(TestCase):
             'logo_image': 'https://edx.org/static/images/logo.png',
             'openedx_link': {
                 'url': 'https://open.edx.org',
-                'image': 'https://files.edx.org/openedx-logos/open-edx-logo-tag.png',
+                'image': 'https://logos.openedx.org/open-edx-logo-tag.png',
                 'title': 'Powered by Open edX'
             },
             'edx_org_link': {

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2006,10 +2006,10 @@ FOOTER_OPENEDX_URL = "https://open.edx.org"
 # We use logo images served from files.edx.org so we can (roughly) track
 # how many OpenEdX installations are running.
 # Site operators can choose from these logo options:
-# * https://files.edx.org/openedx-logos/open-edx-logo-tag.png
-# * https://files.edx.org/openedx-logos/open-edx-logo-tag-light.png"
-# * https://files.edx.org/openedx-logos/open-edx-logo-tag-dark.png
-FOOTER_OPENEDX_LOGO_IMAGE = "https://files.edx.org/openedx-logos/open-edx-logo-tag.png"
+# * https://logos.openedx.org/open-edx-logo-tag.png
+# * https://logos.openedx.org/open-edx-logo-tag-light.png"
+# * https://logos.openedx.org/open-edx-logo-tag-dark.png
+FOOTER_OPENEDX_LOGO_IMAGE = "https://logos.openedx.org/open-edx-logo-tag.png"
 
 # This is just a placeholder image.
 # Site operators can customize this with their organization's image.

--- a/themes/red-theme/lms/templates/footer.html
+++ b/themes/red-theme/lms/templates/footer.html
@@ -110,9 +110,9 @@ from openedx.core.djangolib.markup import HTML, Text
         <a href="http://openedx.org/">
           ## standard powered-by logo
           ## Translators: 'Open edX' is a brand, please keep this untranslated. See http://openedx.org for more information.
-          <img src="https://files.edx.org/openedx-logos/open-edx-logo-tag.png" alt="${_('Powered by Open edX')}" width="175" />
+          <img src="https://logos.openedx.org/open-edx-logo-tag.png" alt="${_('Powered by Open edX')}" width="175" />
           ## white logo for dark background
-          ## <img src="https://files.edx.org/openedx-logos/open-edx-logo-tag-dark.png" alt="${_('Powered by Open edX')}" width="175" />
+          ## <img src="https://logos.openedx.org/open-edx-logo-tag-dark.png" alt="${_('Powered by Open edX')}" width="175" />
         </a>
       </p>
     </div>


### PR DESCRIPTION
Switch from files.edx.org to the logos.openedx.org url for the "Powered
by Open edX" logos.  We should still keep the old url working as many
old versions of Open edX still referr to it.

We're making this change so that for future versions of the edx-platform
the DNS for these logos lives alongside the rest of the Open edX
infrastructure managed by tCRIL.