### PR TITLE
Added date configuration to Schedule & Details settings page

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -1156,6 +1156,11 @@ def settings_handler(request, course_key_string):  # lint-amnesty, pylint: disab
             verified_mode = CourseMode.verified_mode_for_course(course_key, include_expired=True)
             upgrade_deadline = (verified_mode and verified_mode.expiration_datetime and
                                 verified_mode.expiration_datetime.isoformat())
+            date_configuration_format = configuration_helpers.get_value_for_org(
+                course_module.locations.org,
+                'DETAIL_SCHEDULE_FORMAT',
+                settings.FEATURES.get('DETAIL_SCHEDULE_FORMAT', 'mm/dd/yyyy')
+            ).upper()
             settings_context = {
                 'context_course': course_module,
                 'course_locator': course_key,
@@ -1180,6 +1185,7 @@ def settings_handler(request, course_key_string):  # lint-amnesty, pylint: disab
                 'enable_extended_course_details': enable_extended_course_details,
                 'upgrade_deadline': upgrade_deadline,
                 'mfe_proctored_exam_settings_url': get_proctored_exam_settings_url(course_module.id),
+                'date_placeholder_format': date_configuration_format,
             }
             if is_prerequisite_courses_enabled():
                 courses, in_process_course_actions = get_courses_accessible_to_user(request)

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -472,6 +472,12 @@ FEATURES = {
     # .. toggle_target_removal_date: 2021-10-01
     # .. toggle_tickets: 'https://openedx.atlassian.net/browse/MICROBA-1405'
     'ENABLE_V2_CERT_DISPLAY_SETTINGS': False,
+
+    # Configure dates to show up in various formats on Schedule & Detail page
+    #  Supported formats
+    #   mm/dd/yyyy
+    #   dd/mm/yyyy
+    'DETAIL_SCHEDULE_FORMAT': 'mm/dd/yyyy'
 }
 
 # .. toggle_name: ENABLE_COPPA_COMPLIANCE

--- a/cms/static/js/utils/date_utils.js
+++ b/cms/static/js/utils/date_utils.js
@@ -97,7 +97,12 @@ function($, date, TriggerChangeEventOnEnter) {
 
         // instrument as date and time pickers
         timefield.timepicker({timeFormat: 'H:i'});
-        datefield.datepicker();
+        var placeholder = datefield.attr('placeholder')
+        if (placeholder == 'DD/MM/YYYY') {
+            datefield.datepicker({dateFormat: 'dd/mm/yy'})
+        } else {
+            datefield.datepicker();
+        }
 
         // Using the change event causes setfield to be triggered twice, but it is necessary
         // to pick up when the date is typed directly in the field.

--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -223,7 +223,7 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url | n, js_escaped_string}'
             <li class="field-group field-group-course-start" id="course-start">
               <div class="field date" id="field-course-start-date">
                 <label for="course-start-date">${_("Course Start Date")}</label>
-                <input type="text" class="start-date date start datepicker" id="course-start-date" placeholder="MM/DD/YYYY" autocomplete="off" />
+                <input type="text" class="start-date date start datepicker" id="course-start-date" placeholder="${date_placeholder_format}" autocomplete="off" />
                 <span class="icon icon-inline fa fa-calendar-check-o datepicker-icon" aria-hidden="true"></span>
                 <span class="tip tip-stacked">${_("First day the course begins")}</span>
               </div>
@@ -238,7 +238,7 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url | n, js_escaped_string}'
             <li class="field-group field-group-course-end" id="course-end">
               <div class="field date" id="field-course-end-date">
                 <label for="course-end-date">${_("Course End Date")}</label>
-                <input type="text" class="end-date date end" id="course-end-date" placeholder="MM/DD/YYYY" autocomplete="off" />
+                <input type="text" class="end-date date end" id="course-end-date" placeholder="{date_placeholder_format}" autocomplete="off" />
                 <span class="icon icon-inline fa fa-calendar-check-o datepicker-icon" aria-hidden="true"></span>
                 <span class="tip tip-stacked">${_("Last day your course is active")}</span>
               </div>
@@ -304,7 +304,7 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url | n, js_escaped_string}'
                 <div class="field date" id="field-certificate-available-date" >
               % endif
                 <label for="certificate-available-date">${_("Certificates Available Date")}</label>
