### PR TITLE
feat: learner dash enrollment serializers

### DIFF
--- a/lms/djangoapps/learner_dashboard/serializers.py
+++ b/lms/djangoapps/learner_dashboard/serializers.py
@@ -76,6 +76,27 @@ class CertificateSerializer(serializers.Serializer):
     honorCertDownloadUrl = serializers.URLField(allow_null=True)
 
 
+class AvailableEntitlementSessionSerializer(serializers.Serializer):
+    """An available entitlement session"""
+
+    startDate = serializers.DateTimeField()
+    endDate = serializers.DateTimeField()
+    courseNumber = serializers.CharField()
+
+
+class EntitlementSerializer(serializers.Serializer):
+    """Entitlements info"""
+
+    availableSessions = serializers.ListField(
+        child=AvailableEntitlementSessionSerializer(), allow_empty=True
+    )
+    isRefundable = serializers.BooleanField()
+    isFulfilled = serializers.BooleanField()
+    canViewCourse = serializers.BooleanField()
+    changeDeadline = serializers.DateTimeField()
+    isExpired = serializers.BooleanField()
+
+
 class LearnerEnrollmentSerializer(serializers.Serializer):
     """Info for displaying an enrollment on the learner dashboard"""
 
@@ -85,13 +106,15 @@ class LearnerEnrollmentSerializer(serializers.Serializer):
     enrollment = EnrollmentSerializer()
     gradeData = GradeDataSerializer()
     certificate = CertificateSerializer()
+    entitlements = EntitlementSerializer()
 
     # certificate,
     # entitlements,
     # programs,
 
 
-class EntitlementSerializer(serializers.Serializer):
+
+class UnfulfilledEntitlementSerializer(serializers.Serializer):
     """Serializer for an unfulfilled entitlement"""
 
 

--- a/lms/djangoapps/learner_dashboard/serializers.py
+++ b/lms/djangoapps/learner_dashboard/serializers.py
@@ -73,7 +73,7 @@ class CertificateSerializer(serializers.Serializer):
     isDownloadable = serializers.BooleanField()
     certPreviewUrl = serializers.URLField(allow_null=True)
     certDownloadUrl = serializers.URLField(allow_null=True)
-    honerCertDownloadUrl = serializers.URLField(allow_null=True)
+    honorCertDownloadUrl = serializers.URLField(allow_null=True)
 
 
 class LearnerEnrollmentSerializer(serializers.Serializer):

--- a/lms/djangoapps/learner_dashboard/serializers.py
+++ b/lms/djangoapps/learner_dashboard/serializers.py
@@ -22,10 +22,18 @@ class CourseProviderSerializer(serializers.Serializer):
     email = serializers.EmailField()
 
 
+class CourseSerializer(serializers.Serializer):
+    """Serializer for course header info"""
+
+    bannerImgSrc = serializers.URLField()
+    courseName = serializers.CharField()
+
+
 class EnrollmentSerializer(serializers.Serializer):
     """Serializer for an enrollment"""
 
     courseProvider = CourseProviderSerializer(allow_null=True)
+    course = CourseSerializer()
 
 
 class EntitlementSerializer(serializers.Serializer):

--- a/lms/djangoapps/learner_dashboard/serializers.py
+++ b/lms/djangoapps/learner_dashboard/serializers.py
@@ -57,6 +57,12 @@ class EnrollmentSerializer(serializers.Serializer):
     isEmailEnabled = serializers.BooleanField()
 
 
+class GradeDataSerializer(serializers.Serializer):
+    """Info about grades for this enrollment"""
+
+    isPassing = serializers.BooleanField()
+
+
 class LearnerEnrollmentSerializer(serializers.Serializer):
     """Info for displaying an enrollment on the learner dashboard"""
 
@@ -64,6 +70,11 @@ class LearnerEnrollmentSerializer(serializers.Serializer):
     course = CourseSerializer()
     courseRun = CourseRunSerializer()
     enrollment = EnrollmentSerializer()
+    gradeData = GradeDataSerializer()
+
+    # certificate,
+    # entitlements,
+    # programs,
 
 
 class EntitlementSerializer(serializers.Serializer):

--- a/lms/djangoapps/learner_dashboard/serializers.py
+++ b/lms/djangoapps/learner_dashboard/serializers.py
@@ -48,12 +48,22 @@ class CourseRunSerializer(serializers.Serializer):
 
 
 class EnrollmentSerializer(serializers.Serializer):
+    """Info about this particular enrollment"""
+
+    isAudit = serializers.BooleanField()
+    isVerified = serializers.BooleanField()
+    canUpgrade = serializers.BooleanField()
+    isAuditAccessExpired = serializers.BooleanField()
+    isEmailEnabled = serializers.BooleanField()
+
+
 class LearnerEnrollmentSerializer(serializers.Serializer):
     """Info for displaying an enrollment on the learner dashboard"""
 
     courseProvider = CourseProviderSerializer(allow_null=True)
     course = CourseSerializer()
     courseRun = CourseRunSerializer()
+    enrollment = EnrollmentSerializer()
 
 
 class EntitlementSerializer(serializers.Serializer):

--- a/lms/djangoapps/learner_dashboard/serializers.py
+++ b/lms/djangoapps/learner_dashboard/serializers.py
@@ -97,6 +97,29 @@ class EntitlementSerializer(serializers.Serializer):
     isExpired = serializers.BooleanField()
 
 
