### PR TITLE
feat: add table on FA form to show already applied applications

### DIFF
--- a/lms/djangoapps/courseware/utils.py
+++ b/lms/djangoapps/courseware/utils.py
@@ -167,8 +167,9 @@ def get_financial_assistance_application_status(user_id, course_id):
     if response.status_code == status.HTTP_200_OK:
         return True, response.json()
     elif response.status_code in (status.HTTP_400_BAD_REQUEST, status.HTTP_404_NOT_FOUND):
-        log.error(response.json().get('message'))
-        return False, response.json().get('message')
+        error_message = response.json().get('message')
+        log.error(error_message)
+        return False, error_message
     else:
         log.error('%s %s', UNEXPECTED_ERROR_APPLICATION_STATUS, response.content)
         return False, UNEXPECTED_ERROR_APPLICATION_STATUS

--- a/lms/djangoapps/courseware/utils.py
+++ b/lms/djangoapps/courseware/utils.py
@@ -167,6 +167,7 @@ def get_financial_assistance_application_status(user_id, course_id):
     if response.status_code == status.HTTP_200_OK:
         return True, response.json()
     elif response.status_code in (status.HTTP_400_BAD_REQUEST, status.HTTP_404_NOT_FOUND):
+        log.error(response.json().get('message'))
         return False, response.json().get('message')
     else:
         log.error('%s %s', UNEXPECTED_ERROR_APPLICATION_STATUS, response.content)

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -2054,15 +2054,14 @@ def financial_assistance_form(request, course_id=None):
         submit_url = 'submit_financial_assistance_request_v2'
         has_already_applied_applications, applications_status_response = \
             get_financial_assistance_application_status(request.user.id, course_id)
-        if not has_already_applied_applications:
-            log.error(applications_status_response)
-            applications_status_response = None
-        else:
+        if has_already_applied_applications:
             has_one_accepted_application = next((
                 application for application in applications_status_response if application.get('status') == 'ACCEPTED'
             ), None)
-            if has_one_accepted_application:
-                hide_form = True
+            hide_form = bool(has_one_accepted_application)
+        else:
+            log.error(applications_status_response)
+            applications_status_response = None
     else:
         submit_url = 'submit_financial_assistance_request'
 

--- a/lms/static/js/financial-assistance/views/financial_assistance_form_view.js
+++ b/lms/static/js/financial-assistance/views/financial_assistance_form_view.js
@@ -53,7 +53,9 @@
                          header_text: context.header_text,
                          platform_name: context.platform_name,
                          student_faq_url: context.student_faq_url,
-                         account_settings_url: context.account_settings_url
+                         account_settings_url: context.account_settings_url,
+                         applications_status_response: context.applications_status_response,
+                         hide_form: context.hide_form
                      };
 
                     // Make the value accessible to this View

--- a/lms/static/js/spec/financial-assistance/financial_assistance_form_view_spec.js
+++ b/lms/static/js/spec/financial-assistance/financial_assistance_form_view_spec.js
@@ -98,7 +98,9 @@ define([
                 student_faq_url: '/faqs',
                 dashboard_url: '/dashboard',
                 platform_name: 'edx',
-                submit_url: '/api/financial/v1/assistance'
+                submit_url: '/api/financial/v1/assistance',
+                applications_status_response: null,
+                hide_form: false,
             },
             completeForm,
             validSubmission,

--- a/lms/static/sass/views/_financial-assistance.scss
+++ b/lms/static/sass/views/_financial-assistance.scss
@@ -6,6 +6,26 @@
   color: $m-gray-d2;
 }
 
