### PR TITLE
chore: Cleanup last remenants of the edx-microsite code.

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2530,10 +2530,6 @@ BLOCKSTORE_BUNDLE_CACHE_TIMEOUT = 3000
 ###################### LEARNER PORTAL ################################
 LEARNER_PORTAL_URL_ROOT = 'https://learner-portal-localhost:18000'
 
-######################### MICROSITE ###############################
-MICROSITE_ROOT_DIR = '/edx/app/edxapp/edx-microsite'
-MICROSITE_CONFIGURATION = {}
-
 ############################ JWT #################################
 JWT_ISSUER = 'http://127.0.0.1:8000/oauth2'
 DEFAULT_JWT_ISSUER = {

--- a/cms/envs/devstack-experimental.yml
+++ b/cms/envs/devstack-experimental.yml
@@ -352,8 +352,6 @@ LOG_DIR: /edx/var/log/edx
 MAINTENANCE_BANNER_TEXT: Sample banner message
 MEDIA_ROOT: /edx/var/edxapp/media/
 MEDIA_URL: /media/
-MICROSITE_CONFIGURATION: {}
-MICROSITE_ROOT_DIR: /edx/app/edxapp/edx-microsite
 MKTG_URLS: {}
 MKTG_URL_LINK_MAP: {}
 MOBILE_STORE_URLS: {}

--- a/docs/guides/docstrings/common_djangoapps.rst
+++ b/docs/guides/docstrings/common_djangoapps.rst
@@ -13,7 +13,6 @@ LMS and Studio.
     common/djangoapps/edxmako/modules
     common/djangoapps/enrollment/modules
     common/djangoapps/entitlements/modules
-    common/djangoapps/microsite_configuration/modules
     common/djangoapps/pipeline_mako/modules
     common/djangoapps/static_replace/modules
     common/djangoapps/status/modules

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -5039,10 +5039,6 @@ BUNDLE_ASSET_STORAGE_SETTINGS = dict(
     ),
 )
 
-######################### MICROSITE ###############################
-MICROSITE_ROOT_DIR = '/edx/app/edxapp/edx-microsite'
-MICROSITE_CONFIGURATION = {}
-
 SYSLOG_SERVER = ''
 FEEDBACK_SUBMISSION_EMAIL = ''
 GITHUB_REPO_ROOT = '/edx/var/edxapp/data'

--- a/lms/envs/devstack-experimental.yml
+++ b/lms/envs/devstack-experimental.yml
@@ -393,8 +393,6 @@ MAILCHIMP_NEW_USER_LIST_ID: null
 MAINTENANCE_BANNER_TEXT: Sample banner message
 MEDIA_ROOT: /edx/var/edxapp/media/
 MEDIA_URL: /media/
-MICROSITE_CONFIGURATION: {}
-MICROSITE_ROOT_DIR: /edx/app/edxapp/edx-microsite
 MKTG_URLS: {}
 MKTG_URL_LINK_MAP: {}
 MOBILE_STORE_URLS: {}

--- a/openedx/core/djangoapps/theming/helpers.py
+++ b/openedx/core/djangoapps/theming/helpers.py
@@ -37,9 +37,8 @@ def get_template_path(relative_path, **kwargs):  # lint-amnesty, pylint: disable
 
 def is_request_in_themed_site():
     """
-    This is a proxy function to hide microsite_configuration behind comprehensive theming.
+    This is a proxy function to site_configuration.
     """
-    # We need to give priority to theming/site-configuration over microsites
     return configuration_helpers.is_site_configuration_enabled()
 
 


### PR DESCRIPTION
There are still references to the word `microsite` because the
site-configuration code uses it to referr to it's sub-sites in a few
places.
