### PR TITLE
revert: reverts 53041a2 after reports of bulk email message issues

### DIFF
--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -13,7 +13,6 @@ import string
 import random
 import re
 
-import bleach
 import edx_api_doc_tools as apidocs
 from django.conf import settings
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
@@ -2735,16 +2734,11 @@ def send_email(request, course_id):
     # any transaction that has been pending up to this point will also be
     # committed.
     try:
-        # sanitize the email content before storing in the database
-        sanitized_subject = bleach.clean(subject, tags=settings.BULK_COURSE_EMAIL_ALLOWED_HTML_TAGS)
-        sanitized_message = bleach.clean(message, tags=settings.BULK_COURSE_EMAIL_ALLOWED_HTML_TAGS)
-
         email = CourseEmail.create(
             course_id,
             request.user,
             targets,
-            sanitized_subject,
-            sanitized_message,
+            subject, message,
             template_name=template_name,
             from_addr=from_addr
         )

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -4964,12 +4964,3 @@ CUSTOM_PAGES_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-a
 # The expected value is an Integer representing the cutoff point (in months) for inclusion to the message. Example:
 # a value of `3` would include learners who have logged in within the past 3 months.
 BULK_COURSE_EMAIL_LAST_LOGIN_ELIGIBILITY_PERIOD = None
-# HTML tags allowed within the body of a message authored via the Bulk Course Email Tool
-BULK_COURSE_EMAIL_ALLOWED_HTML_TAGS = [
-    "a", "abbr", "address", "area", "article", "aside", "audio", "b", "bdi", "bdo", "blockquote", "br", "caption",
-    "cite", "code", "col", "colgroup", "data", "dd", "del", "dfn", "div", "dl", "dt", "em", "embed", "figcaption",
-    "figure", "footer", "h1", "h2", "h3", "h4", "h5", "h6", "header", "hr", "i", "img", "ins", "kbd", "li", "link",
-    "main", "map", "mark", "meta", "menu", "nav", "object", "ol", "p", "param", "picture", "pre", "q", "rp", "rt",
-    "ruby", "s", "samp", "section", "small", "source", "span", "strong", "style", "sub", "sup", "table", "tbody", "td",
-    "tfoot", "th", "thead", "time", "tr", "track", "u", "ul", "var", "video", "wbr",
-]


### PR DESCRIPTION
## Description

[MICROBA-1666]

This reverts commit 53041a2d34906eafaeff7452dc37f733ad2b2395 after course team started reporting issues of images in emails not respecting dimensions set with the email editor.

After a brief investigation we found attributes (like `width` and `height` of an image) being stripped unexpectedly from the HTML.