+
+
+.financial-assistance-applications-list {
+  .financial-assistance-table {
+    font-size: smaller;
+    width: 100%;
+    th {
+      margin: 0;
+      padding: 0.5rem;
+      border-bottom: 1px solid black;
+      text-align: left;
+    }
+    td {
+      margin: 0;
+      padding: 0.5rem;
+      border-bottom: 1px solid silver;
+    }
+  }
+}
+
 .financial-assistance-wrapper {
   margin: auto;
   padding: $baseline ($baseline/2);

--- a/lms/templates/financial-assistance/apply.html
+++ b/lms/templates/financial-assistance/apply.html
@@ -18,7 +18,9 @@ FinancialAssistanceFactory({
     dashboard_url: '${dashboard_url | n, js_escaped_string}',
     account_settings_url: '${account_settings_url | n, js_escaped_string}',
     platform_name: '${platform_name | n, js_escaped_string}',
-    submit_url: '${submit_url | n, js_escaped_string}'
+    submit_url: '${submit_url | n, js_escaped_string}',
+    applications_status_response: ${applications_status_response | n, dump_js_escaped_json},
+    hide_form: ${bool(hide_form) | n, dump_js_escaped_json}
 });
 </%static:require_module>
 </%block>

--- a/lms/templates/financial-assistance/financial-assistance.html
+++ b/lms/templates/financial-assistance/financial-assistance.html
@@ -43,7 +43,6 @@ from common.djangoapps.edxmako.shortcuts import marketing_link
     </div>
   % endif
 
-
   <div class="financial-assistance-footer">
   <%
     faq_link = marketing_link('FAQ')

--- a/lms/templates/financial-assistance/financial_assessment_form.underscore
+++ b/lms/templates/financial-assistance/financial_assessment_form.underscore
@@ -1,17 +1,13 @@
 <h1><%- gettext('Financial Assistance Application') %></h1>
 
-<div class="intro">
-  <% _.each(header_text, function(copy) { %>
-	<p class="copy"><%- copy %></p>
-  <%  }); %>
-</div>
-
 <% if (applications_status_response) { %>
+  <h1><%- gettext('Submitted Financial Assistance Applications') %></h1>
+
   <div class="financial-assistance-applications-list">
     <table class="financial-assistance-table">
       <thead>
         <tr>
-          <th> - </th>
+          <th><%- gettext('Serial Number') %></th>
           <th><%- gettext('Application Request Date') %></th>
           <th><%- gettext('Status') %></th>
           <th><%- gettext('Coupon Code') %></th>
@@ -44,6 +40,12 @@
 <% } %>
 
 <% if (hide_form == false) { %>
+
+  <div class="intro">
+    <% _.each(header_text, function(copy) { %>
+  	  <p class="copy"><%- copy %></p>
+    <%  }); %>
+  </div>
   <form class="financial-assistance-form" method="POST">
     <div class="js-form-feedback" aria-live="assertive" tabindex="-1">
     </div>

--- a/lms/templates/financial-assistance/financial_assessment_form.underscore
+++ b/lms/templates/financial-assistance/financial_assessment_form.underscore
@@ -6,42 +6,81 @@
   <%  }); %>
 </div>
 
-<form class="financial-assistance-form" method="POST">
-  <div class="js-form-feedback" aria-live="assertive" tabindex="-1">
+<% if (applications_status_response) { %>
+  <div class="financial-assistance-applications-list">
+    <table class="financial-assistance-table">
+      <thead>
+        <tr>
+          <th> - </th>
+          <th><%- gettext('Application Request Date') %></th>
+          <th><%- gettext('Status') %></th>
+          <th><%- gettext('Coupon Code') %></th>
+          <th><%- gettext('Coupon Expiration Date') %></th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% applications_status_response.forEach(function (application, i) { %>
+        <tr>
+          <td><%- i+1 %></td>
+          <td><%- new Date(application.request_date).toDateString() %> <%- new Date(application.request_date).toLocaleTimeString() %></td>
+          <td><%- application.status %></td>
+          <% if (application.coupon_code) { %>
+            <td><%- application.coupon_code %></td>
+          <% } else { %>
+            <td><%- gettext('N/A') %></td>
+          <% } %>
+          <% if (application.expiration_date) { %>
+            <td><%- new Date(application.expiration_date).toDateString() %> <%- new Date(application.expiration_date).toLocaleTimeString() %></td>
+          <% } else { %>
+            <td><%- gettext('N/A') %></td>
+          <% } %>
+          <td></td>
+        </tr>
+        <% }); %>
+      </tbody>
+    </table>
   </div>
+<% } %>
 
