### PR TITLE
feat: Create and use own get_client_ip (only in rate-limiting, for now)

### DIFF
--- a/openedx/core/djangoapps/util/ip.py
+++ b/openedx/core/djangoapps/util/ip.py
@@ -1,0 +1,186 @@
+"""
+Utilities for determining the IP address of a request.
+
+``get_client_ip`` is the main function of interest.
+"""
+
+import ipaddress
+import warnings
+
+from django.conf import settings
+
+
+def get_meta_ips(request_meta, header_name):
+    """
+    Return the list of IPs the request is carrying on this header, which is
+    expected to be comma-delimited if it contains more than one. Response
+    may be an empty list for missing or empty header. List items may not be
+    valid IPs.
+    """
+    if not header_name:
+        return []
+
+    field_name = 'HTTP_' + header_name.replace('-', '_').upper()
+    header_value = request_meta.get(field_name, '').strip()
+
+    if header_value:
+        return [s.strip() for s in header_value.split(',')]
+    else:
+        return []
+
+
+def get_client_ip_by_one_header(request_meta, header_name, index):
+    """
+    Implementation of ``get_client_ip_via_configured_header`` for one header.
+    Returns None if header name and index can't be used.
+    """
+    ip_strs = get_meta_ips(request_meta, header_name)
+
+    if not ip_strs:
+        warnings.warn(f"Configured IP address header was missing: {header_name!r}", UserWarning)
+        return None
+
+    try:
+        return ip_strs[index]
+    except IndexError:
+        warnings.warn(
+            "Configured index into IP address header is out of range: "
+            f"{header_name!r}:{index!r} "
+            f"(actual length {len(ip_strs)})",
+            UserWarning
+        )
+        return None
+
+
+# .. setting_name: CLIENT_IP_HEADERS
+# .. setting_default: []
+# .. setting_description: A list of header/index pairs to use for determining the client's IP
+#   address. Each entry is a map like ``{'name': 'X-Forwarded-For', 'index': -2}``. This will
+#   control how the client's IP address is determined for attribution, tracking, rate-limiting,
+#   or other general-purpose needs.
+#
+#   The named header must contain a list of IP addresses separated by commas, with whitespace
+#   tolerated around each address. (The list must contain at least one address.) The index is
+#   used for a Python list lookup, e.g. 0 is the first element and -2 is the second from the end.
+#   Header/index pairs will be tried in turn and if none yields a result (header missing or index
+#   out of range) or the list is empty, then the client IP will instead be drawn from
+#   ``X-Forwarded-For`` and ``REMOTE_ADDR``.
+#
+#   Deployers using a single local proxy (e.g. a Tutor installation with caddy acting as reverse
+#   proxy, and the LMS or CMS otherwise directly exposed to the internet) will likely be fine
+#   with the default behavior.
+#
+#   For deployments behind a CDN, there may be a CDN-specific header to use. For example,
+#   Cloudflare provides ``CF-Connecting-IP``. In this case, a setting of
+#   ``[{'name': 'CF-Connecting-IP', 'index': 0}]`` would be the most appropriate choice.
+#
+#   Migrations from one network configuration to another may be accomplished by first adding the
+#   new header to the list, making the networking change, and then removing the old one.
+# .. setting_warnings: Changes to the networking configuration that are not coordinated with
+#   this setting may allow callers to spoof their IP address.
+
+
+def get_client_ip_via_configured_headers(request_meta):
+    """
+    Get the client IP by using first usable ``CLIENT_IP_HEADERS`` lookup.
+    Return None if headers all missing or indexes are out of range (or no
+    headers configured.)
+    """
+    for entry in getattr(settings, 'CLIENT_IP_HEADERS', []):
+        if client_ip := get_client_ip_by_one_header(request_meta, entry['name'], entry['index']):
+            return client_ip
+    return None
+
+
+def conservatively_pick_client_ip(chain):
+    """
+    Given a list of (maybe) IP addresses, walk from right to left and pick
+    the one most likely to be the client's IP address.
+
+    - Does not trust that any public IP is an honest proxy (meaning, a proxy
+      which will honestly set or append to X-Forwarded-For).
+    - Tries to find the first public IP but will return a private IP if no
+      public IPs are found.
+    - Returns None if an invalid IP is encountered before the first
+      valid one.
+    """
+    chain = chain[:]  # copy to allow mutation
+
+    # The last IP address we saw, and which we consider as the
+    # conservatively correct choice unless something better comes up.
+    #
+    # This is a parsed IP. We'll stringify it before returning. This
+    # avoids parser-confusion problems where the decider (this code)
+    # and the actor (relying code) work with different interpretations
+    # of any malformed data.
+    current_ip = None
+
+    while len(chain) > 0:
+        try:
+            next_ip = ipaddress.ip_address(chain.pop())
+        except ValueError:
+            # Failed to parse! So, return the current one, even if
+            # it's suboptimal. This could actually be a perfectly fine
+            # IP.  Perhaps the server is directly exposed to the
+            # internet (REMOTE_ADDR is a public IP) and the client
+            # sends in a garbage XFF.
+            return current_ip and str(current_ip)
+
+        if next_ip.is_global:
+            # Lacking any knowledge of trusted proxies and other network
+            # configuration, the first public IP we find is the best we
+            # can do.
+            return str(next_ip)
+        else:
+            # If we're still seeing private-space IPs, keep walking;
+            # maybe we'll find a public one! But keep hold of this as
+            # "current"; we may need to fall back to this if the next
+            # one just turns out to be garbage.
+            current_ip = next_ip
+
+    # Ran off the front of the list, so go with what we have. This
+    # would have to be a private IP, or None if the list was in fact
+    # empty to begin with.
+    return current_ip and str(current_ip)
+
+
+def get_client_ip_via_xff(request_meta):
+    """
+    Get the most likely client IP from the X-Forwarded-For chain, conservatively.
+
+    Pick the first publicly routable IP seen while walking from right to left
+    (starting with REMOTE_ADDR), unless the list is exhausted or an invalid IP
+    is found, in which case use the last IP before that.
+    """
+    # The REMOTE_ADDR is implicitly the beginning of the XFF chain
+    # (this is what we would attach if we were a proxy!), so add it on
+    # explicitly.  This is the IP address we can always rely on
+    # having. If we're behind a proxy it may be a private IP, and if
+    # we're serving directly to the internet then it may well be the
+    # client IP.
+    full_chain = get_meta_ips(request_meta, 'X-Forwarded-For') + [request_meta['REMOTE_ADDR']]
+    chosen_ip = conservatively_pick_client_ip(full_chain)
+
+    # In practice this fallback should never happen, since it would require
+    # REMOTE_ADDR (at the end of the chain above) to be malformed.
+    return chosen_ip or request_meta['REMOTE_ADDR']
+
+
+def get_client_ip(request):
+    """
+    Determine the IP address of the HTTP client by walking the X-Forwarded-For
+    header, unless there's a configured override.
+    """
+    # Restore the original REMOTE_ADDR since it's needed for IP determination.
+    # Once XForwardedForMiddleware is no longer overwriting REMOTE_ADDR this
+    # rewriting can be removed.
+    #
+    # This is also the reason all the other functions in this module take a
+    # request.META -- it's easier to pass in an altered META dict than an
+    # altered request, and this keeps the ORIGINAL_REMOTE_ADDR pollution out
+    # of the other code, making it marginally more reusable.
+    request_meta = request.META.copy()
+    if 'ORIGINAL_REMOTE_ADDR' in request_meta:
+        request_meta['REMOTE_ADDR'] = request_meta['ORIGINAL_REMOTE_ADDR']
+
+    return get_client_ip_via_configured_headers(request_meta) or get_client_ip_via_xff(request_meta)

