### PR TITLE
[BACKPORT] feat: Implement feature flag to disable students un-enrollment (#29326)

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -472,6 +472,18 @@ FEATURES = {
     # .. toggle_target_removal_date: 2021-10-01
     # .. toggle_tickets: 'https://openedx.atlassian.net/browse/MICROBA-1405'
     'ENABLE_V2_CERT_DISPLAY_SETTINGS': False,
+
+    # .. toggle_name: FEATURES['DISABLE_UNENROLLMENT']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Set to True to disable self-unenrollments via REST API.
+    #   This also hides the "Unenroll" button on the Learner Dashboard.
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2021-10-11
+    # .. toggle_warnings: For consistency in user experience, keep the value in sync with the setting of the same name
+    #   in the LMS and CMS.
+    # .. toggle_tickets: 'https://github.com/open-craft/edx-platform/pull/429'
+    'DISABLE_UNENROLLMENT': False,
 }
 
 ENABLE_JASMINE = False

--- a/common/djangoapps/student/tests/test_enrollment.py
+++ b/common/djangoapps/student/tests/test_enrollment.py
@@ -358,6 +358,22 @@ class EnrollmentTest(UrlResetMixin, SharedModuleStoreTestCase, OpenEdxEventsTest
         resp = self._change_enrollment('unenroll', course_id="edx/")
         assert resp.status_code == 400
 
+    @patch.dict(settings.FEATURES, {'DISABLE_UNENROLLMENT': True})
+    def test_unenroll_when_unenrollment_disabled(self):
+        """
+        Tests that a user cannot unenroll when unenrollment has been disabled.
+        """
+        # Enroll the student in the course
+        CourseEnrollment.enroll(self.user, self.course.id, mode="honor")
+
+        # Attempt to unenroll
+        resp = self._change_enrollment('unenroll')
+        assert resp.status_code == 400
+
+        # Verify that user is still enrolled
+        is_enrolled = CourseEnrollment.is_enrolled(self.user, self.course.id)
+        assert is_enrolled
+
     def test_enrollment_limit(self):
         """
         Assert that in a course with max student limit set to 1, we can enroll staff and instructor along with

--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -514,6 +514,10 @@ def student_dashboard(request):  # lint-amnesty, pylint: disable=too-many-statem
     empty_dashboard_message = configuration_helpers.get_value(
         'EMPTY_DASHBOARD_MESSAGE', None
     )
+    disable_unenrollment = configuration_helpers.get_value(
+        'DISABLE_UNENROLLMENT',
+        settings.FEATURES.get('DISABLE_UNENROLLMENT')
+    )
 
     disable_course_limit = request and 'course_limit' in request.GET
     course_limit = get_dashboard_course_limit() if not disable_course_limit else None
@@ -797,6 +801,7 @@ def student_dashboard(request):  # lint-amnesty, pylint: disable=too-many-statem
         # TODO START: clean up as part of REVEM-199 (START)
         'course_info': get_dashboard_course_info(user, course_enrollments),
         # TODO START: clean up as part of REVEM-199 (END)
+        'disable_unenrollment': disable_unenrollment,
     }
 
     # Include enterprise learner portal metadata and messaging

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -397,6 +397,12 @@ def change_enrollment(request, check_access=True):
         # Otherwise, there is only one mode available (the default)
         return HttpResponse()
     elif action == "unenroll":
+        if configuration_helpers.get_value(
+            "DISABLE_UNENROLLMENT",
+            settings.FEATURES.get("DISABLE_UNENROLLMENT")
+        ):
+            return HttpResponseBadRequest(_("Unenrollment is currently disabled"))
+
         enrollment = CourseEnrollment.get_enrollment(user, course_id)
         if not enrollment:
             return HttpResponseBadRequest(_("You are not enrolled in this course"))

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -948,6 +948,18 @@ FEATURES = {
     # .. toggle_target_removal_date: 2021-10-01
     # .. toggle_tickets: 'https://openedx.atlassian.net/browse/MICROBA-1405'
     'ENABLE_V2_CERT_DISPLAY_SETTINGS': False,
+
+    # .. toggle_name: FEATURES['DISABLE_UNENROLLMENT']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Set to True to disable self-unenrollments via REST API.
+    #   This also hides the "Unenroll" button on the Learner Dashboard.
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2021-10-11
+    # .. toggle_warnings: For consistency in user experience, keep the value in sync with the setting of the same name
+    #   in the LMS and CMS.
+    # .. toggle_tickets: 'https://github.com/open-craft/edx-platform/pull/429'
+    'DISABLE_UNENROLLMENT': False,
 }
 
 # Specifies extra XBlock fields that should available when requested via the Course Blocks API

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -209,7 +209,12 @@ from common.djangoapps.student.models import CourseEnrollment
                 cert_status = cert_statuses.get(session_id)
                 can_refund_entitlement = entitlement and entitlement.is_entitlement_refundable()
                 partner_managed_enrollment = enrollment.mode == 'masters'
-                can_unenroll = False if partner_managed_enrollment else (not cert_status) or cert_status.get('can_unenroll') if not unfulfilled_entitlement else False
+                # checks if we can unenroll based on the value of partner_managed_enrollment
+                can_unenroll_partner_managed_enrollment = False if partner_managed_enrollment else (not cert_status)
+                # checks if we can unenroll based on the value of unfulfilled_entitlement
+                can_unenroll_unfulfilled_entitlement = cert_status.get('can_unenroll') if cert_status and not unfulfilled_entitlement else False
+                # compares the three different parameters by which we can unenroll
+                can_unenroll = (can_unenroll_partner_managed_enrollment or can_unenroll_unfulfilled_entitlement) and not disable_unenrollment
                 credit_status = credit_statuses.get(session_id)
                 course_mode_info = all_course_modes.get(session_id)
                 is_paid_course = True if entitlement else (session_id in enrolled_courses_either_paid)

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -250,11 +250,11 @@ from lms.djangoapps.experiments.utils import UPSELL_TRACKING_FLAG
                 % endif
 
                 ## We should only show the gear dropdown if the user is able to refund/unenroll from their entitlement
-                ## and/or if they have selected a course run and email_settings are enabled
+                ## and/or if they have selected a course run, unenrollment is not disabled, and email_settings are enabled
                 ## as these are the only actions currently available
                 % if entitlement and (can_refund_entitlement or show_email_settings):
                     <%include file='_dashboard_entitlement_actions.html' args='course_overview=course_overview,entitlement=entitlement,dashboard_index=dashboard_index, can_refund_entitlement=can_refund_entitlement, show_email_settings=show_email_settings'/>
-                % elif not entitlement:
+                % elif not entitlement and (can_unenroll or partner_managed_enrollment or show_email_settings):
                     <div class="wrapper-action-more" data-course-key="${enrollment.course_id}">
                       <button type="button" class="action action-more" id="actions-dropdown-link-${dashboard_index}" aria-haspopup="true" aria-expanded="false" aria-controls="actions-dropdown-${dashboard_index}" data-course-number="${course_overview.number}" data-course-name="${course_overview.display_name_with_default}" data-dashboard-index="${dashboard_index}">
                         <span class="sr">${_('Course options for')}</span>


### PR DESCRIPTION
## Description

This is the backport of https://github.com/openedx/edx-platform/pull/29326.

The cherry-pick wasn't clean:
```diff
diff --cc cms/envs/common.py
index 974e99370a,b21e07ee99..0000000000
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@@ -472,10 -479,59 +472,50 @@@ FEATURES =
      # .. toggle_target_removal_date: 2021-10-01
      # .. toggle_tickets: 'https://openedx.atlassian.net/browse/MICROBA-1405'
      'ENABLE_V2_CERT_DISPLAY_SETTINGS': False,
++<<<<<<< HEAD
++=======
+
+     # .. toggle_name: FEATURES['ENABLE_INTEGRITY_SIGNATURE']
+     # .. toggle_implementation: DjangoSetting
+     # .. toggle_default: False
+     # .. toggle_description: Whether to replace ID verification course/certificate requirement
+     # with an in-course Honor Code agreement
+     # (https://github.com/edx/edx-name-affirmation)
+     # .. toggle_use_cases: open_edx
+     # .. toggle_creation_date: 2022-02-15
+     # .. toggle_target_removal_date: None
+     # .. toggle_tickets: 'https://openedx.atlassian.net/browse/MST-1348'
+     'ENABLE_INTEGRITY_SIGNATURE': False,
+
+     # .. toggle_name: MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW
+     # .. toggle_implementation: DjangoSetting
+     # .. toggle_default: False
+     # .. toggle_description: If enabled, the Library Content Block is marked as complete when users view it.
+     #   Otherwise (by default), all children of this block must be completed.
+     # .. toggle_use_cases: open_edx
+     # .. toggle_creation_date: 2022-03-22
+     # .. toggle_target_removal_date: None
+     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/28268
+     # .. toggle_warnings: For consistency in user-experience, keep the value in sync with the setting of the same name
+     #   in the LMS and CMS.
+     'MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW': False,
+
+     # .. toggle_name: FEATURES['DISABLE_UNENROLLMENT']
+     # .. toggle_implementation: DjangoSetting
+     # .. toggle_default: False
+     # .. toggle_description: Set to True to disable self-unenrollments via REST API.
+     #   This also hides the "Unenroll" button on the Learner Dashboard.
+     # .. toggle_use_cases: open_edx
+     # .. toggle_creation_date: 2021-10-11
+     # .. toggle_warnings: For consistency in user experience, keep the value in sync with the setting of the same name
+     #   in the LMS and CMS.
+     # .. toggle_tickets: 'https://github.com/open-craft/edx-platform/pull/429'
+     'DISABLE_UNENROLLMENT': False,
++>>>>>>> da4a6d6103... feat: Implement feature flag to disable students un-enrollment (#29326)
  }

 -# .. toggle_name: ENABLE_COPPA_COMPLIANCE
 -# .. toggle_implementation: DjangoSetting
 -# .. toggle_default: False
 -# .. toggle_description: When True, inforces COPPA compliance and removes YOB field from registration form and accounnt
 -# .. settings page. Also hide YOB banner from profile page.
 -# .. toggle_use_cases: open_edx
 -# .. toggle_creation_date: 2021-10-27
 -# .. toggle_tickets: 'https://openedx.atlassian.net/browse/VAN-622'
 -ENABLE_COPPA_COMPLIANCE = False
 -
  ENABLE_JASMINE = False

 -MARKETING_EMAILS_OPT_IN = False
 -
  # List of logout URIs for each IDA that the learner should be logged out of when they logout of the LMS. Only applies to
  # IDA for which the social auth flow uses DOT (Django OAuth Toolkit).
  IDA_LOGOUT_URI_LIST = []
diff --cc lms/envs/common.py
index 958d06ccbf,da7fd16b2c..0000000000
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@@ -948,6 -961,55 +948,58 @@@ FEATURES =
      # .. toggle_target_removal_date: 2021-10-01
      # .. toggle_tickets: 'https://openedx.atlassian.net/browse/MICROBA-1405'
      'ENABLE_V2_CERT_DISPLAY_SETTINGS': False,
++<<<<<<< HEAD
++=======
+
+     # .. toggle_name: FEATURES['ENABLE_INTEGRITY_SIGNATURE']
+     # .. toggle_implementation: DjangoSetting
+     # .. toggle_default: False
+     # .. toggle_description: Whether to replace ID verification course/certificate requirement
+     # with an in-course Honor Code agreement
+     # (https://github.com/edx/edx-name-affirmation)
+     # .. toggle_use_cases: open_edx
+     # .. toggle_creation_date: 2022-02-15
+     # .. toggle_target_removal_date: None
+     # .. toggle_tickets: 'https://openedx.atlassian.net/browse/MST-1348'
+     'ENABLE_INTEGRITY_SIGNATURE': False,
+
+     # .. toggle_name: FEATURES['ENABLE_NEW_BULK_EMAIL_EXPERIENCE']
+     # .. toggle_implementation: DjangoSetting
+     # .. toggle_default: False
+     # .. toggle_description: When true, replaces the bulk email tool found on the
+     #   instructor dashboard with a link to the new communications MFE version instead.
+     #   Stting the tool to false will leave the old bulk email tool experience in place.
+     # .. toggle_use_cases: opt_in
+     # .. toggle_creation_date: 2022-03-21
+     # .. toggle_target_removal_date: None
+     # .. toggle_tickets: 'https://openedx.atlassian.net/browse/MICROBA-1758'
+     'ENABLE_NEW_BULK_EMAIL_EXPERIENCE': False,
+
+     # .. toggle_name: MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW
+     # .. toggle_implementation: DjangoSetting
+     # .. toggle_default: False
+     # .. toggle_description: If enabled, the Library Content Block is marked as complete when users view it.
+     #   Otherwise (by default), all children of this block must be completed.
+     # .. toggle_use_cases: open_edx
+     # .. toggle_creation_date: 2022-03-22
+     # .. toggle_target_removal_date: None
+     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/28268
+     # .. toggle_warnings: For consistency in user-experience, keep the value in sync with the setting of the same name
+     #   in the LMS and CMS.
+     'MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW': False,
+
+     # .. toggle_name: FEATURES['DISABLE_UNENROLLMENT']
+     # .. toggle_implementation: DjangoSetting
+     # .. toggle_default: False
+     # .. toggle_description: Set to True to disable self-unenrollments via REST API.
+     #   This also hides the "Unenroll" button on the Learner Dashboard.
+     # .. toggle_use_cases: open_edx
+     # .. toggle_creation_date: 2021-10-11
+     # .. toggle_warnings: For consistency in user experience, keep the value in sync with the setting of the same name
+     #   in the LMS and CMS.
+     # .. toggle_tickets: 'https://github.com/open-craft/edx-platform/pull/429'
+     'DISABLE_UNENROLLMENT': False,
++>>>>>>> da4a6d6103... feat: Implement feature flag to disable students un-enrollment (#29326)
  }

  # Specifies extra XBlock fields that should available when requested via the Course Blocks API
```