### PR TITLE
Remove django-countries pin

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -108,7 +108,3 @@ scipy<1.8.0
 # This will be fixed when sphinxcontrib-openapi depends on m2r2 instead of m2r
 # See issue: https://github.com/sphinx-contrib/openapi/issues/123
 mistune<2.0.0
-
-# django-countries==7.3 breaks with Python 3.8.
-# Fix is in-progress in PR https://github.com/SmileyChris/django-countries/pull/367
-django-countries<7.3

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -250,9 +250,8 @@ django-config-models==2.3.0
     #   lti-consumer-xblock
 django-cors-headers==3.11.0
     # via -r requirements/edx/base.in
-django-countries==7.2.1
+django-countries==7.3.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   edx-enterprise
 django-crum==0.7.9
@@ -1008,6 +1007,8 @@ text-unidecode==1.3
     # via python-slugify
 tqdm==4.63.0
     # via nltk
+typing-extensions==4.1.1
+    # via django-countries
 unicodecsv==0.14.1
     # via
     #   -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -332,9 +332,8 @@ django-config-models==2.3.0
     #   lti-consumer-xblock
 django-cors-headers==3.11.0
     # via -r requirements/edx/testing.txt
-django-countries==7.2.1
+django-countries==7.3.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
 django-crum==0.7.9
@@ -1464,6 +1463,7 @@ typing-extensions==4.1.1
     # via
     #   -r requirements/edx/testing.txt
     #   astroid
+    #   django-countries
     #   mypy
     #   pydantic
     #   pylint

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -320,9 +320,8 @@ django-config-models==2.3.0
     #   lti-consumer-xblock
 django-cors-headers==3.11.0
     # via -r requirements/edx/base.txt
-django-countries==7.2.1
+django-countries==7.3.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-enterprise
 django-crum==0.7.9
@@ -1350,7 +1349,9 @@ transifex-client==0.14.4
     # via -r requirements/edx/testing.in
 typing-extensions==4.1.1
     # via
+    #   -r requirements/edx/base.txt
     #   astroid
+    #   django-countries
     #   pydantic
     #   pylint
 unicodecsv==0.14.1


### PR DESCRIPTION
## Description 
`django-countries==7.3.1` fixed the issue with `Python<3.9` so the constraint can now be removed.