### PR TITLE
[BD-38] [TNL-9479] [BB-5419] Add API for retrieving moderation reason codes from the LMS settings

### DIFF
--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -971,7 +971,7 @@ def _do_extra_actions(api_content, cc_content, request_fields, actions_form, con
     update that require a separate comments service request.
     """
     for field, form_value in actions_form.cleaned_data.items():
-        if field in request_fields and form_value != api_content[field]:
+        if field in request_fields and field in api_content and form_value != api_content[field]:
             api_content[field] = form_value
             if field == "following":
                 _handle_following_field(form_value, context["cc_requester"], cc_content)

--- a/lms/djangoapps/discussion/rest_api/permissions.py
+++ b/lms/djangoapps/discussion/rest_api/permissions.py
@@ -102,6 +102,7 @@ def get_editable_fields(cc_content: Union[Thread, Comment], context: Dict) -> Se
     editable_fields = {
         "abuse_flagged": True,
         "closed": is_thread and is_privileged,
+        "close_reason_code": is_thread and is_privileged,
         "pinned": is_thread and is_privileged,
         "read": is_thread,
     }
@@ -114,6 +115,7 @@ def get_editable_fields(cc_content: Union[Thread, Comment], context: Dict) -> Se
     editable_fields.update({
         "voted": True,
         "raw_body": is_privileged or is_author,
+        "edit_reason_code": is_privileged,
         "following": is_thread,
         "topic_id": is_thread and (is_author or is_privileged),
         "type": is_thread and (is_author or is_privileged),

--- a/lms/djangoapps/discussion/rest_api/serializers.py
+++ b/lms/djangoapps/discussion/rest_api/serializers.py
@@ -412,8 +412,6 @@ class ThreadSerializer(_ContentSerializer):
         if not _validate_privileged_access(self.context):
             return None
         reason_code = obj.get("close_reason_code")
-        if not reason_code:
-            return None
         return CLOSE_REASON_CODES.get(reason_code)
 
     def get_closed_by(self, obj):

--- a/lms/djangoapps/discussion/rest_api/serializers.py
+++ b/lms/djangoapps/discussion/rest_api/serializers.py
@@ -4,6 +4,7 @@ Discussion API serializers
 from typing import Dict
 from urllib.parse import urlencode, urlunparse
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.db.models import TextChoices
@@ -42,6 +43,9 @@ from openedx.core.djangoapps.django_comment_common.models import (
 from openedx.core.lib.api.serializers import CourseKeyField
 
 User = get_user_model()
+
+CLOSE_REASON_CODES = getattr(settings, "DISCUSSION_MODERATION_CLOSE_REASON_CODES", {})
+EDIT_REASON_CODES = getattr(settings, "DISCUSSION_MODERATION_EDIT_REASON_CODES", {})
 
 
 class TopicOrdering(TextChoices):
@@ -99,6 +103,26 @@ def validate_not_blank(value):
         raise ValidationError("This field may not be blank.")
 
 
+def validate_edit_reason_code(value):
+    """
+    Validate that the value is a valid edit reason code.
+
+    Raises: ValidationError
+    """
+    if value not in EDIT_REASON_CODES:
+        raise ValidationError("Invalid edit reason code")
+
+
+def validate_close_reason_code(value):
+    """
+    Validate that the value is a valid close reason code.
+
+    Raises: ValidationError
+    """
+    if value not in CLOSE_REASON_CODES:
+        raise ValidationError("Invalid close reason code")
+
+
 def _validate_privileged_access(context: Dict) -> bool:
     """
     Return the field specified by ``field_name`` if requesting user is privileged.
@@ -137,7 +161,7 @@ class _ContentSerializer(serializers.Serializer):
     anonymous = serializers.BooleanField(default=False)
     anonymous_to_peers = serializers.BooleanField(default=False)
     last_edit = serializers.SerializerMethodField(required=False)
-    edit_reason_code = serializers.CharField(required=False)
+    edit_reason_code = serializers.CharField(required=False, validators=[validate_edit_reason_code])
 
     non_updatable_fields = set()
 
@@ -245,10 +269,16 @@ class _ContentSerializer(serializers.Serializer):
         Returns information about the last edit for this content for
         privileged users.
         """
-        if _validate_privileged_access(self.context):
-            edit_history = obj.get("edit_history")
-            if edit_history:
-                return edit_history[-1]
+        if not _validate_privileged_access(self.context):
+            return None
+        edit_history = obj.get("edit_history")
+        if not edit_history:
+            return None
+        last_edit = edit_history[-1]
+        reason_code = last_edit.get("reason_code")
+        if reason_code:
+            last_edit["reason"] = EDIT_REASON_CODES.get(reason_code)
+        return last_edit
 
 
 class ThreadSerializer(_ContentSerializer):
@@ -281,8 +311,9 @@ class ThreadSerializer(_ContentSerializer):
     read = serializers.BooleanField(required=False)
     has_endorsed = serializers.BooleanField(source="endorsed", read_only=True)
     response_count = serializers.IntegerField(source="resp_total", read_only=True, required=False)
-    close_reason_code = serializers.SerializerMethodField(required=False)
-    closed_by = serializers.SerializerMethodField(required=False)
+    close_reason_code = serializers.CharField(required=False, validators=[validate_close_reason_code])
+    close_reason = serializers.SerializerMethodField()
+    closed_by = serializers.SerializerMethodField()
 
     non_updatable_fields = NON_UPDATABLE_THREAD_FIELDS
 
@@ -374,12 +405,16 @@ class ThreadSerializer(_ContentSerializer):
         """
         return Truncator(strip_tags(self.get_rendered_body(obj))).chars(35, ).replace('\n', ' ')
 
-    def get_close_reason_code(self, obj):
+    def get_close_reason(self, obj):
         """
         Returns the reason for which the thread was closed.
         """
-        if _validate_privileged_access(self.context):
-            return obj.get("close_reason_code")
+        if not _validate_privileged_access(self.context):
+            return None
+        reason_code = obj.get("close_reason_code")
+        if not reason_code:
+            return None
+        return CLOSE_REASON_CODES.get(reason_code)
 
     def get_closed_by(self, obj):
         """

--- a/lms/djangoapps/discussion/rest_api/tests/test_api.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api.py
@@ -2813,6 +2813,9 @@ class UpdateThreadTest(
         FORUM_ROLE_COMMUNITY_TA,
         FORUM_ROLE_STUDENT,
     )
+    @mock.patch("lms.djangoapps.discussion.rest_api.serializers.EDIT_REASON_CODES", {
+        "test-edit-reason": "Test Edit Reason",
+    })
     def test_update_thread_with_edit_reason_code(self, role_name):
         """
         Test editing comments, specifying and retrieving edit reason codes.
@@ -2822,16 +2825,17 @@ class UpdateThreadTest(
         try:
             result = update_thread(self.request, "test_thread", {
                 "raw_body": "Edited body",
-                "edit_reason_code": "someReason",
+                "edit_reason_code": "test-edit-reason",
             })
             assert role_name != FORUM_ROLE_STUDENT
             assert result["last_edit"] == {
                 "original_body": "Original body",
-                "reason_code": "someReason",
+                "reason": "Test Edit Reason",
+                "reason_code": "test-edit-reason",
                 "author": self.user.username,
             }
             request_body = httpretty.last_request().parsed_body  # pylint: disable=no-member
-            assert request_body["edit_reason_code"] == ["someReason"]
+            assert request_body["edit_reason_code"] == ["test-edit-reason"]
         except ValidationError as error:
             assert role_name == FORUM_ROLE_STUDENT
             assert error.message_dict == {"edit_reason_code": ["This field is not editable."]}
@@ -3225,6 +3229,9 @@ class UpdateCommentTest(
         FORUM_ROLE_COMMUNITY_TA,
         FORUM_ROLE_STUDENT,
     )
+    @mock.patch("lms.djangoapps.discussion.rest_api.serializers.EDIT_REASON_CODES", {
+        "test-edit-reason": "Test Edit Reason",
+    })
     def test_update_comment_with_edit_reason_code(self, role_name):
         """
         Test editing comments, specifying and retrieving edit reason codes.
@@ -3234,16 +3241,17 @@ class UpdateCommentTest(
         try:
             result = update_comment(self.request, "test_comment", {
                 "raw_body": "Edited body",
-                "edit_reason_code": "someReason",
+                "edit_reason_code": "test-edit-reason",
             })
             assert role_name != FORUM_ROLE_STUDENT
             assert result["last_edit"] == {
                 "original_body": "Original body",
-                "reason_code": "someReason",
+                "reason": "Test Edit Reason",
+                "reason_code": "test-edit-reason",
                 "author": self.user.username,
             }
             request_body = httpretty.last_request().parsed_body  # pylint: disable=no-member
-            assert request_body["edit_reason_code"] == ["someReason"]
+            assert request_body["edit_reason_code"] == ["test-edit-reason"]
         except ValidationError:
             assert role_name == FORUM_ROLE_STUDENT
 

--- a/lms/djangoapps/discussion/rest_api/tests/test_permissions.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_permissions.py
@@ -66,7 +66,7 @@ class GetInitializableFieldsTest(ModuleStoreTestCase):
             "abuse_flagged", "course_id", "following", "raw_body", "read", "title", "topic_id", "type", "voted"
         }
         if is_privileged:
-            expected |= {"closed", "pinned"}
+            expected |= {"closed", "pinned", "close_reason_code", "edit_reason_code"}
         if is_privileged and is_cohorted:
             expected |= {"group_id"}
         if allow_anonymous:
@@ -87,6 +87,8 @@ class GetInitializableFieldsTest(ModuleStoreTestCase):
         expected = {
             "anonymous", "abuse_flagged", "parent_id", "raw_body", "thread_id", "voted"
         }
+        if is_privileged:
+            expected |= {"edit_reason_code"}
         if (is_thread_author and thread_type == "question") or is_privileged:
             expected |= {"endorsed"}
         assert actual == expected
@@ -116,7 +118,7 @@ class GetEditableFieldsTest(ModuleStoreTestCase):
         actual = get_editable_fields(thread, context)
         expected = {"abuse_flagged", "following", "read", "voted"}
         if is_privileged:
-            expected |= {"closed", "pinned"}
+            expected |= {"closed", "pinned", "close_reason_code", "edit_reason_code"}
         if is_author or is_privileged:
             expected |= {"topic_id", "type", "title", "raw_body"}
         if is_privileged and is_cohorted:
@@ -148,6 +150,8 @@ class GetEditableFieldsTest(ModuleStoreTestCase):
         )
         actual = get_editable_fields(comment, context)
         expected = {"abuse_flagged", "voted"}
+        if is_privileged:
+            expected |= {"edit_reason_code"}
         if is_author or is_privileged:
             expected |= {"raw_body"}
         if (is_thread_author and thread_type == "question") or is_privileged:

--- a/lms/djangoapps/discussion/rest_api/tests/test_serializers.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_serializers.py
@@ -317,6 +317,7 @@ class CommentSerializerTest(SerializerTestMixin, SharedModuleStoreTestCase):
             "editable_fields": ["abuse_flagged", "voted"],
             "child_count": 0,
             "can_delete": False,
+            "last_edit": None,
         }
 
         assert self.serialize(comment) == expected

--- a/lms/djangoapps/discussion/rest_api/tests/test_views.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views.py
@@ -2675,6 +2675,39 @@ class CourseDiscussionRolesAPIViewTest(APITestCase, UrlResetMixin, ModuleStoreTe
         assertion(any(user.username in x['username'] for x in content['results']))
 
 
+@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+class DiscussionModerationSettingsViewTests(APITestCase):
+    def get_path(self):
+        """
+        Returns the API endpoint.
+        """
+        return "/api/discussion/v1/moderation_settings"
+
+    @mock.patch("django.conf.settings.ENABLE_DISCUSSION_MODERATION_REASON_CODES", True)
+    @mock.patch("django.conf.settings.DISCUSSION_MODERATION_EDIT_REASON_CODES", {
+        "test-edit-reason": "Test Edit Reason",
+    })
+    @mock.patch("django.conf.settings.DISCUSSION_MODERATION_CLOSE_REASON_CODES", {
+        "test-close-reason": "Test Close Reason",
+    })
+    def test_retrieve(self):
+        """
+        Verify that the view returns the reason codes from the settings.
+        """
+        response = self.client.get(self.get_path())
+        assert response.status_code == status.HTTP_200_OK
+        assert response.content_type == "application/json"
+        assert json.loads(response.content) == {
+            "enabled": True,
+            "edit_reason_codes": [
+                {"key": "test-edit-reason", "label": "Test Edit Reason"},
+            ],
+            "close_reason_codes": [
+                {"key": "test-close-reason", "label": "Test Close Reason"},
+            ],
+        }
+
+
 @ddt.ddt
 @httpretty.activate
 class CourseActivityStatsTest(ForumsEnableMixin, UrlResetMixin, CommentsServiceMockMixin, APITestCase):

--- a/lms/djangoapps/discussion/rest_api/tests/test_views.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views.py
@@ -1509,6 +1509,7 @@ class CommentViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase, Pr
             "can_delete": True,
             "anonymous": False,
             "anonymous_to_peers": False,
+            "last_edit": None,
         }
         response_data.update(overrides or {})
         return response_data
@@ -1901,6 +1902,7 @@ class CommentViewSetCreateTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
             "can_delete": True,
             "anonymous": False,
             "anonymous_to_peers": False,
+            "last_edit": None,
         }
         response = self.client.post(
             self.url,
@@ -1991,6 +1993,7 @@ class CommentViewSetPartialUpdateTest(DiscussionAPIViewTestMixin, ModuleStoreTes
             "can_delete": True,
             "anonymous": False,
             "anonymous_to_peers": False,
+            "last_edit": None,
         }
         response_data.update(overrides or {})
         return response_data
@@ -2178,6 +2181,7 @@ class CommentViewSetRetrieveTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase
             "can_delete": True,
             "anonymous": False,
             "anonymous_to_peers": False,
+            "last_edit": None,
         }
 
         response = self.client.get(self.url)

--- a/lms/djangoapps/discussion/rest_api/tests/test_views.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views.py
@@ -7,17 +7,18 @@ import json
 import random
 from datetime import datetime
 from unittest import mock
-from urllib.parse import parse_qs, urlparse, urlencode
+from urllib.parse import parse_qs, urlencode, urlparse
 
 import ddt
 import httpretty
-from django.urls import reverse
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
 from opaque_keys.edx.keys import CourseKey
 from pytz import UTC
+from rest_framework import status
 from rest_framework.parsers import JSONParser
 from rest_framework.test import APIClient, APITestCase
-from rest_framework import status
+from waffle.testutils import override_flag
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
@@ -27,11 +28,7 @@ from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
 from common.djangoapps.student.models import get_retired_username_by_username
 from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole, GlobalStaff
-from common.djangoapps.student.tests.factories import (
-    CourseEnrollmentFactory,
-    SuperuserFactory,
-    UserFactory,
-)
+from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, SuperuserFactory, UserFactory
 from common.djangoapps.util.testing import PatchMediaTypeMixin, UrlResetMixin
 from common.test.utils import disable_signal
 from lms.djangoapps.discussion.django_comment_client.tests.utils import (
@@ -48,6 +45,7 @@ from lms.djangoapps.discussion.rest_api.tests.utils import (
     make_paginated_api_response,
     parsed_body,
 )
+from lms.djangoapps.discussion.toggles import ENABLE_DISCUSSION_MODERATION_REASON_CODES
 from openedx.core.djangoapps.course_groups.tests.helpers import config_course_cohorts
 from openedx.core.djangoapps.django_comment_common.models import CourseDiscussionSettings, Role
 from openedx.core.djangoapps.django_comment_common.utils import seed_permissions_roles
@@ -2683,7 +2681,7 @@ class DiscussionModerationSettingsViewTests(APITestCase):
         """
         return "/api/discussion/v1/moderation_settings"
 
-    @mock.patch("django.conf.settings.ENABLE_DISCUSSION_MODERATION_REASON_CODES", True)
+    @override_flag(ENABLE_DISCUSSION_MODERATION_REASON_CODES, active=True)
     @mock.patch("django.conf.settings.DISCUSSION_MODERATION_EDIT_REASON_CODES", {
         "test-edit-reason": "Test Edit Reason",
     })

--- a/lms/djangoapps/discussion/rest_api/tests/test_views.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views.py
@@ -12,6 +12,7 @@ from urllib.parse import parse_qs, urlencode, urlparse
 import ddt
 import httpretty
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import override_settings
 from django.urls import reverse
 from opaque_keys.edx.keys import CourseKey
 from pytz import UTC
@@ -2679,13 +2680,13 @@ class DiscussionModerationSettingsViewTests(APITestCase):
         """
         Returns the API endpoint.
         """
-        return "/api/discussion/v1/moderation_settings"
+        return reverse("discussion_moderation_settings", kwargs={"course_id": "course-v1:test+test+test"})
 
-    @override_flag(ENABLE_DISCUSSION_MODERATION_REASON_CODES, active=True)
-    @mock.patch("django.conf.settings.DISCUSSION_MODERATION_EDIT_REASON_CODES", {
+    @override_flag(ENABLE_DISCUSSION_MODERATION_REASON_CODES.name, active=True)
+    @override_settings(DISCUSSION_MODERATION_EDIT_REASON_CODES={
         "test-edit-reason": "Test Edit Reason",
     })
-    @mock.patch("django.conf.settings.DISCUSSION_MODERATION_CLOSE_REASON_CODES", {
+    @override_settings(DISCUSSION_MODERATION_CLOSE_REASON_CODES={
         "test-close-reason": "Test Close Reason",
     })
     def test_retrieve(self):

--- a/lms/djangoapps/discussion/rest_api/tests/utils.py
+++ b/lms/djangoapps/discussion/rest_api/tests/utils.py
@@ -487,6 +487,7 @@ class CommentsServiceMockMixin:
             "response_count": 0,
             "last_edit": None,
             "closed_by": None,
+            "close_reason": None,
             "close_reason_code": None,
         }
         response_data.update(overrides or {})

--- a/lms/djangoapps/discussion/rest_api/tests/utils.py
+++ b/lms/djangoapps/discussion/rest_api/tests/utils.py
@@ -31,10 +31,19 @@ def _get_thread_callback(thread_data):
         additional required fields.
         """
         response_data = make_minimal_cs_thread(thread_data)
+        original_data = response_data.copy()
         for key, val_list in parsed_body(request).items():
             val = val_list[0]
             if key in ["anonymous", "anonymous_to_peers", "closed", "pinned"]:
                 response_data[key] = val == "True"
+            elif key == "edit_reason_code":
+                response_data["edit_history"] = [
+                    {
+                        "original_body": original_data["body"],
+                        "author": thread_data.get('username'),
+                        "reason_code": val,
+                    },
+                ]
             else:
                 response_data[key] = val
         return (200, headers, json.dumps(response_data))
@@ -53,6 +62,7 @@ def _get_comment_callback(comment_data, thread_id, parent_id):
         Simulate the comment creation or update endpoint as described above.
         """
         response_data = make_minimal_cs_comment(comment_data)
+        original_data = response_data.copy()
         # thread_id and parent_id are not included in request payload but
         # are returned by the comments service
         response_data["thread_id"] = thread_id
@@ -61,6 +71,14 @@ def _get_comment_callback(comment_data, thread_id, parent_id):
             val = val_list[0]
             if key in ["anonymous", "anonymous_to_peers", "endorsed"]:
                 response_data[key] = val == "True"
+            elif key == "edit_reason_code":
+                response_data["edit_history"] = [
+                    {
+                        "original_body": original_data["body"],
+                        "author": comment_data.get('username'),
+                        "reason_code": val,
+                    },
+                ]
             else:
                 response_data[key] = val
         return (200, headers, json.dumps(response_data))
@@ -438,8 +456,15 @@ class CommentsServiceMockMixin:
             "voted": False,
             "vote_count": 0,
             "editable_fields": [
-                "abuse_flagged", "anonymous", "following", "raw_body", "read",
-                "title", "topic_id", "type", "voted"
+                "abuse_flagged",
+                "anonymous",
+                "following",
+                "raw_body",
+                "read",
+                "title",
+                "topic_id",
+                "type",
+                "voted",
             ],
             "course_id": str(self.course.id),
             "topic_id": "test_topic",
@@ -460,6 +485,9 @@ class CommentsServiceMockMixin:
             "id": "test_thread",
             "type": "discussion",
             "response_count": 0,
+            "last_edit": None,
+            "closed_by": None,
+            "close_reason_code": None,
         }
         response_data.update(overrides or {})
         return response_data
@@ -497,6 +525,8 @@ def make_minimal_cs_thread(overrides=None):
         "read": False,
         "endorsed": False,
         "resp_total": 0,
+        "closed_by": None,
+        "close_reason_code": None,
     }
     ret.update(overrides or {})
     return ret

--- a/lms/djangoapps/discussion/rest_api/urls.py
+++ b/lms/djangoapps/discussion/rest_api/urls.py
@@ -19,6 +19,7 @@ from lms.djangoapps.discussion.rest_api.views import (
     RetireUserView,
     ThreadViewSet,
     UploadFileView,
+    DiscussionModerationSettingsView,
 )
 
 ROUTER = SimpleRouter()
@@ -62,6 +63,7 @@ urlpatterns = [
         CourseTopicsView.as_view(),
         name="course_topics"
     ),
+    path('v1/moderation_settings', DiscussionModerationSettingsView.as_view(), name="discussion_moderation_settings"),
     re_path(
         fr"^v2/course_topics/{settings.COURSE_ID_PATTERN}",
         CourseTopicsViewV2.as_view(),

--- a/lms/djangoapps/discussion/rest_api/urls.py
+++ b/lms/djangoapps/discussion/rest_api/urls.py
@@ -35,6 +35,11 @@ urlpatterns = [
         name="discussion_course_settings",
     ),
     re_path(
+        fr'v1/courses/{settings.COURSE_ID_PATTERN}/moderation_settings',
+        DiscussionModerationSettingsView.as_view(),
+        name="discussion_moderation_settings",
+    ),
+    re_path(
         fr"^v1/courses/{settings.COURSE_KEY_PATTERN}/activity_stats",
         CourseActivityStatsView.as_view(),
         name="discussion_course_activity_stats",
@@ -63,7 +68,6 @@ urlpatterns = [
         CourseTopicsView.as_view(),
         name="course_topics"
     ),
-    path('v1/moderation_settings', DiscussionModerationSettingsView.as_view(), name="discussion_moderation_settings"),
     re_path(
         fr"^v2/course_topics/{settings.COURSE_ID_PATTERN}",
         CourseTopicsViewV2.as_view(),

--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -401,6 +401,14 @@ class ThreadViewSet(DeveloperErrorViewMixin, ViewSet):
 
         * read (optional): A boolean to mark thread as read
 
+        * closed (optional, privileged): A boolean to mark thread as closed.
+
+        * edit_reason_code (optional, privileged): A string containing a reason
+        code for editing the thread's body.
+
+        * close_reason_code (optional, privileged): A string containing a reason
+        code for closing the thread.
+
         * topic_id, type, title, raw_body, anonymous, and anonymous_to_peers
         are accepted with the same meaning as in a POST request
 
@@ -629,6 +637,9 @@ class CommentViewSet(DeveloperErrorViewMixin, ViewSet):
 
         * raw_body, anonymous and anonymous_to_peers are accepted with the same
         meaning as in a POST request
+
+        * edit_reason_code (optional, privileged): A string containing a reason
+        code for a moderator to edit the comment.
 
         If "application/merge-patch+json" is not the specified content type,
         a 415 error is returned.

--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -72,6 +72,7 @@ from ..rest_api.serializers import (
     DiscussionTopicSerializerV2,
     TopicOrdering,
 )
+from ..toggles import ENABLE_DISCUSSION_MODERATION_REASON_CODES
 
 log = logging.getLogger(__name__)
 
@@ -1293,17 +1294,17 @@ class DiscussionModerationSettingsView(DeveloperErrorViewMixin, APIView):
         }
     """
 
-    ENABLED = getattr(settings, "ENABLE_DISCUSSION_MODERATION_REASON_CODES", {})
     EDIT_REASON_CODES = getattr(settings, "DISCUSSION_MODERATION_EDIT_REASON_CODES", {})
     CLOSE_REASON_CODES = getattr(settings, "DISCUSSION_MODERATION_CLOSE_REASON_CODES", {})
 
-    def get(self, _):
+    def get(self, request, course_id):
         """
         Implements the GET method as described in the class documentation.
         """
+        course_key = CourseKey.from_string(course_id)
         return Response(
             {
-                "enabled": self.ENABLED,
+                "enabled": ENABLE_DISCUSSION_MODERATION_REASON_CODES.is_enabled(course_key),
                 "edit_reason_codes": [
                     {"key": reason_code, "label": label}
                     for (reason_code, label) in self.EDIT_REASON_CODES.items()

--- a/lms/djangoapps/discussion/toggles.py
+++ b/lms/djangoapps/discussion/toggles.py
@@ -22,3 +22,16 @@ ENABLE_DISCUSSIONS_MFE = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'enable_discuss
 # .. toggle_creation_date: 2022-02-22
 # .. toggle_target_removal_date: 2022-09-22
 ENABLE_NEW_STRUCTURE_DISCUSSIONS = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'enable_new_structure_discussions', __name__)
+
+# .. toggle_name: discussions.enable_moderation_reason_codes
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Waffle flag to toggle support for the new edit and post close reason codes
+# .. toggle_use_cases: temporary, open_edx
+# .. toggle_creation_date: 2022-02-22
+# .. toggle_target_removal_date: 2022-09-22
+ENABLE_DISCUSSION_MODERATION_REASON_CODES = CourseWaffleFlag(
+    WAFFLE_FLAG_NAMESPACE,
+    'enable_moderation_reason_codes',
+    __name__,
+)

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -4963,9 +4963,6 @@ CUSTOM_PAGES_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-a
 BULK_COURSE_EMAIL_LAST_LOGIN_ELIGIBILITY_PERIOD = None
 
 ################ Settings for the Discussion Service #########
-# Set this to False to disable the reason code selection UI for
-# moderators when editing or closing users' posts.
-ENABLE_DISCUSSION_MODERATION_REASON_CODES = True
 # Provide a list of reason codes for moderators editing posts and
 # comments, as a mapping from the internal reason code representation,
 # and an internationalizable label to be shown to moderators in the form

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -4780,8 +4780,8 @@ LEARNING_MICROFRONTEND_URL = None
 #     waffle flag.
 ORA_GRADING_MICROFRONTEND_URL = None
 # .. setting_name: DISCUSSIONS_MICROFRONTEND_URL
-# .. setting_default: None
 # .. setting_description: Base URL of the micro-frontend-based discussions page.
+# .. setting_default: None
 # .. setting_warning: Also set site's courseware.discussions_mfe waffle flag.
 DISCUSSIONS_MICROFRONTEND_URL = None
 # .. setting_name: DISCUSSIONS_MFE_FEEDBACK_URL = None
@@ -4797,8 +4797,8 @@ DISCUSSIONS_MFE_FEEDBACK_URL = None
 # .. toggle_creation_date: 2021-12-03
 # .. toggle_tickets: https://openedx.atlassian.net/browse/VAN-666
 ENABLE_AUTHN_RESET_PASSWORD_HIBP_POLICY = False
-
 ############### Settings for the ace_common plugin #################
+
 ACE_ENABLED_CHANNELS = ['django_email']
 ACE_ENABLED_POLICIES = ['bulk_email_optout']
 ACE_CHANNEL_SAILTHRU_DEBUG = True
@@ -4961,3 +4961,28 @@ CUSTOM_PAGES_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-a
 # The expected value is an Integer representing the cutoff point (in months) for inclusion to the message. Example:
 # a value of `3` would include learners who have logged in within the past 3 months.
 BULK_COURSE_EMAIL_LAST_LOGIN_ELIGIBILITY_PERIOD = None
+
+################ Settings for the Discussion Service #########
+# Set this to False to disable the reason code selection UI for
+# moderators when editing or closing users' posts.
+ENABLE_DISCUSSION_MODERATION_REASON_CODES = True
+# Provide a list of reason codes for moderators editing posts and
+# comments, as a mapping from the internal reason code representation,
+# and an internationalizable label to be shown to moderators in the form
+# UI.
+DISCUSSION_MODERATION_EDIT_REASON_CODES = {
+    "grammar-spelling": _("Has grammar / spelling issues"),
+    "needs-clarity": _("Content needs clarity"),
+    "academic-integrity": _("Has academic integrity concern"),
+    "inappropriate-language": _("Has inappropriate language"),
+    "contains-pii": _("Contains personally identifiable information"),
+}
+# Provide a list of reason codes for moderators to close posts, in the
+# form of tuples containing the internal reason code representation, and
+# an internationalizable label to be shown to moderators in the form UI.
+DISCUSSION_MODERATION_CLOSE_REASON_CODES = {
+    "academic-integrity": _("Post violates honour code or academic integrity"),
+    "read-only": _("Post should be read-only"),
+    "duplicate": _("Post is a duplicate"),
+    "off-topic": _("Post is off-topic"),
+}

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -4965,8 +4965,7 @@ BULK_COURSE_EMAIL_LAST_LOGIN_ELIGIBILITY_PERIOD = None
 ################ Settings for the Discussion Service #########
 # Provide a list of reason codes for moderators editing posts and
 # comments, as a mapping from the internal reason code representation,
-# and an internationalizable label to be shown to moderators in the form
-# UI.
+# to an internationalizable label to be shown to moderators in the form UI.
 DISCUSSION_MODERATION_EDIT_REASON_CODES = {
     "grammar-spelling": _("Has grammar / spelling issues"),
     "needs-clarity": _("Content needs clarity"),
@@ -4974,9 +4973,9 @@ DISCUSSION_MODERATION_EDIT_REASON_CODES = {
     "inappropriate-language": _("Has inappropriate language"),
     "contains-pii": _("Contains personally identifiable information"),
 }
-# Provide a list of reason codes for moderators to close posts, in the
-# form of tuples containing the internal reason code representation, and
-# an internationalizable label to be shown to moderators in the form UI.
+# Provide a list of reason codes for moderators to close posts, as a mapping
+# from the internal reason code representation, to  an internationalizable label
+#  to be shown to moderators in the form UI.
 DISCUSSION_MODERATION_CLOSE_REASON_CODES = {
     "academic-integrity": _("Post violates honour code or academic integrity"),
     "read-only": _("Post should be read-only"),

--- a/openedx/core/djangoapps/django_comment_common/comment_client/comment.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/comment.py
@@ -14,12 +14,12 @@ class Comment(models.Model):
         'endorsed', 'parent_id', 'thread_id', 'username', 'votes', 'user_id',
         'closed', 'created_at', 'updated_at', 'depth', 'at_position_list',
         'type', 'commentable_id', 'abuse_flaggers', 'endorsement',
-        'child_count',
+        'child_count', 'edit_history',
     ]
 
     updatable_fields = [
         'body', 'anonymous', 'anonymous_to_peers', 'course_id', 'closed',
-        'user_id', 'endorsed', 'endorsement_user_id',
+        'user_id', 'endorsed', 'endorsement_user_id', 'edit_reason_code',
     ]
 
     initializable_fields = updatable_fields

--- a/openedx/core/djangoapps/django_comment_common/comment_client/thread.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/thread.py
@@ -21,19 +21,20 @@ class Thread(models.Model):
         'highlighted_body', 'endorsed', 'read', 'group_id', 'group_name', 'pinned',
         'abuse_flaggers', 'resp_skip', 'resp_limit', 'resp_total', 'thread_type',
         'endorsed_responses', 'non_endorsed_responses', 'non_endorsed_resp_total',
-        'context', 'last_activity_at',
+        'context', 'last_activity_at', 'closed_by', 'close_reason_code', 'edit_history',
     ]
 
     # updateable_fields are sent in PUT requests
     updatable_fields = [
         'title', 'body', 'anonymous', 'anonymous_to_peers', 'course_id', 'read',
-        'closed', 'user_id', 'commentable_id', 'group_id', 'group_name', 'pinned', 'thread_type'
+        'closed', 'user_id', 'commentable_id', 'group_id', 'group_name', 'pinned', 'thread_type',
+        'close_reason_code', 'edit_reason_code',
     ]
 
     # metric_tag_fields are used by Datadog to record metrics about the model
     metric_tag_fields = [
         'course_id', 'group_id', 'pinned', 'closed', 'anonymous', 'anonymous_to_peers',
-        'endorsed', 'read'
+        'endorsed', 'read',
     ]
 
     # initializable_fields are sent in POST requests


### PR DESCRIPTION
## Description

This introduces new settings variables for specifying a list of predefined reasons for editing and closing posts, along with an API endpoint for the discussions micro-frontend to retrieve those reasons. This also changes the behavior of the support implemented in [TNL-8842](https://github.com/openedx/edx-platform/pull/29609) to validate the submitted reason codes on the server side.

### New settings variables:
`DISCUSSION_MODERATION_EDIT_REASON_CODES`
`DISCUSSION_MODERATION_CLOSE_REASON_CODES`

## Supporting information

- Jira Ticket: [TNL-9479](https://openedx.atlassian.net/browse/TNL-9479)
- Sample reason codes to be included as default values: [Jira comment](https://openedx.atlassian.net/browse/TNL-8020?focusedCommentId=587689)

## Testing instructions

`TODO` Please provide detailed step-by-step instructions for testing this change.

## Deadline

None

## Other information

This change is a follow-up to, and depends on, the changes introduced in [this PR](https://github.com/openedx/edx-platform/pull/29609).
