### PR TITLE
feat: ESG logging updates

### DIFF
--- a/lms/djangoapps/ora_staff_grader/errors.py
+++ b/lms/djangoapps/ora_staff_grader/errors.py
@@ -23,6 +23,9 @@ class ExceptionWithContext(Exception):
 class XBlockInternalError(ExceptionWithContext):
     """Errors from XBlock handlers"""
 
+    def __str__(self):
+        return str(self.context)
+
 
 class LockContestedError(ExceptionWithContext):
     """Signal for trying to operate on a lock owned by someone else"""

--- a/lms/djangoapps/ora_staff_grader/ora_api.py
+++ b/lms/djangoapps/ora_staff_grader/ora_api.py
@@ -17,7 +17,7 @@ from lms.djangoapps.ora_staff_grader.errors import (
     XBlockInternalError,
 )
 
-from lms.djangoapps.ora_staff_grader.utils import call_xblock_json_handler
+from lms.djangoapps.ora_staff_grader.utils import call_xblock_json_handler, is_json
 
 
 def get_submissions(request, usage_id):
@@ -42,6 +42,11 @@ def get_submission_info(request, usage_id, submission_uuid):
     response = call_xblock_json_handler(request, usage_id, handler_name, data)
 
     if response.status_code != 200:
+        details = (
+            json.loads(response.content).get("error", "")
+            if is_json(response.content)
+            else ""
+        )
         raise XBlockInternalError(context={"handler": handler_name})
 
     return json.loads(response.content)
@@ -56,7 +61,12 @@ def get_assessment_info(request, usage_id, submission_uuid):
     response = call_xblock_json_handler(request, usage_id, handler_name, data)
 
     if response.status_code != 200:
-        raise XBlockInternalError(context={"handler": handler_name})
+        details = (
+            json.loads(response.content).get("error", "")
+            if is_json(response.content)
+            else ""
+        )
+        raise XBlockInternalError(context={"handler": handler_name, "details": details})
 
     return json.loads(response.content)
 

--- a/lms/djangoapps/ora_staff_grader/ora_api.py
+++ b/lms/djangoapps/ora_staff_grader/ora_api.py
@@ -33,29 +33,6 @@ def get_submissions(request, usage_id):
     return json.loads(response.content)
 
 
-def get_rubric_config(request, usage_id):
-    """
-    Get rubric data from the ORA's 'get_rubric' XBlock.json_handler
-    """
-    handler_name = "get_rubric"
-    data = {"target_rubric_block_id": usage_id}
-    response = call_xblock_json_handler(request, usage_id, handler_name, data)
-
-    # Unhandled errors might not be JSON, catch before loading
-    if response.status_code != 200:
-        raise XBlockInternalError(context={"handler": handler_name})
-
-    response_data = json.loads(response.content)
-
-    # Handled faillure still returns HTTP 200 but with 'success': False and supplied error message "msg"
-    if not response_data.get("success", False):
-        raise XBlockInternalError(
-            context={"handler": handler_name, "msg": response_data.get("msg", "")}
-        )
-
-    return response_data["rubric"]
-
-
 def get_submission_info(request, usage_id, submission_uuid):
     """
     Get submission content from ORA 'get_submission_info' XBlock.json_handler

--- a/lms/djangoapps/ora_staff_grader/utils.py
+++ b/lms/djangoapps/ora_staff_grader/utils.py
@@ -43,7 +43,15 @@ def require_params(param_names):
     return decorator
 
 
-def call_xblock_json_handler(request, usage_id, handler_name, data):
+def is_json(input_string):
+    """ Quick True/False check to see if a value is JSON """
+    try:
+        json.loads(input_string)
+    except ValueError:
+        return False
+    return True
+
+def call_xblock_json_handler(request, usage_id, handler_name, data, auth=False):
     """
     WARN: Tested only for use in ESG. Consult before use outside of ESG.
 

--- a/lms/djangoapps/ora_staff_grader/utils.py
+++ b/lms/djangoapps/ora_staff_grader/utils.py
@@ -44,12 +44,13 @@ def require_params(param_names):
 
 
 def is_json(input_string):
-    """ Quick True/False check to see if a value is JSON """
+    """Quick True/False check to see if a value is JSON"""
     try:
         json.loads(input_string)
     except ValueError:
         return False
     return True
