### PR TITLE
Some tests are skipped due to duplicate names fix

### DIFF
--- a/scripts/xsslint/tests/test_utils.py
+++ b/scripts/xsslint/tests/test_utils.py
@@ -36,7 +36,7 @@ class TestStringLines(TestCase):
         {'string': '\ntest\n', 'line_number': 2, 'line': 'test'},
         {'string': '\ntest\n', 'line_number': 3, 'line': ''},
     )
-    def test_string_lines_start_end_index_two(self, data):
+    def test_string_lines_line_numbers(self, data):
         """
         Test line_number_to_line.
         """

--- a/scripts/xsslint/tests/test_utils.py
+++ b/scripts/xsslint/tests/test_utils.py
@@ -36,7 +36,7 @@ class TestStringLines(TestCase):
         {'string': '\ntest\n', 'line_number': 2, 'line': 'test'},
         {'string': '\ntest\n', 'line_number': 3, 'line': ''},
     )
-    def test_string_lines_start_end_index(self, data):
+    def test_string_lines_start_end_index_two(self, data):
         """
         Test line_number_to_line.
         """


### PR DESCRIPTION
These tests were overriding other tests in the same file with the same name. I renamed so the tests run. Please give the tests a better name than I used. Naming is hard and I'm just a bot :)

This might result in tests failing because the affected tests were previously not running.

More details [here](https://codereview.doctor/features/python/best-practice/avoid-duplicate-unit-test-names).