### PR TITLE
feat!: remove all access to Old Mongo courses

### DIFF
--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -27,6 +27,7 @@ from lms.djangoapps.courseware.access_response import (
     MilestoneAccessError,
     MobileAvailabilityError,
     NoAllowedPartitionGroupsError,
+    OldMongoAccessError,
     VisibilityError
 )
 from lms.djangoapps.courseware.access_utils import (
@@ -329,6 +330,9 @@ def _has_access_course(user, action, courselike):
         # ).or(
         #     _has_staff_access_to_descriptor, user, courselike, courselike.id
         # )
+        if courselike.id.deprecated:  # we no longer support accessing Old Mongo courses
+            return OldMongoAccessError(courselike)
+
         visible_to_nonstaff = _visible_to_nonstaff_users(courselike)
         if not visible_to_nonstaff:
             staff_access = _has_staff_access_to_descriptor(user, courselike, courselike.id)

--- a/lms/djangoapps/courseware/access_response.py
+++ b/lms/djangoapps/courseware/access_response.py
@@ -236,3 +236,16 @@ class AuthenticationRequiredAccessError(AccessError):
         developer_message = "User must be authenticated to view the course"
         user_message = _("You must be logged in to see this course")
         super().__init__(error_code, developer_message, user_message)
+
+
+class OldMongoAccessError(AccessError):
+    """
+    Access denied because the course is in Old Mongo and we no longer support them. See DEPR-58.
+    """
+    def __init__(self, courselike):
+        error_code = 'old_mongo'
+        developer_message = 'Access to Old Mongo courses is unsupported'
+        user_message = _('{course_name} is no longer available.').format(
+            course_name=courselike.display_name_with_default,
+        )
+        super().__init__(error_code, developer_message, user_message)

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -27,6 +27,7 @@ from lms.djangoapps.courseware.access_response import (
     AuthenticationRequiredAccessError,
     EnrollmentRequiredAccessError,
     MilestoneAccessError,
+    OldMongoAccessError,
     StartDateError,
 )
 from lms.djangoapps.courseware.date_summary import (
@@ -211,6 +212,15 @@ def check_course_access_with_redirect(course, user, action, check_if_enrolled=Fa
             raise CourseAccessRedirect('{dashboard_url}?{params}'.format(
                 dashboard_url=reverse('dashboard'),
                 params=params.urlencode()
+            ), access_response)
+
+        # Redirect if trying to access an Old Mongo course
+        if isinstance(access_response, OldMongoAccessError):
+            params = QueryDict(mutable=True)
+            params['access_response_error'] = access_response.user_message
+            raise CourseAccessRedirect('{dashboard_url}?{params}'.format(
+                dashboard_url=reverse('dashboard'),
+                params=params.urlencode(),
             ), access_response)
 
         # Redirect if the user must answer a survey before entering the course.

--- a/lms/djangoapps/courseware/tests/test_courses.py
+++ b/lms/djangoapps/courseware/tests/test_courses.py
@@ -39,6 +39,7 @@ from lms.djangoapps.courseware.courses import (
     get_courses,
     get_current_child
 )
+from lms.djangoapps.courseware.exceptions import CourseAccessRedirect
 from lms.djangoapps.courseware.model_data import FieldDataCache
 from lms.djangoapps.courseware.module_render import get_module_for_descriptor
 from lms.djangoapps.courseware.courseware_access_exception import CoursewareAccessException
@@ -87,6 +88,18 @@ class CoursesTest(ModuleStoreTestCase):
         assert str(error.value) == 'Course not found.'
         assert error.value.access_response.error_code == 'not_visible_to_user'
         assert not error.value.access_response.has_access
+
+    @ddt.data(GET_COURSE_WITH_ACCESS, GET_COURSE_OVERVIEW_WITH_ACCESS)
+    def test_old_mongo_access_error(self, course_access_func_name):
+        course_access_func = self.COURSE_ACCESS_FUNCS[course_access_func_name]
+        user = UserFactory.create()
+        with self.store.default_store(ModuleStoreEnum.Type.mongo):
+            course = CourseFactory.create()
+
+        with pytest.raises(CourseAccessRedirect) as error:
+            course_access_func(user, 'load', course.id)
+        assert error.value.access_error.error_code == 'old_mongo'
+        assert not error.value.access_error.has_access
 
     @ddt.data(
         (GET_COURSE_WITH_ACCESS, 3),

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -527,6 +527,25 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
         )
         self.assertRedirects(response, expected_url)
 
+    def test_old_mongo_access_error(self):
+        """
+        Ensure that a user accessing an Old Mongo course sees a redirect to
+        the student dashboard, not a 404.
+        """
+        course = CourseFactory.create(default_store=ModuleStoreEnum.Type.mongo)
+        user = UserFactory(password=self.TEST_PASSWORD)
+        self.client.login(username=user.username, password=self.TEST_PASSWORD)
+
+        response = self.client.get(course_home_url(course))
+
+        expected_params = QueryDict(mutable=True)
+        expected_params['access_response_error'] = f'{course.display_name_with_default} is no longer available.'
+        expected_url = '{url}?{params}'.format(
+            url=reverse('dashboard'),
+            params=expected_params.urlencode(),
+        )
+        self.assertRedirects(response, expected_url)
+
     @mock.patch.dict(settings.FEATURES, {'DISABLE_START_DATES': False})
     def test_expiration_banner_with_expired_upgrade_deadline(self):
         """


### PR DESCRIPTION
Change has_access to deny 'load' support for Old Mongo courses.

This is in service of dropping support for these ancient courses and removing legacy code that they rely on.

[DEPR-58](https://openedx.atlassian.net/browse/DEPR-58)
[DEPR-123](https://openedx.atlassian.net/browse/DEPR-123)

Here's a screenshot of what the dashboard looks like after this change. You can see both the error message we show when you try to go to an Old Mongo course (you get redirected to dashboard with this mesage). And you can see how an Old Mongo course card shows up - it's still there, but without any links.
![Screenshot from 2022-02-17 11-13-15](https://user-images.githubusercontent.com/1196901/154523097-192656bb-297e-4631-9cd7-3984be8223a3.png)
