### PR TITLE
fix: Update get user timezone logic

### DIFF
--- a/lms/djangoapps/courseware/context_processor.py
+++ b/lms/djangoapps/courseware/context_processor.py
@@ -5,8 +5,11 @@ This is meant to simplify the process of sending user preferences (espec. time_z
 to the templates without having to append every view file.
 
 """
+import string
+
 from django.utils.translation import get_language
 from pytz import timezone
+from pytz.exceptions import UnknownTimeZoneError
 
 from edx_django_utils.cache import TieredCache
 from lms.djangoapps.courseware.models import LastSeenCoursewareTimezone
@@ -81,11 +84,19 @@ def get_user_timezone_or_last_seen_timezone_or_utc(user):
     Helper method for returning a reasonable timezone for a user.
     This method returns the timezone in the user's account if that is set.
     If that is not set, it returns a recent timezone that we have recorded from a user's visit to the courseware.
-    If that is not set, it returns UTC.
+    If that is not set or the timezone is unknown, it returns UTC.
     """
     user_timezone = (
         get_user_preference(user, 'time_zone') or
         get_last_seen_courseware_timezone(user) or
         'UTC'
     )
-    return timezone(user_timezone)
+    # We have seen non-printable characters (i.e. \x00) showing up in the
+    # user_timezone (I believe via the get_last_seen_courseware_timezone method).
+    # This sanitizes the user_timezone before passing it in.
+    user_timezone = filter(lambda l: l in string.printable, user_timezone)
+    user_timezone = ''.join(user_timezone)
+    try:
+        return timezone(user_timezone)
+    except UnknownTimeZoneError as err:
+        return timezone('UTC')


### PR DESCRIPTION
Adds in sanitization of the timezone to ensure the timezone is
formatted correctly and error handling to reasonably fall back to UTC

<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->