### PR TITLE
build: Simplify how we build docs.

### DIFF
--- a/docs/docs_settings.py
+++ b/docs/docs_settings.py
@@ -7,8 +7,10 @@ import all the Studio code.
 
 import os
 
-from lms.envs.devstack import *  # lint-amnesty, pylint: disable=wildcard-import
-from cms.envs.devstack import (  # lint-amnesty, pylint: disable=unused-import
+from openedx.core.lib.derived import derive_settings
+
+from lms.envs.common import *  # lint-amnesty, pylint: disable=wildcard-import
+from cms.envs.common import (  # lint-amnesty, pylint: disable=unused-import
     ADVANCED_PROBLEM_TYPES,
     COURSE_IMPORT_EXPORT_STORAGE,
     GIT_EXPORT_DEFAULT_IDENT,
@@ -16,6 +18,7 @@ from cms.envs.devstack import (  # lint-amnesty, pylint: disable=unused-import
     SCRAPE_YOUTUBE_THUMBNAILS_JOB_QUEUE,
     VIDEO_TRANSCRIPT_MIGRATIONS_JOB_QUEUE,
     UPDATE_SEARCH_INDEX_JOB_QUEUE,
+    FRONTEND_REGISTER_URL,
 )
 
 # Turn on all the boolean feature flags, so that conditionally included
@@ -26,13 +29,18 @@ for key, value in FEATURES.items():
 
 # Settings that will fail if we enable them, and we don't need them for docs anyway.
 FEATURES['RUN_AS_ANALYTICS_SERVER_ENABLED'] = False
+FEATURES['ENABLE_SOFTWARE_SECURE_FAKE'] = False
+FEATURES['ENABLE_MKTG_SITE'] = False
 
 INSTALLED_APPS.extend([
     'cms.djangoapps.contentstore.apps.ContentstoreConfig',
     'cms.djangoapps.course_creators',
     'cms.djangoapps.xblock_config.apps.XBlockConfig',
-    'lms.djangoapps.lti_provider'
+    'lms.djangoapps.lti_provider',
+    'user_tasks',
 ])
 
 
 COMMON_TEST_DATA_ROOT = ''
+
+derive_settings(__name__)

--- a/docs/guides/conf.py
+++ b/docs/guides/conf.py
@@ -235,7 +235,7 @@ def update_settings_module(service='lms'):
     Set the "DJANGO_SETTINGS_MODULE" environment variable appropriately
     for the module sphinx-apidoc is about to be run on.
     """
-    if os.environ['EDX_PLATFORM_SETTINGS'] == 'devstack_docker':
+    if os.environ.get('EDX_PLATFORM_SETTINGS') == 'devstack_docker':
         settings_module = f'{service}.envs.devstack_docker'
     else:
         settings_module = f'{service}.envs.devstack'


### PR DESCRIPTION
Instead of trying to use the devstack settings file for building docs,
use the common settings file as the base for all settings.  The
devstack settings file builds on top of the production settings file
which are both oriented around reading settings from a yaml file and
getting them loaded in sanely into the dev and production environment.

For documentation, start with the common settings files which should be
sufficient to get a default version of the system up and running.

Note: We still leave the loop that enables all the feature flags as a way
of finding conditionally included API endpoints.
