### PR TITLE
feat: add mgmt command to track active_versions

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/compare_course_index_entries.py
+++ b/cms/djangoapps/contentstore/management/commands/compare_course_index_entries.py
@@ -1,12 +1,18 @@
 import logging
-from xmodule.modulestore.split_mongo.mongo_connection import MongoPersistenceBackend, DjangoFlexPersistenceBackend
-from xmodule.modulestore.django import modulestore
 from django.core.management.base import BaseCommand
-
 from django.conf import settings
+from opaque_keys.edx.locator import CourseLocator
+from common.djangoapps.split_modulestore_django.models import SplitModulestoreCourseIndex
+from xmodule.modulestore.split_mongo.mongo_connection import MongoPersistenceBackend, DjangoFlexPersistenceBackend
+
+
+
 
 logger = logging.getLogger(__name__)
 
+"""
+A Command to determine if the Mongo active_versions and Django course_index tables are out of sync with one another.
+"""
 
 class Command(BaseCommand):
 
@@ -15,9 +21,9 @@ class Command(BaseCommand):
     """
 
     def handle(self, *args, **options):
-        module_store = modulestore()
-        courses = module_store.get_courses()
-        course_ids = [x.id for x in courses]
+
+        courses = SplitModulestoreCourseIndex.objects.values('course_id')
+        course_ids = [x['course_id'] for x in courses if isinstance(x['course_id'], CourseLocator)]
         out_of_sync = {}
 
         mongostore = MongoPersistenceBackend(**settings.CONTENTSTORE['DOC_STORE_CONFIG'])
@@ -26,21 +32,32 @@ class Command(BaseCommand):
         def compare_entries(mongo_entry, msql_entry, course_id):
             draft = False
             published = False
-            if(mongo_entry["draft-branch"] != msql_entry["draft-branch"]):
+            if mongo_entry["draft-branch"] != msql_entry["draft-branch"]:
                 draft = True
-            if(mongo_entry["published-branch"] != msql_entry["published-branch"]):
+            if mongo_entry["published-branch"] != msql_entry["published-branch"]:
                 published = True
-            if (draft | published):
-                out_of_sync[course_id._to_string()] = (draft, published)
-            return
+            if draft | published:
+                out_of_sync[str(course_id)] = (
+                    mongo_entry["draft-branch"],
+                    mongo_entry["published-branch"],
+                    msql_entry["draft-branch"],
+                    msql_entry["published-branch"],
+                    mongostore.get_course_index(key=course_id)['last_update'],
+                    msqlstore.get_course_index(key=course_id)['last_update'],
+                )
 
-        for course_id in course_ids:
+        for course_id in sorted(course_ids):
             mongo_entry = mongostore.get_course_index(key=course_id)['versions']
             msql_entry = msqlstore.get_course_index(key=course_id)['versions']
             compare_entries(mongo_entry, msql_entry, course_id)
 
         print(out_of_sync)
-
         for course in out_of_sync:
-            print(f'id: {course} is out of Sync in Draft:{out_of_sync[course][0]} in Published: {out_of_sync[course][1]}')
+            print('*'*8)
+            print(f'{course} is out of sync in course_index tables')
+            print(f'MONGO draft     id: {out_of_sync[course][0]}')
+            print(f'MONGO published id: {out_of_sync[course][1]}')
+            print(f'MYSQL draft     id: {out_of_sync[course][2]}')
+            print(f'MYSQL published id: {out_of_sync[course][3]}')
+        print('*'*8)
         print(f'The number of out-of-sync courses is : {len(out_of_sync)}')

--- a/cms/djangoapps/contentstore/management/commands/compare_course_index_entries.py
+++ b/cms/djangoapps/contentstore/management/commands/compare_course_index_entries.py
@@ -5,10 +5,7 @@ from django.core.management.base import BaseCommand
 
 from django.conf import settings
 
-
 logger = logging.getLogger(__name__)
-
-
 
 class Command(BaseCommand):
 
@@ -25,26 +22,24 @@ class Command(BaseCommand):
         mongostore = MongoPersistenceBackend(**settings.CONTENTSTORE['DOC_STORE_CONFIG'])
         msqlstore = DjangoFlexPersistenceBackend(**settings.CONTENTSTORE['DOC_STORE_CONFIG'])
 
-        def compare_entries(mongo_entry,msql_entry, course_id):
+        def compare_entries(mongo_entry, msql_entry, course_id):
             draft = False
             published = False
             if(mongo_entry["draft-branch"] != msql_entry["draft-branch"]):
                 draft = True
             if(mongo_entry["published-branch"] != msql_entry["published-branch"]):
                 published = True
-            if (draft|published):
-                out_of_sync[course_id._to_string()] = (draft,published)
+            if (draft | published):
+                out_of_sync[course_id._to_string()] = (draft, published)
             return
 
         for course_id in course_ids:
             mongo_entry = mongostore.get_course_index(key=course_id)['versions']
             msql_entry = msqlstore.get_course_index(key=course_id)['versions']
-            compare_entries(mongo_entry,msql_entry,course_id)
+            compare_entries(mongo_entry, msql_entry, course_id)
 
         print(out_of_sync)
 
         for course in out_of_sync:
             print(f'id: {course} is out of Sync in Draft:{out_of_sync[course][0]} in Published: {out_of_sync[course][1]}')
         print(f'The number of out-of-sync courses is : {len(out_of_sync)}')
-
-

--- a/cms/djangoapps/contentstore/management/commands/compare_course_index_entries.py
+++ b/cms/djangoapps/contentstore/management/commands/compare_course_index_entries.py
@@ -7,6 +7,7 @@ from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
+
 class Command(BaseCommand):
 
     """

