### PR TITLE
chore: upgrade xblock_lti_consumer library to version 3.4.5

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -625,7 +625,7 @@ libsass==0.10.0
     #   ora2
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==3.4.4
+lti-consumer-xblock==3.4.5
     # via -r requirements/edx/base.in
 lxml==4.5.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -840,7 +840,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/testing.txt
     #   ora2
-lti-consumer-xblock==3.4.4
+lti-consumer-xblock==3.4.5
     # via -r requirements/edx/testing.txt
 lxml==4.5.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -799,7 +799,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==3.4.4
+lti-consumer-xblock==3.4.5
     # via -r requirements/edx/base.txt
 lxml==4.5.0
     # via


### PR DESCRIPTION
## Description

Upgrade the xblock_lti_consumer library from version 3.4.4 to 3.4.5
In this upgrade, the library is going to use a new CMS permission method to check the permission of the user on modifying course content.
See the related PR at https://github.com/openedx/xblock-lti-consumer/pull/240