### PR TITLE
fix: Hide headers and footer in disucssion mfe UI in edx-platform

### DIFF
--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -706,7 +706,7 @@ def _discussions_mfe_context(query_params: Dict, course_key: CourseKey, user: Us
         A URL for the MFE experience if active for the current request or None
     """
     experience_param = query_params.get("discussions_experience", "").lower()
-    mfe_url = get_discussions_mfe_url(course_key)
+    mfe_url = get_discussions_mfe_url(course_key, 'in_context')
     if not mfe_url:
         return {"show_banner": False, "show_mfe": False}
     show_banner = bool(has_access(user, 'staff', course_key))

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -706,7 +706,7 @@ def _discussions_mfe_context(query_params: Dict, course_key: CourseKey, user: Us
         A URL for the MFE experience if active for the current request or None
     """
     experience_param = query_params.get("discussions_experience", "").lower()
-    mfe_url = get_discussions_mfe_url(course_key, 'in_context')
+    mfe_url = get_discussions_mfe_url(course_key=course_key, view='in_context')
     if not mfe_url:
         return {"show_banner": False, "show_mfe": False}
     show_banner = bool(has_access(user, 'staff', course_key))


### PR DESCRIPTION
Added Missing Param `in_context` to hide header and footer of discussion MFE in Iframe