### PR TITLE
Improvements to the warnings report.

### DIFF
--- a/openedx/core/process_warnings.py
+++ b/openedx/core/process_warnings.py
@@ -10,6 +10,7 @@ import json
 import os
 import re
 from collections import Counter
+from xml.sax.saxutils import escape
 
 from write_to_html import HtmlOutlineWriter  # noqa pylint: disable=import-error,useless-suppression
 
@@ -191,7 +192,7 @@ def write_html_report(warnings_data, html_path):
         for category, group_in_category, category_count in category_sorted_by_count:
             # xss-lint: disable=python-wrap-html
             html = '<span class="count">{category}, count: {count}</span> '.format(
-                category=category, count=category_count
+                category=escape(category), count=category_count
             )
             html_writer.start_section(html, klass="category")
             locations_sorted_by_count = group_and_sort_by_sumof(
@@ -205,7 +206,7 @@ def write_html_report(warnings_data, html_path):
             ) in locations_sorted_by_count:
                 # xss-lint: disable=python-wrap-html
                 html = '<span class="count">{location}, count: {count}</span> '.format(
-                    location=location, count=location_count
+                    location=escape(location), count=location_count
                 )
                 html_writer.start_section(html, klass="location")
                 message_group_sorted_by_count = group_and_sort_by_sumof(
@@ -218,7 +219,7 @@ def write_html_report(warnings_data, html_path):
                 ) in message_group_sorted_by_count:
                     # xss-lint: disable=python-wrap-html
                     html = '<span class="count">{warning_text}, count: {count}</span> '.format(
-                        warning_text=message, count=message_count
+                        warning_text=escape(message), count=message_count
                     )
                     html_writer.start_section(html, klass="warning_text")
                     # warnings_object[location][warning_text] is a list


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Improvements to the warnings report:

1. HTML is properly escaped so that data isn't lost from the message (class objects for example).
2. Data in the messages are scrubbed so that categorization of messages works better.

Before:
```
unclosed file <_io.FileIO name='/runner/_work/edx-platform/edx-platform/test_root/uploads/test.csv' mode='rb' closefd=True>, count: 2
unclosed file <_io.FileIO name='common/test/data//badges/unbalanced.png' mode='rb' closefd=True>, count: 2
unclosed , count: 1
unclosed , count: 1
unclosed , count: 1
unclosed file <_io.BufferedReader name='/runner/_work/edx-platform/edx-platform/test_root/uploads/block-v1:org+course+125a0992-9aa3-4bc2-a9cf-6ab1d971c306+type@course+block@course/2022-04-27-094236-186399'>, count: 1
unclosed file <_io.BufferedReader name='/runner/_work/edx-platform/edx-platform/test_root/uploads/block-v1:org+course+125a0992-9aa3-4bc2-a9cf-6ab1d971c306+type@course+block@course/2022-04-27-094236-188987'>, count: 1
unclosed file <_io.BufferedReader name='/runner/_work/edx-platform/edx-platform/test_root/uploads/block-v1:org+course+181d109b-27f3-46aa-abc5-72a360f0a0a1+type@course+block@course/2022-04-27-094140-394818'>, count: 1
unclosed file <_io.BufferedReader name='/runner/_work/edx-platform/edx-platform/test_root/uploads/block-v1:org+course+181d109b-27f3-46aa-abc5-72a360f0a0a1+type@course+block@course/2022-04-27-094140-397743'>, count: 1 
```

After:
```
unclosed file <_io.FileIO name='/runner/_work/edx-platform/edx-platform/test_root/uploads/block-v1:org+course+GUID+type@course+block@course/#-#-#-#-#' mode='rb' closefd=True>, count: 30
unclosed file <_io.BufferedReader name='/runner/_work/edx-platform/edx-platform/test_root/uploads/block-v1:org+course+GUID+type@course+block@course/#-#-#-#-#'>, count: 11
unclosed file <_io.FileIO name='/runner/_work/edx-platform/edx-platform/test_root/uploads/video-transcripts/SHA.sjson' mode='rb' closefd=True>, count: 6
unclosed file <_io.BufferedReader name='/runner/_work/edx-platform/edx-platform/test_root/uploads/test_TMP.csv'>, count: 3
unclosed file <_io.FileIO name='/runner/_work/edx-platform/edx-platform/test_root/uploads/course_complete_badges/test_TMP.png' mode='rb' closefd=True>, count: 3
unclosed file <_io.FileIO name='/runner/_work/edx-platform/edx-platform/test_root/uploads/test.csv' mode='rb' closefd=True>, count: 2
unclosed file <_io.FileIO name='/runner/_work/edx-platform/edx-platform/test_root/uploads/test_TMP.csv' mode='rb' closefd=True>, count: 2
unclosed file <_io.FileIO name='/runner/_work/edx-platform/edx-platform/test_root/uploads/video-transcripts/SHA.srt' mode='rb' closefd=True>, count: 2
unclosed file <_io.FileIO name='common/test/data//badges/good.png' mode='rb' closefd=True>, count: 2 
```

