### PR TITLE
refactor: Replace videosequence & problemset

### DIFF
--- a/cms/djangoapps/contentstore/outlines.py
+++ b/cms/djangoapps/contentstore/outlines.py
@@ -245,9 +245,7 @@ def _make_section_data(section, unique_sequences):
     if error:
         section_errors.append(error)
 
-    # We haven't officially killed off problemset and videosequence yet, so
-    # treat them as equivalent to sequential for now.
-    valid_sequence_tags = ['sequential', 'problemset', 'videosequence']
+    valid_sequence_tags = ['sequential']
     sequences_data = []
 
     for sequence in section.get_children():

--- a/cms/djangoapps/contentstore/tests/test_outlines.py
+++ b/cms/djangoapps/contentstore/tests/test_outlines.py
@@ -232,12 +232,12 @@ class OutlineFromModuleStoreTestCase(ModuleStoreTestCase):
             )
             ItemFactory.create(
                 parent=section_1,
-                category='problemset',
+                category='sequential',
                 display_name="pset_seq"
             )
             ItemFactory.create(
                 parent=section_1,
-                category='videosequence',
+                category='sequential',
                 display_name="video_seq"
             )
 

--- a/common/lib/xmodule/setup.py
+++ b/common/lib/xmodule/setup.py
@@ -24,7 +24,6 @@ XBLOCKS = [
     "nonstaff_error = xmodule.error_module:NonStaffErrorBlock",
     "poll_question = xmodule.poll_module:PollBlock",
     "problem = xmodule.capa_module:ProblemBlock",
-    "problemset = xmodule.seq_module:SequenceBlock",
     "randomize = xmodule.randomize_module:RandomizeBlock",
     "sequential = xmodule.seq_module:SequenceBlock",
     "slides = xmodule.template_module:TranslateCustomTagBlock",
@@ -35,7 +34,6 @@ XBLOCKS = [
     "video = xmodule.video_module:VideoBlock",
     "videoalpha = xmodule.video_module:VideoBlock",
     "videodev = xmodule.template_module:TranslateCustomTagBlock",
-    "videosequence = xmodule.seq_module:SequenceBlock",
     "word_cloud = xmodule.word_cloud_module:WordCloudBlock",
     "wrapper = xmodule.wrapper_module:WrapperBlock",
 ]

--- a/common/lib/xmodule/xmodule/modulestore/search.py
+++ b/common/lib/xmodule/xmodule/modulestore/search.py
@@ -104,15 +104,15 @@ def path_to_location(modulestore, usage_key, request=None, full_path=False):
         # This block of code will find the position of a module within a nested tree
         # of modules. If a problem is on tab 2 of a sequence that's on tab 3 of a
         # sequence, the resulting position is 3_2. However, no positional modules
-        # (e.g. sequential and videosequence) currently deal with this form of
-        # representing nested positions. This needs to happen before jumping to a
-        # module nested in more than one positional module will work.
+        # (e.g. sequential) currently deal with this form of representing nested
+        # positions. This needs to happen before jumping to a module nested in more
+        # than one positional module will work.
 
         if n > 3:
             position_list = []
             for path_index in range(2, n - 1):
                 category = path[path_index].block_type
-                if category == 'sequential' or category == 'videosequence':  # lint-amnesty, pylint: disable=consider-using-in
+                if category == 'sequential':
                     section_desc = modulestore.get_item(path[path_index])
                     # this calls get_children rather than just children b/c old mongo includes private children
                     # in children but not in get_children

--- a/common/lib/xmodule/xmodule/modulestore/tests/sample_courses.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/sample_courses.py
@@ -49,7 +49,7 @@ TOY_BLOCK_INFO_TREE = [
     BlockInfo(
         'Overview', "chapter", {"display_name": "Overview"}, [
             BlockInfo(
-                "Toy_Videos", "videosequence", {
+                "Toy_Videos", "sequential", {
                     "xml_attributes": {"filename": ["", None]}, "display_name": "Toy Videos", "format": "Lecture Sequence"  # lint-amnesty, pylint: disable=line-too-long
                 }, [
                     BlockInfo(

--- a/common/lib/xmodule/xmodule/modulestore/xml.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml.py
@@ -81,7 +81,7 @@ class ImportSystem(XMLParsingSystem, MakoDescriptorSystem):  # lint-amnesty, pyl
 
                 # tags that really need unique names--they store (or should store) state.
                 need_uniq_names = ('problem', 'sequential', 'video', 'course', 'chapter',
-                                   'videosequence', 'poll_question', 'vertical')
+                                   'poll_question', 'vertical')
 
                 attr = xml_data.attrib
                 tag = xml_data.tag

--- a/common/test/data/graded/course/2012_Fall.xml
+++ b/common/test/data/graded/course/2012_Fall.xml
@@ -1,6 +1,6 @@
 <course>
   <chapter url_name="GradedChapter">
-    
+
     <vertical url_name="Homework1">
       <problem url_name="H1P1">
         <optionresponse>
@@ -8,37 +8,37 @@
           <optioninput options="('Correct', 'Incorrect')" correct="Correct"></optioninput>
         </optionresponse>
       </problem>
-      
+
       <abtest experiment="HiddenProblem">
         <group name="SeeProblem" portion="1">
-          
+
           <problem url_name="H1P2">
             <optionresponse>
               <optioninput options="('Correct', 'Incorrect')" correct="Correct"></optioninput>
               <optioninput options="('Correct', 'Incorrect')" correct="Correct"></optioninput>
             </optionresponse>
           </problem>
-          
+
         </group>
-        
+
         <group name="HiddenProblem" portion="0">
-          
+
           <problem url_name="H1P3">
             <optionresponse>
               <optioninput options="('Correct', 'Incorrect')" correct="Correct"></optioninput>
               <optioninput options="('Correct', 'Incorrect')" correct="Correct"></optioninput>
             </optionresponse>
           </problem>
-          
+
         </group>
 
       </abtest>
     </vertical>
-    
-    
-    <videosequence url_name="Homework2">
+
+
+    <sequential url_name="Homework2">
       <vertical url_name="Homework2Inner">
-        
+
         <problem url_name="H2P1">
           <optionresponse>
             <optioninput options="('Correct', 'Incorrect')" correct="Correct"></optioninput>
@@ -54,11 +54,11 @@
         </problem>
 
       </vertical>
-    </videosequence>
-    
-    <videosequence url_name="Homework3">
+    </sequential>
+
+    <sequential url_name="Homework3">
       <vertical url_name="Homework3Inner">
-        
+
         <problem url_name="H3P1">
           <optionresponse>
             <optioninput options="('Correct', 'Incorrect')" correct="Correct"></optioninput>
@@ -72,16 +72,16 @@
             <optioninput options="('Correct', 'Incorrect')" correct="Correct"></optioninput>
           </optionresponse>
         </problem>
-        
+
       </vertical>
-    </videosequence>
-    
+    </sequential>
+
     <problem url_name="FinalQuestion">
       <optionresponse>
         <optioninput options="('Correct', 'Incorrect')" correct="Correct"></optioninput>
         <optioninput options="('Correct', 'Incorrect')" correct="Correct"></optioninput>
       </optionresponse>
     </problem>
-    
+
   </chapter>
 </course>

--- a/common/test/data/graded/policies/2012_Fall.json
+++ b/common/test/data/graded/policies/2012_Fall.json
@@ -5,44 +5,44 @@
         "display_name": "Graded Course",
         "graded": "true"
     },
-	
-	
+
+
     "vertical/Homework1": {
-        "display_name": "Homework 1", 
-        "graded": true, 
-        "format": "Homework"
-    },
-	
-	
-    "videosequence/Homework2": {
-        "display_name": "Homework 2", 
-        "graded": true, 
-        "format": "Homework"
-    },
-    
-    "problem/H2P1": {
-        "weight": 4
-    },
-    
-    "videosequence/Homework3": {
-        "display_name": "Homework 3", 
-        "graded": true, 
+        "display_name": "Homework 1",
+        "graded": true,
         "format": "Homework"
     },
 
-	
-    "vertical/Homework1": {
-        "display_name": "Homework 1", 
-        "graded": true, 
+
+    "sequential/Homework2": {
+        "display_name": "Homework 2",
+        "graded": true,
         "format": "Homework"
     },
-	
+
+    "problem/H2P1": {
+        "weight": 4
+    },
+
+    "sequential/Homework3": {
+        "display_name": "Homework 3",
+        "graded": true,
+        "format": "Homework"
+    },
+
+
+    "vertical/Homework1": {
+        "display_name": "Homework 1",
+        "graded": true,
+        "format": "Homework"
+    },
+
     "problem/FinalQuestion": {
-        "display_name": "Final Question", 
-        "graded": true, 
+        "display_name": "Final Question",
+        "graded": true,
         "format": "Final"
     },
-	
+
     "chapter/Overview": {
         "display_name": "Overview"
     }

--- a/common/test/data/scoreable/course/course.xml
+++ b/common/test/data/scoreable/course/course.xml
@@ -1,4 +1,4 @@
-<course advanced_modules="[&quot;lti&quot;, &quot;lti_consumer&quot;, &quot;library_content&quot;, &quot;split_test&quot;, &quot;conditional&quot;, &quot;randomize&quot;, &quot;drag-and-drop-v2&quot;, &quot;library&quot;, &quot;videosequence&quot;, &quot;problemset&quot;, &quot;acid_parent&quot;, &quot;done&quot;, &quot;wrapper&quot;, &quot;edx_sga&quot;, &quot;bookmarks&quot;]" cert_html_view_enabled="true" display_name="Introduction to problems." graceperiod="" language="en" minimum_grade_credit="0.8" start="&quot;2030-01-01T00:00:00+00:00&quot;">
+<course advanced_modules="[&quot;lti&quot;, &quot;lti_consumer&quot;, &quot;library_content&quot;, &quot;split_test&quot;, &quot;conditional&quot;, &quot;randomize&quot;, &quot;drag-and-drop-v2&quot;, &quot;library&quot;, &quot;acid_parent&quot;, &quot;done&quot;, &quot;wrapper&quot;, &quot;edx_sga&quot;, &quot;bookmarks&quot;]" cert_html_view_enabled="true" display_name="Introduction to problems." graceperiod="" language="en" minimum_grade_credit="0.8" start="&quot;2030-01-01T00:00:00+00:00&quot;">
   <chapter url_name="chapter1"/>
   <wiki slug="edX.jcd101.2016-10-11"/>
 </course>

--- a/common/test/data/scoreable/policies/course/policy.json
+++ b/common/test/data/scoreable/policies/course/policy.json
@@ -9,8 +9,6 @@
             "randomize",
             "drag-and-drop-v2",
             "library",
-            "videosequence",
-            "problemset",
             "acid_parent",
             "done",
             "wrapper",

--- a/common/test/data/simple/course.xml
+++ b/common/test/data/simple/course.xml
@@ -1,10 +1,10 @@
 <course name="A Simple Course" org="edX" course="simple" graceperiod="1 day 5 hours 59 minutes 59 seconds" slug="2012_Fall">
   <chapter name="Overview">
     <video name="Welcome" youtube_id_0_75="izygArpw-Qo" youtube_id_1_0="p2Q6BrNhdh8" youtube_id_1_25="1EeWXzPdhSA" youtube_id_1_5="rABDYkeK0x8"/>
-    <videosequence format="Lecture Sequence" name="A simple sequence">
+    <sequential format="Lecture Sequence" name="A simple sequence">
       <html name="toylab" filename="toylab"/>
       <video name="S0V1: Video Resources" youtube_id_0_75="EuzkdzfR0i8" youtube_id_1_0="1bK-WdDi6Qw" youtube_id_1_25="0v1VzoDVUTM" youtube_id_1_5="Bxk_-ZJb240"/>
-    </videosequence>
+    </sequential>
     <sequential name="Lecture 2">>
       <video youtube_id_1_0="TBvX7HzxexQ"/>
       <problem name="L1 Problem 1" points="1" type="lecture" showanswer="attempted" filename="L1_Problem_1" rerandomize="never"/>

--- a/common/test/data/simple_with_draft/course.xml
+++ b/common/test/data/simple_with_draft/course.xml
@@ -1,10 +1,10 @@
 <course name="A Simple Course" org="edX" course="simple_with_draft" graceperiod="1 day 5 hours 59 minutes 59 seconds" slug="2012_Fall">
   <chapter name="Overview">
     <video name="Welcome" youtube_id_0_75="izygArpw-Qo" youtube_id_1_0="p2Q6BrNhdh8" youtube_id_1_25="1EeWXzPdhSA" youtube_id_1_5="rABDYkeK0x8"/>
-    <videosequence format="Lecture Sequence" name="A simple sequence">
+    <sequential format="Lecture Sequence" name="A simple sequence">
       <html name="toylab" filename="toylab"/>
       <video name="S0V1: Video Resources" youtube_id_0_75="EuzkdzfR0i8" youtube_id_1_0="1bK-WdDi6Qw" youtube_id_1_25="0v1VzoDVUTM" youtube_id_1_5="Bxk_-ZJb240"/>
-    </videosequence>
+    </sequential>
     <sequential name="Lecture 2">
       <video youtube_id_1_0="TBvX7HzxexQ"/>
       <problem name="L1 Problem 1" points="1" type="lecture" showanswer="attempted" filename="L1_Problem_1" rerandomize="never"/>

--- a/common/test/data/test_exam_registration/course/2012_Fall.xml
+++ b/common/test/data/test_exam_registration/course/2012_Fall.xml
@@ -1,9 +1,10 @@
 <course>
   <chapter url_name="Overview">
-    <videosequence url_name="Toy_Videos">
+    <!-- This is an unsupported structure (a sequential with child elements that are not verticals)! -->
+    <sequential url_name="Toy_Videos">
       <html url_name="toylab"/>
       <video url_name="Video_Resources" youtube_id_1_0="1bK-WdDi6Qw"/>
-    </videosequence>
+    </sequential>
     <video url_name="Welcome" youtube_id_1_0="p2Q6BrNhdh8"/>
   </chapter>
   <chapter url_name="Ch2">

--- a/common/test/data/test_exam_registration/policies/2012_Fall.json
+++ b/common/test/data/test_exam_registration/policies/2012_Fall.json
@@ -11,7 +11,7 @@
        "display_name": "Chapter 2",
        "start": "2015-07-17T12:00"
     },
-    "videosequence/Toy_Videos": {
+    "sequential/Toy_Videos": {
         "display_name": "Toy Videos",
         "format": "Lecture Sequence"
     },

--- a/common/test/data/test_import_course/course/2012_Fall.xml
+++ b/common/test/data/test_import_course/course/2012_Fall.xml
@@ -1,14 +1,14 @@
 <course>
     <textbook title="Textbook" book_url="https://s3.amazonaws.com/edx-textbooks/guttag_computation_v3/"/>
   <chapter url_name="Overview">
-    <videosequence url_name="Toy_Videos">
+    <sequential url_name="Toy_Videos">
       <html url_name="secret:toylab"/>
       <html url_name="toyjumpto"/>
       <html url_name="toyhtml"/>
       <html url_name="nonportable"/>
       <html url_name="nonportable_link"/>
       <video url_name="Video_Resources" youtube_id_1_0="1bK-WdDi6Qw" display_name="Video Resources"/>
-    </videosequence>
+    </sequential>
     <video url_name="Welcome" youtube_id_1_0="p2Q6BrNhdh8" display_name="Welcome"/>
     <video url_name="video_123456789012" youtube_id_1_0="p2Q6BrNhdh8" display_name='Test Video'/>
     <video url_name="video_4f66f493ac8f" youtube_id_1_0="p2Q6BrNhdh8"/>

--- a/common/test/data/test_import_course/policies/2012_Fall.json
+++ b/common/test/data/test_import_course/policies/2012_Fall.json
@@ -17,7 +17,7 @@
     "chapter/Overview": {
         "display_name": "Overview"
     },
-    "videosequence/Toy_Videos": {
+    "sequential/Toy_Videos": {
         "display_name": "Toy Videos",
         "format": "Lecture Sequence"
     },

--- a/common/test/data/test_import_course_2/course/2014_Fall.xml
+++ b/common/test/data/test_import_course_2/course/2014_Fall.xml
@@ -1,14 +1,14 @@
 <course>
     <textbook title="Textbook" book_url="https://s3.amazonaws.com/edx-textbooks/guttag_computation_v3/"/>
   <chapter url_name="Overview">
-    <videosequence url_name="Toy_Videos">
+    <sequential url_name="Toy_Videos">
       <html url_name="secret:toylab"/>
       <html url_name="toyjumpto"/>
       <html url_name="toyhtml"/>
       <html url_name="nonportable"/>
       <html url_name="nonportable_link"/>
       <video url_name="Video_Resources" youtube_id_1_0="1bK-WdDi6Qw" display_name="Video Resources"/>
-    </videosequence>
+    </sequential>
     <video url_name="Welcome" youtube_id_1_0="p2Q6BrNhdh8" display_name="Welcome"/>
     <video url_name="video_123456789012" youtube_id_1_0="p2Q6BrNhdh8" display_name='Test Video'/>
     <video url_name="video_4f66f493ac8f" youtube_id_1_0="p2Q6BrNhdh8"/>

--- a/common/test/data/test_import_course_2/policies/2012_Fall.json
+++ b/common/test/data/test_import_course_2/policies/2012_Fall.json
@@ -17,7 +17,7 @@
     "chapter/Overview": {
         "display_name": "Overview"
     },
-    "videosequence/Toy_Videos": {
+    "sequential/Toy_Videos": {
         "display_name": "Toy Videos",
         "format": "Lecture Sequence"
     },

--- a/common/test/data/test_start_date/course/2012_Fall.xml
+++ b/common/test/data/test_start_date/course/2012_Fall.xml
@@ -1,9 +1,9 @@
 <course>
   <chapter url_name="Overview">
-    <videosequence url_name="Toy_Videos">
+    <sequential url_name="Toy_Videos">
       <html url_name="toylab"/>
       <video url_name="Video_Resources" youtube_id_1_0="1bK-WdDi6Qw"/>
-    </videosequence>
+    </sequential>
     <video url_name="Welcome" youtube_id_1_0="p2Q6BrNhdh8"/>
   </chapter>
   <chapter url_name="Ch2">

--- a/common/test/data/test_start_date/policies/2012_Fall.json
+++ b/common/test/data/test_start_date/policies/2012_Fall.json
@@ -11,7 +11,7 @@
        "display_name": "Chapter 2",
        "start": "2015-07-17T12:00"
     },
-    "videosequence/Toy_Videos": {
+    "sequential/Toy_Videos": {
         "display_name": "Toy Videos",
         "format": "Lecture Sequence"
     },

--- a/common/test/data/toy/course/2012_Fall.xml
+++ b/common/test/data/toy/course/2012_Fall.xml
@@ -1,7 +1,7 @@
 <course course_image="just_a_test.jpg" license="creative-commons: BY">
     <textbook title="Textbook" book_url="https://s3.amazonaws.com/edx-textbooks/guttag_computation_v3/"/>
   <chapter url_name="Overview">
-    <videosequence url_name="Toy_Videos">
+    <sequential url_name="Toy_Videos">
       <html url_name="secret:toylab"/>
       <html url_name="toyjumpto"/>
       <html url_name="toyhtml"/>
@@ -11,7 +11,7 @@
       <html url_name="with_styling"/>
       <html url_name="just_img"/>
       <video url_name="Video_Resources" youtube_id_1_0="1bK-WdDi6Qw" display_name="Video Resources" license="all-rights-reserved"/>
-    </videosequence>
+    </sequential>
     <video url_name="Welcome" youtube_id_1_0="p2Q6BrNhdh8" display_name="Welcome"/>
     <video url_name="video_123456789012" youtube_id_1_0="p2Q6BrNhdh8" display_name='Test Video'/>
     <video url_name="video_4f66f493ac8f" youtube_id_1_0="p2Q6BrNhdh8"/>

--- a/common/test/data/toy/policies/2012_Fall.json
+++ b/common/test/data/toy/policies/2012_Fall.json
@@ -26,7 +26,7 @@
     "chapter/Overview": {
         "display_name": "Overview"
     },
-    "videosequence/Toy_Videos": {
+    "sequential/Toy_Videos": {
         "display_name": "Toy Videos",
         "format": "Lecture Sequence"
     },

--- a/common/test/data/two_toys/chapter/Overview.xml
+++ b/common/test/data/two_toys/chapter/Overview.xml
@@ -1,4 +1,4 @@
 <chapter>
-  <videosequence url_name="Toy_Videos"/>
+  <sequential url_name="Toy_Videos"/>
   <video url_name="Welcome"/>
 </chapter>

--- a/common/test/data/two_toys/policies/TT_2012_Fall/policy.json
+++ b/common/test/data/two_toys/policies/TT_2012_Fall/policy.json
@@ -7,7 +7,7 @@
     "chapter/Overview": {
         "display_name": "Two Toy Overview"
     },
-    "videosequence/Toy_Videos": {
+    "sequential/Toy_Videos": {
         "display_name": "Toy Videos",
         "format": "Lecture Sequence"
     },

--- a/common/test/data/two_toys/videosequence/Toy_Videos.xml
+++ b/common/test/data/two_toys/videosequence/Toy_Videos.xml
@@ -1,3 +1,3 @@
-<videosequence display_name="Toy Videos" format="Lecture Sequence">
+<sequential display_name="Toy Videos" format="Lecture Sequence">
   <video url_name="Video_Resources"/>
-</videosequence>
+</sequential>

--- a/lms/djangoapps/courseware/management/commands/tests/test_dump_course.py
+++ b/lms/djangoapps/courseware/management/commands/tests/test_dump_course.py
@@ -123,7 +123,7 @@ class CommandsTestBase(SharedModuleStoreTestCase):
         assert len(dump[parent_id]['children']) == 3
 
         child_id = dump[parent_id]['children'][1]
-        assert dump[child_id]['category'] == 'videosequence'
+        assert dump[child_id]['category'] == 'sequential'
         assert len(dump[child_id]['children']) == 2
 
         video_id = str(test_course_key.make_usage_key('video', 'Welcome'))
@@ -195,7 +195,7 @@ class CommandsTestBase(SharedModuleStoreTestCase):
         assert_in('edX-simple-2012_Fall', names)
         assert_in(f'edX-simple-2012_Fall/policies/{self.url_name}/policy.json', names)
         assert_in('edX-simple-2012_Fall/html/toylab.html', names)
-        assert_in('edX-simple-2012_Fall/videosequence/A_simple_sequence.xml', names)
+        assert_in('edX-simple-2012_Fall/sequential/A_simple_sequence.xml', names)
         assert_in('edX-simple-2012_Fall/sequential/Lecture_2.xml', names)
 
 

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -318,7 +318,7 @@ class ModuleRenderTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
             'xblock_handler',
             args=[
                 str(self.course_key),
-                quote_slashes(str(self.course_key.make_usage_key('videosequence', 'Toy_Videos'))),
+                quote_slashes(str(self.course_key.make_usage_key('sequential', 'Toy_Videos'))),
                 'xmodule_handler',
                 'goto_position'
             ]
@@ -1323,7 +1323,7 @@ class TestProctoringRendering(ModuleStoreTestCase):
         Helper method to consolidate some courseware/proctoring/credit
         test harness data
         """
-        usage_key = self.course_key.make_usage_key('videosequence', 'Toy_Videos')
+        usage_key = self.course_key.make_usage_key('sequential', 'Toy_Videos')
 
         with self.modulestore.bulk_operations(self.toy_course.id):
             sequence = self.modulestore.get_item(usage_key)

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1671,7 +1671,7 @@ def enclosing_sequence_for_gating_checks(block):
     all. LabXchange uses learning pathways, but even content inside courses like
     `static_tab`, `book`, and `about` live outside the sequence hierarchy.
     """
-    seq_tags = ['sequential', 'problemset', 'videosequence']
+    seq_tags = ['sequential']
 
     # If it's being called on a Sequence itself, then don't bother crawling the
     # ancestor tree, because all the sequence metadata we need for gating checks

--- a/lms/djangoapps/grades/tests/test_scores.py
+++ b/lms/djangoapps/grades/tests/test_scores.py
@@ -58,7 +58,7 @@ class TestScoredBlockTypes(TestCase):
         'course', 'chapter', 'sequential', 'vertical',
         'library_content', 'split_test', 'conditional', 'library', 'randomize',
         'problem', 'drag-and-drop-v2', 'openassessment', 'lti', 'lti_consumer',
-        'videosequence', 'problemset', 'acid_parent', 'done', 'wrapper', 'edx_sga',
+        'acid_parent', 'done', 'wrapper', 'edx_sga',
     }
 
     def test_block_types_possibly_scored(self):


### PR DESCRIPTION
## Description
`problemset` and `videosequence` are old-but-not-entirely-unused aliases to the `sequential` (in Studio-speak, "Subsection")  block type.
Since [these block types have been removed from the 6 courses](https://openedx.atlassian.net/browse/DEPR-151?focusedCommentId=588197) that used them, this ticket removes the support for the `problemset` and `videosequence` block-types.


## Supporting information

See ticket: [DEPR-151](https://openedx.atlassian.net/browse/DEPR-151)

## Testing instructions

1. All mentions of `problemset` and `videosequence` have either been replaced with `sequential` or removed entirely.
2. All checks have passed
3. A sample course has been created within tutor to test that `problemset` and `videosequence` are no longer supported, and are rendered as the default, hidden block type.