### PR TITLE
feat: email linking for SSO

### DIFF
--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -89,7 +89,6 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 from openedx.core.djangoapps.user_api import accounts
 from openedx.core.djangoapps.user_api.accounts.utils import username_suffix_generator
 from openedx.core.djangoapps.user_authn import cookies as user_authn_cookies
-from openedx.core.djangoapps.user_authn.toggles import is_require_third_party_auth_enabled
 from openedx.core.djangoapps.user_authn.utils import is_safe_login_or_logout_redirect
 from common.djangoapps.third_party_auth.utils import (
     get_associated_user_by_email_response,
@@ -757,7 +756,7 @@ def associate_by_email_if_oauth(auth_entry, backend, details, user, strategy, *a
     `ENABLE_REQUIRE_THIRD_PARTY_AUTH` is enabled.
     """
 
-    if is_require_third_party_auth_enabled() and is_oauth_provider(backend.name, **kwargs):
+    if is_oauth_provider(backend.name, **kwargs):
         association_response, user_is_active = get_associated_user_by_email_response(
             backend, details, user, *args, **kwargs)
 

--- a/common/djangoapps/third_party_auth/tests/specs/base.py
+++ b/common/djangoapps/third_party_auth/tests/specs/base.py
@@ -789,11 +789,7 @@ class IntegrationTest(testutil.TestCase, test.TestCase, HelperMixin):
         post_request = self._get_login_post_request(strategy)
         self.assert_json_failure_response_is_missing_social_auth(login_user(post_request))
 
-    @django_utils.override_settings(ENABLE_REQUIRE_THIRD_PARTY_AUTH=True)
     def test_signin_associates_user_if_oauth_provider_and_tpa_is_required(self):
-        """
-        Tests associate user by email with oauth provider and `ENABLE_REQUIRE_THIRD_PARTY_AUTH` enabled
-        """
         username, email, password = self.get_username(), 'user@example.com', 'password'
 
         _, strategy = self.get_request_and_strategy(
@@ -920,12 +916,12 @@ class IntegrationTest(testutil.TestCase, test.TestCase, HelperMixin):
         strategy.storage.user.create_user(username=self.get_username(), email='user@email.com', password='password')
         backend = strategy.request.backend
         backend.auth_complete = mock.MagicMock(return_value=self.fake_auth_complete(strategy))
-        # If learner already has an account then make sure login page is served instead of registration.
         # pylint: disable=protected-access
-        self.assert_redirect_to_login_looks_correct(actions.do_complete(backend, social_views._do_login,
-                                                                        request=request))
-        distinct_username = pipeline.get(request)['kwargs']['username']
-        assert original_username != distinct_username
+        response = actions.do_complete(backend, social_views._do_login, request=request)
+        assert response.status_code == 302
+
+        response = json.loads(create_account(strategy.request).content.decode('utf-8'))
+        assert response['username'] != original_username
 
     def test_new_account_registration_fails_if_email_exists(self):
         request, strategy = self.get_request_and_strategy(


### PR DESCRIPTION
Make email linking for SSO as default behavior.

**Steps to test locally:**
Enable social-auth locally for SSO.
Create account using registration form flow.
SSO through same email which user used for first time registration.
User will redirect to LMS after authentication.
User account will be linked to existing account.

VAN-331

