### PR TITLE
feat: check for retired users from email

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -5241,3 +5241,6 @@ MFE_CONFIG_API_CACHE_TIMEOUT = 60 * 5
 
 ######################## Settings for Outcome Surveys plugin ########################
 OUTCOME_SURVEYS_EVENTS_ENABLED = True
+
+######################## Settings for cancel retirement in Support Tools ########################
+COOL_OFF_DAYS = 14

--- a/openedx/core/djangoapps/user_api/accounts/forms.py
+++ b/openedx/core/djangoapps/user_api/accounts/forms.py
@@ -6,7 +6,7 @@ Django forms for accounts
 from django import forms
 from django.core.exceptions import ValidationError
 
-from edx_django_utils.user import generate_password
+from openedx.core.djangoapps.user_api.accounts.utils import handle_retirement_cancellation
 
 
 class RetirementQueueDeletionForm(forms.Form):
@@ -34,12 +34,4 @@ class RetirementQueueDeletionForm(forms.Form):
             )
             raise ValidationError('Retirement is in the wrong state!')
 
-        # Load the user record using the retired email address -and- change the email address back.
-        retirement.user.email = retirement.original_email
-        # Reset users password so they can request a password reset and log in again.
-        retirement.user.set_password(generate_password(length=25))
-        retirement.user.save()
-
-        # Delete the user retirement status record.
-        # No need to delete the accompanying "permanent" retirement request record - it gets done via Django signal.
-        retirement.delete()
+        handle_retirement_cancellation(retirement)

--- a/openedx/core/djangoapps/user_api/accounts/permissions.py
+++ b/openedx/core/djangoapps/user_api/accounts/permissions.py
@@ -16,6 +16,18 @@ class CanDeactivateUser(permissions.BasePermission):
         return request.user.has_perm('student.can_deactivate_users')
 
 
