### PR TITLE
feat: hide Old Mongo courses from catalog

### DIFF
--- a/lms/djangoapps/course_api/serializers.py
+++ b/lms/djangoapps/course_api/serializers.py
@@ -123,7 +123,7 @@ class CourseSerializer(serializers.Serializer):  # pylint: disable=abstract-meth
         Represents whether course is hidden in LMS
         """
         catalog_visibility = course_overview.catalog_visibility
-        return catalog_visibility in ['about', 'none']
+        return catalog_visibility in ['about', 'none'] or course_overview.id.deprecated  # Old Mongo should be hidden
 
     def get_blocks_url(self, course_overview):
         """

--- a/lms/djangoapps/course_api/tests/test_serializers.py
+++ b/lms/djangoapps/course_api/tests/test_serializers.py
@@ -78,7 +78,7 @@ class TestCourseSerializer(CourseApiFactoryMixin, ModuleStoreTestCase):
             'effort': '6 hours',
             'pacing': 'instructor',
             'mobile_available': True,
-            'hidden': False,
+            'hidden': True,  # because it's an old mongo course
             'invitation_only': False,
 
             # 'course_id' is a deprecated field, please use 'id' instead.


### PR DESCRIPTION
This is step one of removing access altogether. But first, let's not advertise them.

[DEPR-58](https://openedx.atlassian.net/browse/DEPR-58)
[DEPR-123](https://openedx.atlassian.net/browse/DEPR-123)

Related to https://github.com/openedx/edx-platform/pull/29848