### PR TITLE
feat: [AA-1207] remove redundant Tabs fields from courseware API

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2555,7 +2555,6 @@ paths:
                 * `"timestamp"`: generated from the `start` timestamp
                 * `"empty"`: no start date is specified
             * pacing: Course pacing. Possible values: instructor, self
-            * tabs: Course tabs
             * user_timezone: User's chosen timezone setting (or null for browser default)
             * is_staff: Whether the effective user has staff access to the course
             * original_user_is_staff: Whether the original user has staff access to the course

--- a/openedx/core/djangoapps/courseware_api/serializers.py
+++ b/openedx/core/djangoapps/courseware_api/serializers.py
@@ -101,7 +101,6 @@ class CourseInfoSerializer(serializers.Serializer):  # pylint: disable=abstract-
     start_display = serializers.CharField()
     start_type = serializers.CharField()
     pacing = serializers.CharField()
-    tabs = serializers.ListField()
     user_timezone = serializers.CharField()
     verified_mode = serializers.DictField()
     show_calculator = serializers.BooleanField()

--- a/openedx/core/djangoapps/courseware_api/tests/test_views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/test_views.py
@@ -151,14 +151,6 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
             enrollment = response.data['enrollment']
             assert enrollment_mode == enrollment['mode']
             assert enrollment['is_active']
-            assert len(response.data['tabs']) == 5
-            found = False
-            for tab in response.data['tabs']:
-                if tab['type'] == 'external_link':
-                    assert tab['url'] != 'http://hidden.com', "Hidden tab is not hidden"
-                    if tab['url'] == 'http://zombo.com':
-                        found = True
-            assert found, 'external link not in course tabs'
 
             assert not response.data['user_has_passing_grade']
             assert response.data['celebrations']['first_section']

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -4,8 +4,6 @@ Course API Views
 from completion.exceptions import UnavailableCompletionData
 from completion.utilities import get_key_to_last_completed_block
 from django.conf import settings
-from django.urls import reverse
-from django.utils.translation import gettext as _
 from edx_django_utils.cache import TieredCache
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -41,7 +41,6 @@ from lms.djangoapps.courseware.masquerade import (
 )
 from lms.djangoapps.courseware.models import LastSeenCoursewareTimezone
 from lms.djangoapps.courseware.module_render import get_module_by_usage_id
-from lms.djangoapps.courseware.tabs import get_course_tab_list
 from lms.djangoapps.courseware.toggles import (
     courseware_legacy_is_visible,
     course_exit_page_is_active,
@@ -138,23 +137,6 @@ class CoursewareMeta:
     @property
     def license(self):
         return self.course.license
-
-    @property
-    def tabs(self):
-        """
-        Return course tab metadata.
-        """
-        tabs = []
-        for priority, tab in enumerate(get_course_tab_list(self.effective_user, self.overview)):
-            title = tab.title or tab.get('name', '')
-            tabs.append({
-                'title': _(title),  # pylint: disable=translation-of-non-string
-                'slug': tab.tab_id,
-                'priority': priority,
-                'type': tab.type,
-                'url': tab.link_func(self.overview, reverse),
-            })
-        return tabs
 
     @property
     def verified_mode(self):
@@ -438,7 +420,6 @@ class CoursewareInformation(RetrieveAPIView):
             * `"timestamp"`: generated from the `start` timestamp
             * `"empty"`: no start date is specified
         * pacing: Course pacing. Possible values: instructor, self
-        * tabs: Course tabs
         * user_timezone: User's chosen timezone setting (or null for browser default)
         * can_load_course: Whether the user can view the course (AccessResponse object)
         * is_staff: Whether the effective user has staff access to the course


### PR DESCRIPTION
All the tab information now goes through the course home metadata tab fields. This field is redundant.

These are the backend changes to support https://github.com/openedx/frontend-app-learning/pull/861

These changes only impact the backend to the learning MFE BFF.
