### PR TITLE
ARCHBOM-2055: fix: process cookie headers at request time

### DIFF
--- a/openedx/core/lib/request_utils.py
+++ b/openedx/core/lib/request_utils.py
@@ -95,30 +95,26 @@ class CookieMonitoringMiddleware:
     Middleware for monitoring the size and growth of all our cookies, to see if
     we're running into browser limits.
     """
-    COOKIE_MONITORING_REQUEST_CACHE_KEY = "CookieMonitoringMiddleware"
-    COOKIE_HEADER_LOG_MESSAGE_KEY = "cookie_header_log_message"
-
     def __init__(self, get_response):
         self.get_response = get_response
 
     def __call__(self, request):
         # Monitor at request-time to skip any cookies that may be added during the request.
+        log_message = None
         try:
-            self.log_and_monitor_cookies(request)
+            log_message = self.get_log_message_and_monitor_cookies(request)
         except BaseException:
             log.exception("Unexpected error logging and monitoring cookies.")
 
         response = self.get_response(request)
 
         # Delay logging until response-time so that the user id can be included in the log message.
-        request_cache = RequestCache(self.COOKIE_MONITORING_REQUEST_CACHE_KEY)
-        cache_response = request_cache.get_cached_response(self.COOKIE_HEADER_LOG_MESSAGE_KEY)
-        if cache_response.is_found:
-            log.info(cache_response.value)
+        if log_message:
+            log.info(log_message)
 
         return response
 
-    def log_and_monitor_cookies(self, request):
+    def get_log_message_and_monitor_cookies(self, request):
         """
         Add logging and custom attributes for monitoring cookie sizes.
 
@@ -144,6 +140,11 @@ class CookieMonitoringMiddleware:
 
             - COOKIE_HEADER_SIZE_LOGGING_THRESHOLD
             - COOKIE_SAMPLING_REQUEST_COUNT
+
+        Returns: The message to be logged. This is returned, rather than directly
+            logged, so that it can be processed at request time (before any cookies
+            may be changed server-side), but logged at response time, once the user
+            id is available for authenticated calls.
 
         """
 
@@ -202,17 +203,6 @@ class CookieMonitoringMiddleware:
             if not sampling_request_count or random.randint(1, sampling_request_count) > 1:
                 return
 
-        # Sort starting with largest cookies
-        sorted_cookie_items = sorted(request.COOKIES.items(), key=lambda x: len(x[1]), reverse=True)
-        sizes = ', '.join(f"{name}: {len(value)}" for (name, value) in sorted_cookie_items)
-        if is_large_cookie_header_detected:
-            log_prefix = f"Large (>= {logging_threshold}) cookie header detected."
-        else:
-            log_prefix = f"Sampled small (< {logging_threshold}) cookie header."
-        log_message = f"{log_prefix} BEGIN-COOKIE-SIZES(total={cookie_header_size}) {sizes} END-COOKIE-SIZES"
-        request_cache = RequestCache(self.COOKIE_MONITORING_REQUEST_CACHE_KEY)
-        request_cache.set(self.COOKIE_HEADER_LOG_MESSAGE_KEY, log_message)
-
         # The computed header size can be used to double check that there aren't large cookies that are
         #   duplicates in the original header (from different domains) that aren't being accounted for.
         cookies_header_size_computed = max(
@@ -226,6 +216,16 @@ class CookieMonitoringMiddleware:
         #   cookies that are duplicates in the cookie header (from different domains) that aren't being accounted
         #   for.
         set_custom_attribute('cookies.header.size.computed', cookies_header_size_computed)
+
+        # Sort starting with largest cookies
+        sorted_cookie_items = sorted(request.COOKIES.items(), key=lambda x: len(x[1]), reverse=True)
+        sizes = ', '.join(f"{name}: {len(value)}" for (name, value) in sorted_cookie_items)
+        if is_large_cookie_header_detected:
+            log_prefix = f"Large (>= {logging_threshold}) cookie header detected."
+        else:
+            log_prefix = f"Sampled small (< {logging_threshold}) cookie header."
+        log_message = f"{log_prefix} BEGIN-COOKIE-SIZES(total={cookie_header_size}) {sizes} END-COOKIE-SIZES"
+        return log_message
 
 
 def expected_error_exception_handler(exc, context):

--- a/openedx/core/lib/tests/test_request_utils.py
+++ b/openedx/core/lib/tests/test_request_utils.py
@@ -111,6 +111,7 @@ class CookieMonitoringMiddlewareTestCase(unittest.TestCase):
     def setUp(self):
         super().setUp()
         self.mock_response = Mock()
+        RequestCache.clear_all_namespaces()
 
     @patch('openedx.core.lib.request_utils.log', autospec=True)
     @patch("openedx.core.lib.request_utils.set_custom_attribute")

--- a/openedx/core/lib/tests/test_request_utils.py
+++ b/openedx/core/lib/tests/test_request_utils.py
@@ -111,7 +111,6 @@ class CookieMonitoringMiddlewareTestCase(unittest.TestCase):
     def setUp(self):
         super().setUp()
         self.mock_response = Mock()
-        RequestCache.clear_all_namespaces()
 
     @patch('openedx.core.lib.request_utils.log', autospec=True)
     @patch("openedx.core.lib.request_utils.set_custom_attribute")


### PR DESCRIPTION
## Description

Processing cookies at response time included cookies
that were temporary, like the JWT cookie that is
created by the server by combining the JWT header-payload
and JWT signature cookies. Since we are trying to monitor
the cookie header, we do not want to process this cookie.

However, since we want to include the user id in the logging
message, we delay the logging until response time.

Also, fixed docstring which mislabeled a custom attribute.

## Supporting information

ARCHBOM-2055