--- a/openedx/core/djangoapps/util/ip.py
+++ b/openedx/core/djangoapps/util/ip.py
@@ -169,7 +169,7 @@ def get_client_ip_via_xff(request_meta):
 def get_client_ip(request):
     """
     Determine the IP address of the HTTP client.
-    
+
     First searches for IP using CLIENT_IP_HEADERS configuration. If an IP
     is not found, the IP is determined by walking the X-Forwarded-For header.
     """

--- a/openedx/core/djangoapps/util/ip.py
+++ b/openedx/core/djangoapps/util/ip.py
@@ -173,8 +173,11 @@ def get_client_ip(request):
     First searches for IP using CLIENT_IP_HEADERS configuration. If an IP
     is not found, the IP is determined by walking the X-Forwarded-For header.
     """
-    # Restore the original REMOTE_ADDR since it's needed for IP determination.
-    # Once XForwardedForMiddleware is no longer overwriting REMOTE_ADDR this
+    # The XForwardedForMiddleware currently overwrites `REMOTE_ADDR`, but
+    # IP determination requires the original `REMOTE_ADDR`. This will restore
+    # the original REMOTE_ADDR in a copy of request.META.
+    #
+    # TODO: If XForwardedForMiddleware no longer overwrites REMOTE_ADDR, this
     # rewriting can be removed.
     #
     # This is also the reason all the other functions in this module take a

--- a/openedx/core/djangoapps/util/ip.py
+++ b/openedx/core/djangoapps/util/ip.py
@@ -168,8 +168,10 @@ def get_client_ip_via_xff(request_meta):
 
 def get_client_ip(request):
     """
