### PR TITLE
fix:revert api client for course UNENROLL_DONE signal

### DIFF
--- a/openedx/core/djangoapps/commerce/utils.py
+++ b/openedx/core/djangoapps/commerce/utils.py
@@ -4,6 +4,7 @@
 import requests
 from django.conf import settings
 from edx_rest_api_client.auth import SuppliedJwtAuth
+from edx_rest_api_client.client import EdxRestApiClient
 from eventtracking import tracker
 
 from openedx.core.djangoapps.oauth_dispatch.jwt import create_jwt_for_user
@@ -36,6 +37,27 @@ def get_ecommerce_api_base_url():
     Returns an E-Commerce API base URL.
     """
     return configuration_helpers.get_value('ECOMMERCE_API_URL', settings.ECOMMERCE_API_URL)
+
+
+def ecommerce_api_client(user, session=None):
+    """
+    Returns an E-Commerce API client setup with authentication for the specified user.
+
+    DEPRECATED: To be replaced with get_ecommerce_api_client.
+    """
+    claims = {'tracking_context': create_tracking_context(user)}
+    scopes = [
+        'user_id',
+        'email',
+        'profile'
+    ]
+    jwt = create_jwt_for_user(user, additional_claims=claims, scopes=scopes)
+
+    return EdxRestApiClient(
+        configuration_helpers.get_value('ECOMMERCE_API_URL', settings.ECOMMERCE_API_URL),
+        jwt=jwt,
+        session=session
+    )
 
 
 def get_ecommerce_api_client(user):


### PR DESCRIPTION
## Description

This pull request changes the API client in the course unenrolment signal residing in "openedx" part of edx-platform repository. It is required to fix the disturbed flow of coupon refunds where the Python request based client is causing the error code 405. 

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Jira: [ENT-5938](https://2u-internal.atlassian.net/jira/software/c/projects/ENT/boards/629?modal=detail&selectedIssue=ENT-5938)

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