+class RelatedProgramSerializer(serializers.Serializer):
+    """Related programs information"""
+
+    provider = serializers.CharField()
+    programUrl = serializers.URLField()
+    bannerUrl = serializers.URLField()
+    logoUrl = serializers.URLField()
+    title = serializers.CharField()
+    # Note - this should probably be a choice, eventually
+    programType = serializers.CharField()
+    programTypeUrl = serializers.URLField()
+    numberOfCourses = serializers.IntegerField()
+    estimatedNumberOfWeeks = serializers.IntegerField()
+
+
+class ProgramsSerializer(serializers.Serializer):
+    """Programs information"""
+
+    relatedPrograms = serializers.ListField(
+        child=RelatedProgramSerializer(), allow_empty=True
+    )
+
+
 class LearnerEnrollmentSerializer(serializers.Serializer):
     """Info for displaying an enrollment on the learner dashboard"""
 
@@ -107,11 +130,7 @@ class LearnerEnrollmentSerializer(serializers.Serializer):
     gradeData = GradeDataSerializer()
     certificate = CertificateSerializer()
     entitlements = EntitlementSerializer()
-
-    # certificate,
-    # entitlements,
-    # programs,
-
+    programs = ProgramsSerializer()
 
 
 class UnfulfilledEntitlementSerializer(serializers.Serializer):

--- a/lms/djangoapps/learner_dashboard/serializers.py
+++ b/lms/djangoapps/learner_dashboard/serializers.py
@@ -14,8 +14,18 @@ class PlatformSettingsSerializer(serializers.Serializer):
     courseSearchUrl = serializers.URLField()
 
 
+class CourseProviderSerializer(serializers.Serializer):
+    """Info about a course provider (institution/business)"""
+
+    name = serializers.CharField()
+    website = serializers.URLField()
+    email = serializers.EmailField()
+
+
 class EnrollmentSerializer(serializers.Serializer):
     """Serializer for an enrollment"""
+
+    courseProvider = CourseProviderSerializer(allow_null=True)
 
 
 class EntitlementSerializer(serializers.Serializer):
@@ -31,5 +41,9 @@ class LearnerDashboardSerializer(serializers.Serializer):
 
     edx = PlatformSettingsSerializer()
     enrollments = serializers.ListField(child=EnrollmentSerializer(), allow_empty=True)
-    unfulfilledEntitlements = serializers.ListField(child=EntitlementSerializer(), allow_empty=True)
-    suggestedCourses = serializers.ListField(child=SuggestedCourseSerializer(), allow_empty=True)
+    unfulfilledEntitlements = serializers.ListField(
+        child=EntitlementSerializer(), allow_empty=True
+    )
+    suggestedCourses = serializers.ListField(
+        child=SuggestedCourseSerializer(), allow_empty=True
+    )

--- a/lms/djangoapps/learner_dashboard/serializers.py
+++ b/lms/djangoapps/learner_dashboard/serializers.py
@@ -29,11 +29,30 @@ class CourseSerializer(serializers.Serializer):
     courseName = serializers.CharField()
 
 
+class CourseRunSerializer(serializers.Serializer):
+    """Serializer for course run info"""
+
+    isPending = serializers.BooleanField()
+    isStarted = serializers.BooleanField()
+    isFinished = serializers.BooleanField()
+    isArchived = serializers.BooleanField()
+    courseNumber = serializers.CharField()
+    accessExpirationDate = serializers.DateTimeField()
+    minPassingGrade = serializers.DecimalField(max_digits=5, decimal_places=2)
+    endDate = serializers.DateTimeField()
+    homeUrl = serializers.URLField()
+    marketingUrl = serializers.URLField()
+    progressUrl = serializers.URLField()
+    unenrollUrl = serializers.URLField()
+    upgradeUrl = serializers.URLField()
+
+
 class EnrollmentSerializer(serializers.Serializer):
     """Serializer for an enrollment"""
 
     courseProvider = CourseProviderSerializer(allow_null=True)
     course = CourseSerializer()
+    courseRun = CourseRunSerializer()
 
 
 class EntitlementSerializer(serializers.Serializer):

--- a/lms/djangoapps/learner_dashboard/serializers.py
+++ b/lms/djangoapps/learner_dashboard/serializers.py
@@ -63,6 +63,19 @@ class GradeDataSerializer(serializers.Serializer):
     isPassing = serializers.BooleanField()
 
 
+class CertificateSerializer(serializers.Serializer):
+    """Certificate availability info"""
+
+    availableDate = serializers.DateTimeField(allow_null=True)
+    isRestricted = serializers.BooleanField()
+    isAvailable = serializers.BooleanField()
+    isEarned = serializers.BooleanField()
+    isDownloadable = serializers.BooleanField()
+    certPreviewUrl = serializers.URLField(allow_null=True)
+    certDownloadUrl = serializers.URLField(allow_null=True)
+    honerCertDownloadUrl = serializers.URLField(allow_null=True)
+
+
 class LearnerEnrollmentSerializer(serializers.Serializer):
     """Info for displaying an enrollment on the learner dashboard"""
 
@@ -71,6 +84,7 @@ class LearnerEnrollmentSerializer(serializers.Serializer):
     courseRun = CourseRunSerializer()
     enrollment = EnrollmentSerializer()
     gradeData = GradeDataSerializer()
+    certificate = CertificateSerializer()
 
     # certificate,
     # entitlements,

--- a/lms/djangoapps/learner_dashboard/serializers.py
+++ b/lms/djangoapps/learner_dashboard/serializers.py
@@ -48,7 +48,8 @@ class CourseRunSerializer(serializers.Serializer):
 
 
 class EnrollmentSerializer(serializers.Serializer):
-    """Serializer for an enrollment"""
+class LearnerEnrollmentSerializer(serializers.Serializer):
+    """Info for displaying an enrollment on the learner dashboard"""
 
     courseProvider = CourseProviderSerializer(allow_null=True)
     course = CourseSerializer()
