### PR TITLE
temp: add broad exception and log err for resume block

### DIFF
--- a/openedx/core/djangoapps/user_authn/cookies.py
+++ b/openedx/core/djangoapps/user_authn/cookies.py
@@ -256,10 +256,9 @@ def _get_user_info_cookie_data(request, user):
         pass
     except Exception as err:  # pylint: disable=broad-except
         log.exception(
-            '[PROD-2877] Error retrieving resume block for user %s with raw error %s',
-            user.username, str(err),
+            '[PROD-2877] Error retrieving resume block for user %s with raw error %r',
+            user.username, err,
         )
-        pass
 
     header_urls = _convert_to_absolute_uris(request, header_urls)
 

--- a/openedx/core/djangoapps/user_authn/cookies.py
+++ b/openedx/core/djangoapps/user_authn/cookies.py
@@ -254,6 +254,12 @@ def _get_user_info_cookie_data(request, user):
         header_urls['resume_block'] = retrieve_last_sitewide_block_completed(user)
     except User.DoesNotExist:
         pass
+    except Exception as err:  # pylint: disable=broad-except
+        log.exception(
+            '[PROD-2877] Error retrieving resume block for user %s with raw error %s',
+            user.username, str(err),
+        )
+        pass
 
     header_urls = _convert_to_absolute_uris(request, header_urls)
 


### PR DESCRIPTION
## Description

A low-level failure in the `retrieve_last_sitewide_block_completed` method (which provides the information to display a resume coursework button) is bubbling up an exception high enough to halt the auth pipeline. This is currently preventing a lot of edx/ocm staff from accessing their staging accounts.

## References
- https://2u-internal.atlassian.net/browse/ARCHBOM-2137
- https://2u-internal.atlassian.net/browse/PROD-2877