### PR TITLE
chore: switch from github/checkout @v2 to @V3

### DIFF
--- a/.github/workflows/ci-static-analysis.yml
+++ b/.github/workflows/ci-static-analysis.yml
@@ -12,7 +12,7 @@ jobs:
         os: ['ubuntu-20.04']
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build and Push docker image
         env:

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Fetch master to compare coverage
       run: git fetch --depth=1 origin master
 

--- a/.github/workflows/migrations-check-mysql8.yml
+++ b/.github/workflows/migrations-check-mysql8.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/.github/workflows/migrations-check.yml
+++ b/.github/workflows/migrations-check.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/.github/workflows/publish-ci-docker-image.yml
+++ b/.github/workflows/publish-ci-docker-image.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/pylint-checks.yml
+++ b/.github/workflows/pylint-checks.yml
@@ -31,7 +31,7 @@ jobs:
     name: pylint ${{ matrix.module-name }}
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install Required System Packages
       run: sudo apt-get update && sudo apt-get install libxmlsec1-dev

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 2
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - name: sync directory owner
         run: sudo chown runner:runner -R .*
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # This gives Mongo several chances to start. We started getting flakiness
       # around 2022-02-15 wherein the start command would sometimes exit with:
@@ -95,7 +95,7 @@ jobs:
     steps:
       - name: sync directory owner
         run: sudo chown runner:runner -R .*
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: collect pytest warnings files
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/verify-dunder-init.yml
+++ b/.github/workflows/verify-dunder-init.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
 
     - name: Check out branch
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Ensure git is installed
       run: |

--- a/.github/workflows/verify-gha-unit-tests-count.yml
+++ b/.github/workflows/verify-gha-unit-tests-count.yml
@@ -13,7 +13,7 @@ jobs:
       - name: sync directory owner
         run: sudo chown runner:runner -R .*
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: install requirements
         run: |
           sudo pip install -r requirements/pip.txt


### PR DESCRIPTION
 ~~Since some tests fails possobly because v2 isn't supported or
 maintained as v3.)~~

~~There seems to be an issue with github action v2, I have reported an issue on the action repo [here](https://github.com/actions/checkout/issues/724) But I think is better to use v3. If the tests passes now it means that has resolved it. Also the action repo itself start to use v3 for their workflow, [hence](https://github.com/actions/checkout/pull/709)~~

As it turns out and repoted below the test failing weren't related to checkout:
 version rather something hast 
 
> Well to be fair, it turns out it wasn't related because v2/v3, rather it was some temp issue with [microsoft packages](https://packages.microsoft.com/ubuntu/20.04/prod) hence [actions/virtual-environments#5236](https://github.com/actions/virtual-environments/issues/5236) . That being said I am not sure if we I shall close this or keep but rename the commit message to reflect what is suppose to mean


## Supporting information

- V3 Release note: https://github.com/actions/checkout/releases/tag/v3.0.0 

## Testing instructions

Just make sure to run this PR or its effect with self hosted runner (if there are?). 
Since github/checkout@v3 only supprot runner :
> Updated to the node16 runtime by default
This requires a minimum [Actions Runner](https://github.com/actions/runner/releases/tag/v2.285.0)[](https://github.com/actions/checkout#usage) version of v2.285.0 to run, which is by default available in GHES 3.4 or later.
[ref](https://github.com/actions/checkout#whats-new)

If there are no self hosted runner then you can discard it 
