### PR TITLE
[BD-13][BB-6145] Move the rebind_noauth_module_to_user from ModuleSystem argument to service

### DIFF
--- a/common/lib/xmodule/xmodule/lti_2_util.py
+++ b/common/lib/xmodule/xmodule/lti_2_util.py
@@ -79,7 +79,7 @@ class LTI20BlockMixin:
         except LTIError:
             return Response(status=401)  # Unauthorized in this case.  401 is right
 
-        real_user = self.system.service(self, 'user').get_user_by_anonymous_id(anon_id)
+        real_user = self.runtime.service(self, 'user').get_user_by_anonymous_id(anon_id)
         if not real_user:  # that means we can't save to database, as we do not have real user id.
             msg = f"[LTI]: Real user not found against anon_id: {anon_id}"
             log.info(msg)
@@ -171,7 +171,7 @@ class LTI20BlockMixin:
             "@context": "http://purl.imsglobal.org/ctx/lis/v2/Result",
             "@type": "Result"
         }
-        self.system.rebind_noauth_module_to_user(self, real_user)
+        self.runtime.service(self, 'rebind_user').rebind_noauth_module_to_user(self, real_user)
         if self.module_score is None:  # In this case, no score has been ever set
             return Response(json.dumps(base_json_obj).encode('utf-8'), content_type=LTI_2_0_JSON_CONTENT_TYPE)
 
@@ -254,10 +254,10 @@ class LTI20BlockMixin:
         else:
             scaled_score = None
 
-        self.system.rebind_noauth_module_to_user(self, user)
+        self.runtime.service(self, 'rebind_user').rebind_noauth_module_to_user(self, user)
 
         # have to publish for the progress page...
