### PR TITLE
fix: bump pinned pyfilesystem2 version

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -96,7 +96,7 @@ edx-user-state-client
 edx-when
 edxval
 event-tracking
-fs==2.0.18
+fs
 fs-s3fs==0.1.8
 geoip2                              # Python API for the GeoIP web services and databases
 glob2                               # Enhanced glob module, used in openedx.core.lib.rooted_paths

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -559,7 +559,7 @@ frozenlist==1.3.0
     # via
     #   aiohttp
     #   aiosignal
-fs==2.0.18
+fs==2.0.27
     # via
     #   -r requirements/edx/base.in
     #   django-pyfs

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -711,7 +711,7 @@ frozenlist==1.3.0
     #   -r requirements/edx/testing.txt
     #   aiohttp
     #   aiosignal
-fs==2.0.18
+fs==2.0.27
     # via
     #   -r requirements/edx/testing.txt
     #   django-pyfs

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -686,7 +686,7 @@ frozenlist==1.3.0
     #   -r requirements/edx/base.txt
     #   aiohttp
     #   aiosignal
-fs==2.0.18
+fs==2.0.27
     # via
     #   -r requirements/edx/base.txt
     #   django-pyfs


### PR DESCRIPTION
## Description

This PR fixes an unrecoverable LMS worker error, which can be easily triggered from the Studio UI.

Steps to reproduce:
1. Add `Blank Advanced Problem` to some unit.
2. Click `Edit`.
3. Add `<include file="/test/hello.xml" />` between `<problem>` and `</problem>`.

