### PR TITLE
style: bootstrap tooltip added to fix text visibility issue

### DIFF
--- a/lms/static/sass/discussion/_discussion-v1.scss
+++ b/lms/static/sass/discussion/_discussion-v1.scss
@@ -71,25 +71,6 @@
   }
 }
 
-.legacy-tooltip {
-    position: absolute;
-    z-index: 1070;
-    display: none;
-    margin: 0;
-    line-height: 1.55556;
-    font-family: "Inter","Helvetica Neue",Arial,sans-serif;
-    background: white;
-    color: black;
-    padding: 10px;
-    border-radius: 5px;
-    box-shadow: 0 0 5px rgba(0, 0, 0, 0.5);
-    &:hover,
-    &:active,
-    &:focus {
-        display: block;
-    }
-}
-
 // Layout control for discussion modules that does not apply to the discussion board
 .discussion-module {
   .discussion {

--- a/lms/templates/discussion/_switch_experience_fragment.html
+++ b/lms/templates/discussion/_switch_experience_fragment.html
@@ -12,9 +12,7 @@ from django.utils.translation import ugettext as _
     <div class="d-flex w-100 small align-items-center">
         ${_("Welcome to the new discussions experience. Please share your feedback.")}
         <a href="${legacy_url}" class="ml-2 text-white">
-            <i class="fa fa-info-circle">
-                <span class="legacy-tooltip">${_("View legacy experience")}</span>
-            </i>
+            <i class="fa fa-info-circle" data-toggle="tooltip" data-placement="bottom" title="${_('View legacy experience')}"> </i>
         </a>
     </div>
     % else:


### PR DESCRIPTION
- Fixes tooltip visibility issue for switching to legacy experience in the discussion forum. the custom CSS is not picked by component hence for the quick fix part I have added a bootstrap tooltip.

<img width="1296" alt="Screenshot 2022-07-15 at 3 34 30 PM" src="https://user-images.githubusercontent.com/67791278/179206825-3b1b3a4c-1cd2-47d0-bcde-bf3ba27549f2.png">
