### PR TITLE
fix: remove `noreferrer` tag from link to Comms MFE to fix blank page

### DIFF
--- a/lms/templates/instructor/instructor_dashboard_2/send_email.html
+++ b/lms/templates/instructor/instructor_dashboard_2/send_email.html
@@ -10,7 +10,7 @@ from openedx.core.djangolib.markup import HTML
     %if 'communications_mfe_url' in section_data:
     <p>
         <em>
-            ${_("To use the email tool, visit the")} <a href="${section_data['communications_mfe_url']}" target="_blank" rel="noopener noreferrer">${_("new experience")}</a>.
+            ${_("To use the email tool, visit the")} <a href="${section_data['communications_mfe_url']}" target="_blank" rel="noopener">${_("new experience")}</a>.
         </em>
     </p>
     %else:


### PR DESCRIPTION
## Description

[MICROBA-1779 & CR-4684]

- remove `noreferrer` tag from link to the Comms MFE to fix content opening in a blank page