### PR TITLE
fix: Update the slack invite link.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -83,7 +83,7 @@ Note that Slack is no longer the recommended communication channel to ask about
 technical issues. To do so, you should instead join the `official forum <#forum>`__.
 
 .. _Slack: https://slack.com/
-.. _Sign up for a free account: https://openedx-slack-invite.herokuapp.com/
+.. _Sign up for a free account: https://openedx.org/slack
 
 Byte-sized Tasks & Bugs
 -----------------------

--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ invitation`_, then join our `community Slack team`_.
 
 For more information about these options, see the `Getting Help`_ page.
 
-.. _Slack invitation: https://openedx-slack-invite.herokuapp.com/
+.. _Slack invitation: https://openedx.org/slack
 .. _community Slack team: http://openedx.slack.com/
 .. _Getting Help: https://openedx.org/getting-help
 


### PR DESCRIPTION
Point to the openedx.org shortcut which we can update as needed.