@@ -67,7 +68,9 @@ class LearnerDashboardSerializer(serializers.Serializer):
     """Serializer for all info required to render the Learner Dashboard"""
 
     edx = PlatformSettingsSerializer()
-    enrollments = serializers.ListField(child=EnrollmentSerializer(), allow_empty=True)
+    enrollments = serializers.ListField(
+        child=LearnerEnrollmentSerializer(), allow_empty=True
+    )
     unfulfilledEntitlements = serializers.ListField(
         child=EntitlementSerializer(), allow_empty=True
     )

--- a/lms/djangoapps/learner_dashboard/test_serializers.py
+++ b/lms/djangoapps/learner_dashboard/test_serializers.py
@@ -16,6 +16,7 @@ from lms.djangoapps.learner_dashboard.serializers import (
     EntitlementSerializer,
     GradeDataSerializer,
     PlatformSettingsSerializer,
+    ProgramsSerializer,
     LearnerDashboardSerializer,
 )
 
@@ -255,6 +256,57 @@ class TestEntitlementSerializer(TestCase):
             "changeDeadline": datetime_to_django_format(input_data["changeDeadline"]),
             "isExpired": input_data["isExpired"],
         }
+
+
+class TestProgramsSerializer(TestCase):
+    """Tests for the ProgramsSerializer and RelatedProgramsSerializer"""
+
+    @classmethod
+    def generate_test_related_program(cls):
+        """Generate a program with random test data"""
+        return {
+            "provider": f"{uuid4()} Inc.",
+            "programUrl": random_url(),
+            "bannerUrl": random_url(),
+            "logoUrl": random_url(),
+            "title": f"{uuid4()}",
+            "programType": f"{uuid4()}",
+            "programTypeUrl": random_url(),
+            "numberOfCourses": randint(0, 100),
+            "estimatedNumberOfWeeks": randint(0, 45),
+        }
+
+    def test_happy_path(self):
+        input_data = {
+            "relatedPrograms": [
+                self.generate_test_related_program() for _ in range(randint(0, 3))
+            ],
+        }
+        output_data = ProgramsSerializer(input_data).data
+
+        related_programs = output_data.pop("relatedPrograms")
+
+        for i, related_program in enumerate(related_programs):
+            input_program = input_data["relatedPrograms"][i]
+            assert related_program == {
+                "provider": input_program["provider"],
+                "programUrl": input_program["programUrl"],
+                "bannerUrl": input_program["bannerUrl"],
+                "logoUrl": input_program["logoUrl"],
+                "title": input_program["title"],
+                "programType": input_program["programType"],
+                "programTypeUrl": input_program["programTypeUrl"],
+                "numberOfCourses": input_program["numberOfCourses"],
+                "estimatedNumberOfWeeks": input_program["estimatedNumberOfWeeks"],
+            }
+
+        assert output_data == {}
+
+    def test_empty_sessions(self):
+        input_data = {"relatedPrograms": []}
+        output_data = ProgramsSerializer(input_data).data
+
+        assert output_data == {"relatedPrograms": []}
 
 
 class TestLearnerDashboardSerializer(TestCase):

