### PR TITLE
fix: flagged post banner not showing to staff

### DIFF
--- a/lms/djangoapps/discussion/rest_api/serializers.py
+++ b/lms/djangoapps/discussion/rest_api/serializers.py
@@ -211,10 +211,9 @@ class _ContentSerializer(serializers.Serializer):
         Returns a boolean indicating whether the requester has flagged the
         content as abusive.
         """
-        is_user_staff = self.context["request"].user.id in self.context["staff_user_ids"]
         total_abuse_flaggers = len(obj.get("abuse_flaggers", []))
         return (
-            is_user_staff and total_abuse_flaggers > 0 or
+            self.context["is_requester_privileged"] and total_abuse_flaggers > 0 or
             self.context["cc_requester"]["id"] in obj.get("abuse_flaggers", [])
         )
 

--- a/lms/djangoapps/discussion/rest_api/serializers.py
+++ b/lms/djangoapps/discussion/rest_api/serializers.py
@@ -211,7 +211,12 @@ class _ContentSerializer(serializers.Serializer):
         Returns a boolean indicating whether the requester has flagged the
         content as abusive.
         """
-        return self.context["cc_requester"]["id"] in obj.get("abuse_flaggers", [])
+        is_user_staff = self.context["request"].user.id in self.context["staff_user_ids"]
+        total_abuse_flaggers = len(obj.get("abuse_flaggers", []))
+        return (
+            is_user_staff and total_abuse_flaggers or
+            self.context["cc_requester"]["id"] in obj.get("abuse_flaggers", [])
+        )
 
     def get_voted(self, obj):
         """

--- a/lms/djangoapps/discussion/rest_api/serializers.py
+++ b/lms/djangoapps/discussion/rest_api/serializers.py
@@ -214,7 +214,7 @@ class _ContentSerializer(serializers.Serializer):
         is_user_staff = self.context["request"].user.id in self.context["staff_user_ids"]
         total_abuse_flaggers = len(obj.get("abuse_flaggers", []))
         return (
-            is_user_staff and total_abuse_flaggers or
+            is_user_staff and total_abuse_flaggers > 0 or
             self.context["cc_requester"]["id"] in obj.get("abuse_flaggers", [])
         )
 


### PR DESCRIPTION
### Ticket: [TNL-9649](https://openedx.atlassian.net/browse/TNL-9649)
Staff users can now see the flagged banner on posts marked as reported on discussion MFE.
<img width="470" alt="Screenshot 2022-03-10 at 1 10 05 PM" src="https://user-images.githubusercontent.com/51022010/157617128-7fe0b987-a194-475a-8e06-969167d0a189.png">

