### PR TITLE
fix: import+export management commands

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/export_content_library.py
+++ b/cms/djangoapps/contentstore/management/commands/export_content_library.py
@@ -61,6 +61,6 @@ class Command(BaseCommand):
                 filename = prefix + suffix
                 target = os.path.join(dest_path, filename)
                 tarball.file.seek(0)
-                with open(target, 'w') as f:
+                with open(target, 'wb') as f:
                     shutil.copyfileobj(tarball.file, f)
                 print(f'Library "{library.location.library_key}" exported to "{target}"')

--- a/cms/djangoapps/contentstore/management/commands/import_content_library.py
+++ b/cms/djangoapps/contentstore/management/commands/import_content_library.py
@@ -43,13 +43,13 @@ class Command(BaseCommand):
         username = options['owner_username']
 
         data_root = Path(settings.GITHUB_REPO_ROOT)
-        subdir = base64.urlsafe_b64encode(os.path.basename(archive_path))
+        subdir = base64.urlsafe_b64encode(os.path.basename(archive_path).encode('utf-8')).decode('utf-8')
         course_dir = data_root / subdir
 
         # Extract library archive
         tar_file = tarfile.open(archive_path)  # lint-amnesty, pylint: disable=consider-using-with
         try:
-            safetar_extractall(tar_file, course_dir.encode('utf-8'))
+            safetar_extractall(tar_file, course_dir)
         except SuspiciousOperation as exc:
             raise CommandError(f'\n=== Course import {archive_path}: Unsafe tar file - {exc.args[0]}\n')  # lint-amnesty, pylint: disable=raise-missing-from
         finally:


### PR DESCRIPTION
Backports https://github.com/openedx/edx-platform/pull/28219 into Maple.

**Why backport this fix into Maple, when Nutmeg is about to be released?**
* This fix was cut on 12/9 (just after the Maple cut) so the only reason it wasn't part of Maple was dumb luck.
* The library import/export management commands are entirely broken in Maple. Even though Maple is about to go out of support, we should avoid having obviously-broken features in recent releases if possible.
* In the [openedx-test-course](https://github.com/openedx/openedx-test-course) I'm building, I'm testing every PR against the repo by using the latest stable Tutor release import the course and library. Without this patch, that workflow is broken.

**FYI**:
* @alex2bender and @bradenmacdonald (original authors)
* @regisb (release manager)