--- a/cms/djangoapps/contentstore/management/commands/compare_course_index_entries.py
+++ b/cms/djangoapps/contentstore/management/commands/compare_course_index_entries.py
@@ -1,0 +1,50 @@
+import logging
+from xmodule.modulestore.split_mongo.mongo_connection import MongoPersistenceBackend, DjangoFlexPersistenceBackend
+from xmodule.modulestore.django import modulestore
+from django.core.management.base import BaseCommand
+
+from django.conf import settings
+
+
+logger = logging.getLogger(__name__)
+
+
+
+class Command(BaseCommand):
+
+    """
+    A Command to determine if the Mongo active_versions and Django course_index tables are out of sync with one another.
+    """
+
+    def handle(self, *args, **options):
+        module_store = modulestore()
+        courses = module_store.get_courses()
+        course_ids = [x.id for x in courses]
+        out_of_sync = {}
+
+        mongostore = MongoPersistenceBackend(**settings.CONTENTSTORE['DOC_STORE_CONFIG'])
+        msqlstore = DjangoFlexPersistenceBackend(**settings.CONTENTSTORE['DOC_STORE_CONFIG'])
+
+        def compare_entries(mongo_entry,msql_entry, course_id):
+            draft = False
+            published = False
+            if(mongo_entry["draft-branch"] != msql_entry["draft-branch"]):
+                draft = True
+            if(mongo_entry["published-branch"] != msql_entry["published-branch"]):
+                published = True
+            if (draft|published):
+                out_of_sync[course_id._to_string()] = (draft,published)
+            return
+
+        for course_id in course_ids:
+            mongo_entry = mongostore.get_course_index(key=course_id)['versions']
+            msql_entry = msqlstore.get_course_index(key=course_id)['versions']
+            compare_entries(mongo_entry,msql_entry,course_id)
+
+        print(out_of_sync)
+
+        for course in out_of_sync:
+            print(f'id: {course} is out of Sync in Draft:{out_of_sync[course][0]} in Published: {out_of_sync[course][1]}')
+        print(f'The number of out-of-sync courses is : {len(out_of_sync)}')
+
+

