### PR TITLE
fix: More resilience when calling `encrypt_for_log` with missing key

### DIFF
--- a/common/djangoapps/util/tests/test_log_sensitive.py
+++ b/common/djangoapps/util/tests/test_log_sensitive.py
@@ -3,7 +3,13 @@ Tests for util.logging
 """
 
 import re
+
 from common.djangoapps.util.log_sensitive import decrypt_log_message, encrypt_for_log, generate_reader_keys
+
+
+def test_encryption_no_key():
+    to_log = encrypt_for_log("Testing testing 1234", None)
+    assert to_log == '[encryption failed, no key]'
 
 
 def test_encryption_round_trip():

--- a/openedx/core/djangoapps/safe_sessions/middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/middleware.py
@@ -765,7 +765,7 @@ class SafeSessionMiddleware(SessionMiddleware, MiddlewareMixin):
         """
         # NOTE: request.headers seems to pick up initial values, but won't adjust as the request object is edited.
         #   For example, the session cookie will likely be the safe session version.
-        return encrypt_for_log(str(request.headers), settings.SAFE_SESSIONS_DEBUG_PUBLIC_KEY)
+        return encrypt_for_log(str(request.headers), getattr(settings, 'SAFE_SESSIONS_DEBUG_PUBLIC_KEY', None))
 
 
 def obscure_token(value: Union[str, None]) -> Union[str, None]:


### PR DESCRIPTION
It's likely that someone will at some point enable encrypted logging but
forget to deploy the config change that sets the key; if this happens, we
should gracefully return a warning rather than raise an exception.

Along the same lines, make sure that safe-sessions won't raise an exception
if the setting is missing, and document the suggested use of getattr.

Impacted roles: Operator