### PR TITLE
feat: Add core LTI 1.3 and LTI Advantage configuration to LTIConfiguration model and support XBlock using the database

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -649,7 +649,7 @@ libsass==0.10.0
     #   ora2
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==4.2.2
+lti-consumer-xblock==4.3.0
     # via -r requirements/edx/base.in
 lxml==4.9.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -850,7 +850,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/testing.txt
     #   ora2
-lti-consumer-xblock==4.2.1
+lti-consumer-xblock==4.3.0
     # via -r requirements/edx/testing.txt
 lxml==4.9.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -812,7 +812,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==4.2.1
+lti-consumer-xblock==4.3.0
     # via -r requirements/edx/base.txt
 lxml==4.9.0
     # via


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This commit updates the version of the `lti-consumer-xblock` from 4.2.2/4.2.1 to 4.3.0. This installs the newest version of the `lti-consumer-xblock` library. This version includes the following changes.

This version adds additional core LTI 1.3 and LTI Advantage variables to the `LtiConfiguration` model. The additional core LTI 1.3 variables are `lti_1p3_oidc_url, lti_1p3_launch_url`, `lti_1p3_tool_public_key`, and `lti_1p3_tool_keyset_url`. The additional LTI Advantage variables are `lti_advantage_enable_nrps`, `lti_advantage_deep_linking_enabled`, `lti_advantage_deep_linking_launch_url`, and `lti_advantage_ags_mode`.

This commit also adds a configuration type to the `LtiConsumerXBlock` to support the storage of these LTI variables on the `LtiConfiguration model` (i.e. the database) instead of the XBlock itself.

Changes that allow the use of this configuration option are behind the `lti_consumer.enable_database_config` CourseWaffleFlag.

## Supporting information

JIRA: [MST-1467](https://2u-internal.atlassian.net/browse/MST-1467)