### PR TITLE
feat: [AA-1206] remove redundant fields from API

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2557,7 +2557,7 @@ paths:
             * pacing: Course pacing. Possible values: instructor, self
             * tabs: Course tabs
             * user_timezone: User's chosen timezone setting (or null for browser default)
-            * can_load_course: Whether the user can view the course (AccessResponse object)
+            * can_load_courseware: Whether the user can view the course (AccessResponse object)
             * is_staff: Whether the effective user has staff access to the course
             * original_user_is_staff: Whether the original user has staff access to the course
             * can_view_legacy_courseware: Indicates whether the user is able to see the legacy courseware view

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2557,7 +2557,6 @@ paths:
             * pacing: Course pacing. Possible values: instructor, self
             * tabs: Course tabs
             * user_timezone: User's chosen timezone setting (or null for browser default)
-            * can_load_courseware: Whether the user can view the course (AccessResponse object)
             * is_staff: Whether the effective user has staff access to the course
             * original_user_is_staff: Whether the original user has staff access to the course
             * can_view_legacy_courseware: Indicates whether the user is able to see the legacy courseware view

--- a/lms/djangoapps/courseware/access_response.py
+++ b/lms/djangoapps/courseware/access_response.py
@@ -236,14 +236,3 @@ class AuthenticationRequiredAccessError(AccessError):
         developer_message = "User must be authenticated to view the course"
         user_message = _("You must be logged in to see this course")
         super().__init__(error_code, developer_message, user_message)
-
-
-class CoursewareMicrofrontendDisabledAccessError(AccessError):
-    """
-    Access denied because the courseware micro-frontend is disabled for this user.
-    """
-    def __init__(self):
-        error_code = 'microfrontend_disabled'
-        developer_message = 'Micro-frontend is disabled for this user'
-        user_message = _('Please view your course in the existing experience')
-        super().__init__(error_code, developer_message, user_message)

--- a/openedx/core/djangoapps/courseware_api/serializers.py
+++ b/openedx/core/djangoapps/courseware_api/serializers.py
@@ -108,7 +108,6 @@ class CourseInfoSerializer(serializers.Serializer):  # pylint: disable=abstract-
     original_user_is_staff = serializers.BooleanField()
     can_view_legacy_courseware = serializers.BooleanField()
     is_staff = serializers.BooleanField()
-    course_access = serializers.DictField()
     notes = serializers.DictField()
     marketing_url = serializers.CharField()
     celebrations = serializers.DictField()
@@ -120,7 +119,6 @@ class CourseInfoSerializer(serializers.Serializer):  # pylint: disable=abstract-
     linkedin_add_to_profile_url = serializers.URLField()
     is_integrity_signature_enabled = serializers.BooleanField()
     user_needs_integrity_signature = serializers.BooleanField()
