### PR TITLE
fix: release edx-enterprise 3.40.7

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -30,7 +30,7 @@ django-storages<1.9
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==3.40.5
+edx-enterprise==3.40.7
 
 # Newer versions need a more recent version of python-dateutil
 freezegun==0.3.12

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -443,7 +443,7 @@ edx-drf-extensions==8.0.1
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.40.5
+edx-enterprise==3.40.7
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -544,7 +544,7 @@ edx-drf-extensions==8.0.1
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.40.5
+edx-enterprise==3.40.7
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -528,7 +528,7 @@ edx-drf-extensions==8.0.1
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.40.5
+edx-enterprise==3.40.7
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
## Description

[3.40.7] @johnnagro 
---------
fix: Broken Canvas oauth authorization url

[3.40.6] @binodpant 
---------
feat: SAPSF content metadata transmission now also sends course schedule


## References

- [ENT-5479](https://openedx.atlassian.net/browse/ENT-5479)
- https://github.com/openedx/edx-enterprise/pull/1483
- https://pypi.org/project/edx-enterprise/3.40.7/
