### PR TITLE
feat: add batch lock delete endpoint

### DIFF
--- a/lms/djangoapps/ora_staff_grader/ora_api.py
+++ b/lms/djangoapps/ora_staff_grader/ora_api.py
@@ -155,6 +155,7 @@ def delete_submission_lock(request, usage_id, submission_uuid):
 
     return json.loads(response.content)
 
+
 def batch_delete_submission_locks(request, usage_id, submission_uuids):
     """
     Batch delete a list of submission locks. Limited only to those in the list the user owns.

--- a/lms/djangoapps/ora_staff_grader/ora_api.py
+++ b/lms/djangoapps/ora_staff_grader/ora_api.py
@@ -154,3 +154,18 @@ def delete_submission_lock(request, usage_id, submission_uuid):
         raise XBlockInternalError(context={"handler": handler_name})
 
     return json.loads(response.content)
+
+def batch_delete_submission_locks(request, usage_id, submission_uuids):
+    """
+    Batch delete a list of submission locks. Limited only to those in the list the user owns.
+
+    Returns: none
+    """
+    handler_name = "batch_delete_submission_lock"
+    body = {"submission_uuids": submission_uuids}
+
+    response = call_xblock_json_handler(request, usage_id, handler_name, body)
+
+    # Errors should raise a blanket exception. Otherwise body is empty, 200 is implicit success
+    if response.status_code != 200:
+        raise XBlockInternalError(context={"handler": handler_name})

--- a/lms/djangoapps/ora_staff_grader/ora_staff_grader.postman_collection.json
+++ b/lms/djangoapps/ora_staff_grader/ora_staff_grader.postman_collection.json
@@ -1455,6 +1455,173 @@
 					]
 				},
 				{
+					"name": "Bulk Unlock",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "X-CSRFToken",
+								"value": "{{csrftoken}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{protocol}}://{{lms_url}}/api/ora_staff_grader{{mock}}/submission/lock?oraLocation={{block_id_encoded}}&submissionUUID={{submission_id}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{lms_url}}"
+							],
+							"path": [
+								"api",
+								"ora_staff_grader{{mock}}",
+								"submission",
+								"lock"
+							],
+							"query": [
+								{
+									"key": "oraLocation",
+									"value": "{{block_id_encoded}}",
+									"description": "ORA location"
+								},
+								{
+									"key": "submissionUUID",
+									"value": "{{submission_id}}",
+									"description": "Individual submission UUID"
+								},
+								{
+									"key": "oraLocation",
+									"value": "{{team_block_id_encoded}}",
+									"description": "Team ORA location",
+									"disabled": true
+								},
+								{
+									"key": "submissionUUID",
+									"value": "{{team_submission_id}}",
+									"description": "Team submission UUID",
+									"disabled": true
+								}
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "Bulk Unlock Success",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "X-CSRFToken",
+										"value": "{{csrftoken}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"submissionUUIDs\": [{{submission_id}}]\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{protocol}}://{{lms_url}}/api/ora_staff_grader{{mock}}/submission/batch/unlock?oraLocation={{block_id_encoded}}",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{lms_url}}"
+									],
+									"path": [
+										"api",
+										"ora_staff_grader{{mock}}",
+										"submission",
+										"batch",
+										"unlock"
+									],
+									"query": [
+										{
+											"key": "oraLocation",
+											"value": "{{block_id_encoded}}",
+											"description": "ORA location"
+										},
+										{
+											"key": "oraLocation",
+											"value": "{{team_block_id_encoded}}",
+											"description": "Team ORA location",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Date",
+									"value": "Thu, 31 Mar 2022 20:52:57 GMT"
+								},
+								{
+									"key": "Server",
+									"value": "WSGIServer/0.2 CPython/3.8.10"
+								},
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "WWW-Authenticate",
+									"value": "JWT realm=\"api\""
+								},
+								{
+									"key": "Vary",
+									"value": "Accept, Accept-Language, Origin, Cookie"
+								},
+								{
+									"key": "Allow",
+									"value": "GET, POST, HEAD, OPTIONS"
+								},
+								{
+									"key": "Server-Timing",
+									"value": "TimerPanel_utime;dur=37.91900000000048;desc=\"User CPU time\", TimerPanel_stime;dur=1.1920000000000819;desc=\"System CPU time\", TimerPanel_total;dur=39.11100000000056;desc=\"Total CPU time\", TimerPanel_total_time;dur=65.8259391784668;desc=\"Elapsed time\", SQLPanel_sql_time;dur=0;desc=\"SQL 0 queries\""
+								},
+								{
+									"key": "X-Frame-Options",
+									"value": "DENY"
+								},
+								{
+									"key": "Content-Language",
+									"value": "en"
+								},
+								{
+									"key": "Content-Length",
+									"value": "58"
+								},
+								{
+									"key": "Set-Cookie",
+									"value": "lms_sessionid=\"\"; expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/; SameSite=Lax"
+								}
+							],
+							"cookie": [
+								{
+									"expires": "Invalid Date"
+								}
+							],
+							"body": "{}"
+						}
+					]
+				},
+				{
 					"name": "Update Grade Data",
 					"event": [
 						{

--- a/lms/djangoapps/ora_staff_grader/tests/test_views.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_views.py
@@ -548,6 +548,86 @@ class TestSubmissionLockView(BaseViewTest):
         assert json.loads(response.content) == {"error": ERR_UNKNOWN}
 
 
+class TestBatchSubmissionLockView(BaseViewTest):
+    """
+    Tests for the /lock view, locking or unlocking a submission for grading
+    """
+
+    view_name = "ora-staff-grader:batch-unlock"
+
+    test_submission_uuids = [str(uuid4()) for _ in range(3)]
+    test_anon_user_id = "anon-user-id"
+    test_other_anon_user_id = "anon-user-id-2"
+    test_timestamp = "2020-08-29T02:14:00-04:00"
+
+    def setUp(self):
+        super().setUp()
+
+        # Batch unlock includes the ORA location in the params...
+        self.test_request_params = {
+            PARAM_ORA_LOCATION: self.ora_usage_key,
+        }
+
+        # and a list of submission UUIDs in the body
+        self.test_request_body = {
+            "submissionUUIDs": self.test_submission_uuids
+        }
+
+        self.log_in()
+
+    def batch_unlock(self, params, body):
+        """Wrapper for easier calling of 'batch_unlock'"""
+        return self.client.post(self.url_with_params(params), body, format="json")
+
+    def test_batch_unlock_invalid_ora(self):
+        """An invalid ORA returns a 400"""
+        self.test_request_params[PARAM_ORA_LOCATION] = "not_a_real_location"
+
+        response = self.batch_unlock(self.test_request_params, {})
+
+        assert response.status_code == 400
+        assert json.loads(response.content) == {"error": ERR_BAD_ORA_LOCATION}
+
+    @patch("lms.djangoapps.ora_staff_grader.views.batch_delete_submission_locks")
+    def test_batch_unlock(self, mock_batch_delete):
+        """POST tries to delete a group of submission locks. Success returns empty 200"""
+        mock_batch_delete.return_value = None
+
+        response = self.batch_unlock(self.test_request_params, self.test_request_body)
+
+        assert response.status_code == 200
+        assert json.loads(response.content) == {}
+
+    @patch("lms.djangoapps.ora_staff_grader.views.batch_delete_submission_locks")
+    def test_batch_unlock_internal_error(self, mock_batch_delete):
+        """Any internal errors to this API get surfaced as an internal error"""
+        mock_batch_delete.side_effect = XBlockInternalError(
+            context={"handler": "batch_delete_submission_locks"}
+        )
+
+        response = self.batch_unlock(self.test_request_params, self.test_request_body)
+
+        assert response.status_code == 500
+        assert json.loads(response.content) == {
+            "error": ERR_INTERNAL,
+            "handler": "batch_delete_submission_locks",
+        }
+
+    @patch("lms.djangoapps.ora_staff_grader.views.batch_delete_submission_locks")
+    def test_batch_unlock_generic_exception(
+        self,
+        mock_batch_delete,
+    ):
+        """In the even more unlikely event of an unhandled error, shrug exuberantly"""
+        # Mock a generic error inside the API
+        mock_batch_delete.side_effect = Exception()
+
+        response = self.batch_unlock(self.test_request_params, self.test_request_body)
+
+        assert response.status_code == 500
+        assert json.loads(response.content) == {"error": ERR_UNKNOWN}
+
+
 class TestUpdateGradeView(BaseViewTest):
     """
     Tests for updating a grade for a submission

