### PR TITLE
fix: Fixed broken HiddenContentTransformer when course pacing is self_pace

### DIFF
--- a/lms/djangoapps/course_blocks/transformers/hidden_content.py
+++ b/lms/djangoapps/course_blocks/transformers/hidden_content.py
@@ -32,7 +32,7 @@ class HiddenContentTransformer(BlockStructureTransformer):
     in case the 'due' date on a block has been shifted for a user.
     """
     WRITE_VERSION = 4
-    READ_VERSION = 3
+    READ_VERSION = 4
     MERGED_HIDE_AFTER_DUE = 'merged_hide_after_due'
     MERGED_END_DATE = 'merged_end_date'
 
@@ -56,6 +56,16 @@ class HiddenContentTransformer(BlockStructureTransformer):
         )
 
     @classmethod
+    def _get_merged_end_date(cls, block_structure, block_key):
+        """
+        Returns the merged value for the end date for the block with
+        the given block_key in the given block_structure.
+        """
+        return block_structure.get_transformer_block_field(
+            block_key, cls, cls.MERGED_END_DATE
+        )
+
+    @classmethod
     def collect(cls, block_structure):
         """
         Collects any information that's necessary to execute this
@@ -75,7 +85,7 @@ class HiddenContentTransformer(BlockStructureTransformer):
             default_date=MAXIMUM_DATE
         )
 
-        block_structure.request_xblock_fields('self_paced', 'end', 'due')
+        block_structure.request_xblock_fields('self_paced', 'due')
 
     def transform(self, usage_info, block_structure):
         # Users with staff access bypass the Visibility check.
@@ -92,7 +102,7 @@ class HiddenContentTransformer(BlockStructureTransformer):
         hide_after_due = self._get_merged_hide_after_due(block_structure, block_key)
         self_paced = block_structure[block_structure.root_block_usage_key].self_paced
         if self_paced:
-            hidden_date = block_structure[block_structure.root_block_usage_key].end
+            hidden_date = self._get_merged_end_date(block_structure, block_key)
         else:
             # Important Note:
             # A small subtlety of grabbing the due date here is that this transformer relies on the


### PR DESCRIPTION
This PR has changes to fix a [issue](https://discuss.openedx.org/t/attributeerror-field-end-does-not-exist-on-get-block-api-request/7481) reported on openedx forum.

Step to reproduce issue.
1. Create a course with course pacing set to self paced
2. Added few sections, subsection, units and few components in those units
3. Set course start date, enrollment date in past 
4. Create a learner account and enroll in the newly created course
5. Try to access course block using course blocks API
http://localhost:18000/api/courses/v1/blocks/{block_usage_key}/?username={learner_username}&depth=all
6. It should throw `AttributeError: Field end does not exist`

In case of self paced course we are relying on course end date to determine if a block is visible or not. However, when course blocks API is called with a block_key it breaks since blocks do not have `end` field instead only course block has `end` field. Changes in this PR fetch `end` date of block from parent or ancestors blocks.

Part 2/2 - Updating transform method + updating Read version
see also #30823 