### PR TITLE
fix: Make SAMLConfiguration viewset readonly

### DIFF
--- a/common/djangoapps/third_party_auth/saml_configuration/views.py
+++ b/common/djangoapps/third_party_auth/saml_configuration/views.py
@@ -16,7 +16,7 @@ class SAMLConfigurationMixin:
     serializer_class = SAMLConfigurationSerializer
 
 
-class SAMLConfigurationViewSet(SAMLConfigurationMixin, viewsets.ModelViewSet):
+class SAMLConfigurationViewSet(SAMLConfigurationMixin, viewsets.ReadOnlyModelViewSet):
     """
     A View to handle SAMLConfiguration GETs
 


### PR DESCRIPTION
The only use is a GET request in admin portal so this view need not be
post/put friendly right now. It may actually get removed in an upcoming
iteration, or stay readonly.

Fixes: SEC-1418

Backported from 283141a3c7dc17a4f7dcf1c1feefe40abb18c80b