### PR TITLE
fix: fix RTL text in editor of xblock problem.

### DIFF
--- a/common/lib/xmodule/xmodule/css/problem/edit.scss
+++ b/common/lib/xmodule/xmodule/css/problem/edit.scss
@@ -29,7 +29,7 @@
 .simple-editor-cheatsheet {
   position: absolute;
   top: 41px;
-  left: 70%;
+  @include left(70%);
   width: 0;
   border-left: 1px solid $gray-l2;
 


### PR DESCRIPTION

<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->
#  Fix right to left (RTL) text in the editor of xblock problem in Studio.
## Description
Fix overlap of the text editor with the simple editor cheatsheet in right to left orientation(RTL).

## Process
I suggest not to do padding, otherwise, I move the simple-editor-cheatshet to the left in order to preserve the order of RTL. 
Using saas mixins this change only applies in RTL cases.

**Before**:
![ltr1](https://user-images.githubusercontent.com/51926076/157903904-fc415c6f-461e-45b9-848c-01d4836ef599.png)
![ltr2](https://user-images.githubusercontent.com/51926076/157903894-5acfdfe7-522d-449e-99c9-a5aa85391fe8.png)

**After**:
![ltrf1](https://user-images.githubusercontent.com/51926076/157904959-29e3f722-4c1d-4d56-b84f-daca5d1e10e1.png)
![ltrf2](https://user-images.githubusercontent.com/51926076/157904954-2b7c7ad5-571c-4f91-9277-9cf608fa6cef.png)

## Supporting information

**Edunext PR**: https://github.com/eduNEXT/edx-platform/pull/257

## Testing instructions

Checkout to this branch.
In devstack use, the command `make dev.static`.
Refresh your problem with an empty cache.

## Other information
(cherry picked from commit 96e903c86c4a0031b21fc564d824a2c02bf98d9c)