-    Determine the IP address of the HTTP client by walking the X-Forwarded-For
-    header, unless there's a configured override.
+    Determine the IP address of the HTTP client.
+    
+    First searches for IP using CLIENT_IP_HEADERS configuration. If an IP
+    is not found, the IP is determined by walking the X-Forwarded-For header.
     """
     # Restore the original REMOTE_ADDR since it's needed for IP determination.
     # Once XForwardedForMiddleware is no longer overwriting REMOTE_ADDR this

--- a/openedx/core/djangoapps/util/ratelimit.py
+++ b/openedx/core/djangoapps/util/ratelimit.py
@@ -3,11 +3,11 @@ Code to get ip from request.
 """
 from uuid import uuid4
 
-from ipware.ip import get_client_ip
+from openedx.core.djangoapps.util.ip import get_client_ip
 
 
 def real_ip(group, request):  # pylint: disable=unused-argument
-    return get_client_ip(request)[0]
+    return get_client_ip(request)
 
 
 def request_post_email(group, request) -> str:  # pylint: disable=unused-argument

--- a/openedx/core/djangoapps/util/tests/test_ip.py
+++ b/openedx/core/djangoapps/util/tests/test_ip.py
@@ -108,19 +108,19 @@ class TestClientIP(TestCase):
 
     @ddt.unpack
     @ddt.data(
-        # Nothing usable
-        ([], None),
-        (['XXXXXXXXX'], None),
-        # Simple cases, private and public
-        (['::1'], '::1'),
+        # Walk left until first public IP
         (['1.2.3.4'], '1.2.3.4'),
+        (['1.2.3.4', '5.6.7.8', '10.0.0.1', '127.0.0.1'], '5.6.7.8'),
+        # Or until there's junk or we run out of IPs, even if the best we can do is a private IP
+        (['1.2.3.4', 'XXXXXXXXX', '10.0.0.1', '127.0.0.1'], '10.0.0.1'),
+        (['::1'], '::1'),
         # If we get a public IP, don't worry about junk farther on
         (['XXXXXXXXX', '1.2.3.4', '2606:4700::'], '2606:4700::'),
         (['XXXXXXXXX', '2606:4700::', '10.0.0.1'], '2606:4700::'),
-        # Walk left until first public IP
-        (['1.2.3.4', '5.6.7.8', '10.0.0.1', '127.0.0.1'], '5.6.7.8'),
-        # Or until there's junk, even if the best we can do is a private IP
-        (['1.2.3.4', 'XXXXXXXXX', '10.0.0.1', '127.0.0.1'], '10.0.0.1'),
+        # Nothing usable
+        ([], None),
+        (['XXXXXXXXX'], None),
+        (['1.2.3.4', 'XXXXXXXXX'], None),
     )
     def test_conservative_walk(self, chain, expected):
         assert ip.conservatively_pick_client_ip(chain) == expected

