### PR TITLE
temp: increase grading task rate limit

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2289,7 +2289,7 @@ POLICY_CHANGE_GRADES_ROUTING_KEY = 'edx.lms.core.default'
 SOFTWARE_SECURE_VERIFICATION_ROUTING_KEY = 'edx.lms.core.default'
 
 # Rate limit for regrading tasks that a grading policy change can kick off
-POLICY_CHANGE_TASK_RATE_LIMIT = '300/h'
+POLICY_CHANGE_TASK_RATE_LIMIT = '900/h'
 
 ############## Settings for CourseGraph ############################
 

--- a/lms/djangoapps/grades/tasks.py
+++ b/lms/djangoapps/grades/tasks.py
@@ -82,7 +82,7 @@ def compute_all_grades_for_course(**kwargs):
     default_retry_delay=RETRY_DELAY_SECONDS,
     max_retries=1,
     time_limit=COURSE_GRADE_TIMEOUT_SECONDS,
-    rate_limit=settings.POLICY_CHANGE_TASK_RATE_LIMIT,
+    rate_limit='900/h',
 )
 @set_code_owner_attribute
 def compute_grades_for_course_v2(self, **kwargs):

--- a/lms/djangoapps/grades/tasks.py
+++ b/lms/djangoapps/grades/tasks.py
@@ -82,7 +82,7 @@ def compute_all_grades_for_course(**kwargs):
     default_retry_delay=RETRY_DELAY_SECONDS,
     max_retries=1,
     time_limit=COURSE_GRADE_TIMEOUT_SECONDS,
-    rate_limit='900/h',
+    rate_limit=settings.POLICY_CHANGE_TASK_RATE_LIMIT,
 )
 @set_code_owner_attribute
 def compute_grades_for_course_v2(self, **kwargs):

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3656,7 +3656,7 @@ FINANCIAL_REPORTS = {
 
 #### Grading policy change-related settings #####
 # Rate limit for regrading tasks that a grading policy change can kick off
-POLICY_CHANGE_TASK_RATE_LIMIT = '300/h'
+POLICY_CHANGE_TASK_RATE_LIMIT = '900/h'
 
 #### PASSWORD POLICY SETTINGS #####
 AUTH_PASSWORD_VALIDATORS = [


### PR DESCRIPTION
Temporarily increase the rate limit of the `compute_grades_for_course_v2` task