### PR TITLE
docs: fix restricted app adr status

### DIFF
--- a/openedx/core/djangoapps/oauth_dispatch/docs/decisions/0005-restricted-application-for-SSO.rst
+++ b/openedx/core/djangoapps/oauth_dispatch/docs/decisions/0005-restricted-application-for-SSO.rst
@@ -4,7 +4,9 @@
 Status
 ------
 
-Accepted
+Partially Superseded (see ADR `Enforce Scopes in LMS APIs`_)
+
+.. _Enforce Scopes in LMS APIs: https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/oauth_dispatch/docs/decisions/0006-enforce-scopes-in-LMS-APIs.rst#3-restricted-applications-receive-unexpired-jwts-signed-with-a-new-key
 
 Context
 -------
@@ -37,6 +39,9 @@ with edX as an Identity Provider, configure them as a "Restricted Application".
 Although these applications can still request access tokens via the usual
 Authorization Code grant protocol, issue them only **expired** access tokens
 so they cannot make unauthorized calls to our API endpoints.
+
+.. note::
+    Although we still use the new model for "Restricted Applications", the decision to use **expired** access tokens has been superseded.
 
 Consequences
 ------------

--- a/openedx/core/djangoapps/oauth_dispatch/docs/decisions/0005-restricted-application-for-SSO.rst
+++ b/openedx/core/djangoapps/oauth_dispatch/docs/decisions/0005-restricted-application-for-SSO.rst
@@ -4,7 +4,7 @@
 Status
 ------
 
-Partially Superseded (see ADR `Enforce Scopes in LMS APIs`_)
+Partially Replaced (see ADR `Enforce Scopes in LMS APIs`_)
 
 .. _Enforce Scopes in LMS APIs: https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/oauth_dispatch/docs/decisions/0006-enforce-scopes-in-LMS-APIs.rst#3-restricted-applications-receive-unexpired-jwts-signed-with-a-new-key
 

--- a/openedx/core/djangoapps/oauth_dispatch/docs/decisions/0005-restricted-application-for-SSO.rst
+++ b/openedx/core/djangoapps/oauth_dispatch/docs/decisions/0005-restricted-application-for-SSO.rst
@@ -41,7 +41,7 @@ Authorization Code grant protocol, issue them only **expired** access tokens
 so they cannot make unauthorized calls to our API endpoints.
 
 .. note::
-    Although we still use the new model for "Restricted Applications", the decision to use **expired** access tokens has been superseded.
+    Although we still use the new model for "Restricted Applications", the decision to use **expired** access tokens has been superseded by ADR `Enforce Scopes in LMS APIs`_. That ADR specifies a different method to restrict "Restricted Applications" from accessing API endpoints that have not implemented Scopes.
 
 Consequences
 ------------


### PR DESCRIPTION
## Description

The decision to provide Restricted Applications expired
JWTs was superseded by another ADR. This commit simply
adds clarity around that change.

## Author Concerns

I don't plan on updating OEPs, so I just made some things up. OEP-1 and OEP-19 have the following issues that someone could address at some point:
- OEP-1 uses "[Replaced](https://open-edx-proposals.readthedocs.io/en/latest/processes/oep-0001.html#replaced)" for superseded status in OEPs, and OEP-19 uses "Superseded" for ADRs. I went with "Replaced", since OEPs came first, and that language seems simpler for non-native speakers. It would be nice to have these be consistent.
- I actually used "Partially Replaced", because some of the ADR still stands, but a part of it was superseded. I also added a note inside the ADR about the part that was superseded. I do not know if it is worth detailing this in OEP-1 or OEP-19 (for ADRs), or to just allow people to do what they think is right. Again, I do not plan on making any updates to the OEPs.