### PR TITLE
fix: pass a CourseKey not a string to course_home_url

### DIFF
--- a/lms/djangoapps/course_api/api.py
+++ b/lms/djangoapps/course_api/api.py
@@ -11,6 +11,7 @@ from django.urls import reverse
 from edx_django_utils.monitoring import function_trace
 from edx_when.api import get_dates_for_course
 from opaque_keys.edx.django.models import CourseKeyField
+from opaque_keys.edx.keys import CourseKey
 from rest_framework.exceptions import PermissionDenied
 
 from common.djangoapps.student.models import CourseAccessRole, CourseEnrollment
@@ -286,7 +287,8 @@ def get_course_run_url(request, course_id):
     Returns:
         (string): the URL to the course run associated with course_id
     """
-    return request.build_absolute_uri(course_home_url(course_id))
+    course_key = CourseKey.from_string(str(course_id))
+    return request.build_absolute_uri(course_home_url(course_key))
 
 
 def get_course_members(course_key):

--- a/lms/djangoapps/course_api/tests/test_api.py
+++ b/lms/djangoapps/course_api/tests/test_api.py
@@ -9,7 +9,7 @@ from unittest import mock
 import pytest
 from django.contrib.auth.models import AnonymousUser
 from django.http import Http404
-from django.test import override_settings
+from django.test import TestCase, override_settings
 from opaque_keys.edx.keys import CourseKey
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
@@ -20,7 +20,9 @@ from xmodule.modulestore.exceptions import ItemNotFoundError  # lint-amnesty, py
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.factories import ItemFactory, check_mongo_calls  # lint-amnesty, pylint: disable=wrong-import-order
 
-from ..api import UNKNOWN_BLOCK_DISPLAY_NAME, course_detail, get_due_dates, list_courses, get_course_members
+from ..api import (
+    UNKNOWN_BLOCK_DISPLAY_NAME, course_detail, get_due_dates, list_courses, get_course_members, get_course_run_url,
+)
 from ..exceptions import OverEnrollmentLimitException
 from .mixins import CourseApiFactoryMixin
 
@@ -426,3 +428,13 @@ class TestGetCourseMembers(CourseApiTestMixin, SharedModuleStoreTestCase):
         """
         with self.assertRaises(OverEnrollmentLimitException):
             get_course_members(self.course.id)
+
+
+class TestGetCourseRunUrl(TestCase):
+    """
+    Tests of get_course_run_url.
+    """
+    def test_simple_lookup(self):
+        request = Request(APIRequestFactory().get('/'))
+        url = get_course_run_url(request, 'course-v1:org+course+run')
+        assert url == 'http://learning-mfe/course/course-v1:org+course+run/home'


### PR DESCRIPTION
Fixes a frequent enterprise 500 error. (caused by my earlier [legacy-outline-removal PR](https://github.com/openedx/edx-platform/pull/30251))