### PR TITLE
feat: add a waffle switch for new financial assistance flow

### DIFF
--- a/lms/djangoapps/courseware/config.py
+++ b/lms/djangoapps/courseware/config.py
@@ -1,0 +1,18 @@
+"""
+Waffle flags and switches
+"""
+
+from edx_toggles.toggles import WaffleSwitch
+
+WAFFLE_NAMESPACE = 'courseware'
+
+# .. toggle_name: courseware.enable_new_financial_assistance_flow
+# .. toggle_implementation: WaffleSwitch
+# .. toggle_default: False
+# .. toggle_description: enables new internal only financial assistance flow, when active.
+# .. toggle_use_cases: opt_in
+# .. toggle_creation_date: 2022-03-25
+# .. toggle_tickets: https://openedx.atlassian.net/browse/PROD-2588
+ENABLE_NEW_FINANCIAL_ASSISTANCE_FLOW = WaffleSwitch(
+    f"{WAFFLE_NAMESPACE}.enable_new_financial_assistance_flow", __name__
+)


### PR DESCRIPTION
[PROD-2741](https://openedx.atlassian.net/browse/PROD-2741)
Adds a new waffle switch which will be used with the new Financial Assistance flow. All of the new FA backend code will be kept behind the switch so that it doesn't affect the existing workflow and the new flow slowly replaces the existing flow.