### PR TITLE
fix: change user_id query param to username in Learners API

### DIFF
--- a/lms/djangoapps/discussion/rest_api/tests/test_views.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views.py
@@ -1565,7 +1565,7 @@ class LearnerThreadViewAPITest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
             "num_pages": 1,
         }
         self.register_user_active_threads(self.user.id, expected_cs_comments_response)
-        self.url += f"?user_id={self.user.id}"
+        self.url += f"?username={self.user.username}"
         response = self.client.get(self.url)
         assert response.status_code == 200
         response_data = json.loads(response.content.decode('utf-8'))
@@ -1582,12 +1582,12 @@ class LearnerThreadViewAPITest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
             "num_pages": 1,
         }
 
-    def test_no_user_id_given(self):
+    def test_no_username_given(self):
         """
-        Tests that 400 response is returned when no user_id is passed
+        Tests that 404 response is returned when no username is passed
         """
         response = self.client.get(self.url)
-        assert response.status_code == 400
+        assert response.status_code == 404
 
     def test_not_authenticated(self):
         """

--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -560,11 +560,11 @@ class LearnerThreadView(APIView):
 
     **Example Requests**:
 
-        GET /api/discussion/v1/courses/course-v1:ExampleX+Subject101+2015/learner/?page=1&page_size=10
+        GET /api/discussion/v1/courses/course-v1:ExampleX+Subject101+2015/learner/?username=edx&page=1&page_size=10
 
     **GET Thread List Parameters**:
 
-        * user_id: (Required) (Integer) ID of the user whose active threads are required
+        * username: (Required) Username of the user whose active threads are required
 
         * page: The (1-indexed) page to retrieve (default is 1)
 
@@ -589,11 +589,8 @@ class LearnerThreadView(APIView):
         page_num = request.GET.get('page', 1)
         threads_per_page = request.GET.get('page_size', 10)
         discussion_id = None
-        try:
-            user_id = int(request.GET.get('user_id', None))
-        except (TypeError, ValueError):
-            return Response({'details': 'Invalid user id'}, status=400)
-
+        username = request.GET.get('username', None)
+        user = get_object_or_404(User, username=username)
         group_id = None
         try:
             group_id = get_group_id_for_comments_service(request, course_key, discussion_id)
@@ -604,7 +601,7 @@ class LearnerThreadView(APIView):
             "page": page_num,
             "per_page": threads_per_page,
             "course_id": str(course_key),
-            "user_id": user_id,
+            "user_id": user.id,
             "group_id": group_id
         }
         return get_learner_active_thread_list(request, course_key, query_params)


### PR DESCRIPTION
Change user_id query param to username in Learners API. This change is required to make usernames clickable in discussions MFE

Ticket: 
https://2u-internal.atlassian.net/browse/INF-307