### PR TITLE
fix: sort the user stats to maintain best matched username first

### DIFF
--- a/lms/djangoapps/discussion/rest_api/utils.py
+++ b/lms/djangoapps/discussion/rest_api/utils.py
@@ -78,4 +78,5 @@ def add_stats_for_users_with_no_discussion_content(course_stats, users_in_course
             'active_flags': 0,
             'inactive_flags': 0,
         })
+    updated_course_stats = sorted(updated_course_stats, key=lambda d: len(d['username']))
     return updated_course_stats


### PR DESCRIPTION
### [INF-355](https://2u-internal.atlassian.net/browse/INF-355)

#### Description

Partial search results are also not sorted in some cases (When a username with less matching characters has stats for discussion present, this disturbs the ordering). 
This PR addresses this issue, and sorts after the course stats are ready to be returned from API response.