### PR TITLE
reafactor: simplify XModule serialization/deserialization layer [BD-13]

### DIFF
--- a/cms/djangoapps/contentstore/course_info_model.py
+++ b/cms/djangoapps/contentstore/course_info_model.py
@@ -24,7 +24,7 @@ from xmodule.html_module import CourseInfoBlock  # lint-amnesty, pylint: disable
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.exceptions import ItemNotFoundError  # lint-amnesty, pylint: disable=wrong-import-order
 
-# # This should be in a class which inherits from XmlDescriptor
+# # This should be in a class which inherits from XModuleDescriptor
 log = logging.getLogger(__name__)
 
 

--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -1839,9 +1839,10 @@ class VideoBlockTest(TestCase, VideoBlockTestBase):
             val_transcript_language_code=val_transcript_language_code,
             val_transcript_provider=val_transcript_provider
         )
+        xml_object = etree.fromstring(xml_data)
         id_generator = Mock()
         id_generator.target_course_id = "test_course_id"
-        video = self.descriptor.from_xml(xml_data, module_system, id_generator)
+        video = self.descriptor.parse_xml(xml_object, module_system, None, id_generator)
 
         assert video.edx_video_id == 'test_edx_video_id'
         video_data = get_video_info(video.edx_video_id)
@@ -1887,13 +1888,14 @@ class VideoBlockTest(TestCase, VideoBlockTestBase):
         Test that importing a video with no video id, creates a new external video.
         """
         xml_data = """<video><video_asset></video_asset></video>"""
+        xml_object = etree.fromstring(xml_data)
         module_system = DummySystem(load_error_modules=True)
         id_generator = Mock()
 
         # Verify edx_video_id is empty before.
         assert self.descriptor.edx_video_id == ''
 
-        video = self.descriptor.from_xml(xml_data, module_system, id_generator)
+        video = self.descriptor.parse_xml(xml_object, module_system, None, id_generator)
 
         # Verify edx_video_id is populated after the import.
         assert video.edx_video_id != ''
@@ -1923,6 +1925,7 @@ class VideoBlockTest(TestCase, VideoBlockTestBase):
             val_transcript_language_code=val_transcript_language_code,
             val_transcript_provider=val_transcript_provider
         )
+        xml_object = etree.fromstring(xml_data)
         module_system = DummySystem(load_error_modules=True)
         id_generator = Mock()
 
@@ -1940,7 +1943,7 @@ class VideoBlockTest(TestCase, VideoBlockTestBase):
         # Verify edx_video_id is empty before.
         assert self.descriptor.edx_video_id == ''
 
-        video = self.descriptor.from_xml(xml_data, module_system, id_generator)
+        video = self.descriptor.parse_xml(xml_object, module_system, None, id_generator)
 
         # Verify edx_video_id is populated after the import.
         assert video.edx_video_id != ''
@@ -2077,11 +2080,12 @@ class VideoBlockTest(TestCase, VideoBlockTestBase):
             xml_data += val_transcripts
 
         xml_data += '</video_asset></video>'
+        xml_object = etree.fromstring(xml_data)
 
         # Verify edx_video_id is empty before import.
         assert self.descriptor.edx_video_id == ''
 
-        video = self.descriptor.from_xml(xml_data, module_system, id_generator)
+        video = self.descriptor.parse_xml(xml_object, module_system, None, id_generator)
 
         # Verify edx_video_id is not empty after import.
         assert video.edx_video_id != ''
@@ -2107,8 +2111,9 @@ class VideoBlockTest(TestCase, VideoBlockTestBase):
                 </video_asset>
             </video>
         """
+        xml_object = etree.fromstring(xml_data)
         with pytest.raises(ValCannotCreateError):
-            VideoBlock.from_xml(xml_data, module_system, id_generator=Mock())
+            VideoBlock.parse_xml(xml_object, module_system, None, id_generator=Mock())
         with pytest.raises(ValVideoNotFoundError):
             get_video_info("test_edx_video_id")
 

--- a/openedx/core/djangoapps/olx_rest_api/adapters.py
+++ b/openedx/core/djangoapps/olx_rest_api/adapters.py
@@ -1,22 +1,22 @@
 """
 Helpers required to adapt to differing APIs
 """