-                <input type="text" class="certificate-available-date date start datepicker" id="certificate-available-date" placeholder="MM/DD/YYYY" autocomplete="off" />
+                <input type="text" class="certificate-available-date date start datepicker" id="certificate-available-date" placeholder="${date_placeholder_format}" autocomplete="off" />
                 <span class="icon icon-inline fa fa-calendar-check-o datepicker-icon" aria-hidden="true"></span>
               </div>
             </li>
@@ -315,7 +315,7 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url | n, js_escaped_string}'
             <li class="field-group field-group-enrollment-start" id="enrollment-start">
               <div class="field date" id="field-enrollment-start-date">
                 <label for="course-enrollment-start-date">${_("Enrollment Start Date")}</label>
-                <input type="text" class="start-date date start" id="course-enrollment-start-date" placeholder="MM/DD/YYYY" autocomplete="off" />
+                <input type="text" class="start-date date start" id="course-enrollment-start-date" placeholder="${date_placeholder_format}" autocomplete="off" />
                 <span class="icon icon-inline fa fa-calendar-check-o datepicker-icon" aria-hidden="true"></span>
                 <span class="tip tip-stacked">${_("First day students can enroll")}</span>
               </div>
@@ -333,7 +333,7 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url | n, js_escaped_string}'
             <li class="field-group field-group-enrollment-end" id="enrollment-end">
               <div class="field date ${enrollment_end_editable_class}" id="field-enrollment-end-date">
                 <label for="course-enrollment-end-date">${_("Enrollment End Date")}</label>
-                <input type="text" class="end-date date end" id="course-enrollment-end-date" placeholder="MM/DD/YYYY" autocomplete="off" ${enrollment_end_readonly} />
+                <input type="text" class="end-date date end" id="course-enrollment-end-date" placeholder="${date_placeholder_format}" autocomplete="off" ${enrollment_end_readonly} />
                 <span class="icon icon-inline fa fa-calendar-check-o datepicker-icon" aria-hidden="true"></span>
                 <span class="tip tip-stacked">
                   ${_("Last day students can enroll.")}
@@ -356,7 +356,7 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url | n, js_escaped_string}'
             <li class="field-group field-group-upgrade-deadline" id="upgrade-deadline">
               <div class="field date is-not-editable" id="field-upgrade-deadline-date">
                 <label for="course-upgrade-deadline-date">${_("Upgrade Deadline Date")}</label>
-                <input type="text" class="date upgrade-deadline" id="course-upgrade-deadline-date" placeholder="MM/DD/YYYY" autocomplete="off" readonly aria-readonly="true" />
+                <input type="text" class="date upgrade-deadline" id="course-upgrade-deadline-date" placeholder="${date_placeholder_format}" autocomplete="off" readonly aria-readonly="true" />
                 <span class="tip tip-stacked">
                   ${_("Last day students can upgrade to a verified enrollment.")}
                   ${_("Contact your {platform_name} partner manager to update these settings.").format(platform_name=settings.PLATFORM_NAME)}


### PR DESCRIPTION
## Description

Adds the ability to configure Schedule & Details settings page with the ability to show `dd/mm/yyyy` format. Default setting maintains existing behavior and doesn't introduce anything new.
Why:
Some areas of the world operate with the day-first: `dd/mm/yyyy` rather than `mm/dd/yyyy`.

Useful information to include:
- No change to role(s)
- There is no before or after, as the change includes default configuration to remain consistent with preexisting behavior. 
- https://github.com/open-craft/edx-platform/blob/jbcurtin/bb-5429-date-configuration/cms/envs/common.py#L459

## Testing instructions

* Initialize devstack to use branch
* Open file `cms/env/common.py` and find `SCHEDULE_DETAIL_FORMAT`. Alter the string value from `mm/dd/yyyy` -> `dd/mm/yyyy`.
* Load Schedule & Details page ( http://localhost:18010/settings/details/course-v1:edX+DemoX+Demo_Course )
* Scroll down to Course Schedule. Notice the placeholder format in the date-fields.
* Click in various date-fields and make sure the dates are correctly applied in format: `dd/mm/yyyy`

## Deadline

None as of now.