### PR TITLE
fix: moved new mfe behind waffle flag

### DIFF
--- a/lms/djangoapps/discussion/tests/test_views.py
+++ b/lms/djangoapps/discussion/tests/test_views.py
@@ -2280,6 +2280,7 @@ class ForumMFETestCase(ForumsEnableMixin, SharedModuleStoreTestCase):
         self.course = CourseFactory.create()
         self.user = UserFactory.create()
         self.staff_user = AdminFactory.create()
+        CourseEnrollmentFactory.create(user=self.user, course_id=self.course.id)
 
     @ddt.data(*itertools.product(("http://test.url", None), (True, False), (True, False)))
     @ddt.unpack
@@ -2294,16 +2295,12 @@ class ForumMFETestCase(ForumsEnableMixin, SharedModuleStoreTestCase):
                 self.client.login(username=username, password='test')
                 response = self.client.get(reverse("forum_form_discussion", args=[self.course.id]))
                 content = response.content.decode('utf8')
-        if mfe_url and is_staff:
-            assert "You are viewing an educator only preview of the new discussions experience!" in content
-            if toggle_enabled:
-                assert "legacy experience" in content
-                assert "new experience" not in content
-            else:
-                assert "legacy experience" not in content
-                assert "new experience" in content
+        if mfe_url and toggle_enabled:
+            assert "An educator preview of new discussions experience is available!" in content
+            assert "legacy experience" in content
+            assert "new experience" not in content
         else:
-            assert "You are viewing an educator only preview of the new discussions experience!" not in content
+            assert "An educator preview of new discussions experience is available!" not in content
 
     @override_settings(DISCUSSIONS_MICROFRONTEND_URL="http://test.url")
     @ddt.data(*itertools.product((True, False), ("legacy", "new", None)))
@@ -2320,7 +2317,7 @@ class ForumMFETestCase(ForumsEnableMixin, SharedModuleStoreTestCase):
                 experience_in_url = f"discussions_experience={experience}"
             response = self.client.get(f"{url}?{experience_in_url}")
             content = response.content.decode('utf8')
-        if (toggle_enabled and experience != "legacy") or experience == "new":
+        if toggle_enabled and experience != "legacy":
             assert "discussions-mfe-tab-embed" in content
         else:
             assert "discussions-mfe-tab-embed" not in content

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -714,24 +714,23 @@ def _discussions_mfe_context(query_params: Dict, course_key: CourseKey, user: Us
     Returns:
         A URL for the MFE experience if active for the current request or None
     """
-    experience_param = query_params.get("discussions_experience", "").lower()
     mfe_url = get_discussions_mfe_url(course_key)
     if not mfe_url:
         return {"show_banner": False, "show_mfe": False}
-    show_banner = bool(has_access(user, 'staff', course_key))
-    forum_url = reverse("forum_form_discussion", args=[course_key])
+    discussions_mfe_enabled = ENABLE_DISCUSSIONS_MFE.is_enabled(course_key)
     show_mfe = False
-    # Show the MFE if the new experience is requested,
-    # or if the legacy experience is not requested and the MFE is enabled
-    if experience_param == "new" or (experience_param != "legacy" and ENABLE_DISCUSSIONS_MFE.is_enabled(course_key)):
+    # Show the MFE if the new MFE is enabled,
+    # or if the legacy experience is requested show legacy experience
+    if query_params.get("discussions_experience", "").lower() != "legacy" and discussions_mfe_enabled:
         show_mfe = True
+    forum_url = reverse("forum_form_discussion", args=[course_key])
     return {
         "show_mfe": show_mfe,
         "legacy_url": f"{forum_url}?discussions_experience=legacy",
         "mfe_url": f"{forum_url}?discussions_experience=new",
         "share_feedback_url": settings.DISCUSSIONS_MFE_FEEDBACK_URL,
         "course_key": course_key,
-        "show_banner": show_banner,
+        "show_banner": discussions_mfe_enabled,
         "discussions_mfe_url": mfe_url,
     }
 

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -720,7 +720,7 @@ def _discussions_mfe_context(query_params: Dict, course_key: CourseKey, user: Us
     discussions_mfe_enabled = ENABLE_DISCUSSIONS_MFE.is_enabled(course_key)
     show_mfe = False
     # Show the MFE if the new MFE is enabled,
-    # or if the legacy experience is requested show legacy experience
+    # or if the legacy experience is not requested via query param
     if query_params.get("discussions_experience", "").lower() != "legacy" and discussions_mfe_enabled:
         show_mfe = True
     forum_url = reverse("forum_form_discussion", args=[course_key])

--- a/lms/templates/discussion/_switch_experience_fragment.html
+++ b/lms/templates/discussion/_switch_experience_fragment.html
@@ -9,7 +9,7 @@ from django.utils.translation import ugettext as _
 % if show_banner:
 <div class="upgrade-banner d-flex bg-primary text-white align-items-center px-4 py-3">
     <div class="d-flex w-100">
-        ${_("You are viewing an educator only preview of the new discussions experience!")}
+        ${_("An educator preview of new discussions experience is available!")}
     </div>
 
     % if show_mfe:


### PR DESCRIPTION
## Ticket : https://openedx.atlassian.net/browse/TNL-9596

The user was able to access the new MFE by accessing new MFE URL  , Now it is behind the waffle flag and Now banner is also dependent on a waffle.
Also removed banned logic which previously showed banner to all staff now I will also depend on waffle