-from contextlib import contextmanager
 import logging
 import re
+from contextlib import contextmanager
 
-from opaque_keys import InvalidKeyError
-from opaque_keys.edx.keys import AssetKey, CourseKey
 from fs.memoryfs import MemoryFS
 from fs.wrapfs import WrapFS
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import AssetKey, CourseKey
+from xmodule.assetstore.assetmgr import AssetManager
+from xmodule.contentstore.content import StaticContent
+from xmodule.exceptions import NotFoundError
+from xmodule.modulestore.django import modulestore as store
+from xmodule.modulestore.exceptions import ItemNotFoundError
+from xmodule.xml_module import XmlMixin
 
 from common.djangoapps.static_replace import replace_static_urls
-from xmodule.contentstore.content import StaticContent  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.assetstore.assetmgr import AssetManager  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.django import modulestore as store  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.exceptions import ItemNotFoundError  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.exceptions import NotFoundError  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.xml_module import XmlParserMixin  # lint-amnesty, pylint: disable=wrong-import-order
 
 log = logging.getLogger(__name__)
 
@@ -105,7 +105,7 @@ def override_export_fs(block):
     XmlSerializationMixin.add_xml_to_node() method.
     This method temporarily replaces a block's runtime's
     'export_fs' system with an in-memory filesystem.
-    This method also abuses the XmlParserMixin.export_to_file()
+    This method also abuses the XmlMixin.export_to_file()
     API to prevent the XModule export code from exporting each
     block as two files (one .olx pointing to one .xml file).
     The export_to_file was meant to be used only by the
@@ -120,10 +120,10 @@ def override_export_fs(block):
     if hasattr(block, 'export_to_file'):
         old_export_to_file = block.export_to_file
         block.export_to_file = lambda: False
-    old_global_export_to_file = XmlParserMixin.export_to_file
-    XmlParserMixin.export_to_file = lambda _: False  # So this applies to child blocks that get loaded during export
+    old_global_export_to_file = XmlMixin.export_to_file
+    XmlMixin.export_to_file = lambda _: False  # So this applies to child blocks that get loaded during export
     yield fs
     block.runtime.export_fs = old_export_fs
     if hasattr(block, 'export_to_file'):
         block.export_to_file = old_export_to_file
-    XmlParserMixin.export_to_file = old_global_export_to_file
+    XmlMixin.export_to_file = old_global_export_to_file

--- a/openedx/core/djangoapps/xblock/runtime/blockstore_runtime.py
+++ b/openedx/core/djangoapps/xblock/runtime/blockstore_runtime.py
@@ -67,7 +67,7 @@ class BlockstoreXBlockRuntime(XBlockRuntime):
                 # This is a (former) XModule with messy XML parsing code; let its parse_xml() method continue to work
                 # as it currently does in the old runtime, but let this parse_xml_new_runtime() method parse the XML in
                 # a simpler way that's free of tech debt, if defined.
-                # In particular, XmlParserMixin doesn't play well with this new runtime, so this is mostly about
+                # In particular, XmlMixin doesn't play well with this new runtime, so this is mostly about
                 # bypassing that mixin's code.
                 # When a former XModule no longer needs to support the old runtime, its parse_xml_new_runtime method
                 # should be removed and its parse_xml() method should be simplified to just call the super().parse_xml()

--- a/openedx/core/djangoapps/xblock/runtime/serializer.py
+++ b/openedx/core/djangoapps/xblock/runtime/serializer.py
@@ -12,7 +12,7 @@ from fs.wrapfs import WrapFS
 from lxml.etree import Element
 from lxml.etree import tostring as etree_tostring
 
-from xmodule.xml_module import XmlParserMixin
+from xmodule.xml_module import XmlMixin
 
 log = logging.getLogger(__name__)
 
@@ -104,7 +104,7 @@ def override_export_fs(block):
 
     This method temporarily replaces a block's runtime's 'export_fs' system with
     an in-memory filesystem. This method also abuses the
