### PR TITLE
chore: upgrade lti-consumer-xblock library to version 3.4.1

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -613,7 +613,7 @@ libsass==0.10.0
     #   ora2
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==3.3.0
+lti-consumer-xblock==3.4.1
     # via -r requirements/edx/base.in
 lxml==4.5.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -826,7 +826,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/testing.txt
     #   ora2
-lti-consumer-xblock==3.3.0
+lti-consumer-xblock==3.4.1
     # via -r requirements/edx/testing.txt
 lxml==4.5.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -785,7 +785,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==3.3.0
+lti-consumer-xblock==3.4.1
     # via -r requirements/edx/base.txt
 lxml==4.5.0
     # via


### PR DESCRIPTION
With this version upgrade, we have a potential fix for [MST-1320](https://openedx.atlassian.net/browse/MST-1320)

Version 3.4.1 contains:
```Fix the target_link_uri parameter on OIDC login preflight url parameter so it matches claim message definition of the field. See docs at https://www.imsglobal.org/spec/lti/v1p3#target-link-uri```

@openedx/masters-devs-cosmonauts Please review.
@giovannicimolin FYI

