### PR TITLE
test: more Old Mongo removal from tests

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/tests/test_backfill_course_outlines.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_backfill_course_outlines.py
@@ -62,22 +62,22 @@ class BackfillCourseOutlinesTest(SharedModuleStoreTestCase):
                 )
                 with cls.store.bulk_operations(course_key):
                     section = ItemFactory.create(
-                        parent_location=course.location,
+                        parent=course,
                         category="chapter",
                         display_name="A Section"
                     )
                     sequence = ItemFactory.create(
-                        parent_location=section.location,
+                        parent=section,
                         category="sequential",
                         display_name="A Sequence"
                     )
                     unit = ItemFactory.create(
-                        parent_location=sequence.location,
+                        parent=sequence,
                         category="vertical",
                         display_name="A Unit"
                     )
                     ItemFactory.create(
-                        parent_location=unit.location,
+                        parent=unit,
                         category="html",
                         display_name="An HTML Module"
                     )

--- a/cms/djangoapps/contentstore/tests/test_outlines.py
+++ b/cms/djangoapps/contentstore/tests/test_outlines.py
@@ -136,18 +136,18 @@ class OutlineFromModuleStoreTestCase(ModuleStoreTestCase):
         """Make sure sequences go into the right places."""
         with self.store.bulk_operations(self.course_key):
             section_1 = ItemFactory.create(
-                parent_location=self.draft_course.location,
+                parent=self.draft_course,
                 category='chapter',
                 display_name="Section 1 - Three Sequences",
             )
             ItemFactory.create(
-                parent_location=self.draft_course.location,
+                parent=self.draft_course,
                 category='chapter',
                 display_name="Section 2 - Empty",
             )
             for i in range(3):
                 ItemFactory.create(
-                    parent_location=section_1.location,
+                    parent=section_1,
                     category='sequential',
                     display_name=f"Seq_1_{i}",
                 )
