### PR TITLE
feat: include ESG enabled flag in init response

### DIFF
--- a/lms/djangoapps/ora_staff_grader/serializers.py
+++ b/lms/djangoapps/ora_staff_grader/serializers.py
@@ -167,12 +167,14 @@ class InitializeSerializer(serializers.Serializer):
     courseMetadata = CourseMetadataSerializer()
     oraMetadata = OpenResponseMetadataSerializer()
     submissions = serializers.DictField(child=SubmissionMetadataSerializer())
+    isEnabled = serializers.BooleanField()
 
     class Meta:
         fields = [
             "courseMetadata",
             "oraMetadata",
             "submissions",
+            "isEnabled"
         ]
         read_only_fields = fields
 

--- a/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
@@ -347,6 +347,7 @@ class TestInitializeSerializer(TestCase):
             "courseMetadata": self.mock_course_metadata,
             "oraMetadata": self.mock_ora_instance,
             "submissions": self.mock_submissions_data,
+            "isEnabled": True,
         }
 
         output_data = InitializeSerializer(input_data).data
@@ -364,7 +365,7 @@ class TestInitializeSerializer(TestCase):
         assert output_data["courseMetadata"] == expected_course_data
         assert output_data["oraMetadata"] == expected_ora_data
         assert output_data["submissions"] == expected_submissions_data
-
+        assert output_data["isEnabled"] == True
 
 class TestRubricConfigSerializer(TestCase):
     """Tests for RubricConfigSerializer"""

--- a/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_serializers.py
@@ -365,7 +365,8 @@ class TestInitializeSerializer(TestCase):
         assert output_data["courseMetadata"] == expected_course_data
         assert output_data["oraMetadata"] == expected_ora_data
         assert output_data["submissions"] == expected_submissions_data
-        assert output_data["isEnabled"] == True
+        assert output_data["isEnabled"] is True
+
 
 class TestRubricConfigSerializer(TestCase):
     """Tests for RubricConfigSerializer"""

--- a/lms/djangoapps/ora_staff_grader/tests/test_views.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_views.py
@@ -116,7 +116,7 @@ class TestInitializeView(BaseViewTest):
             self.api_url, {PARAM_ORA_LOCATION: self.ora_usage_key}
         )
 
-        expected_keys = set(["courseMetadata", "oraMetadata", "submissions"])
+        expected_keys = set(["courseMetadata", "oraMetadata", "submissions", "isEnabled"])
         assert response.status_code == 200
         assert response.data.keys() == expected_keys
 

--- a/lms/djangoapps/ora_staff_grader/views.py
+++ b/lms/djangoapps/ora_staff_grader/views.py
@@ -94,6 +94,8 @@ class InitializeView(StaffGraderBaseView):
 
     def _is_staff_grader_enabled(self, course_key):
         """ Helper to evaluate if the staff grader flag / overrides are enabled """
+        # This toggle is documented on the edx-ora2 repo in openassessment/xblock/config_mixin.py
+        # pylint: disable=toggle-missing-annotation
         enhanced_staff_grader_flag = CourseWaffleFlag(
             WAFFLE_NAMESPACE,
             ENHANCED_STAFF_GRADER,


### PR DESCRIPTION
## Description

Include ESG enabled flag in init response from BFF

## Testing instructions

Call initialize endpoint for course from which ESG **is not** enabled and verify that isEnabled = **false**
Call initialize endpoint for course from which ESG **is** enabled and verify that isEnabled = **true**
