### PR TITLE
feat!: Remove django-admin default login

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_admin.py
+++ b/cms/djangoapps/contentstore/tests/test_admin.py
@@ -22,7 +22,7 @@ class TestAdminView(TestCase):
     def test_admin_login_redirect(self, admin_url, index):
         """Admin login will redirect towards the site login page."""
         response = self.client.get(admin_url, follow=True)
-        assert any('/login/edx-oauth2/?next=' in r[0] for r in redirect_chain)
+        assert any('/login/edx-oauth2/?next=' in r[0] for r in response.redirect_chain)
 
     def test_admin_login_default(self):
         """Without flag Admin login will redirect towards the admin default login page."""

--- a/cms/djangoapps/contentstore/tests/test_admin.py
+++ b/cms/djangoapps/contentstore/tests/test_admin.py
@@ -22,7 +22,7 @@ class TestAdminView(TestCase):
     def test_admin_login_redirect(self, admin_url, index):
         """Admin login will redirect towards the site login page."""
         response = self.client.get(admin_url, follow=True)
-        self.assertIn('/login/edx-oauth2/?next=', response.redirect_chain[index][0])
+        assert any('/login/edx-oauth2/?next=' in r[0] for r in redirect_chain)
 
     def test_admin_login_default(self):
         """Without flag Admin login will redirect towards the admin default login page."""

--- a/cms/djangoapps/contentstore/tests/test_admin.py
+++ b/cms/djangoapps/contentstore/tests/test_admin.py
@@ -4,7 +4,7 @@ Tests that verify that the admin view loads.
 This is not inside a django app because it is a global property of the system.
 """
 import ddt
-from django.test import Client, TestCase
+from django.test import TestCase
 from django.urls import reverse
 from edx_toggles.toggles.testutils import override_waffle_flag
 

--- a/cms/djangoapps/contentstore/tests/test_admin.py
+++ b/cms/djangoapps/contentstore/tests/test_admin.py
@@ -17,9 +17,8 @@ class TestAdminView(TestCase):
     Tests of the admin view.
     """
     @override_waffle_flag(ADMIN_AUTH_REDIRECT_TO_LMS, True)
-    @ddt.data(('/admin/', 3), ('/admin/login', 3), (reverse('admin:login'), 2))
-    @ddt.unpack
-    def test_admin_login_redirect(self, admin_url, index):
+    @ddt.data('/admin/', '/admin/login', reverse('admin:login'))
+    def test_admin_login_redirect(self, admin_url):
         """Admin login will redirect towards the site login page."""
         response = self.client.get(admin_url, follow=True)
         assert any('/login/edx-oauth2/?next=' in r[0] for r in response.redirect_chain)

--- a/cms/djangoapps/contentstore/tests/test_admin.py
+++ b/cms/djangoapps/contentstore/tests/test_admin.py
@@ -8,7 +8,7 @@ from django.test import TestCase
 from django.urls import reverse
 from edx_toggles.toggles.testutils import override_waffle_flag
 
-from openedx.core.djangoapps.user_authn.config.waffle import REDIRECT_TO_LMS
+from openedx.core.djangoapps.user_authn.config.waffle import ADMIN_AUTH_REDIRECT_TO_LMS
 
 
 @ddt.ddt
@@ -16,7 +16,7 @@ class TestAdminView(TestCase):
     """
     Tests of the admin view.
     """
-    @override_waffle_flag(REDIRECT_TO_LMS, True)
+    @override_waffle_flag(ADMIN_AUTH_REDIRECT_TO_LMS, True)
     @ddt.data(('/admin/', 3), ('/admin/login', 3), (reverse('admin:login'), 2))
     @ddt.unpack
     def test_admin_login_redirect(self, admin_url, index):

