### PR TITLE
fix: [MICROBA-1747] Fix cert download help link

### DIFF
--- a/lms/templates/certificates/_edx-accomplishment-print-help.html
+++ b/lms/templates/certificates/_edx-accomplishment-print-help.html
@@ -8,7 +8,7 @@ from openedx.core.djangolib.markup import HTML, Text
         <div class="accomplishment-support-print">
             <p class="accomplishment-metadata-copy">
                 ${Text(_("For tips and tricks on printing your certificate, view the {link_start}Web Certificates help documentation{link_end}.")).format(
-                    link_start=HTML('<a target="_blank" href="https://edx.readthedocs.io/projects/open-edx-learner-guide/en/latest/OpenSFD_certificates.html#print-a-web-certificate">'),
+                    link_start=HTML('<a href="https://support.edx.org/hc/en-us/articles/1500004191461-How-do-I-download-my-certificate-">'),
                     link_end=HTML('</a>'),
                 )}
             </p>


### PR DESCRIPTION
The certificate help link in the certificate base for all course
certificates seems like it may have broken as we shifted readthedocs
domains. It will now link to a support article.
