### PR TITLE
[BD-13] [BB-6144] deprecate hostname attribute from xmodule ModuleSystem

### DIFF
--- a/common/lib/xmodule/xmodule/lti_module.py
+++ b/common/lib/xmodule/xmodule/lti_module.py
@@ -65,6 +65,7 @@ from urllib import parse
 
 import bleach
 import oauthlib.oauth1
+from django.conf import settings
 from lxml import etree
 from oauthlib.oauth1.rfc5849 import signature
 from pkg_resources import resource_string
@@ -584,7 +585,7 @@ class LTIBlock(
         i4x-2-3-lti-31de800015cf4afb973356dbe81496df this part of resource_link_id:
         makes resource_link_id to be unique among courses inside same system.
         """
-        return str(parse.quote(f"{self.system.hostname}-{self.location.html_id()}"))  # lint-amnesty, pylint: disable=line-too-long
+        return str(parse.quote(f"{settings.LMS_BASE}-{self.location.html_id()}"))
 
     def get_lis_result_sourcedid(self):
         """

--- a/common/lib/xmodule/xmodule/tests/__init__.py
+++ b/common/lib/xmodule/xmodule/tests/__init__.py
@@ -153,7 +153,6 @@ def get_test_system(
         static_url='/static',
         track_function=Mock(name='get_test_system.track_function'),
         get_module=get_module,
-        hostname="edx.org",
         services={
             'user': user_service,
             'mako': mako_service,

--- a/common/lib/xmodule/xmodule/tests/test_lti_unit.py
+++ b/common/lib/xmodule/xmodule/tests/test_lti_unit.py
@@ -3,18 +3,21 @@
 
 import datetime
 import textwrap
-import unittest
 from copy import copy
 from unittest.mock import Mock, PropertyMock, patch
 from urllib import parse
 
+
 import pytest
+from django.conf import settings
+from django.test import TestCase, override_settings
 from lxml import etree
 from opaque_keys.edx.locator import BlockUsageLocator
 from pytz import UTC
 from webob.request import Request
 from xblock.field_data import DictFieldData
 from xblock.fields import ScopeIds
+
 
 from common.djangoapps.xblock_django.constants import ATTR_KEY_ANONYMOUS_USER_ID
 from xmodule.fields import Timedelta
@@ -25,7 +28,8 @@ from xmodule.tests.helpers import StubUserService
 from . import get_test_system
 
 
-class LTIBlockTest(unittest.TestCase):
+@override_settings(LMS_BASE="edx.org")
+class LTIBlockTest(TestCase):
     """Logic tests for LTI module."""
 
     def setUp(self):
@@ -69,8 +73,9 @@ class LTIBlockTest(unittest.TestCase):
         current_user = self.system.service(self.xmodule, 'user').get_current_user()
         self.user_id = current_user.opt_attrs.get(ATTR_KEY_ANONYMOUS_USER_ID)
         self.lti_id = self.xmodule.lti_id
+
         self.unquoted_resource_link_id = '{}-i4x-2-3-lti-31de800015cf4afb973356dbe81496df'.format(
-            self.xmodule.runtime.hostname
+            settings.LMS_BASE
         )
 
         sourced_id = ':'.join(parse.quote(i) for i in (self.lti_id, self.unquoted_resource_link_id, self.user_id))  # lint-amnesty, pylint: disable=line-too-long

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -1621,6 +1621,19 @@ class ModuleSystemShim:
             DeprecationWarning, stacklevel=3
         )
 
+    @property
+    def hostname(self):
+        """
+        Hostname of the site as set in the Django settings `LMS_BASE`
+        Deprecated in favour of direct import of `django.conf.settings`
+        """
+        warnings.warn(
+            'runtime.hostname is deprecated. Please use `LMS_BASE` from `django.conf.settings`.',
+            DeprecationWarning, stacklevel=3,
+        )
+        from django.conf import settings
+        return settings.LMS_BASE
+
 
 class ModuleSystem(MetricsMixin, ConfigurableFragmentWrapper, ModuleSystemShim, Runtime):
     """
@@ -1636,11 +1649,18 @@ class ModuleSystem(MetricsMixin, ConfigurableFragmentWrapper, ModuleSystemShim, 
     """
 
     def __init__(
-            self, static_url, track_function, get_module,
-            descriptor_runtime, hostname="", publish=None,
-            course_id=None, error_descriptor_class=None,
-            field_data=None, rebind_noauth_module_to_user=None,
-            **kwargs):
+        self,
+        static_url,
+        track_function,
+        get_module,
+        descriptor_runtime,
+        publish=None,
+        course_id=None,
+        error_descriptor_class=None,
+        field_data=None,
+        rebind_noauth_module_to_user=None,
+        **kwargs,
+    ):
         """
         Create a closure around the system environment.
 
@@ -1678,7 +1698,6 @@ class ModuleSystem(MetricsMixin, ConfigurableFragmentWrapper, ModuleSystemShim, 
         self.STATIC_URL = static_url
         self.track_function = track_function
         self.get_module = get_module
-        self.HOSTNAME = self.hostname = hostname
         self.course_id = course_id
 
         if publish:

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -729,7 +729,6 @@ def get_module_system_for_user(
         static_url=settings.STATIC_URL,
         get_module=inner_get_module,
         user=user,
-        hostname=settings.SITE_NAME,
         publish=publish,
         course_id=course_id,
         # TODO: When we merge the descriptor and module systems, we can stop reaching into the mixologist (cpennington)

--- a/lms/djangoapps/courseware/tests/test_lti_integration.py
+++ b/lms/djangoapps/courseware/tests/test_lti_integration.py
@@ -43,7 +43,7 @@ class TestLTI(BaseTestXmodule):
         context_id = str(self.item_descriptor.course_id)
         user_service = self.item_descriptor.xmodule_runtime.service(self.item_descriptor, 'user')
         user_id = str(user_service.get_current_user().opt_attrs.get(ATTR_KEY_ANONYMOUS_USER_ID))
-        hostname = self.item_descriptor.xmodule_runtime.hostname
+        hostname = settings.LMS_BASE
         resource_link_id = str(urllib.parse.quote(f'{hostname}-{self.item_descriptor.location.html_id()}'))
 
         sourcedId = "{context}:{resource_link}:{user_id}".format(


### PR DESCRIPTION
## Description

The `hostname` attribute was needed for OAuth in the LTI Module and was
being passed via the `x_module.ModuleSystem` class as a mixin. This attribute has been removed.
It has been replaced in the `xmodule.lti_module` with `get_current_request_hostname` utility function.

This change affects only the `module_renderer` module of the LMS which is also updated to initialize the XBlocks without passing the hostname attribute anymore.

This shouldn't cause any changes for any users and should continue to work just as usual.

## Supporting information
- Related OpenCraft Issue - https://tasks.opencraft.com/browse/BB-6144

## Testing instructions

1. Set your dev environment to `master` branch.
2. Add `"lti"` to the **Advanced Module List** in the **Advanced Settings**. (NOT `lti_consumer` which is an independent xblock, this PR deals with the old `lti` module)
3. Scroll down to **LTI Passports** and add a new entry  `"saltire:consumer_key:secret"`. We will be using the [Saltire Tool Emulator](https://saltire.lti.app/tool) to test the changes
4. **Save Changes**
5. Add a new new unit to your test course and select **Advanced** -> **LTI**
6. Click **Edit** and enter the following details and save the block
    * **LTI ID**: `saltire`
    * **LTI URL**: `https://saltire.lti.app/tool`
    * **Open in New Page**: `False`
7. Once Saltire loads in the block, make sure **Verification** is show as `Passed`
8. Save and publish the unit.
9. Open the unit in LMS and expand the **Message Parameters** in the Saltire Block. Note the value of `resource_link_id`. It should be something like `{hostname}-{random-hash-value}`. Eg., when testing from local devstack `localhost%3A18000-71e809b7a55442afaa590a477145bb6c`
10. Now checkout the `edx-platform` to the PR branch `open-craft:tecoholic/BB-6144-deprecate-hostname-in-ModuleSystem`
11. Restart your studio & lms services to make sure they are loading the changes from PR.
12. Refresh the LMS page with Saltire and expand the **Message Parameters** once again
13. Compare the `resource_link_id` show with the old value. Both should have the same `{hostname}` part.
14. You can create a new Unit + LTI Block after the PR branch has been checked out to ensure `hostname` value is populated as expected.
