### PR TITLE
Combine the two existing coursegraph log messages

### DIFF
--- a/openedx/core/djangoapps/coursegraph/tasks.py
+++ b/openedx/core/djangoapps/coursegraph/tasks.py
@@ -371,13 +371,6 @@ class ModuleStoreSerializer:
             # first, clear the request cache to prevent memory leaks
             RequestCache.clear_all_namespaces()
 
-            log.info(
-                "Now submitting %s for export to neo4j: course %d of %d total courses",
-                course_key,
-                index + 1,
-                total_number_of_courses,
-            )
-
             (needs_dump, reason) = should_dump_course(course_key, graph)
             if not (override_cache or needs_dump):
                 log.info("skipping submitting %s, since it hasn't changed", course_key)
@@ -386,7 +379,15 @@ class ModuleStoreSerializer:
 
             if override_cache:
                 reason = "override_cache is True"
-            log.info("submitting %s, because %s", course_key, reason)
+
+            log.info(
+                "Now submitting %s for export to neo4j, because %s: course %d of %d total courses",
+                course_key,
+                reason,
+                index + 1,
+                total_number_of_courses,
+            )
+
             dump_course_to_neo4j.apply_async(
                 args=[str(course_key), credentials],
             )


### PR DESCRIPTION

<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Combine the two existing coursegraph log messages for submitting courses to Neo4j for viewing in coursegraph for two reasons. First, the existing log message was misleading as it implied that a course was being submitted to Neo4j even when it was being skipped due to not changing since last being sent to Neo4j. Second, the new log message was not distinctive enough for separate searching in Splunk - it will now be distinctive enough for that search.

