### PR TITLE
fix: Fix jasmine-jquery package format to avoid checking out over ssh

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,7 @@
         "eslint-config-edx-es5": "2.0.0",
         "eslint-import-resolver-webpack": "0.8.4",
         "jasmine-core": "2.6.4",
-        "jasmine-jquery": "git+https://github.com/velesin/jasmine-jquery.git#ebad463d592d3fea00c69f26ea18a930e09c7b58",
+        "jasmine-jquery": "git+https://git@github.com/velesin/jasmine-jquery.git#ebad463d592d3fea00c69f26ea18a930e09c7b58",
         "jest": "26.0.0",
         "jest-enzyme": "6.0.2",
         "karma": "0.13.22",
@@ -23675,7 +23675,7 @@
     },
     "node_modules/jasmine-jquery": {
       "version": "2.1.1",
-      "resolved": "git+ssh://git@github.com/velesin/jasmine-jquery.git#ebad463d592d3fea00c69f26ea18a930e09c7b58",
+      "resolved": "git+https://git@github.com/velesin/jasmine-jquery.git#ebad463d592d3fea00c69f26ea18a930e09c7b58",
       "integrity": "sha512-P9aZDwDEAVgAbdHG/ViapRzAUJ6zBSq/4I1lJFluIbrld6Sv6LI+HT2J4dgWqtfaCgIyDnHBHSHiJ/anter7wQ==",
       "dev": true,
       "license": "MIT"
@@ -56974,10 +56974,10 @@
       "dev": true
     },
     "jasmine-jquery": {
-      "version": "git+ssh://git@github.com/velesin/jasmine-jquery.git#ebad463d592d3fea00c69f26ea18a930e09c7b58",
+      "version": "git+https://git@github.com/velesin/jasmine-jquery.git#ebad463d592d3fea00c69f26ea18a930e09c7b58",
       "integrity": "sha512-P9aZDwDEAVgAbdHG/ViapRzAUJ6zBSq/4I1lJFluIbrld6Sv6LI+HT2J4dgWqtfaCgIyDnHBHSHiJ/anter7wQ==",
       "dev": true,
-      "from": "jasmine-jquery@git+https://github.com/velesin/jasmine-jquery.git#ebad463d592d3fea00c69f26ea18a930e09c7b58"
+      "from": "jasmine-jquery@git+https://git@github.com/velesin/jasmine-jquery.git#ebad463d592d3fea00c69f26ea18a930e09c7b58"
     },
     "jest": {
       "version": "26.0.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-config-edx-es5": "2.0.0",
     "eslint-import-resolver-webpack": "0.8.4",
     "jasmine-core": "2.6.4",
-    "jasmine-jquery": "git+https://github.com/velesin/jasmine-jquery.git#ebad463d592d3fea00c69f26ea18a930e09c7b58",
+    "jasmine-jquery": "git+https://git@github.com/velesin/jasmine-jquery.git#ebad463d592d3fea00c69f26ea18a930e09c7b58",
     "jest": "26.0.0",
     "jest-enzyme": "6.0.2",
     "karma": "0.13.22",


### PR DESCRIPTION
## Description

The npm package manager seems to try checking out over ssh unless a github dependency is specified with the git user via git@. Checking out over ssh breaks deployments in CI and deployment environments.

Adding a simple git@ in the package path and regenerating the package lock json file updates the URL to use https instead which works in CIs etc. 

## Supporting information

https://github.com/npm/cli/issues/2610

## Testing instructions

Nothing much to test here. It results in no functional change. When installing dependencies, it should now install them over https instead of ssh, thus allowing installation where fetching from github over ssh is not configured. 

## Deadline

"None"

## Other information

This was breaking our periodic master branch deployments. 