### PR TITLE
[BD-13][BB-6210] refactor: remove `debug` property from `ModuleSystem`

### DIFF
--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -212,7 +212,6 @@ def _preview_module_system(request, descriptor, field_data):
         # TODO (cpennington): Do we want to track how instructors are using the preview problems?
         track_function=lambda event_type, event: None,
         get_module=partial(_load_preview_module, request),
-        debug=True,
         mixins=settings.XBLOCK_MIXINS,
         course_id=course_id,
 

--- a/common/lib/xmodule/xmodule/capa_module.py
+++ b/common/lib/xmodule/xmodule/capa_module.py
@@ -1069,7 +1069,6 @@ class ProblemBlock(
             str(err)
         )
 
-        # TODO (vshnayder): another switch on DEBUG.
         if self.debug:
             msg = HTML(
                 '[courseware.capa.capa_module] '

--- a/common/lib/xmodule/xmodule/lti_2_util.py
+++ b/common/lib/xmodule/xmodule/lti_2_util.py
@@ -12,6 +12,7 @@ import re
 from unittest import mock
 from urllib import parse
 
+from django.conf import settings
 from oauthlib.oauth1 import Client
 from webob import Response
 from xblock.core import XBlock
@@ -63,7 +64,7 @@ class LTI20BlockMixin:
         Returns:
             webob.response:  response to this request.  See above for details.
         """
-        if self.system.debug:
+        if settings.DEBUG:
             self._log_correct_authorization_header(request)
 
         if not self.accept_grades_past_due and self.is_past_due():

--- a/common/lib/xmodule/xmodule/tests/__init__.py
+++ b/common/lib/xmodule/xmodule/tests/__init__.py
@@ -153,7 +153,6 @@ def get_test_system(
         static_url='/static',
         track_function=Mock(name='get_test_system.track_function'),
         get_module=get_module,
-        debug=True,
         hostname="edx.org",
         services={
             'user': user_service,

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -1637,7 +1637,7 @@ class ModuleSystem(MetricsMixin, ConfigurableFragmentWrapper, ModuleSystemShim, 
 
     def __init__(
             self, static_url, track_function, get_module,
-            descriptor_runtime, debug=False, hostname="", publish=None,
+            descriptor_runtime, hostname="", publish=None,
             course_id=None, error_descriptor_class=None,
             field_data=None, rebind_noauth_module_to_user=None,
             **kwargs):
@@ -1678,7 +1678,6 @@ class ModuleSystem(MetricsMixin, ConfigurableFragmentWrapper, ModuleSystemShim, 
         self.STATIC_URL = static_url
         self.track_function = track_function
         self.get_module = get_module
-        self.DEBUG = self.debug = debug
         self.HOSTNAME = self.hostname = hostname
         self.course_id = course_id
 

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -729,7 +729,6 @@ def get_module_system_for_user(
         static_url=settings.STATIC_URL,
         get_module=inner_get_module,
         user=user,
-        debug=settings.DEBUG,
         hostname=settings.SITE_NAME,
         publish=publish,
         course_id=course_id,

--- a/openedx/core/djangoapps/xblock/runtime/shims.py
+++ b/openedx/core/djangoapps/xblock/runtime/shims.py
@@ -97,14 +97,6 @@ class RuntimeShim:
         # TODO: Refactor capa to access this directly, don't bother the runtime. Then remove it from here.
         return False  # Change this if/when we need to support unsafe courses in the new runtime.
 
-    @property
-    def DEBUG(self):
-        """
-        Should DEBUG mode (?) be used? This flag is only read by capa.
-        """
-        # TODO: Refactor capa to access this directly, don't bother the runtime. Then remove it from here.
-        return False
-
     def get_python_lib_zip(self):
         """
         A function returning a bytestring or None. The bytestring is the

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -109,7 +109,7 @@ ipaddress                           # Ip network support for Embargo feature
 jsonfield                           # Django model field for validated JSON; used in several apps
 laboratory                          # Library for testing that code refactors/infrastructure changes produce identical results
 lxml                                # XML parser
-lti-consumer-xblock>=4.1.0
+lti-consumer-xblock>=4.1.1
 mailsnake                           # Needed for mailchimp (mailing djangoapp)
 mako                                # Primary template language used for server-side page rendering
 Markdown                            # Convert text markup to HTML; used in capa problems, forums, and course wikis


### PR DESCRIPTION
## Description

Removes `debug` and `DEBUG` properties from `ModuleSystem`.

**NOTE**: this should be merged after https://github.com/openedx/xblock-lti-consumer/pull/251 is merged, and `lti-consumer-xblock` version is bumped. Otherwise, `lti-consumer-xblock` won't work correctly.

## Supporting information

- [BB-6210](https://tasks.opencraft.com/browse/BB-6210) - OpenCraft's internal ticket.

## Testing instructions

**NOTE**: the sandbox has already updated `lti-consumer-xblock`, and `DEBUG` set to `False`.

1. Open https://studio.bb-6210-deprecate-debug.opencraft.hosting and sign in (`staff@example.com;edx`).
2. Open [the first unit](https://studio.bb-6210-deprecate-debug.opencraft.hosting/container/block-v1:edX+DemoX+Demo_Course+type@vertical+block@vertical_0270f6de40fc).
3. Add `LTI Consumer` XBlock and publish unit.
4. Visit [live version](https://app.bb-6210-deprecate-debug.opencraft.hosting/learning/course/course-v1:edX+DemoX+Demo_Course/block-v1:edX+DemoX+Demo_Course+type@sequential+block@edx_introduction/block-v1:edX+DemoX+Demo_Course+type@vertical+block@vertical_0270f6de40fc) of the first unit, ensure that it's not crashing due to accessing a non-existent `DEBUG` attribute.
5. Open [Studio](https://studio.bb-6210-deprecate-debug.opencraft.hosting/container/block-v1:edX+DemoX+Demo_Course+type@vertical+block@vertical_0270f6de40fc) again.
6. Add `Custom Python-Evaluated Input`.
7. Edit it, and add the following instead of the default content:
    ```xml
    <script type="loncapa/python">
      This will generate a serialization error.
    </script>
    ```
    You should see a Python traceback as a part of the HTML block representation, which is expected, as this is the preview runtime. 
8. Publish.
9. Visit [live version](https://app.bb-6210-deprecate-debug.opencraft.hosting/learning/course/course-v1:edX+DemoX+Demo_Course/block-v1:edX+DemoX+Demo_Course+type@sequential+block@edx_introduction/block-v1:edX+DemoX+Demo_Course+type@vertical+block@vertical_0270f6de40fc). It should fail to load — that's expected behavior for the production environment (`DEBUG` is `False`).