### PR TITLE
revert openedx-events

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -74,3 +74,5 @@ scipy<1.8.0
 # See issue: https://github.com/sphinx-contrib/openapi/issues/123
 mistune<2.0.0
 
+# breaking change on openedx-events==0.10.0
+openedx-events==0.9.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -735,7 +735,7 @@ oauthlib==3.0.1
     #   social-auth-core
 openedx-calc==3.0.1
     # via -r requirements/edx/base.in
-openedx-events==0.10.0
+openedx-events==0.9.1
     # via -r requirements/edx/base.in
 openedx-filters==0.7.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -962,7 +962,7 @@ oauthlib==3.0.1
     #   social-auth-core
 openedx-calc==3.0.1
     # via -r requirements/edx/testing.txt
-openedx-events==0.10.0
+openedx-events==0.9.1
     # via -r requirements/edx/testing.txt
 openedx-filters==0.7.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -913,7 +913,7 @@ oauthlib==3.0.1
     #   social-auth-core
 openedx-calc==3.0.1
     # via -r requirements/edx/base.txt
-openedx-events==0.10.0
+openedx-events==0.9.1
     # via -r requirements/edx/base.txt
 openedx-filters==0.7.0
     # via


### PR DESCRIPTION
TLDR; suspect [openedx-events](https://github.com/openedx/openedx-events/compare/v0.9.1...v0.10.0) package what was upgrade in [this pr](https://github.com/openedx/edx-platform/pull/30581) cause the error in production. This package is used for async eventing and it has changed how serialization of course keys is happening. 