### PR TITLE
fix: edx-enterprise to 3.44.0 and edx-rbac to 1.7.0

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -25,7 +25,7 @@ django-storages<1.9
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==3.43.0
+edx-enterprise==3.44.0
 
 # Newer versions need a more recent version of python-dateutil
 freezegun==0.3.12

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -451,7 +451,7 @@ edx-drf-extensions==8.0.1
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.43.0
+edx-enterprise==3.44.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
@@ -486,7 +486,7 @@ edx-proctoring==4.10.2
     #   edx-proctoring-proctortrack
 edx-proctoring-proctortrack==1.0.5
     # via -r requirements/edx/base.in
-edx-rbac==1.6.0
+edx-rbac==1.7.0
     # via edx-enterprise
 edx-rest-api-client==5.5.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -559,7 +559,7 @@ edx-drf-extensions==8.0.1
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.43.0
+edx-enterprise==3.44.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
@@ -598,7 +598,7 @@ edx-proctoring==4.10.2
     #   edx-proctoring-proctortrack
 edx-proctoring-proctortrack==1.0.5
     # via -r requirements/edx/testing.txt
-edx-rbac==1.6.0
+edx-rbac==1.7.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-enterprise

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -542,7 +542,7 @@ edx-drf-extensions==8.0.1
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.43.0
+edx-enterprise==3.44.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
@@ -582,7 +582,7 @@ edx-proctoring==4.10.2
     #   edx-proctoring-proctortrack
 edx-proctoring-proctortrack==1.0.5
     # via -r requirements/edx/base.txt
-edx-rbac==1.6.0
+edx-rbac==1.7.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise


### PR DESCRIPTION
Overrides the SystemWideEnterpriseUserRoleAssignment.get_assignments() method to return list of (role, context) assignments where the first item in the list corresponds to the currently active enterprise for the user.

https://github.com/openedx/edx-enterprise/pull/1528
https://github.com/openedx/edx-rbac/pull/157

This approach should allow us to remedy the problem without changing behavior of the consumers of JWT-stored roles (e.g. in ecommerce).

https://openedx.atlassian.net/browse/ENT-5700
