### PR TITLE
chore: updated ORA2 to 4.2.0 - ESG release

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -713,7 +713,7 @@ openedx-events==0.8.2
     # via -r requirements/edx/base.in
 openedx-filters==0.6.1
     # via -r requirements/edx/base.in
-ora2==4.1.2
+ora2==4.2.0
     # via -r requirements/edx/base.in
 packaging==21.3
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -946,7 +946,7 @@ openedx-events==0.8.2
     # via -r requirements/edx/testing.txt
 openedx-filters==0.6.1
     # via -r requirements/edx/testing.txt
-ora2==4.1.2
+ora2==4.2.0
     # via -r requirements/edx/testing.txt
 packaging==21.3
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -893,7 +893,7 @@ openedx-events==0.8.2
     # via -r requirements/edx/base.txt
 openedx-filters==0.6.1
     # via -r requirements/edx/base.txt
-ora2==4.1.2
+ora2==4.2.0
     # via -r requirements/edx/base.txt
 packaging==21.3
     # via


### PR DESCRIPTION
## Description

Bump ORA2 version to 4.2.0. Impacts Course Staff by enabling the ORA Staff Grading experience, aka ESG.




