### PR TITLE
build!: drop node12 support

### DIFF
--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-20.04 ]
-        node-version: [ 12, 14, 16 ]
+        node-version: [ 16 ]
         python-version: [ 3.8 ]
 
     steps:

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [ ubuntu-20.04 ]
         python-version: [ 3.8 ]
-        node-version: [ 12, 14, 16 ]
+        node-version: [ 16 ]
         
     steps:
 


### PR DESCRIPTION
This PR drops Node12 support as a part of Node16 upgrade follow up. 