### PR TITLE
chore: update edx-name-affirmation version

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -449,7 +449,7 @@ edx-i18n-tools==0.9.1
     # via ora2
 edx-milestones==0.4.0
     # via -r requirements/edx/base.in
-edx-name-affirmation==2.3.0
+edx-name-affirmation==2.3.1
     # via -r requirements/edx/base.in
 edx-opaque-keys[django]==2.3.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -554,7 +554,7 @@ edx-lint==5.2.1
     # via -r requirements/edx/testing.txt
 edx-milestones==0.4.0
     # via -r requirements/edx/testing.txt
-edx-name-affirmation==2.3.0
+edx-name-affirmation==2.3.1
     # via -r requirements/edx/testing.txt
 edx-opaque-keys[django]==2.3.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -539,7 +539,7 @@ edx-lint==5.2.1
     # via -r requirements/edx/testing.in
 edx-milestones==0.4.0
     # via -r requirements/edx/base.txt
-edx-name-affirmation==2.3.0
+edx-name-affirmation==2.3.1
     # via -r requirements/edx/base.txt
 edx-opaque-keys[django]==2.3.0
     # via


### PR DESCRIPTION
The latest version contains an update to delete VerifiedNames if the associated proctored or IDV attempt are also deleted.
