### PR TITLE
fix: problem_grade_report task parent dir being discarded.

### DIFF
--- a/lms/djangoapps/instructor_task/tasks_helper/grades.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/grades.py
@@ -184,9 +184,22 @@ class GradeReportBase:
         Creates and uploads a CSV for the given headers and rows.
         """
         date = datetime.now(UTC)
-        upload_csv_to_report_store(success_rows, context.upload_filename, context.course_id, date)
+        upload_csv_to_report_store(
+            success_rows,
+            context.upload_filename,
+            context.course_id,
+            date,
+            parent_dir=context.upload_parent_dir
+        )
+
         if len(error_rows) > 1:
-            upload_csv_to_report_store(error_rows, context.upload_filename + '_err', context.course_id, date)
+            upload_csv_to_report_store(
+                error_rows,
+                context.upload_filename + '_err',
+                context.course_id,
+                date,
+                parent_dir=context.upload_parent_dir
+            )
 
     def log_additional_info_for_testing(self, context, message):
         """
@@ -317,7 +330,7 @@ class _ProblemGradeReportContext:
         self.report_for_verified_only = problem_grade_report_verified_only(self.course_id)
         self.task_progress = TaskProgress(self.action_name, total=None, start_time=time())
         self.upload_filename = _task_input.get('filename', 'problem_grade_report')
-        self.upload_dir = _task_input.get('upload_parent_dir', '')
+        self.upload_parent_dir = _task_input.get('upload_parent_dir', '')
 
     @lazy
     def course(self):


### PR DESCRIPTION
## Description

This fixes the Problem Grade Report task so that the `upload_parent_dir` argument is used.

## Testing instructions

Run the problem grade task (example code below). The `upload_parent_dir` argument was not getting parsed.

```python
from django.http import QueryDict
from django.test import RequestFactory
from django.contrib.auth.models import User
from lms.djangoapps.instructor_task.api import submit_problem_grade_report
user = User.objects.first()
request = RequestFactory().get('/')
request.user = user
submit_problem_grade_report(request, upload_parent_dir='mydir', course_key='course-v1:edX+DemoX+Demo_Course')
```

## Supporting information

- https://github.com/open-craft/edx-platform/pull/454

## Deadline

None
