### PR TITLE
Drop courseware legacy view for all but Studio preview mode

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2554,7 +2554,6 @@ paths:
                 * `"empty"`: no start date is specified
             * pacing: Course pacing. Possible values: instructor, self
             * user_timezone: User's chosen timezone setting (or null for browser default)
-            * can_view_legacy_courseware: Indicates whether the user is able to see the legacy courseware view
             * user_has_passing_grade: Whether or not the effective user's grade is equal to or above the courses minimum
                 passing grade
             * course_exit_page_is_active: Flag for the learning mfe on whether or not the course exit page should display

--- a/lms/djangoapps/ccx/tests/test_views.py
+++ b/lms/djangoapps/ccx/tests/test_views.py
@@ -17,7 +17,6 @@ from django.test.utils import override_settings
 from django.urls import resolve, reverse
 from django.utils.translation import gettext as _
 from edx_django_utils.cache import RequestCache
-from edx_toggles.toggles.testutils import override_waffle_flag
 from opaque_keys.edx.keys import CourseKey
 from pytz import UTC
 from xmodule.modulestore import ModuleStoreEnum
@@ -41,7 +40,6 @@ from lms.djangoapps.courseware.tabs import get_course_tab_list
 from lms.djangoapps.courseware.tests.factories import StudentModuleFactory
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from lms.djangoapps.courseware.testutils import FieldOverrideTestMixin
-from lms.djangoapps.courseware.toggles import COURSEWARE_USE_LEGACY_FRONTEND
 from lms.djangoapps.discussion.django_comment_client.utils import has_forum_access
 from lms.djangoapps.grades.api import task_compute_all_grades_for_course
 from lms.djangoapps.instructor.access import allow_access, list_with_level
@@ -1219,12 +1217,8 @@ class TestStudentViewsWithCCX(ModuleStoreTestCase):
         assert response.status_code == 200
         assert re.search('Test CCX', response.content.decode('utf-8'))
 
-    @override_waffle_flag(COURSEWARE_USE_LEGACY_FRONTEND, active=True)
     def test_load_courseware(self):
         self.client.login(username=self.student.username, password=self.student_password)
-        response = self.client.get(reverse('courseware_section', kwargs={
-            'course_id': str(self.ccx_course_key),
-            'chapter': 'chapter_x',
-            'section': 'sequential_x1',
-        }))
+        sequence_key = self.ccx_course_key.make_usage_key('sequential', 'sequential_x1')
+        response = self.client.get(reverse('render_xblock', args=[str(sequence_key)]))
         assert response.status_code == 200

--- a/lms/djangoapps/course_home_api/course_metadata/views.py
+++ b/lms/djangoapps/course_home_api/course_metadata/views.py
@@ -21,7 +21,6 @@ from lms.djangoapps.courseware.context_processor import user_timezone_locale_pre
 from lms.djangoapps.courseware.courses import check_course_access
 from lms.djangoapps.courseware.masquerade import setup_masquerade
 from lms.djangoapps.courseware.tabs import get_course_tab_list
-from lms.djangoapps.courseware.toggles import courseware_mfe_is_visible
 
 
 class CourseHomeMetadataView(RetrieveAPIView):
@@ -102,12 +101,6 @@ class CourseHomeMetadataView(RetrieveAPIView):
         enrollment = CourseEnrollment.get_enrollment(request.user, course_key_string)
         user_is_enrolled = bool(enrollment and enrollment.is_active)
 
-        can_load_courseware = courseware_mfe_is_visible(
-            course_key=course_key,
-            is_global_staff=original_user_is_global_staff,
-            is_course_staff=original_user_is_staff
-        )
-
         # User locale settings
         user_timezone_locale = user_timezone_locale_prefs(request)
         user_timezone = user_timezone_locale['user_timezone']
@@ -133,7 +126,7 @@ class CourseHomeMetadataView(RetrieveAPIView):
             'is_self_paced': getattr(course, 'self_paced', False),
             'is_enrolled': user_is_enrolled,
             'course_access': load_access.to_json(),
-            'can_load_courseware': can_load_courseware,
+            'can_load_courseware': True,  # can be removed once the MFE no longer references this field
             'celebrations': celebrations,
             'user_timezone': user_timezone,
             'can_view_certificate': certificates_viewable_for_course(course),

--- a/lms/djangoapps/courseware/tests/helpers.py
+++ b/lms/djangoapps/courseware/tests/helpers.py
@@ -7,8 +7,9 @@ import ast
 import json
 from collections import OrderedDict
 from datetime import timedelta
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.test import TestCase
@@ -18,6 +19,7 @@ from django.utils.timezone import now
 from xblock.field_data import DictFieldData
 
 from common.djangoapps.edxmako.shortcuts import render_to_string
+from lms.djangoapps.courseware import access_utils
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.utils import verified_upgrade_deadline_link
 from lms.djangoapps.courseware.masquerade import MasqueradeView
@@ -451,3 +453,11 @@ def get_context_dict_from_string(data):
         sorted(json.loads(cleaned_data['metadata']).items(), key=lambda t: t[0])
     )
     return cleaned_data
+
+
+def set_preview_mode(preview_mode: bool):
+    """
+    A decorator to force the preview mode on or off.
+    """
+    hostname = settings.FEATURES.get('PREVIEW_LMS_BASE') if preview_mode else None
+    return patch.object(access_utils, 'get_current_request_hostname', new=lambda: hostname)

--- a/lms/djangoapps/courseware/tests/test_entrance_exam.py
+++ b/lms/djangoapps/courseware/tests/test_entrance_exam.py
@@ -3,10 +3,9 @@ Tests use cases related to LMS Entrance Exam behavior, such as gated content acc
 """
 
 
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 from crum import set_current_request
 from django.urls import reverse
-from edx_toggles.toggles.testutils import override_waffle_flag
 from milestones.tests.utils import MilestonesTestCaseMixin
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
@@ -21,11 +20,9 @@ from lms.djangoapps.courseware.entrance_exams import (
 from lms.djangoapps.courseware.model_data import FieldDataCache
 from lms.djangoapps.courseware.module_render import get_module, handle_xblock_callback, toc_for_course
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
-from lms.djangoapps.courseware.toggles import COURSEWARE_USE_LEGACY_FRONTEND
 from openedx.core.djangolib.testing.utils import get_mock_request
-from openedx.features.course_experience import DISABLE_COURSE_OUTLINE_PAGE_FLAG, DISABLE_UNIFIED_COURSE_TAB_FLAG
 from common.djangoapps.student.models import CourseEnrollment
-from common.djangoapps.student.tests.factories import AnonymousUserFactory, CourseEnrollmentFactory
+from common.djangoapps.student.tests.factories import AnonymousUserFactory
 from common.djangoapps.student.tests.factories import InstructorFactory
 from common.djangoapps.student.tests.factories import RequestFactoryNoCsrf
 from common.djangoapps.student.tests.factories import StaffFactory
@@ -40,7 +37,6 @@ from common.djangoapps.util.milestones_helpers import (
 )
 
 
-@override_waffle_flag(COURSEWARE_USE_LEGACY_FRONTEND, active=True)
 @patch.dict('django.conf.settings.FEATURES', {'ENTRANCE_EXAMS': True})
 class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase, MilestonesTestCaseMixin):
     """
@@ -216,54 +212,6 @@ class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase, Milest
             ]
         )
 
