### PR TITLE
docs: fix release notes URL

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,5 +4,5 @@ either the `edX Release Notes`_ or the `GitHub commit history`_.
 
 
 
-.. _edX Release Notes: https://edx.readthedocs.org/projects/edx-release-notes/en/latest/
+.. _edX Release Notes: https://edx.readthedocs.io/projects/open-edx-release-notes/en/latest/
 .. _GitHub commit history: https://github.com/edx/edx-platform/commits/master


### PR DESCRIPTION
## Description

https://edx.readthedocs.org/projects/edx-release-notes/en/latest/ page doesn't exist.