+class CanCancelUserRetirement(permissions.BasePermission):
+    """
+    Grants access to cancel retirement if the requesting user is a superuser,
+    or has the explicit permission to cancel retirement of a User account.
+    """
+
+    def has_permission(self, request, view):
+        return request.user.is_superuser or (
+            request.user.is_staff and request.user.has_perm('user_api.change_userretirementstatus')
+        )
+
+
 class CanRetireUser(permissions.BasePermission):
     """
     Grants access to the various retirement API endpoints if the requesting user is

--- a/openedx/core/djangoapps/user_api/accounts/tests/factories.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/factories.py
@@ -1,0 +1,29 @@
+"""
+Model Factories for testing purposes of User Accounts
+"""
+from factory import SubFactory
+from factory.django import DjangoModelFactory
+from openedx.core.djangoapps.user_api.models import UserRetirementStatus, RetirementState
+from common.djangoapps.student.tests.factories import UserFactory
+
+
+class RetirementStateFactory(DjangoModelFactory):
+    """
+    Simple factory class for storing retirement state.
+    """
+
+    class Meta:
+        model = RetirementState
+
+
+class UserRetirementStatusFactory(DjangoModelFactory):
+    """
+    Simple factory class for storing user retirement status.
+    """
+
+    class Meta:
+        model = UserRetirementStatus
+
+    user = SubFactory(UserFactory)
+    current_state = SubFactory(RetirementStateFactory)
+    last_state = SubFactory(RetirementStateFactory)

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_permissions.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_permissions.py
@@ -5,8 +5,18 @@ Tests for User deactivation API permissions
 
 from django.test import RequestFactory, TestCase
 
-from openedx.core.djangoapps.user_api.accounts.permissions import CanDeactivateUser, CanRetireUser
-from common.djangoapps.student.tests.factories import ContentTypeFactory, PermissionFactory, SuperuserFactory, UserFactory  # lint-amnesty, pylint: disable=line-too-long
+from common.djangoapps.student.tests.factories import (  # lint-amnesty, pylint: disable=line-too-long
+    AdminFactory,
+    ContentTypeFactory,
+    PermissionFactory,
+    SuperuserFactory,
+    UserFactory
+)
+from openedx.core.djangoapps.user_api.accounts.permissions import (
+    CanCancelUserRetirement,
+    CanDeactivateUser,
+    CanRetireUser
+)
 
 
 class CanDeactivateUserTest(TestCase):
@@ -67,3 +77,36 @@ class CanRetireUserTest(TestCase):
         self.request.user = UserFactory()
         result = CanRetireUser().has_permission(self.request, None)
         assert not result
+
+
+class CanCancelUserRetirementTest(TestCase):
+    """ Tests for cancel user retirement API permissions """
+
+    def setUp(self):
+        super().setUp()
+        self.request = RequestFactory().get('/test/url')
+
+    def test_permission_superuser(self):
+        self.request.user = SuperuserFactory()
+
+        can_cancel_retirement = CanCancelUserRetirement().has_permission(self.request, None)
+        assert can_cancel_retirement is True
+
+    def test_permission_user_granted_permission(self):
+        user = AdminFactory()
+        permission = PermissionFactory(
+            codename='change_userretirementstatus',
+            content_type=ContentTypeFactory(
+                app_label='user_api'
+            )
+        )
+        user.user_permissions.add(permission)
+        self.request.user = user
+
+        can_cancel_retirement = CanCancelUserRetirement().has_permission(self.request, None)
+        assert can_cancel_retirement is True
+
+    def test_api_permission_user_without_permission(self):
+        self.request.user = UserFactory()
+        can_cancel_retirement = CanCancelUserRetirement().has_permission(self.request, None)
+        assert can_cancel_retirement is False

--- a/openedx/core/djangoapps/user_api/management/commands/cancel_user_retirement_request.py
+++ b/openedx/core/djangoapps/user_api/management/commands/cancel_user_retirement_request.py
@@ -9,9 +9,8 @@ import logging
 
 from django.core.management.base import BaseCommand, CommandError
 
+from openedx.core.djangoapps.user_api.accounts.utils import handle_retirement_cancellation
 from openedx.core.djangoapps.user_api.models import UserRetirementStatus
-
-from edx_django_utils.user import generate_password  # lint-amnesty, pylint: disable=wrong-import-order
 
 LOGGER = logging.getLogger(__name__)
 
@@ -50,13 +49,6 @@ class Command(BaseCommand):
                 )
             )
 
-        # Load the user record using the retired email address -and- change the email address back.
-        retirement_status.user.email = email_address
-        retirement_status.user.set_password(generate_password(length=25))
-        retirement_status.user.save()
-
-        # Delete the user retirement status record.
-        # No need to delete the accompanying "permanent" retirement request record - it gets done via Django signal.
-        retirement_status.delete()
+        handle_retirement_cancellation(retirement_status, email_address)
 
         print(f"Successfully cancelled retirement request for user with email address '{email_address}'.")

--- a/openedx/core/djangoapps/user_api/urls.py
+++ b/openedx/core/djangoapps/user_api/urls.py
@@ -17,7 +17,7 @@ from .accounts.views import (
     DeactivateLogoutView,
     LMSAccountRetirementView,
     NameChangeView,
-    UsernameReplacementView
+    UsernameReplacementView, CancelAccountRetirementStatusView
 )
 from . import views as user_api_views
 from .models import UserPreference
@@ -60,6 +60,10 @@ PARTNER_REPORT = AccountRetirementPartnerReportView.as_view({
 
 PARTNER_REPORT_CLEANUP = AccountRetirementPartnerReportView.as_view({
     'post': 'retirement_partner_cleanup'
+})
+
+CANCEL_RETIREMENT = CancelAccountRetirementStatusView.as_view({
+    'post': 'cancel_retirement'
 })
 
 RETIREMENT_QUEUE = AccountRetirementStatusView.as_view({
@@ -157,6 +161,9 @@ urlpatterns = [
          ),
     path('v1/accounts/retirement_partner_report_cleanup/', PARTNER_REPORT_CLEANUP,
          name='accounts_retirement_partner_report_cleanup'
+         ),
+    path('v1/accounts/cancel_retirement/', CANCEL_RETIREMENT,
+         name='cancel_account_retirement'
          ),
     path('v1/accounts/retirement_queue/', RETIREMENT_QUEUE,
          name='accounts_retirement_queue'


### PR DESCRIPTION
[PROD-2521](https://2u-internal.atlassian.net/browse/PROD-2521)
Adds a new endpoint to cancel a retirement of a user account that is under 14 days cooloff period. Also changes an existing user api endpoint through email which now gives information on if the email is retired and can we even cancel the retirement.