### PR TITLE
docs: a better mention of Devstack

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ recommend that you use a service provider to run the software for you.  They
 have free trials that make it easy to get started:
 https://openedx.org/get-started/
 
-If you will be modifying edx-platform code, the `Open edX Developer Stack`_ (Developer Stack) is
+If you will be modifying edx-platform code, the `Open edX Developer Stack`_ (Devstack) is
 a Docker-based development environment.
 
 If you want to run your own Open edX server and have the technical skills to do


### PR DESCRIPTION
There's no point saying, `Open edX Developer Stack (Developer Stack)`.