### PR TITLE
feat: Added management command dump_course_ids_with_filter.

### DIFF
--- a/lms/djangoapps/courseware/management/commands/dump_course_ids_with_filter.py
+++ b/lms/djangoapps/courseware/management/commands/dump_course_ids_with_filter.py
@@ -1,0 +1,35 @@
+"""
+Dump the course_ids available to the lms, excluding courses
+that have ended prior to the given date.
+
+Output is UTF-8 encoded by default.
+The output format is one course_id per line.
+"""
+
+import datetime
+
+from textwrap import dedent
+
+from django.core.management.base import BaseCommand
+from django.db.models import Q
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+
+
+class Command(BaseCommand):  # lint-amnesty, pylint: disable=missing-class-docstring
+    help = dedent(__doc__).strip()
+
+    def add_arguments(self, parser):
+        parser.add_argument('--end',
+                            default=None,
+                            help='Date to filter out courses that have ended before the provided date')
+
+    def handle(self, *args, **options):
+        course_overviews = CourseOverview.objects.all()
+        courseoverview_filter = Q()
+        if options['end']:
+            courseoverview_filter |= Q(end__gte=datetime.datetime.strptime(options['end'], "%Y-%m-%d"))
+            courseoverview_filter |= Q(end=None)
+            course_overviews = course_overviews.filter(courseoverview_filter)
+
+        output = '\n'.join(str(course_overview.id) for course_overview in course_overviews) + '\n'
+        return output

--- a/lms/djangoapps/courseware/management/commands/tests/test_dump_course.py
+++ b/lms/djangoapps/courseware/management/commands/tests/test_dump_course.py
@@ -2,11 +2,12 @@
 Tests for Django management commands
 """
 
-
+import datetime
 import json
 from io import StringIO
 
 import factory
+import pytz
 from django.conf import settings
 from django.core.management import call_command
 
@@ -22,6 +23,8 @@ from xmodule.modulestore.xml_importer import import_course_from_xml
 
 DATA_DIR = settings.COMMON_TEST_DATA_ROOT
 XML_COURSE_DIRS = ['simple']
+TEST_COURSE_START = datetime.datetime(2012, 7, 1, tzinfo=pytz.UTC)
+TEST_COURSE_END = datetime.datetime(2012, 12, 31, tzinfo=pytz.UTC)
 
 
 class CommandsTestBase(SharedModuleStoreTestCase):
@@ -56,7 +59,9 @@ class CommandsTestBase(SharedModuleStoreTestCase):
             course='simple',
             run="run",
             display_name='2012_Fáĺĺ',
-            modulestore=store
+            modulestore=store,
+            start=TEST_COURSE_START,
+            end=TEST_COURSE_END,
         )
 
         cls.discussion = ItemFactory.create(
@@ -80,6 +85,25 @@ class CommandsTestBase(SharedModuleStoreTestCase):
         call_command(name, *args, stdout=out, **kwargs)
         out.seek(0)
         return out.read()
+
+    def test_dump_course_ids_with_filter(self):
+        """
+        Test that `dump_course_ids_with_filter` works correctly by
+        only returning courses that have not ended before the provided `end` data.
+
+        `load_courses` method creates two courses first by calling CourseFactory.create
+        which creates a course with end=2012-12-31. Then it creates a second course
+        by calling import_course_from_xml which creates a course with end=None.
+
+        This test makes sure that only the second course is returned when
+        `end`=2013-01-01 is passed to `dump_course_ids_with_filter`.
+        """
+        args = []
+        kwargs = {'end': '2013-01-01'}  # exclude any courses which have ended before 2013-01-01
+        output = self.call_command('dump_course_ids_with_filter', *args, **kwargs)
+        dumped_courses = output.strip().split('\n')
+        dumped_ids = set(dumped_courses)
+        assert {str(self.test_course_key)} == dumped_ids
 
     def test_dump_course_ids(self):
         output = self.call_command('dump_course_ids')


### PR DESCRIPTION
<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

We want to be able to limit the courses for which analytics exporter exports data packages for partners. This PR adds a new management command which returns all course ids excluding any courses which have ended before the given end date argument.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
