### PR TITLE
fix: capa numerical response with scientic notation

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/problem/edit_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/problem/edit_spec.js
@@ -145,6 +145,9 @@ Enter the numerical value of Pi:
 Enter the approximate value of 502*9:
 = 502*9 +- 15%
 
+Enter the approximate number of atoms in a mol:
+= 6.022e23 +- 10%
+
 Enter the number of fingers on a human hand:
 = 5
 
@@ -178,6 +181,10 @@ If you look at your hand, you can count that you have five fingers.
   <p>Enter the approximate value of 502*9:</p>
   <numericalresponse answer="502*9">
     <responseparam type="tolerance" default="15%" />
+    <formulaequationinput />
+  <p>Enter the approximate number of atoms in a mol</p>
+  <numericalresponse answer="6.022e23">
+    <responseparam type="tolerance" default="10%" />
     <formulaequationinput />
   </numericalresponse>
   <p>Enter the number of fingers on a human hand:</p>

--- a/common/lib/xmodule/xmodule/js/spec/problem/edit_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/problem/edit_spec.js
@@ -182,7 +182,8 @@ If you look at your hand, you can count that you have five fingers.
   <numericalresponse answer="502*9">
     <responseparam type="tolerance" default="15%" />
     <formulaequationinput />
-  <p>Enter the approximate number of atoms in a mol</p>
+  </numericalresponse>
+  <p>Enter the approximate number of atoms in a mol:</p>
   <numericalresponse answer="6.022e23">
     <responseparam type="tolerance" default="10%" />
     <formulaequationinput />

--- a/common/lib/xmodule/xmodule/js/src/problem/edit.js
+++ b/common/lib/xmodule/xmodule/js/src/problem/edit.js
@@ -564,7 +564,7 @@
                                 stringValue = stringValue.replace(/{{[\s\S]*?}}/g, '').trim();
                             }
                             // allow for "e" for scientific notation and "i" for complex numbers, otherwise, exclude letters
-                            if (stringValue.match(/[a-df-hj-z]/i)) {
+                            if (stringValue.match(/[a-df-z]/i)) {
                                 return false;
                             }
                             return !isNaN(parseFloat(stringValue));

--- a/common/lib/xmodule/xmodule/js/src/problem/edit.js
+++ b/common/lib/xmodule/xmodule/js/src/problem/edit.js
@@ -563,6 +563,7 @@
                             if ((stringValue.indexOf('{{') !== -1) && (stringValue.indexOf('}}') !== -1)) {
                                 stringValue = stringValue.replace(/{{[\s\S]*?}}/g, '').trim();
                             }
+                            // allow for "e" for scientific notation and "i" for complex numbers, otherwise, exclude letters
                             if (stringValue.match(/[a-df-hj-z]/i)) {
                                 return false;
                             }

--- a/common/lib/xmodule/xmodule/js/src/problem/edit.js
+++ b/common/lib/xmodule/xmodule/js/src/problem/edit.js
@@ -563,7 +563,7 @@
                             if ((stringValue.indexOf('{{') !== -1) && (stringValue.indexOf('}}') !== -1)) {
                                 stringValue = stringValue.replace(/{{[\s\S]*?}}/g, '').trim();
                             }
-                            // allow for "e" for scientific notation and "i" for complex numbers, otherwise, exclude letters
+                            // allow for "e" for scientific notation, otherwise, exclude letters
                             if (stringValue.match(/[a-df-z]/i)) {
                                 return false;
                             }

--- a/common/lib/xmodule/xmodule/js/src/problem/edit.js
+++ b/common/lib/xmodule/xmodule/js/src/problem/edit.js
@@ -563,7 +563,7 @@
                             if ((stringValue.indexOf('{{') !== -1) && (stringValue.indexOf('}}') !== -1)) {
                                 stringValue = stringValue.replace(/{{[\s\S]*?}}/g, '').trim();
                             }
-                            if (stringValue.match(/[a-z]/i)) {
+                            if (stringValue.match(/[a-df-hj-z]/i)) {
                                 return false;
                             }
                             return !isNaN(parseFloat(stringValue));


### PR DESCRIPTION
<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

I found a potential location for a solution to the [numericalinput bug](https://openedx.atlassian.net/browse/TNL-9547). The problem stemmed from. In the convert markdown -> xml process, here, the checkIsNumeric  function rejects the input if stringValue.match(/[a-z]/i) which says: does this value contain any letters, regardless of case? This rejection would cause uses of e and i in answers like the described problem to be string input problems. A simple fix would be to replace that match with regex like '/[a-df-hj-z]/i'.

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.
-checkout branch
-remake static assets in lms/cms
-Create a capa problem using the following markdown:
`

> If we measure the energy of this oscillator, what is the probability of finding the oscillator in its lowest energy state?
> = 6.76e-4 +- 1
> 
> [explanation]
> The expansion coefficients for the coherent state are given by \(c_{Nn}=\sqrt{\frac{N^n \exp(-N)}{n!}}\), where \(n\) is the number of the state (in this case, \(n=0\)).  Therefore the probability of finding the oscillator in the ground state is given by \(|c_{N0}|^2=\frac{7.3^0 \exp(-7.3)}{0!}=0.000676\).
> [explanation]

`
Ensure that 6.76e-4 is a correct answer, and that exporting to xml using the "advanced editor" tab in the editor inserts the following xml
```xml
<responseparam type="tolerance" default="1"/>
<formulaequationinput/><solution>
```
## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
 Desired behavior is described here: https://support.edx.org/hc/en-us/articles/360000038208-Scientific-notation-and-metric-affixes