### PR TITLE
fix: add as style for the link tag that preloads

### DIFF
--- a/lms/templates/courseware/courseware-chromeless.html
+++ b/lms/templates/courseware/courseware-chromeless.html
@@ -42,7 +42,7 @@ ${static.get_page_title_breadcrumbs(course_name())}
 <script type="text/javascript" src="${static.url('js/jquery.autocomplete.js')}" async></script>
 <script type="text/javascript" src="${static.url('js/src/tooltip_manager.js')}" async></script>
 
-<link href="${static.url('css/vendor/jquery.autocomplete.css')}" rel="preload" type="text/css">
+<link href="${static.url('css/vendor/jquery.autocomplete.css')}" rel="preload" type="text/css" as="style">
   ${HTML(fragment.head_html())}
 
 % if is_learning_mfe:


### PR DESCRIPTION

<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Adding a as `as="style"` for link tag which preloads a CSS resource
That is requried to set otherwise chrome/browser would issue a warning about it. 

## Supporting information

Ref: https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preload

## Testing instructions

When rendering a course block it the devtools will issue a warning like: 

`<link rel=preload> must have a valid `as` value` . 

After apply the changes the above error shouldn't show up. 