### PR TITLE
feat: update discussion settings API to handle changes reported_content_email_notification field

### DIFF
--- a/lms/djangoapps/discussion/django_comment_client/tests/utils.py
+++ b/lms/djangoapps/discussion/django_comment_client/tests/utils.py
@@ -83,7 +83,8 @@ def config_course_discussions(
         course,
         discussion_topics={},
         divided_discussions=[],
-        always_divide_inline_discussions=False
+        always_divide_inline_discussions=False,
+        reported_content_email_notifications=False,
 ):
     """
     Set discussions and configure divided discussions for a course.
@@ -96,6 +97,8 @@ def config_course_discussions(
             list to use the same ids as discussion topic names.
         always_divide_inline_discussions (bool): Whether inline discussions
             should be divided by default.
+        reported_content_email_notifications (bool): Whether email notifications
+            are enabled for reported content for moderators.
 
     Returns:
         Nothing -- modifies course in place.
@@ -113,6 +116,7 @@ def config_course_discussions(
         ],
         'always_divide_inline_discussions': always_divide_inline_discussions,
         'division_scheme': CourseDiscussionSettings.COHORT,
+        'reported_content_email_notifications': reported_content_email_notifications,
     })
 
     course.discussion_topics = {name: {"sort_key": "A", "id": to_id(name)}

--- a/lms/djangoapps/discussion/rest_api/tests/test_views.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views.py
@@ -2313,7 +2313,9 @@ class CourseDiscussionSettingsAPIViewTest(APITestCase, UrlResetMixin, ModuleStor
             'divided_course_wide_discussions': [],
             'id': 1,
             'division_scheme': 'cohort',
-            'available_division_schemes': ['cohort']
+            'available_division_schemes': ['cohort'],
+            'reported_content_email_notifications': False,
+            'reported_content_email_notifications_flag': False,
         }
 
     def patch_request(self, data, headers=None):
@@ -2490,6 +2492,15 @@ class CourseDiscussionSettingsAPIViewTest(APITestCase, UrlResetMixin, ModuleStor
         self._assert_current_settings(expected_response)
         expected_response['division_scheme'] = 'none'
         self._assert_patched_settings({'division_scheme': 'none'}, expected_response)
+
+    def test_update_reported_content_email_notifications(self):
+        """Test whether the 'reported_content_email_notifications' setting is updated."""
+        config_course_cohorts(self.course, is_cohorted=True)
+        config_course_discussions(self.course, reported_content_email_notifications=True)
+        expected_response = self._get_expected_response()
+        expected_response['reported_content_email_notifications'] = True
+        self._login_as_staff()
+        self._assert_current_settings(expected_response)
 
 
 @ddt.ddt

--- a/lms/djangoapps/discussion/toggles.py
+++ b/lms/djangoapps/discussion/toggles.py
@@ -45,3 +45,16 @@ ENABLE_DISCUSSION_MODERATION_REASON_CODES = CourseWaffleFlag(
     'enable_moderation_reason_codes',
     __name__,
 )
+
+# .. toggle_name: discussions.enable_reported_content_email_notifications
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Waffle flag to toggle email notifications for reported content for moderators
+# .. toggle_use_cases: temporary, open_edx
+# .. toggle_creation_date: 2022-03-08
+# .. toggle_target_removal_date: 2022-12-31
+ENABLE_REPORTED_CONTENT_EMAIL_NOTIFICATIONS = CourseWaffleFlag(
+    WAFFLE_FLAG_NAMESPACE,
+    'enable_reported_content_email_notifications',
+    __name__,
+)

--- a/openedx/core/djangoapps/discussions/serializers.py
+++ b/openedx/core/djangoapps/discussions/serializers.py
@@ -6,6 +6,7 @@ from lti_consumer.api import get_lti_pii_sharing_state_for_course
 from lti_consumer.models import LtiConfiguration
 from rest_framework import serializers
 
+from lms.djangoapps.discussion.toggles import ENABLE_REPORTED_CONTENT_EMAIL_NOTIFICATIONS
 from openedx.core.djangoapps.django_comment_common.models import CourseDiscussionSettings
 from openedx.core.lib.courses import get_course_by_id
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
@@ -84,6 +85,7 @@ class LegacySettingsSerializer(serializers.BaseSerializer):
             'divided_course_wide_discussions',
             'divided_inline_discussions',
             'division_scheme',
+            'reported_content_email_notifications'
         ]
 
     def create(self, validated_data):
@@ -363,6 +365,7 @@ class DiscussionSettingsSerializer(serializers.Serializer):
         read_only=True,
     )
     always_divide_inline_discussions = serializers.BooleanField()
+    reported_content_email_notifications = serializers.BooleanField()
     division_scheme = serializers.CharField()
 
     def to_internal_value(self, data: dict) -> dict:
@@ -406,7 +409,10 @@ class DiscussionSettingsSerializer(serializers.Serializer):
             'divided_course_wide_discussions': divided_course_wide_discussions,
             'always_divide_inline_discussions': instance.always_divide_inline_discussions,
             'division_scheme': instance.division_scheme,
-            'available_division_schemes': available_division_schemes(course_key)
+            'available_division_schemes': available_division_schemes(course_key),
+            'reported_content_email_notifications': instance.reported_content_email_notifications,
+            'reported_content_email_notifications_flag':
+                ENABLE_REPORTED_CONTENT_EMAIL_NOTIFICATIONS.is_enabled(course_key),
         }
         return payload
 

--- a/openedx/core/djangoapps/discussions/tests/test_views.py
+++ b/openedx/core/djangoapps/discussions/tests/test_views.py
@@ -47,7 +47,8 @@ DEFAULT_LEGACY_CONFIGURATION = {
     'divided_course_wide_discussions': [],
     'division_scheme': 'none',
     'available_division_schemes': [],
-
+    'reported_content_email_notifications': False,
+    'reported_content_email_notifications_flag': False,
 }
 DEFAULT_LTI_CONFIGURATION = {
     'lti_1p1_client_key': '',
@@ -350,6 +351,7 @@ class DataTest(AuthorizedApiTest):
             'plugin_configuration': {
                 'allow_anonymous': False,
                 'custom_field': 'custom_value',
+                'reported_content_email_notifications': True,
             },
         }
         response = self._post(payload)
@@ -357,6 +359,7 @@ class DataTest(AuthorizedApiTest):
         assert data['plugin_configuration'] == {
             'allow_anonymous': False,
             'custom_field': 'custom_value',
+            'reported_content_email_notifications': True,
         }
 
         course = self.store.get_course(self.course.id)

--- a/openedx/core/djangoapps/django_comment_common/models.py
+++ b/openedx/core/djangoapps/django_comment_common/models.py
@@ -298,6 +298,7 @@ class CourseDiscussionSettings(models.Model):
             'division_scheme': (str,)[0],
             'always_divide_inline_discussions': bool,
             'divided_discussions': list,
+            'reported_content_email_notifications': bool,
         }
         for field, field_type in fields.items():
             if field in validated_data:


### PR DESCRIPTION
### [TNL-9799](https://openedx.atlassian.net/browse/TNL-9799)

### Description
Update discussion settings API to handle changes to the `reported_content_email_notifications` when this setting is toggled on/off from the discussions configurations page.
We will also be sending a flag `discussions.reported_content_email_notifications_flag` within the response to hide/show the related UI on the frontend!