### PR TITLE
chore: add more logs in send_segment_events_for_failed_learners command

### DIFF
--- a/lms/djangoapps/grades/management/commands/send_segment_events_for_failed_learners.py
+++ b/lms/djangoapps/grades/management/commands/send_segment_events_for_failed_learners.py
@@ -53,7 +53,10 @@ class Command(BaseCommand):
         but we are adding grace period of 1 day to mitigate any edge cases due to last minute grade override.
         """
         thirty_one_days_ago = timezone.now().date() - timedelta(days=31)
-        return CourseOverview.objects.exclude(end__isnull=True).filter(end__date=thirty_one_days_ago)
+        courses = CourseOverview.objects.exclude(end__isnull=True).filter(end__date=thirty_one_days_ago)
+        thirty_one_days_ago_ended_course_keys = [str(course) for course in courses.values_list('id', flat=True)]
+        log.info(f"Found {thirty_one_days_ago_ended_course_keys} courses that were ended on [{thirty_one_days_ago}]")
+        return courses
 
     def get_course_failed_user_ids(self, course):
         """


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
