### PR TITLE
chore: rolling back unique entity ID validation on saml provider configs

### DIFF
--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -12,7 +12,7 @@ from config_models.models import ConfigurationModel, cache
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError
-from django.db import models, IntegrityError
+from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from organizations.models import Organization
@@ -746,7 +746,10 @@ class SAMLProviderConfig(ProviderConfig):
         # If any exist, raise an integrity error
         if existing_provider_configs:
             exc_str = f'Entity ID: {self.entity_id} already in use'
-            raise IntegrityError(exc_str)
+            # There are cases of preexisting configurations that share entity id's so we can't blow up if we
+            # encounter this issue. Instead just log for clarity.
+            # raise IntegrityError(exc_str)
+            log.warning(exc_str)
         super().save(*args, **kwargs)
 
     def get_url_params(self):

--- a/common/djangoapps/third_party_auth/samlproviderconfig/serializers.py
+++ b/common/djangoapps/third_party_auth/samlproviderconfig/serializers.py
@@ -2,9 +2,12 @@
 Serializer for SAMLProviderConfig
 """
 
+import logging
 from rest_framework import serializers
 
 from common.djangoapps.third_party_auth.models import SAMLProviderConfig, SAMLConfiguration
+
+log = logging.getLogger(__name__)
 
 
 class SAMLProviderConfigSerializer(serializers.ModelSerializer):  # lint-amnesty, pylint: disable=missing-class-docstring
@@ -27,7 +30,10 @@ class SAMLProviderConfigSerializer(serializers.ModelSerializer):  # lint-amnesty
                 entity_id=data['entity_id'],
                 archived=False,
             ).exclude(slug=data['slug']):
-                raise serializers.ValidationError(f"Entity ID: {data['entity_id']} already taken")
+                # There are cases of preexisting configurations that share entity id's so we can't blow up if we
+                # encounter this issue. Instead just log for clarity.
+                # raise serializers.ValidationError(f"Entity ID: {data['entity_id']} already taken")
+                log.warning(f"Entity ID: {data['entity_id']} already taken")
         return data
 
     def create(self, validated_data):

--- a/common/djangoapps/third_party_auth/tests/test_models.py
+++ b/common/djangoapps/third_party_auth/tests/test_models.py
@@ -1,15 +1,14 @@
 """
 Tests for third_party_auth/models.py.
 """
-import pytest
+import unittest
 from django.test import TestCase
-from django.db.utils import IntegrityError
 
 from .factories import SAMLProviderConfigFactory
 from ..models import SAMLProviderConfig
 
 
-class TestSamlProviderConfigModel(TestCase):
+class TestSamlProviderConfigModel(TestCase, unittest.TestCase):
     """
     Test model operations for the saml provider config model.
     """
@@ -22,19 +21,21 @@ class TestSamlProviderConfigModel(TestCase):
         """
         Test that the unique entity ID enforcement does not apply to noncurrent configs
         """
-        assert len(SAMLProviderConfig.objects.all()) == 1
-        old_entity_id = self.saml_provider_config.entity_id
-        self.saml_provider_config.entity_id = f'{self.saml_provider_config.entity_id}-ayylmao'
-        self.saml_provider_config.save()
+        with self.assertLogs() as ctx:
+            assert len(SAMLProviderConfig.objects.all()) == 1
+            old_entity_id = self.saml_provider_config.entity_id
+            self.saml_provider_config.entity_id = f'{self.saml_provider_config.entity_id}-ayylmao'
+            self.saml_provider_config.save()
 
-        # check that we now have two records, one non-current
-        assert len(SAMLProviderConfig.objects.all()) == 2
-        assert len(SAMLProviderConfig.objects.current_set()) == 1
+            # check that we now have two records, one non-current
+            assert len(SAMLProviderConfig.objects.all()) == 2
+            assert len(SAMLProviderConfig.objects.current_set()) == 1
 
-        # Make sure we can use that old entity id
-        SAMLProviderConfigFactory(entity_id=old_entity_id)
+            # Make sure we can use that old entity id
+            SAMLProviderConfigFactory(entity_id=old_entity_id)
 
-        # Now if we try and create a new model using a current entity ID then it should throw the integrity error
-        with pytest.raises(IntegrityError):
+            # 7/21/22 : Disabling the exception on duplicate entity ID's because of existing data.
+            # with pytest.raises(IntegrityError):
             bad_config = SAMLProviderConfig(entity_id=self.saml_provider_config.entity_id)
             bad_config.save()
+        assert ctx.records[0].msg == f'Entity ID: {self.saml_provider_config.entity_id} already in use'


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
