### PR TITLE
temp: disable outcome surveys events

### DIFF
--- a/lms/djangoapps/grades/events.py
+++ b/lms/djangoapps/grades/events.py
@@ -246,9 +246,9 @@ def fire_segment_event_on_course_grade_passed_first_time(user_id, course_locator
         'COURSE_TITLE': courserun_display_name,
         'COURSE_ORG_NAME': courserun_org,
     }
-    segment.track(user_id, event_name, event_properties)
+    if getattr(settings, 'OUTCOME_SURVEYS_EVENTS_ENABLED', False):
+        segment.track(user_id, event_name, event_properties)
 
-    if getattr(settings, 'OUTCOME_SURVEYS_FOLLOW_UP_SIGNAL_ENABLED', False):
         # fire signal so that a follow up event can be scheduled in outcome_surveys app
         SCHEDULE_FOLLOW_UP_SEGMENT_EVENT_FOR_COURSE_PASSED_FIRST_TIME.send(
             sender=None,

--- a/lms/djangoapps/grades/tests/test_signals.py
+++ b/lms/djangoapps/grades/tests/test_signals.py
@@ -389,7 +389,7 @@ class CourseEventsSignalsTest(ModuleStoreTestCase):
             }
         )
 
-    @override_settings(OUTCOME_SURVEYS_FOLLOW_UP_SIGNAL_ENABLED=True)
+    @override_settings(OUTCOME_SURVEYS_EVENTS_ENABLED=True)
     @patch('lms.djangoapps.grades.events.segment.track')
     @patch('lms.djangoapps.grades.signals.signals.SCHEDULE_FOLLOW_UP_SEGMENT_EVENT_FOR_COURSE_PASSED_FIRST_TIME.send')
     def test_segment_event_on_course_grade_passed_first_time(self, signal_mock, segment_track_mock):

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -5191,4 +5191,4 @@ MFE_CONFIG = {}
 MFE_CONFIG_API_CACHE_TIMEOUT = 60 * 5
 
 ######################## Settings for Outcome Surveys plugin ########################
-OUTCOME_SURVEYS_FOLLOW_UP_SIGNAL_ENABLED = False
+OUTCOME_SURVEYS_EVENTS_ENABLED = False


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
