### PR TITLE
fix: allowing for provider config fields to be provided on create

### DIFF
--- a/common/djangoapps/third_party_auth/samlproviderdata/tests/test_samlproviderdata.py
+++ b/common/djangoapps/third_party_auth/samlproviderdata/tests/test_samlproviderdata.py
@@ -93,6 +93,19 @@ class SAMLProviderDataTests(APITestCase):
         assert len(results) == 1
         assert results[0]['sso_url'] == SINGLE_PROVIDER_DATA['sso_url']
 
+    def test_get_one_provider_data_with_pk_success(self):
+        # GET auth/saml/v0/providerdata/<provider data ID>/?enterprise_customer_uuid=id
+        url_base = reverse('saml_provider_data-list')
+        query_kwargs = {'enterprise_customer_uuid': ENTERPRISE_ID}
+        url = f'{url_base}{self.saml_provider_data.id}/?{urlencode(query_kwargs)}'
+
+        response = self.client.get(url, format='json')
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data.get('id') == self.saml_provider_data.id
+        assert response.data.get('entity_id') == self.saml_provider_data.entity_id
+        assert response.data.get('sso_url') == self.saml_provider_data.sso_url
+        assert response.data.get('public_key') == self.saml_provider_data.public_key
+
     def test_create_one_provider_data_success(self):
         # POST auth/saml/v0/providerdata/ -d data
         url = reverse('saml_provider_data-list')


### PR DESCRIPTION
Allowing create/update endpoint to provide direct field input rather than only fetching fields from metadata url.

<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
