### PR TITLE
revert: remove ADR on bulk email HTML sanitization

### DIFF
--- a/lms/djangoapps/bulk_email/docs/decisions/001-bulk-email-content-sanitization.rst
+++ b/lms/djangoapps/bulk_email/docs/decisions/001-bulk-email-content-sanitization.rst
@@ -23,9 +23,8 @@ We will not sanitize the HTML content received through the bulk course email too
 Rejected solutions
 ------------------
 
+Bleach with allowlist ****************************
 
-Bleach with allowlist
-Santization using blocklists is vulnerable to obfuscation attacks, and the industry standard is to use an allowlist and explicitly enumerate all supported values. Given that this tool has been live for many years with no sanitization in place, a highly restrictive allowlist would be difficult to roll out to users, resulting in broken email templates and angry instructors who are used to having free rein. A permissive allowlist would potentially address this, but presents the non-trivial problem of assembling and maintaining a comprehensive list.
+It has been standard practice for us to use Bleach with an allowlist to sanitize user provided content within the Open edX ecosystem. Santization using blocklists is vulnerable to obfuscation attacks, and the industry standard is to use an allowlist and explicitly enumerate all supported values. Given that this tool has been live for many years with no sanitization in place, a highly restrictive allowlist would be difficult to roll out to users, resulting in broken email templates and angry instructors who are used to having free rein. A permissive allowlist would potentially address this, but presents the non-trivial problem of assembling and maintaining a comprehensive list.
 
-
-TODO - add link to bleach
+_bleach: https://bleach.readthedocs.io/en/latest/

--- a/lms/djangoapps/bulk_email/docs/decisions/001-bulk-email-content-sanitization.rst
+++ b/lms/djangoapps/bulk_email/docs/decisions/001-bulk-email-content-sanitization.rst
@@ -1,6 +1,6 @@
-====================================
-Bulk Email HTML Content Sanitization
-====================================
+=============================================
+Bulk Email HTML Content Will Not Be Sanitized
+=============================================
 
 Status
 ------
@@ -17,16 +17,15 @@ It is considered good security practice to scan and sanitize user-provided conte
 Decision
 --------
 
-We will sanitize the HTML content received through the bulk course email tool before sending the messages to any recipients.
+We will not sanitize the HTML content received through the bulk course email tool on the back end. The content that instructors create for courses also allows unfiltered html, which is arguably a larger risk than email, which will block the execution of certain types of code. In the future, if a standard is set for filtering course content, the same standard could be applied here.
 
-We will use the `bleach`_ Python package to sanitize the data.
 
-We will introduce a new configuration setting called ``BULK_COURSE_EMAIL_ALLOWED_HTML_TAGS`` that acts as an *allowlist* of HTML tags permitted for use within the body of a message authored by the bulk course email tool. A default list of options is provided in the ``lms/envs/common.py`` `configuration file`_. Offending data will be escaped (converted to plaintext) over being stripped out.
+Rejected solutions
+------------------
 
-Consequences
-------------
 
-A message sent through the Bulk Course Email tool that includes any restricted HTML content will not appear as intended to the recipients of the message. The restricted HTML content will be converted to plaintext and will not render.
+Bleach with allowlist
+Santization using blocklists is vulnerable to obfuscation attacks, and the industry standard is to use an allowlist and explicitly enumerate all supported values. Given that this tool has been live for many years with no sanitization in place, a highly restrictive allowlist would be difficult to roll out to users, resulting in broken email templates and angry instructors who are used to having free rein. A permissive allowlist would potentially address this, but presents the non-trivial problem of assembling and maintaining a comprehensive list.
 
-.. _bleach: https://bleach.readthedocs.io/en/latest/
-.. _configuration file: https://github.com/openedx/edx-platform/blob/e608db847c39c2e3d723ef81f7dac66f63663a28/lms/envs/common.py#L4965
+
+TODO - add link to bleach


### PR DESCRIPTION
## Description

[MICROBA-1666]

This reverts commit 884e8af0f2aaeb42e20d0ac4e4610f4f1b69a3f0. After implementing the `BULK_COURSE_EMAIL_ALLOWED_HTML_TAGS` allowlist and using Bleach to clean the bulk course email content, we had reports of HTML attributes being stripped from the messages. This broke a number of things like image sizing and text styling within the course messages.
