### PR TITLE
feat: use new financial assistance flow in FinancialAssistanceTool

### DIFF
--- a/lms/djangoapps/courseware/constants.py
+++ b/lms/djangoapps/courseware/constants.py
@@ -2,7 +2,7 @@
 Constants for courseware app.
 """
 UNEXPECTED_ERROR_IS_ELIGIBLE = "An unexpected error occurred while fetching " \
-                               "financial assistance eligibility criteria for a course"
+                               "financial assistance eligibility criteria for this course"
 UNEXPECTED_ERROR_APPLICATION_STATUS = "An unexpected error occurred while getting " \
                                       "financial assistance application status"
 UNEXPECTED_ERROR_CREATE_APPLICATION = "An unexpected error occurred while creating financial assistance application"

--- a/lms/djangoapps/courseware/course_tools.py
+++ b/lms/djangoapps/courseware/course_tools.py
@@ -7,12 +7,14 @@ import datetime
 
 import pytz
 from django.conf import settings
-from django.utils.translation import gettext as _
 from django.urls import reverse
+from django.utils.translation import gettext as _
+
 from common.djangoapps.course_modes.models import CourseMode
-from openedx.features.course_experience.course_tools import CourseTool
 from common.djangoapps.student.models import CourseEnrollment
+from lms.djangoapps.courseware.utils import _use_new_financial_assistance_flow
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from openedx.features.course_experience.course_tools import CourseTool
 
 
 class FinancialAssistanceTool(CourseTool):
@@ -86,4 +88,6 @@ class FinancialAssistanceTool(CourseTool):
         """
         Returns the URL for this tool for the specified course key.
         """
+        if _use_new_financial_assistance_flow(str(course_key)):
+            return reverse('financial_assistance_v2', args=[course_key])
         return reverse('financial_assistance')

--- a/lms/templates/financial-assistance/financial-assistance.html
+++ b/lms/templates/financial-assistance/financial-assistance.html
@@ -5,47 +5,54 @@ from django.urls import reverse
 from django.utils.translation import ugettext as _
 
 from common.djangoapps.edxmako.shortcuts import marketing_link
+
 %>
 
 <div class="financial-assistance-wrapper">
 
-  <div class="financial-assistance financial-assistance-header">
-    <h1>${_("Financial Assistance Application")}</h1>
-    % for line in header_text:
-      <p>${line}</p>
-    % endfor
-  </div>
+  % if reason:
+    <p>This course is not eligible for Financial Assistance for the following reason: <b>${reason}</b></p>
+  % else:
+    <div class="financial-assistance financial-assistance-header">
+      <h1>${_("Financial Assistance Application")}</h1>
+      % for line in header_text:
+        <p>${line}</p>
+      % endfor
+    </div>
+    <div class="financial-assistance financial-assistance-body">
+      <h2>${_("A Note to Learners")}</h2>
+      ## Translators: This string will not be used in Open edX installations.
+      <p>${_("Dear edX Learner,")}</p>
 
-  <div class="financial-assistance financial-assistance-body">
-    <h2>${_("A Note to Learners")}</h2>
-    ## Translators: This string will not be used in Open edX installations.
-    <p>${_("Dear edX Learner,")}</p>
+      ## Translators: This string will not be used in Open edX installations.
+      <p>${_("EdX Financial Assistance is a program we created to give learners in all financial circumstances a chance to earn a Verified Certificate upon successful completion of an edX course.")}</p>
 
-    ## Translators: This string will not be used in Open edX installations.
-    <p>${_("EdX Financial Assistance is a program we created to give learners in all financial circumstances a chance to earn a Verified Certificate upon successful completion of an edX course.")}</p>
+      ## Translators: This string will not be used in Open edX installations.
+      <p>${_("If you are interested in working toward a Verified Certificate, but cannot afford to pay the fee, please apply now. Please note that financial assistance is limited and may not be awarded to all eligible candidates.")}</p>
 
-    ## Translators: This string will not be used in Open edX installations.
-    <p>${_("If you are interested in working toward a Verified Certificate, but cannot afford to pay the fee, please apply now. Please note that financial assistance is limited and may not be awarded to all eligible candidates.")}</p>
+      ## Translators: This string will not be used in Open edX installations.
+      <p>${_("In order to be eligible for edX Financial Assistance, you must demonstrate that paying the Verified Certificate fee would cause you economic hardship. To apply, you will be asked to answer a few questions about why you are applying and how the Verified Certificate will benefit you.")}</p>
 
-    ## Translators: This string will not be used in Open edX installations.
-    <p>${_("In order to be eligible for edX Financial Assistance, you must demonstrate that paying the Verified Certificate fee would cause you economic hardship. To apply, you will be asked to answer a few questions about why you are applying and how the Verified Certificate will benefit you.")}</p>
+      ## Translators: This string will not be used in Open edX installations.
+      <p>${_("If your application is approved, we'll give you instructions for verifying your identity on edx.org so you can start working toward completing your edX course.")}</p>
 
-    ## Translators: This string will not be used in Open edX installations.
-    <p>${_("If your application is approved, we'll give you instructions for verifying your identity on edx.org so you can start working toward completing your edX course.")}</p>
+      ## Translators: This string will not be used in Open edX installations.
+      <p>${_("EdX is committed to making it possible for you to take high quality courses from leading institutions regardless of your financial situation, earn a Verified Certificate, and share your success with others.")}</p>
+      ## Translators: This string will not be used in Open edX installations. Do not translate the name "Anant".
+      <p class="signature">${_("Sincerely, Anant")}</p>
+    </div>
+  % endif
 
-    ## Translators: This string will not be used in Open edX installations.
-    <p>${_("EdX is committed to making it possible for you to take high quality courses from leading institutions regardless of your financial situation, earn a Verified Certificate, and share your success with others.")}</p>
-    ## Translators: This string will not be used in Open edX installations. Do not translate the name "Anant".
-    <p class="signature">${_("Sincerely, Anant")}</p>
-  </div>
 
   <div class="financial-assistance-footer">
-    <%
-      faq_link = marketing_link('FAQ')
-    %>
-    % if faq_link != '#':
-      <a class="faq-link" href="${faq_link}">${_("Back to Student FAQs")}</a>
-    % endif
-    <a class="action-link" href="${reverse('financial_assistance_form')}">${_("Apply for Financial Assistance")}</a>
+  <%
+    faq_link = marketing_link('FAQ')
+  %>
+  % if faq_link != '#':
+    <a class="faq-link" href="${faq_link}">${_("Back to Student FAQs")}</a>
+  % endif
+  % if not reason:
+    <a class="action-link" href="${apply_url}">${_("Apply for Financial Assistance")}</a>
+  % endif
   </div>
 </div>

--- a/lms/templates/student_account/form_field.underscore
+++ b/lms/templates/student_account/form_field.underscore
@@ -33,6 +33,8 @@
             <%  });
             } %>
             <% if ( required ) { %> aria-required="true" required<% } %>
+            <% if ( typeof disabled !== 'undefined' && disabled ) { %> disabled<% } %>
+
         >
             <% _.each(options, function(el) { %>
                 <option value="<%- el.value%>"<% if ( el.default ) { %> data-isdefault="true" selected<% } %>><%- el.name %></option>

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -4,18 +4,18 @@ URLs for LMS
 
 from config_models.views import ConfigurationModelCurrentAPIView
 from django.conf import settings
-from django.urls import include, re_path
 from django.conf.urls.static import static
+from django.contrib import admin
 from django.contrib.admin import autodiscover as django_autodiscover
-from django.urls import path
+from django.urls import include, path, re_path
 from django.utils.translation import gettext_lazy as _
 from django.views.generic.base import RedirectView
 from edx_api_doc_tools import make_docs_urls
 from edx_django_utils.plugins import get_plugin_url_patterns
-from django.contrib import admin
 
+from common.djangoapps.student import views as student_views
+from common.djangoapps.util import views as util_views
 from lms.djangoapps.branding import views as branding_views
-from lms.djangoapps.debug import views as debug_views
 from lms.djangoapps.courseware.masquerade import MasqueradeView
 from lms.djangoapps.courseware.module_render import (
     handle_xblock_callback,
@@ -26,13 +26,14 @@ from lms.djangoapps.courseware.module_render import (
 from lms.djangoapps.courseware.views import views as courseware_views
 from lms.djangoapps.courseware.views.index import CoursewareIndex
 from lms.djangoapps.courseware.views.views import CourseTabView, EnrollStaffView, StaticCourseTabView
+from lms.djangoapps.debug import views as debug_views
 from lms.djangoapps.discussion import views as discussion_views
 from lms.djangoapps.discussion.config.settings import is_forum_daily_digest_enabled
 from lms.djangoapps.discussion.notification_prefs import views as notification_prefs_views
 from lms.djangoapps.instructor.views import instructor_dashboard as instructor_dashboard_views
 from lms.djangoapps.instructor_task import views as instructor_task_views
-from lms.djangoapps.staticbook import views as staticbook_views
 from lms.djangoapps.static_template_view import views as static_template_view_views
+from lms.djangoapps.staticbook import views as staticbook_views
 from openedx.core.apidocs import api_info
 from openedx.core.djangoapps.auth_exchange.views import LoginWithAccessTokenView
 from openedx.core.djangoapps.catalog.models import CatalogIntegration
@@ -51,8 +52,6 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 from openedx.core.djangoapps.user_authn.views.login import redirect_to_lms_login
 from openedx.core.djangoapps.verified_track_content import views as verified_track_content_views
 from openedx.features.enterprise_support.api import enterprise_enabled
-from common.djangoapps.student import views as student_views
-from common.djangoapps.util import views as util_views
 
 RESET_COURSE_DEADLINES_NAME = 'reset_course_deadlines'
 RENDER_XBLOCK_NAME = 'render_xblock'
@@ -240,9 +239,10 @@ urlpatterns += [
 # Multicourse wiki (Note: wiki urls must be above the courseware ones because of
 # the custom tab catch-all)
 if settings.WIKI_ENABLED:
-    from wiki.urls import get_pattern as wiki_pattern
-    from lms.djangoapps.course_wiki import views as course_wiki_views
     from django_notify.urls import get_pattern as notify_pattern
+    from wiki.urls import get_pattern as wiki_pattern
+
+    from lms.djangoapps.course_wiki import views as course_wiki_views
 
     wiki_url_patterns, wiki_app_name = wiki_pattern()
     notify_url_patterns, notify_app_name = notify_pattern()
@@ -948,6 +948,16 @@ if settings.FEATURES.get('ENABLE_FINANCIAL_ASSISTANCE_FORM'):
             'financial-assistance_v2/submit/',
             courseware_views.financial_assistance_request_v2,
             name='submit_financial_assistance_request_v2'
+        ),
+        re_path(
+            fr'financial-assistance/{settings.COURSE_ID_PATTERN}/apply/',
+            courseware_views.financial_assistance_form,
+            name='financial_assistance_form_v2'
+        ),
+        re_path(
+            fr'financial-assistance/{settings.COURSE_ID_PATTERN}',
+            courseware_views.financial_assistance,
+            name='financial_assistance_v2'
         )
     ]
 


### PR DESCRIPTION
[PROD-2739](https://openedx.atlassian.net/browse/PROD-2739)

## Description

Handles new financial assistance flow while keeping the existing flow. Adds new urls for course specific financial assistance pages which also handle the errors in case the course is not eligible.

<img width="1432" alt="Screenshot 2022-04-21 at 5 51 15 PM" src="https://user-images.githubusercontent.com/52413434/164461939-00da6cf5-49a9-433d-878c-8d58e648c79c.png">


## Testing instructions
Follow these instructions to setup FA for your machine before going into the testing instructions: https://2u-internal.atlassian.net/wiki/spaces/IM/pages/26738692/Financial+Assistance+setup+instructions

1. Run migrations to get the latest models in your devstack. run `paver update_db` in `lms-shell`
2. Pull [frontend-app-learning](https://github.com/openedx/frontend-app-learning/ run `npm install` then run `npm start`
3. Go to both `course-v1:edX+DemoX+Demo_Course` and `course-v1:edX+E2E-101+course`. Click financial assistance button and expect to see two different url patterns on your browser. (`Demo_Course` will use the new flow while `E2E-101+course` will use the older flow. This is because of the limited `fa_backend_enabled_courses_percentage` that will use in our platform moving forward)
4. Verify that each url takes their courses/flow to their respective new/old FA form as well. The new flow will now take the request to the edx-financial-assistance backend rather than sending a post request against zendesk.