### PR TITLE
BOM-3365: Remove python-slugify constraint & python transifex client

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -51,10 +51,6 @@ pymongo<3.11
 # python3-saml==1.10.0 version started breaking a11y tests
 python3-saml<1.10.0
 
-# transifex-client==0.14.2(latest) requires python-slugify<5.0.0 for Python 2.0 support.
-# This can be removed once transifex-client drops support for Python 2.0 and removes the required constraint.
-python-slugify<5.0.0
-
 # greater version has breaking changes and requires some migration steps.
 django-webpack-loader==0.7.0
 

--- a/requirements/edx-sandbox/py38.txt
+++ b/requirements/edx-sandbox/py38.txt
@@ -71,7 +71,7 @@ python-dateutil==2.4.0
     #   matplotlib
 random2==1.0.1
     # via -r requirements/edx-sandbox/py38.in
-regex==2022.3.15
+regex==2022.4.24
     # via nltk
 scipy==1.7.3
     # via

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -209,6 +209,7 @@ django==3.2.13
     #   django-wiki
     #   djangorestframework
     #   drf-jwt
+    #   drf-nested-routers
     #   drf-yasg
     #   edx-ace
     #   edx-api-doc-tools
@@ -383,8 +384,8 @@ djangorestframework==3.12.4
     #   blockstore
     #   django-config-models
     #   django-user-tasks
-    #   djangorestframework-expander
     #   drf-jwt
+    #   drf-nested-routers
     #   drf-yasg
     #   edx-api-doc-tools
     #   edx-completion
@@ -396,8 +397,6 @@ djangorestframework==3.12.4
     #   edx-submissions
     #   ora2
     #   super-csv
-djangorestframework-expander==0.2.3
-    # via blockstore
 djangorestframework-xml==2.0.0
     # via edx-enterprise
 docopt==0.6.2
@@ -410,6 +409,8 @@ done-xblock==2.0.4
     # via -r requirements/edx/base.in
 drf-jwt==1.19.2
     # via edx-drf-extensions
+drf-nested-routers==0.93.4
+    # via blockstore
 drf-yasg==1.20.0
     # via edx-api-doc-tools
 edx-ace==1.5.0
@@ -418,8 +419,11 @@ edx-api-doc-tools==1.6.0
     # via
     #   -r requirements/edx/base.in
     #   blockstore
+    #   edx-name-affirmation
 edx-auth-backends==4.1.0
-    # via -r requirements/edx/base.in
+    # via
+    #   -r requirements/edx/base.in
+    #   blockstore
 edx-braze-client==0.1.3
     # via -r requirements/edx/base.in
 edx-bulk-grades==1.0.0
@@ -698,11 +702,12 @@ multidict==6.0.2
     #   aiohttp
     #   yarl
 mysqlclient==2.1.0
-    # via -r requirements/edx/base.in
-newrelic==7.10.0.175
     # via
     #   -r requirements/edx/base.in
     #   blockstore
+newrelic==7.10.0.175
+    # via
+    #   -r requirements/edx/base.in
     #   edx-django-utils
 nltk==3.7
     # via
@@ -786,7 +791,7 @@ pycryptodomex==3.14.1
     #   edx-proctoring
     #   lti-consumer-xblock
     #   pyjwkest
-pygments==2.11.2
+pygments==2.12.0
     # via
     #   -r requirements/edx/base.in
     #   py2neo
@@ -807,7 +812,7 @@ pyjwt[crypto]==2.3.0
     #   social-auth-core
 pylatexenc==2.10
     # via olxcleaner
-pylti1p3==1.10.0
+pylti1p3==1.11.0
     # via -r requirements/edx/base.in
 pymongo==3.10.1
     # via
@@ -849,10 +854,8 @@ python-levenshtein==0.12.2
     # via -r requirements/edx/base.in
 python-memcached==1.59
     # via -r requirements/edx/paver.txt
-python-slugify==4.0.1
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   code-annotations
+python-slugify==6.1.1
+    # via code-annotations
 python-swiftclient==3.13.1
     # via ora2
 python3-openid==3.2.0 ; python_version >= "3"
@@ -898,7 +901,7 @@ recommender-xblock==2.0.1
     # via -r requirements/edx/base.in
 redis==4.2.2
     # via -r requirements/edx/base.in
-regex==2022.3.15
+regex==2022.4.24
     # via nltk
 requests==2.27.1
     # via

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -16,5 +16,5 @@ markupsafe==2.1.1
     # via jinja2
 pluggy==1.0.0
     # via diff-cover
-pygments==2.11.2
+pygments==2.12.0
     # via diff-cover

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -295,6 +295,7 @@ django==3.2.13
     #   django-wiki
     #   djangorestframework
     #   drf-jwt
