### PR TITLE
fix: enterprise-3.44.3, which overrides get_assignments() and handles…

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -25,7 +25,7 @@ django-storages<1.9
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==3.44.2
+edx-enterprise==3.44.3
 
 # Newer versions need a more recent version of python-dateutil
 freezegun==0.3.12

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -450,7 +450,7 @@ edx-drf-extensions==8.0.1
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.44.2
+edx-enterprise==3.44.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -559,7 +559,7 @@ edx-drf-extensions==8.0.1
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.44.2
+edx-enterprise==3.44.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -542,7 +542,7 @@ edx-drf-extensions==8.0.1
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.44.2
+edx-enterprise==3.44.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
… null contexts gracefully

Overrides the SystemWideEnterpriseUserRoleAssignment.get_assignments() method to return
a list of (role, context) assignments, where the first item in the list corresponds
to the currently active enterprise for the user.  Also ensures that
EnterpriseSystemWideUserRoleAssignment.get_assignments() can handle null values that might be returned by get_context().

https://github.com/openedx/edx-enterprise/pull/1534 (version 3.44.0)
https://github.com/openedx/edx-enterprise/pull/1536 (fixes a defect introduced by 3.44.0)
...and https://github.com/openedx/edx-enterprise/pull/1539 for the version bump to 3.44.3