### PR TITLE
feat: Get microfrontend URLs from site configuration - tests

### DIFF
--- a/common/djangoapps/student/management/commands/recover_account.py
+++ b/common/djangoapps/student/management/commands/recover_account.py
@@ -106,7 +106,7 @@ class Command(BaseCommand):
         message_context = get_base_template_context(site)
         email = user.email
         if should_redirect_to_authn_microfrontend():
-            site_url = settings.AUTHN_MICROFRONTEND_URL
+            site_url = configuration_helpers.get_value('AUTHN_MICROFRONTEND_URL', settings.AUTHN_MICROFRONTEND_URL)
         else:
             site_url = configuration_helpers.get_value('SITE_NAME', settings.SITE_NAME)
         message_context.update({

--- a/common/djangoapps/student/management/tests/test_recover_account.py
+++ b/common/djangoapps/student/management/tests/test_recover_account.py
@@ -20,6 +20,7 @@ from common.djangoapps.student.tests.factories import UserFactory
 from common.djangoapps.student.models import AccountRecoveryConfiguration
 
 from openedx.core.djangolib.testing.utils import skip_unless_lms
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_authn.toggles import REDIRECT_TO_AUTHN_MICROFRONTEND
 
 LOGGER_NAME = 'common.djangoapps.student.management.commands.recover_account'
@@ -87,8 +88,9 @@ class RecoverAccountTests(TestCase):
 
             assert len(mail.outbox) == 1
 
-        authn_mfe_url = re.findall(settings.AUTHN_MICROFRONTEND_URL, mail.outbox[0].body)[0]
-        self.assertEqual(authn_mfe_url, settings.AUTHN_MICROFRONTEND_URL)
+        mfe_url = configuration_helpers.get_value('AUTHN_MICROFRONTEND_URL', settings.AUTHN_MICROFRONTEND_URL)
+        authn_mfe_url = re.findall(mfe_url, mail.outbox[0].body)[0]
+        self.assertEqual(authn_mfe_url, mfe_url)
 
     def test_file_not_found_error(self):
         """

--- a/common/djangoapps/student/tests/test_activate_account.py
+++ b/common/djangoapps/student/tests/test_activate_account.py
@@ -232,7 +232,7 @@ class TestActivateAccount(TestCase):
         login page with correct query param.
         """
         login_page_url = "{authn_mfe}/login?account_activation_status=".format(
-            authn_mfe=settings.AUTHN_MICROFRONTEND_URL
+            authn_mfe=configuration_helpers.get_value('AUTHN_MICROFRONTEND_URL', settings.AUTHN_MICROFRONTEND_URL)
         )
 
         self._assert_user_active_state(expected_active_state=False)
@@ -260,7 +260,7 @@ class TestActivateAccount(TestCase):
         as a parameter in the login page the requesting user is redirected to.
         """
         login_page_url = "{authn_mfe}/login?account_activation_status=".format(
-            authn_mfe=settings.AUTHN_MICROFRONTEND_URL
+            authn_mfe=configuration_helpers.get_value('AUTHN_MICROFRONTEND_URL', settings.AUTHN_MICROFRONTEND_URL)
         )
 
         self._assert_user_active_state(expected_active_state=False)

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -612,7 +612,7 @@ def activate_account(request, key):
         if redirect_url:
             params['next'] = redirect_url
         url_path = '/login?{}'.format(urllib.parse.urlencode(params))
-        return redirect(settings.AUTHN_MICROFRONTEND_URL + url_path)
+        return redirect(configuration_helpers.get_value('AUTHN_MICROFRONTEND_URL', settings.AUTHN_MICROFRONTEND_URL) + url_path)
 
     response = redirect(redirect_url) if redirect_url and is_enterprise_learner(request.user) else redirect('dashboard')
     if show_account_activation_popup:

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -76,6 +76,7 @@ from openedx.core.djangoapps.content.course_overviews.models import CourseOvervi
 from openedx.core.djangoapps.crawlers.models import CrawlersConfig
 from openedx.core.djangoapps.credit.api import set_credit_requirements
 from openedx.core.djangoapps.credit.models import CreditCourse, CreditProvider
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES
 from openedx.core.djangolib.testing.utils import get_mock_request
 from openedx.core.lib.gating import api as gating_api
@@ -501,7 +502,7 @@ class BaseViewsTestCase(ModuleStoreTestCase):  # lint-amnesty, pylint: disable=m
             }
         )
         mfe_url = '{}/course/{}/{}'.format(
-            settings.LEARNING_MICROFRONTEND_URL,
+            configuration_helpers.get_value('LEARNING_MICROFRONTEND_URL', settings.LEARNING_MICROFRONTEND_URL)
             self.course_key,
             self.section2.location
         )

--- a/lms/djangoapps/verify_student/management/commands/send_verification_expiry_email.py
+++ b/lms/djangoapps/verify_student/management/commands/send_verification_expiry_email.py
@@ -22,6 +22,7 @@ from lms.djangoapps.verify_student.message_types import VerificationExpiry
 from lms.djangoapps.verify_student.models import ManualVerification, SoftwareSecurePhotoVerification, SSOVerification
 from openedx.core.djangoapps.ace_common.template_context import get_base_template_context
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preference
 from openedx.core.lib.celery.task_utils import emulate_http_request
 
@@ -191,7 +192,9 @@ class Command(BaseCommand):
         message_context = get_base_template_context(site)
         message_context.update({
             'platform_name': settings.PLATFORM_NAME,
-            'lms_verification_link': f'{settings.ACCOUNT_MICROFRONTEND_URL}/id-verification',
+            'lms_verification_link': '{}/id-verification'.format(
+                configuration_helpers.get_value('ACCOUNT_MICROFRONTEND_URL', settings.ACCOUNT_MICROFRONTEND_URL)
+            ),
             'help_center_link': settings.ID_VERIFICATION_SUPPORT_LINK
         })
 

--- a/lms/djangoapps/verify_student/services.py
+++ b/lms/djangoapps/verify_student/services.py
@@ -236,7 +236,8 @@ class IDVerificationService:
         Returns a string:
             Returns URL for IDV on Account Microfrontend
         """
-        location = f'{settings.ACCOUNT_MICROFRONTEND_URL}/id-verification'
+        mfe_url = configuration_helpers.get_value('ACCOUNT_MICROFRONTEND_URL', settings.ACCOUNT_MICROFRONTEND_URL)
+        location = f'{mfe_url}/id-verification'
         if course_id:
             location += f'?course_id={quote(str(course_id))}'
         return location

--- a/lms/djangoapps/verify_student/tests/test_services.py
+++ b/lms/djangoapps/verify_student/tests/test_services.py
@@ -120,7 +120,8 @@ class TestIDVerificationService(ModuleStoreTestCase):
         Test for the path to the IDV flow with no course key given
         """
         path = IDVerificationService.get_verify_location()
-        expected_path = f'{settings.ACCOUNT_MICROFRONTEND_URL}/id-verification'
+        mfe_url = configuration_helpers.get_value('ACCOUNT_MICROFRONTEND_URL', settings.ACCOUNT_MICROFRONTEND_URL)
+        expected_path = f'{mfe_url}/id-verification'
         assert path == expected_path
 
     def test_get_verify_location_from_course_id(self):
@@ -129,7 +130,8 @@ class TestIDVerificationService(ModuleStoreTestCase):
         """
         course = CourseFactory.create(org='Robot', number='999', display_name='Test Course')
         path = IDVerificationService.get_verify_location(course.id)
-        expected_path = f'{settings.ACCOUNT_MICROFRONTEND_URL}/id-verification'
+        mfe_url = configuration_helpers.get_value('ACCOUNT_MICROFRONTEND_URL', settings.ACCOUNT_MICROFRONTEND_URL)
+        expected_path = f'{mfe_url}/id-verification'
         assert path == (expected_path + '?course_id=Robot/999/Test_Course')
 
     def test_get_verify_location_from_string(self):
@@ -137,7 +139,8 @@ class TestIDVerificationService(ModuleStoreTestCase):
         Test for the path to the IDV flow with a course key string
         """
         path = IDVerificationService.get_verify_location('course-v1:edX+DemoX+Demo_Course')
-        expected_path = f'{settings.ACCOUNT_MICROFRONTEND_URL}/id-verification'
+        mfe_url = configuration_helpers.get_value('ACCOUNT_MICROFRONTEND_URL', settings.ACCOUNT_MICROFRONTEND_URL)
+        expected_path = f'{mfe_url}/id-verification'
         assert path == (expected_path + '?course_id=course-v1%3AedX%2BDemoX%2BDemo_Course')
 
 

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -1177,7 +1177,8 @@ def results_callback(request):  # lint-amnesty, pylint: disable=too-many-stateme
     elif result == "FAIL":
         log.debug("Denying verification for %s", receipt_id)
         attempt.deny(json.dumps(reason), error_code=error_code)
-        reverify_url = f'{settings.ACCOUNT_MICROFRONTEND_URL}/id-verification'
+        mfe_url = configuration_helpers.get_value('ACCOUNT_MICROFRONTEND_URL', settings.ACCOUNT_MICROFRONTEND_URL)
+        reverify_url = f'{mfe_url}/id-verification'
         verification_status_email_vars['reasons'] = reason
         verification_status_email_vars['reverify_url'] = reverify_url
         verification_status_email_vars['faq_url'] = settings.ID_VERIFICATION_SUPPORT_LINK

--- a/openedx/core/djangoapps/user_api/accounts/settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/settings_views.py
@@ -58,7 +58,7 @@ def account_settings(request):
 
     """
     if should_redirect_to_account_microfrontend():
-        url = settings.ACCOUNT_MICROFRONTEND_URL
+        url = configuration_helpers.get_value('ACCOUNT_MICROFRONTEND_URL', settings.ACCOUNT_MICROFRONTEND_URL)
 
         duplicate_provider = pipeline.get_duplicate_provider(messages.get_messages(request))
         if duplicate_provider:

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_settings_views.py
@@ -18,6 +18,7 @@ from lms.djangoapps.commerce.tests.mocks import mock_get_orders
 from openedx.core.djangoapps.dark_lang.models import DarkLangConfig
 from openedx.core.djangoapps.lang_pref.tests.test_api import EN, LT_LT
 from openedx.core.djangoapps.programs.tests.mixins import ProgramsApiConfigMixin
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
 from openedx.core.djangoapps.site_configuration.tests.mixins import SiteMixin
 from openedx.core.djangoapps.user_api.accounts.settings_views import account_settings_context, get_user_orders
@@ -245,7 +246,7 @@ class AccountSettingsViewTest(ThirdPartyAuthTestMixin, SiteMixin, ProgramsApiCon
         with override_waffle_flag(REDIRECT_TO_ACCOUNT_MICROFRONTEND, active=True):
             # Test with waffle flag active and none site setting, redirects to microfrontend
             response = self.client.get(path=old_url_path)
-            self.assertRedirects(response, settings.ACCOUNT_MICROFRONTEND_URL, fetch_redirect_response=False)
+            self.assertRedirects(response, configuration_helpers.get_value('ACCOUNT_MICROFRONTEND_URL', settings.ACCOUNT_MICROFRONTEND_URL), fetch_redirect_response=False)
 
         # Test with waffle flag disabled and site setting disabled, does not redirect
         response = self.client.get(path=old_url_path)
@@ -268,4 +269,4 @@ class AccountSettingsViewTest(ThirdPartyAuthTestMixin, SiteMixin, ProgramsApiCon
         site.configuration.save()
         site.__class__.objects.clear_cache()
         response = self.client.get(path=old_url_path)
-        self.assertRedirects(response, settings.ACCOUNT_MICROFRONTEND_URL, fetch_redirect_response=False)
+        self.assertRedirects(response, configuration_helpers.get_value('ACCOUNT_MICROFRONTEND_URL', settings.ACCOUNT_MICROFRONTEND_URL), fetch_redirect_response=False)

--- a/openedx/core/djangoapps/user_authn/views/login_form.py
+++ b/openedx/core/djangoapps/user_authn/views/login_form.py
@@ -219,7 +219,7 @@ def login_and_registration_form(request, initial_mode="login"):
             initial_mode,
             '?' + query_params if query_params else ''
         )
-        return redirect(settings.AUTHN_MICROFRONTEND_URL + url_path)
+        return redirect(configuration_helpers.get_value('AUTHN_MICROFRONTEND_URL', settings.AUTHN_MICROFRONTEND_URL) + url_path)
 
     # Account activation message
     account_activation_messages = [

--- a/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
@@ -24,6 +24,7 @@ from pytz import UTC
 
 from common.djangoapps.course_modes.models import CourseMode
 from lms.djangoapps.branding.api import get_privacy_url
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.site_configuration.tests.mixins import SiteMixin
 from openedx.core.djangoapps.theming.tests.test_util import with_comprehensive_theme_context
 from openedx.core.djangoapps.user_authn.cookies import JWT_COOKIE_NAMES
@@ -90,7 +91,7 @@ class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleSto
         # Test with setting enabled and waffle flag active, redirects to microfrontend
         with override_waffle_flag(REDIRECT_TO_AUTHN_MICROFRONTEND, active=True):
             response = self.client.get(reverse(url_name))
-            self.assertRedirects(response, settings.AUTHN_MICROFRONTEND_URL + path, fetch_redirect_response=False)
+            self.assertRedirects(response, configuration_helpers.get_value('AUTHN_MICROFRONTEND_URL', settings.AUTHN_MICROFRONTEND_URL) + path, fetch_redirect_response=False)
 
     @ddt.data(
         (
@@ -112,7 +113,7 @@ class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleSto
         Test that if request is redirected to logistration MFE,
         query params are passed to the redirect url.
         """
-        expected_url = settings.AUTHN_MICROFRONTEND_URL + path + '?' + urlencode(query_params)
+        expected_url = configuration_helpers.get_value('AUTHN_MICROFRONTEND_URL', settings.AUTHN_MICROFRONTEND_URL) + path + '?' + urlencode(query_params)
         response = self.client.get(reverse(url_name), query_params)
 
         self.assertRedirects(response, expected_url, fetch_redirect_response=False)

--- a/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
@@ -353,7 +353,7 @@ class ResetPasswordTests(EventTestMixin, CacheIsolationTestCase):
                 reset_msg = reset_msg.format(site_name)
 
                 assert reset_msg in msg
-                assert settings.AUTHN_MICROFRONTEND_URL in msg
+                assert configuration_helpers.get_value('AUTHN_MICROFRONTEND_URL', settings.AUTHN_MICROFRONTEND_URL) in msg
 
                 sign_off = f"The {platform_name} Team"
                 assert sign_off in msg

--- a/openedx/features/course_experience/url_helpers.py
+++ b/openedx/features/course_experience/url_helpers.py
@@ -16,6 +16,7 @@ from opaque_keys.edx.keys import CourseKey, UsageKey
 from six.moves.urllib.parse import urlencode, urlparse
 
 from lms.djangoapps.courseware.toggles import courseware_mfe_is_active
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.search import navigation_index, path_to_location
 
@@ -177,7 +178,10 @@ def make_learning_mfe_courseware_url(
     `course_key`, `sequence_key`, and `unit_key` can be either OpaqueKeys or
     strings. They're only ever used to concatenate a URL string.
     """
-    mfe_link = f'{settings.LEARNING_MICROFRONTEND_URL}/course/{course_key}'
+    mfe_link = '{}/course/{}'.format(
+        configuration_helpers.get_value('LEARNING_MICROFRONTEND_URL', settings.LEARNING_MICROFRONTEND_URL),
+        course_key
+    )
 
     if sequence_key:
         mfe_link += f'/{sequence_key}'
@@ -201,7 +205,10 @@ def get_learning_mfe_home_url(
     `course_key` can be either an OpaqueKey or a string.
     `view_name` is an optional string.
     """
-    mfe_link = f'{settings.LEARNING_MICROFRONTEND_URL}/course/{course_key}'
+    mfe_link = '{}/course/{}'.format(
+        configuration_helpers.get_value('LEARNING_MICROFRONTEND_URL', settings.LEARNING_MICROFRONTEND_URL),
+        course_key
+    )
 
     if view_name:
         mfe_link += f'/{view_name}'
@@ -213,9 +220,10 @@ def is_request_from_learning_mfe(request: HttpRequest):
     """
     Returns whether the given request was made by the frontend-app-learning MFE.
     """
-    if not settings.LEARNING_MICROFRONTEND_URL:
+    mfe_url = configuration_helpers.get_value('LEARNING_MICROFRONTEND_URL', settings.LEARNING_MICROFRONTEND_URL)
+    if not mfe_url:
         return False
 
-    url = urlparse(settings.LEARNING_MICROFRONTEND_URL)
+    url = urlparse(mfe_url)
     mfe_url_base = f'{url.scheme}://{url.netloc}'
     return request.META.get('HTTP_REFERER', '').startswith(mfe_url_base)

--- a/openedx/features/learner_profile/tests/views/test_learner_profile.py
+++ b/openedx/features/learner_profile/tests/views/test_learner_profile.py
@@ -18,6 +18,7 @@ from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
 from lms.envs.test import CREDENTIALS_PUBLIC_SERVICE_URL
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.site_configuration.tests.mixins import SiteMixin
 from openedx.features.learner_profile.toggles import REDIRECT_TO_PROFILE_MICROFRONTEND
 from openedx.features.learner_profile.views.learner_profile import learner_profile_context
@@ -118,7 +119,7 @@ class LearnerProfileViewTest(SiteMixin, UrlResetMixin, ModuleStoreTestCase):
             })
             self.client.login(username=self.USERNAME, password=self.PASSWORD)
             response = self.client.get(path=profile_path)
-            profile_url = settings.PROFILE_MICROFRONTEND_URL
+            profile_url = configuration_helpers.get_value('PROFILE_MICROFRONTEND_URL', settings.PROFILE_MICROFRONTEND_URL)
             self.assertRedirects(response, profile_url + self.USERNAME, fetch_redirect_response=False)
 
     def test_records_link(self):

--- a/openedx/features/learner_profile/views/learner_profile.py
+++ b/openedx/features/learner_profile/views/learner_profile.py
@@ -44,7 +44,10 @@ def learner_profile(request, username):
         GET /account/profile
     """
     if should_redirect_to_profile_microfrontend():
-        profile_microfrontend_url = f"{settings.PROFILE_MICROFRONTEND_URL}{username}"
+        profile_microfrontend_url = "{}{}".format(
+            configuration_helpers.get_value('PROFILE_MICROFRONTEND_URL', settings.PROFILE_MICROFRONTEND_URL),
+            username
+        )
         return redirect(profile_microfrontend_url)
 
     try:


### PR DESCRIPTION
## Description

Since Maple release, Learning Micro-Frontend (MFE) becomes the default courseware experience, but Multisites have not been considered.
The Learning MFE URL cannot be conifgured per site because the value is not being retrieved through the site configuration
by using the site configuration helper, as it is being done in other points of the platform to obtain other values from the settings.
This commit changes this behaviour introducing the retrieval of Learning but also Account, Profile and Authn MFE URLs through the helper.

This change has impact in "Operator" roles, because they can override MFE URLs in every site configuration.

## Supporting information

We have an open discussion about this topic:
https://discuss.openedx.org/t/how-to-use-microfrontend-in-a-multitenant-instance/6936/1

## Testing instructions

1. Create a Site in LMS administration: http(s)://{{ LMS_BASE }}/admin/sites/site/
2. Create a Site Configuration: http(s)://{{ LMS_BASE }}/admin/site_configuration/siteconfiguration/
3. Provide a Site value for the LEARNING_MICROFRONTEND_URL property
4. Browse the dashboard of the Site you have created at first step and check that the link of the course corresponds with the LEARNING_MICROFRONTEND_URL value

## Deadline

May 1, 2022 We have commitments with our customers in next month that cannot address without Multisites and we have done the migration to Maple release and now go back would be painful.

## Other information

This change would be complemented by extending the initialization handler for [config runtime](https://openedx.github.io/frontend-platform/module-Config.html) in the microfrontends platform to get the site configuration values through a REST API with a new handler, as mentioned in the discussion by [dcoa](https://discuss.openedx.org/t/how-to-use-microfrontend-in-a-multitenant-instance/6936?u=jboo)