### PR TITLE
feat: add retired email msg

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/__init__.py
+++ b/openedx/core/djangoapps/user_api/accounts/__init__.py
@@ -63,6 +63,9 @@ EMAIL_CONFLICT_MSG = _(
 )
 AUTHN_EMAIL_CONFLICT_MSG = _(  # pylint: disable=translation-of-non-string
     f'This email is already associated with an existing or previous {settings.PLATFORM_NAME} account')
+RETIRED_EMAIL_MSG = _(
+    "This email is associated to a retired account."
+)
 AUTHN_PASSWORD_COMPROMISED_MSG = _(
     "The password you entered is on a list of known compromised passwords. Please choose a different one."
 )

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 from copy import deepcopy
 from unittest import mock
+from urllib.parse import quote
 
 import ddt
 import pytz
@@ -20,6 +21,7 @@ from rest_framework.test import APIClient, APITestCase
 from common.djangoapps.student.models import PendingEmailChange, UserProfile
 from common.djangoapps.student.models_api import do_name_change_request, get_pending_name_change
 from common.djangoapps.student.tests.factories import TEST_PASSWORD, RegistrationFactory, UserFactory
+from openedx.core.djangoapps.user_api.accounts import RETIRED_EMAIL_MSG
 from openedx.core.djangoapps.oauth_dispatch.jwt import create_jwt_for_user
 from openedx.core.djangoapps.user_api.accounts import ACCOUNT_VISIBILITY_PREF_KEY
 from openedx.core.djangoapps.user_api.models import UserPreference
@@ -478,6 +480,17 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
 
         response = client.get(url + f'?lms_user_id={non_integer_id}')
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    @mock.patch('openedx.core.djangoapps.user_api.accounts.views.is_email_retired')
+    def test_get_retired_user_from_email(self, mock_is_email_retired):
+        """
+        Tests that the retired user from email cannot be accessed and shows an error message.
+        """
+        mock_is_email_retired.return_value = True
+        client = self.login_client('staff_client', 'staff_user')
+        url = reverse("accounts_detail_api")
+        response = client.get(url + f'?email={quote(self.user.email)}')
+        assert response.data == {"error_msg": RETIRED_EMAIL_MSG}
 
     def test_search_emails(self):
         client = self.login_client('staff_client', 'staff_user')

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -48,13 +48,15 @@ from common.djangoapps.student.models import (  # lint-amnesty, pylint: disable=
     get_potentially_retired_user_by_username,
     get_retired_email_by_email,
     get_retired_username_by_username,
-    is_username_retired
+    is_username_retired,
+    is_email_retired
 )
 from common.djangoapps.student.models_api import (
     confirm_name_change,
     do_name_change_request,
     get_pending_name_change
 )
+from openedx.core.djangoapps.user_api.accounts import RETIRED_EMAIL_MSG
 from openedx.core.djangoapps.ace_common.template_context import get_base_template_context
 from openedx.core.djangoapps.api_admin.models import ApiAccessRequest
 from openedx.core.djangoapps.course_groups.models import UnregisteredLearnerCohortAssignments
@@ -318,6 +320,8 @@ class AccountViewSet(ViewSet):
         if usernames:
             search_usernames = usernames.strip(',').split(',')
         elif user_email:
+            if is_email_retired(user_email):
+                return Response({'error_msg': RETIRED_EMAIL_MSG}, status=status.HTTP_404_NOT_FOUND)
             user_email = user_email.strip('')
             try:
                 user = User.objects.get(email=user_email)


### PR DESCRIPTION
[PROD-2521](https://openedx.atlassian.net/browse/PROD-2521)
## Description

Adds an error message in User api if the email is retired. 

## Testing Instructions
1. Go to admin and create an entry against RetirementState model with name `PENDING` and order 1.
2. Deactivate a user on local `http://localhost:18000/account/settings`
3. Go to `http://localhost:18000/api/user/v1/accounts?{email}` and enter the email of the retired account
4. verify that you can see `{"error_msg": "This email is associated to a retired account."}` as a response