### PR TITLE
build: kickoff the Nutmeg release

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,20 +1,3 @@
-<!--
-
-🍁🍁
-🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
-    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
-🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
-🍁🍁
-
-Please give your pull request a short but descriptive title.
-Use conventional commits to separate and summarize commits logically:
-https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html
-
-Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
-(link will be updated when that document merges)
--->
-
 ## Description
 
 Describe what this pull request changes, and why. Include implications for people using this change.

--- a/.tx/config
+++ b/.tx/config
@@ -67,3 +67,14 @@ source_file = conf/locale/en/LC_MESSAGES/wiki.po
 source_lang = en
 type        = PO
 
+[open-edx-releases.release-nutmeg]
+file_filter = conf/locale/<lang>/LC_MESSAGES/django.po
+source_file = conf/locale/en/LC_MESSAGES/django.po
+source_lang = en
+type = PO
+
+[open-edx-releases.release-nutmeg-js]
+file_filter = conf/locale/<lang>/LC_MESSAGES/djangojs.po
+source_file = conf/locale/en/LC_MESSAGES/djangojs.po
+source_lang = en
+type = PO

--- a/openedx/core/release.py
+++ b/openedx/core/release.py
@@ -8,7 +8,7 @@ import unittest
 # The release line: an Open edX release name ("ficus"), or "master".
 # This should always be "master" on the master branch, and will be changed
 # manually when we start release-line branches, like open-release/ficus.master.
-RELEASE_LINE = "master"
+RELEASE_LINE = "nutmeg"
 
 
 def doc_version():


### PR DESCRIPTION
## Description

Here, we follow the instructions from [this page](https://openedx.atlassian.net/wiki/spaces/COMM/pages/19662426/Process+to+Create+an+Open+edX+Release#tag_release.py) to kickoff the Nutmeg release.