### PR TITLE
Remove Old Pymongo pin (#30569)

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -229,6 +229,17 @@ add_plugins(__name__, ProjectType.CMS, SettingsType.DEVSTACK)
 OPENAPI_CACHE_TIMEOUT = 0
 
 #####################################################################
+# set replica set of contentstore to none as we haven't setup any for cms in devstack
+CONTENTSTORE['DOC_STORE_CONFIG']['replicaSet'] = None
+
+#####################################################################
+# set replica sets of moduelstore to none as we haven't setup any for cms in devstack
+for store in MODULESTORE['default']['OPTIONS']['stores']:
+    if 'DOC_STORE_CONFIG' in store and 'replicaSet' in store['DOC_STORE_CONFIG']:
+        store['DOC_STORE_CONFIG']['replicaSet'] = None
+
+
+#####################################################################
 # Lastly, run any migrations, if needed.
 MODULESTORE = convert_module_store_setting_if_needed(MODULESTORE)
 

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -324,8 +324,20 @@ REST_FRAMEWORK['DEFAULT_RENDERER_CLASSES'] += (
 OPENAPI_CACHE_TIMEOUT = 0
 
 #####################################################################
+# set replica set of contentstore to none as we haven't setup any for lms in devstack
+CONTENTSTORE['DOC_STORE_CONFIG']['replicaSet'] = None
+
+#####################################################################
+# set replica sets of moduelstore to none as we haven't setup any for lms in devstack
+for store in MODULESTORE['default']['OPTIONS']['stores']:
+    if 'DOC_STORE_CONFIG' in store and 'replicaSet' in store['DOC_STORE_CONFIG']:
+        store['DOC_STORE_CONFIG']['replicaSet'] = None
+
+
+#####################################################################
 # Lastly, run any migrations, if needed.
 MODULESTORE = convert_module_store_setting_if_needed(MODULESTORE)
+
 
 SECRET_KEY = '85920908f28904ed733fe576320db18cabd7b6cd'
 

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -49,8 +49,9 @@ matplotlib<3.4.0
 # Constraint from astroid 2.3.3
 wrapt==1.11.*
 
-# tests failing for pymongo==3.11
-pymongo<3.11
+# constrained in opaque_keys. migration guide here: https://pymongo.readthedocs.io/en/4.0/migrate-to-pymongo4.html
+# Major upgrade will be done in separate ticket.
+pymongo<4.0.0
 
 # sympy latest version causing test failures.
 # may be related to python35 version drop in 1.7.0. Needs to be tested before removing.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -822,9 +822,8 @@ pylatexenc==2.10
     # via olxcleaner
 pylti1p3==1.10.0
     # via -r requirements/edx/base.in
-pymongo==3.10.1
+pymongo==3.12.3
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   -r requirements/edx/paver.txt
     #   edx-opaque-keys

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1139,9 +1139,8 @@ pylint-pytest==0.3.0
     # via -r requirements/edx/testing.txt
 pylti1p3==1.10.0
     # via -r requirements/edx/testing.txt
-pymongo==3.10.1
+pymongo==3.12.3
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   edx-opaque-keys
     #   event-tracking

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -28,7 +28,7 @@ pbr==5.8.1
     # via stevedore
 psutil==5.9.0
     # via -r requirements/edx/paver.in
-pymongo==3.10.1
+pymongo==3.12.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/paver.in

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1068,9 +1068,8 @@ pylint-pytest==0.3.0
     # via -r requirements/edx/testing.in
 pylti1p3==1.10.0
     # via -r requirements/edx/base.txt
-pymongo==3.10.1
+pymongo==3.12.3
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-opaque-keys
     #   event-tracking


### PR DESCRIPTION
Back port for https://github.com/openedx/edx-platform/pull/30569
Older version of pymongo is causing issues in Nutmeg which can be seen here in this discussion:
https://discuss.openedx.org/t/mongodb-intermittent-connection-timeout-errors-in-pymongo-topology-py/7278