### PR TITLE
fix: use safer ip-chain logic when checking ip for embargos

### DIFF
--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -22,7 +22,6 @@ from django.utils.translation import get_language, to_locale
 from django.utils.translation import gettext as _
 from django.views.generic.base import View
 from edx_django_utils.monitoring.utils import increment
-from ipware.ip import get_client_ip
 from opaque_keys.edx.keys import CourseKey
 from urllib.parse import urljoin  # lint-amnesty, pylint: disable=wrong-import-order
 
@@ -103,12 +102,7 @@ class ChooseModeView(View):
 
         # Check whether the user has access to this course
         # based on country access rules.
-        embargo_redirect = embargo_api.redirect_if_blocked(
-            course_key,
-            user=request.user,
-            ip_address=get_client_ip(request)[0],
-            url=request.path
-        )
+        embargo_redirect = embargo_api.redirect_if_blocked(request, course_key)
         if embargo_redirect:
             return redirect(embargo_redirect)
 

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -31,7 +31,6 @@ from edx_django_utils import monitoring as monitoring_utils
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser  # lint-amnesty, pylint: disable=wrong-import-order
 from eventtracking import tracker
-from ipware.ip import get_client_ip
 # Note that this lives in LMS, so this dependency should be refactored.
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
@@ -365,10 +364,7 @@ def change_enrollment(request, check_access=True):
         # This can occur if the user's IP is on a global blacklist
         # or if the user is enrolling in a country in which the course
         # is not available.
-        redirect_url = embargo_api.redirect_if_blocked(
-            course_id, user=user, ip_address=get_client_ip(request)[0],
-            url=request.path
-        )
+        redirect_url = embargo_api.redirect_if_blocked(request, course_id)
         if redirect_url:
             return HttpResponse(redirect_url)
 

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -22,7 +22,6 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from django.views.generic.base import View
 from edx_rest_api_client.exceptions import SlumberBaseException
-from ipware.ip import get_client_ip
 from opaque_keys.edx.keys import CourseKey
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -235,12 +234,7 @@ class PayAndVerifyView(View):
 
         # Check whether the user has access to this course
         # based on country access rules.
-        redirect_url = embargo_api.redirect_if_blocked(
-            course_key,
-            user=request.user,
-            ip_address=get_client_ip(request)[0],
-            url=request.path
-        )
+        redirect_url = embargo_api.redirect_if_blocked(request, course_key)
         if redirect_url:
             return redirect(redirect_url)
 

--- a/openedx/core/djangoapps/embargo/api.py
+++ b/openedx/core/djangoapps/embargo/api.py
@@ -7,34 +7,53 @@ This API is exposed via the middleware(emabargo/middileware.py) layer but may be
 """
 
 import logging
+from typing import List, Optional
 
 from django.conf import settings
 from django.core.cache import cache
-from ipware.ip import get_client_ip
+from opaque_keys.edx.keys import CourseKey
 from rest_framework import status
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from common.djangoapps.student.auth import has_course_author_access
+from openedx.core import types
 from openedx.core.djangoapps.geoinfo.api import country_code_from_ip
+from openedx.core.djangoapps.util import ip
 
 from .models import CountryAccessRule, RestrictedCourse
 
 log = logging.getLogger(__name__)
 
 
-def redirect_if_blocked(course_key, access_point='enrollment', **kwargs):
-    """Redirect if the user does not have access to the course. In case of blocked if access_point
-    is not enrollment and course has enabled is_disabled_access_check then user can view that course.
+def redirect_if_blocked(
+    request: Request,
+    course_key: CourseKey,
+    access_point: str = 'enrollment',
+    user: Optional[types.User] = None,
+) -> Optional[str]:
+    """
+    Redirect if the user does not have access to the course.
+
+    Even if the user would normally be blocked, if the given access_point is 'courseware' and the course has enabled
+    the `is_disabled_access_check` flag, then the user can still view that course.
 
     Arguments:
-        course_key (CourseKey): Location of the course the user is trying to access.
+        request: The current request to be checked.
+        course_key: Location of the course the user is trying to access.
+        access_point: Type of page being accessed (e.g. 'courseware', 'enrollment', etc)
+        user: User to check for (uses request.user if None)
 
-    Keyword Arguments:
-        Same as `check_course_access` and `message_url_path`
-
+    Returns:
+        If blocked, a URL path to a page explaining why the user was blocked. Else None.
     """
     if settings.FEATURES.get('EMBARGO'):
