### PR TITLE
feat: mark Old Mongo courses as invitation-only

### DIFF
--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -253,4 +253,5 @@ def streak_celebration_is_active(course_key):
 
 def course_is_invitation_only(courselike) -> bool:
     """Returns whether the course is invitation only or not."""
-    return COURSES_INVITE_ONLY.is_enabled() or courselike.invitation_only
+    # We also mark Old Mongo courses (deprecated keys) as invitation only to cut off enrollment
+    return COURSES_INVITE_ONLY.is_enabled() or courselike.invitation_only or courselike.id.deprecated


### PR DESCRIPTION
This is in service of dropping support for these ancient courses and removing legacy code that they rely on.

Eventually, we'll remove all access. But this is a first step, to reduce enrolled learners.

DEPR-58