### PR TITLE
fix: share urls in course about page

### DIFF
--- a/lms/templates/courseware/course_about_sidebar_header.html
+++ b/lms/templates/courseware/course_about_sidebar_header.html
@@ -20,33 +20,27 @@ from six import text_type
         site_domain = static.get_value('site_domain', settings.SITE_NAME)
         site_protocol = 'https' if settings.HTTPS == 'on' else 'http'
         platform_name = static.get_platform_name()
+        course_path = reverse('about_course', args=[text_type(course.id)])
+        course_url = f"{site_protocol}://{site_domain}{course_path}"
 
         ## Translators: This text will be automatically posted to the student's
         ## Twitter account. {url} should appear at the end of the text.
-        tweet_text = _("I just enrolled in {number} {title} through {account}: {url}").format(
+        tweet_text = _("I just enrolled in {number} {title} through {account} {url}").format(
             number=course.number,
             title=course.display_name_with_default,
             account=static.get_value('course_about_twitter_account', settings.PLATFORM_TWITTER_ACCOUNT),
-            url=u"{protocol}://{domain}{path}".format(
-                protocol=site_protocol,
-                domain=site_domain,
-                path=reverse('about_course', args=[text_type(course.id)])
-            )
+            url=course_url
         )
 
         tweet_action = u"https://twitter.com/intent/tweet?text={tweet_text}".format(tweet_text=six.moves.urllib.parse.quote(tweet_text))
 
-        facebook_link = static.get_value('course_about_facebook_link', settings.PLATFORM_FACEBOOK_ACCOUNT)
+        facebook_link = f"https://www.facebook.com/sharer/sharer.php?u={six.moves.urllib.parse.quote(course_url)}"
 
         email_body = _("I just enrolled in {number} {title} through {platform} {url}").format(
                 number=course.number,
                 title=course.display_name_with_default,
                 platform=platform_name,
-                url=u"{protocol}://{domain}{path}".format(
-                    protocol=site_protocol,
-                    domain=site_domain,
-                    path=reverse('about_course', args=[text_type(course.id)]),
-                )
+                url=course_url
         )
 
         email_subject = _("Take a course with {platform} online").format(platform=platform_name)
@@ -59,7 +53,7 @@ from six import text_type
         <span class="icon fa fa-twitter" aria-hidden="true"></span><span class="sr">${_("Tweet that you've enrolled in this course")}</span>
       </a>
       <a href="${facebook_link}" class="share">
-        <span class="icon fa fa-thumbs-up" aria-hidden="true"></span><span class="sr">${_("Post a Facebook message to say you've enrolled in this course")}</span>
+        <span class="icon fa fa-facebook" aria-hidden="true"></span><span class="sr">${_("Post a Facebook message to say you've enrolled in this course")}</span>
       </a>
       <a href="${email_link}" class="share">
         <span class="icon fa fa-envelope" aria-hidden="true"></span><span class="sr">${_("Email someone to say you've enrolled in this course")}</span>


### PR DESCRIPTION

<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

  This commit does few changes fixes for the course_about_sidebar_template
  - It fixes incorrect share url ref: openedx/build-test-release-wg/issues/174
  - It changes the icon for facebook instead of thump up to faceboook logo
  - It remove redundancy in getting course about page url.
## Supporting information

Go to course about page and share via facebook. 
Before it would link to https://www.facebook.com/YourPlatformFacebookAccount which event if the settings platform account is set, it wouldn't make a shareable expirence, add to that it assume that in order to share to facebook, the platform or the course must have a facebook account. 

After applying this change it would use the official way of creating a fasebook share url: 

https://www.facebook.com/sharer/sharer.php?u=course_url 

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

Before Nutmeg release, (need to be cherry-picked to nutmeg once approaved/merged). 