-        is_blocked = not check_course_access(course_key, **kwargs)
+        if ip.USE_LEGACY_IP.is_enabled():
+            client_ips = [ip.get_legacy_ip(request)]
+        else:
+            client_ips = ip.get_all_client_ips(request)
+        user = user or request.user
+        is_blocked = not check_course_access(course_key, user=user, ip_addresses=client_ips, url=request.path)
         if is_blocked:
             if access_point == "courseware":
                 if not RestrictedCourse.is_disabled_access_check(course_key):
@@ -43,22 +62,23 @@ def redirect_if_blocked(course_key, access_point='enrollment', **kwargs):
                 return message_url_path(course_key, access_point)
 
 
-def check_course_access(course_key, user=None, ip_address=None, url=None):
+def check_course_access(
+        course_key: CourseKey,
+        user: Optional[types.User] = None,
+        ip_addresses: Optional[List[str]] = None,
+        url: Optional[str] = None,
+) -> bool:
     """
-    Check is the user with this ip_address has access to the given course
+    Check is the user with this ip_addresses chain has access to the given course
 
     Arguments:
-        course_key (CourseKey): Location of the course the user is trying to access.
-
-    Keyword Arguments:
-        user (User): The user making the request.  Can be None, in which case
-            the user's profile country will not be checked.
-        ip_address (str): The IP address of the request.
-        url (str): The URL the user is trying to access.  Used in
-            log messages.
+        course_key: Location of the course the user is trying to access.
+        user: The user making the request. Can be None, in which case the user's profile country will not be checked.
+        ip_addresses: The full external chain of IP addresses of the request.
+        url: The URL the user is trying to access. Used in log messages.
 
     Returns:
-        Boolean: True if the user has access to the course; False otherwise
+        True if the user has access to the course; False otherwise
 
     """
     # No-op if the country access feature is not enabled
@@ -76,25 +96,27 @@ def check_course_access(course_key, user=None, ip_address=None, url=None):
     if user is not None and has_course_author_access(user, course_key):
         return True
 
-    if ip_address is not None:
-        # Retrieve the country code from the IP address
-        # and check it against the allowed countries list for a course
-        user_country_from_ip = country_code_from_ip(ip_address)
+    if ip_addresses is not None:
+        # Check every IP address provided and deny access if ANY of them fail our country checks
+        for ip_address in ip_addresses:
+            # Retrieve the country code from the IP address
+            # and check it against the allowed countries list for a course
+            user_country_from_ip = country_code_from_ip(ip_address)
 
-        if not CountryAccessRule.check_country_access(course_key, user_country_from_ip):
-            log.info(
-                (
-                    "Blocking user %s from accessing course %s at %s "
-                    "because the user's IP address %s appears to be "
-                    "located in %s."
-                ),
-                getattr(user, 'id', '<Not Authenticated>'),
-                course_key,
-                url,
-                ip_address,
-                user_country_from_ip
-            )
-            return False
+            if not CountryAccessRule.check_country_access(course_key, user_country_from_ip):
+                log.info(
+                    (
+                        "Blocking user %s from accessing course %s at %s "
+                        "because the user's IP address %s appears to be "
+                        "located in %s."
+                    ),
+                    getattr(user, 'id', '<Not Authenticated>'),
+                    course_key,
+                    url,
+                    ip_address,
+                    user_country_from_ip
+                )
+                return False
 
     if user is not None:
         # Retrieve the country code from the user's profile
@@ -114,19 +136,19 @@ def check_course_access(course_key, user=None, ip_address=None, url=None):
     return True
 
 
