### PR TITLE
[BD-38] fix: [TNL-9585][BB-5558] fix page load to the correct thread

### DIFF
--- a/lms/djangoapps/discussion/templates/discussion/discussion_mfe_embed.html
+++ b/lms/djangoapps/discussion/templates/discussion/discussion_mfe_embed.html
@@ -7,7 +7,26 @@
 <%!
 import json
 from django.utils.translation import ugettext as _
+from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string
+from cms.djangoapps.contentstore import utils
+
 %>
+<script>
+    const domain = (new URL("${discussions_mfe_url  | n, js_escaped_string}"));
+    window.addEventListener("message", (event) => {
+        if ((event.origin !== domain.origin) || (event.data.type !== "discussions.path.change"))
+            return;
+        const {postId ,topicId} = event.data.payload;
+        let url = "${mfe_url  | n, js_escaped_string}".split('discussion/forum/')[0].concat("discussion/forum/");
+        if (topicId) {
+            url += topicId;
+            if (postId){
+                url = url.concat("/threads/",postId);
+            }
+        }
+        window.history.pushState(null, null, url);
+    }, false);
+</script>
 
 <section class="discussion discussion-board page-content-container" id="discussion-container"
          data-course-id="${course_key}" >

--- a/openedx/core/djangoapps/discussions/url_helpers.py
+++ b/openedx/core/djangoapps/discussions/url_helpers.py
@@ -20,37 +20,35 @@ def _get_url_with_view_query_params(path: str, view: Optional[str] = None) -> st
 
     """
     if settings.DISCUSSIONS_MICROFRONTEND_URL is None:
-        return ''
+        return ""
     url = f"{settings.DISCUSSIONS_MICROFRONTEND_URL}/{path}"
     if view == "in_context":
         url = f"{url}?inContext"
     return url
 
 
-def get_discussions_mfe_url(course_key: CourseKey, view: Optional[str] = None) -> str:
-    """
-    Returns the url for discussions for the specified course in the discussions MFE.
-
-    Args:
-        course_key (CourseKey): course key of course for which to get url
-        view (str): which view to generate url for
-
-    Returns:
-        (str) URL link for MFE. Empty if the base url isn't configured
-    """
-    return _get_url_with_view_query_params(f"{course_key}/", view)
-
-
-def get_discussions_mfe_topic_url(course_key: CourseKey, topic_id: str, view: Optional[str] = None) -> str:
+def get_discussions_mfe_topic_url(
+    course_key: CourseKey,
+    topic_id: Optional[str] = None,
+    thread_id: Optional[str] = None,
+    view: Optional[str] = None,
+) -> str:
     """
     Returns the url for discussions for the specified course and topic in the discussions MFE.
 
     Args:
         course_key (CourseKey): course key of course for which to get url
         topic_id (str): topic id for topic to get url for
+        thread_id (str): thread id for topic to get url for
         view (str): which view to generate url for
 
     Returns:
         (str) URL link for MFE. Empty if the base url isn't configured
     """
-    return _get_url_with_view_query_params(f"{course_key}/topics/{topic_id}", view)
+    if thread_id and topic_id:
+        return _get_url_with_view_query_params(
+            f"{course_key}/topics/{topic_id}/posts/{thread_id}", view
+        )
+    elif topic_id:
+        return _get_url_with_view_query_params(f"{course_key}/topics/{topic_id}", view)
+    return _get_url_with_view_query_params(f"{course_key}/", view)


### PR DESCRIPTION
**Description**
Fix page loading to open the correct post/thread.

**Supporting information**

https://tasks.opencraft.com/browse/BB-5558
https://openedx.atlassian.net/browse/TNL-9585
**Testing instructions**

- Open the course discussion page.
- Open any post.
- Open any thread of that post.
- Refresh the page.
- You should have your post and threat open.

Check this recording
https://www.loom.com/share/83c80b183a2a438eb6ba467e7dc11e55
Requires https://github.com/openedx/frontend-app-discussions/pull/78