--- a/cms/djangoapps/contentstore/tests/test_admin.py
+++ b/cms/djangoapps/contentstore/tests/test_admin.py
@@ -1,0 +1,33 @@
+"""
+Tests that verify that the admin view loads.
+
+This is not inside a django app because it is a global property of the system.
+"""
+import ddt
+from django.test import Client, TestCase
+from django.urls import reverse
+from edx_toggles.toggles.testutils import override_waffle_flag
+
+from openedx.core.djangoapps.user_authn.config.waffle import REDIRECT_TO_LMS
+
+
+@ddt.ddt
+class TestAdminView(TestCase):
+    """
+    Tests of the admin view.
+    """
+    @override_waffle_flag(REDIRECT_TO_LMS, True)
+    @ddt.data(('/admin/', 3), ('/admin/login', 3), (reverse('admin:login'), 2))
+    @ddt.unpack
+    def test_admin_login_redirect(self, admin_url, index):
+        """Admin login will redirect towards the site login page."""
+        response = self.client.get(admin_url, follow=True)
+        self.assertIn('/login/edx-oauth2/?next=', response.redirect_chain[index][0])
+
+    def test_admin_login_default(self):
+        """Without flag Admin login will redirect towards the admin default login page."""
+        response = self.client.get('/admin/', follow=True)
+        assert response.status_code == 200
+        self.assertIn('/admin/login/?next=/admin/', response.redirect_chain[0])
+        assert len(response.redirect_chain) == 1
+        assert response.template_name == ['admin/login.html']

--- a/cms/djangoapps/contentstore/views/public.py
+++ b/cms/djangoapps/contentstore/views/public.py
@@ -16,7 +16,7 @@ from ..config import waffle
 
 __all__ = [
     'register_redirect_to_lms', 'login_redirect_to_lms', 'howitworks', 'accessibility',
-    'redirect_to_lms_login_for_admin'
+    'redirect_to_lms_login_for_admin',
 ]
 
 

--- a/cms/djangoapps/contentstore/views/public.py
+++ b/cms/djangoapps/contentstore/views/public.py
@@ -7,12 +7,17 @@ from django.conf import settings
 from django.shortcuts import redirect
 from urllib.parse import quote_plus  # lint-amnesty, pylint: disable=wrong-import-order
 from waffle.decorators import waffle_switch
+from django.contrib import admin
 
 from common.djangoapps.edxmako.shortcuts import render_to_response
+from openedx.core.djangoapps.user_authn.config.waffle import REDIRECT_TO_LMS
 
 from ..config import waffle
 
-__all__ = ['register_redirect_to_lms', 'login_redirect_to_lms', 'howitworks', 'accessibility']
+__all__ = [
+    'register_redirect_to_lms', 'login_redirect_to_lms', 'howitworks', 'accessibility',
+    'redirect_to_lms_login_for_admin'
+]
 
 
 def register_redirect_to_lms(request):
@@ -37,6 +42,16 @@ def login_redirect_to_lms(request):
         params=_build_next_param(request),
     )
     return redirect(login_url)
+
+
+def redirect_to_lms_login_for_admin(request):
+    """
+    This view redirect the admin/login url to the site's login page.
+    """
+    if REDIRECT_TO_LMS.is_enabled():
+        return redirect('/login?next=/admin')
+    else:
+        return admin.site.login(request)
 
 
 def _build_next_param(request):

--- a/cms/djangoapps/contentstore/views/public.py
+++ b/cms/djangoapps/contentstore/views/public.py
@@ -10,7 +10,7 @@ from waffle.decorators import waffle_switch
 from django.contrib import admin
 
 from common.djangoapps.edxmako.shortcuts import render_to_response
-from openedx.core.djangoapps.user_authn.config.waffle import REDIRECT_TO_LMS
+from openedx.core.djangoapps.user_authn.config.waffle import ADMIN_AUTH_REDIRECT_TO_LMS
 
 from ..config import waffle
 
@@ -48,7 +48,7 @@ def redirect_to_lms_login_for_admin(request):
     """
     This view redirect the admin/login url to the site's login page.
     """
-    if REDIRECT_TO_LMS.is_enabled():
+    if ADMIN_AUTH_REDIRECT_TO_LMS.is_enabled():
         return redirect('/login?next=/admin')
     else:
         return admin.site.login(request)