-def message_url_path(course_key, access_point):
-    """Determine the URL path for the message explaining why the user was blocked.
+def message_url_path(course_key: CourseKey, access_point: str) -> str:
+    """
+    Determine the URL path for the message explaining why the user was blocked.
 
     This is configured per-course.  See `RestrictedCourse` in the `embargo.models`
     module for more details.
 
     Arguments:
-        course_key (CourseKey): The location of the course.
-        access_point (str): How the user was trying to access the course.
-            Can be either "enrollment" or "courseware".
+        course_key: The location of the course.
+        access_point: How the user was trying to access the course. Can be either "enrollment" or "courseware".
 
     Returns:
-        unicode: The URL path to a page explaining why the user was blocked.
+        The URL path to a page explaining why the user was blocked.
 
     Raises:
         InvalidAccessPoint: Raised if access_point is not a supported value.
@@ -135,7 +157,7 @@ def message_url_path(course_key, access_point):
     return RestrictedCourse.message_url_path(course_key, access_point)
 
 
-def _get_user_country_from_profile(user):
+def _get_user_country_from_profile(user: types.User) -> str:
     """
     Check whether the user is embargoed based on the country code in the user's profile.
 
@@ -159,28 +181,27 @@ def _get_user_country_from_profile(user):
     return profile_country
 
 
-def get_embargo_response(request, course_id, user):
+def get_embargo_response(request: Request, course_key: CourseKey, user: types.User) -> Optional[Response]:
     """
     Check whether any country access rules block the user from enrollment.
 
     Args:
-        request (HttpRequest): The request object
-        course_id (str): The requested course ID
-        user (str): The current user object
+        request: The request object
+        course_key: The requested course ID
+        user: The current user object
 
     Returns:
-        HttpResponse: Response of the embargo page if embargoed, None if not
+        Response of the embargo page if embargoed, None if not
 
     """
-    redirect_url = redirect_if_blocked(
-        course_id, user=user, ip_address=get_client_ip(request)[0], url=request.path)
+    redirect_url = redirect_if_blocked(request, course_key, user=user)
     if redirect_url:
         return Response(
             status=status.HTTP_403_FORBIDDEN,
             data={
                 "message": (
                     "Users from this location cannot access the course '{course_id}'."
-                ).format(course_id=course_id),
+                ).format(course_id=str(course_key)),
                 "user_message_url": request.build_absolute_uri(redirect_url)
             }
         )

--- a/openedx/core/djangoapps/embargo/models.py
+++ b/openedx/core/djangoapps/embargo/models.py
@@ -15,6 +15,7 @@ file and check it in at the same time as your model changes. To do that,
 import ipaddress
 import json
 import logging
+from typing import List, Optional
 
 from config_models.models import ConfigurationModel
 from django.core.cache import cache
@@ -26,6 +27,7 @@ from django.utils.translation import gettext_lazy
 from django_countries import countries
 from django_countries.fields import CountryField
 from opaque_keys.edx.django.models import CourseKeyField
+from opaque_keys.edx.keys import CourseKey
 
 from openedx.core.djangoapps.xmodule_django.models import NoneToEmptyManager
 
@@ -158,37 +160,35 @@ class RestrictedCourse(models.Model):
     )
 
     @classmethod
-    def is_restricted_course(cls, course_id):
+    def is_restricted_course(cls, course_key: CourseKey) -> bool:
         """
         Check if the course is in restricted list
 
         Args:
-            course_id (str): course_id to look for
+            course_key: course to look for
 
         Returns:
-            Boolean
-            True if course is in restricted course list.
+            True if the course is in the restricted course list.
         """
-        return str(course_id) in cls._get_restricted_courses_from_cache()
+        return str(course_key) in cls._get_restricted_courses_from_cache()
 
     @classmethod
-    def is_disabled_access_check(cls, course_id):
+    def is_disabled_access_check(cls, course_key: CourseKey) -> bool:
         """
         Check if the course is in restricted list has disabled_access_check
 
         Args:
