### PR TITLE
[BD-32] feat: add filter before dashboard rendering process starts 

### DIFF
--- a/common/djangoapps/student/tests/test_filters.py
+++ b/common/djangoapps/student/tests/test_filters.py
@@ -1,10 +1,11 @@
 """
 Test that various filters are fired for models/views in the student app.
 """
+from django.http import HttpResponse
 from django.test import override_settings
 from django.urls import reverse
 from openedx_filters import PipelineStep
-from openedx_filters.learning.filters import CourseEnrollmentStarted, CourseUnenrollmentStarted
+from openedx_filters.learning.filters import DashboardRenderStarted, CourseEnrollmentStarted, CourseUnenrollmentStarted
 from rest_framework import status
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
@@ -41,6 +42,72 @@ class TestUnenrollmentPipelineStep(PipelineStep):
         enrollment.user.profile.set_meta({"unenrolled_from": str(enrollment.course_id)})
         enrollment.user.profile.save()
         return {}
+
+
+class TestDashboardRenderPipelineStep(PipelineStep):
+    """
+    Utility class used when getting steps for pipeline.
+    """
+
+    def run_filter(self, context, template_name):  # pylint: disable=arguments-differ
+        """Pipeline step that modifies dashboard data."""
+        context["course_enrollments"] = []
+        return {
+            "context": context,
+            "template_name": template_name,
+        }
+
+
+class TestRenderInvalidDashboard(PipelineStep):
+    """
+    Utility class used when getting steps for pipeline.
+    """
+
+    def run_filter(self, context, template_name):  # pylint: disable=arguments-differ
+        """Pipeline step that stops the dashboard render process."""
+        raise DashboardRenderStarted.RenderInvalidDashboard(
+            "You can't render this sites dashboard.",
+            dashboard_template="static_templates/server-error.html"
+        )
+
+
+class TestRedirectDashboardPageStep(PipelineStep):
+    """
+    Utility class used when getting steps for pipeline.
+    """
+
+    def run_filter(self, context, template_name):  # pylint: disable=arguments-differ
+        """Pipeline step that redirects before the dashboard is rendered."""
+        raise DashboardRenderStarted.RedirectToPage(
+            "You can't see this site's dashboard, redirecting to the correct location.",
+            redirect_to="https://custom-dashboard.com",
+        )
+
+
+class TestRedirectToAccSettingsPage(PipelineStep):
+    """
+    Utility class used when getting steps for pipeline.
+    """
+
+    def run_filter(self, context, template_name):  # pylint: disable=arguments-differ
+        """Pipeline step that redirects to account settings before the dashboard is rendered."""
+        raise DashboardRenderStarted.RedirectToPage(
+            "You can't see this site's dashboard, redirecting to the correct location.",
+        )
+
+
+class TestRenderCustomResponse(PipelineStep):
+    """
+    Utility class used when getting steps for pipeline.
+    """
+
+    def run_filter(self, context, template_name):  # pylint: disable=arguments-differ
+        """Pipeline step that changes dashboard view response before the dashboard is rendered."""
+        response = HttpResponse("This is a custom response.")
+        raise DashboardRenderStarted.RenderCustomResponse(
+            "You can't see this site's dashboard.",
+            response=response,
+        )
 
 
 @skip_unless_lms
@@ -235,3 +302,164 @@ class UnenrollmentFiltersTest(ModuleStoreTestCase):
 
         self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
         self.assertEqual("You can't un-enroll from this site.", response.content.decode("utf-8"))
