### PR TITLE
fix: release edx-enterprise 3.40.16

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -31,7 +31,7 @@ django-storages<1.9
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==3.40.15
+edx-enterprise==3.40.16
 
 # Newer versions need a more recent version of python-dateutil
 freezegun==0.3.12

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -449,7 +449,7 @@ edx-drf-extensions==8.0.1
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.40.15
+edx-enterprise==3.40.16
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -556,7 +556,7 @@ edx-drf-extensions==8.0.1
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.40.15
+edx-enterprise==3.40.16
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -539,7 +539,7 @@ edx-drf-extensions==8.0.1
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.40.15
+edx-enterprise==3.40.16
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
-  fix: CSOD Learner Audit Django Admin Timeouts

## References

- [ENT-5565](https://openedx.atlassian.net/browse/ENT-5565)
- https://github.com/openedx/edx-enterprise/pull/1495
- https://pypi.org/project/edx-enterprise/3.40.16/