### PR TITLE
[BD-13][BB-6146] refactor: delete ModuleSystem's `file_data` property

### DIFF
--- a/xmodule/x_module.py
+++ b/xmodule/x_module.py
@@ -1668,7 +1668,6 @@ class ModuleSystem(MetricsMixin, ConfigurableFragmentWrapper, ModuleSystemShim, 
         publish=None,
         course_id=None,
         error_descriptor_class=None,
-        field_data=None,
         **kwargs,
     ):
         """
@@ -1692,15 +1691,11 @@ class ModuleSystem(MetricsMixin, ConfigurableFragmentWrapper, ModuleSystemShim, 
         publish(event) - A function that allows XModules to publish events (such as grade changes)
 
         error_descriptor_class - The class to use to render XModules with errors
-
-        field_data - the `FieldData` to use for backing XBlock storage.
         """
 
-        # Usage_store is unused, and field_data is often supplanted with an
-        # explicit field_data during construct_xblock.
         kwargs.setdefault('id_reader', getattr(descriptor_runtime, 'id_reader', OpaqueKeyReader()))
         kwargs.setdefault('id_generator', getattr(descriptor_runtime, 'id_generator', AsideKeyGenerator()))
-        super().__init__(field_data=field_data, **kwargs)
+        super().__init__(**kwargs)
 
         self.STATIC_URL = static_url
         self.track_function = track_function


### PR DESCRIPTION
## Description

Removes `field_data` argument from the `ModuleSystem`s constructor.

## Impact analysis

There are many `field_data` usages in the platform. Let's categorize them and determine, which are related to this change and in what way.

