### PR TITLE
add an xblock renderer endpoint to serve videos as public having public access set by course author in studio

### DIFF
--- a/cms/static/js/views/metadata.js
+++ b/cms/static/js/views/metadata.js
@@ -299,6 +299,27 @@ function(Backbone, BaseView, _, MetadataModel, AbstractEditor, FileUpload, Uploa
         }
     });
 
+    Metadata.PublicAccess = Metadata.Option.extend({
+
+      templateName: 'metadata-option-public-access',
+
+      initialize: function() {
+        Metadata.Option.prototype.initialize.apply(this, arguments);
+        this.listenTo(this.model, 'change', this.updateUrlFieldVisibility);
+        this.updateUrlFieldVisibility();
+      },
+
+      updateUrlFieldVisibility: function() {
+        const urlContainer = this.$el.find('.public-access-block-url-container');
+
+        if(this.getValueFromEditor()) {
+          urlContainer.removeClass('is-hidden');
+        } else {
+          urlContainer.addClass('is-hidden');
+        }
+      }
+    });
+
     Metadata.List = AbstractEditor.extend({
 
         events: {

--- a/cms/templates/js/metadata-option-public-access.underscore
+++ b/cms/templates/js/metadata-option-public-access.underscore
@@ -1,0 +1,21 @@
+<div class="wrapper-comp-setting">
+    <label class="label setting-label" for="<%- uniqueId %>"><%- model.get('display_name') %></label>
+    <select class="input setting-input" id="<%- uniqueId %>" name="<%- model.get('display_name') %>">
+        <% _.each(model.get('options'), function(option) { %>
+            <% if (option.display_name !== undefined) { %>
+                <option value="<%- option['display_name'] %>"><%- option['display_name'] %></option>
+            <% } else { %>
+                <option value="<%- option %>"><%- option %></option>
+            <% } %>
+        <% }) %>
+    </select>
+    <button class="action setting-clear inactive" type="button" name="setting-clear" value="<%- gettext("Clear") %>" data-tooltip="<%- gettext("Clear") %>">
+        <span class="icon fa fa-undo" aria-hidden="true"></span><span class="sr">"<%- gettext("Clear Value") %>"</span>
+    </button>
+</div>
+<span class="tip setting-help"><%- model.get('help') %></span>
+<br>
+<div class="public-access-block-url-container is-hidden">
+    <label class="label setting-label" for="<%- uniqueId %>"><%- gettext("URL") %></label>
+    <input class="input setting-input" type="text" id="<%- uniqueId %>" value='<%- model.get("url") %>' readonly/>
+</div>

--- a/cms/templates/widgets/metadata-edit.html
+++ b/cms/templates/widgets/metadata-edit.html
@@ -16,7 +16,7 @@
         <%static:include path="js/${template_name}.underscore" />
     </script>
 % endfor
-% for template_name in ["metadata-number-entry", "metadata-string-entry", "metadata-option-entry", "metadata-list-entry", "metadata-dict-entry", "metadata-file-uploader-entry", "metadata-file-uploader-item"]:
+% for template_name in ["metadata-number-entry", "metadata-string-entry", "metadata-option-entry", "metadata-option-public-access", "metadata-list-entry", "metadata-dict-entry", "metadata-file-uploader-entry", "metadata-file-uploader-item"]:
     <script id="${template_name}" type="text/template">
         <%static:include path="js/${template_name}.underscore" />
     </script>

--- a/cms/templates/widgets/tabs/metadata-edit-tab.html
+++ b/cms/templates/widgets/tabs/metadata-edit-tab.html
@@ -8,7 +8,7 @@
     <%static:include path="js/metadata-editor.underscore" />
 </script>
 
-% for template_name in ["metadata-number-entry", "metadata-string-entry", "metadata-option-entry", "metadata-list-entry", "metadata-dict-entry", "metadata-file-uploader-entry", "metadata-file-uploader-item"]:
+% for template_name in ["metadata-number-entry", "metadata-string-entry", "metadata-option-entry", "metadata-option-public-access", "metadata-list-entry", "metadata-dict-entry", "metadata-file-uploader-entry", "metadata-file-uploader-item"]:
     <script id="${template_name}" type="text/template">
         <%static:include path="js/${template_name}.underscore" />
     </script>

--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -589,6 +589,13 @@ class VideoBlock(
         # Backbonjs view can handle it.
         editable_fields['edx_video_id']['type'] = 'VideoID'
 
+        # `public_access` is a boolean field and by default backbonejs code render it as a dropdown with 2 options
+        # but in our case we also need to show an input field with dropdown, the input field will show the url to
+        # be shared with leaners. This is not possible with default rendering logic in backbonjs code, that is why
+        # we are setting a new type and then do a custom rendering in backbonejs code to render the desired UI.
+        editable_fields['public_access']['type'] = 'PublicAccess'
+        editable_fields['public_access']['url'] = fr'{settings.LMS_ROOT_URL}/videos/{str(self.location)}'
+
         # construct transcripts info and also find if `en` subs exist
         transcripts_info = self.get_transcripts_info()
         possible_sub_ids = [self.sub, self.youtube_id_1_0] + get_html5_ids(self.html5_sources)

--- a/common/lib/xmodule/xmodule/video_module/video_xfields.py
+++ b/common/lib/xmodule/xmodule/video_module/video_xfields.py
@@ -206,3 +206,9 @@ class VideoFields:
         scope=Scope.preferences,
         default=False,
     )
+    public_access = Boolean(
+        help=_("Specify whether the video can be accessed publicly by learners."),
+        display_name=_("Public Access"),
+        scope=Scope.settings,
+        default=False
+    )

--- a/lms/djangoapps/courseware/testutils.py
+++ b/lms/djangoapps/courseware/testutils.py
@@ -116,6 +116,11 @@ class RenderXBlockTestMixin(MasqueradeMixin, metaclass=ABCMeta):
                 category='problem',
                 display_name='Problem'
             )
+            self.video_block = ItemFactory.create(
+                parent=self.vertical_block,
+                category='video',
+                display_name='Video'
+            )
         CourseOverview.load_from_module_store(self.course.id)
 
         # block_name_to_be_tested can be `html_block` or `vertical_block`.

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -113,6 +113,7 @@ from openedx.core.djangoapps.credit.api import (
     is_credit_course,
     is_user_eligible_for_credit
 )
+from openedx.core.lib.courses import get_course_by_id
 from openedx.core.djangoapps.enrollments.api import add_enrollment
 from openedx.core.djangoapps.enrollments.permissions import ENROLL_IN_COURSE
 from openedx.core.djangoapps.models.course_details import CourseDetails
@@ -1820,6 +1821,58 @@ def render_xblock(request, usage_key_string, check_if_enrolled=True):
             'render_course_wide_assets': True,
 
             **optimization_flags,
+        }
+        return render_to_response('courseware/courseware-chromeless.html', context)
+
+
+@require_http_methods(["GET"])
+@ensure_valid_usage_key
+@xframe_options_exempt
+@transaction.non_atomic_requests
+def render_public_video_xblock(request, usage_key_string):
+    """
+    Returns an HttpResponse with HTML content for the Video xBlock with the given usage_key.
+    The returned HTML is a chromeless rendering of the Video xBlock (excluding content of the containing courseware).
+    """
+    view = 'public_view'
+
+    usage_key = UsageKey.from_string(usage_key_string)
+    usage_key = usage_key.replace(course_key=modulestore().fill_in_run(usage_key.course_key))
+    course_key = usage_key.course_key
+
+    # usage key block type must be `video` else raise 404
+    if usage_key.block_type != 'video':
+        raise Http404("Video not found.")
+
+    with modulestore().bulk_operations(course_key):
+        course = get_course_by_id(course_key, 0)
+
+        block, _ = get_module_by_usage_id(
+            request,
+            str(course_key),
+            str(usage_key),
+            disable_staff_debug_info=True,
+            course=course,
+            will_recheck_access=False
+        )
+
+        # video must be public (`Public Access` field set to True) by course author in studio in video advanced settings
+        if not block.public_access:
+            raise Http404("Video not found.")
+
+        fragment = block.render(view, context={})
+
+        context = {
+            'fragment': fragment,
+            'course': course,
+            'disable_accordion': False,
+            'allow_iframing': True,
+            'disable_header': False,
+            'disable_footer': False,
+            'disable_window_wrap': True,
+            'edx_notes_enabled': False,
+            'is_learning_mfe': True,
+            'is_mobile_app': False,
         }
         return render_to_response('courseware/courseware-chromeless.html', context)
 

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -56,6 +56,7 @@ from common.djangoapps.util import views as util_views
 
 RESET_COURSE_DEADLINES_NAME = 'reset_course_deadlines'
 RENDER_XBLOCK_NAME = 'render_xblock'
+RENDER_VIDEO_XBLOCK_NAME = 'render_public_video_xblock'
 COURSE_DATES_NAME = 'dates'
 COURSE_PROGRESS_NAME = 'progress'
 
@@ -317,6 +318,11 @@ urlpatterns += [
         fr'^xblock/{settings.USAGE_KEY_PATTERN}$',
         courseware_views.render_xblock,
         name=RENDER_XBLOCK_NAME,
+    ),
+    re_path(
+        fr'^videos/{settings.USAGE_KEY_PATTERN}$',
+        courseware_views.render_public_video_xblock,
+        name=RENDER_VIDEO_XBLOCK_NAME,
     ),
 
     # xblock Resource URL


### PR DESCRIPTION
**JIRA:** https://openedx.atlassian.net/browse/ENT-5456

**Description:** The goal is to have video urls that can be accessed publicly. Added a separate xblock video renderer endpoint that will only render video and one that has explicitly marked as public in video advanced settings. The purpose of this work is to share the public video urls with learners for an experiment and then depend on the results of experiment link the videos in `enterprise learner portal`.


https://user-images.githubusercontent.com/6767924/159925857-feb8f9a9-cf0c-4f15-9187-4d7f9630f236.mov

 

<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
