### PR TITLE
fix: remove constraint for openedx-events

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -74,8 +74,6 @@ scipy<1.8.0
 # See issue: https://github.com/sphinx-contrib/openapi/issues/123
 mistune<2.0.0
 
-# breaking change on openedx-events==0.10.0
-openedx-events==0.9.1
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -741,10 +741,8 @@ oauthlib==3.0.1
     #   social-auth-core
 openedx-calc==3.0.1
     # via -r requirements/edx/base.in
-openedx-events==0.9.1
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/base.in
+openedx-events==0.10.0
+    # via -r requirements/edx/base.in
 openedx-filters==0.7.0
     # via
     #   -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -966,10 +966,8 @@ oauthlib==3.0.1
     #   social-auth-core
 openedx-calc==3.0.1
     # via -r requirements/edx/testing.txt
-openedx-events==0.9.1
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/testing.txt
+openedx-events==0.10.0
+    # via -r requirements/edx/testing.txt
 openedx-filters==0.7.0
     # via
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -917,10 +917,8 @@ oauthlib==3.0.1
     #   social-auth-core
 openedx-calc==3.0.1
     # via -r requirements/edx/base.txt
-openedx-events==0.9.1
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/base.txt
+openedx-events==0.10.0
+    # via -r requirements/edx/base.txt
 openedx-filters==0.7.0
     # via
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
Remove constraint for openedx-events to revert [this change](https://github.com/openedx/edx-platform/commit/e0f7d31f0eef492fdf3ed05b3ab403779d956525)