### PR TITLE
fix: use client-credential oauth2 application entry

### DIFF
--- a/lms/djangoapps/courseware/utils.py
+++ b/lms/djangoapps/courseware/utils.py
@@ -121,7 +121,10 @@ def _request_financial_assistance(method, url, params=None, data=None):
     """
     financial_assistance_configuration = FinancialAssistanceConfiguration.current()
     if financial_assistance_configuration.enabled:
-        oauth_application = Application.objects.get(user=financial_assistance_configuration.get_service_user())
+        oauth_application = Application.objects.get(
+            user=financial_assistance_configuration.get_service_user(),
+            authorization_grant_type=Application.GRANT_CLIENT_CREDENTIALS
+        )
         client = OAuthAPIClient(
             settings.LMS_ROOT_URL,
             oauth_application.client_id,


### PR DESCRIPTION
[PROD-2764](https://2u-internal.atlassian.net/browse/PROD-2764)

Since more than 1 oauth application entries were added during the process of stage deployment, an error 500 occurs when accessing the new financial assistance flow.

![image](https://user-images.githubusercontent.com/52413434/169848460-e1c034c0-66c7-426c-a065-69f71aba54c9.png)

This PR fixes this issue by getting only a single oauth that is used with the grant type `client credentials`