### PR TITLE
fix: allow for multiple customer idps

### DIFF
--- a/common/djangoapps/third_party_auth/samlproviderconfig/views.py
+++ b/common/djangoapps/third_party_auth/samlproviderconfig/views.py
@@ -58,14 +58,14 @@ class SAMLProviderConfigViewSet(PermissionRequiredMixin, SAMLProviderMixin, view
             EnterpriseCustomerIdentityProvider,
             enterprise_customer__uuid=self.requested_enterprise_uuid
         )
-        slug_list  = []
+        slug_list = []
         config_list = []
         for idp in enterprise_customer_idps:
             slug_list.append(convert_saml_slug_provider_id(idp.provider_id))
 
         for config in SAMLProviderConfig.objects.current_set():
             slug = convert_saml_slug_provider_id(config.provider_id)
-            if slug in slug_list: 
+            if slug in slug_list:
                 config_list.append(config)
 
         return config_list

--- a/common/djangoapps/third_party_auth/samlproviderconfig/views.py
+++ b/common/djangoapps/third_party_auth/samlproviderconfig/views.py
@@ -58,8 +58,8 @@ class SAMLProviderConfigViewSet(PermissionRequiredMixin, SAMLProviderMixin, view
             EnterpriseCustomerIdentityProvider,
             enterprise_customer__uuid=self.requested_enterprise_uuid
         )
-        slug_list = [ idp.provider_id for idp in enterprise_customer_idps ]
-        return [ config for config in SAMLProviderConfig.objects.current_set() if config.provider_id in slug_list ]
+        slug_list = [idp.provider_id for idp in enterprise_customer_idps]
+        return [config for config in SAMLProviderConfig.objects.current_set() if config.provider_id in slug_list]
 
     @property
     def requested_enterprise_uuid(self):

--- a/common/djangoapps/third_party_auth/samlproviderconfig/views.py
+++ b/common/djangoapps/third_party_auth/samlproviderconfig/views.py
@@ -58,17 +58,8 @@ class SAMLProviderConfigViewSet(PermissionRequiredMixin, SAMLProviderMixin, view
             EnterpriseCustomerIdentityProvider,
             enterprise_customer__uuid=self.requested_enterprise_uuid
         )
-        slug_list = []
-        config_list = []
-        for idp in enterprise_customer_idps:
-            slug_list.append(convert_saml_slug_provider_id(idp.provider_id))
-
-        for config in SAMLProviderConfig.objects.current_set():
-            slug = convert_saml_slug_provider_id(config.provider_id)
-            if slug in slug_list:
-                config_list.append(config)
-
-        return config_list
+        slug_list = [ idp.provider_id for idp in enterprise_customer_idps ]
+        return [ config for config in SAMLProviderConfig.objects.current_set() if config.provider_id in slug_list ]
 
     @property
     def requested_enterprise_uuid(self):


### PR DESCRIPTION
## Description

This PR allows for customers to have multiple saml provider configs associated with their enterprise user. Needed for this ticket https://openedx.atlassian.net/browse/ENT-5498

## Supporting information

This PR needs to be merged prior to this PR in admin-portal 
https://github.com/openedx/frontend-app-admin-portal/runs/6117868021?check_suite_focus=true
