### PR TITLE
fix: Added default config_store while creating new empty settings

### DIFF
--- a/openedx/core/djangoapps/course_live/plugins.py
+++ b/openedx/core/djangoapps/course_live/plugins.py
@@ -11,6 +11,8 @@ from openedx.core.djangoapps.course_apps.plugins import CourseApp
 from openedx.core.djangoapps.course_live.config.waffle import ENABLE_COURSE_LIVE
 
 from .models import CourseLiveConfiguration
+from lti_consumer.models import LtiConfiguration
+
 
 User = get_user_model()
 
@@ -49,6 +51,10 @@ class LiveCourseApp(CourseApp):
         """
         configuration, _ = CourseLiveConfiguration.objects.get_or_create(course_key=course_key)
         configuration.enabled = enabled
+        if not configuration.lti_configuration:
+            configuration.lti_configuration = LtiConfiguration.objects.create(
+                config_store=LtiConfiguration.CONFIG_ON_DB
+            )
         configuration.save()
         return configuration.enabled
 

--- a/openedx/core/djangoapps/course_live/plugins.py
+++ b/openedx/core/djangoapps/course_live/plugins.py
@@ -5,14 +5,13 @@ from typing import Dict, Optional
 
 from django.contrib.auth import get_user_model
 from django.utils.translation import gettext_noop as _
+from lti_consumer.models import LtiConfiguration
 from opaque_keys.edx.keys import CourseKey
 
 from openedx.core.djangoapps.course_apps.plugins import CourseApp
 from openedx.core.djangoapps.course_live.config.waffle import ENABLE_COURSE_LIVE
 
 from .models import CourseLiveConfiguration
-from lti_consumer.models import LtiConfiguration
-
 
 User = get_user_model()
 


### PR DESCRIPTION
When course_app API is updated if `CourseLiveConfiguration` instance is not available it will create a new instance of CourseLiveConfiguration with empty LTI settings with the default `config_store`  which is not expected behavior and it is fixed now by updating it by CONFIG_ON_DB 