### PR TITLE
fix: [REV-2608] add missing CSS class for currency conversion on Track Selection

### DIFF
--- a/lms/templates/course_modes/track_selection.html
+++ b/lms/templates/course_modes/track_selection.html
@@ -68,7 +68,6 @@ from openedx.core.djangolib.js_utils import js_escaped_string
     </script>
 </%block>
 
-## REV-2133 TODO: check with Website if this is required in the new Track Selection template.
 <%static:webpack entry="Currency">
     new Currency();
 </%static:webpack>
@@ -110,7 +109,7 @@ from openedx.core.djangolib.js_utils import js_escaped_string
                                             <path d="M26.6667 3.33333H23.3333V0H6.66667V3.33333H3.33333C1.5 3.33333 0 4.83333 0 6.66667V8.33333C0 12.5833 3.2 16.05 7.31667 16.5667C8.36667 19.0667 10.6167 20.95 13.3333 21.5V26.6667H6.66667V30H23.3333V26.6667H16.6667V21.5C19.3833 20.95 21.6333 19.0667 22.6833 16.5667C26.8 16.05 30 12.5833 30 8.33333V6.66667C30 4.83333 28.5 3.33333 26.6667 3.33333ZM3.33333 8.33333V6.66667H6.66667V13.0333C4.73333 12.3333 3.33333 10.5 3.33333 8.33333ZM26.6667 8.33333C26.6667 10.5 25.2667 12.3333 23.3333 13.0333V6.66667H26.6667V8.33333Z" fill="#EFF8FA"/>
                                         </svg>
                                     </span>
-                                    <p class="price-display">${currency_symbol}${min_price} ${currency}</p>
+                                    <p class="price-display upgrade-price-string">${currency_symbol}${min_price} ${currency}</p>
                                     <div class="choice-title"><h4>${_("Earn a certificate")}</h4></div>
                                     <%block name="track_selection_certificate_bullets"/> 
                                     <ul class="list-actions">


### PR DESCRIPTION
## Description

The Track Selection page is shown to learners when they first search for and then opt to enroll in a course. It (in most cases) prompts the user whether they want to continue in a free audit track, or upgrade to a paid track with a verified certificate.

The Track Selection page is currently not displaying course prices for learners in their local currency. Instead, it is showing prices in the platform's default currency.

This PR fixes the Track Selection page so it displays course prices for learners in their local currency.

## Supporting information

* Jira:
    * Found while testing: [REV-2608](https://openedx.atlassian.net/browse/REV-2608)
    * Related to: [REV-1241](https://openedx.atlassian.net/browse/REV-1241)
* Confluence: [Research](https://openedx.atlassian.net/wiki/spaces/~931919476/pages/3330507388/REV-2608#Aside:-Track-Selection-Currency-Conversion)

## Testing instructions

* In devstack:
   * [X] Get test course Track Selection page URL (mine is http://localhost:18000/course_modes/choose/course-v1:ecomm-test-courses+7833+1/)
   * [X] Check test course Track Selection page shows platform default currency
   * [X] Use `make develop-fast` in prospectus to access course page http://localhost:5335/course/data-analytics-for-business
   * [X] Manually set cookie `localhost-edx-cf-loc` with value `IN`, refresh the page, and check cookie `edx-price-l10n` is set.
   * [X] Reload the test course Track Selection page URL and check it shows converted currency.
* In prod:
   * [x] Use Console to monitor for JS errors.
   * [x] Check a course page in prospectus looks right and leads to a track selection in the platform's default currency.
   * [x] Record test course Prospectus URL and Track Selection URL.
   * [x] Simulate a learner from a country that does not use the platform's default currency:
      1. Go to test course Prospectus URL.
      2. In Chrome DevTools Sources pane, set breakpoint on line 106 of src/data/actions/user.jsx (the first line of getUserCurrencyAndSetCookie()).
      3. Refresh page and wait for breakpoint to hit.
      4. In Chrome DevTools Application pane, change edx.org Cookie `prod-edx-cf-loc` from US to IN. This will simulate a user in India.
      5. In Chrome DevTools Sources pane, continue script execution.
   * [x] Check the same cookie can be used in Track Selection with no JS error.
   * [x] Access test course Track Selection URL and check price is converted to a foreign currency.
   * [x] Monitor purchases telemetry dashboard.

## Deadline

None.

## Other information

For currency conversion to work in a Mako template, it must:
1. Call `Currency()` to invoke [currency.js](https://github.com/openedx/edx-platform/blob/master/openedx/features/course_experience/static/course_experience/js/currency.js#L32).
2. Be in a page flow after cookie `edx-price-l10n` is set (usually on the prospectus course information page).
3. Have the price in an HTML node with CSS class `upgrade-price-string`.
4. Have the HTML node with the price match the regex `/(\$)([\d|.]*)( USD)/`, where the price is in the second group.