--- a/lms/djangoapps/ora_staff_grader/urls.py
+++ b/lms/djangoapps/ora_staff_grader/urls.py
@@ -7,6 +7,7 @@ from django.urls import path
 
 from lms.djangoapps.ora_staff_grader.views import (
     InitializeView,
+    SubmissionBatchUnlockView,
     SubmissionFetchView,
     SubmissionLockView,
     SubmissionStatusFetchView,
@@ -20,6 +21,7 @@ app_name = "ora-staff-grader"
 urlpatterns += [
     path("mock/", include("lms.djangoapps.ora_staff_grader.mock.urls")),
     path("initialize", InitializeView.as_view(), name="initialize"),
+    path("submission/batch/unlock", SubmissionBatchUnlockView.as_view(), name="batch-unlock"),
     path(
         "submission/status",
         SubmissionStatusFetchView.as_view(),

--- a/lms/djangoapps/ora_staff_grader/views.py
+++ b/lms/djangoapps/ora_staff_grader/views.py
@@ -30,6 +30,7 @@ from lms.djangoapps.ora_staff_grader.errors import (
     InternalErrorResponse,
     LockContestedError,
     LockContestedResponse,
+    MissingParamResponse,
     UnknownErrorResponse,
     XBlockInternalError,
 )
@@ -457,6 +458,8 @@ class SubmissionBatchUnlockView(StaffGraderBaseView):
 
             # Pull submission UUIDs list from request body
             submission_uuids = request.data.get('submissionUUIDs')
+            if not isinstance(submission_uuids, list):
+                return MissingParamResponse()
             batch_delete_submission_locks(request, ora_location, submission_uuids)
 
             # Return empty response

--- a/lms/djangoapps/ora_staff_grader/views.py
+++ b/lms/djangoapps/ora_staff_grader/views.py
@@ -430,6 +430,7 @@ class SubmissionLockView(StaffGraderBaseView):
             log.exception(ex)
             return UnknownErrorResponse()
 
+
 class SubmissionBatchUnlockView(StaffGraderBaseView):
     """
     POST delete a group of submission locks, limited to just those in the list that the user owns.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -715,7 +715,7 @@ openedx-events==0.8.1
     # via -r requirements/edx/base.in
 openedx-filters==0.5.0
     # via -r requirements/edx/base.in
-ora2==4.0.6
+ora2==4.1.0
     # via -r requirements/edx/base.in
 packaging==21.3
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -953,7 +953,7 @@ openedx-events==0.8.1
     # via -r requirements/edx/testing.txt
 openedx-filters==0.5.0
     # via -r requirements/edx/testing.txt
-ora2==4.0.6
+ora2==4.1.0
     # via -r requirements/edx/testing.txt
 packaging==21.3
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -901,7 +901,7 @@ openedx-events==0.8.1
     # via -r requirements/edx/base.txt
 openedx-filters==0.5.0
     # via -r requirements/edx/base.txt
-ora2==4.0.6
+ora2==4.1.0
     # via -r requirements/edx/base.txt
 packaging==21.3
     # via


### PR DESCRIPTION
## Description

For new staff grading experience, add an endpoint to batch remove a set of locks for a user.

JIRA: https://openedx.atlassian.net/browse/AU-592

## Other Details

- See [design docs](https://openedx.atlassian.net/wiki/spaces/PT/pages/3154542730/Enhanced+Staff+Grader+Data+Flow+Design#Batch-Unlock)

## Testing instructions

- [ ] Test using the example postman collection ("Enhanced Staff Grader > BFF > Batch Unlock").

Create a bunch of locks (both for this user and others). Call the endpoint with a list of submission UUIDs in the request body, some that you own, some from other users. Should unlock just the locks you own from that list. 

```
POST https://{{lms_url}}/api/ora_staff_grader/submission/batch/unlock?oraLocation={{block_id_encoded}}

{
    "submissionUUIDs": [<list of submission UUIDs>]
}
```

- [ ] Unit testing