-        self.system.publish(
+        self.runtime.publish(
             self,
             'grade',
             {

--- a/common/lib/xmodule/xmodule/lti_module.py
+++ b/common/lib/xmodule/xmodule/lti_module.py
@@ -275,6 +275,7 @@ class LTIFields:
 @XBlock.needs("i18n")
 @XBlock.needs("mako")
 @XBlock.needs("user")
+@XBlock.needs("rebind_user")
 class LTIBlock(
     LTIFields,
     LTI20BlockMixin,

--- a/common/lib/xmodule/xmodule/tests/test_lti_unit.py
+++ b/common/lib/xmodule/xmodule/tests/test_lti_unit.py
@@ -63,7 +63,7 @@ class LTIBlockTest(TestCase):
             """)
         self.system = get_test_system()
         self.system.publish = Mock()
-        self.system.rebind_noauth_module_to_user = Mock()
+        self.system._services['rebind_user'] = Mock()  # pylint: disable=protected-access
 
         self.xmodule = LTIBlock(
             self.system,

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -1634,6 +1634,22 @@ class ModuleSystemShim:
         from django.conf import settings
         return settings.LMS_BASE
 
+    @property
+    def rebind_noauth_module_to_user(self):
+        """
+        A function that was used to bind modules initialized by AnonymousUsers to real users. Mainly used
+        by the LTI Module to connect the right users with the requests from LTI tools.
+
+        Deprecated in favour of the "rebind_user" service.
+        """
+        warnings.warn(
+            "rebind_noauth_module_to_user is deprecated. Please use the 'rebind_user' service instead.",
+            DeprecationWarning, stacklevel=3
+        )
+        rebind_user_service = self._services.get('rebind_user')
+        if rebind_user_service:
+            return partial(rebind_user_service.rebind_noauth_module_to_user)
+
 
 class ModuleSystem(MetricsMixin, ConfigurableFragmentWrapper, ModuleSystemShim, Runtime):
     """
@@ -1658,7 +1674,6 @@ class ModuleSystem(MetricsMixin, ConfigurableFragmentWrapper, ModuleSystemShim, 
         course_id=None,
         error_descriptor_class=None,
         field_data=None,
-        rebind_noauth_module_to_user=None,
         **kwargs,
     ):
         """
@@ -1684,9 +1699,6 @@ class ModuleSystem(MetricsMixin, ConfigurableFragmentWrapper, ModuleSystemShim, 
         error_descriptor_class - The class to use to render XModules with errors
 
         field_data - the `FieldData` to use for backing XBlock storage.
-
-        rebind_noauth_module_to_user - rebinds module bound to AnonymousUser to a real user...used in LTI
-           modules, which have an anonymous handler, to set legitimate users' data
         """
 
         # Usage_store is unused, and field_data is often supplanted with an
@@ -1706,7 +1718,6 @@ class ModuleSystem(MetricsMixin, ConfigurableFragmentWrapper, ModuleSystemShim, 
         self.xmodule_instance = None
 
         self.descriptor_runtime = descriptor_runtime
-        self.rebind_noauth_module_to_user = rebind_noauth_module_to_user
 
     def get(self, attr):
         """	provide uniform access to attributes (like etree)."""

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -45,6 +45,7 @@ from xmodule.exceptions import NotFoundError, ProcessingError
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
 from xmodule.util.sandboxing import SandboxService
+from xmodule.services import RebindUserService
 from common.djangoapps.static_replace.services import ReplaceURLService
 from common.djangoapps.static_replace.wrapper import replace_urls_wrapper
 from common.djangoapps.xblock_django.constants import ATTR_KEY_USER_ID
@@ -63,7 +64,6 @@ from lms.djangoapps.courseware.services import UserStateService
 from lms.djangoapps.grades.api import GradesUtilService
 from lms.djangoapps.grades.api import signals as grades_signals
 from lms.djangoapps.lms_xblock.field_data import LmsFieldData
-from lms.djangoapps.lms_xblock.models import XBlockAsidesConfig
 from lms.djangoapps.lms_xblock.runtime import LmsModuleSystem
 from lms.djangoapps.verify_student.services import XBlockVerificationService
 from openedx.core.djangoapps.bookmarks.services import BookmarksService
@@ -483,12 +483,12 @@ def get_module_system_for_user(
             student_data=student_data,
             course_id=course_id,
             track_function=track_function,
+            request_token=request_token,
             position=position,
             wrap_xmodule_display=wrap_xmodule_display,
             grade_bucket_type=grade_bucket_type,
             static_asset_path=static_asset_path,
             user_location=user_location,
-            request_token=request_token,
             course=course,
             will_recheck_access=will_recheck_access,
         )
@@ -608,65 +608,20 @@ def get_module_system_for_user(
                     completion=1.0,
                 )
 
-    def rebind_noauth_module_to_user(module, real_user):
-        """
-        A function that allows a module to get re-bound to a real user if it was previously bound to an AnonymousUser.
-
-        Will only work within a module bound to an AnonymousUser, e.g. one that's instantiated by the noauth_handler.
-
-        Arguments:
-            module (any xblock type):  the module to rebind
-            real_user (django.contrib.auth.models.User):  the user to bind to
-
-        Returns:
-            nothing (but the side effect is that module is re-bound to real_user)
-        """
-        if user.is_authenticated:
-            err_msg = ("rebind_noauth_module_to_user can only be called from a module bound to "
-                       "an anonymous user")
-            log.error(err_msg)
-            raise LmsModuleRenderError(err_msg)
-
-        field_data_cache_real_user = FieldDataCache.cache_for_descriptor_descendents(
-            course_id,
-            real_user,
-            module,
-            asides=XBlockAsidesConfig.possible_asides(),
-        )
-        student_data_real_user = KvsFieldData(DjangoKeyValueStore(field_data_cache_real_user))
-
-        (inner_system, inner_student_data) = get_module_system_for_user(
-            user=real_user,
-            student_data=student_data_real_user,  # These have implicit user bindings, rest of args considered not to
-            descriptor=module,
-            course_id=course_id,
-            track_function=track_function,
-            position=position,
-            wrap_xmodule_display=wrap_xmodule_display,
-            grade_bucket_type=grade_bucket_type,
-            static_asset_path=static_asset_path,
-            user_location=user_location,
-            request_token=request_token,
-            course=course,
-            will_recheck_access=will_recheck_access,
-        )
-
-        module.bind_for_student(
-            inner_system,
-            real_user.id,
-            [
-                partial(DateLookupFieldData, course_id=course_id, user=user),
-                partial(OverrideFieldData.wrap, real_user, course),
-                partial(LmsFieldData, student_data=inner_student_data),
-            ],
-        )
-
-        module.scope_ids = (
-            module.scope_ids._replace(user_id=real_user.id)
-        )
-        # now bind the module to the new ModuleSystem instance and vice-versa
-        module.runtime = inner_system
-        inner_system.xmodule_instance = module
+    # Rebind module service to deal with noauth modules getting attached to users
+    rebind_user_service = RebindUserService(
+        user,
+        course_id,
+        get_module_system_for_user,
+        track_function=track_function,
+        position=position,
+        wrap_xmodule_display=wrap_xmodule_display,
+        grade_bucket_type=grade_bucket_type,
+        static_asset_path=static_asset_path,
+        user_location=user_location,
+        request_token=request_token,
+        will_recheck_access=will_recheck_access,
+    )
 
     # Build a list of wrapping functions that will be applied in order
     # to the Fragment content coming out of the xblocks that are about to be rendered.
@@ -751,10 +706,10 @@ def get_module_system_for_user(
             'cache': CacheService(cache),
             'sandbox': SandboxService(contentstore=contentstore, course_id=course_id),
             'xqueue': xqueue_service,
-            'replace_urls': replace_url_service
+            'replace_urls': replace_url_service,
+            'rebind_user': rebind_user_service,
         },
         descriptor_runtime=descriptor._runtime,  # pylint: disable=protected-access
-        rebind_noauth_module_to_user=rebind_noauth_module_to_user,
         request_token=request_token,
     )
 

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -55,6 +55,7 @@ from xmodule.modulestore.tests.django_utils import (
 )
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, ToyCourseFactory, check_mongo_calls  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.test_asides import AsideTestType  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.services import RebindUserServiceError
 from xmodule.video_module import VideoBlock  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.x_module import STUDENT_VIEW, CombinedSystem  # lint-amnesty, pylint: disable=wrong-import-order
 from common.djangoapps import static_replace
@@ -2175,10 +2176,10 @@ class TestRebindModule(TestSubmittingProblems):
         user2 = UserFactory()
         user2.id = 2
         with self.assertRaisesRegex(
-            render.LmsModuleRenderError,
+            RebindUserServiceError,
             "rebind_noauth_module_to_user can only be called from a module bound to an anonymous user"
         ):
-            assert module.system.rebind_noauth_module_to_user(module, user2)
+            assert module.runtime.service(module, 'rebind_user').rebind_noauth_module_to_user(module, user2)
 
     def test_rebind_noauth_module_to_user_anonymous(self):
         """
@@ -2188,7 +2189,7 @@ class TestRebindModule(TestSubmittingProblems):
         module = self.get_module_for_user(self.anon_user)
         user2 = UserFactory()
         user2.id = 2
-        module.system.rebind_noauth_module_to_user(module, user2)
+        module.runtime.service(module, 'rebind_user').rebind_noauth_module_to_user(module, user2)
         assert module
         assert module.system.anonymous_student_id == anonymous_id_for_user(user2, self.course.id)
         assert module.scope_ids.user_id == user2.id


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This removes the `rebind_noauth_module_to_user` argument from the `ModuleSystem` constructor and moves it to a separate service called "rebinder" in the class `RebindModuleService`. This is used in the LTI module to bind calls received by its noauth endpoint to bind the module the real_user.

The original function is defined as a local function and calls its parent function recursively to perform rebinding. Due to the heavy dependency of local variables, this new service is defined in the same module to minimize imports.

## Supporting information

* OpenCraft ticket - https://tasks.opencraft.com/browse/BB-6145

## Testing instructions

The changes primarily impact the LTI 2.0 JSON endpoint handlers in `common/lib/xmodule/xmodule/lti_2_util.py` (lines 173 and 256). We will test PUT handler to verify that the module rebinding is working as expected and the anonymous ID resolves into the correct user_id when updating the scores from external LTI tools.

1. Checkout to the `master` branch of `edx-platform` Setup a test course in the dev environment of choice.
2. Go to **Advanced Settings** and add `"lti"` to the **Advanced Modules List**. (Note: this is not the current `lti_consumer` module, this is the older `lti` module)
3. Scroll down to the **LTI Passports** and add `"saltire:consumer_key:secret"` to it. We will use the Saltire testing tool to get the various values for testing.
4. **Save** and go to the course editing page
5. Add a new Unit to the course
6. Select **Advanced** block type and select the **LTI** block to add an LTI XBlock
7. Click **Edit** on the LTI Block and set the following values and save the Block
    * **LTI ID**: `saltire`
    * **LTI URL**: `https://saltire.lti.app/tool`
    * **Open in New Page**: `False`
    * **Scored**: `True`
8. In the course overview, select the Settings button for the subsection with the unit and mark it as **Graded** (eg., Homework)
8. Publish the course and open the course as a student in the LMS
9. Expand the **Message Parameters** section in the Saltire Iframe and copy the `user_id` value. eg., `e449db316ca1652a94487273c2e9f042`
10. In a new tab open the URL `http://<your-domain>/courses/<your-course-id>/lti_rest_endpoints/`. eg., `http://localhost:18000/courses/course-v1:UNIV+CS101+2022_T2/lti_rest_endpoints/`
11. Note down the **lti_2_0_result_service_json_endpoint** URL. We will use this URL and the username later.
12. Now open the course as a staff/admin and navigate to **Instructor** -> **Student Admin** -> **View Gradebook**. Ideally the student user should be listed with no scores for the homework.

The next steps involve running a Python script to make OAuth requests. You can achieve the same with any API client which supports OAuth 1.0.

1. Setup a virtual environment and pip install [requests-oauthlib](https://github.com/requests/requests-oauthlib)
2. Create a Python file (`test.py`) with the following contents and fill in the `REST_URL` and `USER_ID` values we noted previously
```py
# test.py
# Test script to make a OAuth signed PUT request to update the homework score via LTI 2.0 endpoint
import json

from requests_oauthlib import OAuth1Session
from oauthlib import oauth1

REST_URL = "<url-copied-from-the-rest-endpoints>"
USER_ID = "<user-id-copied-from-Saltire-ifram>"

url = f"{REST_URL}{USER_ID}"
lms = OAuth1Session('client_key', client_secret='secret', signature_method=oauth1.SIGNATURE_HMAC_SHA1, force_include_body=True)

score = {
    "@context" : "http://purl.imsglobal.org/ctx/lis/v2/Result",
    "@type" : "Result",
    "resultScore" : 0.9,
    "comment" : "This is exceptional work."
}

res = lms.put(url, data=json.dumps(score), headers={'Content-Type': 'application/vnd.ims.lis.v2.result+json'})

print(res.status_code)
```
3. Now when you run `python test.py`, it should print `200` and exit indicating the PUT request with a `resultScore` of successful. You can verify the same in the LMS logs and even notice the anonymous id getting translated into LMS's internal numerical ID in celery task logs.
4. Refresh the gradebook to verify that the homework now has a score of `90` for the student
5. Change the values (range 0.0-1.0) for `resultScore` to verify the scores are updated.

#### Testing the PR doesn't break module rebinding

1. Checkout the `edx-platform` to the PR branch: `open-craft:tecoholic/BB-6145-deprecate-rebind-noauth-module-to-user`
2. Restart the LMS service to ensure PR changes are loaded
3. Change the `resultScore` value and rerun the test script. 
4. Verify the changes are reflected in the "Gradebook" and the requests are returning 200 without any errors. Additionally, see that the celery tasks are getting the correct user_id values in the logs.

## Deadline

"None"