### PR TITLE
Clarify a potentially confusing deprecation message [MNG-3057]

### DIFF
--- a/openedx/core/djangoapps/xblock/runtime/shims.py
+++ b/openedx/core/djangoapps/xblock/runtime/shims.py
@@ -161,7 +161,9 @@ class RuntimeShim:
         """
         warnings.warn(
             "Use of runtime.render_template is deprecated. "
-            "Use xblockutils.resources.ResourceLoader.render_mako_template or a JavaScript-based template instead.",
+            "For template files included with your XBlock (which is preferable), use "
+            "xblockutils.resources.ResourceLoader.render_mako_template to render them, or use a JavaScript-based "
+            "template instead. For template files that are part of the LMS/Studio, use the 'mako' XBlock service.",
             DeprecationWarning, stacklevel=2,
         )
         try:


### PR DESCRIPTION
## Description

I just noticed that a certain deprecation warning hasn't been updated to mention the mako service which was introduced in https://github.com/openedx/edx-platform/pull/29354 , so this updates the text. I'm not sure if/when anyone is going to see this though if all the existing blocks have been converted to the new service already.

## Supporting information



## Testing instructions

Not really necessary.

## Deadline

None

## Other information

Suggested reviewer: @pomegranited 