### PR TITLE
Removed hardcoded social media and mobile store Images hosted on Sailthru

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -606,8 +606,6 @@ SOCIAL_SHARING_SETTINGS = {
     'DASHBOARD_TWITTER': False
 }
 
-SOCIAL_MEDIA_FOOTER_URLS = {}
-
 # This is just a placeholder image.
 # Site operators can customize this with their organization's image.
 FOOTER_ORGANIZATION_IMAGE = "images/logo.png"
@@ -2265,11 +2263,6 @@ DEFAULT_MOBILE_AVAILABLE = False
 
 # How long to cache OpenAPI schemas and UI, in seconds.
 OPENAPI_CACHE_TIMEOUT = 0
-
-################# Mobile URLS ##########################
-
-# These are URLs to the app store for mobile.
-MOBILE_STORE_URLS = {}
 
 ############################# Persistent Grades ####################################
 

--- a/cms/envs/devstack-experimental.yml
+++ b/cms/envs/devstack-experimental.yml
@@ -354,7 +354,7 @@ MEDIA_ROOT: /edx/var/edxapp/media/
 MEDIA_URL: /media/
 MKTG_URLS: {}
 MKTG_URL_LINK_MAP: {}
-MOBILE_STORE_URLS: {}
+MOBILE_STORE_ACE_URLS: {}
 MODULESTORE:
     default:
         ENGINE: xmodule.modulestore.mixed.MixedModuleStore

--- a/lms/djangoapps/branding/api.py
+++ b/lms/djangoapps/branding/api.py
@@ -167,7 +167,7 @@ def _footer_social_links():
             {
                 "name": social_name,
                 "title": str(display.get("title", "")),
-                "url": settings.SOCIAL_MEDIA_FOOTER_URLS.get(social_name, "#"),
+                "url": settings.SOCIAL_MEDIA_FOOTER_ACE_URLS.get(social_name, "#"),
                 "icon-class": display.get("icon", ""),
                 "action": str(display.get("action", "")).format(platform_name=platform_name),
             }
@@ -428,7 +428,7 @@ def _footer_mobile_links(is_secure):
                 "title": _(
                     "Download the {platform_name} mobile app from the Apple App Store"
                 ).format(platform_name=platform_name),
-                "url": settings.MOBILE_STORE_URLS.get('apple', '#'),
+                "url": settings.MOBILE_STORE_ACE_URLS.get('apple', '#'),
                 "image": _absolute_url_staticfile(is_secure, 'images/app/app_store_badge_135x40.svg'),
             },
             {
@@ -436,7 +436,7 @@ def _footer_mobile_links(is_secure):
                 "title": _(
                     "Download the {platform_name} mobile app from Google Play"
                 ).format(platform_name=platform_name),
-                "url": settings.MOBILE_STORE_URLS.get('google', '#'),
+                "url": settings.MOBILE_STORE_ACE_URLS.get('google', '#'),
                 "image": _absolute_url_staticfile(is_secure, 'images/app/google_play_badge_45.png'),
             }
         ]

--- a/lms/djangoapps/branding/tests/test_api.py
+++ b/lms/djangoapps/branding/tests/test_api.py
@@ -86,6 +86,10 @@ class TestFooter(TestCase):
     def test_get_footer(self):
         actual_footer = get_footer(is_secure=True)
         business_url = 'https://business.edx.org/?utm_campaign=edX.org+Referral&utm_source=edX.org&utm_medium=Footer'
