### PR TITLE
post anonymously option is removed from add post section

### DIFF
--- a/common/static/common/templates/discussion/templates.underscore
+++ b/common/static/common/templates/discussion/templates.underscore
@@ -477,12 +477,6 @@
                 <span class="icon fa fa-star" aria-hidden="true"></span><%- gettext("follow this post") %>
             </span>
         </label>
-        <% if (allow_anonymous) { %>
-        <label for="anonymous" class="field-label label-inline">
-            <input id="anonymous" type="checkbox" name="anonymous" class="field-input input-checkbox">
-            <span class="field-input-label"><%- gettext("post anonymously") %></span>
-        </label>
-        <% } %>
         <% if (allow_anonymous_to_peers) { %>
         <label for="anonymous_to_peers" class="field-label label-inline">
             <input id="anonymous_to_peers" type="checkbox" name="anonymous_to_peers" class="field-input input-checkbox">


### PR DESCRIPTION
## Description
TNL TIcket : [9469](https://openedx.atlassian.net/browse/TNL-9469)
This PR is a part of the change mentioned in the above ticket, more related PRs in different repos are linked.

Useful information to include:
- Which edX user roles will this change impact?  Learner

the screen even if the course was configured to allow anonymous posts
![Screenshot 2022-04-06 at 4 41 16 PM](https://user-images.githubusercontent.com/67791278/161967274-a5bdc937-4e3c-4e3b-95e4-6b4219d8a8f8.png)


## Supporting information
TNL TIcket : [9469](https://openedx.atlassian.net/browse/TNL-9469)
#https://github.com/openedx/frontend-app-course-authoring/pull/284
#https://github.com/openedx/frontend-app-discussions/pull/118

## Testing instructions

checkout in all the three mentioned branches in different repos

- configure discussion provider will no longer show toggle-switch to post anonymously
- add post both using new MFE and legacy experience post anonymously options is removed
- for courses already configured to allow post anonymous feature still won't show the option to post anonymously
