### PR TITLE
fix: make the studio user_id the actual anonymous_user_id

### DIFF
--- a/cms/djangoapps/contentstore/toggles.py
+++ b/cms/djangoapps/contentstore/toggles.py
@@ -2,6 +2,7 @@
 CMS feature toggles.
 """
 from edx_toggles.toggles import SettingDictToggle, WaffleFlag
+from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
 # .. toggle_name: FEATURES['ENABLE_EXPORT_GIT']
 # .. toggle_implementation: SettingDictToggle
@@ -138,3 +139,23 @@ def use_new_problem_editor():
     Returns a boolean if new problem editor is enabled
     """
     return ENABLE_NEW_PROBLEM_EDITOR_FLAG.is_enabled()
+
+
+# .. toggle_name: contentstore.individualize_anonymous_user_id
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: This flag enables the use of unique anonymous_user_id during studio preview
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2022-05-04
+# .. toggle_target_removal_date: 2022-05-30
+# .. toggle_tickets: MST-1455
+INDIVIDUALIZE_ANONYMOUS_USER_ID = CourseWaffleFlag(
+    f'{CONTENTSTORE_NAMESPACE}.individualize_anonymous_user_id', __name__
+)
+
+
+def individualize_anonymous_user_id(course_id):
+    """
+    Returns a boolean if individualized anonymous_user_id is enabled on the course
+    """
+    return INDIVIDUALIZE_ANONYMOUS_USER_ID.is_enabled(course_id)


### PR DESCRIPTION
## Description
[MST-1455](https://openedx.atlassian.net/browse/MST-1455)
Currently, during studio preview of the xblock, we would render the xblock using the anonymous_user_id with value `student`. Why not just render the xblock using the actual anonymous_user_id?
One uncertainty is that the anonymous_user_id for non edX staff user would be `none`. That might be a problem?

## Testing instructions

1. Create a course override waffle flag in the django admin on edx-platform. The name of the waffle flag is `contentstore.individualize_anonymous_user_id`
2. Enable and activate the above waffle flag for a course in test
3. Go into the studio website and go into the course where you had the waffle flag turned on
4. Create a new LTI xblock
5. Configure the xblock connecting against a TurnItIn content instance. You can find examples of it on stage or prod
6. Preview the xblock instance upon save.
7. During preview rendering, monitor the network tab of the Chrome developer tool and see the data posted into the LTI handler endpoint has user_id to be a unique value, instead of `student` value.

