### PR TITLE
fix: add event tracking for viewing thread for discussions api

### DIFF
--- a/lms/djangoapps/discussion/django_comment_client/base/views.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/views.py
@@ -170,10 +170,10 @@ def track_thread_viewed_event(request, course, thread):
     """
     event_name = _EVENT_NAME_TEMPLATE.format(obj_type='thread', action_name='viewed')
     event_data = {}
-    event_data['commentable_id'] = thread.commentable_id
+    event_data['commentable_id'] = thread.get('commentable_id', '')
     if hasattr(thread, 'username'):
-        event_data['target_username'] = thread.username
-    add_truncated_title_to_event_data(event_data, thread.title)
+        event_data['target_username'] = thread.get('username', '')
+    add_truncated_title_to_event_data(event_data, thread.get('title', ''))
     track_forum_event(request, event_name, course, thread, event_data)
 
 

--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -76,6 +76,7 @@ from .utils import discussion_open_for_user
 from ..django_comment_client.base.views import (
     track_comment_created_event,
     track_thread_created_event,
+    track_thread_viewed_event,
     track_voted_event,
 )
 from ..django_comment_client.utils import (
@@ -892,6 +893,7 @@ def get_comment_list(request, thread_id, endorsed, page, page_size, flagged=Fals
     results = _serialize_discussion_entities(request, context, responses, requested_fields, DiscussionEntity.comment)
 
     paginator = DiscussionAPIPagination(request, page, num_pages, resp_total)
+    track_thread_viewed_event(request, context["course"], cc_thread)
     return paginator.get_paginated_response(results)
 
 


### PR DESCRIPTION
### [TNL-9625](https://openedx.atlassian.net/browse/TNL-9625)

### Description
Add tracking of thread view event for discussions (rest API).

We have one event that is not being currently tracked `edx.forum.thread.viewed`.
This PR will address the tracking of this event.