### PR TITLE
Inf 309

### DIFF
--- a/lms/djangoapps/discussion/tests/test_views.py
+++ b/lms/djangoapps/discussion/tests/test_views.py
@@ -2301,11 +2301,10 @@ class ForumMFETestCase(ForumsEnableMixin, SharedModuleStoreTestCase):
                 response = self.client.get(reverse("forum_form_discussion", args=[self.course.id]))
                 content = response.content.decode('utf8')
         if mfe_url and toggle_enabled:
-            assert "You are viewing an educator only preview of the new discussions experience!" in content
-            assert "legacy experience" in content
-            assert "new experience" not in content
+            assert "Welcome to the new discussions experience. Please share your feedback." in content
+            assert "Switch to new experience" not in content
         else:
-            assert "You are viewing an educator only preview of the new discussions experience!" not in content
+            assert "Welcome to the new discussions experience. Please share your feedback." not in content
 
     @override_settings(DISCUSSIONS_MICROFRONTEND_URL="http://test.url")
     @ddt.data(*itertools.product((True, False), ("legacy", "new", None)))

--- a/lms/static/sass/discussion/_discussion-v1.scss
+++ b/lms/static/sass/discussion/_discussion-v1.scss
@@ -71,6 +71,25 @@
   }
 }
 
+.legacy-tooltip {
+    position: absolute;
+    z-index: 1070;
+    display: none;
+    margin: 0;
+    line-height: 1.55556;
+    font-family: "Inter","Helvetica Neue",Arial,sans-serif;
+    background: white;
+    color: black;
+    padding: 10px;
+    border-radius: 5px;
+    box-shadow: 0 0 5px rgba(0, 0, 0, 0.5);
+    &:hover,
+    &:active,
+    &:focus {
+        display: block;
+    }
+}
+
 // Layout control for discussion modules that does not apply to the discussion board
 .discussion-module {
   .discussion {

--- a/lms/templates/discussion/_switch_experience_fragment.html
+++ b/lms/templates/discussion/_switch_experience_fragment.html
@@ -9,28 +9,28 @@ from django.utils.translation import ugettext as _
 % if show_banner:
 <div class="upgrade-banner d-flex bg-primary text-white align-items-center px-4 py-1">
     % if show_mfe:
-    <div class="d-flex w-100 small">
-        ${_("You are viewing an educator only preview of the new discussions experience!")}
+    <div class="d-flex w-100 small align-items-center">
+        ${_("Welcome to the new discussions experience. Please share your feedback.")}
+        <a href="${legacy_url}" class="ml-2 text-white">
+            <i class="fa fa-info-circle">
+                <span class="legacy-tooltip">${_("View legacy experience")}</span>
+            </i>
+        </a>
     </div>
     % else:
     <div class="d-flex w-100 small">
-        ${_("An educator preview of new discussions experience is available!")}
+        ${_("You are currently using the old discussions experience that will be deprecated soon. If you are facing any issues with the new experience, please share using the feedback button.")}
     </div>
+    <a class="btn btn-inverse-primary ml-2" style="font-size: 12px;" href="${mfe_url}">
+        ${_("Switch to new experience")}
+    </a>
     %endif
 
-    % if show_mfe:
-    <a class="btn btn-inverse-primary" style="font-size: 12px;" href="${legacy_url}">
-        ${_("View legacy experience")}
-    </a>
     % if share_feedback_url:
         <a class="btn btn-inverse-primary ml-2" style="font-size: 12px;" href="${share_feedback_url}" target="_blank" rel="noopener">
             ${_("Share feedback")}
         </a>
     % endif
-    % else:
-    <a class="btn btn-inverse-primary ml-2" style="font-size: 12px;" href="${mfe_url}">
-        ${_("View the new experience")}
-    </a>
-    % endif
 </div>
 % endif
+


### PR DESCRIPTION
switch to legacy option is moved under info icon. a tooltip is added which will be visible on hover to show information to the user.

- message improvements for both legacy and MFE view
- give feedback option visible in all cases.
- switch to legacy option moved inside tooltip/info icon

<img width="1318" alt="Screenshot 2022-07-07 at 4 00 10 PM" src="https://user-images.githubusercontent.com/67791278/177759364-aea90ea8-3c2c-4a6b-9d96-381e7c77b927.png">
