### PR TITLE
fix: add separate flag for new structure discussions

### DIFF
--- a/lms/djangoapps/discussion/toggles.py
+++ b/lms/djangoapps/discussion/toggles.py
@@ -13,3 +13,12 @@ WAFFLE_FLAG_NAMESPACE = "discussions"
 # .. toggle_creation_date: 2021-11-05
 # .. toggle_target_removal_date: 2022-03-05
 ENABLE_DISCUSSIONS_MFE = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'enable_discussions_mfe', __name__)
+
+# .. toggle_name: discussions.enable_new_structure_discussions
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Waffle flag to toggle on the new structure for in context discussions
+# .. toggle_use_cases: temporary, open_edx
+# .. toggle_creation_date: 2022-02-22
+# .. toggle_target_removal_date: 2022-09-22
+ENABLE_NEW_STRUCTURE_DISCUSSIONS = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'enable_new_structure_discussions', __name__)

--- a/openedx/core/djangoapps/discussions/tests/test_views.py
+++ b/openedx/core/djangoapps/discussions/tests/test_views.py
@@ -19,7 +19,7 @@ from xmodule.modulestore.tests.factories import CourseFactory
 
 from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.discussion.django_comment_client.tests.factories import RoleFactory
-from lms.djangoapps.discussion.toggles import ENABLE_DISCUSSIONS_MFE
+from lms.djangoapps.discussion.toggles import ENABLE_NEW_STRUCTURE_DISCUSSIONS
 
 from ..models import AVAILABLE_PROVIDER_MAP, DEFAULT_CONFIG_ENABLED, DEFAULT_PROVIDER_TYPE, Provider
 
@@ -379,12 +379,14 @@ class DataTest(AuthorizedApiTest):
         (Provider.PIAZZA, [Provider.OPEN_EDX, Provider.LEGACY], 'dummy', True),
     )
     @ddt.unpack
-    def test_available_providers_legacy(self, current_provider, visible_providers, hidden_provider, mfe_enabled):
+    def test_available_providers_legacy(
+        self, current_provider, visible_providers, hidden_provider, new_structure_enabled
+    ):
         """
         Tests that providers available depending on the course.
         """
         self._configure_lti_discussion_provider(provider=current_provider)
-        with override_waffle_flag(ENABLE_DISCUSSIONS_MFE, mfe_enabled):
+        with override_waffle_flag(ENABLE_NEW_STRUCTURE_DISCUSSIONS, new_structure_enabled):
             response = self._get()
             data = response.json()
             for visible_provider in visible_providers:

--- a/openedx/core/djangoapps/discussions/views.py
+++ b/openedx/core/djangoapps/discussions/views.py
@@ -11,7 +11,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from lms.djangoapps.discussion.toggles import ENABLE_DISCUSSIONS_MFE
+from lms.djangoapps.discussion.toggles import ENABLE_NEW_STRUCTURE_DISCUSSIONS
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from openedx.core.lib.api.view_utils import validate_course_key
@@ -180,8 +180,8 @@ class DiscussionsProvidersView(APIView):
             hidden_providers.append(Provider.LEGACY)
         else:
             # If this is a new course, or some other provider is selected, the new provider
-            # should only show up if the MFE is enabled
-            if not ENABLE_DISCUSSIONS_MFE.is_enabled(course_key):
+            # should only show up if the new structure for in context discussions flag is enabled
+            if not ENABLE_NEW_STRUCTURE_DISCUSSIONS.is_enabled(course_key):
                 hidden_providers.append(Provider.OPEN_EDX)
         serializer = DiscussionsProvidersSerializer(
             {


### PR DESCRIPTION
[TNL-9602](https://openedx.atlassian.net/browse/TNL-9602)

Add a separate flag to enable the new OPEN_EDX provider.