### PR TITLE
chore: upgrade edx-name-affirmation to 2.3.3 for new api docs

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -474,7 +474,7 @@ edx-i18n-tools==0.9.1
     # via ora2
 edx-milestones==0.4.0
     # via -r requirements/edx/base.in
-edx-name-affirmation==2.3.2
+edx-name-affirmation==2.3.3
     # via -r requirements/edx/base.in
 edx-opaque-keys[django]==2.3.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -589,7 +589,7 @@ edx-lint==5.2.2
     # via -r requirements/edx/testing.txt
 edx-milestones==0.4.0
     # via -r requirements/edx/testing.txt
-edx-name-affirmation==2.3.2
+edx-name-affirmation==2.3.3
     # via -r requirements/edx/testing.txt
 edx-opaque-keys[django]==2.3.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -577,7 +577,7 @@ edx-lint==5.2.2
     # via -r requirements/edx/testing.in
 edx-milestones==0.4.0
     # via -r requirements/edx/base.txt
-edx-name-affirmation==2.3.2
+edx-name-affirmation==2.3.3
     # via -r requirements/edx/base.txt
 edx-opaque-keys[django]==2.3.0
     # via


### PR DESCRIPTION
### Description

[MST-1457](https://openedx.atlassian.net/browse/MST-1457)

Update the library edx-name-affirmation to version 2.3.3
With this upgrade, we improved API docs on edx_name_affirmation section.

@openedx/masters-devs-cosmonauts Please review.