### PR TITLE
[BB-5819] Make course description editable in certs

### DIFF
--- a/cms/djangoapps/contentstore/views/certificates.py
+++ b/cms/djangoapps/contentstore/views/certificates.py
@@ -231,6 +231,8 @@ class CertificateManager:
         # Some keys are not required, such as the title override...
         if certificate_data.get('course_title'):
             certificate_response["course_title"] = certificate_data['course_title']
+        if certificate_data.get('course_description'):
+            certificate_response['course_description'] = certificate_data['course_description']
 
         return certificate_response
 

--- a/cms/static/js/certificates/models/certificate.js
+++ b/cms/static/js/certificates/models/certificate.js
@@ -19,6 +19,7 @@ function(_, Backbone, BackboneRelational, BackboneAssociations, gettext, CoffeeS
         defaults: {
             // Metadata fields currently displayed in web forms
             course_title: '',
+            course_description: '',
 
             // Metadata fields not currently displayed in web forms
             name: 'Name of the certificate',

--- a/cms/static/js/certificates/views/certificate_editor.js
+++ b/cms/static/js/certificates/views/certificate_editor.js
@@ -24,6 +24,7 @@ function($, _, Backbone, gettext,
             'change .collection-name-input': 'setName',
             'change .certificate-description-input': 'setDescription',
             'change .certificate-course-title-input': 'setCourseTitle',
+            'change .certificate-course-description-input': 'setCourseDescription',
             'focus .input-text': 'onFocus',
             'blur .input-text': 'onBlur',
             submit: 'setAndClose',
@@ -103,6 +104,7 @@ function($, _, Backbone, gettext,
                 name: this.model.get('name'),
                 description: this.model.get('description'),
                 course_title: this.model.get('course_title'),
+                course_description: this.model.get('course_description'),
                 org_logo_path: this.model.get('org_logo_path'),
                 is_active: this.model.get('is_active'),
                 isNew: this.model.isNew()
@@ -143,11 +145,22 @@ function($, _, Backbone, gettext,
             );
         },
 
+        setCourseDescription: function(event) {
+            // Updates the indicated model field (still requires persistence on server)
+            if (event && event.preventDefault) { event.preventDefault(); }
+            this.model.set(
+                'course_description',
+                this.$('.certificate-course-description-input').val(),
+                {silent: true}
+            );
+        },
+
         setValues: function() {
             // Update the specified values in the local model instance
             this.setName();
             this.setDescription();
             this.setCourseTitle();
+            this.setCourseDescription();
             return this;
         }
     });

--- a/cms/templates/js/certificate-details.underscore
+++ b/cms/templates/js/certificate-details.underscore
@@ -29,6 +29,12 @@
                             <span class="certificate-value"><%- course_title %></span>
                         </p>
                     <% } %>
+                    <% if (course_description) { %>
+                        <p class="course-description">
+                            <span class="certificate-label"><b><%- gettext('Course Description') %>: </b></span>
+                            <span class="certificate-value"><%- course_description %></span>
+                        </p>
+                    <% } %>
                  </div>
 
                 <div class='course-number-section pull-left'>

--- a/cms/templates/js/certificate-editor.underscore
+++ b/cms/templates/js/certificate-editor.underscore
@@ -31,6 +31,11 @@
                 <input id="certificate-course-title-<%- uniqueId %>" class="certificate-course-title-input input-text" name="certificate-course-title" type="text" placeholder="<%- gettext("Course title") %>" value="<%- course_title %>" aria-describedby="certificate-course-title-<%-uniqueId %>-tip" />
                 <span id="certificate-course-title-<%- uniqueId %>-tip" class="tip tip-stacked"><%- gettext("Specify an alternative to the official course title to display on certificates. Leave blank to use the official course title.") %></span>
             </div>
