### PR TITLE
fix: resolved caching issue in discussions iframe

### DIFF
--- a/lms/djangoapps/discussion/templates/discussion/discussion_mfe_embed.html
+++ b/lms/djangoapps/discussion/templates/discussion/discussion_mfe_embed.html
@@ -15,7 +15,8 @@ from openedx.core.djangolib.js_utils import js_escaped_string
     window.addEventListener("load", function () {
         const mfeUrl = (new URL("${discussions_mfe_url  | n, js_escaped_string}"));
         const iframe = document.querySelector('#discussions-mfe-tab-embed');
-        iframe.src = mfeUrl.href + window.location.hash.slice(1);
+        let timestamp = "?no-cache=" + Date.now();
+        iframe.src = mfeUrl.href + window.location.hash.slice(1) + timestamp;
         window.addEventListener("message", (event) => {
             const payload = event.data.payload;
             if (event.origin !== mfeUrl.origin) {


### PR DESCRIPTION
Adding time stamp to discussions URL to avoid caching HTML because whenever a new build is created users were not able to load the page because the app was trying to access older resources that no longer existed.