-            course_id (str): course_id to look for
+            course_key: course to look for
 
         Returns:
-            Boolean
             disabled_access_check attribute of restricted course
         """
 
         # checking is_restricted_course method also here to make sure course exists in the list otherwise in case of
         # no course found it will throw the key not found error on 'disable_access_check'
         return (
-            cls.is_restricted_course(str(course_id))
-            and cls._get_restricted_courses_from_cache().get(str(course_id))["disable_access_check"]
+            cls.is_restricted_course(course_key)
+            and cls._get_restricted_courses_from_cache().get(str(course_key))["disable_access_check"]
         )
 
     @classmethod
@@ -244,7 +244,7 @@ class RestrictedCourse(models.Model):
             ]
         }
 
-    def message_key_for_access_point(self, access_point):
+    def message_key_for_access_point(self, access_point: str) -> Optional[str]:
         """Determine which message to show the user.
 
         The message can be configured per-course and depends
@@ -252,11 +252,10 @@ class RestrictedCourse(models.Model):
         (trying to enroll or accessing courseware).
 
         Arguments:
-            access_point (str): Either "courseware" or "enrollment"
+            access_point: Either "courseware" or "enrollment"
 
         Returns:
-            str: The message key.  If the access point is not valid,
-                returns None instead.
+            The message key. If the access point is not valid, returns None instead.
 
         """
         if access_point == 'enrollment':
@@ -268,19 +267,18 @@ class RestrictedCourse(models.Model):
         return str(self.course_key)
 
     @classmethod
-    def message_url_path(cls, course_key, access_point):
+    def message_url_path(cls, course_key: CourseKey, access_point: str) -> str:
         """Determine the URL path for the message explaining why the user was blocked.
 
         This is configured per-course.  See `RestrictedCourse` in the `embargo.models`
         module for more details.
 
         Arguments:
-            course_key (CourseKey): The location of the course.
-            access_point (str): How the user was trying to access the course.
-                Can be either "enrollment" or "courseware".
+            course_key: The location of the course.
+            access_point: How the user was trying to access the course. Can be either "enrollment" or "courseware".
 
         Returns:
-            unicode: The URL path to a page explaining why the user was blocked.
+            The URL path to a page explaining why the user was blocked.
 
         Raises:
             InvalidAccessPoint: Raised if access_point is not a supported value.
@@ -306,16 +304,15 @@ class RestrictedCourse(models.Model):
         return url
 
     @classmethod
-    def _get_message_url_path_from_db(cls, course_key, access_point):
+    def _get_message_url_path_from_db(cls, course_key: CourseKey, access_point: str) -> str:
         """Retrieve the "blocked" message from the database.
 
         Arguments:
-            course_key (CourseKey): The location of the course.
-            access_point (str): How the user was trying to access the course.
-                Can be either "enrollment" or "courseware".
+            course_key: The location of the course.
+            access_point: How the user was trying to access the course. Can be either "enrollment" or "courseware".
 
         Returns:
-            unicode: The URL path to a page explaining why the user was blocked.
+            The URL path to a page explaining why the user was blocked.
 
         """
         # Fallback in case we're not able to find a message path
@@ -355,7 +352,7 @@ class RestrictedCourse(models.Model):
             return default_path
 
     @classmethod
-    def invalidate_cache_for_course(cls, course_key):
+    def invalidate_cache_for_course(cls, course_key: CourseKey) -> None:
         """Invalidate the caches for the restricted course. """
         cache.delete(cls.COURSE_LIST_CACHE_KEY)
         log.info("Invalidated cached list of restricted courses.")
@@ -450,18 +447,16 @@ class CountryAccessRule(models.Model):
     ALL_COUNTRIES = {code[0] for code in list(countries)}
 
     @classmethod