--- a/cms/djangoapps/course_creators/tests/test_admin.py
+++ b/cms/djangoapps/course_creators/tests/test_admin.py
@@ -176,18 +176,3 @@ class CourseCreatorAdminTest(TestCase):
 
         self.request.user = self.user
         self.assertFalse(self.creator_admin.has_change_permission(self.request))
-
-    def test_rate_limit_login(self):
-        with mock.patch.dict('django.conf.settings.FEATURES', {'ENABLE_CREATOR_GROUP': True}):
-            post_params = {'username': self.user.username, 'password': 'wrong_password'}
-            # try logging in 30 times, the default limit in the number of failed
-            # login attempts in one 5 minute period before the rate gets limited
-            for _ in range(30):
-                response = self.client.post('/admin/login/', post_params)
-                self.assertEqual(response.status_code, 200)
-
-            response = self.client.post('/admin/login/', post_params)
-            # Since we are using the default rate limit behavior, we are
-            # expecting this to return a 403 error to indicate that there have
-            # been too many attempts
-            self.assertEqual(response.status_code, 403)

--- a/cms/templates/admin/base_site.html
+++ b/cms/templates/admin/base_site.html
@@ -17,7 +17,7 @@
         {% endif %}
     {% endif %}
 
-    {% flag "user_authn.redirect_to_lms" %}
+    {% flag "user_authn.admin_auth_redirect_to_lms" %}
         <a href="/logout/">{% trans 'Log out' as tmsg %} {{tmsg|force_escape}}</a>
     {% else %}
         <a href="{% url 'admin:logout' %}">{% trans 'Log out' as tmsg %} {{tmsg|force_escape}}</a>

--- a/cms/templates/admin/base_site.html
+++ b/cms/templates/admin/base_site.html
@@ -1,5 +1,6 @@
 {% extends "admin/base.html" %}
 {% load i18n admin_urls %}
+{% load waffle_tags %}
 {% block title %}{{ title }} | {{ site_title|default:_('Django site admin') }}{% endblock %}
 {% block branding %}
 <h1 id="site-name"><a href="{% url 'admin:index' %}">{{ site_header|default:_('Django administration') }}</a></h1>
@@ -15,5 +16,11 @@
             <a href="{{ docsroot }}">{% trans 'Documentation' as tmsg %} {{tmsg|force_escape}}</a> /
         {% endif %}
     {% endif %}
-    <a href="{% url 'admin:logout' %}">{% trans 'Log out' as tmsg %} {{tmsg|force_escape}}</a>
+
+    {% flag "user_authn.redirect_to_lms" %}
+        <a href="/logout/">{% trans 'Log out' as tmsg %} {{tmsg|force_escape}}</a>
+    {% else %}
+        <a href="{% url 'admin:logout' %}">{% trans 'Log out' as tmsg %} {{tmsg|force_escape}}</a>
+    {% endflag %}
+
 {% endblock %}

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -230,6 +230,9 @@ if settings.FEATURES.get('ENABLE_SERVICE_STATUS'):
 if not settings.FEATURES.get('ENABLE_CHANGE_USER_PASSWORD_ADMIN'):
     urlpatterns.append(re_path(r'^admin/auth/user/\d+/password/$', handler404))
 urlpatterns.append(path('admin/password_change/', handler404))
+urlpatterns.append(
+    path('admin/login/', contentstore_views.redirect_to_lms_login_for_admin, name='redirect_to_lms_login_for_admin')
+)
 urlpatterns.append(path('admin/', admin.site.urls))
 
 # enable entrance exams

--- a/lms/templates/admin/base_site.html
+++ b/lms/templates/admin/base_site.html
@@ -17,7 +17,7 @@
         {% endif %}
     {% endif %}
 
-    {% flag "user_authn.redirect_to_lms" %}
+    {% flag "user_authn.admin_auth_redirect_to_lms" %}
         <a href="{% url 'logout' %}">{% trans 'Log out' as tmsg%}{{tmsg|force_escape}}</a>
     {% else %}
         <a href="{% url 'admin:logout' %}">{% trans 'Log out' as tmsg%}{{tmsg|force_escape}}</a>