+
+
+@skip_unless_lms
+class StudentDashboardFiltersTest(ModuleStoreTestCase):
+    """
+    Tests for the Open edX Filters associated with the dashboard rendering process.
+
+    This class guarantees that the following filters are triggered during the students dashboard rendering:
+    - DashboardRenderStarted
+    """
+
+    def setUp(self):  # pylint: disable=arguments-differ
+        super().setUp()
+        self.user = UserFactory()
+        self.client.login(username=self.user.username, password="test")
+        self.dashboard_url = reverse("dashboard")
+        self.first_course = CourseFactory.create(
+            org="test1", course="course1", display_name="run1",
+        )
+        self.second_course = CourseFactory.create(
+            org="test2", course="course2", display_name="run1",
+        )
+
+    @override_settings(
+        OPEN_EDX_FILTERS_CONFIG={
+            "org.openedx.learning.dashboard.render.started.v1": {
+                "pipeline": [
+                    "common.djangoapps.student.tests.test_filters.TestDashboardRenderPipelineStep",
+                ],
+                "fail_silently": False,
+            },
+        },
+    )
+    def test_dashboard_render_filter_executed(self):
+        """
+        Test whether the student dashboard filter is triggered before the user's
+        dashboard rendering process.
+
+        Expected result:
+            - DashboardRenderStarted is triggered and executes TestDashboardRenderPipelineStep.
+            - The dashboard is rendered using the filtered enrollments list.
+        """
+        CourseEnrollment.enroll(self.user, self.first_course.id)
+        CourseEnrollment.enroll(self.user, self.second_course.id)
+
+        response = self.client.get(self.dashboard_url)
+
+        self.assertNotContains(response, self.first_course.id)
+        self.assertNotContains(response, self.second_course.id)
+
+    @override_settings(
+        OPEN_EDX_FILTERS_CONFIG={
+            "org.openedx.learning.dashboard.render.started.v1": {
+                "pipeline": [
+                    "common.djangoapps.student.tests.test_filters.TestRenderInvalidDashboard",
+                ],
+                "fail_silently": False,
+            },
+        },
+        PLATFORM_NAME="My site",
+    )
+    def test_dashboard_render_invalid(self):
+        """
+        Test rendering an invalid template after catching PreventDashboardRender exception.
+
+        Expected result:
+            - DashboardRenderStarted is triggered and executes TestRenderInvalidDashboard.
+            - The server error template is rendered instead of the usual dashboard.
+        """
+        response = self.client.get(self.dashboard_url)
+
+        self.assertContains(response, "There has been a 500 error on the <em>My site</em> servers")
+
+    @override_settings(
+        OPEN_EDX_FILTERS_CONFIG={
+            "org.openedx.learning.dashboard.render.started.v1": {
+                "pipeline": [
+                    "common.djangoapps.student.tests.test_filters.TestRedirectDashboardPageStep",
+                ],
+                "fail_silently": False,
+            },
+        },
+    )
+    def test_dashboard_redirect(self):
+        """
+        Test redirecting to a new page after catching RedirectDashboardPage exception.
+
+        Expected result:
+            - DashboardRenderStarted is triggered and executes TestRedirectDashboardPageStep.
+            - The view response is a redirection.
+            - The redirection url is the custom dashboard specified in the filter.
+        """
+        response = self.client.get(self.dashboard_url)
+
+        self.assertEqual(status.HTTP_302_FOUND, response.status_code)
+        self.assertEqual("https://custom-dashboard.com", response.url)
+
+    @override_settings(
+        OPEN_EDX_FILTERS_CONFIG={
+            "org.openedx.learning.dashboard.render.started.v1": {
+                "pipeline": [
+                    "common.djangoapps.student.tests.test_filters.TestRedirectToAccSettingsPage",
+                ],
+                "fail_silently": False,
+            },
+        },
+    )
+    def test_dashboard_redirect_account_settings(self):
+        """
+        Test redirecting to the account settings page after catching RedirectDashboardPage exception.
+
+        Expected result:
+            - DashboardRenderStarted is triggered and executes TestRedirectToAccSettingsPage.
+            - The view response is a redirection.
+            - The redirection url is the account settings (as the default when not specifying one).
+        """
+        response = self.client.get(self.dashboard_url)
+
+        self.assertEqual(status.HTTP_302_FOUND, response.status_code)
+        self.assertEqual(reverse("account_settings"), response.url)
+
+    @override_settings(
+        OPEN_EDX_FILTERS_CONFIG={
+            "org.openedx.learning.dashboard.render.started.v1": {
+                "pipeline": [
+                    "common.djangoapps.student.tests.test_filters.TestRenderCustomResponse",
+                ],
+                "fail_silently": False,
+            },
+        },
+    )
+    def test_dashboard_custom_response(self):
+        """
+        Test returning a custom response after catching RenderCustomResponse exception.
+
+        Expected result:
+            - DashboardRenderStarted is triggered and executes TestRenderCustomResponse.
+            - The view response contains the custom response text.
+        """
+        response = self.client.get(self.dashboard_url)
+
+        self.assertEqual("This is a custom response.", response.content.decode("utf-8"))
+
+    @override_settings(OPEN_EDX_FILTERS_CONFIG={})
+    def test_dashboard_render_without_filter_config(self):
+        """
+        Test whether the student dashboard filter is triggered before the user's
+        dashboard rendering process without any modification in the app flow.
+
+        Expected result:
+            - DashboardRenderStarted executes a noop (empty pipeline).
+            - The view response is HTTP_200_OK.
+            - There's no modification in the dashboard.
+        """
+        CourseEnrollment.enroll(self.user, self.first_course.id)
+        CourseEnrollment.enroll(self.user, self.second_course.id)
+
+        response = self.client.get(self.dashboard_url)
+
+        self.assertContains(response, self.first_course.id)
+        self.assertContains(response, self.second_course.id)