+    #   drf-nested-routers
     #   drf-yasg
     #   edx-ace
     #   edx-api-doc-tools
@@ -369,7 +370,9 @@ django-crum==0.7.9
 django-debug-toolbar==3.2.4
     # via -r requirements/edx/development.in
 django-environ==0.8.1
-    # via blockstore
+    # via
+    #   -r requirements/edx/testing.txt
+    #   blockstore
 django-fernet-fields==0.6
     # via
     #   -r requirements/edx/testing.txt
@@ -481,8 +484,8 @@ djangorestframework==3.12.4
     #   blockstore
     #   django-config-models
     #   django-user-tasks
-    #   djangorestframework-expander
     #   drf-jwt
+    #   drf-nested-routers
     #   drf-yasg
     #   edx-api-doc-tools
     #   edx-completion
@@ -494,8 +497,6 @@ djangorestframework==3.12.4
     #   edx-submissions
     #   ora2
     #   super-csv
-djangorestframework-expander==0.2.3
-    # via blockstore
 djangorestframework-xml==2.0.0
     # via
     #   -r requirements/edx/testing.txt
@@ -517,6 +518,10 @@ drf-jwt==1.19.2
     # via
     #   -r requirements/edx/testing.txt
     #   edx-drf-extensions
+drf-nested-routers==0.93.4
+    # via
+    #   -r requirements/edx/testing.txt
+    #   blockstore
 drf-yasg==1.20.0
     # via
     #   -r requirements/edx/testing.txt
@@ -527,12 +532,13 @@ edx-api-doc-tools==1.6.0
     # via
     #   -r requirements/edx/testing.txt
     #   blockstore
+    #   edx-name-affirmation
 edx-auth-backends==4.1.0
-    # via -r requirements/edx/testing.txt
-edx-braze-client==0.1.3
     # via
     #   -r requirements/edx/testing.txt
     #   blockstore
+edx-braze-client==0.1.3
+    # via -r requirements/edx/testing.txt
 edx-bulk-grades==1.0.0
     # via
     #   -r requirements/edx/testing.txt
@@ -678,7 +684,7 @@ execnet==1.9.0
     #   pytest-xdist
 factory-boy==3.2.1
     # via -r requirements/edx/testing.txt
-faker==13.3.5
+faker==13.4.0
     # via
     #   -r requirements/edx/testing.txt
     #   factory-boy
@@ -721,14 +727,6 @@ future==0.18.2
     #   pyjwkest
 geoip2==4.5.0
     # via -r requirements/edx/testing.txt
-gitdb==4.0.9
-    # via
-    #   -r requirements/edx/testing.txt
-    #   gitpython
-gitpython==3.1.27
-    # via
-    #   -r requirements/edx/testing.txt
-    #   transifex-client
 glob2==0.7
     # via -r requirements/edx/testing.txt
 gunicorn==20.1.0
@@ -932,11 +930,12 @@ mypy==0.942
 mypy-extensions==0.4.3
     # via mypy
 mysqlclient==2.1.0
-    # via -r requirements/edx/testing.txt
-newrelic==7.10.0.175
     # via
     #   -r requirements/edx/testing.txt
     #   blockstore
+newrelic==7.10.0.175
+    # via
+    #   -r requirements/edx/testing.txt
     #   edx-django-utils
 nltk==3.7
     # via
@@ -1048,7 +1047,9 @@ py2neo==2021.2.3
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
 pyblake2==1.1.2
-    # via blockstore
+    # via
+    #   -r requirements/edx/testing.txt
+    #   blockstore
 pycodestyle==2.8.0
     # via -r requirements/edx/testing.txt
 pycountry==22.3.5
@@ -1067,7 +1068,7 @@ pydantic==1.9.0
     # via
     #   -r requirements/edx/testing.txt
     #   fastapi
-pygments==2.11.2
+pygments==2.12.0
     # via
     #   -r requirements/edx/testing.txt
     #   diff-cover
@@ -1115,7 +1116,7 @@ pylint-plugin-utils==0.7
     #   pylint-django
 pylint-pytest==0.3.0
     # via -r requirements/edx/testing.txt
-pylti1p3==1.10.0
+pylti1p3==1.11.0
     # via -r requirements/edx/testing.txt
 pymongo==3.10.1
     # via
@@ -1143,7 +1144,7 @@ pysrt==1.1.2
     # via
     #   -r requirements/edx/testing.txt
     #   edxval
-pytest==7.1.1
+pytest==7.1.2
     # via
     #   -r requirements/edx/testing.txt
     #   pylint-pytest
