### PR TITLE
feat: Add config that extends instructor analytics

### DIFF
--- a/lms/djangoapps/instructor_analytics/basic.py
+++ b/lms/djangoapps/instructor_analytics/basic.py
@@ -119,6 +119,10 @@ def enrolled_students_features(course_key, features):
         for program_enrollment in program_enrollments:
             external_user_key_dict[program_enrollment.user_id] = program_enrollment.external_user_key
 
+    STUDENT_FEATURES_WITH_CUSTOM = STUDENT_FEATURES + tuple(
+        getattr(settings, "STUDENT_PROFILE_DOWNLOAD_FIELDS_CUSTOM_STUDENT_ATTRIBUTES", ())
+    )
+
     def extract_attr(student, feature):
         """Evaluate a student attribute that is ready for JSON serialization"""
         attr = getattr(student, feature)
@@ -130,7 +134,7 @@ def enrolled_students_features(course_key, features):
 
     def extract_student(student, features):
         """ convert student to dictionary """
-        student_features = [x for x in STUDENT_FEATURES if x in features]
+        student_features = [x for x in STUDENT_FEATURES_WITH_CUSTOM if x in features]
         profile_features = [x for x in PROFILE_FEATURES if x in features]
 
         # For data extractions on the 'meta' field

--- a/lms/djangoapps/instructor_analytics/tests/test_basic.py
+++ b/lms/djangoapps/instructor_analytics/tests/test_basic.py
@@ -131,7 +131,7 @@ class TestAnalyticsBasic(ModuleStoreTestCase):
             user.profile.save()
         for feature in query_features:
             assert feature in AVAILABLE_FEATURES
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(2):
             userreports = enrolled_students_features(self.course_key, query_features)
         assert len(userreports) == len(self.users)
 
@@ -159,7 +159,7 @@ class TestAnalyticsBasic(ModuleStoreTestCase):
         Assert that we can query individual fields in the 'meta' field in the UserProfile
         """
         query_features = ('meta.position', 'meta.company')
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(2):
             userreports = enrolled_students_features(self.course_key, query_features)
         assert len(userreports) == len(self.users)
         for userreport in userreports:
@@ -211,11 +211,12 @@ class TestAnalyticsBasic(ModuleStoreTestCase):
         self.client.login(username=instructor.username, password='test')
 
         query_features = ('username', 'cohort')
-        # There should be a constant of 2 SQL queries when calling
+        # There should be a constant of 3 SQL queries when calling
         # enrolled_students_features.  The first query comes from the call to
         # User.objects.filter(...), and the second comes from
-        # prefetch_related('course_groups').
-        with self.assertNumQueries(2):
+        # prefetch_related('course_groups'), and the third comes from the query
+        # to site configuration.
+        with self.assertNumQueries(3):
             userreports = enrolled_students_features(course.id, query_features)
         assert len([r for r in userreports if r['username'] in cohorted_usernames]) == len(cohorted_students)
         assert len([r for r in userreports if r['username'] == non_cohorted_student.username]) == 1
@@ -237,7 +238,7 @@ class TestAnalyticsBasic(ModuleStoreTestCase):
                 ProgramEnrollmentFactory.create(user=user, external_user_key=external_user_key)
                 username_with_external_user_key_dict[user.username] = external_user_key
 
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(3):
             userreports = enrolled_students_features(self.course_key, query_features)
         assert len(userreports) == 30
         for report in userreports:


### PR DESCRIPTION


<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This PR adds a new configuration `STUDENT_PROFILE_DOWNLOAD_FIELDS_CUSTOM_STUDENT_ATTRIBUTES` that allows custom student fields to be exported on the student profile information csv.

On [NAU](https://lms.nau.edu.pt/register) we have some custom attributes. We use the `REGISTRATION_EXTENSION_FORM` configuration to it but, we can't include those fields on the Instructor analytics csv files. This PR allow us to include those fields indirectly.

It requires a bridge between the class configured on `REGISTRATION_EXTENSION_FORM` and Django User. It adds dynamically a new attribute to the User class, like:
```python
def get_nau_user_extended_model_employment_situation(self):
    if hasattr(self, "nauuserextendedmodel"):
        return self.nauuserextendedmodel.employment_situation
    return None
setattr(User, 'nau_user_extended_model_employment_situation', property(get_nau_user_extended_model_employment_situation))
```

The PR uses `configuration_helpers.get_value_for_org` that allows the site administrator to configure the new configuration per site or on all the platform.

## Supporting information

https://lms.nau.edu.pt/register > view "Employment situation" 

## Testing instructions

It requires a custom registration extension form.

## Deadline

None

