### PR TITLE
fix: add staff permission to privileges check for learner tab

### DIFF
--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -1626,7 +1626,7 @@ def get_course_discussion_user_stats(
 
     """
     course_key = CourseKey.from_string(course_key_str)
-    is_privileged = has_discussion_privileges(user=request.user, course_id=course_key)
+    is_privileged = has_discussion_privileges(user=request.user, course_id=course_key) or request.user.is_staff
     if is_privileged:
         order_by = order_by or UserOrdering.BY_FLAGS
     else:


### PR DESCRIPTION
### [INF-361](https://2u-internal.atlassian.net/browse/INF-361)

#### Description
The learner area is not rendering a list of learners. Instead, ValidationError is raised when **an admin** user tries to access the learner tab. Below is the code snippet.
```    else:
        order_by = order_by or UserOrdering.BY_ACTIVITY
        if order_by != UserOrdering.BY_ACTIVITY:
            raise ValidationError({"order_by": "Invalid value"})
```

We want to set order **BY ACTIVITY** for privileged users. Currently, only **discussion roles** are considered privileged. We need to add `is_staff` check for requesting user


#### Testing Instruction

-  Log in with a staff/global user,
-  Visit the learner's tab on discussions MFE,
-  Verify that learners' stats for the course are loaded,
-  Verify that learners' stats are sorted **BY ACTIVITY**.