### PR TITLE
fix: discussion moderators can't create posts for specific cohorts

### DIFF
--- a/lms/djangoapps/discussion/rest_api/forms.py
+++ b/lms/djangoapps/discussion/rest_api/forms.py
@@ -179,7 +179,7 @@ class CourseDiscussionSettingsForm(Form):
         course_id = self.cleaned_data['course_id']
         try:
             course_key = CourseKey.from_string(course_id)
-            self.cleaned_data['course'] = get_course_with_access(self.request_user, 'staff', course_key)
+            self.cleaned_data['course'] = get_course_with_access(self.request_user, 'load', course_key)
             self.cleaned_data['course_key'] = course_key
             return course_id
         except InvalidKeyError:

--- a/lms/djangoapps/discussion/rest_api/permissions.py
+++ b/lms/djangoapps/discussion/rest_api/permissions.py
@@ -161,6 +161,7 @@ class IsStaffOrCourseTeamOrEnrolled(permissions.BasePermission):
             has_discussion_privileges(request.user, course_key)
         )
 
+
 class IsStaffOrAdmin(permissions.BasePermission):
     """
     Permission that checks if the user is staff or an admin.
@@ -171,10 +172,10 @@ class IsStaffOrAdmin(permissions.BasePermission):
         course_key = CourseKey.from_string(view.kwargs.get('course_id'))
         user_roles = get_user_role_names(request.user, course_key)
         is_user_staff = bool(user_roles & {
-                FORUM_ROLE_ADMINISTRATOR,
-                FORUM_ROLE_MODERATOR,
-                FORUM_ROLE_COMMUNITY_TA,
-            })
+            FORUM_ROLE_ADMINISTRATOR,
+            FORUM_ROLE_MODERATOR,
+            FORUM_ROLE_COMMUNITY_TA,
+        })
         return (
             GlobalStaff().has_user(request.user) or
             request.user.is_staff or

--- a/lms/djangoapps/discussion/rest_api/permissions.py
+++ b/lms/djangoapps/discussion/rest_api/permissions.py
@@ -13,10 +13,14 @@ from common.djangoapps.student.roles import (
     GlobalStaff,
 )
 from lms.djangoapps.discussion.django_comment_client.utils import (
+    get_user_role_names,
     has_discussion_privileges,
 )
 from openedx.core.djangoapps.django_comment_common.comment_client.comment import Comment
 from openedx.core.djangoapps.django_comment_common.comment_client.thread import Thread
+from openedx.core.djangoapps.django_comment_common.models import (
+    FORUM_ROLE_ADMINISTRATOR, FORUM_ROLE_COMMUNITY_TA, FORUM_ROLE_MODERATOR
+)
 
 
 def _is_author(cc_content, context):
@@ -155,4 +159,24 @@ class IsStaffOrCourseTeamOrEnrolled(permissions.BasePermission):
             CourseInstructorRole(course_key).has_user(request.user) or
             CourseEnrollment.is_enrolled(request.user, course_key) or
             has_discussion_privileges(request.user, course_key)
+        )
+
+class IsStaffOrAdmin(permissions.BasePermission):
+    """
+    Permission that checks if the user is staff or an admin.
+    """
+
+    def has_permission(self, request, view):
+        """Returns true if the user is admin or staff and request method is GET."""
+        course_key = CourseKey.from_string(view.kwargs.get('course_id'))
+        user_roles = get_user_role_names(request.user, course_key)
+        is_user_staff = bool(user_roles & {
+                FORUM_ROLE_ADMINISTRATOR,
+                FORUM_ROLE_MODERATOR,
+                FORUM_ROLE_COMMUNITY_TA,
+            })
+        return (
+            GlobalStaff().has_user(request.user) or
+            request.user.is_staff or
+            is_user_staff and request.method == "GET"
         )

--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -63,7 +63,7 @@ from ..rest_api.forms import (
     UserCommentListGetForm,
     UserOrdering,
 )
-from ..rest_api.permissions import IsStaffOrCourseTeamOrEnrolled
+from ..rest_api.permissions import IsStaffOrAdmin, IsStaffOrCourseTeamOrEnrolled
 from ..rest_api.serializers import (
     CourseMetadataSerailizer,
     DiscussionRolesListSerializer,
@@ -1096,7 +1096,7 @@ class CourseDiscussionSettingsAPIView(DeveloperErrorViewMixin, APIView):
         SessionAuthenticationAllowInactiveUser,
     )
     parser_classes = (JSONParser, MergePatchParser,)
-    permission_classes = (permissions.IsAuthenticated, permissions.IsAdminUser)
+    permission_classes = (permissions.IsAuthenticated, IsStaffOrAdmin)
 
     def _get_request_kwargs(self, course_id):
         return dict(course_id=course_id)

--- a/openedx/core/djangoapps/course_groups/permissions.py
+++ b/openedx/core/djangoapps/course_groups/permissions.py
@@ -1,0 +1,33 @@
+"""
+Permissions for cohorts API
+"""
+
+from opaque_keys.edx.keys import CourseKey
+from rest_framework import permissions
+
+from openedx.core.djangoapps.django_comment_common.models import (
+    FORUM_ROLE_ADMINISTRATOR, FORUM_ROLE_COMMUNITY_TA, FORUM_ROLE_MODERATOR
+)
+from common.djangoapps.student.roles import GlobalStaff
+from lms.djangoapps.discussion.django_comment_client.utils import get_user_role_names
+
+
+class IsStaffOrAdmin(permissions.BasePermission):
+    """
+    Permission that checks if the user is staff or an admin.
+    """
+
+    def has_permission(self, request, view):
+        """Returns true if the user is admin or staff and request method is GET."""
+        course_key = CourseKey.from_string(view.kwargs.get('course_key_string'))
+        user_roles = get_user_role_names(request.user, course_key)
+        is_user_staff = bool(user_roles & {
+                FORUM_ROLE_ADMINISTRATOR,
+                FORUM_ROLE_MODERATOR,
+                FORUM_ROLE_COMMUNITY_TA,
+            })
+        return (
+            GlobalStaff().has_user(request.user) or
+            request.user.is_staff or
+            is_user_staff and request.method == "GET"
+        )

--- a/openedx/core/djangoapps/course_groups/permissions.py
+++ b/openedx/core/djangoapps/course_groups/permissions.py
@@ -22,10 +22,10 @@ class IsStaffOrAdmin(permissions.BasePermission):
         course_key = CourseKey.from_string(view.kwargs.get('course_key_string'))
         user_roles = get_user_role_names(request.user, course_key)
         is_user_staff = bool(user_roles & {
-                FORUM_ROLE_ADMINISTRATOR,
-                FORUM_ROLE_MODERATOR,
-                FORUM_ROLE_COMMUNITY_TA,
-            })
+            FORUM_ROLE_ADMINISTRATOR,
+            FORUM_ROLE_MODERATOR,
+            FORUM_ROLE_COMMUNITY_TA,
+        })
         return (
             GlobalStaff().has_user(request.user) or
             request.user.is_staff or

--- a/openedx/core/djangoapps/course_groups/views.py
+++ b/openedx/core/djangoapps/course_groups/views.py
@@ -27,6 +27,7 @@ from rest_framework.serializers import Serializer
 from lms.djangoapps.courseware.courses import get_course, get_course_with_access
 from common.djangoapps.edxmako.shortcuts import render_to_response
 from openedx.core.djangoapps.course_groups.models import CohortMembership
+from openedx.core.djangoapps.course_groups.permissions import IsStaffOrAdmin
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin
 from common.djangoapps.student.auth import has_course_author_access
@@ -431,7 +432,7 @@ class APIPermissions(GenericAPIView):
         BearerAuthenticationAllowInactiveUser,
         SessionAuthenticationAllowInactiveUser,
     )
-    permission_classes = (permissions.IsAuthenticated, permissions.IsAdminUser)
+    permission_classes = (permissions.IsAuthenticated, IsStaffOrAdmin)
     serializer_class = Serializer
 
 
@@ -505,7 +506,7 @@ class CohortHandler(DeveloperErrorViewMixin, APIPermissions):
         """
         Endpoint to get either one or all cohorts.
         """
-        course_key, course = _get_course_with_access(request, course_key_string)
+        course_key, course = _get_course_with_access(request, course_key_string, 'load')
         if not cohort_id:
             all_cohorts = cohorts.get_course_cohorts(course)
             paginator = NamespacedPageNumberPagination()


### PR DESCRIPTION
## [Ticket](https://openedx.atlassian.net/browse/INF-166)

Users with discussion moderation roles were not getting the option to create a post for a specific cohort.

Before:
<img width="1083" alt="Screenshot 2022-05-06 at 8 09 30 PM" src="https://user-images.githubusercontent.com/51022010/167161073-2a815fe0-6523-4cd6-89ab-fbf503c4f3f2.png">

Fixed:
<img width="1083" alt="Screenshot 2022-05-06 at 8 07 49 PM" src="https://user-images.githubusercontent.com/51022010/167160726-68f71ab4-47f2-42be-b224-25fad0cfed75.png">

