### PR TITLE
feat: Schedule a follow up segment event for first time passed learners

### DIFF
--- a/lms/djangoapps/grades/management/commands/tests/test_send_segment_events_for_failed_learners.py
+++ b/lms/djangoapps/grades/management/commands/tests/test_send_segment_events_for_failed_learners.py
@@ -37,7 +37,6 @@ class TestSendSegmentEventsForFailedLearnersCommand(SharedModuleStoreTestCase):
         # we will create enrollments for paid modes plus `audit` mode
         enrollment_modes = PAID_ENROLLMENT_MODES + ['audit']
 
-        # import pdb ; pdb.set_trace()
         cls.course_end = timezone.now() - timedelta(days=31)
         cls.course_overviews = CourseOverviewFactory.create_batch(4, end=cls.course_end)
 

--- a/lms/djangoapps/grades/signals/signals.py
+++ b/lms/djangoapps/grades/signals/signals.py
@@ -112,3 +112,11 @@ SUBSECTION_OVERRIDE_CHANGED = Signal()
 #     ]
 COURSE_GRADE_PASSED_FIRST_TIME = Signal()
 COURSE_GRADE_PASSED_UPDATE_IN_LEARNER_PATHWAY = Signal()
+
+# This Signal indicates that a segment event has fired for user who has passed a course for the first time
+# providing_args=[
+#     'user_id',  # User object id
+#     'course_id',  # Course object id
+#     'event_properties',  # Segment event properties that will be needed for follow up event
+# ]
+SCHEDULE_FOLLOW_UP_SEGMENT_EVENT_FOR_COURSE_PASSED_FIRST_TIME = Signal()

--- a/lms/djangoapps/grades/tests/test_signals.py
+++ b/lms/djangoapps/grades/tests/test_signals.py
@@ -11,15 +11,16 @@ import ddt
 import pytest
 import pytz
 from django.test import TestCase
+from django.test.utils import override_settings
 from opaque_keys.edx.locator import CourseLocator
 from submissions.models import score_reset, score_set
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
 from common.djangoapps.track.event_transaction_utils import get_event_transaction_id, get_event_transaction_type
 from common.djangoapps.util.date_utils import to_timestamp
 from lms.djangoapps.grades.models import PersistentCourseGrade
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 
 from ..constants import ScoreDatabaseTableEnum
 from ..signals.handlers import (
@@ -388,8 +389,10 @@ class CourseEventsSignalsTest(ModuleStoreTestCase):
             }
         )
 
+    @override_settings(OUTCOME_SURVEYS_FOLLOW_UP_SIGNAL_ENABLED=True)
     @patch('lms.djangoapps.grades.events.segment.track')
-    def test_segment_event_on_course_grade_passed_first_time(self, segment_track_mock):
+    @patch('lms.djangoapps.grades.signals.signals.SCHEDULE_FOLLOW_UP_SEGMENT_EVENT_FOR_COURSE_PASSED_FIRST_TIME.send')
+    def test_segment_event_on_course_grade_passed_first_time(self, signal_mock, segment_track_mock):
         course = CourseOverviewFactory()
         enrollment = CourseEnrollmentFactory(
             is_active=True,
@@ -420,6 +423,18 @@ class CourseEventsSignalsTest(ModuleStoreTestCase):
             self.user.id,
             'edx.course.learner.passed.first_time',
             {
+                'LMS_ENROLLMENT_ID': enrollment.id,
+                'COURSE_TITLE': course.display_name,
+                'COURSE_ORG_NAME': course.org,
+            }
+        )
+
+        assert signal_mock.call_count == 1
+        signal_mock.assert_called_with(
+            sender=None,
+            user_id=self.user.id,
+            course_id=course.id,
+            event_properties={
                 'LMS_ENROLLMENT_ID': enrollment.id,
                 'COURSE_TITLE': course.display_name,
                 'COURSE_ORG_NAME': course.org,

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -5179,3 +5179,6 @@ MFE_CONFIG = {}
 # .. setting_description: The MFE Config API response will be cached during the
 #   specified time
 MFE_CONFIG_API_CACHE_TIMEOUT = 60 * 5
+
+######################## Settings for Outcome Surveys plugin ########################
+OUTCOME_SURVEYS_FOLLOW_UP_SIGNAL_ENABLED = False

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -126,6 +126,7 @@ openedx-calc                        # Library supporting mathematical calculatio
 openedx-events                      # Open edX Events from Hooks Extension Framework (OEP-50)
 openedx-filters                     # Open edX Filters from Hooks Extension Framework (OEP-50)
 ora2>=4.4.0
+outcome-surveys                     # edx-platform plugin to send and track segment events needed for surveys
 path
 piexif                              # Exif image metadata manipulation, used in the profile_images app
 Pillow                              # Image manipulation library; used for course assets, profile images, invoice PDFs, etc.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -747,6 +747,8 @@ ora2==4.4.4
     # via -r requirements/edx/base.in
 oscrypto==1.3.0
     # via snowflake-connector-python
+outcome-surveys==1.1.0
+    # via -r requirements/edx/base.in
 packaging==21.3
     # via
     #   drf-yasg

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -974,6 +974,8 @@ oscrypto==1.3.0
     # via
     #   -r requirements/edx/testing.txt
     #   snowflake-connector-python
+outcome-surveys==1.1.0
+    # via -r requirements/edx/testing.txt
 packaging==21.3
     # via
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -925,6 +925,8 @@ oscrypto==1.3.0
     # via
     #   -r requirements/edx/base.txt
     #   snowflake-connector-python
+outcome-surveys==1.1.0
+    # via -r requirements/edx/base.txt
 packaging==21.3
     # via
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
