### PR TITLE
fix: [BB-6261] trim name for site configuration before saving

### DIFF
--- a/openedx/core/djangoapps/site_configuration/management/commands/create_or_update_site_configuration.py
+++ b/openedx/core/djangoapps/site_configuration/management/commands/create_or_update_site_configuration.py
@@ -70,6 +70,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         site_id = options.get('site_id')
         domain = options.get('domain')
+        name = domain
         configuration = options.get('configuration')
         config_file_data = options.get('config_file_data')
 
@@ -78,9 +79,18 @@ class Command(BaseCommand):
         if site_id is not None:
             site, created = Site.objects.get_or_create(id=site_id)
         else:
+            name_max_length = Site._meta.get_field("name").max_length
+            if name:
+                if len(str(name)) > name_max_length:
+                    LOG.warning(
+                        f"The name {name} is too long, truncating to {name_max_length}"
+                        " characters. Please update site name in admin."
+                    )
+                # trim name as the column has a limit of 50 characters
+                name = name[:name_max_length]
             site, created = Site.objects.get_or_create(
                 domain=domain,
-                name=domain,
+                name=name,
             )
         if created:
             LOG.info(f"Site does not exist. Created new site '{site.domain}'")

--- a/openedx/core/djangoapps/site_configuration/management/commands/tests/test_create_or_update_site_configuration.py
+++ b/openedx/core/djangoapps/site_configuration/management/commands/tests/test_create_or_update_site_configuration.py
@@ -107,6 +107,19 @@ class CreateOrUpdateSiteConfigurationTest(TestCase):
         assert not site_configuration.site_values
         assert not site_configuration.enabled
 
+    def test_site_created_when_domain_longer_than_50_characters(self):
+        """
+        Verify that a SiteConfiguration instance is created with name trimmed
+        to 50 characters when domain is longer than 50 characters
+        """
+        self.assert_site_configuration_does_not_exist()
+
+        domain = "studio.newtestserverwithlongname.development.opencraft.hosting"
+        call_command(self.command, f"{domain}")
+        site = Site.objects.filter(domain=domain)
+        assert site.exists()
+        assert site[0].name == domain[:50]
+
     def test_both_enabled_disabled_flags(self):
         """
         Verify the error on providing both the --enabled and --disabled flags.


### PR DESCRIPTION
## Description

At OpenCraft we want to have long instance names as well, so we can ensure all client's instance is created. This MR fixes an issue which occurs when instance domain names exceed 50 characters in length by trimming name to 50 characters before saving.

Error log:
```console
Assigning theme edx-simple-theme to studio.alongtestname.development.opencraft.hosting.
--
Traceback (most recent call last):
File "/openedx/venv/lib/python3.8/site-packages/django/db/backends/utils.py", line 84, in _execute
return self.cursor.execute(sql, params)
File "/openedx/venv/lib/python3.8/site-packages/django/db/backends/mysql/base.py", line 73, in execute
return self.cursor.execute(query, args)
File "/openedx/venv/lib/python3.8/site-packages/MySQLdb/cursors.py", line 206, in execute
res = self._query(query)
File "/openedx/venv/lib/python3.8/site-packages/MySQLdb/cursors.py", line 319, in _query
db.query(q)
File "/openedx/venv/lib/python3.8/site-packages/MySQLdb/connections.py", line 259, in query
_mysql.connection.query(self, query)
MySQLdb._exceptions.DataError: (1406, "Data too long for column 'name' at row 1")

```

## Supporting information

We are utilizing [django's sites framework](https://docs.djangoproject.com/en/4.0/ref/contrib/sites/#module-django.contrib.sites) to store domain names in the database.
The `max_length=50` specified for the `name` column in the [Site model](https://github.com/django/django/blob/main/django/contrib/sites/models.py#L87) is causing this [section](https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/site_configuration/management/commands/create_or_update_site_configuration.py#L81-L84) of the edx-platform codebase to fail.

[Related opencraft ticket](https://tasks.opencraft.com/browse/BB-6261)

## Testing instructions

- Using management command `create_or_update_site_configuration` to create a new site configuration with a long domain name like below without this commit would fail with `Data too long` error
```sh
./manage.py lms create_or_update_site_configuration studio.newtestserverwithlongname.development.opencraft.hosting
```
- With this commit, it should run successfully and the site name should be trimmed to 50 characters.
- Also a test case is included for this scenario.

