### PR TITLE
fix: resolved discussions banner permissions issue

### DIFF
--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -752,7 +752,7 @@ def _discussions_mfe_context(query_params: Dict,
         "mfe_url": f"{forum_url}?discussions_experience=new",
         "share_feedback_url": settings.DISCUSSIONS_MFE_FEEDBACK_URL,
         "course_key": course_key,
-        "show_banner": enable_mfe and (is_privileged or ENABLE_DISCUSSIONS_MFE_BANNER),
+        "show_banner": enable_mfe and (is_privileged or ENABLE_DISCUSSIONS_MFE_BANNER.is_enabled()),
         "discussions_mfe_url": mfe_url,
     }
 


### PR DESCRIPTION
Switching Banner was visible for learner on discussions page, now fixed in this PR