### PR TITLE
feat: add authn to devstack

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -866,7 +866,7 @@ FEATURES = {
     # .. toggle_tickets: 'https://github.com/edx/edx-platform/pull/24908'
     # .. toggle_warnings: Also set settings.AUTHN_MICROFRONTEND_URL for rollout. This temporary feature
     #   toggle does not have a target removal date.
-    'ENABLE_AUTHN_MICROFRONTEND': False,
+    'ENABLE_AUTHN_MICROFRONTEND': os.environ.get("EDXAPP_ENABLE_AUTHN_MFE", False),
 
     ### ORA Feature Flags ###
     # .. toggle_name: FEATURES['ENABLE_ORA_ALL_FILE_URLS']


### PR DESCRIPTION
Ticket: https://openedx.atlassian.net/browse/VAN-315

This PR is adds an option to set Authn MFE's feature flag value using environment variable. This can be used by devstack to enable Authn MFE by default. 
