### PR TITLE
[BB-6206] Adds a openedx-filter event to hook into XBlock Rendering

### DIFF
--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1609,7 +1609,7 @@ def render_xblock(request, usage_key_string, check_if_enrolled=True):
         try:
             # .. filter_implemented_name: XBlockRenderStarted
             # .. filter_type: org.openedx.learning.xblock.render.started.v1
-            context, template_name = XBlockRenderStarted.run_filter(context, template_name)
+            context, template_name = XBlockRenderStarted.run_filter(block, context, template_name)
         except XBlockRenderStarted.RenderCustomReponse as exc:
             response = exc.response
         else:


### PR DESCRIPTION
## Description

This PR introduces a new [openedx-filters](/openedx/openedx-filters) event `org.openedx.learning.xblock.render.started.v1` hook in the platform. This is implemented a part of the PoC to implement "Edit Link" in the course content for Open Source courses.

Users impacted by the change:
- "Students"

## Supporting information

- [Discussion about the proposal for "Edit Links"](https://discuss.openedx.org/t/request-for-feedback-adding-edit-links-to-course-content/7340)

## Testing instructions

This PR is 1 of the 3 PRs that implement the Edit Link PoC and should be tested in tandem.

* Follow instructions in the [openedx-edit-links](https://github.com/open-craft/openedx-edit-links/pull/1) PR to test these changes.

### Other related PRs

1. openedx-filters - https://github.com/openedx/openedx-filters/pull/35
2. openedx-edit-links - https://github.com/open-craft/openedx-edit-links/pull/1

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

