### PR TITLE
fix: Remove reference to course info SASS.

### DIFF
--- a/lms/static/sass/_build-course.scss
+++ b/lms/static/sass/_build-course.scss
@@ -45,7 +45,6 @@
 @import "course/wiki/table";
 
 // course - views
-@import "course/info";
 @import "course/syllabus"; // TODO arjun replace w/ custom tabs, see courseware/courses.py
 @import "course/textbook";
 @import "course/profile";


### PR DESCRIPTION
We removed this SASS file in PR #30299. This removes the reference to it.
