### PR TITLE
feat: add corrupt cookie header monitoring

### DIFF
--- a/openedx/core/lib/request_utils.py
+++ b/openedx/core/lib/request_utils.py
@@ -143,6 +143,14 @@ class CookieMonitoringMiddleware:
         # .. custom_attribute_description: The total size in bytes of the cookie header.
         set_custom_attribute('cookies.header.size', cookie_header_size)
 
+        if 'Cookie:' in raw_header_cookie and any('Cookie: ' in key for key in request.COOKIES.keys()):
+            # .. custom_attribute_name: cookies.header.is_corrupt
+            # .. custom_attribute_description: The attribute will only appear for corrupt cookie headers, where
+            #   "Cookie: " seems to appear inside cookie keys. If this custom attribute is seen on the same
+            #   requests where other mysterious cookie problems are occurring, then this may help you troubleshoot.
+            #   See https://openedx.atlassian.net/browse/CR-4614 for more details.
+            set_custom_attribute('cookies.header.is_corrupt', True)
+
         # .. setting_name: COOKIE_HEADER_SIZE_LOGGING_THRESHOLD
         # .. setting_default: None
         # .. setting_description: The minimum size for the full cookie header to log a list of cookie names and sizes.

--- a/openedx/core/lib/request_utils.py
+++ b/openedx/core/lib/request_utils.py
@@ -143,13 +143,27 @@ class CookieMonitoringMiddleware:
         # .. custom_attribute_description: The total size in bytes of the cookie header.
         set_custom_attribute('cookies.header.size', cookie_header_size)
 
-        if 'Cookie:' in raw_header_cookie and any('Cookie: ' in key for key in request.COOKIES.keys()):
-            # .. custom_attribute_name: cookies.header.is_corrupt
-            # .. custom_attribute_description: The attribute will only appear for corrupt cookie headers, where
-            #   "Cookie: " seems to appear inside cookie keys. If this custom attribute is seen on the same
-            #   requests where other mysterious cookie problems are occurring, then this may help you troubleshoot.
+        if cookie_header_size == 0:
+            return
+
+        if corrupt_cookie_count := raw_header_cookie.count('Cookie: '):
+            # .. custom_attribute_name: cookies.header.corrupt_count
+            # .. custom_attribute_description: The attribute will only appear for potentially corrupt cookie headers,
+            #   where "Cookie: " is found in the header. If this custom attribute is seen on the same
+            #   requests where other mysterious cookie problems are occurring, this may help troubleshoot.
             #   See https://openedx.atlassian.net/browse/CR-4614 for more details.
-            set_custom_attribute('cookies.header.is_corrupt', True)
+            #   Also see cookies.header.corrupt_key_count
+            set_custom_attribute('cookies.header.corrupt_count', corrupt_cookie_count)
+            # .. custom_attribute_name: cookies.header.corrupt_key_count
+            # .. custom_attribute_description: The attribute will only appear for potentially corrupt cookie headers,
+            #   where "Cookie: " is found in some of the cookie keys. If this custom attribute is seen on the same
+            #   requests where other mysterious cookie problems are occurring, this may help troubleshoot.
+            #   See https://openedx.atlassian.net/browse/CR-4614 for more details.
+            #   Also see cookies.header.corrupt_count.
+            set_custom_attribute(
+                'cookies.header.corrupt_key_count',
+                sum(1 for key in request.COOKIES.keys() if 'Cookie: ' in key)
+            )
 
         # .. setting_name: COOKIE_HEADER_SIZE_LOGGING_THRESHOLD
         # .. setting_default: None

--- a/openedx/core/lib/tests/test_request_utils.py
+++ b/openedx/core/lib/tests/test_request_utils.py
@@ -138,18 +138,26 @@ class CookieMonitoringMiddlewareTestCase(unittest.TestCase):
     @override_settings(COOKIE_HEADER_SIZE_LOGGING_THRESHOLD=None)
     @override_settings(COOKIE_SAMPLING_REQUEST_COUNT=None)
     @patch("openedx.core.lib.request_utils.set_custom_attribute")
-    def test_cookie_header_corrupt_monitoring(self, mock_set_custom_attribute):
+    @ddt.data(
+        # A corrupt cookie header contains "Cookie: ".
+        ('corruptCookie: normal-cookie=value', 1, 1),
+        ('corrupt1Cookie: normal-cookie1=value1;corrupt2Cookie: normal-cookie2=value2', 2, 2),
+        ('corrupt=Cookie: value', 1, 0),
+    )
+    @ddt.unpack
+    def test_cookie_header_corrupt_monitoring(
+        self, corrupt_cookie_header, expected_corrupt_count, expected_corrupt_key_count, mock_set_custom_attribute
+    ):
         middleware = CookieMonitoringMiddleware(self.mock_response)
         request = RequestFactory().request()
-        # A corrupt cookie header contains "Cookie: ". See custom attribute
-        #   cookies.header.is_corrupt documentation for more details.
-        request.META['HTTP_COOKIE'] = 'corruptCookie: test=1'
+        request.META['HTTP_COOKIE'] = corrupt_cookie_header
 
         middleware(request)
 
         mock_set_custom_attribute.assert_has_calls([
             call('cookies.header.size', len(request.META['HTTP_COOKIE'])),
-            call('cookies.header.is_corrupt', True),
+            call('cookies.header.corrupt_count', expected_corrupt_count),
+            call('cookies.header.corrupt_key_count', expected_corrupt_key_count),
         ])
 
     @override_settings(COOKIE_HEADER_SIZE_LOGGING_THRESHOLD=1)
@@ -194,6 +202,21 @@ class CookieMonitoringMiddlewareTestCase(unittest.TestCase):
         mock_logger.info.assert_called_once_with(
             "Sampled small (< 9999) cookie header. BEGIN-COOKIE-SIZES(total=16) b: 3, a: 2, c: 1 END-COOKIE-SIZES"
         )
+
+    @override_settings(COOKIE_HEADER_SIZE_LOGGING_THRESHOLD=9999)
+    @override_settings(COOKIE_SAMPLING_REQUEST_COUNT=1)
+    @patch('openedx.core.lib.request_utils.log', autospec=True)
+    @patch("openedx.core.lib.request_utils.set_custom_attribute")
+    def test_empty_cookie_header_skips_sampling(self, mock_set_custom_attribute, mock_logger):
+        middleware = CookieMonitoringMiddleware(self.mock_response)
+        cookies_dict = {}
+
+        middleware(self.get_mock_request(cookies_dict))
+
+        mock_set_custom_attribute.assert_has_calls([
+            call('cookies.header.size', 0),
+        ])
+        mock_logger.info.assert_not_called()
 
     def get_mock_request(self, cookies_dict):
         """


### PR DESCRIPTION
## Description

In case of unusual cookie headers containing "Cookie ",
add custom attributes for monitoring:
- cookies.header.corrupt_count
- cookies.header.corrupt_key_count

See annotation documentation for more details.

Separately, updated to skip cookie log sampling for
0 size cookie header.

## Supporting information

[CR-4614](https://openedx.atlassian.net/browse/CR-4614)