### PR TITLE
fix: Upgrade npm package @edx/studio-frontend to ^1.19.1 to fix missing assets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3768,29 +3768,29 @@
       },
       "dependencies": {
         "@edx/edx-proctoring": {
-          "version": "3.11.4",
-          "resolved": "https://registry.npmjs.org/@edx/edx-proctoring/-/edx-proctoring-3.11.4.tgz",
-          "integrity": "sha512-xG7y4dz+/VpVqufH+aXdwsxBh1VYrjI40eRBRQjN0EVee1hTCxzRQ0bG7C67NWlnqh6dOmAdvI6A1vig97mg9g==",
+          "version": "3.25.0",
+          "resolved": "https://registry.npmjs.org/@edx/edx-proctoring/-/edx-proctoring-3.25.0.tgz",
+          "integrity": "sha512-XZ0FishhNVsziMRqG5b/Qx5dfATR0WeTB0rqRTOzEq8KZ5mOR+HXzLCY8DYHGwdYG/TY6ZEsuiinTWKzkKidRg==",
           "dependencies": {
             "@babel/code-frame": {
-              "version": "7.12.13",
-              "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-              "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+              "version": "7.14.5",
+              "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+              "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
               "requires": {
-                "@babel/highlight": "^7.12.13"
+                "@babel/highlight": "^7.14.5"
               }
             },
             "@babel/helper-validator-identifier": {
-              "version": "7.14.0",
-              "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
-              "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A=="
+              "version": "7.14.5",
+              "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+              "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg=="
             },
             "@babel/highlight": {
-              "version": "7.14.0",
-              "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
-              "integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
+              "version": "7.14.5",
+              "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+              "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
               "requires": {
-                "@babel/helper-validator-identifier": "^7.14.0",
+                "@babel/helper-validator-identifier": "^7.14.5",
                 "chalk": "^2.0.0",
                 "js-tokens": "^4.0.0"
               }
@@ -3837,11 +3837,6 @@
               "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
               "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ=="
             },
-            "@types/json5": {
-              "version": "0.0.29",
-              "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-              "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
-            },
             "abbrev": {
               "version": "1.0.9",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
@@ -3869,9 +3864,9 @@
               "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ=="
             },
             "acorn-jsx": {
-              "version": "5.3.1",
-              "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
-              "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng=="
+              "version": "5.3.2",
+              "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+              "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="
             },
             "active-x-obfuscator": {
               "version": "0.0.1",
@@ -4077,9 +4072,9 @@
               "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8="
             },
             "array-filter": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
-              "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM="
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+              "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
             },
             "array-find-index": {
               "version": "1.0.2",
@@ -4200,12 +4195,9 @@
               "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
             },
             "available-typed-arrays": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
-              "integrity": "sha512-XWX3OX8Onv97LMk/ftVyBibpGwY5a8SmuxZPzeOxqmuEqUCOM9ZE+uIaD1VNJ5QnvU2UQusvmKbuM1FR8QWGfQ==",
-              "requires": {
-                "array-filter": "^1.0.0"
-              }
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.4.tgz",
+              "integrity": "sha512-SA5mXJWrId1TaQjfxUYghbqQ/hYioKmLJvPJyDuYRtXXenFNMjj4hSSt1Cf1xsuXSXrtxrVC5Ot4eU6cOtBDdA=="
             },
             "aws-sign2": {
               "version": "0.5.0",
@@ -4412,15 +4404,6 @@
               "version": "1.13.1",
               "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
               "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
-            },
-            "bindings": {
-              "version": "1.5.0",
-              "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-              "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-              "optional": true,
-              "requires": {
-                "file-uri-to-path": "1.0.0"
-              }
             },
             "bl": {
               "version": "0.9.5",
@@ -5303,9 +5286,9 @@
               }
             },
             "config-chain": {
-              "version": "1.1.12",
-              "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
-              "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
+              "version": "1.1.13",
+              "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+              "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
               "requires": {
                 "ini": "^1.3.4",
                 "proto-list": "~1.2.1"
@@ -5359,15 +5342,6 @@
                   "resolved": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz",
                   "integrity": "sha1-IP9NJvXkIstoobrLu2EDmtjBwTA="
                 }
-              }
-            },
-            "contains-path": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-1.0.0.tgz",
-              "integrity": "sha1-NFizMhhWA+ju0Y9RjUoQiIo6vJE=",
-              "requires": {
-                "normalize-path": "^2.1.1",
-                "path-starts-with": "^1.0.0"
               }
             },
             "content-type": {
@@ -5477,9 +5451,9 @@
               "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
             },
             "debug": {
-              "version": "4.3.1",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-              "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+              "version": "4.3.2",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+              "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
               "requires": {
                 "ms": "2.1.2"
               }
@@ -5815,9 +5789,9 @@
               }
             },
             "engine.io-client": {
-              "version": "1.8.5",
-              "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.5.tgz",
-              "integrity": "sha512-AYTgHyeVUPitsseqjoedjhYJapNVoSPShbZ+tEUX9/73jgZ/Z3sUlJf9oYgdEBBdVhupUpUqSxH0kBCXlQnmZg==",
+              "version": "1.8.6",
+              "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.6.tgz",
+              "integrity": "sha512-6+rInQu8xU7c0fIF6RC4SRKuHVWPt8Xq0bZYS4lMrTwmhRineOlEMsU3X0zS5mHIvCgJsmpOKEX7DhihGk7j0g==",
               "requires": {
                 "component-emitter": "1.2.1",
                 "component-inherit": "0.0.3",
@@ -5829,7 +5803,7 @@
                 "parseqs": "0.0.5",
                 "parseuri": "0.0.5",
                 "ws": "~1.1.5",
-                "xmlhttprequest-ssl": "1.5.3",
+                "xmlhttprequest-ssl": "1.6.3",
                 "yeast": "0.1.2"
               },
               "dependencies": {
@@ -5889,9 +5863,9 @@
               }
             },
             "es-abstract": {
-              "version": "1.18.0",
-              "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
-              "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+              "version": "1.18.3",
+              "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
+              "integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
               "requires": {
                 "call-bind": "^1.0.2",
                 "es-to-primitive": "^1.2.1",
@@ -5901,14 +5875,14 @@
                 "has-symbols": "^1.0.2",
                 "is-callable": "^1.2.3",
                 "is-negative-zero": "^2.0.1",
-                "is-regex": "^1.1.2",
-                "is-string": "^1.0.5",
-                "object-inspect": "^1.9.0",
+                "is-regex": "^1.1.3",
+                "is-string": "^1.0.6",
+                "object-inspect": "^1.10.3",
                 "object-keys": "^1.1.1",
                 "object.assign": "^4.1.2",
                 "string.prototype.trimend": "^1.0.4",
                 "string.prototype.trimstart": "^1.0.4",
-                "unbox-primitive": "^1.0.0"
+                "unbox-primitive": "^1.0.1"
               }
             },
             "es-get-iterator": {
@@ -6673,13 +6647,12 @@
               "integrity": "sha512-AtA5MJpMAh0kKzSx/u7DuDbPRijIZmlt6n75CR8Q3UQ18Fo4QFfYK15lJ8OhXQQUYR7zTMMB2x37KyP3LnAC/g=="
             },
             "eslint-plugin-import": {
-              "version": "2.23.2",
-              "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.23.2.tgz",
-              "integrity": "sha512-LmNoRptHBxOP+nb0PIKz1y6OSzCJlB+0g0IGS3XV4KaKk2q4szqQ6s6F1utVf5ZRkxk/QOTjdxe7v4VjS99Bsg==",
+              "version": "2.23.4",
+              "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.23.4.tgz",
+              "integrity": "sha512-6/wP8zZRsnQFiR3iaPFgh5ImVRM1WN5NUWfTIRqwOdeiGJlBcSk82o1FEVq8yXmy4lkIzTo7YhHCIxlU/2HyEQ==",
               "requires": {
                 "array-includes": "^3.1.3",
                 "array.prototype.flat": "^1.2.4",
-                "contains-path": "^1.0.0",
                 "debug": "^2.6.9",
                 "doctrine": "^2.1.0",
                 "eslint-import-resolver-node": "^0.3.4",
@@ -6740,9 +6713,9 @@
               }
             },
             "eslint-plugin-react": {
-              "version": "7.23.2",
-              "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.23.2.tgz",
-              "integrity": "sha512-AfjgFQB+nYszudkxRkTFu0UR1zEQig0ArVMPloKhxwlwkzaw/fBiH0QWcBBhZONlXqQC51+nfqFrkn4EzHcGBw==",
+              "version": "7.24.0",
+              "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.24.0.tgz",
+              "integrity": "sha512-KJJIx2SYx7PBx3ONe/mEeMz4YE0Lcr7feJTCMyyKb/341NcjuAgim3Acgan89GfPv7nxXK2+0slu0CWXYM4x+Q==",
               "requires": {
                 "array-includes": "^3.1.3",
                 "array.prototype.flatmap": "^1.2.4",
@@ -6750,12 +6723,12 @@
                 "has": "^1.0.3",
                 "jsx-ast-utils": "^2.4.1 || ^3.0.0",
                 "minimatch": "^3.0.4",
-                "object.entries": "^1.1.3",
+                "object.entries": "^1.1.4",
                 "object.fromentries": "^2.0.4",
-                "object.values": "^1.1.3",
+                "object.values": "^1.1.4",
                 "prop-types": "^15.7.2",
                 "resolve": "^2.0.0-next.3",
-                "string.prototype.matchall": "^4.0.4"
+                "string.prototype.matchall": "^4.0.5"
               },
               "dependencies": {
                 "doctrine": {
@@ -7212,9 +7185,9 @@
               "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
             },
             "fast-safe-stringify": {
-              "version": "2.0.7",
-              "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
-              "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
+              "version": "2.0.8",
+              "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.8.tgz",
+              "integrity": "sha512-lXatBjf3WPjmWD6DpIZxkeSsCOwqI0maYMpgDlx8g4U2qi4lbjA9oH/HD2a87G+KfsUmo5WbJFmqBZlPxtptag=="
             },
             "fd-slicer": {
               "version": "1.1.0",
@@ -7244,12 +7217,6 @@
               "requires": {
                 "flat-cache": "^2.0.1"
               }
-            },
-            "file-uri-to-path": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-              "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-              "optional": true
             },
             "filename-regex": {
               "version": "2.0.1",
@@ -7485,6 +7452,14 @@
               "optional": true,
               "requires": {
                 "nan": "~0.8.0"
+              },
+              "dependencies": {
+                "nan": {
+                  "version": "0.8.0",
+                  "resolved": "https://registry.npmjs.org/nan/-/nan-0.8.0.tgz",
+                  "integrity": "sha1-AiqPpen+hCCWSsH7PclOF/RJ9f0=",
+                  "optional": true
+                }
               }
             },
             "fstream": {
@@ -8131,9 +8106,9 @@
                   "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
                 },
                 "uglify-js": {
-                  "version": "3.13.6",
-                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.6.tgz",
-                  "integrity": "sha512-rRprLwl8RVaS+Qvx3Wh5hPfPBn9++G6xkGlUupya0s5aDmNjI7z3lnRLB3u7sN4OmbB0pWgzhM9BEJyiWAwtAA==",
+                  "version": "3.13.10",
+                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.10.tgz",
+                  "integrity": "sha512-57H3ACYFXeo1IaZ1w02sfA71wI60MGco/IQFjOqK+WtKoprh7Go2/yvd2HPtoJILO2Or84ncLccI4xoHMTSbGg==",
                   "optional": true
                 },
                 "wordwrap": {
@@ -8629,9 +8604,9 @@
               "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ=="
             },
             "is-core-module": {
-              "version": "2.4.0",
-              "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
-              "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
+              "version": "2.5.0",
+              "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
+              "integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
               "requires": {
                 "has": "^1.0.3"
               }
@@ -9019,11 +8994,11 @@
               "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
             },
             "json5": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-              "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+              "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
               "requires": {
-                "minimist": "^1.2.0"
+                "minimist": "^1.2.5"
               }
             },
             "jsonfile": {
@@ -9178,11 +9153,7 @@
                   "version": "1.2.13",
                   "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
                   "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-                  "optional": true,
-                  "requires": {
-                    "bindings": "^1.5.0",
-                    "nan": "^2.12.1"
-                  }
+                  "optional": true
                 },
                 "http-proxy": {
                   "version": "1.18.1",
@@ -9221,12 +9192,6 @@
                   "version": "2.0.0",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                   "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-                },
-                "nan": {
-                  "version": "2.14.2",
-                  "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-                  "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-                  "optional": true
                 },
                 "object-assign": {
                   "version": "4.1.0",
@@ -9985,16 +9950,16 @@
               "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA="
             },
             "mime-db": {
-              "version": "1.47.0",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
-              "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw=="
+              "version": "1.48.0",
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
+              "integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ=="
             },
             "mime-types": {
-              "version": "2.1.30",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz",
-              "integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
+              "version": "2.1.31",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
+              "integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==",
               "requires": {
-                "mime-db": "1.47.0"
+                "mime-db": "1.48.0"
               }
             },
             "mimic-fn": {
@@ -10108,10 +10073,9 @@
               "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
             },
             "nan": {
-              "version": "0.8.0",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-0.8.0.tgz",
-              "integrity": "sha1-AiqPpen+hCCWSsH7PclOF/RJ9f0=",
-              "optional": true
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz",
+              "integrity": "sha1-riT4hQgY1mL8q1rPfzuVv6oszzg="
             },
             "nanomatch": {
               "version": "1.2.13",
@@ -10306,9 +10270,9 @@
               }
             },
             "object-inspect": {
-              "version": "1.10.3",
-              "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
-              "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw=="
+              "version": "1.11.0",
+              "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+              "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg=="
             },
             "object-is": {
               "version": "1.1.5",
@@ -10355,14 +10319,13 @@
               }
             },
             "object.entries": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.3.tgz",
