### PR TITLE
fix: Run course discussion settings update task when settings change [BD-38]

### DIFF
--- a/openedx/core/djangoapps/discussions/serializers.py
+++ b/openedx/core/djangoapps/discussions/serializers.py
@@ -5,11 +5,12 @@ from django.core.exceptions import ValidationError
 from lti_consumer.api import get_lti_pii_sharing_state_for_course
 from lti_consumer.models import LtiConfiguration
 from rest_framework import serializers
+from xmodule.modulestore.django import modulestore
 
 from lms.djangoapps.discussion.toggles import ENABLE_REPORTED_CONTENT_EMAIL_NOTIFICATIONS
+from openedx.core.djangoapps.discussions.tasks import update_discussions_settings_from_course_task
 from openedx.core.djangoapps.django_comment_common.models import CourseDiscussionSettings
 from openedx.core.lib.courses import get_course_by_id
-from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 from .models import DiscussionsConfiguration, Provider
 from .utils import available_division_schemes, get_divided_discussions
 
@@ -257,6 +258,7 @@ class DiscussionsConfigurationSerializer(serializers.ModelSerializer):
         # have already been set
         instance = self._update_lti(instance, validated_data)
         instance.save()
+        update_discussions_settings_from_course_task.delay(str(instance.context_key))
         return instance
 
     def _update_lti(


### PR DESCRIPTION
## Description

When discussion settings change in a course, call the discussion settings update task so that topics are updated automatically.

## Supporting information


## Testing instructions

- Create a new course and add a few units
- Enabled the new provider for the course (or globally) using the `discussions.enable_new_structure_discussions` flag
- Use the course authoring MFE to switch to an LTI provider. (This might also require you to create a PII sharing override for the course here at /admin/lti_consumer/courseallowpiisharinginltiflag/)
- Switch to the second (new) edX provider in the course authoring MFE. 
- Check the course topics v2 API here /api/discussion/v2/course_topics/ and see that it shows topics for each unit. 