### PR TITLE
feat: enable abuse flagging even when filtering comments by user [BD-38] [INF-171]

### DIFF
--- a/lms/djangoapps/discussion/rest_api/permissions.py
+++ b/lms/djangoapps/discussion/rest_api/permissions.py
@@ -99,8 +99,8 @@ def get_editable_fields(cc_content: Union[Thread, Comment], context: Dict) -> Se
     elif context.get("thread"):
         is_thread_closed = context["thread"]["closed"]
     else:
-        # No editable fields when outside thread context
-        return set()
+        # Flagging/un-flagging is always available.
+        return {"abuse_flagged"}
 
     # Map each field to the condition in which it's editable.
     editable_fields = {


### PR DESCRIPTION
## Description

Abuse flagging is always supported, so allow abuse flagging even when no other actions are available due to the lack of a thread context in the comment API.

## Supporting information

- https://openedx.atlassian.net/browse/INF-171

## Testing instructions

- TBD

## Deadline

"None" 