### PR TITLE
fix: Use legacy view for legacy URLs [BD-38] [TNL-9651]

### DIFF
--- a/lms/djangoapps/discussion/tests/test_views.py
+++ b/lms/djangoapps/discussion/tests/test_views.py
@@ -1468,6 +1468,11 @@ class UserProfileTestCase(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCase)
     def test_html(self, mock_request):
         self.check_html(mock_request)
 
+    @override_settings(DISCUSSIONS_MICROFRONTEND_URL="http://test.url")
+    @override_waffle_flag(ENABLE_DISCUSSIONS_MFE, True)
+    def test_html_with_mfe_enabled(self, mock_request):
+        self.check_html(mock_request)
+
     def test_ajax(self, mock_request):
         self.check_ajax(mock_request)
 


### PR DESCRIPTION
## Description

If a user navigates to a legacy URL, then use the legacy view for discussions. This fixes an issue where navigating to a user profile page in the legacy view will take you back to the MFE if the MFE is enabled. 

## Supporting information
- https://openedx.atlassian.net/browse/TNL-9651
 
## Testing instructions

With the new MFE enabled, click on the legacy experience link to force loading the legacy view. After that, click on a user profile link, or a post and the legacy UI should remain. Try reloading, the legacy UI will continue to display. 

## Deadline

ASAP