-              "integrity": "sha512-ym7h7OZebNS96hn5IJeyUmaWhaSM4SVtAPPfNLQEI2MYWCO2egsITb9nab2+i/Pwibx+R0mtn+ltKJXRSeTMGg==",
+              "version": "1.1.4",
+              "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.4.tgz",
+              "integrity": "sha512-h4LWKWE+wKQGhtMjZEBud7uLGhqyLwj8fpHOarZhD2uY3C9cRtk57VQ89ke3moByLXMedqs3XCHzyb4AmA2DjA==",
               "requires": {
-                "call-bind": "^1.0.0",
+                "call-bind": "^1.0.2",
                 "define-properties": "^1.1.3",
-                "es-abstract": "^1.18.0-next.1",
-                "has": "^1.0.3"
+                "es-abstract": "^1.18.2"
               }
             },
             "object.fromentries": {
@@ -10413,14 +10376,13 @@
               }
             },
             "object.values": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.3.tgz",
-              "integrity": "sha512-nkF6PfDB9alkOUxpf1HNm/QlkeW3SReqL5WXeBLpEJJnlPSvRaDQpW3gQTksTN3fgJX4hL42RzKyOin6ff3tyw==",
+              "version": "1.1.4",
+              "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.4.tgz",
+              "integrity": "sha512-TnGo7j4XSnKQoK3MfvkzqKCi0nVe/D9I9IjwTNYdb/fxYHpjrluHVOgw0AF6jrRFGMPHdfuidR09tIDiIvnaSg==",
               "requires": {
                 "call-bind": "^1.0.2",
                 "define-properties": "^1.1.3",
-                "es-abstract": "^1.18.0-next.2",
-                "has": "^1.0.3"
+                "es-abstract": "^1.18.2"
               }
             },
             "on-finished": {
@@ -10697,9 +10659,9 @@
               "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
             },
             "path-parse": {
-              "version": "1.0.6",
-              "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-              "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+              "version": "1.0.7",
+              "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+              "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
             },
             "path-root": {
               "version": "0.1.1",
@@ -10713,14 +10675,6 @@
               "version": "0.1.2",
               "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
               "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0="
-            },
-            "path-starts-with": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/path-starts-with/-/path-starts-with-1.0.0.tgz",
-              "integrity": "sha1-soJDAV6LE43lcmgqxS2kLmRq2E4=",
-              "requires": {
-                "normalize-path": "^2.1.1"
-              }
             },
             "path-to-regexp": {
               "version": "1.8.0",
@@ -11605,13 +11559,6 @@
                 "array-map": "~0.0.0",
                 "array-reduce": "~0.0.0",
                 "jsonify": "~0.0.0"
-              },
-              "dependencies": {
-                "array-filter": {
-                  "version": "0.0.1",
-                  "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
-                  "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
-                }
               }
             },
             "side-channel": {
@@ -11928,9 +11875,9 @@
               }
             },
             "spdx-license-ids": {
-              "version": "3.0.8",
-              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.8.tgz",
-              "integrity": "sha512-NDgA96EnaLSvtbM7trJj+t1LUR3pirkDCcz9nOUlPb5DMBGsH7oES6C3hs3j7R9oHEa1EMvReS/BUAIT5Tcr0g=="
+              "version": "3.0.9",
+              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.9.tgz",
+              "integrity": "sha512-Ki212dKK4ogX+xDo4CtOZBVIwhsKBEfsEEcwmJfLQzirgc2jIWdzg40Unxz/HzEUqM1WFzVlQSMF9kZZ2HboLQ=="
             },
             "split": {
               "version": "0.2.10",
@@ -12090,14 +12037,15 @@
               }
             },
             "string.prototype.matchall": {
-              "version": "4.0.4",
-              "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.4.tgz",
-              "integrity": "sha512-pknFIWVachNcyqRfaQSeu/FUfpvJTe4uskUSZ9Wc1RijsPuzbZ8TyYT8WCNnntCjUEqQ3vUHMAfVj2+wLAisPQ==",
+              "version": "4.0.5",
+              "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.5.tgz",
+              "integrity": "sha512-Z5ZaXO0svs0M2xd/6By3qpeKpLKd9mO4v4q3oMEQrk8Ck4xOD5d5XeBOOjGrmVZZ/AHB1S0CgG4N5r1G9N3E2Q==",
               "requires": {
                 "call-bind": "^1.0.2",
                 "define-properties": "^1.1.3",
-                "es-abstract": "^1.18.0-next.2",
-                "has-symbols": "^1.0.1",
+                "es-abstract": "^1.18.2",
+                "get-intrinsic": "^1.1.1",
+                "has-symbols": "^1.0.2",
                 "internal-slot": "^1.0.3",
                 "regexp.prototype.flags": "^1.3.1",
                 "side-channel": "^1.0.4"
@@ -12432,12 +12380,11 @@
               "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
             },
             "tsconfig-paths": {
-              "version": "3.9.0",
-              "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
-              "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+              "version": "3.10.1",
+              "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.10.1.tgz",
+              "integrity": "sha512-rETidPDgCpltxF7MjBZlAFPUHv5aHH2MymyPvh+vEyWAED4Eb/WeMbsnD/JDr4OKPOA1TssDHgIcpTN5Kh0p6Q==",
               "requires": {
-                "@types/json5": "^0.0.29",
-                "json5": "^1.0.1",
+                "json5": "^2.2.0",
                 "minimist": "^1.2.0",
                 "strip-bom": "^3.0.0"
               }
@@ -12979,11 +12926,6 @@
                   "version": "2.1.0",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
                   "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E="
-                },
-                "nan": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz",
-                  "integrity": "sha1-riT4hQgY1mL8q1rPfzuVv6oszzg="
                 }
               }
             },