-    username = serializers.CharField()
 
     def __init__(self, *args, **kwargs):
         """

--- a/openedx/core/djangoapps/courseware_api/tests/test_views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/test_views.py
@@ -226,7 +226,6 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
 
             if enable_anonymous and not logged_in:
                 # multiple checks use this handler
-                check_public_access.assert_called()
                 assert response.data['enrollment']['mode'] is None
                 assert response.data['course_goals']['selected_goal'] is None
                 assert response.data['course_goals']['weekly_learning_goal_enabled'] is False

--- a/openedx/core/djangoapps/courseware_api/tests/test_views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/test_views.py
@@ -130,9 +130,7 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
     )
     @ddt.unpack
     @mock.patch.dict('django.conf.settings.FEATURES', {'CERTIFICATES_HTML_VIEW': True})
-    @mock.patch('openedx.core.djangoapps.courseware_api.views.CoursewareMeta.is_microfrontend_enabled_for_user')
-    def test_enrolled_course_metadata(self, logged_in, enrollment_mode, is_microfrontend_enabled_for_user):
-        is_microfrontend_enabled_for_user.return_value = True
+    def test_enrolled_course_metadata(self, logged_in, enrollment_mode):
         check_public_access = mock.Mock()
         check_public_access.return_value = ACCESS_DENIED
         with mock.patch('lms.djangoapps.courseware.access_utils.check_public_access', check_public_access):
@@ -178,7 +176,7 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
 
             if enrollment_mode == 'audit':
                 assert response.data['verify_identity_url'] is None
-                assert response.data['verification_status'] == 'none'  # lint-amnesty, pylint: disable=literal-comparison
+                assert response.data['verification_status'] == 'none'
                 assert response.data['linkedin_add_to_profile_url'] is None
             else:
                 assert response.data['certificate_data']['cert_status'] == 'earned_but_not_available'
@@ -187,7 +185,7 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
                 )
                 # The response contains an absolute URL so this is only checking the path of the final
                 assert expected_verify_identity_url in response.data['verify_identity_url']
-                assert response.data['verification_status'] == 'none'  # lint-amnesty, pylint: disable=literal-comparison
+                assert response.data['verification_status'] == 'none'
 
                 request = RequestFactory().request()
                 cert_url = get_certificate_url(course_id=self.course.id, uuid=cert.verify_uuid)
@@ -216,9 +214,7 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
     )
     @ddt.unpack
     @mock.patch.dict('django.conf.settings.FEATURES', {'CERTIFICATES_HTML_VIEW': True})
-    @mock.patch('openedx.core.djangoapps.courseware_api.views.CoursewareMeta.is_microfrontend_enabled_for_user')
-    def test_unenrolled_course_metadata(self, logged_in, enable_anonymous, is_microfrontend_enabled_for_user):
-        is_microfrontend_enabled_for_user.return_value = True
+    def test_unenrolled_course_metadata(self, logged_in, enable_anonymous):
         check_public_access = mock.Mock()
         check_public_access.return_value = enable_anonymous
         with mock.patch('lms.djangoapps.courseware.access_utils.check_public_access', check_public_access):
@@ -232,11 +228,8 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
                 # multiple checks use this handler
                 check_public_access.assert_called()
                 assert response.data['enrollment']['mode'] is None
-                assert response.data['course_access']['has_access']
                 assert response.data['course_goals']['selected_goal'] is None
                 assert response.data['course_goals']['weekly_learning_goal_enabled'] is False
-            else:
-                assert not response.data['course_access']['has_access']
 
     @ddt.data(
         # Who has access to MFE courseware?
@@ -246,7 +239,6 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
             "username": "student",
             "enroll_user": True,
             "masquerade_role": None,
-            "expect_course_access": True,
         },
         {
             # Un-enrolled learners should NOT have access.
@@ -254,7 +246,6 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
             "username": "student",
             "enroll_user": False,
             "masquerade_role": None,
-            "expect_course_access": False,
         },
         {
             # Un-enrolled instructors should have access.
@@ -262,7 +253,6 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
             "username": "instructor",
             "enroll_user": False,
             "masquerade_role": None,
-            "expect_course_access": True,
         },
         {
             # Un-enrolled instructors masquerading as students should have access.
@@ -270,7 +260,6 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
             "username": "instructor",
             "enroll_user": False,
             "masquerade_role": "student",
-            "expect_course_access": True,
         },
         {
             # If MFE is not visible, enrolled learners shouldn't have access.
@@ -278,7 +267,6 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
             "username": "student",
             "enroll_user": True,
             "masquerade_role": None,
-            "expect_course_access": False,
         },
         {
             # If MFE is not visible, instructors shouldn't have access.
@@ -286,7 +274,6 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
             "username": "instructor",
             "enroll_user": False,
             "masquerade_role": None,
-            "expect_course_access": False,
         },
         {
             # If MFE is not visible, masquerading instructors shouldn't have access.
@@ -294,7 +281,6 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
             "username": "instructor",
             "enroll_user": False,
             "masquerade_role": "student",
-            "expect_course_access": False,
         },
     )
     @ddt.unpack
@@ -304,7 +290,6 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
             username: str,
             enroll_user: bool,
             masquerade_role: Optional[str],
-            expect_course_access: bool,
     ):
         """
         Test that course_access is calculated correctly based on
@@ -314,22 +299,13 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
         if enroll_user:
             CourseEnrollment.enroll(user, self.course.id, 'audit')
 
-        patch_mfe_visible = mock.patch(
-            'openedx.core.djangoapps.courseware_api.views.courseware_mfe_is_visible',
-            return_value=mfe_is_visible,
-        )
         self.client.login(username=user, password='foo')
         if masquerade_role:
             self.update_masquerade(role=masquerade_role)
-        with patch_mfe_visible:
-            response = self.client.get(self.url)
+
+        response = self.client.get(self.url)
 
         assert response.status_code == 200
-        assert response.data['username'] == masquerade_role or username
-        if expect_course_access:
-            assert response.data['course_access']['has_access']
-        else:
-            assert not response.data['course_access']['has_access']
 
     def test_streak_data_in_response(self):
         """ Test that metadata endpoint returns data for the streak celebration """

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -33,7 +33,6 @@ from lms.djangoapps.course_goals.api import get_course_goal
 from lms.djangoapps.courseware.access import has_access
 
 from lms.djangoapps.courseware.context_processor import user_timezone_locale_prefs
-from lms.djangoapps.courseware.courses import check_course_access
 from lms.djangoapps.courseware.masquerade import (
     is_masquerading_as_specific_student,
     setup_masquerade,
@@ -82,16 +81,7 @@ class CoursewareMeta:
             username or self.request.user.username,
             course_key,
         )
-        # We must compute course load access *before* setting up masquerading,
-        # else course staff (who are not enrolled) will not be able view
-        # their course from the perspective of a learner.
-        self.load_access = check_course_access(
-            self.overview,
-            self.request.user,
-            'load',
-            check_if_enrolled=True,
-            check_if_authenticated=True,
-        )
+
         self.original_user_is_staff = has_access(self.request.user, 'staff', self.overview).has_access
         self.original_user_is_global_staff = self.request.user.is_staff
         self.course_key = course_key


### PR DESCRIPTION
Part of a larger effort to clean up the MFE BFF endpoints.
Remove the redundant fields username and course_access, both of which are also available in the course home metadata call.

This API is a BackendForFrontend API, and therefore does not need to deprecate the change.
This work is the follow on to https://openedx.atlassian.net/browse/AA-1018 which removed the dependency of the frontend on these fields.

Related frontend work is on https://github.com/openedx/frontend-app-learning/pull/838