### PR TITLE
fix: improvments to the saml config and data endpoints

### DIFF
--- a/common/djangoapps/third_party_auth/samlproviderconfig/views.py
+++ b/common/djangoapps/third_party_auth/samlproviderconfig/views.py
@@ -61,6 +61,24 @@ class SAMLProviderConfigViewSet(PermissionRequiredMixin, SAMLProviderMixin, view
         return SAMLProviderConfig.objects.current_set().filter(
             slug=convert_saml_slug_provider_id(enterprise_customer_idp.provider_id))
 
+    def destroy(self, request, *args, **kwargs):
+        saml_provider_config = self.get_object()
+        config_id = saml_provider_config.id
+        provider_config_provider_id = saml_provider_config.provider_id
+        customer_uuid = self.requested_enterprise_uuid
+        try:
+            enterprise_customer = EnterpriseCustomer.objects.get(pk=customer_uuid)
+        except EnterpriseCustomer.DoesNotExist:
+            raise ValidationError(f'Enterprise customer not found at uuid: {customer_uuid}')  # lint-amnesty, pylint: disable=raise-missing-from
+
+        enterprise_saml_provider = EnterpriseCustomerIdentityProvider.objects.filter(
+            enterprise_customer=enterprise_customer,
+            provider_id=provider_config_provider_id,
+        )
+        enterprise_saml_provider.delete()
+        saml_provider_config.delete()
+        return Response(data=config_id, status=status.HTTP_200_OK)
+
     @property
     def requested_enterprise_uuid(self):
         """


### PR DESCRIPTION
## Description

 [ENT-5499](https://2u-internal.atlassian.net/browse/ENT-5499)

1) Deleting a saml provider config via the api endpoint would put the customer in a bad state as it would not remove the enterprise provider config
2) Added better exception handling around bad saml provider data metadata urls. Before the endpoint would 500 if a bad url was provided.
3) made it so provider data configs validate metadata urls on updates as well as creates.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.
