### PR TITLE
fix: registration form validation message

### DIFF
--- a/lms/static/js/student_account/views/RegisterView.js
+++ b/lms/static/js/student_account/views/RegisterView.js
@@ -479,12 +479,14 @@
                                     return _.map(
                                         errorList,
                                         function(errorItem) {
-                                            return StringUtils.interpolate('<li {suppressAttr} >{error}</li>', {
-                                                error: errorItem.user_message,
-                                                suppressAttr: (
-                                                  key === 'email' || key === 'username'
-                                                ) ? 'data-hj-suppress' : ''
-                                            });
+                                            if (errorItem.user_message) {
+                                                return StringUtils.interpolate('<li {suppressAttr} >{error}</li>', {
+                                                    error: errorItem.user_message,
+                                                    suppressAttr: (
+                                                    key === 'email' || key === 'username'
+                                                    ) ? 'data-hj-suppress' : ''
+                                                });
+                                            }
                                         }
                                   );
                                 }


### PR DESCRIPTION

## Description

In the https://github.com/openedx/edx-platform/pull/27387 the username suggestions were added. They are breaking the validation messages.

STR:
1. Go to Register page
2. Fill in Full Name, Password, Country with valid data
3. Fill in Public Username using the existed username 
4. Fill in Email using existed email 
5. Click on the [Create Account] button
6. Observe the validation message

![image (4)](https://user-images.githubusercontent.com/47273130/151791321-d86f1aca-c34b-4474-aec1-b28faf8de46d.png)
