### PR TITLE
chore: bump django-wiki to v1.1.1

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -10,7 +10,7 @@
     # via -r requirements/edx/local.in
 -e git+https://github.com/edx/codejail.git@3.1.3#egg=codejail==3.1.3
     # via -r requirements/edx/github.in
--e git+https://github.com/edx/django-wiki.git@1.1.0#egg=django-wiki
+-e git+https://github.com/edx/django-wiki.git@1.1.1#egg=django-wiki
     # via -r requirements/edx/github.in
 -e git+https://github.com/openedx/olxcleaner.git@2f0d6c7f126cbd69c9724b7b57a0b2565330a297#egg=olxcleaner
     # via -r requirements/edx/github.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -10,7 +10,7 @@
     # via -r requirements/edx/testing.txt
 -e git+https://github.com/edx/codejail.git@3.1.3#egg=codejail==3.1.3
     # via -r requirements/edx/testing.txt
--e git+https://github.com/edx/django-wiki.git@1.1.0#egg=django-wiki
+-e git+https://github.com/edx/django-wiki.git@1.1.1#egg=django-wiki
     # via -r requirements/edx/testing.txt
 -e git+https://github.com/openedx/olxcleaner.git@2f0d6c7f126cbd69c9724b7b57a0b2565330a297#egg=olxcleaner
     # via -r requirements/edx/testing.txt

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -54,7 +54,7 @@
 # Python libraries to install directly from github
 
 # Third-party:
--e git+https://github.com/edx/django-wiki.git@1.1.0#egg=django-wiki
+-e git+https://github.com/edx/django-wiki.git@1.1.1#egg=django-wiki
 -e git+https://github.com/openedx/olxcleaner.git@2f0d6c7f126cbd69c9724b7b57a0b2565330a297#egg=olxcleaner
 git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2
 

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -10,7 +10,7 @@
     # via -r requirements/edx/base.txt
 -e git+https://github.com/edx/codejail.git@3.1.3#egg=codejail==3.1.3
     # via -r requirements/edx/base.txt
--e git+https://github.com/edx/django-wiki.git@1.1.0#egg=django-wiki
+-e git+https://github.com/edx/django-wiki.git@1.1.1#egg=django-wiki
     # via -r requirements/edx/base.txt
 -e git+https://github.com/openedx/olxcleaner.git@2f0d6c7f126cbd69c9724b7b57a0b2565330a297#egg=olxcleaner
     # via -r requirements/edx/base.txt


### PR DESCRIPTION
## Description

Bumps the django-wiki version to v1.1.1 to incorporate the fix for migrations not passing by default on Digital Ocean managed MySQL.

## Supporting information

- https://github.com/openedx/django-wiki/pull/116/

## Testing instructions

- Set up MySQL with the setting disabled:
  - create a `conf` directory containing the file `primary_key.cnf` with the content:
     ```
     [mysqld]
     sql_require_primary_key=true
     ````
   - Start a MySQL container with the command: `docker run -v $(pwd)/conf:/etc/mysql/conf.d -p 3306:3306 --name mysql8 -e MYSQL_ROOT_PASSWORD=root -d mysql:latest`
   - Log into the container and create your edx database
   - Point your edx install to this db (you'll likely need to use your network ip)
- The migrations will run without a problem. With django-wiki==1.1.0 they will fail with an error as described in the linked PR.
   
