### PR TITLE
fix: add Learner as another role posted to LTI tools for the LTI embed

### DIFF
--- a/lms/djangoapps/learner_dashboard/programs.py
+++ b/lms/djangoapps/learner_dashboard/programs.py
@@ -158,7 +158,7 @@ class ProgramLTI(ABC):
     """
       Encapsulates methods for program LTI iframe rendering.
     """
-    DEFAULT_ROLE = 'Student'
+    DEFAULT_ROLE = 'Student,Learner'
     ADMIN_ROLE = 'Administrator'
 
     def __init__(self, program_uuid, request):

--- a/openedx/features/lti_course_tab/tab.py
+++ b/openedx/features/lti_course_tab/tab.py
@@ -29,11 +29,11 @@ class LtiCourseLaunchMixin:
     """
 
     ROLE_MAP = {
-        'student': 'Student',
+        'student': 'Student,Learner',
         'staff': 'Administrator',
         'instructor': 'Instructor',
     }
-    DEFAULT_ROLE = 'Student'
+    DEFAULT_ROLE = 'Student,Learner'
 
     def _get_pii_lti_parameters(self, course: CourseBlock, request: HttpRequest) -> Dict[str, str]:
         """


### PR DESCRIPTION
## Description
[MST-1503](https://2u-internal.atlassian.net/browse/MST-1503)
Update the student role for LTI embed to include `Learner` according to http://www.imsglobal.org/specs/ltiv1p0/implementation-guide. 
The addition of the role would cover both the Institution role as well as Context role according to the guide above.

@openedx/masters-devs-cosmonauts Please review
