### PR TITLE
feat: enable moderators to unreport content for discussion api

### DIFF
--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -21,6 +21,8 @@ from rest_framework import status
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
 from rest_framework.request import Request
+
+from lms.djangoapps.discussion.views import is_privileged_user
 from xmodule.course_module import CourseBlock
 from xmodule.modulestore.django import modulestore
 from xmodule.tabs import CourseTabList
@@ -1174,7 +1176,9 @@ def _handle_abuse_flagged_field(form_value, user, cc_content):
             else:
                 comment_flagged.send(sender='flag_abuse_for_comment', user=user, post=cc_content)
     else:
-        cc_content.unFlagAbuse(user, cc_content, removeAll=False)
+        remove_all = bool(user.id != cc_content["user_id"] and is_privileged_user(course_key,
+                                                                                  User.objects.get(id=user.id)))
+        cc_content.unFlagAbuse(user, cc_content, remove_all)
 
 
 def _handle_voted_field(form_value, cc_content, api_content, request, context):


### PR DESCRIPTION
### [INF-366](https://2u-internal.atlassian.net/browse/INF-365)

#### Description
Reported content is not being unflagged currently. Right now, if a user is not within the `abuse_flaggers` list (list of users who have reported the content), they are not able to unreport the content. 
This is not helpful to users with privileges (**Moderators, Discussion Admins etc.**), as they are not able to unreport content, and carry on with their moderation actions. This PR address this issue by using the `all` / `removeAll` param available on the API.

The PR also restrict the moderators from unreporting their own reported content with the `all` / `removeAll` flag, as we don't want moderators to remove all `abuse_flaggers` from their own reported content. 

