### PR TITLE
Revert "fix: post preview body shows html tags in legacy discussion"

### DIFF
--- a/common/static/common/js/discussion/views/discussion_thread_list_view.js
+++ b/common/static/common/js/discussion/views/discussion_thread_list_view.js
@@ -359,11 +359,7 @@
                         },
                         thread.toJSON()
                     );
-                let $threadHTML = $(this.threadListItemTemplate(context).toString());
-                let previewBody = $threadHTML.find('.thread-preview-body').text();
-                previewBody = new DOMParser().parseFromString(previewBody, "text/html").documentElement.textContent;
-                $threadHTML.find('.thread-preview-body').text(previewBody);
-                return $threadHTML;
+                return $(this.threadListItemTemplate(context).toString());
             };
 
             DiscussionThreadListView.prototype.threadSelected = function(e) {


### PR DESCRIPTION
Reverts openedx/edx-platform#30007

This was failing the GoCD build with:
```
pipeline.exceptions.CompressorError: b'Parse error at -:3052,20\nSyntaxError: Unexpected token: name ($threadHTML)\nError\n    at new JS_Parse_Error (eval at <anonymous> (/edx/app/edxapp/edx-platform/node_modules/uglify-js/tools/node.js:28:1), <anonymous>:1543:18)\n    at js_error (eval at <anonymous> (/edx/app/edxapp/edx-platform/node_modules/uglify-js/tools/node.js:28:1), <anonymous>:1551:11)\n    at croak (eval at <anonymous> (/edx/app/edxapp/edx-platform/node_modules/uglify-js/tools/node.js:28:1), <anonymous>:2087:9)\n    at token_error (eval at <anonymous> (/edx/app/edxapp/edx-platform/node_modules/uglify-js/tools/node.js:28:1), <anonymous>:2095:9)\n    at unexpected (eval at <anonymous> (/edx/app/edxapp/edx-platform/node_modules/uglify-js/tools/node.js:28:1), <anonymous>:2101:9)\n    at semicolon (eval at <anonymous> (/edx/app/edxapp/edx-platform/node_modules/uglify-js/tools/node.js:28:1), <anonymous>:2121:56)\n    at simple_statement (eval at <anonymous> (/edx/app/edxapp/edx-platform/node_modules/uglify-js/tools/node.js:28:1), <anonymous>:2312:73)\n    at eval (eval at <anonymous> (/edx/app/edxapp/edx-platform/node_modules/uglify-js/tools/node.js:28:1), <anonymous>:2181:19)\n    at eval (eval at <anonymous> (/edx/app/edxapp/edx-platform/node_modules/uglify-js/tools/node.js:28:1), <anonymous>:2134:24)\n    at block_ (eval at <anonymous> (/edx/app/edxapp/edx-platform/node_modules/uglify-js/tools/node.js:28:1), <anonymous>:2427:20)\n'
```