### PR TITLE
feat: add provider info to the discussion configuration API [BD-38] [TNL-9333] [BB-5248]

### DIFF
--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -278,6 +278,8 @@ def get_course(request, course_key):
 
     course = _get_course(course_key, request.user)
     user_roles = get_user_role_names(request.user, course_key)
+    course_config = DiscussionsConfiguration.get(course_key)
+
     return {
         "id": str(course_key),
         "blackouts": [
@@ -299,7 +301,10 @@ def get_course(request, course_key):
             FORUM_ROLE_ADMINISTRATOR,
             FORUM_ROLE_MODERATOR,
             FORUM_ROLE_COMMUNITY_TA,
-        })
+        }),
+        "provider": course_config.provider_type,
+        "enable_in_context": course_config.enable_in_context,
+        "group_at_subsection": course_config.plugin_configuration.get("group_at_subsection", False),
     }
 
 

--- a/lms/djangoapps/discussion/rest_api/serializers.py
+++ b/lms/djangoapps/discussion/rest_api/serializers.py
@@ -739,10 +739,10 @@ class CourseMetadataSerailizer(serializers.Serializer):
     )
     topics_url = serializers.URLField(help_text="The URL of the topic listing for the course.")
     allow_anonymous = serializers.BooleanField(
-        help_text="A boolean which indicating whether anonymous posts are allowed or not.",
+        help_text="A boolean indicating whether anonymous posts are allowed or not.",
     )
     allow_anonymous_to_peers = serializers.BooleanField(
-        help_text="A boolean which indicating whether posts anonymous to peers are allowed or not.",
+        help_text="A boolean indicating whether posts anonymous to peers are allowed or not.",
     )
     user_roles = serializers.ListField(
         child=serializers.CharField(),
@@ -750,4 +750,13 @@ class CourseMetadataSerailizer(serializers.Serializer):
     )
     user_is_privileged = serializers.BooleanField(
         help_text="A boolean indicating if the current user has a privileged role",
+    )
+    provider = serializers.CharField(
+        help_text="The discussion provider used by this course",
+    )
+    enable_in_context = serializers.BooleanField(
+        help_text="A boolean indicating whether in-context discussion is enabled for the course",
+    )
+    group_at_subsection = serializers.BooleanField(
+        help_text="A boolean indicating whether discussions should be grouped at subsection",
     )

--- a/lms/djangoapps/discussion/rest_api/tests/test_api.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api.py
@@ -191,6 +191,9 @@ class GetCourseTest(ForumsEnableMixin, UrlResetMixin, SharedModuleStoreTestCase)
             'topics_url': 'http://testserver/api/discussion/v1/course_topics/course-v1:x+y+z',
             'allow_anonymous': True,
             'allow_anonymous_to_peers': False,
+            'enable_in_context': True,
+            'group_at_subsection': False,
+            'provider': 'legacy',
             'user_is_privileged': False,
             'user_roles': {'Student'},
         }

--- a/lms/djangoapps/discussion/rest_api/tests/test_views.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views.py
@@ -512,6 +512,9 @@ class CourseViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
                     "http://testserver/api/discussion/v1/threads/?course_id=course-v1%3Ax%2By%2Bz&following=True"
                 ),
                 "topics_url": "http://testserver/api/discussion/v1/course_topics/course-v1:x+y+z",
+                'enable_in_context': True,
+                'group_at_subsection': False,
+                'provider': 'legacy',
                 "allow_anonymous": True,
                 "allow_anonymous_to_peers": False,
                 'user_is_privileged': False,


### PR DESCRIPTION
## Description

Adds information about the discussion provider to the discussion configuration API to allow MFEs to change the experience based on the provider and settings in use. 

## Supporting information

- [TNL-9333](https://openedx.atlassian.net/browse/TNL-9333)

## Testing instructions

- Use along with https://github.com/openedx/frontend-app-discussions/pull/54
