### PR TITLE
Add openedx-filters hook to VerticalBlock before rendering of child blocks

### DIFF
--- a/docs/guides/hooks/filters.rst
+++ b/docs/guides/hooks/filters.rst
@@ -181,3 +181,7 @@ well as the trigger location in this same repository.
    * - `DashboardRenderStarted <https://github.com/openedx/openedx-filters/blob/main/openedx_filters/learning/filters.py#L354>`_
      - org.openedx.learning.dashboard.render.started.v1
      - `2022-06-14 <https://github.com/eduNEXT/edx-platform/blob/master/common/djangoapps/student/views/dashboard.py#L878>`_
+
+   * - `VerticalChildRenderStarted <https://github.com/openedx/openedx-filters/blob/main/openedx_filters/learning/filters.py#L427>`_
+     - org.openedx.learning.veritical_child_block.render.started.v1
+     - `2022-08-18 <https://github.com/openedx/edx-platform/blob/master/xmodule/vertical_block.py#L122>`_

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -746,7 +746,7 @@ openedx-calc==3.0.1
     # via -r requirements/edx/base.in
 openedx-events==0.11.1
     # via -r requirements/edx/base.in
-openedx-filters==0.7.0
+openedx-filters==0.8.0
     # via
     #   -r requirements/edx/base.in
     #   lti-consumer-xblock

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -974,7 +974,7 @@ openedx-calc==3.0.1
     # via -r requirements/edx/testing.txt
 openedx-events==0.11.1
     # via -r requirements/edx/testing.txt
-openedx-filters==0.7.0
+openedx-filters==0.8.0
     # via
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -921,7 +921,7 @@ openedx-calc==3.0.1
     # via -r requirements/edx/base.txt
 openedx-events==0.11.1
     # via -r requirements/edx/base.txt
-openedx-filters==0.7.0
+openedx-filters==0.8.0
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock

--- a/xmodule/vertical_block.py
+++ b/xmodule/vertical_block.py
@@ -13,6 +13,7 @@ from lxml import etree
 from web_fragments.fragment import Fragment
 from xblock.core import XBlock  # lint-amnesty, pylint: disable=wrong-import-order
 from xblock.fields import Boolean, Scope
+from openedx_filters.learning.filters import VerticalBlockChildRenderStarted
 from xmodule.mako_module import MakoTemplateBlockBase
 from xmodule.progress import Progress
 from xmodule.seq_module import SequenceFields
@@ -117,6 +118,13 @@ class VerticalBlock(
                 child_block_context['wrap_xblock_data'] = {
                     'mark-completed-on-view-after-delay': complete_on_view_delay
                 }
+
+            # .. filter_implemented_name: VerticalBlockChildRenderStarted
+            # .. filter_type: org.openedx.learning.vertical_block_child.render.started.v1
+            child, child_block_context = VerticalBlockChildRenderStarted.run_filter(
+                block=child, context=child_block_context
+            )
+
             rendered_child = child.render(view, child_block_context)
             fragment.add_fragment_resources(rendered_child)
 


### PR DESCRIPTION
## Description

Supersedes #30650

This PR introduces a new [openedx-filters](https://github.com/openedx/openedx-filters) event `org.openedx.learning.vertical_block_child.render.started.v1` hook in the platform at `xmodule/vertical_block.py`. This is implemented as a part of the effort to implement "Edit Link" in the course content for Open Source courses stored in [OLX format](https://edx.readthedocs.io/projects/edx-open-learning-xml/en/latest/front_matter/read_me.html). 

Users impacted by the change:
*  "Students"

- This doesn't introduce any changes to the UI or the VerticalBlock's rendering by itself. It provides a way to hook into the vertical block's rendering process that the plugins implementing the filter can use to introspect the child blocks and the rendering context and perform operations.

## Supporting information

No direct openedx related ticket is available. Related tickets that add context to this change are:

* https://gitlab.com/mooc-floss/mooc-floss/-/issues/112
* https://gitlab.com/mooc-floss/mooc-floss/-/issues/121
* https://github.com/open-craft/openedx-edit-links/pull/1
* https://github.com/openedx/openedx-filters/pull/38

## Testing instructions

The change can be tested as a part of testing the [openedx-edit-links plugin](https://github.com/open-craft/openedx-edit-links/pull/1)

## Deadline

"None" 

## Other information

Once accepted, this should be merged only after https://github.com/openedx/openedx-filters/pull/38 is merged and the requirements are updated.

**Settings**
```yaml
EDXAPP_EXTRA_REQUIREMENTS:
  - name: git+https://github.com/open-craft/openedx-edit-links.git@tecoholic/BB-6206-edit-links-poc
```
