### PR TITLE
Unpin numpy

### DIFF
--- a/requirements/edx-sandbox/py38.in
+++ b/requirements/edx-sandbox/py38.in
@@ -12,10 +12,3 @@ random2                             # Implementation of random module that works
 scipy                               # Math, science, and engineering library
 sympy                               # Symbolic math library
 codejail-includes                   # CodeJail manages execution of untrusted code in secure sandboxes.
-
-# numpy>=1.17.0 caused failures in importing numpy in code-jail environment.
-# The issue will be investigated and fixed in https://openedx.atlassian.net/browse/BOM-2841.
-numpy>=1.16.0,<1.17.0
-
-
-

--- a/requirements/edx-sandbox/py38.txt
+++ b/requirements/edx-sandbox/py38.txt
@@ -42,9 +42,8 @@ nltk==3.7
     # via
     #   -r requirements/edx-sandbox/py38.in
     #   chem
-numpy==1.16.6
+numpy==1.22.4
     # via
-    #   -r requirements/edx-sandbox/py38.in
     #   chem
     #   matplotlib
     #   openedx-calc

--- a/xmodule/capa/safe_exec/safe_exec.py
+++ b/xmodule/capa/safe_exec/safe_exec.py
@@ -28,6 +28,7 @@ from six.moves import xrange
 
 random = random_module.Random(%r)
 random.Random = random_module.Random
+random.SystemRandom = random_module.SystemRandom
 sys.modules['random'] = random
 """
 


### PR DESCRIPTION
We are using a fake `random` module which is a properly-seeded stand-in for the random module in `safe_exec.py` for loncapa problems. Numpy version(1.17.0) included a new random module in it which tries to import `from random import SystemRandom` in a sub module and fails to do so because we haven't specified this class in our stand-in random module. This PR fixes this issue and adds `SystemRandom` class to our stand-in random module.
Tested the changes on sandbox: https://numpy.sandbox.edx.org/