### PR TITLE
[BD-32] feat: add unenrollment Open edX Filter

### DIFF
--- a/common/djangoapps/student/tests/test_filters.py
+++ b/common/djangoapps/student/tests/test_filters.py
@@ -1,13 +1,15 @@
 """
-Test that various filters are fired for models in the student app.
+Test that various filters are fired for models/views in the student app.
 """
 from django.test import override_settings
+from django.urls import reverse
+from openedx_filters import PipelineStep
+from openedx_filters.learning.filters import CourseEnrollmentStarted, CourseUnenrollmentStarted
+from rest_framework import status
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
-from openedx_filters.learning.filters import CourseEnrollmentStarted
-from openedx_filters import PipelineStep
 
-from common.djangoapps.student.models import CourseEnrollment, EnrollmentNotAllowed
+from common.djangoapps.student.models import CourseEnrollment, EnrollmentNotAllowed, UnenrollmentNotAllowed
 from common.djangoapps.student.tests.factories import UserFactory, UserProfileFactory
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 
@@ -22,6 +24,23 @@ class TestEnrollmentPipelineStep(PipelineStep):
         if mode == "no-id-professional":
             raise CourseEnrollmentStarted.PreventEnrollment()
         return {"mode": "honor"}
+
+
+class TestUnenrollmentPipelineStep(PipelineStep):
+    """
+    Utility function used when getting steps for pipeline.
+    """
+
+    def run_filter(self, enrollment):  # pylint: disable=arguments-differ
+        """Pipeline steps that modifies user's profile before unenrolling."""
+        if enrollment.mode == "no-id-professional":
+            raise CourseUnenrollmentStarted.PreventUnenrollment(
+                "You can't un-enroll from this site."
+            )
+
+        enrollment.user.profile.set_meta({"unenrolled_from": str(enrollment.course_id)})
+        enrollment.user.profile.save()
+        return {}
 
 
 @skip_unless_lms
@@ -102,3 +121,117 @@ class EnrollmentFiltersTest(ModuleStoreTestCase):
 
         self.assertEqual('audit', enrollment.mode)
         self.assertTrue(CourseEnrollment.is_enrolled(self.user, self.course.id))
+
+
+@skip_unless_lms
+class UnenrollmentFiltersTest(ModuleStoreTestCase):
+    """
+    Tests for the Open edX Filters associated with the unenrollment process through the unenroll method.
+
+    This class guarantees that the following filters are triggered during the user's unenrollment:
+
+    - CourseUnenrollmentStarted
+    """
+
+    USERNAME = "test"
+    EMAIL = "test@example.com"
+    PASSWORD = "password"
+
+    def setUp(self):  # pylint: disable=arguments-differ
+        super().setUp()
+        self.course = CourseFactory.create()
+        self.user = UserFactory.create(username=self.USERNAME, email=self.EMAIL, password=self.PASSWORD)
+        self.client.login(username=self.USERNAME, password=self.PASSWORD)
+
+    @override_settings(
+        OPEN_EDX_FILTERS_CONFIG={
+            "org.openedx.learning.course.unenrollment.started.v1": {
+                "pipeline": [
+                    "common.djangoapps.student.tests.test_filters.TestUnenrollmentPipelineStep",
+                ],
+                "fail_silently": False,
+            },
+        },
+    )
+    def test_unenrollment_filter_executed(self):
+        """
+        Test whether the student unenrollment filter is triggered before the user's
+        unenrollment process.
+
+        Expected result:
+            - CourseUnenrollmentStarted is triggered and executes TestUnenrollmentPipelineStep.
+            - The user's profile has unenrolled_from in its meta field.
+        """
+        CourseEnrollment.enroll(self.user, self.course.id, mode="audit")
+
+        CourseEnrollment.unenroll(self.user, self.course.id)
+
+        self.assertFalse(CourseEnrollment.is_enrolled(self.user, self.course.id))
+
+    @override_settings(
+        OPEN_EDX_FILTERS_CONFIG={
+            "org.openedx.learning.course.unenrollment.started.v1": {
+                "pipeline": [
+                    "common.djangoapps.student.tests.test_filters.TestUnenrollmentPipelineStep",
+                ],
+                "fail_silently": False,
+            },
+        },
+    )
+    def test_unenrollment_filter_prevent_unenroll(self):
+        """
+        Test prevent the user's unenrollment through a pipeline step.
+
+        Expected result:
+            - CourseUnenrollmentStarted is triggered and executes TestUnenrollmentPipelineStep.
+            - The user can't unenroll.
+        """
+        CourseEnrollment.enroll(self.user, self.course.id, mode="no-id-professional")
+
+        with self.assertRaises(UnenrollmentNotAllowed):
+            CourseEnrollment.unenroll(self.user, self.course.id)
+
+    @override_settings(OPEN_EDX_FILTERS_CONFIG={})
+    def test_unenrollment_without_filter_configuration(self):
+        """
+        Test usual unenrollment process without filter's intervention.
+
+        Expected result:
+            - CourseUnenrollmentStarted does not have any effect on the unenrollment process.
+            - The unenrollment process ends successfully.
+        """
+        CourseEnrollment.enroll(self.user, self.course.id, mode="audit")
+
+        CourseEnrollment.unenroll(self.user, self.course.id)
+
+        self.assertFalse(CourseEnrollment.is_enrolled(self.user, self.course.id))
+
+    @override_settings(
+        OPEN_EDX_FILTERS_CONFIG={
+            "org.openedx.learning.course.unenrollment.started.v1": {
+                "pipeline": [
+                    "common.djangoapps.student.tests.test_filters.TestUnenrollmentPipelineStep",
+                ],
+                "fail_silently": False,
+            },
+        },
+    )
+    def test_unenrollment_blocked_by_filter(self):
+        """
+        Test cannot unenroll using change_enrollment view course when UnenrollmentNotAllowed is
+        raised by unenroll method.
+
+        Expected result:
+            - CourseUnenrollmentStarted does not have any effect on the unenrollment process.
+            - The unenrollment process ends successfully.
+        """
+        CourseEnrollment.enroll(self.user, self.course.id, mode="no-id-professional")
+        params = {
+            "enrollment_action": "unenroll",
+            "course_id": str(self.course.id)
+        }
+
+        response = self.client.post(reverse("change_enrollment"), params)
+
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
+        self.assertEqual("You can't un-enroll from this site.", response.content.decode("utf-8"))

