### PR TITLE
BOM-3380: remove deprecated LibraryLocator fields usage

### DIFF
--- a/common/djangoapps/split_modulestore_django/models.py
+++ b/common/djangoapps/split_modulestore_django/models.py
@@ -9,6 +9,7 @@ from opaque_keys.edx.django.models import LearningContextKeyField
 from simple_history.models import HistoricalRecords
 
 from xmodule.modulestore import ModuleStoreEnum
+from xmodule.util.misc import get_library_or_course_attribute
 
 User = get_user_model()
 
@@ -92,7 +93,7 @@ class SplitModulestoreCourseIndex(models.Model):
         return {
             "_id": ObjectId(self.objectid),
             "org": self.course_id.org,
-            "course": self.course_id.course,
+            "course": get_library_or_course_attribute(self.course_id),
             "run": self.course_id.run,  # pylint: disable=no-member
             "edited_by": self.edited_by_id,
             "edited_on": self.edited_on,

--- a/common/lib/xmodule/xmodule/contentstore/mongo.py
+++ b/common/lib/xmodule/xmodule/contentstore/mongo.py
@@ -18,7 +18,7 @@ from xmodule.contentstore.content import XASSET_LOCATION_TAG
 from xmodule.exceptions import NotFoundError
 from xmodule.modulestore.django import ASSET_IGNORE_REGEX
 from xmodule.mongo_utils import connect_to_mongodb, create_collection_index
-from xmodule.util.misc import escape_invalid_characters
+from xmodule.util.misc import escape_invalid_characters, get_library_or_course_attribute
 
 from .content import ContentStore, StaticContent, StaticContentStream
 
@@ -614,7 +614,7 @@ def query_for_course(course_key, category=None):
     dbkey = SON([
         (f'{prefix}.tag', XASSET_LOCATION_TAG),
         (f'{prefix}.org', course_key.org),
-        (f'{prefix}.course', course_key.course),
+        (f'{prefix}.course', get_library_or_course_attribute(course_key)),
     ])
     if category:
         dbkey[f'{prefix}.category'] = category

--- a/common/lib/xmodule/xmodule/modulestore/__init__.py
+++ b/common/lib/xmodule/xmodule/modulestore/__init__.py
@@ -26,6 +26,7 @@ from xblock.runtime import Mixologist
 from openedx.core.lib.json_utils import EdxJSONEncoder
 from xmodule.assetstore import AssetMetadata
 from xmodule.errortracker import make_error_tracker
+from xmodule.util.misc import get_library_or_course_attribute
 
 from .exceptions import InsufficientSpecificationError, InvalidLocationError
 
@@ -203,9 +204,11 @@ class BulkOperationsMixin:
         if ignore_case:
             for key, record in self._active_bulk_ops.records.items():
                 # Shortcut: check basic equivalence for cases where org/course/run might be None.
+                key_library = get_library_or_course_attribute(key)
+                course_library = get_library_or_course_attribute(course_key)
                 if (key == course_key) or (  # lint-amnesty, pylint: disable=too-many-boolean-expressions
                         (key.org and key.org.lower() == course_key.org.lower()) and
-                        (key.course and key.course.lower() == course_key.course.lower()) and
+                        (key_library and key_library.lower() == course_library.lower()) and
                         (key.run and key.run.lower() == course_key.run.lower())
                 ):
                     return record

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/caching_descriptor_system.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/caching_descriptor_system.py
@@ -20,6 +20,7 @@ from xmodule.modulestore.split_mongo import BlockKey, CourseEnvelope
 from xmodule.modulestore.split_mongo.definition_lazy_loader import DefinitionLazyLoader
 from xmodule.modulestore.split_mongo.id_manager import SplitMongoIdManager
 from xmodule.modulestore.split_mongo.split_mongo_kvs import SplitMongoKVS
+from xmodule.util.misc import get_library_or_course_attribute
 from xmodule.x_module import XModuleMixin
 
 log = logging.getLogger(__name__)
@@ -47,8 +48,9 @@ class CachingDescriptorSystem(MakoDescriptorSystem, EditInfoRuntimeMixin):  # li
             underlying modulestore
         """
         # needed by capa_problem (as runtime.resources_fs via this.resources_fs)
-        if course_entry.course_key.course:
-            root = modulestore.fs_root / course_entry.course_key.org / course_entry.course_key.course / course_entry.course_key.run  # lint-amnesty, pylint: disable=line-too-long
+        course_library = get_library_or_course_attribute(course_entry.course_key)
+        if course_library:
+            root = modulestore.fs_root / course_entry.course_key.org / course_library / course_entry.course_key.run  # lint-amnesty, pylint: disable=line-too-long
         else:
             root = modulestore.fs_root / str(course_entry.structure['_id'])
         root.makedirs_p()  # create directory if it doesn't exist

--- a/common/lib/xmodule/xmodule/util/misc.py
+++ b/common/lib/xmodule/xmodule/util/misc.py
@@ -6,6 +6,10 @@ Miscellaneous utility functions.
 import re
 
 from xmodule.annotator_mixin import html_to_text
+from opaque_keys.edx.locator import (
+    CourseLocator,
+    LibraryLocator,
+)
 
 
 def escape_invalid_characters(name, invalid_char_list, replace_with='_'):
@@ -110,3 +114,13 @@ def is_xblock_an_assignment(xblock):
     weight = getattr(xblock, 'weight', 1)
     scored = has_score and (weight is None or weight > 0)
     return graded and scored
+
+
+def get_library_or_course_attribute(locator):
+    """
+    Returns respective attribute to distinguish betweeen LibraryLocator and CourseLocator objects.
+    """
+    if isinstance(locator, CourseLocator):
+        return locator.course
+    if isinstance(locator, LibraryLocator):
+        return locator.library


### PR DESCRIPTION
**Issue:** [BOM-3380](https://openedx.atlassian.net/browse/BOM-3380)

### Description
- Refactor the deprecated LibraryLocator fields usage. See https://github.com/openedx/opaque-keys/blob/master/opaque_keys/edx/locator.py#L485
- Fixed 1187 Deprecation Warnings by making this change.

### Testing
- tested the change by creating sandbox against the changes https://deprecation.sandbox.edx.org/dashboard.