### PR TITLE
[BD-13] [BB-5967] refactor: deprecate get_module and descriptor_runtime attributes from ModuleSystem

### DIFF
--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -35,6 +35,7 @@ from common.djangoapps.student.models import anonymous_id_for_user
 from common.djangoapps.edxmako.shortcuts import render_to_string
 from common.djangoapps.edxmako.services import MakoService
 from common.djangoapps.xblock_django.user_service import DjangoXBlockUserService
+from lms.djangoapps.courseware.services import ModuleService
 from lms.djangoapps.lms_xblock.field_data import LmsFieldData
 from openedx.core.lib.license import wrap_with_license
 from openedx.core.lib.cache_utils import CacheService
@@ -207,11 +208,12 @@ def _preview_module_system(request, descriptor, field_data):
         else:
             preview_anonymous_user_id = anonymous_id_for_user(request.user, course_id)
 
+    module_service = ModuleService(partial(_load_preview_module, request=request))
+
     return PreviewModuleSystem(
         static_url=settings.STATIC_URL,
         # TODO (cpennington): Do we want to track how instructors are using the preview problems?
         track_function=lambda event_type, event: None,
-        get_module=partial(_load_preview_module, request),
         debug=True,
         mixins=settings.XBLOCK_MIXINS,
         course_id=course_id,
@@ -236,7 +238,8 @@ def _preview_module_system(request, descriptor, field_data):
             "teams_configuration": TeamsConfigurationService(),
             "sandbox": SandboxService(contentstore=contentstore, course_id=course_id),
             "cache": CacheService(cache),
-            'replace_urls': replace_url_service
+            'replace_urls': replace_url_service,
+            'module': module_service
         },
     )
 

--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -35,6 +35,7 @@ from common.djangoapps.student.models import anonymous_id_for_user
 from common.djangoapps.edxmako.shortcuts import render_to_string
 from common.djangoapps.edxmako.services import MakoService
 from common.djangoapps.xblock_django.user_service import DjangoXBlockUserService
+from common.lib.xmodule.xmodule.x_module import AsideKeyGenerator, OpaqueKeyReader
 from lms.djangoapps.courseware.services import ModuleService
 from lms.djangoapps.lms_xblock.field_data import LmsFieldData
 from openedx.core.lib.license import wrap_with_license
@@ -223,7 +224,6 @@ def _preview_module_system(request, descriptor, field_data):
         wrappers_asides=wrappers_asides,
         error_descriptor_class=ErrorBlock,
         # Get the raw DescriptorSystem, not the CombinedSystem
-        descriptor_runtime=descriptor._runtime,  # pylint: disable=protected-access
         services={
             "field-data": field_data,
             "i18n": ModuleI18nService,
@@ -241,6 +241,8 @@ def _preview_module_system(request, descriptor, field_data):
             'replace_urls': replace_url_service,
             'module': module_service
         },
+        id_reader=getattr(descriptor._runtime, 'id_reader', OpaqueKeyReader()),  # pylint: disable=protected-access
+        id_generator=getattr(descriptor._runtime, 'id_generator', AsideKeyGenerator()),  # pylint: disable=protected-access
     )
 
 

--- a/cms/djangoapps/contentstore/views/tests/test_preview.py
+++ b/cms/djangoapps/contentstore/views/tests/test_preview.py
@@ -28,7 +28,7 @@ from cms.djangoapps.xblock_config.models import StudioConfig
 from common.djangoapps import static_replace
 from common.djangoapps.student.tests.factories import UserFactory
 
-from ..preview import _preview_module_system, get_preview_fragment
+from ..preview import _preview_module_system, get_preview_fragment, _load_preview_module
 
 
 @ddt.ddt
@@ -178,6 +178,7 @@ class GetPreviewHtmlTestCase(ModuleStoreTestCase):
 @XBlock.needs("field-data")
 @XBlock.needs("i18n")
 @XBlock.needs("mako")
+@XBlock.needs("module")
 @XBlock.needs("replace_urls")
 @XBlock.needs("user")
 @XBlock.needs("teams_configuration")
