### PR TITLE
fix: add () to print statement so template works in newer versions

### DIFF
--- a/common/lib/xmodule/xmodule/templates/problem/problem_with_hint.yaml
+++ b/common/lib/xmodule/xmodule/templates/problem/problem_with_hint.yaml
@@ -11,7 +11,7 @@ data: |
             <customresponse cfn="test_str" expect="python">
             <script type="text/python" system_path="python_lib">
     def test_str(expect, ans):
-      print expect, ans
+      print(expect, ans)
       ans = ans.strip("'")
       ans = ans.strip('"')
       return expect == ans.lower()
@@ -19,7 +19,7 @@ data: |
     def hint_fn(answer_ids, student_answers, new_cmap, old_cmap):
       aid = answer_ids[0]
       ans = str(student_answers[aid]).lower()
-      print 'hint_fn called, ans=', ans
+      print('hint_fn called, ans=', ans)
       hint = ''
       if 'java' in ans:
          hint = 'that is only good for drinking'


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This PR updates the problem with hint template so it works with Python3+. It simply adds parenthesis to a print statement that was causing an error while rendering this kind of problem.

## Supporting information

This bug was reported on [this](https://github.com/openedx/build-test-release-wg/issues/159#issuecomment-1146380986) BTR issue.

## Testing instructions

(tested on tutor Nutmeg version)
1. Install the codejail plugin following [these](https://github.com/eduNEXT/tutor-contrib-codejail) instructions
2. Create a problem with hint unit, it shouldn't throw any errors (like the one reported)

## Deadline

None
