### PR TITLE
fix: guard against resume button failures halting auth pipeline

### DIFF
--- a/openedx/core/djangoapps/user_authn/cookies.py
+++ b/openedx/core/djangoapps/user_authn/cookies.py
@@ -252,7 +252,8 @@ def _get_user_info_cookie_data(request, user):
     # Add 'resume course' last completed block
     try:
         header_urls['resume_block'] = retrieve_last_sitewide_block_completed(user)
-    except User.DoesNotExist:
+    except Exception:  # pylint: disable=broad-except
+        log.exception('retrieve_last_sitewide_block_completed exception ARCHBOM-2137 PROD-2877')
         pass
 
     header_urls = _convert_to_absolute_uris(request, header_urls)


### PR DESCRIPTION
## Description

A low-level failure in the `retrieve_last_sitewide_block_completed` method (which provides the information to display a resume coursework button) is bubbling up an exception high enough to halt the auth pipeline. This is currently preventing a lot of edx/ocm staff from accessing their staging accounts.

## References
- https://2u-internal.atlassian.net/browse/ARCHBOM-2137
- https://2u-internal.atlassian.net/browse/PROD-2877