### PR TITLE
fix: adding empty live configuration

### DIFF
--- a/openedx/core/djangoapps/course_live/plugins.py
+++ b/openedx/core/djangoapps/course_live/plugins.py
@@ -47,9 +47,7 @@ class LiveCourseApp(CourseApp):
         """
         Set live enabled status in CourseLiveConfiguration model.
         """
-        configuration = CourseLiveConfiguration.get(course_key)
-        if configuration is None:
-            raise ValueError("Can't enable/disable live for course before it is configured.")
+        configuration, _ = CourseLiveConfiguration.objects.get_or_create(course_key=course_key)
         configuration.enabled = enabled
         configuration.save()
         return configuration.enabled


### PR DESCRIPTION
Added empty live configuration if no prior configuration exists 

Ticket:
https://openedx.atlassian.net/browse/TNL-9787

