### PR TITLE
build: use pinned Django version for tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,7 +13,9 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.8']
-        django-version: ["3.2"]
+        django-version:
+          - "pinned"
+          #- "4.0"
         shard_name: [
             "lms-1",
             "lms-2",
@@ -37,7 +39,9 @@ jobs:
     steps:
       - name: sync directory owner
         run: sudo chown runner:runner -R .*
-      - uses: actions/checkout@v2
+
+      - name: checkout repo
+        uses: actions/checkout@v2
 
       # This gives Mongo several chances to start. We started getting flakiness
       # around 2022-02-15 wherein the start command would sometimes exit with:
@@ -58,7 +62,15 @@ jobs:
         run: |
           sudo pip install -r requirements/pip.txt
           sudo pip install -r requirements/edx/testing.txt
-          sudo pip install "django~=${{ matrix.django-version }}.0"
+          if [[ "${{ matrix.django-version }}" == "pinned" ]]; then
+            sudo pip install -r requirements/edx/django.txt
+          else
+            sudo pip install "django~=${{ matrix.django-version }}.0"
+          fi
+
+      - name: list installed package versions
+        run: |
+          sudo pip freeze
 
       - name: Setup and run tests
         uses: ./.github/actions/unit-tests
@@ -90,5 +102,3 @@ jobs:
           name: pytest-warning-report-html
           path: |
             reports/pytest_warnings/warning_report_all.html
-
-


### PR DESCRIPTION
The existing method of installing Django will continue to use 3.2.11 even though 3.2.12 is available.  We ran into this on the maple.master branch when we upgraded the pin to 3.2.12, and saw that the tests were still using 3.2.11

I've tried to accommodate both "master" and "upgrading" workflows here with the Django matrix, but maybe there is a better way?  Installing "Django==~4.0.0"  won't work now because it conflicts with too many of our other requirements.  

Note: I've made one change to the action just for temporary testing of this pull request.