### PR TITLE
feat: add order number information in support enrollment view

### DIFF
--- a/common/djangoapps/student/tests/factories.py
+++ b/common/djangoapps/student/tests/factories.py
@@ -17,6 +17,7 @@ from common.djangoapps.student.models import (
     CourseAccessRole,
     CourseEnrollment,
     CourseEnrollmentAllowed,
+    CourseEnrollmentAttribute,
     CourseEnrollmentCelebration,
     PendingEmailChange,
     Registration,
@@ -192,6 +193,13 @@ class CourseEnrollmentFactory(DjangoModelFactory):  # lint-amnesty, pylint: disa
 class CourseEnrollmentCelebrationFactory(DjangoModelFactory):
     class Meta:
         model = CourseEnrollmentCelebration
+
+    enrollment = factory.SubFactory(CourseEnrollmentFactory)
+
+
+class CourseEnrollmentAttributeFactory(DjangoModelFactory):
+    class Meta:
+        model = CourseEnrollmentAttribute
 
     enrollment = factory.SubFactory(CourseEnrollmentFactory)
 

--- a/lms/djangoapps/support/tests/test_views.py
+++ b/lms/djangoapps/support/tests/test_views.py
@@ -347,7 +347,7 @@ class SupportViewEnrollmentsTests(SharedModuleStoreTestCase, SupportViewTestCase
                 enrollment=self.enrollment,
                 namespace='order',
                 name='order_number',
-                value='ORD-00{}'.format(count+1)
+                value='ORD-00{}'.format(count + 1)
             )
         url = reverse(
             'support:enrollment_list',

--- a/lms/djangoapps/support/views/enrollments.py
+++ b/lms/djangoapps/support/views/enrollments.py
@@ -267,6 +267,12 @@ class EnrollmentSupportListView(GenericAPIView):
     def include_order_number(enrollment):
         """
         For a provided enrollment data dictionary, include order_number from CourseEnrollmentAttribute if available.
+
+        From all the attributes of a course enrollment:
+
+          * Filter order_number attributes namespaced under `order`
+          * Use the last/latest order number attr if multiple attrs found
+             * This is to keep the usage consistent with get_order_attribute_value method in CourseEnrollment
         """
         username = enrollment['user']
         course_id = enrollment['course_id']
@@ -283,7 +289,6 @@ class EnrollmentSupportListView(GenericAPIView):
                 course_id
             )
         enrollment['order_number'] = order_attribute[-1] if order_attribute else ''
-
 
     @staticmethod
     def manual_enrollment_data(enrollment_data, course_key):


### PR DESCRIPTION
### [PROD-2375](https://2u-internal.atlassian.net/browse/PROD-2375)

### Description

- Use [CourseEnrollmentAtttribute](https://github.com/openedx/edx-platform/blob/7a1d263477d3248cf7e0320e39354fdb700ba44b/common/djangoapps/student/models.py#L3021) to get order number for course enrollment and return that in support enrollment listing endpoint
- Get attribute details using [enrollment internal api](https://github.com/openedx/edx-platform/blob/7a1d263477d3248cf7e0320e39354fdb700ba44b/openedx/core/djangoapps/enrollments/api.py#L426) and filter to get only order number


### Testing
- The model CourseEnrollmentAtttribute is not present on admin. For testing, you will need to register it manually in the student app
- Add and enable switch `student.courseenrollment_admin` to display CourseEnrollment on admin
- Add an attribute with:
    - namespace: order
    - name: order_number
    - value: (Any str)
- Go to `http://localhost:18000/support/enrollment/{username/email}` and see the correct order number
- Add more attrs for the same enrollment. Make sure the latest order number is returned

**Note: While I am yet to see how Attr model is populated, the read replica has the latest values for enrollments (See info on ticket). That's why I went with this approach instead of calling ecommerce to get order number**