### PR TITLE
fix: post summary taking more than one lines

### DIFF
--- a/lms/djangoapps/discussion/rest_api/serializers.py
+++ b/lms/djangoapps/discussion/rest_api/serializers.py
@@ -345,7 +345,7 @@ class ThreadSerializer(_ContentSerializer):
         Returns a cleaned and truncated version of the thread's body to display in a
         preview capacity.
         """
-        return Truncator(strip_tags(self.get_rendered_body(obj))).words(10, )
+        return Truncator(strip_tags(self.get_rendered_body(obj))).chars(35, ).replace('\n', ' ')
 
     def create(self, validated_data):
         thread = Thread(user_id=self.context["cc_requester"]["id"], **validated_data)

--- a/lms/djangoapps/discussion/rest_api/tests/test_views.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views.py
@@ -1226,7 +1226,7 @@ class ThreadViewSetCreateTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         assert response_data == self.expected_thread_data({
             "read": True,
             "raw_body": "# Test \n This is a very long body that will be truncated for the preview.",
-            "preview_body": "Test This is a very long body that will be…",
+            "preview_body": "Test This is a very long body that…",
             "rendered_body": "<h1>Test</h1>\n<p>This is a very long body that will be truncated for the preview.</p>",
         })
         assert httpretty.last_request().parsed_body == {  # lint-amnesty, pylint: disable=no-member


### PR DESCRIPTION
Post summary was taking more than one lines. 

https://openedx.atlassian.net/browse/TNL-9619

![tnl-9619](https://user-images.githubusercontent.com/77053848/155955798-90dc21db-ffca-4a24-b24b-a34e2b2447c8.png)

