### PR TITLE
test: add debugging log statements for user_id LtiError

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -658,7 +658,7 @@ libsass==0.10.0
     #   ora2
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==4.3.1
+lti-consumer-xblock==4.3.2
     # via -r requirements/edx/base.in
 lxml==4.9.1
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -862,7 +862,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/testing.txt
     #   ora2
-lti-consumer-xblock==4.3.1
+lti-consumer-xblock==4.3.2
     # via -r requirements/edx/testing.txt
 lxml==4.9.1
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -820,7 +820,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==4.3.1
+lti-consumer-xblock==4.3.2
     # via -r requirements/edx/base.txt
 lxml==4.9.1
     # via


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This commit updates the version of the lti-consumer-xblock from 4.3.1 to 4.3.2. This installs the newest version of the lti-consumer-xblock library. This version includes the following changes.

This version adds supplemental logging to diagnose the bug reported in [MST-1540](https://2u-internal.atlassian.net/browse/MST-1540). The bug is that learners are encountering the `LtiError` when trying to do an LTI launch. The learners appear to be authenticated, so this error should not occur. The bug is not easily reproducible in production or development, so this supplemental logging is added to help understand the user's state when the error is raised.

The current hypothesis is that user is temporarily represented by the AnonymousUser in the request that is made when doing the LTI launch, despite the user otherwise being authenticated. Logging in Splunk suggests that this is the case, because logs are of the following form, 

`2022-07-22 15:10:14,214 ERROR 5067 [django.request] [user None] [ip <ip>] log.py:224 - Internal Server Error: /courses/<course_key>/xblock/<usage_key>/handler/lti_launch_handler`,

where the "user" is "None". This logging should prove or disprove this hypothesis and provide direction about where else to look.

This logging should be removed once [MST-1540](https://2u-internal.atlassian.net/browse/MST-1540) is resolved.

## Supporting information

JIRA: [MST-1540](https://2u-internal.atlassian.net/browse/MST-1540)