### PR TITLE
fix: test non-ascii works in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,10 +22,10 @@ python_files = tests.py test_*.py tests_*.py *_tests.py __init__.py
 [pycodestyle]
 # error codes: https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes
 # E501: line too long
-# E265: block comment should start with '# '
+# E265: block comment should start with ‘# ’
 #   We ignore this because pep8 used to erroneously lump E266 into it also.
 #   We should probably fix these now.
-# E266: too many leading '#' for block comment
+# E266: too many leading ‘#’ for block comment
 #   We have lots of comments that look like "##### HEADING #####" which violate
 #   this rule, because they don't have a space after the first #. However,
 #   they're still perfectly reasonable comments, so we disable this rule.


### PR DESCRIPTION
Testing whether non-ascii characters in setup.cfg work with current setup tools version