### PR TITLE
Removed PII sharing requirement from Live API

### DIFF
--- a/openedx/core/djangoapps/course_live/models.py
+++ b/openedx/core/djangoapps/course_live/models.py
@@ -11,7 +11,11 @@ from simple_history.models import HistoricalRecords
 AVAILABLE_PROVIDERS = {
     'zoom': {
         'name': 'Zoom LTI PRO',
-        'features': []
+        'features': [],
+        'pii_sharing': {
+            'username': False,
+            'email': False,
+        }
     }
 }
 

--- a/openedx/core/djangoapps/course_live/serializers.py
+++ b/openedx/core/djangoapps/course_live/serializers.py
@@ -52,10 +52,10 @@ class LtiSerializer(serializers.ModelSerializer):
             if key in set(self.Meta.fields).difference(self.Meta.read_only):
                 setattr(instance, key, value)
 
-        pii_sharing_allowed = self.context.get('pii_sharing_allowed', False)
+        share_email, share_username = self.pii_sharing_allowed()
         instance.lti_config = {
-            "pii_share_username": pii_sharing_allowed,
-            "pii_share_email": pii_sharing_allowed,
+            "pii_share_username": share_username,
+            "pii_share_email": share_email,
             "additional_parameters": lti_config['additional_parameters']
         }
         instance.save()
@@ -75,11 +75,20 @@ class LtiSerializer(serializers.ModelSerializer):
                 if key in self.Meta.fields:
                     setattr(instance, key, value)
 
-            pii_sharing_allowed = self.context.get('pii_sharing_allowed', False)
-            instance.pii_share_username = pii_sharing_allowed
-            instance.pii_share_email = pii_sharing_allowed
+            share_email, share_username = self.pii_sharing_allowed()
+            instance.pii_share_username = share_username
+            instance.pii_share_email = share_email
             instance.save()
         return instance
+
+    def pii_sharing_allowed(self):
+        pii_sharing_allowed = self.context.get('pii_sharing_allowed', False)
+        provider = AVAILABLE_PROVIDERS.get(self.context.get('provider_type', None))
+
+        email = pii_sharing_allowed and provider['pii_sharing']['email'] if provider else False
+        username = pii_sharing_allowed and provider['pii_sharing']['username'] if provider else False
+
+        return email, username
 
 
 class CourseLiveConfigurationSerializer(serializers.ModelSerializer):
@@ -154,6 +163,7 @@ class CourseLiveConfigurationSerializer(serializers.ModelSerializer):
             partial=True,
             context={
                 'pii_sharing_allowed': self.context.get('pii_sharing_allowed', False),
+                'provider_type': self.context.get('provider_type', ''),
             }
         )
         if lti_serializer.is_valid(raise_exception=True):

--- a/openedx/core/djangoapps/course_live/serializers.py
+++ b/openedx/core/djangoapps/course_live/serializers.py
@@ -82,6 +82,9 @@ class LtiSerializer(serializers.ModelSerializer):
         return instance
 
     def pii_sharing_allowed(self):
+        """
+        Check if email and username sharing is required and allowed
+        """
         pii_sharing_allowed = self.context.get('pii_sharing_allowed', False)
         provider = AVAILABLE_PROVIDERS.get(self.context.get('provider_type', None))
 

--- a/openedx/core/djangoapps/course_live/tests/test_views.py
+++ b/openedx/core/djangoapps/course_live/tests/test_views.py
@@ -113,8 +113,8 @@ class TestCourseLiveConfigurationView(ModuleStoreTestCase, APITestCase):
         self.assertEqual(lti_config['lti_1p1_client_secret'], lti_configuration.lti_1p1_client_secret)
         self.assertEqual(lti_config['lti_1p1_launch_url'], lti_configuration.lti_1p1_launch_url)
         self.assertEqual({
-            'pii_share_username': True,
-            'pii_share_email': True,
+            'pii_share_username': False,
+            'pii_share_email': False,
             'additional_parameters': {'custom_instructor_email': 'email@example.com'}
         }, lti_configuration.lti_config)
 
