### PR TITLE
fix: icon on course outline was not showing correctly

### DIFF
--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -51,7 +51,7 @@ def get_course_outline_block_tree(request, course_id, user=None, allow_start_dat
         is_scored = block.get('has_score', False) and block.get('weight', 1) > 0
         # Use a list comprehension to force the recursion over all children, rather than just stopping
         # at the first child that is scored.
-        children_scored = any(recurse_mark_scored(child) for child in block.get('children', []))
+        children_scored = any(tuple(recurse_mark_scored(child) for child in block.get('children', [])))
         if is_scored or children_scored:
             block['scored'] = True
             return True


### PR DESCRIPTION
## Description

On the course outline, the icon for graded and scored problems was showing inconsistently. The cause was the parameter of the any() function. Before the change it was a generator so, the function recurse_mark_scored(child) was not called for all children, now it receives a list comprehension with the result of recurse_mark_scored(child) for all children.

When the generator parameter was passed, only the first block that meets the condition was marked as scored. With this change now all blocks that meet the condition were marked as scored.

## Testing instructions

1. On Studio go to a course
2. Mark some subsections as graded (configure a grading policy is necessary)
3. Add a problem to the subsections you marked as graded.
4. On LMS you should see the icon for every graded and scored units.

Before:
![image](https://user-images.githubusercontent.com/33465240/155019697-e6356569-e2b4-4209-b66f-08fac8c1d1f9.png)
After:
![image](https://user-images.githubusercontent.com/33465240/155019585-b372565a-7ff1-4cac-b8cb-28c614b5210b.png)