-    def test_view_redirect_if_entrance_exam_required(self):
-        """
-        Unit Test: if entrance exam is required. Should return a redirect.
-        """
-        url = reverse('courseware', kwargs={'course_id': str(self.course.id)})
-        expected_url = reverse('courseware_section',
-                               kwargs={
-                                   'course_id': str(self.course.id),
-                                   'chapter': self.entrance_exam.location.block_id,
-                                   'section': self.exam_1.location.block_id
-                               })
-        resp = self.client.get(url)
-        self.assertRedirects(resp, expected_url, status_code=302, target_status_code=200)
-
-    @patch.dict('django.conf.settings.FEATURES', {'ENTRANCE_EXAMS': False})
-    def test_entrance_exam_content_absence(self):
-        """
-        Unit Test: If entrance exam is not enabled then page should be redirected with chapter contents.
-        """
-        url = reverse('courseware', kwargs={'course_id': str(self.course.id)})
-        expected_url = reverse('courseware_section',
-                               kwargs={
-                                   'course_id': str(self.course.id),
-                                   'chapter': self.chapter.location.block_id,
-                                   'section': self.welcome.location.block_id
-                               })
-        resp = self.client.get(url)
-        self.assertRedirects(resp, expected_url, status_code=302, target_status_code=200)
-        resp = self.client.get(expected_url)
-        self.assertNotContains(resp, 'Exam Vertical - Unit 1')
-
-    def test_entrance_exam_content_presence(self):
-        """
-        Unit Test: If entrance exam is enabled then its content e.g. problems should be loaded and redirection will
-        occur with entrance exam contents.
-        """
-        url = reverse('courseware', kwargs={'course_id': str(self.course.id)})
-        expected_url = reverse('courseware_section',
-                               kwargs={
-                                   'course_id': str(self.course.id),
-                                   'chapter': self.entrance_exam.location.block_id,
-                                   'section': self.exam_1.location.block_id
-                               })
-        resp = self.client.get(url)
-        self.assertRedirects(resp, expected_url, status_code=302, target_status_code=200)
-        resp = self.client.get(expected_url)
-        self.assertContains(resp, 'Exam Vertical - Unit 1')
-
     def test_get_entrance_exam_content(self):
         """
         test get entrance exam content method
@@ -278,95 +226,6 @@ class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase, Milest
         exam_chapter = get_entrance_exam_content(self.request.user, self.course)
         assert exam_chapter is None
         assert user_has_passed_entrance_exam(self.request.user, self.course)
-
-    def test_entrance_exam_requirement_message(self):
-        """
-        Unit Test: entrance exam requirement message should be present in response
-        """
-        url = reverse(
-            'courseware_section',
-            kwargs={
-                'course_id': str(self.course.id),
-                'chapter': self.entrance_exam.location.block_id,
-                'section': self.exam_1.location.block_id,
-            }
-        )
-        resp = self.client.get(url)
-        self.assertContains(resp, 'To access course materials, you must score')
-
-    def test_entrance_exam_requirement_message_with_correct_percentage(self):
-        """
-        Unit Test: entrance exam requirement message should be present in response
-        and percentage of required score should be rounded as expected
-        """
-        minimum_score_pct = 29
-        self.course.entrance_exam_minimum_score_pct = float(minimum_score_pct) / 100
-        self.update_course(self.course, self.request.user.id)
-
-        # answer the problem so it results in only 20% correct.
-        answer_entrance_exam_problem(self.course, self.request, self.problem_1, value=1, max_value=5)
-
-        url = reverse(
-            'courseware_section',
-            kwargs={
-                'course_id': str(self.course.id),
-                'chapter': self.entrance_exam.location.block_id,
-                'section': self.exam_1.location.block_id
-            }
-        )
-        resp = self.client.get(url)
-        self.assertContains(
-            resp,
-            f'To access course materials, you must score {minimum_score_pct}% or higher',
-        )
-        assert 'Your current score is 20%.' in resp.content.decode(resp.charset)
-
-    def test_entrance_exam_requirement_message_hidden(self):
-        """
-        Unit Test: entrance exam message should not be present outside the context of entrance exam subsection.
-        """
-        # Login as staff to avoid redirect to entrance exam
-        self.client.logout()
-        staff_user = StaffFactory(course_key=self.course.id)
-        self.client.login(username=staff_user.username, password='test')
-        CourseEnrollment.enroll(staff_user, self.course.id)
-
-        url = reverse(
-            'courseware_section',
-            kwargs={
-                'course_id': str(self.course.id),
-                'chapter': self.chapter.location.block_id,
-                'section': self.chapter_subsection.location.block_id
-            }
-        )
-        resp = self.client.get(url)
-        assert resp.status_code == 200
-        self.assertNotContains(resp, 'To access course materials, you must score')
-        self.assertNotContains(resp, 'You have passed the entrance exam.')
-
-    # TODO: LEARNER-71: Do we need to adjust or remove this test?
-    @override_waffle_flag(DISABLE_COURSE_OUTLINE_PAGE_FLAG, active=True)
-    def test_entrance_exam_passed_message_and_course_content(self):
-        """
-        Unit Test: exam passing message and rest of the course section should be present
-        when user achieves the entrance exam milestone/pass the exam.
-        """
-        url = reverse(
-            'courseware_section',
-            kwargs={
-                'course_id': str(self.course.id),
-                'chapter': self.entrance_exam.location.block_id,
-                'section': self.exam_1.location.block_id
-            }
-        )
-
-        answer_entrance_exam_problem(self.course, self.request, self.problem_1)
-        answer_entrance_exam_problem(self.course, self.request, self.problem_2)
-
-        resp = self.client.get(url)
-        self.assertNotContains(resp, 'To access course materials, you must score')
-        self.assertContains(resp, 'Your score is 100%. You have passed the entrance exam.')
-        self.assertContains(resp, 'Lesson 1')
 
     def test_entrance_exam_gating(self):
         """
@@ -427,71 +286,6 @@ class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase, Milest
         for toc_section in self.expected_unlocked_toc:
             assert toc_section in unlocked_toc
 
-    def test_courseware_page_access_without_passing_entrance_exam(self):
-        """
-        Test courseware access page without passing entrance exam
-        """
-        url = reverse(
-            'courseware_chapter',
-            kwargs={'course_id': str(self.course.id), 'chapter': self.chapter.url_name}
-        )
-        response = self.client.get(url)
-        expected_url = reverse('courseware_section',
-                               kwargs={
-                                   'course_id': str(self.course.id),
-                                   'chapter': self.entrance_exam.location.block_id,
-                                   'section': self.exam_1.location.block_id
-                               })
-        self.assertRedirects(response, expected_url, status_code=302, target_status_code=200)
-
-    @override_waffle_flag(DISABLE_UNIFIED_COURSE_TAB_FLAG, active=True)
-    def test_courseinfo_page_access_without_passing_entrance_exam(self):
-        """
-        Test courseware access page without passing entrance exam
-        """
-        url = reverse('info', args=[str(self.course.id)])
-        response = self.client.get(url)
-        redirect_url = reverse('courseware', args=[str(self.course.id)])
-        self.assertRedirects(response, redirect_url, status_code=302, target_status_code=302)
-        response = self.client.get(redirect_url)
-        exam_url = response.get('Location')
-        self.assertRedirects(response, exam_url)
-
-    @patch('lms.djangoapps.courseware.entrance_exams.get_entrance_exam_content', Mock(return_value=None))
-    def test_courseware_page_access_after_passing_entrance_exam(self):
-        """
-        Test courseware access page after passing entrance exam
-        """
-        self._assert_chapter_loaded(self.course, self.chapter)
-
-    @patch('common.djangoapps.util.milestones_helpers.get_required_content', Mock(return_value=['a value']))
-    def test_courseware_page_access_with_staff_user_without_passing_entrance_exam(self):
-        """
-        Test courseware access page without passing entrance exam but with staff user
-        """
-        self.logout()
-        staff_user = StaffFactory.create(course_key=self.course.id)
-        self.login(staff_user.email, 'test')
-        CourseEnrollmentFactory(user=staff_user, course_id=self.course.id)
-        self._assert_chapter_loaded(self.course, self.chapter)
-
-    def test_courseware_page_access_with_staff_user_after_passing_entrance_exam(self):
-        """
-        Test courseware access page after passing entrance exam but with staff user
-        """
-        self.logout()
-        staff_user = StaffFactory.create(course_key=self.course.id)
-        self.login(staff_user.email, 'test')
-        CourseEnrollmentFactory(user=staff_user, course_id=self.course.id)
-        self._assert_chapter_loaded(self.course, self.chapter)
-
-    @patch.dict("django.conf.settings.FEATURES", {'ENTRANCE_EXAMS': False})
-    def test_courseware_page_access_when_entrance_exams_disabled(self):
-        """
-        Test courseware page access when ENTRANCE_EXAMS feature is disabled
-        """
-        self._assert_chapter_loaded(self.course, self.chapter)
-
     def test_can_skip_entrance_exam_with_anonymous_user(self):
         """
         Test can_skip_entrance_exam method with anonymous user
@@ -539,17 +333,6 @@ class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase, Milest
         )
         assert response.status_code == 200
         self.assertContains(response, 'entrance_exam_passed')
-
-    def _assert_chapter_loaded(self, course, chapter):
-        """
-        Asserts courseware chapter load successfully.
-        """
-        url = reverse(
-            'courseware_chapter',
-            kwargs={'course_id': str(course.id), 'chapter': chapter.url_name}
-        )
-        response = self.client.get(url)
-        assert response.status_code == 200
 
     def _return_table_of_contents(self):
         """

