### PR TITLE
fix: remove pre tag processing for course import

### DIFF
--- a/common/lib/xmodule/xmodule/raw_module.py
+++ b/common/lib/xmodule/xmodule/raw_module.py
@@ -24,21 +24,7 @@ class RawMixin:
 
     @classmethod
     def definition_from_xml(cls, xml_object, system):  # lint-amnesty, pylint: disable=missing-function-docstring, unused-argument
-        try:
-            data = etree.tostring(xml_object, pretty_print=True, encoding='unicode')
-            pre_tag_data = []
-            for pre_tag_info in xml_object.findall('.//pre'):
-                if len(pre_tag_info.findall('.//pre')) == 0:
-                    pre_tag_data.append(etree.tostring(pre_tag_info))
-
-            if pre_tag_data:
-                matches = re.finditer(PRE_TAG_REGEX, data)
-                for match_num, match in enumerate(matches):
-                    data = re.sub(match.group(), pre_tag_data[match_num].decode(), data)
-            etree.XML(data)  # it just checks if generated string is valid xml
-            return {'data': data}, []
-        except etree.XMLSyntaxError:
-            return {'data': etree.tostring(xml_object, pretty_print=True, encoding='unicode')}, []
+        return {'data': etree.tostring(xml_object, pretty_print=True, encoding='unicode')}, []
 
     def definition_to_xml(self, resource_fs):  # lint-amnesty, pylint: disable=unused-argument
         """


### PR DESCRIPTION
### [TNL-9525](https://openedx.atlassian.net/browse/TNL-9525)

#### Description

Remove pre-tag processing within course import workflow. We encountered an xml file containing a lot of pre tag within it (nested pre-tag) in it as well, and the processing of the file resulted in a MemoryException where we ran out of memory computing the file for pre-tags. 
We have decided to remove this process for the time being to stop course import being a blocker, and will revisit this to resolve the initial minor issue faced when spaces are added to the xml when processing a file with pre tags in them.