### PR TITLE
fix: Delete JWTs and other cookies when SafeSessions deletes session cookie

### DIFF
--- a/openedx/core/djangoapps/safe_sessions/middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/middleware.py
@@ -95,6 +95,7 @@ from edx_django_utils.monitoring import set_custom_attribute
 from edx_toggles.toggles import SettingToggle
 
 from common.djangoapps.util.log_sensitive import encrypt_for_log
+from openedx.core.djangoapps.user_authn.cookies import delete_logged_in_cookies
 from openedx.core.lib.mobile_utils import is_request_from_mobile_app
 
 # .. toggle_name: LOG_REQUEST_USER_CHANGES
@@ -833,6 +834,7 @@ def _delete_cookie(request, response):
         secure=settings.SESSION_COOKIE_SECURE or None,
         httponly=settings.SESSION_COOKIE_HTTPONLY or None,
     )
+    delete_logged_in_cookies(response)
 
     # Note, there is no request.user attribute at this point.
     if hasattr(request, 'session') and hasattr(request.session, 'session_key'):

--- a/openedx/core/djangoapps/safe_sessions/middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/middleware.py
@@ -823,17 +823,15 @@ def _is_cookie_present(response):
 
 def _delete_cookie(request, response):
     """
-    Delete the cookie by setting the expiration to a date in the past,
-    while maintaining the domain, secure, and httponly settings.
+    Delete session cookie, as well as related login cookies.
     """
-    response.set_cookie(
+    response.delete_cookie(
         settings.SESSION_COOKIE_NAME,
-        max_age=0,
-        expires='Thu, 01-Jan-1970 00:00:00 GMT',
+        path='/',
         domain=settings.SESSION_COOKIE_DOMAIN,
-        secure=settings.SESSION_COOKIE_SECURE or None,
-        httponly=settings.SESSION_COOKIE_HTTPONLY or None,
     )
+    # Keep JWT cookies and others in sync with session cookie
+    # (meaning, in this case, delete them too).
     delete_logged_in_cookies(response)
 
     # Note, there is no request.user attribute at this point.

--- a/openedx/core/djangoapps/user_authn/cookies.py
+++ b/openedx/core/djangoapps/user_authn/cookies.py
@@ -68,7 +68,7 @@ def are_logged_in_cookies_set(request):
 
 def delete_logged_in_cookies(response):
     """
-    Delete cookies indicating that the user is logged in.
+    Delete cookies indicating that the user is logged in (except for session cookie.)
     Arguments:
         response (HttpResponse): The response sent to the client.
     Returns:


### PR DESCRIPTION
This is more correct and may reduce the likelihood of perpetuating a bad
mixed-auth state.

In general, we should probably be modifying session and JWT cookies in sync at all times, never individually. This specific code probably won't make anything worse, but a clean reset might improve user experience in the rare cases where someone somehow gets their browser into a weird state.

ref: ARCHBOM-2030 (internal)