@@ -210,7 +211,7 @@ class StudioXBlockServiceBindingTest(ModuleStoreTestCase):
         self.field_data = mock.Mock()
 
     @XBlock.register_temp_plugin(PureXBlock, identifier='pure')
-    @ddt.data("user", "i18n", "field-data", "teams_configuration", "replace_urls")
+    @ddt.data("user", "i18n", "field-data", "teams_configuration", "replace_urls", "module")
     def test_expected_services_exist(self, expected_service):
         """
         Tests that the 'user' and 'i18n' services are provided by the Studio runtime.
@@ -297,6 +298,9 @@ class CmsModuleSystemShimTest(ModuleStoreTestCase):
         html = '<a href="/static/id">'
         assert self.runtime.replace_urls(html) == \
             static_replace.replace_static_urls(html, course_id=self.runtime.course_id)
+
+    def test_get_module(self):
+        assert self.runtime.get_module(self.descriptor) == _load_preview_module(self.request, self.descriptor)
 
     def test_anonymous_user_id_preview(self):
         assert self.runtime.anonymous_student_id == 'student'

--- a/common/lib/xmodule/xmodule/conditional_module.py
+++ b/common/lib/xmodule/xmodule/conditional_module.py
@@ -39,6 +39,7 @@ _ = lambda text: text
 
 
 @XBlock.needs('mako')
+@XBlock.needs('module')
 class ConditionalBlock(
     SequenceMixin,
     MakoTemplateBlockBase,
@@ -317,7 +318,8 @@ class ConditionalBlock(
         """
         Returns a list of bound XBlocks instances upon which XBlock depends.
         """
-        return [self.system.get_module(descriptor) for descriptor in self.get_required_module_descriptors()]
+        module_service = self.runtime.service(self, 'module')
+        return [module_service.get_module(descriptor) for descriptor in self.get_required_module_descriptors()]
 
     def get_required_module_descriptors(self):
         """

