### PR TITLE
fix: catch and log the CourseOverview.DoesNotExist instead of raising

### DIFF
--- a/openedx/core/djangoapps/credit/services.py
+++ b/openedx/core/djangoapps/credit/services.py
@@ -100,11 +100,18 @@ class CreditService:
         }
 
         if return_course_info:
-            course_overview = CourseOverview.get_from_id(course_key)
-            result.update({
-                'course_name': course_overview.display_name,
-                'course_end_date': course_overview.end,
-            })
+            try:
+                course_overview = CourseOverview.get_from_id(course_key)
+                result.update({
+                    'course_name': course_overview.display_name,
+                    'course_end_date': course_overview.end,
+                })
+            except CourseOverview.DoesNotExist:
+                log.exception(
+                    "Could not get name and end_date for course %s, This happened because we were unable to "
+                    "get/create CourseOverview object for the course. It's possible that the Course has been deleted.",
+                    str(course_key),
+                )
         return result
 
     def set_credit_requirement_status(self, user_id, course_key_or_id, req_namespace,

--- a/openedx/core/djangoapps/credit/services.py
+++ b/openedx/core/djangoapps/credit/services.py
@@ -1,6 +1,7 @@
 """
 Implementation of "credit" XBlock service
 """
+from datetime import datetime, timedelta
 import logging
 
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
@@ -107,6 +108,18 @@ class CreditService:
                     'course_end_date': course_overview.end,
                 })
             except CourseOverview.DoesNotExist:
+                # NOTE: Since the caller requested "return_course_info=True" and we don't have course to get that info.
+                # Also, The "get_credit_state" is called from several places directly or indirectly (Mostly from
+                # exams/grades services) which relatively depend upon course end date.
+                # As per the current structure of edX the exam attempts can exist without a course and they can request
+                # credit state so, the safest options would be to send some date/time in the past (One hour in past to
+                # be safe) so that those attempts can be marked or treated as expired/completed instead of any other
+                # status that could be error prone.
+
+                one_hour_past = datetime.now() - timedelta(hours=1)
+                result.update({
+                    'course_end_date': one_hour_past,
+                })
                 log.exception(
                     "Could not get name and end_date for course %s, This happened because we were unable to "
                     "get/create CourseOverview object for the course. It's possible that the Course has been deleted.",

--- a/openedx/core/djangoapps/credit/tests/test_services.py
+++ b/openedx/core/djangoapps/credit/tests/test_services.py
@@ -4,6 +4,7 @@ Tests for the Credit xBlock service
 
 
 from unittest.mock import patch
+from datetime import datetime
 import ddt
 
 from common.djangoapps.course_modes.models import CourseMode
@@ -273,7 +274,11 @@ class CreditServiceTests(ModuleStoreTestCase):
 
             self.enroll()
             credit_state = self.service.get_credit_state(self.user.id, self.course.id, return_course_info=True)
+
             assert credit_state is not None
+            # When exception is caught, the course_end_date should always be in past
+            assert credit_state["course_end_date"] < datetime.now()
+
             exception_log.exception.assert_called_once_with(
                 "Could not get name and end_date for course %s, This happened because we were unable to "
                 "get/create CourseOverview object for the course. It's possible that the Course has been deleted.",

--- a/openedx/core/djangoapps/credit/tests/test_services.py
+++ b/openedx/core/djangoapps/credit/tests/test_services.py
@@ -264,7 +264,7 @@ class CreditServiceTests(ModuleStoreTestCase):
         assert credit_state['course_name'] == self.course.display_name
 
     @patch("openedx.core.djangoapps.credit.services.log")
-    def test_course_exception_log(self, exception_log):
+    def test_get_info_from_non_existent_course(self, exception_log):
         """
         Make sure we catch the CourseOverview.DoesNotExist exception and log it instead of raising
         """


### PR DESCRIPTION
<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Related Ticket:
https://github.com/mitodl/edx-platform/issues/286

## Description
There have been cases in which we were seeing `CourseOverview. DoesNotExist` exceptions when some users had unfinished & expired exam attempts in a course but the course was deleted. So whenever a user would open any course an exception would be raised.

What was happening, in this case, has been explained in detail [here](https://github.com/mitodl/edx-platform/issues/286#issuecomment-1018471128)
## Supporting information

See [this forum thread](https://discuss.openedx.org/t/is-deleting-courses-actually-supported/6479) for some high-level context of what might be expected when a course is deleted. 

## Reproduction Steps:
1- Create a course with timed exams
2- Enroll and open the course, open a timed problem and start it (A timer will start within the learning MFE)
3- Now get back to some other course (You will see a ticker on top regarding a timed problem in another course)
4- Let the timer expire without submitting your response.
5- Delete the course e.g. using `edx-sysadmin` (https://github.com/mitodl/edx-sysadmin).
6- Now, Open any course you'll see this exception propagating.


## Testing instructions
- Follow the reproduction steps
- And then check that the exception(CourseOverview.DoesNotExist ) now should be logged instead of being raised & you won't see any error messages on the MFE.