+        facebook_url = 'http://www.facebook.com/EdxOnline'
+        linkedin_url = 'http://www.linkedin.com/company/edx'
+        twitter_url = 'https://twitter.com/edXOnline'
+        reddit_url = 'http://www.reddit.com/r/edx'
         expected_footer = {
             'copyright': '\xa9 \xe9dX.  All rights reserved except where noted. '
                          ' edX, Open edX and their respective logos are '
@@ -143,15 +147,15 @@ class TestFooter(TestCase):
                  'url': 'https://edx.org/media-kit'}
             ],
             'social_links': [
-                {'url': '#', 'action': 'Like \xe9dX on Facebook', 'name': 'facebook',
+                {'url': facebook_url, 'action': 'Like \xe9dX on Facebook', 'name': 'facebook',
                  'icon-class': 'fa-facebook-square', 'title': 'Facebook'},
-                {'url': '#', 'action': 'Follow \xe9dX on Twitter', 'name': 'twitter',
+                {'url': twitter_url, 'action': 'Follow \xe9dX on Twitter', 'name': 'twitter',
                  'icon-class': 'fa-twitter-square', 'title': 'Twitter'},
-                {'url': '#', 'action': 'Follow \xe9dX on LinkedIn', 'name': 'linkedin',
+                {'url': linkedin_url, 'action': 'Follow \xe9dX on LinkedIn', 'name': 'linkedin',
                  'icon-class': 'fa-linkedin-square', 'title': 'LinkedIn'},
                 {'url': '#', 'action': 'Follow \xe9dX on Instagram', 'name': 'instagram',
                  'icon-class': 'fa-instagram', 'title': 'Instagram'},
-                {'url': '#', 'action': 'Subscribe to the \xe9dX subreddit',
+                {'url': reddit_url, 'action': 'Subscribe to the \xe9dX subreddit',
                  'name': 'reddit', 'icon-class': 'fa-reddit-square', 'title': 'Reddit'}
             ],
             'mobile_links': [],

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3376,7 +3376,36 @@ SOCIAL_MEDIA_FOOTER_NAMES = [
 
 # The footer URLs dictionary maps social footer names
 # to URLs defined in configuration.
-SOCIAL_MEDIA_FOOTER_URLS = {}
+SOCIAL_MEDIA_FOOTER_ACE_URLS = {
+    'reddit': 'http://www.reddit.com/r/edx',
+    'twitter': 'https://twitter.com/edXOnline',
+    'linkedin': 'http://www.linkedin.com/company/edx',
+    'facebook': 'http://www.facebook.com/EdxOnline',
+}
+
+# The mobile store URLs dictionary maps mobile store names
+# to URLs defined in configuration.
+MOBILE_STORE_ACE_URLS = {
+    'google': 'https://play.google.com/store/apps/details?id=org.edx.mobile',
+    'apple': 'https://itunes.apple.com/us/app/edx/id945480667?mt=8',
+}
+
+# The social media logo urls dictionary maps social media names
+# to the respective icons
+SOCIAL_MEDIA_LOGO_URLS = {
+    'reddit': 'http://email-media.s3.amazonaws.com/edX/2021/social_5_reddit.png',
+    'twitter': 'http://email-media.s3.amazonaws.com/edX/2021/social_2_twitter.png',
+    'linkedin': 'http://email-media.s3.amazonaws.com/edX/2021/social_3_linkedin.png',
+    'facebook': 'http://email-media.s3.amazonaws.com/edX/2021/social_1_fb.png',
+}
+
+# The mobile store logo urls dictionary maps mobile store names
+# to the respective icons
+MOBILE_STORE_LOGO_URLS = {
+    'google': 'http://email-media.s3.amazonaws.com/edX/2021/store_google_253x78.jpg',
+    'apple': 'http://email-media.s3.amazonaws.com/edX/2021/store_apple_229x78.jpg',
+}
+
 
 # The display dictionary defines the title
 # and icon class for each social media link.
@@ -3451,11 +3480,6 @@ SOCIAL_MEDIA_FOOTER_DISPLAY = {
 
 #################SOCAIL AUTH OAUTH######################
 SOCIAL_AUTH_OAUTH_SECRETS = {}
-
-################# Mobile URLS ##########################
-
-# These are URLs to the app store for mobile.
-MOBILE_STORE_URLS = {}
 
 ################# Student Verification #################
 VERIFY_STUDENT = {

--- a/openedx/core/djangoapps/ace_common/template_context.py
+++ b/openedx/core/djangoapps/ace_common/template_context.py
@@ -40,8 +40,10 @@ def get_base_template_context(site):
             'CONTACT_EMAIL', site=site, site_config_name='contact_email'),
         'contact_mailing_address': get_config_value_from_site_or_settings(
             'CONTACT_MAILING_ADDRESS', site=site, site_config_name='contact_mailing_address'),
-        'social_media_urls': get_config_value_from_site_or_settings('SOCIAL_MEDIA_FOOTER_URLS', site=site),
-        'mobile_store_urls': get_config_value_from_site_or_settings('MOBILE_STORE_URLS', site=site),
+        'social_media_urls': get_config_value_from_site_or_settings('SOCIAL_MEDIA_FOOTER_ACE_URLS', site=site),
+        'social_media_logo_urls': get_config_value_from_site_or_settings('SOCIAL_MEDIA_LOGO_URLS', site=site),
+        'mobile_store_urls': get_config_value_from_site_or_settings('MOBILE_STORE_ACE_URLS', site=site),
+        'mobile_store_logo_urls': get_config_value_from_site_or_settings('MOBILE_STORE_LOGO_URLS', site=site),
         'logo_url': get_logo_url_for_email(),
         'site_configuration_values': site_configuration_values,
     }

--- a/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_body.html
+++ b/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_body.html
@@ -152,7 +152,7 @@
               {% if social_media_urls.linkedin %}
                 <td height="32" width="42">
                   <a href="{{ social_media_urls.linkedin|safe }}">
-                    <img src="https://media.sailthru.com/595/1k1/8/o/599f354ec70cb.png"
+                    <img src="{{ social_media_logo_urls.linkedin }}"
                       width="32" height="32" alt="{% filter force_escape %}{% blocktrans %}{{ platform_name }} on LinkedIn{% endblocktrans %}{% endfilter %}"/>
                   </a>
                 </td>
@@ -160,7 +160,7 @@
               {% if social_media_urls.twitter %}
                 <td height="32" width="42">
                   <a href="{{ social_media_urls.twitter|safe }}">
-                    <img src="https://media.sailthru.com/595/1k1/8/o/599f354d9c26e.png"
+                    <img src= "{{ social_media_logo_urls.twitter }}"
                       width="32" height="32" alt="{% filter force_escape %}{% blocktrans %}{{ platform_name }} on Twitter{% endblocktrans %}{% endfilter %}"/>
                   </a>
                 </td>
@@ -168,7 +168,7 @@
               {% if social_media_urls.facebook %}
                 <td height="32" width="42">
                   <a href="{{ social_media_urls.facebook|safe }}">
-                    <img src="https://media.sailthru.com/595/1k1/8/o/599f355052c8e.png"
+                    <img src="{{ social_media_logo_urls.facebook }}"
                       width="32" height="32" alt="{% filter force_escape %}{% blocktrans %}{{ platform_name }} on Facebook{% endblocktrans %}{% endfilter %}"/>
                   </a>
                 </td>
@@ -176,7 +176,7 @@
               {% if social_media_urls.google_plus %}
                 <td height="32" width="42">
                   <a href="{{ social_media_urls.google_plus|safe }}">
-                    <img src="https://media.sailthru.com/595/1k1/8/o/599f354fc554a.png"
+                    <img src="{{ social_media_logo_urls.google_plus}}"
                       width="32" height="32" alt="{% filter force_escape %}{% blocktrans %}{{ platform_name }} on Google Plus{% endblocktrans %}{% endfilter %}"/>
                   </a>
                 </td>
@@ -184,7 +184,7 @@
               {% if social_media_urls.reddit %}
                 <td height="32" width="42">
                   <a href="{{ social_media_urls.reddit|safe }}">
-                    <img src="https://media.sailthru.com/595/1k1/8/o/599f354e326b9.png"
+                    <img src="{{ social_media_logo_urls.reddit}}"
                       width="32" height="32" alt="{% filter force_escape %}{% blocktrans %}{{ platform_name }} on Reddit{% endblocktrans %}{% endfilter %}"/>
                   </a>
                 </td>
@@ -198,14 +198,14 @@
         <td style="padding-bottom: 20px;">
           {% if mobile_store_urls.apple %}
             <a href="{{ mobile_store_urls.apple|safe }}" style="text-decoration: none">
-              <img src="https://media.sailthru.com/595/1k1/6/2/5931cfbba391b.png"
+              <img src="{{ mobile_store_logo_urls.apple}}"
                 alt="{% trans "Download the iOS app on the Apple Store" as tmsg %}{{ tmsg | force_escape }}"
                 width="136" height="50" style="margin-{{ LANGUAGE_BIDI|yesno:"left,right" }}: 10px"/>
             </a>
           {% endif %}
           {% if mobile_store_urls.google %}
             <a href="{{ mobile_store_urls.google|safe }}" style="text-decoration: none">
-              <img src="https://media.sailthru.com/595/1k1/6/2/5931cf879a033.png"
+              <img src="{{ mobile_store_logo_urls.google}}"
                 alt="{% trans "Download the Android app on the Google Play Store" as tmsg %}{{ tmsg | force_escape }}"
                 width="136" height="50"/>
             </a>

--- a/openedx/core/djangoapps/schedules/tests/test_resolvers.py
+++ b/openedx/core/djangoapps/schedules/tests/test_resolvers.py
@@ -165,6 +165,18 @@ class TestCourseUpdateResolver(SchedulesResolverTestMixin, ModuleStoreTestCase):
     def test_schedule_context(self):
         resolver = self.create_resolver()
         schedules = list(resolver.schedules_for_bin())
+        apple_logo_url = 'http://email-media.s3.amazonaws.com/edX/2021/store_apple_229x78.jpg'
+        google_logo_url = 'http://email-media.s3.amazonaws.com/edX/2021/store_google_253x78.jpg'
+        apple_store_url = 'https://itunes.apple.com/us/app/edx/id945480667?mt=8'
+        google_store_url = 'https://play.google.com/store/apps/details?id=org.edx.mobile'
+        facebook_url = 'http://www.facebook.com/EdxOnline'
+        linkedin_url = 'http://www.linkedin.com/company/edx'
+        twitter_url = 'https://twitter.com/edXOnline'
+        reddit_url = 'http://www.reddit.com/r/edx'
+        facebook_logo_url = 'http://email-media.s3.amazonaws.com/edX/2021/social_1_fb.png'
+        linkedin_logo_url = 'http://email-media.s3.amazonaws.com/edX/2021/social_3_linkedin.png'
+        twitter_logo_url = 'http://email-media.s3.amazonaws.com/edX/2021/social_2_twitter.png'
+        reddit_logo_url = 'http://email-media.s3.amazonaws.com/edX/2021/social_5_reddit.png'
         expected_context = {
             'contact_email': 'info@example.com',
             'contact_mailing_address': '123 Sesame Street',
@@ -173,12 +185,22 @@ class TestCourseUpdateResolver(SchedulesResolverTestMixin, ModuleStoreTestCase):
             'course_url': f'http://learning-mfe/course/{self.course.id}/home',
             'dashboard_url': '/dashboard',
             'homepage_url': '/',
-            'mobile_store_urls': {},
+            'mobile_store_logo_urls': {'apple': apple_logo_url,
+                                       'google': google_logo_url},
+            'mobile_store_urls': {'apple': apple_store_url,
+                                  'google': google_store_url},
             'logo_url': 'https://www.logo.png',
             'platform_name': '\xe9dX',
             'show_upsell': False,
             'site_configuration_values': {},
-            'social_media_urls': {},
+            'social_media_logo_urls': {'facebook': facebook_logo_url,
+                                       'linkedin': linkedin_logo_url,
+                                       'reddit': reddit_logo_url,
+                                       'twitter': twitter_logo_url},
+            'social_media_urls': {'facebook': facebook_url,
+                                  'linkedin': linkedin_url,
+                                  'reddit': reddit_url,
+                                  'twitter': twitter_url},
             'template_revision': 'release',
             'unsubscribe_url': None,
             'week_highlights': ['good stuff'],
@@ -255,7 +277,18 @@ class TestCourseNextSectionUpdateResolver(SchedulesResolverTestMixin, ModuleStor
         with self.assertNumQueries(38):
             sc = resolver.get_schedules()
             schedules = list(sc)
-
+        apple_logo_url = 'http://email-media.s3.amazonaws.com/edX/2021/store_apple_229x78.jpg'
+        google_logo_url = 'http://email-media.s3.amazonaws.com/edX/2021/store_google_253x78.jpg'
+        apple_store_url = 'https://itunes.apple.com/us/app/edx/id945480667?mt=8'
+        google_store_url = 'https://play.google.com/store/apps/details?id=org.edx.mobile'
+        facebook_url = 'http://www.facebook.com/EdxOnline'
+        linkedin_url = 'http://www.linkedin.com/company/edx'
+        twitter_url = 'https://twitter.com/edXOnline'
+        reddit_url = 'http://www.reddit.com/r/edx'
+        facebook_logo_url = 'http://email-media.s3.amazonaws.com/edX/2021/social_1_fb.png'
+        linkedin_logo_url = 'http://email-media.s3.amazonaws.com/edX/2021/social_3_linkedin.png'
+        twitter_logo_url = 'http://email-media.s3.amazonaws.com/edX/2021/social_2_twitter.png'
+        reddit_logo_url = 'http://email-media.s3.amazonaws.com/edX/2021/social_5_reddit.png'
         expected_context = {
             'contact_email': 'info@example.com',
             'contact_mailing_address': '123 Sesame Street',
@@ -264,12 +297,22 @@ class TestCourseNextSectionUpdateResolver(SchedulesResolverTestMixin, ModuleStor
             'course_url': f'http://learning-mfe/course/{self.course.id}/home',
             'dashboard_url': '/dashboard',
             'homepage_url': '/',
-            'mobile_store_urls': {},
+            'mobile_store_logo_urls': {'apple': apple_logo_url,
+                                       'google': google_logo_url},
+            'mobile_store_urls': {'apple': apple_store_url,
+                                  'google': google_store_url},
             'logo_url': 'https://www.logo.png',
             'platform_name': '\xe9dX',
             'show_upsell': False,
             'site_configuration_values': {},
-            'social_media_urls': {},
+            'social_media_logo_urls': {'facebook': facebook_logo_url,
+                                       'linkedin': linkedin_logo_url,
+                                       'reddit': reddit_logo_url,
+                                       'twitter': twitter_logo_url},
+            'social_media_urls': {'facebook': facebook_url,
+                                  'linkedin': linkedin_url,
+                                  'reddit': reddit_url,
+                                  'twitter': twitter_url},
             'template_revision': 'release',
             'unsubscribe_url': None,
             'week_highlights': ['good stuff 2'],


### PR DESCRIPTION
Removed links to Images that were hosted on Sailthru from the base edx template below.

 https://github.com/openedx/edx-platform/blob/db32ff2cdf678fa8edd12c9da76a76eef0478614/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_body.html

Replaced the image sources to the social medial and mobile store links in base template by a variable. The URL links and the logos for the social media and mobile store links are now defined in the lms/envs/common.py file.

This fixes this issue https://github.com/openedx/build-test-release-wg/issues/148

