### PR TITLE
fix: remove fields based on extended_profile configuration

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -497,6 +497,8 @@ class UserProfile(models.Model):
     user = models.OneToOneField(User, unique=True, db_index=True, related_name='profile', on_delete=models.CASCADE)
     name = models.CharField(blank=True, max_length=255, db_index=True)
 
+    # How meta field works: meta will only store those fields which are available in extended_profile configuration,
+    # so in order to store a field in meta, it must be available in extended_profile configuration.
     meta = models.TextField(blank=True)  # JSON dictionary for future expansion
     courseware = models.CharField(blank=True, max_length=255, default='course.xml')
 

--- a/openedx/core/djangoapps/user_authn/api/form_fields.py
+++ b/openedx/core/djangoapps/user_authn/api/form_fields.py
@@ -177,7 +177,7 @@ def add_profession_field(is_field_required=False):
 
 def add_specialty_field(is_field_required=False):
     """
-    Returns the user speciality field description
+    Returns the user specialty field description
     """
     # Translators: This label appears above a dropdown menu to select
     # the user's specialty

--- a/openedx/core/djangoapps/user_authn/api/helper.py
+++ b/openedx/core/djangoapps/user_authn/api/helper.py
@@ -9,6 +9,7 @@ from rest_framework.views import APIView
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_authn.api import form_fields
 from openedx.core.djangoapps.user_authn.views.registration_form import get_registration_extension_form
+from common.djangoapps.student.models import UserProfile
 
 
 class RegistrationFieldsContext(APIView):
@@ -37,6 +38,7 @@ class RegistrationFieldsContext(APIView):
         'specialty',
         'marketing_emails_opt_in',
     ]
+    user_profile_fields = [field.name for field in UserProfile._meta.get_fields()]
 
     def _get_field_order(self):
         """
@@ -84,6 +86,16 @@ class RegistrationFieldsContext(APIView):
                 ):
                     self.valid_fields.append(field_name)
 
+    def _field_can_be_saved(self, field):
+        """
+        Checks if the field exists in UserProfile Model fields or extended_profile configuration,
+        if it exists, then the field is valid to save because the meta field in UserProfile model
+        only stores those fields which are available in extended_profile configuration, so we only
+        want to send those fields which can be saved.
+        """
+        return (field in self.user_profile_fields or
+                field in configuration_helpers.get_value('extended_profile_fields', []))
+
     def _get_fields(self):
         """
         Returns the required or optional fields configured in REGISTRATION_EXTRA_FIELDS settings.
@@ -92,6 +104,8 @@ class RegistrationFieldsContext(APIView):
         custom_form = get_registration_extension_form() or {}
         response = {}
         for field in self.valid_fields:
+            if field == 'confirm_email' and self.field_type == 'optional' or not self._field_can_be_saved(field):
+                continue
             if custom_form and field in custom_form.fields:
                 response[field] = form_fields.add_extension_form_field(
                     field, custom_form, custom_form.fields[field], self.field_type
@@ -99,10 +113,6 @@ class RegistrationFieldsContext(APIView):
             else:
                 field_handler = getattr(form_fields, f'add_{field}_field', None)
                 if field_handler:
-                    if field == 'confirm_email':
-                        if self.field_type == 'required':
-                            response[field] = field_handler(self.field_type == 'required')
-                    else:
-                        response[field] = field_handler(self.field_type == 'required')
+                    response[field] = field_handler(self.field_type == 'required')
 
         return response


### PR DESCRIPTION
Meta field in UserProfile model will only store those fields which are available in extended_profile configuration,
so we are removing the fields that are not available in the extended_profile configuration because their data will
not be stored

[VAN-977](https://2u-internal.atlassian.net/browse/VAN-977)