@@ -164,23 +164,23 @@ class OutlineFromModuleStoreTestCase(ModuleStoreTestCase):
     def test_duplicate_children(self):
         with self.store.bulk_operations(self.course_key):
             section_1 = ItemFactory.create(
-                parent_location=self.draft_course.location,
+                parent=self.draft_course,
                 category='chapter',
                 display_name="Section",
             )
             seq = ItemFactory.create(
-                parent_location=section_1.location,
+                parent=section_1,
                 category='sequential',
                 display_name="standard_seq"
             )
             section_2 = ItemFactory.create(
-                parent_location=self.draft_course.location,
+                parent=self.draft_course,
                 category='chapter',
                 display_name="Section 2",
                 children=[seq.location]
             )
             section_3 = ItemFactory.create(
-                parent_location=self.draft_course.location,
+                parent=self.draft_course,
                 category='chapter',
                 display_name="Section 3",
                 children=[seq.location]
@@ -215,42 +215,42 @@ class OutlineFromModuleStoreTestCase(ModuleStoreTestCase):
         # Course -> Section -> Unit (No Sequence)
         with self.store.bulk_operations(self.course_key):
             section_1 = ItemFactory.create(
-                parent_location=self.draft_course.location,
+                parent=self.draft_course,
                 category='chapter',
                 display_name="Section",
             )
             # This Unit should be skipped
             ItemFactory.create(
-                parent_location=section_1.location,
+                parent=section_1,
                 category='vertical',
                 display_name="u1"
             )
             ItemFactory.create(
-                parent_location=section_1.location,
+                parent=section_1,
                 category='sequential',
                 display_name="standard_seq"
             )
             ItemFactory.create(
-                parent_location=section_1.location,
+                parent=section_1,
                 category='problemset',
                 display_name="pset_seq"
             )
             ItemFactory.create(
-                parent_location=section_1.location,
+                parent=section_1,
                 category='videosequence',
                 display_name="video_seq"
             )
 
             # This should work fine
             section_2 = ItemFactory.create(
-                parent_location=self.draft_course.location,
+                parent=self.draft_course,
                 category='chapter',
                 display_name="Section 2",
             )
 
             # Second error message here
             ItemFactory.create(
-                parent_location=section_2.location,
+                parent=section_2,
                 category='vertical',
                 display_name="u2"
             )
@@ -278,12 +278,12 @@ class OutlineFromModuleStoreTestCase(ModuleStoreTestCase):
         # Course -> Sequence (No Section)
         with self.store.bulk_operations(self.course_key):
             seq = ItemFactory.create(
-                parent_location=self.draft_course.location,
+                parent=self.draft_course,
                 category='sequential',
                 display_name="Sequence",
             )
             ItemFactory.create(
-                parent_location=seq.location,
+                parent=seq,
                 category='vertical',
                 display_name="Unit",
             )
@@ -302,12 +302,12 @@ class OutlineFromModuleStoreTestCase(ModuleStoreTestCase):
         """
         with self.store.bulk_operations(self.course_key):
             section = ItemFactory.create(
-                parent_location=self.draft_course.location,
+                parent=self.draft_course,
                 category='chapter',
                 display_name=None,
             )
             sequence = ItemFactory.create(
-                parent_location=section.location,
+                parent=section,
                 category='sequential',
                 display_name=None,
             )
@@ -325,7 +325,7 @@ class OutlineFromModuleStoreTestCase(ModuleStoreTestCase):
         """
         with self.store.bulk_operations(self.course_key):
             section = ItemFactory.create(
-                parent_location=self.draft_course.location,
+                parent=self.draft_course,
                 category='chapter',
                 display_name='Ch 1',
                 group_access={
@@ -335,7 +335,7 @@ class OutlineFromModuleStoreTestCase(ModuleStoreTestCase):
                 }
             )
             ItemFactory.create(
-                parent_location=section.location,
+                parent=section,
                 category='sequential',
                 display_name='Seq 1',
                 group_access={
@@ -354,14 +354,14 @@ class OutlineFromModuleStoreTestCase(ModuleStoreTestCase):
         """Testing empty case to make sure bubble-up code doesn't break."""
         with self.store.bulk_operations(self.course_key):
             section = ItemFactory.create(
-                parent_location=self.draft_course.location,
+                parent=self.draft_course,
                 category='chapter',
                 display_name='Ch 0',
             )
 
             # Bubble up with no children (nothing happens)
             ItemFactory.create(
-                parent_location=section.location,
+                parent=section,
                 category='sequential',
                 display_name='Seq 0',
                 group_access={}
@@ -375,20 +375,20 @@ class OutlineFromModuleStoreTestCase(ModuleStoreTestCase):
         """Group settings should bubble up from Unit to Seq. if only one unit"""
         with self.store.bulk_operations(self.course_key):
             section = ItemFactory.create(
-                parent_location=self.draft_course.location,
+                parent=self.draft_course,
                 category='chapter',
                 display_name='Ch 0',
             )
 
             # Bubble up with 1 child (grabs the setting from child)
             seq_1 = ItemFactory.create(
-                parent_location=section.location,
+                parent=section,
                 category='sequential',
                 display_name='Seq 1',
                 group_access={}
             )
             ItemFactory.create(
-                parent_location=seq_1.location,
+                parent=seq_1,
                 category='vertical',
                 display_name='Single Vertical',
                 group_access={
@@ -406,27 +406,27 @@ class OutlineFromModuleStoreTestCase(ModuleStoreTestCase):
         """If all Units have the same group_access, bubble up to Sequence."""
         with self.store.bulk_operations(self.course_key):
             section = ItemFactory.create(
-                parent_location=self.draft_course.location,
+                parent=self.draft_course,
                 category='chapter',
                 display_name='Ch 0',
             )
 
             # Bubble up with n children, all matching for one group
             seq_n = ItemFactory.create(
-                parent_location=section.location,
+                parent=section,
                 category='sequential',
                 display_name='Seq N',
                 group_access={}
             )
             for i in range(4):
                 ItemFactory.create(
-                    parent_location=seq_n.location,
+                    parent=seq_n,
                     category='vertical',
                     display_name=f'vertical {i}',
                     group_access={50: [3, 4], 51: [i]}  # Only 50 should get bubbled up
                 )
             ItemFactory.create(
-                parent_location=seq_n.location,
+                parent=seq_n,
                 category='vertical',
                 display_name='vertical 5',
                 group_access={50: [4, 3], 51: [5]}  # Ordering should be normalized
@@ -441,20 +441,20 @@ class OutlineFromModuleStoreTestCase(ModuleStoreTestCase):
         """Don't bubble up from Unit if Seq has a conflicting group_access."""
         with self.store.bulk_operations(self.course_key):
             section = ItemFactory.create(
-                parent_location=self.draft_course.location,
+                parent=self.draft_course,
                 category='chapter',
                 display_name='Ch 0',
             )
 
             # Bubble up with 1 child (grabs the setting from child)
             seq_1 = ItemFactory.create(
-                parent_location=section.location,
+                parent=section,
                 category='sequential',
                 display_name='Seq 1',
                 group_access={50: [3, 4]}
             )
             ItemFactory.create(
-                parent_location=seq_1.location,
+                parent=seq_1,
                 category='vertical',
                 display_name='Single Vertical',
                 group_access={50: [1, 2]},
@@ -494,12 +494,12 @@ class OutlineFromModuleStoreTestCase(ModuleStoreTestCase):
         """
         with self.store.bulk_operations(self.course_key):
             section = ItemFactory.create(
-                parent_location=self.draft_course.location,
+                parent=self.draft_course,
                 category='chapter',
                 display_name="Generated Section",
             )
             sequence = ItemFactory.create(
-                parent_location=section.location,
+                parent=section,
                 category='sequential',
                 **kwargs,
             )

--- a/common/djangoapps/student/tests/test_enrollment.py
+++ b/common/djangoapps/student/tests/test_enrollment.py
@@ -11,7 +11,7 @@ import pytest
 from django.conf import settings
 from django.urls import reverse
 from openedx_events.tests.utils import OpenEdxEventsTestMixin
-from xmodule.modulestore.tests.django_utils import TEST_DATA_MONGO_AMNESTY_MODULESTORE, SharedModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
 from common.djangoapps.course_modes.models import CourseMode
@@ -31,12 +31,11 @@ from openedx.core.djangoapps.embargo.test_utils import restrict_course
 @ddt.ddt
 @patch.dict('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': True})
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
-class EnrollmentTest(UrlResetMixin, SharedModuleStoreTestCase, OpenEdxEventsTestMixin):
+class EnrollmentTest(UrlResetMixin, ModuleStoreTestCase, OpenEdxEventsTestMixin):
     """
     Test student enrollment, especially with different course modes.
     """
 
-    MODULESTORE = TEST_DATA_MONGO_AMNESTY_MODULESTORE
     ENABLED_OPENEDX_EVENTS = []
 
     USERNAME = "Bob"
@@ -54,23 +53,21 @@ class EnrollmentTest(UrlResetMixin, SharedModuleStoreTestCase, OpenEdxEventsTest
         """
         super().setUpClass()
         cls.start_events_isolation()
-        cls.course = CourseFactory.create()
-        cls.course_limited = CourseFactory.create()
-        cls.proctored_course = CourseFactory(
-            enable_proctored_exams=True, enable_timed_exams=True
-        )
-        cls.proctored_course_no_exam = CourseFactory(
-            enable_proctored_exams=True, enable_timed_exams=True
-        )
 
     @patch.dict(settings.FEATURES, {'EMBARGO': True})
     def setUp(self):
         """ Create a course and user, then log in. """
         super().setUp()
+        self.course = CourseFactory.create()
+        self.course_limited = CourseFactory.create(max_student_enrollments_allowed=1)
+        self.proctored_course = CourseFactory(
+            enable_proctored_exams=True, enable_timed_exams=True
+        )
+        self.proctored_course_no_exam = CourseFactory(
+            enable_proctored_exams=True, enable_timed_exams=True
+        )
         self.user = UserFactory.create(username=self.USERNAME, email=self.EMAIL, password=self.PASSWORD)
         self.client.login(username=self.USERNAME, password=self.PASSWORD)
-        self.course_limited.max_student_enrollments_allowed = 1
-        self.store.update_item(self.course_limited, self.user.id)
         self.urls = [
             reverse('course_modes_choose', kwargs={'course_id': str(self.course.id)})
         ]
@@ -87,7 +84,7 @@ class EnrollmentTest(UrlResetMixin, SharedModuleStoreTestCase, OpenEdxEventsTest
         ItemFactory.create(
             parent=chapter, category='sequential', display_name='Test Proctored Exam',
             graded=True, is_time_limited=True, default_time_limit_minutes=10,
-            is_proctored_exam=True, publish_item=True
+            is_proctored_enabled=True, publish_item=True
         )
 
     @ddt.data(

--- a/common/lib/xmodule/xmodule/modulestore/tests/factories.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/factories.py
@@ -23,6 +23,7 @@ from xblock.core import XBlock
 
 from xmodule.course_module import Textbook
 from xmodule.modulestore import ModuleStoreEnum, prefer_xmodules
+from xmodule.modulestore.mixed import strip_key
 from xmodule.modulestore.tests.sample_courses import TOY_BLOCK_INFO_TREE, default_block_info_tree
 from xmodule.tabs import CourseTab
 
@@ -324,6 +325,7 @@ class ItemFactory(XModuleFactory):
         return parent.location
 
     @classmethod
+    @strip_key
     def _create(cls, target_class, **kwargs):  # lint-amnesty, pylint: disable=arguments-differ, too-many-statements, unused-argument
         """
         Uses ``**kwargs``:
@@ -364,6 +366,9 @@ class ItemFactory(XModuleFactory):
         has_score = kwargs.pop('has_score', None)
         submission_start = kwargs.pop('submission_start', None)
         submission_end = kwargs.pop('submission_end', None)
+
+        # Remove this variable passed in by `strip_key`
+        kwargs.pop('field_decorator')
 
         # Remove the descriptive_tag, it's just for generating display_name,
         # and doesn't need to be passed into the object constructor

--- a/lms/djangoapps/ccx/tests/test_field_override_performance.py
+++ b/lms/djangoapps/ccx/tests/test_field_override_performance.py
@@ -20,7 +20,7 @@ from edx_django_utils.cache import RequestCache
 from opaque_keys.edx.keys import CourseKey
 from pytz import UTC
 from xblock.core import XBlock
-from xmodule.modulestore.tests.django_utils import TEST_DATA_MONGO_MODULESTORE, ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, check_mongo_calls, check_sum_of_calls
 from xmodule.modulestore.tests.utils import ProceduralCourseTestMixin
 
@@ -215,9 +215,6 @@ class FieldOverridePerformanceTestCase(FieldOverrideTestMixin, ProceduralCourseT
         if not enable_ccx and view_as_ccx:
             pytest.skip("Can't view a ccx course if ccx is disabled on the course")
 
-        if self.MODULESTORE == TEST_DATA_MONGO_MODULESTORE and view_as_ccx:
-            pytest.skip("Can't use a MongoModulestore test as a CCX course")
-
         with self.settings(
             XBLOCK_FIELD_DATA_WRAPPERS=['lms.djangoapps.courseware.field_overrides:OverrideModulestoreFieldData.wrap'],
             MODULESTORE_FIELD_OVERRIDE_PROVIDERS=providers[overrides],
@@ -228,35 +225,6 @@ class FieldOverridePerformanceTestCase(FieldOverrideTestMixin, ProceduralCourseT
             self.instrument_course_progress_render(
                 course_width, enable_ccx, view_as_ccx, sql_queries, mongo_reads,
             )
-
-
-class TestFieldOverrideMongoPerformance(FieldOverridePerformanceTestCase):
-    """
-    Test cases for instrumenting field overrides against the Mongo modulestore.
-    """
-    MODULESTORE = TEST_DATA_MONGO_MODULESTORE
-    __test__ = True
-
-    # TODO: decrease query count as part of REVO-28
-    QUERY_COUNT = 31
-    TEST_DATA = {
-        # (providers, course_width, enable_ccx, view_as_ccx): (
-        #     # of sql queries to default,
-        #     # of mongo queries,
-        # )
-        ('no_overrides', 1, True, False): (QUERY_COUNT, 1),
-        ('no_overrides', 2, True, False): (QUERY_COUNT, 1),
-        ('no_overrides', 3, True, False): (QUERY_COUNT, 1),
-        ('ccx', 1, True, False): (QUERY_COUNT, 1),
-        ('ccx', 2, True, False): (QUERY_COUNT, 1),
-        ('ccx', 3, True, False): (QUERY_COUNT, 1),
-        ('no_overrides', 1, False, False): (QUERY_COUNT, 1),
-        ('no_overrides', 2, False, False): (QUERY_COUNT, 1),
-        ('no_overrides', 3, False, False): (QUERY_COUNT, 1),
-        ('ccx', 1, False, False): (QUERY_COUNT, 1),
-        ('ccx', 2, False, False): (QUERY_COUNT, 1),
-        ('ccx', 3, False, False): (QUERY_COUNT, 1),
-    }
 
 
 class TestFieldOverrideSplitPerformance(FieldOverridePerformanceTestCase):

--- a/lms/djangoapps/course_blocks/transformers/tests/helpers.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/helpers.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
-from xmodule.modulestore.tests.django_utils import TEST_DATA_MONGO_AMNESTY_MODULESTORE, ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
 from common.djangoapps.course_modes.models import CourseMode
@@ -43,7 +43,6 @@ class CourseStructureTestCase(TransformerRegistryTestMixin, ModuleStoreTestCase)
     """
     Helper for test cases that need to build course structures.
     """
-    MODULESTORE = TEST_DATA_MONGO_AMNESTY_MODULESTORE
 
     def setUp(self):
         """
@@ -116,6 +115,7 @@ class CourseStructureTestCase(TransformerRegistryTestMixin, ModuleStoreTestCase)
                 Mapping from '#ref' values to their XBlocks.
 
         """
+        store = modulestore()
         parents = block_hierarchy.get('#parents', [])
         if parents:
             block_key = block_map[block_hierarchy['#ref']].location
@@ -123,14 +123,16 @@ class CourseStructureTestCase(TransformerRegistryTestMixin, ModuleStoreTestCase)
             # First remove the block from the course.
             # It would be re-added to the course if the course was
             # explicitly listed in parents.
-            course = modulestore().get_item(block_map['course'].location)
+            with store.branch_setting(ModuleStoreEnum.Branch.draft_preferred, block_map['course'].id):
+                course = store.get_item(block_map['course'].location)
             if block_key in course.children:
                 course.children.remove(block_key)
                 block_map['course'] = update_block(course)
 
             # Add this to block to each listed parent.
             for parent_ref in parents:
-                parent_block = modulestore().get_item(block_map[parent_ref].location)
+                with store.branch_setting(ModuleStoreEnum.Branch.draft_preferred, course.id):
+                    parent_block = store.get_item(block_map[parent_ref].location)
                 parent_block.children.append(block_key)
                 block_map[parent_ref] = update_block(parent_block)
 
@@ -208,8 +210,6 @@ class BlockParentsMapTestCase(TransformerRegistryTestMixin, ModuleStoreTestCase)
     Test helper class for creating a test course of
     a graph of vertical blocks based on a parents_map.
     """
-
-    MODULESTORE = TEST_DATA_MONGO_AMNESTY_MODULESTORE
 
     # Tree formed by parent_map:
     #        0
@@ -310,7 +310,9 @@ class BlockParentsMapTestCase(TransformerRegistryTestMixin, ModuleStoreTestCase)
         Helper method to retrieve the requested block (index) from the
         modulestore
         """
-        return modulestore().get_item(self.xblock_keys[block_index])
+        store = modulestore()
+        with store.branch_setting(ModuleStoreEnum.Branch.draft_preferred, self.course.id):
+            return store.get_item(self.xblock_keys[block_index])
 
     def _check_results(self, user, expected_accessible_blocks, blocks_with_differing_access, transformers):
         """
@@ -350,7 +352,9 @@ def update_block(block):
     """
     Helper method to update the block in the modulestore
     """
-    return modulestore().update_item(block, ModuleStoreEnum.UserID.test)
+    store = modulestore()
+    with store.branch_setting(ModuleStoreEnum.Branch.draft_preferred, block.course_id):
+        return store.update_item(block, ModuleStoreEnum.UserID.test)
 
 
 def publish_course(course):

--- a/lms/djangoapps/course_blocks/transformers/tests/test_library_content.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_library_content.py
@@ -70,7 +70,6 @@ class ContentLibraryTransformerTestCase(CourseStructureTestCase):
                                     '#ref': 'vertical1',
                                     '#children': [
                                         {
-                                            'metadata': {'category': 'library_content'},
                                             '#type': 'library_content',
                                             '#ref': 'library_content1',
                                             '#children': [
@@ -205,7 +204,6 @@ class ContentLibraryOrderTransformerTestCase(CourseStructureTestCase):
                                     '#ref': 'vertical1',
                                     '#children': [
                                         {
-                                            'metadata': {'category': 'library_content'},
                                             '#type': 'library_content',
                                             '#ref': 'library_content1',
                                             '#children': [

--- a/lms/djangoapps/course_blocks/transformers/tests/test_split_test.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_split_test.py
@@ -103,7 +103,6 @@ class SplitTestTransformerTestCase(CourseStructureTestCase):
             {
                 '#type': 'split_test',
                 '#ref': 'BSplit',
-                'metadata': {'category': 'split_test'},
                 'user_partition_id': self.TEST_PARTITION_ID,
                 'group_id_to_child': {
                     '0': location('E'),
@@ -128,7 +127,6 @@ class SplitTestTransformerTestCase(CourseStructureTestCase):
             {
                 '#type': 'split_test',
                 '#ref': 'KSplit',
-                'metadata': {'category': 'split_test'},
                 'user_partition_id': self.TEST_PARTITION_ID,
                 'group_id_to_child': {
                     '1': location('M'),
@@ -143,7 +141,6 @@ class SplitTestTransformerTestCase(CourseStructureTestCase):
             {
                 '#type': 'split_test',
                 '#ref': 'CSplit',
-                'metadata': {'category': 'split_test'},
                 'user_partition_id': self.TEST_PARTITION_ID,
                 'group_id_to_child': {
                     '0': location('H'),

--- a/lms/djangoapps/course_blocks/transformers/tests/test_start_date.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_start_date.py
@@ -72,7 +72,7 @@ class StartDateTransformerTestCase(BlockParentsMapTestCase):
 
         # has_access checks on block directly and doesn't follow negative access set on parent/ancestor (i.e., 0)
         (STUDENT, {1: StartDateType.released}, {}, {1, 3, 4, 6}),
-        (STUDENT, {2: StartDateType.released}, {}, {2, 5, 6}),
+        (STUDENT, {2: StartDateType.released}, {}, {2, 5}),
         (STUDENT, {1: StartDateType.released, 2: StartDateType.released}, {}, {1, 2, 3, 4, 5, 6}),
 
         # DAG conflicts: has_access relies on field inheritance so it takes only the value from the first parent-chain

--- a/lms/djangoapps/courseware/tests/test_course_info.py
+++ b/lms/djangoapps/courseware/tests/test_course_info.py
@@ -13,6 +13,11 @@ from django.http import QueryDict
 from django.test.utils import override_settings
 from django.urls import reverse
 from edx_toggles.toggles.testutils import override_waffle_flag
+from pyquery import PyQuery as pq
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, check_mongo_calls
+from xmodule.modulestore.tests.utils import TEST_DATA_DIR
+from xmodule.modulestore.xml_importer import import_course_from_xml
 
 from lms.djangoapps.ccx.tests.factories import CcxFactory
 from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
@@ -21,18 +26,9 @@ from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES
 from openedx.features.content_type_gating.models import ContentTypeGatingConfig
 from openedx.features.course_experience import DISABLE_UNIFIED_COURSE_TAB_FLAG
 from openedx.features.enterprise_support.tests.mixins.enterprise import EnterpriseTestConsentRequired
-from pyquery import PyQuery as pq  # lint-amnesty, pylint: disable=wrong-import-order
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import AdminFactory
 from common.djangoapps.util.date_utils import strftime_localized
-from xmodule.modulestore.tests.django_utils import (  # lint-amnesty, pylint: disable=wrong-import-order
-    TEST_DATA_MIXED_MODULESTORE,
-    ModuleStoreTestCase,
-    SharedModuleStoreTestCase
-)
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, check_mongo_calls  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.utils import TEST_DATA_DIR  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.xml_importer import import_course_from_xml  # lint-amnesty, pylint: disable=wrong-import-order
 
 from .helpers import LoginEnrollmentTestCase
 
@@ -341,8 +337,6 @@ class CourseInfoTestCaseXML(LoginEnrollmentTestCase, ModuleStoreTestCase):
     """
     Tests for the Course Info page for an XML course
     """
-    MODULESTORE = TEST_DATA_MIXED_MODULESTORE
-
     def setUp(self):
         """
         Set up the tests
@@ -355,7 +349,7 @@ class CourseInfoTestCaseXML(LoginEnrollmentTestCase, ModuleStoreTestCase):
         self.xml_course_key = self.store.make_course_key('edX', 'detached_pages', '2014')
         import_course_from_xml(
             self.store,
-            'test_user',
+            self.user.id,
             TEST_DATA_DIR,
             source_dirs=['2014'],
             static_content_store=None,

--- a/lms/djangoapps/courseware/tests/test_course_survey.py
+++ b/lms/djangoapps/courseware/tests/test_course_survey.py
@@ -8,19 +8,21 @@ from copy import deepcopy
 
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.urls import reverse
-from xmodule.modulestore.tests.django_utils import TEST_DATA_MONGO_AMNESTY_MODULESTORE, SharedModuleStoreTestCase
+from edx_toggles.toggles.testutils import override_waffle_flag
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
 from common.test.utils import XssTestMixin
+from lms.djangoapps.course_home_api.toggles import COURSE_HOME_USE_LEGACY_FRONTEND
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from lms.djangoapps.survey.models import SurveyAnswer, SurveyForm
 
 
+@override_waffle_flag(COURSE_HOME_USE_LEGACY_FRONTEND, active=True)
 class SurveyViewsTests(LoginEnrollmentTestCase, SharedModuleStoreTestCase, XssTestMixin):
     """
     All tests for the views.py file
     """
-    MODULESTORE = TEST_DATA_MONGO_AMNESTY_MODULESTORE
     STUDENT_INFO = [('view@test.com', 'foo')]
 
     @classmethod

--- a/lms/djangoapps/courseware/tests/test_courses.py
+++ b/lms/djangoapps/courseware/tests/test_courses.py
@@ -54,7 +54,6 @@ TEST_DATA_DIR = settings.COMMON_TEST_DATA_ROOT
 @ddt.ddt
 class CoursesTest(ModuleStoreTestCase):
     """Test methods related to fetching courses."""
-    MODULESTORE = TEST_DATA_MONGO_AMNESTY_MODULESTORE
     ENABLED_SIGNALS = ['course_published']
     GET_COURSE_WITH_ACCESS = 'get_course_with_access'
     GET_COURSE_OVERVIEW_WITH_ACCESS = 'get_course_overview_with_access'
@@ -90,7 +89,7 @@ class CoursesTest(ModuleStoreTestCase):
         assert not error.value.access_response.has_access
 
     @ddt.data(
-        (GET_COURSE_WITH_ACCESS, 1),
+        (GET_COURSE_WITH_ACCESS, 3),
         (GET_COURSE_OVERVIEW_WITH_ACCESS, 0),
     )
     @ddt.unpack
@@ -370,11 +369,11 @@ class CourseInstantiationTests(ModuleStoreTestCase):
 
         self.factory = RequestFactory()
 
-    @ddt.data(*itertools.product(range(5), [ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split], [None, 0, 5]))
+    @ddt.data(*itertools.product(range(5), [None, 0, 5]))
     @ddt.unpack
-    def test_repeated_course_module_instantiation(self, loops, default_store, course_depth):
+    def test_repeated_course_module_instantiation(self, loops, course_depth):
 
-        with modulestore().default_store(default_store):
+        with modulestore().default_store(ModuleStoreEnum.Type.split):
             course = CourseFactory.create()
             chapter = ItemFactory(parent=course, category='chapter', graded=True)
             section = ItemFactory(parent=chapter, category='sequential')

--- a/lms/djangoapps/courseware/tests/test_split_module.py
+++ b/lms/djangoapps/courseware/tests/test_split_module.py
@@ -5,23 +5,25 @@ Test for split test XModule
 
 from unittest.mock import MagicMock
 from django.urls import reverse
-from xmodule.modulestore.tests.django_utils import TEST_DATA_MONGO_AMNESTY_MODULESTORE, SharedModuleStoreTestCase
+from edx_toggles.toggles.testutils import override_waffle_flag
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from xmodule.partitions.partitions import Group, UserPartition
 
 from lms.djangoapps.courseware.model_data import FieldDataCache
 from lms.djangoapps.courseware.module_render import get_module_for_descriptor
+from lms.djangoapps.courseware.toggles import COURSEWARE_USE_LEGACY_FRONTEND
 from openedx.core.djangoapps.user_api.tests.factories import UserCourseTagFactory
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
 
 
-class SplitTestBase(SharedModuleStoreTestCase):
+@override_waffle_flag(COURSEWARE_USE_LEGACY_FRONTEND, active=True)
+class SplitTestBase(ModuleStoreTestCase):
     """
     Sets up a basic course and user for split test testing.
     Also provides tests of rendered HTML for two user_tag conditions, 0 and 1.
     """
     __test__ = False
-    MODULESTORE = TEST_DATA_MONGO_AMNESTY_MODULESTORE
     COURSE_NUMBER = 'split-test-base'
     ICON_CLASSES = None
     TOOLTIPS = None
@@ -40,24 +42,23 @@ class SplitTestBase(SharedModuleStoreTestCase):
             ]
         )
 
-        cls.course = CourseFactory.create(
-            number=cls.COURSE_NUMBER,
-            user_partitions=[cls.partition]
-        )
+    def setUp(self):
+        super().setUp()
 
-        cls.chapter = ItemFactory.create(
-            parent_location=cls.course.location,
+        self.course = CourseFactory.create(
+            number=self.COURSE_NUMBER,
+            user_partitions=[self.partition]
+        )
+        self.chapter = ItemFactory.create(
+            parent_location=self.course.location,
             category="chapter",
             display_name="test chapter",
         )
-        cls.sequential = ItemFactory.create(
-            parent_location=cls.chapter.location,
+        self.sequential = ItemFactory.create(
+            parent_location=self.chapter.location,
             category="sequential",
             display_name="Split Test Tests",
         )
-
-    def setUp(self):
-        super().setUp()
 
         self.student = UserFactory.create()
         CourseEnrollmentFactory.create(user=self.student, course_id=self.course.id)

--- a/lms/djangoapps/courseware/tests/test_tabs.py
+++ b/lms/djangoapps/courseware/tests/test_tabs.py
@@ -237,8 +237,6 @@ class TextbooksTestCase(TabTestCase):
 class StaticTabDateTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase):
     """Test cases for Static Tab Dates."""
 
-    MODULESTORE = TEST_DATA_MIXED_MODULESTORE
-
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -294,8 +292,6 @@ class StaticTabDateTestCaseXML(LoginEnrollmentTestCase, ModuleStoreTestCase):
     Tests for the static tab dates of an XML course
     """
 
-    MODULESTORE = TEST_DATA_MIXED_MODULESTORE
-
     def setUp(self):
         """
         Set up the tests
@@ -308,7 +304,7 @@ class StaticTabDateTestCaseXML(LoginEnrollmentTestCase, ModuleStoreTestCase):
         self.xml_course_key = self.store.make_course_key('edX', 'detached_pages', '2014')
         import_course_from_xml(
             self.store,
-            'test_user',
+            self.user.id,
             TEST_DATA_DIR,
             source_dirs=['2014'],
             static_content_store=None,
@@ -341,8 +337,6 @@ class EntranceExamsTabsTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, Mi
     """
     Validate tab behavior when dealing with Entrance Exams
     """
-    MODULESTORE = TEST_DATA_MIXED_MODULESTORE
-
     @patch.dict('django.conf.settings.FEATURES', {'ENTRANCE_EXAMS': True})
     def setUp(self):
         """
@@ -351,10 +345,6 @@ class EntranceExamsTabsTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, Mi
         super().setUp()
 
         self.course = CourseFactory.create()
-        self.instructor_tab = ItemFactory.create(
-            category="instructor", parent_location=self.course.location,
-            data="Instructor Tab", display_name="Instructor"
-        )
         self.extra_tab_2 = ItemFactory.create(
             category="static_tab", parent_location=self.course.location,
             data="Extra Tab", display_name="Extra Tab 2"
@@ -376,7 +366,6 @@ class EntranceExamsTabsTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, Mi
         entrance_exam = ItemFactory.create(
             category="chapter",
             parent_location=self.course.location,
-            data="Exam Data",
             display_name="Entrance Exam",
             is_entrance_exam=True
         )

--- a/lms/djangoapps/discussion/django_comment_client/base/tests.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/tests.py
@@ -403,7 +403,6 @@ class ViewsQueryCountTestCase(
         return inner
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 3, 4, 39),
         (ModuleStoreEnum.Type.split, 3, 11, 39),
     )
     @ddt.unpack
@@ -412,7 +411,6 @@ class ViewsQueryCountTestCase(
         self.create_thread_helper(mock_request)
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 3, 3, 35),
         (ModuleStoreEnum.Type.split, 3, 9, 35),
     )
     @ddt.unpack

--- a/lms/djangoapps/grades/tests/base.py
+++ b/lms/djangoapps/grades/tests/base.py
@@ -4,7 +4,7 @@ Base file for Grades tests
 
 
 from crum import set_current_request
-from xmodule.modulestore.tests.django_utils import TEST_DATA_MONGO_AMNESTY_MODULESTORE, SharedModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
 from capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
@@ -21,8 +21,6 @@ class GradeTestBase(SharedModuleStoreTestCase):
     """
     Base class for some Grades tests.
     """
-    MODULESTORE = TEST_DATA_MONGO_AMNESTY_MODULESTORE
-
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -66,7 +64,7 @@ class GradeTestBase(SharedModuleStoreTestCase):
             cls.problem2 = ItemFactory.create(
                 parent=cls.sequence2,
                 category="problem",
-                display_name="Test Problem",
+                display_name="Test Problem 2",
                 data=problem_xml
             )
             # AED 2017-06-19: make cls.sequence belong to multiple parents,

--- a/lms/djangoapps/grades/tests/test_course_grade_factory.py
+++ b/lms/djangoapps/grades/tests/test_course_grade_factory.py
@@ -98,7 +98,7 @@ class TestCourseGradeFactory(GradeTestBase):
         with self.assertNumQueries(4), mock_get_score(1, 2):
             _assert_read(expected_pass=False, expected_percent=0)  # start off with grade of 0
 
-        num_queries = 42
+        num_queries = 41
         with self.assertNumQueries(num_queries), mock_get_score(1, 2):
             grade_factory.update(self.request.user, self.course, force_update_subsections=True)
 
@@ -112,14 +112,14 @@ class TestCourseGradeFactory(GradeTestBase):
         with self.assertNumQueries(3):
             _assert_read(expected_pass=True, expected_percent=0.5)  # NOT updated to grade of .25
 
-        num_queries = 23
+        num_queries = 18
         with self.assertNumQueries(num_queries), mock_get_score(2, 2):
             grade_factory.update(self.request.user, self.course, force_update_subsections=True)
 
         with self.assertNumQueries(3):
             _assert_read(expected_pass=True, expected_percent=1.0)  # updated to grade of 1.0
 
-        num_queries = 29
+        num_queries = 28
         with self.assertNumQueries(num_queries), mock_get_score(0, 0):  # the subsection now is worth zero
             grade_factory.update(self.request.user, self.course, force_update_subsections=True)
 

--- a/lms/djangoapps/grades/tests/test_transformer.py
+++ b/lms/djangoapps/grades/tests/test_transformer.py
@@ -9,15 +9,14 @@ from copy import deepcopy
 
 import ddt
 import pytz
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
+from xmodule.modulestore.tests.factories import check_mongo_calls
 
 from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.course_blocks.api import get_course_blocks
 from lms.djangoapps.course_blocks.transformers.tests.helpers import CourseStructureTestCase
 from openedx.core.djangoapps.content.block_structure.api import clear_course_from_cache
-from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import check_mongo_calls  # lint-amnesty, pylint: disable=wrong-import-order
 
 from ..transformer import GradesTransformer
 
@@ -49,7 +48,7 @@ class GradesTransformerTestCase(CourseStructureTestCase):
         Helper to update a course's grading policy in the modulestore.
         """
         course.set_grading_policy(grading_policy)
-        modulestore().update_item(course, self.user.id)
+        self.update_course(course, self.user.id)
 
     def _validate_grading_policy_hash(self, course_location, grading_policy_hash):
         """
@@ -115,10 +114,10 @@ class GradesTransformerTestCase(CourseStructureTestCase):
                 '#ref': 'course',
                 '#children': [
                     {
-                        'metadata': metadata,
                         '#type': 'problem',
                         '#ref': 'problem',
                         'data': data,
+                        **metadata,
                     }
                 ]
             }
@@ -369,13 +368,13 @@ class GradesTransformerTestCase(CourseStructureTestCase):
         )
 
     def test_course_version_not_collected_in_old_mongo(self):
-        blocks = self.build_course_with_problems()
+        with self.store.default_store(ModuleStoreEnum.Type.mongo):
+            blocks = self.build_course_with_problems()
         block_structure = get_course_blocks(self.student, blocks['course'].location, self.transformers)
         assert block_structure.get_xblock_field(blocks['course'].location, 'course_version') is None
 
     def test_course_version_collected_in_split(self):
-        with self.store.default_store(ModuleStoreEnum.Type.split):
-            blocks = self.build_course_with_problems()
+        blocks = self.build_course_with_problems()
         block_structure = get_course_blocks(self.student, blocks['course'].location, self.transformers)
         assert block_structure.get_xblock_field(blocks['course'].location, 'course_version') is not None
         assert block_structure.get_xblock_field(

--- a/lms/djangoapps/lti_provider/tests/test_views.py
+++ b/lms/djangoapps/lti_provider/tests/test_views.py
@@ -221,21 +221,3 @@ class LtiLaunchTestRender(LtiTestMixin, RenderXBlockTestMixin, ModuleStoreTestCa
         self.setup_course()
         self.setup_user(admin=False, enroll=True, login=False)
         self.verify_response()
-
-    def get_success_enrolled_staff_mongo_count(self):
-        """
-        Override because mongo queries are higher for this
-        particular test. This has not been investigated exhaustively
-        as mongo is no longer used much, and removing user_partitions
-        from inheritance fixes the problem.
-
-        # The 9 mongoDB calls include calls for
-        # Old Mongo:
-        #   (1) fill_in_run
-        #   (2) get_course in get_course_with_access
-        #   (3) get_item for HTML block in get_module_by_usage_id
-        #   (4) get_parent when loading HTML block
-        #   (5)-(8) calls related to the inherited user_partitions field.
-        #   (9) edx_notes descriptor call to get_course
-        """
-        return 9

--- a/lms/djangoapps/mobile_api/course_info/tests.py
+++ b/lms/djangoapps/mobile_api/course_info/tests.py
@@ -104,118 +104,76 @@ class TestHandouts(MobileAPITestCase, MobileAuthTestMixin, MobileCourseAccessTes
     """
     REVERSE_INFO = {'name': 'course-handouts-list', 'params': ['course_id', 'api_version']}
 
-    @ddt.data(
-        (ModuleStoreEnum.Type.mongo, API_V05),
-        (ModuleStoreEnum.Type.mongo, API_V1),
-        (ModuleStoreEnum.Type.split, API_V05),
-        (ModuleStoreEnum.Type.split, API_V1),
-    )
-    @ddt.unpack
-    def test_handouts(self, default_ms, api_version):
-        with self.store.default_store(default_ms):
-            self.add_mobile_available_toy_course()
-            response = self.api_response(expected_response_code=200, api_version=api_version)
-            assert 'Sample' in response.data['handouts_html']
+    @ddt.data(API_V05, API_V1)
+    def test_handouts(self, api_version):
+        self.add_mobile_available_toy_course()
+        response = self.api_response(expected_response_code=200, api_version=api_version)
+        assert 'Sample' in response.data['handouts_html']
 
-    @ddt.data(
-        (ModuleStoreEnum.Type.mongo, API_V05),
-        (ModuleStoreEnum.Type.mongo, API_V1),
-        (ModuleStoreEnum.Type.split, API_V05),
-        (ModuleStoreEnum.Type.split, API_V1),
-    )
-    @ddt.unpack
-    def test_no_handouts(self, default_ms, api_version):
-        with self.store.default_store(default_ms):
-            self.add_mobile_available_toy_course()
+    @ddt.data(API_V05, API_V1)
+    def test_no_handouts(self, api_version):
+        self.add_mobile_available_toy_course()
 
-            # delete handouts in course
-            handouts_usage_key = self.course.id.make_usage_key('course_info', 'handouts')
-            with self.store.branch_setting(ModuleStoreEnum.Branch.draft_preferred, self.course.id):
-                self.store.delete_item(handouts_usage_key, self.user.id)
+        # delete handouts in course
+        handouts_usage_key = self.course.id.make_usage_key('course_info', 'handouts')
+        with self.store.branch_setting(ModuleStoreEnum.Branch.draft_preferred, self.course.id):
+            self.store.delete_item(handouts_usage_key, self.user.id)
 
-            response = self.api_response(expected_response_code=200, api_version=api_version)
-            assert response.data['handouts_html'] is None
+        response = self.api_response(expected_response_code=200, api_version=api_version)
+        assert response.data['handouts_html'] is None
 
-    @ddt.data(
-        (ModuleStoreEnum.Type.mongo, API_V05),
-        (ModuleStoreEnum.Type.mongo, API_V1),
-        (ModuleStoreEnum.Type.split, API_V05),
-        (ModuleStoreEnum.Type.split, API_V1),
-    )
-    @ddt.unpack
-    def test_empty_handouts(self, default_ms, api_version):
-        with self.store.default_store(default_ms):
-            self.add_mobile_available_toy_course()
+    @ddt.data(API_V05, API_V1)
+    def test_empty_handouts(self, api_version):
+        self.add_mobile_available_toy_course()
 
-            # set handouts to empty tags
-            handouts_usage_key = self.course.id.make_usage_key('course_info', 'handouts')
-            underlying_handouts = self.store.get_item(handouts_usage_key)
-            underlying_handouts.data = "<ol></ol>"
-            self.store.update_item(underlying_handouts, self.user.id)
-            response = self.api_response(expected_response_code=200, api_version=api_version)
-            assert response.data['handouts_html'] is None
+        # set handouts to empty tags
+        handouts_usage_key = self.course.id.make_usage_key('course_info', 'handouts')
+        underlying_handouts = self.store.get_item(handouts_usage_key)
+        underlying_handouts.data = "<ol></ol>"
+        self.store.update_item(underlying_handouts, self.user.id)
+        response = self.api_response(expected_response_code=200, api_version=api_version)
+        assert response.data['handouts_html'] is None
 
-    @ddt.data(
-        (ModuleStoreEnum.Type.mongo, API_V05),
-        (ModuleStoreEnum.Type.mongo, API_V1),
-        (ModuleStoreEnum.Type.split, API_V05),
-        (ModuleStoreEnum.Type.split, API_V1),
-    )
-    @ddt.unpack
-    def test_handouts_static_rewrites(self, default_ms, api_version):
-        with self.store.default_store(default_ms):
-            self.add_mobile_available_toy_course()
+    @ddt.data(API_V05, API_V1)
+    def test_handouts_static_rewrites(self, api_version):
+        self.add_mobile_available_toy_course()
 
-            # check that we start with relative static assets
-            handouts_usage_key = self.course.id.make_usage_key('course_info', 'handouts')
-            underlying_handouts = self.store.get_item(handouts_usage_key)
-            assert "'/static/" in underlying_handouts.data
+        # check that we start with relative static assets
+        handouts_usage_key = self.course.id.make_usage_key('course_info', 'handouts')
+        underlying_handouts = self.store.get_item(handouts_usage_key)
+        assert "'/static/" in underlying_handouts.data
 
-            # but shouldn't finish with any
-            response = self.api_response(api_version=api_version)
-            assert "'/static/" not in response.data['handouts_html']
+        # but shouldn't finish with any
+        response = self.api_response(api_version=api_version)
+        assert "'/static/" not in response.data['handouts_html']
 
-    @ddt.data(
-        (ModuleStoreEnum.Type.mongo, API_V05),
-        (ModuleStoreEnum.Type.mongo, API_V1),
-        (ModuleStoreEnum.Type.split, API_V05),
-        (ModuleStoreEnum.Type.split, API_V1),
-    )
-    @ddt.unpack
-    def test_jump_to_id_handout_href(self, default_ms, api_version):
-        with self.store.default_store(default_ms):
-            self.add_mobile_available_toy_course()
+    @ddt.data(API_V05, API_V1)
+    def test_jump_to_id_handout_href(self, api_version):
+        self.add_mobile_available_toy_course()
 
-            # check that we start with relative static assets
-            handouts_usage_key = self.course.id.make_usage_key('course_info', 'handouts')
-            underlying_handouts = self.store.get_item(handouts_usage_key)
-            underlying_handouts.data = "<a href=\"/jump_to_id/identifier\">Intracourse Link</a>"
-            self.store.update_item(underlying_handouts, self.user.id)
+        # check that we start with relative static assets
+        handouts_usage_key = self.course.id.make_usage_key('course_info', 'handouts')
+        underlying_handouts = self.store.get_item(handouts_usage_key)
+        underlying_handouts.data = "<a href=\"/jump_to_id/identifier\">Intracourse Link</a>"
+        self.store.update_item(underlying_handouts, self.user.id)
 
-            # but shouldn't finish with any
-            response = self.api_response(api_version=api_version)
-            assert f'/courses/{self.course.id}/jump_to_id/' in response.data['handouts_html']
+        # but shouldn't finish with any
+        response = self.api_response(api_version=api_version)
+        assert f'/courses/{self.course.id}/jump_to_id/' in response.data['handouts_html']
 
-    @ddt.data(
-        (ModuleStoreEnum.Type.mongo, API_V05),
-        (ModuleStoreEnum.Type.mongo, API_V1),
-        (ModuleStoreEnum.Type.split, API_V05),
-        (ModuleStoreEnum.Type.split, API_V1),
-    )
-    @ddt.unpack
-    def test_course_url_handout_href(self, default_ms, api_version):
-        with self.store.default_store(default_ms):
-            self.add_mobile_available_toy_course()
+    @ddt.data(API_V05, API_V1)
+    def test_course_url_handout_href(self, api_version):
+        self.add_mobile_available_toy_course()
 
-            # check that we start with relative static assets
-            handouts_usage_key = self.course.id.make_usage_key('course_info', 'handouts')
-            underlying_handouts = self.store.get_item(handouts_usage_key)
-            underlying_handouts.data = "<a href=\"/course/identifier\">Linked Content</a>"
-            self.store.update_item(underlying_handouts, self.user.id)
+        # check that we start with relative static assets
+        handouts_usage_key = self.course.id.make_usage_key('course_info', 'handouts')
+        underlying_handouts = self.store.get_item(handouts_usage_key)
+        underlying_handouts.data = "<a href=\"/course/identifier\">Linked Content</a>"
+        self.store.update_item(underlying_handouts, self.user.id)
 
-            # but shouldn't finish with any
-            response = self.api_response(api_version=api_version)
-            assert f'/courses/{self.course.id}/' in response.data['handouts_html']
+        # but shouldn't finish with any
+        response = self.api_response(api_version=api_version)
+        assert f'/courses/{self.course.id}/' in response.data['handouts_html']
 
     def add_mobile_available_toy_course(self):
         """ use toy course with handouts, and make it mobile_available """

--- a/lms/djangoapps/mobile_api/testutils.py
+++ b/lms/djangoapps/mobile_api/testutils.py
@@ -22,7 +22,7 @@ from django.urls import reverse
 from django.utils import timezone
 from opaque_keys.edx.keys import CourseKey
 from rest_framework.test import APITestCase
-from xmodule.modulestore.tests.django_utils import TEST_DATA_MONGO_AMNESTY_MODULESTORE, ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
 from common.djangoapps.student import auth
@@ -41,8 +41,6 @@ class MobileAPITestCase(ModuleStoreTestCase, APITestCase):
        REVERSE_INFO = {'name': <django reverse name>, 'params': [<list of params in the URL>]}
     They may also override any of the methods defined in this class to control the behavior of the TestMixins.
     """
-    MODULESTORE = TEST_DATA_MONGO_AMNESTY_MODULESTORE
-
     def setUp(self):
         super().setUp()
         self.course = CourseFactory.create(

--- a/openedx/core/djangoapps/bookmarks/tests/test_models.py
+++ b/openedx/core/djangoapps/bookmarks/tests/test_models.py
@@ -14,7 +14,7 @@ from opaque_keys.edx.keys import UsageKey
 from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
-from xmodule.modulestore.tests.django_utils import TEST_DATA_MONGO_AMNESTY_MODULESTORE, ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, check_mongo_calls
 
 from openedx.core.djangolib.testing.utils import skip_unless_lms
@@ -35,9 +35,8 @@ class BookmarksTestsBase(ModuleStoreTestCase):
     """
     Test the Bookmark model.
     """
-    MODULESTORE = TEST_DATA_MONGO_AMNESTY_MODULESTORE
     ALL_FIELDS = DEFAULT_FIELDS + OPTIONAL_FIELDS
-    STORE_TYPE = ModuleStoreEnum.Type.mongo
+    STORE_TYPE = ModuleStoreEnum.Type.split
     TEST_PASSWORD = 'test'
 
     ENABLED_CACHES = ['default', 'mongo_metadata_inheritance', 'loc_cache']
@@ -50,7 +49,7 @@ class BookmarksTestsBase(ModuleStoreTestCase):
         self.other_user = UserFactory.create(password=self.TEST_PASSWORD)
         self.setup_data(self.STORE_TYPE)
 
-    def setup_data(self, store_type=ModuleStoreEnum.Type.mongo):
+    def setup_data(self, store_type=ModuleStoreEnum.Type.split):
         """ Create courses and add some test blocks. """
 
         with self.store.default_store(store_type):
@@ -58,35 +57,33 @@ class BookmarksTestsBase(ModuleStoreTestCase):
             self.course = CourseFactory.create(display_name='An Introduction to API Testing')
             self.course_id = str(self.course.id)
 
-            with self.store.bulk_operations(self.course.id):
+            self.chapter_1 = ItemFactory.create(
+                parent=self.course, category='chapter', display_name='Week 1'
+            )
+            self.chapter_2 = ItemFactory.create(
+                parent=self.course, category='chapter', display_name='Week 2'
+            )
 
-                self.chapter_1 = ItemFactory.create(
-                    parent_location=self.course.location, category='chapter', display_name='Week 1'
-                )
-                self.chapter_2 = ItemFactory.create(
-                    parent_location=self.course.location, category='chapter', display_name='Week 2'
-                )
+            self.sequential_1 = ItemFactory.create(
+                parent=self.chapter_1, category='sequential', display_name='Lesson 1'
+            )
+            self.sequential_2 = ItemFactory.create(
+                parent=self.chapter_1, category='sequential', display_name='Lesson 2'
+            )
 
-                self.sequential_1 = ItemFactory.create(
-                    parent_location=self.chapter_1.location, category='sequential', display_name='Lesson 1'
-                )
-                self.sequential_2 = ItemFactory.create(
-                    parent_location=self.chapter_1.location, category='sequential', display_name='Lesson 2'
-                )
+            self.vertical_1 = ItemFactory.create(
+                parent=self.sequential_1, category='vertical', display_name='Subsection 1'
+            )
+            self.vertical_2 = ItemFactory.create(
+                parent=self.sequential_2, category='vertical', display_name='Subsection 2'
+            )
+            self.vertical_3 = ItemFactory.create(
+                parent=self.sequential_2, category='vertical', display_name='Subsection 3'
+            )
 
-                self.vertical_1 = ItemFactory.create(
-                    parent_location=self.sequential_1.location, category='vertical', display_name='Subsection 1'
-                )
-                self.vertical_2 = ItemFactory.create(
-                    parent_location=self.sequential_2.location, category='vertical', display_name='Subsection 2'
-                )
-                self.vertical_3 = ItemFactory.create(
-                    parent_location=self.sequential_2.location, category='vertical', display_name='Subsection 3'
-                )
-
-                self.html_1 = ItemFactory.create(
-                    parent_location=self.vertical_2.location, category='html', display_name='Details 1'
-                )
+            self.html_1 = ItemFactory.create(
+                parent=self.vertical_2, category='html', display_name='Details 1'
+            )
 
         self.path = [
             PathItem(self.chapter_1.location, self.chapter_1.display_name),
@@ -135,24 +132,25 @@ class BookmarksTestsBase(ModuleStoreTestCase):
         with self.store.bulk_operations(self.other_course.id):
 
             self.other_chapter_1 = ItemFactory.create(
-                parent_location=self.other_course.location, category='chapter', display_name='Other Week 1'
+                parent=self.other_course, category='chapter', display_name='Other Week 1'
             )
             self.other_sequential_1 = ItemFactory.create(
-                parent_location=self.other_chapter_1.location, category='sequential', display_name='Other Lesson 1'
+                parent=self.other_chapter_1, category='sequential', display_name='Other Lesson 1'
             )
             self.other_sequential_2 = ItemFactory.create(
-                parent_location=self.other_chapter_1.location, category='sequential', display_name='Other Lesson 2'
+                parent=self.other_chapter_1, category='sequential', display_name='Other Lesson 2'
             )
             self.other_vertical_1 = ItemFactory.create(
-                parent_location=self.other_sequential_1.location, category='vertical', display_name='Other Subsection 1'
+                parent=self.other_sequential_1, category='vertical', display_name='Other Subsection 1'
             )
             self.other_vertical_2 = ItemFactory.create(
-                parent_location=self.other_sequential_1.location, category='vertical', display_name='Other Subsection 2'
+                parent=self.other_sequential_1, category='vertical', display_name='Other Subsection 2'
             )
 
             # self.other_vertical_1 has two parents
             self.other_sequential_2.children.append(self.other_vertical_1.location)
-            modulestore().update_item(self.other_sequential_2, self.admin.id)
+            with self.store.branch_setting(ModuleStoreEnum.Branch.draft_preferred, self.course.id):
+                self.store.update_item(self.other_sequential_2, self.admin.id)
 
         self.other_bookmark_1 = BookmarkFactory.create(
             user=self.user,
@@ -164,7 +162,7 @@ class BookmarksTestsBase(ModuleStoreTestCase):
             }),
         )
 
-    def create_course_with_blocks(self, children_per_block=1, depth=1, store_type=ModuleStoreEnum.Type.mongo):
+    def create_course_with_blocks(self, children_per_block=1, depth=1, store_type=ModuleStoreEnum.Type.split):
         """
         Create a course and add blocks.
         """
@@ -173,23 +171,23 @@ class BookmarksTestsBase(ModuleStoreTestCase):
             course = CourseFactory.create()
             display_name = 0
 
-            with self.store.bulk_operations(course.id):
-                blocks_at_next_level = [course]
+            blocks_at_next_level = [course]
 
-                for __ in range(depth):
-                    blocks_at_current_level = blocks_at_next_level
-                    blocks_at_next_level = []
+            for __ in range(depth):
+                blocks_at_current_level = blocks_at_next_level
+                blocks_at_next_level = []
 
-                    for block in blocks_at_current_level:
-                        for __ in range(children_per_block):
-                            blocks_at_next_level += [ItemFactory.create(
-                                parent_location=block.scope_ids.usage_id, display_name=str(display_name)
-                            )]
-                            display_name += 1
+                for block in blocks_at_current_level:
+                    for __ in range(children_per_block):
+                        blocks_at_next_level += [ItemFactory.create(
+                            parent_location=block.location, display_name=str(display_name)
+                        )]
+                        display_name += 1
 
-        return course
+        with self.store.branch_setting(ModuleStoreEnum.Branch.draft_preferred, course.id):
+            return self.store.get_course(course.id, depth=None)
 
-    def create_course_with_bookmarks_count(self, count, store_type=ModuleStoreEnum.Type.mongo):
+    def create_course_with_bookmarks_count(self, count, store_type=ModuleStoreEnum.Type.split):
         """
         Create a course, add some content and add bookmarks.
         """
@@ -197,10 +195,9 @@ class BookmarksTestsBase(ModuleStoreTestCase):
 
             course = CourseFactory.create()
 
-            with self.store.bulk_operations(course.id):
-                blocks = [ItemFactory.create(
-                    parent_location=course.location, category='chapter', display_name=str(index)
-                ) for index in range(count)]
+            blocks = [ItemFactory.create(
+                parent=course, category='chapter', display_name=str(index)
+            ) for index in range(count)]
 
             bookmarks = [BookmarkFactory.create(
                 user=self.user,
@@ -255,7 +252,7 @@ class BookmarkModelTests(BookmarksTestsBase):
         super().setUp()
 
         self.vertical_4 = ItemFactory.create(
-            parent_location=self.sequential_2.location,
+            parent=self.sequential_2,
             category='vertical',
             display_name=None
         )
@@ -272,26 +269,21 @@ class BookmarkModelTests(BookmarksTestsBase):
         }
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 'course', [], 3),
-        (ModuleStoreEnum.Type.mongo, 'chapter_1', [], 3),
-        (ModuleStoreEnum.Type.mongo, 'sequential_1', ['chapter_1'], 4),
-        (ModuleStoreEnum.Type.mongo, 'vertical_1', ['chapter_1', 'sequential_1'], 6),
-        (ModuleStoreEnum.Type.mongo, 'html_1', ['chapter_1', 'sequential_2', 'vertical_2'], 7),
-        (ModuleStoreEnum.Type.split, 'course', [], 3),
-        (ModuleStoreEnum.Type.split, 'chapter_1', [], 2),
-        (ModuleStoreEnum.Type.split, 'sequential_1', ['chapter_1'], 2),
-        (ModuleStoreEnum.Type.split, 'vertical_1', ['chapter_1', 'sequential_1'], 2),
-        (ModuleStoreEnum.Type.split, 'html_1', ['chapter_1', 'sequential_2', 'vertical_2'], 2),
+        ('course', [], 3),
+        ('chapter_1', [], 2),
+        ('sequential_1', ['chapter_1'], 2),
+        ('vertical_1', ['chapter_1', 'sequential_1'], 2),
+        ('html_1', ['chapter_1', 'sequential_2', 'vertical_2'], 2),
     )
     @ddt.unpack
-    def test_path_and_queries_on_create(self, store_type, block_to_bookmark, ancestors_attrs, expected_mongo_calls):
+    def test_path_and_queries_on_create(self, block_to_bookmark, ancestors_attrs, expected_mongo_calls):
         """
         In case of mongo, 1 query is used to fetch the block, and 2
         by path_to_location(), and then 1 query per parent in path
         is needed to fetch the parent blocks.
         """
 
-        self.setup_data(store_type)
+        self.setup_data()
         user = UserFactory.create()
 
         expected_path = [PathItem(
@@ -353,7 +345,7 @@ class BookmarkModelTests(BookmarksTestsBase):
         mock_get_path.return_value = block_path
 
         html = ItemFactory.create(
-            parent_location=self.other_chapter_1.location, category='html', display_name='Other Lesson 1'
+            parent=self.other_chapter_1, category='html', display_name='Other Lesson 1'
         )
 
         bookmark_data = self.get_bookmark_data(html)
@@ -369,32 +361,23 @@ class BookmarkModelTests(BookmarksTestsBase):
         assert mock_get_path.call_count == get_path_call_count
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 2, 2, 2),
-        (ModuleStoreEnum.Type.mongo, 4, 2, 2),
-        (ModuleStoreEnum.Type.mongo, 6, 2, 2),
-        (ModuleStoreEnum.Type.mongo, 2, 3, 3),
-        (ModuleStoreEnum.Type.mongo, 4, 3, 3),
-        # (ModuleStoreEnum.Type.mongo, 6, 3, 3), Too slow.
-        (ModuleStoreEnum.Type.mongo, 2, 4, 4),
-        # (ModuleStoreEnum.Type.mongo, 4, 4, 4),
-        (ModuleStoreEnum.Type.split, 2, 2, 1),
-        (ModuleStoreEnum.Type.split, 4, 2, 1),
-        (ModuleStoreEnum.Type.split, 2, 3, 1),
-        # (ModuleStoreEnum.Type.split, 4, 3, 1),
-        (ModuleStoreEnum.Type.split, 2, 4, 1),
-
+        (2, 2, 1),
+        (4, 2, 1),
+        (2, 3, 1),
+        # (4, 3, 1),
+        (2, 4, 1),
     )
     @ddt.unpack
-    def test_get_path_queries(self, store_type, children_per_block, depth, expected_mongo_calls):
+    def test_get_path_queries(self, children_per_block, depth, expected_mongo_calls):
         """
         In case of mongo, 2 queries are used by path_to_location(), and then
         1 query per parent in path is needed to fetch the parent blocks.
         """
 
-        course = self.create_course_with_blocks(children_per_block, depth, store_type)
+        course = self.create_course_with_blocks(children_per_block, depth)
 
         # Find a leaf block.
-        block = modulestore().get_course(course.id, depth=None)
+        block = course
         for __ in range(depth - 1):
             children = block.get_children()
             block = children[-1]
@@ -408,8 +391,8 @@ class BookmarkModelTests(BookmarksTestsBase):
         user = UserFactory.create()
 
         # Block does not exist
-        usage_key = UsageKey.from_string('i4x://edX/apis/html/interactive')
-        usage_key.replace(course_key=self.course.id)
+        key = self.course.id
+        usage_key = UsageKey.from_string(f'block-v1:{key.org}+{key.course}+{key.run}+type@vertical+block@interactive')
         assert not Bookmark.get_path(usage_key)
 
         # Block is an orphan

--- a/openedx/core/djangoapps/bookmarks/tests/test_tasks.py
+++ b/openedx/core/djangoapps/bookmarks/tests/test_tasks.py
@@ -6,7 +6,6 @@ Tests for tasks.
 import ddt
 
 from xmodule.modulestore import ModuleStoreEnum
-from xmodule.modulestore.tests.django_utils import TEST_DATA_MONGO_AMNESTY_MODULESTORE
 from xmodule.modulestore.tests.factories import ItemFactory, check_mongo_calls
 
 from ..models import XBlockCache
@@ -19,8 +18,6 @@ class XBlockCacheTaskTests(BookmarksTestsBase):
     """
     Test the XBlockCache model.
     """
-    MODULESTORE = TEST_DATA_MONGO_AMNESTY_MODULESTORE
-
     def setUp(self):
         super().setUp()
 
@@ -104,21 +101,15 @@ class XBlockCacheTaskTests(BookmarksTestsBase):
         }
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 2, 2, 4),
-        (ModuleStoreEnum.Type.mongo, 4, 2, 4),
-        (ModuleStoreEnum.Type.mongo, 2, 3, 5),
-        (ModuleStoreEnum.Type.mongo, 4, 3, 5),
-        (ModuleStoreEnum.Type.mongo, 2, 4, 6),
-        # (ModuleStoreEnum.Type.mongo, 4, 4, 6), Too slow.
-        (ModuleStoreEnum.Type.split, 2, 2, 3),
-        (ModuleStoreEnum.Type.split, 4, 2, 3),
-        (ModuleStoreEnum.Type.split, 2, 3, 3),
-        (ModuleStoreEnum.Type.split, 2, 4, 3),
+        (2, 2, 3),
+        (4, 2, 3),
+        (2, 3, 3),
+        (2, 4, 3),
     )
     @ddt.unpack
-    def test_calculate_course_xblocks_data_queries(self, store_type, children_per_block, depth, expected_mongo_calls):
+    def test_calculate_course_xblocks_data_queries(self, children_per_block, depth, expected_mongo_calls):
 
-        course = self.create_course_with_blocks(children_per_block, depth, store_type)
+        course = self.create_course_with_blocks(children_per_block, depth, ModuleStoreEnum.Type.split)
 
         # clear cache to get consistent query counts
         self.clear_caches()
@@ -174,7 +165,7 @@ class XBlockCacheTaskTests(BookmarksTestsBase):
         Test that the xblocks data is persisted correctly with display_name=None.
         """
         block_with_display_name_none = ItemFactory.create(
-            parent_location=self.sequential_2.location,
+            parent=self.sequential_2,
             category='vertical', display_name=None
         )
 

--- a/openedx/core/djangoapps/enrollments/tests/fixtures/course-enrollments-api-list-valid-data.json
+++ b/openedx/core/djangoapps/enrollments/tests/fixtures/course-enrollments-api-list-valid-data.json
@@ -1,18 +1,18 @@
 [
     [
         {
-            "course_id": "e/d/X"
+            "course_id": "course-v1:e+d+X"
         },
         [
             {
-                "course_id": "e/d/X",
+                "course_id": "course-v1:e+d+X",
                 "is_active": true,
                 "mode": "honor",
                 "user": "student1",
                 "created": "2018-01-01T00:00:01Z"
             },
             {
-                "course_id": "e/d/X",
+                "course_id": "course-v1:e+d+X",
                 "is_active": true,
                 "mode": "honor",
                 "user": "student2",
@@ -22,25 +22,25 @@
     ],
     [
         {
-            "course_id": "x/y/Z"
+            "course_id": "course-v1:x+y+Z"
         },
         [
             {
-                "course_id": "x/y/Z",
+                "course_id": "course-v1:x+y+Z",
                 "is_active": true,
                 "mode": "verified",
                 "user": "staff",
                 "created": "2018-01-01T00:00:01Z"
             },
             {
-                "course_id": "x/y/Z",
+                "course_id": "course-v1:x+y+Z",
                 "is_active": true,
                 "mode": "honor",
                 "user": "student2",
                 "created": "2018-01-01T00:00:01Z"
             },
             {
-                "course_id": "x/y/Z",
+                "course_id": "course-v1:x+y+Z",
                 "is_active": true,
                 "mode": "verified",
                 "user": "student3",
@@ -50,19 +50,19 @@
     ],
     [
         {
-            "course_id": "x/y/Z",
+            "course_id": "course-v1:x+y+Z",
             "username": "student2,student3"
         },
         [
             {
-                "course_id": "x/y/Z",
+                "course_id": "course-v1:x+y+Z",
                 "is_active": true,
                 "mode": "honor",
                 "user": "student2",
                 "created": "2018-01-01T00:00:01Z"
             },
             {
-                "course_id": "x/y/Z",
+                "course_id": "course-v1:x+y+Z",
                 "is_active": true,
                 "mode": "verified",
                 "user": "student3",
@@ -72,12 +72,12 @@
     ],
     [
         {
-            "course_id": "x/y/Z",
+            "course_id": "course-v1:x+y+Z",
             "username": "student1,student2"
         },
         [
             {
-                "course_id": "x/y/Z",
+                "course_id": "course-v1:x+y+Z",
                 "is_active": true,
                 "mode": "honor",
                 "user": "student2",
@@ -91,21 +91,21 @@
         },
         [
             {
-                "course_id": "x/y/Z",
+                "course_id": "course-v1:x+y+Z",
                 "is_active": true,
                 "mode": "verified",
                 "user": "staff",
                 "created": "2018-01-01T00:00:01Z"
             },
             {
-                "course_id": "e/d/X",
+                "course_id": "course-v1:e+d+X",
                 "is_active": true,
                 "mode": "honor",
                 "user": "student2",
                 "created": "2018-01-01T00:00:01Z"
             },
             {
-                "course_id": "x/y/Z",
+                "course_id": "course-v1:x+y+Z",
                 "is_active": true,
                 "mode": "honor",
                 "user": "student2",
@@ -118,35 +118,35 @@
         null,
         [
             {
-                "course_id": "e/d/X",
+                "course_id": "course-v1:e+d+X",
                 "is_active": true,
                 "mode": "honor",
                 "user": "student1",
                 "created": "2018-01-01T00:00:01Z"
             },
             {
-                "course_id": "e/d/X",
+                "course_id": "course-v1:e+d+X",
                 "is_active": true,
                 "mode": "honor",
                 "user": "student2",
                 "created": "2018-01-01T00:00:01Z"
             },
             {
-                "course_id": "x/y/Z",
+                "course_id": "course-v1:x+y+Z",
                 "is_active": true,
                 "mode": "verified",
                 "user": "student3",
                 "created": "2018-01-01T00:00:01Z"
             },
             {
-                "course_id": "x/y/Z",
+                "course_id": "course-v1:x+y+Z",
                 "is_active": true,
                 "mode": "honor",
                 "user": "student2",
                 "created": "2018-01-01T00:00:01Z"
             },
             {
-                "course_id": "x/y/Z",
+                "course_id": "course-v1:x+y+Z",
                 "is_active": true,
                 "mode": "verified",
                 "user": "staff",

--- a/openedx/core/djangoapps/enrollments/tests/test_views.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_views.py
@@ -25,7 +25,7 @@ from django.urls import reverse
 from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.test import APITestCase
-from xmodule.modulestore.tests.django_utils import TEST_DATA_MONGO_AMNESTY_MODULESTORE, ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, check_mongo_calls_range
 
 from common.djangoapps.course_modes.models import CourseMode
@@ -1600,7 +1600,6 @@ class CourseEnrollmentsApiListTest(APITestCase, ModuleStoreTestCase):
     """
     Test the course enrollments list API.
     """
-    MODULESTORE = TEST_DATA_MONGO_AMNESTY_MODULESTORE
     CREATED_DATA = datetime.datetime(2018, 1, 1, 0, 0, 1, tzinfo=pytz.UTC)
 
     def setUp(self):
@@ -1613,7 +1612,7 @@ class CourseEnrollmentsApiListTest(APITestCase, ModuleStoreTestCase):
         self.rate_limit, __ = throttle.parse_rate(throttle.rate)
 
         self.course = CourseFactory.create(org='e', number='d', run='X', emit_signals=True)
-        self.course2 = CourseFactory.create(org='x', number='y', run='Z', emit_signal=True)
+        self.course2 = CourseFactory.create(org='x', number='y', run='Z', emit_signals=True)
 
         for mode_slug in ('honor', 'verified', 'audit'):
             CourseModeFactory.create(

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_utils.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_utils.py
@@ -84,13 +84,10 @@ class CompletionUtilsTestCase(SharedModuleStoreTestCase, CompletionWaffleTestMix
         """
         course = CourseFactory.create()
         with self.store.bulk_operations(course.id):
-            self.chapter = ItemFactory.create(category='chapter', parent_location=course.location)
-            self.sequential = ItemFactory.create(category='sequential', parent_location=self.chapter.location)
-            self.vertical1 = ItemFactory.create(category='vertical', parent_location=self.sequential.location)
-            self.vertical2 = ItemFactory.create(category='vertical', parent_location=self.sequential.location)
-        course.children = [self.chapter]
-        self.chapter.children = [self.sequential]
-        self.sequential.children = [self.vertical1, self.vertical2]
+            self.chapter = ItemFactory.create(category='chapter', parent=course)
+            self.sequential = ItemFactory.create(category='sequential', parent=self.chapter)
+            self.vertical1 = ItemFactory.create(category='vertical', parent=self.sequential)
+            self.vertical2 = ItemFactory.create(category='vertical', parent=self.sequential)
 
         if hasattr(self, 'user_one'):
             CourseEnrollment.enroll(self.engaged_user, course.id)
@@ -100,9 +97,9 @@ class CompletionUtilsTestCase(SharedModuleStoreTestCase, CompletionWaffleTestMix
 
     def submit_faux_completions(self):
         """
-        Submit completions (only for user_one)g
+        Submit completions (only for user_one)
         """
-        for block in self.course.children[0].children[0].children:
+        for block in self.sequential.get_children():
             models.BlockCompletion.objects.submit_completion(
                 user=self.engaged_user,
                 block_key=block.location,

--- a/openedx/features/content_type_gating/tests/test_access.py
+++ b/openedx/features/content_type_gating/tests/test_access.py
@@ -12,6 +12,7 @@ from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils import timezone
 from django.contrib.auth import get_user_model
+from edx_toggles.toggles.testutils import override_waffle_flag
 from pyquery import PyQuery as pq
 from xmodule.modulestore.tests.django_utils import (
     TEST_DATA_MONGO_AMNESTY_MODULESTORE, ModuleStoreTestCase, SharedModuleStoreTestCase,
@@ -29,6 +30,7 @@ from common.djangoapps.student.tests.factories import OrgStaffFactory
 from common.djangoapps.student.tests.factories import StaffFactory
 from lms.djangoapps.courseware.module_render import load_single_xblock
 from lms.djangoapps.courseware.tests.helpers import MasqueradeMixin
+from lms.djangoapps.courseware.toggles import COURSEWARE_USE_LEGACY_FRONTEND
 from lms.djangoapps.discussion.django_comment_client.tests.factories import RoleFactory
 from openedx.core.djangoapps.django_comment_common.models import (
     FORUM_ROLE_ADMINISTRATOR,
@@ -163,9 +165,9 @@ def _assert_block_is_empty(block, user_id, course, request_factory):
 @override_settings(FIELD_OVERRIDE_PROVIDERS=(
     'openedx.features.content_type_gating.field_override.ContentTypeGatingFieldOverride',
 ))
+@override_waffle_flag(COURSEWARE_USE_LEGACY_FRONTEND, active=True)
 class TestProblemTypeAccess(SharedModuleStoreTestCase, MasqueradeMixin):  # pylint: disable=missing-class-docstring
 
-    MODULESTORE = TEST_DATA_MONGO_AMNESTY_MODULESTORE
     PROBLEM_TYPES = ['problem', 'openassessment', 'drag-and-drop-v2', 'done', 'edx_sga']
     # 'html' is a component that just displays html, in these tests it is used to test that users who do not have access
     # to graded problems still have access to non-problems
@@ -208,16 +210,19 @@ class TestProblemTypeAccess(SharedModuleStoreTestCase, MasqueradeMixin):  # pyli
         cls.graded_score_weight_blocks = {}
         for graded, has_score, weight, gated in cls.GRADED_SCORE_WEIGHT_TEST_CASES:
             case_name = ' Graded: ' + str(graded) + ' Has Score: ' + str(has_score) + ' Weight: ' + str(weight)
-            block = ItemFactory.create(
-                parent=cls.blocks_dict['vertical'],
+            block_args = {
+                'parent': cls.blocks_dict['vertical'],
                 # has_score is determined by XBlock type. It is not a value set on an instance of an XBlock.
                 # Therefore, we create a problem component when has_score is True
                 # and an html component when has_score is False.
-                category='problem' if has_score else 'html',
-                graded=graded,
-                weight=weight,
-                metadata=METADATA if (graded and has_score and weight) else {},
-            )
+                'category': 'problem' if has_score else 'html',
+                'graded': graded,
+            }
+            if has_score:
+                block_args['weight'] = weight
+            if graded and has_score and weight:
+                block_args['metadata'] = METADATA
+            block = ItemFactory.create(**block_args)
             # Intersperse HTML so that the content-gating renders in all blocks
             ItemFactory.create(
                 parent=cls.blocks_dict['vertical'],
@@ -230,7 +235,6 @@ class TestProblemTypeAccess(SharedModuleStoreTestCase, MasqueradeMixin):  # pyli
         metadata_lti_xblock = {
             'lti_id': 'correct_lti_id',
             'launch_url': 'http://{}:{}/{}'.format(host, '8765', 'correct_lti_endpoint'),
-            'open_in_a_new_page': False
         }
 
         scored_lti_metadata = {}
@@ -781,13 +785,12 @@ class TestProblemTypeAccess(SharedModuleStoreTestCase, MasqueradeMixin):  # pyli
 @override_settings(FIELD_OVERRIDE_PROVIDERS=(
     'openedx.features.content_type_gating.field_override.ContentTypeGatingFieldOverride',
 ))
+@override_waffle_flag(COURSEWARE_USE_LEGACY_FRONTEND, active=True)
 class TestConditionalContentAccess(TestConditionalContent):
     """
     Conditional Content allows course authors to run a/b tests on course content.  We want to make sure that
     even if one of these a/b tests are being run, the student still has the correct access to the content.
     """
-    MODULESTORE = TEST_DATA_MONGO_AMNESTY_MODULESTORE
-
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -883,6 +886,7 @@ class TestConditionalContentAccess(TestConditionalContent):
 @override_settings(FIELD_OVERRIDE_PROVIDERS=(
     'openedx.features.content_type_gating.field_override.ContentTypeGatingFieldOverride',
 ))
+@override_waffle_flag(COURSEWARE_USE_LEGACY_FRONTEND, active=True)
 class TestMessageDeduplication(ModuleStoreTestCase):
     """
     Tests to verify that access denied messages isn't shown if multiple items in a row are denied.
@@ -895,7 +899,6 @@ class TestMessageDeduplication(ModuleStoreTestCase):
     how it's currently tested). If that method changes to use something other than the template
     message, this method's checks will need to be updated.
     """
-    MODULESTORE = TEST_DATA_MONGO_AMNESTY_MODULESTORE
 
     def setUp(self):
         super().setUp()

--- a/openedx/tests/xblock_integration/test_crowdsource_hinter.py
+++ b/openedx/tests/xblock_integration/test_crowdsource_hinter.py
@@ -8,7 +8,7 @@ import unittest
 import simplejson as json
 from django.conf import settings
 from django.urls import reverse
-from xmodule.modulestore.tests.django_utils import TEST_DATA_MONGO_AMNESTY_MODULESTORE, SharedModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
@@ -20,7 +20,6 @@ class TestCrowdsourceHinter(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Create the test environment with the crowdsourcehinter xblock.
     """
-    MODULESTORE = TEST_DATA_MONGO_AMNESTY_MODULESTORE
     STUDENTS = [
         {'email': 'view@test.com', 'password': 'foo'},
         {'email': 'view2@test.com', 'password': 'foo'}

--- a/openedx/tests/xblock_integration/test_recommender.py
+++ b/openedx/tests/xblock_integration/test_recommender.py
@@ -14,19 +14,21 @@ import simplejson as json
 from ddt import data, ddt
 from django.conf import settings
 from django.urls import reverse
-from xmodule.modulestore.tests.django_utils import TEST_DATA_MONGO_AMNESTY_MODULESTORE, SharedModuleStoreTestCase
+from edx_toggles.toggles.testutils import override_waffle_flag
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
+from lms.djangoapps.courseware.toggles import COURSEWARE_USE_LEGACY_FRONTEND
 from openedx.core.lib.url_utils import quote_slashes
 
 
+@override_waffle_flag(COURSEWARE_USE_LEGACY_FRONTEND, active=True)
 class TestRecommender(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Check that Recommender state is saved properly
     """
-    MODULESTORE = TEST_DATA_MONGO_AMNESTY_MODULESTORE
     STUDENTS = [
         {'email': 'view@test.com', 'password': 'foo'},
         {'email': 'view2@test.com', 'password': 'foo'}

--- a/openedx/tests/xblock_integration/xblock_testcase.py
+++ b/openedx/tests/xblock_integration/xblock_testcase.py
@@ -48,12 +48,14 @@ import pytz
 from bs4 import BeautifulSoup
 from django.conf import settings
 from django.urls import reverse
+from edx_toggles.toggles.testutils import override_waffle_flag
 from xblock.plugin import Plugin
-from xmodule.modulestore.tests.django_utils import TEST_DATA_MONGO_AMNESTY_MODULESTORE, SharedModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
 import lms.djangoapps.lms_xblock.runtime
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
+from lms.djangoapps.courseware.toggles import COURSEWARE_USE_LEGACY_FRONTEND
 
 
 class XBlockEventTestMixin:
@@ -240,7 +242,7 @@ class XBlockScenarioTestCaseMixin:
         with cls.store.bulk_operations(cls.course.id, emit_signals=False):
             for chapter_config in cls.test_configuration:
                 chapter = ItemFactory.create(
-                    parent=cls.course,
+                    parent_location=cls.course.location,
                     display_name="ch_" + chapter_config['urlname'],
                     category='chapter'
                 )
@@ -335,6 +337,7 @@ class XBlockStudentTestCaseMixin:
         self.login(email, password)
 
 
+@override_waffle_flag(COURSEWARE_USE_LEGACY_FRONTEND, active=True)
 class XBlockTestCase(XBlockStudentTestCaseMixin,
                      XBlockScenarioTestCaseMixin,
                      XBlockEventTestMixin,
@@ -346,7 +349,6 @@ class XBlockTestCase(XBlockStudentTestCaseMixin,
     Class for all XBlock-internal test cases (as opposed to
     integration tests).
     """
-    MODULESTORE = TEST_DATA_MONGO_AMNESTY_MODULESTORE
     test_configuration = None  # Children must override this!
 
     entry_point = 'xblock.test.v0'


### PR DESCRIPTION
**This PR has only test changes**

Convert more tests from MONGO_AMNESTY to SPLIT modulestores.

This is in preparation for just wholesale denying access to Old
Mongo, so I either converted tests to split or just deleted some
test variants that were Old Mongo specific. (e.g. ddt lines)
