### PR TITLE
fix: guard access to course block children in outline tab data

### DIFF
--- a/lms/djangoapps/course_home_api/outline/views.py
+++ b/lms/djangoapps/course_home_api/outline/views.py
@@ -289,7 +289,7 @@ class OutlineTabView(RetrieveAPIView):
 
             # course_blocks is a reference to the root of the course, so we go
             # through the chapters (sections) to look for sequences to remove.
-            for chapter_data in course_blocks['children']:
+            for chapter_data in course_blocks.get('children', []):
                 chapter_data['children'] = [
                     seq_data
                     for seq_data in chapter_data['children']


### PR DESCRIPTION
In some cases the course blocks API was returning a dict without a 'children' key, which was causing a traceback.

If the course blocks API has no children, that IS a problem, but still better than erroring out due to a KeyError.

[AA-1267](https://openedx.atlassian.net/browse/AA-1267)