-        XmlParserMixin.export_to_file()
+        XmlMixin.export_to_file()
     API to prevent the XModule export code from exporting each block as two
     files (one .olx pointing to one .xml file). The export_to_file was meant to
     be used only by the customtag XModule but it makes our lives here much
@@ -119,8 +119,8 @@ def override_export_fs(block):
     if hasattr(block, 'export_to_file'):
         old_export_to_file = block.export_to_file
         block.export_to_file = lambda: False
-    old_global_export_to_file = XmlParserMixin.export_to_file
-    XmlParserMixin.export_to_file = lambda _: False  # So this applies to child blocks that get loaded during export
+    old_global_export_to_file = XmlMixin.export_to_file
+    XmlMixin.export_to_file = lambda _: False  # So this applies to child blocks that get loaded during export
     try:
         yield fs
     except:  # lint-amnesty, pylint: disable=try-except-raise
@@ -129,4 +129,4 @@ def override_export_fs(block):
         block.runtime.export_fs = old_export_fs
         if hasattr(block, 'export_to_file'):
             block.export_to_file = old_export_to_file
-        XmlParserMixin.export_to_file = old_global_export_to_file
+        XmlMixin.export_to_file = old_global_export_to_file

--- a/openedx/core/djangoapps/xblock/runtime/shims.py
+++ b/openedx/core/djangoapps/xblock/runtime/shims.py
@@ -154,7 +154,7 @@ class RuntimeShim:
 
     def process_xml(self, xml):
         """
-        Code to handle parsing of child XML for old blocks that use XmlParserMixin.
+        Code to handle parsing of child XML for old blocks that use XmlMixin.
         """
         # We can't parse XML in a vacuum - we need to know the parent block and/or the
         # OLX file that holds this XML in order to generate useful definition keys etc.

--- a/xmodule/course_module.py
+++ b/xmodule/course_module.py
@@ -6,7 +6,6 @@ Django module container for classes and operations related to the "Course Module
 import json
 import logging
 from datetime import datetime, timedelta
-from io import BytesIO
 
 import dateutil.parser
 import requests
