### PR TITLE
fix: [MICROBA-1769] Fix early nonpassing status

### DIFF
--- a/lms/djangoapps/course_home_api/course_metadata/serializers.py
+++ b/lms/djangoapps/course_home_api/course_metadata/serializers.py
@@ -48,3 +48,4 @@ class CourseHomeMetadataSerializer(VerifiedModeSerializer):
     title = serializers.CharField()
     username = serializers.CharField()
     user_timezone = serializers.CharField()
+    can_view_certificate = serializers.BooleanField()

--- a/lms/djangoapps/course_home_api/course_metadata/views.py
+++ b/lms/djangoapps/course_home_api/course_metadata/views.py
@@ -8,6 +8,7 @@ from rest_framework.response import Response
 
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
+from lms.djangoapps.certificates.api import certificates_viewable_for_course
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from openedx.core.djangoapps.courseware_api.utils import get_celebrations_dict
 
@@ -55,6 +56,7 @@ class CourseHomeMetadataView(RetrieveAPIView):
         title: (str) The Course's display title
         celebrations: (dict) a dict of celebration data
         user_timezone: (str) The timezone of the given user
+        can_view_certificate: Flag to determine whether or not the learner can view their course certificate.
 
     **Returns**
 
@@ -134,6 +136,7 @@ class CourseHomeMetadataView(RetrieveAPIView):
             'can_load_courseware': can_load_courseware,
             'celebrations': celebrations,
             'user_timezone': user_timezone,
+            'can_view_certificate': certificates_viewable_for_course(course),
         }
         context = self.get_serializer_context()
         context['course'] = course


### PR DESCRIPTION
In certain situations, learners in the nonpassing state (or sometimes students who have finished a course too early and passed) were getting information about their grad and certificate status before they were
supposed too.

This adds some data to the courseware api that will allow us to mirror availability states for certifictes of passing learners without revealing information through the api. Now, no matter the status of the students grade or certificate display behavior, a student should not see information about certificates early.

The idea here is that if a student can view their certificate status, then they can view a nonpassing status.
