### PR TITLE
fix: revert discussion xblock from MFE view to legacy view.

### DIFF
--- a/lms/djangoapps/courseware/tests/test_discussion_xblock.py
+++ b/lms/djangoapps/courseware/tests/test_discussion_xblock.py
@@ -12,9 +12,7 @@ import uuid
 
 from unittest import mock
 import ddt
-from django.test import override_settings
 from django.urls import reverse
-from edx_toggles.toggles.testutils import override_waffle_flag
 from opaque_keys.edx.keys import CourseKey
 from web_fragments.fragment import Fragment
 from xblock.field_data import DictFieldData
@@ -26,7 +24,6 @@ from xmodule.modulestore.tests.factories import ItemFactory, ToyCourseFactory
 from lms.djangoapps.course_api.blocks.tests.helpers import deserialize_usage_key
 from lms.djangoapps.courseware.module_render import get_module_for_descriptor_internal
 from lms.djangoapps.courseware.tests.helpers import XModuleRenderingTestBase
-from lms.djangoapps.discussion.toggles import ENABLE_DISCUSSIONS_MFE
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
 
 
@@ -308,34 +305,6 @@ class TestXBlockInCourse(SharedModuleStoreTestCase):
         assert 'data-user-create-comment="false"' in html
         assert 'data-user-create-subcomment="false"' in html
 
-    @override_settings(DISCUSSIONS_MICROFRONTEND_URL="http://test.url")
-    @override_waffle_flag(ENABLE_DISCUSSIONS_MFE, True)
-    def test_embed_mfe_in_course(self):
-        """
-        Test that the xblock embeds the MFE UI when the flag is enabled
-        """
-        discussion_xblock = get_module_for_descriptor_internal(
-            user=self.user,
-            descriptor=self.discussion,
-            student_data=mock.Mock(name='student_data'),
-            course_id=self.course.id,
-            track_function=mock.Mock(name='track_function'),
-            request_token='request_token',
-        )
-
-        fragment = discussion_xblock.render('student_view')
-        html = fragment.content
-        self.assertInHTML(
-            """
-            <iframe
-                id='discussions-mfe-tab-embed'
-                title='Discussions'
-                src='http://test.url/edX/toy/2012_Fall/topics/test_discussion_xblock_id'
-            />
-            """,
-            html,
-        )
-
     @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
     def test_discussion_render_successfully_with_orphan_parent(self, default_store):
         """
@@ -431,14 +400,13 @@ class TestXBlockQueryLoad(SharedModuleStoreTestCase):
                 discussion_target='Target Discussion',
             ))
 
-        # 7 queries are required to do first discussion xblock render:
+        # 4 queries are required to do first discussion xblock render:
         # * split_modulestore_django_splitmodulestorecourseindex x2
-        # * waffle_utils_wafflecourseoverridemodel
         # * waffle_utils_waffleorgoverridemodel
-        # * waffle_flag
         # * django_comment_client_role
-        # * lms_xblock_xblockasidesconfig
-        num_queries = 7
+
+        num_queries = 4
+
         for discussion in discussions:
             discussion_xblock = get_module_for_descriptor_internal(
                 user=user,
@@ -451,9 +419,9 @@ class TestXBlockQueryLoad(SharedModuleStoreTestCase):
             with self.assertNumQueries(num_queries):
                 fragment = discussion_xblock.render('student_view')
 
-            # Permissions are cached, so only 1  query required for subsequent renders
-            # to check the waffle flag
-            num_queries = 1
+            # Permissions are cached, so no queries required for subsequent renders
+
+            num_queries = 0
 
             html = fragment.content
             assert 'data-user-create-comment="false"' in html

--- a/openedx/core/lib/xblock_builtin/xblock_discussion/xblock_discussion/__init__.py
+++ b/openedx/core/lib/xblock_builtin/xblock_discussion/xblock_discussion/__init__.py
@@ -169,22 +169,6 @@ class DiscussionXBlock(XBlock, StudioEditableXBlockMixin, XmlParserMixin):  # li
         Renders student view for LMS.
         """
         fragment = Fragment()
-        mfe_url = get_discussions_mfe_topic_url(self.course_key, self.discussion_id)
-        if ENABLE_DISCUSSIONS_MFE.is_enabled(self.course_key) and mfe_url:
-            fragment.add_content(HTML(
-                "<iframe id='discussions-mfe-tab-embed' src='{src}' title='{title}'></iframe>"
-            ).format(src=mfe_url, title=_("Discussions")))
-            fragment.add_css(
-                """
-                #discussions-mfe-tab-embed {
-                    width: 100%;
-                    height: 800px;
-                    border: none;
-                }
-                """
-            )
-            return fragment
-
         self.add_resource_urls(fragment)
 
         login_msg = ''


### PR DESCRIPTION
### [TNL-9778](https://openedx.atlassian.net/browse/TNL-9778)

### Description
At present, the discussion xblock shows new MFE. However, the new MFE shown in xblock is also showing navigation bar (“My Posts”, “All Posts”, “Topics”) and breadcrumb bar. This should not be the case since xblock should be limited to context of this Unit it is in.

We can address this problem later in another ticket, and for now, show legacy experience in xblocks for all roles.

### New MFE xBlock
<img width="964" alt="image-20220328-134917" src="https://user-images.githubusercontent.com/30112155/160630844-f56b1d4d-a574-4615-92c6-f0a2062f453f.png">


### Legacy xBlock

<img width="963" alt="image-20220328-135024" src="https://user-images.githubusercontent.com/30112155/160630858-9ee227fa-1c0b-4074-a32b-aefe52f3d507.png">


