### PR TITLE
fix: old links edx-guide-for-students

### DIFF
--- a/lms/static/js/fixtures/calculator.html
+++ b/lms/static/js/fixtures/calculator.html
@@ -13,8 +13,8 @@
                         <li class="hint-item" id="hint-moreinfo" tabindex="-1">
                             <p>
                                 <span class="bold">For detailed information, see
-                                <a id="hint-link-first" href="https://edx.readthedocs.io/projects/edx-guide-for-students/en/latest/completing_assignments/SFD_mathformatting.html#math-formatting">Entering Mathematical and Scientific Expressions</a> in the
-                                <a id="hint-link-second" href="https://edx-guide-for-students.readthedocs.io/en/latest/index.html">EdX Learner's Guide</a>.
+                                <a id="hint-link-first" href="https://edx.readthedocs.io/projects/open-edx-learner-guide/en/latest/completing_assignments/SFD_mathformatting.html#math-formatting" target="_blank" >Entering Mathematical and Scientific Expressions</a> in the
+                                <a id="hint-link-second" href="https://edx.readthedocs.io/projects/open-edx-learner-guide/en/latest/index.html" target="_blank" >EdX Learner's Guide</a>.
                                 </span>
                             </p>
                         </li>

--- a/lms/static/js/student_account/components/StudentAccountDeletion.jsx
+++ b/lms/static/js/student_account/components/StudentAccountDeletion.jsx
@@ -41,7 +41,7 @@ export class StudentAccountDeletion extends React.Component {
     const loseAccessText = StringUtils.interpolate(
       gettext('You may also lose access to verified certificates and other program credentials like MicroMasters certificates. If you want to make a copy of these for your records before proceeding with deletion, follow the instructions for {htmlStart}printing or downloading a certificate{htmlEnd}.'),
       {
-        htmlStart: '<a href="https://edx.readthedocs.io/projects/edx-guide-for-students/en/latest/SFD_certificates.html#printing-a-certificate" rel="noopener" target="_blank">',
+        htmlStart: '<a href="https://edx.readthedocs.io/projects/open-edx-learner-guide/en/latest/OpenSFD_certificates.html#print-a-web-certificate" rel="noopener" target="_blank">',
         htmlEnd: '</a>',
       },
     );

--- a/lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
+++ b/lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
@@ -95,7 +95,7 @@ class StudentAccountDeletionConfirmationModal extends React.Component {
     const loseAccessText = StringUtils.interpolate(
       gettext('You may also lose access to verified certificates and other program credentials like MicroMasters certificates. If you want to make a copy of these for your records before proceeding with deletion, follow the instructions for {htmlStart}printing or downloading a certificate{htmlEnd}.'),
       {
-        htmlStart: '<a href="https://edx.readthedocs.io/projects/edx-guide-for-students/en/latest/SFD_certificates.html#printing-a-certificate" rel="noopener" target="_blank">',
+        htmlStart: '<a href="https://edx.readthedocs.io/projects/open-edx-learner-guide/en/latest/OpenSFD_certificates.html#print-a-web-certificate" rel="noopener" target="_blank">',
         htmlEnd: '</a>',
       },
     );

--- a/lms/templates/calculator/toggle_calculator.html
+++ b/lms/templates/calculator/toggle_calculator.html
@@ -25,9 +25,9 @@ from openedx.core.djangolib.markup import HTML, Text
                             <p>
                                 <span class="bold">
                                     ${Text(_("For detailed information, see {math_link_start}Entering Mathematical and Scientific Expressions{math_link_end} in the {guide_link_start}edX Guide for Students{guide_link_end}.")).format(
-                                        math_link_start=HTML('<a href="https://edx.readthedocs.io/projects/edx-guide-for-students/en/latest/completing_assignments/SFD_mathformatting.html#math-formatting">'),
+                                        math_link_start=HTML('<a href="https://edx.readthedocs.io/projects/open-edx-learner-guide/en/latest/completing_assignments/SFD_mathformatting.html"  target="_blank" >'),
                                         math_link_end=HTML('</a>'),
-                                        guide_link_start=HTML('<a href="https://edx-guide-for-students.readthedocs.io/en/latest/index.html">'),
+                                        guide_link_start=HTML('<a href="https://edx.readthedocs.io/projects/open-edx-learner-guide/en/latest/index.html" target="_blank">'),
                                         guide_link_end=HTML('</a>'),
                                     )}
                                 </span>

--- a/lms/templates/certificates/_edx-accomplishment-print-help.html
+++ b/lms/templates/certificates/_edx-accomplishment-print-help.html
@@ -8,7 +8,7 @@ from openedx.core.djangolib.markup import HTML, Text
         <div class="accomplishment-support-print">
             <p class="accomplishment-metadata-copy">
                 ${Text(_("For tips and tricks on printing your certificate, view the {link_start}Web Certificates help documentation{link_end}.")).format(
-                    link_start=HTML('<a href="https://edx.readthedocs.org/projects/edx-guide-for-students/en/latest/SFD_certificates.html#web-certificates">'),
+                    link_start=HTML('<a target="_blank" href="https://edx.readthedocs.io/projects/open-edx-learner-guide/en/latest/OpenSFD_certificates.html#print-a-web-certificate">'),
                     link_end=HTML('</a>'),
                 )}
             </p>


### PR DESCRIPTION
## Description

Links to the old edx-guide-for-students were updated to the new open-edx-learner-guide. Before the change, those links were broken because this resources were moved.

>[old math formatting]( https://edx.readthedocs.io/projects/edx-guide-for-students/en/latest/completing_assignments/SFD_mathformatting.html#math-formatting) to [new math formatting](https://edx.readthedocs.io/projects/open-edx-learner-guide/en/latest/completing_assignments/SFD_mathformatting.html#math-formatting)
>[old print certificate]( https://edx.readthedocs.io/projects/edx-guide-for-students/en/latest/SFD_certificates.html#printing-a-certificate) to [new print certificate](https://edx.readthedocs.io/projects/open-edx-learner-guide/en/latest/OpenSFD_certificates.html#print-a-web-certificate)

Also, the target was changed to open in a new tab
```html
target="_blank"
```

## Testing instructions

On Studio > Advanced settings set "show calculator" to true, go to the course, and open the calculator. On the LMS on any unit you should see a button on the bottom right corner. Click it.
![image](https://user-images.githubusercontent.com/33465240/154734976-479fb3e6-e08f-417c-919a-3f5f5df10981.png)

Once the bottom bar appears you should select the help button (i icon):
![image](https://user-images.githubusercontent.com/33465240/154735137-01032192-2120-45e9-8275-cdec02d573fc.png)

Now a message appears with information. Open those two links. It should open on a new tab the right documentation:
![image](https://user-images.githubusercontent.com/33465240/154735331-14e7ae2e-ab48-483a-9589-46cf6741bc52.png)