@@ -13006,9 +12948,9 @@
               "integrity": "sha1-AUU6HZvtHo8XL2SVu/TIxCYyFQA="
             },
             "xmlhttprequest-ssl": {
-              "version": "1.5.3",
-              "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz",
-              "integrity": "sha1-GFqIjATspGw+QHDZn3tJ3jUomS0="
+              "version": "1.6.3",
+              "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.3.tgz",
+              "integrity": "sha512-3XfeQE/wNkvrIktn2Kf0869fC0BN6UpydVasGIeSm2B1Llihf7/0UfZM+eCkOw3P7bP4+qPgqhm7ZoxuJtFU0Q=="
             },
             "xtend": {
               "version": "4.0.2",
@@ -14630,22 +14572,26 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "optional": true
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "optional": true,
           "requires": {
             "delegates": "^1.0.0",
@@ -14654,12 +14600,14 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -14668,32 +14616,38 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "optional": true
         },
         "debug": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "optional": true,
           "requires": {
             "ms": "^2.1.1"
@@ -14701,22 +14655,26 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "optional": true,
           "requires": {
             "minipass": "^2.2.1"
@@ -14724,12 +14682,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "optional": true,
           "requires": {
             "aproba": "^1.0.3",
@@ -14744,7 +14704,8 @@
         },
         "glob": {
           "version": "7.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -14757,12 +14718,14 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "optional": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
@@ -14770,7 +14733,8 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "optional": true,
           "requires": {
             "minimatch": "^3.0.4"
@@ -14778,7 +14742,8 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "optional": true,
           "requires": {
             "once": "^1.3.0",
@@ -14787,17 +14752,20 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "optional": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -14805,12 +14773,14 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -14818,12 +14788,14 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "optional": true
         },
         "minipass": {
           "version": "2.3.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
@@ -14832,7 +14804,8 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "optional": true,
           "requires": {
             "minipass": "^2.2.1"
@@ -14840,7 +14813,8 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "optional": true,
           "requires": {
             "minimist": "0.0.8"
@@ -14848,12 +14822,14 @@
         },
         "ms": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "optional": true
         },
         "needle": {
           "version": "2.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
           "optional": true,
           "requires": {
             "debug": "^4.1.0",
@@ -14863,7 +14839,8 @@
         },
         "node-pre-gyp": {
           "version": "0.12.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
           "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
@@ -14880,7 +14857,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "optional": true,
           "requires": {
             "abbrev": "1",
@@ -14889,12 +14867,14 @@
         },
         "npm-bundled": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
           "optional": true,
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -14903,7 +14883,8 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "optional": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
@@ -14914,17 +14895,20 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "optional": true,
           "requires": {
             "wrappy": "1"
@@ -14932,17 +14916,20 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "optional": true,
           "requires": {
             "os-homedir": "^1.0.0",
@@ -14951,17 +14938,20 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "optional": true,
           "requires": {
             "deep-extend": "^0.6.0",
@@ -14972,14 +14962,16 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "optional": true
             }
           }
         },
         "readable-stream": {
           "version": "2.3.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -14993,7 +14985,8 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "optional": true,
           "requires": {
             "glob": "^7.1.3"
@@ -15001,37 +14994,44 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "optional": true
         },
         "semver": {
           "version": "5.7.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
@@ -15041,7 +15041,8 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -15049,7 +15050,8 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -15057,12 +15059,14 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "optional": true,
           "requires": {
             "chownr": "^1.1.1",
@@ -15076,12 +15080,14 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "optional": true,
           "requires": {
             "string-width": "^1.0.2 || 2"
@@ -15089,12 +15095,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "optional": true
         }
       }
@@ -16627,7 +16635,7 @@
     },
     "jasmine-jquery": {
       "version": "git+https://github.com/velesin/jasmine-jquery.git#ebad463d592d3fea00c69f26ea18a930e09c7b58",
-      "from": "jasmine-jquery@git+https://github.com/velesin/jasmine-jquery.git#ebad463d592d3fea00c69f26ea18a930e09c7b58",
+      "from": "git+https://github.com/velesin/jasmine-jquery.git#ebad463d592d3fea00c69f26ea18a930e09c7b58",
       "dev": true
     },
     "jest": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,22 @@
         "js-tokens": "^3.0.0"
       }
     },
+    "@babel/polyfill": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
+      "integrity": "sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==",
+      "requires": {
+        "core-js": "^2.6.5",
+        "regenerator-runtime": "^0.13.4"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.12",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
+        }
+      }
+    },
     "@babel/runtime": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.0.tgz",
@@ -179,14 +195,14 @@
       }
     },
     "@edx/studio-frontend": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@edx/studio-frontend/-/studio-frontend-1.17.0.tgz",
-      "integrity": "sha512-lWULlPavlL5IxXUV3WBJWJlStB8AFIYZxzX3UROnISspCnNMSmyu94VsVOJrJGdFNmmh+5Bj6UVpmTSdTyL3mg==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/@edx/studio-frontend/-/studio-frontend-1.19.1.tgz",
+      "integrity": "sha512-Zj8lNs7lVq5qyC3zeRzimoS06qylAYzPXDj7Ifgwk1zsPz/G+fCt4Hg6K/QG+0WoPVt1Ht6y3Ob0p2I0U5uduA==",
       "requires": {
+        "@babel/polyfill": "^7.0.0",
         "@edx/edx-bootstrap": "^1.0.0",
         "@edx/paragon": "3.4.8",
         "airbnb-prop-types": "^2.10.0",
-        "babel-polyfill": "^6.26.0",
         "classnames": "^2.2.5",
         "copy-to-clipboard": "^3.0.8",
         "custom-event-polyfill": "^0.3.0",
@@ -201,13 +217,21 @@
         "react-intl-translations-manager": "^5.0.1",
         "react-redux": "^5.0.6",
         "react-transition-group": "^2.2.1",
-        "redux": "^3.7.2",
-        "redux-devtools-extension": "^2.13.2",
+        "redux": "^4.0.0",
+        "redux-devtools-extension": "^2.13.3",
         "redux-thunk": "^2.2.0",
         "reselect": "^3.0.1",
         "whatwg-fetch": "^2.0.3"
       },
       "dependencies": {
+        "@babel/runtime": {
+          "version": "7.18.0",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.0.tgz",
+          "integrity": "sha512-YMQvx/6nKEaucl0MY56mwIG483xk8SDNdlUwb2Ts6FUpr7fm85DxEmsY18LXBNhcTz6tO6JwZV8w1W06v8UKeg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
         "@edx/paragon": {
           "version": "3.4.8",
           "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-3.4.8.tgz",
@@ -240,13 +264,13 @@
           },
           "dependencies": {
             "prop-types": {
-              "version": "15.7.2",
-              "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-              "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+              "version": "15.8.1",
+              "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+              "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
               "requires": {
                 "loose-envify": "^1.4.0",
                 "object-assign": "^4.1.1",
-                "react-is": "^16.8.1"
+                "react-is": "^16.13.1"
               },
               "dependencies": {
                 "loose-envify": {
@@ -265,6 +289,14 @@
           "version": "16.13.1",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
           "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        },
+        "redux": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
+          "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
+          "requires": {
+            "@babel/runtime": "^7.9.2"
+          }
         }
       }
     },
@@ -20803,13 +20835,13 @@
           }
         },
         "prop-types": {
-          "version": "15.7.2",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "version": "15.8.1",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+          "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
           "requires": {
             "loose-envify": "^1.4.0",
             "object-assign": "^4.1.1",
-            "react-is": "^16.8.1"
+            "react-is": "^16.13.1"
           }
         },
         "react-is": {
@@ -20989,6 +21021,11 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
       "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
+    },
+    "regenerator-runtime": {
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "regenerator-transform": {
       "version": "0.10.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@edx/edx-proctoring": "^1.5.0",
     "@edx/frontend-component-cookie-policy-banner": "1.0.0",
     "@edx/paragon": "2.6.4",
-    "@edx/studio-frontend": "^1.17.0",
+    "@edx/studio-frontend": "1.17.0",
     "axios": "^0.21.1",
     "babel-core": "6.26.0",
     "babel-loader": "6.4.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@edx/edx-proctoring": "^1.5.0",
     "@edx/frontend-component-cookie-policy-banner": "1.0.0",
     "@edx/paragon": "2.6.4",
-    "@edx/studio-frontend": "1.17.0",
+    "@edx/studio-frontend": "^1.19.1",
     "axios": "^0.21.1",
     "babel-core": "6.26.0",
     "babel-loader": "6.4.1",


### PR DESCRIPTION
## Description

The `@edx/studio-frontend package` is a requirement of edx-platform, with version `^1.17.0`, which basically mean “anything between 1.0.0 (included) and 2.0.0 (excluded)” (see: https://semver.npmjs.com/).

The [1.18.0](https://github.com/openedx/studio-frontend/releases/tag/v1.18.0) update to the `@edx/studio-frontend` npm package breaks the current asset collection flow causing the following assets listed in the Supporting Information section to be missing from the Open edX images.

This Pull Request hopes to solve this issue by pinning `@edx/studio-frontend` package to `1.17.0`. 

## Supporting information

The first version in which the dist/ folder was missing is 1.18.0: https://registry.npmjs.org/@edx/studio-frontend/-/studio-frontend-1.18.0.tgz Compare with 1.17.0 where the dist/ foldr was present: https://registry.npmjs.org/@edx/studio-frontend/-/studio-frontend-1.17.0.tgz

The following assets are missing:
- static/studio/common/css/vendor/common.min.css
- static/studio/common/css/vendor/courseOutlineHealthCheck.min.css
- static/studio/common/css/vendor/assets.min.css
- static/studio/common/js/vendor/runtime.min.js
- static/studio/common/js/vendor/common.min.js
- static/studio/common/js/vendor/courseOutlineHealthCheck.min.js
- static/studio/common/js/vendor/assets.min.js 

The discussion for this issue can be found here at the Tutor Discussion forum: https://discuss.overhang.io/t/missing-js-css-files-missing-from-openedx-docker-image-in-studio/2629/18

## Testing instructions

The missing assets can be checked by running:
```bash
find node_modules/@edx/studio-frontend/ -name "common*.css"
node_modules/@edx/studio-frontend/dist/common.min.js
```

Thank you @regisb for organizing this information.