### PR TITLE
feat: remove check for password reset API if request is comming from support tools

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/password_reset.py
+++ b/openedx/core/djangoapps/user_authn/views/password_reset.py
@@ -601,14 +601,15 @@ def password_change_request_handler(request):
 
     """
     user = request.user
-    if (user.is_staff or user.is_superuser) and request.POST.get('email_from_support_tools'):
+    request_from_support_tools = (user.is_staff or user.is_superuser) and request.POST.get('email_from_support_tools')
+    if request_from_support_tools:
         email = request.POST.get('email_from_support_tools')
     else:
         # Prefer logged-in user's email
         email = user.email if user.is_authenticated else request.POST.get('email')
     AUDIT_LOG.info("Password reset initiated for email %s.", email)
 
-    if getattr(request, 'limited', False):
+    if getattr(request, 'limited', False) and not request_from_support_tools:
         AUDIT_LOG.warning("Password reset rate limit exceeded for email %s.", email)
         return HttpResponse(
             _("Your previous request is in progress, please try again in a few moments."),

--- a/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
@@ -34,7 +34,7 @@ from openedx.core.djangoapps.user_api.tests.test_views import UserAPITestCase
 from openedx.core.djangoapps.user_api.accounts import EMAIL_MAX_LENGTH, EMAIL_MIN_LENGTH
 from openedx.core.djangoapps.user_authn.views.password_reset import (
     SETTING_CHANGE_INITIATED, password_reset, LogistrationPasswordResetView,
-    PasswordResetConfirmWrapper)
+    PasswordResetConfirmWrapper, password_change_request_handler)
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
 from common.djangoapps.student.tests.factories import TEST_PASSWORD, UserFactory
 from common.djangoapps.student.tests.test_configuration_overrides import fake_get_value
@@ -177,6 +177,55 @@ class ResetPasswordTests(EventTestMixin, CacheIsolationTestCase):
         # then the rate limiter should kick in and give a HttpForbidden response
         bad_resp = password_reset(password_reset_req)
         assert bad_resp.status_code == 403
+
+        cache.clear()
+
+    @patch("openedx.core.djangoapps.user_authn.views.password_reset.request_password_change", Mock(return_value=None))
+    def test_password_change_non_staff_user(self):
+        """
+        Test that password reset endpoint does not allow more than 1 call for non staff users.
+        """
+        cache.clear()
+        password_reset_req = self.request_factory.post(
+            '/account/password/',
+            {'email': self.user.email, 'email_from_support_tools': self.user.email},
+        )
+
+        password_reset_req.user = self.user
+        password_reset_req.is_secure = Mock(return_value=True)
+        good_resp = password_change_request_handler(password_reset_req)
+        assert good_resp.status_code == 200
+
+        bad_resp = password_change_request_handler(password_reset_req)
+        assert bad_resp.status_code == 403
+        assert bad_resp.content == b'Your previous request is in progress, please try again in a few moments.'
+
+        cache.clear()
+
+    @patch("openedx.core.djangoapps.user_authn.views.password_reset.request_password_change", Mock(return_value=None))
+    def test_password_change_staff_user(self):
+        """
+        Test that password reset endpoint allow multiple requests for staff users.
+        """
+        cache.clear()
+        password_reset_req = self.request_factory.post(
+            '/account/password/',
+            {'email': self.user.email, 'email_from_support_tools': self.user.email},
+        )
+        self.user.is_staff = True
+        password_reset_req.user = self.user
+        password_reset_req.is_secure = Mock(return_value=True)
+        good_resp = password_change_request_handler(password_reset_req)
+        assert good_resp.status_code == 200
+
+        good_resp = password_change_request_handler(password_reset_req)
+        assert good_resp.status_code == 200
+
+        good_resp = password_change_request_handler(password_reset_req)
+        assert good_resp.status_code == 200
+
+        good_resp = password_change_request_handler(password_reset_req)
+        assert good_resp.status_code == 200
 
         cache.clear()
 


### PR DESCRIPTION
<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

-->

## Description
This PR will add a functionality through which staff user or super users don't have any rate limit for password reset. Support staff can send multiple password reset requests

## Context
Support staff can reset password for any user but previously we have a rate limit that reset password API call can not be called more than 2 per hour which was causing hindrance for support team. So we need to remove that limit for support users, so they can call multiple reset password requests for multiple users. 

## Technical implementation
Ratelimit decorator add an additional attribute `limited` if rate limit is exceeding from the mentioned limit. And we can customize response by checking this attributes value. So before this we were returning 403 response for all users if rate limit is exceeding. But now we are checking if user is staff user then we don't have to return 403 response

## Supporting information

[remove rate limit from password reset endpoint for staff users](https://openedx.atlassian.net/browse/PROD-2599)

## Testing instructions

- Login in support tools as staff user
- Hit multiple password reset requests for multiple users
- It will not throw any error of exceeding rate limit