The worker will crash with the following error output:
```python
2022-05-02 14:21:16,374 WARNING 37 [capa.capa_problem] [user None] [ip None] capa_problem.py:820 - Error resource '/static_test1/test_problem.xml' not found in problem xml include: b'<include file="/static_test1/test_problem.xml"/>\n\n'
2022-05-02 14:21:16,374 WARNING 37 [capa.capa_problem] [user None] [ip None] capa_problem.py:825 - Cannot find file /static_test1/test_problem.xml in <osfs '/openedx/data/modulestore/Test/Test/Test'>
2022-05-02 14:21:16,374 ERROR 37 [edx.celery.task] [user None] [ip None] tasks.py:121 - BlockStructure: update_course_in_cache_v2 encountered unknown error in course course-v1:Test+Test+Test, task_id 0ca065ae-2dc3-4fa6-a309-e392f4015203. Retry #4
Traceback (most recent call last):
  File "/openedx/venv/lib/python3.8/site-packages/fs/osfs.py", line 379, in open
    return io.open(
FileNotFoundError: [Errno 2] No such file or directory: '/openedx/data/modulestore/Test/Test/Test/static_test1/test_problem.xml'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/openedx/edx-platform/openedx/core/djangoapps/content/block_structure/tasks.py", line 107, in _call_and_retry_if_needed
    api_method(course_key)
  File "/openedx/edx-platform/openedx/core/djangoapps/content/block_structure/api.py", line 32, in update_course_in_cache
    return get_block_structure_manager(course_key).update_collected_if_needed()
  File "/openedx/edx-platform/openedx/core/djangoapps/content/block_structure/manager.py", line 116, in update_collected_if_needed
    self._update_collected()
  File "/openedx/edx-platform/openedx/core/djangoapps/content/block_structure/manager.py", line 128, in _update_collected
    BlockStructureTransformers.collect(block_structure)
  File "/openedx/edx-platform/openedx/core/djangoapps/content/block_structure/transformers.py", line 78, in collect
    transformer.collect(block_structure)
  File "/openedx/edx-platform/lms/djangoapps/grades/transformer.py", line 70, in collect
    cls._collect_max_scores(block_structure)
  File "/openedx/edx-platform/lms/djangoapps/grades/transformer.py", line 144, in _collect_max_scores
    cls._collect_max_score(block_structure, block)
  File "/openedx/edx-platform/lms/djangoapps/grades/transformer.py", line 152, in _collect_max_score
    max_score = module.max_score()
  File "/openedx/edx-platform/common/lib/xmodule/xmodule/capa_module.py", line 622, in max_score
    lcp = LoncapaProblem(
  File "/openedx/edx-platform/common/lib/capa/capa/capa_problem.py", line 205, in __init__
    self._process_includes()
  File "/openedx/edx-platform/common/lib/capa/capa/capa_problem.py", line 818, in _process_includes
    ifp = self.capa_system.resources_fs.open(filename)
  File "/openedx/venv/lib/python3.8/site-packages/fs/osfs.py", line 379, in open
    return io.open(
  File "/openedx/venv/lib/python3.8/site-packages/fs/error_tools.py", line 76, in __exit__
    reraise(
  File "/openedx/venv/lib/python3.8/site-packages/six.py", line 718, in reraise
    raise value.with_traceback(tb)
  File "/openedx/venv/lib/python3.8/site-packages/fs/osfs.py", line 379, in open
    return io.open(
fs.errors.ResourceNotFound: resource '/static_test1/test_problem.xml' not found
2022-05-02 14:21:16,383 INFO 1 [celery.worker.strategy] [user None] [ip None] strategy.py:161 - Task openedx.core.djangoapps.content.block_structure.tasks.update_course_in_cache_v2[0ca065ae-2dc3-4fa6-a309-e392f4015203] received
2022-05-02 14:21:16,385 INFO 37 [celery.app.trace] [user None] [ip None] trace.py:131 - Task openedx.core.djangoapps.content.block_structure.tasks.update_course_in_cache_v2[0ca065ae-2dc3-4fa6-a309-e392f4015203] retry: Retry in 30s: ResourceNotFound("resource '/static_test1/test_problem.xml' not found")
2022-05-02 14:21:16,386 CRITICAL 1 [celery.worker] [user None] [ip None] worker.py:207 - Unrecoverable error: TypeError("__init__() missing 1 required positional argument: 'path'")
Traceback (most recent call last):
  File "/openedx/venv/lib/python3.8/site-packages/celery/worker/worker.py", line 203, in start
    self.blueprint.start(self)
  File "/openedx/venv/lib/python3.8/site-packages/celery/bootsteps.py", line 116, in start
    step.start(parent)
  File "/openedx/venv/lib/python3.8/site-packages/celery/bootsteps.py", line 365, in start
    return self.obj.start()
  File "/openedx/venv/lib/python3.8/site-packages/celery/worker/consumer/consumer.py", line 332, in start
    blueprint.start(self)
  File "/openedx/venv/lib/python3.8/site-packages/celery/bootsteps.py", line 116, in start
    step.start(parent)
  File "/openedx/venv/lib/python3.8/site-packages/celery/worker/consumer/consumer.py", line 628, in start
    c.loop(*c.loop_args())
  File "/openedx/venv/lib/python3.8/site-packages/celery/worker/loops.py", line 97, in asynloop
    next(loop)
  File "/openedx/venv/lib/python3.8/site-packages/kombu/asynchronous/hub.py", line 362, in create_loop
    cb(*cbargs)
  File "/openedx/venv/lib/python3.8/site-packages/celery/concurrency/asynpool.py", line 325, in on_result_readable
    next(it)
  File "/openedx/venv/lib/python3.8/site-packages/celery/concurrency/asynpool.py", line 306, in _recv_message
    message = load(bufv)
TypeError: __init__() missing 1 required positional argument: 'path'
2022-05-02 14:21:47,182 ERROR 1 [celery.worker.request] [user None] [ip None] request.py:596 - Task handler raised error: WorkerLostError('Worker exited prematurely: exitcode 0 Job: 0.')
Traceback (most recent call last):
  File "/openedx/venv/lib/python3.8/site-packages/celery/worker/worker.py", line 203, in start
    self.blueprint.start(self)
  File "/openedx/venv/lib/python3.8/site-packages/celery/bootsteps.py", line 116, in start
    step.start(parent)
  File "/openedx/venv/lib/python3.8/site-packages/celery/bootsteps.py", line 365, in start
    return self.obj.start()
  File "/openedx/venv/lib/python3.8/site-packages/celery/worker/consumer/consumer.py", line 332, in start
    blueprint.start(self)
  File "/openedx/venv/lib/python3.8/site-packages/celery/bootsteps.py", line 116, in start
    step.start(parent)
  File "/openedx/venv/lib/python3.8/site-packages/celery/worker/consumer/consumer.py", line 628, in start
    c.loop(*c.loop_args())
  File "/openedx/venv/lib/python3.8/site-packages/celery/worker/loops.py", line 97, in asynloop
    next(loop)
  File "/openedx/venv/lib/python3.8/site-packages/kombu/asynchronous/hub.py", line 362, in create_loop
    cb(*cbargs)
  File "/openedx/venv/lib/python3.8/site-packages/celery/concurrency/asynpool.py", line 325, in on_result_readable
    next(it)
  File "/openedx/venv/lib/python3.8/site-packages/celery/concurrency/asynpool.py", line 306, in _recv_message
    message = load(bufv)
TypeError: __init__() missing 1 required positional argument: 'path'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/openedx/venv/lib/python3.8/site-packages/billiard/pool.py", line 1265, in mark_as_worker_lost
    raise WorkerLostError(
billiard.exceptions.WorkerLostError: Worker exited prematurely: exitcode 0 Job: 0.
```

