### PR TITLE
temp: guard against resume button failures in dropdown template

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/utils.py
+++ b/openedx/core/djangoapps/user_api/accounts/utils.py
@@ -170,7 +170,11 @@ def retrieve_last_sitewide_block_completed(user):
 
     try:
         item = modulestore().get_item(candidate_block_key, depth=1)
-    except ItemNotFoundError:
+    except Exception as err:  # pylint: disable=broad-except
+        log.exception(
+            '[PROD-2877] Error retrieving resume block for user %s with raw error %r',
+            user.username, err,
+        )
         item = None
 
     if not (lms_root and item):

--- a/openedx/core/djangoapps/user_api/accounts/utils.py
+++ b/openedx/core/djangoapps/user_api/accounts/utils.py
@@ -2,6 +2,7 @@
 Utility methods for the account settings.
 """
 
+import logging
 import random
 import re
 import string
@@ -24,6 +25,7 @@ from xmodule.modulestore.exceptions import ItemNotFoundError  # lint-amnesty, py
 from ..models import UserRetirementStatus
 
 ENABLE_SECONDARY_EMAIL_FEATURE_SWITCH = 'enable_secondary_email_feature'
+LOGGER = logging.getLogger(__name__)
 
 
 def validate_social_link(platform_name, new_social_link):
@@ -171,7 +173,7 @@ def retrieve_last_sitewide_block_completed(user):
     try:
         item = modulestore().get_item(candidate_block_key, depth=1)
     except Exception as err:  # pylint: disable=broad-except
-        log.exception(
+        LOGGER.exception(
             '[PROD-2877] Error retrieving resume block for user %s with raw error %r',
             user.username, err,
         )

--- a/openedx/core/djangoapps/user_api/accounts/utils.py
+++ b/openedx/core/djangoapps/user_api/accounts/utils.py
@@ -20,7 +20,6 @@ from openedx.core.djangolib.oauth2_retirement_utils import retire_dot_oauth2_mod
 from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
 from openedx.core.djangoapps.theming.helpers import get_config_value_from_site_or_settings, get_current_site
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.exceptions import ItemNotFoundError  # lint-amnesty, pylint: disable=wrong-import-order
 
 from ..models import UserRetirementStatus
 


### PR DESCRIPTION
## Description

Follow-on to #30701 which allowed the auth pipeline to complete however, we realized that the header's user dropdown template also calls the same method and blows up the newly logged in user. Implementing a temp patch at a lower level.

## References
- https://github.com/edx/edx-platform/blob/master/lms/templates/header/user_dropdown.html#L23
- https://github.com/openedx/edx-platform/pull/30701
- https://2u-internal.atlassian.net/browse/ARCHBOM-2137
- https://2u-internal.atlassian.net/browse/PROD-2877