--- a/common/lib/xmodule/xmodule/library_sourced_block.py
+++ b/common/lib/xmodule/xmodule/library_sourced_block.py
@@ -101,13 +101,39 @@ class LibrarySourcedBlock(StudioEditableXBlockMixin, EditableChildrenMixin, XBlo
         Renders the view that learners see.
         """
         result = Fragment()
-        child_frags = self.runtime.render_children(self, context=context)
+
+        # TODO: uncomment this line and remove _render_children() once
+        # merger of ModuleSystem and DescriptorSystem is complete
+
+        # child_frags = self.runtime.render_children(self, context=context)
+        child_frags = self._render_children(context)
+
         result.add_resources(child_frags)
         result.add_content('<div class="library-sourced-content">')
         for frag in child_frags:
             result.add_content(frag.content)
         result.add_content('</div>')
         return result
+
+    def _render_children(self, context):
+        """
+        Use CombinedSystem runtime to get block and render each child individually.
+
+        The runtime.render_children() method was earlier used to render each child
+        However, this caused a problem, when we removed the get_block() and
+        descriptor_runtime properties from the ModuleSystem, as the render_children
+        method ran in the context of LmsModuleSystem which is a child class of
+        ModuleSystem.
+
+        This is intended to be a temporary method until deprecation of all properties
+        of ModuleSystem and merger of ModuleSystem and DescriptorSystem is complete.
+        """
+        results = []
+        for child_id in self.children:
+            child = self.runtime.get_block(child_id)
+            result = self.runtime.render_child(child, context=context)
+            results.append(result)
+        return results
 
     def validate_field_data(self, validation, data):
         """

--- a/common/lib/xmodule/xmodule/split_test_module.py
+++ b/common/lib/xmodule/xmodule/split_test_module.py
@@ -125,6 +125,7 @@ def get_split_user_partitions(user_partitions):
 @XBlock.needs('mako')
 @XBlock.needs('partitions')
 @XBlock.needs('user')
+@XBlock.needs('module')
 class SplitTestBlock(  # lint-amnesty, pylint: disable=abstract-method
     SplitTestFields,
     SequenceMixin,
@@ -192,7 +193,7 @@ class SplitTestBlock(  # lint-amnesty, pylint: disable=abstract-method
         Return the user bound child block for the partition or None.
         """
         if self.child_descriptor is not None:
-            return self.system.get_module(self.child_descriptor)
+            return self.runtime.service(self, 'module').get_module(self.child_descriptor)
         else:
             return None
 
@@ -272,7 +273,7 @@ class SplitTestBlock(  # lint-amnesty, pylint: disable=abstract-method
 
         for child_location in self.children:  # pylint: disable=no-member
             child_descriptor = self.get_child_descriptor_by_location(child_location)
-            child = self.system.get_module(child_descriptor)
+            child = self.runtime.service(self, 'module').get_module(child_descriptor)
             rendered_child = child.render(STUDENT_VIEW, context)
             fragment.add_fragment_resources(rendered_child)
             group_name, updated_group_id = self.get_data_for_vertical(child)
@@ -347,7 +348,7 @@ class SplitTestBlock(  # lint-amnesty, pylint: disable=abstract-method
         """
         html = ""
         for active_child_descriptor in children:
-            active_child = self.system.get_module(active_child_descriptor)
+            active_child = self.runtime.service(self, 'module').get_module(active_child_descriptor)
             rendered_child = active_child.render(StudioEditableBlock.get_preview_view_name(active_child), context)
             if active_child.category == 'vertical':
                 group_name, group_id = self.get_data_for_vertical(active_child)

--- a/common/lib/xmodule/xmodule/tests/__init__.py
+++ b/common/lib/xmodule/xmodule/tests/__init__.py
@@ -172,7 +172,6 @@ def get_test_system(
         node_path=os.environ.get("NODE_PATH", "/usr/local/lib/node_modules"),
         course_id=course_id,
         error_descriptor_class=ErrorBlock,
-        descriptor_runtime=descriptor_system,
     )
 
 

--- a/common/lib/xmodule/xmodule/tests/__init__.py
+++ b/common/lib/xmodule/xmodule/tests/__init__.py
@@ -15,10 +15,11 @@ import sys
 import traceback
 import unittest
 from contextlib import contextmanager
-from functools import wraps
+from functools import partial, wraps
 from unittest.mock import Mock
 
 from django.test import TestCase
+from lms.djangoapps.courseware.services import ModuleService
 
 from opaque_keys.edx.keys import CourseKey
 from path import Path as path
@@ -152,7 +153,6 @@ def get_test_system(
     return TestModuleSystem(
         static_url='/static',
         track_function=Mock(name='get_test_system.track_function'),
-        get_module=get_module,
         debug=True,
         hostname="edx.org",
         services={
@@ -166,7 +166,8 @@ def get_test_system(
                 waittime=10,
                 construct_callback=Mock(name='get_test_system.xqueue.construct_callback', side_effect="/"),
             ),
-            'replace_urls': replace_url_service
+            'replace_urls': replace_url_service,
+            'module': ModuleService(partial(get_module))
         },
         node_path=os.environ.get("NODE_PATH", "/usr/local/lib/node_modules"),
         course_id=course_id,

--- a/common/lib/xmodule/xmodule/tests/test_library_content.py
+++ b/common/lib/xmodule/xmodule/tests/test_library_content.py
@@ -3,10 +3,12 @@ Basic unit tests for LibraryContentBlock
 
 Higher-level tests are in `cms/djangoapps/contentstore/tests/test_libraries.py`.
 """
+from functools import partial
 from unittest.mock import Mock, patch
 
 from bson.objectid import ObjectId
 from fs.memoryfs import MemoryFS
+from lms.djangoapps.courseware.services import ModuleService
 from lxml import etree
 from search.search_engine_base import SearchEngine
 from web_fragments.fragment import Fragment
@@ -61,12 +63,12 @@ class LibraryContentTest(MixedSplitTestCase):
         def get_module(descriptor):
             """Mocks module_system get_module function"""
             sub_module_system = get_test_system(course_id=module.location.course_key)
-            sub_module_system.get_module = get_module
+            sub_module_system._services['module'] = ModuleService(partial(get_module))
             sub_module_system.descriptor_runtime = descriptor._runtime  # pylint: disable=protected-access
             descriptor.bind_for_student(sub_module_system, self.user_id)
             return descriptor
 
-        module_system.get_module = get_module
+        module_system._services['module'] = ModuleService(partial(get_module))
         module.xmodule_runtime = module_system
 
 

--- a/common/lib/xmodule/xmodule/unit_block.py
+++ b/common/lib/xmodule/xmodule/unit_block.py
@@ -44,13 +44,39 @@ class UnitBlock(XBlock):
     def student_view(self, context=None):
         """Provide default student view."""
         result = Fragment()
-        child_frags = self.runtime.render_children(self, context=context)
+
+        # TODO: uncomment this line and remove _render_children() once
+        # merger of ModuleSystem and DescriptorSystem is complete
+
+        # child_frags = self.runtime.render_children(self, context=context)
+        child_frags = self._render_children(context)
+
         result.add_resources(child_frags)
         result.add_content('<div class="unit-xblock vertical">')
         for frag in child_frags:
             result.add_content(frag.content)
         result.add_content('</div>')
         return result
+
+    def _render_children(self, context):
+        """
+        Use CombinedSystem runtime to get block and render each child individually.
+
+        The runtime.render_children() method was earlier used to render each child
+        However, this caused a problem, when we removed the get_block() and
+        descriptor_runtime properties from the ModuleSystem, as the render_children
+        method ran in the context of LmsModuleSystem which is a child class of
+        ModuleSystem.
+
+        This is intended to be a temporary method until deprecation of all properties
+        of ModuleSystem and merger of ModuleSystem and DescriptorSystem is complete.
+        """
+        results = []
+        for child_id in self.children:
+            child = self.runtime.get_block(child_id)
+            result = self.runtime.render_child(child, context=context)
+            results.append(result)
+        return results
 
     public_view = student_view
 

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -1609,6 +1609,21 @@ class ModuleSystemShim:
         )
         return self.resources_fs
 
+    @property
+    def get_module(self):
+        """
+        Returns a function to bind module system and user data to given descriptor
+
+        Deprecated in favor of module service.
+        """
+        warnings.warn(
+            'runtime.get_module is deprecated. Please use the module service instead.',
+            DeprecationWarning, stacklevel=3,
+        )
+        module_service = self._services.get('module')
+        if module_service:
+            return partial(module_service.get_module)
+
 
 class ModuleSystem(MetricsMixin, ConfigurableFragmentWrapper, ModuleSystemShim, Runtime):
     """
@@ -1624,7 +1639,7 @@ class ModuleSystem(MetricsMixin, ConfigurableFragmentWrapper, ModuleSystemShim, 
     """
 
     def __init__(
-            self, static_url, track_function, get_module,
+            self, static_url, track_function,
             descriptor_runtime, debug=False, hostname="", publish=None,
             node_path="", course_id=None, error_descriptor_class=None,
             field_data=None, rebind_noauth_module_to_user=None,
@@ -1638,10 +1653,6 @@ class ModuleSystem(MetricsMixin, ConfigurableFragmentWrapper, ModuleSystemShim, 
                          or otherwise tracking the event.
                          TODO: Not used, and has inconsistent args in different
                          files.  Update or remove.
-
-        get_module - function that takes a descriptor and returns a corresponding
-                         module instance object.  If the current user does not have
-                         access to that location, returns None.
 
         descriptor_runtime - A `DescriptorSystem` to use for loading xblocks by id
 
@@ -1665,7 +1676,6 @@ class ModuleSystem(MetricsMixin, ConfigurableFragmentWrapper, ModuleSystemShim, 
 
         self.STATIC_URL = static_url
         self.track_function = track_function
-        self.get_module = get_module
         self.DEBUG = self.debug = debug
         self.HOSTNAME = self.hostname = hostname
         self.node_path = node_path

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -48,6 +48,7 @@ from xmodule.util.sandboxing import SandboxService
 from common.djangoapps.static_replace.services import ReplaceURLService
 from common.djangoapps.static_replace.wrapper import replace_urls_wrapper
 from common.djangoapps.xblock_django.constants import ATTR_KEY_USER_ID
+from common.lib.xmodule.xmodule.x_module import AsideKeyGenerator, OpaqueKeyReader
 from capa.xqueue_interface import XQueueService  # lint-amnesty, pylint: disable=wrong-import-order
 from lms.djangoapps.courseware.access import get_user_role, has_access
 from lms.djangoapps.courseware.entrance_exams import user_can_skip_entrance_exam, user_has_passed_entrance_exam
@@ -748,9 +749,10 @@ def get_module_system_for_user(
             'replace_urls': replace_url_service,
             'module': module_service
         },
-        descriptor_runtime=descriptor._runtime,  # pylint: disable=protected-access
         rebind_noauth_module_to_user=rebind_noauth_module_to_user,
         request_token=request_token,
+        id_reader=getattr(descriptor._runtime, 'id_reader', OpaqueKeyReader()),  # pylint: disable=protected-access
+        id_generator=getattr(descriptor._runtime, 'id_generator', AsideKeyGenerator()),  # pylint: disable=protected-access
     )
 
     # pass position specified in URL to module through ModuleSystem

--- a/lms/djangoapps/courseware/services.py
+++ b/lms/djangoapps/courseware/services.py
@@ -39,3 +39,18 @@ class UserStateService:
             return json.loads(student_module.state)
         except StudentModule.DoesNotExist:
             return {}
+
+
+class ModuleService:
+    """
+    A service to bind user data and module system to descriptor using the given callback functiion
+    """
+
+    def __init__(self, module_callback) -> None:
+        self.module_callback = module_callback
+
+    def get_module(self, descriptor):
+        """
+        Invokes the callback function to bind user data and module system to given descriptor
+        """
+        return self.module_callback(descriptor=descriptor)

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -2717,3 +2717,25 @@ class LmsModuleSystemShimTest(SharedModuleStoreTestCase):
         jump_to_id_base_url = reverse('jump_to_id', kwargs={'course_id': str(self.runtime.course_id), 'module_id': ''})
         assert self.runtime.replace_jump_to_id_urls(html) == \
             static_replace.replace_jump_to_id_urls(html, self.runtime.course_id, jump_to_id_base_url)
+
+    def test_get_module(self):
+        runtime, _ = render.get_module_system_for_user(
+            self.user,
+            self.student_data,
+            self.descriptor,
+            self.course.id,
+            self.track_function,
+            self.request_token,
+            course=self.course,
+        )
+        module = render.get_module_for_descriptor_internal(
+            user=self.user,
+            descriptor=self.descriptor,
+            student_data=self.student_data,
+            course_id=self.course.id,
+            track_function=self.track_function,
+            request_token=self.request_token,
+            course=self.course
+        )
+
+        assert runtime.get_module(self.descriptor) == module

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -2446,7 +2446,13 @@ class ViewCheckerBlock(XBlock):
         """
         msg = f"{self.state} != {self.scope_ids.usage_id}"
         assert self.state == str(self.scope_ids.usage_id), msg
-        fragments = self.runtime.render_children(self)
+
+        # TODO: uncomment this line and remove _render_children() once
+        # merger of ModuleSystem and DescriptorSystem is complete
+
+        # fragments = self.runtime.render_children(self)
+        fragments = self._render_children()
+
         result = Fragment(
             content="<p>ViewCheckerPassed: {}</p>\n{}".format(
                 str(self.scope_ids.usage_id),
@@ -2454,6 +2460,26 @@ class ViewCheckerBlock(XBlock):
             )
         )
         return result
+
+    def _render_children(self):
+        """
+        Use CombinedSystem runtime to get block and render each child individually.
+
+        The runtime.render_children() method was earlier used to render each child
+        However, this caused a problem, when we removed the get_block() and
+        descriptor_runtime properties from the ModuleSystem, as the render_children
+        method ran in the context of LmsModuleSystem which is a child class of
+        ModuleSystem.
+
+        This is intended to be a temporary method until deprecation of all properties
+        of ModuleSystem and merger of ModuleSystem and DescriptorSystem is complete.
+        """
+        results = []
+        for child_id in self.children:
+            child = self.runtime.get_block(child_id)
+            result = self.runtime.render_child(child)
+            results.append(result)
+        return results
 
 
 @ddt.ddt

--- a/lms/djangoapps/lms_xblock/test/test_runtime.py
+++ b/lms/djangoapps/lms_xblock/test/test_runtime.py
@@ -18,6 +18,7 @@ from xblock.fields import ScopeIds
 from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.badges.tests.factories import BadgeClassFactory
 from lms.djangoapps.badges.tests.test_models import get_image
+from lms.djangoapps.courseware.services import ModuleService
 from lms.djangoapps.lms_xblock.runtime import LmsModuleSystem
 from xmodule.modulestore.django import ModuleI18nService  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
@@ -62,7 +63,9 @@ class TestHandlerUrl(TestCase):
         self.runtime = LmsModuleSystem(
             static_url='/static',
             track_function=Mock(),
-            get_module=Mock(),
+            services={
+                'module': ModuleService(Mock())
+            },
             course_id=self.course_key,
             user=Mock(),
             descriptor_runtime=Mock(),
@@ -127,7 +130,9 @@ class TestUserServiceAPI(TestCase):
         self.runtime = LmsModuleSystem(
             static_url='/static',
             track_function=Mock(),
-            get_module=Mock(),
+            services={
+                'module': ModuleService(Mock())
+            },
             user=self.user,
             course_id=self.course_id,
             descriptor_runtime=Mock(),
@@ -177,7 +182,9 @@ class TestBadgingService(ModuleStoreTestCase):
         return LmsModuleSystem(
             static_url='/static',
             track_function=Mock(),
-            get_module=Mock(),
+            services={
+                'module': ModuleService(Mock())
+            },
             course_id=self.course_id,
             user=self.user,
             descriptor_runtime=Mock(),
@@ -230,7 +237,9 @@ class TestI18nService(ModuleStoreTestCase):
         self.runtime = LmsModuleSystem(
             static_url='/static',
             track_function=Mock(),
-            get_module=Mock(),
+            services={
+                'module': ModuleService(Mock())
+            },
             course_id=self.course.id,
             user=Mock(),
             descriptor_runtime=Mock(),

--- a/lms/djangoapps/lms_xblock/test/test_runtime.py
+++ b/lms/djangoapps/lms_xblock/test/test_runtime.py
@@ -68,7 +68,8 @@ class TestHandlerUrl(TestCase):
             },
             course_id=self.course_key,
             user=Mock(),
-            descriptor_runtime=Mock(),
+            id_reader=Mock(),
+            id_generator=Mock()
         )
 
     def test_trailing_characters(self):
@@ -135,7 +136,8 @@ class TestUserServiceAPI(TestCase):
             },
             user=self.user,
             course_id=self.course_id,
-            descriptor_runtime=Mock(),
+            id_reader=Mock(),
+            id_generator=Mock()
         )
         self.scope = 'course'
         self.key = 'key1'
@@ -187,7 +189,8 @@ class TestBadgingService(ModuleStoreTestCase):
             },
             course_id=self.course_id,
             user=self.user,
-            descriptor_runtime=Mock(),
+            id_reader=Mock(),
+            id_generator=Mock()
         )
 
     @patch.dict(settings.FEATURES, {'ENABLE_OPENBADGES': True})
@@ -242,7 +245,8 @@ class TestI18nService(ModuleStoreTestCase):
             },
             course_id=self.course.id,
             user=Mock(),
-            descriptor_runtime=Mock(),
+            id_reader=Mock(),
+            id_generator=Mock()
         )
 
         self.mock_block = Mock()


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Builds on the shim added by https://github.com/openedx/edx-platform/pull/29190 to deprecate the following `ModuleSystem` attributes:

- `get_module`: in favour of the new `ModuleService`
- `descriptor_runtime`: The `DescriptorSystem` object was passed to `ModuleSystem` using this attribute.
    This was used to access the `id_reader`, `id_generator` and `get_block` properties of the the `DescriptorSystem` from the `ModuleSystem`. Each of these are now being handled differently as explained below and so this `descriptor_runtime` attribute has been removed and has not been replaced with anything else.

How the properties of `DescriptorSystem` which were accessed from `ModuleSystem` are now being handled:
- `id_reader`: This property of the `DescriptorSystem` was fetched to set the `id_reader` keyword argument of the `ModuleSystem` in its `__init__` method as this is required by the base `Runtime` class. This is now being supplied during initialization as keyword argument from the calling functions.
- `id_generator`: Same as `id_reader`
- `get_block`: This property of the `DescriptorSystem` was invoked from the `get_block` method of the `ModuleSystem` to fetch the block descriptor based on `block_id` and `for_parent`. This descriptor was then passed to `get_module` method (being deprecated) to bind the user data and module system.

As part of the PR, we have removed the `get_block` method from the `ModuleSystem` and created a new `get_block` method in the `CombinedSystem` class. Here, the `get_block` method of the descriptor_system is invoked to fetch the block. Further, its checked if the `_module_system` is initalized and if it contains the new `ModuleService`. If so, then this service is used to bind the user data and module system to the block descriptor.

This change should not affect any user of edx-platform

## Supporting information

[BB-5967](https://tasks.opencraft.com/browse/BB-5967) - OpenCraft internal ticket

## Testing instructions

LMS: https://pr30436.sandbox.opencraft.hosting/
Studio: https://studio.pr30436.sandbox.opencraft.hosting/

LMS:
1. Login as demo staff (staff@example.com / edx)
2. Go to the [CAPA unit](https://app.pr30436.sandbox.opencraft.hosting/learning/course/course-v1:IntroX+CS101+2021_T1/block-v1:IntroX+CS101+2021_T1+type@sequential+block@e84ccfae14e9468787b2f2d99525a795/block-v1:IntroX+CS101+2021_T1+type@vertical+block@4f8893f02b864ff88317aa691cf11c03)
3. Attempt the multiple choice problem
4. Go to the [Poll-Conditional unit](https://app.pr30436.sandbox.opencraft.hosting/learning/course/course-v1:IntroX+CS101+2021_T1/block-v1:IntroX+CS101+2021_T1+type@sequential+block@e84ccfae14e9468787b2f2d99525a795/block-v1:IntroX+CS101+2021_T1+type@vertical+block@052071d2a1034a5f9f755a99c11322f2)
5. Verify the conditional xblock works correctly after attempting the CAPA unit. The content should be visible.
6. Reset the user data in CAPA unit
7. Verify conditional xblock works correctly. The content should now be hidden.
8. Go to the [split test unit](https://app.pr30436.sandbox.opencraft.hosting/learning/course/course-v1:IntroX+CS101+2021_T1/block-v1:IntroX+CS101+2021_T1+type@sequential+block@e84ccfae14e9468787b2f2d99525a795/block-v1:IntroX+CS101+2021_T1+type@vertical+block@3bcf6fbdae86476a9221e323874c0603)
9. Verify the split test xblock works correctly and content for both groups are displayed
10. Go to [randomized-library unit](https://app.pr30436.sandbox.opencraft.hosting/learning/course/course-v1:IntroX+CS101+2021_T1/block-v1:IntroX+CS101+2021_T1+type@sequential+block@e84ccfae14e9468787b2f2d99525a795/block-v1:IntroX+CS101+2021_T1+type@vertical+block@a6e76a4f99c24765bca56916552757bd)
11. Verify the randomized library xblock works without any errors
12. Navigate to the [BlockstoreContent unit](https://app.pr30436.sandbox.opencraft.hosting/learning/course/course-v1:IntroX+CS101+2021_T1/block-v1:IntroX+CS101+2021_T1+type@sequential+block@e84ccfae14e9468787b2f2d99525a795/block-v1:IntroX+CS101+2021_T1+type@vertical+block@d926defd1a5a48cab023c888689a9fe3)
13. Verify the html is rendered without any errors.


Studio:
1. Login as a demo staff (staff@example.com / edx)
2. Open sample course [Introduction to Edx](https://studio.pr30436.sandbox.opencraft.hosting/course/course-v1:IntroX+CS101+2021_T1)
3. Navigate to different units already configured
4. Edit some units and create new ones
5. Verify everything works without any errors