### PR TITLE
fix: add field to check if user is admin

### DIFF
--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -308,6 +308,7 @@ def get_course(request, course_key):
             FORUM_ROLE_MODERATOR,
             FORUM_ROLE_COMMUNITY_TA,
         }),
+        "is_user_admin": request.user.is_staff,
         "provider": course_config.provider_type,
         "enable_in_context": course_config.enable_in_context,
         "group_at_subsection": course_config.plugin_configuration.get("group_at_subsection", False),

--- a/lms/djangoapps/discussion/rest_api/tests/test_api.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api.py
@@ -200,6 +200,7 @@ class GetCourseTest(ForumsEnableMixin, UrlResetMixin, SharedModuleStoreTestCase)
             'group_at_subsection': False,
             'provider': 'legacy',
             'user_is_privileged': False,
+            'is_user_admin': False,
             'user_roles': {'Student'},
             'learners_tab_enabled': False,
             'reason_codes_enabled': False,

--- a/lms/djangoapps/discussion/rest_api/tests/test_views.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views.py
@@ -517,6 +517,7 @@ class CourseViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
                 "allow_anonymous": True,
                 "allow_anonymous_to_peers": False,
                 "user_is_privileged": False,
+                'is_user_admin': False,
                 "user_roles": ["Student"],
                 'learners_tab_enabled': False,
                 "reason_codes_enabled": False,


### PR DESCRIPTION
## Ticket: [TNL-9731](https://openedx.atlassian.net/browse/TNL-9731)

Added a field, in general discussion information for a course, to check whether a user is admin or not.