+
 
 def call_xblock_json_handler(request, usage_id, handler_name, data, auth=False):
     """

--- a/lms/djangoapps/ora_staff_grader/views.py
+++ b/lms/djangoapps/ora_staff_grader/views.py
@@ -113,6 +113,7 @@ class InitializeView(StaffGraderBaseView):
 
         # Issues with the XBlock handlers
         except XBlockInternalError as ex:
+            log.error(ex)
             return InternalErrorResponse(context=ex.context)
 
         # Blanket exception handling in case something blows up
@@ -178,12 +179,14 @@ class SubmissionFetchView(StaffGraderBaseView):
 
         # Issues with the XBlock handlers
         except XBlockInternalError as ex:
+            log.error(ex)
             return InternalErrorResponse(context=ex.context)
 
         # Blanket exception handling in case something blows up
         except Exception as ex:
             log.exception(ex)
             return UnknownErrorResponse()
+
 
 class SubmissionStatusFetchView(StaffGraderBaseView):
     """
@@ -232,6 +235,7 @@ class SubmissionStatusFetchView(StaffGraderBaseView):
 
         # Issues with the XBlock handlers
         except XBlockInternalError as ex:
+            log.error(ex)
             return InternalErrorResponse(context=ex.context)
 
         # Blanket exception handling in case something blows up
@@ -321,6 +325,7 @@ class UpdateGradeView(StaffGraderBaseView):
 
         # Issues with the XBlock handlers
         except XBlockInternalError as ex:
+            log.error(ex)
             return InternalErrorResponse(context=ex.context)
 
         # Blanket exception handling in case something blows up
@@ -370,6 +375,7 @@ class SubmissionLockView(StaffGraderBaseView):
 
         # Issues with the XBlock handlers
         except XBlockInternalError as ex:
+            log.error(ex)
             return InternalErrorResponse(context=ex.context)
 
         # Blanket exception handling
@@ -397,6 +403,7 @@ class SubmissionLockView(StaffGraderBaseView):
 
         # Issues with the XBlock handlers
         except XBlockInternalError as ex:
+            log.error(ex)
             return InternalErrorResponse(context=ex.context)
 
         # Blanket exception handling in case something blows up

--- a/lms/djangoapps/ora_staff_grader/views.py
+++ b/lms/djangoapps/ora_staff_grader/views.py
@@ -383,7 +383,8 @@ class SubmissionLockView(StaffGraderBaseView):
             return InternalErrorResponse(context=ex.context)
 
         # Blanket exception handling
-        except Exception:
+        except Exception as ex:
+            log.exception(ex)
             return UnknownErrorResponse()
 
     @require_params([PARAM_ORA_LOCATION, PARAM_SUBMISSION_ID])
@@ -397,6 +398,7 @@ class SubmissionLockView(StaffGraderBaseView):
 
         # Catch bad ORA location
         except (InvalidKeyError, ItemNotFoundError):
+            log.error(f'Bad ORA location provided: {ora_location}')
             return BadOraLocationResponse()
 
         # Return updated lock info on error

--- a/lms/djangoapps/ora_staff_grader/views.py
+++ b/lms/djangoapps/ora_staff_grader/views.py
@@ -109,6 +109,7 @@ class InitializeView(StaffGraderBaseView):
 
         # Catch bad ORA location
         except (InvalidKeyError, ItemNotFoundError):
+            log.error(f'Bad ORA location provided: {ora_location}')
             return BadOraLocationResponse()
 
         # Issues with the XBlock handlers
@@ -365,6 +366,7 @@ class SubmissionLockView(StaffGraderBaseView):
 
         # Catch bad ORA location
         except (InvalidKeyError, ItemNotFoundError):
+            log.error(f'Bad ORA location provided: {ora_location}')
             return BadOraLocationResponse()
 
         # Return updated lock info on error

--- a/lms/djangoapps/ora_staff_grader/views.py
+++ b/lms/djangoapps/ora_staff_grader/views.py
@@ -111,7 +111,7 @@ class InitializeView(StaffGraderBaseView):
 
         # Catch bad ORA location
         except (InvalidKeyError, ItemNotFoundError):
-            log.error(f'Bad ORA location provided: {ora_location}')
+            log.error(f"Bad ORA location provided: {ora_location}")
             return BadOraLocationResponse()
 
         # Issues with the XBlock handlers
