### PR TITLE
fix: cohorts api not working

### DIFF
--- a/openedx/core/djangoapps/course_groups/views.py
+++ b/openedx/core/djangoapps/course_groups/views.py
@@ -502,6 +502,8 @@ class CohortHandler(DeveloperErrorViewMixin, APIPermissions):
             * user_partition_id: The integer identified of the UserPartition.
             * group_id: The integer identified of the specific group in the partition.
     """
+    queryset = []
+
     def get(self, request, course_key_string, cohort_id=None):
         """
         Endpoint to get either one or all cohorts.


### PR DESCRIPTION
GET request on cohorts API was raising assertion error. Fixed by adding get_queryset function as stub.
API Url: /api/cohorts/v1/courses/{course_id}/cohorts/

Ticket: 
https://2u-internal.atlassian.net/browse/INF-224

Before:
![before](https://user-images.githubusercontent.com/77053848/169176794-4074ee54-5f27-41d0-9fcd-c1569f61622e.png)

After:
![after](https://user-images.githubusercontent.com/77053848/169176812-14ccd43b-11b6-4d1e-beaa-38e83cb3e4ef.png)

