### PR TITLE
BOM-3358: Remove django-config-models constraint

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -19,12 +19,6 @@ celery>=5.2.2,<6.0.0
 # required for celery>=5.2.0;<5.3.0
 click>=8.0,<9.0
 
-# edx-platform currently only supported for Django 3.2.x
-django<3.3
-
-# We do not support version django-config-models<1.0.0
-django-config-models>=1.0.0
-
 # django-storages version 1.9 drops support for boto storage backend.
 django-storages<1.9
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -182,7 +182,6 @@ deprecated==1.2.13
 django==3.2.12
     # via
     #   -c requirements/edx/../common_constraints.txt
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   django-appconf
     #   django-classy-tags
@@ -255,7 +254,6 @@ django-classy-tags==3.0.1
     # via django-sekizai
 django-config-models==2.3.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   edx-enterprise
     #   edx-name-affirmation

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -268,7 +268,6 @@ distlib==0.3.4
 django==3.2.12
     # via
     #   -c requirements/edx/../common_constraints.txt
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   django-appconf
     #   django-classy-tags
@@ -346,7 +345,6 @@ django-classy-tags==3.0.1
     #   django-sekizai
 django-config-models==2.3.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
     #   edx-name-affirmation

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -255,7 +255,6 @@ distlib==0.3.4
     # via virtualenv
     # via
     #   -c requirements/edx/../common_constraints.txt
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   django-appconf
     #   django-classy-tags
@@ -332,7 +331,6 @@ django-classy-tags==3.0.1
     #   django-sekizai
 django-config-models==2.3.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   edx-name-affirmation


### PR DESCRIPTION
### Description
- Removed the `django-config-models` constraint from `constraints.txt`.