### PR TITLE
feat: warn when old safe_lxml import path is used

### DIFF
--- a/safe_lxml/__init__.py
+++ b/safe_lxml/__init__.py
@@ -1,5 +1,5 @@
 """
-Temporary import path shim module.
+Temporary import path shim module for openedx.core.lib.safe_lxml.
 
 Previously, the safe_lxml package was housed in common/lib/safe_lxml.
 It was installed as its own Python project, so instead of its import path
@@ -11,17 +11,26 @@ it was instead just:
 
     import safe_lxml
 
-To increase the sanity of edx-platform and simplify its tooling, we are
-moving the safe_lxml package to openedx/core/lib (in tihs same repo) and
+To increase the sanity of edx-platform and simplify its tooling, we have
+moved the safe_lxml package to openedx/core/lib (in tihs same repo) and
 changing its import path to:
 
     import openedx.core.lib.safe_lxml
 
-In order to maintain backwards-compatibility with code using the
-old import path for one release, we expose this compatibility module.
+For details, see:
+https://openedx.atlassian.net/browse/BOM-2583 (public, but requires account)
 
-Jira ticket (public, but requires account): https://openedx.atlassian.net/browse/BOM-2583
-Target removal for this shim module: by Olive.
+In order to maintain backwards-compatibility with code using the
+old import path for one release, we expose this temporary compatibility
+module and raise a warning when the old import path is used.
+This entire `safe_lxml` shim folder can be removed after 2023-01-01.
+In the Poplar release, 'import safe_lxml' will stop working entirely.
 """
+import warnings
+
+warnings.warn(
+    "Importing from 'safe_lxml' instead of 'openedx.core.lib.safe_lxml' is deprecated.",
+    stacklevel=3,  # Should surface the line that is doing the importing.
+)
 
 from openedx.core.lib.safe_lxml import *  # pylint: disable=unused-wildcard-import,wrong-import-order


### PR DESCRIPTION
## Description

See docstring of `./safe_lxml/__init__.py` for details.

## Testing instructions

Within `./manage.py lms shell`:

```
>>> from safe_lxml import defuse_xml_libs
sys:1: UserWarning: Importing from 'safe_lxml' instead of 'openedx.core.lib.safe_lxml' is deprecated.
>>> defuse_xml_libs
<function defuse_xml_libs at 0x7fa092e2a040>
>>> from openedx.core.lib.safe_lxml import defuse_xml_libs as correct_path_defuse_xml_libs
>>> defuse_xml_libs == correct_path_defuse_xml_libs
True
```

This ensures that:
* you can import from the old location, but you get a warning
* you can import from the new location
* both imported `defuse_xml_libs` functions are equal

## Deadline

None.

## Other information

This is a small improvement to https://github.com/openedx/edx-platform/pull/25689.

Raising a warning when the old import path is used gives us the opportunity to remove the `safe_lxml` compatibility folder.