### PR TITLE
test: Use autospec=True in most @patch calls

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/tests/test_views.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/tests/test_views.py
@@ -305,7 +305,7 @@ class ProctoringExamSettingsPostTests(ProctoringExamSettingsTestMixin, ModuleSto
             'software_secure': {},
         },
     )
-    @patch('logging.Logger.info')
+    @patch('logging.Logger.info', autospec=True)
     @ddt.data(
         ('proctortrack', False, False),
         ('software_secure', True, False),

--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -1302,7 +1302,7 @@ class CourseMetadataEditingTest(CourseTestCase):
         self.assertEqual(test_model['advertised_start']['value'], 'start B', "advertised_start not expected value")
 
     @patch.dict(settings.FEATURES, {'ENABLE_EDXNOTES': True})
-    @patch('xmodule.util.xmodule_django.get_current_request')
+    @patch('xmodule.util.xmodule_django.get_current_request', autospec=True)
     def test_post_settings_with_staff_not_enrolled(self, mock_request):
         """
         Tests that we can post advance settings when course staff is not enrolled.

--- a/cms/djangoapps/contentstore/tests/test_gating.py
+++ b/cms/djangoapps/contentstore/tests/test_gating.py
@@ -46,8 +46,8 @@ class TestHandleItemDeleted(ModuleStoreTestCase, MilestonesTestCaseMixin):
         gating_api.add_prerequisite(self.course.id, self.open_seq.location)
         gating_api.set_required_content(self.course.id, self.gated_seq.location, self.open_seq.location, 100, 100)
 
-    @patch('cms.djangoapps.contentstore.signals.handlers.gating_api.set_required_content')
-    @patch('cms.djangoapps.contentstore.signals.handlers.gating_api.remove_prerequisite')
+    @patch('cms.djangoapps.contentstore.signals.handlers.gating_api.set_required_content', autospec=True)
+    @patch('cms.djangoapps.contentstore.signals.handlers.gating_api.remove_prerequisite', autospec=True)
     def test_chapter_deleted(self, mock_remove_prereq, mock_set_required):
         """ Test gating milestone data is cleanup up when course content item is deleted """
         handle_item_deleted(usage_key=self.chapter.location, user_id=0)
@@ -56,8 +56,8 @@ class TestHandleItemDeleted(ModuleStoreTestCase, MilestonesTestCaseMixin):
             self.open_seq.location.course_key, self.open_seq.location, None, None, None
         )
 
-    @patch('cms.djangoapps.contentstore.signals.handlers.gating_api.set_required_content')
-    @patch('cms.djangoapps.contentstore.signals.handlers.gating_api.remove_prerequisite')
+    @patch('cms.djangoapps.contentstore.signals.handlers.gating_api.set_required_content', autospec=True)
+    @patch('cms.djangoapps.contentstore.signals.handlers.gating_api.remove_prerequisite', autospec=True)
     def test_sequential_deleted(self, mock_remove_prereq, mock_set_required):
         """ Test gating milestone data is cleanup up when course content item is deleted """
         handle_item_deleted(usage_key=self.open_seq.location, user_id=0)

--- a/cms/djangoapps/contentstore/tests/test_signals.py
+++ b/cms/djangoapps/contentstore/tests/test_signals.py
@@ -26,8 +26,8 @@ class LockedTest(ModuleStoreTestCase):
         self.user = UserFactory.create()
         CourseEnrollment.enroll(self.user, self.course.id)
 
-    @patch('cms.djangoapps.contentstore.signals.handlers.cache.add')
-    @patch('cms.djangoapps.contentstore.signals.handlers.task_compute_all_grades_for_course.apply_async')
+    @patch('cms.djangoapps.contentstore.signals.handlers.cache.add', autospec=True)
+    @patch('cms.djangoapps.contentstore.signals.handlers.task_compute_all_grades_for_course.apply_async', autospec=True)
     @ddt.data(True, False)
     def test_locked(self, lock_available, compute_grades_async_mock, add_mock):
         add_mock.return_value = lock_available

--- a/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
@@ -253,7 +253,7 @@ class TestDownloadYoutubeSubs(TestYoutubeSubsBase):
         self.assertEqual(html5_ids[2], 'baz.1.4')
         self.assertEqual(html5_ids[3], 'foo')
 
-    @patch('xmodule.video_module.transcripts_utils.requests.get')
+    @patch('xmodule.video_module.transcripts_utils.requests.get', autospec=True)
     def test_fail_downloading_subs(self, mock_get):
 
         mock_get.return_value = Mock(status_code=404, text='Error 404')
@@ -287,7 +287,7 @@ class TestDownloadYoutubeSubs(TestYoutubeSubsBase):
 
         self.clear_sub_content(good_youtube_sub)
 
-    @patch('xmodule.video_module.transcripts_utils.requests.get')
+    @patch('xmodule.video_module.transcripts_utils.requests.get', autospec=True)
     def test_get_transcript_name_youtube_server_success(self, mock_get):
         """
         Get transcript name from transcript_list fetch from youtube server api
@@ -306,7 +306,7 @@ class TestDownloadYoutubeSubs(TestYoutubeSubsBase):
         transcript_name = transcripts_utils.youtube_video_transcript_name(youtube_text_api)
         self.assertEqual(transcript_name, 'Custom')
 
-    @patch('xmodule.video_module.transcripts_utils.requests.get')
+    @patch('xmodule.video_module.transcripts_utils.requests.get', autospec=True)
     def test_get_transcript_name_youtube_server_no_transcripts(self, mock_get):
         """
         When there are no transcripts of video transcript name will be None
@@ -319,7 +319,7 @@ class TestDownloadYoutubeSubs(TestYoutubeSubsBase):
         transcript_name = transcripts_utils.youtube_video_transcript_name(youtube_text_api)
         self.assertIsNone(transcript_name)
 
-    @patch('xmodule.video_module.transcripts_utils.requests.get')
+    @patch('xmodule.video_module.transcripts_utils.requests.get', autospec=True)
     def test_get_transcript_name_youtube_server_language_not_exist(self, mock_get):
         """
         When the language does not exist in transcript_list transcript name will be None
@@ -518,14 +518,14 @@ class TestYoutubeTranscripts(unittest.TestCase):
     """
     Tests for checking right datastructure returning when using youtube api.
     """
-    @patch('xmodule.video_module.transcripts_utils.requests.get')
+    @patch('xmodule.video_module.transcripts_utils.requests.get', autospec=True)
     def test_youtube_bad_status_code(self, mock_get):
         mock_get.return_value = Mock(status_code=404, text='test')
         youtube_id = 'bad_youtube_id'
         with self.assertRaises(transcripts_utils.GetTranscriptsFromYouTubeException):
             transcripts_utils.get_transcripts_from_youtube(youtube_id, settings, translation)
 
-    @patch('xmodule.video_module.transcripts_utils.requests.get')
+    @patch('xmodule.video_module.transcripts_utils.requests.get', autospec=True)
     def test_youtube_empty_text(self, mock_get):
         mock_get.return_value = Mock(status_code=200, text='')
         youtube_id = 'bad_youtube_id'
@@ -939,7 +939,7 @@ class TestGetTranscript(SharedModuleStoreTestCase):
         self.assertEqual(filename, 'ur_video_101.sjson')
         self.assertEqual(mimetype, self.sjson_mime_type)
 
-    @patch('xmodule.video_module.transcripts_utils.get_video_transcript_content')
+    @patch('xmodule.video_module.transcripts_utils.get_video_transcript_content', autospec=True)
     def test_get_transcript_from_val(self, mock_get_video_transcript_content):
         """
         Verify that `get_transcript` function returns correct data when transcript is in val.
@@ -1001,7 +1001,7 @@ class TestGetTranscript(SharedModuleStoreTestCase):
         exception_message = str(no_en_transcript_exception.exception)
         self.assertEqual(exception_message, 'No transcript for `en` language')
 
-    @patch('xmodule.video_module.transcripts_utils.edxval_api.get_video_transcript_data')
+    @patch('xmodule.video_module.transcripts_utils.edxval_api.get_video_transcript_data', autospec=True)
     def test_get_transcript_incorrect_json_(self, mock_get_video_transcript_data):
         """
         Verify that `get transcript` function returns a working json file if the original throws an error
@@ -1015,7 +1015,7 @@ class TestGetTranscript(SharedModuleStoreTestCase):
         transcripts_utils.TranscriptsGenerationException,
         UnicodeDecodeError('aliencodec', b'\x02\x01', 1, 2, 'alien codec found!')
     )
-    @patch('xmodule.video_module.transcripts_utils.Transcript')
+    @patch('xmodule.video_module.transcripts_utils.Transcript', autospec=True)
     def test_get_transcript_val_exceptions(self, exception_to_raise, mock_Transcript):
         """
         Verify that `get_transcript_from_val` function raises `NotFoundError` when specified exceptions raised.
@@ -1035,7 +1035,7 @@ class TestGetTranscript(SharedModuleStoreTestCase):
         transcripts_utils.TranscriptsGenerationException,
         UnicodeDecodeError('aliencodec', b'\x02\x01', 1, 2, 'alien codec found!')
     )
-    @patch('xmodule.video_module.transcripts_utils.Transcript')
+    @patch('xmodule.video_module.transcripts_utils.Transcript', autospec=True)
     def test_get_transcript_content_store_exceptions(self, exception_to_raise, mock_Transcript):
         """
         Verify that `get_transcript_from_contentstore` function raises `NotFoundError` when specified exceptions raised.

--- a/cms/djangoapps/contentstore/tests/test_video_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_video_utils.py
@@ -141,7 +141,7 @@ class ScrapeVideoThumbnailsTestCase(CourseTestCase):
         return mocked_response
 
     @override_settings(AWS_ACCESS_KEY_ID='test_key_id', AWS_SECRET_ACCESS_KEY='test_secret')
-    @patch('requests.get')
+    @patch('requests.get', autospec=True)
     @ddt.data(
         (
             {
@@ -225,7 +225,7 @@ class ScrapeVideoThumbnailsTestCase(CourseTestCase):
         self.assertEqual(thumbnail_content_type, 'image/jpeg')
 
     @override_settings(AWS_ACCESS_KEY_ID='test_key_id', AWS_SECRET_ACCESS_KEY='test_secret')
-    @patch('requests.get')
+    @patch('requests.get', autospec=True)
     def test_scrape_youtube_thumbnail(self, mocked_request):
         """
         Test that youtube thumbnails are correctly scrapped.
@@ -270,8 +270,8 @@ class ScrapeVideoThumbnailsTestCase(CourseTestCase):
         )
     )
     @override_settings(AWS_ACCESS_KEY_ID='test_key_id', AWS_SECRET_ACCESS_KEY='test_secret')
-    @patch('cms.djangoapps.contentstore.video_utils.LOGGER')
-    @patch('requests.get')
+    @patch('cms.djangoapps.contentstore.video_utils.LOGGER', autospec=True)
+    @patch('requests.get', autospec=True)
     @ddt.unpack
     def test_scrape_youtube_thumbnail_logging(
         self,
@@ -330,8 +330,8 @@ class ScrapeVideoThumbnailsTestCase(CourseTestCase):
             )
         ),
     )
-    @patch('cms.djangoapps.contentstore.video_utils.LOGGER')
-    @patch('cms.djangoapps.contentstore.video_utils.download_youtube_video_thumbnail')
+    @patch('cms.djangoapps.contentstore.video_utils.LOGGER', autospec=True)
+    @patch('cms.djangoapps.contentstore.video_utils.download_youtube_video_thumbnail', autospec=True)
     @ddt.unpack
     def test_no_video_thumbnail_downloaded(
         self,

--- a/cms/djangoapps/contentstore/views/tests/test_assets.py
+++ b/cms/djangoapps/contentstore/views/tests/test_assets.py
@@ -396,7 +396,7 @@ class DownloadTestCase(AssetsTestCase):
         resp = self.client.get(url, HTTP_ACCEPT='text/html')
         self.assertEqual(resp.status_code, 404)
 
-    @patch('xmodule.modulestore.mixed.MixedModuleStore.find_asset_metadata')
+    @patch('xmodule.modulestore.mixed.MixedModuleStore.find_asset_metadata', autospec=True)
     def test_pickling_calls(self, patched_find_asset_metadata):
         """ Tests if assets are not calling find_asset_metadata
         """

--- a/cms/djangoapps/contentstore/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_index.py
@@ -596,7 +596,7 @@ class TestCourseOutline(CourseTestCase):
         )
 
     @override_settings(FEATURES={'ENABLE_EXAM_SETTINGS_HTML_VIEW': True})
-    @patch('cms.djangoapps.models.settings.course_metadata.CourseMetadata.validate_proctoring_settings')
+    @patch('cms.djangoapps.models.settings.course_metadata.CourseMetadata.validate_proctoring_settings', autospec=True)
     def test_proctoring_link_is_visible(self, mock_validate_proctoring_settings):
         """
         Test to check proctored exam settings mfe url is rendering properly

--- a/cms/djangoapps/contentstore/views/tests/test_exam_settings_view.py
+++ b/cms/djangoapps/contentstore/views/tests/test_exam_settings_view.py
@@ -170,7 +170,7 @@ class TestExamSettingsView(CourseTestCase, UrlResetMixin):
         assert len(alert_nodes) == 0
 
     @override_settings(FEATURES={'ENABLE_EXAM_SETTINGS_HTML_VIEW': True})
-    @patch('cms.djangoapps.models.settings.course_metadata.CourseMetadata.validate_proctoring_settings')
+    @patch('cms.djangoapps.models.settings.course_metadata.CourseMetadata.validate_proctoring_settings', autospec=True)
     def test_proctoring_link_is_visible(self, mock_validate_proctoring_settings):
 
         """

--- a/cms/djangoapps/contentstore/views/tests/test_gating.py
+++ b/cms/djangoapps/contentstore/views/tests/test_gating.py
@@ -57,7 +57,7 @@ class TestSubsectionGating(CourseTestCase):
         )
         self.seq2_url = reverse_usage_url('xblock_handler', self.seq2.location)
 
-    @patch('cms.djangoapps.contentstore.views.item.gating_api.add_prerequisite')
+    @patch('cms.djangoapps.contentstore.views.item.gating_api.add_prerequisite', autospec=True)
     def test_add_prerequisite(self, mock_add_prereq):
         """
         Test adding a subsection as a prerequisite
@@ -69,7 +69,7 @@ class TestSubsectionGating(CourseTestCase):
         )
         mock_add_prereq.assert_called_with(self.course.id, self.seq1.location)
 
-    @patch('cms.djangoapps.contentstore.views.item.gating_api.remove_prerequisite')
+    @patch('cms.djangoapps.contentstore.views.item.gating_api.remove_prerequisite', autospec=True)
     def test_remove_prerequisite(self, mock_remove_prereq):
         """
         Test removing a subsection as a prerequisite
@@ -81,7 +81,7 @@ class TestSubsectionGating(CourseTestCase):
         )
         mock_remove_prereq.assert_called_with(self.seq1.location)
 
-    @patch('cms.djangoapps.contentstore.views.item.gating_api.set_required_content')
+    @patch('cms.djangoapps.contentstore.views.item.gating_api.set_required_content', autospec=True)
     def test_add_gate(self, mock_set_required_content):
         """
         Test adding a gated subsection
@@ -100,7 +100,7 @@ class TestSubsectionGating(CourseTestCase):
             '100'
         )
 
-    @patch('cms.djangoapps.contentstore.views.item.gating_api.set_required_content')
+    @patch('cms.djangoapps.contentstore.views.item.gating_api.set_required_content', autospec=True)
     def test_remove_gate(self, mock_set_required_content):
         """
         Test removing a gated subsection
@@ -118,9 +118,9 @@ class TestSubsectionGating(CourseTestCase):
             ''
         )
 
-    @patch('cms.djangoapps.contentstore.views.item.gating_api.get_prerequisites')
-    @patch('cms.djangoapps.contentstore.views.item.gating_api.get_required_content')
-    @patch('cms.djangoapps.contentstore.views.item.gating_api.is_prerequisite')
+    @patch('cms.djangoapps.contentstore.views.item.gating_api.get_prerequisites', autospec=True)
+    @patch('cms.djangoapps.contentstore.views.item.gating_api.get_required_content', autospec=True)
+    @patch('cms.djangoapps.contentstore.views.item.gating_api.is_prerequisite', autospec=True)
     @ddt.data(
         (90, None),
         (None, 90),
@@ -147,8 +147,8 @@ class TestSubsectionGating(CourseTestCase):
         self.assertEqual(resp['prereq_min_completion'], min_completion)
         self.assertEqual(resp['visibility_state'], VisibilityState.gated)
 
-    @patch('cms.djangoapps.contentstore.signals.handlers.gating_api.set_required_content')
-    @patch('cms.djangoapps.contentstore.signals.handlers.gating_api.remove_prerequisite')
+    @patch('cms.djangoapps.contentstore.signals.handlers.gating_api.set_required_content', autospec=True)
+    @patch('cms.djangoapps.contentstore.signals.handlers.gating_api.remove_prerequisite', autospec=True)
     def test_delete_item_signal_handler_called(self, mock_remove_prereq, mock_set_required):
         seq3 = ItemFactory.create(
             parent_location=self.chapter.location,

--- a/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
+++ b/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
@@ -1169,7 +1169,7 @@ class GroupConfigurationsValidationTestCase(CourseTestCase, HelperMethods):
     Tests for validation in Group Configurations.
     """
 
-    @patch('xmodule.split_test_module.SplitTestBlock.validate_split_test')
+    @patch('xmodule.split_test_module.SplitTestBlock.validate_split_test', autospec=True)
     def verify_validation_add_usage_info(self, expected_result, mocked_message, mocked_validation_messages):
         """
         Helper method for testing validation information present after add_usage_info.
@@ -1204,7 +1204,7 @@ class GroupConfigurationsValidationTestCase(CourseTestCase, HelperMethods):
         )
         self.verify_validation_add_usage_info(expected_result, mocked_message)  # pylint: disable=no-value-for-parameter
 
-    @patch('xmodule.split_test_module.SplitTestBlock.validate_split_test')
+    @patch('xmodule.split_test_module.SplitTestBlock.validate_split_test', autospec=True)
     def verify_validation_update_usage_info(self, expected_result, mocked_message, mocked_validation_messages):
         """
         Helper method for testing validation information present after update_usage_info.

--- a/cms/djangoapps/contentstore/views/tests/test_import_export.py
+++ b/cms/djangoapps/contentstore/views/tests/test_import_export.py
@@ -607,9 +607,9 @@ class ImportTestCase(CourseTestCase):
         self.assertImportStatusResponse(status_response, self.UnpackingError, import_error.UNKNOWN_ERROR_IN_UNPACKING)
 
     @patch(TASK_LOGGER)
-    @patch('olxcleaner.validate')
-    @patch('cms.djangoapps.contentstore.tasks.report_error_summary')
-    @patch('cms.djangoapps.contentstore.tasks.report_errors')
+    @patch('olxcleaner.validate', autospec=True)
+    @patch('cms.djangoapps.contentstore.tasks.report_error_summary', autospec=True)
+    @patch('cms.djangoapps.contentstore.tasks.report_errors', autospec=True)
     def test_import_failed_with_olx_validations(self, mocked_report, mocked_summary, mocked_validate, mocked_log):
         """
         Tests that course import failure for unknown error while unpacking
@@ -946,8 +946,8 @@ class ExportTestCase(CourseTestCase):
         mock_artifact.file.storage.url.return_value = file_url
         return mock_artifact
 
-    @patch('cms.djangoapps.contentstore.views.import_export._latest_task_status')
-    @patch('user_tasks.models.UserTaskArtifact.objects.get')
+    @patch('cms.djangoapps.contentstore.views.import_export._latest_task_status', autospec=True)
+    @patch('user_tasks.models.UserTaskArtifact.objects.get', autospec=True)
     def test_export_status_handler_other(
         self,
         mock_get_user_task_artifact,
@@ -967,8 +967,8 @@ class ExportTestCase(CourseTestCase):
         self.assertEqual(result['ExportOutput'], '/path/to/testfile.tar.gz')
 
     @ddt.data(S3BotoStorage, S3Boto3Storage)
-    @patch('cms.djangoapps.contentstore.views.import_export._latest_task_status')
-    @patch('user_tasks.models.UserTaskArtifact.objects.get')
+    @patch('cms.djangoapps.contentstore.views.import_export._latest_task_status', autospec=True)
+    @patch('user_tasks.models.UserTaskArtifact.objects.get', autospec=True)
     def test_export_status_handler_s3(
         self,
         s3_storage,
@@ -988,8 +988,8 @@ class ExportTestCase(CourseTestCase):
         result = json.loads(resp.content.decode('utf-8'))
         self.assertEqual(result['ExportOutput'], '/s3/file/path/testfile.tar.gz')
 
-    @patch('cms.djangoapps.contentstore.views.import_export._latest_task_status')
-    @patch('user_tasks.models.UserTaskArtifact.objects.get')
+    @patch('cms.djangoapps.contentstore.views.import_export._latest_task_status', autospec=True)
+    @patch('user_tasks.models.UserTaskArtifact.objects.get', autospec=True)
     def test_export_status_handler_filesystem(
         self,
         mock_get_user_task_artifact,

--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -1237,7 +1237,7 @@ class TestMoveItem(ItemTest):
         validation = html.validate()
         self.assertEqual(len(validation.messages), 0)
 
-    @patch('cms.djangoapps.contentstore.views.item.log')
+    @patch('cms.djangoapps.contentstore.views.item.log', autospec=True)
     def test_move_logging(self, mock_logger):
         """
         Test logging when an item is successfully moved.

--- a/cms/djangoapps/contentstore/views/tests/test_transcript_settings.py
+++ b/cms/djangoapps/contentstore/views/tests/test_transcript_settings.py
@@ -94,7 +94,7 @@ class TranscriptCredentialsTest(CourseTestCase):
         )
     )
     @ddt.unpack
-    @patch('cms.djangoapps.contentstore.views.transcript_settings.update_3rd_party_transcription_service_credentials')
+    @patch('cms.djangoapps.contentstore.views.transcript_settings.update_3rd_party_transcription_service_credentials', autospec=True)
     def test_transcript_credentials_handler(self, request_payload, update_credentials_response, expected_status_code,
                                             expected_response, mock_update_credentials):
         """
@@ -211,7 +211,7 @@ class TranscriptDownloadTest(CourseTestCase):
         response = self.client.post(self.view_url, content_type='application/json')
         self.assertEqual(response.status_code, 405)
 
-    @patch('cms.djangoapps.contentstore.views.transcript_settings.get_video_transcript_data')
+    @patch('cms.djangoapps.contentstore.views.transcript_settings.get_video_transcript_data', autospec=True)
     def test_transcript_download_handler(self, mock_get_video_transcript_data):
         """
         Tests that transcript download handler works as expected.
@@ -303,7 +303,7 @@ class TranscriptUploadTest(CourseTestCase):
         response = self.client.get(self.view_url, content_type='application/json')
         self.assertEqual(response.status_code, 405)
 
