### PR TITLE
feat: add monitoring for users across requests

### DIFF
--- a/openedx/core/lib/x_forwarded_for/middleware.py
+++ b/openedx/core/lib/x_forwarded_for/middleware.py
@@ -56,7 +56,7 @@ class XForwardedForMiddleware(MiddlewareMixin):
             # .. custom_attribute_description: The actual contents of the raw IP chain. Could
             #      be used to correlate authenticated and unauthenticated requests for the same
             #      user.
-            set_custom_attribute('ip_chain.raw', ip_chain)
+            set_custom_attribute('ip_chain.raw', ', '.join(ip_chain))
             set_custom_attribute('ip_chain.count', len(ip_chain))
             set_custom_attribute('ip_chain.types', '-'.join(_ip_type(s) for s in ip_chain))
 

--- a/openedx/core/lib/x_forwarded_for/middleware.py
+++ b/openedx/core/lib/x_forwarded_for/middleware.py
@@ -51,6 +51,12 @@ class XForwardedForMiddleware(MiddlewareMixin):
             # Give some observability into IP chain length and composition. Useful
             # for monitoring in case of unexpected network config changes, etc.
             ip_chain = ip.get_raw_ip_chain(request)
+            
+            # .. custom_attribute_name: ip_chain.raw
+            # .. custom_attribute_description: The actual contents of the raw IP chain. Could
+            #      be used to correlate authenticated and unauthenticated requests for the same
+            #      user.
+            set_custom_attribute('ip_chain.raw', ip_chain)
             set_custom_attribute('ip_chain.count', len(ip_chain))
             set_custom_attribute('ip_chain.types', '-'.join(_ip_type(s) for s in ip_chain))
 

--- a/openedx/core/lib/x_forwarded_for/middleware.py
+++ b/openedx/core/lib/x_forwarded_for/middleware.py
@@ -51,7 +51,7 @@ class XForwardedForMiddleware(MiddlewareMixin):
             # Give some observability into IP chain length and composition. Useful
             # for monitoring in case of unexpected network config changes, etc.
             ip_chain = ip.get_raw_ip_chain(request)
-            
+
             # .. custom_attribute_name: ip_chain.raw
             # .. custom_attribute_description: The actual contents of the raw IP chain. Could
             #      be used to correlate authenticated and unauthenticated requests for the same


### PR DESCRIPTION
## Description

We already add the user id (imperfectly) to many requests.
However, when a user starts off unauthenticated, it is not
possible to correlate to those requests. Adding the raw
IP chain provides that possibility. See new custom attribute
ip_chain.raw.