### PR TITLE
fix: remove a couple unused learning MFE serializer fields

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -7431,7 +7431,6 @@ definitions:
       - original_user_is_staff
       - tabs
       - title
-      - can_load_courseware
       - celebrations
     type: object
     properties:
@@ -7479,9 +7478,6 @@ definitions:
         title: Title
         type: string
         minLength: 1
-      can_load_courseware:
-        title: Can load courseware
-        type: boolean
       celebrations:
         title: Celebrations
         type: object

--- a/lms/djangoapps/course_home_api/course_metadata/serializers.py
+++ b/lms/djangoapps/course_home_api/course_metadata/serializers.py
@@ -33,7 +33,6 @@ class CourseHomeMetadataSerializer(VerifiedModeSerializer):
     """
     Serializer for the Course Home Course Metadata
     """
-    can_load_courseware = serializers.BooleanField()
     celebrations = serializers.DictField()
     course_access = serializers.DictField()
     course_id = serializers.CharField()

--- a/lms/djangoapps/course_home_api/course_metadata/views.py
+++ b/lms/djangoapps/course_home_api/course_metadata/views.py
@@ -126,7 +126,6 @@ class CourseHomeMetadataView(RetrieveAPIView):
             'is_self_paced': getattr(course, 'self_paced', False),
             'is_enrolled': user_is_enrolled,
             'course_access': load_access.to_json(),
-            'can_load_courseware': True,  # can be removed once the MFE no longer references this field
             'celebrations': celebrations,
             'user_timezone': user_timezone,
             'can_view_certificate': certificates_viewable_for_course(course),

--- a/lms/djangoapps/course_home_api/outline/serializers.py
+++ b/lms/djangoapps/course_home_api/outline/serializers.py
@@ -51,7 +51,6 @@ class CourseBlockSerializer(serializers.Serializer):
                 'icon': icon,
                 'id': block_key,
                 'lms_web_url': block['lms_web_url'] if enable_links else None,
-                'legacy_web_url': block['legacy_web_url'] if enable_links else None,
                 'resume_block': block.get('resume_block', False),
                 'type': block_type,
                 'has_scheduled_content': block.get('has_scheduled_content'),

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -440,7 +440,6 @@ class CoursewareInformation(RetrieveAPIView):
             * `"empty"`: no start date is specified
         * pacing: Course pacing. Possible values: instructor, self
         * user_timezone: User's chosen timezone setting (or null for browser default)
-        * can_load_course: Whether the user can view the course (AccessResponse object)
         * user_has_passing_grade: Whether or not the effective user's grade is equal to or above the courses minimum
             passing grade
         * course_exit_page_is_active: Flag for the learning mfe on whether or not the course exit page should display


### PR DESCRIPTION
Now that the frontend [assumes there are no legacy courseware pages](https://github.com/openedx/frontend-app-learning/pull/929), we can stop sending them info about it.