### PR TITLE
docs: update xmodule README

### DIFF
--- a/xmodule/README.rst
+++ b/xmodule/README.rst
@@ -1,19 +1,50 @@
-Status: Deprecated (DEPR-24)
+xmodule
+#######
 
-Responsibilities
-================
-XModules render specific course run content types to users for both authoring and learning. For instance, there is an XModule for Videos, another for HTML snippets, and another for Sequences. This package provides both the implementations of these XModules as well as some supporting utilities.
+The ``xmodule`` folder contains a variety of old-yet-important functionality core to both LMS and CMS, most notably:
 
-Direction: Convert and Extract
-==============================
-XModule exists today as a complex set of compatibility shims on top of XBlock (all XModules currently inherit from XBlock). The goal is for all XModules to either be converted into pure XBlocks or be deleted altogether. Extracting them into separate repositories would be ideal, but even just converting them to pure XBlocks would significantly simplify the runtime.
+* the ModuleStore, edx-platform's "Version 1" learning content storage backend;
+* an XBlock Runtime implementation for ModuleStore-backed content;
+* the "partitions" framework for differentiated XBlock content;
+* implementations for the "stuctural" XBlocks: ``course``, ``chapter``, and ``sequential``; and
+* the implementations of several different content-level XBlocks, such as ``problem`` and ``html``.
 
-Glossary
-========
+Historical Context
+******************
 
-More Documentation
-==================
+"XModule" was the original content framework for edx-platform, which gives the folder its current name.
+XModules rendered specific course run content types to users for both authoring and learning.
+For instance, there was an XModule for Videos, another for HTML snippets, and another for Sequences. 
 
-`DEPR-24 <https://openedx.atlassian.net/browse/DEPR-24>`_
+XModule was succeeded in ~2013 by the "XBlock" framework, which served the same purpose, but put additional focus into flexibility and modularity.
+XBlock allows new content types to be created by anyone, completely external the edx-platform repository.
+It remains the platform's flagship content plugin framework to this day.
 
-`Example conversion of Capa <https://github.com/edx/edx-platform/pull/20023/>`_
+For years, edx-platform supported both content frameworks simultaneously via a Frankenstein-ish hybrid XBlock+XModule runtime implementation in this directory.
+Fortunately, in 2021, `all remaining XModules were converted into XBlocks`_.
+Since support for the XModule framework is no longer necessary, `the BD-13 project`_ is now working to radically simplify the remaining XBlock runtime implementation.
+
+.. _all remaining XModules were converted into XBlocks: https://discuss.openedx.org/t/xmodule-xblock-conversion-complete/4555
+.. _the BD-13 project: https://openedx.atlassian.net/wiki/spaces/COMM/pages/3062333478/BD-13+xModule+--+xBlock+Conversion+Phase+2
+
+Direction
+*********
+
+**Maintain, Simplify, Extract & Replace.**
+
+Currently, this directory contains a lot of mission-critical functionality, so continued maintenance and simplification of it is important.
+Still, we aim to eventually dissolve the directory in favor of more focused & decoupled subsystems:
+
+* ModuleStore is superseded by the `Blockstore`_ storage backend.
+* Blockstore-backend content is rendered by a new, simplified `edx-platform XBlock runtime`_.
+* Navigation, partitioning, and composition of learning content is being re-architected in the `openedx-learning`_ library.
+* All new XBlocks are implemented in separate repositories, such as `xblock-drag-and-drop-v2`_.
+
+To help with this direction, please **do not add new functionality to this directory**. If you feel that you need to add code to this directory, reach out on `the forums`_; it's likely that someone can help you find a different way to implement your change that will be more robust and architecturally sound!
+
+.. _Blockstore: https://github.com/openedx/blockstore/
+.. _edx-platform XBlock runtime: https://github.com/openedx/edx-platform/tree/master/openedx/core/djangoapps/xblock
+.. _openedx-learning: https://github.com/openedx/openedx-learning 
+.. _xblock-drag-and-drop-v2: https://github.com/openedx/xblock-drag-and-drop-v2
+.. _the forums: https://discuss.openedx.org
+


### PR DESCRIPTION
Since [the xmodule directory has just been moved the repo root](https://github.com/openedx/edx-platform/pull/30394), it seemed like a good time to give the directory's README a refresh.