### PR TITLE
fix: revert blockstore to 1.2.1

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
--e git+https://github.com/openedx/blockstore.git@1.2.2#egg=blockstore==1.2.2
+-e git+https://github.com/openedx/blockstore.git@1.2.1#egg=blockstore==1.2.1
     # via -r requirements/edx/github.in
 -e common/lib/capa
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
--e git+https://github.com/openedx/blockstore.git@1.2.2#egg=blockstore==1.2.2
+-e git+https://github.com/openedx/blockstore.git@1.2.1#egg=blockstore==1.2.1
     # via -r requirements/edx/testing.txt
 -e common/lib/capa
     # via

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -63,7 +63,7 @@ git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752
 git+https://github.com/edx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776#egg=django-require==1.0.12
 
 # Our libraries:
--e git+https://github.com/openedx/blockstore.git@1.2.2#egg=blockstore==1.2.2
+-e git+https://github.com/openedx/blockstore.git@1.2.1#egg=blockstore==1.2.1  # Note: Blockstore 1.2.2 is failing.
 -e git+https://github.com/edx/codejail.git@3.1.3#egg=codejail==3.1.3
 -e git+https://github.com/edx/RateXBlock.git@2.0.1#egg=rate-xblock
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
--e git+https://github.com/openedx/blockstore.git@1.2.2#egg=blockstore==1.2.2
+-e git+https://github.com/openedx/blockstore.git@1.2.1#egg=blockstore==1.2.1
     # via -r requirements/edx/base.txt
 -e common/lib/capa
     # via
@@ -75,7 +75,6 @@ attrs==21.4.0
     #   blockstore
     #   edx-ace
     #   openedx-events
-    #   outcome
     #   pytest
 babel==2.10.2
     # via


### PR DESCRIPTION
## Description

Blockstore 1.2.2 currently has a bug. This reverts it to 1.2.1.
See https://github.com/openedx/blockstore/commit/7794a65d63605ebe55fcb67b7f769528b5095963#r76182896