### PR TITLE
fix: don't reroute xblock settings button.

### DIFF
--- a/cms/static/js/views/pages/container.js
+++ b/cms/static/js/views/pages/container.js
@@ -186,18 +186,19 @@ define(['jquery', 'underscore', 'backbone', 'gettext', 'js/views/pages/base_page
                     modal = new EditXBlockModal(options);
                 event.preventDefault();
 
-                  // check if we want to launch with the new editors (behind waffle flag)
-                var useNewTextEditor = this.$('.edit-button').attr("use-new-editor-text"),
-                    useNewVideoEditor = this.$('.edit-button').attr("use-new-editor-video"),
-                    useNewProblemEditor = this.$('.edit-button').attr("use-new-editor-problem"),
-                    blockType = xblockElement.find('.xblock').attr("data-block-type");
-                if( (useNewTextEditor === "True" && blockType === "html") ||
-                    (useNewVideoEditor === "True" && blockType === "video") ||
-                    (useNewProblemEditor === "True" && blockType === "problem")
-                ) {
-                    var destinationUrl = this.$('.edit-button').attr("authoring_MFE_base_url") + '/' + blockType + '/' + encodeURI(xblockElement.find('.xblock').attr("data-usage-id"));
-                    window.location.href = destinationUrl;
-                    return;
+                if(!options || options.view !== 'visibility_view' ){
+                    var useNewTextEditor = this.$('.edit-button').attr("use-new-editor-text"),
+                        useNewVideoEditor = this.$('.edit-button').attr("use-new-editor-video"),
+                        useNewProblemEditor = this.$('.edit-button').attr("use-new-editor-problem"),
+                        blockType = xblockElement.find('.xblock').attr("data-block-type");
+                    if( (useNewTextEditor === "True" && blockType === "html") ||
+                        (useNewVideoEditor === "True" && blockType === "video") ||
+                        (useNewProblemEditor === "True" && blockType === "problem")
+                    ) {
+                        var destinationUrl = this.$('.edit-button').attr("authoring_MFE_base_url") + '/' + blockType + '/' + encodeURI(xblockElement.find('.xblock').attr("data-usage-id"));
+                        window.location.href = destinationUrl;
+                        return;
+                    }
                 }
                 modal.edit(xblockElement, this.model, {
                     readOnlyView: !this.options.canEdit,


### PR DESCRIPTION
<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.

for: https://openedx.atlassian.net/browse/TNL-9831

https://user-images.githubusercontent.com/49422820/162280634-198fa738-1edc-4d85-9d5a-ec2904160950.mov

Note, this goes to a blank course authoring page on edit button click because I don't have it up right now. You can try this fix for yourself though, just make sure to run `paver update_assets` in lms shell. All we are doing is just wrapping this in an if statement to make sure we aren't actually editing the xblock settings. It is not elegant, but it gets the job done.

