### PR TITLE
fix: Made lti_config optional field

### DIFF
--- a/openedx/core/djangoapps/course_live/serializers.py
+++ b/openedx/core/djangoapps/course_live/serializers.py
@@ -100,7 +100,8 @@ class CourseLiveConfigurationSerializer(serializers.ModelSerializer):
     """
     Serialize configuration responses
     """
-    lti_configuration = LtiSerializer(many=False, read_only=False)
+
+    lti_configuration = LtiSerializer(many=False, read_only=False, required=False)
     pii_sharing_allowed = serializers.SerializerMethodField()
 
     class Meta:
@@ -134,7 +135,7 @@ class CourseLiveConfigurationSerializer(serializers.ModelSerializer):
         """
         Create a new CourseLiveConfiguration entry in model
         """
-        lti_config = validated_data.pop('lti_configuration')
+        lti_config = validated_data.pop('lti_configuration', None)
         instance = CourseLiveConfiguration()
         instance = self._update_course_live_instance(instance, validated_data)
         if not validated_data.get('free_tier', False):
@@ -146,7 +147,7 @@ class CourseLiveConfigurationSerializer(serializers.ModelSerializer):
         """
         Update and save an existing instance
         """
-        lti_config = validated_data.pop('lti_configuration')
+        lti_config = validated_data.pop('lti_configuration', None)
         instance = self._update_course_live_instance(instance, validated_data)
         if not validated_data.get('free_tier', False):
             instance = self._update_lti(instance, lti_config)

--- a/openedx/core/djangoapps/course_live/tests/test_views.py
+++ b/openedx/core/djangoapps/course_live/tests/test_views.py
@@ -230,7 +230,6 @@ class TestCourseLiveConfigurationView(ModuleStoreTestCase, APITestCase):
         content = json.loads(response.content.decode('utf-8'))
         expected_data = {
             'provider_type': ['This field is required.'],
-            'lti_configuration': ['This field is required.']
         }
         self.assertEqual(content, expected_data)
         self.assertEqual(response.status_code, 400)
@@ -276,21 +275,10 @@ class TestCourseLiveConfigurationView(ModuleStoreTestCase, APITestCase):
         if providers.get(provider).requires_pii_sharing():
             CourseAllowPIISharingInLTIFlag.objects.create(course_id=self.course.id, enabled=True)
 
-        lti_config = {
-            'lti_1p1_client_key': 'this_is_key',
-            'lti_1p1_client_secret': 'this_is_secret',
-            'lti_1p1_launch_url': 'example.com',
-            'lti_config': {
-                'additional_parameters': {
-                    'custom_instructor_email': "email@example.com"
-                }
-            },
-        }
         course_live_config_data = {
             'free_tier': True,
             'enabled': True,
             'provider_type': provider,
-            'lti_configuration': lti_config
         }
         response = self._post(course_live_config_data)
 


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/INF-325

Some providers have free tier which do not require LTI configurations like Big blue button, and it will be unnecessary to require LTI configs in case this provider is selected.