### PR TITLE
fix: staff masquerade role removed on back from other masquerade role

### DIFF
--- a/lms/djangoapps/courseware/masquerade.py
+++ b/lms/djangoapps/courseware/masquerade.py
@@ -198,7 +198,10 @@ class MasqueradeView(View):
             group_id=group_id,
             user_name=found_user_name,
         )
-        request.session[MASQUERADE_SETTINGS_KEY] = masquerade_settings
+        if role == 'staff':
+            del request.session[MASQUERADE_SETTINGS_KEY]
+        else:
+            request.session[MASQUERADE_SETTINGS_KEY] = masquerade_settings
         return JsonResponse({'success': True})
 
 


### PR DESCRIPTION
## Description

This PR fixes an issue with the edx_sga xblock that causes that when an **instructor** uses the feature _"View this course as"_ and selects any option but **_"staff"_** and then came back as **_"staff"_** he wouldn't have the option to approve the notes on an edx_sga component.

This PR shouldn't affect any functionality of the platform as the change restore the state of the session of the user as if the user just logged in (when the feature work) and the real user role will be taken by the [method](https://github.com/openedx/edx-platform/blob/master/lms/djangoapps/courseware/access.py#L896) get_user_role:

```python
def get_user_role(user, course_key):
    """
    Return corresponding string if user has staff, instructor or student
    course role in LMS.
    """
    role = get_masquerade_role(user, course_key)
    if role:
        return role
    elif has_access(user, 'instructor', course_key):
        return 'instructor'
    elif has_access(user, 'staff', course_key):
        return 'staff'
    else:
        return 'student'
```

- The change is not made in sga_xblock because there the instructors are only allowed to approve grades and this case cannot be managed by the xblock.
- Also, we are aware that this feature (masquerade) had caused some similar issues with instructors and the staff role. This change should solve those issues.

## Testing instructions

- To an account without any permissions (includes superuser and django staff) create an student access role with instructor permissions for a course.
- Go to the course in Studio. Then Advanced Settings > Advanced Module List and add "edx_sga"
- Add an SGA Advanced component
- Preview live version
- Submit a file (any)
- Select **"GRADE SUBMISSIONS"**. Enter a grade for the submission.
- Submit a new file.
- Select "View this course as" "Student".
- Select "View this course as" "Staff".
- Select **"GRADE SUBMISSIONS"**. You have the option to enter a grade, but because you are "staff" you cannot approve the grade.

## Deadline

None
