### PR TITLE
fix: update lti-consumer-xblock library to v4.0.1

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -643,7 +643,7 @@ libsass==0.10.0
     #   ora2
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==3.4.6
+lti-consumer-xblock==4.0.1
     # via -r requirements/edx/base.in
 lxml==4.8.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -848,7 +848,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/testing.txt
     #   ora2
-lti-consumer-xblock==3.4.6
+lti-consumer-xblock==4.0.1
     # via -r requirements/edx/testing.txt
 lxml==4.8.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -809,7 +809,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==3.4.6
+lti-consumer-xblock==4.0.1
     # via -r requirements/edx/base.txt
 lxml==4.8.0
     # via


### PR DESCRIPTION
## Description
[MST-1503](https://2u-internal.atlassian.net/browse/MST-1503)
Update the lti-consumer-xblock library to version 4.0.1 so it includes the addition of `Learner` into LTI roles

@openedx/masters-devs-cosmonauts Please review