### PR TITLE
fix: Do not hardcode LMS_CFG for lms-docker dockerfile target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -122,7 +122,8 @@ RUN pip install -r requirements/edx/base.txt
 # Define LMS docker-based non-dev target.
 FROM base as lms-docker
 ENV SERVICE_VARIANT lms
-ENV LMS_CFG="/vault-api-secrets/secrets/edx-platform.yml"
+ARG LMS_CFG
+ENV LMS_CFG="$LMS_CFG"
 ENV EDX_PLATFORM_SETTINGS='docker-production'
 ENV DJANGO_SETTINGS_MODULE="lms.envs.$EDX_PLATFORM_SETTINGS"
 EXPOSE 8000


### PR DESCRIPTION
<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Allow docker image to be built with your own LMS_CFG path of choice when building the lms-docker target:

```
docker build --target lms-docker --build-arg LMS_CFG=/my/config/path .
```

Note: I have tested locally and confirmed that not providing a build arg will in fact use the previously defined (higher up in the Dockerfile) value for LMS_CFG

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
