### PR TITLE
fix: post preview body shows html tags in legacy discussion

### DIFF
--- a/common/static/common/js/discussion/views/discussion_thread_list_view.js
+++ b/common/static/common/js/discussion/views/discussion_thread_list_view.js
@@ -359,7 +359,11 @@
                         },
                         thread.toJSON()
                     );
-                return $(this.threadListItemTemplate(context).toString());
+                let $threadHTML = $(this.threadListItemTemplate(context).toString());
+                let previewBody = $threadHTML.find('.thread-preview-body').text();
+                $threadHTML.find('.thread-preview-body').html(previewBody);
+                $threadHTML.find('.thread-preview-body').css({'line-height': '16px', 'max-height': '32px'});
+                return $threadHTML;
             };
 
             DiscussionThreadListView.prototype.threadSelected = function(e) {

--- a/common/static/common/js/discussion/views/discussion_thread_list_view.js
+++ b/common/static/common/js/discussion/views/discussion_thread_list_view.js
@@ -360,7 +360,7 @@
                         thread.toJSON()
                     );
                 let $threadHTML = $(this.threadListItemTemplate(context).toString());
-                let previewBody = $threadHTML.find('.thread-preview-body')[0].textContent;
+                let previewBody = $threadHTML.find('.thread-preview-body').text();
                 previewBody = new DOMParser().parseFromString(previewBody, "text/html").documentElement.textContent;
                 $threadHTML.find('.thread-preview-body').text(previewBody);
                 return $threadHTML;

--- a/common/static/common/js/discussion/views/discussion_thread_list_view.js
+++ b/common/static/common/js/discussion/views/discussion_thread_list_view.js
@@ -360,9 +360,9 @@
                         thread.toJSON()
                     );
                 let $threadHTML = $(this.threadListItemTemplate(context).toString());
-                let previewBody = $threadHTML.find('.thread-preview-body').text();
-                $threadHTML.find('.thread-preview-body').html(previewBody);
-                $threadHTML.find('.thread-preview-body').css({'line-height': '16px', 'max-height': '32px'});
+                let previewBody = $threadHTML.find('.thread-preview-body')[0].textContent;
+                previewBody = new DOMParser().parseFromString(previewBody, "text/html").documentElement.textContent;
+                $threadHTML.find('.thread-preview-body').text(previewBody);
                 return $threadHTML;
             };
 


### PR DESCRIPTION
## Ticket: [TNL-9645](https://openedx.atlassian.net/browse/TNL-9645)

Post preview body, in the legacy discussion, was showing HTML tags.
Before fix:
<img width="282" alt="Screenshot 2022-03-03 at 4 40 13 PM" src="https://user-images.githubusercontent.com/51022010/156558806-27ac2016-ad51-428b-acc2-1b955058e6f3.png">

After fix:
<img width="278" alt="Screenshot 2022-03-03 at 4 41 04 PM" src="https://user-images.githubusercontent.com/51022010/156558864-79ca480d-cbdc-4d07-bcaf-4bff1694c9dd.png">