@@ -376,7 +376,7 @@ class SubmissionLockView(StaffGraderBaseView):
 
         # Catch bad ORA location
         except (InvalidKeyError, ItemNotFoundError):
-            log.error(f'Bad ORA location provided: {ora_location}')
+            log.error(f"Bad ORA location provided: {ora_location}")
             return BadOraLocationResponse()
 
         # Return updated lock info on error
@@ -410,7 +410,7 @@ class SubmissionLockView(StaffGraderBaseView):
 
         # Catch bad ORA location
         except (InvalidKeyError, ItemNotFoundError):
-            log.error(f'Bad ORA location provided: {ora_location}')
+            log.error(f"Bad ORA location provided: {ora_location}")
             return BadOraLocationResponse()
 
         # Return updated lock info on error

--- a/lms/djangoapps/ora_staff_grader/views.py
+++ b/lms/djangoapps/ora_staff_grader/views.py
@@ -105,7 +105,9 @@ class InitializeView(StaffGraderBaseView):
             # Get list of submissions for this ORA
             init_data["submissions"] = get_submissions(request, ora_location)
 
-            return Response(InitializeSerializer(init_data).data)
+            response_data = InitializeSerializer(init_data).data
+            log.info(response_data)
+            return Response(response_data)
 
         # Catch bad ORA location
         except (InvalidKeyError, ItemNotFoundError):
@@ -168,15 +170,16 @@ class SubmissionFetchView(StaffGraderBaseView):
             )
             lock_info = check_submission_lock(request, ora_location, submission_uuid)
 
-            serializer = SubmissionFetchSerializer(
+            response_data = SubmissionFetchSerializer(
                 {
                     "submission_info": submission_info,
                     "assessment_info": assessment_info,
                     "lock_info": lock_info,
                 }
-            )
+            ).data
 
-            return Response(serializer.data)
+            log.info(response_data)
+            return Response(response_data)
 
         # Issues with the XBlock handlers
         except XBlockInternalError as ex:
@@ -225,14 +228,15 @@ class SubmissionStatusFetchView(StaffGraderBaseView):
             )
             lock_info = check_submission_lock(request, ora_location, submission_uuid)
 
-            serializer = SubmissionStatusFetchSerializer(
+            response_data = SubmissionStatusFetchSerializer(
                 {
                     "assessment_info": assessment_info,
                     "lock_info": lock_info,
                 }
-            )
+            ).data
 
-            return Response(serializer.data)
+            log.info(response_data)
+            return Response(response_data)
 
         # Issues with the XBlock handlers
         except XBlockInternalError as ex:
@@ -317,13 +321,15 @@ class UpdateGradeView(StaffGraderBaseView):
                 request, ora_location, submission_uuid
             )
             lock_info = check_submission_lock(request, ora_location, submission_uuid)
-            serializer = SubmissionStatusFetchSerializer(
+            response_data = SubmissionStatusFetchSerializer(
                 {
                     "assessment_info": assessment_info,
                     "lock_info": lock_info,
                 }
-            )
-            return Response(serializer.data)
+            ).data
+
+            log.info(response_data)
+            return Response(response_data)
 
         # Issues with the XBlock handlers
         except XBlockInternalError as ex:
@@ -363,7 +369,10 @@ class SubmissionLockView(StaffGraderBaseView):
             # Validate ORA location
             UsageKey.from_string(ora_location)
             lock_info = claim_submission_lock(request, ora_location, submission_uuid)
-            return Response(LockStatusSerializer(lock_info).data)
+
+            response_data = LockStatusSerializer(lock_info).data
+            log.info(response_data)
+            return Response(response_data)
 
         # Catch bad ORA location
         except (InvalidKeyError, ItemNotFoundError):
@@ -394,7 +403,10 @@ class SubmissionLockView(StaffGraderBaseView):
             # Validate ORA location
             UsageKey.from_string(ora_location)
             lock_info = delete_submission_lock(request, ora_location, submission_uuid)
-            return Response(LockStatusSerializer(lock_info).data)
+
+            response_data = LockStatusSerializer(lock_info).data
+            log.info(response_data)
+            return Response(response_data)
 
         # Catch bad ORA location
         except (InvalidKeyError, ItemNotFoundError):

