### PR TITLE
feat: change text xblock title to 'Text' v2

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_utils.py
@@ -741,30 +741,25 @@ class ValidateCourseOlxTests(CourseTestCase):
 class DetermineLabelTests(TestCase):
     """Tests for xblock Title"""
 
-    def setUp(self):
-        super().setUp()
-
-    def validate_html_replaced_with_text_for_none(self):
+    def test_html_replaced_with_text_for_none(self):
         """
         Tests that display names for "html" xblocks are replaced with "Text" when the display name is otherwise unset.
         """
         display_name = None
         block_type = "html"
         result = utils.determine_label(display_name, block_type)
-        self.assertTrue(False)
         self.assertEqual(result, "Text")
 
-    def validate_html_replaced_with_text_for_empty(self):
+    def test_html_replaced_with_text_for_empty(self):
         """
         Tests that display names for "html" xblocks are replaced with "Text" when the display name is empty.
         """
         display_name = ""
         block_type = "html"
         result = utils.determine_label(display_name, block_type)
-        assert result == display_name
         self.assertEqual(result, "Text")
 
-    def validate_set_titles_not_replaced(self):
+    def test_set_titles_not_replaced(self):
         """
         Tests that display names for "html" xblocks are not replaced with "Text" when the display name is set.
         """
@@ -773,7 +768,7 @@ class DetermineLabelTests(TestCase):
         result = utils.determine_label(display_name, block_type)
         self.assertEqual(result, "Something")
 
-    def validate_non_html_blocks_titles_not_replaced(self):
+    def test_non_html_blocks_titles_not_replaced(self):
         """
         Tests that display names for non-"html" xblocks are not replaced with "Text" when the display name is set.
         """

--- a/cms/djangoapps/contentstore/tests/test_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_utils.py
@@ -736,3 +736,48 @@ class ValidateCourseOlxTests(CourseTestCase):
                 ignore=ignore,
                 allowed_xblocks=allowed_xblocks
             )
+
+
+class DetermineLabelTests(TestCase):
+    """Tests for xblock Title"""
+
+    def setUp(self):
+        super().setUp()
+
+    def validate_html_replaced_with_text_for_none(self):
+        """
+        Tests that display names for "html" xblocks are replaced with "Text" when the display name is otherwise unset.
+        """
+        display_name = None
+        block_type = "html"
+        result = utils.determine_label(display_name, block_type)
+        self.assertTrue(False)
+        self.assertEqual(result, "Text")
+
+    def validate_html_replaced_with_text_for_empty(self):
+        """
+        Tests that display names for "html" xblocks are replaced with "Text" when the display name is empty.
+        """
+        display_name = ""
+        block_type = "html"
+        result = utils.determine_label(display_name, block_type)
+        assert result == display_name
+        self.assertEqual(result, "Text")
+
+    def validate_set_titles_not_replaced(self):
+        """
+        Tests that display names for "html" xblocks are not replaced with "Text" when the display name is set.
+        """
+        display_name = "Something"
+        block_type = "html"
+        result = utils.determine_label(display_name, block_type)
+        self.assertEqual(result, "Something")
+
+    def validate_non_html_blocks_titles_not_replaced(self):
+        """
+        Tests that display names for non-"html" xblocks are not replaced with "Text" when the display name is set.
+        """
+        display_name = None
+        block_type = "something else"
+        result = utils.determine_label(display_name, block_type)
+        self.assertEqual(result, "something else")

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -703,6 +703,20 @@ def get_sibling_urls(subsection, unit_location):    # pylint: disable=too-many-s
     return prev_url, next_url
 
 
+def determine_label(display_name, block_type):
+    """
+    Returns the name of the xblock to display in studio.
+    Please see TNL-9838.
+    """
+    if display_name == '' or display_name == None:
+        if block_type == 'html':
+            return _("Text")
+        else:
+            return block_type
+    else:
+        return display_name
+
+
 @contextmanager
 def translation_language(language):
     """Context manager to override the translation language for the scope

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -708,7 +708,7 @@ def determine_label(display_name, block_type):
     Returns the name of the xblock to display in studio.
     Please see TNL-9838.
     """
-    if display_name == '' or display_name == None:
+    if display_name in {"", None}:
         if block_type == 'html':
             return _("Text")
         else:

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -427,13 +427,16 @@ def xblock_view_handler(request, usage_key_string, view_name):
 
             # Note that the container view recursively adds headers into the preview fragment,
             # so only the "Pages" view requires that this extra wrapper be included.
+            display_label = xblock.display_name or xblock.scope_ids.block_type
+            if not xblock.display_name and xblock.scope_ids.block_type == 'html':
+                display_label = _("Text")
             if is_pages_view:
                 fragment.content = render_to_string('component.html', {
                     'xblock_context': context,
                     'xblock': xblock,
                     'locator': usage_key,
                     'preview': fragment.content,
-                    'label': xblock.display_name or xblock.scope_ids.block_type,
+                    'label': display_label,
                 })
         else:
             raise Http404

--- a/cms/templates/studio_xblock_wrapper.html
+++ b/cms/templates/studio_xblock_wrapper.html
@@ -2,7 +2,7 @@
 <%!
 from django.utils.translation import gettext as _
 from cms.djangoapps.contentstore.views.helpers import xblock_studio_url
-from cms.djangoapps.contentstore.utils import is_visible_to_specific_partition_groups, get_editor_page_base_url
+from cms.djangoapps.contentstore.utils import is_visible_to_specific_partition_groups, get_editor_page_base_url, determine_label
 from lms.lib.utils import is_unit
 from openedx.core.djangolib.js_utils import (
     dump_js_escaped_json, js_escaped_string
@@ -17,7 +17,7 @@ xblock_url = xblock_studio_url(xblock)
 show_inline = xblock.has_children and not xblock_url
 section_class = "level-nesting" if show_inline else "level-element"
 collapsible_class = "is-collapsible" if xblock.has_children else ""
-label = xblock.display_name_with_default or xblock.scope_ids.block_type
+label = determine_label(xblock.display_name_with_default, xblock.scope_ids.block_type)
 messages = xblock.validate().to_json()
 block_is_unit = is_unit(xblock)
 %>


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

The default title for an xblock (when it's empty or missing) is the block type. This change will change the default title for 'html' blocks to 'Text'.

## Supporting information

Code change for https://2u-internal.atlassian.net/browse/TNL-9838

## Testing instructions

1. Edit a Text xblock.
2. Edit the title to be empty.
3. On the unit page, the xblock should have a title of 'Text'.