### PR TITLE
fix: return a sorted list so tests can be deterministic

### DIFF
--- a/lms/djangoapps/bulk_user_retirement/views.py
+++ b/lms/djangoapps/bulk_user_retirement/views.py
@@ -66,7 +66,7 @@ class BulkUsersRetirementView(APIView):
                 log.exception(f'500 error retiring account {exc}')
                 failed_user_retirements.append(username)
 
-        successful_user_retirements = list(set(usernames_to_retire).difference(failed_user_retirements))
+        successful_user_retirements = sorted(set(usernames_to_retire).difference(failed_user_retirements))
 
         return Response(
             status=status.HTTP_200_OK,


### PR DESCRIPTION
Tests on Maple were failing:

```
    def test_retirement_for_multiple_users(self):
        user_retirement_url = reverse('bulk_retirement_api')
        expected_response = {
            'successful_user_retirements': [self.user3.username, self.user4.username],
            'failed_user_retirements': []
        }
        with self.settings(RETIREMENT_SERVICE_WORKER_USERNAME=self.user1.username):
            response = self.client.post(user_retirement_url, {
                "usernames": f'{self.user3.username},{self.user4.username}'
            })
            assert response.status_code == 200
>           assert response.data == expected_response
E           AssertionError: assert {'failed_user... 'testuser3']} == {'failed_user... 'testuser4']}
E             Omitting 1 identical items, use -vv to show
E             Differing items:
E             {'successful_user_retirements': ['testuser4', 'testuser3']} != {'successful_user_retirements': ['testuser3', 'testuser4']}
E             Use -v to get the full diff
```

`sorted(set(...))` still produces a list, and I guess we didn't care
about the order before, since it wasn't determined.  So this should be
an acceptable change.
