### PR TITLE
Enterprise learner with enabled learner portal should be redirect to B2B course about page.

### DIFF
--- a/lms/djangoapps/program_enrollments/management/commands/send_program_course_nudge_email.py
+++ b/lms/djangoapps/program_enrollments/management/commands/send_program_course_nudge_email.py
@@ -20,6 +20,7 @@ from lms.djangoapps.grades.models import PersistentCourseGrade
 from openedx.core.constants import COURSE_PUBLISHED
 from openedx.core.djangoapps.catalog.utils import get_programs
 from openedx.core.djangoapps.programs.utils import ProgramProgressMeter
+from openedx.features.enterprise_support.api import get_enterprise_learner_data_from_db
 
 User = get_user_model()
 
@@ -84,10 +85,10 @@ class Command(BaseCommand):
         Returns: Suggested program and course_run dicts
         """
         for program in programs_progress:
-            for not_started_courses in program['not_started']:
-                for course_run in not_started_courses['course_runs']:
+            for not_started_course in program['not_started']:
+                for course_run in not_started_course['course_runs']:
                     if self.valid_course_run(course_run) and course_run['key'] != completed_course_id:
-                        return program, course_run
+                        return program, course_run, not_started_course
         return None, None
 
     def sort_programs(self, programs):
@@ -124,17 +125,28 @@ class Command(BaseCommand):
             if program['uuid'] == program_progress['uuid']:
                 return program
 
-    def emit_event(self, user, program, suggested_course_run, completed_course_run):
+    def emit_event(self, user, program, suggested_course_run, suggested_course, completed_course_run):
         """
          Emit the Segment event which will be used by Braze to send the email
         """
+        learner_data = get_enterprise_learner_data_from_db(user)
+        enterprise_customer = learner_data[0]['enterprise_customer'] if learner_data else None
+        if enterprise_customer and enterprise_customer['enable_learner_portal']:
+            # If user is an enterprise learner then we want to redirect to B2B course landing page on learner portal.
+            recommended_course_url = urljoin(
+                settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL,
+                '/'.join([enterprise_customer['slug'], 'course', suggested_course['key']]),
+            )
+        else:
+            recommended_course_url = urljoin(settings.MKTG_URLS.get('ROOT'), suggested_course_run['marketing_url'])
+
         event_properties = {
             'COURSE_ONE_NAME': completed_course_run['title'],
             'PROGRAM_TYPE': program['type'],
             'PROGRAM_TITLE': program['title'],
             'COURSE_TWO_NAME': suggested_course_run['title'],
             'COURSE_TWO_SHORT_DESCRIPTION': suggested_course_run['short_description'],
-            'COURSE_TWO_LINK': urljoin(settings.MKTG_URLS.get('ROOT'), suggested_course_run['marketing_url']),
+            'COURSE_TWO_LINK': recommended_course_url,
             'COURSE_TWO_IMAGE_LINK': suggested_course_run['image'].get('src'),
         }
         segment.track(user.id, 'edx.bi.program.course-enrollment.nudge', event_properties)
@@ -177,14 +189,16 @@ class Command(BaseCommand):
                 for user in users:
                     meter = ProgramProgressMeter(site=site, user=user, include_course_entitlements=False)
                     programs_progress = meter.progress(programs=course_linked_programs, count_only=False)
-                    suggested_program_progress, suggested_course_run = self.get_course_run_to_suggest(
+                    suggested_program_progress, suggested_course_run, suggested_course = self.get_course_run_to_suggest(
                         programs_progress, completed_course_id
                     )
-                    if suggested_course_run:
+                    if suggested_course_run and suggested_course:
                         suggested_program = self.get_program(course_linked_programs, suggested_program_progress)
                         completed_course_run = self.get_course_run(suggested_program, completed_course_id)
                         if should_commit:
-                            self.emit_event(user, suggested_program, suggested_course_run, completed_course_run)
+                            self.emit_event(
+                                user, suggested_program, suggested_course_run, suggested_course, completed_course_run,
+                            )
                         email_sent_records.append(
                             f'User: {user.username}, Completed Course: {completed_course_id}, '
                             f'Suggested Course: {suggested_course_run["key"]}'

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -484,6 +484,10 @@ ECOMMERCE_PUBLIC_URL_ROOT = None
 ENTERPRISE_API_URL = 'http://enterprise.example.com/enterprise/api/v1/'
 ENTERPRISE_CONSENT_API_URL = 'http://enterprise.example.com/consent/api/v1/'
 
+########################## ENTERPRISE LEARNER PORTAL ##############################
+ENTERPRISE_LEARNER_PORTAL_NETLOC = 'example.com:8734'
+ENTERPRISE_LEARNER_PORTAL_BASE_URL = 'http://' + ENTERPRISE_LEARNER_PORTAL_NETLOC
+
 ACTIVATION_EMAIL_FROM_ADDRESS = 'test_activate@edx.org'
 
 TEMPLATES[0]['OPTIONS']['debug'] = True

--- a/openedx/features/enterprise_support/tests/factories.py
+++ b/openedx/features/enterprise_support/tests/factories.py
@@ -42,6 +42,7 @@ class EnterpriseCustomerFactory(factory.django.DjangoModelFactory):
     site = factory.SubFactory(SiteFactory)
     enable_data_sharing_consent = True
     enforce_data_sharing_consent = EnterpriseCustomer.AT_ENROLLMENT
+    enable_learner_portal = False
 
 
 class EnterpriseCustomerUserFactory(factory.django.DjangoModelFactory):


### PR DESCRIPTION


<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