@@ -1195,12 +1196,10 @@ python-levenshtein==0.12.2
     # via -r requirements/edx/testing.txt
 python-memcached==1.59
     # via -r requirements/edx/testing.txt
-python-slugify==4.0.1
+python-slugify==6.1.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   code-annotations
-    #   transifex-client
 python-swiftclient==3.13.1
     # via
     #   -r requirements/edx/testing.txt
@@ -1251,7 +1250,7 @@ recommender-xblock==2.0.1
     # via -r requirements/edx/testing.txt
 redis==4.2.2
     # via -r requirements/edx/testing.txt
-regex==2022.3.15
+regex==2022.4.24
     # via
     #   -r requirements/edx/testing.txt
     #   nltk
@@ -1277,7 +1276,6 @@ requests==2.27.1
     #   social-auth-core
     #   sphinx
     #   tableauserverclient
-    #   transifex-client
 requests-oauthlib==1.3.1
     # via
     #   -r requirements/edx/testing.txt
@@ -1365,7 +1363,6 @@ six==1.16.0
     #   singledispatch
     #   sphinxcontrib-httpdomain
     #   tox
-    #   transifex-client
     #   virtualenv
 slumber==0.7.1
     # via
@@ -1373,10 +1370,6 @@ slumber==0.7.1
     #   edx-bulk-grades
     #   edx-enterprise
     #   edx-rest-api-client
-smmap==5.0.0
-    # via
-    #   -r requirements/edx/testing.txt
-    #   gitdb
 sniffio==1.2.0
     # via
     #   -r requirements/edx/testing.txt
@@ -1490,8 +1483,6 @@ tqdm==4.64.0
     # via
     #   -r requirements/edx/testing.txt
     #   nltk
-transifex-client==0.14.4
-    # via -r requirements/edx/testing.txt
 typing-extensions==4.2.0
     # via
     #   -r requirements/edx/testing.txt
@@ -1520,7 +1511,6 @@ urllib3==1.26.9
     #   py2neo
     #   requests
     #   selenium
-    #   transifex-client
 user-util==1.0.0
     # via -r requirements/edx/testing.txt
 uvicorn==0.17.6

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -44,14 +44,12 @@ packaging==21.3
     # via sphinx
 pbr==5.8.1
     # via stevedore
-pygments==2.11.2
+pygments==2.12.0
     # via sphinx
 pyparsing==3.0.8
     # via packaging
-python-slugify==4.0.1
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   code-annotations
+python-slugify==6.1.1
+    # via code-annotations
 pytz==2022.1
     # via babel
 pyyaml==6.0

--- a/requirements/edx/testing.in
+++ b/requirements/edx/testing.in
@@ -45,8 +45,6 @@ singledispatch            # Backport of functools.singledispatch from Python 3.4
 testfixtures              # Provides a LogCapture utility used by several tests
 tox                       # virtualenv management for tests
 tox-battery               # Makes tox aware of requirements file changes
-transifex-client          # Command-line interface for the Transifex localization service
 unidiff                   # Required by coverage_pytest_plugin
 pylint-pytest==0.3.0      # A Pylint plugin to suppress pytest-related false positives.
-pact-python               # Library for contract testing 
-
+pact-python               # Library for contract testing

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -282,6 +282,7 @@ distlib==0.3.4
     #   django-wiki
     #   djangorestframework
     #   drf-jwt
+    #   drf-nested-routers
     #   drf-yasg
     #   edx-ace
     #   edx-api-doc-tools
@@ -468,8 +469,8 @@ djangorestframework==3.12.4
     #   blockstore
     #   django-config-models
     #   django-user-tasks
-    #   djangorestframework-expander
     #   drf-jwt
+    #   drf-nested-routers
     #   drf-yasg
     #   edx-api-doc-tools
     #   edx-completion
@@ -481,10 +482,6 @@ djangorestframework==3.12.4
     #   edx-submissions
     #   ora2
     #   super-csv
-djangorestframework-expander==0.2.3
-    # via
-    #   -r requirements/edx/base.txt
-    #   blockstore
 djangorestframework-xml==2.0.0
     # via
     #   -r requirements/edx/base.txt
@@ -504,6 +501,10 @@ drf-jwt==1.19.2
     # via
     #   -r requirements/edx/base.txt
     #   edx-drf-extensions
+drf-nested-routers==0.93.4
+    # via
+    #   -r requirements/edx/base.txt
+    #   blockstore
 drf-yasg==1.20.0
     # via
     #   -r requirements/edx/base.txt
@@ -514,12 +515,13 @@ edx-api-doc-tools==1.6.0
     # via
     #   -r requirements/edx/base.txt
     #   blockstore
