### PR TITLE
feat: remaining learner dash serializers

### DIFF
--- a/lms/djangoapps/learner_dashboard/learner_views.py
+++ b/lms/djangoapps/learner_dashboard/learner_views.py
@@ -25,6 +25,8 @@ def get_platform_settings():
 def dashboard_view(request):  # pylint: disable=unused-argument
     """List of courses a user is enrolled in or entitled to"""
     learner_dash_data = {
+        "emailConfirmation": None,
+        "enterpriseDashboards": None,
         "platformSettings": get_platform_settings(),
         "enrollments": [],
         "unfulfilledEntitlements": [],

--- a/lms/djangoapps/learner_dashboard/serializers.py
+++ b/lms/djangoapps/learner_dashboard/serializers.py
@@ -160,10 +160,27 @@ class EmailConfirmationSerializer(serializers.Serializer):
     sendEmailUrl = serializers.URLField()
 
 
+class EnterpriseDashboardSerializer(serializers.Serializer):
+    """Serializer for individual enterprise dashboard data"""
+
+    label = serializers.CharField()
+    url = serializers.URLField()
+
+
+class EnterpriseDashboardsSerializer(serializers.Serializer):
+    """Listing of available enterprise dashboards"""
+
+    availableDashboards = serializers.ListField(
+        child=EnterpriseDashboardSerializer(), allow_empty=True
+    )
+    mostRecentDashboard = EnterpriseDashboardSerializer()
+
+
 class LearnerDashboardSerializer(serializers.Serializer):
     """Serializer for all info required to render the Learner Dashboard"""
 
     emailConfirmation = EmailConfirmationSerializer()
+    enterpriseDashboards = EnterpriseDashboardsSerializer()
     platformSettings = PlatformSettingsSerializer()
     enrollments = serializers.ListField(
         child=LearnerEnrollmentSerializer(), allow_empty=True

--- a/lms/djangoapps/learner_dashboard/serializers.py
+++ b/lms/djangoapps/learner_dashboard/serializers.py
@@ -145,8 +145,8 @@ class SuggestedCourseSerializer(serializers.Serializer):
     """Serializer for a suggested course"""
 
     bannerUrl = serializers.URLField()
-    logoUrl =serializers.URLField()
-    title= serializers.CharField()
+    logoUrl = serializers.URLField()
+    title = serializers.CharField()
     courseUrl = serializers.URLField()
 
 

--- a/lms/djangoapps/learner_dashboard/serializers.py
+++ b/lms/djangoapps/learner_dashboard/serializers.py
@@ -54,6 +54,8 @@ class EnrollmentSerializer(serializers.Serializer):
     canUpgrade = serializers.BooleanField()
     isAuditAccessExpired = serializers.BooleanField()
     isEmailEnabled = serializers.BooleanField()
+    lastEnrolled = serializers.DateTimeField()
+    isEnrolled = serializers.BooleanField()
 
 
 class GradeDataSerializer(serializers.Serializer):

--- a/lms/djangoapps/learner_dashboard/serializers.py
+++ b/lms/djangoapps/learner_dashboard/serializers.py
@@ -144,6 +144,11 @@ class UnfulfilledEntitlementSerializer(serializers.Serializer):
 class SuggestedCourseSerializer(serializers.Serializer):
     """Serializer for a suggested course"""
 
+    bannerUrl = serializers.URLField()
+    logoUrl =serializers.URLField()
+    title= serializers.CharField()
+    courseUrl = serializers.URLField()
+
 
 class LearnerDashboardSerializer(serializers.Serializer):
     """Serializer for all info required to render the Learner Dashboard"""

--- a/lms/djangoapps/learner_dashboard/serializers.py
+++ b/lms/djangoapps/learner_dashboard/serializers.py
@@ -158,7 +158,7 @@ class LearnerDashboardSerializer(serializers.Serializer):
         child=LearnerEnrollmentSerializer(), allow_empty=True
     )
     unfulfilledEntitlements = serializers.ListField(
-        child=EntitlementSerializer(), allow_empty=True
+        child=UnfulfilledEntitlementSerializer(), allow_empty=True
     )
     suggestedCourses = serializers.ListField(
         child=SuggestedCourseSerializer(), allow_empty=True

--- a/lms/djangoapps/learner_dashboard/serializers.py
+++ b/lms/djangoapps/learner_dashboard/serializers.py
@@ -135,6 +135,11 @@ class LearnerEnrollmentSerializer(serializers.Serializer):
 class UnfulfilledEntitlementSerializer(serializers.Serializer):
     """Serializer for an unfulfilled entitlement"""
 
+    courseProvider = CourseProviderSerializer(allow_null=True)
+    course = CourseSerializer()
+    entitlements = EntitlementSerializer()
+    programs = ProgramsSerializer()
+
 
 class SuggestedCourseSerializer(serializers.Serializer):
     """Serializer for a suggested course"""

--- a/lms/djangoapps/learner_dashboard/serializers.py
+++ b/lms/djangoapps/learner_dashboard/serializers.py
@@ -153,9 +153,17 @@ class SuggestedCourseSerializer(serializers.Serializer):
     courseUrl = serializers.URLField()
 
 
+class EmailConfirmationSerializer(serializers.Serializer):
+    """Serializer for email confirmation banner resources"""
+
+    isNeeded = serializers.BooleanField()
+    sendEmailUrl = serializers.URLField()
+
+
 class LearnerDashboardSerializer(serializers.Serializer):
     """Serializer for all info required to render the Learner Dashboard"""
 
+    emailConfirmation = EmailConfirmationSerializer()
     platformSettings = PlatformSettingsSerializer()
     enrollments = serializers.ListField(
         child=LearnerEnrollmentSerializer(), allow_empty=True

--- a/lms/djangoapps/learner_dashboard/serializers.py
+++ b/lms/djangoapps/learner_dashboard/serializers.py
@@ -96,6 +96,7 @@ class EntitlementSerializer(serializers.Serializer):
     canViewCourse = serializers.BooleanField()
     changeDeadline = serializers.DateTimeField()
     isExpired = serializers.BooleanField()
+    expirationDate = serializers.DateTimeField()
 
 
 class RelatedProgramSerializer(serializers.Serializer):

--- a/lms/djangoapps/learner_dashboard/test_learner_views.py
+++ b/lms/djangoapps/learner_dashboard/test_learner_views.py
@@ -89,6 +89,8 @@ class TestDashboardView(SharedModuleStoreTestCase, APITestCase):
         response_data = json.loads(response.content)
         expected_keys = set(
             [
+                "emailConfirmation",
+                "enterpriseDashboards",
                 "platformSettings",
                 "enrollments",
                 "unfulfilledEntitlements",

--- a/lms/djangoapps/learner_dashboard/test_serializers.py
+++ b/lms/djangoapps/learner_dashboard/test_serializers.py
@@ -19,6 +19,7 @@ from lms.djangoapps.learner_dashboard.serializers import (
     PlatformSettingsSerializer,
     ProgramsSerializer,
     LearnerDashboardSerializer,
+    UnfulfilledEntitlementSerializer,
 )
 
 
@@ -412,6 +413,48 @@ class TestLearnerEnrollmentsSerializer(TestCase):
             "enrollment",
             "gradeData",
             "certificate",
+            "entitlements",
+            "programs",
+        ]
+        assert output_data.keys() == set(expected_keys)
+
+
+class TestUnfulfilledEntitlementSerializer(TestCase):
+    """High-level tests for UnfulfilledEntitlementSerializer"""
+
+    @classmethod
+    def generate_test_entitlements_data(cls):
+        return {
+            "courseProvider": TestCourseProviderSerializer.generate_test_provider_info(),
+            "course": TestCourseSerializer.generate_test_course_info(),
+            "entitlements": TestEntitlementSerializer.generate_test_entitlement_info(),
+            "programs": TestProgramsSerializer.generate_test_programs_info(),
+        }
+
+    def test_happy_path(self):
+        """Test that nothing breaks and the output fields look correct"""
+        input_data = self.generate_test_entitlements_data()
+
+        output_data = UnfulfilledEntitlementSerializer(input_data).data
+
+        expected_keys = [
+            "courseProvider",
+            "course",
+            "entitlements",
+            "programs",
+        ]
+        assert output_data.keys() == set(expected_keys)
+
+    def test_allowed_empty(self):
+        """Tests for allowed null fields, mostly that nothing breaks"""
+        input_data = self.generate_test_entitlements_data()
+        input_data["courseProvider"] = None
+
+        output_data = UnfulfilledEntitlementSerializer(input_data).data
+
+        expected_keys = [
+            "courseProvider",
+            "course",
             "entitlements",
             "programs",
         ]

--- a/lms/djangoapps/learner_dashboard/test_serializers.py
+++ b/lms/djangoapps/learner_dashboard/test_serializers.py
@@ -192,19 +192,26 @@ class TestEnrollmentSerializer(TestCase):
             "canUpgrade": random_bool(),
             "isAuditAccessExpired": random_bool(),
             "isEmailEnabled": random_bool(),
+            "lastEnrolled": random_date(),
+            "isEnrolled": random_bool(),
         }
 
     def test_happy_path(self):
         input_data = self.generate_test_enrollment_info()
         output_data = EnrollmentSerializer(input_data).data
 
-        assert output_data == {
-            "isAudit": input_data["isAudit"],
-            "isVerified": input_data["isVerified"],
-            "canUpgrade": input_data["canUpgrade"],
-            "isAuditAccessExpired": input_data["isAuditAccessExpired"],
-            "isEmailEnabled": input_data["isEmailEnabled"],
-        }
+        self.assertDictEqual(
+            output_data,
+            {
+                "isAudit": input_data["isAudit"],
+                "isVerified": input_data["isVerified"],
+                "canUpgrade": input_data["canUpgrade"],
+                "isAuditAccessExpired": input_data["isAuditAccessExpired"],
+                "isEmailEnabled": input_data["isEmailEnabled"],
+                "lastEnrolled": datetime_to_django_format(input_data["lastEnrolled"]),
+                "isEnrolled": input_data["isEnrolled"],
+            },
+        )
 
 
 class TestGradeDataSerializer(TestCase):

--- a/lms/djangoapps/learner_dashboard/test_serializers.py
+++ b/lms/djangoapps/learner_dashboard/test_serializers.py
@@ -19,6 +19,7 @@ from lms.djangoapps.learner_dashboard.serializers import (
     PlatformSettingsSerializer,
     ProgramsSerializer,
     LearnerDashboardSerializer,
+    SuggestedCourseSerializer,
     UnfulfilledEntitlementSerializer,
 )
 
@@ -459,6 +460,50 @@ class TestUnfulfilledEntitlementSerializer(TestCase):
             "programs",
         ]
         assert output_data.keys() == set(expected_keys)
+
+
+class TestSuggestedCourseSerializer(TestCase):
+    """High-level tests for SuggestedCourseSerializer"""
+
+    @classmethod
+    def generate_test_suggested_courses(cls):
+        return {
+            "bannerUrl": random_url(),
+            "logoUrl": random_url(),
+            "title": f"{uuid4()}",
+            "courseUrl": random_url(),
+        }
+
+    def test_structure(self):
+        """Test that nothing breaks and the output fields look correct"""
+        input_data = self.generate_test_suggested_courses()
+
+        output_data = SuggestedCourseSerializer(input_data).data
+
+        expected_keys = [
+            "bannerUrl",
+            "logoUrl",
+            "title",
+            "courseUrl",
+        ]
+        assert output_data.keys() == set(expected_keys)
+
+    def test_happy_path(self):
+        """Test that data serializes correctly"""
+
+        input_data = self.generate_test_suggested_courses()
+
+        output_data = SuggestedCourseSerializer(input_data).data
+
+        self.assertDictEqual(
+            output_data,
+            {
+                "bannerUrl": input_data["bannerUrl"],
+                "logoUrl": input_data["logoUrl"],
+                "title": input_data["title"],
+                "courseUrl": input_data["courseUrl"],
+            },
+        )
 
 
 class TestLearnerDashboardSerializer(TestCase):

--- a/lms/djangoapps/learner_dashboard/test_serializers.py
+++ b/lms/djangoapps/learner_dashboard/test_serializers.py
@@ -49,6 +49,16 @@ def random_url(allow_null=False):
     return choice([f"{random_uuid}.example.com", f"example.com/{random_uuid}"])
 
 
+def random_grade():
+    """Return a random grade (0-100) with 2 decimal places of padding"""
+    return randint(0, 10000) / 100
+
+
+def decimal_to_grade_format(decimal):
+    """Util for matching serialized grade format, pads a decimal to 2 places"""
+    return "{:.2f}".format(decimal)
+
+
 def datetime_to_django_format(datetime_obj):
     """Util for matching serialized Django datetime format for comparison"""
     if datetime_obj:
@@ -136,7 +146,7 @@ class TestCourseRunSerializer(TestCase):
             "isArchived": random_bool(),
             "courseNumber": f"{uuid4()}-101",
             "accessExpirationDate": random_date(),
-            "minPassingGrade": randint(0, 10000) / 100,
+            "minPassingGrade": random_grade(),
             "endDate": random_date(),
             "homeUrl": f"{uuid4()}.example.com",
             "marketingUrl": f"{uuid4()}.example.com",
@@ -158,7 +168,7 @@ class TestCourseRunSerializer(TestCase):
             "accessExpirationDate": datetime_to_django_format(
                 input_data["accessExpirationDate"]
             ),
-            "minPassingGrade": str(input_data["minPassingGrade"]),
+            "minPassingGrade": decimal_to_grade_format(input_data["minPassingGrade"]),
             "endDate": datetime_to_django_format(input_data["endDate"]),
             "homeUrl": input_data["homeUrl"],
             "marketingUrl": input_data["marketingUrl"],

--- a/lms/djangoapps/learner_dashboard/test_serializers.py
+++ b/lms/djangoapps/learner_dashboard/test_serializers.py
@@ -290,6 +290,7 @@ class TestEntitlementSerializer(TestCase):
             "canViewCourse": random_bool(),
             "changeDeadline": random_date(),
             "isExpired": random_bool(),
+            "expirationDate": random_date(),
         }
 
     def test_happy_path(self):
@@ -314,6 +315,7 @@ class TestEntitlementSerializer(TestCase):
             "canViewCourse": input_data["canViewCourse"],
             "changeDeadline": datetime_to_django_format(input_data["changeDeadline"]),
             "isExpired": input_data["isExpired"],
+            "expirationDate": datetime_to_django_format(input_data["expirationDate"]),
         }
 
 


### PR DESCRIPTION
## Description

Added the remaining missing serializers for learner dashboard:
1. `unfulfilledEntitlements`
2. `suggestedCourses`
3. `emailConfirmation`
4. `enterpriseDashboards`

Updated the following contract changes:
1. Added `lastEnrolled` and `isEnrolled` fields to `enrollments`.
2. Added `expirationDate` to `entitlements`

Various updates, fixes, and refactors in support.

JIRA: https://2u-internal.atlassian.net/browse/AU-696
FYI: @openedx/content-aurora 
