### PR TITLE
fix: python-dateutil version issue

### DIFF
--- a/lms/djangoapps/courseware/access_utils.py
+++ b/lms/djangoapps/courseware/access_utils.py
@@ -87,7 +87,13 @@ def check_start_date(user, days_early_for_beta, start, course_key, display_error
         if now is None:
             now = datetime.now(UTC)
         effective_start = adjust_start_date(user, days_early_for_beta, start, course_key)
-        if now > effective_start:
+
+        # Todo: This log statement is added for temporary use only
+        log.info('Python-dateutil logs: Comparing current date with effective start date')
+        should_grant_access = now > effective_start
+        # Todo: This log statement is added for temporary use only
+        log.info('Python-dateutil logs: Successfully compared current date with effective start date')
+        if should_grant_access:
             return ACCESS_GRANTED
 
         return StartDateError(start, display_error_to_user=display_error_to_user)

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -557,6 +557,11 @@ def get_course_assignments(course_key, user, include_access=False):  # lint-amne
     """
     if not user.id:
         return []
+
+    # Todo: This log statement is added for temporary use only
+    log.info('Python-dateutil logs: Trying to get course assignment for user: {} of course: {}'.format(
+        user.id, course_key))
+
     store = modulestore()
     course_usage_key = store.make_course_usage_key(course_key)
     block_data = get_course_blocks(user, course_usage_key, allow_start_dates_in_future=True, include_completion=True)
@@ -658,7 +663,9 @@ def get_course_assignments(course_key, user, include_access=False):  # lint-amne
                             _("Open Response Assessment due dates are set by your instructor and can't be shifted."),
                             first_component_block_id,
                         ))
-
+    # Todo: This log statement is added for temporary use only
+    log.info('Python-dateutil logs: Successfully got course assignments for user: {} of course: {}'.format(
+        user.id, course_key))
     return assignments
 
 

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -3506,8 +3506,8 @@ class TestInstructorSendEmail(SiteMixin, SharedModuleStoreTestCase, LoginEnrollm
         schedule = "Blub Glub"
         self.full_test_message['schedule'] = "Blub Glub"
         expected_message = (
-            f"Error occurred creating a scheduled bulk email task. Schedule provided: '{schedule}'. Error: unknown "
-            "string format"
+            f"Error occurred creating a scheduled bulk email task. Schedule provided: '{schedule}'. Error: Unknown "
+            "string format: Blub Glub"
         )
 
         url = reverse('send_email', kwargs={'course_id': str(self.course.id)})

--- a/openedx/core/djangoapps/content/block_structure/block_structure.py
+++ b/openedx/core/djangoapps/content/block_structure/block_structure.py
@@ -11,8 +11,11 @@ The following internal data structures are implemented:
 
 
 from copy import deepcopy
+from datetime import datetime
 from functools import partial
 from logging import getLogger
+
+from dateutil.tz import tzlocal
 
 from openedx.core.lib.graph_traversals import traverse_post_order, traverse_topologically
 
@@ -464,7 +467,8 @@ class BlockStructureBlockData(BlockStructure):
                 not found.
         """
         block_data = self._block_data_map.get(usage_key)
-        return getattr(block_data, field_name, default) if block_data else default
+        xblock_field = getattr(block_data, field_name, default) if block_data else default
+        return self._make_datetime_field_compatible(xblock_field)
 
     def override_xblock_field(self, usage_key, field_name, override_data):
         """
@@ -554,7 +558,8 @@ class BlockStructureBlockData(BlockStructure):
             transformer_data = self.get_transformer_block_data(usage_key, transformer)
         except KeyError:
             return default
-        return getattr(transformer_data, key, default)
+        field = getattr(transformer_data, key, default)
+        return self._make_datetime_field_compatible(field)
 
     def set_transformer_block_field(self, usage_key, transformer, key, value):
         """
@@ -762,6 +767,24 @@ class BlockStructureBlockData(BlockStructure):
             block_data = BlockData(usage_key)
             self._block_data_map[usage_key] = block_data
             return block_data
+
+    def _make_datetime_field_compatible(self, field):
+        """
+        Creates a new datetime object to avoid issues occurring due to upgrading
+        python-datetuil version from 2.4.0
+
+        More info: https://openedx.atlassian.net/browse/BOM-2245
+        """
+        if isinstance(field, datetime):
+            if isinstance(field.tzinfo, tzlocal) and not hasattr(field.tzinfo, '_hasdst'):
+                # Todo: This log statement is added for temporary use only
+                logger.info('Python-dateutil logs: Making datetime field compatible to python-dateutil package')
+                return datetime(
+                    year=field.year, month=field.month, day=field.day,
+                    hour=field.hour, minute=field.minute, second=field.second,
+                    tzinfo=tzlocal()
+                )
+        return field
 
 
 class BlockStructureModulestoreData(BlockStructureBlockData):

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -27,23 +27,14 @@ django-storages<1.9
 # for them.
 edx-enterprise==3.49.7
 
-# Newer versions need a more recent version of python-dateutil
-freezegun==0.3.12
-
 # oauthlib>3.0.1 causes test failures ( also remove the django-oauth-toolkit constraint when this is fixed )
 oauthlib==3.0.1
 
 # django-auth-toolkit==1.3.3 requires oauthlib>=3.1.0 which is pinned because of test failures
 django-oauth-toolkit<=1.3.2
 
-# Upgrading to 2.5.3 on 2020-01-03 triggered "'tzlocal' object has no attribute '_std_offset'" errors in production
-python-dateutil==2.4.0
-# matplotlib>=3.4.0 requires python-dateutil>=2.7
+# Will be updated once we update python-dateutil package
 matplotlib<3.4.0
-# pandas>0.22.0 requires python-dateutil>=2.5.0
-pandas==0.22.0
-# networkx>=2.6 requires pandas>=1.1
-networkx<2.6
 
 # tests failing for pymongo==3.11
 pymongo<3.11
@@ -65,6 +56,9 @@ edxval<2.1
 # version of py2neo will work with Neo4j 3.5.
 py2neo<2022
 
+# pylint==2.14.0 is causing test failures
+pylint==2.13.9
+
 # Sphinx requires docutils<0.18. This pin can be removed once https://github.com/sphinx-doc/sphinx/issues/9777 is closed.
 docutils<0.18
 
@@ -79,4 +73,3 @@ scipy<1.8.0
 # This will be fixed when sphinxcontrib-openapi depends on m2r2 instead of m2r
 # See issue: https://github.com/sphinx-contrib/openapi/issues/123
 mistune<2.0.0
-

--- a/requirements/edx-sandbox/py38.txt
+++ b/requirements/edx-sandbox/py38.txt
@@ -18,13 +18,11 @@ cryptography==37.0.2
     # via -r requirements/edx-sandbox/py38.in
 cycler==0.11.0
     # via matplotlib
-decorator==4.4.2
-    # via networkx
 joblib==1.1.0
     # via nltk
 kiwisolver==1.4.2
     # via matplotlib
-lxml==4.8.0
+lxml==4.9.0
     # via
     #   -r requirements/edx-sandbox/py38.in
     #   openedx-calc
@@ -38,10 +36,8 @@ matplotlib==3.3.4
     #   -r requirements/edx-sandbox/py38.in
 mpmath==1.2.1
     # via sympy
-networkx==2.5.1
-    # via
-    #   -c requirements/edx-sandbox/../constraints.txt
-    #   -r requirements/edx-sandbox/py38.in
+networkx==2.8.2
+    # via -r requirements/edx-sandbox/py38.in
 nltk==3.7
     # via
     #   -r requirements/edx-sandbox/py38.in
@@ -65,13 +61,11 @@ pyparsing==3.0.9
     #   chem
     #   matplotlib
     #   openedx-calc
-python-dateutil==2.4.0
-    # via
-    #   -c requirements/edx-sandbox/../constraints.txt
-    #   matplotlib
+python-dateutil==2.8.2
+    # via matplotlib
 random2==1.0.1
     # via -r requirements/edx-sandbox/py38.in
-regex==2022.4.24
+regex==2022.6.2
     # via nltk
 scipy==1.7.3
     # via

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -161,7 +161,7 @@ cryptography==37.0.2
     #   jwcrypto
     #   pyjwt
     #   social-auth-core
-cssutils==2.4.0
+cssutils==2.4.1
     # via pynliner
 ddt==1.5.0
     # via
@@ -639,9 +639,9 @@ libsass==0.10.0
     #   ora2
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==4.1.0
+lti-consumer-xblock==4.1.1
     # via -r requirements/edx/base.in
-lxml==4.8.0
+lxml==4.9.0
     # via
     #   -r requirements/edx/base.in
     #   edxval
@@ -834,9 +834,8 @@ pysrt==1.1.2
     # via
     #   -r requirements/edx/base.in
     #   edxval
-python-dateutil==2.4.0
+python-dateutil==2.8.2
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   analytics-python
     #   botocore
@@ -897,9 +896,9 @@ random2==1.0.1
     # via -r requirements/edx/base.in
 recommender-xblock==2.0.1
     # via -r requirements/edx/base.in
-redis==4.3.1
+redis==4.3.3
     # via -r requirements/edx/base.in
-regex==2022.4.24
+regex==2022.6.2
     # via nltk
 requests==2.27.1
     # via

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -6,7 +6,7 @@
 #
 chardet==4.0.0
     # via diff-cover
-coverage==6.4
+coverage==6.4.1
     # via -r requirements/edx/coverage.in
 diff-cover==6.5.0
     # via -r requirements/edx/coverage.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -214,7 +214,7 @@ coreschema==0.0.4
     #   -r requirements/edx/testing.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==6.4
+coverage[toml]==6.4.1
     # via
     #   -r requirements/edx/testing.txt
     #   pytest-cov
@@ -232,7 +232,7 @@ cssselect==1.1.0
     # via
     #   -r requirements/edx/testing.txt
     #   pyquery
-cssutils==2.4.0
+cssutils==2.4.1
     # via
     #   -r requirements/edx/testing.txt
     #   pynliner
@@ -693,15 +693,13 @@ fastavro==1.4.12
     # via
     #   -r requirements/edx/testing.txt
     #   openedx-events
-filelock==3.7.0
+filelock==3.7.1
     # via
     #   -r requirements/edx/testing.txt
     #   tox
     #   virtualenv
-freezegun==0.3.12
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/testing.txt
+freezegun==1.2.1
+    # via -r requirements/edx/testing.txt
 frozenlist==1.3.0
     # via
     #   -r requirements/edx/testing.txt
@@ -813,7 +811,7 @@ jsonfield==3.1.0
     #   edx-submissions
     #   lti-consumer-xblock
     #   ora2
-jsonschema==4.5.1
+jsonschema==4.6.0
     # via sphinxcontrib-openapi
 jwcrypto==1.3.1
     # via
@@ -844,9 +842,9 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/testing.txt
     #   ora2
-lti-consumer-xblock==4.1.0
+lti-consumer-xblock==4.1.1
     # via -r requirements/edx/testing.txt
-lxml==4.8.0
+lxml==4.9.0
     # via
     #   -r requirements/edx/testing.txt
     #   edxval
@@ -1093,6 +1091,7 @@ pylatexenc==2.10
     #   olxcleaner
 pylint==2.13.9
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   edx-lint
     #   pylint-celery
@@ -1176,9 +1175,8 @@ pytest-randomly==3.12.0
     # via -r requirements/edx/testing.txt
 pytest-xdist[psutil]==2.5.0
     # via -r requirements/edx/testing.txt
-python-dateutil==2.4.0
+python-dateutil==2.8.2
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   analytics-python
     #   botocore
@@ -1248,9 +1246,9 @@ random2==1.0.1
     # via -r requirements/edx/testing.txt
 recommender-xblock==2.0.1
     # via -r requirements/edx/testing.txt
-redis==4.3.1
+redis==4.3.3
     # via -r requirements/edx/testing.txt
-regex==2022.4.24
+regex==2022.6.2
     # via
     #   -r requirements/edx/testing.txt
     #   nltk
@@ -1346,7 +1344,6 @@ six==1.16.0
     #   edx-rbac
     #   edx-sphinx-theme
     #   event-tracking
-    #   freezegun
     #   fs
     #   fs-s3fs
     #   html5lib
@@ -1395,7 +1392,7 @@ soupsieve==2.3.2.post1
     # via
     #   -r requirements/edx/testing.txt
     #   beautifulsoup4
-sphinx==5.0.0
+sphinx==5.0.1
     # via
     #   edx-sphinx-theme
     #   sphinxcontrib-httpdomain

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -62,7 +62,7 @@ smmap==5.0.0
     # via gitdb
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==5.0.0
+sphinx==5.0.1
     # via
     #   -r requirements/edx/doc.in
     #   edx-sphinx-theme

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -206,7 +206,7 @@ coreschema==0.0.4
     #   -r requirements/edx/base.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==6.4
+coverage[toml]==6.4.1
     # via
     #   -r requirements/edx/coverage.txt
     #   pytest-cov
@@ -224,7 +224,7 @@ cssselect==1.1.0
     # via
     #   -r requirements/edx/testing.in
     #   pyquery
-cssutils==2.4.0
+cssutils==2.4.1
     # via
     #   -r requirements/edx/base.txt
     #   pynliner
@@ -669,14 +669,12 @@ fastavro==1.4.12
     # via
     #   -r requirements/edx/base.txt
     #   openedx-events
-filelock==3.7.0
+filelock==3.7.1
     # via
     #   tox
     #   virtualenv
-freezegun==0.3.12
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/testing.in
+freezegun==1.2.1
+    # via -r requirements/edx/testing.in
 frozenlist==1.3.0
     # via
     #   -r requirements/edx/base.txt
@@ -806,9 +804,9 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==4.1.0
+lti-consumer-xblock==4.1.1
     # via -r requirements/edx/base.txt
-lxml==4.8.0
+lxml==4.9.0
     # via
     #   -r requirements/edx/base.txt
     #   edxval
@@ -1034,6 +1032,7 @@ pylatexenc==2.10
     #   olxcleaner
 pylint==2.13.9
     # via
+    #   -c requirements/edx/../constraints.txt
     #   edx-lint
     #   pylint-celery
     #   pylint-django
@@ -1107,9 +1106,8 @@ pytest-randomly==3.12.0
     # via -r requirements/edx/testing.in
 pytest-xdist[psutil]==2.5.0
     # via -r requirements/edx/testing.in
-python-dateutil==2.4.0
+python-dateutil==2.8.2
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   analytics-python
     #   botocore
@@ -1176,9 +1174,9 @@ random2==1.0.1
     # via -r requirements/edx/base.txt
 recommender-xblock==2.0.1
     # via -r requirements/edx/base.txt
-redis==4.3.1
+redis==4.3.3
     # via -r requirements/edx/base.txt
-regex==2022.4.24
+regex==2022.6.2
     # via
     #   -r requirements/edx/base.txt
     #   nltk
@@ -1272,7 +1270,6 @@ six==1.16.0
     #   edx-milestones
     #   edx-rbac
     #   event-tracking
-    #   freezegun
     #   fs
     #   fs-s3fs
     #   html5lib


### PR DESCRIPTION
When the previous PR [30255](https://github.com/openedx/edx-platform/pull/30255) was deployed we got the following error
```rst
May 31 15:56:21 ip-10-2-10-225 [service_variant=lms][root][env:prod-edx-edxapp] ERROR [ip-10-2-10-225  1323] [user None] [ip None] [signals.py:22] - Uncaught exception from None
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/base.py", line 181, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/lib/python3.8/contextlib.py", line 75, in inner
    return func(*args, **kwds)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/newrelic/hooks/framework_django.py", line 552, in wrapper
    return wrapped(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/contrib/auth/decorators.py", line 21, in _wrapped_view
    return view_func(request, *args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/decorators.py", line 130, in _wrapped_view
    response = view_func(request, *args, **kwargs)
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/util/maintenance_banner.py", line 42, in _decorated
    return func(request, *args, **kwargs)
  File "/edx/app/edxapp/edx-platform/common/djangoapps/student/views/dashboard.py", line 866, in student_dashboard
    for url in get_resume_urls_for_enrollments(user, course_enrollments).values():
  File "/edx/app/edxapp/edx-platform/common/djangoapps/student/helpers.py", line 776, in get_resume_urls_for_enrollments
    block_data = get_course_blocks(user, block_key)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/course_blocks/api.py", line 107, in get_course_blocks
    return get_block_structure_manager(starting_block_usage_key.course_key).get_transformed(
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/content/block_structure/manager.py", line 78, in get_transformed
    transformers.transform(block_structure)
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/content/block_structure/transformers.py", line 113, in transform
    self._transform_with_filters(block_structure)
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/content/block_structure/transformers.py", line 132, in _transform_with_filters
    block_structure.filter_topological_traversal(combined_filters)
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/content/block_structure/block_structure.py", line 743, in filter_topological_traversal
    for _ in self.topological_traversal(filter_func=filter_func, **kwargs):
  File "/edx/app/edxapp/edx-platform/openedx/core/lib/graph_traversals.py", line 329, in _traverse_generic
    should_yield_node = filter_func(current_node)
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/content/block_structure/transformer.py", line 228, in <lambda>
    return lambda block_key: accumulated(block_key) and additional(block_key)
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/content/block_structure/transformer.py", line 228, in <lambda>
    return lambda block_key: accumulated(block_key) and additional(block_key)
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/content/block_structure/block_structure.py", line 699, in retain_or_remove
    if removal_condition(block_key):
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/course_blocks/transformers/start_date.py", line 99, in <lambda>
    removal_condition = lambda block_key: not check_start_date(
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/access_utils.py", line 90, in check_start_date
    if now > effective_start:
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/dateutil/tz/tz.py", line 222, in utcoffset
    if self._isdst(dt):
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/dateutil/tz/tz.py", line 287, in _isdst
    if not self._hasdst:
AttributeError: 'tzlocal' object has no attribute '_hasdst'
```

We didn't apply the patch on method 
https://github.com/openedx/edx-platform/blob/3492bede446e4523ee09f965b7639b55af0472d0/openedx/core/djangoapps/content/block_structure/block_structure.py#L550
 of  class

https://github.com/openedx/edx-platform/blob/3492bede446e4523ee09f965b7639b55af0472d0/openedx/core/djangoapps/content/block_structure/block_structure.py#L398


Now we have applied the patch on the mentioned method as well. Also we've added some temporary log statements to do testing. These log statemetns will be removed later on.