### PR TITLE
style: heading color and mobile screen fix

### DIFF
--- a/lms/static/sass/views/_program-details.scss
+++ b/lms/static/sass/views/_program-details.scss
@@ -301,12 +301,14 @@ $btn-color-primary: $primary-dark;
     display: flex;
     justify-content: flex-start;
     flex-direction: column;
+    margin-right: 48px;
 
     .program-heading-title {
       font-family: $font-family-sans-serif;
       font-weight: 700;
       margin-bottom: 5px;
       line-height: normal;
+      color: theme-color("primary") !important;
     }
 
     .program-heading-message {

--- a/lms/templates/learner_dashboard/program_details_tab_view.underscore
+++ b/lms/templates/learner_dashboard/program_details_tab_view.underscore
@@ -26,7 +26,7 @@
 </div>
 <div class="tab-content" id="ProgramTabContent">
   <div class="tab-pane fade show active" id="journey" role="tabpanel" aria-labelledby="journey-tab">
-    <div class="col-md-12 d-flex">
+    <div class="col-md-12 d-md-flex">
         <article class="program-details-content col-md-8">
             <div class="program-heading">
                 <% if (completedCount === totalCount) { %>
@@ -115,7 +115,7 @@
 
   <div class="tab-pane fade" id="pathways" role="tabpanel" aria-labelledby="pathaways-tab">
     <% if (creditPathways.length > 0) { %>
-        <div class="js-program-pathways program-credit-pathways col-md-12 d-flex">
+        <div class="js-program-pathways program-credit-pathways col-md-12 d-md-flex">
             <aside class="col-md-4 program-heading">
                 <h2 class = "divider-heading program-heading-title"><%- gettext('Additional Credit Opportunities') %></h2>
                 <div class="program-heading-message">
@@ -129,7 +129,7 @@
                    </div>
                 </div>
             </aside>
-            <div class="col-md-8">
+            <div class="col-md-8 pr-5">
                 <% for (var i = 0; i < creditPathways.length; i++) {
                     var pathway = creditPathways[i];
                 %>
@@ -154,7 +154,7 @@
     <% } %>
 
     <% if (industryPathways.length > 0) { %>
-        <div class="js-program-pathways program-industry-pathways col-md-12 d-flex">
+        <div class="js-program-pathways program-industry-pathways col-md-12 d-md-flex">
             <aside class="col-md-4">
                <h2 class ="program-heading-title"><%- gettext('Additional Professional Opportunities') %></h2>
             </aside>

--- a/lms/templates/learner_dashboard/program_details_view.underscore
+++ b/lms/templates/learner_dashboard/program_details_view.underscore
@@ -1,7 +1,7 @@
 <header class="js-program-header program-header full-width-banner"></header>
 <!-- TODO: consider if article is the most appropriate element here -->
 
-<div class="col-md-12 d-flex">
+<div class="col-md-12 d-md-flex">
 <article class="program-details-content col-md-8">
     <div class="program-heading">
             <% if (completedCount === totalCount) { %>


### PR DESCRIPTION
Addressed feedback UI issues along with a fix for mobile screen size 

Mobile screen size UI fix

<img width="293" alt="Screenshot 2022-02-15 at 1 13 56 AM" src="https://user-images.githubusercontent.com/67791278/153939303-ce7d45aa-f13f-4168-8027-871490bfd9b7.png">


Color FIx for headings 

<img width="819" alt="Screenshot 2022-02-15 at 1 13 33 AM" src="https://user-images.githubusercontent.com/67791278/153939295-fb456278-2be2-423c-843c-7bf4a9a26b4e.png">