--- a/lms/djangoapps/learner_dashboard/test_serializers.py
+++ b/lms/djangoapps/learner_dashboard/test_serializers.py
@@ -8,6 +8,7 @@ from unittest import mock
 from uuid import uuid4
 
 from lms.djangoapps.learner_dashboard.serializers import (
+    CertificateSerializer,
     CourseProviderSerializer,
     CourseRunSerializer,
     CourseSerializer,
@@ -172,6 +173,36 @@ class TestGradeDataSerializer(TestCase):
 
         assert output_data == {
             "isPassing": input_data["isPassing"],
+        }
+
+
+class TestCertificateSerializer(TestCase):
+    """Tests for the CertificateSerializer"""
+
+    def test_happy_path(self):
+        input_data = {
+            "availableDate": random_date(allow_null=True),
+            "isRestricted": random_bool(),
+            "isAvailable": random_bool(),
+            "isEarned": random_bool(),
+            "isDownloadable": random_bool(),
+            "certPreviewUrl": random_url(allow_null=True),
+            "certDownloadUrl": random_url(allow_null=True),
+            "honorCertDownloadUrl": random_url(allow_null=True),
+        }
+        output_data = CertificateSerializer(input_data).data
+
+        assert output_data == {
+            "availableDate": input_data["availableDate"].strftime("%Y-%m-%dT%H:%M:%SZ")
+            if input_data["availableDate"]
+            else None,
+            "isRestricted": input_data["isRestricted"],
+            "isAvailable": input_data["isAvailable"],
+            "isEarned": input_data["isEarned"],
+            "isDownloadable": input_data["isDownloadable"],
+            "certPreviewUrl": input_data["certPreviewUrl"],
+            "certDownloadUrl": input_data["certDownloadUrl"],
+            "honorCertDownloadUrl": input_data["honorCertDownloadUrl"],
         }
 
 

--- a/lms/djangoapps/learner_dashboard/test_serializers.py
+++ b/lms/djangoapps/learner_dashboard/test_serializers.py
@@ -46,6 +46,12 @@ def random_url(allow_null=False):
     return choice([f"{random_uuid}.example.com", f"example.com/{random_uuid}"])
 
 
+def datetime_to_django_format(datetime_obj):
+    """Util for matching serialized Django datetime format for comparison"""
+    if datetime_obj:
+        return datetime_obj.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
 class TestPlatformSettingsSerializer(TestCase):
     """Tests for the PlatformSettingsSerializer"""
 
@@ -127,11 +133,11 @@ class TestCourseRunSerializer(TestCase):
             "isFinished": input_data["isFinished"],
             "isArchived": input_data["isArchived"],
             "courseNumber": input_data["courseNumber"],
-            "accessExpirationDate": input_data["accessExpirationDate"].strftime(
-                "%Y-%m-%dT%H:%M:%SZ"
+            "accessExpirationDate": datetime_to_django_format(
+                input_data["accessExpirationDate"]
             ),
             "minPassingGrade": str(input_data["minPassingGrade"]),
-            "endDate": input_data["endDate"].strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "endDate": datetime_to_django_format(input_data["endDate"]),
             "homeUrl": input_data["homeUrl"],
             "marketingUrl": input_data["marketingUrl"],
             "progressUrl": input_data["progressUrl"],
@@ -193,9 +199,7 @@ class TestCertificateSerializer(TestCase):
         output_data = CertificateSerializer(input_data).data
 
         assert output_data == {
-            "availableDate": input_data["availableDate"].strftime("%Y-%m-%dT%H:%M:%SZ")
-            if input_data["availableDate"]
-            else None,
+            "availableDate": datetime_to_django_format(input_data["availableDate"]),
             "isRestricted": input_data["isRestricted"],
             "isAvailable": input_data["isAvailable"],
             "isEarned": input_data["isEarned"],

--- a/lms/djangoapps/learner_dashboard/test_serializers.py
+++ b/lms/djangoapps/learner_dashboard/test_serializers.py
@@ -1,15 +1,24 @@
 """Tests for serializers for the Learner Dashboard"""
 
+import datetime
+from random import getrandbits, randint
+from time import time
 from unittest import TestCase
 from unittest import mock
 from uuid import uuid4
 
 from lms.djangoapps.learner_dashboard.serializers import (
     CourseProviderSerializer,
+    CourseRunSerializer,
     CourseSerializer,
     PlatformSettingsSerializer,
     LearnerDashboardSerializer,
 )
+
+
+def random_date():
+    d = randint(1, int(time()))
+    return datetime.datetime.fromtimestamp(d)
 
 
 class TestPlatformSettingsSerializer(TestCase):
@@ -63,6 +72,46 @@ class TestCourseSerializer(TestCase):
         assert output_data == {
             "bannerImgSrc": input_data["bannerImgSrc"],
             "courseName": input_data["courseName"],
+        }
+
+
+class TestCourseRunSerializer(TestCase):
+    """Tests for the CourseRunSerializer"""
+
+    def test_happy_path(self):
+        input_data = {
+            "isPending": bool(getrandbits(1)),
+            "isStarted": bool(getrandbits(1)),
+            "isFinished": bool(getrandbits(1)),
+            "isArchived": bool(getrandbits(1)),
+            "courseNumber": f"{uuid4()}-101",
+            "accessExpirationDate": random_date(),
+            "minPassingGrade": randint(0, 10000) / 100,
+            "endDate": random_date(),
+            "homeUrl": f"{uuid4()}.example.com",
+            "marketingUrl": f"{uuid4()}.example.com",
+            "progressUrl": f"{uuid4()}.example.com",
+            "unenrollUrl": f"{uuid4()}.example.com",
+            "upgradeUrl": f"{uuid4()}.example.com",
+        }
+        output_data = CourseRunSerializer(input_data).data
+
+        assert output_data == {
+            "isPending": input_data["isPending"],
+            "isStarted": input_data["isStarted"],
+            "isFinished": input_data["isFinished"],
+            "isArchived": input_data["isArchived"],
+            "courseNumber": input_data["courseNumber"],
+            "accessExpirationDate": input_data["accessExpirationDate"].strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            ),
+            "minPassingGrade": str(input_data["minPassingGrade"]),
+            "endDate": input_data["endDate"].strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "homeUrl": input_data["homeUrl"],
+            "marketingUrl": input_data["marketingUrl"],
+            "progressUrl": input_data["progressUrl"],
+            "unenrollUrl": input_data["unenrollUrl"],
+            "upgradeUrl": input_data["upgradeUrl"],
         }
 
 

--- a/lms/djangoapps/learner_dashboard/test_serializers.py
+++ b/lms/djangoapps/learner_dashboard/test_serializers.py
@@ -23,8 +23,13 @@ def random_bool():
     return bool(getrandbits(1))
 
 
-def random_date():
-    """Test util for generating a random date"""
+def random_date(allow_null=False):
+    """Test util for generating a random date, optionally blank"""
+
+    # If null allowed, return null half the time
+    if allow_null and random_bool():
+        return None
+
     d = randint(1, int(time()))
     return datetime.datetime.fromtimestamp(d)
 

--- a/lms/djangoapps/learner_dashboard/test_serializers.py
+++ b/lms/djangoapps/learner_dashboard/test_serializers.py
@@ -217,7 +217,7 @@ class TestEntitlementSerializer(TestCase):
     @classmethod
     def generate_test_session(cls):
         """Generate an test session with random dates and course run numbers"""
-        yield {
+        return {
             "startDate": random_date(),
             "endDate": random_date(),
             "courseNumber": f"{uuid4()}-101",

--- a/lms/djangoapps/learner_dashboard/test_serializers.py
+++ b/lms/djangoapps/learner_dashboard/test_serializers.py
@@ -17,7 +17,13 @@ from lms.djangoapps.learner_dashboard.serializers import (
 )
 
 
+def random_bool():
+    """Test util for generating a random boolean"""
+    return bool(getrandbits(1))
+
+
 def random_date():
+    """Test util for generating a random date"""
     d = randint(1, int(time()))
     return datetime.datetime.fromtimestamp(d)
 
@@ -81,10 +87,10 @@ class TestCourseRunSerializer(TestCase):
 
     def test_happy_path(self):
         input_data = {
-            "isPending": bool(getrandbits(1)),
-            "isStarted": bool(getrandbits(1)),
-            "isFinished": bool(getrandbits(1)),
-            "isArchived": bool(getrandbits(1)),
+            "isPending": random_bool(),
+            "isStarted": random_bool(),
+            "isFinished": random_bool(),
+            "isArchived": random_bool(),
             "courseNumber": f"{uuid4()}-101",
             "accessExpirationDate": random_date(),
             "minPassingGrade": randint(0, 10000) / 100,
@@ -121,11 +127,11 @@ class TestEnrollmentSerializer(TestCase):
 
     def test_happy_path(self):
         input_data = {
-            "isAudit": bool(getrandbits(1)),
-            "isVerified": bool(getrandbits(1)),
-            "canUpgrade": bool(getrandbits(1)),
-            "isAuditAccessExpired": bool(getrandbits(1)),
-            "isEmailEnabled": bool(getrandbits(1)),
+            "isAudit": random_bool(),
+            "isVerified": random_bool(),
+            "canUpgrade": random_bool(),
+            "isAuditAccessExpired": random_bool(),
+            "isEmailEnabled": random_bool(),
         }
         output_data = EnrollmentSerializer(input_data).data
 

--- a/lms/djangoapps/learner_dashboard/test_serializers.py
+++ b/lms/djangoapps/learner_dashboard/test_serializers.py
@@ -5,6 +5,7 @@ from unittest import mock
 from uuid import uuid4
 
 from lms.djangoapps.learner_dashboard.serializers import (
+    CourseProviderSerializer,
     PlatformSettingsSerializer,
     LearnerDashboardSerializer,
 )
@@ -27,6 +28,24 @@ class TestPlatformSettingsSerializer(TestCase):
             "supportEmail": input_data["supportEmail"],
             "billingEmail": input_data["billingEmail"],
             "courseSearchUrl": input_data["courseSearchUrl"],
+        }
+
+
+class TestCourseProviderSerializer(TestCase):
+    """Tests for the CourseProviderSerializer"""
+
+    def test_happy_path(self):
+        input_data = {
+            "name": f"{uuid4()}",
+            "website": f"{uuid4()}.example.com",
+            "email": f"{uuid4()}@example.com",
+        }
+        output_data = CourseProviderSerializer(input_data).data
+
+        assert output_data == {
+            "name": input_data["name"],
+            "website": input_data["website"],
+            "email": input_data["email"],
         }
 
 
@@ -69,7 +88,9 @@ class TestLearnerDashboardSerializer(TestCase):
         with mock.patch(
             "lms.djangoapps.learner_dashboard.serializers.PlatformSettingsSerializer.to_representation"
         ) as mock_platform_settings_serializer:
-            mock_platform_settings_serializer.return_value = mock_platform_settings_serializer
+            mock_platform_settings_serializer.return_value = (
+                mock_platform_settings_serializer
+            )
             output_data = serializer.data
 
         self.assertDictEqual(
@@ -87,7 +108,9 @@ class TestLearnerDashboardSerializer(TestCase):
     )
     def test_linkage2(self, mock_platform_settings_serializer):
         """Second example of paradigm using test-level patching"""
-        mock_platform_settings_serializer.return_value = mock_platform_settings_serializer
+        mock_platform_settings_serializer.return_value = (
+            mock_platform_settings_serializer
+        )
 
         input_data = {
             "edx": {},

--- a/lms/djangoapps/learner_dashboard/test_serializers.py
+++ b/lms/djangoapps/learner_dashboard/test_serializers.py
@@ -11,6 +11,7 @@ from lms.djangoapps.learner_dashboard.serializers import (
     CourseProviderSerializer,
     CourseRunSerializer,
     CourseSerializer,
+    EnrollmentSerializer,
     PlatformSettingsSerializer,
     LearnerDashboardSerializer,
 )
@@ -112,6 +113,28 @@ class TestCourseRunSerializer(TestCase):
             "progressUrl": input_data["progressUrl"],
             "unenrollUrl": input_data["unenrollUrl"],
             "upgradeUrl": input_data["upgradeUrl"],
+        }
+
+
+class TestEnrollmentSerializer(TestCase):
+    """Tests for the EnrollmentSerializer"""
+
+    def test_happy_path(self):
+        input_data = {
+            "isAudit": bool(getrandbits(1)),
+            "isVerified": bool(getrandbits(1)),
+            "canUpgrade": bool(getrandbits(1)),
+            "isAuditAccessExpired": bool(getrandbits(1)),
+            "isEmailEnabled": bool(getrandbits(1)),
+        }
+        output_data = EnrollmentSerializer(input_data).data
+
+        assert output_data == {
+            "isAudit": input_data["isAudit"],
+            "isVerified": input_data["isVerified"],
+            "canUpgrade": input_data["canUpgrade"],
+            "isAuditAccessExpired": input_data["isAuditAccessExpired"],
+            "isEmailEnabled": input_data["isEmailEnabled"],
         }
 
 

--- a/lms/djangoapps/learner_dashboard/test_serializers.py
+++ b/lms/djangoapps/learner_dashboard/test_serializers.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 
 from lms.djangoapps.learner_dashboard.serializers import (
     CourseProviderSerializer,
+    CourseSerializer,
     PlatformSettingsSerializer,
     LearnerDashboardSerializer,
 )
@@ -46,6 +47,22 @@ class TestCourseProviderSerializer(TestCase):
             "name": input_data["name"],
             "website": input_data["website"],
             "email": input_data["email"],
+        }
+
+
+class TestCourseSerializer(TestCase):
+    """Tests for the CourseSerializer"""
+
+    def test_happy_path(self):
+        input_data = {
+            "bannerImgSrc": f"example.com/assets/{uuid4()}",
+            "courseName": f"{uuid4()}",
+        }
+        output_data = CourseSerializer(input_data).data
+
+        assert output_data == {
+            "bannerImgSrc": input_data["bannerImgSrc"],
+            "courseName": input_data["courseName"],
         }
 
 

--- a/lms/djangoapps/learner_dashboard/test_serializers.py
+++ b/lms/djangoapps/learner_dashboard/test_serializers.py
@@ -12,6 +12,7 @@ from lms.djangoapps.learner_dashboard.serializers import (
     CourseRunSerializer,
     CourseSerializer,
     EnrollmentSerializer,
+    GradeDataSerializer,
     PlatformSettingsSerializer,
     LearnerDashboardSerializer,
 )
@@ -141,6 +142,20 @@ class TestEnrollmentSerializer(TestCase):
             "canUpgrade": input_data["canUpgrade"],
             "isAuditAccessExpired": input_data["isAuditAccessExpired"],
             "isEmailEnabled": input_data["isEmailEnabled"],
+        }
+
+
+class TestGradeDataSerializer(TestCase):
+    """Tests for the GradeDataSerializer"""
+
+    def test_happy_path(self):
+        input_data = {
+            "isPassing": random_bool(),
+        }
+        output_data = GradeDataSerializer(input_data).data
+
+        assert output_data == {
+            "isPassing": input_data["isPassing"],
         }
 
 

--- a/lms/djangoapps/learner_dashboard/test_serializers.py
+++ b/lms/djangoapps/learner_dashboard/test_serializers.py
@@ -57,13 +57,18 @@ def datetime_to_django_format(datetime_obj):
 class TestPlatformSettingsSerializer(TestCase):
     """Tests for the PlatformSettingsSerializer"""
 
-    def test_happy_path(self):
-        input_data = {
+    @classmethod
+    def generate_test_platform_settings(cls):
+        """Util to generate test platform settings data"""
+        return {
             "feedbackEmail": f"{uuid4()}@example.com",
             "supportEmail": f"{uuid4()}@example.com",
             "billingEmail": f"{uuid4()}@example.com",
             "courseSearchUrl": f"{uuid4()}.example.com/search",
         }
+
+    def test_happy_path(self):
+        input_data = self.generate_test_platform_settings()
         output_data = PlatformSettingsSerializer(input_data).data
 
         assert output_data == {
@@ -77,12 +82,17 @@ class TestPlatformSettingsSerializer(TestCase):
 class TestCourseProviderSerializer(TestCase):
     """Tests for the CourseProviderSerializer"""
 
-    def test_happy_path(self):
-        input_data = {
+    @classmethod
+    def generate_test_provider_info(cls):
+        """Util to generate test provider info"""
+        return {
             "name": f"{uuid4()}",
             "website": f"{uuid4()}.example.com",
             "email": f"{uuid4()}@example.com",
         }
+
+    def test_happy_path(self):
+        input_data = self.generate_test_provider_info()
         output_data = CourseProviderSerializer(input_data).data
 
         assert output_data == {
@@ -95,11 +105,16 @@ class TestCourseProviderSerializer(TestCase):
 class TestCourseSerializer(TestCase):
     """Tests for the CourseSerializer"""
 
-    def test_happy_path(self):
-        input_data = {
+    @classmethod
+    def generate_test_course_info(cls):
+        """Util to generate test course info"""
+        return {
             "bannerImgSrc": f"example.com/assets/{uuid4()}",
             "courseName": f"{uuid4()}",
         }
+
+    def test_happy_path(self):
+        input_data = self.generate_test_course_info()
         output_data = CourseSerializer(input_data).data
 
         assert output_data == {
@@ -111,8 +126,10 @@ class TestCourseSerializer(TestCase):
 class TestCourseRunSerializer(TestCase):
     """Tests for the CourseRunSerializer"""
 
-    def test_happy_path(self):
-        input_data = {
+    @classmethod
+    def generate_test_course_run_info(cls):
+        """Util to generate test course run info"""
+        return {
             "isPending": random_bool(),
             "isStarted": random_bool(),
             "isFinished": random_bool(),
@@ -127,6 +144,9 @@ class TestCourseRunSerializer(TestCase):
             "unenrollUrl": f"{uuid4()}.example.com",
             "upgradeUrl": f"{uuid4()}.example.com",
         }
+
+    def test_happy_path(self):
+        input_data = self.generate_test_course_run_info()
         output_data = CourseRunSerializer(input_data).data
 
         assert output_data == {
@@ -151,14 +171,19 @@ class TestCourseRunSerializer(TestCase):
 class TestEnrollmentSerializer(TestCase):
     """Tests for the EnrollmentSerializer"""
 
-    def test_happy_path(self):
-        input_data = {
+    @classmethod
+    def generate_test_enrollment_info(cls):
+        """Util to generate test enrollment info"""
+        return {
             "isAudit": random_bool(),
             "isVerified": random_bool(),
             "canUpgrade": random_bool(),
             "isAuditAccessExpired": random_bool(),
             "isEmailEnabled": random_bool(),
         }
+
+    def test_happy_path(self):
+        input_data = self.generate_test_enrollment_info()
         output_data = EnrollmentSerializer(input_data).data
 
         assert output_data == {
@@ -173,10 +198,15 @@ class TestEnrollmentSerializer(TestCase):
 class TestGradeDataSerializer(TestCase):
     """Tests for the GradeDataSerializer"""
 
-    def test_happy_path(self):
-        input_data = {
+    @classmethod
+    def generate_test_grade_data(cls):
+        """Util to generate test grade data"""
+        return {
             "isPassing": random_bool(),
         }
+
+    def test_happy_path(self):
+        input_data = self.generate_test_grade_data()
         output_data = GradeDataSerializer(input_data).data
 
         assert output_data == {
@@ -187,8 +217,10 @@ class TestGradeDataSerializer(TestCase):
 class TestCertificateSerializer(TestCase):
     """Tests for the CertificateSerializer"""
 
-    def test_happy_path(self):
-        input_data = {
+    @classmethod
+    def generate_test_certificate_info(cls):
+        """Util to generate test certificate info"""
+        return {
             "availableDate": random_date(allow_null=True),
             "isRestricted": random_bool(),
             "isAvailable": random_bool(),
@@ -198,6 +230,9 @@ class TestCertificateSerializer(TestCase):
             "certDownloadUrl": random_url(allow_null=True),
             "honorCertDownloadUrl": random_url(allow_null=True),
         }
+
+    def test_happy_path(self):
+        input_data = self.generate_test_certificate_info()
         output_data = CertificateSerializer(input_data).data
 
         assert output_data == {
@@ -224,10 +259,12 @@ class TestEntitlementSerializer(TestCase):
             "courseNumber": f"{uuid4()}-101",
         }
 
-    def test_happy_path(self):
-        input_data = {
+    @classmethod
+    def generate_test_entitlement_info(cls):
+        """Util to generate test entitlement info"""
+        return {
             "availableSessions": [
-                self.generate_test_session() for _ in range(randint(0, 3))
+                cls.generate_test_session() for _ in range(randint(0, 3))
             ],
             "isRefundable": random_bool(),
             "isFulfilled": random_bool(),
@@ -235,6 +272,9 @@ class TestEntitlementSerializer(TestCase):
             "changeDeadline": random_date(),
             "isExpired": random_bool(),
         }
+
+    def test_happy_path(self):
+        input_data = self.generate_test_entitlement_info()
         output_data = EntitlementSerializer(input_data).data
 
         # Compare output sessions separately, since they're more complicated
@@ -276,12 +316,17 @@ class TestProgramsSerializer(TestCase):
             "estimatedNumberOfWeeks": randint(0, 45),
         }
 
-    def test_happy_path(self):
-        input_data = {
+    @classmethod
+    def generate_test_programs_info(cls):
+        """Util to generate test programs info"""
+        return {
             "relatedPrograms": [
-                self.generate_test_related_program() for _ in range(randint(0, 3))
+                cls.generate_test_related_program() for _ in range(randint(0, 3))
             ],
         }
+
+    def test_happy_path(self):
+        input_data = self.generate_test_programs_info()
         output_data = ProgramsSerializer(input_data).data
 
         related_programs = output_data.pop("relatedPrograms")

--- a/lms/djangoapps/learner_dashboard/test_serializers.py
+++ b/lms/djangoapps/learner_dashboard/test_serializers.py
@@ -15,6 +15,7 @@ from lms.djangoapps.learner_dashboard.serializers import (
     EnrollmentSerializer,
     EntitlementSerializer,
     GradeDataSerializer,
+    LearnerEnrollmentSerializer,
     PlatformSettingsSerializer,
     ProgramsSerializer,
     LearnerDashboardSerializer,
@@ -352,6 +353,60 @@ class TestProgramsSerializer(TestCase):
         output_data = ProgramsSerializer(input_data).data
 
         assert output_data == {"relatedPrograms": []}
+
+
+class TestLearnerEnrollmentsSerializer(TestCase):
+    """High-level tests for LearnerEnrollmentsSerializer"""
+
+    @classmethod
+    def generate_test_enrollments_data(cls):
+        return {
+            "courseProvider": TestCourseProviderSerializer.generate_test_provider_info(),
+            "course": TestCourseSerializer.generate_test_course_info(),
+            "courseRun": TestCourseRunSerializer.generate_test_course_run_info(),
+            "enrollment": TestEnrollmentSerializer.generate_test_enrollment_info(),
+            "gradeData": TestGradeDataSerializer.generate_test_grade_data(),
+            "certificate": TestCertificateSerializer.generate_test_certificate_info(),
+            "entitlements": TestEntitlementSerializer.generate_test_entitlement_info(),
+            "programs": TestProgramsSerializer.generate_test_programs_info(),
+        }
+
+    def test_happy_path(self):
+        """Test that nothing breaks and the output fields look correct"""
+        input_data = self.generate_test_enrollments_data()
+
+        output_data = LearnerEnrollmentSerializer(input_data).data
+
+        expected_keys = [
+            "courseProvider",
+            "course",
+            "courseRun",
+            "enrollment",
+            "gradeData",
+            "certificate",
+            "entitlements",
+            "programs",
+        ]
+        assert output_data.keys() == set(expected_keys)
+
+    def test_allowed_empty(self):
+        """Tests for allowed null fields, mostly that nothing breaks"""
+        input_data = self.generate_test_enrollments_data()
+        input_data["courseProvider"] = None
+
+        output_data = LearnerEnrollmentSerializer(input_data).data
+
+        expected_keys = [
+            "courseProvider",
+            "course",
+            "courseRun",
+            "enrollment",
+            "gradeData",
+            "certificate",
+            "entitlements",
+            "programs",
+        ]
+        assert output_data.keys() == set(expected_keys)
 
 
 class TestLearnerDashboardSerializer(TestCase):

--- a/lms/djangoapps/learner_dashboard/test_serializers.py
+++ b/lms/djangoapps/learner_dashboard/test_serializers.py
@@ -336,38 +336,10 @@ class TestLearnerDashboardSerializer(TestCase):
             },
         )
 
-    def test_linkage(self):
-        """Test that serializers link to their appropriate outputs"""
-        input_data = {
-            "edx": {},
-            "enrollments": [],
-            "unfulfilledEntitlements": [],
-            "suggestedCourses": [],
-        }
-        serializer = LearnerDashboardSerializer(input_data)
-        with mock.patch(
-            "lms.djangoapps.learner_dashboard.serializers.PlatformSettingsSerializer.to_representation"
-        ) as mock_platform_settings_serializer:
-            mock_platform_settings_serializer.return_value = (
-                mock_platform_settings_serializer
-            )
-            output_data = serializer.data
-
-        self.assertDictEqual(
-            output_data,
-            {
-                "edx": mock_platform_settings_serializer,
-                "enrollments": [],
-                "unfulfilledEntitlements": [],
-                "suggestedCourses": [],
-            },
-        )
-
     @mock.patch(
         "lms.djangoapps.learner_dashboard.serializers.PlatformSettingsSerializer.to_representation"
     )
-    def test_linkage2(self, mock_platform_settings_serializer):
-        """Second example of paradigm using test-level patching"""
+    def test_linkage(self, mock_platform_settings_serializer):
         mock_platform_settings_serializer.return_value = (
             mock_platform_settings_serializer
         )

--- a/lms/djangoapps/learner_dashboard/test_serializers.py
+++ b/lms/djangoapps/learner_dashboard/test_serializers.py
@@ -1,7 +1,7 @@
 """Tests for serializers for the Learner Dashboard"""
 
 import datetime
-from random import choice, getrandbits, randint, random
+from random import choice, getrandbits, randint
 from time import time
 from unittest import TestCase
 from unittest import mock

--- a/lms/djangoapps/learner_dashboard/test_serializers.py
+++ b/lms/djangoapps/learner_dashboard/test_serializers.py
@@ -437,16 +437,24 @@ class TestLearnerDashboardSerializer(TestCase):
         )
 
     @mock.patch(
+        "lms.djangoapps.learner_dashboard.serializers.LearnerEnrollmentSerializer.to_representation"
+    )
+    @mock.patch(
         "lms.djangoapps.learner_dashboard.serializers.PlatformSettingsSerializer.to_representation"
     )
-    def test_linkage(self, mock_platform_settings_serializer):
+    def test_linkage(
+        self, mock_platform_settings_serializer, mock_learner_enrollment_serializer
+    ):
         mock_platform_settings_serializer.return_value = (
             mock_platform_settings_serializer
+        )
+        mock_learner_enrollment_serializer.return_value = (
+            mock_learner_enrollment_serializer
         )
 
         input_data = {
             "edx": {},
-            "enrollments": [],
+            "enrollments": [{}],
             "unfulfilledEntitlements": [],
             "suggestedCourses": [],
         }
@@ -456,7 +464,7 @@ class TestLearnerDashboardSerializer(TestCase):
             output_data,
             {
                 "edx": mock_platform_settings_serializer,
-                "enrollments": [],
+                "enrollments": [mock_learner_enrollment_serializer],
                 "unfulfilledEntitlements": [],
                 "suggestedCourses": [],
             },

--- a/lms/djangoapps/learner_dashboard/test_serializers.py
+++ b/lms/djangoapps/learner_dashboard/test_serializers.py
@@ -1,7 +1,7 @@
 """Tests for serializers for the Learner Dashboard"""
 
 import datetime
-from random import getrandbits, randint
+from random import choice, getrandbits, randint
 from time import time
 from unittest import TestCase
 from unittest import mock
@@ -32,6 +32,17 @@ def random_date(allow_null=False):
 
     d = randint(1, int(time()))
     return datetime.datetime.fromtimestamp(d)
+
+
+def random_url(allow_null=False):
+    """Test util for generating a random URL, optionally blank"""
+
+    # If null allowed, return null half the time
+    if allow_null and random_bool():
+        return None
+
+    random_uuid = uuid4()
+    return choice([f"{random_uuid}.example.com", f"example.com/{random_uuid}"])
 
 
 class TestPlatformSettingsSerializer(TestCase):

--- a/lms/djangoapps/learner_dashboard/test_serializers.py
+++ b/lms/djangoapps/learner_dashboard/test_serializers.py
@@ -346,7 +346,7 @@ class TestProgramsSerializer(TestCase):
                 "estimatedNumberOfWeeks": input_program["estimatedNumberOfWeeks"],
             }
 
-        assert output_data == {}
+        self.assertDictEqual(output_data, {})
 
     def test_empty_sessions(self):
         input_data = {"relatedPrograms": []}


### PR DESCRIPTION
## Description

Add serializers for learner enrollments for the Learner Dashboard as described [here](https://2u-internal.atlassian.net/wiki/spaces/PT/pages/45416495/Learner+Dashboard+Frontend+API+Contracts).

This adds the majority of the low-level serializers. Follow-ups will largely just assemble these into their high-level components (e.g. entitlements, enrollments).

This also puts in place a lot of test tooling. Specifically, each serializer test class has the ability to generate random test data which can be leveraged across tests for integration testing. The hope is that this can also be extended to fuzz data for the mock views in the near future.

JIRA: https://2u-internal.atlassian.net/browse/AU-693
FYI: @openedx/content-aurora 

## Testing instructions

- Unit testing
