### PR TITLE
feat: Add authoring organization logo in API response for all learner enrolled programs

### DIFF
--- a/lms/djangoapps/learner_dashboard/api/v0/tests/test_views.py
+++ b/lms/djangoapps/learner_dashboard/api/v0/tests/test_views.py
@@ -166,7 +166,8 @@ class TestProgramsView(SharedModuleStoreTestCase, ProgramCacheMixin):
             title='Journey to cooking',
             type='MicroMasters',
             authoring_organizations=[{
-                'key': 'MAX'
+                'key': 'MAX',
+                'logo_image_url': 'http://test.org/media/organization/logos/test-logo.png'
             }],
         )
         cls.site = SiteFactory(domain='test.localhost')

--- a/lms/djangoapps/learner_dashboard/api/v0/views.py
+++ b/lms/djangoapps/learner_dashboard/api/v0/views.py
@@ -134,7 +134,12 @@ class Programs(APIView):
             """
             transformed_authoring_organizations = []
             for authoring_organization in authoring_organizations:
-                transformed_authoring_organizations.append({'key': authoring_organization['key']})
+                transformed_authoring_organizations.append(
+                    {
+                        'key': authoring_organization['key'],
+                        'logo_image_url': authoring_organization['logo_image_url']
+                    }
+                )
 
             return transformed_authoring_organizations
 


### PR DESCRIPTION

<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
