### PR TITLE
fix: upgrade bleach to 5.0.0

### DIFF
--- a/common/lib/capa/capa/util.py
+++ b/common/lib/capa/capa/util.py
@@ -13,6 +13,7 @@ import six
 from calc import evaluator
 from lxml import etree
 
+from bleach.css_sanitizer import CSSSanitizer
 from openedx.core.djangolib.markup import HTML
 
 #-----------------------------------------------------------------------------
@@ -192,7 +193,7 @@ def sanitize_html(html_code):
         html_code,
         protocols=bleach.ALLOWED_PROTOCOLS + ['data'],
         tags=bleach.ALLOWED_TAGS + ['div', 'p', 'audio', 'pre', 'img', 'span'],
-        styles=['white-space'],
+        css_sanitizer=CSSSanitizer(allowed_css_properties=["white-space"]),
         attributes=attributes
     )
     return output

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -92,8 +92,3 @@ mistune<2.0.0
 # The PR https://github.com/celery/django-celery-results/pull/292 fixing this issue has been merged but
 # new version hasn't been released yet with the fix so pinning the version until django-celery-results>2.3.0 is out.
 django-celery-results<2.3.0
-
-# bleach==5.0.0 contains breaking changes related to clean() function used to sanitize css
-# Code needs to be refactored to fix the test failures with the new version.
-# Will be done in https://openedx.atlassian.net/browse/BOM-3374
-bleach<5.0.0

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -10,7 +10,7 @@
     #   xmodule
 -e git+https://github.com/edx/codejail.git@3.1.3#egg=codejail==3.1.3
     # via -r requirements/edx/github.in
--e git+https://github.com/edx/django-wiki.git@1.0.2#egg=django-wiki
+-e git+https://github.com/edx/django-wiki.git@1.1.0#egg=django-wiki
     # via -r requirements/edx/github.in
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
     # via -r requirements/edx/github.in
@@ -67,9 +67,8 @@ beautifulsoup4==4.11.1
     # via pynliner
 billiard==3.6.4.0
     # via celery
-bleach==4.1.0
+bleach[css]==5.0.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   django-wiki
     #   edx-enterprise
@@ -717,7 +716,6 @@ ora2==4.1.2
     # via -r requirements/edx/base.in
 packaging==21.3
     # via
-    #   bleach
     #   drf-yasg
     #   py2neo
     #   redis
@@ -1014,6 +1012,8 @@ testfixtures==6.18.5
     # via edx-enterprise
 text-unidecode==1.3
     # via python-slugify
+tinycss2==1.1.1
+    # via bleach
 tqdm==4.64.0
     # via nltk
 typing-extensions==4.2.0
@@ -1058,6 +1058,7 @@ webencodings==0.5.1
     # via
     #   bleach
     #   html5lib
+    #   tinycss2
 webob==1.8.7
     # via
     #   xblock

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -10,7 +10,7 @@
     #   xmodule
 -e git+https://github.com/edx/codejail.git@3.1.3#egg=codejail==3.1.3
     # via -r requirements/edx/testing.txt
--e git+https://github.com/edx/django-wiki.git@1.0.2#egg=django-wiki
+-e git+https://github.com/edx/django-wiki.git@1.1.0#egg=django-wiki
     # via -r requirements/edx/testing.txt
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
     # via -r requirements/edx/testing.txt
@@ -101,9 +101,8 @@ billiard==3.6.4.0
     # via
     #   -r requirements/edx/testing.txt
     #   celery
-bleach==4.1.0
+bleach[css]==5.0.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   django-wiki
     #   edx-enterprise
@@ -951,7 +950,6 @@ ora2==4.1.2
 packaging==21.3
     # via
     #   -r requirements/edx/testing.txt
-    #   bleach
     #   drf-yasg
     #   py2neo
     #   pytest
@@ -1441,6 +1439,10 @@ text-unidecode==1.3
     # via
     #   -r requirements/edx/testing.txt
     #   python-slugify
+tinycss2==1.1.1
+    # via
+    #   -r requirements/edx/testing.txt
+    #   bleach
 toml==0.10.2
     # via
     #   -r requirements/edx/testing.txt
@@ -1537,6 +1539,7 @@ webencodings==0.5.1
     #   -r requirements/edx/testing.txt
     #   bleach
     #   html5lib
+    #   tinycss2
 webob==1.8.7
     # via
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -54,7 +54,7 @@
 # Python libraries to install directly from github
 
 # Third-party:
--e git+https://github.com/edx/django-wiki.git@1.0.2#egg=django-wiki
+-e git+https://github.com/edx/django-wiki.git@1.1.0#egg=django-wiki
 -e git+https://github.com/openedx/olxcleaner.git@2f0d6c7f126cbd69c9724b7b57a0b2565330a297#egg=olxcleaner
 git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -10,7 +10,7 @@
     #   xmodule
 -e git+https://github.com/edx/codejail.git@3.1.3#egg=codejail==3.1.3
     # via -r requirements/edx/base.txt
--e git+https://github.com/edx/django-wiki.git@1.0.2#egg=django-wiki
+-e git+https://github.com/edx/django-wiki.git@1.1.0#egg=django-wiki
     # via -r requirements/edx/base.txt
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
     # via -r requirements/edx/base.txt
@@ -96,9 +96,8 @@ billiard==3.6.4.0
     # via
     #   -r requirements/edx/base.txt
     #   celery
-bleach==4.1.0
+bleach[css]==5.0.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   django-wiki
     #   edx-enterprise
@@ -898,7 +897,6 @@ ora2==4.1.2
 packaging==21.3
     # via
     #   -r requirements/edx/base.txt
-    #   bleach
     #   drf-yasg
     #   py2neo
     #   pytest
@@ -1334,6 +1332,10 @@ text-unidecode==1.3
     # via
     #   -r requirements/edx/base.txt
     #   python-slugify
+tinycss2==1.1.1
+    # via
+    #   -r requirements/edx/base.txt
+    #   bleach
 toml==0.10.2
     # via tox
 tomli==2.0.1
@@ -1416,6 +1418,7 @@ webencodings==0.5.1
     #   -r requirements/edx/base.txt
     #   bleach
     #   html5lib
+    #   tinycss2
 webob==1.8.7
     # via
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
### Description
- `bleach==5.0.0` introduced a new function to sanitize css attributes instead of using the default `style` parameter. For details check the thread https://github.com/mozilla/bleach/issues/633.
- https://github.com/mozilla/bleach/pull/648 removed the usage of `styles` from the `clean()` function.
- Bumped the `django-wiki` to `django-wiki==1.1.0` to resolve the failures.