### PR TITLE
perf: use CourseOverview instead of modulestore when getting course summaries

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -489,7 +489,7 @@ def _accessible_courses_list_from_groups(request):
     course_keys = list(course_keys.values())
 
     if course_keys:
-        courses_list = modulestore().get_course_summaries(course_keys=course_keys)
+        courses_list = CourseOverview.get_all_courses(filter_={'id__in': course_keys})
 
     return courses_list, []
 

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -461,7 +461,7 @@ def _accessible_courses_iter_for_tests(request):
 
         return has_studio_read_access(request.user, course.id)
 
-    courses = filter(course_filter, modulestore().get_course_summaries())
+    courses = filter(course_filter, CourseOverview.get_all_courses())
 
     in_process_course_actions = get_in_process_course_actions(request)
     return courses, in_process_course_actions

--- a/cms/djangoapps/contentstore/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_index.py
@@ -31,6 +31,7 @@ from common.djangoapps.course_action_state.models import CourseRerunState
 from common.djangoapps.student.auth import has_course_author_access
 from common.djangoapps.student.roles import CourseStaffRole, GlobalStaff, LibraryUserRole
 from common.djangoapps.student.tests.factories import UserFactory
+from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.exceptions import ItemNotFoundError  # lint-amnesty, pylint: disable=wrong-import-order
@@ -341,6 +342,7 @@ class TestCourseIndexArchived(CourseTestCase):
         self.course.display_name = 'Active Course 1'
         self.ORG = self.course.location.org
         self.save_course()
+        CourseOverviewFactory.create(id=self.course.id, org=self.ORG)
 
         # Active course has end date set to tomorrow
         self.active_course = CourseFactory.create(
@@ -348,10 +350,20 @@ class TestCourseIndexArchived(CourseTestCase):
             org=self.ORG,
             end=self.TOMORROW,
         )
+        CourseOverviewFactory.create(
+            id=self.active_course.id,
+            org=self.ORG,
+            end=self.TOMORROW,
+        )
 
         # Archived course has end date set to yesterday
         self.archived_course = CourseFactory.create(
             display_name='Archived Course',
+            org=self.ORG,
+            end=self.YESTERDAY,
+        )
+        CourseOverviewFactory.create(
+            id=self.archived_course.id,
             org=self.ORG,
             end=self.YESTERDAY,
         )
@@ -391,8 +403,8 @@ class TestCourseIndexArchived(CourseTestCase):
 
     @ddt.data(
         # Staff user has course staff access
-        (True, 'staff', None, 3, 18),
-        (False, 'staff', None, 3, 18),
+        (True, 'staff', None, 1, 19),
+        (False, 'staff', None, 1, 19),
         # Base user has global staff access
         (True, 'user', ORG, 3, 18),
         (False, 'user', ORG, 3, 18),


### PR DESCRIPTION
## Description

This PR improves studio course listing performance for users with course access roles like staff or instructor by changing from MongoDB queries to Mysql queries. 

We measured the improvements as follows:

After 100 requests:

| Number of courses | Avg time elapsed before (s)  | Avg time elapsed after (s) |
|---------------------------|---------------------------------------|------------------------------------|
|         50                   |                2.34                        |         2.28                           |
|         107                 |                3.16                        |         2.57                           |
|         548                 |                7.91                        |         3.16                           |
|         1069               |                Error 500                |         4.62                           |
|         3380               |                Error 500                |         8.21                           |


If you go to /home using users with access roles staff/instructor in an org with more than ~500 courses, the page will collapse and raise a Network Timeout avoiding users to create new courses from the home page.

**Versions**
Mongo 4.0
MySQL 5.7
Lilac release

## Testing instructions

Go to Studio Home with a user with access roles (instructor/staff) over an organization, then the list of courses must match the CourseOverviews.

## Rejected strategies

We first tried to paginate the course listing (1st attempt in this [PR](https://github.com/openedx/edx-platform/pull/29902/)) but then realized we had to paginate both the course overview queryset and the mongo cursor. After trying with the cursor, we dropped the idea, given all the changes needed to make it work. Has this been tried before? I found [this](https://openedx.atlassian.net/browse/EDUCATOR-1258) ticket, but no implementation info.

## Concerns
According to [this](https://discuss.openedx.org/t/adr-for-removing-mongodb-from-edx-platform/6001), this change won't be necessary after altogether deprecating MongoDB from edxapp. There are some PR(s) linked on the post, but according to [these lines](https://github.com/openedx/edx-platform/pull/29058/files#diff-8eb3411fa751186021d817958f3bad09004d6a6e18d925f909677cba6b01c493R604-R647), we are still reading from MongoDB so that these changes could be helpful for organizations with numerous courses.