--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -10,6 +10,7 @@ from collections import defaultdict
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
+from django.http import HttpResponseRedirect
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.translation import gettext as _
@@ -18,6 +19,7 @@ from edx_django_utils import monitoring as monitoring_utils
 from edx_django_utils.plugins import get_plugins_view_context
 from edx_toggles.toggles import WaffleFlag
 from opaque_keys.edx.keys import CourseKey
+from openedx_filters.learning.filters import DashboardRenderStarted
 from pytz import UTC
 
 from lms.djangoapps.bulk_email.api import is_bulk_email_feature_enabled
@@ -853,7 +855,22 @@ def student_dashboard(request):  # lint-amnesty, pylint: disable=too-many-statem
         'resume_button_urls': resume_button_urls
     })
 
-    response = render_to_response('dashboard.html', context)
+    dashboard_template = 'dashboard.html'
+    try:
+        # .. filter_implemented_name: DashboardRenderStarted
+        # .. filter_type: org.openedx.learning.dashboard.render.started.v1
+        context, dashboard_template = DashboardRenderStarted.run_filter(
+            context=context, template_name=dashboard_template,
+        )
+    except DashboardRenderStarted.RenderInvalidDashboard as exc:
+        response = render_to_response(exc.dashboard_template, exc.template_context)
+    except DashboardRenderStarted.RedirectToPage as exc:
+        response = HttpResponseRedirect(exc.redirect_to or reverse('account_settings'))
+    except DashboardRenderStarted.RenderCustomResponse as exc:
+        response = exc.response
+    else:
+        response = render_to_response(dashboard_template, context)
+
     if show_account_activation_popup:
         response.delete_cookie(
             settings.SHOW_ACTIVATE_CTA_POPUP_COOKIE_NAME,


### PR DESCRIPTION
## Description

As part of the Hooks Extension Framework implementation plan, this PR adds a filter before the dashboard rendering process starts. 

## Supporting information

- [Hooks Extension Framework OEP-50](https://open-edx-proposals.readthedocs.io/en/latest/oep-0050-hooks-extension-framework.html)
ADR(s) on:
- [Open edX Filters naming and versioning](https://github.com/eduNEXT/openedx-filters/blob/main/docs/decisions/0004-filters-naming-and-versioning.rst): about how to identify filters and manage its versions
- [Open edX Filters configuration](https://github.com/eduNEXT/openedx-filters/blob/main/docs/decisions/0002-hooks-filter-config-location.rst): how to configure filters
- [Open edX Filters tooling](https://github.com/eduNEXT/openedx-filters/blob/main/docs/decisions/0003-hooks-filter-tooling-pipeline.rst): what to use to run filters
- [Open edX Filters payload](https://github.com/eduNEXT/openedx-filters/blob/main/docs/decisions/0005-filters-payload.rst): input arguments for filters

## Testing instructions

1. Install openedx-filters library:
```
pip install openedx-filters==0.6.0
```
2. Implement your pipeline steps in your favorite plugin. We created some as illustration in [openedx-filters-samples](https://github.com/eduNEXT/openedx-filters-samples). We'll be using those in this example.
3. Install openedx-filters-samples
```
pip install -e git+https://github.com/eduNEXT/openedx-filters-samples.git@master#egg=openedx_filters_samples
``` 
4. Configure your filters:
With this configuration, you won't be able to:
- Render the dashboard. Instead, an error will be raised or a different dashboard template will be rendered (if you define its path [here](https://github.com/eduNEXT/openedx-filters-samples/blob/master/openedx_filters_samples/samples/pipeline.py#L459))
```
OPEN_EDX_FILTERS_CONFIG = {
     "org.openedx.learning.dashboard.render.started.v1": {
            "fail_silently": False,
            "pipeline": [
                "openedx_filters_samples.samples.pipeline.RenderAlternativeDashboard",
            ]
    },
}
```
- And with this one, you'll be able to filter course enrollments from the dashboard.

```
OPEN_EDX_FILTERS_CONFIG = {
     "org.openedx.learning.dashboard.render.started.v1": {
            "fail_silently": False,
            "pipeline": [
                "openedx_filters_samples.samples.pipeline.FilterEnrollmentDashboard",
            ]
    },
}
```
- If you want to redirect to your custom dashboard, then:

```
OPEN_EDX_FILTERS_CONFIG = {
     "org.openedx.learning.dashboard.render.started.v1": {
            "fail_silently": False,
            "pipeline": [
                "openedx_filters_samples.samples.pipeline.RedirectFromDashboard",
            ]
    },
}
```

- If you want to return a custom response, then:

```
OPEN_EDX_FILTERS_CONFIG = {
     "org.openedx.learning.dashboard.render.started.v1": {
            "fail_silently": False,
            "pipeline": [
                "openedx_filters_samples.samples.pipeline.RenderCustomDashboardResponse",
            ]
    },
}
```
