### PR TITLE
feat: add ora grading/gradebook urls for devstack

### DIFF
--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -252,6 +252,12 @@ ENTERPRISE_LEARNER_PORTAL_BASE_URL = 'http://' + ENTERPRISE_LEARNER_PORTAL_NETLO
 ENTERPRISE_ADMIN_PORTAL_NETLOC = 'localhost:1991'
 ENTERPRISE_ADMIN_PORTAL_BASE_URL = 'http://' + ENTERPRISE_ADMIN_PORTAL_NETLOC
 
+########################## GRADEBOOK APP ##############################
+WRITABLE_GRADEBOOK_URL = 'http://localhost:1994'
+
+########################## ORA STAFF GRADING APP ##############################
+ORA_GRADING_MICROFRONTEND_URL = 'http://localhost:1993'
+
 ###################### Cross-domain requests ######################
 FEATURES['ENABLE_CORS_HEADERS'] = True
 CORS_ALLOW_CREDENTIALS = True


### PR DESCRIPTION
## Description

Add devstack URL configs for Gradebook and ORA Staff Grading MFEs. This will simplify development "out-of-the-box".

Previously, we used to have to override these locally. I think, since then, we've made it more of a practice to write these in to devstack config.

FYI: @openedx/content-aurora 
