### PR TITLE
fix: update LTI XBlock to fix DarkLangMiddleware issue

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -648,7 +648,7 @@ libsass==0.10.0
     #   ora2
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==3.4.6
+lti-consumer-xblock==3.4.7
     # via -r requirements/edx/base.in
 lxml==4.5.0
     # via


### PR DESCRIPTION
This fixes Names and Roles + Grades for LTI 1.3. For details, see:

  https://github.com/openedx/xblock-lti-consumer/pull/261

This pulls from the 3.4.7 release of lti-consumer-xblock (the nutmeg
branch backport), not from the latest 4.2.2 (which was too risky since
it had many unrelated changes).