+            <div class="input-wrap field text add-certification-course-description">
+                <label for="certificate-course-description-<%- uniqueId %>"><%- gettext("Course Description") %></label>
+                <input id="certificate-course-description-<%- uniqueId %>" class="certificate-course-description-input input-text" name="certificate-course-description" type="text" placeholder="<%- gettext("Course Description") %>" value="<%- course_description %>" aria-describedby="certificate-course-description-<%-uniqueId %>-tip" />
+                <span id="certificate-course-description-<%- uniqueId %>-tip" class="tip tip-stacked"><%- gettext("Specify an alternative to the official course description to display on certificates. Leave blank to use default text.") %></span>
+            </div>
         </fieldset>
          <header>
             <h2 class="title title-2"><%- gettext("Certificate Signatories") %></h2>

--- a/lms/djangoapps/certificates/tests/test_webview_views.py
+++ b/lms/djangoapps/certificates/tests/test_webview_views.py
@@ -140,6 +140,7 @@ class CommonCertificatesTestCase(ModuleStoreTestCase):
                 'name': 'Name ' + str(i),
                 'description': 'Description ' + str(i),
                 'course_title': 'course_title_' + str(i),
+                'course_description': 'course_description_' + str(i),
                 'org_logo_path': f'/t4x/orgX/testX/asset/org-logo-{i}.png',
                 'signatories': signatories,
                 'version': 1,
@@ -460,11 +461,6 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             uuid=self.cert.verify_uuid
         )
         response = self.client.get(test_url)
-        self.assertContains(
-            response,
-            'a course of study offered by test_organization, an online learning initiative of test organization',
-        )
-        self.assertNotContains(response, 'a course of study offered by testorg')
         self.assertContains(response, f'<title>test_organization {self.course.number} Certificate |')
         self.assertContains(response, 'logo_test1.png')
 
@@ -549,21 +545,13 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertContains(response, '<a class="logo" href="http://test_site.localhost">')
         # Test an item from course info
         self.assertContains(response, 'course_title_0')
+        # Test an item from course description
+        self.assertContains(response, 'course_description_0')
         # Test an item from user info
         self.assertContains(response, f"{self.user.profile.name}, you earned a certificate!")
         # Test an item from social info
         self.assertContains(response, "Post on Facebook")
         self.assertContains(response, "Share on Twitter")
-        # Test an item from certificate/org info
-        self.assertContains(
-            response,
-            "a course of study offered by {partner_short_name}, "
-            "an online learning initiative of "
-            "{partner_long_name}.".format(
-                partner_short_name=short_org_name,
-                partner_long_name=long_org_name,
-            ),
-        )
         # Test item from badge info
         self.assertContains(response, "Add to Mozilla Backpack")
         # Test item from site configuration

--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -254,7 +254,10 @@ def _update_course_context(request, context, course, platform_name):
     course_number = course.display_coursenumber if course.display_coursenumber else course.number
     context['course_number'] = course_number
     context['idv_enabled_for_certificates'] = settings.FEATURES.get('ENABLE_CERTIFICATES_IDV_REQUIREMENT')
-    if context['organization_long_name']:
+    course_description_override = context['certificate_data'].get('course_description', '')
+    if course_description_override:
+        context['accomplishment_copy_course_description'] = course_description_override
+    elif context['organization_long_name']:
         # Translators:  This text represents the description of course
         context['accomplishment_copy_course_description'] = _('a course of study offered by {partner_short_name}, '
                                                               'an online learning initiative of '


### PR DESCRIPTION
## Description

This PR makes the default description text that appears under the course title editable/configurable for certificates.

## Supporting information

**JIRA tickets:** [BB-5819](https://tasks.opencraft.com/browse/BB-5819)

## Screenshots

Creating new certificates:

![certs-editable-field-during-creation](https://user-images.githubusercontent.com/13742492/151926011-fbec7f13-7640-444d-abb4-2ee09ff90dd4.png)

## Testing instructions

1. Check out this branch and open Studio.
2. Enable certificates on the a course.
3. On clicking "Set up your certificate", you should see the additional field "Course Description".
4. Add in some text for course description and preview certificate.
5. Verify that the custom course description is shown on the certificate. 


**Reviewers:**

- [x] @gabor-boros 
- [ ] edX reviewer: @hurtstotouchfire 