--- a/lms/djangoapps/courseware/tests/test_masquerade.py
+++ b/lms/djangoapps/courseware/tests/test_masquerade.py
@@ -26,9 +26,10 @@ from lms.djangoapps.courseware.masquerade import (
     setup_masquerade,
 )
 
-from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase, MasqueradeMixin, masquerade_as_group_member
+from lms.djangoapps.courseware.tests.helpers import (
+    LoginEnrollmentTestCase, MasqueradeMixin, masquerade_as_group_member, set_preview_mode,
+)
 from lms.djangoapps.courseware.tests.test_submitting_problems import ProblemSubmissionTestMixin
-from lms.djangoapps.courseware.toggles import COURSEWARE_USE_LEGACY_FRONTEND
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
 from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preference, set_user_preference
@@ -42,7 +43,6 @@ from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # li
 from xmodule.partitions.partitions import Group, UserPartition  # lint-amnesty, pylint: disable=wrong-import-order
 
 
-@override_waffle_flag(COURSEWARE_USE_LEGACY_FRONTEND, active=True)
 class MasqueradeTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase, MasqueradeMixin):
     """
     Base class for masquerade tests that sets up a test course and enrolls a user in the course.
@@ -189,32 +189,6 @@ class MasqueradeTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase, Mas
         assert 200 == masquerade_as_group_member(self.test_user, self.course, partition_id, group_id)
 
 
-class NormalStudentVisibilityTest(MasqueradeTestCase):
-    """
-    Verify the course displays as expected for a "normal" student (to ensure test setup is correct).
-    """
-
-    def create_user(self):
-        """
-        Creates a normal student user.
-        """
-        return UserFactory()
-
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
-    def test_staff_debug_not_visible(self):
-        """
-        Tests that staff debug control is not present for a student.
-        """
-        self.verify_staff_debug_present(False)
-
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
-    def test_show_answer_not_visible(self):
-        """
-        Tests that "Show Answer" is not visible for a student.
-        """
-        self.verify_show_answer_present(False)
-
-
 class StaffMasqueradeTestCase(MasqueradeTestCase):
     """
     Base class for tests of the masquerade behavior for a staff member.
@@ -285,6 +259,7 @@ class TestMasqueradeOptionsNoContentGroups(StaffMasqueradeTestCase):
         assert is_target_available == expected
 
 
+@set_preview_mode(True)
 class TestStaffMasqueradeAsStudent(StaffMasqueradeTestCase):
     """
     Check for staff being able to masquerade as student.

--- a/lms/djangoapps/courseware/tests/test_navigation.py
+++ b/lms/djangoapps/courseware/tests/test_navigation.py
@@ -15,19 +15,15 @@ from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
-from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
-from lms.djangoapps.courseware.toggles import COURSEWARE_USE_LEGACY_FRONTEND
+from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase, set_preview_mode
 from openedx.features.course_experience import DISABLE_COURSE_OUTLINE_PAGE_FLAG
-from common.djangoapps.student.tests.factories import UserFactory
 
 
-@override_waffle_flag(COURSEWARE_USE_LEGACY_FRONTEND, active=True)
+@set_preview_mode(True)
 class TestNavigation(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Check that navigation state is saved properly.
     """
-    STUDENT_INFO = [('view@test.com', 'foo'), ('view2@test.com', 'foo')]
-
     @classmethod
     def setUpClass(cls):
         # pylint: disable=super-method-not-called
@@ -71,18 +67,11 @@ class TestNavigation(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
                                          display_name='pdf_textbooks_tab',
                                          default_tab='progress')
 
-        cls.staff_user = GlobalStaffFactory()
-        cls.user = UserFactory()
+        cls.user = GlobalStaffFactory(password='test')
 
     def setUp(self):
         super().setUp()
-
-        # Create student accounts and activate them.
-        for i in range(len(self.STUDENT_INFO)):
-            email, password = self.STUDENT_INFO[i]
-            username = f'u{i}'
-            self.create_account(username, email, password)
-            self.activate_user(email)
+        self.login(self.user.email, 'test')
 
     def assertTabActive(self, tabname, response):
         ''' Check if the progress tab is active in the tab set '''
