### PR TITLE
[BD-38]  feat: add flag to toggle learners tab in the discussions MFE [TNL-9481][BB-5421]

### DIFF
--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -25,6 +25,7 @@ from xmodule.tabs import CourseTabList
 from lms.djangoapps.course_blocks.api import get_course_blocks
 from lms.djangoapps.courseware.courses import get_course_with_access
 from lms.djangoapps.courseware.exceptions import CourseAccessRedirect
+from lms.djangoapps.discussion.toggles import ENABLE_LEARNERS_TAB_IN_DISCUSSIONS_MFE
 from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration, DiscussionTopicLink, Provider
 from openedx.core.djangoapps.discussions.utils import get_accessible_discussion_xblocks
 from openedx.core.djangoapps.django_comment_common.comment_client.comment import Comment
@@ -305,6 +306,7 @@ def get_course(request, course_key):
         "provider": course_config.provider_type,
         "enable_in_context": course_config.enable_in_context,
         "group_at_subsection": course_config.plugin_configuration.get("group_at_subsection", False),
+        'learners_tab_enabled': ENABLE_LEARNERS_TAB_IN_DISCUSSIONS_MFE.is_enabled(course_key),
     }
 
 

--- a/lms/djangoapps/discussion/rest_api/tests/test_api.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api.py
@@ -12,6 +12,7 @@ from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 import ddt
 import httpretty
 import pytest
+from edx_toggles.toggles.testutils import override_waffle_flag
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.test.client import RequestFactory
@@ -35,6 +36,7 @@ from common.djangoapps.student.tests.factories import (
 from common.djangoapps.util.testing import UrlResetMixin
 from common.test.utils import MockSignalHandlerMixin, disable_signal
 from lms.djangoapps.discussion.django_comment_client.tests.utils import ForumsEnableMixin
+from lms.djangoapps.discussion.toggles import ENABLE_LEARNERS_TAB_IN_DISCUSSIONS_MFE
 from lms.djangoapps.discussion.rest_api import api
 from lms.djangoapps.discussion.rest_api.api import (
     create_comment,
@@ -196,6 +198,7 @@ class GetCourseTest(ForumsEnableMixin, UrlResetMixin, SharedModuleStoreTestCase)
             'provider': 'legacy',
             'user_is_privileged': False,
             'user_roles': {'Student'},
+            'learners_tab_enabled': False,
         }
 
     @ddt.data(
@@ -211,6 +214,15 @@ class GetCourseTest(ForumsEnableMixin, UrlResetMixin, SharedModuleStoreTestCase)
         course_meta = get_course(self.request, self.course.id)
         assert course_meta["user_is_privileged"]
         assert course_meta["user_roles"] == {FORUM_ROLE_STUDENT} | {role}
+
+    @ddt.data(True, False)
+    def test_learner_tab_enabled_flag(self, learners_tab_enabled):
+        """
+        Test the 'learners_tab_enabled' flag.
+        """
+        with override_waffle_flag(ENABLE_LEARNERS_TAB_IN_DISCUSSIONS_MFE, learners_tab_enabled):
+            course_meta = get_course(self.request, self.course.id)
+            assert course_meta['learners_tab_enabled'] == learners_tab_enabled
 
 
 @ddt.ddt

--- a/lms/djangoapps/discussion/rest_api/tests/test_views.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views.py
@@ -519,6 +519,7 @@ class CourseViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
                 "allow_anonymous_to_peers": False,
                 'user_is_privileged': False,
                 'user_roles': ['Student'],
+                'learners_tab_enabled': False,
             }
         )
 

--- a/lms/djangoapps/discussion/toggles.py
+++ b/lms/djangoapps/discussion/toggles.py
@@ -22,3 +22,13 @@ ENABLE_DISCUSSIONS_MFE = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'enable_discuss
 # .. toggle_creation_date: 2022-02-22
 # .. toggle_target_removal_date: 2022-09-22
 ENABLE_NEW_STRUCTURE_DISCUSSIONS = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'enable_new_structure_discussions', __name__)
+
+# .. toggle_name: discussions.enable_learners_tab_in_discussions_mfe
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Waffle flag to enable learners tab in the new MFE experience for discussions
+# .. toggle_use_cases: temporary, open_edx
+# .. toggle_creation_date: 2022-02-21
+# .. toggle_target_removal_date: 2022-05-21
+# lint-amnesty, pylint: disable=line-too-long
+ENABLE_LEARNERS_TAB_IN_DISCUSSIONS_MFE = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'enable_learners_tab_in_discussions_mfe', __name__)


### PR DESCRIPTION
## Description

Add a flag to toggle learners tab in the Discussions MFE.

## Supporting information

[TNL-9481](https://openedx.atlassian.net/browse/TNL-9481)
[BB-5421](https://tasks.opencraft.com/browse/BB-5421)

## Testing instructions

* Check that `<LMS URL>/api/discussion/v1/courses/<course-id>` returns `False` for `learners_tab_enabled` by default
* Go to `<LMS URL>/admin/waffle/flag/` and add a flag with `discussions.enable_learners_tab_in_discussions_mfe` name
* Check that `<LMS URL>/api/discussion/v1/courses/<course-id>` now returns `True` for `learners_tab_enabled`

## Deadline

"None"