### PR TITLE
fix: edx-enterprise-3.46.0 | fix redirect_if_blocked signature

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -25,7 +25,7 @@ django-storages<1.9
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==3.44.4
+edx-enterprise==3.46.0
 
 # Newer versions need a more recent version of python-dateutil
 freezegun==0.3.12

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -470,7 +470,7 @@ edx-drf-extensions==8.0.1
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.44.4
+edx-enterprise==3.46.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -583,7 +583,7 @@ edx-drf-extensions==8.0.1
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.44.4
+edx-enterprise==3.46.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -566,7 +566,7 @@ edx-drf-extensions==8.0.1
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.44.4
+edx-enterprise==3.46.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
https://github.com/openedx/edx-enterprise/pull/1544
Make the signature in edx-enterprise match and use the same signature that
openedx.core.djangoapps.embargo.redirect_if_blocked() now uses.