### PR TITLE
[BD-32] feat: add 2nd batch of Open edX Filters

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -66,7 +66,7 @@ from openedx_events.learning.signals import (
     COURSE_ENROLLMENT_CREATED,
     COURSE_UNENROLLMENT_COMPLETED,
 )
-from openedx_filters.learning.filters import CourseEnrollmentStarted
+from openedx_filters.learning.filters import CourseEnrollmentStarted, CourseUnenrollmentStarted
 import openedx.core.djangoapps.django_comment_common.comment_client as cc
 from common.djangoapps.course_modes.models import CourseMode, get_cosmetic_verified_display_price
 from common.djangoapps.student.emails import send_proctoring_requirements_email
@@ -1122,6 +1122,10 @@ class EnrollmentNotAllowed(CourseEnrollmentException):
     pass
 
 
+class UnenrollmentNotAllowed(CourseEnrollmentException):
+    pass
+
+
 class CourseEnrollmentManager(models.Manager):
     """
     Custom manager for CourseEnrollment with Table-level filter methods.
@@ -1767,6 +1771,12 @@ class CourseEnrollment(models.Model):
 
         try:
             record = cls.objects.get(user=user, course_id=course_id)
+
+            try:
+                record = CourseUnenrollmentStarted.run_filter(enrollment=record)
+            except CourseUnenrollmentStarted.PreventUnenrollment as exc:
+                raise UnenrollmentNotAllowed(str(exc)) from exc
+
             record.update_enrollment(is_active=False, skip_refund=skip_refund)
 
         except cls.DoesNotExist:

--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -879,7 +879,7 @@ def student_dashboard(request):  # lint-amnesty, pylint: disable=too-many-statem
 
     dashboard_template = 'dashboard.html'
     try:
-        context = DashboardRenderStarted.run_filter(
+        context, dashboard_template = DashboardRenderStarted.run_filter(
             context=context, template_name=dashboard_template,
         )
     except DashboardRenderStarted.PreventDashboardRender as exc:

--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -877,12 +877,15 @@ def student_dashboard(request):  # lint-amnesty, pylint: disable=too-many-statem
         'resume_button_urls': resume_button_urls
     })
 
+    dashboard_template = 'dashboard.html'
     try:
-        context = DashboardRenderStarted.run_filter(context=context)
+        context = DashboardRenderStarted.run_filter(
+            context=context, template_name=dashboard_template,
+        )
     except DashboardRenderStarted.PreventDashboardRender as exc:
         raise DashboardRenderNotAllowed(reverse(exc.redirect_to or 'account_settings')) from exc
 
-    response = render_to_response('dashboard.html', context)
+    response = render_to_response(dashboard_template, context)
     if show_account_activation_popup:
         response.delete_cookie(
             settings.SHOW_ACTIVATE_CTA_POPUP_COOKIE_NAME,

--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -18,6 +18,7 @@ from django.utils.encoding import smart_str
 from eventtracking import tracker
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
+from openedx_filters.learning.filters import CertificateRenderStarted
 from organizations import api as organizations_api
 from edx_django_utils.plugins import pluggable_override
 
@@ -642,6 +643,11 @@ def render_html_view(request, course_id, certificate=None):
 
         # Track certificate view events
         _track_certificate_events(request, course, user, user_certificate)
+
+        try:
+            context = CertificateRenderStarted.run_filter(context=context)
+        except CertificateRenderStarted.PreventCertificateRender:
+            return _render_invalid_certificate(request, course_id, platform_name, configuration)
 
         # Render the certificate
         return _render_valid_certificate(request, context, custom_template)

--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -645,7 +645,9 @@ def render_html_view(request, course_id, certificate=None):
         _track_certificate_events(request, course, user, user_certificate)
 
         try:
-            context = CertificateRenderStarted.run_filter(context=context)
+            context, custom_template = CertificateRenderStarted.run_filter(
+                context=context, custom_template=custom_template,
+            )
         except CertificateRenderStarted.PreventCertificateRender:
             return _render_invalid_certificate(request, course_id, platform_name, configuration)
 

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -38,6 +38,7 @@ from ipware.ip import get_client_ip
 from markupsafe import escape
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, UsageKey
+from openedx_filters.learning.filters import CourseAboutRenderStarted
 from pytz import UTC
 from requests.exceptions import ConnectionError, Timeout  # pylint: disable=redefined-builtin
 from rest_framework import status
@@ -1024,6 +1025,11 @@ def course_about(request, course_id):
             'sidebar_html_enabled': sidebar_html_enabled,
             'allow_anonymous': allow_anonymous,
         }
+
+        try:
+            context = CourseAboutRenderStarted.run_filter(context=context)
+        except CourseAboutRenderStarted.PreventCourseAboutRender as exc:
+            raise CourseAccessRedirect(reverse(exc.redirect_to or 'dashboard')) from exc
 
         return render_to_response('courseware/course_about.html', context)
 

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1026,12 +1026,15 @@ def course_about(request, course_id):
             'allow_anonymous': allow_anonymous,
         }
 
+        course_about_template = 'courseware/course_about.html'
         try:
-            context = CourseAboutRenderStarted.run_filter(context=context)
+            context, course_about_template = CourseAboutRenderStarted.run_filter(
+                context=context, template_name=course_about_template,
+            )
         except CourseAboutRenderStarted.PreventCourseAboutRender as exc:
             raise CourseAccessRedirect(reverse(exc.redirect_to or 'dashboard')) from exc
 
-        return render_to_response('courseware/course_about.html', context)
+        return render_to_response(course_about_template, context)
 
 
 @ensure_csrf_cookie

--- a/openedx/core/djangoapps/course_groups/models.py
+++ b/openedx/core/djangoapps/course_groups/models.py
@@ -132,8 +132,8 @@ class CohortMembership(models.Model):
                 previous_cohort = membership.course_user_group
 
                 try:
-                    membership, previous_cohort = CohortChangeRequested.run_filter(
-                        current_cohort=membership, previous_cohort=previous_cohort,
+                    membership, cohort = CohortChangeRequested.run_filter(
+                        membership=membership, cohort=cohort,
                     )
                 except CohortChangeRequested.PreventCohortChange as exc:
                     raise CohortChangeNotAllowed(str(exc)) from exc

--- a/openedx/core/djangoapps/course_groups/models.py
+++ b/openedx/core/djangoapps/course_groups/models.py
@@ -13,13 +13,21 @@ from django.db.models.signals import pre_delete
 from django.dispatch import receiver
 
 from opaque_keys.edx.django.models import CourseKeyField
+from openedx_filters.learning.filters import CohortChangeRequested
 
 from openedx.core.djangolib.model_mixins import DeletableByUserValue
 
 from openedx_events.learning.data import CohortData, CourseData, UserData, UserPersonalData  # lint-amnesty, pylint: disable=wrong-import-order
 from openedx_events.learning.signals import COHORT_MEMBERSHIP_CHANGED  # lint-amnesty, pylint: disable=wrong-import-order
-
 log = logging.getLogger(__name__)
+
+
+class CohortMembershipException(Exception):
+    pass
+
+
+class CohortChangeNotAllowed(CohortMembershipException):
+    pass
 
 
 class CourseUserGroup(models.Model):
@@ -122,6 +130,14 @@ class CohortMembership(models.Model):
                     cohort_name=cohort.name))
             else:
                 previous_cohort = membership.course_user_group
+
+                try:
+                    membership, previous_cohort = CohortChangeRequested.run_filter(
+                        current_cohort=membership, previous_cohort=previous_cohort,
+                    )
+                except CohortChangeRequested.PreventCohortChange as exc:
+                    raise CohortChangeNotAllowed(str(exc)) from exc
+
                 previous_cohort.users.remove(user)
 
                 membership.course_user_group = cohort

--- a/openedx/core/djangoapps/course_groups/models.py
+++ b/openedx/core/djangoapps/course_groups/models.py
@@ -133,7 +133,7 @@ class CohortMembership(models.Model):
 
                 try:
                     membership, cohort = CohortChangeRequested.run_filter(
-                        membership=membership, cohort=cohort,
+                        current_membership=membership, target_cohort=cohort,
                     )
                 except CohortChangeRequested.PreventCohortChange as exc:
                     raise CohortChangeNotAllowed(str(exc)) from exc

--- a/openedx/features/course_experience/views/course_home.py
+++ b/openedx/features/course_experience/views/course_home.py
@@ -242,10 +242,13 @@ class CourseHomeFragmentView(EdxFragmentView):
             'show_search': show_search,
         }
 
+        course_home_template = 'course_experience/course-home-fragment.html'
         try:
-            context = CourseHomeRenderStarted.run_filter(context=context)
+            context, course_home_template = CourseHomeRenderStarted.run_filter(
+                context=context, template_name=course_home_template,
+            )
         except CourseHomeRenderStarted.PreventCourseHomeRender as exc:
             raise CourseAccessRedirect(reverse(exc.redirect_to or 'dashboard')) from exc
 
-        html = render_to_string('course_experience/course-home-fragment.html', context)
+        html = render_to_string(course_home_template, context)
         return Fragment(html)

--- a/openedx/features/course_experience/views/course_home.py
+++ b/openedx/features/course_experience/views/course_home.py
@@ -11,6 +11,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_control
 from django.views.decorators.csrf import ensure_csrf_cookie
 from opaque_keys.edx.keys import CourseKey
+from openedx_filters.learning.filters import CourseHomeRenderStarted
 from web_fragments.fragment import Fragment
 
 from lms.djangoapps.course_home_api.toggles import course_home_legacy_is_active
@@ -240,5 +241,11 @@ class CourseHomeFragmentView(EdxFragmentView):
             'has_discount': has_discount,
             'show_search': show_search,
         }
+
+        try:
+            context = CourseHomeRenderStarted.run_filter(context=context)
+        except CourseHomeRenderStarted.PreventCourseHomeRender as exc:
+            raise CourseAccessRedirect(reverse(exc.redirect_to or 'dashboard')) from exc
+
         html = render_to_string('course_experience/course-home-fragment.html', context)
         return Fragment(html)

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -702,7 +702,7 @@ openedx-calc==2.0.1
     #   -r requirements/edx/base.in
 openedx-events==0.7.1
     # via -r requirements/edx/base.in
-git+https://github.com/eduNEXT/openedx-filters.git@MJG/2nd_filters_batch#egg=openedx_filters==0.5.0_beta
+git+https://github.com/eduNEXT/openedx-filters.git@MJG/2nd_filters_batch#egg=openedx_filters==0.5.0_gamma
     # via -r requirements/edx/base.in
 ora2==3.8.1
     # via -r requirements/edx/base.in

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -702,7 +702,7 @@ openedx-calc==2.0.1
     #   -r requirements/edx/base.in
 openedx-events==0.7.1
     # via -r requirements/edx/base.in
-git+https://github.com/eduNEXT/openedx-filters.git@MJG/2nd_filters_batch#egg=openedx_filters==0.5.0_alpha
+git+https://github.com/eduNEXT/openedx-filters.git@MJG/2nd_filters_batch#egg=openedx_filters==0.5.0_beta
     # via -r requirements/edx/base.in
 ora2==3.8.1
     # via -r requirements/edx/base.in

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -702,7 +702,7 @@ openedx-calc==2.0.1
     #   -r requirements/edx/base.in
 openedx-events==0.7.1
     # via -r requirements/edx/base.in
-openedx-filters==0.4.3
+git+https://github.com/eduNEXT/openedx-filters.git@MJG/2nd_filters_batch#egg=openedx_filters==0.5.0_alpha
     # via -r requirements/edx/base.in
 ora2==3.8.1
     # via -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -937,7 +937,7 @@ openedx-calc==2.0.1
     #   -r requirements/edx/testing.txt
 openedx-events==0.7.1
     # via -r requirements/edx/testing.txt
-git+https://github.com/eduNEXT/openedx-filters.git@MJG/2nd_filters_batch#egg=openedx_filters==0.5.0_beta
+git+https://github.com/eduNEXT/openedx-filters.git@MJG/2nd_filters_batch#egg=openedx_filters==0.5.0_gamma
     # via -r requirements/edx/testing.txt
 ora2==3.8.1
     # via -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -937,7 +937,7 @@ openedx-calc==2.0.1
     #   -r requirements/edx/testing.txt
 openedx-events==0.7.1
     # via -r requirements/edx/testing.txt
-openedx-filters==0.4.3
+git+https://github.com/eduNEXT/openedx-filters.git@MJG/2nd_filters_batch#egg=openedx_filters==0.5.0_alpha
     # via -r requirements/edx/testing.txt
 ora2==3.8.1
     # via -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -937,7 +937,7 @@ openedx-calc==2.0.1
     #   -r requirements/edx/testing.txt
 openedx-events==0.7.1
     # via -r requirements/edx/testing.txt
-git+https://github.com/eduNEXT/openedx-filters.git@MJG/2nd_filters_batch#egg=openedx_filters==0.5.0_alpha
+git+https://github.com/eduNEXT/openedx-filters.git@MJG/2nd_filters_batch#egg=openedx_filters==0.5.0_beta
     # via -r requirements/edx/testing.txt
 ora2==3.8.1
     # via -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -887,7 +887,7 @@ openedx-calc==2.0.1
     #   -r requirements/edx/base.txt
 openedx-events==0.7.1
     # via -r requirements/edx/base.txt
-git+https://github.com/eduNEXT/openedx-filters.git@MJG/2nd_filters_batch#egg=openedx_filters==0.5.0_beta
+git+https://github.com/eduNEXT/openedx-filters.git@MJG/2nd_filters_batch#egg=openedx_filters==0.5.0_gamma
     # via -r requirements/edx/base.txt
 ora2==3.8.1
     # via -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -887,7 +887,7 @@ openedx-calc==2.0.1
     #   -r requirements/edx/base.txt
 openedx-events==0.7.1
     # via -r requirements/edx/base.txt
-openedx-filters==0.4.3
+git+https://github.com/eduNEXT/openedx-filters.git@MJG/2nd_filters_batch#egg=openedx_filters==0.5.0_alpha
     # via -r requirements/edx/base.txt
 ora2==3.8.1
     # via -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -887,7 +887,7 @@ openedx-calc==2.0.1
     #   -r requirements/edx/base.txt
 openedx-events==0.7.1
     # via -r requirements/edx/base.txt
-git+https://github.com/eduNEXT/openedx-filters.git@MJG/2nd_filters_batch#egg=openedx_filters==0.5.0_alpha
+git+https://github.com/eduNEXT/openedx-filters.git@MJG/2nd_filters_batch#egg=openedx_filters==0.5.0_beta
     # via -r requirements/edx/base.txt
 ora2==3.8.1
     # via -r requirements/edx/base.txt


### PR DESCRIPTION
<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This PR adds the 2nd Open edX Filters batch as part of the implementation plan of Hooks Extension Framework:

- CourseUnenrollmentStarted: intended to be executed before the un-enrollment process starts.
- CertificateCreationRequested: intended to be executed before the certificate creation process starts.
- CertificateRenderStarted: intended to be executed before the certificate template rendering process starts.
- CohortChangeRequested: intended to be executed before the cohort change process starts.
- CourseAboutRenderStarted:  intended to be executed before course about template render starts.
- CourseHomeRenderStarted: intended to be executed before course home template render starts.
- DashboardRenderStarted: intended to be executed before the student's dashboard render starts.

## Supporting information

- [Hooks Extension Framework OEP-50](https://open-edx-proposals.readthedocs.io/en/latest/oep-0050-hooks-extension-framework.html)
ADR(s) on:
- [Open edX Filters naming and versioning](https://github.com/eduNEXT/openedx-filters/blob/main/docs/decisions/0004-filters-naming-and-versioning.rst): about how to identify filters and manage its versions
- [Open edX Filters configuration](https://github.com/eduNEXT/openedx-filters/blob/main/docs/decisions/0002-hooks-filter-config-location.rst): how to configure filters
- [Open edX Filters tooling](https://github.com/eduNEXT/openedx-filters/blob/main/docs/decisions/0003-hooks-filter-tooling-pipeline.rst): what to use to run filters
- [Open edX Filters payload](https://github.com/eduNEXT/openedx-filters/blob/main/docs/decisions/0005-filters-payload.rst): input arguments for filters

## Testing instructions

1. Install openedx-filters library:
```
pip install git+https://github.com/eduNEXT/openedx-filters.git@MJG/2nd_filters_batch#egg=openedx_filters==0.5.0_alpha
```
2. Implement your pipeline steps in your favorite plugin. We created some as illustration in [openedx-filters-samples](https://github.com/eduNEXT/openedx-filters-samples). We'll be using those in this example.
3. Install openedx-filters-samples
```
pip install git+https://github.com/eduNEXT/openedx-filters-samples.git@master#egg=openedx_filters_samples
``` 
4. Configure your filters:
With this configuration, you won't be able to:
- Generate a certificate with `org.openedx.learning.certificate.creation.requested.v1` 
- Render certificate for `org.openedx.learning.certificate.render.started.v1`
- Un-enroll from a course `org.openedx.learning.course.unenrollment.started.v1`
- Rendering course about page (courses/COURSE_ID/about) `org.openedx.learning.course_about.render.started.v1`
- Rendering course home page (courses/COURSE_ID/course) `org.openedx.learning.course_home.render.started.v1`
- Rendering student's dashboard page (/dashboard) `org.openedx.learning.course_home.render.started.v1`
- Change a student from cohort A to cohort B with `org.openedx.learning.cohort.change.requested.v1`
To change the behavior you can replace `Stop<process>` with `NoopFilter` or remove it completely.
```
OPEN_EDX_FILTERS_CONFIG = {
    "org.openedx.learning.certificate.creation.requested.v1": {
        "fail_silently": False,
        "pipeline": [
            "openedx_filters_samples.samples.pipeline.StopCertificateCreation"
        ]
    },
    "org.openedx.learning.course.unenrollment.started.v1": {
        "fail_silently": False,
        "pipeline": [
            "openedx_filters_samples.samples.pipeline.StopUnenrollment"
        ]
    },
    "org.openedx.learning.course_about.render.started.v1": {
        "fail_silently": False,
        "pipeline": [
            "openedx_filters_samples.samples.pipeline.StopCourseAboutRendering",
        ]
    },
    "org.openedx.learning.course_home.render.started.v1": {
        "fail_silently": False,
        "pipeline": [
            "openedx_filters_samples.samples.pipeline.StopCourseHomeRendering",
        ]
    },
    "org.openedx.learning.dashboard.render.started.v1": {
        "fail_silently": False,
        "pipeline": [
            "openedx_filters_samples.samples.pipeline.StopDashboardRender",
        ]
    },
     "org.openedx.learning.certificate.render.started.v1": {
            "fail_silently": False,
            "pipeline": [
                "openedx_filters_samples.samples.pipeline.StopCertificateRender",
            ]
    },
     "org.openedx.learning.cohort.change.requested.v1": {
            "fail_silently": False,
            "pipeline": [
                "openedx_filters_samples.samples.pipeline.StopCohortChange",
            ]
    },
}
```
Notes about the filters steps:
- ModifyContextBeforeRender: changes context before rendering. As it is right now just adds a new variable.
The other ones halt the app execution.

Simple and straightforward implementations as a way of illustrating how they work. More complex steps are coming.