### PR TITLE
feat: use new flow with with financial assistance form

### DIFF
--- a/lms/djangoapps/courseware/utils.py
+++ b/lms/djangoapps/courseware/utils.py
@@ -6,6 +6,7 @@ import hashlib
 import logging
 
 from django.conf import settings
+from django.http import HttpResponse, HttpResponseBadRequest
 from edx_rest_api_client.client import OAuthAPIClient
 from oauth2_provider.models import Application
 from pytz import utc  # lint-amnesty, pylint: disable=wrong-import-order
@@ -180,20 +181,21 @@ def create_financial_assistance_application(form_data):
         "income": <income_from_range>,
         "learner_reasons": <TEST_LONG_STRING>,
         "learner_goals": <TEST_LONG_STRING>,
-        "learner_plans": <TEST_LONG_STRING>
+        "learner_plans": <TEST_LONG_STRING>,
+        "allow_for_marketing": <Boolean>
     }
-    TODO: marketing checkmark field will be added in the backend and needs to be updated here.
     """
     response = _request_financial_assistance(
         'POST', f"{settings.CREATE_FINANCIAL_ASSISTANCE_APPLICATION_URL}/", data=form_data
     )
     if response.status_code == status.HTTP_200_OK:
-        return True, None
+        return HttpResponse(status=status.HTTP_204_NO_CONTENT)
     elif response.status_code == status.HTTP_400_BAD_REQUEST:
-        return False, response.json().get('message')
+        log.error(response.json().get('message'))
+        return HttpResponseBadRequest(response.content)
     else:
         log.error('%s %s', UNEXPECTED_ERROR_CREATE_APPLICATION, response.content)
-        return False, UNEXPECTED_ERROR_CREATE_APPLICATION
+        return HttpResponse(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
 def get_course_hash_value(course_key):

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -943,6 +943,11 @@ if settings.FEATURES.get('ENABLE_FINANCIAL_ASSISTANCE_FORM'):
             'financial-assistance/submit/',
             courseware_views.financial_assistance_request,
             name='submit_financial_assistance_request'
+        ),
+        path(
+            'financial-assistance_v2/submit/',
+            courseware_views.financial_assistance_request_v2,
+            name='submit_financial_assistance_request_v2'
         )
     ]
 


### PR DESCRIPTION
[PROD-2738](https://openedx.atlassian.net/browse/PROD-2738)

Uses new FA flow with financial assistance form.

## Testing instructions
1. Run migrations to get the latest models in your devstack. run `paver update_db` in `lms-shell`
2. Create a superuser at `/admin/auth/user/` (or you can use the existing `edx` user) which will be used to initiate the API calls against FA backend
3. add a new configuration against `/admin/courseware/financialassistanceconfiguration/` with internal api url as `http://financial.assistance.app:7556/`, service username being the one superuser you've created and enable it.
4. Add an oauth application if not added already in `/admin/oauth2_provider/application/` with the same superuser you've created with the following client_id and client_secret:
```
financial_assistance-lms-service-key
financial_assistance-lms-service-secret
```
5. Pull [edx-financial-assistance](https://github.com/edx/edx-financial-assistance/) and run backend containers: `make dev.up` (this may take a while for the first time as it runs the provision and ups all the containers)
6. Go to `/financial-assistance/apply/` in LMS and fill the form. Observe form to be using the new flow. (You need to enable `ENABLE_FINANCIAL_ASSISTANCE_FORM` or comment out the if condition https://github.com/openedx/edx-platform/blob/master/lms/urls.py#L951)