This is caused by `_process_includes` function, that throws [ResourceNotFound](https://github.com/PyFilesystem/pyfilesystem2/blob/897b21d3b1cca00b882894b2a140be2c30be33b8/fs/errors.py#L207-L211) exception (you can see it in the logs above):
https://github.com/openedx/edx-platform/blob/0be6d3c8abbbab3d88b618f3713fd5f2287b2b87/common/lib/capa/capa/capa_problem.py#L816-L833

After an initial failure, Celery pickles the exception object and tries to [unpickle](
https://github.com/celery/celery/blob/128f0027005f2bf9d4b93082049d2c96c2bcd879/celery/concurrency/asynpool.py#L305-L306) it when retrying to execute a task that failed.

Unpickling `ResourceNotFound` instance causes `TypeError`, which breaks the worker: [source](https://github.com/PyFilesystem/pyfilesystem2/blob/897b21d3b1cca00b882894b2a140be2c30be33b8/fs/errors.py#L195-L204), [explanation](https://stackoverflow.com/a/41809333).

`fs==2.0.26` has [the correct implementation](https://github.com/PyFilesystem/pyfilesystem2/blob/731f99ed03b4b2a6864f6712389dccb902ee0d76/fs/errors.py#L260-L273), which allows Celery to unpickle the exception object successfully.

## Testing instructions

### `pyfilesystem2`

1. Install the pinned version of `fs`:
    ```sh
    pip install fs==2.0.18
    ```
2. This should throw `TypeError`:
    ```python
    import pickle
    from fs.errors import ResourceNotFound
    error = ResourceNotFound("/static/example.xml")
    pickled = pickle.dumps(error)
    pickle.loads(pickled)
    ```
3. Try the same with `fs==2.0.26`. `pickle.loads` shouldn't fail.

### `edx-platform`

1. Add `Blank Advanced Problem` to some unit.
2. Click `Edit`.
3. Add `<include file="/test/hello.xml" />` between `<problem>` and `</problem>`.
4. The worker should crash.
5. Switch `edx-platform` to [0x29a/bb5968/fix-celery-worker-crash](https://github.com/open-craft/edx-platform/tree/0x29a/bb5968/fix-celery-worker-crash) and reinstall dependencies.
6. Repeat the steps from 1 to 3.
7. The worker shouldn't crash.