### PR TITLE
fix: set bulk email link to open in new tab

### DIFF
--- a/lms/templates/instructor/instructor_dashboard_2/send_email.html
+++ b/lms/templates/instructor/instructor_dashboard_2/send_email.html
@@ -10,7 +10,7 @@ from openedx.core.djangolib.markup import HTML
     %if 'communications_mfe_url' in section_data:
     <p>
         <em>
-            ${_("To use the email tool, visit the")} <a href="${section_data['communications_mfe_url']}">${_("new experience")}</a>.
+            ${_("To use the email tool, visit the")} <a href="${section_data['communications_mfe_url']}" target="_blank" rel="noopener noreferrer">${_("new experience")}</a>.
         </em>
     </p>
     %else:


### PR DESCRIPTION
Adds `_blank` target to the new bulk email url to keep the same pattern as insights
