### PR TITLE
BOM-3372: Remove lxml constraint

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -30,10 +30,6 @@ edx-enterprise==3.44.4
 # Newer versions need a more recent version of python-dateutil
 freezegun==0.3.12
 
-# 4.5.1 introduced a bug when used together with xmlsec: https://bugs.launchpad.net/lxml/+bug/1880251
-# Tests passed, but hit a problem in stage
-lxml<4.5.1
-
 # oauthlib>3.0.1 causes test failures ( also remove the django-oauth-toolkit constraint when this is fixed )
 oauthlib==3.0.1
 

--- a/requirements/edx-sandbox/py38.txt
+++ b/requirements/edx-sandbox/py38.txt
@@ -24,9 +24,8 @@ joblib==1.1.0
     # via nltk
 kiwisolver==1.4.2
     # via matplotlib
-lxml==4.5.0
+lxml==4.8.0
     # via
-    #   -c requirements/edx-sandbox/../constraints.txt
     #   -r requirements/edx-sandbox/py38.in
     #   openedx-calc
 markupsafe==2.1.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -56,7 +56,7 @@ attrs==21.4.0
     #   aiohttp
     #   edx-ace
     #   openedx-events
-babel==2.9.1
+babel==2.10.1
     # via
     #   -r requirements/edx/base.in
     #   enmerkar
@@ -623,9 +623,8 @@ loremipsum==1.0.5
     # via ora2
 lti-consumer-xblock==3.4.6
     # via -r requirements/edx/base.in
-lxml==4.5.0
+lxml==4.8.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   edxval
     #   lti-consumer-xblock

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -65,7 +65,7 @@ asgiref==3.5.0
     #   -r requirements/edx/testing.txt
     #   django
     #   uvicorn
-astroid==2.11.2
+astroid==2.11.3
     # via
     #   -r requirements/edx/testing.txt
     #   pylint
@@ -83,7 +83,7 @@ attrs==21.4.0
     #   jsonschema
     #   openedx-events
     #   pytest
-babel==2.9.1
+babel==2.10.1
     # via
     #   -r requirements/edx/testing.txt
     #   enmerkar
@@ -659,7 +659,7 @@ execnet==1.9.0
     #   pytest-xdist
 factory-boy==3.2.1
     # via -r requirements/edx/testing.txt
-faker==13.3.4
+faker==13.3.5
     # via
     #   -r requirements/edx/testing.txt
     #   factory-boy
@@ -832,9 +832,8 @@ loremipsum==1.0.5
     #   ora2
 lti-consumer-xblock==3.4.6
     # via -r requirements/edx/testing.txt
-lxml==4.5.0
+lxml==4.8.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   edxval
     #   lti-consumer-xblock
@@ -1071,7 +1070,7 @@ pylatexenc==2.10
     # via
     #   -r requirements/edx/testing.txt
     #   olxcleaner
-pylint==2.13.5
+pylint==2.13.7
     # via
     #   -r requirements/edx/testing.txt
     #   edx-lint

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -6,7 +6,7 @@
 #
 alabaster==0.7.12
     # via sphinx
-babel==2.9.1
+babel==2.10.1
     # via sphinx
 certifi==2021.10.8
     # via requests

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -61,7 +61,7 @@ asgiref==3.5.0
     #   -r requirements/edx/base.txt
     #   django
     #   uvicorn
-astroid==2.11.2
+astroid==2.11.3
     # via
     #   pylint
     #   pylint-celery
@@ -78,7 +78,7 @@ attrs==21.4.0
     #   openedx-events
     #   outcome
     #   pytest
-babel==2.9.1
+babel==2.10.1
     # via
     #   -r requirements/edx/base.txt
     #   enmerkar
@@ -639,7 +639,7 @@ execnet==1.9.0
     # via pytest-xdist
 factory-boy==3.2.1
     # via -r requirements/edx/testing.in
-faker==13.3.4
+faker==13.3.5
     # via factory-boy
 fastapi==0.75.2
     # via pact-python
@@ -790,9 +790,8 @@ loremipsum==1.0.5
     #   ora2
 lti-consumer-xblock==3.4.6
     # via -r requirements/edx/base.txt
-lxml==4.5.0
+lxml==4.8.0
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edxval
     #   lti-consumer-xblock
@@ -1008,7 +1007,7 @@ pylatexenc==2.10
     # via
     #   -r requirements/edx/base.txt
     #   olxcleaner
-pylint==2.13.5
+pylint==2.13.7
     # via
     #   edx-lint
     #   pylint-celery


### PR DESCRIPTION
### Description
- Removed `lxml` constraint and bumped the version to latest.

### Testing
- Sandbox created successfully for this change: [lxml.sandbox.edx.org](https://lxml.sandbox.edx.org/)