### PR TITLE
[MST-1362] Add REST endpoint to confirm name changes

### DIFF
--- a/common/djangoapps/student/models_api.py
+++ b/common/djangoapps/student/models_api.py
@@ -111,11 +111,11 @@ def get_course_access_role(user, org, course_id, role):
 
 def get_pending_name_change(user):
     """
-    Return a string representing the user's pending name change, or None if it does not exist.
+    Return the user's pending name change, or None if it does not exist.
     """
     try:
         pending_name_change = _PendingNameChange.objects.get(user=user)
-        return pending_name_change.new_name
+        return pending_name_change
     except _PendingNameChange.DoesNotExist:
         return None
 

--- a/lms/djangoapps/verify_student/signals.py
+++ b/lms/djangoapps/verify_student/signals.py
@@ -53,7 +53,11 @@ def send_idv_update(sender, instance, **kwargs):  # pylint: disable=unused-argum
     import the SoftwareSecurePhotoVerification model.
     """
     # Prioritize pending name change over current profile name, if the user has one
-    full_name = get_pending_name_change(instance.user) or get_name(instance.user.id)
+    pending_name_change = get_pending_name_change(instance.user)
+    if pending_name_change:
+        full_name = pending_name_change.new_name
+    else:
+        full_name = get_name(instance.user.id)
 
     log.info(
         'IDV sending name_affirmation task (idv_id={idv_id}, user_id={user_id}) to update status={status}'.format(

--- a/openedx/core/djangoapps/user_api/urls.py
+++ b/openedx/core/djangoapps/user_api/urls.py
@@ -41,6 +41,14 @@ ACCOUNT_DETAIL = AccountViewSet.as_view({
     'patch': 'partial_update',
 })
 
+REQUEST_NAME_CHANGE = NameChangeView.as_view({
+    'post': 'create'
+})
+
+CONFIRM_NAME_CHANGE = NameChangeView.as_view({
+    'post': 'confirm'
+})
+
 PARTNER_REPORT = AccountRetirementPartnerReportView.as_view({
     'post': 'retirement_partner_report',
     'put': 'retirement_partner_status_create'
@@ -120,8 +128,13 @@ urlpatterns = [
     ),
     url(
         r'^v1/accounts/name_change/$',
-        NameChangeView.as_view(),
-        name='name_change'
+        REQUEST_NAME_CHANGE,
+        name='request_name_change'
+    ),
+    url(
+        fr'^v1/accounts/name_change/{settings.USERNAME_PATTERN}/confirm/$',
+        CONFIRM_NAME_CHANGE,
+        name='confirm_name_change'
     ),
     url(
         fr'^v1/accounts/{settings.USERNAME_PATTERN}/verification_status/$',


### PR DESCRIPTION
<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Add POST endpoint to `NameChangeView` to allow staff users to confirm name change requests.

## Supporting information

https://openedx.atlassian.net/browse/MST-1362