--- a/lms/static/js/learner_dashboard/views/unenroll_view.js
+++ b/lms/static/js/learner_dashboard/views/unenroll_view.js
@@ -75,6 +75,11 @@ class UnenrollView extends Backbone.View {
         this.switchToSlideOne();
         this.$('.reasons_survey:first .submit_reasons').click(this.switchToSlideTwo.bind(this));
       }
+    } else if (xhr.status === 400) {
+      $('#unenroll_error').text(
+        xhr.responseText,
+      ).stop()
+       .css('display', 'block');
     } else if (xhr.status === 403) {
       location.href = `${this.urls.signInUser}?course_id=${
         encodeURIComponent($('#unenroll_course_id').val())}&enrollment_action=unenroll`;


### PR DESCRIPTION
## Description

As part of the Hooks Extension Framework implementation plan, this PR adds a filter before the unenrollment process starts. 

## Supporting information

- [Hooks Extension Framework OEP-50](https://open-edx-proposals.readthedocs.io/en/latest/oep-0050-hooks-extension-framework.html)
ADR(s) on:
- [Open edX Filters naming and versioning](https://github.com/eduNEXT/openedx-filters/blob/main/docs/decisions/0004-filters-naming-and-versioning.rst): about how to identify filters and manage its versions
- [Open edX Filters configuration](https://github.com/eduNEXT/openedx-filters/blob/main/docs/decisions/0002-hooks-filter-config-location.rst): how to configure filters
- [Open edX Filters tooling](https://github.com/eduNEXT/openedx-filters/blob/main/docs/decisions/0003-hooks-filter-tooling-pipeline.rst): what to use to run filters
- [Open edX Filters payload](https://github.com/eduNEXT/openedx-filters/blob/main/docs/decisions/0005-filters-payload.rst): input arguments for filters

## Testing instructions

1. Install openedx-filters library:
```
pip install openedx-filters==0.5.0
```
2. Implement your pipeline steps in your favorite plugin. We created some as illustration in [openedx-filters-samples](https://github.com/eduNEXT/openedx-filters-samples). We'll be using those in this example.
3. Install openedx-filters-samples
```
pip install git+https://github.com/eduNEXT/openedx-filters-samples.git@master#egg=openedx_filters_samples
``` 
4. Configure your filters:
With this configuration, you won't be able to:
- Un-enroll from a course `org.openedx.learning.course.unenrollment.started.v1`
```
OPEN_EDX_FILTERS_CONFIG = {
    "org.openedx.learning.course.unenrollment.started.v1": {
        "fail_silently": False,
        "pipeline": [
            "openedx_filters_samples.samples.pipeline.StopUnenrollment"
        ]
    },
}
```
And with this one, the user's profile will be modified before the unenrollment process starts
```
OPEN_EDX_FILTERS_CONFIG = {
    "org.openedx.learning.course.unenrollment.started.v1": {
        "fail_silently": False,
        "pipeline": [
            "openedx_filters_samples.samples.pipeline.ModifyUserProfileBeforeUnenrollment"
        ]
    },
}
```
Straightforward implementations as a way of illustrating how they work. More complex steps are coming.
