### PR TITLE
[BD-32] feat: integrate cohort assignment filter definition

### DIFF
--- a/lms/static/js/groups/views/cohort_editor.js
+++ b/lms/static/js/groups/views/cohort_editor.js
@@ -260,15 +260,16 @@
 
                     // Show error messages.
                     this.undelegateViewEvents(this.errorNotifications);
-                    numErrors = modifiedUsers.unknown.length + modifiedUsers.invalid.length;
+                    numErrors = modifiedUsers.unknown.length + modifiedUsers.invalid.length + modifiedUsers.not_allowed.length;
                     if (numErrors > 0) {
-                        createErrorDetails = function(unknownUsers, invalidEmails, showAllErrors) {
+                        createErrorDetails = function(unknownUsers, invalidEmails, notAllowed, showAllErrors) {
                             var unknownErrorsShown = showAllErrors ? unknownUsers.length :
                                 Math.min(errorLimit, unknownUsers.length);
                             var invalidErrorsShown = showAllErrors ? invalidEmails.length :
                                 Math.min(errorLimit - unknownUsers.length, invalidEmails.length);
+                            var notAllowedErrorsShown = showAllErrors ? notAllowed.length :
+                                Math.min(errorLimit - notAllowed.length, notAllowed.length);
                             details = [];
-
 
                             for (i = 0; i < unknownErrorsShown; i++) {
                                 details.push(interpolate_text(gettext('Unknown username: {user}'),
@@ -278,6 +279,10 @@
                                 details.push(interpolate_text(gettext('Invalid email address: {email}'),
                                     {email: invalidEmails[i]}));
                             }
+                            for (i = 0; i < notAllowedErrorsShown; i++) {
+                                details.push(interpolate_text(gettext('Cohort assignment not allowed: {email_or_username}'),
+                                    {email_or_username: notAllowed[i]}));
+                            }
                             return details;
                         };
 
@@ -286,12 +291,12 @@
                                 '{numErrors} learners could not be added to this cohort:', numErrors),
                             {numErrors: numErrors}
                         );
-                        details = createErrorDetails(modifiedUsers.unknown, modifiedUsers.invalid, false);
+                        details = createErrorDetails(modifiedUsers.unknown, modifiedUsers.invalid, modifiedUsers.not_allowed, false);
 
                         errorActionCallback = function(view) {
                             view.model.set('actionText', null);
                             view.model.set('details',
-                                createErrorDetails(modifiedUsers.unknown, modifiedUsers.invalid, true));
+                                createErrorDetails(modifiedUsers.unknown, modifiedUsers.invalid, modifiedUsers.not_allowed, true));
                             view.render();
                         };
 

--- a/lms/static/js/spec/groups/views/cohorts_spec.js
+++ b/lms/static/js/spec/groups/views/cohorts_spec.js
@@ -14,6 +14,7 @@ define(['backbone', 'jquery', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers
             var catLoversInitialCount = 123,
                 dogLoversInitialCount = 456,
                 unknownUserMessage,
+                notAllowedUserMessage,
                 invalidEmailMessage, createMockCohort, createMockCohorts, createMockContentGroups,
                 createMockCohortSettingsJson,
                 createCohortsView, cohortsView, requests, respondToRefresh, verifyMessage, verifyNoMessage,
@@ -208,6 +209,10 @@ define(['backbone', 'jquery', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers
 
             invalidEmailMessage = function(name) {
                 return 'Invalid email address: ' + name;
+            };
+
+            notAllowedUserMessage = function(email) {
+                return 'Cohort assignment not allowed: ' + email;
             };
 
             beforeEach(function() {
@@ -602,7 +607,7 @@ define(['backbone', 'jquery', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers
                 respondToAdd = function(result) {
                     AjaxHelpers.respondWithJson(
                         requests,
-                        _.extend({unknown: [], added: [], present: [], changed: [],
+                        _.extend({unknown: [], added: [], present: [], changed: [], not_allowed: [],
                             success: true, preassigned: [], invalid: []}, result)
                     );
                 };
@@ -670,6 +675,19 @@ define(['backbone', 'jquery', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers
                     );
                 });
 
+                it('shows an error when user assignment not allowed', function() {
+                    createCohortsView(this, {selectCohort: 1});
+                    addStudents('not_allowed');
+                    AjaxHelpers.expectRequest(
+                        requests, 'POST', '/mock_service/cohorts/1/add', 'users=not_allowed'
+                    );
+                    respondToAdd({not_allowed: ['not_allowed']});
+                    respondToRefresh(catLoversInitialCount, dogLoversInitialCount);
+                    verifyHeader(1, 'Cat Lovers', catLoversInitialCount);
+                    verifyDetailedMessage('There was an error when trying to add learners:', 'error',
+                        [notAllowedUserMessage('not_allowed')]
+                    );
+                });
 
                 it('shows a "view all" button when more than 5 students do not exist', function() {
                     var sixUsers = 'unknown1, unknown2, unknown3, unknown4, unknown5, unknown6';

--- a/openedx/core/djangoapps/course_groups/tests/test_filters.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_filters.py
@@ -3,12 +3,16 @@ Test that various filters are executed for models in the course_groups app.
 """
 from django.test import override_settings
 from openedx_filters import PipelineStep
-from openedx_filters.learning.filters import CohortChangeRequested
+from openedx_filters.learning.filters import CohortAssignmentRequested, CohortChangeRequested
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 
 from common.djangoapps.student.tests.factories import UserFactory
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
-from openedx.core.djangoapps.course_groups.models import CohortChangeNotAllowed, CohortMembership
+from openedx.core.djangoapps.course_groups.models import (
+    CohortAssignmentNotAllowed,
+    CohortChangeNotAllowed,
+    CohortMembership,
+)
 from openedx.core.djangoapps.course_groups.tests.helpers import CohortFactory
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 
@@ -31,6 +35,23 @@ class TestCohortChangeStep(PipelineStep):
         return {}
 
 
+class TestCohortAssignmentStep(PipelineStep):
+    """
+    Utility function used when getting steps for pipeline.
+    """
+
+    def run_filter(self, user, target_cohort):  # pylint: disable=arguments-differ
+        """Pipeline step that adds cohort info to the users profile."""
+        user.profile.set_meta(
+            {
+                "cohort_info":
+                f"User assigned to Cohort {str(target_cohort)}",
+            }
+        )
+        user.profile.save()
+        return {}
+
+
 class TestStopCohortChangeStep(PipelineStep):
     """
     Utility function used when getting steps for pipeline.
@@ -39,6 +60,16 @@ class TestStopCohortChangeStep(PipelineStep):
     def run_filter(self, current_membership, target_cohort, *args, **kwargs):  # pylint: disable=arguments-differ
         """Pipeline step that stops the cohort change process."""
         raise CohortChangeRequested.PreventCohortChange("You can't change cohorts.")
+
+
+class TestStopAssignmentChangeStep(PipelineStep):
+    """
+    Utility function used when getting steps for pipeline.
+    """
+
+    def run_filter(self, user, target_cohort, *args, **kwargs):  # pylint: disable=arguments-differ
+        """Pipeline step that stops the cohort change process."""
+        raise CohortAssignmentRequested.PreventCohortAssignment("You can't be assign to this cohort.")
 
 
 @skip_unless_lms
@@ -94,6 +125,33 @@ class CohortFiltersTest(SharedModuleStoreTestCase):
 
     @override_settings(
         OPEN_EDX_FILTERS_CONFIG={
+            "org.openedx.learning.cohort.assignment.requested.v1": {
+                "pipeline": [
+                    "openedx.core.djangoapps.course_groups.tests.test_filters.TestCohortAssignmentStep",
+                ],
+                "fail_silently": False,
+            },
+        },
+    )
+    def test_cohort_assignment_filter_executed(self):
+        """
+        Test whether the student cohort assignment filter is triggered before the user's
+        assignment.
+
+        Expected result:
+            - CohortAssignmentRequested is triggered and executes TestCohortAssignmentStep.
+            - The user's profile meta contains cohort_info.
+        """
+
+        cohort_membership, _ = CohortMembership.assign(user=self.user, cohort=self.second_cohort, )
+
+        self.assertEqual(
+            {"cohort_info": "User assigned to Cohort SecondCohort"},
+            cohort_membership.user.profile.get_meta(),
+        )
+
+    @override_settings(
+        OPEN_EDX_FILTERS_CONFIG={
             "org.openedx.learning.cohort.change.requested.v1": {
                 "pipeline": [
                     "openedx.core.djangoapps.course_groups.tests.test_filters.TestStopCohortChangeStep",
@@ -115,6 +173,27 @@ class CohortFiltersTest(SharedModuleStoreTestCase):
         with self.assertRaises(CohortChangeNotAllowed):
             CohortMembership.assign(cohort=self.second_cohort, user=self.user)
 
+    @override_settings(
+        OPEN_EDX_FILTERS_CONFIG={
+            "org.openedx.learning.cohort.assignment.requested.v1": {
+                "pipeline": [
+                    "openedx.core.djangoapps.course_groups.tests.test_filters.TestStopAssignmentChangeStep",
+                ],
+                "fail_silently": False,
+            },
+        },
+    )
+    def test_cohort_assignment_filter_prevent_move(self):
+        """
+        Test prevent the user's cohort assignment through a pipeline step.
+
+        Expected result:
+            - CohortAssignmentRequested is triggered and executes TestStopAssignmentChangeStep.
+            - The user can't be assigned to the cohort.
+        """
+        with self.assertRaises(CohortAssignmentNotAllowed):
+            CohortMembership.assign(cohort=self.second_cohort, user=self.user)
+
     @override_settings(OPEN_EDX_FILTERS_CONFIG={})
     def test_cohort_change_without_filter_configuration(self):
         """
@@ -126,6 +205,19 @@ class CohortFiltersTest(SharedModuleStoreTestCase):
         """
         CohortMembership.assign(cohort=self.first_cohort, user=self.user)
 
+        cohort_membership, _ = CohortMembership.assign(cohort=self.second_cohort, user=self.user)
+
+        self.assertEqual({}, cohort_membership.user.profile.get_meta())
+
+    @override_settings(OPEN_EDX_FILTERS_CONFIG={})
+    def test_cohort_assignment_without_filter_configuration(self):
+        """
+        Test usual cohort assignment process, without filter's intervention.
+
+        Expected result:
+            - CohortAssignmentRequested does not have any effect on the cohort change process.
+            - The cohort assignment process ends successfully.
+        """
         cohort_membership, _ = CohortMembership.assign(cohort=self.second_cohort, user=self.user)
 
         self.assertEqual({}, cohort_membership.user.profile.get_meta())


### PR DESCRIPTION
## Description

This PR integrates the Cohort Assignment filter definition meant to be triggered when assigning a user into a cohort.
## Supporting information

- [Hooks Extension Framework OEP-50](https://open-edx-proposals.readthedocs.io/en/latest/oep-0050-hooks-extension-framework.html)
ADR(s) on:
- [Open edX Filters naming and versioning](https://github.com/eduNEXT/openedx-filters/blob/main/docs/decisions/0004-filters-naming-and-versioning.rst): about how to identify filters and manage its versions
- [Open edX Filters configuration](https://github.com/eduNEXT/openedx-filters/blob/main/docs/decisions/0002-hooks-filter-config-location.rst): how to configure filters
- [Open edX Filters tooling](https://github.com/eduNEXT/openedx-filters/blob/main/docs/decisions/0003-hooks-filter-tooling-pipeline.rst): what to use to run filters
- [Open edX Filters payload](https://github.com/eduNEXT/openedx-filters/blob/main/docs/decisions/0005-filters-payload.rst): input arguments for filters

## Testing instructions

1. Install openedx-filters library:
```
pip install openedx-filters==0.7.0
```
2. Implement your pipeline steps in your favorite plugin. We created some as illustration in [openedx-filters-samples](https://github.com/eduNEXT/openedx-filters-samples). We'll be using those in this example.
3. Install openedx-filters-samples
```
pip install git+https://github.com/eduNEXT/openedx-filters-samples.git@master#egg=openedx_filters_samples
``` 
4. Configure your filters:
With this configuration, you won't be able to:
- Change user from cohort `org.openedx.learning.cohort.assignment.requested.v1`
```
OPEN_EDX_FILTERS_CONFIG = {
  "org.openedx.learning.cohort.assignment.requested.v1": {
          "fail_silently": False,
          "pipeline": [
              "openedx_filters_samples.samples.pipeline.StopCohortAssignment"
          ]
      },
}
```

## Deadline

Before nutmeg official release (this PR it's intended to be backported along with the other filters that didn't make it)
