### PR TITLE
fix: login bug where finish_auth_url is not found

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -591,8 +591,11 @@ def login_user(request, api_version='v1'):
 
         if third_party_auth_requested:
             running_pipeline = pipeline.get(request)
-            finish_auth_url = pipeline.get_complete_url(backend_name=running_pipeline['backend'])
-
+            if running_pipeline:
+                finish_auth_url = pipeline.get_complete_url(backend_name=running_pipeline['backend'])
+            else:
+                log.warning("Unable to find finish_auth_url for user %s. Using default of ''.", user.id) 
+                
         if is_user_third_party_authenticated:
             redirect_url = finish_auth_url
         elif should_redirect_to_authn_microfrontend():


### PR DESCRIPTION
## Description

The pipeline data cannot be found in certain cases, and the current code
was raising "TypeError: 'NoneType' object is not subscriptable", which left
login in a bad state. Instead, we will use the default finish_auth_url of '' and
complete the login.

## Supporting information

[ARCHBOM-2028](https://openedx.atlassian.net/browse/ARCHBOM-2028)

## Testing instructions

May need to add a test for this?