@@ -1128,18 +1127,11 @@ class CourseBlock(
         return policy_str
 
     @classmethod
-    def from_xml(cls, xml_data, system, id_generator):
-        instance = super().from_xml(xml_data, system, id_generator)
-
-        # bleh, have to parse the XML here to just pull out the url_name attribute
-        # I don't think it's stored anywhere in the instance.
-        if isinstance(xml_data, str):
-            xml_data = xml_data.encode('ascii', 'ignore')
-        course_file = BytesIO(xml_data)
-        xml_obj = etree.parse(course_file, parser=edx_xml_parser).getroot()
+    def parse_xml(cls, node, runtime, keys, id_generator):
+        instance = super().parse_xml(node, runtime, keys, id_generator)
 
         policy_dir = None
-        url_name = xml_obj.get('url_name', xml_obj.get('slug'))
+        url_name = node.get('url_name')
         if url_name:
             policy_dir = 'policies/' + url_name
 
@@ -1149,9 +1141,9 @@ class CourseBlock(
             paths = [policy_dir + '/grading_policy.json'] + paths
 
         try:
-            policy = json.loads(cls.read_grading_policy(paths, system))
+            policy = json.loads(cls.read_grading_policy(paths, runtime))
         except ValueError:
-            system.error_tracker("Unable to decode grading policy as json")
+            runtime.error_tracker("Unable to decode grading policy as json")
             policy = {}
 
         # now set the current instance. set_grading_policy() will apply some inheritance rules

--- a/xmodule/discussion_block.py
+++ b/xmodule/discussion_block.py
@@ -18,7 +18,7 @@ from xblockutils.studio_editable import StudioEditableXBlockMixin
 from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration, Provider
 from openedx.core.djangolib.markup import HTML, Text
 from openedx.core.lib.xblock_utils import get_css_dependencies, get_js_dependencies
-from xmodule.xml_module import XmlParserMixin
+from xmodule.xml_module import XmlMixin
 
 log = logging.getLogger(__name__)
 loader = ResourceLoader(__name__)  # pylint: disable=invalid-name
@@ -34,7 +34,7 @@ def _(text):
 @XBlock.needs('user')  # pylint: disable=abstract-method
 @XBlock.needs('i18n')
 @XBlock.needs('mako')
-class DiscussionXBlock(XBlock, StudioEditableXBlockMixin, XmlParserMixin):  # lint-amnesty, pylint: disable=abstract-method
+class DiscussionXBlock(XBlock, StudioEditableXBlockMixin, XmlMixin):  # lint-amnesty, pylint: disable=abstract-method
     """
     Provides a discussion forum that is inline with other content in the courseware.
     """

--- a/xmodule/raw_module.py
+++ b/xmodule/raw_module.py
@@ -4,7 +4,6 @@ import re
 
 from lxml import etree
 from xblock.fields import Scope, String
-from xmodule.xml_module import XmlDescriptor  # pylint: disable=unused-import
 
 from .exceptions import SerializationError
 

--- a/xmodule/template_module.py
+++ b/xmodule/template_module.py
@@ -147,19 +147,18 @@ class TranslateCustomTagBlock(  # pylint: disable=abstract-method
     resources_dir = None
 
     @classmethod
-    def from_xml(cls, xml_data, system, id_generator):
+    def parse_xml(cls, node, runtime, _keys, _id_generator):
         """
         Transforms the xml_data from <$custom_tag attr="" attr=""/> to
         <customtag attr="" attr="" impl="$custom_tag"/>
         """
 
-        xml_object = etree.fromstring(xml_data)
-        system.error_tracker(Text('WARNING: the <{tag}> tag is deprecated.  '
-                             'Instead, use <customtag impl="{tag}" attr1="..." attr2="..."/>. ')
-                             .format(tag=xml_object.tag))
+        runtime.error_tracker(Text('WARNING: the <{tag}> tag is deprecated.  '
+                              'Instead, use <customtag impl="{tag}" attr1="..." attr2="..."/>. ')
+                              .format(tag=node.tag))
 
-        tag = xml_object.tag
-        xml_object.tag = 'customtag'
-        xml_object.attrib['impl'] = tag
+        tag = node.tag
+        node.tag = 'customtag'
+        node.attrib['impl'] = tag
 
-        return system.process_xml(etree.tostring(xml_object))
+        return runtime.process_xml(etree.tostring(node))

--- a/xmodule/tests/test_video.py
+++ b/xmodule/tests/test_video.py
@@ -282,7 +282,7 @@ class VideoBlockImportTestCase(TestCase):
             'transcripts': {'ua': 'ukrainian_translation.srt', 'ge': 'german_translation.srt'}
         })
 
-    def test_from_xml(self):
+    def test_parse_xml(self):
         module_system = DummySystem(load_error_modules=True)
         xml_data = '''
             <video display_name="Test Video"
@@ -299,7 +299,8 @@ class VideoBlockImportTestCase(TestCase):
               <transcript language="de" src="german_translation.srt" />
             </video>
         '''
-        output = VideoBlock.from_xml(xml_data, module_system, Mock())
+        xml_object = etree.fromstring(xml_data)
+        output = VideoBlock.parse_xml(xml_object, module_system, None, Mock())
         self.assert_attributes_equal(output, {
             'youtube_id_0_75': 'izygArpw-Qo',
             'youtube_id_1_0': 'p2Q6BrNhdh8',
@@ -323,7 +324,7 @@ class VideoBlockImportTestCase(TestCase):
         ('test_org/test_course/test_run', '/c4x/test_org/test_course/asset/test.png')
     )
     @ddt.unpack
-    def test_from_xml_when_handout_is_course_asset(self, course_id_string, expected_handout_link):
+    def test_parse_xml_when_handout_is_course_asset(self, course_id_string, expected_handout_link):
         """
         Test that if handout link is course_asset then it will contain targeted course_id in handout link.
         """
@@ -344,10 +345,11 @@ class VideoBlockImportTestCase(TestCase):
               <transcript language="de" src="german_translation.srt" />
             </video>
         '''
+        xml_object = etree.fromstring(xml_data)
         id_generator = Mock()
         id_generator.target_course_id = course_id
 
-        output = VideoBlock.from_xml(xml_data, module_system, id_generator)
+        output = VideoBlock.parse_xml(xml_object, module_system, None, id_generator)
         self.assert_attributes_equal(output, {
             'youtube_id_0_75': 'izygArpw-Qo',
             'youtube_id_1_0': 'p2Q6BrNhdh8',
@@ -365,7 +367,7 @@ class VideoBlockImportTestCase(TestCase):
             'transcripts': {'uk': 'ukrainian_translation.srt', 'de': 'german_translation.srt'},
         })
 
-    def test_from_xml_missing_attributes(self):
+    def test_parse_xml_missing_attributes(self):
         """
         Ensure that attributes have the right values if they aren't
         explicitly set in XML.
@@ -378,7 +380,8 @@ class VideoBlockImportTestCase(TestCase):
               <source src="http://www.example.com/source.mp4"/>
             </video>
         '''
-        output = VideoBlock.from_xml(xml_data, module_system, Mock())
+        xml_object = etree.fromstring(xml_data)
+        output = VideoBlock.parse_xml(xml_object, module_system, None, Mock())
         self.assert_attributes_equal(output, {
             'youtube_id_0_75': '',
             'youtube_id_1_0': 'p2Q6BrNhdh8',
@@ -395,7 +398,7 @@ class VideoBlockImportTestCase(TestCase):
             'data': ''
         })
 
-    def test_from_xml_missing_download_track(self):
+    def test_parse_xml_missing_download_track(self):
         """
         Ensure that attributes have the right values if they aren't
         explicitly set in XML.
@@ -409,7 +412,8 @@ class VideoBlockImportTestCase(TestCase):
               <track src="http://www.example.com/track"/>
             </video>
         '''
-        output = VideoBlock.from_xml(xml_data, module_system, Mock())
+        xml_object = etree.fromstring(xml_data)
+        output = VideoBlock.parse_xml(xml_object, module_system, None, Mock())
         self.assert_attributes_equal(output, {
             'youtube_id_0_75': '',
             'youtube_id_1_0': 'p2Q6BrNhdh8',
@@ -426,13 +430,14 @@ class VideoBlockImportTestCase(TestCase):
             'transcripts': {},
         })
 
-    def test_from_xml_no_attributes(self):
+    def test_parse_xml_no_attributes(self):
         """
         Make sure settings are correct if none are explicitly set in XML.
         """
         module_system = DummySystem(load_error_modules=True)
         xml_data = '<video></video>'
-        output = VideoBlock.from_xml(xml_data, module_system, Mock())
+        xml_object = etree.fromstring(xml_data)
+        output = VideoBlock.parse_xml(xml_object, module_system, None, Mock())
         self.assert_attributes_equal(output, {
             'youtube_id_0_75': '',
             'youtube_id_1_0': '3_yD_cEKoCk',
@@ -450,7 +455,7 @@ class VideoBlockImportTestCase(TestCase):
             'transcripts': {},
         })
 
-    def test_from_xml_double_quotes(self):
+    def test_parse_xml_double_quotes(self):
         """
         Make sure we can handle the double-quoted string format (which was used for exporting for
         a few weeks).
@@ -471,7 +476,8 @@ class VideoBlockImportTestCase(TestCase):
                 youtube_id_1_0="&quot;OEoXaMPEzf10&quot;"
                 />
         '''
-        output = VideoBlock.from_xml(xml_data, module_system, Mock())
+        xml_object = etree.fromstring(xml_data)
+        output = VideoBlock.parse_xml(xml_object, module_system, None, Mock())
         self.assert_attributes_equal(output, {
             'youtube_id_0_75': 'OEoXaMPEzf65',
             'youtube_id_1_0': 'OEoXaMPEzf10',
@@ -488,14 +494,15 @@ class VideoBlockImportTestCase(TestCase):
             'data': ''
         })
 
-    def test_from_xml_double_quote_concatenated_youtube(self):
+    def test_parse_xml_double_quote_concatenated_youtube(self):
         module_system = DummySystem(load_error_modules=True)
         xml_data = '''
             <video display_name="Test Video"
                    youtube="1.0:&quot;p2Q6BrNhdh8&quot;,1.25:&quot;1EeWXzPdhSA&quot;">
             </video>
         '''
-        output = VideoBlock.from_xml(xml_data, module_system, Mock())
+        xml_object = etree.fromstring(xml_data)
+        output = VideoBlock.parse_xml(xml_object, module_system, None, Mock())
         self.assert_attributes_equal(output, {
             'youtube_id_0_75': '',
             'youtube_id_1_0': 'p2Q6BrNhdh8',
@@ -528,7 +535,8 @@ class VideoBlockImportTestCase(TestCase):
               <track src="http://www.example.com/track"/>
             </video>
         """
-        output = VideoBlock.from_xml(xml_data, module_system, Mock())
+        xml_object = etree.fromstring(xml_data)
+        output = VideoBlock.parse_xml(xml_object, module_system, None, Mock())
         self.assert_attributes_equal(output, {
             'youtube_id_0_75': 'izygArpw-Qo',
             'youtube_id_1_0': 'p2Q6BrNhdh8',
@@ -558,7 +566,8 @@ class VideoBlockImportTestCase(TestCase):
               <track src="http://www.example.com/track"/>
             </video>
         """
-        video = VideoBlock.from_xml(xml_data, module_system, Mock())
+        xml_object = etree.fromstring(xml_data)
+        video = VideoBlock.parse_xml(xml_object, module_system, None, Mock())
         self.assert_attributes_equal(video, {
             'youtube_id_0_75': 'izygArpw-Qo',
             'youtube_id_1_0': 'p2Q6BrNhdh8',
@@ -588,7 +597,8 @@ class VideoBlockImportTestCase(TestCase):
               <track src="http://www.example.com/track"/>
             </video>
         """
-        video = VideoBlock.from_xml(xml_data, module_system, Mock())
+        xml_object = etree.fromstring(xml_data)
+        video = VideoBlock.parse_xml(xml_object, module_system, None, Mock())
         self.assert_attributes_equal(video, {
             'youtube_id_0_75': 'izygArpw-Qo',
             'youtube_id_1_0': 'p2Q6BrNhdh8',
@@ -606,10 +616,10 @@ class VideoBlockImportTestCase(TestCase):
     @patch('xmodule.video_module.video_module.edxval_api')
     def test_import_val_data(self, mock_val_api):
         """
-        Test that `from_xml` works method works as expected.
+        Test that `parse_xml` works method works as expected.
         """
         def mock_val_import(xml, edx_video_id, resource_fs, static_dir, external_transcripts, course_id):
-            """Mock edxval.api.import_from_xml"""
+            """Mock edxval.api.import_parse_xml"""
             assert xml.tag == 'video_asset'
             assert dict(list(xml.items())) == {'mock_attr': ''}
             assert edx_video_id == 'test_edx_video_id'
@@ -634,9 +644,10 @@ class VideoBlockImportTestCase(TestCase):
         """.format(
             edx_video_id=edx_video_id
         )
+        xml_object = etree.fromstring(xml_data)
         id_generator = Mock()
         id_generator.target_course_id = 'test_course_id'
-        video = VideoBlock.from_xml(xml_data, module_system, id_generator)
+        video = VideoBlock.parse_xml(xml_object, module_system, None, id_generator)
 
         self.assert_attributes_equal(video, {'edx_video_id': edx_video_id})
         mock_val_api.import_from_xml.assert_called_once_with(
@@ -660,8 +671,9 @@ class VideoBlockImportTestCase(TestCase):
                 <video_asset client_video_id="test_client_video_id" duration="-1"/>
             </video>
         """
+        xml_object = etree.fromstring(xml_data)
         with pytest.raises(mock_val_api.ValCannotCreateError):
-            VideoBlock.from_xml(xml_data, module_system, id_generator=Mock())
+            VideoBlock.parse_xml(xml_object, module_system, None, Mock())
 
 
 class VideoExportTestCase(VideoBlockTestBase):

--- a/xmodule/tests/test_xml_module.py
+++ b/xmodule/tests/test_xml_module.py
@@ -20,7 +20,7 @@ from xmodule.tests import get_test_descriptor_system
 from xmodule.tests.xml import XModuleXmlImportTest
 from xmodule.tests.xml.factories import CourseFactory, ProblemFactory, SequenceFactory
 from xmodule.x_module import XModuleMixin
-from xmodule.xml_module import XmlDescriptor, deserialize_field, serialize_field
+from xmodule.xml_module import XmlMixin, deserialize_field, serialize_field
 
 
 class CrazyJsonString(String):
@@ -65,7 +65,7 @@ class InheritingFieldDataTest(unittest.TestCase):
     Tests of InheritingFieldData.
     """
 
-    class TestableInheritingXBlock(XmlDescriptor):  # lint-amnesty, pylint: disable=abstract-method
+    class TestableInheritingXBlock(XmlMixin):  # lint-amnesty, pylint: disable=abstract-method
         """
         An XBlock we can use in these tests.
         """
@@ -227,11 +227,15 @@ class InheritingFieldDataTest(unittest.TestCase):
 
 
 class EditableMetadataFieldsTest(unittest.TestCase):
+    class TestableXmlXBlock(XmlMixin, XModuleMixin):  # lint-amnesty, pylint: disable=abstract-method
+        """
+        This is subclassing `XModuleMixin` to use metadata fields in the unmixed class.
+        """
 
     def test_display_name_field(self):
         editable_fields = self.get_xml_editable_fields(DictFieldData({}))
         # Tests that the xblock fields (currently tags and name) get filtered out.
-        # Also tests that xml_attributes is filtered out of XmlDescriptor.
+        # Also tests that xml_attributes is filtered out of XmlMixin.
         assert 1 == len(editable_fields), editable_fields
         self.assert_field_values(
             editable_fields, 'display_name', XModuleMixin.display_name,
@@ -334,13 +338,13 @@ class EditableMetadataFieldsTest(unittest.TestCase):
     def get_xml_editable_fields(self, field_data):
         runtime = get_test_descriptor_system()
         return runtime.construct_xblock_from_class(
-            XmlDescriptor,
+            self.TestableXmlXBlock,
             scope_ids=Mock(),
             field_data=field_data,
         ).editable_metadata_fields
 
     def get_descriptor(self, field_data):
-        class TestModuleDescriptor(TestFields, XmlDescriptor):  # lint-amnesty, pylint: disable=abstract-method
+        class TestModuleDescriptor(TestFields, self.TestableXmlXBlock):  # lint-amnesty, pylint: disable=abstract-method
             @property
             def non_editable_metadata_fields(self):
                 non_editable_fields = super().non_editable_metadata_fields

--- a/xmodule/vertical_block.py
+++ b/xmodule/vertical_block.py
@@ -21,7 +21,7 @@ from xmodule.studio_editable import StudioEditableBlock
 from xmodule.util.misc import is_xblock_an_assignment
 from xmodule.util.xmodule_django import add_webpack_to_fragment
 from xmodule.x_module import PUBLIC_VIEW, STUDENT_VIEW, XModuleFields
-from xmodule.xml_module import XmlParserMixin
+from xmodule.xml_module import XmlMixin
 
 log = logging.getLogger(__name__)
 
@@ -55,7 +55,7 @@ class VerticalBlock(
     VerticalFields,
     XModuleFields,
     StudioEditableBlock,
-    XmlParserMixin,
+    XmlMixin,
     MakoTemplateBlockBase,
     XBlock
 ):

--- a/xmodule/x_module.py
+++ b/xmodule/x_module.py
@@ -279,6 +279,7 @@ class XModuleFields:
     )
 
 
+@XBlock.needs("i18n")
 class XModuleMixin(XModuleFields, XBlock):
     """
     Fields and methods used by XModules internally.

--- a/xmodule/x_module.py
+++ b/xmodule/x_module.py
@@ -1169,7 +1169,7 @@ class DescriptorSystem(MetricsMixin, ConfigurableFragmentWrapper, Runtime):
         raise NotImplementedError("edX Platform doesn't currently implement XBlock resource urls")
 
     def add_block_as_child_node(self, block, node):
-        child = etree.SubElement(node, "unknown")
+        child = etree.SubElement(node, block.category)
         child.set('url_name', block.url_name)
         block.add_xml_to_node(child)
 

--- a/xmodule/xml_module.py
+++ b/xmodule/xml_module.py
@@ -8,13 +8,11 @@ import os
 
 from lxml import etree
 from lxml.etree import ElementTree, XMLParser
-from xblock.core import XBlock, XML_NAMESPACES
+from xblock.core import XML_NAMESPACES
 from xblock.fields import Dict, Scope, ScopeIds
 from xblock.runtime import KvsFieldData
 from xmodule.modulestore import EdxJSONEncoder
 from xmodule.modulestore.inheritance import InheritanceKeyValueStore, own_metadata
-
-from .x_module import XModuleMixin
 
 log = logging.getLogger(__name__)
 
@@ -505,8 +503,3 @@ class XmlMixin:
         non_editable_fields = super().non_editable_metadata_fields
         non_editable_fields.append(XmlMixin.xml_attributes)
         return non_editable_fields
-
-
-@XBlock.needs("i18n")
-class XmlDescriptor(XmlMixin, XModuleMixin):  # lint-amnesty, pylint: disable=abstract-method
-    pass

--- a/xmodule/xml_module.py
+++ b/xmodule/xml_module.py
@@ -107,6 +107,8 @@ class XmlParserMixin:
     """
     Class containing XML parsing functionality shared between XBlock and XModuleDescriptor.
     """
+    resources_dir = None
+
     # Extension to append to filename paths
     filename_extension = 'xml'
 
@@ -509,8 +511,6 @@ class XmlMixin(XmlParserMixin):  # lint-amnesty, pylint: disable=abstract-method
     """
     Mixin class for standardized parsing of XModule xml.
     """
-    resources_dir = None
-
     @classmethod
     def from_xml(cls, xml_data, system, id_generator):
         """


### PR DESCRIPTION
## Description

Most of the methods in `XmlMixin` act as wrappers for the official API for serialization and deserialization (`parse_xml()` and `add_xml_to_node()`). `XmlParserMixin` contains the code which does the actual serialization and deserialization.

This simplifies the serialization layer by:
1. Replacing remaining old `from_xml` deserialization methods with `parse_xml`, which is used by XBlocks.
2. Removing the `XmlMixin` class and renaming `XmlParserMixin` to `XmlMixin`. This way, the code handling the serialization and deserialization is retained.
3. Removing the `XmlDescriptor` class, which was used only in tests.
4. Removing `slug` from `url_name` lookup, as we had already removed its translation in https://github.com/openedx/edx-platform/pull/29927.

## Sandbox

LMS: https://pr30072.sandbox.opencraft.hosting/
Studio: https://studio.pr30072.sandbox.opencraft.hosting/

The sandbox contains one manual change because the Error XBlock is not loaded by default when importing a course. [This line](https://github.com/openedx/edx-platform/blob/a389a9ff10fd06bd053107fc6a4f19c7d24f7233/xmodule/modulestore/xml.py#L332) is replaced with:
```diff
---         self.load_error_modules = load_error_modules
+++         self.load_error_modules = True
```


## Testing instructions

1. Log in as a `staff` user.
1. Open any sample course or create a new course. Go to Tools > Import and upload file [good.tar.gz](https://github.com/openedx/edx-platform/files/8098012/good.tar.gz)
1. Once the file is imported, verify that all XBlocks were loaded correctly
1. Go to Tools > Export and download the file.
1. Verify that the export's structure is correct.
1. Go to Tools > Import again, and upload file [bad.tar.gz](https://github.com/openedx/edx-platform/files/8098030/bad.tar.gz).
1. In this file, the CAPA module is malformed. Verify that the Error block is rendered in place of the CAPA Multiple choice block.

## Other information

`XmlParserMixin` (renamed to `XmlMixin` now)  and some XBlock classes will continue to retain their custom logic. This logic cannot be removed without breaking backward compatibility. Since this logic does not impact the complexity of the system there are no negatives to retaining it.

Private-ref: [BB-5573](https://tasks.opencraft.com/browse/BB-5573)