### PR TITLE
chore: update edx-name-affirmation version to latest release

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -451,7 +451,7 @@ edx-i18n-tools==0.9.1
     # via ora2
 edx-milestones==0.3.3
     # via -r requirements/edx/base.in
-edx-name-affirmation==2.2.0
+edx-name-affirmation==2.2.1
     # via -r requirements/edx/base.in
 edx-opaque-keys[django]==2.3.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -556,7 +556,7 @@ edx-lint==5.2.1
     # via -r requirements/edx/testing.txt
 edx-milestones==0.3.3
     # via -r requirements/edx/testing.txt
-edx-name-affirmation==2.2.0
+edx-name-affirmation==2.2.1
     # via -r requirements/edx/testing.txt
 edx-opaque-keys[django]==2.3.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -541,7 +541,7 @@ edx-lint==5.2.1
     # via -r requirements/edx/testing.in
 edx-milestones==0.3.3
     # via -r requirements/edx/base.txt
-edx-name-affirmation==2.2.0
+edx-name-affirmation==2.2.1
     # via -r requirements/edx/base.txt
 edx-opaque-keys[django]==2.3.0
     # via


### PR DESCRIPTION
The latest version of edx-name-affirmation contains a fix that allows a proctoring `error` status to update a verified name status to `denied`.