-    def check_country_access(cls, course_id, country):
+    def check_country_access(cls, course_key: CourseKey, country: str) -> bool:
         """
         Check if the country is either in whitelist or blacklist of countries for the course_id
 
         Args:
-            course_id (str): course_id to look for
-            country (str): A 2 characters code of country
+            course_key: course to look for
+            country: A 2 characters code of country
 
         Returns:
-            Boolean
-            True if country found in allowed country
-            otherwise check given country exists in list
+            True if country found in allowed country, otherwise check given country exists in list
         """
         # If the country code is not in the list of all countries,
         # we don't want to automatically exclude the user.
@@ -471,25 +466,24 @@ class CountryAccessRule(models.Model):
         if country not in cls.ALL_COUNTRIES:
             return True
 
-        cache_key = cls.CACHE_KEY.format(course_key=course_id)
+        cache_key = cls.CACHE_KEY.format(course_key=course_key)
         allowed_countries = cache.get(cache_key)
         if allowed_countries is None:
-            allowed_countries = cls._get_country_access_list(course_id)
+            allowed_countries = cls._get_country_access_list(course_key)
             cache.set(cache_key, allowed_countries)
 
         return country == '' or country in allowed_countries
 
     @classmethod
-    def _get_country_access_list(cls, course_id):
+    def _get_country_access_list(cls, course_key: CourseKey) -> List[str]:
         """
         if a course is blacklist for two countries then course can be accessible from
         any where except these two countries.
         if a course is whitelist for two countries then course can be accessible from
         these countries only.
         Args:
-            course_id (str): course_id to look for
+            course_key: course to look for
         Returns:
-            List
             Consolidated list of accessible countries for given course
         """
 
@@ -498,7 +492,7 @@ class CountryAccessRule(models.Model):
 
         # Retrieve all rules in one database query, performing the "join" with the Country table
         rules_for_course = CountryAccessRule.objects.select_related('country').filter(
-            restricted_course__course_key=course_id
+            restricted_course__course_key=course_key
         )
 
         # Filter the rules into a whitelist and blacklist in one pass
@@ -529,7 +523,7 @@ class CountryAccessRule(models.Model):
             )
 
     @classmethod
-    def invalidate_cache_for_course(cls, course_key):
+    def invalidate_cache_for_course(cls, course_key: CourseKey) -> None:
         """Invalidate the cache. """
         cache_key = cls.CACHE_KEY.format(course_key=course_key)
         cache.delete(cache_key)

--- a/openedx/core/djangoapps/embargo/views.py
+++ b/openedx/core/djangoapps/embargo/views.py
@@ -45,11 +45,12 @@ class CheckCourseAccessView(APIView):  # lint-amnesty, pylint: disable=missing-c
         if course_ids and user and user_ip_address:
             for course_id in course_ids:
                 try:
-                    if not check_course_access(CourseKey.from_string(course_id), user, user_ip_address):
-                        response['access'] = False
-                        break
-                except InvalidKeyError:
-                    raise ValidationError('Invalid course_ids')  # lint-amnesty, pylint: disable=raise-missing-from
+                    course_key = CourseKey.from_string(course_id)
+                except InvalidKeyError as exc:
+                    raise ValidationError('Invalid course_ids') from exc
+                if not check_course_access(course_key, user=user, ip_addresses=[user_ip_address]):
+                    response['access'] = False
+                    break
         else:
             raise ValidationError('Missing parameters')
 


### PR DESCRIPTION
Specifically:
- check ALL ip addresses in the client ip chain for blocking
- check RIGHTMOST ip address in the client ip chain for allowing

Before, we always checked the LEFTMOST ip address in both cases.

I also went a bit crazy with some type-hinting. I saw some inaccurate docstrings and couldn't help cleaning things up (docstrings that said keys were strings when they were clearly written as actual course key objects, plus inconsistent use of course_key vs course_id, etc). Hopefully this doesn't distract too much from the main thrust of this PR.

I know whitelist/blacklist are not the preferred terms of art these days, but I wanted to keep the terminology in this djangoapp consistent, so I didn't change anything around that here.

[AA-1234](https://openedx.atlassian.net/browse/AA-1234) (that's a fun ticket number)