### PR TITLE
fix: Backport some required changes to the CI workflow

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run-tests:
-    runs-on: [ self-hosted ]
+    runs-on: [ edx-platform-runner ]
     strategy:
       matrix:
         python-version: ['3.8']

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -35,9 +35,11 @@ jobs:
       - name: sync directory owner
         run: sudo chown runner:runner -R .*
       - uses: actions/checkout@v2
-      - name: start mongodb service
+      - name: start mongod server for tests
         run: |
-          sudo /etc/init.d/mongodb start
+          sudo mkdir -p /data/db
+          sudo chmod -R a+rw /data/db
+          mongod &
 
       - name: set top-level module name
         run: |

--- a/.github/workflows/verify-gha-unit-tests-count.yml
+++ b/.github/workflows/verify-gha-unit-tests-count.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   collect-and-verify:
-    runs-on: [ self-hosted ]
+    runs-on: [ edx-platform-runner ]
     steps:
       - name: sync directory owner
         run: sudo chown runner:runner -R .*


### PR DESCRIPTION
I'm not sure whether the labeled runner thing is necessary, but it wasn't sufficient -- I also had to backport the mongo change.