### PR TITLE
fix: update LTI XBlock to fix DarkLangMiddleware issue

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -651,7 +651,7 @@ libsass==0.10.0
     #   ora2
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==4.2.1
+lti-consumer-xblock==4.2.2
     # via -r requirements/edx/base.in
 lxml==4.9.0
     # via


### PR DESCRIPTION
## Description

Updates LTI XBlock to 4.2.2, which brings [this fix](https://github.com/openedx/xblock-lti-consumer/pull/261), which addresses an issue where DarkLangMiddleware was breaking both Names and Roles and Grades functionality for LTI 1.3.

I'm bumping this manually instead of doing a manual run of the requirements update bot because there is an unrelated conflict there.

## Supporting information

* https://github.com/openedx/xblock-lti-consumer/pull/261

## Other information

I need to push this to the Nutmeg branch as well.