### PR TITLE
fix: Avoid overcounting former pending users who changed their emails.

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -2541,12 +2541,11 @@ class CourseEnrollmentAllowed(DeletableByUserValue, models.Model):
         Return QuerySet of students who are allowed to enroll in a course.
 
         Result excludes students who have already enrolled in the
-        course.
+        course. Even if they change their emails after registration.
 
         `course_id` identifies the course for which to compute the QuerySet.
         """
-        enrolled = CourseEnrollment.objects.users_enrolled_in(course_id=course_id).values_list('email', flat=True)
-        return CourseEnrollmentAllowed.objects.filter(course_id=course_id).exclude(email__in=enrolled)
+        return CourseEnrollmentAllowed.objects.filter(course_id=course_id, user__isnull=True)
 
 
 @total_ordering

--- a/lms/djangoapps/instructor_analytics/tests/test_basic.py
+++ b/lms/djangoapps/instructor_analytics/tests/test_basic.py
@@ -51,7 +51,9 @@ class TestAnalyticsBasic(ModuleStoreTestCase):
         self.students_who_may_enroll = list(self.users) + [UserFactory() for _ in range(5)]
         for student in self.students_who_may_enroll:
             CourseEnrollmentAllowed.objects.create(
-                email=student.email, course_id=self.course_key
+                email=student.email,
+                course_id=self.course_key,
+                user=student if student in self.users else None,
             )
 
     @ddt.data(


### PR DESCRIPTION
## Description

The issue this PR brings to the table impacts instructor's "learners who can enroll" report, as well as any other plugin developer who might use the following class method to get the count of allowed students to be enrolled in a particular course.

[may_enroll_and_unenrolled](https://github.com/openedx/edx-platform/blob/c807af628f7e6ba1d30054a11130eec74890e7f6/common/djangoapps/student/models.py#L2532-L2542) is returning a query with wrong result if the following case occures:

_If an invited student who registers in the platform changes its user's email, then the `may_enroll_and_unenrolled` method will have it in its resulting query._

Currently, `may_enroll_and_unenrolled` checks the emails of the users who are enrolled and uses their emails as an excluding filter to get the allowed enrollments queryset. However this mechanism doesn't consider the fact that an user can change the email.
 
## Solution
Once an enrollment from this `CourseEnrollmentAllowed` table effectively happens, the object is marked in its `user` field with the student who enrolled. Therefore, `may_enroll_and_unenrolled` must exclude all `CourseEnrollmentAllowed` objects which already have an user assigned.

## Why is TestAnalyticsBasic test updated?
`CourseEnrollmentAllowed` table is populated with the emails of users who are not yet registered in the platform, and the setUp method was creating `CourseEnrollmentAllowed` for users who were already registered and enrolled in the course. The issue with this is that for those registered and enrolled users, the platform automatically marks the user field but the test was not assigning users to the created `CourseEnrollmentAllowed`.

## Testing instructions
let's see first the error
### How to replicate the error and test this PR's changes:
Do no pull the changes until it is required by the following step-by-step.

- Given a created course.
- Go to membership in the Instructor Dashboard within instructor tab, and enroll a user _(Make sure you use an email which isn't registered in the platform yet)_
- Check that email is an allowed student to enroll.\*
- Register with the email you used in the previous step.
- Now you should be enrolled.
- Check that email is **not** an allowed student to enroll*
- Change your email and confirm it.
- Check again and you will see that email is an allowed student to enroll **AGAIN**.
- Pull this PR's changes
- Check again and you will see that email is not an allowed student as it is supposed to be.

\* To check this you can either open a shell to call directly the method or see it indirectly clicking on the "Download a CSV of learners who can enroll" option found at Instructor Dashboard - Data Download - Reports, or calling the method directly.
`
from student.models import CourseEnrollmentAllowed
CourseEnrollmentAllowed.may_enroll_and_unenrolled(course_id='your_course_id')
`



