### PR TITLE
[MST-1360] Only enable verified name feature if Name Affirmation is installed

### DIFF
--- a/common/djangoapps/student/tests/test_receivers.py
+++ b/common/djangoapps/student/tests/test_receivers.py
@@ -1,6 +1,6 @@
 """ Tests for student signal receivers. """
 
-from edx_name_affirmation.signals import VERIFIED_NAME_APPROVED
+from unittest import skipUnless
 from edx_toggles.toggles.testutils import override_waffle_flag
 from lms.djangoapps.courseware.toggles import COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES
 from common.djangoapps.student.models import (
@@ -13,7 +13,13 @@ from common.djangoapps.student.tests.factories import (
     UserFactory,
     UserProfileFactory
 )
+from openedx.features.name_affirmation_api.utils import is_name_affirmation_installed
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
+
+name_affirmation_installed = is_name_affirmation_installed()
+if name_affirmation_installed:
+    # pylint: disable=import-error
+    from edx_name_affirmation.signals import VERIFIED_NAME_APPROVED
 
 
 class ReceiversTest(SharedModuleStoreTestCase):
@@ -47,6 +53,7 @@ class ReceiversTest(SharedModuleStoreTestCase):
         CourseEnrollmentFactory()
         assert CourseEnrollmentCelebration.objects.count() == 0
 
+    @skipUnless(name_affirmation_installed, "Requires Name Affirmation")
     def test_listen_for_verified_name_approved(self):
         """
         Test that profile name is updated when a pending name change is approved

--- a/lms/djangoapps/certificates/tests/test_generation.py
+++ b/lms/djangoapps/certificates/tests/test_generation.py
@@ -3,10 +3,7 @@ Tests for certificate generation
 """
 import ddt
 import logging  # lint-amnesty, pylint: disable=wrong-import-order
-from unittest import mock  # lint-amnesty, pylint: disable=wrong-import-order
-
-from edx_name_affirmation.api import create_verified_name, create_verified_name_config
-from edx_name_affirmation.statuses import VerifiedNameStatus
+from unittest import mock, skipUnless  # lint-amnesty, pylint: disable=wrong-import-order
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.models import UserProfile
@@ -16,12 +13,14 @@ from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.certificates.generation import generate_course_certificate
 from lms.djangoapps.certificates.models import GeneratedCertificate
 from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
+from openedx.features.name_affirmation_api.utils import get_name_affirmation_service
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 log = logging.getLogger(__name__)
 
 PROFILE_NAME_METHOD = 'common.djangoapps.student.models_api.get_name'
+name_affirmation_service = get_name_affirmation_service()
 
 
 @ddt.ddt
@@ -193,9 +192,10 @@ class CertificateTests(EventTestMixin, ModuleStoreTestCase):
             assert cert.grade == self.grade
             assert cert.name == ''
 
-    @ddt.data((True, VerifiedNameStatus.APPROVED),
-              (True, VerifiedNameStatus.DENIED),
-              (False, VerifiedNameStatus.PENDING))
+    @skipUnless(name_affirmation_service is not None, 'Requires Name Affirmation')
+    @ddt.data((True, 'approved'),
+              (True, 'denied'),
+              (False, 'pending'))
     @ddt.unpack
     def test_generation_verified_name(self, should_use_verified_name_for_certs, status):
         """
@@ -204,8 +204,11 @@ class CertificateTests(EventTestMixin, ModuleStoreTestCase):
         their profile name.
         """
         verified_name = 'Jonathan Doe'
-        create_verified_name(self.u, verified_name, self.name, status=status)
-        create_verified_name_config(self.u, use_verified_name_for_certs=should_use_verified_name_for_certs)
+        name_affirmation_service.create_verified_name(self.u, verified_name, self.name, status=status)
+        name_affirmation_service.create_verified_name_config(
+            self.u,
+            use_verified_name_for_certs=should_use_verified_name_for_certs
+        )
 
         GeneratedCertificateFactory(
             user=self.u,
@@ -220,7 +223,7 @@ class CertificateTests(EventTestMixin, ModuleStoreTestCase):
 
         cert = GeneratedCertificate.objects.get(user=self.u, course_id=self.key)
 
-        if should_use_verified_name_for_certs and status == VerifiedNameStatus.APPROVED:
+        if should_use_verified_name_for_certs and status == 'approved':
             assert cert.name == verified_name
         else:
             assert cert.name == self.name

--- a/lms/djangoapps/certificates/tests/test_models.py
+++ b/lms/djangoapps/certificates/tests/test_models.py
@@ -3,7 +3,7 @@
 
 import json
 from unittest.mock import patch
-from unittest import mock
+from unittest import mock, skipUnless
 
 import ddt
 import pytest
@@ -12,8 +12,6 @@ from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 from django.test.utils import override_settings
-from edx_name_affirmation.api import create_verified_name, create_verified_name_config
-from edx_name_affirmation.statuses import VerifiedNameStatus
 from opaque_keys.edx.locator import CourseKey, CourseLocator
 from openedx_events.tests.utils import OpenEdxEventsTestMixin
 from path import Path as path
@@ -39,6 +37,7 @@ from lms.djangoapps.certificates.tests.factories import (
 )
 from lms.djangoapps.instructor_task.tests.factories import InstructorTaskFactory
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
+from openedx.features.name_affirmation_api.utils import get_name_affirmation_service
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
@@ -52,6 +51,8 @@ TEST_DIR = path(__file__).dirname()
 TEST_DATA_DIR = 'common/test/data/'
 PLATFORM_ROOT = TEST_DIR.parent.parent.parent.parent
 TEST_DATA_ROOT = PLATFORM_ROOT / TEST_DATA_DIR
+
+name_affirmation_service = get_name_affirmation_service()
 
 
 class ExampleCertificateTest(TestCase, OpenEdxEventsTestMixin):
@@ -624,9 +625,10 @@ class GeneratedCertificateTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin
 
         self._assert_event_data(mock_emit_certificate_event, expected_event_data)
 
-    @ddt.data((True, VerifiedNameStatus.APPROVED),
-              (True, VerifiedNameStatus.DENIED),
-              (False, VerifiedNameStatus.PENDING))
+    @skipUnless(name_affirmation_service is not None, 'Requires Name Affirmation')
+    @ddt.data((True, 'approved'),
+              (True, 'denied'),
+              (False, 'pending'))
     @ddt.unpack
     def test_invalidate_with_verified_name(self, should_use_verified_name_for_certs, status):
         """
@@ -634,8 +636,11 @@ class GeneratedCertificateTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin
         """
         verified_name = 'Jonathan Doe'
         profile = UserProfile.objects.get(user=self.user)
-        create_verified_name(self.user, verified_name, profile.name, status=status)
-        create_verified_name_config(self.user, use_verified_name_for_certs=should_use_verified_name_for_certs)
+        name_affirmation_service.create_verified_name(self.user, verified_name, profile.name, status=status)
+        name_affirmation_service.create_verified_name_config(
+            self.user,
+            use_verified_name_for_certs=should_use_verified_name_for_certs
+        )
 
         cert = GeneratedCertificateFactory.create(
             status=CertificateStatuses.downloadable,
@@ -649,7 +654,7 @@ class GeneratedCertificateTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin
         cert.invalidate(mode=mode, source=source)
 
         cert = GeneratedCertificate.objects.get(user=self.user, course_id=self.course_key)
-        if should_use_verified_name_for_certs and status == VerifiedNameStatus.APPROVED:
+        if should_use_verified_name_for_certs and status == 'approved':
             assert cert.name == verified_name
         else:
             assert cert.name == profile.name

--- a/lms/djangoapps/certificates/utils.py
+++ b/lms/djangoapps/certificates/utils.py
@@ -4,8 +4,6 @@ Certificates utilities
 from datetime import datetime
 import logging
 
-from edx_name_affirmation.api import get_verified_name, should_use_verified_name_for_certs
-
 from django.conf import settings
 from django.urls import reverse
 from eventtracking import tracker
@@ -16,6 +14,7 @@ from common.djangoapps.student import models_api as student_api
 from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.certificates.models import GeneratedCertificate
 from openedx.core.djangoapps.content.course_overviews.api import get_course_overview_or_none
+from openedx.features.name_affirmation_api.utils import get_name_affirmation_service
 from xmodule.data import CertificatesDisplayBehaviors  # lint-amnesty, pylint: disable=wrong-import-order
 
 log = logging.getLogger(__name__)
@@ -240,9 +239,10 @@ def get_preferred_certificate_name(user):
     name, or an empty string if it doesn't exist.
     """
     name_to_use = student_api.get_name(user.id)
+    name_affirmation_service = get_name_affirmation_service()
 
-    if should_use_verified_name_for_certs(user):
-        verified_name_obj = get_verified_name(user, is_verified=True)
+    if name_affirmation_service and name_affirmation_service.should_use_verified_name_for_certs(user):
+        verified_name_obj = name_affirmation_service.get_verified_name(user, is_verified=True)
         if verified_name_obj:
             name_to_use = verified_name_obj.verified_name
 

--- a/openedx/core/djangoapps/user_api/accounts/serializers.py
+++ b/openedx/core/djangoapps/user_api/accounts/serializers.py
@@ -11,7 +11,6 @@ from django.conf import settings
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.core.exceptions import ObjectDoesNotExist
 from django.urls import reverse
-from edx_name_affirmation.api import get_verified_name
 from rest_framework import serializers
 
 
@@ -29,6 +28,7 @@ from openedx.core.djangoapps.user_api.accounts.utils import is_secondary_email_f
 from openedx.core.djangoapps.user_api.models import RetirementState, UserPreference, UserRetirementStatus
 from openedx.core.djangoapps.user_api.serializers import ReadOnlyFieldsSerializerMixin
 from openedx.core.djangoapps.user_authn.views.registration_form import contains_html, contains_url
+from openedx.features.name_affirmation_api.utils import get_name_affirmation_service
 
 from . import (
     ACCOUNT_VISIBILITY_PREF_KEY,
@@ -170,11 +170,10 @@ class UserReadOnlySerializer(serializers.Serializer):  # lint-amnesty, pylint: d
             "extended_profile_fields": None,
             "phone_number": None,
             "pending_name_change": None,
+            "verified_name": None,
         }
 
         if user_profile:
-            verified_name_obj = get_verified_name(user, is_verified=True)
-            verified_name = verified_name_obj.verified_name if verified_name_obj else None
             data.update(
                 {
                     "bio": AccountLegacyProfileSerializer.convert_empty_to_None(user_profile.bio),
@@ -187,7 +186,6 @@ class UserReadOnlySerializer(serializers.Serializer):  # lint-amnesty, pylint: d
                         user_profile.language_proficiencies.all().order_by('code'), many=True
                     ).data,
                     "name": user_profile.name,
-                    "verified_name": verified_name,
                     "gender": AccountLegacyProfileSerializer.convert_empty_to_None(user_profile.gender),
                     "goals": user_profile.goals,
                     "year_of_birth": user_profile.year_of_birth,
@@ -210,6 +208,12 @@ class UserReadOnlySerializer(serializers.Serializer):  # lint-amnesty, pylint: d
             data.update({"pending_name_change": pending_name_change.new_name})
         except PendingNameChange.DoesNotExist:
             pass
+
+        name_affirmation_service = get_name_affirmation_service()
+        if name_affirmation_service:
+            verified_name_obj = name_affirmation_service.get_verified_name(user, is_verified=True)
+            if verified_name_obj:
+                data.update({"verified_name": verified_name_obj.verified_name})
 
         if is_secondary_email_feature_enabled():
             data.update(

--- a/openedx/features/name_affirmation_api/apps.py
+++ b/openedx/features/name_affirmation_api/apps.py
@@ -7,10 +7,12 @@ from django.apps import AppConfig
 from django.conf import settings
 from edx_proctoring.runtime import set_runtime_service
 
+from openedx.features.name_affirmation_api.utils import get_name_affirmation_service
+
 
 class NameAffirmationApiConfig(AppConfig):
     """
-    Application Configuration for Misc Services.
+    Application Configuration for Name Affirmation API.
     """
     name = 'openedx.features.name_affirmation_api'
 
@@ -19,5 +21,6 @@ class NameAffirmationApiConfig(AppConfig):
         Connect services.
         """
         if settings.FEATURES.get('ENABLE_SPECIAL_EXAMS'):
-            from edx_name_affirmation.services import NameAffirmationService
-            set_runtime_service('name_affirmation', NameAffirmationService())
+            name_affirmation_service = get_name_affirmation_service()
+            if name_affirmation_service:
+                set_runtime_service('name_affirmation', name_affirmation_service)

--- a/openedx/features/name_affirmation_api/tests/test_utils.py
+++ b/openedx/features/name_affirmation_api/tests/test_utils.py
@@ -1,0 +1,36 @@
+""" Tests for Name Affirmation API utils """
+
+from unittest import TestCase
+from unittest.mock import patch
+
+import ddt
+from edx_django_utils.plugins import PluginError
+
+from openedx.features.name_affirmation_api.utils import is_name_affirmation_installed, get_name_affirmation_service
+
+
+@ddt.ddt
+class TestNameAffirmationAPIUtils(TestCase):
+    """ Tests for Name Affirmation API utils """
+
+    @patch('openedx.features.name_affirmation_api.utils.PluginManager')
+    def test_name_affirmation_installed(self, mock_manager):
+        mock_manager.get_plugin.return_value = 'mock plugin'
+        self.assertTrue(is_name_affirmation_installed())
+
+    @patch('openedx.features.name_affirmation_api.utils.PluginManager')
+    def test_name_affirmation_not_installed(self, mock_manager):
+        mock_manager.side_effect = PluginError('No such plugin')
+        with self.assertRaises(PluginError):
+            self.assertFalse(is_name_affirmation_installed())
+
+    @patch('edx_name_affirmation.services.NameAffirmationService')
+    @ddt.data(True, False)
+    def test_get_name_affirmation_service(self, name_affirmation_installed, mock_service):
+        with patch('openedx.features.name_affirmation_api.utils.is_name_affirmation_installed',
+                   return_value=name_affirmation_installed):
+            name_affirmation_service = get_name_affirmation_service()
+            if name_affirmation_installed:
+                self.assertEqual(name_affirmation_service, mock_service())
+            else:
+                self.assertIsNone(name_affirmation_service)

--- a/openedx/features/name_affirmation_api/utils.py
+++ b/openedx/features/name_affirmation_api/utils.py
@@ -1,0 +1,31 @@
+"""
+Utility functions for integration with Name Affirmation plugin
+(https://github.com/edx/edx-name-affirmation)
+"""
+
+from edx_django_utils.plugins import PluginError, PluginManager
+
+
+def is_name_affirmation_installed():
+    """
+    Returns boolean describing whether Name Affirmation plugin is installed.
+    """
+    manager = PluginManager()
+    try:
+        plugin = manager.get_plugin('edx_name_affirmation', 'lms.djangoapp')
+        return bool(plugin)
+    except PluginError:
+        return False
+
+
+def get_name_affirmation_service():
+    """
+    Returns Name Affirmation service which exposes API .
+    If Name Affirmation is not installed, return None.
+    """
+    if is_name_affirmation_installed():
+        # pylint: disable=import-error
+        from edx_name_affirmation.services import NameAffirmationService
+        return NameAffirmationService()
+
+    return None


### PR DESCRIPTION
<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

@openedx/masters-devs-cosmonauts 

Make use of https://github.com/edx/edx-name-affirmation as a true plugin, and only enable functionality if it is installed. This means that, if it is not installed:

- Certificate generation will not check for a verified name to use
- `VERIFIED_NAME_APPROVED` signal receivers will not be connected (currently used to confirm pending name changes in LMS)
- Profile name changes will not be blocked by name validation
- Verified name will not be passed down in user account API
- Verified name service will not be enabled in edx-proctoring

## Supporting information

- https://openedx.atlassian.net/browse/MST-1360
- [Discovery doc](https://openedx.atlassian.net/wiki/spaces/PT/pages/3330802190/Discovery+Name+Affirmation+without+Account+MFE)