### PR TITLE
refactor: import common/lib/ modules from canonical locations

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1112,10 +1112,10 @@ COURSES_WITH_UNSAFE_CODE = []
 # Cojail REST service
 ENABLE_CODEJAIL_REST_SERVICE = False
 # .. setting_name: CODE_JAIL_REST_SERVICE_REMOTE_EXEC
-# .. setting_default: 'common.lib.capa.capa.safe_exec.remote_exec.send_safe_exec_request_v0'
+# .. setting_default: 'capa.safe_exec.remote_exec.send_safe_exec_request_v0'
 # .. setting_description: Set the python package.module.function that is reponsible of
 #   calling the remote service in charge of jailed code execution
-CODE_JAIL_REST_SERVICE_REMOTE_EXEC = 'common.lib.capa.capa.safe_exec.remote_exec.send_safe_exec_request_v0'
+CODE_JAIL_REST_SERVICE_REMOTE_EXEC = 'capa.safe_exec.remote_exec.send_safe_exec_request_v0'
 # .. setting_name: CODE_JAIL_REST_SERVICE_HOST
 # .. setting_default: 'http://127.0.0.1:8550'
 # .. setting_description: Set the codejail remote service host

--- a/cms/lib/xblock/test/test_authoring_mixin.py
+++ b/cms/lib/xblock/test/test_authoring_mixin.py
@@ -14,9 +14,9 @@ from xmodule.partitions.partitions import (
     Group,
     UserPartition
 )
+from xmodule.tests.test_export import PureXBlock
 
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
-from common.lib.xmodule.xmodule.tests.test_export import PureXBlock
 
 
 class AuthoringMixinTestCase(ModuleStoreTestCase):

--- a/lms/djangoapps/discussion/tasks.py
+++ b/lms/djangoapps/discussion/tasks.py
@@ -18,10 +18,10 @@ from edx_django_utils.monitoring import set_code_owner_attribute
 from eventtracking import tracker
 from opaque_keys.edx.keys import CourseKey
 from six.moves.urllib.parse import urljoin
+from xmodule.modulestore.django import modulestore
 
 import openedx.core.djangoapps.django_comment_common.comment_client as cc
 from common.djangoapps.track import segment
-from common.lib.xmodule.xmodule.modulestore.django import modulestore
 from lms.djangoapps.discussion.django_comment_client.utils import (
     permalink,
     get_users_with_moderator_roles,

--- a/openedx/core/djangoapps/course_live/tab.py
+++ b/openedx/core/djangoapps/course_live/tab.py
@@ -4,8 +4,8 @@ Configurations to render Course Live Tab
 from django.utils.translation import gettext_lazy
 from lti_consumer.models import LtiConfiguration
 
-from common.lib.xmodule.xmodule.course_module import CourseBlock
-from common.lib.xmodule.xmodule.tabs import TabFragmentViewMixin
+from xmodule.course_module import CourseBlock
+from xmodule.tabs import TabFragmentViewMixin
 from lms.djangoapps.courseware.tabs import EnrolledTab
 from openedx.core.djangoapps.course_live.config.waffle import ENABLE_COURSE_LIVE
 from openedx.core.djangoapps.course_live.models import CourseLiveConfiguration

--- a/setup.py
+++ b/setup.py
@@ -135,7 +135,7 @@ setup(
             'lib = openedx.core.djangoapps.content_libraries.library_context:LibraryContextImpl',
         ],
         'openedx.dynamic_partition_generator': [
-            'enrollment_track = common.lib.xmodule.xmodule.partitions.enrollment_track_partition_generator:create_enrollment_track_partition',  # lint-amnesty, pylint: disable=line-too-long
+            'enrollment_track = xmodule.partitions.enrollment_track_partition_generator:create_enrollment_track_partition',  # lint-amnesty, pylint: disable=line-too-long
             'content_type_gating = openedx.features.content_type_gating.partitions:create_content_gating_partition'
         ],
     }


### PR DESCRIPTION
## Description

Unfortunately, some code in edx-platform is imported
relative to sub-projects instead of the repository root.
The only three remaining instances of this are:
* common/lib/xmodule/xmodule (imported as just 'xmodule')
* common/lib/capa/capa (imported as just 'capa')
* openedx/core/lib/xblock_builtin/xblock_discussion
  (imported as just 'xblock_discussion')

For more details on the situation, see:
https://openedx.atlassian.net/browse/BOM-2579
(public, but requires Atlassian account creation).

We would like to get to a point where all edx-platform
import paths match their folder paths, relative to the repo
root. For now, though, all common/lib/capa and common/lib/xmodule
code should be imported as just `from capa` and `from xmodule`,
respectively. Importing using the full `common.lib.xmodule.xmodule...`
path will often work, but it instantiates a second instance of all
modules imported this way, which in the past has led to very
difficult-to-diagnose bugs.  It also confuses tooling such as
import-linter, which we are trying to add to edx-platform
(see https://openedx.atlassian.net/browse/BOM-2576)

## Testing information

N/A

## Deadline

Not urgent, but this blocks https://github.com/openedx/edx-platform/pull/27011.