### PR TITLE
BOM-2245 : Unpin python-dateutil

### DIFF
--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -3550,7 +3550,7 @@ class TestInstructorSendEmail(SiteMixin, SharedModuleStoreTestCase, LoginEnrollm
         self.full_test_message['schedule'] = "Blub Glub"
         self.full_test_message['browser_timezone'] = "America/New_York"
         expected_messages = [
-            "Error occurred while attempting to create a scheduled bulk email task: unknown string format",
+            "Error occurred while attempting to create a scheduled bulk email task: Unknown string format: Blub Glub",
         ]
 
         url = reverse('send_email', kwargs={'course_id': str(self.course.id)})

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -27,23 +27,14 @@ django-storages<1.9
 # for them.
 edx-enterprise==3.49.5
 
-# Newer versions need a more recent version of python-dateutil
-freezegun==0.3.12
-
 # oauthlib>3.0.1 causes test failures ( also remove the django-oauth-toolkit constraint when this is fixed )
 oauthlib==3.0.1
 
 # django-auth-toolkit==1.3.3 requires oauthlib>=3.1.0 which is pinned because of test failures
 django-oauth-toolkit<=1.3.2
 
-# Upgrading to 2.5.3 on 2020-01-03 triggered "'tzlocal' object has no attribute '_std_offset'" errors in production
-python-dateutil==2.4.0
-# matplotlib>=3.4.0 requires python-dateutil>=2.7
+# Will be updated once we update python-dateutil package
 matplotlib<3.4.0
-# pandas>0.22.0 requires python-dateutil>=2.5.0
-pandas==0.22.0
-# networkx>=2.6 requires pandas>=1.1
-networkx<2.6
 
 # tests failing for pymongo==3.11
 pymongo<3.11

--- a/requirements/edx-sandbox/py38.txt
+++ b/requirements/edx-sandbox/py38.txt
@@ -18,8 +18,6 @@ cryptography==37.0.2
     # via -r requirements/edx-sandbox/py38.in
 cycler==0.11.0
     # via matplotlib
-decorator==4.4.2
-    # via networkx
 joblib==1.1.0
     # via nltk
 kiwisolver==1.4.2
@@ -38,10 +36,8 @@ matplotlib==3.3.4
     #   -r requirements/edx-sandbox/py38.in
 mpmath==1.2.1
     # via sympy
-networkx==2.5.1
-    # via
-    #   -c requirements/edx-sandbox/../constraints.txt
-    #   -r requirements/edx-sandbox/py38.in
+networkx==2.8
+    # via -r requirements/edx-sandbox/py38.in
 nltk==3.7
     # via
     #   -r requirements/edx-sandbox/py38.in
@@ -65,10 +61,8 @@ pyparsing==3.0.9
     #   chem
     #   matplotlib
     #   openedx-calc
-python-dateutil==2.4.0
-    # via
-    #   -c requirements/edx-sandbox/../constraints.txt
-    #   matplotlib
+python-dateutil==2.8.2
+    # via matplotlib
 random2==1.0.1
     # via -r requirements/edx-sandbox/py38.in
 regex==2022.4.24

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -834,9 +834,8 @@ pysrt==1.1.2
     # via
     #   -r requirements/edx/base.in
     #   edxval
-python-dateutil==2.4.0
+python-dateutil==2.8.2
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   analytics-python
     #   botocore

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -698,10 +698,8 @@ filelock==3.7.0
     #   -r requirements/edx/testing.txt
     #   tox
     #   virtualenv
-freezegun==0.3.12
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/testing.txt
+freezegun==1.2.1
+    # via -r requirements/edx/testing.txt
 frozenlist==1.3.0
     # via
     #   -r requirements/edx/testing.txt
@@ -1176,9 +1174,8 @@ pytest-randomly==3.12.0
     # via -r requirements/edx/testing.txt
 pytest-xdist[psutil]==2.5.0
     # via -r requirements/edx/testing.txt
-python-dateutil==2.4.0
+python-dateutil==2.8.2
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   analytics-python
     #   botocore
@@ -1345,7 +1342,6 @@ six==1.16.0
     #   edx-rbac
     #   edx-sphinx-theme
     #   event-tracking
-    #   freezegun
     #   fs
     #   fs-s3fs
     #   html5lib

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -673,10 +673,8 @@ filelock==3.7.0
     # via
     #   tox
     #   virtualenv
-freezegun==0.3.12
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/testing.in
+freezegun==1.2.1
+    # via -r requirements/edx/testing.in
 frozenlist==1.3.0
     # via
     #   -r requirements/edx/base.txt
@@ -1107,9 +1105,8 @@ pytest-randomly==3.12.0
     # via -r requirements/edx/testing.in
 pytest-xdist[psutil]==2.5.0
     # via -r requirements/edx/testing.in
-python-dateutil==2.4.0
+python-dateutil==2.8.2
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   analytics-python
     #   botocore
@@ -1271,7 +1268,6 @@ six==1.16.0
     #   edx-milestones
     #   edx-rbac
     #   event-tracking
-    #   freezegun
     #   fs
     #   fs-s3fs
     #   html5lib


### PR DESCRIPTION
Last time we tried to bump the version of `python-dateutil`  ([PR#27196](https://github.com/openedx/edx-platform/pull/27196)) we got this error
<img width="948" alt="image" src="https://user-images.githubusercontent.com/42294172/164424785-cbf09b8d-fe7b-4317-925f-b8a82bcf8ea3.png">

Line 585 in method `get_course_assignments` was causing the error at that time

https://github.com/openedx/edx-platform/blob/072b6b8875e2a6323b6666998a3bf5c5e6444039/lms/djangoapps/courseware/courses.py#L585

The  reason of the error was that `start` datetime object which we were getting from `BlockStructureBlockData` wasn't updated as per the latest version of `python-dateutil`
https://github.com/openedx/edx-platform/blob/072b6b8875e2a6323b6666998a3bf5c5e6444039/lms/djangoapps/courseware/courses.py#L584

https://github.com/openedx/edx-platform/blob/072b6b8875e2a6323b6666998a3bf5c5e6444039/openedx/core/djangoapps/content/block_structure/block_structure.py#L396

The `tzlocal` object assigned to `tzinfo` variable of `start` date was like this
<img width="355" alt="image" src="https://user-images.githubusercontent.com/42294172/164431366-55874f3e-2803-4232-9463-91bb14783394.png">
But according to the latest version of `python-dateutil` it should have been like this
<img width="887" alt="image" src="https://user-images.githubusercontent.com/42294172/164431638-819e67b0-0acd-47c1-9e77-02cf1f8cd020.png">

So now as we know that the problem is with the outdated datetime objects. We should update them and this is what we are doing in this PR. We have added  a patch where we are creating updated datetime objects using the outdated ones and using them for calculations and comparisons.

#### How did I test?
I used follwoing 3 branches to test this solution.
1. bom-2245-attempt-3 (`current branch`)
     - Has updated  version of `python-dateutil`
     - Has patch where we are creating updated datetime objects from the outdated ones
2. test-bom-2245-attempt-3 
     - Has updated  version of `python-dateutil`
     - Has `no` patch, we're using outdated datetime objects
3. master
     - Has outdated version of `python-dateutil`
     - Has no `patch`

I also created a code snippet to replicate the `behavior` of `get_course_assingments` method, so that I can trigger that behavior from `lms-shell`
```python
from xmodule.modulestore.django import modulestore
from opaque_keys.edx.keys import CourseKey
from lms.djangoapps.course_blocks.api import get_course_blocks
from django.contrib.auth.models import User
from datetime import datetime
import pytz


course_key_string = 'course-v1:edX+DemoX+Demo_Course'
course_key = CourseKey.from_string(course_key_string)  
store = modulestore()
course_usage_key = store.make_course_usage_key(course_key)

user = User.objects.get(username='admin')
block_data = get_course_blocks(user, course_usage_key, allow_start_dates_in_future=True, include_completion=True)

dates = []

for section_key in block_data.get_children(course_usage_key):
    for subsection_key in block_data.get_children(section_key):
        due = block_data.get_xblock_field(subsection_key, 'due')
        graded = block_data.get_xblock_field(subsection_key, 'graded', False)
        if due and graded:
            start = block_data.get_xblock_field(subsection_key, 'start')
            dates.append(start)



print(dates)
vars(dates[0].tzinfo)

now = datetime.now(pytz.UTC)
print(now)
print(now < dates[0])

``` 

So I executed the `above` code snippet on the mentioned branches and I got the following outputs:

##### For `master`
 - The datetime objects are outdated
 - The date comparisons are working fine with the outdated version of `python-dateutil`
<img width="1130" alt="image" src="https://user-images.githubusercontent.com/42294172/164441780-5649e928-a79c-423a-bfc9-7ebc1f0ab011.png">

##### When I switched from `master` to `bom-2245-attempt-3` (`current branch`)
- The datetime objects are updated due to the patch we have applied
- The date comparsons are working fine with the updated version of `python-dateutil`
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/42294172/164447777-94528f4b-05ca-415e-a480-25c00881085d.png">



##### When I switched from `bom-2245-attempt-3` to `test-bom-2245-attempt-3`
- The datetime objects are not updated due to the absense of patch
- The date comparisons are not working as datetime objects are outdated
<img width="1133" alt="image" src="https://user-images.githubusercontent.com/42294172/164441936-4ca6cd94-8e22-4a94-b1e3-56eadc804216.png">

