### PR TITLE
feat: add partial username search for course discussion user stats

### DIFF
--- a/lms/djangoapps/discussion/rest_api/forms.py
+++ b/lms/djangoapps/discussion/rest_api/forms.py
@@ -229,3 +229,4 @@ class TopicListGetForm(Form):
 class CourseActivityStatsForm(_PaginationForm):
     """Form for validating course activity stats API query parameters"""
     order_by = ChoiceField(choices=UserOrdering.choices, required=False)
+    username = CharField(required=False)

--- a/lms/djangoapps/discussion/rest_api/utils.py
+++ b/lms/djangoapps/discussion/rest_api/utils.py
@@ -2,6 +2,10 @@
 Utils for discussion API.
 """
 
+from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
+from django.core.paginator import Paginator
+from django.db.models.functions import Length
+
 from lms.djangoapps.discussion.django_comment_client.utils import has_discussion_privileges
 
 
@@ -28,3 +32,50 @@ def set_attribute(threads, attribute, value):
     for thread in threads:
         thread[attribute] = value
     return threads
+
+
+def get_usernames_from_search_string(course_id, search_string, page_number, page_size):
+    """
+    Gets usernames for all users in course that match string.
+
+    Args:
+            course_id (CourseKey): Course to check discussions for
+            search_string (str): String to search matching
+            page_number (int): Page number to fetch
+            page_size (int): Number of items in each page
+
+    Returns:
+            page_matched_users (str): comma seperated usernames for the page
+            matched_users_count (int): count of matched users in course
+            matched_users_pages (int): pages of matched users in course
+    """
+    matched_users_in_course = User.objects.filter(
+        courseenrollment__course_id=course_id,
+        username__contains=search_string).order_by(Length('username').asc()).values_list('username', flat=True)
+    if not matched_users_in_course:
+        return '', 0, 0
+    matched_users_count = len(matched_users_in_course)
+    paginator = Paginator(matched_users_in_course, page_size)
+    page_matched_users = paginator.page(page_number)
+    matched_users_pages = int(matched_users_count / page_size)
+    return ','.join(page_matched_users), matched_users_count, matched_users_pages
+
+
+def add_stats_for_users_with_no_discussion_content(course_stats, users_in_course):
+    """
+    Update users stats for users with no discussion stats available in course
+    """
+    users_returned_from_api = [user['username'] for user in course_stats]
+    user_list = users_in_course.split(',')
+    users_with_no_discussion_content = set(user_list) ^ set(users_returned_from_api)
+    updated_course_stats = course_stats
+    for user in users_with_no_discussion_content:
+        updated_course_stats.append({
+            'username': user,
+            'threads': 0,
+            'replies': 0,
+            'responses': 0,
+            'active_flags': 0,
+            'inactive_flags': 0,
+        })
+    return updated_course_stats

--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -173,12 +173,14 @@ class CourseActivityStatsView(DeveloperErrorViewMixin, APIView):
             raise ValidationError(form_query_string.errors)
         order_by = form_query_string.cleaned_data.get('order_by', None)
         order_by = UserOrdering(order_by) if order_by else None
+        username_search_string = form_query_string.cleaned_data.get('username', None)
         data = get_course_discussion_user_stats(
             request,
             course_key_string,
             form_query_string.cleaned_data['page'],
             form_query_string.cleaned_data['page_size'],
             order_by,
+            username_search_string,
         )
         return data
 


### PR DESCRIPTION
### [INF-220](https://2u-internal.atlassian.net/browse/INF-220)

#### Description
Add support to get discussion stats for users based on **username** string provided. Previously, the endpoint was restricted to returning stats for all the users within the course.

Test with this [PR on cs_comment_service](https://github.com/openedx/cs_comments_service/pull/380)