### PR TITLE
fix: send COURSE_CERT_DATE_CHANGE signal on_commit

### DIFF
--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -874,17 +874,16 @@ def _course_uses_available_date(course):
     )
 
 
-def available_date_for_certificate(course, certificate, certificate_available_date=None):
+def available_date_for_certificate(course, certificate):
     """
     Returns the available date to use with a certificate
 
     Arguments:
         course (CourseOverview or course descriptor): The course we're checking
         certificate (GeneratedCertificate): The certificate we're getting the date for
-        certificate_available_date (datetime): An optional date to override the from the course overview.
     """
     if _course_uses_available_date(course):
-        return certificate_available_date or course.certificate_available_date
+        return course.certificate_available_date
     return certificate.modified_date
 
 

--- a/openedx/core/djangoapps/content/course_overviews/signals.py
+++ b/openedx/core/djangoapps/content/course_overviews/signals.py
@@ -5,6 +5,7 @@ Signal handler for invalidating cached course overviews
 
 import logging
 
+from django.db import transaction
 from django.dispatch import Signal
 from django.dispatch.dispatcher import receiver
 
@@ -92,8 +93,11 @@ def _check_for_cert_availability_date_changes(previous_course_overview, updated_
             f"{previous_course_overview.certificate_available_date} to " +
             f"{updated_course_overview.certificate_available_date}. Sending COURSE_CERT_DATE_CHANGE signal."
         )
-        COURSE_CERT_DATE_CHANGE.send_robust(
-            sender=None,
-            course_key=updated_course_overview.id,
-            available_date=updated_course_overview.certificate_available_date
-        )
+
+        def _send_course_cert_date_change_signal():
+            COURSE_CERT_DATE_CHANGE.send_robust(
+                sender=None,
+                course_key=updated_course_overview.id,
+            )
+
+        transaction.on_commit(_send_course_cert_date_change_signal)

--- a/openedx/core/djangoapps/content/course_overviews/tests/test_signals.py
+++ b/openedx/core/djangoapps/content/course_overviews/tests/test_signals.py
@@ -84,14 +84,16 @@ class CourseOverviewSignalsTestCase(ModuleStoreTestCase):
         )
 
         # changing display name doesn't fire the signal
-        course.display_name = course.display_name + 'changed'
-        self.store.update_item(course, ModuleStoreEnum.UserID.test)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            course.display_name = course.display_name + 'changed'
+            self.store.update_item(course, ModuleStoreEnum.UserID.test)
         assert not mock_signal.called
 
         # changing the given field fires the signal
-        for change in changes:
-            setattr(course, change.field_name, change.changed_value)
-        self.store.update_item(course, ModuleStoreEnum.UserID.test)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            for change in changes:
+                setattr(course, change.field_name, change.changed_value)
+            self.store.update_item(course, ModuleStoreEnum.UserID.test)
         assert mock_signal.called
 
     @patch('openedx.core.djangoapps.content.course_overviews.signals.COURSE_START_DATE_CHANGED.send')

--- a/openedx/core/djangoapps/programs/signals.py
+++ b/openedx/core/djangoapps/programs/signals.py
@@ -177,7 +177,7 @@ def handle_course_cert_revoked(sender, user, course_key, mode, status, **kwargs)
 
 
 @receiver(COURSE_CERT_DATE_CHANGE, dispatch_uid='course_certificate_date_change_handler')
