### PR TITLE
[BD-14] chore: bumps blockstore version

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
--e git+https://github.com/openedx/blockstore.git@1.2.1#egg=blockstore==1.2.1
+-e git+https://github.com/openedx/blockstore.git@1.2.2#egg=blockstore==1.2.2
     # via -r requirements/edx/github.in
 -e common/lib/capa
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
--e git+https://github.com/openedx/blockstore.git@1.2.1#egg=blockstore==1.2.1
+-e git+https://github.com/openedx/blockstore.git@1.2.2#egg=blockstore==1.2.2
     # via -r requirements/edx/testing.txt
 -e common/lib/capa
     # via

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -63,7 +63,7 @@ git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752
 git+https://github.com/edx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776#egg=django-require==1.0.12
 
 # Our libraries:
--e git+https://github.com/openedx/blockstore.git@1.2.1#egg=blockstore==1.2.1
+-e git+https://github.com/openedx/blockstore.git@1.2.2#egg=blockstore==1.2.2
 -e git+https://github.com/edx/codejail.git@3.1.3#egg=codejail==3.1.3
 -e git+https://github.com/edx/RateXBlock.git@2.0.1#egg=rate-xblock
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
--e git+https://github.com/openedx/blockstore.git@1.2.1#egg=blockstore==1.2.1
+-e git+https://github.com/openedx/blockstore.git@1.2.2#egg=blockstore==1.2.2
     # via -r requirements/edx/base.txt
 -e common/lib/capa
     # via


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Bumps blockstore version to assist with debugging blockstore app storage configuration.

Useful information to include:
- This change will increase log output, but has no user-facing effects.
- Applies change from https://github.com/openedx/blockstore/pull/182

## Supporting information

See [Slack discussion](https://openedx.slack.com/archives/C02QN50TYMD/p1655234358696019) for context.

## Testing instructions

Sandbox is provisioning:

* LMS: https://pr30587.sandbox.opencraft.hosting/
* Studio: https://studio.pr30587.sandbox.opencraft.hosting/

1. Install the branch from https://github.com/openedx/blockstore/pull/182 on your devstack LMS/Studio virtualenvs.
    ```
    paver install_prereqs
    ```
2. Note when LMS/Studio restart, log messages like this appear:
   ```
   INFO 7249 [blockstore.apps.bundles.storage] [user None] [ip None] storage.py:156 - BLOCKSTORE AssetStorage: asset_backend=<django.core.files.storage.FileSystemStorage object at 0x7f709d76bb50>(bucket_name=None, access_key=NOT SET), url_backend=<django.core.files.storage.FileSystemStorage object at 0x7f709d76bb50>)
   ```
3. Create and enable the waffle switch in the LMS Django Admin, `blockstore.use_blockstore_app_api`.

   If this switch is enabled, the following log messages will appear in the LMS/Studio logs.
   If this switch is disabled, the following log messages will appear in the Blockstore service logs.
3. Note that whenever a blockstore bundle snapshot is accessed (e.g. when reading/writing OLX definition or other bundle files), log messages like this appear:
   ```
   INFO 7760 [blockstore.apps.bundles.store] [user 8] [ip 172.20.0.22] store.py:287 - BLOCKSTORE: SnapshotRepo.storage=asset_backend=<django.core.files.storage.FileSystemStorage object at 0x7f5f7c336be0>(bucket_name=None, access_key=NOT SET), url_backend=<django.core.files.storage.FileSystemStorage object at 0x7f5f7c336be0>)
   ```

## Deadline

ASAP -- testing this on stage.edx starting at 3:30pm EST 15 June 2022.

## Other information

None