@@ -106,10 +95,6 @@ class TestNavigation(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         - Accordion enabled, or disabled
         - Navigation tabs enabled, disabled, or redirected
         '''
-        email, password = self.STUDENT_INFO[0]
-        self.login(email, password)
-        self.enroll(self.course, True)
-
         test_data = (
             ('tabs', False, True),
             ('none', False, False),
@@ -143,9 +128,6 @@ class TestNavigation(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         Verify that an inactive session times out and redirects to the
         login page
         """
-        email, password = self.STUDENT_INFO[0]
-        self.login(email, password)
-
         # make sure we can access courseware immediately
         resp = self.client.get(reverse('dashboard'))
         assert resp.status_code == 200
@@ -163,11 +145,6 @@ class TestNavigation(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         Verify that the first time we click on the courseware tab we are
         redirected to the 'Welcome' section.
         """
-        email, password = self.STUDENT_INFO[0]
-        self.login(email, password)
-        self.enroll(self.course, True)
-        self.enroll(self.test_course, True)
-
         resp = self.client.get(reverse('courseware',
                                kwargs={'course_id': str(self.course.id)}))
         self.assertRedirects(resp, reverse(
@@ -180,11 +157,6 @@ class TestNavigation(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         Verify the accordion remembers we've already visited the Welcome section
         and redirects correspondingly.
         """
-        email, password = self.STUDENT_INFO[0]
-        self.login(email, password)
-        self.enroll(self.course, True)
-        self.enroll(self.test_course, True)
-
         section_url = reverse(
             'courseware_section',
             kwargs={
@@ -203,11 +175,6 @@ class TestNavigation(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         """
         Verify the accordion remembers which chapter you were last viewing.
         """
-        email, password = self.STUDENT_INFO[0]
-        self.login(email, password)
-        self.enroll(self.course, True)
-        self.enroll(self.test_course, True)
-
         # Now we directly navigate to a section in a chapter other than 'Overview'.
         section_url = reverse(
             'courseware_section',
@@ -230,11 +197,6 @@ class TestNavigation(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     # TODO: LEARNER-71: Do we need to adjust or remove this test?
     @override_waffle_flag(DISABLE_COURSE_OUTLINE_PAGE_FLAG, active=True)
     def test_incomplete_course(self):
-        email = self.staff_user.email
-        password = "test"
-        self.login(email, password)
-        self.enroll(self.test_course, True)
-
         test_course_id = str(self.test_course.id)
 
         url = reverse(
@@ -284,11 +246,6 @@ class TestNavigation(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         courseware pages if either the FEATURE flag is turned off
         or the course is not proctored enabled
         """
-
-        email, password = self.STUDENT_INFO[0]
-        self.login(email, password)
-        self.enroll(self.test_course_proctored, True)
-
         test_course_id = str(self.test_course_proctored.id)
 
         with patch.dict(settings.FEATURES, {'ENABLE_SPECIAL_EXAMS': False}):

--- a/lms/djangoapps/courseware/tests/test_split_module.py
+++ b/lms/djangoapps/courseware/tests/test_split_module.py
@@ -5,19 +5,16 @@ Test for split test XModule
 
 from unittest.mock import MagicMock
 from django.urls import reverse
-from edx_toggles.toggles.testutils import override_waffle_flag
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from xmodule.partitions.partitions import Group, UserPartition
 
 from lms.djangoapps.courseware.model_data import FieldDataCache
 from lms.djangoapps.courseware.module_render import get_module_for_descriptor
-from lms.djangoapps.courseware.toggles import COURSEWARE_USE_LEGACY_FRONTEND
 from openedx.core.djangoapps.user_api.tests.factories import UserCourseTagFactory
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
 
 
-@override_waffle_flag(COURSEWARE_USE_LEGACY_FRONTEND, active=True)
 class SplitTestBase(ModuleStoreTestCase):
     """
     Sets up a basic course and user for split test testing.
@@ -118,12 +115,7 @@ class SplitTestBase(ModuleStoreTestCase):
             value=str(user_tag)
         )
 
-        resp = self.client.get(reverse(
-            'courseware_section',
-            kwargs={'course_id': str(self.course.id),
-                    'chapter': self.chapter.url_name,
-                    'section': self.sequential.url_name}
-        ))
+        resp = self.client.get(reverse('render_xblock', args=[str(self.sequential.location)]))
         unicode_content = resp.content.decode(resp.charset)
 
         # Assert we see the proper icon in the top display

--- a/lms/djangoapps/courseware/testutils.py
+++ b/lms/djangoapps/courseware/testutils.py
@@ -11,8 +11,9 @@ from urllib.parse import urlencode
 import ddt
 
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from lms.djangoapps.courseware.tests.helpers import set_preview_mode
 from lms.djangoapps.courseware.utils import is_mode_upsellable
-from openedx.features.course_experience.url_helpers import get_courseware_url, ExperienceOption
+from openedx.features.course_experience.url_helpers import get_courseware_url
 from common.djangoapps.student.tests.factories import AdminFactory, CourseEnrollmentFactory, UserFactory
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
@@ -170,6 +171,7 @@ class RenderXBlockTestMixin(MasqueradeMixin, metaclass=ABCMeta):
         ('html_block', 4),
     )
     @ddt.unpack
+    @set_preview_mode(True)
     def test_courseware_html(self, block_name, mongo_calls):
         """
         To verify that the removal of courseware chrome elements is working,
@@ -184,10 +186,7 @@ class RenderXBlockTestMixin(MasqueradeMixin, metaclass=ABCMeta):
             self.setup_user(admin=True, enroll=True, login=True)
 
             with check_mongo_calls(mongo_calls):
-                url = get_courseware_url(
-                    self.block_to_be_tested.location,
-                    experience=ExperienceOption.LEGACY,
-                )
+                url = get_courseware_url(self.block_to_be_tested.location)
                 response = self.client.get(url)
                 expected_elements = self.block_specific_chrome_html_elements + self.COURSEWARE_CHROME_HTML_ELEMENTS
                 for chrome_element in expected_elements:

--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -3,42 +3,12 @@ Toggles for courseware in-course experience.
 """
 
 from edx_toggles.toggles import LegacyWaffleFlagNamespace, SettingToggle
-from opaque_keys.edx.keys import CourseKey
 
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
 # Namespace for courseware waffle flags.
 WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name='courseware')
 
-
-# .. toggle_name: courseware.use_legacy_frontend
-# .. toggle_implementation: CourseWaffleFlag
-# .. toggle_default: False
-# .. toggle_description: Waffle flag to direct learners to the legacy courseware experience - the default behavior
-#   directs to the new MFE-based courseware in frontend-app-learning. Supports the ability to globally flip back to
-#   the legacy courseware experience.
-# .. toggle_use_cases: temporary, open_edx
-# .. toggle_creation_date: 2021-06-03
-# .. toggle_target_removal_date: 2021-10-09
-# .. toggle_tickets: DEPR-109
-COURSEWARE_USE_LEGACY_FRONTEND = CourseWaffleFlag(
-    WAFFLE_FLAG_NAMESPACE, 'use_legacy_frontend', __name__
-)
-
-# .. toggle_name: courseware.microfrontend_course_team_preview
-# .. toggle_implementation: CourseWaffleFlag
-# .. toggle_default: False
-# .. toggle_description: Waffle flag to display a link for the new learner experience to course teams without
-#   redirecting students. Supports staged rollout to course teams of a new micro-frontend-based implementation of the
-#   courseware page.
-# .. toggle_use_cases: temporary, open_edx
-# .. toggle_creation_date: 2020-03-09
-# .. toggle_target_removal_date: 2020-12-31
-# .. toggle_warnings: Also set settings.LEARNING_MICROFRONTEND_URL.
-# .. toggle_tickets: DEPR-109
-COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW = CourseWaffleFlag(
-    WAFFLE_FLAG_NAMESPACE, 'microfrontend_course_team_preview', __name__
-)
 
 # Waffle flag to enable the course exit page in the learning MFE.
 #
@@ -128,118 +98,25 @@ COURSEWARE_OPTIMIZED_RENDER_XBLOCK = CourseWaffleFlag(
 COURSES_INVITE_ONLY = SettingToggle('COURSES_INVITE_ONLY', default=False)
 
 
-def courseware_mfe_is_active(course_key: CourseKey) -> bool:
+def courseware_mfe_is_active() -> bool:
     """
     Should we serve the Learning MFE as the canonical courseware experience?
     """
-    #Avoid circular imports.
-    from lms.djangoapps.courseware.access_utils import in_preview_mode
-    # NO: Old Mongo courses are always served in the Legacy frontend,
-    #     regardless of configuration.
-    if course_key.deprecated:
-        return False
-    # NO: MFE courseware can be disabled for users/courses/globally via this
-    #     Waffle flag.
-    if COURSEWARE_USE_LEGACY_FRONTEND.is_enabled(course_key):
-        return False
-    # NO: Course preview doesn't work in the MFE
-    if in_preview_mode():
-        return False
-    # OTHERWISE: MFE courseware experience is active by default.
-    return True
-
-
-def courseware_mfe_is_visible(
-        course_key: CourseKey,
-        is_global_staff=False,
-        is_course_staff=False,
-) -> bool:
-    """
-    Can we see a course run's content in the Learning MFE?
-    """
-    #Avoid circular imports.
-    from lms.djangoapps.courseware.access_utils import in_preview_mode
-    # DENY: Old Mongo courses don't work in the MFE.
-    if course_key.deprecated:
-        return False
-    # DENY: Course preview doesn't work in the MFE
-    if in_preview_mode():
-        return False
-    # ALLOW: Where techincally possible, global staff may always see the MFE.
-    if is_global_staff:
-        return True
-    # ALLOW: If course team preview is enabled, then course staff may see their
-    #        course in the MFE.
-    if is_course_staff and COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW.is_enabled(course_key):
-        return True
-    # OTHERWISE: The MFE is only visible if it's the active (ie canonical) experience.
-    return courseware_mfe_is_active(course_key)
-
-
-def courseware_mfe_is_advertised(
-        course_key: CourseKey,
-        is_global_staff=False,
-        is_course_staff=False,
-) -> bool:
-    """
-    Should we invite the user to view a course run's content in the Learning MFE?
-
-    This check is slightly different than `courseware_mfe_is_visible`, in that
-    we always *permit* global staff to view MFE content (assuming it's deployed),
-    but we do not shove the New Experience in their face if the preview isn't
-    enabled.
-    """
-    #Avoid circular imports.
-    from lms.djangoapps.courseware.access_utils import in_preview_mode
-    # DENY: Old Mongo courses don't work in the MFE.
-    if course_key.deprecated:
-        return False
-    # DENY: Course preview doesn't work in the MFE
-    if in_preview_mode():
-        return False
-    # ALLOW: Both global and course staff can see the MFE link if the course team
-    #        preview is enabled.
-    is_staff = is_global_staff or is_course_staff
-    if is_staff and COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW.is_enabled(course_key):
-        return True
-    # OTHERWISE: The MFE is only advertised if it's the active (ie canonical) experience.
-    return courseware_mfe_is_active(course_key)
-
-
-def courseware_legacy_is_visible(
-        course_key: CourseKey,
-        is_global_staff=False,
-) -> bool:
-    """
-    Can we see a course run's content in the Legacy frontend?
-
-    Note: This function will always return True for Old Mongo courses,
-    since `courseware_mfe_is_active` will always return False for them.
-    """
-    #Avoid circular imports.
-    from lms.djangoapps.courseware.access_utils import in_preview_mode
-    # ALLOW: Global staff may always see the Legacy experience.
-    if is_global_staff:
-        return True
-    # ALLOW: All course previews will be shown in Legacy experience
-    if in_preview_mode():
-        return True
-    # OTHERWISE: Legacy is only visible if it's the active (ie canonical) experience.
-    #            Note that Old Mongo courses are never the active experience,
-    #            so we effectively always ALLOW them to be viewed in Legacy.
-    return not courseware_mfe_is_active(course_key)
+    from lms.djangoapps.courseware.access_utils import in_preview_mode  # avoid a circular import
+    # We only use legacy views for the Studio "preview mode" feature these days, while everyone else gets the MFE
+    return not in_preview_mode()
 
 
 def course_exit_page_is_active(course_key):
     return (
-        courseware_mfe_is_active(course_key) and
+        courseware_mfe_is_active() and
         COURSEWARE_MICROFRONTEND_COURSE_EXIT_PAGE.is_enabled(course_key)
     )
 
 
 def courseware_mfe_progress_milestones_are_active(course_key):
     return (
-        courseware_mfe_is_active(course_key) and
+        courseware_mfe_is_active() and
         COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES.is_enabled(course_key)
     )
 

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -64,10 +64,7 @@ from ..masquerade import check_content_start_date_for_masquerade_user, setup_mas
 from ..model_data import FieldDataCache
 from ..module_render import get_module_for_descriptor, toc_for_course
 from ..permissions import MASQUERADE_AS_STUDENT
-from ..toggles import (
-    courseware_legacy_is_visible,
-    courseware_mfe_is_advertised
-)
+from ..toggles import courseware_mfe_is_active
 from .views import CourseTabView
 
 log = logging.getLogger("edx.courseware.views.index")
@@ -172,23 +169,11 @@ class CoursewareIndex(View):
 
     def _redirect_to_learning_mfe(self):
         """
-        Can the user access this sequence in Legacy courseware? If not, redirect to MFE.
-
-        We specifically allow users to stay in the Legacy frontend for special
-        (ie timed/proctored) exams since they're not yet supported by the MFE.
+        Can the user access this sequence in the courseware MFE? If so, redirect to MFE.
         """
-        # STAY: if the course run as a whole is visible in the Legacy experience.
-        if courseware_legacy_is_visible(
-                course_key=self.course_key,
-                is_global_staff=self.request.user.is_staff,
-        ):
-            return
-        # STAY: if we are in a special (ie proctored/timed) exam, which isn't yet
-        #       supported on the MFE.
-        if getattr(self.section, 'is_time_limited', False):
-            return
-        # REDIRECT otherwise.
-        raise Redirect(self.microfrontend_url)
+        # If the MFE is active, prefer that
+        if courseware_mfe_is_active():
+            raise Redirect(self.microfrontend_url)
 
     @property
     def microfrontend_url(self):
@@ -496,16 +481,6 @@ class CoursewareIndex(View):
 
             if self.section.position and self.section.has_children:
                 self._add_sequence_title_to_context(courseware_context)
-
-        # Courseware MFE link
-        if courseware_mfe_is_advertised(
-                is_global_staff=request.user.is_staff,
-                is_course_staff=staff_access,
-                course_key=self.course.id,
-        ):
-            courseware_context['microfrontend_link'] = self.microfrontend_url
-        else:
-            courseware_context['microfrontend_link'] = None
 
         return courseware_context
 

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -119,7 +119,6 @@ from openedx.features.course_duration_limits.access import generate_course_expir
 from openedx.features.course_experience import DISABLE_UNIFIED_COURSE_TAB_FLAG, course_home_url
 from openedx.features.course_experience.course_tools import CourseToolsPluginManager
 from openedx.features.course_experience.url_helpers import (
-    ExperienceOption,
     get_courseware_url,
     get_learning_mfe_home_url,
     is_request_from_learning_mfe
@@ -410,19 +409,10 @@ def jump_to(request, course_id, location):
     except InvalidKeyError as exc:
         raise Http404("Invalid course_key or usage_key") from exc
 
-    experience_param = request.GET.get("experience", "").lower()
-    if experience_param == "new":
-        experience = ExperienceOption.NEW
-    elif experience_param == "legacy":
-        experience = ExperienceOption.LEGACY
-    else:
-        experience = ExperienceOption.ACTIVE
-
     try:
         redirect_url = get_courseware_url(
             usage_key=usage_key,
             request=request,
-            experience=experience,
         )
     except (ItemNotFoundError, NoPathToItem):
         # We used to 404 here, but that's ultimately a bad experience. There are real world use cases where a user
@@ -432,7 +422,6 @@ def jump_to(request, course_id, location):
         redirect_url = get_courseware_url(
             usage_key=course_location_from_key(course_key),
             request=request,
-            experience=experience,
         )
 
     return redirect(redirect_url)

--- a/lms/templates/preview_menu.html
+++ b/lms/templates/preview_menu.html
@@ -91,11 +91,6 @@ show_preview_menu = course and can_masquerade and supports_preview_menu
                 </div>
             % endif
             <div style="flex-shrink: 1; text-align: center;">
-            % if microfrontend_link:
-                <a class="btn btn-primary" style="border: solid 1px white;" href="${microfrontend_link}">
-                    ${_("View in the new experience")}
-                </a>
-            % endif
             % if studio_url:
                 <a
                     class="btn btn-primary view-in-studio"

--- a/openedx/core/djangoapps/courseware_api/serializers.py
+++ b/openedx/core/djangoapps/courseware_api/serializers.py
@@ -102,7 +102,6 @@ class CourseInfoSerializer(serializers.Serializer):  # pylint: disable=abstract-
     pacing = serializers.CharField()
     user_timezone = serializers.CharField()
     show_calculator = serializers.BooleanField()
-    can_view_legacy_courseware = serializers.BooleanField()
     can_access_proctored_exams = serializers.BooleanField()
     notes = serializers.DictField()
     marketing_url = serializers.CharField()

--- a/openedx/core/djangoapps/courseware_api/tests/pacts/api-courseware-contract.json
+++ b/openedx/core/djangoapps/courseware_api/tests/pacts/api-courseware-contract.json
@@ -70,7 +70,6 @@
           },
           "show_calculator": false,
           "original_user_is_staff": true,
-          "can_view_legacy_courseware": true,
           "is_staff": true,
           "course_access": {
             "has_access": true,
@@ -198,9 +197,6 @@
             "match": "type"
           },
           "$.body.original_user_is_staff": {
-            "match": "type"
-          },
-          "$.body.can_view_legacy_courseware": {
             "match": "type"
           },
           "$.body.is_staff": {

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -41,10 +41,7 @@ from lms.djangoapps.courseware.masquerade import (
 )
 from lms.djangoapps.courseware.models import LastSeenCoursewareTimezone
 from lms.djangoapps.courseware.module_render import get_module_by_usage_id
-from lms.djangoapps.courseware.toggles import (
-    courseware_legacy_is_visible,
-    course_exit_page_is_active,
-)
+from lms.djangoapps.courseware.toggles import course_exit_page_is_active
 from lms.djangoapps.courseware.views.views import get_cert_data
 from lms.djangoapps.gating.api import get_entrance_exam_score, get_entrance_exam_usage_key
 from lms.djangoapps.grades.api import CourseGradeFactory
@@ -94,10 +91,6 @@ class CoursewareMeta:
         self.request.user = self.effective_user
         self.enrollment_object = CourseEnrollment.get_enrollment(self.effective_user, self.course_key,
                                                                  select_related=['celebration', 'user__celebration'])
-        self.can_view_legacy_courseware = courseware_legacy_is_visible(
-            course_key=course_key,
-            is_global_staff=self.original_user_is_global_staff,
-        )
 
     def __getattr__(self, name):
         return getattr(self.overview, name)
@@ -448,7 +441,6 @@ class CoursewareInformation(RetrieveAPIView):
         * pacing: Course pacing. Possible values: instructor, self
         * user_timezone: User's chosen timezone setting (or null for browser default)
         * can_load_course: Whether the user can view the course (AccessResponse object)
-        * can_view_legacy_courseware: Indicates whether the user is able to see the legacy courseware view
         * user_has_passing_grade: Whether or not the effective user's grade is equal to or above the courses minimum
             passing grade
         * course_exit_page_is_active: Flag for the learning mfe on whether or not the course exit page should display

--- a/openedx/features/content_type_gating/tests/test_access.py
+++ b/openedx/features/content_type_gating/tests/test_access.py
@@ -12,7 +12,6 @@ from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils import timezone
 from django.contrib.auth import get_user_model
-from edx_toggles.toggles.testutils import override_waffle_flag
 from pyquery import PyQuery as pq
 from xmodule.modulestore.tests.django_utils import (
     TEST_DATA_MONGO_AMNESTY_MODULESTORE, ModuleStoreTestCase, SharedModuleStoreTestCase,
@@ -30,7 +29,6 @@ from common.djangoapps.student.tests.factories import OrgStaffFactory
 from common.djangoapps.student.tests.factories import StaffFactory
 from lms.djangoapps.courseware.module_render import load_single_xblock
 from lms.djangoapps.courseware.tests.helpers import MasqueradeMixin
-from lms.djangoapps.courseware.toggles import COURSEWARE_USE_LEGACY_FRONTEND
 from lms.djangoapps.discussion.django_comment_client.tests.factories import RoleFactory
 from openedx.core.djangoapps.django_comment_common.models import (
     FORUM_ROLE_ADMINISTRATOR,
@@ -59,7 +57,7 @@ User = get_user_model()
 
 
 @patch("crum.get_current_request")
-def _get_content_from_fragment(block, user_id, course, request_factory, mock_get_current_request):
+def _get_content_from_fragment(_store, block, user_id, course, request_factory, mock_get_current_request):
     """
     Returns the content from the rendered fragment of a block
     Arguments:
@@ -84,29 +82,30 @@ def _get_content_from_fragment(block, user_id, course, request_factory, mock_get
     return frag.content
 
 
-def _get_content_from_lms_index(block, user_id, course, request_factory):
+def _get_content_from_lms_index(store, block, user_id, _course, _request_factory):
     """
     Returns the content from the lms index view of the block
     Arguments:
         block: some sort of xblock descriptor, must implement .scope_ids.usage_id
         user_id (int): id of user
-        course_id (CourseLocator): id of course
     """
     client = Client()
     client.login(username=User.objects.get(id=user_id).username, password=TEST_PASSWORD)
+
+    # Re-load the block from the store to ensure that its `parent` field is filled out correctly
+    block = store.get_item(block.location)
+
     page_content = client.get(
-        reverse('courseware', kwargs={'course_id': block.scope_ids.usage_id.course_key}),
+        reverse('render_xblock', args=[str(block.parent)]) + '?recheck_access=1',
         follow=True,
     )
-    page = pq(page_content.content)
-    seq_contents = page('#seq_contents_0').html()
-    seq = pq(seq_contents)
-    block_contents = seq(f'[data-id="{block.scope_ids.usage_id}"]')
 
+    page = pq(page_content.content)
+    block_contents = page(f'[data-id="{block.scope_ids.usage_id}"]')
     return block_contents.html()
 
 
-def _assert_block_is_gated(block, is_gated, user, course, request_factory, has_upgrade_link=True):
+def _assert_block_is_gated(store, block, is_gated, user, course, request_factory, has_upgrade_link=True):
     """
     Asserts that a block in a specific course is gated for a specific user
     Arguments:
@@ -118,7 +117,7 @@ def _assert_block_is_gated(block, is_gated, user, course, request_factory, has_u
     checkout_link = '#' if has_upgrade_link else None
     for content_getter in (_get_content_from_fragment, _get_content_from_lms_index):
         with patch.object(ContentTypeGatingPartition, '_get_checkout_link', return_value=checkout_link):
-            content = content_getter(block, user.id, course, request_factory)  # pylint: disable=no-value-for-parameter
+            content = content_getter(store, block, user.id, course, request_factory)  # pylint: disable=no-value-for-parameter
         if is_gated:
             assert 'content-paywall' in content
             if has_upgrade_link:
@@ -148,7 +147,7 @@ def _assert_block_is_gated(block, is_gated, user, course, request_factory, has_u
             assert 'student_view_data' in course_api_block
 
 
-def _assert_block_is_empty(block, user_id, course, request_factory):
+def _assert_block_is_empty(store, block, user_id, course, request_factory):
     """
     Asserts that a block in a specific course is empty for a specific user
     Arguments:
@@ -157,7 +156,7 @@ def _assert_block_is_empty(block, user_id, course, request_factory):
         user_id (int): id of user
         course_id (CourseLocator): id of course
     """
-    content = _get_content_from_lms_index(block, user_id, course, request_factory)
+    content = _get_content_from_lms_index(store, block, user_id, course, request_factory)
     assert content is None
 
 
@@ -165,7 +164,6 @@ def _assert_block_is_empty(block, user_id, course, request_factory):
 @override_settings(FIELD_OVERRIDE_PROVIDERS=(
     'openedx.features.content_type_gating.field_override.ContentTypeGatingFieldOverride',
 ))
-@override_waffle_flag(COURSEWARE_USE_LEGACY_FRONTEND, active=True)
 class TestProblemTypeAccess(SharedModuleStoreTestCase, MasqueradeMixin):  # pylint: disable=missing-class-docstring
 
     PROBLEM_TYPES = ['problem', 'openassessment', 'drag-and-drop-v2', 'done', 'edx_sga']
@@ -465,6 +463,7 @@ class TestProblemTypeAccess(SharedModuleStoreTestCase, MasqueradeMixin):  # pyli
     @ddt.unpack
     def test_access_to_problems(self, prob_type, is_gated):
         _assert_block_is_gated(
+            self.store,
             block=self.blocks_dict[prob_type],
             user=self.users['audit'],
             course=self.course,
@@ -472,6 +471,7 @@ class TestProblemTypeAccess(SharedModuleStoreTestCase, MasqueradeMixin):  # pyli
             request_factory=self.factory,
         )
         _assert_block_is_gated(
+            self.store,
             block=self.blocks_dict[prob_type],
             user=self.users['verified'],
             course=self.course,
@@ -487,6 +487,7 @@ class TestProblemTypeAccess(SharedModuleStoreTestCase, MasqueradeMixin):  # pyli
         # Verify that graded, has_score and weight must all be true for a component to be gated
         block = self.graded_score_weight_blocks[(graded, has_score, weight)]
         _assert_block_is_gated(
+            self.store,
             block=block,
             user=self.audit_user,
             course=self.course,
@@ -522,6 +523,7 @@ class TestProblemTypeAccess(SharedModuleStoreTestCase, MasqueradeMixin):  # pyli
          All users should have access to non-problem component types, the 'html' components test that.
          """
         _assert_block_is_gated(
+            self.store,
             block=self.courses[course]['blocks'][component_type],
             user=self.users[user_track],
             course=self.courses[course]['course'],
@@ -535,6 +537,7 @@ class TestProblemTypeAccess(SharedModuleStoreTestCase, MasqueradeMixin):  # pyli
         the user will continue to see gated content, but the upgrade messaging will be removed.
         """
         _assert_block_is_gated(
+            self.store,
             block=self.courses['expired_upgrade_deadline']['blocks']['problem'],
             user=self.users['audit'],
             course=self.courses['expired_upgrade_deadline']['course'],
@@ -599,6 +602,7 @@ class TestProblemTypeAccess(SharedModuleStoreTestCase, MasqueradeMixin):  # pyli
 
         # assert that course team members have access to graded content
         _assert_block_is_gated(
+            self.store,
             block=self.blocks_dict['problem'],
             user=user,
             course=self.course,
@@ -626,6 +630,7 @@ class TestProblemTypeAccess(SharedModuleStoreTestCase, MasqueradeMixin):  # pyli
             mode='audit',
         )
         _assert_block_is_gated(
+            self.store,
             block=self.blocks_dict['problem'],
             user=user,
             course=self.course,
@@ -650,6 +655,7 @@ class TestProblemTypeAccess(SharedModuleStoreTestCase, MasqueradeMixin):  # pyli
         graded, has_score, weight = True, True, 1
         block = self.graded_score_weight_blocks[(graded, has_score, weight)]
         _assert_block_is_gated(
+            self.store,
             block=block,
             user=user,
             course=self.course,
@@ -758,6 +764,7 @@ class TestProblemTypeAccess(SharedModuleStoreTestCase, MasqueradeMixin):  # pyli
         self.update_masquerade(username=user.username)
 
         _assert_block_is_gated(
+            self.store,
             block=self.blocks_dict['problem'],
             user=user,
             course=self.course,
@@ -772,12 +779,8 @@ class TestProblemTypeAccess(SharedModuleStoreTestCase, MasqueradeMixin):  # pyli
     def test_discount_display(self):
 
         with patch.object(ContentTypeGatingPartition, '_get_checkout_link', return_value='#'):
-            block_content = _get_content_from_lms_index(
-                block=self.blocks_dict['problem'],
-                user_id=self.audit_user.id,
-                course=self.course,
-                request_factory=self.factory,
-            )
+            block_content = _get_content_from_lms_index(self.store, self.blocks_dict['problem'], self.audit_user.id,
+                                                        self.course, self.factory)
 
         assert '<span>DISCOUNT_PRICE</span>' in block_content
 
@@ -785,7 +788,6 @@ class TestProblemTypeAccess(SharedModuleStoreTestCase, MasqueradeMixin):  # pyli
 @override_settings(FIELD_OVERRIDE_PROVIDERS=(
     'openedx.features.content_type_gating.field_override.ContentTypeGatingFieldOverride',
 ))
-@override_waffle_flag(COURSEWARE_USE_LEGACY_FRONTEND, active=True)
 class TestConditionalContentAccess(TestConditionalContent):
     """
     Conditional Content allows course authors to run a/b tests on course content.  We want to make sure that
@@ -852,6 +854,7 @@ class TestConditionalContentAccess(TestConditionalContent):
 
         # Make sure that all audit enrollments are gated regardless of if they see vertical a or vertical b
         _assert_block_is_gated(
+            self.store,
             block=self.block_a,
             user=self.student_audit_a,
             course=self.course,
@@ -859,6 +862,7 @@ class TestConditionalContentAccess(TestConditionalContent):
             request_factory=self.factory,
         )
         _assert_block_is_gated(
+            self.store,
             block=self.block_b,
             user=self.student_audit_b,
             course=self.course,
@@ -868,6 +872,7 @@ class TestConditionalContentAccess(TestConditionalContent):
 
         # Make sure that all verified enrollments are not gated regardless of if they see vertical a or vertical b
         _assert_block_is_gated(
+            self.store,
             block=self.block_a,
             user=self.student_verified_a,
             course=self.course,
@@ -875,6 +880,7 @@ class TestConditionalContentAccess(TestConditionalContent):
             request_factory=self.factory,
         )
         _assert_block_is_gated(
+            self.store,
             block=self.block_b,
             user=self.student_verified_b,
             course=self.course,
@@ -886,7 +892,6 @@ class TestConditionalContentAccess(TestConditionalContent):
 @override_settings(FIELD_OVERRIDE_PROVIDERS=(
     'openedx.features.content_type_gating.field_override.ContentTypeGatingFieldOverride',
 ))
-@override_waffle_flag(COURSEWARE_USE_LEGACY_FRONTEND, active=True)
 class TestMessageDeduplication(ModuleStoreTestCase):
     """
     Tests to verify that access denied messages isn't shown if multiple items in a row are denied.
@@ -943,12 +948,13 @@ class TestMessageDeduplication(ModuleStoreTestCase):
             mode='audit'
         )
         blocks_dict['graded_1'] = ItemFactory.create(
-            parent=blocks_dict['vertical'],
+            parent_location=blocks_dict['vertical'].location,
             category='problem',
             graded=True,
             metadata=METADATA,
         )
         _assert_block_is_gated(
+            self.store,
             block=blocks_dict['graded_1'],
             user=self.user,
             course=course['course'],
@@ -978,6 +984,7 @@ class TestMessageDeduplication(ModuleStoreTestCase):
             mode='audit'
         )
         _assert_block_is_gated(
+            self.store,
             block=blocks_dict['graded_1'],
             user=self.user,
             course=course['course'],
@@ -985,6 +992,7 @@ class TestMessageDeduplication(ModuleStoreTestCase):
             request_factory=self.request_factory,
         )
         _assert_block_is_empty(
+            self.store,
             block=blocks_dict['graded_2'],
             user_id=self.user.id,
             course=course['course'],
@@ -1025,6 +1033,7 @@ class TestMessageDeduplication(ModuleStoreTestCase):
             mode='audit'
         )
         _assert_block_is_gated(
+            self.store,
             block=blocks_dict['graded_1'],
             user=self.user,
             course=course['course'],
@@ -1032,18 +1041,21 @@ class TestMessageDeduplication(ModuleStoreTestCase):
             request_factory=self.request_factory,
         )
         _assert_block_is_empty(
+            self.store,
             block=blocks_dict['graded_2'],
             user_id=self.user.id,
             course=course['course'],
             request_factory=self.request_factory,
         )
         _assert_block_is_empty(
+            self.store,
             block=blocks_dict['graded_3'],
             user_id=self.user.id,
             course=course['course'],
             request_factory=self.request_factory,
         )
         _assert_block_is_empty(
+            self.store,
             block=blocks_dict['graded_4'],
             user_id=self.user.id,
             course=course['course'],
@@ -1077,6 +1089,7 @@ class TestMessageDeduplication(ModuleStoreTestCase):
             mode='audit'
         )
         _assert_block_is_gated(
+            self.store,
             block=blocks_dict['graded_1'],
             user=self.user,
             course=course['course'],
@@ -1084,6 +1097,7 @@ class TestMessageDeduplication(ModuleStoreTestCase):
             request_factory=self.request_factory,
         )
         _assert_block_is_gated(
+            self.store,
             block=blocks_dict['ungraded_2'],
             user=self.user,
             course=course['course'],
@@ -1091,6 +1105,7 @@ class TestMessageDeduplication(ModuleStoreTestCase):
             request_factory=self.request_factory,
         )
         _assert_block_is_gated(
+            self.store,
             block=blocks_dict['graded_3'],
             user=self.user,
             course=course['course'],

--- a/openedx/features/course_duration_limits/tests/test_course_expiration.py
+++ b/openedx/features/course_duration_limits/tests/test_course_expiration.py
@@ -9,7 +9,6 @@ import ddt
 from django.conf import settings
 from django.urls import reverse
 from django.utils.timezone import now
-from edx_toggles.toggles.testutils import override_waffle_flag
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from xmodule.partitions.partitions import ENROLLMENT_TRACK_PARTITION_ID
@@ -25,7 +24,6 @@ from common.djangoapps.student.tests.factories import OrgInstructorFactory
 from common.djangoapps.student.tests.factories import OrgStaffFactory
 from common.djangoapps.student.tests.factories import StaffFactory
 from lms.djangoapps.courseware.tests.helpers import MasqueradeMixin
-from lms.djangoapps.courseware.toggles import COURSEWARE_USE_LEGACY_FRONTEND
 from lms.djangoapps.discussion.django_comment_client.tests.factories import RoleFactory
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.course_date_signals.utils import MAX_DURATION, MIN_DURATION
@@ -44,7 +42,6 @@ from openedx.features.course_experience.tests.views.helpers import add_course_mo
 
 # pylint: disable=no-member
 @ddt.ddt
-@override_waffle_flag(COURSEWARE_USE_LEGACY_FRONTEND, active=True)
 class CourseExpirationTestCase(ModuleStoreTestCase, MasqueradeMixin):
     """Tests to verify the get_user_course_expiration_date function is working correctly"""
     def setUp(self):
@@ -80,14 +77,7 @@ class CourseExpirationTestCase(ModuleStoreTestCase, MasqueradeMixin):
 
     def get_courseware(self):
         """Returns a response from a GET on a courseware section"""
-        courseware_url = reverse(
-            'courseware_section',
-            kwargs={
-                'course_id': str(self.course.id),
-                'chapter': self.chapter.location.block_id,
-                'section': self.sequential.location.block_id,
-            },
-        )
+        courseware_url = reverse('render_xblock', args=[str(self.sequential.location)])
         return self.client.get(courseware_url, follow=True)
 
     def test_enrollment_mode(self):

--- a/openedx/features/course_experience/tests/test_url_helpers.py
+++ b/openedx/features/course_experience/tests/test_url_helpers.py
@@ -284,4 +284,4 @@ class GetCoursewareUrlTests(SharedModuleStoreTestCase):
         path = url.split('?')[0]
         assert path == expected_path
         course_run = self.items[store_type]['course_run']
-        mock_mfe_is_active.assert_called_once_with(course_run.id)
+        mock_mfe_is_active.assert_called_once()

--- a/openedx/features/course_experience/tests/views/test_course_sock.py
+++ b/openedx/features/course_experience/tests/views/test_course_sock.py
@@ -11,7 +11,7 @@ from edx_toggles.toggles.testutils import override_waffle_flag
 
 from common.djangoapps.course_modes.models import CourseMode
 from lms.djangoapps.commerce.models import CommerceConfiguration
-from lms.djangoapps.courseware.toggles import COURSEWARE_USE_LEGACY_FRONTEND
+from lms.djangoapps.courseware.tests.helpers import set_preview_mode
 from openedx.core.djangolib.markup import HTML
 from openedx.features.course_experience import DISPLAY_COURSE_SOCK_FLAG
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
@@ -25,7 +25,7 @@ TEST_VERIFICATION_SOCK_LOCATOR = '<div class="verification-sock"'
 
 
 @ddt.ddt
-@override_waffle_flag(COURSEWARE_USE_LEGACY_FRONTEND, active=True)
+@set_preview_mode(True)
 class TestCourseSockView(SharedModuleStoreTestCase):
     """
     Tests for the course verification sock fragment view.
@@ -47,7 +47,7 @@ class TestCourseSockView(SharedModuleStoreTestCase):
 
     def setUp(self):
         super().setUp()
-        self.user = UserFactory.create()
+        self.user = UserFactory.create(is_staff=True)
 
         # Enroll the user in the four courses
         CourseEnrollmentFactory.create(user=self.user, course_id=self.standard_course.id)

--- a/openedx/features/course_experience/tests/views/test_masquerade.py
+++ b/openedx/features/course_experience/tests/views/test_masquerade.py
@@ -5,8 +5,7 @@ Tests for masquerading functionality on course_experience
 from django.urls import reverse
 
 from edx_toggles.toggles.testutils import override_waffle_flag
-from lms.djangoapps.courseware.tests.helpers import MasqueradeMixin
-from lms.djangoapps.courseware.toggles import COURSEWARE_USE_LEGACY_FRONTEND
+from lms.djangoapps.courseware.tests.helpers import MasqueradeMixin, set_preview_mode
 from openedx.features.course_experience import DISPLAY_COURSE_SOCK_FLAG
 from common.djangoapps.student.roles import CourseStaffRole
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
@@ -62,12 +61,12 @@ class MasqueradeTestBase(SharedModuleStoreTestCase, MasqueradeMixin):
         return None
 
 
+@set_preview_mode(True)
 class TestVerifiedUpgradesWithMasquerade(MasqueradeTestBase):
     """
     Tests for the course verification upgrade messages while the user is being masqueraded.
     """
 
-    @override_waffle_flag(COURSEWARE_USE_LEGACY_FRONTEND, active=True)
     @override_waffle_flag(DISPLAY_COURSE_SOCK_FLAG, active=True)
     def test_masquerade_as_student(self):
         # Elevate the staff user to be student
@@ -75,7 +74,6 @@ class TestVerifiedUpgradesWithMasquerade(MasqueradeTestBase):
         response = self.client.get(reverse('courseware', kwargs={'course_id': str(self.verified_course.id)}))
         self.assertContains(response, TEST_VERIFICATION_SOCK_LOCATOR, html=False)
 
-    @override_waffle_flag(COURSEWARE_USE_LEGACY_FRONTEND, active=True)
     @override_waffle_flag(DISPLAY_COURSE_SOCK_FLAG, active=True)
     def test_masquerade_as_verified_student(self):
         user_group_id = self.get_group_id_by_course_mode_name(
@@ -87,7 +85,6 @@ class TestVerifiedUpgradesWithMasquerade(MasqueradeTestBase):
         response = self.client.get(reverse('courseware', kwargs={'course_id': str(self.verified_course.id)}))
         self.assertNotContains(response, TEST_VERIFICATION_SOCK_LOCATOR, html=False)
 
-    @override_waffle_flag(COURSEWARE_USE_LEGACY_FRONTEND, active=True)
     @override_waffle_flag(DISPLAY_COURSE_SOCK_FLAG, active=True)
     def test_masquerade_as_masters_student(self):
         user_group_id = self.get_group_id_by_course_mode_name(

--- a/openedx/features/course_experience/url_helpers.py
+++ b/openedx/features/course_experience/url_helpers.py
@@ -4,7 +4,6 @@ Helper functions for logic related to learning (courseare & course home) URLs.
 Centralized in openedx/features/course_experience instead of lms/djangoapps/courseware
 because the Studio course outline may need these utilities.
 """
-from enum import Enum
 from typing import Optional
 
 from django.conf import settings
@@ -22,24 +21,9 @@ from xmodule.modulestore.search import navigation_index, path_to_location  # lin
 User = get_user_model()
 
 
-class ExperienceOption(Enum):
-    """
-    Versions of the courseware experience that can be requested.
-
-    `ACTIVE` indicates that the default experience (in the context of the
-    course run) should be used.
-
-    To be removed as part of DEPR-109.
-    """
-    ACTIVE = 'courseware-experience-active'
-    NEW = 'courseware-experience-new'
-    LEGACY = 'courseware-experience-legacy'
-
-
 def get_courseware_url(
         usage_key: UsageKey,
         request: Optional[HttpRequest] = None,
-        experience: ExperienceOption = ExperienceOption.ACTIVE,
 ) -> str:
     """
     Return the URL to the canonical learning experience for a given block.
@@ -56,12 +40,7 @@ def get_courseware_url(
         * ItemNotFoundError if no data at the `usage_key`.
         * NoPathToItem if we cannot build a path to the `usage_key`.
     """
-    course_key = usage_key.course_key.replace(version_guid=None, branch=None)
-    if experience == ExperienceOption.NEW:
-        get_url_fn = _get_new_courseware_url
-    elif experience == ExperienceOption.LEGACY:
-        get_url_fn = _get_legacy_courseware_url
-    elif courseware_mfe_is_active(course_key):
+    if courseware_mfe_is_active():
         get_url_fn = _get_new_courseware_url
     else:
         get_url_fn = _get_legacy_courseware_url

--- a/openedx/tests/xblock_integration/test_recommender.py
+++ b/openedx/tests/xblock_integration/test_recommender.py
@@ -14,17 +14,14 @@ import simplejson as json
 from ddt import data, ddt
 from django.conf import settings
 from django.urls import reverse
-from edx_toggles.toggles.testutils import override_waffle_flag
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
-from lms.djangoapps.courseware.toggles import COURSEWARE_USE_LEGACY_FRONTEND
 from openedx.core.lib.url_utils import quote_slashes
 
 
-@override_waffle_flag(COURSEWARE_USE_LEGACY_FRONTEND, active=True)
 class TestRecommender(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Check that Recommender state is saved properly
@@ -68,14 +65,7 @@ class TestRecommender(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
                 display_name='recommender_second'
             )
 
-        cls.course_url = reverse(
-            'courseware_section',
-            kwargs={
-                'course_id': str(cls.course.id),
-                'chapter': 'Overview',
-                'section': 'Welcome',
-            }
-        )
+        cls.course_url = reverse('render_xblock', args=[str(cls.section.location)])
 
         cls.resource_urls = [
             (

--- a/openedx/tests/xblock_integration/xblock_testcase.py
+++ b/openedx/tests/xblock_integration/xblock_testcase.py
@@ -48,14 +48,12 @@ import pytz
 from bs4 import BeautifulSoup
 from django.conf import settings
 from django.urls import reverse
-from edx_toggles.toggles.testutils import override_waffle_flag
 from xblock.plugin import Plugin
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
 import lms.djangoapps.lms_xblock.runtime
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
-from lms.djangoapps.courseware.toggles import COURSEWARE_USE_LEGACY_FRONTEND
 
 
 class XBlockEventTestMixin:
@@ -273,14 +271,7 @@ class XBlockScenarioTestCaseMixin:
                     )
                     cls.xblocks[xblock_config['urlname']] = xblock
 
-                scenario_url = str(reverse(
-                    'courseware_section',
-                    kwargs={
-                        'course_id': str(cls.course.id),
-                        'chapter': "ch_" + chapter_config['urlname'],
-                        'section': "sec_" + chapter_config['urlname']
-                    }
-                ))
+                scenario_url = reverse('render_xblock', args=[str(section.location)])
 
                 cls.scenario_urls[chapter_config['urlname']] = scenario_url
 
@@ -337,7 +328,6 @@ class XBlockStudentTestCaseMixin:
         self.login(email, password)
 
 
-@override_waffle_flag(COURSEWARE_USE_LEGACY_FRONTEND, active=True)
 class XBlockTestCase(XBlockStudentTestCaseMixin,
                      XBlockScenarioTestCaseMixin,
                      XBlockEventTestMixin,


### PR DESCRIPTION
This leaves most of the legacy view templating in place, because Studio's preview mode still uses it. But I've removed all other access points (casual staff access, opt-out waffle, old mongo, query param).

Test changes have taken a few forms:
* Use preview mode if the test cares about the template chrome surrounding an xblock. This requires using a staff user.
* Use the xblock_render endpoint (like the MFE does) if we just care about the xblock rendering itself (which lets the test continue using real normal users).
* Removal of the test if it specifically cares about the template chrome we are disabling but also needs normal-user mode for that chrome (like access checks or some such).

Landing this should let us close DEPR https://github.com/openedx/edx-platform/issues/35803