-def handle_course_cert_date_change(sender, course_key, available_date, **kwargs):  # lint-amnesty, pylint: disable=unused-argument
+def handle_course_cert_date_change(sender, course_key, **kwargs):  # lint-amnesty, pylint: disable=unused-argument
     """
     If course is updated and the certificate_available_date is changed,
     schedule a celery task to update visible_date for all certificates
@@ -185,7 +185,6 @@ def handle_course_cert_date_change(sender, course_key, available_date, **kwargs)
 
     Args:
         course_key (CourseLocator): refers to the course whose certificate_available_date was updated.
-        available_date (datetime): the date to update the certificate's available date to
 
     Returns:
         None
@@ -208,4 +207,4 @@ def handle_course_cert_date_change(sender, course_key, available_date, **kwargs)
 
     # import here, because signal is registered at startup, but items in tasks are not yet loaded
     from openedx.core.djangoapps.programs.tasks import update_certificate_visible_date_on_course_update
-    update_certificate_visible_date_on_course_update.delay(str(course_key), available_date)
+    update_certificate_visible_date_on_course_update.delay(str(course_key))

--- a/openedx/core/djangoapps/signals/signals.py
+++ b/openedx/core/djangoapps/signals/signals.py
@@ -16,7 +16,7 @@ COURSE_GRADE_CHANGED = Signal()
 COURSE_CERT_CHANGED = Signal()
 COURSE_CERT_AWARDED = Signal()
 COURSE_CERT_REVOKED = Signal()
-# providing_args=["course_key", "available_date"]
+# providing_args=["course_key",]
 COURSE_CERT_DATE_CHANGE = Signal()
 
 # providing_args=['user', 'course_id', 'subsection_id', 'subsection_grade', ]


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

**Previously**
When a course administrator changed the `certificates_display_behavior` (presumably to `end_with_date`) AND set the `certificate_available_date` in Studio, the `certificate_available_date` was not syncing to Credentials.

This was because we chose to send the `certificate_available_date` only if the course is self-paced and the `certificate_display_behavior` is set to `end_with_date`. [See PR ##28275](https://github.com/openedx/edx-platform/pull/28275). However, we were checking those two conditions by looking at the relevant `CourseOverview`, which was not yet truly saved to reflect the updated display behavior at the time of the check due to atomic requests. [Read more about atomic requests and transactions here](https://docs.djangoproject.com/en/4.0/topics/db/transactions/#tying-transactions-to-http-requests-1); we have `ATOMIC_REQUESTS` set to `TRUE` in our codebase. Because the `certificate_display_behavior` was not (yet) `end_with_date`, the post to Credentials was not being fired.

**Solution**
To fix, this commit sends the `COURSE_CERT_DATE_CHANGE` signal `on_commit` instead, which waits until the transaction has completed and the update to the `CourseOverview` has been truly applied to the database. [Read more about `on_commit` here](https://docs.djangoproject.com/en/4.0/topics/db/transactions/#django.db.transaction.on_commit). Now, when the relevant `CourseOverview` is read, it will have the updated `certificate_display_behavior`.

This commit also cleans up some previous code that was meant to get around the problem caused by atomic requests, that is now unneccessary with this fix. It essentially reverses the work done in [PR #26991](https://github.com/openedx/edx-platform/pull/26991): we no longer need to explicitly pass the `certificate_available_date` since we can trust the `CourseOverview` to be properly updated.

**Rejected Solutions**
A. Simply publish the `COURSE_CERT_DATE_CHANGE` signal `on_commit`; no other changes. Rejected because: This would fix the problem, but leaves a lot of unnecessary code and some puzzling inconsistencies. I prefer the solution above because we are cleaning up behind ourselves.

B. Pass the new `certificate_display_behavior` along with the `certificate_available_date`; read those direclty instead of checking the (not-yet-properly-updated) `CourseOverview`. Rejected because: The pattern of passing the new `certificate_available_date` down through all these methods was put in place to get around the atomic requests problem. I believe `on_commit` to be a better solution to getting around that problem. I’d like to move away from passing data down through several functions / methods.

C. Start the celery task `on_commit` (rather than send the signal `on_commit`). Rejected because: The signal receiver basically only starts the celery task, and I find the break to be a bit more readable when sending the signal. No need to split hairs here.

D. Remove the check for pacing and display behavior; send the updated `certificate_available_date` every time there is a change, no matter what the current display behavior is. Rejected because: We intentionally added this check in [PR #28275](https://github.com/openedx/edx-platform/pull/28275) because the task was not behaving as expected without it (specifically around self-paced courses). I assume this is still necessary.

**Relevant Prior Work**
The following PRs--in order--show how this section (and other relevant sections) of the code have been changed over time:
1. [Move cert date signals to avoid race conditions #26841](https://github.com/openedx/edx-platform/pull/26841)
2. [feat: Pass date in cert date update signal #26991](https://github.com/openedx/edx-platform/pull/26991)
3. [Fix certificate available date sync #28275](https://github.com/openedx/edx-platform/pull/28275)
4. [fix: Correct an issue where cert available date was not sent to Crede… #28524](https://github.com/openedx/edx-platform/pull/28524)

MICROBA-1818

## Supporting information

[MICROBA-1818](https://openedx.atlassian.net/browse/MICROBA-1818)

## Testing instructions

Cannot test locally as transactions behave differently than on prod.

On stage or prod:
1. Find or make a course where the `certificates_display_behavior` is set to `end`
2. In Studio, change the `certificates_display_behavior` to `end` and set a `certificate_available_date`
3. The `certificate_available_date` should immediately sync to Credentials

## Deadline

None
