### PR TITLE
feat: Course app Model is in sync with courseLive

### DIFF
--- a/openedx/core/djangoapps/course_live/apps.py
+++ b/openedx/core/djangoapps/course_live/apps.py
@@ -28,3 +28,6 @@ class CourseLiveConfig(AppConfig):
             },
         }
     }
+
+    def ready(self):
+        from . import handlers  # lint-amnesty, pylint: disable=unused-import

--- a/openedx/core/djangoapps/course_live/handlers.py
+++ b/openedx/core/djangoapps/course_live/handlers.py
@@ -1,0 +1,22 @@
+"""
+Signal handlers for course live app
+"""
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from ..course_apps.signals import COURSE_APP_STATUS_INIT
+from .models import CourseLiveConfiguration
+
+
+@receiver(post_save, sender=CourseLiveConfiguration)
+def post_save_handler(sender, **kwargs):
+    """
+    Whenever object is created or updated in CourseLiveConfiguration this handler will be trigred and It will
+    create and/or update course_app status
+    """
+    course_live_config = kwargs.get('instance', None)
+    COURSE_APP_STATUS_INIT.send(
+        course_key=course_live_config.course_key,
+        sender='lti_live',
+        is_enabled=course_live_config.enabled
+    )


### PR DESCRIPTION
At the moment when we call course_live API to update data in CourseLiveConfiguration model it only updates data in that model, but expected behavior is to update courseApp model to reflect the current state of CourseLiveConfiguration if it is enabled or not

Task 
https://openedx.atlassian.net/browse/TNL-9787