### PR TITLE
feat: [Microba-1758] link new bulk email tool

### DIFF
--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -702,6 +702,10 @@ def _section_send_email(course, access):
             'list_email_content', kwargs={'course_id': str(course_key)}
         ),
     }
+    if settings.FEATURES.get("ENABLE_NEW_BULK_EMAIL_EXPERIENCE", False) is not False:
+        section_data[
+            "communications_mfe_url"
+        ] = f"{settings.COMMUNICATIONS_MICROFRONTEND_URL}/courses/{str(course_key)}/bulk_email"
     return section_data
 
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -960,6 +960,18 @@ FEATURES = {
     # .. toggle_target_removal_date: None
     # .. toggle_tickets: 'https://openedx.atlassian.net/browse/MST-1348'
     'ENABLE_INTEGRITY_SIGNATURE': False,
+
+    # .. toggle_name: FEATURES['ENABLE_NEW_BULK_EMAIL_EXPERIENCE']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: When true, replaces the bulk email tool found on the
+    #   instructor dashboard with a link to the new communications MFE version instead.
+    #   Stting the tool to false will leave the old bulk email tool experience in place.
+    # .. toggle_use_cases: opt_in
+    # .. toggle_creation_date: 2022-03-21
+    # .. toggle_target_removal_date: None
+    # .. toggle_tickets: 'https://openedx.atlassian.net/browse/MICROBA-1758'
+    'ENABLE_NEW_BULK_EMAIL_EXPERIENCE': False,
 }
 
 # Specifies extra XBlock fields that should available when requested via the Course Blocks API

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -336,6 +336,7 @@ EDXNOTES_CLIENT_NAME = 'edx_notes_api-backend-service'
 ############## Settings for Microfrontends  #########################
 LEARNING_MICROFRONTEND_URL = 'http://localhost:2000'
 ACCOUNT_MICROFRONTEND_URL = 'http://localhost:1997'
+COMMUNICATIONS_MICROFRONTEND_URL = 'http://localhost:1984'
 AUTHN_MICROFRONTEND_URL = 'http://localhost:1999'
 AUTHN_MICROFRONTEND_DOMAIN = 'localhost:1999'
 

--- a/lms/templates/instructor/instructor_dashboard_2/send_email.html
+++ b/lms/templates/instructor/instructor_dashboard_2/send_email.html
@@ -4,8 +4,16 @@ from django.utils.translation import ugettext as _
 from openedx.core.djangolib.markup import HTML
 %>
 
+
 <div class="vert-left send-email" id="section-send-email">
     <div class="request-response msg msg-confirm copy" id="request-response"></div>
+    %if 'communications_mfe_url' in section_data:
+    <p>
+        <em>
+            ${_("To use the email tool, visit the")} <a href="${section_data['communications_mfe_url']}">${_("new experience")}</a>.
+        </em>
+    </p>
+    %else:
     <ul class="list-fields">
         <li class="field">
             <div class="send_to_list">${_("Send to:")}</div>
@@ -134,5 +142,5 @@ from openedx.core.djangolib.markup import HTML
         </div>
     </div>
     %endif
-
+    %endif
 </div> <!-- end section send-email -->


### PR DESCRIPTION
Creates a link to the new communication mfe's bulk email tool in place of the instructor dashboard version. Course staff will now be using the communications MFE if the feature flag is turned on. we will be able to go back to the tool at any time by turning off the feature flag.

In order to test locally, the communications MFE must be up and running on your local machine.

The flag is off by default, and should not affect any environment until it is turned on.

![image](https://user-images.githubusercontent.com/16495365/159325884-21424288-1a68-467f-8699-f6b3196913be.png)

