### PR TITLE
feat!: change JWT access token expires

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1211,14 +1211,6 @@ OAUTH_ENFORCE_SECURE = True
 OAUTH_EXPIRE_CONFIDENTIAL_CLIENT_DAYS = 365
 OAUTH_EXPIRE_PUBLIC_CLIENT_DAYS = 30
 
-# .. setting_name: JWT_ACCESS_TOKEN_EXPIRE_SECONDS
-# .. setting_default: 60 * 60
-# .. setting_description: The number of seconds a JWT access token remains valid. We use this
-#     custom setting for JWT formatted access tokens, rather than the django-oauth-toolkit setting
-#     ACCESS_TOKEN_EXPIRE_SECONDS, because the JWT is non-revocable and we want it to be shorter
-#     lived than the legacy Bearer (opaque) access tokens, and thus to have a smaller default.
-JWT_ACCESS_TOKEN_EXPIRE_SECONDS = 60 * 60
-
 ################################## THIRD_PARTY_AUTH CONFIGURATION #############################
 TPA_PROVIDER_BURST_THROTTLE = '10/min'
 TPA_PROVIDER_SUSTAINED_THROTTLE = '50/hr'

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1211,6 +1211,14 @@ OAUTH_ENFORCE_SECURE = True
 OAUTH_EXPIRE_CONFIDENTIAL_CLIENT_DAYS = 365
 OAUTH_EXPIRE_PUBLIC_CLIENT_DAYS = 30
 
+# .. setting_name: JWT_ACCESS_TOKEN_EXPIRE_SECONDS
+# .. setting_default: 60 * 60
+# .. setting_description: The number of seconds a JWT access token remains valid. We use this
+#     custom setting for JWT formatted access tokens, rather than the django-oauth-toolkit setting
+#     ACCESS_TOKEN_EXPIRE_SECONDS, because the JWT is non-revocable and we want it to be shorter
+#     lived than the legacy Bearer (opaque) access tokens, and thus to have a smaller default.
+JWT_ACCESS_TOKEN_EXPIRE_SECONDS = 60 * 60
+
 ################################## THIRD_PARTY_AUTH CONFIGURATION #############################
 TPA_PROVIDER_BURST_THROTTLE = '10/min'
 TPA_PROVIDER_SUSTAINED_THROTTLE = '50/hr'

--- a/openedx/core/djangoapps/oauth_dispatch/jwt.py
+++ b/openedx/core/djangoapps/oauth_dispatch/jwt.py
@@ -61,6 +61,9 @@ def create_jwt_from_token(token_dict, oauth_adapter, use_asymmetric_key=None):
     access_token = oauth_adapter.get_access_token(token_dict['access_token'])
     client = oauth_adapter.get_client_for_token(access_token)
 
+    # use a JWT specific expiration
+    token_dict['expires_in'] = settings.JWT_ACCESS_TOKEN_EXPIRE_SECONDS
+
     # TODO (ARCH-204) put access_token as a JWT ID claim (jti)
     return _create_jwt(
         access_token.user,

--- a/openedx/core/djangoapps/oauth_dispatch/jwt.py
+++ b/openedx/core/djangoapps/oauth_dispatch/jwt.py
@@ -61,8 +61,15 @@ def create_jwt_from_token(token_dict, oauth_adapter, use_asymmetric_key=None):
     access_token = oauth_adapter.get_access_token(token_dict['access_token'])
     client = oauth_adapter.get_client_for_token(access_token)
 
-    # use a JWT specific expiration
-    token_dict['expires_in'] = settings.JWT_ACCESS_TOKEN_EXPIRE_SECONDS
+    # .. setting_name: JWT_ACCESS_TOKEN_EXPIRE_SECONDS
+    # .. setting_default: 60 * 60
+    # .. setting_description: The number of seconds a JWT access token remains valid. We use this
+    #     custom setting for JWT formatted access tokens, rather than the django-oauth-toolkit setting
+    #     ACCESS_TOKEN_EXPIRE_SECONDS, because the JWT is non-revocable and we want it to be shorter
+    #     lived than the legacy Bearer (opaque) access tokens, and thus to have a smaller default.
+    # .. setting_warning: For security purposes, 1 hour (the default) is the maximum recommended setting
+    #     value. For tighter security, you can use a shorter amount of time.
+    token_dict['expires_in'] = getattr(settings, 'JWT_ACCESS_TOKEN_EXPIRE_SECONDS', 60 * 60)
 
     # TODO (ARCH-204) put access_token as a JWT ID claim (jti)
     return _create_jwt(

--- a/openedx/core/djangoapps/oauth_dispatch/tests/mixins.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/mixins.py
@@ -16,7 +16,8 @@ class AccessTokenMixin:
     """ Mixin for tests dealing with OAuth 2 access tokens. """
 
     def assert_valid_jwt_access_token(self, access_token, user, scopes=None, should_be_expired=False, filters=None,
-                                      should_be_asymmetric_key=False, should_be_restricted=None, aud=None, secret=None):
+                                      should_be_asymmetric_key=False, should_be_restricted=None, aud=None, secret=None,
+                                      expires_in=None):
         """
         Verify the specified JWT access token is valid, and belongs to the specified user.
         Returns:
@@ -95,6 +96,9 @@ class AccessTokenMixin:
             expected['is_restricted'] = should_be_restricted
 
         self.assertDictContainsSubset(expected, payload)
+
+        if expires_in:
+            assert payload['exp'] == payload['iat'] + expires_in
 
         # Since we suppressed checking of expiry
         # in the claim in the above check, because we want

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_views.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_views.py
@@ -179,13 +179,15 @@ class TestAccessTokenView(AccessTokenLoginMixin, mixins.AccessTokenMixin, _Dispa
         response = self._post_request(self.user, client, token_type=token_type, headers=headers or {})
         assert response.status_code == 200
         data = json.loads(response.content.decode('utf-8'))
-        assert 'expires_in' in data
+        expected_default_expires_in = 60 * 60
+        assert data['expires_in'] == expected_default_expires_in
         assert data['token_type'] == 'JWT'
         self.assert_valid_jwt_access_token(
             data['access_token'],
             self.user,
             data['scope'].split(' '),
             should_be_restricted=False,
+            expires_in=expected_default_expires_in,
         )
 
     @ddt.data('dot_app')


### PR DESCRIPTION
## Description

Introduces JWT_ACCESS_TOKEN_EXPIRE_SECONDS setting. This is the number
of seconds a JWT access token remains valid. We use this custom
setting for JWT formatted access tokens, rather than the
django-oauth-toolkit setting ACCESS_TOKEN_EXPIRE_SECONDS, because the
JWT is non-revocable and we want it to be shorter lived than the
legacy Bearer (opaque) access tokens, and thus to have a smaller
default.

BREAKING CHANGE: The thing that is breaking is that JWT access tokens
will now have a 1 hour default, instead of a 10 hours default. If
third-party scripts are appropriately checking/refreshing the access
token, this should be ok. However, you can always override with a
longer duration temporarily. From a security perspective, we don't
recommend a longer duration, and you may consider a shorter duration.

ARCHBOM-2099

## Testing instructions

In devstack, tested with:
```
curl -X POST -d "client_id=studio-backend-service-key&client_secret=studio-backend-service-secret&grant_type=client_credentials&token_type=jwt" http://localhost:18000/oauth2/access_token/
```
Note: The updated expires should be represented in the JWT access token, as well as the API results. This is all unit tested as well.