### PR TITLE
test!: ensure pytest can be run without specifying env vars

### DIFF
--- a/cms/pytest.ini
+++ b/cms/pytest.ini
@@ -3,8 +3,7 @@
 # this file is used for the tests in the cms tree, and setup.cfg is ignored.
 # Details at https://docs.pytest.org/en/latest/reference/customize.html
 
-DJANGO_SETTINGS_MODULE = cms.envs.test
-addopts = --nomigrations --reuse-db --durations=20 -p no:randomly --json-report --json-report-omit keywords streams collectors log traceback tests --json-report-file=none
+addopts = --ds=cms.envs.test --nomigrations --reuse-db --durations=20 -p no:randomly --json-report --json-report-omit keywords streams collectors log traceback tests --json-report-file=none
 # Enable default handling for all warnings, including those that are ignored by default;
 # but hide rate-limit warnings (because we deliberately don't throttle test user logins)
 # and field_data deprecation warnings (because fixing them requires a major low-priority refactoring)

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,8 +3,7 @@
 # this file is only used for tests that don't find a pytest.ini file first.
 # Details at https://docs.pytest.org/en/latest/reference/customize.html
 
-DJANGO_SETTINGS_MODULE = lms.envs.test
-addopts = --nomigrations --reuse-db --durations=20 --json-report --json-report-omit keywords streams collectors log traceback tests --json-report-file=none
+addopts = --ds=lms.envs.test --nomigrations --reuse-db --durations=20 --json-report --json-report-omit keywords streams collectors log traceback tests --json-report-file=none
 # Enable default handling for all warnings, including those that are ignored by default;
 # but hide rate-limit warnings (because we deliberately don't throttle test user logins)
 # and field_data deprecation warnings (because fixing them requires a major low-priority refactoring)


### PR DESCRIPTION
## Description

See the commit message, taking note of the `BREAKING CHANGE`.

Blocks https://github.com/kdmccormick/tutor/pull/10


## Supporting information

Part of https://gifthub.com/overhangio/2u-tutor-adoption/issues/48

## Testing instructions

Start either Tutor Nightly or Devstack, with this edx-platform branch mounted. Enter an LMS shell. Run some tests with pytest, both LMS ones and shared ones:
```
pytest lms/djangoapps/ccx
pytest openedx/core/djangoapps/content
```
Switch to a CMS shell. Run some more tests, both CMS ones and shared ones:
```
pytest cms/djangoapps/contentstore
pytest --rootdir=cms openedx/core/djangoapps/content
```

## Deadline

Friday evening, 2022-04-22(goal is to have this available for the "tutor dev quickstart" workshop at the conference in Lisbon)

## Other information

N/A