### PR TITLE
fix: Disallow endorsements for replies to comments [BD-38] [INF-160]

### DIFF
--- a/lms/djangoapps/discussion/rest_api/permissions.py
+++ b/lms/djangoapps/discussion/rest_api/permissions.py
@@ -122,7 +122,7 @@ def get_editable_fields(cc_content: Union[Thread, Comment], context: Dict) -> Se
         "title": is_thread and (is_author or is_privileged),
         "group_id": is_thread and is_privileged and context["discussion_division_enabled"],
         "endorsed": (
-            is_comment and
+            (is_comment and cc_content.get("parent_id", None) is None) and
             (is_privileged or
              (_is_author(context["thread"], context) and context["thread"]["thread_type"] == "question"))
         ),

--- a/lms/djangoapps/discussion/rest_api/tests/test_api.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api.py
@@ -2244,8 +2244,17 @@ class CreateCommentTest(
             parent_id=parent_id
         )
         data = self.minimal_data.copy()
+        editable_fields = [
+            "abuse_flagged",
+            "anonymous",
+            "edit_reason_code",
+            "raw_body",
+            "voted",
+        ]
         if parent_id:
             data["parent_id"] = parent_id
+        else:
+            editable_fields.insert(3, "endorsed")
 
         _set_course_discussion_blackout(course=self.course, user_id=self.user.id)
         _assign_role_to_user(user=self.user, course_id=self.course.id, role=FORUM_ROLE_MODERATOR)
@@ -2271,14 +2280,7 @@ class CreateCommentTest(
             "voted": False,
             "vote_count": 0,
             "children": [],
-            "editable_fields": [
-                "abuse_flagged",
-                "anonymous",
-                "edit_reason_code",
-                "endorsed",
-                "raw_body",
-                "voted",
-            ],
+            "editable_fields": editable_fields,
             "child_count": 0,
             "can_delete": True,
             "anonymous": False,

--- a/lms/djangoapps/discussion/rest_api/tests/test_permissions.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_permissions.py
@@ -129,7 +129,7 @@ class GetEditableFieldsTest(ModuleStoreTestCase):
             expected |= {"anonymous_to_peers"}
         assert actual == expected
 
-    @ddt.data(*itertools.product(*[[True, False] for _ in range(5)], ["question", "discussion"]))
+    @ddt.data(*itertools.product(*[[True, False] for _ in range(6)], ["question", "discussion"]))
     @ddt.unpack
     def test_comment(
         self,
@@ -138,9 +138,14 @@ class GetEditableFieldsTest(ModuleStoreTestCase):
         is_privileged,
         allow_anonymous,
         allow_anonymous_to_peers,
+        has_parent,
         thread_type
     ):
-        comment = Comment(user_id="5" if is_author else "6", type="comment")
+        comment = Comment(
+            user_id="5" if is_author else "6",
+            type="comment",
+            parent_id="parent-id" if has_parent else None,
+        )
         context = _get_context(
             requester_id="5",
             is_requester_privileged=is_privileged,
@@ -154,7 +159,7 @@ class GetEditableFieldsTest(ModuleStoreTestCase):
             expected |= {"edit_reason_code"}
         if is_author or is_privileged:
             expected |= {"raw_body"}
-        if (is_thread_author and thread_type == "question") or is_privileged:
+        if not has_parent and ((is_thread_author and thread_type == "question") or is_privileged):
             expected |= {"endorsed"}
         if is_author and allow_anonymous:
             expected |= {"anonymous"}


### PR DESCRIPTION
## Description

Removes the endorsement action for comments that are nested.

## Supporting information

- https://openedx.atlassian.net/browse/INF-160
 
## Testing instructions

Use the discussions MFE and check that the endorsement action is no longer present for nested comments. 