--- a/lms/djangoapps/ora_staff_grader/views.py
+++ b/lms/djangoapps/ora_staff_grader/views.py
@@ -301,6 +301,7 @@ class UpdateGradeView(StaffGraderBaseView):
                         "lock_info": lock_info,
                     }
                 ).data
+                log.error(f"Grade contested for submission: {submission_uuid}")
                 return GradeContestedResponse(context=submission_status)
 
             # Transform grade data and submit assessment, rasies on failure
@@ -373,6 +374,7 @@ class SubmissionLockView(StaffGraderBaseView):
         except LockContestedError:
             lock_info = check_submission_lock(request, ora_location, submission_uuid)
             lock_status = LockStatusSerializer(lock_info).data
+            log.error(f"Lock contested for submission: {submission_uuid}")
             return LockContestedResponse(context=lock_status)
 
         # Issues with the XBlock handlers

--- a/lms/djangoapps/ora_staff_grader/views.py
+++ b/lms/djangoapps/ora_staff_grader/views.py
@@ -6,6 +6,7 @@ Views for Enhanced Staff Grader
 
 # NOTE: we intentionally add extra args using @require_params
 # pylint: disable=arguments-differ
+import logging
 
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from edx_rest_framework_extensions.auth.session.authentication import (
@@ -53,6 +54,8 @@ from openedx.core.djangoapps.content.course_overviews.api import (
     get_course_overview_or_none,
 )
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
+
+log = logging.getLogger(__name__)
 
 
 class StaffGraderBaseView(RetrieveAPIView):
@@ -112,8 +115,9 @@ class InitializeView(StaffGraderBaseView):
         except XBlockInternalError as ex:
             return InternalErrorResponse(context=ex.context)
 
-        # Blanket exception handling
-        except Exception:
+        # Blanket exception handling in case something blows up
+        except Exception as ex:
+            log.exception(ex)
             return UnknownErrorResponse()
 
 
@@ -176,10 +180,10 @@ class SubmissionFetchView(StaffGraderBaseView):
         except XBlockInternalError as ex:
             return InternalErrorResponse(context=ex.context)
 
-        # Blanket exception handling
-        except Exception:
+        # Blanket exception handling in case something blows up
+        except Exception as ex:
+            log.exception(ex)
             return UnknownErrorResponse()
-
 
 class SubmissionStatusFetchView(StaffGraderBaseView):
     """
@@ -230,8 +234,9 @@ class SubmissionStatusFetchView(StaffGraderBaseView):
         except XBlockInternalError as ex:
             return InternalErrorResponse(context=ex.context)
 
-        # Blanket exception handling
-        except Exception:
+        # Blanket exception handling in case something blows up
+        except Exception as ex:
+            log.exception(ex)
             return UnknownErrorResponse()
 
 
@@ -318,8 +323,9 @@ class UpdateGradeView(StaffGraderBaseView):
         except XBlockInternalError as ex:
             return InternalErrorResponse(context=ex.context)
 
-        # Blanket exception handling
-        except Exception:
+        # Blanket exception handling in case something blows up
+        except Exception as ex:
+            log.exception(ex)
             return UnknownErrorResponse()
 
 
@@ -393,6 +399,7 @@ class SubmissionLockView(StaffGraderBaseView):
         except XBlockInternalError as ex:
             return InternalErrorResponse(context=ex.context)
 
-        # Blanket exception handling
-        except Exception:
+        # Blanket exception handling in case something blows up
+        except Exception as ex:
+            log.exception(ex)
             return UnknownErrorResponse()


### PR DESCRIPTION
## Description

Add logging for the ESG BFF to give us the ability to trace output from any BFF endpoint (we already get traceability for input with Django). Specifically:
- `INFO` Log returned data payloads on successful requests.
- `ERROR` Log lock/grade contests
- `ERROR` Log bad ORA location
- `ERROR` Log other XBlock handler exceptions
- `EXCEPTION` Log blanket/otherwise unhandled exceptions

Additional cleanup:
- Remove unused `get_rubric_config` XBlock handler
- Additional error unpacking for 

See copious notes at https://openedx.atlassian.net/browse/AU-492

## Testing instructions

Exercise endpoints and errors, verify that they log to `stdout` and, eventually, to Splunk.