### PR TITLE
fix: discussion configuration not saved to course for new provider [BD-38] [TNL-8622] 

### DIFF
--- a/openedx/core/djangoapps/discussions/serializers.py
+++ b/openedx/core/djangoapps/discussions/serializers.py
@@ -295,7 +295,7 @@ class DiscussionsConfigurationSerializer(serializers.ModelSerializer):
         plugin_configuration = validated_data.pop('plugin_configuration', {})
         updated_provider_type = validated_data.get('provider_type') or instance.provider_type
 
-        if updated_provider_type == Provider.LEGACY:
+        if updated_provider_type in [Provider.LEGACY, Provider.OPEN_EDX]:
             legacy_settings = LegacySettingsSerializer(
                 self._get_course(),
                 context={


### PR DESCRIPTION
## Description

Fix discussion configuration API to save changes made to the new provider to the course. 

## Supporting information

- https://openedx.atlassian.net/browse/TNL-8622

## Testing instructions

- Switch to this PR https://github.com/openedx/frontend-app-course-authoring/pull/217
- Try changing settings (adding topics, updating toggles etc) for the new edX provider. 
- The settings will not be saved. 
- Switch to this PR and try again. 
- The settings should be saved. 