--- a/cms/djangoapps/contentstore/management/commands/compare_course_index_entries.py
+++ b/cms/djangoapps/contentstore/management/commands/compare_course_index_entries.py
@@ -1,3 +1,4 @@
+"""A Command to determine if the Mongo active_versions and Django course_index tables are out of sync with one another."""
 import logging
 from django.core.management.base import BaseCommand
 from django.conf import settings
@@ -6,10 +7,6 @@ from common.djangoapps.split_modulestore_django.models import SplitModulestoreCo
 from xmodule.modulestore.split_mongo.mongo_connection import MongoPersistenceBackend, DjangoFlexPersistenceBackend
 
 logger = logging.getLogger(__name__)
-
-"""
-A Command to determine if the Mongo active_versions and Django course_index tables are out of sync with one another.
-"""
 
 
 class Command(BaseCommand):

--- a/cms/djangoapps/contentstore/management/commands/compare_course_index_entries.py
+++ b/cms/djangoapps/contentstore/management/commands/compare_course_index_entries.py
@@ -5,9 +5,6 @@ from opaque_keys.edx.locator import CourseLocator
 from common.djangoapps.split_modulestore_django.models import SplitModulestoreCourseIndex
 from xmodule.modulestore.split_mongo.mongo_connection import MongoPersistenceBackend, DjangoFlexPersistenceBackend
 
-
-
-
 logger = logging.getLogger(__name__)
 
 """
@@ -15,6 +12,7 @@ A Command to determine if the Mongo active_versions and Django course_index tabl
 """
 
 class Command(BaseCommand):
+
 
     """
     A Command to determine if the Mongo active_versions and Django course_index tables are out of sync with one another.
@@ -53,7 +51,7 @@ class Command(BaseCommand):
 
         print(out_of_sync)
         for course in out_of_sync:
-            print('*'*8)
+            print('*' * 8)
             print(f'{course} is out of sync in course_index tables')
             print(f'MONGO draft     id: {out_of_sync[course][0]}')
             print(f'MONGO published id: {out_of_sync[course][1]}')

--- a/cms/djangoapps/contentstore/management/commands/compare_course_index_entries.py
+++ b/cms/djangoapps/contentstore/management/commands/compare_course_index_entries.py
@@ -11,8 +11,8 @@ logger = logging.getLogger(__name__)
 A Command to determine if the Mongo active_versions and Django course_index tables are out of sync with one another.
 """
 
-class Command(BaseCommand):
 
+class Command(BaseCommand):
 
     """
     A Command to determine if the Mongo active_versions and Django course_index tables are out of sync with one another.
@@ -57,5 +57,5 @@ class Command(BaseCommand):
             print(f'MONGO published id: {out_of_sync[course][1]}')
             print(f'MYSQL draft     id: {out_of_sync[course][2]}')
             print(f'MYSQL published id: {out_of_sync[course][3]}')
-        print('*'*8)
+        print('*' * 8)
         print(f'The number of out-of-sync courses is : {len(out_of_sync)}')

--- a/cms/djangoapps/contentstore/management/commands/compare_course_index_entries.py
+++ b/cms/djangoapps/contentstore/management/commands/compare_course_index_entries.py
@@ -1,4 +1,4 @@
-"""A Command to determine if the Mongo active_versions and Django course_index tables are out of sync with one another."""
+"""A Command to determine if the Mongo active_versions and Django course_index tables are out of sync"""
 import logging
 from django.core.management.base import BaseCommand
 from django.conf import settings


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

In order to gain more information about ongoing questions related to the potentially out-of-sync nature of the SQL and MongoDb tables in Split Modulestore, I have created the management command to list all courses with out-of-sync active_versions and course_index entires.

This should have no direct impact on anyone, nor alter anything.

part of an on-going investigation to figure out 500 errors in studio.

## Testing instructions

to test locally, change a version value on http://localhost:18010/admin/split_modulestore_django/splitmodulestorecourseindex/,
 then from devstack run 
$make dev.shell.lms
$python manage.py cms compare_course_index_entries


## Deadline
ASAP

## Other information

Please feel free to critique all python styling
