### PR TITLE
fix: hidden lti_version and 1.3 fields in edit view and incorrect menu behavior in Javascript

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -658,7 +658,7 @@ libsass==0.10.0
     #   ora2
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==4.3.0
+lti-consumer-xblock==4.3.1
     # via -r requirements/edx/base.in
 lxml==4.9.1
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -862,7 +862,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/testing.txt
     #   ora2
-lti-consumer-xblock==4.3.0
+lti-consumer-xblock==4.3.1
     # via -r requirements/edx/testing.txt
 lxml==4.9.1
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -820,7 +820,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==4.3.0
+lti-consumer-xblock==4.3.1
     # via -r requirements/edx/base.txt
 lxml==4.9.1
     # via


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This commit updates the version of the `lti-consumer-xblock` from `4.3.0` to `4.3.1`. This installs the newest version of the `lti-consumer-xblock` library. This version includes the following changes.

This commit fixes three bugs.

1. The first bug is that the `lti_version` field is inappropriately hidden in the Studio author view edit menu when the selected `config_type` is `database`.

2. The second bug is that the `editable_fields` property of the `LtiConsumerXBlock` is inappropriately excluding LTI 1.3 fields when the `config_type` is `database`. The `editable_fields` property should include LTI 1.3 fields even when the `config_type` is `database`, because the Javascript defined in `xblock_studio_view.js` may want to show these fields if the user selects a different `config_type` in the menu. We want to support a dynamic edit menu, so these fields must be considered editable by the XBlock in order for the Javascript to be able to manipulate them.

3. The third bug is in inconsistent rendering of the Studio author view edit menu. Depending on the order in which a user selects `lti_version`, `config_type`, or `lti_1p3_tool_key_mode`, different sets of fields are displayed, due to the overlapping sets of rules that govern what fields should be hidden or shown for a given field selection. This commit corrects this inconsistent rendering by first showing all fields and then gradually hiding fields depending on the sets of rules, for each change to the fields.

## Supporting information

JIRA: [MST-1467](https://2u-internal.atlassian.net/browse/MST-1467)