+    #   edx-name-affirmation
 edx-auth-backends==4.1.0
-    # via -r requirements/edx/base.txt
-edx-braze-client==0.1.3
     # via
     #   -r requirements/edx/base.txt
     #   blockstore
+edx-braze-client==0.1.3
+    # via -r requirements/edx/base.txt
 edx-bulk-grades==1.0.0
     # via
     #   -r requirements/edx/base.txt
@@ -662,7 +664,7 @@ execnet==1.9.0
     # via pytest-xdist
 factory-boy==3.2.1
     # via -r requirements/edx/testing.in
-faker==13.3.5
+faker==13.4.0
     # via factory-boy
 fastapi==0.75.2
     # via pact-python
@@ -700,10 +702,6 @@ future==0.18.2
     #   pyjwkest
 geoip2==4.5.0
     # via -r requirements/edx/base.txt
-gitdb==4.0.9
-    # via gitpython
-gitpython==3.1.27
-    # via transifex-client
 glob2==0.7
     # via -r requirements/edx/base.txt
 gunicorn==20.1.0
@@ -883,11 +881,12 @@ multidict==6.0.2
     #   aiohttp
     #   yarl
 mysqlclient==2.1.0
-    # via -r requirements/edx/base.txt
-newrelic==7.10.0.175
     # via
     #   -r requirements/edx/base.txt
     #   blockstore
+newrelic==7.10.0.175
+    # via
+    #   -r requirements/edx/base.txt
     #   edx-django-utils
 nltk==3.7
     # via
@@ -1010,7 +1009,7 @@ pycryptodomex==3.14.1
     #   pyjwkest
 pydantic==1.9.0
     # via fastapi
-pygments==2.11.2
+pygments==2.12.0
     # via
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/coverage.txt
@@ -1052,7 +1051,7 @@ pylint-plugin-utils==0.7
     #   pylint-django
 pylint-pytest==0.3.0
     # via -r requirements/edx/testing.in
-pylti1p3==1.10.0
+pylti1p3==1.11.0
     # via -r requirements/edx/base.txt
 pymongo==3.10.1
     # via
@@ -1078,7 +1077,7 @@ pysrt==1.1.2
     # via
     #   -r requirements/edx/base.txt
     #   edxval
-pytest==7.1.1
+pytest==7.1.2
     # via
     #   -r requirements/edx/testing.in
     #   pylint-pytest
@@ -1128,12 +1127,10 @@ python-levenshtein==0.12.2
     # via -r requirements/edx/base.txt
 python-memcached==1.59
     # via -r requirements/edx/base.txt
-python-slugify==4.0.1
+python-slugify==6.1.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   code-annotations
-    #   transifex-client
 python-swiftclient==3.13.1
     # via
     #   -r requirements/edx/base.txt
@@ -1181,7 +1178,7 @@ recommender-xblock==2.0.1
     # via -r requirements/edx/base.txt
 redis==4.2.2
     # via -r requirements/edx/base.txt
-regex==2022.3.15
+regex==2022.4.24
     # via
     #   -r requirements/edx/base.txt
     #   nltk
@@ -1206,7 +1203,6 @@ requests==2.27.1
     #   slumber
     #   social-auth-core
     #   tableauserverclient
-    #   transifex-client
 requests-oauthlib==1.3.1
     # via
     #   -r requirements/edx/base.txt
@@ -1292,7 +1288,6 @@ six==1.16.0
     #   python-swiftclient
     #   singledispatch
     #   tox
-    #   transifex-client
     #   virtualenv
 slumber==0.7.1
     # via
@@ -1300,8 +1295,6 @@ slumber==0.7.1
     #   edx-bulk-grades
     #   edx-enterprise
     #   edx-rest-api-client
-smmap==5.0.0
-    # via gitdb
 sniffio==1.2.0
     # via anyio
 social-auth-app-django==5.0.0
@@ -1382,8 +1375,6 @@ tqdm==4.64.0
     # via
     #   -r requirements/edx/base.txt
     #   nltk
-transifex-client==0.14.4
-    # via -r requirements/edx/testing.in
 typing-extensions==4.2.0
     # via
     #   -r requirements/edx/base.txt
@@ -1411,7 +1402,6 @@ urllib3==1.26.9
     #   py2neo
     #   requests
     #   selenium
-    #   transifex-client
 user-util==1.0.0
     # via -r requirements/edx/base.txt
 uvicorn==0.17.6


### PR DESCRIPTION
### Description 
- Removed `python-slugify` constraint. 
- Removed `transifex-client` as a base requirement since we've moved to use the latest transifex `Go Client` instead.