### PR TITLE
fix: missing file extension for csv file exports

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -993,7 +993,7 @@ sqlparse==0.4.2
     # via
     #   -r requirements/edx/base.in
     #   django
-staff-graded-xblock==2.0.0
+staff-graded-xblock==2.0.1
     # via -r requirements/edx/base.in
 stevedore==3.5.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1414,7 +1414,7 @@ sqlparse==0.4.2
     #   -r requirements/edx/testing.txt
     #   django
     #   django-debug-toolbar
-staff-graded-xblock==2.0.0
+staff-graded-xblock==2.0.1
     # via -r requirements/edx/testing.txt
 starlette==0.17.1
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1309,7 +1309,7 @@ sqlparse==0.4.2
     # via
     #   -r requirements/edx/base.txt
     #   django
-staff-graded-xblock==2.0.0
+staff-graded-xblock==2.0.1
     # via -r requirements/edx/base.txt
 starlette==0.17.1
     # via fastapi


### PR DESCRIPTION
see https://github.com/openedx/staff_graded-xblock/pull/97

JIRA:TNL-9720

<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

CSV downloads from staff graded points used to not have file extensions, which were removed in staff-graded-xblock version 2.0.0. This restores the .csv file extension.

## Testing instructions

https://github.com/openedx/staff_graded-xblock/pull/97#issuecomment-1091846634