### PR TITLE
docs: Update a help string to reference a more up-to-date sample course.

### DIFF
--- a/cms/djangoapps/contentstore/git_export_utils.py
+++ b/cms/djangoapps/contentstore/git_export_utils.py
@@ -37,7 +37,7 @@ class GitExportError(Exception):
                       "please create it, or configure a different path with "
                       "GIT_REPO_EXPORT_DIR").format(GIT_REPO_EXPORT_DIR)
     URL_BAD = _('Non writable git url provided. Expecting something like:'
-                ' git@github.com:edx/edx4edx_lite.git')
+                ' git@github.com:openedx/openedx-demo-course.git')
     URL_NO_AUTH = _('If using http urls, you must provide the username '
                     'and password in the url. Similar to '
                     'https://user:pass@github.com/user/course.')


### PR DESCRIPTION
Per https://github.com/openedx/public-engineering/issues/73 the edx4edx_lite repo
is going away.  Remove this reference to it to avoid future confusion.