--- a/lms/templates/admin/base_site.html
+++ b/lms/templates/admin/base_site.html
@@ -1,5 +1,6 @@
 {% extends "admin/base.html" %}
 {% load i18n admin_urls %}
+{% load waffle_tags %}
 {% block title %}{{ title }} | {{ site_title|default:_('Django site admin') }}{% endblock %}
 {% block branding %}
 <h1 id="site-name"><a href="{% url 'admin:index' %}">{{ site_header|default:_('Django administration') }}</a></h1>
@@ -15,5 +16,11 @@
             <a href="{{ docsroot }}">{% trans 'Documentation' as tmsg%}{{tmsg|force_escape}}</a> /
         {% endif %}
     {% endif %}
-    <a href="{% url 'admin:logout' %}">{% trans 'Log out' as tmsg%}{{tmsg|force_escape}}</a>
+
+    {% flag "user_authn.redirect_to_lms" %}
+        <a href="{% url 'logout' %}">{% trans 'Log out' as tmsg%}{{tmsg|force_escape}}</a>
+    {% else %}
+        <a href="{% url 'admin:logout' %}">{% trans 'Log out' as tmsg%}{{tmsg|force_escape}}</a>
+    {% endflag %}
+
 {% endblock %}

--- a/openedx/core/djangoapps/user_authn/config/waffle.py
+++ b/openedx/core/djangoapps/user_authn/config/waffle.py
@@ -42,10 +42,10 @@ ENABLE_PWNED_PASSWORD_API = LegacyWaffleSwitch(
 # .. toggle_name: REDIRECT_TO_LMS
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
-# .. toggle_description: Set this to True if you want to cms-admin login from lms login.
-# .. in case of logout it will use lms logout also.
+# .. toggle_description: Set this to True if you want to redirect cms-admin login to lms login.
+#   In case of logout it will use lms logout also.
 # .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 8-Feb-2022
+# .. toggle_creation_date: 2022-02-08
 # .. toggle_target_removal_date: None
 # .. toggle_warnings: This temporary feature toggle does not have a target removal date.
 REDIRECT_TO_LMS = WaffleFlag(   # lint-amnesty, pylint: disable=toggle-missing-annotation

--- a/openedx/core/djangoapps/user_authn/config/waffle.py
+++ b/openedx/core/djangoapps/user_authn/config/waffle.py
@@ -39,7 +39,7 @@ ENABLE_PWNED_PASSWORD_API = LegacyWaffleSwitch(
 )
 
 
-# .. toggle_name: REDIRECT_TO_LMS
+# .. toggle_name: ADMIN_AUTH_REDIRECT_TO_LMS
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Set this to True if you want to redirect cms-admin login to lms login.
@@ -47,7 +47,6 @@ ENABLE_PWNED_PASSWORD_API = LegacyWaffleSwitch(
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2022-02-08
 # .. toggle_target_removal_date: None
-# .. toggle_warnings: This temporary feature toggle does not have a target removal date.
-REDIRECT_TO_LMS = WaffleFlag(   # lint-amnesty, pylint: disable=toggle-missing-annotation
-    "user_authn.redirect_to_lms", module_name=__name__
+ADMIN_AUTH_REDIRECT_TO_LMS = WaffleFlag(   # lint-amnesty, pylint: disable=toggle-missing-annotation
+    "user_authn.admin_auth_redirect_to_lms", module_name=__name__
 )

--- a/openedx/core/djangoapps/user_authn/config/waffle.py
+++ b/openedx/core/djangoapps/user_authn/config/waffle.py
@@ -3,7 +3,7 @@ Waffle flags and switches for user authn.
 """
 
 
-from edx_toggles.toggles import LegacyWaffleSwitch, LegacyWaffleSwitchNamespace
+from edx_toggles.toggles import LegacyWaffleSwitch, LegacyWaffleSwitchNamespace, WaffleFlag
 
 _WAFFLE_NAMESPACE = 'user_authn'
 _WAFFLE_SWITCH_NAMESPACE = LegacyWaffleSwitchNamespace(name=_WAFFLE_NAMESPACE, log_prefix='UserAuthN: ')
@@ -36,4 +36,18 @@ ENABLE_PWNED_PASSWORD_API = LegacyWaffleSwitch(
     _WAFFLE_SWITCH_NAMESPACE,
     'enable_pwned_password_api',
     __name__
+)
+
+
+# .. toggle_name: REDIRECT_TO_LMS
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Set this to True if you want to cms-admin login from lms login.
+# .. in case of logout it will use lms logout also.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 8-Feb-2022
+# .. toggle_target_removal_date: None
+# .. toggle_warnings: This temporary feature toggle does not have a target removal date.
+REDIRECT_TO_LMS = WaffleFlag(   # lint-amnesty, pylint: disable=toggle-missing-annotation
+    "user_authn.redirect_to_lms", module_name=__name__
 )

--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -43,7 +43,7 @@ from common.djangoapps.util.password_policy_validators import normalize_password
 from openedx.core.djangoapps.password_policy import compliance as password_policy_compliance
 from openedx.core.djangoapps.safe_sessions.middleware import mark_user_change_as_expected
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-from openedx.core.djangoapps.user_authn.config.waffle import ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY, REDIRECT_TO_LMS
+from openedx.core.djangoapps.user_authn.config.waffle import ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY, ADMIN_AUTH_REDIRECT_TO_LMS
 from openedx.core.djangoapps.user_authn.cookies import get_response_with_refreshed_jwt_cookies, set_logged_in_cookies
 from openedx.core.djangoapps.user_authn.exceptions import AuthFailedError
 from openedx.core.djangoapps.user_authn.toggles import (
@@ -655,7 +655,7 @@ def redirect_to_lms_login(request):
     This view redirect the admin/login url to the site's login page if
     waffle switch is on otherwise returns the admin site's login view.
     """
-    if ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY.is_enabled() or REDIRECT_TO_LMS.is_enabled():
+    if ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY.is_enabled() or ADMIN_AUTH_REDIRECT_TO_LMS.is_enabled():
         return redirect('/login?next=/admin')
     else:
         return admin.site.login(request)

--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -43,7 +43,7 @@ from common.djangoapps.util.password_policy_validators import normalize_password
 from openedx.core.djangoapps.password_policy import compliance as password_policy_compliance
 from openedx.core.djangoapps.safe_sessions.middleware import mark_user_change_as_expected
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-from openedx.core.djangoapps.user_authn.config.waffle import ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY
+from openedx.core.djangoapps.user_authn.config.waffle import ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY, REDIRECT_TO_LMS
 from openedx.core.djangoapps.user_authn.cookies import get_response_with_refreshed_jwt_cookies, set_logged_in_cookies
 from openedx.core.djangoapps.user_authn.exceptions import AuthFailedError
 from openedx.core.djangoapps.user_authn.toggles import (
@@ -655,7 +655,7 @@ def redirect_to_lms_login(request):
     This view redirect the admin/login url to the site's login page if
     waffle switch is on otherwise returns the admin site's login view.
     """
-    if ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY.is_enabled():
+    if ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY.is_enabled() or REDIRECT_TO_LMS.is_enabled():
         return redirect('/login?next=/admin')
     else:
         return admin.site.login(request)

--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -43,7 +43,10 @@ from common.djangoapps.util.password_policy_validators import normalize_password
 from openedx.core.djangoapps.password_policy import compliance as password_policy_compliance
 from openedx.core.djangoapps.safe_sessions.middleware import mark_user_change_as_expected
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-from openedx.core.djangoapps.user_authn.config.waffle import ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY, ADMIN_AUTH_REDIRECT_TO_LMS
+from openedx.core.djangoapps.user_authn.config.waffle import (
+    ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY,
+    ADMIN_AUTH_REDIRECT_TO_LMS
+)
 from openedx.core.djangoapps.user_authn.cookies import get_response_with_refreshed_jwt_cookies, set_logged_in_cookies
 from openedx.core.djangoapps.user_authn.exceptions import AuthFailedError
 from openedx.core.djangoapps.user_authn.toggles import (

--- a/openedx/core/tests/test_admin_view.py
+++ b/openedx/core/tests/test_admin_view.py
@@ -6,8 +6,9 @@ This is not inside a django app because it is a global property of the system.
 
 from django.test import Client, TestCase
 from django.urls import reverse
-from edx_toggles.toggles.testutils import override_waffle_switch
+from edx_toggles.toggles.testutils import override_waffle_switch, override_waffle_flag
 from common.djangoapps.student.tests.factories import UserFactory, TEST_PASSWORD
+from openedx.core.djangoapps.user_authn.config.waffle import REDIRECT_TO_LMS
 
 from openedx.core.djangoapps.user_authn.views.login import ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY
 
@@ -43,6 +44,16 @@ class TestAdminView(TestCase):
             response = self.client.get(reverse('admin:login'))
             assert response.url == '/login?next=/admin'
             assert response.status_code == 302
+
+        with override_waffle_flag(REDIRECT_TO_LMS, True):
+            response = self.client.get(reverse('admin:login'))
+            assert response.url == '/login?next=/admin'
+            assert response.status_code == 302
+
         with override_waffle_switch(ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY, False):
+            response = self.client.get(reverse('admin:login'))
+            assert response.template_name == ['admin/login.html']
+
+        with override_waffle_flag(REDIRECT_TO_LMS, False):
             response = self.client.get(reverse('admin:login'))
             assert response.template_name == ['admin/login.html']

--- a/openedx/core/tests/test_admin_view.py
+++ b/openedx/core/tests/test_admin_view.py
@@ -8,7 +8,7 @@ from django.test import Client, TestCase
 from django.urls import reverse
 from edx_toggles.toggles.testutils import override_waffle_switch, override_waffle_flag
 from common.djangoapps.student.tests.factories import UserFactory, TEST_PASSWORD
-from openedx.core.djangoapps.user_authn.config.waffle import REDIRECT_TO_LMS
+from openedx.core.djangoapps.user_authn.config.waffle import ADMIN_AUTH_REDIRECT_TO_LMS
 
 from openedx.core.djangoapps.user_authn.views.login import ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY
 
@@ -45,7 +45,7 @@ class TestAdminView(TestCase):
             assert response.url == '/login?next=/admin'
             assert response.status_code == 302
 
-        with override_waffle_flag(REDIRECT_TO_LMS, True):
+        with override_waffle_flag(ADMIN_AUTH_REDIRECT_TO_LMS, True):
             response = self.client.get(reverse('admin:login'))
             assert response.url == '/login?next=/admin'
             assert response.status_code == 302
@@ -54,6 +54,6 @@ class TestAdminView(TestCase):
             response = self.client.get(reverse('admin:login'))
             assert response.template_name == ['admin/login.html']
 
-        with override_waffle_flag(REDIRECT_TO_LMS, False):
+        with override_waffle_flag(ADMIN_AUTH_REDIRECT_TO_LMS, False):
             response = self.client.get(reverse('admin:login'))
             assert response.template_name == ['admin/login.html']


### PR DESCRIPTION
- CMS admin login will redirect it towards `lms-login` page.
- Logout from admin will redirect towards studio logout and then redirected towards lms logout.
- Added waffle flag.


[BOM-2855](https://openedx.atlassian.net/browse/BOM-2855)


**Current behaviour before this PR :**
**Admin login to LMS:**
- `securedomain.courses.stage.com/admin` will take you towards  `lms` login. After giving proper credentials it will take you towards the (https://courses.stage.edx.org/admin) with `403 Forbidden msg`. Now manually add the securedomain in url to access the admin page.
- Logout takes you towards admin logout page. After this PR it will call the lms logout.
**Admin login to CMS:**
- `studio-securedomain.stage.edx.org/admin` will take you towards admin login page ( here need a fix to redirect towards lms login )

In case of logout call lms logout 

TODO: Add a waffle flag on stage and prod. https://github.com/edx/app-permissions/pull/1670

- [x] [Sandbox](https://awais786.sandbox.edx.org/) testing done.