### PR TITLE
fix: Check discussion_link exists as an attr before accessing

### DIFF
--- a/lms/djangoapps/courseware/tabs.py
+++ b/lms/djangoapps/courseware/tabs.py
@@ -277,7 +277,9 @@ class ExternalDiscussionCourseTab(LinkTab):
     def is_enabled(cls, course, user=None):
         if not super().is_enabled(course, user=user):
             return False
-        return course.discussion_link
+        # Course Overview objects don't have this attribute so avoid the error for now and figure
+        # out a better long-term solution
+        return hasattr(course, 'discussion_link') and course.discussion_link
 
 
 class ExternalLinkCourseTab(LinkTab):


### PR DESCRIPTION
This is a patch to fix CR-4621. A longer term solution should
be implemented.