### PR TITLE
fix: update is_marketable value for Braze

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -350,6 +350,7 @@ def _link_user_to_third_party_provider(
 def _track_user_registration(user, profile, params, third_party_provider, registration):
     """ Track the user's registration. """
     if hasattr(settings, 'LMS_SEGMENT_KEY') and settings.LMS_SEGMENT_KEY:
+        is_marketable = params.get('marketing_emails_opt_in') in ['true', '1']
         traits = {
             'email': user.email,
             'username': user.username,
@@ -361,10 +362,10 @@ def _track_user_registration(user, profile, params, third_party_provider, regist
             'address': profile.mailing_address,
             'gender': profile.gender_display,
             'country': str(profile.country),
-            'is_marketable': params.get('marketing_emails_opt_in') == 'true'
+            'is_marketable': is_marketable
         }
         if settings.MARKETING_EMAILS_OPT_IN and params.get('marketing_emails_opt_in'):
-            email_subscribe = 'subscribed' if params.get('marketing_emails_opt_in') == 'true' else 'unsubscribed'
+            email_subscribe = 'subscribed' if is_marketable else 'unsubscribed'
             traits['email_subscribe'] = email_subscribe
 
         # .. pii: Many pieces of PII are sent to Segment here. Retired directly through Segment API call in Tubular.
@@ -386,7 +387,7 @@ def _track_user_registration(user, profile, params, third_party_provider, regist
         }
         # VAN-738 - added below properties to experiment marketing emails opt in/out events on Braze.
         if params.get('marketing_emails_opt_in') and settings.MARKETING_EMAILS_OPT_IN:
-            properties['marketing_emails_opt_in'] = params.get('marketing_emails_opt_in') == 'true'
+            properties['marketing_emails_opt_in'] = is_marketable
 
         # DENG-803: For segment events forwarded along to Hubspot, duplicate the `properties` section of
         # the event payload into the `traits` section so that they can be received. This is a temporary


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

In the payload we are getting '1' or 'true' for the `marketing_emails_opt_in` param. Added a check for it to fix value when we send it to Braze or segment. 

