### PR TITLE
fix: do not deny proctoring access when masquerading as verified learner

### DIFF
--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -391,9 +391,18 @@ class CoursewareMeta:
 
     @property
     def can_access_proctored_exams(self):
-        enrollment_mode = self.enrollment['mode']
-        enrollment_active = self.enrollment['is_active']
-        return enrollment_active and CourseMode.is_eligible_for_certificate(enrollment_mode)
+        """Returns if the user is eligible to access proctored exams"""
+        if is_masquerading_as_non_audit_enrollment(
+            self.effective_user,
+            self.course_key,
+            self.course_masquerade
+        ):
+            # Masquerading should mimic the correct enrollment track behavior.
+            return True
+        else:
+            enrollment_mode = self.enrollment['mode']
+            enrollment_active = self.enrollment['is_active']
+            return enrollment_active and CourseMode.is_eligible_for_certificate(enrollment_mode)
 
 
 class CoursewareInformation(RetrieveAPIView):


### PR DESCRIPTION
### Description
This is a bug fix for [the PR](https://github.com/openedx/edx-platform/pull/29929) created for [MST-1273](https://openedx.atlassian.net/browse/MST-1273). In this fix, we fix the bug if the staff user is masquerading as a generic verified learner, we can provide proctoring access properly.
@openedx/masters-devs-cosmonauts Please review