-    @patch('cms.djangoapps.contentstore.views.transcript_settings.create_or_update_video_transcript')
+    @patch('cms.djangoapps.contentstore.views.transcript_settings.create_or_update_video_transcript', autospec=True)
     @patch(
         'cms.djangoapps.contentstore.views.transcript_settings.get_available_transcript_languages',
         Mock(return_value=['en']),
@@ -588,7 +588,7 @@ class TranscriptUploadApiTest(CourseTestCase):
         response = self.client.get(self.view_url, content_type='application/json')
         self.assertEqual(response.status_code, 405)
 
-    @patch('cms.djangoapps.contentstore.views.transcript_settings.create_or_update_video_transcript')
+    @patch('cms.djangoapps.contentstore.views.transcript_settings.create_or_update_video_transcript', autospec=True)
     @patch(
         'cms.djangoapps.contentstore.views.transcript_settings.get_available_transcript_languages',
         Mock(return_value=['en']),

--- a/cms/djangoapps/contentstore/views/tests/test_transcripts.py
+++ b/cms/djangoapps/contentstore/views/tests/test_transcripts.py
@@ -1080,7 +1080,7 @@ class TestCheckTranscripts(BaseTranscripts):
             'Transcripts are supported only for "video" modules.',
         )
 
-    @patch('xmodule.video_module.transcripts_utils.get_video_transcript_content')
+    @patch('xmodule.video_module.transcripts_utils.get_video_transcript_content', autospec=True)
     def test_command_for_fallback_transcript(self, mock_get_video_transcript_content):
         """
         Verify the command if a transcript is there in edx-val.

--- a/cms/djangoapps/contentstore/views/tests/test_videos.py
+++ b/cms/djangoapps/contentstore/views/tests/test_videos.py
@@ -209,8 +209,8 @@ class VideoUploadPostTestsMixin:
     Shared test cases for video post tests.
     """
     @override_settings(AWS_ACCESS_KEY_ID='test_key_id', AWS_SECRET_ACCESS_KEY='test_secret')
-    @patch('boto.s3.key.Key')
-    @patch('boto.s3.connection.S3Connection')
+    @patch('boto.s3.key.Key', autospec=True)
+    @patch('boto.s3.connection.S3Connection', autospec=True)
     def test_post_success(self, mock_conn, mock_key):
         files = [
             {
@@ -523,7 +523,7 @@ class VideosHandlerTestCase(VideoUploadTestMixin, VideoUploadPostTestsMixin, Cou
             self.assertEqual(response['error'], "Request 'files' entry contain unsupported content_type")
 
     @override_settings(AWS_ACCESS_KEY_ID='test_key_id', AWS_SECRET_ACCESS_KEY='test_secret')
-    @patch('boto.s3.connection.S3Connection')
+    @patch('boto.s3.connection.S3Connection', autospec=True)
     def test_upload_with_non_ascii_charaters(self, mock_conn):
         """
         Test that video uploads throws error message when file name contains special characters.
@@ -544,8 +544,8 @@ class VideosHandlerTestCase(VideoUploadTestMixin, VideoUploadPostTestsMixin, Cou
         self.assertEqual(response['error'], 'The file name for %s must contain only ASCII characters.' % file_name)
 
     @override_settings(AWS_ACCESS_KEY_ID='test_key_id', AWS_SECRET_ACCESS_KEY='test_secret', AWS_SECURITY_TOKEN='token')
-    @patch('boto.s3.key.Key')
-    @patch('boto.s3.connection.S3Connection')
+    @patch('boto.s3.key.Key', autospec=True)
+    @patch('boto.s3.connection.S3Connection', autospec=True)
     @override_flag(waffle_flags()[ENABLE_DEVSTACK_VIDEO_UPLOADS].name, active=True)
     def test_devstack_upload_connection(self, mock_conn, mock_key):
         files = [{'file_name': 'first.mp4', 'content_type': 'video/mp4'}]
@@ -571,8 +571,8 @@ class VideosHandlerTestCase(VideoUploadTestMixin, VideoUploadPostTestsMixin, Cou
             security_token=settings.AWS_SECURITY_TOKEN
         )
 
-    @patch('boto.s3.key.Key')
-    @patch('boto.s3.connection.S3Connection')
+    @patch('boto.s3.key.Key', autospec=True)
+    @patch('boto.s3.connection.S3Connection', autospec=True)
     def test_send_course_to_vem_pipeline(self, mock_conn, mock_key):
         """
         Test that uploads always go to VEM S3 bucket by default.
@@ -600,8 +600,8 @@ class VideosHandlerTestCase(VideoUploadTestMixin, VideoUploadPostTestsMixin, Cou
         )
 
     @override_settings(AWS_ACCESS_KEY_ID='test_key_id', AWS_SECRET_ACCESS_KEY='test_secret')
-    @patch('boto.s3.key.Key')
-    @patch('boto.s3.connection.S3Connection')
+    @patch('boto.s3.key.Key', autospec=True)
+    @patch('boto.s3.connection.S3Connection', autospec=True)
     @ddt.data(
         {
             'global_waffle': True,
@@ -762,7 +762,7 @@ class VideosHandlerTestCase(VideoUploadTestMixin, VideoUploadPostTestsMixin, Cou
         # Test should fail if video not found
         self.assertEqual(True, False, 'Invalid edx_video_id')
 
-    @patch('cms.djangoapps.contentstore.views.videos.LOGGER')
+    @patch('cms.djangoapps.contentstore.views.videos.LOGGER', autospec=True)
     def test_video_status_update_request(self, mock_logger):
         """
         Verifies that video status update request works as expected.
@@ -826,7 +826,7 @@ class VideosHandlerTestCase(VideoUploadTestMixin, VideoUploadPostTestsMixin, Cou
         self.assert_video_status(url, edx_video_id, expected_video_status_text)
 
     @ddt.data(True, False)
-    @patch('openedx.core.djangoapps.video_config.models.VideoTranscriptEnabledFlag.feature_enabled')
+    @patch('openedx.core.djangoapps.video_config.models.VideoTranscriptEnabledFlag.feature_enabled', autospec=True)
     def test_video_index_transcript_feature_enablement(self, is_video_transcript_enabled, video_transcript_feature):
         """
         Test that when video transcript is enabled/disabled, correct response is rendered.
@@ -1434,9 +1434,9 @@ class TranscriptPreferencesTestCase(VideoUploadTestBase, CourseTestCase):
     )
     @ddt.unpack
     @override_settings(AWS_ACCESS_KEY_ID='test_key_id', AWS_SECRET_ACCESS_KEY='test_secret')
-    @patch('boto.s3.key.Key')
-    @patch('boto.s3.connection.S3Connection')
-    @patch('cms.djangoapps.contentstore.views.videos.get_transcript_preferences')
+    @patch('boto.s3.key.Key', autospec=True)
+    @patch('boto.s3.connection.S3Connection', autospec=True)
+    @patch('cms.djangoapps.contentstore.views.videos.get_transcript_preferences', autospec=True)
     def test_transcript_preferences_metadata(self, transcript_preferences, is_video_transcript_enabled,
                                              mock_transcript_preferences, mock_conn, mock_key):
         """

--- a/cms/djangoapps/export_course_metadata/management/commands/tests/test_export_course_metadata_for_all_courses.py
+++ b/cms/djangoapps/export_course_metadata/management/commands/tests/test_export_course_metadata_for_all_courses.py
@@ -23,7 +23,7 @@ class ExportAllCourses(ModuleStoreTestCase):
         CourseFactory.create()
         CourseFactory.create()
 
-    @patch('cms.djangoapps.export_course_metadata.tasks.course_metadata_export_storage.save')
+    @patch('cms.djangoapps.export_course_metadata.tasks.course_metadata_export_storage.save', autospec=True)
     def test_exporting_all_courses(self, patched_storage):
         """
         Test for exporting course metadata for all courses.

--- a/cms/djangoapps/export_course_metadata/test_signals.py
+++ b/cms/djangoapps/export_course_metadata/test_signals.py
@@ -37,8 +37,8 @@ class TestExportCourseMetadata(SharedModuleStoreTestCase):
             **kwargs
         )
 
-    @patch('cms.djangoapps.export_course_metadata.tasks.course_metadata_export_storage')
-    @patch('cms.djangoapps.export_course_metadata.tasks.ContentFile')
+    @patch('cms.djangoapps.export_course_metadata.tasks.course_metadata_export_storage', autospec=True)
+    @patch('cms.djangoapps.export_course_metadata.tasks.ContentFile', autospec=True)
     def test_happy_path(self, patched_content, patched_storage):
         """ Ensure we call the storage class with the correct parameters and course metadata """
         all_highlights = [["week1highlight1", "week1highlight2"], ["week1highlight1", "week1highlight2"], [], []]

--- a/common/djangoapps/course_modes/tests/test_views.py
+++ b/common/djangoapps/course_modes/tests/test_views.py
@@ -211,8 +211,8 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
             self.assertNotContains(response, "Credit")
 
     @httpretty.activate
-    @patch('common.djangoapps.course_modes.views.enterprise_customer_for_request')
-    @patch('common.djangoapps.course_modes.views.get_course_final_price')
+    @patch('common.djangoapps.course_modes.views.enterprise_customer_for_request', autospec=True)
+    @patch('common.djangoapps.course_modes.views.get_course_final_price', autospec=True)
     @ddt.data(
         (1.0, True),
         (50.0, False),
@@ -516,7 +516,7 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
         (True, {'unsupported_mode': True}, 'Enrollment mode not supported', 200),
     )
     @ddt.unpack
-    @patch('django.contrib.auth.models.PermissionsMixin.has_perm')
+    @patch('django.contrib.auth.models.PermissionsMixin.has_perm', autospec=True)
     def test_errors(self, has_perm, post_params, error_msg, status_code, mock_has_perm):
         """
         Test the error template is rendered on different types of errors.

--- a/common/djangoapps/entitlements/rest_api/v1/tests/test_views.py
+++ b/common/djangoapps/entitlements/rest_api/v1/tests/test_views.py
@@ -1059,7 +1059,7 @@ class EntitlementEnrollmentViewSetTest(ModuleStoreTestCase):
         assert not CourseEnrollment.is_enrolled(self.user, fake_course_key)
 
     @patch('common.djangoapps.entitlements.models.refund_entitlement', return_value=True)
-    @patch('common.djangoapps.entitlements.rest_api.v1.views.get_course_runs_for_course')
+    @patch('common.djangoapps.entitlements.rest_api.v1.views.get_course_runs_for_course', autospec=True)
     @patch("common.djangoapps.entitlements.models.get_course_uuid_for_course")
     def test_user_can_revoke_and_refund(self, mock_course_uuid, mock_get_course_runs, mock_refund_entitlement):
         course_entitlement = CourseEntitlementFactory.create(user=self.user, mode=CourseMode.VERIFIED)
@@ -1102,7 +1102,7 @@ class EntitlementEnrollmentViewSetTest(ModuleStoreTestCase):
 
     @patch('common.djangoapps.entitlements.rest_api.v1.views.CourseEntitlement.is_entitlement_refundable', return_value=False)  # lint-amnesty, pylint: disable=line-too-long
     @patch('common.djangoapps.entitlements.models.refund_entitlement', return_value=True)
-    @patch('common.djangoapps.entitlements.rest_api.v1.views.get_course_runs_for_course')
+    @patch('common.djangoapps.entitlements.rest_api.v1.views.get_course_runs_for_course', autospec=True)
     def test_user_can_revoke_and_no_refund_available(
             self,
             mock_get_course_runs,

--- a/common/djangoapps/static_replace/test/test_static_replace.py
+++ b/common/djangoapps/static_replace/test/test_static_replace.py
@@ -111,8 +111,8 @@ def test_storage_url_not_exists(mock_storage):
 
 @patch('common.djangoapps.static_replace.StaticContent', autospec=True)
 @patch('xmodule.modulestore.django.modulestore', autospec=True)
-@patch('common.djangoapps.static_replace.models.AssetBaseUrlConfig.get_base_url')
-@patch('common.djangoapps.static_replace.models.AssetExcludedExtensionsConfig.get_excluded_extensions')
+@patch('common.djangoapps.static_replace.models.AssetBaseUrlConfig.get_base_url', autospec=True)
+@patch('common.djangoapps.static_replace.models.AssetExcludedExtensionsConfig.get_excluded_extensions', autospec=True)
 def test_mongo_filestore(mock_get_excluded_extensions, mock_get_base_url, mock_modulestore, mock_static_content):
 
     mock_modulestore.return_value = Mock(MongoModuleStore)

--- a/common/djangoapps/student/management/tests/test_bulk_change_enrollment.py
+++ b/common/djangoapps/student/management/tests/test_bulk_change_enrollment.py
@@ -27,7 +27,7 @@ class BulkChangeEnrollmentTests(SharedModuleStoreTestCase):
         self.users = UserFactory.create_batch(5)
         CourseOverview.load_from_module_store(self.course.id)
 
-    @patch('common.djangoapps.student.models.tracker')
+    @patch('common.djangoapps.student.models.tracker', autospec=True)
     @ddt.data(('audit', 'honor'), ('honor', 'audit'))
     @ddt.unpack
     def test_bulk_convert(self, from_mode, to_mode, mock_tracker):
@@ -55,7 +55,7 @@ class BulkChangeEnrollmentTests(SharedModuleStoreTestCase):
             CourseEnrollment.objects.get(mode=to_mode, course_id=self.course.id, user=user)
             self._assert_mode_changed(mock_tracker, self.course, user, to_mode)
 
-    @patch('common.djangoapps.student.models.tracker')
+    @patch('common.djangoapps.student.models.tracker', autospec=True)
     @ddt.data(('audit', 'no-id-professional'), ('no-id-professional', 'audit'))
     @ddt.unpack
     def test_bulk_convert_with_org(self, from_mode, to_mode, mock_tracker):
@@ -108,7 +108,7 @@ class BulkChangeEnrollmentTests(SharedModuleStoreTestCase):
 
         assert 'Error: argument -o/--org: not allowed with argument -c/--course' == str(err.value)
 
-    @patch('common.djangoapps.student.models.tracker')
+    @patch('common.djangoapps.student.models.tracker', autospec=True)
     def test_with_org_and_invalid_to_mode(self, mock_tracker):
         """Verify that enrollments are changed correctly when org was given."""
         from_mode = 'audit'

--- a/common/djangoapps/student/management/tests/test_change_enrollment.py
+++ b/common/djangoapps/student/management/tests/test_change_enrollment.py
@@ -42,7 +42,7 @@ class ChangeEnrollmentTests(SharedModuleStoreTestCase):
             self.users.append(user)
             self.enrollments.append(CourseEnrollment.enroll(user, self.course.id, mode='audit'))
 
-    @patch('common.djangoapps.student.management.commands.change_enrollment.logger')
+    @patch('common.djangoapps.student.management.commands.change_enrollment.logger', autospec=True)
     @ddt.data(
         ('email', False, 3),
         ('username', False, 3),
@@ -80,7 +80,7 @@ class ChangeEnrollmentTests(SharedModuleStoreTestCase):
             len(self.users)
         )
 
-    @patch('common.djangoapps.student.management.commands.change_enrollment.logger')
+    @patch('common.djangoapps.student.management.commands.change_enrollment.logger', autospec=True)
     @ddt.data(
         ('email', 'dtennant@thedoctor.com', 3),
         ('username', 'dtennant', 3),

--- a/common/djangoapps/student/tests/test_activate_account.py
+++ b/common/djangoapps/student/tests/test_activate_account.py
@@ -77,7 +77,7 @@ class TestActivateAccount(TestCase):
         assert self.user.is_active
         assert not mock_segment_identify.called
 
-    @patch('common.djangoapps.student.models.USER_ACCOUNT_ACTIVATED')
+    @patch('common.djangoapps.student.models.USER_ACCOUNT_ACTIVATED', autospec=True)
     def test_activation_signal(self, mock_signal):
         """
         Verify that USER_ACCOUNT_ACTIVATED is emitted upon account email activation.

--- a/common/djangoapps/student/tests/test_email.py
+++ b/common/djangoapps/student/tests/test_email.py
@@ -196,7 +196,7 @@ class ActivationEmailTests(EmailTemplateTagMixin, CacheIsolationTestCase):
                             assert user.is_active
                             assert email.called is False, 'method should not have been called'
 
-    @patch('common.djangoapps.student.views.management.compose_activation_email')
+    @patch('common.djangoapps.student.views.management.compose_activation_email', autospec=True)
     def test_send_email_to_inactive_user(self, email):
         """
         Tests that when an inactive user logs-in using the social auth, system
@@ -376,7 +376,7 @@ class EmailChangeRequestTests(EventTestMixin, EmailTemplateTagMixin, CacheIsolat
         """
         assert self.do_email_validation(self.user.email) == 'Old email is the same as the new email.'
 
-    @patch('django.core.mail.EmailMultiAlternatives.send')
+    @patch('django.core.mail.EmailMultiAlternatives.send', autospec=True)
     def test_email_failure(self, send_mail):
         """
         Test the return value if sending the email for the user to click fails.
@@ -561,7 +561,7 @@ class EmailChangeConfirmationTests(EmailTestMixin, EmailTemplateTagMixin, CacheI
         self.assertFailedBeforeEmailing()
 
     @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', "Test only valid in LMS")
-    @patch('common.djangoapps.student.views.management.ace')
+    @patch('common.djangoapps.student.views.management.ace', autospec=True)
     def test_old_email_fails(self, ace_mail):
         ace_mail.send.side_effect = [Exception, None]
         self.check_confirm_email_change('email_change_failed.html', {
@@ -571,7 +571,7 @@ class EmailChangeConfirmationTests(EmailTestMixin, EmailTemplateTagMixin, CacheI
         self.assertRolledBack()
 
     @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', "Test only valid in LMS")
-    @patch('common.djangoapps.student.views.management.ace')
+    @patch('common.djangoapps.student.views.management.ace', autospec=True)
     def test_new_email_fails(self, ace_mail):
         ace_mail.send.side_effect = [None, Exception]
         self.check_confirm_email_change('email_change_failed.html', {
@@ -664,7 +664,7 @@ class SecondaryEmailChangeRequestTests(EventTestMixin, EmailTemplateTagMixin, Ca
         for email in ('bad_email', 'bad_email@', '@bad_email'):
             assert self.do_email_validation(email) == 'Valid e-mail address required.'
 
-    @patch('django.core.mail.EmailMultiAlternatives.send')
+    @patch('django.core.mail.EmailMultiAlternatives.send', autospec=True)
     def test_email_failure(self, send_mail):
         """
         Test the return value if sending the email for the user to click fails.

--- a/common/djangoapps/student/tests/test_enrollment.py
+++ b/common/djangoapps/student/tests/test_enrollment.py
@@ -190,7 +190,7 @@ class EnrollmentTest(UrlResetMixin, ModuleStoreTestCase, OpenEdxEventsTestMixin)
         assert traits['email'] == self.EMAIL
 
     @patch.dict(settings.FEATURES, {'ENABLE_MKTG_EMAIL_OPT_IN': True})
-    @patch('openedx.core.djangoapps.user_api.preferences.api.update_email_opt_in')
+    @patch('openedx.core.djangoapps.user_api.preferences.api.update_email_opt_in', autospec=True)
     @ddt.data(
         ([], 'true'),
         ([], 'false'),

--- a/common/djangoapps/student/tests/test_helpers.py
+++ b/common/djangoapps/student/tests/test_helpers.py
@@ -102,7 +102,7 @@ class TestLoginHelper(TestCase):
         for method in ['GET', 'POST']
     ]
 
-    @patch('common.djangoapps.student.helpers.third_party_auth.pipeline.get')
+    @patch('common.djangoapps.student.helpers.third_party_auth.pipeline.get', autospec=True)
     @ddt.data(*tpa_hint_test_cases_with_method)
     @ddt.unpack
     def test_third_party_auth_hint(

--- a/common/djangoapps/student/tests/test_refunds.py
+++ b/common/djangoapps/student/tests/test_refunds.py
@@ -65,13 +65,13 @@ class RefundableTest(SharedModuleStoreTestCase):
         self.client = Client()
         cache.clear()
 
-    @patch('common.djangoapps.student.models.CourseEnrollment.refund_cutoff_date')
+    @patch('common.djangoapps.student.models.CourseEnrollment.refund_cutoff_date', autospec=True)
     def test_refundable(self, cutoff_date):
         """ Assert base case is refundable"""
         cutoff_date.return_value = datetime.now(pytz.UTC) + timedelta(days=1)
         assert self.enrollment.refundable()
 
-    @patch('common.djangoapps.student.models.CourseEnrollment.refund_cutoff_date')
+    @patch('common.djangoapps.student.models.CourseEnrollment.refund_cutoff_date', autospec=True)
     def test_refundable_expired_verification(self, cutoff_date):
         """ Assert that enrollment is refundable if course mode has expired."""
         cutoff_date.return_value = datetime.now(pytz.UTC) + timedelta(days=1)
@@ -79,7 +79,7 @@ class RefundableTest(SharedModuleStoreTestCase):
         self.verified_mode.save()
         assert self.enrollment.refundable()
 
-    @patch('common.djangoapps.student.models.CourseEnrollment.refund_cutoff_date')
+    @patch('common.djangoapps.student.models.CourseEnrollment.refund_cutoff_date', autospec=True)
     def test_refundable_when_certificate_exists(self, cutoff_date):
         """ Assert that enrollment is not refundable once a certificat has been generated."""
 
@@ -108,7 +108,7 @@ class RefundableTest(SharedModuleStoreTestCase):
         self.enrollment.can_refund = True
         assert self.enrollment.refundable()
 
-    @patch('common.djangoapps.student.models.CourseEnrollment.refund_cutoff_date')
+    @patch('common.djangoapps.student.models.CourseEnrollment.refund_cutoff_date', autospec=True)
     def test_refundable_with_cutoff_date(self, cutoff_date):
         """ Assert enrollment is refundable before cutoff and not refundable after."""
         cutoff_date.return_value = datetime.now(pytz.UTC) + timedelta(days=1)
@@ -235,7 +235,7 @@ class RefundableTest(SharedModuleStoreTestCase):
         )
         assert self.enrollment.is_order_voucher_refundable() is False
 
-    @patch('openedx.core.djangoapps.commerce.utils.ecommerce_api_client')
+    @patch('openedx.core.djangoapps.commerce.utils.ecommerce_api_client', autospec=True)
     def test_get_order_attribute_from_ecommerce(self, mock_ecommerce_api_client):
         """
         Assert that the get_order_attribute_from_ecommerce method returns order details if it's already cached,
@@ -254,7 +254,7 @@ class RefundableTest(SharedModuleStoreTestCase):
         assert self.enrollment.get_order_attribute_from_ecommerce("vouchers") == order_details["vouchers"]
         mock_ecommerce_api_client.assert_not_called()
 
-    @patch('openedx.core.djangoapps.commerce.utils.ecommerce_api_client')
+    @patch('openedx.core.djangoapps.commerce.utils.ecommerce_api_client', autospec=True)
     def test_refund_cutoff_date_with_date_placed_attr(self, mock_ecommerce_api_client):
         """
         Assert that the refund_cutoff_date returns order placement date if order:date_placed

--- a/common/djangoapps/student/tests/test_views.py
+++ b/common/djangoapps/student/tests/test_views.py
@@ -324,9 +324,9 @@ class StudentDashboardTests(SharedModuleStoreTestCase, MilestonesTestCaseMixin, 
         response = self.client.get(reverse('dashboard'))
         self.assertNotContains(response, '<div class="prerequisites">')
 
-    @patch('openedx.core.djangoapps.programs.utils.get_programs')
-    @patch('common.djangoapps.student.views.dashboard.get_visible_sessions_for_entitlement')
-    @patch('common.djangoapps.student.views.dashboard.get_pseudo_session_for_entitlement')
+    @patch('openedx.core.djangoapps.programs.utils.get_programs', autospec=True)
+    @patch('common.djangoapps.student.views.dashboard.get_visible_sessions_for_entitlement', autospec=True)
+    @patch('common.djangoapps.student.views.dashboard.get_pseudo_session_for_entitlement', autospec=True)
     @patch.object(CourseOverview, 'get_from_id')
     def test_unfulfilled_entitlement(self, mock_course_overview, mock_pseudo_session,
                                      mock_course_runs, mock_get_programs):
@@ -385,7 +385,7 @@ class StudentDashboardTests(SharedModuleStoreTestCase, MilestonesTestCaseMixin, 
         self.assertContains(response, 'You must select a session to access the course.')
         self.assertNotContains(response, 'To access the course, select a session.')
 
-    @patch('common.djangoapps.student.views.dashboard.get_visible_sessions_for_entitlement')
+    @patch('common.djangoapps.student.views.dashboard.get_visible_sessions_for_entitlement', autospec=True)
     @patch.object(CourseOverview, 'get_from_id')
     def test_unfulfilled_expired_entitlement(self, mock_course_overview, mock_course_runs):
         """
@@ -411,7 +411,7 @@ class StudentDashboardTests(SharedModuleStoreTestCase, MilestonesTestCaseMixin, 
         response = self.client.get(self.path)
         self.assertNotContains(response, '<li class="course-item">')
 
-    @patch('common.djangoapps.entitlements.rest_api.v1.views.get_course_runs_for_course')
+    @patch('common.djangoapps.entitlements.rest_api.v1.views.get_course_runs_for_course', autospec=True)
     @patch.object(CourseOverview, 'get_from_id')
     def test_sessions_for_entitlement_course_runs(self, mock_course_overview, mock_course_runs):
         """
@@ -477,8 +477,8 @@ class StudentDashboardTests(SharedModuleStoreTestCase, MilestonesTestCaseMixin, 
         # response = self.client.get(self.path)
         # self.assertNotIn(noAvailableSessions, response.content)
 
-    @patch('openedx.core.djangoapps.programs.utils.get_programs')
-    @patch('common.djangoapps.student.views.dashboard.get_visible_sessions_for_entitlement')
+    @patch('openedx.core.djangoapps.programs.utils.get_programs', autospec=True)
+    @patch('common.djangoapps.student.views.dashboard.get_visible_sessions_for_entitlement', autospec=True)
     @patch.object(CourseOverview, 'get_from_id')
     def test_fulfilled_entitlement(self, mock_course_overview, mock_course_runs, mock_get_programs):
         """
@@ -513,8 +513,8 @@ class StudentDashboardTests(SharedModuleStoreTestCase, MilestonesTestCaseMixin, 
         self.assertContains(response, '<button class="change-session btn-link "')
         self.assertContains(response, 'Related Programs:')
 
-    @patch('openedx.core.djangoapps.programs.utils.get_programs')
-    @patch('common.djangoapps.student.views.dashboard.get_visible_sessions_for_entitlement')
+    @patch('openedx.core.djangoapps.programs.utils.get_programs', autospec=True)
+    @patch('common.djangoapps.student.views.dashboard.get_visible_sessions_for_entitlement', autospec=True)
     @patch.object(CourseOverview, 'get_from_id')
     def test_fulfilled_expired_entitlement(self, mock_course_overview, mock_course_runs, mock_get_programs):
         """
@@ -548,8 +548,8 @@ class StudentDashboardTests(SharedModuleStoreTestCase, MilestonesTestCaseMixin, 
         self.assertContains(response, 'You can no longer change sessions.')
         self.assertContains(response, 'Related Programs:')
 
-    @patch('openedx.core.djangoapps.catalog.utils.get_course_runs_for_course')
-    @patch('common.djangoapps.student.views.dashboard.is_bulk_email_feature_enabled')
+    @patch('openedx.core.djangoapps.catalog.utils.get_course_runs_for_course', autospec=True)
+    @patch('common.djangoapps.student.views.dashboard.is_bulk_email_feature_enabled', autospec=True)
     def test_email_settings_fulfilled_entitlement(self, mock_email_feature, mock_get_course_runs):
         """
         Assert that the Email Settings action is shown when the user has a fulfilled entitlement.
@@ -570,7 +570,7 @@ class StudentDashboardTests(SharedModuleStoreTestCase, MilestonesTestCaseMixin, 
         assert pq(response.content)(self.EMAIL_SETTINGS_ELEMENT_ID).length == 1
 
     @patch.object(CourseOverview, 'get_from_id')
-    @patch('common.djangoapps.student.views.dashboard.is_bulk_email_feature_enabled')
+    @patch('common.djangoapps.student.views.dashboard.is_bulk_email_feature_enabled', autospec=True)
     def test_email_settings_unfulfilled_entitlement(self, mock_email_feature, mock_course_overview):
         """
         Assert that the Email Settings action is not shown when the entitlement is not fulfilled.
@@ -1022,7 +1022,7 @@ class TestCourseDashboardNoticesRedirects(SharedModuleStoreTestCase):
 
         assert results is None
 
-    @patch('common.djangoapps.student.views.dashboard.check_for_unacknowledged_notices')
+    @patch('common.djangoapps.student.views.dashboard.check_for_unacknowledged_notices', autospec=True)
     def test_user_with_unacknowledged_notice(self, mock_notices):
         """
         Verifies that we will redirect the learner to the URL returned from the `check_for_unacknowledged_notices`
@@ -1037,7 +1037,7 @@ class TestCourseDashboardNoticesRedirects(SharedModuleStoreTestCase):
         assert response.url == "/about"
         mock_notices.assert_called_once()
 
-    @patch('common.djangoapps.student.views.dashboard.check_for_unacknowledged_notices')
+    @patch('common.djangoapps.student.views.dashboard.check_for_unacknowledged_notices', autospec=True)
     def test_user_with_unacknowledged_notice_no_notices(self, mock_notices):
         """
         Verifies that we will NOT redirect the user if the result of calling the `check_for_unacknowledged_notices`
@@ -1051,7 +1051,7 @@ class TestCourseDashboardNoticesRedirects(SharedModuleStoreTestCase):
         assert response.status_code == 200
         mock_notices.assert_called_once()
 
-    @patch('common.djangoapps.student.views.dashboard.check_for_unacknowledged_notices')
+    @patch('common.djangoapps.student.views.dashboard.check_for_unacknowledged_notices', autospec=True)
     def test_user_with_unacknowledged_notice_plugin_disabled(self, mock_notices):
         """
         Verifies that the `check_for_unacknowledged_notices` function is NOT called if the feature is disabled.

--- a/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
@@ -161,9 +161,9 @@ class TestShibIntegrationTest(SamlIntegrationTestUtilities, IntegrationTestMixin
         'session_index': '1',
     }
 
-    @patch('openedx.features.enterprise_support.api.enterprise_customer_for_request')
-    @patch('openedx.core.djangoapps.user_api.accounts.settings_views.enterprise_customer_for_request')
-    @patch('openedx.features.enterprise_support.utils.third_party_auth.provider.Registry.get')
+    @patch('openedx.features.enterprise_support.api.enterprise_customer_for_request', autospec=True)
+    @patch('openedx.core.djangoapps.user_api.accounts.settings_views.enterprise_customer_for_request', autospec=True)
+    @patch('openedx.features.enterprise_support.utils.third_party_auth.provider.Registry.get', autospec=True)
     def test_full_pipeline_succeeds_for_unlinking_testshib_account(
         self,
         mock_auth_provider,

--- a/common/lib/capa/capa/tests/test_inputtypes.py
+++ b/common/lib/capa/capa/tests/test_inputtypes.py
@@ -1222,7 +1222,7 @@ class ChemicalEquationTest(unittest.TestCase):
         assert 'error' in response
         assert "Couldn't parse formula" in response['error']
 
-    @patch('capa.inputtypes.log')
+    @patch('capa.inputtypes.log', autospec=True)
     def test_ajax_other_err(self, mock_log):
         """
         With other errors, test that ChemicalEquationInput also logs it
@@ -1370,7 +1370,7 @@ class FormulaEquationTest(unittest.TestCase):
         assert 'error' in response
         assert response['error'] == "Sorry, couldn't parse formula"
 
-    @patch('capa.inputtypes.log')
+    @patch('capa.inputtypes.log', autospec=True)
     def test_ajax_other_err(self, mock_log):
         """
         With other errors, test that FormulaEquationInput also logs it

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
@@ -852,7 +852,7 @@ class TestCourseStructureCache(CacheIsolationMixin, SplitModuleTest):
 
         super().setUp()
 
-    @patch('xmodule.modulestore.split_mongo.mongo_connection.get_cache')
+    @patch('xmodule.modulestore.split_mongo.mongo_connection.get_cache', autospec=True)
     def test_course_structure_cache(self, mock_get_cache):
         # force get_cache to return the default cache so we can test
         # its caching behavior
@@ -878,7 +878,7 @@ class TestCourseStructureCache(CacheIsolationMixin, SplitModuleTest):
         # now make sure that you get the same structure
         assert not_corrupt_structure == not_cached_structure
 
-    @patch('xmodule.modulestore.split_mongo.mongo_connection.get_cache')
+    @patch('xmodule.modulestore.split_mongo.mongo_connection.get_cache', autospec=True)
     def test_course_structure_cache_no_cache_configured(self, mock_get_cache):
         mock_get_cache.side_effect = InvalidCacheBackendError
 

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_split_mongo_mongo_connection.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_split_mongo_mongo_connection.py
@@ -14,8 +14,8 @@ from xmodule.modulestore.split_mongo.mongo_connection import MongoPersistenceBac
 class TestHeartbeatFailureException(unittest.TestCase):
     """ Test that a heartbeat failure is thrown at the appropriate times """
 
-    @patch('pymongo.MongoClient')
-    @patch('pymongo.database.Database')
+    @patch('pymongo.MongoClient', autospec=True)
+    @patch('pymongo.database.Database', autospec=True)
     def test_heartbeat_raises_exception_when_connection_alive_is_false(self, *calls):
         # pylint: disable=W0613
         with patch('mongodb_proxy.MongoProxy') as mock_proxy:

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_xml.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_xml.py
@@ -112,7 +112,7 @@ class TestXMLModuleStore(TestCase):
                 # verify that the above context manager raises a ValueError
                 pass  # pragma: no cover
 
-    @patch('xmodule.modulestore.xml.log')
+    @patch('xmodule.modulestore.xml.log', autospec=True)
     def test_dag_course(self, mock_logging):
         """
         Test a course whose structure is not a tree.

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -1913,8 +1913,8 @@ class ProblemBlockTest(unittest.TestCase):  # lint-amnesty, pylint: disable=miss
             assert 0 <= module.seed < 1000
             i -= 1
 
-    @patch('xmodule.capa_module.log')
-    @patch('xmodule.capa_module.Progress')
+    @patch('xmodule.capa_module.log', autospec=True)
+    @patch('xmodule.capa_module.Progress', autospec=True)
     def test_get_progress_error(self, mock_progress, mock_log):
         """
         Check that an exception given in `Progress` produces a `log.exception` call.
@@ -1927,7 +1927,7 @@ class ProblemBlockTest(unittest.TestCase):  # lint-amnesty, pylint: disable=miss
             mock_log.exception.assert_called_once_with('Got bad progress')
             mock_log.reset_mock()
 
-    @patch('xmodule.capa_module.Progress')
+    @patch('xmodule.capa_module.Progress', autospec=True)
     def test_get_progress_no_error_if_weight_zero(self, mock_progress):
         """
         Check that if the weight is 0 get_progress does not try to create a Progress object.
@@ -1939,7 +1939,7 @@ class ProblemBlockTest(unittest.TestCase):  # lint-amnesty, pylint: disable=miss
         assert progress is None
         assert not mock_progress.called
 
-    @patch('xmodule.capa_module.Progress')
+    @patch('xmodule.capa_module.Progress', autospec=True)
     def test_get_progress_calculate_progress_fraction(self, mock_progress):
         """
         Check that score and total are calculated correctly for the progress fraction.

--- a/common/lib/xmodule/xmodule/tests/test_conditional.py
+++ b/common/lib/xmodule/xmodule/tests/test_conditional.py
@@ -200,7 +200,7 @@ class ConditionalBlockBasicTest(unittest.TestCase):
         fragments = ajax['fragments']
         assert not any(('This is a secret' in item['content']) for item in fragments)
 
-    @patch('xmodule.conditional_module.log')
+    @patch('xmodule.conditional_module.log', autospec=True)
     def test_conditional_with_staff_only_source_module(self, mock_log):
         modules = ConditionalFactory.create(
             self.test_system,
@@ -231,7 +231,7 @@ class ConditionalBlockXmlTest(unittest.TestCase):
         descriptor = self.modulestore.get_item(location, depth=None)
         return self.test_system.get_module(descriptor)
 
-    @patch('xmodule.x_module.descriptor_global_local_resource_url')
+    @patch('xmodule.x_module.descriptor_global_local_resource_url', autospec=True)
     @patch.dict(settings.FEATURES, {'ENABLE_EDXNOTES': False})
     def test_conditional_module(self, _):
         """Make sure that conditional module works"""

--- a/common/lib/xmodule/xmodule/tests/test_content.py
+++ b/common/lib/xmodule/xmodule/tests/test_content.py
@@ -127,7 +127,7 @@ class ContentTest(unittest.TestCase):  # lint-amnesty, pylint: disable=missing-c
         assert AssetLocator(CourseLocator('mitX', '800', 'ignore_run'), 'thumbnail', thumbnail_filename) ==\
                thumbnail_file_location
 
-    @patch('xmodule.contentstore.content.Image')
+    @patch('xmodule.contentstore.content.Image', autospec=True)
     def test_image_is_closed_when_generating_thumbnail(self, image_class_mock):
         # We used to keep the Image's file descriptor open when generating a thumbnail.
         # It should be closed after being used.

--- a/common/lib/xmodule/xmodule/tests/test_course_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_course_module.py
@@ -171,7 +171,7 @@ class IsNewCourseTestCase(unittest.TestCase):
         mocked_datetime.now.return_value = NOW
         self.addCleanup(datetime_patcher.stop)
 
-    @patch('xmodule.course_metadata_utils.datetime.now')
+    @patch('xmodule.course_metadata_utils.datetime.now', autospec=True)
     def test_sorting_score(self, gmtime_mock):
         gmtime_mock.return_value = NOW
 

--- a/common/lib/xmodule/xmodule/tests/test_import.py
+++ b/common/lib/xmodule/xmodule/tests/test_import.py
@@ -108,7 +108,7 @@ class PureXBlockImportTest(BaseCourseTestCase):
         "<genericxblock field1='abc' field2='23' />",
         "<genericxblock field1='abc' field2='23'><genericxblock/></genericxblock>",
     )
-    @patch('xmodule.x_module.XModuleMixin.location')
+    @patch('xmodule.x_module.XModuleMixin.location', autospec=True)
     def test_parsing_pure_xblock(self, xml, mock_location):
         system = self.get_system(load_error_modules=False)
         descriptor = system.process_xml(xml)

--- a/common/lib/xmodule/xmodule/tests/test_library_tools.py
+++ b/common/lib/xmodule/xmodule/tests/test_library_tools.py
@@ -31,7 +31,7 @@ class LibraryToolsServiceTest(MixedSplitTestCase):
         assert all_libraries
         assert len(all_libraries) == 1
 
-    @patch('xmodule.modulestore.split_mongo.split.SplitMongoModuleStore.get_library_summaries')
+    @patch('xmodule.modulestore.split_mongo.split.SplitMongoModuleStore.get_library_summaries', autospec=True)
     def test_list_available_libraries_fetch(self, mock_get_library_summaries):
         """
         Test that library list is compiled using light weight library summary objects.

--- a/common/lib/xmodule/xmodule/tests/test_sequence.py
+++ b/common/lib/xmodule/xmodule/tests/test_sequence.py
@@ -165,7 +165,7 @@ class SequenceBlockTestCase(XModuleXmlImportTest):
         assert 'fa fa-check-circle check-circle is-hidden' not in html
 
     # pylint: disable=line-too-long
-    @patch('xmodule.seq_module.SequenceBlock.gate_entire_sequence_if_it_is_a_timed_exam_and_contains_content_type_gated_problems')
+    @patch('xmodule.seq_module.SequenceBlock.gate_entire_sequence_if_it_is_a_timed_exam_and_contains_content_type_gated_problems', autospec=True)
     def test_timed_exam_gating_waffle_flag(self, mocked_function):  # pylint: disable=unused-argument
         """
         Verify the code inside the waffle flag is not executed with the flag off

--- a/common/lib/xmodule/xmodule/tests/test_split_test_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_split_test_module.py
@@ -167,7 +167,7 @@ class SplitTestBlockLMSTest(SplitTestBlockTest):
         assert self.split_test_module.child_descriptor.url_name == self.split_test_module.child_descriptor.url_name
 
     # Patch the definition_to_xml for the html children.
-    @patch('xmodule.html_module.HtmlBlock.definition_to_xml')
+    @patch('xmodule.html_module.HtmlBlock.definition_to_xml', autospec=True)
     def test_export_import_round_trip(self, def_to_xml):
         # The HtmlBlock definition_to_xml tries to write to the filesystem
         # before returning an xml object. Patch this to just return the xml.
@@ -270,7 +270,7 @@ class SplitTestBlockStudioTest(SplitTestBlockTest):
         assert SplitTestBlock.user_partitions in non_editable_metadata_fields
         assert SplitTestBlock.display_name not in non_editable_metadata_fields
 
-    @patch('xmodule.split_test_module.user_partition_values.values')
+    @patch('xmodule.split_test_module.user_partition_values.values', autospec=True)
     def test_available_partitions(self, _):
         """
         Tests that the available partitions are populated correctly when editable_metadata_fields are called

--- a/common/lib/xmodule/xmodule/tests/test_video.py
+++ b/common/lib/xmodule/xmodule/tests/test_video.py
@@ -603,7 +603,7 @@ class VideoBlockImportTestCase(TestCase):
             'data': ''
         })
 
-    @patch('xmodule.video_module.video_module.edxval_api')
+    @patch('xmodule.video_module.video_module.edxval_api', autospec=True)
     def test_import_val_data(self, mock_val_api):
         """
         Test that `from_xml` works method works as expected.
@@ -648,7 +648,7 @@ class VideoBlockImportTestCase(TestCase):
             course_id='test_course_id'
         )
 
-    @patch('xmodule.video_module.video_module.edxval_api')
+    @patch('xmodule.video_module.video_module.edxval_api', autospec=True)
     def test_import_val_data_invalid(self, mock_val_api):
         mock_val_api.ValCannotCreateError = _MockValCannotCreateError
         mock_val_api.import_from_xml = Mock(side_effect=mock_val_api.ValCannotCreateError)
@@ -675,7 +675,7 @@ class VideoExportTestCase(VideoBlockTestBase):
         self.file_system = OSFS(self.temp_dir)
         self.addCleanup(shutil.rmtree, self.temp_dir)
 
-    @patch('xmodule.video_module.video_module.edxval_api')
+    @patch('xmodule.video_module.video_module.edxval_api', autospec=True)
     def test_export_to_xml(self, mock_val_api):
         """
         Test that we write the correct XML on export.
@@ -734,7 +734,7 @@ class VideoExportTestCase(VideoBlockTestBase):
             course_id=str(self.descriptor.runtime.course_id.for_branch(None)),
         )
 
-    @patch('xmodule.video_module.video_module.edxval_api')
+    @patch('xmodule.video_module.video_module.edxval_api', autospec=True)
     def test_export_to_xml_val_error(self, mock_val_api):
         # Export should succeed without VAL data if video does not exist
         mock_val_api.ValVideoNotFoundError = _MockValVideoNotFoundError
@@ -868,8 +868,8 @@ class VideoBlockStudentViewDataTestCase(unittest.TestCase):
     @patch('xmodule.video_module.video_module.HLSPlaybackEnabledFlag.feature_enabled', Mock(return_value=True))
     @patch('xmodule.video_module.transcripts_utils.get_available_transcript_languages', Mock(return_value=['es']))
     @patch('edxval.api.get_video_info_for_course_and_profiles', Mock(return_value={}))
-    @patch('xmodule.video_module.transcripts_utils.get_video_transcript_content')
-    @patch('edxval.api.get_video_info')
+    @patch('xmodule.video_module.transcripts_utils.get_video_transcript_content', autospec=True)
+    @patch('edxval.api.get_video_info', autospec=True)
     def test_student_view_data_with_hls_flag(self, mock_get_video_info, mock_get_video_transcript_content):
         mock_get_video_info.return_value = {
             'url': '/edxval/video/example',

--- a/lms/djangoapps/badges/backends/tests/test_badgr_backend.py
+++ b/lms/djangoapps/badges/backends/tests/test_badgr_backend.py
@@ -108,7 +108,7 @@ class BadgrBackendTestCase(ModuleStoreTestCase, EventTrackingTestCase):
         self.handler._get_access_token = Mock(return_value='12345')
         self.check_headers(self.handler._get_headers())  # lint-amnesty, pylint: disable=no-member
 
-    @patch('requests.post')
+    @patch('requests.post', autospec=True)
     def test_create_badge(self, post):
         """
         Verify badge spec creation works.
@@ -145,7 +145,7 @@ class BadgrBackendTestCase(ModuleStoreTestCase, EventTrackingTestCase):
         assert self.handler._slugify(getattr(self, badge_class_type)) == slug
         # lint-amnesty, pylint: disable=no-member
 
-    @patch('requests.get')
+    @patch('requests.get', autospec=True)
     def test_ensure_badge_created_checks(self, get):
         response = Mock()
         response.status_code = 200
@@ -163,7 +163,7 @@ class BadgrBackendTestCase(ModuleStoreTestCase, EventTrackingTestCase):
         assert BADGR_SERVER_SLUG in BadgrBackend.badges
         assert not self.handler._create_badge.called
 
-    @patch('requests.get')
+    @patch('requests.get', autospec=True)
     def test_ensure_badge_created_creates(self, get):
         response = Mock()
         response.status_code = 404
@@ -176,7 +176,7 @@ class BadgrBackendTestCase(ModuleStoreTestCase, EventTrackingTestCase):
         assert self.handler._create_badge.call_args == call(self.badge_class)
         assert BADGR_SERVER_SLUG in BadgrBackend.badges
 
-    @patch('requests.post')
+    @patch('requests.post', autospec=True)
     def test_badge_creation_event(self, post):
         result = {
             'result': [{

--- a/lms/djangoapps/badges/tests/test_models.py
+++ b/lms/djangoapps/badges/tests/test_models.py
@@ -214,7 +214,7 @@ class BadgeClassTest(ModuleStoreTestCase):
         BADGR_USERNAME='example@example.com',
         BADGR_PASSWORD='password',
         BADGR_TOKENS_CACHE_KEY='badgr-test-cache-key')
-    @patch('lms.djangoapps.badges.backends.badgr.BadgrBackend.award')
+    @patch('lms.djangoapps.badges.backends.badgr.BadgrBackend.award', autospec=True)
     def test_award(self, mock_award):
         """
         Verify that the award command calls the award function on the backend with the right parameters.

--- a/lms/djangoapps/bulk_email/tests/test_email.py
+++ b/lms/djangoapps/bulk_email/tests/test_email.py
@@ -556,7 +556,7 @@ class TestEmailSendFromDashboardMockedHtmlToText(EmailSendFromDashboardTestCase)
         assert len(from_email) == 61
 
     @override_settings(BULK_EMAIL_EMAILS_PER_TASK=3)
-    @patch('lms.djangoapps.bulk_email.tasks.update_subtask_status')
+    @patch('lms.djangoapps.bulk_email.tasks.update_subtask_status', autospec=True)
     def test_chunked_queries_send_numerous_emails(self, email_mock):
         """
         Test sending a large number of emails, to test the chunked querying

--- a/lms/djangoapps/bulk_email/tests/test_err_handling.py
+++ b/lms/djangoapps/bulk_email/tests/test_err_handling.py
@@ -75,7 +75,7 @@ class TestEmailErrors(ModuleStoreTestCase):
         BulkEmailFlag.objects.all().delete()
 
     @patch('lms.djangoapps.bulk_email.tasks.get_connection', autospec=True)
-    @patch('lms.djangoapps.bulk_email.tasks.send_course_email.retry')
+    @patch('lms.djangoapps.bulk_email.tasks.send_course_email.retry', autospec=True)
     def test_data_err_retry(self, retry, get_conn):
         """
         Test that celery handles transient SMTPDataErrors by retrying.
@@ -97,8 +97,8 @@ class TestEmailErrors(ModuleStoreTestCase):
         assert isinstance(exc, SMTPDataError)
 
     @patch('lms.djangoapps.bulk_email.tasks.get_connection', autospec=True)
-    @patch('lms.djangoapps.bulk_email.tasks.update_subtask_status')
-    @patch('lms.djangoapps.bulk_email.tasks.send_course_email.retry')
+    @patch('lms.djangoapps.bulk_email.tasks.update_subtask_status', autospec=True)
+    @patch('lms.djangoapps.bulk_email.tasks.send_course_email.retry', autospec=True)
     def test_data_err_fail(self, retry, result, get_conn):
         """
         Test that celery handles permanent SMTPDataErrors by failing and not retrying.
@@ -130,7 +130,7 @@ class TestEmailErrors(ModuleStoreTestCase):
         assert subtask_status.succeeded == (settings.BULK_EMAIL_EMAILS_PER_TASK - expected_fails)
 
     @patch('lms.djangoapps.bulk_email.tasks.get_connection', autospec=True)
-    @patch('lms.djangoapps.bulk_email.tasks.send_course_email.retry')
+    @patch('lms.djangoapps.bulk_email.tasks.send_course_email.retry', autospec=True)
     def test_disconn_err_retry(self, retry, get_conn):
         """
         Test that celery handles SMTPServerDisconnected by retrying.
@@ -151,7 +151,7 @@ class TestEmailErrors(ModuleStoreTestCase):
         assert isinstance(exc, SMTPServerDisconnected)
 
     @patch('lms.djangoapps.bulk_email.tasks.get_connection', autospec=True)
-    @patch('lms.djangoapps.bulk_email.tasks.send_course_email.retry')
+    @patch('lms.djangoapps.bulk_email.tasks.send_course_email.retry', autospec=True)
     def test_conn_err_retry(self, retry, get_conn):
         """
         Test that celery handles SMTPConnectError by retrying.
@@ -172,8 +172,8 @@ class TestEmailErrors(ModuleStoreTestCase):
         exc = kwargs['exc']
         assert isinstance(exc, SMTPConnectError)
 
-    @patch('lms.djangoapps.bulk_email.tasks.SubtaskStatus.increment')
-    @patch('lms.djangoapps.bulk_email.tasks.log')
+    @patch('lms.djangoapps.bulk_email.tasks.SubtaskStatus.increment', autospec=True)
+    @patch('lms.djangoapps.bulk_email.tasks.log', autospec=True)
     def test_nonexistent_email(self, mock_log, result):
         """
         Tests retries when the email doesn't exist

--- a/lms/djangoapps/ccx/tests/test_views.py
+++ b/lms/djangoapps/ccx/tests/test_views.py
@@ -463,7 +463,7 @@ class TestCoachDashboard(CcxTestCase, LoginEnrollmentTestCase):
                     assert get_date(ccx, unit, 'due', parent_node=subsection) == self.mooc_due
 
     @patch('lms.djangoapps.ccx.views.render_to_response', intercept_renderer)
-    @patch('lms.djangoapps.ccx.views.TODAY')
+    @patch('lms.djangoapps.ccx.views.TODAY', autospec=True)
     def test_edit_schedule(self, today):
         """
         Get CCX schedule, modify it, save it.
@@ -885,7 +885,7 @@ class TestCoachDashboardSchedule(CcxTestCase, LoginEnrollmentTestCase, ModuleSto
         self.mstore.update_item(node, self.coach.id)
 
     @patch('lms.djangoapps.ccx.views.render_to_response', intercept_renderer)
-    @patch('lms.djangoapps.ccx.views.TODAY')
+    @patch('lms.djangoapps.ccx.views.TODAY', autospec=True)
     def test_get_ccx_schedule(self, today):
         """
         Gets CCX schedule and checks number of blocks in it.

--- a/lms/djangoapps/certificates/apis/v0/tests/test_views.py
+++ b/lms/djangoapps/certificates/apis/v0/tests/test_views.py
@@ -184,7 +184,7 @@ class CertificatesListRestApiTest(AuthAndScopesTestMixin, SharedModuleStoreTestC
                  'is_passing': True,
                  'download_url': download_url, 'grade': '0.88'}]
 
-    @patch('edx_rest_framework_extensions.permissions.log')
+    @patch('edx_rest_framework_extensions.permissions.log', autospec=True)
     @ddt.data(*list(AuthType))
     def test_another_user(self, auth_type, mock_log):
         """
@@ -276,7 +276,7 @@ class CertificatesListRestApiTest(AuthAndScopesTestMixin, SharedModuleStoreTestC
         assert resp.status_code == status.HTTP_200_OK
         assert len(resp.data) == 1
 
-    @patch('edx_rest_framework_extensions.permissions.log')
+    @patch('edx_rest_framework_extensions.permissions.log', autospec=True)
     @ddt.data(*JWT_AUTH_TYPES)
     def test_jwt_on_behalf_of_other_user(self, auth_type, mock_log):
         """ Returns 403 when scopes are enforced with JwtHasUserFilterForRequestedUser. """
@@ -290,7 +290,7 @@ class CertificatesListRestApiTest(AuthAndScopesTestMixin, SharedModuleStoreTestC
             assert resp.status_code == status.HTTP_200_OK
             assert len(resp.data) == 1
 
-    @patch('edx_rest_framework_extensions.permissions.log')
+    @patch('edx_rest_framework_extensions.permissions.log', autospec=True)
     @ddt.data(*JWT_AUTH_TYPES)
     def test_jwt_no_filter(self, auth_type, mock_log):
         assert True  # pylint: disable=redundant-unittest-assert
@@ -396,7 +396,7 @@ class CertificatesListRestApiTest(AuthAndScopesTestMixin, SharedModuleStoreTestC
         expected_download_url = reverse('certificates:render_cert_by_uuid', kwargs=kwargs)
         self.assert_success_response_for_student(response, download_url=expected_download_url)
 
-    @patch('openedx.core.djangoapps.content.course_overviews.api.get_course_run_details')
+    @patch('openedx.core.djangoapps.content.course_overviews.api.get_course_run_details', autospec=True)
     def test_certificate_without_course(self, mock_get_course_run_details):
         """
         Verify that certificates are returned for deleted XML courses.

--- a/lms/djangoapps/certificates/tests/test_models.py
+++ b/lms/djangoapps/certificates/tests/test_models.py
@@ -416,7 +416,7 @@ class CertificateInvalidationTest(SharedModuleStoreTestCase, OpenEdxEventsTestMi
         # After making the certificate valid method will return false.
         assert not CertificateInvalidation.has_certificate_invalidation(self.user, self.course_id)
 
-    @patch('openedx.core.djangoapps.programs.tasks.revoke_program_certificates.delay')
+    @patch('openedx.core.djangoapps.programs.tasks.revoke_program_certificates.delay', autospec=True)
     @patch(
         'openedx.core.djangoapps.credentials.models.CredentialsApiConfig.is_learner_issuance_enabled',
         return_value=True,
@@ -466,7 +466,7 @@ class GeneratedCertificateTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin
             event_data=expected_event_data
         )
 
-    @patch('lms.djangoapps.certificates.utils.emit_certificate_event')
+    @patch('lms.djangoapps.certificates.utils.emit_certificate_event', autospec=True)
     def test_invalidate(self, mock_emit_certificate_event):
         """
         Test the invalidate method
@@ -498,7 +498,7 @@ class GeneratedCertificateTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin
 
         self._assert_event_data(mock_emit_certificate_event, expected_event_data)
 
-    @patch('lms.djangoapps.certificates.utils.emit_certificate_event')
+    @patch('lms.djangoapps.certificates.utils.emit_certificate_event', autospec=True)
     def test_invalidate_find_mode(self, mock_emit_certificate_event):
         """
         Test the invalidate method when mode is retrieved from the enrollment
@@ -529,7 +529,7 @@ class GeneratedCertificateTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin
 
             self._assert_event_data(mock_emit_certificate_event, expected_event_data)
 
-    @patch('lms.djangoapps.certificates.utils.emit_certificate_event')
+    @patch('lms.djangoapps.certificates.utils.emit_certificate_event', autospec=True)
     def test_invalidate_no_mode(self, mock_emit_certificate_event):
         """
         Test the invalidate method when there is no enrollment mode
@@ -560,7 +560,7 @@ class GeneratedCertificateTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin
 
             self._assert_event_data(mock_emit_certificate_event, expected_event_data)
 
-    @patch('lms.djangoapps.certificates.utils.emit_certificate_event')
+    @patch('lms.djangoapps.certificates.utils.emit_certificate_event', autospec=True)
     def test_invalidate_no_profile(self, mock_emit_certificate_event):
         """
         Test the invalidate method when there is no user profile
@@ -593,7 +593,7 @@ class GeneratedCertificateTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin
 
             self._assert_event_data(mock_emit_certificate_event, expected_event_data)
 
-    @patch('lms.djangoapps.certificates.utils.emit_certificate_event')
+    @patch('lms.djangoapps.certificates.utils.emit_certificate_event', autospec=True)
     def test_notpassing(self, mock_emit_certificate_event):
         """
         Test the notpassing method
@@ -654,7 +654,7 @@ class GeneratedCertificateTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin
         else:
             assert cert.name == profile.name
 
-    @patch('lms.djangoapps.certificates.utils.emit_certificate_event')
+    @patch('lms.djangoapps.certificates.utils.emit_certificate_event', autospec=True)
     def test_unverified(self, mock_emit_certificate_event):
         """
         Test the unverified method

--- a/lms/djangoapps/certificates/tests/test_webview_views.py
+++ b/lms/djangoapps/certificates/tests/test_webview_views.py
@@ -467,7 +467,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertContains(response, 'logo_test1.png')
 
     @ddt.data(True, False)
-    @patch('lms.djangoapps.certificates.views.webview.get_completion_badge')
+    @patch('lms.djangoapps.certificates.views.webview.get_completion_badge', autospec=True)
     def test_fetch_badge_info(self, issue_badges, mock_get_completion_badge):
         """
         Test: Fetch badge class info if badges are enabled.
@@ -1061,7 +1061,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
     # TEMPLATES WITHOUT LANGUAGE TESTS
     @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
     @override_settings(LANGUAGE_CODE='fr')
-    @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
+    @patch('lms.djangoapps.certificates.views.webview.get_course_run_details', autospec=True)
     def test_certificate_custom_template_with_org_mode_and_course_key(self, mock_get_course_run_details):
         """
         Tests custom template search and rendering.
@@ -1095,7 +1095,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             self.assertContains(response, 'course name: test_template_3_course')
 
     @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
-    @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
+    @patch('lms.djangoapps.certificates.views.webview.get_course_run_details', autospec=True)
     def test_certificate_custom_template_with_org_and_mode(self, mock_get_course_run_details):
         """
         Tests custom template search if no template matches course_key, but a template does
@@ -1130,7 +1130,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             self.assertContains(response, 'course name: test_template_1_course')
 
     @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
-    @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
+    @patch('lms.djangoapps.certificates.views.webview.get_course_run_details', autospec=True)
     def test_certificate_custom_template_with_org(self, mock_get_course_run_details):
         """
         Tests custom template search when we have a single template for a organization.
@@ -1154,7 +1154,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             self.assertContains(response, 'course name: test_template_1_course')
 
     @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
-    @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
+    @patch('lms.djangoapps.certificates.views.webview.get_course_run_details', autospec=True)
     def test_certificate_custom_template_with_mode(self, mock_get_course_run_details):
         """
         Tests custom template search if we have a single template for a course mode.
@@ -1183,8 +1183,8 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
     # 1
     @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
     @override_settings(LANGUAGE_CODE='fr')
-    @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
-    @patch('lms.djangoapps.certificates.api.get_course_organization_id')
+    @patch('lms.djangoapps.certificates.views.webview.get_course_run_details', autospec=True)
+    @patch('lms.djangoapps.certificates.api.get_course_organization_id', autospec=True)
     def test_certificate_custom_language_template_with_org_mode_and_course_key(
             self,
             mock_get_org_id,
@@ -1267,8 +1267,8 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
 
     # 2
     @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
-    @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
-    @patch('lms.djangoapps.certificates.api.get_course_organization_id')
+    @patch('lms.djangoapps.certificates.views.webview.get_course_run_details', autospec=True)
+    @patch('lms.djangoapps.certificates.api.get_course_organization_id', autospec=True)
     def test_certificate_custom_language_template_with_org_and_mode(self, mock_get_org_id, mock_get_course_run_details):
         """
         Tests custom template search if no template matches course_key, but a template does
@@ -1327,8 +1327,8 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
 
     # 3
     @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
-    @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
-    @patch('lms.djangoapps.certificates.api.get_course_organization_id')
+    @patch('lms.djangoapps.certificates.views.webview.get_course_run_details', autospec=True)
+    @patch('lms.djangoapps.certificates.api.get_course_organization_id', autospec=True)
     def test_certificate_custom_language_template_with_org(self, mock_get_org_id, mock_get_course_run_details):
         """
         Tests custom template search when we have a single template for a organization.
@@ -1385,8 +1385,8 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
 
     # 4
     @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
-    @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
-    @patch('lms.djangoapps.certificates.api.get_course_organization_id')
+    @patch('lms.djangoapps.certificates.views.webview.get_course_run_details', autospec=True)
+    @patch('lms.djangoapps.certificates.api.get_course_organization_id', autospec=True)
     def test_certificate_custom_language_template_with_mode(self, mock_get_org_id, mock_get_course_run_details):
         """
         Tests custom template search if we have a single template for a course mode.
@@ -1443,8 +1443,8 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertContains(response, 'course name: test_right_lang_template')
 
     @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
-    @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
-    @patch('lms.djangoapps.certificates.api.get_course_organization_id')
+    @patch('lms.djangoapps.certificates.views.webview.get_course_run_details', autospec=True)
+    @patch('lms.djangoapps.certificates.api.get_course_organization_id', autospec=True)
     def test_certificate_custom_language_template_with_locale_language_from_catalogue(
             self,
             mock_get_org_id,
@@ -1506,8 +1506,8 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
 
     @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
     @ddt.data(True, False)
-    @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
-    @patch('lms.djangoapps.certificates.api.get_course_organization_id')
+    @patch('lms.djangoapps.certificates.views.webview.get_course_run_details', autospec=True)
+    @patch('lms.djangoapps.certificates.api.get_course_organization_id', autospec=True)
     def test_certificate_custom_template_with_hours_of_effort(
             self,
             include_effort,
@@ -1541,7 +1541,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             self.assertNotContains(response, 'hours of effort')
 
     @ddt.data(True, False)
-    @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
+    @patch('lms.djangoapps.certificates.views.webview.get_course_run_details', autospec=True)
     def test_certificate_custom_template_with_unicode_data(self, custom_certs_enabled, mock_get_course_run_details):
         """
         Tests custom template renders properly with unicode data.
@@ -1576,7 +1576,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
                         self.assertContains(response, 'https://twitter.com/intent/tweet')
 
     @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
-    @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
+    @patch('lms.djangoapps.certificates.views.webview.get_course_run_details', autospec=True)
     def test_certificate_asset_by_slug(self, mock_get_course_run_details):
         """
         Tests certificate template asset display by slug using static.certificate_asset_url method.

--- a/lms/djangoapps/commerce/tests/test_utils.py
+++ b/lms/djangoapps/commerce/tests/test_utils.py
@@ -41,7 +41,7 @@ def update_commerce_config(enabled=False, checkout_page='/test_basket/add/'):
 class AuditLogTests(TestCase):
     """Tests of the commerce audit logging helper."""
 
-    @patch('openedx.core.lib.log_utils.log')
+    @patch('openedx.core.lib.log_utils.log', autospec=True)
     def test_log_message(self, mock_log):
         """Verify that log messages are constructed correctly."""
         audit_log('foo', qux='quux', bar='baz')
@@ -82,7 +82,7 @@ class EcommerceServiceTests(TestCase):
         is_enabled = EcommerceService().is_enabled(self.user)
         assert is_enabled
 
-    @patch('openedx.core.djangoapps.theming.helpers.is_request_in_themed_site')
+    @patch('openedx.core.djangoapps.theming.helpers.is_request_in_themed_site', autospec=True)
     def test_is_enabled_for_sites(self, is_site):
         """Verify that is_enabled() returns True if used for a site."""
         is_site.return_value = True

--- a/lms/djangoapps/course_api/blocks/tests/test_api.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_api.py
@@ -142,7 +142,7 @@ class TestGetBlocksVideoUrls(SharedModuleStoreTestCase):
         self.request = RequestFactory().get("/dummy")
         self.request.user = self.user
 
-    @patch('xmodule.video_module.VideoBlock.student_view_data')
+    @patch('xmodule.video_module.VideoBlock.student_view_data', autospec=True)
     def test_video_urls_rewrite(self, video_data_patch):
         """
         Verify the video blocks returned have their URL re-written for

--- a/lms/djangoapps/course_home_api/outline/tests/test_view.py
+++ b/lms/djangoapps/course_home_api/outline/tests/test_view.py
@@ -237,7 +237,7 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         assert course_goals == expected_course_goals
 
     @patch.dict('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': True})
-    @patch('lms.djangoapps.course_api.blocks.transformers.milestones.get_attempt_status_summary')
+    @patch('lms.djangoapps.course_api.blocks.transformers.milestones.get_attempt_status_summary', autospec=True)
     def test_proctored_exam(self, mock_summary):
         course = CourseFactory.create(
             org='edX',

--- a/lms/djangoapps/courseware/tests/test_course_tools.py
+++ b/lms/djangoapps/courseware/tests/test_course_tools.py
@@ -91,13 +91,13 @@ class FinancialAssistanceToolTest(SharedModuleStoreTestCase):
         assert not FinancialAssistanceTool().is_enabled(self.request, self.course.id)
 
     # mock the response from get_enrollment to use enrollment with course_upgrade_deadline in the past
-    @patch('lms.djangoapps.courseware.course_tools.CourseEnrollment.get_enrollment')
+    @patch('lms.djangoapps.courseware.course_tools.CourseEnrollment.get_enrollment', autospec=True)
     def test_not_visible_when_upgrade_deadline_has_passed(self, get_enrollment_mock):
         get_enrollment_mock.return_value = self.enrollment_deadline_past
         assert not FinancialAssistanceTool().is_enabled(self.request, self.course.id)
 
     # mock the response from get_enrollment to use enrollment with no course_upgrade_deadline
-    @patch('lms.djangoapps.courseware.course_tools.CourseEnrollment.get_enrollment')
+    @patch('lms.djangoapps.courseware.course_tools.CourseEnrollment.get_enrollment', autospec=True)
     def test_not_visible_when_no_upgrade_deadline(self, get_enrollment_mock):
         get_enrollment_mock.return_value = self.enrollment_deadline_missing
         assert not FinancialAssistanceTool().is_enabled(self.request, self.course.id)
@@ -108,7 +108,7 @@ class FinancialAssistanceToolTest(SharedModuleStoreTestCase):
         assert not FinancialAssistanceTool().is_enabled(self.request, self.course_overview.id)
 
     # mock the response from get_enrollment to use enrollment where learner upgraded
-    @patch('lms.djangoapps.courseware.course_tools.CourseEnrollment.get_enrollment')
+    @patch('lms.djangoapps.courseware.course_tools.CourseEnrollment.get_enrollment', autospec=True)
     def test_tool_not_visible_when_already_upgraded(self, get_enrollment_mock):
         self.course_financial_mode.save()
         get_enrollment_mock.return_value = self.enrollment_upgraded

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -887,7 +887,7 @@ class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCas
             BlockCompletion.objects.get(block_key=block.scope_ids.usage_id)
 
     @XBlock.register_temp_plugin(GradedStatelessXBlock, identifier='stateless_scorer')
-    @patch('lms.djangoapps.courseware.module_render.grades_signals.SCORE_PUBLISHED.send')
+    @patch('lms.djangoapps.courseware.module_render.grades_signals.SCORE_PUBLISHED.send', autospec=True)
     def test_anonymous_user_not_be_graded(self, mock_score_signal):
         course = CourseFactory.create()
         descriptor_kwargs = {
@@ -2115,7 +2115,7 @@ class TestXmoduleRuntimeEvent(TestSubmittingProblems):
         assert student_module.grade is None
         assert student_module.max_grade is None
 
-    @patch('lms.djangoapps.grades.signals.handlers.PROBLEM_RAW_SCORE_CHANGED.send')
+    @patch('lms.djangoapps.grades.signals.handlers.PROBLEM_RAW_SCORE_CHANGED.send', autospec=True)
     def test_score_change_signal(self, send_mock):
         """Test that a Django signal is generated when a score changes"""
         with freeze_time(datetime.now().replace(tzinfo=pytz.UTC)):

--- a/lms/djangoapps/courseware/tests/test_tabs.py
+++ b/lms/djangoapps/courseware/tests/test_tabs.py
@@ -712,7 +712,7 @@ class ProgressTestCase(TabTestCase):
             invalid_dict_tab=None,
         )
 
-    @patch('common.djangoapps.student.models.CourseEnrollment.is_enrolled')
+    @patch('common.djangoapps.student.models.CourseEnrollment.is_enrolled', autospec=True)
     def test_progress(self, is_enrolled):
         is_enrolled.return_value = True
         self.course.hide_progress_tab = False
@@ -876,7 +876,7 @@ class DiscussionLinkTestCase(TabTestCase):
 
 class DatesTabTestCase(TabListTestCase):
     """Test cases for dates tab"""
-    @patch('common.djangoapps.student.models.CourseEnrollment.is_enrolled')
+    @patch('common.djangoapps.student.models.CourseEnrollment.is_enrolled', autospec=True)
     def test_dates_tab_disabled_if_unenrolled(self, is_enrolled):
         tab = DatesTab({'type': DatesTab.type, 'name': 'dates'})
 

--- a/lms/djangoapps/courseware/tests/test_video_handlers.py
+++ b/lms/djangoapps/courseware/tests/test_video_handlers.py
@@ -285,7 +285,7 @@ class TestTranscriptAvailableTranslationsDispatch(TestVideo):  # lint-amnesty, p
         response = self.item.transcript(request=request, dispatch='available_translations')
         assert json.loads(response.body.decode('utf-8')) == ['uk']
 
-    @patch('xmodule.video_module.transcripts_utils.get_video_transcript_content')
+    @patch('xmodule.video_module.transcripts_utils.get_video_transcript_content', autospec=True)
     def test_multiple_available_translations(self, mock_get_video_transcript_content):
         mock_get_video_transcript_content.return_value = {
             'content': json.dumps({
@@ -311,8 +311,8 @@ class TestTranscriptAvailableTranslationsDispatch(TestVideo):  # lint-amnesty, p
         response = self.item.transcript(request=request, dispatch='available_translations')
         assert sorted(json.loads(response.body.decode('utf-8'))) == sorted(['en', 'uk'])
 
-    @patch('xmodule.video_module.transcripts_utils.get_video_transcript_content')
-    @patch('xmodule.video_module.transcripts_utils.get_available_transcript_languages')
+    @patch('xmodule.video_module.transcripts_utils.get_video_transcript_content', autospec=True)
+    @patch('xmodule.video_module.transcripts_utils.get_available_transcript_languages', autospec=True)
     @ddt.data(
         (
             ['en', 'uk', 'ro'],
@@ -388,7 +388,7 @@ class TestTranscriptAvailableTranslationsDispatch(TestVideo):  # lint-amnesty, p
         response = self.item.transcript(request=request, dispatch='available_translations')
         self.assertCountEqual(json.loads(response.body.decode('utf-8')), result)
 
-    @patch('xmodule.video_module.transcripts_utils.edxval_api.get_available_transcript_languages')
+    @patch('xmodule.video_module.transcripts_utils.edxval_api.get_available_transcript_languages', autospec=True)
     def test_val_available_translations_feature_disabled(self, mock_get_available_transcript_languages):
         """
         Tests available translations with val transcript languages when feature is disabled.
@@ -438,7 +438,7 @@ class TestTranscriptAvailableTranslationsBumperDispatch(TestVideo):  # lint-amne
         response = self.item.transcript(request=request, dispatch=self.dispatch)
         assert json.loads(response.body.decode('utf-8')) == [lang]
 
-    @patch('xmodule.video_module.transcripts_utils.get_available_transcript_languages')
+    @patch('xmodule.video_module.transcripts_utils.get_available_transcript_languages', autospec=True)
     def test_multiple_available_translations(self, mock_get_transcript_languages):
         """
         Verify that available translations dispatch works as expected for multiple
@@ -538,7 +538,7 @@ class TestTranscriptDownloadDispatch(TestVideo):  # lint-amnesty, pylint: disabl
         assert response.headers['Content-Type'] == 'application/x-subrip; charset=utf-8'
         assert response.headers['Content-Disposition'] == 'attachment; filename="en_塞.srt"'
 
-    @patch('xmodule.video_module.transcripts_utils.edxval_api.get_video_transcript_data')
+    @patch('xmodule.video_module.transcripts_utils.edxval_api.get_video_transcript_data', autospec=True)
     @patch('xmodule.video_module.get_transcript', Mock(side_effect=NotFoundError))
     def test_download_fallback_transcript(self, mock_get_video_transcript_data):
         """
@@ -799,7 +799,7 @@ class TestTranscriptTranslationGetDispatch(TestVideo):  # lint-amnesty, pylint: 
         with store.branch_setting(ModuleStoreEnum.Branch.draft_preferred, self.course.id):
             store.update_item(self.course, self.user.id)
 
-    @patch('xmodule.video_module.transcripts_utils.edxval_api.get_video_transcript_data')
+    @patch('xmodule.video_module.transcripts_utils.edxval_api.get_video_transcript_data', autospec=True)
     @patch('xmodule.video_module.VideoBlock.translation', Mock(side_effect=NotFoundError))
     @patch('xmodule.video_module.VideoBlock.get_static_transcript', Mock(return_value=Response(status=404)))
     def test_translation_fallback_transcript(self, mock_get_video_transcript_data):

--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -793,8 +793,8 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
         return context, expected_context
 
     # pylint: disable=invalid-name
-    @patch('xmodule.video_module.video_module.BrandingInfoConfig')
-    @patch('xmodule.video_module.video_module.rewrite_video_url')
+    @patch('xmodule.video_module.video_module.BrandingInfoConfig', autospec=True)
+    @patch('xmodule.video_module.video_module.rewrite_video_url', autospec=True)
     def test_get_html_cdn_source(self, mocked_get_video, mock_BrandingInfoConfig):
         """
         Test if sources got from CDN
@@ -1038,7 +1038,7 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
                 )
 
     @patch('xmodule.video_module.video_module.HLSPlaybackEnabledFlag.feature_enabled', Mock(return_value=True))
-    @patch('xmodule.video_module.video_module.edxval_api.get_urls_for_profiles')
+    @patch('xmodule.video_module.video_module.edxval_api.get_urls_for_profiles', autospec=True)
     def test_get_html_hls(self, get_urls_for_profiles):
         """
         Verify that hls profile functionality works as expected.
@@ -1093,7 +1093,7 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
         context = self.item_descriptor.render(PUBLIC_VIEW).content
         assert '"saveStateEnabled": false' in context
 
-    @patch('xmodule.video_module.video_module.edxval_api.get_course_video_image_url')
+    @patch('xmodule.video_module.video_module.edxval_api.get_course_video_image_url', autospec=True)
     def test_poster_image(self, get_course_video_image_url):
         """
         Verify that poster image functionality works as expected.
@@ -1106,7 +1106,7 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
 
         assert '"poster": "/media/video-images/poster.png"' in context
 
-    @patch('xmodule.video_module.video_module.edxval_api.get_course_video_image_url')
+    @patch('xmodule.video_module.video_module.edxval_api.get_course_video_image_url', autospec=True)
     def test_poster_image_without_edx_video_id(self, get_course_video_image_url):
         """
         Verify that poster image is set to None and there is no crash when no edx_video_id.
@@ -1574,7 +1574,7 @@ class TestVideoBlockStudentViewJson(BaseTestVideoXBlock, CacheIsolationTestCase)
         ({'uk': 1, 'de': 1}, 'en-subs', ['de', 'en'], ['en', 'uk', 'de']),
     )
     @ddt.unpack
-    @patch('xmodule.video_module.transcripts_utils.edxval_api.get_available_transcript_languages')
+    @patch('xmodule.video_module.transcripts_utils.edxval_api.get_available_transcript_languages', autospec=True)
     def test_student_view_with_val_transcripts_enabled(self, transcripts, english_sub, val_transcripts,
                                                        expected_transcripts, mock_get_transcript_languages):
         """
@@ -1770,7 +1770,7 @@ class VideoBlockTest(TestCase, VideoBlockTestBase):
         expected = etree.XML(expected_str, parser=parser)
         self.assertXmlEqual(expected, actual)
 
-    @patch('xmodule.video_module.transcripts_utils.get_video_ids_info')
+    @patch('xmodule.video_module.transcripts_utils.get_video_ids_info', autospec=True)
     def test_export_no_video_ids(self, mock_get_video_ids_info):
         """
         Tests export when there is no video id. `export_to_xml` only works in case of video id.
@@ -2125,7 +2125,7 @@ class TestVideoWithBumper(TestVideo):  # pylint: disable=test-inherits-tests
     # Use temporary FEATURES in this test without affecting the original
     FEATURES = dict(settings.FEATURES)
 
-    @patch('xmodule.video_module.bumper_utils.get_bumper_settings')
+    @patch('xmodule.video_module.bumper_utils.get_bumper_settings', autospec=True)
     def test_is_bumper_enabled(self, get_bumper_settings):
         """
         Check that bumper is (not)shown if ENABLE_VIDEO_BUMPER is (False)True
@@ -2149,9 +2149,9 @@ class TestVideoWithBumper(TestVideo):  # pylint: disable=test-inherits-tests
         with override_settings(FEATURES=self.FEATURES):
             assert not bumper_utils.is_bumper_enabled(self.item_descriptor)
 
-    @patch('xmodule.video_module.bumper_utils.is_bumper_enabled')
-    @patch('xmodule.video_module.bumper_utils.get_bumper_settings')
-    @patch('edxval.api.get_urls_for_profiles')
+    @patch('xmodule.video_module.bumper_utils.is_bumper_enabled', autospec=True)
+    @patch('xmodule.video_module.bumper_utils.get_bumper_settings', autospec=True)
+    @patch('edxval.api.get_urls_for_profiles', autospec=True)
     def test_bumper_metadata(self, get_url_for_profiles, get_bumper_settings, is_bumper_enabled):
         """
         Test content with rendered bumper metadata.

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -1100,7 +1100,7 @@ class ViewsTestCase(BaseViewsTestCase):
 
 # Patching 'lms.djangoapps.courseware.views.views.get_programs' would be ideal,
 # but for some unknown reason that patch doesn't seem to be applied.
-@patch('openedx.core.djangoapps.catalog.utils.cache')
+@patch('openedx.core.djangoapps.catalog.utils.cache', autospec=True)
 class TestProgramMarketingView(SharedModuleStoreTestCase):
     """Unit tests for the program marketing page."""
     program_uuid = str(uuid4())
@@ -2670,8 +2670,8 @@ class TestIndexView(ModuleStoreTestCase):
                     assert 'xblock-student_view-html' in unicode_content
                     assert 'xblock-student_view-video' in unicode_content
 
-    @patch('lms.djangoapps.courseware.views.views.CourseTabView.course_open_for_learner_enrollment')
-    @patch('openedx.core.djangoapps.util.user_messages.PageLevelMessages.register_warning_message')
+    @patch('lms.djangoapps.courseware.views.views.CourseTabView.course_open_for_learner_enrollment', autospec=True)
+    @patch('openedx.core.djangoapps.util.user_messages.PageLevelMessages.register_warning_message', autospec=True)
     def test_courseware_messages_differentiate_for_anonymous_users(
             self, patch_register_warning_message, patch_course_open_for_learner_enrollment
     ):
@@ -2698,7 +2698,7 @@ class TestIndexView(ModuleStoreTestCase):
 
         assert open_for_enrollment_message != closed_to_enrollment_message
 
-    @patch('openedx.core.djangoapps.util.user_messages.PageLevelMessages.register_warning_message')
+    @patch('openedx.core.djangoapps.util.user_messages.PageLevelMessages.register_warning_message', autospec=True)
     def test_courseware_messages_masters_only(self, patch_register_warning_message):
         with patch(
                 'lms.djangoapps.courseware.views.views.CourseTabView.course_open_for_learner_enrollment'
@@ -3260,7 +3260,7 @@ class TestRenderXBlock(RenderXBlockTestMixin, ModuleStoreTestCase, CompletionWaf
         banner_text = get_expiration_banner_text(self.user, self.course)
         self.assertContains(response, banner_text, html=True)
 
-    @patch('lms.djangoapps.courseware.views.views.is_request_from_mobile_app')
+    @patch('lms.djangoapps.courseware.views.views.is_request_from_mobile_app', autospec=True)
     def test_render_xblock_with_course_duration_limits_in_mobile_browser(self, mock_is_request_from_mobile_app):
         """
         Verify that expired banner message doesn't appear on xblock page in a mobile browser, if learner is enrolled
@@ -3387,7 +3387,7 @@ class EnterpriseConsentTestCase(EnterpriseTestConsentRequired, ModuleStoreTestCa
         CourseOverview.load_from_module_store(self.course.id)
         CourseEnrollmentFactory(user=self.user, course_id=self.course.id)
 
-    @patch('openedx.features.enterprise_support.api.enterprise_customer_for_request')
+    @patch('openedx.features.enterprise_support.api.enterprise_customer_for_request', autospec=True)
     def test_consent_required(self, mock_enterprise_customer_for_request):
         """
         Test that enterprise data sharing consent is required when enabled for the various courseware views.
@@ -3485,7 +3485,7 @@ class DatesTabTestCase(ModuleStoreTestCase):
         assert response.status_code == 200
 
     @override_waffle_flag(RELATIVE_DATES_FLAG, active=True)
-    @patch('edx_django_utils.monitoring.set_custom_attribute')
+    @patch('edx_django_utils.monitoring.set_custom_attribute', autospec=True)
     def test_defaults(self, mock_set_custom_attribute):
         enrollment = CourseEnrollmentFactory(course_id=self.course.id, user=self.user, mode=CourseMode.VERIFIED)
         now = datetime.now(utc)

--- a/lms/djangoapps/discussion/django_comment_client/tests/test_utils.py
+++ b/lms/djangoapps/discussion/django_comment_client/tests/test_utils.py
@@ -1678,7 +1678,7 @@ class ClientConfigurationTestCase(TestCase):
         with pytest.raises(CommentClientMaintenanceError):
             perform_request('GET', 'http://www.google.com')
 
-    @patch('requests.request')
+    @patch('requests.request', autospec=True)
     def test_enabled(self, mock_request):
         """Ensures that requests proceed normally when forums are enabled."""
         config = ForumsConfig.current()

--- a/lms/djangoapps/discussion/tests/test_views.py
+++ b/lms/djangoapps/discussion/tests/test_views.py
@@ -110,8 +110,8 @@ class ViewsExceptionTestCase(UrlResetMixin, ModuleStoreTestCase):  # lint-amnest
         config.enabled = True
         config.save()
 
-    @patch('common.djangoapps.student.models.cc.User.from_django_user')
-    @patch('common.djangoapps.student.models.cc.User.active_threads')
+    @patch('common.djangoapps.student.models.cc.User.from_django_user', autospec=True)
+    @patch('common.djangoapps.student.models.cc.User.active_threads', autospec=True)
     def test_user_profile_exception(self, mock_threads, mock_from_django_user):
 
         # Mock the code that makes the HTTP requests to the cs_comment_service app
@@ -127,8 +127,8 @@ class ViewsExceptionTestCase(UrlResetMixin, ModuleStoreTestCase):  # lint-amnest
         response = self.client.get(url)
         assert response.status_code == 404
 
-    @patch('common.djangoapps.student.models.cc.User.from_django_user')
-    @patch('common.djangoapps.student.models.cc.User.subscribed_threads')
+    @patch('common.djangoapps.student.models.cc.User.from_django_user', autospec=True)
+    @patch('common.djangoapps.student.models.cc.User.subscribed_threads', autospec=True)
     def test_user_followed_threads_exception(self, mock_threads, mock_from_django_user):
 
         # Mock the code that makes the HTTP requests to the cs_comment_service app
@@ -1661,7 +1661,7 @@ class ForumDiscussionXSSTestCase(ForumsEnableMixin, UrlResetMixin, ModuleStoreTe
         assert self.client.login(username=username, password=password)
 
     @ddt.data('"><script>alert(1)</script>', '<script>alert(1)</script>', '</script><script>alert(1)</script>')
-    @patch('common.djangoapps.student.models.cc.User.from_django_user')
+    @patch('common.djangoapps.student.models.cc.User.from_django_user', autospec=True)
     def test_forum_discussion_xss_prevent(self, malicious_code, mock_user, mock_req):
         """
         Test that XSS attack is prevented
@@ -1677,8 +1677,8 @@ class ForumDiscussionXSSTestCase(ForumsEnableMixin, UrlResetMixin, ModuleStoreTe
         self.assertNotContains(resp, malicious_code)
 
     @ddt.data('"><script>alert(1)</script>', '<script>alert(1)</script>', '</script><script>alert(1)</script>')
-    @patch('common.djangoapps.student.models.cc.User.from_django_user')
-    @patch('common.djangoapps.student.models.cc.User.active_threads')
+    @patch('common.djangoapps.student.models.cc.User.from_django_user', autospec=True)
+    @patch('common.djangoapps.student.models.cc.User.active_threads', autospec=True)
     def test_forum_user_profile_xss_prevent(self, malicious_code, mock_threads, mock_from_django_user, mock_request):
         """
         Test that XSS attack is prevented
@@ -1865,7 +1865,7 @@ class EnterpriseConsentTestCase(EnterpriseTestConsentRequired, ForumsEnableMixin
 
         self.addCleanup(translation.deactivate)
 
-    @patch('openedx.features.enterprise_support.api.enterprise_customer_for_request')
+    @patch('openedx.features.enterprise_support.api.enterprise_customer_for_request', autospec=True)
     def test_consent_required(self, mock_enterprise_customer_for_request, mock_request):
         """
         Test that enterprise data sharing consent is required when enabled for the various discussion views.
@@ -2223,7 +2223,7 @@ class ThreadViewedEventTestCase(EventTestMixin, ForumsEnableMixin, UrlResetMixin
         self.client.login(username=self.student.username, password=PASSWORD)
 
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
-    @patch('openedx.core.djangoapps.django_comment_common.comment_client.utils.perform_request')
+    @patch('openedx.core.djangoapps.django_comment_common.comment_client.utils.perform_request', autospec=True)
     def test_thread_viewed_event(self, mock_perform_request):
         mock_perform_request.side_effect = make_mock_perform_request_impl(
             course=self.course,

--- a/lms/djangoapps/gating/tests/test_api.py
+++ b/lms/djangoapps/gating/tests/test_api.py
@@ -81,7 +81,7 @@ class TestEvaluatePrerequisite(GatingTestCase, MilestonesTestCaseMixin):
         )
         self.prereq_milestone = gating_api.get_gating_milestone(self.course.id, self.seq1.location, 'fulfills')
 
-    @patch('openedx.core.lib.gating.api.get_subsection_completion_percentage')
+    @patch('openedx.core.lib.gating.api.get_subsection_completion_percentage', autospec=True)
     @data(
         (50, 0, 50, 0, True),
         (50, 0, 10, 0, False),
@@ -102,8 +102,8 @@ class TestEvaluatePrerequisite(GatingTestCase, MilestonesTestCaseMixin):
         evaluate_prerequisite(self.course, self.subsection_grade, self.user)
         assert milestones_api.user_has_milestone(self.user_dict, self.prereq_milestone) == result
 
-    @patch('openedx.core.lib.gating.api.get_subsection_completion_percentage')
-    @patch('openedx.core.lib.gating.api._get_minimum_required_percentage')
+    @patch('openedx.core.lib.gating.api.get_subsection_completion_percentage', autospec=True)
+    @patch('openedx.core.lib.gating.api._get_minimum_required_percentage', autospec=True)
     @data((50, 50, False), (100, 50, False), (50, 100, False), (100, 100, True))
     @unpack
     def test_invalid_min_score(self, module_score, module_completion, result, mock_min_score, mock_completion):
@@ -115,12 +115,12 @@ class TestEvaluatePrerequisite(GatingTestCase, MilestonesTestCaseMixin):
         evaluate_prerequisite(self.course, self.subsection_grade, self.user)
         assert milestones_api.user_has_milestone(self.user_dict, self.prereq_milestone) == result
 
-    @patch('openedx.core.lib.gating.api.get_subsection_grade_percentage')
+    @patch('openedx.core.lib.gating.api.get_subsection_grade_percentage', autospec=True)
     def test_no_prerequisites(self, mock_score):
         evaluate_prerequisite(self.course, self.subsection_grade, self.user)
         assert not mock_score.called
 
-    @patch('openedx.core.lib.gating.api.get_subsection_grade_percentage')
+    @patch('openedx.core.lib.gating.api.get_subsection_grade_percentage', autospec=True)
     def test_no_gated_content(self, mock_score):
         gating_api.add_prerequisite(self.course.id, self.seq1.location)
 

--- a/lms/djangoapps/gating/tests/test_signals.py
+++ b/lms/djangoapps/gating/tests/test_signals.py
@@ -23,7 +23,7 @@ class TestHandleScoreChanged(ModuleStoreTestCase):
         self.user = UserFactory.create()
         self.subsection_grade = Mock()
 
-    @patch('lms.djangoapps.gating.api.gating_api.get_gating_milestone')
+    @patch('lms.djangoapps.gating.api.gating_api.get_gating_milestone', autospec=True)
     def test_gating_enabled(self, mock_gating_milestone):
         self.course.enable_subsection_gating = True
         modulestore().update_item(self.course, 0)
@@ -35,7 +35,7 @@ class TestHandleScoreChanged(ModuleStoreTestCase):
         )
         assert mock_gating_milestone.called
 
-    @patch('lms.djangoapps.gating.api.gating_api.get_gating_milestone')
+    @patch('lms.djangoapps.gating.api.gating_api.get_gating_milestone', autospec=True)
     def test_gating_disabled(self, mock_gating_milestone):
         evaluate_subsection_gated_milestones(
             sender=None,

--- a/lms/djangoapps/grades/management/commands/tests/test_compute_grades.py
+++ b/lms/djangoapps/grades/management/commands/tests/test_compute_grades.py
@@ -60,7 +60,7 @@ class TestComputeGrades(SharedModuleStoreTestCase):
             self.command._get_course_keys({'from_settings': True})
 
     @ddt.data(True, False)
-    @patch('lms.djangoapps.grades.tasks.compute_grades_for_course_v2')
+    @patch('lms.djangoapps.grades.tasks.compute_grades_for_course_v2', autospec=True)
     def test_tasks_fired(self, estimate_first_attempted, mock_task):
         command = [
             'compute_grades',
@@ -107,7 +107,7 @@ class TestComputeGrades(SharedModuleStoreTestCase):
         for call in expected:
             assert call in actual
 
-    @patch('lms.djangoapps.grades.tasks.compute_grades_for_course_v2')
+    @patch('lms.djangoapps.grades.tasks.compute_grades_for_course_v2', autospec=True)
     def test_tasks_fired_from_settings(self, mock_task):
         ComputeGradesSetting.objects.create(course_ids=self.course_keys[1], batch_size=2)
         call_command('compute_grades', '--from_settings')

--- a/lms/djangoapps/grades/management/commands/tests/test_recalculate_subsection_grades.py
+++ b/lms/djangoapps/grades/management/commands/tests/test_recalculate_subsection_grades.py
@@ -32,9 +32,9 @@ class TestRecalculateSubsectionGrades(HasCourseWithProblemsMixin, ModuleStoreTes
         super().setUp()
         self.command = recalculate_subsection_grades.Command()
 
-    @patch('lms.djangoapps.grades.management.commands.recalculate_subsection_grades.Submission')
-    @patch('lms.djangoapps.grades.management.commands.recalculate_subsection_grades.user_by_anonymous_id')
-    @patch('lms.djangoapps.grades.management.commands.recalculate_subsection_grades.recalculate_subsection_grade_v3')
+    @patch('lms.djangoapps.grades.management.commands.recalculate_subsection_grades.Submission', autospec=True)
+    @patch('lms.djangoapps.grades.management.commands.recalculate_subsection_grades.user_by_anonymous_id', autospec=True)
+    @patch('lms.djangoapps.grades.management.commands.recalculate_subsection_grades.recalculate_subsection_grade_v3', autospec=True)
     def test_submissions(self, task_mock, id_mock, subs_mock):
         submission = MagicMock()
         submission.student_item = MagicMock(
@@ -48,9 +48,9 @@ class TestRecalculateSubsectionGrades(HasCourseWithProblemsMixin, ModuleStoreTes
         id_mock.return_value.id = "ID"
         self._run_command_and_check_output(task_mock, ScoreDatabaseTableEnum.submissions, include_anonymous_id=True)
 
-    @patch('lms.djangoapps.grades.management.commands.recalculate_subsection_grades.StudentModule')
-    @patch('lms.djangoapps.grades.management.commands.recalculate_subsection_grades.user_by_anonymous_id')
-    @patch('lms.djangoapps.grades.management.commands.recalculate_subsection_grades.recalculate_subsection_grade_v3')
+    @patch('lms.djangoapps.grades.management.commands.recalculate_subsection_grades.StudentModule', autospec=True)
+    @patch('lms.djangoapps.grades.management.commands.recalculate_subsection_grades.user_by_anonymous_id', autospec=True)
+    @patch('lms.djangoapps.grades.management.commands.recalculate_subsection_grades.recalculate_subsection_grade_v3', autospec=True)
     def test_csm(self, task_mock, id_mock, csm_mock):
         csm_record = MagicMock()
         csm_record.student_id = "ID"

--- a/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
@@ -244,7 +244,7 @@ class CourseGradingViewTest(SharedModuleStoreTestCase, APITestCase):
             expected_data['grades_frozen'] = True
             assert expected_data == resp.data
 
-    @patch('lms.djangoapps.grades.rest_api.v1.gradebook_views.get_course_enrollment_details')
+    @patch('lms.djangoapps.grades.rest_api.v1.gradebook_views.get_course_enrollment_details', autospec=True)
     def test_can_see_bulk_management_non_masters(self, mock_course_enrollment_details):
         # Given a course without a master's track
         mock_course_enrollment_details.return_value = {'course_modes': [{'slug': 'not-masters'}]}
@@ -257,7 +257,7 @@ class CourseGradingViewTest(SharedModuleStoreTestCase, APITestCase):
         assert resp.status_code == status.HTTP_200_OK
         assert resp.data['can_see_bulk_management'] is False
 
-    @patch('lms.djangoapps.grades.rest_api.v1.gradebook_views.get_course_enrollment_details')
+    @patch('lms.djangoapps.grades.rest_api.v1.gradebook_views.get_course_enrollment_details', autospec=True)
     def test_can_see_bulk_management_masters(self, mock_course_enrollment_details):
         # Given a course with a master's track
         mock_course_enrollment_details.return_value = {'course_modes': [{'slug': 'not-masters'}, {'slug': 'masters'}]}
@@ -1860,7 +1860,7 @@ class SubsectionGradeViewTest(GradebookViewTestBase):
         )
         return f"{base_url}?user_id={user_id or self.user_id}&history_record_limit={history_record_limit}"
 
-    @patch('lms.djangoapps.grades.subsection_grade_factory.SubsectionGradeFactory.create')
+    @patch('lms.djangoapps.grades.subsection_grade_factory.SubsectionGradeFactory.create', autospec=True)
     @ddt.data(
         'login_staff',
         'login_course_admin',

--- a/lms/djangoapps/grades/tests/integration/test_events.py
+++ b/lms/djangoapps/grades/tests/integration/test_events.py
@@ -75,7 +75,7 @@ class GradesEventIntegrationTest(ProblemSubmissionTestMixin, SharedModuleStoreTe
         self.instructor = UserFactory.create(is_staff=True, username='test_instructor', password='test')
         self.refresh_course()
 
-    @patch('lms.djangoapps.grades.events.tracker')
+    @patch('lms.djangoapps.grades.events.tracker', autospec=True)
     def test_submit_answer(self, events_tracker):
         self.submit_question_answer('p1', {'2_1': 'choice_choice_2'})
         course = self.store.get_course(self.course.id, depth=0)

--- a/lms/djangoapps/grades/tests/test_course_data.py
+++ b/lms/djangoapps/grades/tests/test_course_data.py
@@ -39,7 +39,7 @@ class CourseDataTest(ModuleStoreTestCase):
             'location': self.course.location,
         }
 
-    @patch('lms.djangoapps.grades.course_data.get_course_blocks')
+    @patch('lms.djangoapps.grades.course_data.get_course_blocks', autospec=True)
     def test_fill_course_data(self, mock_get_blocks):
         """
         Tests to ensure that course data is fully filled with just a single input.

--- a/lms/djangoapps/grades/tests/test_course_grade_factory.py
+++ b/lms/djangoapps/grades/tests/test_course_grade_factory.py
@@ -298,7 +298,7 @@ class TestGradeIteration(SharedModuleStoreTestCase):
             assert course_grade.letter_grade is None
             assert course_grade.percent == 0.0
 
-    @patch('lms.djangoapps.grades.course_grade_factory.CourseGradeFactory.read')
+    @patch('lms.djangoapps.grades.course_grade_factory.CourseGradeFactory.read', autospec=True)
     def test_grading_exception(self, mock_course_grade):
         """Test that we correctly capture exception messages that bubble up from
         grading. Note that we only see errors at this level if the grading

--- a/lms/djangoapps/grades/tests/test_models.py
+++ b/lms/djangoapps/grades/tests/test_models.py
@@ -425,7 +425,7 @@ class PersistentCourseGradesTest(GradesModelTestCase):
         assert grade.letter_grade == ''
         assert grade.passed_timestamp == passed_timestamp
 
-    @patch('lms.djangoapps.grades.signals.signals.COURSE_GRADE_PASSED_FIRST_TIME.send')
+    @patch('lms.djangoapps.grades.signals.signals.COURSE_GRADE_PASSED_FIRST_TIME.send', autospec=True)
     def test_passed_timestamp_is_now(self, mock):
         with freeze_time(now()):
             grade = PersistentCourseGrade.update_or_create(**self.params)

--- a/lms/djangoapps/grades/tests/test_tasks.py
+++ b/lms/djangoapps/grades/tests/test_tasks.py
@@ -141,7 +141,7 @@ class RecalculateSubsectionGradeTest(HasCourseWithProblemsMixin, ModuleStoreTest
             PROBLEM_WEIGHTED_SCORE_CHANGED.send(sender=None, **send_args)
             mock_task_apply.assert_called_once_with(countdown=RECALCULATE_GRADE_DELAY_SECONDS, kwargs=local_task_args)
 
-    @patch('lms.djangoapps.grades.signals.signals.SUBSECTION_SCORE_CHANGED.send')
+    @patch('lms.djangoapps.grades.signals.signals.SUBSECTION_SCORE_CHANGED.send', autospec=True)
     def test_triggers_subsection_score_signal(self, mock_subsection_signal):
         """
         Ensures that a subsection grade recalculation triggers a signal.
@@ -198,7 +198,7 @@ class RecalculateSubsectionGradeTest(HasCourseWithProblemsMixin, ModuleStoreTest
                 with self.assertNumQueries(num_sql_calls):
                     self._apply_recalculate_subsection_grade()
 
-    @patch('lms.djangoapps.grades.signals.signals.SUBSECTION_SCORE_CHANGED.send')
+    @patch('lms.djangoapps.grades.signals.signals.SUBSECTION_SCORE_CHANGED.send', autospec=True)
     def test_other_inaccessible_subsection(self, mock_subsection_signal):
         self.set_up_course()
         accessible_seq = ItemFactory.create(parent=self.chapter, category='sequential')
@@ -252,8 +252,8 @@ class RecalculateSubsectionGradeTest(HasCourseWithProblemsMixin, ModuleStoreTest
             assert PersistentCourseGrade.read(self.user.id, self.course.id) is not None
             assert len(PersistentSubsectionGrade.bulk_read_grades(self.user.id, self.course.id)) > 0
 
-    @patch('lms.djangoapps.grades.signals.signals.SUBSECTION_SCORE_CHANGED.send')
-    @patch('lms.djangoapps.grades.subsection_grade_factory.SubsectionGradeFactory.update')
+    @patch('lms.djangoapps.grades.signals.signals.SUBSECTION_SCORE_CHANGED.send', autospec=True)
+    @patch('lms.djangoapps.grades.subsection_grade_factory.SubsectionGradeFactory.update', autospec=True)
     def test_retry_first_time_only(self, mock_update, mock_course_signal):
         """
         Ensures that a task retry completes after a one-time failure.
@@ -263,8 +263,8 @@ class RecalculateSubsectionGradeTest(HasCourseWithProblemsMixin, ModuleStoreTest
         self._apply_recalculate_subsection_grade()
         assert mock_course_signal.call_count == 1
 
-    @patch('lms.djangoapps.grades.tasks.recalculate_subsection_grade_v3.retry')
-    @patch('lms.djangoapps.grades.subsection_grade_factory.SubsectionGradeFactory.update')
+    @patch('lms.djangoapps.grades.tasks.recalculate_subsection_grade_v3.retry', autospec=True)
+    @patch('lms.djangoapps.grades.subsection_grade_factory.SubsectionGradeFactory.update', autospec=True)
     def test_retry_on_integrity_error(self, mock_update, mock_retry):
         """
         Ensures that tasks will be retried if IntegrityErrors are encountered.
@@ -276,8 +276,8 @@ class RecalculateSubsectionGradeTest(HasCourseWithProblemsMixin, ModuleStoreTest
 
     @ddt.data(ScoreDatabaseTableEnum.courseware_student_module, ScoreDatabaseTableEnum.submissions,
               ScoreDatabaseTableEnum.overrides)
-    @patch('lms.djangoapps.grades.tasks.recalculate_subsection_grade_v3.retry')
-    @patch('lms.djangoapps.grades.tasks.log')
+    @patch('lms.djangoapps.grades.tasks.recalculate_subsection_grade_v3.retry', autospec=True)
+    @patch('lms.djangoapps.grades.tasks.log', autospec=True)
     def test_retry_when_db_not_updated(self, score_db_table, mock_log, mock_retry):
         self.set_up_course()
         self.recalculate_subsection_grade_kwargs['score_db_table'] = score_db_table
@@ -312,8 +312,8 @@ class RecalculateSubsectionGradeTest(HasCourseWithProblemsMixin, ModuleStoreTest
         )
     )
     @ddt.unpack
-    @patch('lms.djangoapps.grades.tasks.recalculate_subsection_grade_v3.retry')
-    @patch('lms.djangoapps.grades.tasks.log')
+    @patch('lms.djangoapps.grades.tasks.recalculate_subsection_grade_v3.retry', autospec=True)
+    @patch('lms.djangoapps.grades.tasks.log', autospec=True)
     def test_when_no_score_found(self, score_deleted, score_db_table, mock_log, mock_retry):
         self.set_up_course()
         self.recalculate_subsection_grade_kwargs['score_deleted'] = score_deleted
@@ -339,9 +339,9 @@ class RecalculateSubsectionGradeTest(HasCourseWithProblemsMixin, ModuleStoreTest
             assert 'Grades: tasks._has_database_updated_with_new_score is False.'\
                    in mock_log.info.call_args_list[0][0][0]
 
-    @patch('lms.djangoapps.grades.tasks.log')
-    @patch('lms.djangoapps.grades.tasks.recalculate_subsection_grade_v3.retry')
-    @patch('lms.djangoapps.grades.subsection_grade_factory.SubsectionGradeFactory.update')
+    @patch('lms.djangoapps.grades.tasks.log', autospec=True)
+    @patch('lms.djangoapps.grades.tasks.recalculate_subsection_grade_v3.retry', autospec=True)
+    @patch('lms.djangoapps.grades.subsection_grade_factory.SubsectionGradeFactory.update', autospec=True)
     def test_log_unknown_error(self, mock_update, mock_retry, mock_log):
         """
         Ensures that unknown errors are logged before a retry.
@@ -352,9 +352,9 @@ class RecalculateSubsectionGradeTest(HasCourseWithProblemsMixin, ModuleStoreTest
         assert 'General exception with no further detail!' in mock_log.info.call_args[0][0]
         self._assert_retry_called(mock_retry)
 
-    @patch('lms.djangoapps.grades.tasks.log')
-    @patch('lms.djangoapps.grades.tasks.recalculate_subsection_grade_v3.retry')
-    @patch('lms.djangoapps.grades.subsection_grade_factory.SubsectionGradeFactory.update')
+    @patch('lms.djangoapps.grades.tasks.log', autospec=True)
+    @patch('lms.djangoapps.grades.tasks.recalculate_subsection_grade_v3.retry', autospec=True)
+    @patch('lms.djangoapps.grades.subsection_grade_factory.SubsectionGradeFactory.update', autospec=True)
     def test_no_log_known_error(self, mock_update, mock_retry, mock_log):
         """
         Ensures that known errors are not logged before a retry.
@@ -521,7 +521,7 @@ class FreezeGradingAfterCourseEndTest(HasCourseWithProblemsMixin, ModuleStoreTes
         )
     )
     @ddt.unpack
-    @patch('lms.djangoapps.grades.tasks.log')
+    @patch('lms.djangoapps.grades.tasks.log', autospec=True)
     def test_compute_all_grades_for_course(self, freeze_flag_value, end_date_adjustment, mock_log):
         self.set_up_course(course_end=timezone.now() - timedelta(end_date_adjustment))
         for user in self.users:
@@ -553,7 +553,7 @@ class FreezeGradingAfterCourseEndTest(HasCourseWithProblemsMixin, ModuleStoreTes
         )
     )
     @ddt.unpack
-    @patch('lms.djangoapps.grades.tasks.log')
+    @patch('lms.djangoapps.grades.tasks.log', autospec=True)
     def test_compute_grades_for_course(self, freeze_flag_value, end_date_adjustment, mock_log):
         self.set_up_course(course_end=timezone.now() - timedelta(end_date_adjustment))
         for user in self.users:
@@ -586,7 +586,7 @@ class FreezeGradingAfterCourseEndTest(HasCourseWithProblemsMixin, ModuleStoreTes
         )
     )
     @ddt.unpack
-    @patch('lms.djangoapps.grades.tasks.log')
+    @patch('lms.djangoapps.grades.tasks.log', autospec=True)
     def test_recalculate_course_and_subsection_grades(self, freeze_flag_value, end_date_adjustment, mock_log):
         self.set_up_course(course_end=timezone.now() - timedelta(end_date_adjustment))
         CourseEnrollment.enroll(self.user, self.course.id)
@@ -615,7 +615,7 @@ class FreezeGradingAfterCourseEndTest(HasCourseWithProblemsMixin, ModuleStoreTes
         )
     )
     @ddt.unpack
-    @patch('lms.djangoapps.grades.tasks.log')
+    @patch('lms.djangoapps.grades.tasks.log', autospec=True)
     def test_recalculate_subsection_grade_v3(self, freeze_flag_value, end_date_adjustment, mock_log):
         self.set_up_course(course_end=timezone.now() - timedelta(end_date_adjustment))
         for user in self.users:

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -634,7 +634,7 @@ class TestInstructorAPIBulkAccountCreationAndEnrollment(SharedModuleStoreTestCas
             last_name='Student'
         )
 
-    @patch('lms.djangoapps.instructor.views.api.log.info')
+    @patch('lms.djangoapps.instructor.views.api.log.info', autospec=True)
     def test_account_creation_and_enrollment_with_csv(self, info_log):
         """
         Happy path test to create a single new user
@@ -655,7 +655,7 @@ class TestInstructorAPIBulkAccountCreationAndEnrollment(SharedModuleStoreTestCas
         # test the log for email that's send to new created user.
         info_log.assert_called_with('email sent to new created user at %s', 'test_student@example.com')
 
-    @patch('lms.djangoapps.instructor.views.api.log.info')
+    @patch('lms.djangoapps.instructor.views.api.log.info', autospec=True)
     def test_account_creation_and_enrollment_with_csv_with_blank_lines(self, info_log):
         """
         Happy path test to create a single new user
@@ -676,7 +676,7 @@ class TestInstructorAPIBulkAccountCreationAndEnrollment(SharedModuleStoreTestCas
         # test the log for email that's send to new created user.
         info_log.assert_called_with('email sent to new created user at %s', 'test_student@example.com')
 
-    @patch('lms.djangoapps.instructor.views.api.log.info')
+    @patch('lms.djangoapps.instructor.views.api.log.info', autospec=True)
     def test_email_and_username_already_exist(self, info_log):
         """
         If the email address and username already exists
@@ -768,7 +768,7 @@ class TestInstructorAPIBulkAccountCreationAndEnrollment(SharedModuleStoreTestCas
         manual_enrollments = ManualEnrollmentAudit.objects.all()
         assert manual_enrollments.count() == 0
 
-    @patch('lms.djangoapps.instructor.views.api.log.info')
+    @patch('lms.djangoapps.instructor.views.api.log.info', autospec=True)
     def test_csv_user_exist_and_not_enrolled(self, info_log):
         """
         If the email address and username already exists
@@ -1532,7 +1532,7 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
             assert 'This email was automatically sent from edx.org to robot-allowed@robot.org' in body
 
     @ddt.data('http', 'https')
-    @patch('lms.djangoapps.instructor.enrollment.uses_shib')
+    @patch('lms.djangoapps.instructor.enrollment.uses_shib', autospec=True)
     def test_enroll_with_email_not_registered_with_shib(self, protocol, mock_uses_shib):
         mock_uses_shib.return_value = True
 
@@ -1567,7 +1567,7 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
 
             assert 'This email was automatically sent from edx.org to robot-not-an-email-yet@robot.org' in body
 
-    @patch('lms.djangoapps.instructor.enrollment.uses_shib')
+    @patch('lms.djangoapps.instructor.enrollment.uses_shib', autospec=True)
     @patch.dict(settings.FEATURES, {'ENABLE_MKTG_SITE': True})
     def test_enroll_email_not_registered_shib_mktgsite(self, mock_uses_shib):
         # Try with marketing site enabled and shib on
@@ -1593,7 +1593,7 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
             assert 'This email was automatically sent from edx.org to robot-not-an-email-yet@robot.org' in body
 
     @ddt.data('http', 'https')
-    @patch('lms.djangoapps.instructor.enrollment.uses_shib')
+    @patch('lms.djangoapps.instructor.enrollment.uses_shib', autospec=True)
     def test_enroll_with_email_not_registered_with_shib_autoenroll(self, protocol, mock_uses_shib):
         mock_uses_shib.return_value = True
 
@@ -2733,7 +2733,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         decorated_func(request, str(self.course.id))
         assert func.called
 
-    @patch('lms.djangoapps.instructor_task.models.logger.error')
+    @patch('lms.djangoapps.instructor_task.models.logger.error', autospec=True)
     @patch.dict(settings.GRADES_DOWNLOAD, {'STORAGE_TYPE': 's3', 'ROOT_PATH': 'tmp/edx-s3/grades'})
     @ddt.data('list_report_downloads', 'instructor_api_v1:list_report_downloads')
     def test_list_report_downloads_error(self, endpoint, mock_error):
@@ -2988,7 +2988,7 @@ class TestInstructorAPIRegradeTask(SharedModuleStoreTestCase, LoginEnrollmentTes
         assert json.loads(changed_module.state)['attempts'] == 0
 
     # mock out the function which should be called to execute the action.
-    @patch('lms.djangoapps.instructor_task.api.submit_reset_problem_attempts_for_all_students')
+    @patch('lms.djangoapps.instructor_task.api.submit_reset_problem_attempts_for_all_students', autospec=True)
     def test_reset_student_attempts_all(self, act):
         """ Test reset all student attempts. """
         url = reverse('reset_student_attempts', kwargs={'course_id': str(self.course.id)})
@@ -3008,7 +3008,7 @@ class TestInstructorAPIRegradeTask(SharedModuleStoreTestCase, LoginEnrollmentTes
         })
         assert response.status_code == 400
 
-    @patch('lms.djangoapps.grades.signals.handlers.PROBLEM_WEIGHTED_SCORE_CHANGED.send')
+    @patch('lms.djangoapps.grades.signals.handlers.PROBLEM_WEIGHTED_SCORE_CHANGED.send', autospec=True)
     def test_reset_student_attempts_delete(self, _mock_signal):
         """ Test delete single student state. """
         url = reverse('reset_student_attempts', kwargs={'course_id': str(self.course.id)})
@@ -3032,7 +3032,7 @@ class TestInstructorAPIRegradeTask(SharedModuleStoreTestCase, LoginEnrollmentTes
         })
         assert response.status_code == 400
 
-    @patch('lms.djangoapps.instructor_task.api.submit_rescore_problem_for_student')
+    @patch('lms.djangoapps.instructor_task.api.submit_rescore_problem_for_student', autospec=True)
     def test_rescore_problem_single(self, act):
         """ Test rescoring of a single student. """
         url = reverse('rescore_problem', kwargs={'course_id': str(self.course.id)})
@@ -3043,7 +3043,7 @@ class TestInstructorAPIRegradeTask(SharedModuleStoreTestCase, LoginEnrollmentTes
         assert response.status_code == 200
         assert act.called
 
-    @patch('lms.djangoapps.instructor_task.api.submit_rescore_problem_for_student')
+    @patch('lms.djangoapps.instructor_task.api.submit_rescore_problem_for_student', autospec=True)
     def test_rescore_problem_single_from_uname(self, act):
         """ Test rescoring of a single student. """
         url = reverse('rescore_problem', kwargs={'course_id': str(self.course.id)})
@@ -3054,7 +3054,7 @@ class TestInstructorAPIRegradeTask(SharedModuleStoreTestCase, LoginEnrollmentTes
         assert response.status_code == 200
         assert act.called
 
-    @patch('lms.djangoapps.instructor_task.api.submit_rescore_problem_for_all_students')
+    @patch('lms.djangoapps.instructor_task.api.submit_rescore_problem_for_all_students', autospec=True)
     def test_rescore_problem_all(self, act):
         """ Test rescoring for all students. """
         url = reverse('rescore_problem', kwargs={'course_id': str(self.course.id)})
@@ -3205,7 +3205,7 @@ class TestEntranceExamInstructorAPIRegradeTask(SharedModuleStoreTestCase, LoginE
             assert json.loads(changed_module.state)['attempts'] == 0
 
     # mock out the function which should be called to execute the action.
-    @patch('lms.djangoapps.instructor_task.api.submit_reset_problem_attempts_in_entrance_exam')
+    @patch('lms.djangoapps.instructor_task.api.submit_reset_problem_attempts_in_entrance_exam', autospec=True)
     def test_reset_entrance_exam_all_student_attempts(self, act):
         """ Test reset all student attempts for entrance exam. """
         url = reverse('reset_student_attempts_for_entrance_exam',
@@ -3261,7 +3261,7 @@ class TestEntranceExamInstructorAPIRegradeTask(SharedModuleStoreTestCase, LoginE
         })
         assert response.status_code == 400
 
-    @patch('lms.djangoapps.instructor_task.api.submit_rescore_entrance_exam_for_student')
+    @patch('lms.djangoapps.instructor_task.api.submit_rescore_entrance_exam_for_student', autospec=True)
     def test_rescore_entrance_exam_single_student(self, act):
         """ Test re-scoring of entrance exam for single student. """
         url = reverse('rescore_entrance_exam', kwargs={'course_id': str(self.course.id)})
@@ -3575,7 +3575,7 @@ class TestInstructorAPITaskLists(SharedModuleStoreTestCase, LoginEnrollmentTestC
         self.tasks = [self.FakeTask(mock_factory.mock_get_task_completion_info) for _ in range(7)]
         self.tasks[-1].make_invalid_output()
 
-    @patch('lms.djangoapps.instructor_task.api.get_running_instructor_tasks')
+    @patch('lms.djangoapps.instructor_task.api.get_running_instructor_tasks', autospec=True)
     @ddt.data('instructor_api_v1:list_instructor_tasks', 'list_instructor_tasks')
     def test_list_instructor_tasks_running(self, endpoint, act):
         """ Test list of all running tasks. """
@@ -3600,7 +3600,7 @@ class TestInstructorAPITaskLists(SharedModuleStoreTestCase, LoginEnrollmentTestC
             self.assertDictEqual(exp_task, act_task)
         assert actual_tasks == expected_tasks
 
-    @patch('lms.djangoapps.instructor_task.api.get_instructor_task_history')
+    @patch('lms.djangoapps.instructor_task.api.get_instructor_task_history', autospec=True)
     def test_list_background_email_tasks(self, act):
         """Test list of background email tasks."""
         act.return_value = self.tasks
@@ -3621,7 +3621,7 @@ class TestInstructorAPITaskLists(SharedModuleStoreTestCase, LoginEnrollmentTestC
             self.assertDictEqual(exp_task, act_task)
         assert actual_tasks == expected_tasks
 
-    @patch('lms.djangoapps.instructor_task.api.get_instructor_task_history')
+    @patch('lms.djangoapps.instructor_task.api.get_instructor_task_history', autospec=True)
     @ddt.data('instructor_api_v1:list_instructor_tasks', 'list_instructor_tasks')
     def test_list_instructor_tasks_problem(self, endpoint, act):
         """ Test list task history for problem. """
@@ -3650,7 +3650,7 @@ class TestInstructorAPITaskLists(SharedModuleStoreTestCase, LoginEnrollmentTestC
             self.assertDictEqual(exp_task, act_task)
         assert actual_tasks == expected_tasks
 
-    @patch('lms.djangoapps.instructor_task.api.get_instructor_task_history')
+    @patch('lms.djangoapps.instructor_task.api.get_instructor_task_history', autospec=True)
     @ddt.data('list_instructor_tasks', 'instructor_api_v1:list_instructor_tasks')
     def test_list_instructor_tasks_problem_student(self, endpoint, act):
         """ Test list task history for problem AND student. """
@@ -4364,8 +4364,8 @@ class TestBulkCohorting(SharedModuleStoreTestCase):
         response = self.call_add_users_to_cohorts('')
         assert response.status_code == 403
 
-    @patch('lms.djangoapps.instructor_task.api.submit_cohort_students')
-    @patch('lms.djangoapps.instructor.views.api.store_uploaded_file')
+    @patch('lms.djangoapps.instructor_task.api.submit_cohort_students', autospec=True)
+    @patch('lms.djangoapps.instructor.views.api.store_uploaded_file', autospec=True)
     def test_success_username(self, mock_store_upload, mock_cohort_task):
         """
         Verify that we store the input CSV and call a background task when
@@ -4375,8 +4375,8 @@ class TestBulkCohorting(SharedModuleStoreTestCase):
             'username,cohort\nfoo_username,bar_cohort', mock_store_upload, mock_cohort_task
         )
 
-    @patch('lms.djangoapps.instructor_task.api.submit_cohort_students')
-    @patch('lms.djangoapps.instructor.views.api.store_uploaded_file')
+    @patch('lms.djangoapps.instructor_task.api.submit_cohort_students', autospec=True)
+    @patch('lms.djangoapps.instructor.views.api.store_uploaded_file', autospec=True)
     def test_success_email(self, mock_store_upload, mock_cohort_task):
         """
         Verify that we store the input CSV and call the cohorting background
@@ -4386,8 +4386,8 @@ class TestBulkCohorting(SharedModuleStoreTestCase):
             'email,cohort\nfoo_email,bar_cohort', mock_store_upload, mock_cohort_task
         )
 
-    @patch('lms.djangoapps.instructor_task.api.submit_cohort_students')
-    @patch('lms.djangoapps.instructor.views.api.store_uploaded_file')
+    @patch('lms.djangoapps.instructor_task.api.submit_cohort_students', autospec=True)
+    @patch('lms.djangoapps.instructor.views.api.store_uploaded_file', autospec=True)
     def test_success_username_and_email(self, mock_store_upload, mock_cohort_task):
         """
         Verify that we store the input CSV and call the cohorting background
@@ -4397,8 +4397,8 @@ class TestBulkCohorting(SharedModuleStoreTestCase):
             'username,email,cohort\nfoo_username,bar_email,baz_cohort', mock_store_upload, mock_cohort_task
         )
 
-    @patch('lms.djangoapps.instructor_task.api.submit_cohort_students')
-    @patch('lms.djangoapps.instructor.views.api.store_uploaded_file')
+    @patch('lms.djangoapps.instructor_task.api.submit_cohort_students', autospec=True)
+    @patch('lms.djangoapps.instructor.views.api.store_uploaded_file', autospec=True)
     def test_success_carriage_return(self, mock_store_upload, mock_cohort_task):
         """
         Verify that we store the input CSV and call the cohorting background
@@ -4408,8 +4408,8 @@ class TestBulkCohorting(SharedModuleStoreTestCase):
             'username,email,cohort\rfoo_username,bar_email,baz_cohort', mock_store_upload, mock_cohort_task
         )
 
-    @patch('lms.djangoapps.instructor_task.api.submit_cohort_students')
-    @patch('lms.djangoapps.instructor.views.api.store_uploaded_file')
+    @patch('lms.djangoapps.instructor_task.api.submit_cohort_students', autospec=True)
+    @patch('lms.djangoapps.instructor.views.api.store_uploaded_file', autospec=True)
     def test_success_carriage_return_line_feed(self, mock_store_upload, mock_cohort_task):
         """
         Verify that we store the input CSV and call the cohorting background

--- a/lms/djangoapps/instructor/tests/test_enrollment.py
+++ b/lms/djangoapps/instructor/tests/test_enrollment.py
@@ -444,7 +444,7 @@ class TestInstructorEnrollmentStudentModule(SharedModuleStoreTestCase):
         reset_student_attempts(self.course_key, self.user, msk, requesting_user=self.user)
         assert json.loads(module().state)['attempts'] == 0
 
-    @patch('lms.djangoapps.grades.signals.handlers.PROBLEM_WEIGHTED_SCORE_CHANGED.send')
+    @patch('lms.djangoapps.grades.signals.handlers.PROBLEM_WEIGHTED_SCORE_CHANGED.send', autospec=True)
     def test_delete_student_attempts(self, _mock_signal):
         msk = self.course_key.make_usage_key('dummy', 'module')
         original_state = json.dumps({'attempts': 32, 'otherstuff': 'alsorobots'})
@@ -466,7 +466,7 @@ class TestInstructorEnrollmentStudentModule(SharedModuleStoreTestCase):
 
     # Disable the score change signal to prevent other components from being
     # pulled into tests.
-    @patch('lms.djangoapps.grades.signals.handlers.PROBLEM_WEIGHTED_SCORE_CHANGED.send')
+    @patch('lms.djangoapps.grades.signals.handlers.PROBLEM_WEIGHTED_SCORE_CHANGED.send', autospec=True)
     def test_delete_submission_scores(self, mock_send_signal):
         user = UserFactory()
         problem_location = self.course_key.make_usage_key('dummy', 'module')
@@ -586,7 +586,7 @@ class TestInstructorEnrollmentStudentModule(SharedModuleStoreTestCase):
         # Still should have no state
         self.assert_no_student_module(self.lazy_teammate, team_ora_location)
 
-    @patch('lms.djangoapps.grades.signals.handlers.PROBLEM_WEIGHTED_SCORE_CHANGED.send')
+    @patch('lms.djangoapps.grades.signals.handlers.PROBLEM_WEIGHTED_SCORE_CHANGED.send', autospec=True)
     def test_delete_team_attempts(self, _mock_signal):
         self.setup_team()
         team_ora_location = self.team_enabled_ora.location
@@ -606,7 +606,7 @@ class TestInstructorEnrollmentStudentModule(SharedModuleStoreTestCase):
         self.assert_no_student_module(self.teammate_b, team_ora_location)
         self.assert_no_student_module(self.lazy_teammate, team_ora_location)
 
-    @patch('lms.djangoapps.grades.signals.handlers.PROBLEM_WEIGHTED_SCORE_CHANGED.send')
+    @patch('lms.djangoapps.grades.signals.handlers.PROBLEM_WEIGHTED_SCORE_CHANGED.send', autospec=True)
     def test_delete_team_attempts_no_team_fallthrough(self, _mock_signal):
         self.setup_team()
         team_ora_location = self.team_enabled_ora.location
@@ -762,7 +762,7 @@ class TestStudentModuleGrading(SharedModuleStoreTestCase):
         assert grade.all_total.possible == all_possible
         assert grade.graded_total.possible == graded_possible
 
-    @patch('crum.get_current_request')
+    @patch('crum.get_current_request', autospec=True)
     def test_delete_student_state(self, _crum_mock):
         problem_location = self.problem.location
         self._get_subsection_grade_and_verify(0, 1, 0, 1)

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -128,8 +128,8 @@ class TestInstructorGradeReport(InstructorGradeReportTestCase):
         num_students = len(emails)
         self.assertDictContainsSubset({'attempted': num_students, 'succeeded': num_students, 'failed': 0}, result)
 
-    @patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task')
-    @patch('lms.djangoapps.grades.course_grade_factory.CourseGradeFactory.iter')
+    @patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task', autospec=True)
+    @patch('lms.djangoapps.grades.course_grade_factory.CourseGradeFactory.iter', autospec=True)
     def test_grading_failure(self, mock_grades_iter, _mock_current_task):
         """
         Test that any grading errors are properly reported in the
@@ -305,8 +305,8 @@ class TestInstructorGradeReport(InstructorGradeReportTestCase):
             '',
         )
 
-    @patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task')
-    @patch('lms.djangoapps.grades.course_grade_factory.CourseGradeFactory.iter')
+    @patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task', autospec=True)
+    @patch('lms.djangoapps.grades.course_grade_factory.CourseGradeFactory.iter', autospec=True)
     def test_unicode_in_csv_header(self, mock_grades_iter, _mock_current_task):
         """
         Tests that CSV grade report works if unicode in headers.
@@ -705,7 +705,7 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
         )
         assert len(student_data) == filtered_count
 
-    @patch('lms.djangoapps.instructor_task.tasks_helper.grades.list_problem_responses')
+    @patch('lms.djangoapps.instructor_task.tasks_helper.grades.list_problem_responses', autospec=True)
     @patch('xmodule.capa_module.ProblemBlock.generate_report_data', create=True)
     def test_build_student_data_for_block_with_generate_report_data_not_implemented(
             self,
@@ -801,7 +801,7 @@ class TestProblemGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
         self.student_2 = self.create_student('üser_2')
         self.csv_header_row = ['Student ID', 'Email', 'Username', 'Enrollment Status', 'Grade']
 
-    @patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task')
+    @patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task', autospec=True)
     def test_no_problems(self, _get_current_task):
         """
         Verify that we see no grade information for a course with no graded
@@ -820,7 +820,7 @@ class TestProblemGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
             )))
         ])
 
-    @patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task')
+    @patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task', autospec=True)
     def test_single_problem(self, _get_current_task):
         vertical = ItemFactory.create(
             parent_location=self.problem_section.location,
@@ -858,7 +858,7 @@ class TestProblemGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
             )))
         ])
 
-    @patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task')
+    @patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task', autospec=True)
     def test_single_problem_verified_student_only(self, _get_current_task):
         with patch(
             'lms.djangoapps.instructor_task.tasks_helper.grades.problem_grade_report_verified_only',
@@ -880,7 +880,7 @@ class TestProblemGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
                 {'action_name': 'graded', 'attempted': 1, 'succeeded': 1, 'failed': 0}, result
             )
 
-    @patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task')
+    @patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task', autospec=True)
     def test_inactive_enrollment_included(self, _get_current_task):
         """
         Students with inactive enrollments in a course should be included in Problem Grade Report.
@@ -1866,7 +1866,7 @@ class TestGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
                 ignore_other_columns=True,
             )
 
-    @patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task')
+    @patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task', autospec=True)
     def test_course_grade_with_verified_student_only(self, _get_current_task):
         """
         Tests that course grade report has expected data when it is generated only for

--- a/lms/djangoapps/lti_provider/tests/test_users.py
+++ b/lms/djangoapps/lti_provider/tests/test_users.py
@@ -46,7 +46,7 @@ class UserManagementHelperTest(TestCase):
         with pytest.raises(PermissionDenied):
             users.switch_user(self.request, self.lti_user, self.lti_consumer)
 
-    @patch('lms.djangoapps.lti_provider.users.login')
+    @patch('lms.djangoapps.lti_provider.users.login', autospec=True)
     def test_authenticate_called(self, _login_mock):
         with patch('lms.djangoapps.lti_provider.users.authenticate', return_value=self.new_user) as authenticate:
             users.switch_user(self.request, self.lti_user, self.lti_consumer)
@@ -56,7 +56,7 @@ class UserManagementHelperTest(TestCase):
                 lti_consumer=self.lti_consumer
             )
 
-    @patch('lms.djangoapps.lti_provider.users.login')
+    @patch('lms.djangoapps.lti_provider.users.login', autospec=True)
     def test_login_called(self, login_mock):
         with patch('lms.djangoapps.lti_provider.users.authenticate', return_value=self.new_user):
             users.switch_user(self.request, self.lti_user, self.lti_consumer)

--- a/lms/djangoapps/lti_provider/tests/test_views.py
+++ b/lms/djangoapps/lti_provider/tests/test_views.py
@@ -87,8 +87,8 @@ class LtiLaunchTest(LtiTestMixin, TestCase):
     """
     Tests for the lti_launch view
     """
-    @patch('lms.djangoapps.lti_provider.views.render_courseware')
-    @patch('lms.djangoapps.lti_provider.views.authenticate_lti_user')
+    @patch('lms.djangoapps.lti_provider.views.render_courseware', autospec=True)
+    @patch('lms.djangoapps.lti_provider.views.authenticate_lti_user', autospec=True)
     def test_valid_launch(self, _authenticate, render):
         """
         Verifies that the LTI launch succeeds when passed a valid request.
@@ -97,9 +97,9 @@ class LtiLaunchTest(LtiTestMixin, TestCase):
         views.lti_launch(request, str(COURSE_KEY), str(USAGE_KEY))
         render.assert_called_with(request, USAGE_KEY)
 
-    @patch('lms.djangoapps.lti_provider.views.render_courseware')
-    @patch('lms.djangoapps.lti_provider.views.store_outcome_parameters')
-    @patch('lms.djangoapps.lti_provider.views.authenticate_lti_user')
+    @patch('lms.djangoapps.lti_provider.views.render_courseware', autospec=True)
+    @patch('lms.djangoapps.lti_provider.views.store_outcome_parameters', autospec=True)
+    @patch('lms.djangoapps.lti_provider.views.authenticate_lti_user', autospec=True)
     def test_valid_launch_with_optional_params(self, _authenticate, store_params, _render):
         """
         Verifies that the LTI launch succeeds when passed a valid request.
@@ -112,9 +112,9 @@ class LtiLaunchTest(LtiTestMixin, TestCase):
             self.consumer
         )
 
-    @patch('lms.djangoapps.lti_provider.views.render_courseware')
-    @patch('lms.djangoapps.lti_provider.views.store_outcome_parameters')
-    @patch('lms.djangoapps.lti_provider.views.authenticate_lti_user')
+    @patch('lms.djangoapps.lti_provider.views.render_courseware', autospec=True)
+    @patch('lms.djangoapps.lti_provider.views.store_outcome_parameters', autospec=True)
+    @patch('lms.djangoapps.lti_provider.views.authenticate_lti_user', autospec=True)
     def test_outcome_service_registered(self, _authenticate, store_params, _render):
         """
         Verifies that the LTI launch succeeds when passed a valid request.
@@ -165,7 +165,7 @@ class LtiLaunchTest(LtiTestMixin, TestCase):
         assert response.status_code == 403
         assert response.status_code == 403
 
-    @patch('lms.djangoapps.lti_provider.views.render_courseware')
+    @patch('lms.djangoapps.lti_provider.views.render_courseware', autospec=True)
     def test_lti_consumer_record_supplemented_with_guid(self, _render):
         self.mock_verify.return_value = False
 

--- a/lms/djangoapps/program_enrollments/api/tests/test_linking.py
+++ b/lms/djangoapps/program_enrollments/api/tests/test_linking.py
@@ -295,7 +295,7 @@ class TestLinkProgramEnrollments(TestLinkProgramEnrollmentsMixin, TestCase):
         ('learner-2', 'LEArneR-2'),
     )
     @ddt.unpack
-    @patch('lms.djangoapps.program_enrollments.api.linking.CourseMode.modes_for_course_dict')
+    @patch('lms.djangoapps.program_enrollments.api.linking.CourseMode.modes_for_course_dict', autospec=True)
     def test_update_linking_enrollment_to_another_user(
         self,
         linked_external_key,

--- a/lms/djangoapps/rss_proxy/tests/test_views.py
+++ b/lms/djangoapps/rss_proxy/tests/test_views.py
@@ -40,7 +40,7 @@ class RssProxyViewTests(TestCase):
         WhitelistedRssUrl.objects.create(url=self.whitelisted_url1)
         WhitelistedRssUrl.objects.create(url=self.whitelisted_url2)
 
-    @patch('lms.djangoapps.rss_proxy.views.requests.get')
+    @patch('lms.djangoapps.rss_proxy.views.requests.get', autospec=True)
     def test_proxy_with_whitelisted_url(self, mock_requests_get):
         """
         Test the proxy view with a whitelisted URL
@@ -51,7 +51,7 @@ class RssProxyViewTests(TestCase):
         assert resp['Content-Type'] == 'application/xml'
         assert resp.content.decode('utf-8') == self.rss
 
-    @patch('lms.djangoapps.rss_proxy.views.requests.get')
+    @patch('lms.djangoapps.rss_proxy.views.requests.get', autospec=True)
     def test_proxy_with_whitelisted_url_404(self, mock_requests_get):
         """
         Test the proxy view with a whitelisted URL that is not found

--- a/lms/djangoapps/save_for_later/api/v1/tests/test_views.py
+++ b/lms/djangoapps/save_for_later/api/v1/tests/test_views.py
@@ -117,7 +117,7 @@ class ProgramSaveForLaterApiViewTest(ThirdPartyAuthTestMixin, APITestCase):
         self.program = ProgramFactory(uuid=self.uuid)
 
     @patch('lms.djangoapps.save_for_later.helper.BrazeClient', MagicMock())
-    @patch('lms.djangoapps.save_for_later.api.v1.views.get_programs')
+    @patch('lms.djangoapps.save_for_later.api.v1.views.get_programs', autospec=True)
     def test_save_program_using_email(self, mock_get_programs):
         """
         Test successfully email sent

--- a/lms/djangoapps/support/tests/test_views.py
+++ b/lms/djangoapps/support/tests/test_views.py
@@ -762,7 +762,7 @@ class SupportViewLinkProgramEnrollmentsTests(SupportViewTestCase):
         '0001,learner-01,apple,orange\n0002,learner-02,purple',  # extra fields
         '\t0001        ,    \t  learner-01    \n   0002 , learner-02    ',  # whitespace
     )
-    @patch('lms.djangoapps.support.views.utils.link_program_enrollments')
+    @patch('lms.djangoapps.support.views.utils.link_program_enrollments', autospec=True)
     def test_text(self, text, mocked_link):
         self.client.post(self.url, data={
             'program_uuid': self.program_uuid,
@@ -1678,7 +1678,7 @@ class LinkProgramEnrollmentSupportAPIViewTests(SupportViewTestCase):
         '0001,learner-01,apple,orange\n0002,learner-02,purple',  # extra fields
         '\t0001        ,    \t  learner-01    \n   0002 , learner-02    ',  # whitespace
     )
-    @patch('lms.djangoapps.support.views.utils.link_program_enrollments')
+    @patch('lms.djangoapps.support.views.utils.link_program_enrollments', autospec=True)
     def test_username_pair_text(self, username_pair_text, mocked_link):
         """
         Tests if enrollment linkages are created for different types of

--- a/lms/djangoapps/verify_student/management/commands/tests/test_trigger_softwaresecurephotoverifications_post_save_signal.py
+++ b/lms/djangoapps/verify_student/management/commands/tests/test_trigger_softwaresecurephotoverifications_post_save_signal.py
@@ -38,7 +38,7 @@ class TestTriggerSoftwareSecurePhotoVerificationsPostSaveSignal(MockS3BotoMixin,
         for _ in range(num_attempts):
             self.create_and_submit_attempt_for_user()
 
-    @patch('lms.djangoapps.verify_student.signals.idv_update_signal.send')
+    @patch('lms.djangoapps.verify_student.signals.idv_update_signal.send', autospec=True)
     def test_command(self, send_idv_update_mock):
         call_command('trigger_softwaresecurephotoverifications_post_save_signal', start_date_time='2021-10-31 06:00:00')
 

--- a/lms/djangoapps/verify_student/tests/test_signals.py
+++ b/lms/djangoapps/verify_student/tests/test_signals.py
@@ -121,7 +121,7 @@ class PostSavePhotoVerificationTest(ModuleStoreTestCase):
         self.photo_id_image_url = 'https://test.photo'
         self.photo_id_key = 'test+key'
 
-    @patch('lms.djangoapps.verify_student.signals.idv_update_signal.send')
+    @patch('lms.djangoapps.verify_student.signals.idv_update_signal.send', autospec=True)
     def test_post_save_signal(self, mock_signal):
         # create new softwaresecureverification
         attempt = SoftwareSecurePhotoVerification.objects.create(
@@ -154,7 +154,7 @@ class PostSavePhotoVerificationTest(ModuleStoreTestCase):
             full_name=attempt.user.profile.name
         )
 
-    @patch('lms.djangoapps.verify_student.signals.idv_update_signal.send')
+    @patch('lms.djangoapps.verify_student.signals.idv_update_signal.send', autospec=True)
     def test_post_save_signal_pending_name(self, mock_signal):
         pending_name_change = do_name_change_request(self.user, 'Pending Name', 'test')[0]
 

--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -1574,8 +1574,8 @@ class TestPhotoVerificationResultsCallback(ModuleStoreTestCase, TestVerification
         'lms.djangoapps.verify_student.ssencrypt.has_valid_signature',
         mock.Mock(side_effect=mocked_has_valid_signature)
     )
-    @patch('lms.djangoapps.verify_student.views.log.error')
-    @patch('lms.djangoapps.verify_student.views.segment.track')
+    @patch('lms.djangoapps.verify_student.views.log.error', autospec=True)
+    @patch('lms.djangoapps.verify_student.views.segment.track', autospec=True)
     def test_passed_status_template(self, mock_segment_track, _mock_log_error):
         """
         Test for verification passed.
@@ -1639,8 +1639,8 @@ class TestPhotoVerificationResultsCallback(ModuleStoreTestCase, TestVerification
         'lms.djangoapps.verify_student.ssencrypt.has_valid_signature',
         mock.Mock(side_effect=mocked_has_valid_signature)
     )
-    @patch('lms.djangoapps.verify_student.views.log.error')
-    @patch('lms.djangoapps.verify_student.views.segment.track')
+    @patch('lms.djangoapps.verify_student.views.log.error', autospec=True)
+    @patch('lms.djangoapps.verify_student.views.segment.track', autospec=True)
     def test_first_time_verification(self, mock_segment_track, _mock_log_error):
         """
         Test for verification passed if the learner does not have any previous verification
@@ -1673,8 +1673,8 @@ class TestPhotoVerificationResultsCallback(ModuleStoreTestCase, TestVerification
         'lms.djangoapps.verify_student.ssencrypt.has_valid_signature',
         mock.Mock(side_effect=mocked_has_valid_signature)
     )
-    @patch('lms.djangoapps.verify_student.views.log.error')
-    @patch('lms.djangoapps.verify_student.views.segment.track')
+    @patch('lms.djangoapps.verify_student.views.log.error', autospec=True)
+    @patch('lms.djangoapps.verify_student.views.segment.track', autospec=True)
     def test_failed_status_template(self, mock_segment_track, _mock_log_error):
         """
         Test for failed verification.
@@ -1704,7 +1704,7 @@ class TestPhotoVerificationResultsCallback(ModuleStoreTestCase, TestVerification
         'lms.djangoapps.verify_student.ssencrypt.has_valid_signature',
         mock.Mock(side_effect=mocked_has_valid_signature)
     )
-    @patch('lms.djangoapps.verify_student.views.segment.track')
+    @patch('lms.djangoapps.verify_student.views.segment.track', autospec=True)
     def test_system_fail_result(self, mock_segment_track):
         """
         Test for software secure result system failure.

--- a/openedx/core/djangoapps/api_admin/management/commands/tests/test_create_api_access_request.py
+++ b/openedx/core/djangoapps/api_admin/management/commands/tests/test_create_api_access_request.py
@@ -33,14 +33,14 @@ class TestCreateApiAccessRequest(TestCase):
         call_command(self.command, self.user.username, create_config=create_config)
         self.assert_models_exist(True, create_config)
 
-    @patch('openedx.core.djangoapps.api_admin.models._send_new_pending_email')
+    @patch('openedx.core.djangoapps.api_admin.models._send_new_pending_email', autospec=True)
     def test_create_api_access_request_signals_disconnected(self, mock_send_new_pending_email):
         self.assert_models_exist(False, False)
         call_command(self.command, self.user.username, create_config=True, disconnect_signals=True)
         self.assert_models_exist(True, True)
         assert not mock_send_new_pending_email.called
 
-    @patch('openedx.core.djangoapps.api_admin.models._send_new_pending_email')
+    @patch('openedx.core.djangoapps.api_admin.models._send_new_pending_email', autospec=True)
     def test_create_api_access_request_signals_connected(self, mock_send_new_pending_email):
         self.assert_models_exist(False, False)
         call_command(self.command, self.user.username, create_config=True, disconnect_signals=False)
@@ -57,7 +57,7 @@ class TestCreateApiAccessRequest(TestCase):
         with self.assertRaisesRegex(CommandError, r'User .*? not found'):
             call_command(self.command, 'not-a-user-notfound-nope')
 
-    @patch('openedx.core.djangoapps.api_admin.models.ApiAccessRequest.objects.create')
+    @patch('openedx.core.djangoapps.api_admin.models.ApiAccessRequest.objects.create', autospec=True)
     def test_api_request_error(self, mocked_method):
         mocked_method.side_effect = Exception()
 
@@ -68,7 +68,7 @@ class TestCreateApiAccessRequest(TestCase):
 
         self.assert_models_exist(False, False)
 
-    @patch('openedx.core.djangoapps.api_admin.models.send_request_email')
+    @patch('openedx.core.djangoapps.api_admin.models.send_request_email', autospec=True)
     def test_api_request_permission_denied_error(self, mocked_method):
         """
         When a Permission denied OSError with 'mako_lms' in the message occurs in the post_save receiver,
@@ -82,7 +82,7 @@ class TestCreateApiAccessRequest(TestCase):
 
         self.assert_models_exist(True, True)
 
-    @patch('openedx.core.djangoapps.api_admin.models.ApiAccessRequest.objects.create')
+    @patch('openedx.core.djangoapps.api_admin.models.ApiAccessRequest.objects.create', autospec=True)
     def test_api_request_other_oserrors_raise(self, mocked_method):
         """
         When some other Permission denied OSError occurs, we should still raise.
@@ -96,7 +96,7 @@ class TestCreateApiAccessRequest(TestCase):
 
         self.assert_models_exist(False, False)
 
-    @patch('openedx.core.djangoapps.api_admin.models.ApiAccessConfig.objects.get_or_create')
+    @patch('openedx.core.djangoapps.api_admin.models.ApiAccessConfig.objects.get_or_create', autospec=True)
     def test_api_config_error(self, mocked_method):
         mocked_method.side_effect = Exception()
         self.assert_models_exist(False, False)

--- a/openedx/core/djangoapps/bookmarks/tests/test_api.py
+++ b/openedx/core/djangoapps/bookmarks/tests/test_api.py
@@ -111,7 +111,7 @@ class BookmarksAPITests(BookmarkApiEventTestMixin, BookmarksTestsBase):
             assert len(bookmarks) == count
         assert bookmarks.model is Bookmark
 
-    @patch('openedx.core.djangoapps.bookmarks.api.tracker.emit')
+    @patch('openedx.core.djangoapps.bookmarks.api.tracker.emit', autospec=True)
     def test_create_bookmark(self, mock_tracker):
         """
         Verifies that create_bookmark create & returns data as expected.
@@ -132,7 +132,7 @@ class BookmarksAPITests(BookmarkApiEventTestMixin, BookmarksTestsBase):
 
         assert len(api.get_bookmarks(user=self.user, course_key=self.course.id)) == 5
 
-    @patch('openedx.core.djangoapps.bookmarks.api.tracker.emit')
+    @patch('openedx.core.djangoapps.bookmarks.api.tracker.emit', autospec=True)
     def test_create_bookmark_do_not_create_duplicates(self, mock_tracker):
         """
         Verifies that create_bookmark do not create duplicate bookmarks.
@@ -163,7 +163,7 @@ class BookmarksAPITests(BookmarkApiEventTestMixin, BookmarksTestsBase):
 
         self.assert_no_events_were_emitted(mock_tracker)
 
-    @patch('openedx.core.djangoapps.bookmarks.api.tracker.emit')
+    @patch('openedx.core.djangoapps.bookmarks.api.tracker.emit', autospec=True)
     def test_create_bookmark_raises_error(self, mock_tracker):
         """
         Verifies that create_bookmark raises error as expected.
@@ -174,7 +174,7 @@ class BookmarksAPITests(BookmarkApiEventTestMixin, BookmarksTestsBase):
 
         self.assert_no_events_were_emitted(mock_tracker)
 
-    @patch('openedx.core.djangoapps.bookmarks.api.tracker.emit')
+    @patch('openedx.core.djangoapps.bookmarks.api.tracker.emit', autospec=True)
     @patch('django.conf.settings.MAX_BOOKMARKS_PER_COURSE', 5)
     def bookmark_more_than_limit_raise_error(self, mock_tracker):
         """
@@ -200,7 +200,7 @@ class BookmarksAPITests(BookmarkApiEventTestMixin, BookmarksTestsBase):
         api.create_bookmark(user=self.other_user, usage_key=blocks[-1].location)
         assert len(api.get_bookmarks(user=self.other_user, course_key=blocks[(- 1)].location.course_key)) == 1
 
-    @patch('openedx.core.djangoapps.bookmarks.api.tracker.emit')
+    @patch('openedx.core.djangoapps.bookmarks.api.tracker.emit', autospec=True)
     def test_delete_bookmark(self, mock_tracker):
         """
         Verifies that delete_bookmark removes bookmark as expected.
@@ -224,7 +224,7 @@ class BookmarksAPITests(BookmarkApiEventTestMixin, BookmarksTestsBase):
         assert str(self.sequential_1.location) != bookmarks_data[0]['usage_id']
         assert str(self.sequential_1.location) != bookmarks_data[1]['usage_id']
 
-    @patch('openedx.core.djangoapps.bookmarks.api.tracker.emit')
+    @patch('openedx.core.djangoapps.bookmarks.api.tracker.emit', autospec=True)
     def test_delete_bookmarks_with_vertical_block_type(self, mock_tracker):
         assert len(api.get_bookmarks(user=self.user)) == 5
 
@@ -241,8 +241,8 @@ class BookmarksAPITests(BookmarkApiEventTestMixin, BookmarksTestsBase):
 
         assert len(api.get_bookmarks(self.user)) == 4
 
-    @patch('openedx.core.djangoapps.bookmarks.api.modulestore')
-    @patch('openedx.core.djangoapps.bookmarks.api.tracker.emit')
+    @patch('openedx.core.djangoapps.bookmarks.api.modulestore', autospec=True)
+    @patch('openedx.core.djangoapps.bookmarks.api.tracker.emit', autospec=True)
     def test_delete_bookmarks_with_chapter_block_type(self, mock_tracker, mocked_modulestore):
         mocked_modulestore().get_item().get_children = Mock(
             return_value=[Mock(get_children=Mock(return_value=[Mock(
@@ -263,7 +263,7 @@ class BookmarksAPITests(BookmarkApiEventTestMixin, BookmarksTestsBase):
         )
         assert len(api.get_bookmarks(self.user)) == 4
 
-    @patch('openedx.core.djangoapps.bookmarks.api.tracker.emit')
+    @patch('openedx.core.djangoapps.bookmarks.api.tracker.emit', autospec=True)
     def test_delete_bookmark_raises_error(self, mock_tracker):
         """
         Verifies that delete_bookmark raises error as expected.

--- a/openedx/core/djangoapps/bookmarks/tests/test_views.py
+++ b/openedx/core/djangoapps/bookmarks/tests/test_views.py
@@ -83,7 +83,7 @@ class BookmarksListViewTests(BookmarksViewsTestsBase):
         (25, True),
     )
     @ddt.unpack
-    @patch('eventtracking.tracker.emit')
+    @patch('eventtracking.tracker.emit', autospec=True)
     def test_get_bookmarks_successfully(self, bookmarks_count, check_all_fields, mock_tracker):
         """
         Test that requesting bookmarks for a course returns records successfully in
@@ -127,7 +127,7 @@ class BookmarksListViewTests(BookmarksViewsTestsBase):
     @ddt.data(
         10, 25
     )
-    @patch('eventtracking.tracker.emit')
+    @patch('eventtracking.tracker.emit', autospec=True)
     def test_get_bookmarks_with_pagination(self, bookmarks_count, mock_tracker):
         """
         Test that requesting bookmarks for a course return results with pagination 200 code.
@@ -166,7 +166,7 @@ class BookmarksListViewTests(BookmarksViewsTestsBase):
             page_number=1
         )
 
-    @patch('eventtracking.tracker.emit')
+    @patch('eventtracking.tracker.emit', autospec=True)
     def test_get_bookmarks_with_invalid_data(self, mock_tracker):
         """
         Test that requesting bookmarks with invalid data returns 0 records.
@@ -182,7 +182,7 @@ class BookmarksListViewTests(BookmarksViewsTestsBase):
         assert len(bookmarks_data) == 0
         assert not mock_tracker.emit.called
 
-    @patch('eventtracking.tracker.emit')
+    @patch('eventtracking.tracker.emit', autospec=True)
     def test_get_all_bookmarks_when_course_id_not_given(self, mock_tracker):
         """
         Test that requesting bookmarks returns all records for that user.
@@ -326,7 +326,7 @@ class BookmarksListViewTests(BookmarksViewsTestsBase):
         assert 405 == self.client.put(reverse('bookmarks')).status_code
         assert 405 == self.client.delete(reverse('bookmarks')).status_code
 
-    @patch('eventtracking.tracker.emit')
+    @patch('eventtracking.tracker.emit', autospec=True)
     @ddt.unpack
     @ddt.data(
         {'page_size': -1, 'expected_bookmarks_count': 4, 'expected_page_size': 10, 'expected_page_number': 1},
@@ -350,7 +350,7 @@ class BookmarksListViewTests(BookmarksViewsTestsBase):
             page_number=expected_page_number
         )
 
-    @patch('openedx.core.djangoapps.bookmarks.views.eventtracking.tracker.emit')
+    @patch('openedx.core.djangoapps.bookmarks.views.eventtracking.tracker.emit', autospec=True)
     def test_listed_event_for_page_number(self, mock_tracker):
         """ Test that edx.course.bookmark.listed event values are as expected when we request a specific page number """
         self.send_get(client=self.client, url=reverse('bookmarks'), query_parameters='page_size=2&page=2')

--- a/openedx/core/djangoapps/content/block_structure/management/commands/tests/test_generate_course_blocks.py
+++ b/openedx/core/djangoapps/content/block_structure/management/commands/tests/test_generate_course_blocks.py
@@ -140,7 +140,7 @@ class TestGenerateCourseBlocks(ModuleStoreTestCase):
                     else:
                         assert 'routing_key' not in task_options
 
-    @patch('openedx.core.djangoapps.content.block_structure.management.commands.generate_course_blocks.log')
+    @patch('openedx.core.djangoapps.content.block_structure.management.commands.generate_course_blocks.log', autospec=True)
     def test_not_found_key(self, mock_log):
         self.command.handle(courses=['fake/course/id'])
         assert mock_log.exception.called

--- a/openedx/core/djangoapps/content/block_structure/tests/test_models.py
+++ b/openedx/core/djangoapps/content/block_structure/tests/test_models.py
@@ -79,7 +79,7 @@ class BlockStructureModelTestCase(TestCase):
             assert created == expect_created
         return bsm
 
-    @patch('openedx.core.djangoapps.content.block_structure.models.log')
+    @patch('openedx.core.djangoapps.content.block_structure.models.log', autospec=True)
     @patch.dict(settings.BLOCK_STRUCTURES_SETTINGS, {'PRUNING_ACTIVE': False})
     def test_update_or_create(self, mock_log):
         serialized_data = 'initial data'
@@ -113,8 +113,8 @@ class BlockStructureModelTestCase(TestCase):
         self._assert_file_count_equal(1)
 
     @patch('openedx.core.djangoapps.content.block_structure.config.num_versions_to_keep', Mock(return_value=1))
-    @patch('openedx.core.djangoapps.content.block_structure.models.BlockStructureModel._delete_files')
-    @patch('openedx.core.djangoapps.content.block_structure.models.log')
+    @patch('openedx.core.djangoapps.content.block_structure.models.BlockStructureModel._delete_files', autospec=True)
+    @patch('openedx.core.djangoapps.content.block_structure.models.log', autospec=True)
     def test_prune_exception(self, mock_log, mock_delete):
         mock_delete.side_effect = Exception
         self._verify_update_or_create_call('test data', expect_created=True)
@@ -163,7 +163,7 @@ class BlockStructureModelTestCase(TestCase):
                 else:
                     raise error_raised_in_operation
 
-    @patch('openedx.core.djangoapps.content.block_structure.models.log')
+    @patch('openedx.core.djangoapps.content.block_structure.models.log', autospec=True)
     def test_old_mongo_keys(self, mock_log):
         self.course_key = CourseLocator('org2', 'course2', str(uuid4()), deprecated=True)
         self.usage_key = BlockUsageLocator(course_key=self.course_key, block_type='course', block_id='course')

--- a/openedx/core/djangoapps/content/block_structure/tests/test_signals.py
+++ b/openedx/core/djangoapps/content/block_structure/tests/test_signals.py
@@ -46,7 +46,7 @@ class CourseBlocksSignalTest(ModuleStoreTestCase):
         assert test_display_name == updated_block_structure.get_xblock_field(self.course_usage_key, 'display_name')
 
     @ddt.data(True, False)
-    @patch('openedx.core.djangoapps.content.block_structure.manager.BlockStructureManager.clear')
+    @patch('openedx.core.djangoapps.content.block_structure.manager.BlockStructureManager.clear', autospec=True)
     def test_cache_invalidation(self, invalidate_cache_enabled, mock_bs_manager_clear):
         test_display_name = "Jedi 101"
 
@@ -72,7 +72,7 @@ class CourseBlocksSignalTest(ModuleStoreTestCase):
         (LibraryLocator(org='org', library='course'), False),
     )
     @ddt.unpack
-    @patch('openedx.core.djangoapps.content.block_structure.tasks.update_course_in_cache_v2.apply_async')
+    @patch('openedx.core.djangoapps.content.block_structure.tasks.update_course_in_cache_v2.apply_async', autospec=True)
     def test_update_only_for_courses(self, key, expect_update_called, mock_update):
         update_block_structure_on_course_publish(sender=None, course_key=key)
         assert mock_update.called == expect_update_called

--- a/openedx/core/djangoapps/content/block_structure/tests/test_tasks.py
+++ b/openedx/core/djangoapps/content/block_structure/tests/test_tasks.py
@@ -14,8 +14,8 @@ class UpdateCourseInCacheTaskTest(ModuleStoreTestCase):
     """
     Ensures that the update_course_in_cache task runs as expected.
     """
-    @patch('openedx.core.djangoapps.content.block_structure.tasks.update_course_in_cache_v2.retry')
-    @patch('openedx.core.djangoapps.content.block_structure.api.update_course_in_cache')
+    @patch('openedx.core.djangoapps.content.block_structure.tasks.update_course_in_cache_v2.retry', autospec=True)
+    @patch('openedx.core.djangoapps.content.block_structure.api.update_course_in_cache', autospec=True)
     def test_retry_on_error(self, mock_update, mock_retry):
         """
         Ensures that tasks will be retried if IntegrityErrors are encountered.

--- a/openedx/core/djangoapps/content/course_overviews/management/commands/tests/test_generate_course_overview.py
+++ b/openedx/core/djangoapps/content/course_overviews/management/commands/tests/test_generate_course_overview.py
@@ -86,7 +86,7 @@ class TestGenerateCourseOverview(ModuleStoreTestCase):
         with pytest.raises(CommandError):
             self.command.handle('not/found', all_courses=False)
 
-    @patch('openedx.core.djangoapps.content.course_overviews.models.log')
+    @patch('openedx.core.djangoapps.content.course_overviews.models.log', autospec=True)
     def test_not_found_key(self, mock_log):
         """
         Test keys not found are logged.
@@ -101,7 +101,7 @@ class TestGenerateCourseOverview(ModuleStoreTestCase):
         with pytest.raises(CommandError):
             self.command.handle(all_courses=False)
 
-    @patch('openedx.core.djangoapps.content.course_overviews.tasks.async_course_overview_update')
+    @patch('openedx.core.djangoapps.content.course_overviews.tasks.async_course_overview_update', autospec=True)
     def test_routing_key(self, mock_async_task):
         self.command.handle(all_courses=True, force_update=True, routing_key='my-routing-key', chunk_size=10000)
 

--- a/openedx/core/djangoapps/content/course_overviews/tests/test_signals.py
+++ b/openedx/core/djangoapps/content/course_overviews/tests/test_signals.py
@@ -94,15 +94,15 @@ class CourseOverviewSignalsTestCase(ModuleStoreTestCase):
         self.store.update_item(course, ModuleStoreEnum.UserID.test)
         assert mock_signal.called
 
-    @patch('openedx.core.djangoapps.content.course_overviews.signals.COURSE_START_DATE_CHANGED.send')
+    @patch('openedx.core.djangoapps.content.course_overviews.signals.COURSE_START_DATE_CHANGED.send', autospec=True)
     def test_start_changed(self, mock_signal):
         self.assert_changed_signal_sent([Change('start', self.TODAY, self.NEXT_WEEK)], mock_signal)
 
-    @patch('openedx.core.djangoapps.content.course_overviews.signals.COURSE_PACING_CHANGED.send')
+    @patch('openedx.core.djangoapps.content.course_overviews.signals.COURSE_PACING_CHANGED.send', autospec=True)
     def test_pacing_changed(self, mock_signal):
         self.assert_changed_signal_sent([Change('self_paced', True, False)], mock_signal)
 
-    @patch('openedx.core.djangoapps.content.course_overviews.signals.COURSE_CERT_DATE_CHANGE.send_robust')
+    @patch('openedx.core.djangoapps.content.course_overviews.signals.COURSE_CERT_DATE_CHANGE.send_robust', autospec=True)
     def test_cert_date_changed(self, mock_signal):
         changes = [
             Change("certificate_available_date", self.TODAY, self.NEXT_WEEK),

--- a/openedx/core/djangoapps/content/learning_sequences/api/tests/test_outlines.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/tests/test_outlines.py
@@ -1026,7 +1026,7 @@ class SpecialExamsTestCase(OutlineProcessorTestCase):  # lint-amnesty, pylint: d
             assert key in student_details.outline.sequences
 
     @patch.dict(settings.FEATURES, {'ENABLE_SPECIAL_EXAMS': True})
-    @patch('openedx.core.djangoapps.content.learning_sequences.api.processors.special_exams.get_attempt_status_summary')
+    @patch('openedx.core.djangoapps.content.learning_sequences.api.processors.special_exams.get_attempt_status_summary', autospec=True)
     def test_special_exam_attempt_data_in_details(self, mock_get_attempt_status_summary):
         at_time = datetime(2020, 5, 22, tzinfo=timezone.utc)  # lint-amnesty, pylint: disable=unused-variable
 
@@ -1060,7 +1060,7 @@ class SpecialExamsTestCase(OutlineProcessorTestCase):  # lint-amnesty, pylint: d
             assert attempt_summary["summary"]["usage_key"] == str(sequence_key)
 
     @patch.dict(settings.FEATURES, {'ENABLE_SPECIAL_EXAMS': False})
-    @patch('openedx.core.djangoapps.content.learning_sequences.api.processors.special_exams.get_attempt_status_summary')
+    @patch('openedx.core.djangoapps.content.learning_sequences.api.processors.special_exams.get_attempt_status_summary', autospec=True)
     def test_special_exam_attempt_data_empty_when_disabled(self, mock_get_attempt_status_summary):
         at_time = datetime(2020, 5, 22, tzinfo=timezone.utc)  # lint-amnesty, pylint: disable=unused-variable
 

--- a/openedx/core/djangoapps/contentserver/test/test_contentserver.py
+++ b/openedx/core/djangoapps/contentserver/test/test_contentserver.py
@@ -296,7 +296,7 @@ class ContentStoreToyCourseTest(SharedModuleStoreTestCase):
         assert resp.status_code == 200
         assert 'Origin' == resp['Vary']
 
-    @patch('openedx.core.djangoapps.contentserver.models.CourseAssetCacheTtlConfig.get_cache_ttl')
+    @patch('openedx.core.djangoapps.contentserver.models.CourseAssetCacheTtlConfig.get_cache_ttl', autospec=True)
     def test_cache_headers_with_ttl_unlocked(self, mock_get_cache_ttl):
         """
         Tests that when a cache TTL is set, an unlocked asset will be sent back with
@@ -309,7 +309,7 @@ class ContentStoreToyCourseTest(SharedModuleStoreTestCase):
         assert 'Expires' in resp
         assert 'public, max-age=10, s-maxage=10' == resp['Cache-Control']
 
-    @patch('openedx.core.djangoapps.contentserver.models.CourseAssetCacheTtlConfig.get_cache_ttl')
+    @patch('openedx.core.djangoapps.contentserver.models.CourseAssetCacheTtlConfig.get_cache_ttl', autospec=True)
     def test_cache_headers_with_ttl_locked(self, mock_get_cache_ttl):
         """
         Tests that when a cache TTL is set, a locked asset will be sent back without
@@ -326,7 +326,7 @@ class ContentStoreToyCourseTest(SharedModuleStoreTestCase):
         assert 'Expires' not in resp
         assert 'private, no-cache, no-store' == resp['Cache-Control']
 
-    @patch('openedx.core.djangoapps.contentserver.models.CourseAssetCacheTtlConfig.get_cache_ttl')
+    @patch('openedx.core.djangoapps.contentserver.models.CourseAssetCacheTtlConfig.get_cache_ttl', autospec=True)
     def test_cache_headers_without_ttl_unlocked(self, mock_get_cache_ttl):
         """
         Tests that when a cache TTL is not set, an unlocked asset will be sent back without
@@ -339,7 +339,7 @@ class ContentStoreToyCourseTest(SharedModuleStoreTestCase):
         assert 'Expires' not in resp
         assert 'Cache-Control' not in resp
 
-    @patch('openedx.core.djangoapps.contentserver.models.CourseAssetCacheTtlConfig.get_cache_ttl')
+    @patch('openedx.core.djangoapps.contentserver.models.CourseAssetCacheTtlConfig.get_cache_ttl', autospec=True)
     def test_cache_headers_without_ttl_locked(self, mock_get_cache_ttl):
         """
         Tests that when a cache TTL is not set, a locked asset will be sent back with a
@@ -361,7 +361,7 @@ class ContentStoreToyCourseTest(SharedModuleStoreTestCase):
         near_expire_dt = StaticContentServer.get_expiration_value(start_dt, 55)
         assert 'Thu, 01 Dec 1983 20:00:55 GMT' == near_expire_dt
 
-    @patch('openedx.core.djangoapps.contentserver.models.CdnUserAgentsConfig.get_cdn_user_agents')
+    @patch('openedx.core.djangoapps.contentserver.models.CdnUserAgentsConfig.get_cdn_user_agents', autospec=True)
     def test_cache_is_cdn_with_normal_request(self, mock_get_cdn_user_agents):
         """
         Tests that when a normal request is made -- i.e. from an end user with their
@@ -375,7 +375,7 @@ class ContentStoreToyCourseTest(SharedModuleStoreTestCase):
         is_from_cdn = StaticContentServer.is_cdn_request(browser_request)
         assert is_from_cdn is False
 
-    @patch('openedx.core.djangoapps.contentserver.models.CdnUserAgentsConfig.get_cdn_user_agents')
+    @patch('openedx.core.djangoapps.contentserver.models.CdnUserAgentsConfig.get_cdn_user_agents', autospec=True)
     def test_cache_is_cdn_with_cdn_request(self, mock_get_cdn_user_agents):
         """
         Tests that when a CDN request is made -- i.e. from an edge node back to the
@@ -389,7 +389,7 @@ class ContentStoreToyCourseTest(SharedModuleStoreTestCase):
         is_from_cdn = StaticContentServer.is_cdn_request(browser_request)
         assert is_from_cdn is True
 
-    @patch('openedx.core.djangoapps.contentserver.models.CdnUserAgentsConfig.get_cdn_user_agents')
+    @patch('openedx.core.djangoapps.contentserver.models.CdnUserAgentsConfig.get_cdn_user_agents', autospec=True)
     def test_cache_is_cdn_with_cdn_request_multiple_user_agents(self, mock_get_cdn_user_agents):
         """
         Tests that when a CDN request is made -- i.e. from an edge node back to the

--- a/openedx/core/djangoapps/enrollments/tests/test_views.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_views.py
@@ -1062,7 +1062,7 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
     @httpretty.activate
     @override_settings(ENTERPRISE_SERVICE_WORKER_USERNAME='enterprise_worker',
                        FEATURES=dict(ENABLE_ENTERPRISE_INTEGRATION=True))
-    @patch('openedx.features.enterprise_support.api.enterprise_customer_from_api')
+    @patch('openedx.features.enterprise_support.api.enterprise_customer_from_api', autospec=True)
     def test_enterprise_course_enrollment_with_ec_uuid(self, mock_enterprise_customer_from_api):
         """Verify that the enrollment completes when the EnterpriseCourseEnrollment creation succeeds. """
         UserFactory.create(

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_jwt.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_jwt.py
@@ -75,7 +75,7 @@ class TestCreateJWTs(AccessTokenMixin, TestCase):
         )
         self._assert_jwt_is_valid(jwt_token, should_be_asymmetric_key=client_restricted)
 
-    @patch('openedx.core.djangoapps.oauth_dispatch.jwt.create_role_auth_claim_for_user')
+    @patch('openedx.core.djangoapps.oauth_dispatch.jwt.create_role_auth_claim_for_user', autospec=True)
     @ddt.data(True, False)
     def test_create_jwt_for_user(self, user_email_verified, mock_create_roles):
         mock_create_roles.return_value = ['superuser', 'enterprise-admin']

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_views.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_views.py
@@ -230,7 +230,7 @@ class TestAccessTokenView(AccessTokenLoginMixin, mixins.AccessTokenMixin, _Dispa
         (None, 'no_token_type_supplied'),
     )
     @ddt.unpack
-    @patch('edx_django_utils.monitoring.set_custom_attribute')
+    @patch('edx_django_utils.monitoring.set_custom_attribute', autospec=True)
     def test_access_token_attributes(self, token_type, expected_token_type, mock_set_custom_attribute):
         response = self._post_request(self.user, self.dot_app, token_type=token_type)
         assert response.status_code == 200
@@ -240,7 +240,7 @@ class TestAccessTokenView(AccessTokenLoginMixin, mixins.AccessTokenMixin, _Dispa
         ]
         mock_set_custom_attribute.assert_has_calls(expected_calls, any_order=True)
 
-    @patch('edx_django_utils.monitoring.set_custom_attribute')
+    @patch('edx_django_utils.monitoring.set_custom_attribute', autospec=True)
     def test_access_token_attributes_for_bad_request(self, mock_set_custom_attribute):
         grant_type = dot_models.Application.GRANT_PASSWORD
         invalid_body = {

--- a/openedx/core/djangoapps/password_policy/tests/test_apps.py
+++ b/openedx/core/djangoapps/password_policy/tests/test_apps.py
@@ -23,7 +23,7 @@ class TestApps(TestCase):
         'GENERAL_USER_COMPLIANCE_DEADLINE': '2018-01-01 00:00:00+00:00',
         'STAFF_USER_COMPLIANCE_DEADLINE': 'foo',
     })
-    @patch('openedx.core.djangoapps.password_policy.apps.log')
+    @patch('openedx.core.djangoapps.password_policy.apps.log', autospec=True)
     def test_settings_misconfiguration(self, mock_log):
         """
         Test that we gracefully handle misconfigurations

--- a/openedx/core/djangoapps/password_policy/tests/test_hibp.py
+++ b/openedx/core/djangoapps/password_policy/tests/test_hibp.py
@@ -19,7 +19,7 @@ class PwnedPasswordsAPITest(TestCase):
     Tests pwned password service
     """
     @override_waffle_switch(ENABLE_PWNED_PASSWORD_API, True)
-    @patch('requests.get')
+    @patch('requests.get', autospec=True)
     def test_matched_pwned_passwords(self, mock_get):
         """
         Test that pwned service returns pwned passwords dict

--- a/openedx/core/djangoapps/profile_images/tests/test_views.py
+++ b/openedx/core/djangoapps/profile_images/tests/test_views.py
@@ -342,7 +342,7 @@ class ProfileImageViewPostTestCase(ProfileImageEndpointMixin, APITestCase):
         assert not mock_log.info.called
         self.assert_no_events_were_emitted()
 
-    @patch('PIL.Image.open')
+    @patch('PIL.Image.open', autospec=True)
     def test_upload_failure(self, image_open, mock_log):
         """
         Test that when upload validation fails, the proper HTTP response and
@@ -441,7 +441,7 @@ class ProfileImageViewDeleteTestCase(ProfileImageEndpointMixin, APITestCase):
         )
         self.check_remove_event_emitted()
 
-    @patch('common.djangoapps.student.models.UserProfile.save')
+    @patch('common.djangoapps.student.models.UserProfile.save', autospec=True)
     def test_remove_failure(self, user_profile_save, mock_log):
         """
         Test that when remove validation fails, the proper HTTP response and

--- a/openedx/core/djangoapps/schedules/tests/test_content_highlights.py
+++ b/openedx/core/djangoapps/schedules/tests/test_content_highlights.py
@@ -118,7 +118,7 @@ class TestContentHighlights(ModuleStoreTestCase):  # lint-amnesty, pylint: disab
         with pytest.raises(CourseUpdateDoesNotExist):
             get_week_highlights(self.user, self.course_key, week_num=1)
 
-    @patch('openedx.core.djangoapps.course_date_signals.utils.get_expected_duration')
+    @patch('openedx.core.djangoapps.course_date_signals.utils.get_expected_duration', autospec=True)
     def test_get_next_section_highlights(self, mock_duration):
         # All of the dates chosen here are to make things easy and clean to calculate with date offsets
         # It only goes up to 6 days because we are using two_days_ago as our reference point
@@ -161,7 +161,7 @@ class TestContentHighlights(ModuleStoreTestCase):  # lint-amnesty, pylint: disab
         with pytest.raises(CourseUpdateDoesNotExist):
             get_next_section_highlights(self.user, self.course_key, two_days_ago, six_days.date())
 
-    @patch('lms.djangoapps.courseware.module_render.get_module_for_descriptor')
+    @patch('lms.djangoapps.courseware.module_render.get_module_for_descriptor', autospec=True)
     def test_get_highlights_without_module(self, mock_get_module):
         mock_get_module.return_value = None
 

--- a/openedx/core/djangoapps/schedules/tests/test_signals.py
+++ b/openedx/core/djangoapps/schedules/tests/test_signals.py
@@ -65,8 +65,8 @@ class CreateScheduleTests(SharedModuleStoreTestCase):  # lint-amnesty, pylint: d
     def test_create_schedule_course_updates_experience(self, _mock_highlights):
         self.assert_schedule_created(experience_type=ScheduleExperience.EXPERIENCES.course_updates)
 
-    @patch('openedx.core.djangoapps.schedules.signals.log.exception')
-    @patch('openedx.core.djangoapps.schedules.signals.Schedule.objects.create')
+    @patch('openedx.core.djangoapps.schedules.signals.log.exception', autospec=True)
+    @patch('openedx.core.djangoapps.schedules.signals.Schedule.objects.create', autospec=True)
     def test_create_schedule_error(self, mock_create_schedule, mock_log):
         mock_create_schedule.side_effect = ValueError('Fake error')
         self.assert_schedule_not_created()

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
@@ -245,8 +245,8 @@ class TestAccountApi(UserSettingsEventTestMixin, EmailTemplateTagMixin, CreateAc
         account_settings = get_account_settings(self.default_request)[0]
         assert level_of_education == account_settings['level_of_education']
 
-    @patch('openedx.features.enterprise_support.api.enterprise_customer_for_request')
-    @patch('openedx.features.enterprise_support.utils.third_party_auth.provider.Registry.get')
+    @patch('openedx.features.enterprise_support.api.enterprise_customer_for_request', autospec=True)
+    @patch('openedx.features.enterprise_support.utils.third_party_auth.provider.Registry.get', autospec=True)
     @ddt.data(
         *itertools.product(
             # field_name_value values
@@ -437,7 +437,7 @@ class TestAccountApi(UserSettingsEventTestMixin, EmailTemplateTagMixin, CreateAc
         account_settings = get_account_settings(self.default_request)[0]
         assert account_settings['name'] == 'New Name'
 
-    @patch('django.core.mail.EmailMultiAlternatives.send')
+    @patch('django.core.mail.EmailMultiAlternatives.send', autospec=True)
     @patch('common.djangoapps.student.views.management.render_to_string', Mock(side_effect=mock_render_to_string, autospec=True))  # lint-amnesty, pylint: disable=line-too-long
     def test_update_sending_email_fails(self, send_mail):
         """Test what happens if all validation checks pass, but sending the email for email change fails."""
@@ -489,7 +489,7 @@ class TestAccountApi(UserSettingsEventTestMixin, EmailTemplateTagMixin, CreateAc
         # No error should be thrown, and we need to check that the email update was skipped.
         assert self.user.email == original_email
 
-    @patch('openedx.core.djangoapps.user_api.accounts.serializers.AccountUserSerializer.save')
+    @patch('openedx.core.djangoapps.user_api.accounts.serializers.AccountUserSerializer.save', autospec=True)
     def test_serializer_save_fails(self, serializer_save):
         """
         Test the behavior of one of the serializers failing to save. Note that email request change

--- a/openedx/core/djangoapps/user_api/preferences/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/preferences/tests/test_api.py
@@ -113,7 +113,7 @@ class TestPreferenceAPI(CacheIsolationTestCase):
         set_user_preference(self.user, test_key, "new_value", username=self.user.username)
         assert get_user_preference(self.user, test_key) == 'new_value'
 
-    @patch('openedx.core.djangoapps.user_api.models.UserPreference.save')
+    @patch('openedx.core.djangoapps.user_api.models.UserPreference.save', autospec=True)
     def test_set_user_preference_errors(self, user_preference_save):
         """
         Verifies that set_user_preference returns appropriate errors.
@@ -187,8 +187,8 @@ class TestPreferenceAPI(CacheIsolationTestCase):
         update_user_preferences(self.user, update_data, user=self.user)
         assert get_user_preference(self.user, self.test_preference_key) == 'new_value'
 
-    @patch('openedx.core.djangoapps.user_api.models.UserPreference.delete')
-    @patch('openedx.core.djangoapps.user_api.models.UserPreference.save')
+    @patch('openedx.core.djangoapps.user_api.models.UserPreference.delete', autospec=True)
+    @patch('openedx.core.djangoapps.user_api.models.UserPreference.save', autospec=True)
     def test_update_user_preferences_errors(self, user_preference_save, user_preference_delete):
         """
         Verifies that set_user_preferences returns appropriate errors.
@@ -249,7 +249,7 @@ class TestPreferenceAPI(CacheIsolationTestCase):
         assert delete_user_preference(self.user, self.test_preference_key, username=self.user.username)
         assert not delete_user_preference(self.user, 'no_such_key')
 
-    @patch('openedx.core.djangoapps.user_api.models.UserPreference.delete')
+    @patch('openedx.core.djangoapps.user_api.models.UserPreference.delete', autospec=True)
     def test_delete_user_preference_errors(self, user_preference_delete):
         """
         Verifies that delete_user_preference returns appropriate errors.

--- a/openedx/core/djangoapps/user_api/preferences/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/preferences/tests/test_views.py
@@ -300,7 +300,7 @@ class TestPreferencesAPITransactions(TransactionTestCase):
         self.user = UserFactory.create(password=TEST_PASSWORD)
         self.url = reverse("preferences_api", kwargs={'username': self.user.username})
 
-    @patch('openedx.core.djangoapps.user_api.models.UserPreference.delete')
+    @patch('openedx.core.djangoapps.user_api.models.UserPreference.delete', autospec=True)
     def test_update_preferences_rollback(self, delete_user_preference):
         """
         Verify that updating preferences is transactional when a failure happens.

--- a/openedx/core/djangoapps/user_authn/api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_authn/api/tests/test_views.py
@@ -197,7 +197,7 @@ class SendAccountActivationEmail(UserAPITestCase):
         assert result, 'Could not log in'
         self.path = reverse('send_account_activation_email')
 
-    @patch('common.djangoapps.student.views.management.compose_activation_email')
+    @patch('common.djangoapps.student.views.management.compose_activation_email', autospec=True)
     def test_send_email_to_inactive_user_via_cta_dialog(self, email):
         """
         Tests when user clicks on resend activation email on CTA dialog box, system

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -213,8 +213,8 @@ class LoginTest(SiteMixin, CacheIsolationTestCase, OpenEdxEventsTestMixin):
     @ddt.unpack
     @patch.dict(settings.FEATURES, {'ENABLE_AUTHN_MICROFRONTEND': True, 'ENABLE_ENTERPRISE_INTEGRATION': True})
     @override_settings(LOGIN_REDIRECT_WHITELIST=['openedx.service'])
-    @patch('openedx.features.enterprise_support.api.EnterpriseApiClient')
-    @patch('openedx.core.djangoapps.user_authn.views.login.reverse')
+    @patch('openedx.features.enterprise_support.api.EnterpriseApiClient', autospec=True)
+    @patch('openedx.core.djangoapps.user_authn.views.login.reverse', autospec=True)
     @skip_unless_lms
     def test_login_success_for_multiple_enterprises(
         self, expected_redirect, user_has_multiple_enterprises, reverse_mock, mock_api_client_class
@@ -262,9 +262,9 @@ class LoginTest(SiteMixin, CacheIsolationTestCase, OpenEdxEventsTestMixin):
     @ddt.data(('', True), ('/enterprise/select/active/?success_url=', False))
     @ddt.unpack
     @patch.dict(settings.FEATURES, {'ENABLE_AUTHN_MICROFRONTEND': True, 'ENABLE_ENTERPRISE_INTEGRATION': True})
-    @patch('openedx.features.enterprise_support.api.EnterpriseApiClient')
-    @patch('openedx.core.djangoapps.user_authn.views.login.activate_learner_enterprise')
-    @patch('openedx.core.djangoapps.user_authn.views.login.reverse')
+    @patch('openedx.features.enterprise_support.api.EnterpriseApiClient', autospec=True)
+    @patch('openedx.core.djangoapps.user_authn.views.login.activate_learner_enterprise', autospec=True)
+    @patch('openedx.core.djangoapps.user_authn.views.login.reverse', autospec=True)
     @skip_unless_lms
     def test_enterprise_in_url(
         self, expected_redirect, is_activated, reverse_mock, mock_activate_learner_enterprise, mock_api_client_class
@@ -404,7 +404,7 @@ class LoginTest(SiteMixin, CacheIsolationTestCase, OpenEdxEventsTestMixin):
         self._assert_response(response, success=False, error_code="inactive-user")
         self._assert_audit_log(mock_audit_log, 'warning', ['Login failed', 'Account not active for user'])
 
-    @patch('openedx.core.djangoapps.user_authn.views.login._log_and_raise_inactive_user_auth_error')
+    @patch('openedx.core.djangoapps.user_authn.views.login._log_and_raise_inactive_user_auth_error', autospec=True)
     def test_login_inactivated_user_with_incorrect_credentials(self, mock_inactive_user_email_and_error):
         """
         Tests that when user login with incorrect credentials and an inactive account,
@@ -524,7 +524,7 @@ class LoginTest(SiteMixin, CacheIsolationTestCase, OpenEdxEventsTestMixin):
         response, _audit_log = self._login_response(self.user_email, self.password)
         self._assert_response(response, success=True)
 
-    @patch('openedx.core.djangoapps.util.ratelimit.real_ip')
+    @patch('openedx.core.djangoapps.util.ratelimit.real_ip', autospec=True)
     def test_excessive_login_attempts_by_email(self, real_ip_mock):
         # try logging in 6 times, the defalutlimit for the number of failed
         # login attempts in one 5 minute period before the rate gets limited
@@ -1062,7 +1062,7 @@ class LoginSessionViewTest(ApiTestCase, OpenEdxEventsTestMixin):
                                         'loginIssueSupportLink': 'https://support.example.com/login-issue-help.html'}]
 
     @ddt.data(True, False)
-    @patch('openedx.core.djangoapps.user_authn.views.login.segment')
+    @patch('openedx.core.djangoapps.user_authn.views.login.segment', autospec=True)
     def test_login(self, include_analytics, mock_segment):
         data = {
             "email": self.EMAIL,

--- a/openedx/core/djangoapps/video_pipeline/tests/test_api.py
+++ b/openedx/core/djangoapps/video_pipeline/tests/test_api.py
@@ -54,8 +54,8 @@ class TestAPIUtils(VideoPipelineMixin, TestCase):
             'api_secret': '11111111',
         }
     )
-    @patch('openedx.core.djangoapps.video_pipeline.api.log')
-    @patch('openedx.core.djangoapps.video_pipeline.utils.OAuthAPIClient')
+    @patch('openedx.core.djangoapps.video_pipeline.api.log', autospec=True)
+    @patch('openedx.core.djangoapps.video_pipeline.utils.OAuthAPIClient', autospec=True)
     def test_update_transcription_service_credentials(self, credentials_payload, mock_client, mock_logger):
         """
         Tests that the update transcription service credentials api util works as expected.
@@ -74,8 +74,8 @@ class TestAPIUtils(VideoPipelineMixin, TestCase):
             credentials_payload.get('org'), credentials_payload.get('provider')
         ))
 
-    @patch('openedx.core.djangoapps.video_pipeline.api.log')
-    @patch('openedx.core.djangoapps.video_pipeline.utils.OAuthAPIClient')
+    @patch('openedx.core.djangoapps.video_pipeline.api.log', autospec=True)
+    @patch('openedx.core.djangoapps.video_pipeline.utils.OAuthAPIClient', autospec=True)
     def test_update_transcription_service_credentials_exceptions(self, mock_client, mock_logger):
         """
         Tests that the update transcription service credentials logs the exception occurring

--- a/openedx/core/lib/gating/tests/test_api.py
+++ b/openedx/core/lib/gating/tests/test_api.py
@@ -76,7 +76,7 @@ class TestGatingApi(ModuleStoreTestCase, MilestonesTestCaseMixin):
             'namespace': str(self.seq1.location),
         }
 
-    @patch('openedx.core.lib.gating.api.log.warning')
+    @patch('openedx.core.lib.gating.api.log.warning', autospec=True)
     def test_get_prerequisite_milestone_returns_none(self, mock_log):
         """ Test test_get_prerequisite_milestone_returns_none """
 

--- a/openedx/core/lib/tests/test_course_tabs.py
+++ b/openedx/core/lib/tests/test_course_tabs.py
@@ -11,7 +11,7 @@ from openedx.core.lib.course_tabs import CourseTabPluginManager
 class CourseTabPluginManagerTestCase(TestCase):
     """Test cases for CourseTabPluginManager class"""
 
-    @patch('openedx.core.lib.course_tabs.CourseTabPluginManager.get_available_plugins')
+    @patch('openedx.core.lib.course_tabs.CourseTabPluginManager.get_available_plugins', autospec=True)
     def test_get_tab_types(self, get_available_plugins):
         """
         Verify that get_course_view_types sorts appropriately

--- a/openedx/core/lib/tests/test_request_utils.py
+++ b/openedx/core/lib/tests/test_request_utils.py
@@ -309,7 +309,7 @@ class TestGetExpectedErrorSettingsDict(unittest.TestCase):
         expected_error_settings_dict = _get_expected_error_settings_dict()
         assert expected_error_settings_dict == {}
 
-    @patch('openedx.core.lib.request_utils.log')
+    @patch('openedx.core.lib.request_utils.log', autospec=True)
     @override_settings(EXPECTED_ERRORS=[{}])
     def test_get_with_missing_module_and_class(self, mock_logger):
         expected_error_settings_dict = _get_expected_error_settings_dict()
@@ -321,7 +321,7 @@ class TestGetExpectedErrorSettingsDict(unittest.TestCase):
         )
         assert expected_error_settings_dict == {}
 
-    @patch('openedx.core.lib.request_utils.log')
+    @patch('openedx.core.lib.request_utils.log', autospec=True)
     @override_settings(EXPECTED_ERRORS=[
         {
             'MODULE_AND_CLASS': 'colon.separator.warning:Class',
@@ -338,7 +338,7 @@ class TestGetExpectedErrorSettingsDict(unittest.TestCase):
         )
         assert 'colon.separator.warning.Class' in expected_error_settings_dict
 
-    @patch('openedx.core.lib.request_utils.log')
+    @patch('openedx.core.lib.request_utils.log', autospec=True)
     @override_settings(EXPECTED_ERRORS=[
         {
             'MODULE_AND_CLASS': 'valid.module.DuplicateClass',
@@ -360,7 +360,7 @@ class TestGetExpectedErrorSettingsDict(unittest.TestCase):
         assert 'valid.module.DuplicateClass' in expected_error_settings_dict
         assert expected_error_settings_dict['valid.module.DuplicateClass']['reason_expected'] == 'Because overridden'
 
-    @patch('openedx.core.lib.request_utils.log')
+    @patch('openedx.core.lib.request_utils.log', autospec=True)
     @override_settings(EXPECTED_ERRORS=[{'MODULE_AND_CLASS': 'valid.module.and.class.ButMissingReason'}])
     def test_get_with_missing_reason(self, mock_logger):
         expected_error_settings_dict = _get_expected_error_settings_dict()
@@ -371,7 +371,7 @@ class TestGetExpectedErrorSettingsDict(unittest.TestCase):
         )
         assert expected_error_settings_dict == {}
 
-    @patch('openedx.core.lib.request_utils.log')
+    @patch('openedx.core.lib.request_utils.log', autospec=True)
     @override_settings(EXPECTED_ERRORS=['not-a-dict'])
     def test_get_with_invalid_dict(self, mock_logger):
         expected_error_settings_dict = _get_expected_error_settings_dict()
@@ -424,16 +424,16 @@ class TestExpectedErrorMiddleware(unittest.TestCase):
 
         assert response == expected_response
 
-    @patch('openedx.core.lib.request_utils.set_custom_attribute')
-    @patch('openedx.core.lib.request_utils.log')
+    @patch('openedx.core.lib.request_utils.set_custom_attribute', autospec=True)
+    @patch('openedx.core.lib.request_utils.log', autospec=True)
     def test_process_exception_no_expected_errors(self, mock_logger, mock_set_custom_attribute):
         ExpectedErrorMiddleware('mock-response').process_exception(self.mock_request, self.mock_exception)
 
         mock_logger.info.assert_not_called()
         mock_set_custom_attribute.assert_not_called()
 
-    @patch('openedx.core.lib.request_utils.set_custom_attribute')
-    @patch('openedx.core.lib.request_utils.log')
+    @patch('openedx.core.lib.request_utils.set_custom_attribute', autospec=True)
+    @patch('openedx.core.lib.request_utils.log', autospec=True)
     @ddt.data(None, [])
     def test_process_exception_with_empty_expected_errors(
         self, expected_errors_setting, mock_logger, mock_set_custom_attribute,
@@ -448,8 +448,8 @@ class TestExpectedErrorMiddleware(unittest.TestCase):
         'MODULE_AND_CLASS': 'test.module.TestException',
         'REASON_EXPECTED': 'Because',
     }])
-    @patch('openedx.core.lib.request_utils.set_custom_attribute')
-    @patch('openedx.core.lib.request_utils.log')
+    @patch('openedx.core.lib.request_utils.set_custom_attribute', autospec=True)
+    @patch('openedx.core.lib.request_utils.log', autospec=True)
     def test_process_exception_not_matching_expected_errors(self, mock_logger, mock_set_custom_attribute):
         ExpectedErrorMiddleware('mock-response').process_exception(self.mock_request, self.mock_exception)
 
@@ -466,8 +466,8 @@ class TestExpectedErrorMiddleware(unittest.TestCase):
             'REASON_EXPECTED': 'Because',
         }
     ])
-    @patch('openedx.core.lib.request_utils.set_custom_attribute')
-    @patch('openedx.core.lib.request_utils.log')
+    @patch('openedx.core.lib.request_utils.set_custom_attribute', autospec=True)
+    @patch('openedx.core.lib.request_utils.log', autospec=True)
     def test_process_exception_expected_error_with_defaults(self, mock_logger, mock_set_custom_attribute):
         ExpectedErrorMiddleware('mock-response').process_exception(self.mock_request, self.mock_exception)
 
@@ -492,7 +492,7 @@ class TestExpectedErrorMiddleware(unittest.TestCase):
             'REASON_EXPECTED': 'Because',
         }
     ])
-    @patch('openedx.core.lib.request_utils.set_custom_attribute')
+    @patch('openedx.core.lib.request_utils.set_custom_attribute', autospec=True)
     @ddt.data(True, False)
     def test_process_exception_called_multiple_times(self, use_same_exception, mock_set_custom_attribute):
         mock_first_exception = self.mock_exception
@@ -521,7 +521,7 @@ class TestExpectedErrorMiddleware(unittest.TestCase):
         'MODULE_AND_CLASS': 'Exception',
         'REASON_EXPECTED': 'Because',
     }])
-    @patch('openedx.core.lib.request_utils.set_custom_attribute')
+    @patch('openedx.core.lib.request_utils.set_custom_attribute', autospec=True)
     def test_process_exception_with_plain_exception(self, mock_set_custom_attribute):
         mock_exception = Exception("Oops")
         ExpectedErrorMiddleware('mock-response').process_exception(self.mock_request, mock_exception)
@@ -532,8 +532,8 @@ class TestExpectedErrorMiddleware(unittest.TestCase):
             call('error_ignored_message', 'Oops'),
         ])
 
-    @patch('openedx.core.lib.request_utils.set_custom_attribute')
-    @patch('openedx.core.lib.request_utils.log')
+    @patch('openedx.core.lib.request_utils.set_custom_attribute', autospec=True)
+    @patch('openedx.core.lib.request_utils.log', autospec=True)
     @ddt.data(
         (False, True),  # skip logging
         (True, False),  # log without stacktrace
@@ -590,8 +590,8 @@ class TestExpectedErrorExceptionHandler(unittest.TestCase):
         'LOG_ERROR': True,
         'REASON_EXPECTED': 'Because',
     }])
-    @patch('openedx.core.lib.request_utils.set_custom_attribute')
-    @patch('openedx.core.lib.request_utils.log')
+    @patch('openedx.core.lib.request_utils.set_custom_attribute', autospec=True)
+    @patch('openedx.core.lib.request_utils.log', autospec=True)
     @ddt.data(True, False)
     def test_handler_with_expected_error(
         self, use_valid_context, mock_logger, mock_set_custom_attribute

--- a/openedx/features/enterprise_support/tests/test_signals.py
+++ b/openedx/features/enterprise_support/tests/test_signals.py
@@ -133,7 +133,7 @@ class EnterpriseSupportSignals(SharedModuleStoreTestCase):
 
         return enrollment
 
-    @patch('common.djangoapps.student.models.CourseEnrollment.is_order_voucher_refundable')
+    @patch('common.djangoapps.student.models.CourseEnrollment.is_order_voucher_refundable', autospec=True)
     @ddt.data(
         (True, True, 2, True, False),  # test if skip_refund
         (False, True, 20, True, False),  # test refundable time passed
@@ -159,7 +159,7 @@ class EnterpriseSupportSignals(SharedModuleStoreTestCase):
             enrollment.update_enrollment(is_active=False, skip_refund=skip_refund)
             assert mock_ecommerce_api_client.called == api_called
 
-    @patch('common.djangoapps.student.models.CourseEnrollment.is_order_voucher_refundable')
+    @patch('common.djangoapps.student.models.CourseEnrollment.is_order_voucher_refundable', autospec=True)
     @ddt.data(
         (HttpClientError, 'INFO'),
         (HttpServerError, 'ERROR'),

--- a/pavelib/paver_tests/test_paver_get_quality_reports.py
+++ b/pavelib/paver_tests/test_paver_get_quality_reports.py
@@ -15,7 +15,7 @@ class TestGetReportFiles(unittest.TestCase):
     Ensure only the report files we want are returned as part of run_quality.
     """
 
-    @patch('os.walk')
+    @patch('os.walk', autospec=True)
     def test_get_pylint_reports(self, my_mock):
 
         my_mock.return_value = iter([
@@ -25,7 +25,7 @@ class TestGetReportFiles(unittest.TestCase):
         reports = pavelib.quality.get_violations_reports("pylint")
         assert len(reports) == 2
 
-    @patch('os.walk')
+    @patch('os.walk', autospec=True)
     def test_get_pep8_reports(self, my_mock):
         my_mock.return_value = iter([
             ('/foo', (None,), ('pep8.report',)),
@@ -34,7 +34,7 @@ class TestGetReportFiles(unittest.TestCase):
         reports = pavelib.quality.get_violations_reports("pep8")
         assert len(reports) == 2
 
-    @patch('os.walk')
+    @patch('os.walk', autospec=True)
     def test_get_pep8_reports_noisy(self, my_mock):
         """ Several conditions: different report types, different files, multiple files """
         my_mock.return_value = iter([

--- a/pavelib/paver_tests/test_pii_check.py
+++ b/pavelib/paver_tests/test_pii_check.py
@@ -25,7 +25,7 @@ class TestPaverPIICheck(unittest.TestCase):
         self.addCleanup(shutil.rmtree, self.report_dir)
 
     @patch.object(pavelib.quality.run_pii_check, 'needs')
-    @patch('pavelib.quality.sh')
+    @patch('pavelib.quality.sh', autospec=True)
     def test_pii_check_report_dir_override(self, mock_paver_sh, mock_needs):
         """
         run_pii_check succeeds with proper report dir
@@ -47,7 +47,7 @@ class TestPaverPIICheck(unittest.TestCase):
         assert open(metrics_file).read() == 'Number of PII Annotation violations: 66\n'
 
     @patch.object(pavelib.quality.run_pii_check, 'needs')
-    @patch('pavelib.quality.sh')
+    @patch('pavelib.quality.sh', autospec=True)
     def test_pii_check_failed(self, mock_paver_sh, mock_needs):
         """
         run_pii_check fails due to crossing the threshold.

--- a/pavelib/paver_tests/test_utils.py
+++ b/pavelib/paver_tests/test_utils.py
@@ -18,7 +18,7 @@ class TestUtils(unittest.TestCase):
     Test utils.py under pavelib/utils/test
     """
 
-    @patch('subprocess.check_output')
+    @patch('subprocess.check_output', autospec=True)
     def test_firefox_version_ok(self, _mock_subprocesss):
         test_version = MINIMUM_FIREFOX_VERSION
         _mock_subprocesss.return_value = "Mozilla Firefox {version}".format(
@@ -27,7 +27,7 @@ class TestUtils(unittest.TestCase):
         # No exception should be raised
         check_firefox_version()
 
-    @patch('subprocess.check_output')
+    @patch('subprocess.check_output', autospec=True)
     def test_firefox_version_below_expected(self, _mock_subprocesss):
         test_version = MINIMUM_FIREFOX_VERSION - 1
         _mock_subprocesss.return_value = "Mozilla Firefox {version}".format(
@@ -36,13 +36,13 @@ class TestUtils(unittest.TestCase):
         with pytest.raises(Exception):
             check_firefox_version()
 
-    @patch('subprocess.check_output')
+    @patch('subprocess.check_output', autospec=True)
     def test_firefox_version_not_detected(self, _mock_subprocesss):
         _mock_subprocesss.return_value = "Mozilla Firefox"
         with pytest.raises(Exception):
             check_firefox_version()
 
-    @patch('subprocess.check_output')
+    @patch('subprocess.check_output', autospec=True)
     def test_firefox_version_bad(self, _mock_subprocesss):
         _mock_subprocesss.return_value = "garbage"
         with pytest.raises(Exception):


### PR DESCRIPTION
I used this command to generate the diff:

```
ack '@patch\(' -l . | grep '/test_.*\.py$' | grep -v venv | while IFS= read -r fpath; do sed -i "s/^\(\s*@patch('[^']\+'\))$/\1, autospec=True)/" -- "$fpath"; done
```

- Only test files
- Only single-line @patch decorators that were by themselves on a line
- Only decorators with a single string argument using single-quotes (no
  other arguments, such as mock objects, return values, etc.)