### PR TITLE
docs: Remove IE from supported browsers in Open edX course overviews

### DIFF
--- a/common/lib/xmodule/xmodule/templates/about/overview.yaml
+++ b/common/lib/xmodule/xmodule/templates/about/overview.yaml
@@ -41,7 +41,7 @@ data: |
         <h2>Frequently Asked Questions</h2>
         <article class="response">
           <h3>What web browser should I use?</h3>
-          <p>The Open edX platform works best with current versions of Chrome, Edge, Firefox, Internet Explorer, or Safari.</p>
+          <p>The Open edX platform works best with current versions of Chrome, Edge, Firefox, or Safari.</p>
           <p>See our <a href="https://edx.readthedocs.org/projects/open-edx-learner-guide/en/latest/front_matter/browsers.html">list of supported browsers</a> for the most up-to-date information.</p>
         </article>
 


### PR DESCRIPTION
<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Per https://github.com/openedx/frontend-wg/issues/3 we no longer support IE 🎉 

I was just making a new course on an Open edX instance and saw this is the default Course Overview:

![image](https://user-images.githubusercontent.com/1985317/161171268-fa0c85f9-423f-4aa0-be1e-e3e29ef39b2e.png)

Note that the [Learner Help Center for edX.org](https://support.edx.org/hc/en-us/articles/206211848-What-are-the-system-requirements-and-supported-browsers-on-edX-) indicates that IE is not supported but the [Open edX learner's guide](https://edx.readthedocs.io/projects/open-edx-learner-guide/en/latest/front_matter/browsers.html) does not, I will fix there too.

@davidjoy 


## Deadline

Nutmeg cut

## Other information

@davidjoy it seems totally fine to leave `common/static/js/src/ie_shim.js` where it is but I wonder if there's a point where we'll do a large excising of IE cruft? 🤞🏻 
