### PR TITLE
feat: Exchange JWT token with session cookies

### DIFF
--- a/openedx/core/djangoapps/auth_exchange/README.rst
+++ b/openedx/core/djangoapps/auth_exchange/README.rst
@@ -10,4 +10,4 @@ The following are currently implemented:
 
 2. LoginWithAccessTokenView
 
-   1st party (open-edx) OAuth 2.0 access token -> session cookie
+   1st party (open-edx) OAuth 2.0 access token (bearer/jwt) -> session cookie

--- a/openedx/core/djangoapps/oauth_dispatch/views.py
+++ b/openedx/core/djangoapps/oauth_dispatch/views.py
@@ -117,7 +117,9 @@ class AccessTokenView(_DispatchingView):
         Includes the JWT token and token type in the response.
         """
         opaque_token_dict = json.loads(response.content.decode('utf-8'))
-        jwt_token_dict = create_jwt_token_dict(opaque_token_dict, self.get_adapter(request))
+        use_asymmetric_key = request.POST.get('asymmetric_jwt', False)
+        jwt_token_dict = create_jwt_token_dict(opaque_token_dict, self.get_adapter(request),
+                                               use_asymmetric_key=use_asymmetric_key)
         return json.dumps(jwt_token_dict)
 
 
@@ -150,7 +152,9 @@ class AccessTokenExchangeView(_DispatchingView):
         Includes the JWT token and token type in the response.
         """
         opaque_token_dict = response.data
-        jwt_token_dict = create_jwt_token_dict(opaque_token_dict, self.get_adapter(request))
+        use_asymmetric_key = request.POST.get('asymmetric_jwt', False)
+        jwt_token_dict = create_jwt_token_dict(opaque_token_dict, self.get_adapter(request),
+                                               use_asymmetric_key=use_asymmetric_key)
         return jwt_token_dict
 
 


### PR DESCRIPTION
Exchange JWT token with session cookies

## Description

Exchange JWT token with session cookies so that it can work on mobile.
Mobile platform is moving to JWT and to authenticate xblocks we need session cookies
in exchange of JWT token.

[LEARNER-8518](https://openedx.atlassian.net/browse/LEARNER-8518)

## Review pre-merge checks

Additional details in the[ Mobile JWT Confluence page](https://openedx.atlassian.net/wiki/spaces/AC/pages/3351609433/Mobile+authentication+with+JWTs).

For additional details, see:
https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/oauth_dispatch/docs/decisions/0013-mobile-migration-to-jwt.rst

- [x] Requires asymmetrically signed JWT.
- [x] Grant_type added to JWT and checked.
- [x] JWT related calls using library functions.
- [x] Ensure user account is not disabled.
- [x] Ensure JWT expiration reduced to one hour (may block usage, but not merging?)
- [x] Ensure ADR exists and is shared