--- a/openedx/core/djangoapps/util/tests/test_ip.py
+++ b/openedx/core/djangoapps/util/tests/test_ip.py
@@ -79,10 +79,9 @@ class TestClientIP(TestCase):
             [
                 {'name': 'CF-Connecting-IP', 'index': 0},
                 {'name': 'X-Forwarded-For', 'index': -2},
-                {'name': 'X-Real-IP', 'index': 0},
             ],
             None,
-            3,
+            2,
         ),
         # One lookup failure before finding a usable header
         (
@@ -92,7 +91,6 @@ class TestClientIP(TestCase):
             [
                 {'name': 'CF-Connecting-IP', 'index': 0},
                 {'name': 'X-Forwarded-For', 'index': -2},
-                {'name': 'X-Real-IP', 'index': 0},
             ],
             '3.3.3.3',
             1,

--- a/openedx/core/djangoapps/util/tests/test_ip.py
+++ b/openedx/core/djangoapps/util/tests/test_ip.py
@@ -110,17 +110,17 @@ class TestClientIP(TestCase):
     @ddt.data(
         # Nothing usable
         ([], None),
-        (['any-old-junk'], None),
+        (['XXXXXXXXX'], None),
         # Simple cases, private and public
         (['::1'], '::1'),
         (['1.2.3.4'], '1.2.3.4'),
         # If we get a public IP, don't worry about junk farther on
-        (['junk', '1.2.3.4', '2606:4700::'], '2606:4700::'),
-        (['junk', '2606:4700::', '10.0.0.1'], '2606:4700::'),
+        (['XXXXXXXXX', '1.2.3.4', '2606:4700::'], '2606:4700::'),
+        (['XXXXXXXXX', '2606:4700::', '10.0.0.1'], '2606:4700::'),
         # Walk left until first public IP
         (['1.2.3.4', '5.6.7.8', '10.0.0.1', '127.0.0.1'], '5.6.7.8'),
         # Or until there's junk, even if the best we can do is a private IP
-        (['1.2.3.4', 'XXXXXXX', '10.0.0.1', '127.0.0.1'], '10.0.0.1'),
+        (['1.2.3.4', 'XXXXXXXXX', '10.0.0.1', '127.0.0.1'], '10.0.0.1'),
     )
     def test_conservative_walk(self, chain, expected):
         assert ip.conservatively_pick_client_ip(chain) == expected

--- a/openedx/core/djangoapps/util/tests/test_ip.py
+++ b/openedx/core/djangoapps/util/tests/test_ip.py
@@ -35,7 +35,7 @@ class TestClientIP(TestCase):
 
     @ddt.unpack
     @ddt.data(
-        ({}, 'Something', []),
+        ({}, 'Some-Thing', []),
         ({'HTTP_SOME_THING': 'stuff'}, 'Some-Thing', ['stuff']),
         ({'HTTP_SOME_THING': 'stuff'}, 'Some-Thing', ['stuff']),
         ({'HTTP_SOME_THING': '   so,much , stuff '}, 'Some-Thing', ['so', 'much', 'stuff']),

--- a/openedx/core/djangoapps/util/tests/test_ip.py
+++ b/openedx/core/djangoapps/util/tests/test_ip.py
@@ -1,0 +1,194 @@
+"""Tests for IP determination"""
+
+import warnings
+from contextlib import contextmanager
+
+import ddt
+from django.test import TestCase
+from django.test.client import RequestFactory
+from django.test.utils import override_settings
+
+import openedx.core.djangoapps.util.ip as ip
+
+
+@contextmanager
+def warning_messages():
+    """
+    Context manager which produces a list of warning messages as the context
+    value (only populated after block ends).
+    """
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        warnings.simplefilter('always')
+        messages = []
+        yield messages
+        # Converted to message strings for easier debugging
+        messages.extend(str(w.message) for w in caught_warnings)
+
+
+@ddt.ddt
+class TestClientIP(TestCase):
+    """Tests for get_client_ip and helpers."""
+
+    def setUp(self):
+        super().setUp()
+        self.request = RequestFactory().get('/somewhere')
+
+    @ddt.unpack
+    @ddt.data(
+        ({}, 'Something', []),
+        ({'HTTP_SOME_THING': 'stuff'}, 'Some-Thing', ['stuff']),
+        ({'HTTP_SOME_THING': 'stuff'}, 'Some-Thing', ['stuff']),
+        ({'HTTP_SOME_THING': '   so,much , stuff '}, 'Some-Thing', ['so', 'much', 'stuff']),
+    )
+    def test_get_meta_ips(self, add_meta, header_name, expected):
+        self.request.META.update(add_meta)
+        assert ip.get_meta_ips(self.request.META, header_name) == expected
+
+    @ddt.unpack
+    @ddt.data(
+        # Header missing
+        ({}, 'Some-Thing', 0, None, "missing"),
+        # Header present, index out of range
+        ({'HTTP_SOME_THING': '1.2.3.4'}, 'Some-Thing', 1, None, "out of range"),
+        ({'HTTP_SOME_THING': '1.2.3.4'}, 'Some-Thing', -2, None, "out of range"),
+        # Happy path
+        ({'HTTP_SOME_THING': '1.2.3.4'}, 'Some-Thing', 0, '1.2.3.4', None),
+        ({'HTTP_SOME_THING': '::6, ::5, ::4, ::3, ::2, ::1'}, 'Some-Thing', -2, '::2', None),
+    )
+    def test_get_by_one_header(self, add_meta, header_name, index, expected, warning_substr):
+        self.request.META.update(add_meta)
+
+        with warning_messages() as caught_warnings:
+            actual = ip.get_client_ip_by_one_header(self.request.META, header_name, index)
+
+        assert actual == expected
+
+        if warning_substr is None:
+            assert len(caught_warnings) == 0
+        else:
+            assert len(caught_warnings) == 1
+            assert warning_substr in caught_warnings[0]
+
+    @ddt.unpack
+    @ddt.data(
+        # No config
+        ({}, [], None, 0),
+        # Configured, but none of the headers are present
+        (
+            {},
+            [
+                {'name': 'CF-Connecting-IP', 'index': 0},
+                {'name': 'X-Forwarded-For', 'index': -2},
+                {'name': 'X-Real-IP', 'index': 0},
+            ],
+            None,
+            3,
+        ),
+        # One lookup failure before finding a usable header
+        (
+            {
+                'HTTP_X_FORWARDED_FOR': '1.1.1.1, 2.2.2.2, 3.3.3.3, 4.4.4.4'
+            },
+            [
+                {'name': 'CF-Connecting-IP', 'index': 0},
+                {'name': 'X-Forwarded-For', 'index': -2},
+                {'name': 'X-Real-IP', 'index': 0},
+            ],
+            '3.3.3.3',
+            1,
+        ),
+    )
+    def test_get_via_configured_headers(self, add_meta, cnf_headers, expected, warning_count):
+        self.request.META.update(add_meta)
+
+        with override_settings(**{'CLIENT_IP_HEADERS': cnf_headers}):
+            with warning_messages() as caught_warnings:
+                actual = ip.get_client_ip_via_configured_headers(self.request.META)
+
+        assert actual == expected
+        assert len(caught_warnings) == warning_count
+
+    @ddt.unpack
+    @ddt.data(
+        # Nothing usable
+        ([], None),
+        (['any-old-junk'], None),
+        # Simple cases, private and public
+        (['::1'], '::1'),
+        (['1.2.3.4'], '1.2.3.4'),
+        # If we get a public IP, don't worry about junk farther on
+        (['junk', '1.2.3.4', '2606:4700::'], '2606:4700::'),
+        (['junk', '2606:4700::', '10.0.0.1'], '2606:4700::'),
+        # Walk left until first public IP
+        (['1.2.3.4', '5.6.7.8', '10.0.0.1', '127.0.0.1'], '5.6.7.8'),
+        # Or until there's junk, even if the best we can do is a private IP
+        (['1.2.3.4', 'XXXXXXX', '10.0.0.1', '127.0.0.1'], '10.0.0.1'),
+    )
+    def test_conservative_walk(self, chain, expected):
+        assert ip.conservatively_pick_client_ip(chain) == expected
+
+    @ddt.unpack
+    @ddt.data(
+        # Publicly exposed server, perhaps
+        ({'REMOTE_ADDR': '4.3.2.1'}, '4.3.2.1'),
+        # ...maybe with someone trying to spoof their IP
+        ({'HTTP_X_FORWARDED_FOR': '5.5.5.5', 'REMOTE_ADDR': '4.3.2.1'}, '4.3.2.1'),
+        # If XFF is missing, just accept a private IP
+        ({'REMOTE_ADDR': '127.0.0.1'}, '127.0.0.1'),
+        # General case, walk from right
+        ({'HTTP_X_FORWARDED_FOR': '8.7.6.5, 4.3.2.1, 10.0.0.1', 'REMOTE_ADDR': '127.0.0.1'}, '4.3.2.1'),
+    )
+    def test_get_via_xff(self, add_meta, expected):
+        self.request.META.update(add_meta)
+        assert ip.get_client_ip_via_xff(self.request.META) == expected
+
+    @ddt.unpack
+    @ddt.data(
+        # By default, do something useful
+        (None, {'REMOTE_ADDR': '127.0.0.2'}, '127.0.0.2', 0),
+        # Can use arbitrary headers
+        (
+            [{'name': 'CF-Connecting-IP', 'index': 0}],
+            {'HTTP_X_FORWARDED_FOR': '4.3.2.1', 'HTTP_CF_CONNECTING_IP': '5.6.7.8', 'REMOTE_ADDR': '127.0.0.2'},
+            '5.6.7.8',
+            0,
+        ),
+        # Fall back when all override headers are unusable, with warnings
+        (
+            [
+                {'name': 'CF-Connecting-IP', 'index': 0},  # not actually passed in this request
+                {'name': 'X-Real-IP', 'index': 2},  # index out of range, so unusable
+            ],
+            {
+                'HTTP_X_FORWARDED_FOR': '5.6.7.8, 4.3.2.1, 137.0.55.99, 10.0.0.8',
+                'HTTP_X_REAL_IP': '101.102.3.4',
+                'REMOTE_ADDR': '127.0.0.2',
+            },
+            '137.0.55.99',
+            2,
+        ),
+        # Our idiosyncratic ORIGINAL_REMOTE_ADDR takes precedence
+        (
+            None,
+            {'ORIGINAL_REMOTE_ADDR': '4.3.2.1', 'REMOTE_ADDR': '5.5.5.5'},
+            '4.3.2.1',
+            0,
+        ),
+    )
+    def test_get_client_ip(self, cnf_headers, add_meta, expected, expect_warnings):
+        """
+        Just a few tests to confirm that the correct branch is taken, basically.
+        """
+        if cnf_headers is None:
+            overrides = {}
+        else:
+            overrides = {'CLIENT_IP_HEADERS': cnf_headers}
+
+        self.request.META.update(add_meta)
+
+        with override_settings(**overrides):
+            with warning_messages() as caught_warnings:
+                actual = ip.get_client_ip(self.request)
+
+        assert actual == expected
+        assert len(caught_warnings) == expect_warnings

--- a/openedx/core/lib/x_forwarded_for/middleware.py
+++ b/openedx/core/lib/x_forwarded_for/middleware.py
@@ -1,31 +1,48 @@
 """
-Middleware to use the X-Forwarded-For header as the request IP.
-Updated the libray to use HTTP_HOST and X-Forwarded-Port as
-SERVER_NAME and SERVER_PORT.
+Middleware to adjust some IP/port/host request values. This is a
+compatibility hack, and nothing should rely on the values this
+middleware sets.
 """
 from django.utils.deprecation import MiddlewareMixin
+
+import openedx.core.djangoapps.util.ip as ip
 
 
 class XForwardedForMiddleware(MiddlewareMixin):
     """
-    Gunicorn 19.0 has breaking changes for REMOTE_ADDR, SERVER_* headers
-    that can not override with forwarded and host headers.
-    This middleware can be used to update these headers set by proxy configuration.
-
+    The middleware name is now outdated, since it no longer uses a hardcoded reference
+    to X-Forwarded-For.
     """
 
-    def process_request(self, request):  # lint-amnesty, pylint: disable=useless-return
+    def process_request(self, request):
         """
-        Process the given request, update the value of REMOTE_ADDR, SERVER_NAME and SERVER_PORT based
-        on X-Forwarded-For, HTTP_HOST and X-Forwarded-Port headers
+        Process the given request, update the value of SERVER_NAME and SERVER_PORT based
+        on HTTP_HOST and X-Forwarded-Port headers
         """
-
-        for field, header in [("HTTP_X_FORWARDED_FOR", "REMOTE_ADDR"), ("HTTP_HOST", "SERVER_NAME"),
+        # Older code for the Gunicorn 19.0 upgrade. Original docstring:
+        #
+        # Gunicorn 19.0 has breaking changes for REMOTE_ADDR, SERVER_* headers
+        # that can not override with forwarded and host headers.
+        # This middleware can be used to update these headers set by proxy configuration.
+        for field, header in [("HTTP_HOST", "SERVER_NAME"),
                               ("HTTP_X_FORWARDED_PORT", "SERVER_PORT")]:
             if field in request.META:
-                if ',' in request.META[field]:
-                    request.META[header] = request.META[field].split(",")[0].strip()
-                else:
-                    request.META[header] = request.META[field]
+                request.META[header] = request.META[field]
 
-        return None
+        # This should be deleted, but is here to avoid breaking legacy
+        # code. This override was previously implemented in the above
+        # code by using the first IP in X-Forwarded-For, and just
+        # overwrote REMOTE_ADDR, which probably creates more problems
+        # elsewhere (as the full IP chain is then no longer possible
+        # to construct.)
+        #
+        # Any code that is relying on this override should instead be
+        # calling `get_client_ip` itself, which is configurable and
+        # makes it possible to handle multi-valued headers correctly.
+        # After that, this override can be removed.
+        #
+        # The ORIGINAL_REMOTE_ADDR is just there so that we can
+        # actually use the remote addr in IP determination
+        # code... including in this call that overwrites it!
+        request.META['ORIGINAL_REMOTE_ADDR'] = request.META['REMOTE_ADDR']
+        request.META['REMOTE_ADDR'] = ip.get_client_ip(request)


### PR DESCRIPTION
## Description

Instead of using a default of XFF[0] or XFF[-1] or REMOTE_ADDR[0], all of
which are certainly wrong for someone, make IP determination customizable
(but fall back to a good default of XFF-walking.)

This gives us a path forward to removing use of the django-ipware package
which is no longer maintained and has a handful of bugs that make it
difficult to use safely.

Main changes:

- New `get_client_ip` that first tries to use specified headers from new
  `CLIENT_IP_HEADERS` setting, then falls back to walking XFF.
- Use new code in rate-limiting function
- Save off original `REMOTE_ADDR` before overwriting it
- Add some comments warning people away from relying on REMOTE_ADDR
  directly until we can remove that middleware

Also:

- Some unused code cleanup (remaining headers don't contain commas) and
  delinting.

Internal ticket: ARCHBOM-2025
----

Impact: Operator

Pre-merge:

- [x] Unit tests
- [ ] Document in release notes
- [ ] Adjust own settings
