### PR TITLE
refactor: Update pathways progress when course is passed for first time

### DIFF
--- a/lms/djangoapps/grades/course_grade_factory.py
+++ b/lms/djangoapps/grades/course_grade_factory.py
@@ -9,9 +9,6 @@ from openedx.core.djangoapps.signals.signals import (
     COURSE_GRADE_NOW_FAILED,
     COURSE_GRADE_NOW_PASSED
 )
-from lms.djangoapps.grades.signals.signals import (
-    COURSE_GRADE_PASSED_UPDATE_IN_LEARNER_PATHWAY,
-)
 from .config import assume_zero_if_absent, should_persist_grades
 from .course_data import CourseData
 from .course_grade import CourseGrade, ZeroCourseGrade
@@ -173,7 +170,6 @@ class CourseGradeFactory:
             COURSE_GRADE_CHANGED signal to listeners and
             COURSE_GRADE_NOW_PASSED if learner has passed course or
             COURSE_GRADE_NOW_FAILED if learner is now failing course
-            COURSE_GRADE_PASSED_UPDATE_IN_LEARNER_PATHWAY if learner has passed course
         """
         should_persist = should_persist_grades(course_data.course_key)
         if should_persist and force_update_subsections:
@@ -212,11 +208,6 @@ class CourseGradeFactory:
                 COURSE_GRADE_NOW_PASSED.send(
                     sender=CourseGradeFactory,
                     user=user,
-                    course_id=course_data.course_key,
-                )
-                COURSE_GRADE_PASSED_UPDATE_IN_LEARNER_PATHWAY.send(
-                    sender=CourseGradeFactory,
-                    user_id=user.id,
                     course_id=course_data.course_key,
                 )
             else:


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Update pathways progress when a course is passed for the first time

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
