### PR TITLE
fix: config_on_db if live is already enabled

### DIFF
--- a/openedx/core/djangoapps/course_live/serializers.py
+++ b/openedx/core/djangoapps/course_live/serializers.py
@@ -46,6 +46,7 @@ class LtiSerializer(serializers.ModelSerializer):
         lti_config = validated_data.pop('lti_config', None)
         instance = LtiConfiguration()
         instance.version = 'lti_1p1'
+        instance.config_store = LtiConfiguration.CONFIG_ON_DB
 
         for key, value in validated_data.items():
             if key in set(self.Meta.fields).difference(self.Meta.read_only):


### PR DESCRIPTION
Creates `config_on_model` configuration instead of `config_on_xblocks` when live app is already enabled for course but not configured.

Ticket:
https://openedx.atlassian.net/browse/TNL-9811