### PR TITLE
fix: post preview body shows html tags in legacy discussion (updated)

### DIFF
--- a/common/static/common/js/discussion/views/discussion_thread_list_view.js
+++ b/common/static/common/js/discussion/views/discussion_thread_list_view.js
@@ -359,8 +359,8 @@
                         },
                         thread.toJSON()
                     );
-                let $threadHTML = $(this.threadListItemTemplate(context).toString());
-                let previewBody = $threadHTML.find('.thread-preview-body').text();
+                var $threadHTML = $(this.threadListItemTemplate(context).toString());
+                var previewBody = $threadHTML.find('.thread-preview-body').text();
                 previewBody = new DOMParser().parseFromString(previewBody, "text/html").documentElement.textContent;
                 $threadHTML.find('.thread-preview-body').text(previewBody);
                 return $threadHTML;

--- a/common/static/common/js/discussion/views/discussion_thread_list_view.js
+++ b/common/static/common/js/discussion/views/discussion_thread_list_view.js
@@ -359,7 +359,11 @@
                         },
                         thread.toJSON()
                     );
-                return $(this.threadListItemTemplate(context).toString());
+                let $threadHTML = $(this.threadListItemTemplate(context).toString());
+                let previewBody = $threadHTML.find('.thread-preview-body').text();
+                previewBody = new DOMParser().parseFromString(previewBody, "text/html").documentElement.textContent;
+                $threadHTML.find('.thread-preview-body').text(previewBody);
+                return $threadHTML;
             };
 
             DiscussionThreadListView.prototype.threadSelected = function(e) {


### PR DESCRIPTION
## Ticket: [TNL-9645](https://openedx.atlassian.net/browse/TNL-9645)

Post preview body, in the legacy discussion, was showing HTML tags.
Before fix:
<img width="282" alt="Screenshot 2022-03-03 at 4 40 13 PM" src="https://user-images.githubusercontent.com/51022010/156558806-27ac2016-ad51-428b-acc2-1b955058e6f3.png">

After fix:
<img width="329" alt="Screenshot 2022-03-04 at 8 39 39 PM" src="https://user-images.githubusercontent.com/51022010/156794124-4f1ba6b0-0c0a-42d3-afc9-1e0ca0aa1244.png">


