### PR TITLE
feat: introduce new setting to control IDV requirements for certificates

### DIFF
--- a/lms/djangoapps/certificates/management/commands/tests/test_regenerate_noidv_cert.py
+++ b/lms/djangoapps/certificates/management/commands/tests/test_regenerate_noidv_cert.py
@@ -21,9 +21,9 @@ PASSING_GRADE_METHOD = 'lms.djangoapps.certificates.generation_handler._is_passi
 WEB_CERTS_METHOD = 'lms.djangoapps.certificates.generation_handler.has_html_certificates_enabled'
 
 
-# base setup is unverified users, integrity signature turned on,
+# base setup is unverified users, Enable certificates IDV requirements turned off,
 # and normal passing grade certificates for convenience
-@mock.patch.dict(settings.FEATURES, ENABLE_INTEGRITY_SIGNATURE=True)
+@mock.patch.dict(settings.FEATURES, ENABLE_CERTIFICATES_IDV_REQUIREMENT=False)
 @mock.patch(ID_VERIFIED_METHOD, mock.Mock(return_value=False))
 @mock.patch(PASSING_GRADE_METHOD, mock.Mock(return_value=True))
 @mock.patch(WEB_CERTS_METHOD, mock.Mock(return_value=True))

--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -84,7 +84,7 @@ def get_certificate_description(mode, certificate_type, platform_name, course_ke
                                          "{platform_name} and has completed all of the required tasks for this course "
                                          "under its guidelines. ").format(cert_type=certificate_type,
                                                                           platform_name=platform_name)
-        if not settings.FEATURES.get('ENABLE_INTEGRITY_SIGNATURE'):
+        if settings.FEATURES.get('ENABLE_CERTIFICATES_IDV_REQUIREMENT'):
             certificate_type_description += _("A {cert_type} certificate also indicates that the "
                                               "identity of the learner has been checked and "
                                               "is valid.").format(cert_type=certificate_type)
@@ -252,7 +252,7 @@ def _update_course_context(request, context, course, platform_name):
     context['accomplishment_copy_course_name'] = accomplishment_copy_course_name
     course_number = course.display_coursenumber if course.display_coursenumber else course.number
     context['course_number'] = course_number
-    context['is_integrity_signature_enabled_for_course'] = settings.FEATURES.get('ENABLE_INTEGRITY_SIGNATURE')
+    context['idv_enabled_for_certificates'] = settings.FEATURES.get('ENABLE_CERTIFICATES_IDV_REQUIREMENT')
     if context['organization_long_name']:
         # Translators:  This text represents the description of course
         context['accomplishment_copy_course_description'] = _('a course of study offered by {partner_short_name}, '

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1159,7 +1159,7 @@ def _downloadable_certificate_message(course, cert_downloadable_status):  # lint
 
 
 def _missing_required_verification(student, enrollment_mode):
-    return not settings.FEATURES.get('ENABLE_INTEGRITY_SIGNATURE') and (
+    return settings.FEATURES.get('ENABLE_CERTIFICATES_IDV_REQUIREMENT') and (
         enrollment_mode in CourseMode.VERIFIED_MODES and not IDVerificationService.user_is_verified(student)
     )
 

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -2080,7 +2080,7 @@ class TestCertificateGeneration(InstructorTaskModuleTestCase):
             'failed': 0,
             'skipped': 2
         }
-        with self.assertNumQueries(76):
+        with self.assertNumQueries(61):
             self.assertCertificatesGenerated(task_input, expected_results)
 
     @ddt.data(

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -965,8 +965,7 @@ FEATURES = {
     # .. toggle_name: FEATURES['ENABLE_INTEGRITY_SIGNATURE']
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
-    # .. toggle_description: Whether to replace ID verification course/certificate requirement
-    # with an in-course Honor Code agreement
+    # .. toggle_description: Whether to display honor code agreement for learners before their first grade assignment
     # (https://github.com/edx/edx-name-affirmation)
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2022-02-15
@@ -1010,6 +1009,16 @@ FEATURES = {
     #   in the LMS and CMS.
     # .. toggle_tickets: 'https://github.com/open-craft/edx-platform/pull/429'
     'DISABLE_UNENROLLMENT': False,
+
+    # .. toggle_name: FEATURES['ENABLE_CERTIFICATES_IDV_REQUIREMENT']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Whether to enforce ID Verification requirements for couse certificates generation
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2022-04-26
+    # .. toggle_target_removal_date: None
+    # .. toggle_tickets: 'https://openedx.atlassian.net/browse/MST-1458'
+    'ENABLE_CERTIFICATES_IDV_REQUIREMENT': False,
 }
 
 # Specifies extra XBlock fields that should available when requested via the Course Blocks API


### PR DESCRIPTION
## Description
[MST-1458](https://openedx.atlassian.net/browse/MST-1458)
Introduce a new Features Settings value `ENABLE_CERTIFICATES_IDV_REQUIREMENT` to be used for the course certificates business logic. It has a `False` value by default. Please note that when `ENABLE_INTEGRITY_SIGNATURE` is `True`, the setting `ENABLE_CERTIFICATES_IDV_REQUIREMENT` should be `False`. Although, for a new edX instance, the Integrity Signature functionality should be independent from Cert generation IDV requirements.

This is currently a draft PR. There are lots of existing unit tests I need to fix. Feel free to review nonetheless.