### PR TITLE
fix: remove the data point on zoom since edx_zoom is deprecated

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -16,7 +16,7 @@ from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model, logout
 from django.contrib.sites.models import Site
 from django.core.cache import cache
-from django.db import models, transaction
+from django.db import transaction
 from django.utils.translation import gettext as _
 from edx_ace import ace
 from edx_ace.recipient import Recipient
@@ -652,16 +652,6 @@ class AccountRetirementPartnerReportView(ViewSet):
             # Org can conceivably be blank or this bogus default value
             if org and org != 'outdated_entry':
                 orgs.add(org)
-        try:
-            # if the user has ever launched a managed Zoom xblock,
-            # we'll notify Zoom to delete their records.
-            # We use models.Value(1) to make use of the indexing on the field. MySQL does not
-            # support boolean types natively, and checking for False will cause a table scan.
-            if user.launchlog_set.filter(managed=models.Value(1)).count():
-                orgs.add('zoom')
-        except AttributeError:
-            # Zoom XBlock not installed
-            pass
         return orgs
 
     def retirement_partner_report(self, request):  # pylint: disable=unused-argument


### PR DESCRIPTION
## Description
Since the edx-zoom library is being deprecated, we no longer can show the data point about zoom usage on the org level.
Remove this data point form the retirement report.
@pwnage101 and @openedx/masters-devs-cosmonauts Please review.