### PR TITLE
feat: added flag to access course live in learning mfe

### DIFF
--- a/openedx/core/djangoapps/course_live/tab.py
+++ b/openedx/core/djangoapps/course_live/tab.py
@@ -10,6 +10,7 @@ from lms.djangoapps.courseware.tabs import EnrolledTab
 from openedx.core.djangoapps.course_live.config.waffle import ENABLE_COURSE_LIVE
 from openedx.core.djangoapps.course_live.models import CourseLiveConfiguration
 from openedx.core.lib.cache_utils import request_cached
+from openedx.features.course_experience.url_helpers import get_learning_mfe_home_url
 from openedx.features.lti_course_tab.tab import LtiCourseLaunchMixin
 
 
@@ -27,6 +28,13 @@ class CourseLiveTab(LtiCourseLaunchMixin, TabFragmentViewMixin, EnrolledTab):
         'staff': 'Administrator',
         'instructor': 'Administrator',
     }
+
+    @property
+    def link_func(self):
+        def _link_func(course, reverse_func):
+            return get_learning_mfe_home_url(course_key=course.id, url_fragment='live')
+
+        return _link_func
 
     @request_cached()
     def _get_lti_config(self, course: CourseBlock) -> LtiConfiguration:

--- a/openedx/core/djangoapps/course_live/tests/test_tab.py
+++ b/openedx/core/djangoapps/course_live/tests/test_tab.py
@@ -33,7 +33,7 @@ class CourseLiveTabTestCase(TabTestCase):
             lti_1p1_client_secret='test_client_secret',
         )
         self.course_live_config.save()
-        self.url = self.reverse('course_tab_view', args=[str(self.course.id), CourseLiveTab.type])
+        self.url = f"http://learning-mfe/course/{str(self.course.id)}/live"
 
     def check_course_live_tab(self):
         """

--- a/openedx/core/djangoapps/course_live/tests/test_views.py
+++ b/openedx/core/djangoapps/course_live/tests/test_views.py
@@ -234,7 +234,7 @@ class TestCourseLiveConfigurationView(ModuleStoreTestCase, APITestCase):
         self.assertEqual(data, {
             'tab_id': 'lti_live',
             'title': 'Live',
-            'url': f'http://testserver/courses/{self.course.id}/tab/lti_live/'
+            'url': f'http://learning-mfe/course/{self.course.id}/live'
         })
 
 


### PR DESCRIPTION
When live tab is clicked in learning mfe it redirects to lms. Added a flag to access course live in learning mfe instead of redirecting it to lms.

Ticket:
https://openedx.atlassian.net/browse/TNL-9871