### PR TITLE
style: button font reduced to reduce button size

### DIFF
--- a/lms/templates/discussion/_switch_experience_fragment.html
+++ b/lms/templates/discussion/_switch_experience_fragment.html
@@ -7,7 +7,7 @@ from django.utils.translation import ugettext as _
 %>
 
 % if show_banner:
-<div class="upgrade-banner d-flex bg-primary text-white align-items-center px-4">
+<div class="upgrade-banner d-flex bg-primary text-white align-items-center px-4 py-1">
     % if show_mfe:
     <div class="d-flex w-100 small">
         ${_("You are viewing an educator only preview of the new discussions experience!")}
@@ -19,16 +19,16 @@ from django.utils.translation import ugettext as _
     %endif
 
     % if show_mfe:
-    <a class="btn btn-inverse-primary" href="${legacy_url}">
+    <a class="btn btn-inverse-primary" style="font-size: 12px;" href="${legacy_url}">
         ${_("View legacy experience")}
     </a>
     % if share_feedback_url:
-        <a class="btn btn-inverse-primary ml-2" href="${share_feedback_url}" target="_blank" rel="noopener">
+        <a class="btn btn-inverse-primary ml-2" style="font-size: 12px;" href="${share_feedback_url}" target="_blank" rel="noopener">
             ${_("Share feedback")}
         </a>
     % endif
     % else:
-    <a class="btn btn-inverse-primary ml-2" href="${mfe_url}">
+    <a class="btn btn-inverse-primary ml-2" style="font-size: 12px;" href="${mfe_url}">
         ${_("View the new experience")}
     </a>
     % endif


### PR DESCRIPTION
TNL Ticket: https://openedx.atlassian.net/browse/TNL-9853
The banner length was reduced in #30241 but the buttons were still taking the same height as button classes are applied to an anchor tag and it's not picking typography CSS classes. inline styling is applied to get reduced button heights to resolve ugly behavior.

Screenshots before:

<img width="1320" alt="Screenshot 2022-04-15 at 2 44 03 PM" src="https://user-images.githubusercontent.com/67791278/163555891-fb73d7e4-e738-4e52-8942-46e58ec2f8eb.png">

Screenshot after:

<img width="1319" alt="Screenshot 2022-04-15 at 2 43 39 PM" src="https://user-images.githubusercontent.com/67791278/163555847-0b2808ef-ffe4-4ac7-a3ac-4a2021ef4b45.png">