@@ -136,8 +136,8 @@ class TestCourseLiveConfigurationView(ModuleStoreTestCase, APITestCase):
                 'lti_1p1_launch_url': 'example.com',
                 'version': 'lti_1p1',
                 'lti_config': {
-                    'pii_share_email': True,
-                    'pii_share_username': True,
+                    'pii_share_email': False,
+                    'pii_share_username': False,
                     'additional_parameters': {
                         'custom_instructor_email': 'email@example.com'
                     },
@@ -180,8 +180,8 @@ class TestCourseLiveConfigurationView(ModuleStoreTestCase, APITestCase):
                 'lti_1p1_launch_url': 'example01.com',
                 'version': 'lti_1p1',
                 'lti_config': {
-                    'pii_share_username': True,
-                    'pii_share_email': True,
+                    'pii_share_username': False,
+                    'pii_share_email': False,
                     'additional_parameters': {
                         'custom_instructor_email':
                             'new_email@example.com'

--- a/openedx/core/djangoapps/course_live/tests/test_views.py
+++ b/openedx/core/djangoapps/course_live/tests/test_views.py
@@ -71,7 +71,19 @@ class TestCourseLiveConfigurationView(ModuleStoreTestCase, APITestCase):
         """
         response = self._get()
         self.assertEqual(response.status_code, 200)
-        expected_data = {'pii_sharing_allowed': False, 'message': 'PII sharing is not allowed on this course'}
+        expected_data = {
+            'course_key': None,
+            'provider_type': '',
+            'enabled': True,
+            'lti_configuration': {
+                'lti_1p1_client_key': '',
+                'lti_1p1_client_secret': '',
+                'lti_1p1_launch_url': '',
+                'version': 'lti_1p1',
+                'lti_config': {}
+            },
+            'pii_sharing_allowed': False
+        }
         self.assertEqual(response.data, expected_data)
 
     def test_pii_sharing_is_allowed(self):

--- a/openedx/core/djangoapps/course_live/utils.py
+++ b/openedx/core/djangoapps/course_live/utils.py
@@ -1,0 +1,14 @@
+"""
+Util functions for course live app
+"""
+from openedx.core.djangoapps.course_live.models import AVAILABLE_PROVIDERS
+
+
+def provider_requires_pii_sharing(provider_type):
+    """
+    Check if provider requires any PII ie username or email
+    """
+    provider =AVAILABLE_PROVIDERS.get(provider_type, None)
+    if provider:
+        return provider['pii_sharing']['email'] or provider['pii_sharing']['username']
+    return False

--- a/openedx/core/djangoapps/course_live/utils.py
+++ b/openedx/core/djangoapps/course_live/utils.py
@@ -8,7 +8,7 @@ def provider_requires_pii_sharing(provider_type):
     """
     Check if provider requires any PII ie username or email
     """
-    provider =AVAILABLE_PROVIDERS.get(provider_type, None)
+    provider = AVAILABLE_PROVIDERS.get(provider_type, None)
     if provider:
         return provider['pii_sharing']['email'] or provider['pii_sharing']['username']
     return False

--- a/openedx/core/djangoapps/course_live/views.py
+++ b/openedx/core/djangoapps/course_live/views.py
@@ -19,6 +19,7 @@ from lms.djangoapps.courseware.courses import get_course_with_access
 from openedx.core.djangoapps.course_live.permissions import IsEnrolledOrStaff, IsStaffOrInstructor
 from openedx.core.djangoapps.course_live.tab import CourseLiveTab
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
+from .utils import provider_requires_pii_sharing
 
 from ...lib.api.view_utils import verify_course_exists
 from .models import AVAILABLE_PROVIDERS, CourseLiveConfiguration
@@ -114,7 +115,7 @@ class CourseLiveConfigurationView(APIView):
         Handle HTTP/POST requests
         """
         pii_sharing_allowed = get_lti_pii_sharing_state_for_course(course_id)
-        if not pii_sharing_allowed:
+        if not pii_sharing_allowed and provider_requires_pii_sharing(request.data.get('provider_type','')):
             return Response({
                 "pii_sharing_allowed": pii_sharing_allowed,
                 "message": "PII sharing is not allowed on this course"

--- a/openedx/core/djangoapps/course_live/views.py
+++ b/openedx/core/djangoapps/course_live/views.py
@@ -115,7 +115,7 @@ class CourseLiveConfigurationView(APIView):
         Handle HTTP/POST requests
         """
         pii_sharing_allowed = get_lti_pii_sharing_state_for_course(course_id)
-        if not pii_sharing_allowed and provider_requires_pii_sharing(request.data.get('provider_type','')):
+        if not pii_sharing_allowed and provider_requires_pii_sharing(request.data.get('provider_type', '')):
             return Response({
                 "pii_sharing_allowed": pii_sharing_allowed,
                 "message": "PII sharing is not allowed on this course"

--- a/openedx/core/djangoapps/course_live/views.py
+++ b/openedx/core/djangoapps/course_live/views.py
@@ -57,16 +57,9 @@ class CourseLiveConfigurationView(APIView):
         """
         Handle HTTP/GET requests
         """
-        pii_sharing_allowed = get_lti_pii_sharing_state_for_course(course_id)
-        if not pii_sharing_allowed:
-            return Response({
-                "pii_sharing_allowed": pii_sharing_allowed,
-                "message": "PII sharing is not allowed on this course"
-            })
-
         configuration = CourseLiveConfiguration.get(course_id) or CourseLiveConfiguration()
         serializer = CourseLiveConfigurationSerializer(configuration, context={
-            "pii_sharing_allowed": pii_sharing_allowed,
+            "pii_sharing_allowed": get_lti_pii_sharing_state_for_course(course_id),
             "course_id": course_id
         })
 


### PR DESCRIPTION
Removed PII sharing requirement from API now it is dependent on Provider.
Now PII sharing error will be triggered If provider requires PII sharing 

https://openedx.atlassian.net/browse/INF-151