-	<div class="user-info">
-		<h2><%- gettext('About You') %></h2>
-		<p><%- interpolate_text(
-			gettext("The following information is already a part of your {platform} profile. We've included it here for your application."),
-			{platform: platform_name}
-		) %></p>
-		<div class="info-column">
-			<div class="title"><%- gettext('Username') %></div>
-			<div class="data"><%- username %></div>
-		</div>
-		<div class="info-column">
-			<div class="title"><%- gettext('Email address') %></div>
-			<div class="data"><%- email %></div>
-		</div>
-		<div class="info-column">
-			<div class="title"><%- gettext('Legal name') %></div>
-			<div class="data"><%- name %></div>
-		</div>
-		<div class="info-column">
-			<div id="user-country-title" class="title"><%- gettext('Country of residence') %></div>
-			<div class="data"><%- country %></div>
-		</div>
-	</div>
+<% if (hide_form == false) { %>
+  <form class="financial-assistance-form" method="POST">
+    <div class="js-form-feedback" aria-live="assertive" tabindex="-1">
+    </div>
 
-    <% // xss-lint: disable=underscore-not-escaped %>
-	<%= fields %> 
+      <div class="user-info">
+          <h2><%- gettext('About You') %></h2>
+          <p><%- interpolate_text(
+              gettext("The following information is already a part of your {platform} profile. We've included it here for your application."),
+              {platform: platform_name}
+          ) %></p>
+          <div class="info-column">
+              <div class="title"><%- gettext('Username') %></div>
+              <div class="data"><%- username %></div>
+          </div>
+          <div class="info-column">
+              <div class="title"><%- gettext('Email address') %></div>
+              <div class="data"><%- email %></div>
+          </div>
+          <div class="info-column">
+              <div class="title"><%- gettext('Legal name') %></div>
+              <div class="data"><%- name %></div>
+          </div>
+          <div class="info-column">
+              <div id="user-country-title" class="title"><%- gettext('Country of residence') %></div>
+              <div class="data"><%- country %></div>
+          </div>
+      </div>
 
-	<div class="cta-wrapper clearfix">
-		<a href="<%- student_faq_url %>" class="nav-link"><%- interpolate_text(
-			gettext('Back to {platform} FAQs'),
-    		{platform: platform_name}
-    	) %></a>
-		<button type="submit" class="action action-primary action-update js-submit-form submit-form"><%- gettext("Submit Application") %></button>
-	</div>
-</form>
+      <% // xss-lint: disable=underscore-not-escaped %>
+      <%= fields %>
+
+      <div class="cta-wrapper clearfix">
+          <a href="<%- student_faq_url %>" class="nav-link"><%- interpolate_text(
+              gettext('Back to {platform} FAQs'),
+              {platform: platform_name}
+          ) %></a>
+          <button type="submit" class="action action-primary action-update js-submit-form submit-form"><%- gettext("Submit Application") %></button>
+      </div>
+  </form>
+<% } %>


### PR DESCRIPTION
[PROD-2739](https://2u-internal.atlassian.net/browse/PROD-2739)

## Description

Adds a list of application that the learner has applied. If the user has an approved application, the form is not shown at all.

<img width="1640" alt="Screenshot 2022-05-19 at 11 44 56 AM" src="https://user-images.githubusercontent.com/52413434/169227658-f8ee93c8-ba2e-4b9d-848f-130d5acd22db.png">

<img width="1638" alt="Screenshot 2022-05-19 at 2 41 54 AM" src="https://user-images.githubusercontent.com/52413434/169231425-b4cda81b-51be-4bf5-a5c3-366aa95fa332.png">

Testing Instruction:
1. Make sure you've followed [the setup instructions](https://2u-internal.atlassian.net/wiki/spaces/PROD/pages/26738692/Financial+Assistance+setup+instructions)
2. Just for the testing purpose alone, temporarily remove `readonly_fields` in `FinancialAssistanceApplicationAdmin` and add a bunch of financial assistance application through django admin.
3. Go to the new financial assistance form and see the application statuses. 

NOTE: Make sure to check the following usecases:

- One non-approved application shows both the application list AND the form
- One approved application shows only the application list