1. [ModuleSystem's argument](https://github.com/openedx/edx-platform/blob/d9f54b9f460bed0001e999dac8884d3b8e8a949f/xmodule/x_module.py#L1671). This is what we're removing.
2. [Runtime.field_data](https://github.com/openedx/XBlock/blob/6be6c417254489d4e0674e25c56e98bf6661a2da/xblock/runtime.py#L520). Directly related, as `Runtime` is `ModuleSystem`'s superclass. Analysis below this list is centered around this.
3. [XBlock.field_data](https://github.com/openedx/XBlock/blob/6be6c417254489d4e0674e25c56e98bf6661a2da/xblock/runtime.py#L520). Not related anymore. [Runtime.construct_xblock](https://github.com/openedx/XBlock/blob/6be6c417254489d4e0674e25c56e98bf6661a2da/xblock/runtime.py#L630-L640) was passing runtime's `field_data` to the XBlock's constructor, but [that was ~8 years ago](https://github.com/cpennington/XBlock/blob/2fa8ef27efe30e3974e34430e8c0088f31c36972/xblock/runtime.py#L255).
4. `DescriptorSystem.field_data`. Not related anymore. `field_data` [has been removed](https://github.com/openedx/edx-platform/blob/3a6450c3fc4f9020e5e440f963078c6d0a931fb6/common/lib/xmodule/xmodule/x_module.py#L701) from the constructor long time ago, but you still can see its ancestors instantiated with `field_data=<value>` here and there. It's important to note, that it has been added here in the first place, because `field_data` [was required](https://github.com/cpennington/XBlock/blob/2fa8ef27efe30e3974e34430e8c0088f31c36972/xblock/runtime.py#L227) in `Runtime`. 
5. [DummySystem](https://github.com/openedx/edx-platform/blob/d9f54b9f460bed0001e999dac8884d3b8e8a949f/xmodule/tests/test_import.py#L32), [CachingDescriptorSystem](https://github.com/openedx/edx-platform/blob/d9f54b9f460bed0001e999dac8884d3b8e8a949f/xmodule/modulestore/mongo/base.py#L168), [ImportSystem](https://github.com/openedx/edx-platform/blob/d9f54b9f460bed0001e999dac8884d3b8e8a949f/xmodule/modulestore/xml.py#L49), [InMemorySystem](https://github.com/openedx/edx-platform/blob/d9f54b9f460bed0001e999dac8884d3b8e8a949f/xmodule/tests/xml/__init__.py#L19). Not related anymore. All these classes inherit `MakoDescriptorSystem`, which inherits `DescriptorSystem` itself. So, see №4.
6. [PreviewModuleSystem](https://github.com/openedx/edx-platform/blob/8886f29e52bf23368a88cadc5e2c372a173ccbbe/cms/djangoapps/contentstore/views/preview.py#L98), [TestModuleSystem](https://github.com/openedx/edx-platform/blob/d9f54b9f460bed0001e999dac8884d3b8e8a949f/xmodule/tests/__init__.py#L50), [LmsModuleSystem](https://github.com/openedx/edx-platform/blob/6ae76816f725806b12fc3110ed43499f34e52c4d/lms/djangoapps/lms_xblock/runtime.py#L131) — `ModuleSystem`'s ancestors. Directly related.

<details>
  <summary>A few words about `field_data` history.</summary>

  [Here](https://github.com/openedx/edx-platform/pull/1100/files#diff-8552615a0e0066a72d15c4de70a3fc92eb10bfd8e148fe566bce2937a7bb52fcR824-R826) is the place where `field_data` superclass passing was added in `ModuleSystem`, that was October 1, 2013. Back then, it wasn't possible to pass `field_data` to the `ModuleSystem`s constructor, so you see just `None` here. One day before, on 30 September 2013, `field_data` was added to `Runtime`, and [made required](https://github.com/openedx/XBlock/pull/86/files#diff-6c69360460167b0c93a62fc6dee73251b54a196f1b98db6ac18a3dbdca83be2aR227) (I guess that's why we have `field_data=None` leftovers here and there). `field_data` [became optional](https://github.com/openedx/XBlock/pull/86/files#diff-6c69360460167b0c93a62fc6dee73251b54a196f1b98db6ac18a3dbdca83be2aR260) in `construct_xblock_from_class` method, which was the only one using `Runtime.field_data` directly, effectively making `Runtime.field_data` the _default_ field data store for every XBlock within a given runtime. These two changes were the part of preparation for XML serialization / deserialization implementation.

On January 4, 2014, XML serialization / deserialization landed, and `ModuleSystem` [started passing](https://github.com/openedx/edx-platform/pull/2129/files#diff-8552615a0e0066a72d15c4de70a3fc92eb10bfd8e148fe566bce2937a7bb52fcR1079) `field_data` to the `Runtime` superclass, though I couldn't find any `ModuleSystem` subclass, instantiated with `field_data`. My guess is that this has been done to unify runtimes signatures.

Then, almost a year later, on November 4, 2014, `Runtime.field_data` accessing [was removed](https://github.com/openedx/XBlock/pull/253/files#diff-6c69360460167b0c93a62fc6dee73251b54a196f1b98db6ac18a3dbdca83be2aR510) from `construct_xblock_from_class` in favor of runtime services. This is the moment when, I guess, some cleaning was forgotten to be done, leaving what we're trying to remove in this PR, in place. Or, some code was still touching `Runtime.field_data` — I couldn't prove this by running `git log -S"runtime.field_data"` (`_field_data`, `__field_data`, `system` instead `runtime`, etc.), so it looks like there are no runtimes overriding / using `field_data` or `_deprecated_per_instance_field_data` left.

So, to summarize: unless there is at least one runtime, which is using `field_data` or `_deprecated_per_instance_field_data`, we're safe to remove this property from `ModuleSystem` and other `Runtime` subclasses. For instance, [xblock-sdk](https://github.com/openedx/xblock-sdk)'s runtime never used old `field_data`, only runtime service.
</details>

So, all in all, the only necessary check was to search for `ModuleSystem`'s ancestors using `field_data` or `_deprecated_per_instance_field_data`. I couldn't find such cases, neither in the actual codebase, nor in the git history.

## Testing instructions

1. Switch your devstack to use this branch.
2. Create a course, add one XBlock to some unit.
3. Ensure, that both the preview in Studio, and the live version of the unit are working as expected.
4. Export the course, import. Ensure that both processes work fine.