### PR TITLE
fix: transifex config file syntax

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -67,13 +67,13 @@ source_file = conf/locale/en/LC_MESSAGES/wiki.po
 source_lang = en
 type        = PO
 
-[open-edx-releases.release-nutmeg]
+[o:open-edx:p:open-edx-releases:r:release-nutmeg]
 file_filter = conf/locale/<lang>/LC_MESSAGES/django.po
 source_file = conf/locale/en/LC_MESSAGES/django.po
 source_lang = en
 type = PO
 
-[open-edx-releases.release-nutmeg-js]
+[o:open-edx:p:open-edx-releases:r:release-nutmeg-js]
 file_filter = conf/locale/<lang>/LC_MESSAGES/djangojs.po
 source_file = conf/locale/en/LC_MESSAGES/djangojs.po
 source_lang = en


### PR DESCRIPTION
## Description

Fix the Transifex config file. The Transifex config file syntax was modified due to a recent change of the Transifex API. As a consequence, the .tx/config file is invalid in the nutmeg branch and translations cannot be pushed to transifex. See this other PR for reference: https://github.com/openedx/edx-platform/pull/30084

I _think_ that I correctly selected the right project/resource names in the config file, but don't take my word for it. Someone with access to Transifex should check that they can upload strings for the Nutmeg release.

You should be able to push the strings with:

```
i18n_tool extract; i18n_tool dummy; i18n_tool generate
paver i18n_compilejs
paver i18n_release_push
```

(according to [these docs](https://openedx.atlassian.net/wiki/spaces/COMM/pages/19662426/Process+to+Create+an+Open+edX+Release#3.-Update-and-upload-translations-on-the-test-branch))

## Deadline

This is pretty urgent, as we are in the process of releasing Nutmeg.
