### PR TITLE
Fix: provide a new data property on CoursewareMeta for proctoring exam access

### DIFF
--- a/openedx/core/djangoapps/courseware_api/serializers.py
+++ b/openedx/core/djangoapps/courseware_api/serializers.py
@@ -107,6 +107,7 @@ class CourseInfoSerializer(serializers.Serializer):  # pylint: disable=abstract-
     show_calculator = serializers.BooleanField()
     original_user_is_staff = serializers.BooleanField()
     can_view_legacy_courseware = serializers.BooleanField()
+    can_access_proctored_exams = serializers.BooleanField()
     is_staff = serializers.BooleanField()
     course_access = serializers.DictField()
     notes = serializers.DictField()

--- a/openedx/core/djangoapps/courseware_api/tests/test_views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/test_views.py
@@ -417,6 +417,26 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
         assert 'user_needs_integrity_signature' in courseware_data
         assert courseware_data['user_needs_integrity_signature'] == needs_signature
 
+    @ddt.data(
+        ('audit', False),
+        ('honor', False),
+        ('verified', True),
+        ('masters', True),
+        ('professional', True),
+        ('no-id-professional', True),
+        ('executive-education', True),
+        ('credit', True),
+    )
+    @ddt.unpack
+    @mock.patch.dict('django.conf.settings.FEATURES', {'DISABLE_HONOR_CERTIFICATES': True})
+    def test_can_access_proctored_exams(self, mode, result):
+        CourseEnrollment.enroll(self.user, self.course.id, mode)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        courseware_data = response.json()
+        assert 'can_access_proctored_exams' in courseware_data
+        assert courseware_data['can_access_proctored_exams'] == result
+
 
 @ddt.ddt
 class SequenceApiTestViews(MasqueradeMixin, BaseCoursewareTests):

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -388,6 +388,12 @@ class CoursewareMeta:
         user_timezone_locale = user_timezone_locale_prefs(self.request)
         return user_timezone_locale['user_timezone']
 
+    @property
+    def can_access_proctored_exams(self):
+        enrollment_mode = self.enrollment['mode']
+        enrollment_active = self.enrollment['is_active']
+        return enrollment_active and CourseMode.is_eligible_for_certificate(enrollment_mode)
+
 
 class CoursewareInformation(RetrieveAPIView):
     """


### PR DESCRIPTION
## Description

[MST-1273](https://openedx.atlassian.net/browse/MST-1273)
In order to determine whether the learner can access proctoring exams on the learning MFE, we should provide that data point from courswareMeta object. This is the change to provide the data point.

@openedx/masters-devs-cosmonauts Please review.

I won't merge this until my PRs on learning MFE and special exams MFE libraries are also ready.