### PR TITLE
fix!: supply the editor and closing user as separate params to cs_comments_service [BD-38] [TNL-9809]

### DIFF
--- a/lms/djangoapps/discussion/rest_api/serializers.py
+++ b/lms/djangoapps/discussion/rest_api/serializers.py
@@ -434,6 +434,11 @@ class ThreadSerializer(_ContentSerializer):
     def update(self, instance, validated_data):
         for key, val in validated_data.items():
             instance[key] = val
+            requesting_user_id = self.context["cc_requester"]["id"]
+            if key == "closed" and val:
+                instance["closing_user_id"] = requesting_user_id
+            if key == "body" and val:
+                instance["editing_user_id"] = requesting_user_id
         instance.save()
         return instance
 
@@ -573,8 +578,11 @@ class CommentSerializer(_ContentSerializer):
             # TODO: The comments service doesn't populate the endorsement
             # field on comment creation, so we only provide
             # endorsement_user_id on update
+            requesting_user_id = self.context["cc_requester"]["id"]
             if key == "endorsed":
-                instance["endorsement_user_id"] = self.context["cc_requester"]["id"]
+                instance["endorsement_user_id"] = requesting_user_id
+            if key == "body" and val:
+                instance["editing_user_id"] = requesting_user_id
 
         instance.save()
         return instance

--- a/lms/djangoapps/discussion/rest_api/tests/test_serializers.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_serializers.py
@@ -592,7 +592,8 @@ class ThreadSerializerDeserializationTest(
             'closed': ['False'],
             'pinned': ['False'],
             'user_id': [str(self.user.id)],
-            'read': [str(read)]
+            'read': [str(read)],
+            'editing_user_id': [str(self.user.id)],
         }
         for key in data:
             assert saved[key] == data[key]
@@ -877,7 +878,8 @@ class CommentSerializerDeserializationTest(ForumsEnableMixin, CommentsServiceMoc
             'anonymous': ['False'],
             'anonymous_to_peers': ['False'],
             'endorsed': ['True'],
-            'endorsement_user_id': [str(self.user.id)]
+            'endorsement_user_id': [str(self.user.id)],
+            'editing_user_id': [str(self.user.id)],
         }
         for key in data:
             assert saved[key] == data[key]

--- a/lms/djangoapps/discussion/rest_api/tests/test_views.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views.py
@@ -1306,7 +1306,7 @@ class ThreadViewSetPartialUpdateTest(DiscussionAPIViewTestMixin, ModuleStoreTest
             'updated_at': 'Test Updated Date',
             'comment_count': 1,
             'read': True,
-            'response_count': 2
+            'response_count': 2,
         })
         assert parsed_body(httpretty.last_request()) == {
             'course_id': [str(self.course.id)],
@@ -1319,7 +1319,8 @@ class ThreadViewSetPartialUpdateTest(DiscussionAPIViewTestMixin, ModuleStoreTest
             'anonymous_to_peers': ['False'],
             'closed': ['False'],
             'pinned': ['False'],
-            'read': ['True']
+            'read': ['True'],
+            'editing_user_id': [str(self.user.id)],
         }
 
     def test_error(self):
@@ -2022,7 +2023,8 @@ class CommentViewSetPartialUpdateTest(DiscussionAPIViewTestMixin, ModuleStoreTes
             'user_id': [str(self.user.id)],
             'anonymous': ['False'],
             'anonymous_to_peers': ['False'],
-            'endorsed': ['False']
+            'endorsed': ['False'],
+            'editing_user_id': [str(self.user.id)],
         }
 
     def test_error(self):

--- a/openedx/core/djangoapps/django_comment_common/comment_client/comment.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/comment.py
@@ -20,6 +20,7 @@ class Comment(models.Model):
     updatable_fields = [
         'body', 'anonymous', 'anonymous_to_peers', 'course_id', 'closed',
         'user_id', 'endorsed', 'endorsement_user_id', 'edit_reason_code',
+        'closing_user_id', 'editing_user_id',
     ]
 
     initializable_fields = updatable_fields

--- a/openedx/core/djangoapps/django_comment_common/comment_client/thread.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/thread.py
@@ -28,7 +28,7 @@ class Thread(models.Model):
     updatable_fields = [
         'title', 'body', 'anonymous', 'anonymous_to_peers', 'course_id', 'read',
         'closed', 'user_id', 'commentable_id', 'group_id', 'group_name', 'pinned', 'thread_type',
-        'close_reason_code', 'edit_reason_code',
+        'close_reason_code', 'edit_reason_code', 'closing_user_id', 'editing_user_id',
     ]
 
     # metric_tag_fields are used by Datadog to record metrics about the model


### PR DESCRIPTION
## Description

The forum service doesn't get the requesting user id for any operation, only the user id of the content creator. So to apply a different user id for an editor or post closing user, those need to be explicitly passed.

## Supporting information

- https://openedx.atlassian.net/browse/TNL-9809

## Testing instructions

- Check out https://github.com/openedx/cs_comments_service/pull/379 
- Check out this PR
- Enable the `discussions.enable_moderation_reason_codes` course waffle flag
- As a moderator edit another user's posts and specify an edit reason. The UI should reflect the correct editing user. 
- As a moderator close a post. The UI should show hte correct closing user. 
