### PR TITLE
[WIP] fix: fix npm cli by marking fsevents optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1769,7 +1769,10 @@
       "version": "4.10.2",
       "resolved": "https://registry.npmjs.org/@edx/edx-proctoring/-/edx-proctoring-4.10.2.tgz",
       "integrity": "sha512-RFwIfz0jrS1C1X2KK3qxBIjxvCA20l6YZyiktzyEUeEujUsjwsck0urLFzxjTZa8tOl8nxjVnCkM7bh7Tb4lAg==",
-      "hasShrinkwrap": true
+      "hasShrinkwrap": true,
+      "optionalDependencies": {
+        "fsevents": "1.2.13"
+      }
     },
     "node_modules/@edx/edx-proctoring/node_modules/@babel/code-frame": {
       "version": "7.16.7",
@@ -2691,7 +2694,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "extraneous": true,
+      "optional": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
@@ -5529,7 +5532,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "extraneous": true
+      "optional": true
     },
     "node_modules/@edx/edx-proctoring/node_modules/filename-regex": {
       "version": "2.0.1",
@@ -6158,8 +6161,8 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
       "deprecated": "fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.",
-      "extraneous": true,
       "hasInstallScript": true,
+      "optional": true,
       "os": [
         "darwin"
       ],
@@ -9839,7 +9842,7 @@
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
       "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
-      "extraneous": true
+      "optional": true
     },
     "node_modules/@edx/edx-proctoring/node_modules/nanomatch": {
       "version": "1.2.13",
@@ -39065,6 +39068,9 @@
       "version": "4.10.2",
       "resolved": "https://registry.npmjs.org/@edx/edx-proctoring/-/edx-proctoring-4.10.2.tgz",
       "integrity": "sha512-RFwIfz0jrS1C1X2KK3qxBIjxvCA20l6YZyiktzyEUeEujUsjwsck0urLFzxjTZa8tOl8nxjVnCkM7bh7Tb4lAg==",
+      "requires": {
+        "fsevents": "1.2.13"
+      },
       "dependencies": {
         "@babel/code-frame": {
           "version": "7.16.7",
@@ -39806,7 +39812,7 @@
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
           "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-          "extraneous": true,
+          "optional": true,
           "requires": {
             "file-uri-to-path": "1.0.0"
           }
@@ -42224,7 +42230,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
           "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-          "extraneous": true
+          "optional": true
         },
         "filename-regex": {
           "version": "2.0.1",
@@ -42744,7 +42750,7 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "extraneous": true,
+          "optional": true,
           "requires": {
             "bindings": "^1.5.0",
             "nan": "^2.12.1"
@@ -45715,7 +45721,7 @@
           "version": "2.15.0",
           "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
           "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
-          "extraneous": true
+          "optional": true
         },
         "nanomatch": {
           "version": "1.2.13",


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Attempt to fix `npm ci` by marking an instance of `fsevents` as optinal in `package-lock.json`