### PR TITLE
feat: Add a little bit more detail to REVOKED (scheduled) bulk email tasks

### DIFF
--- a/lms/djangoapps/instructor_task/rest_api/v1/tests/test_views.py
+++ b/lms/djangoapps/instructor_task/rest_api/v1/tests/test_views.py
@@ -166,6 +166,8 @@ class TestScheduledBulkEmailAPIViews(APITestCase, ModuleStoreTestCase):
         This test verifies that, when a task schedule is cancelled, the data is in the correct state and that the task
         is no longer returned with GET requests.
         """
+        expected_task_output_msg = "Task revoked before running"
+
         self._create_scheduled_course_emails_for_course(self.course1.id, self.instructor_course1, SCHEDULED, 3)
         self.client.login(username=self.instructor_course1.username, password="test")
         response = self.client.get(self._build_api_url(self.course1.id))
@@ -189,6 +191,7 @@ class TestScheduledBulkEmailAPIViews(APITestCase, ModuleStoreTestCase):
         # verify the task status is REVOKED for the scheduled we cancelled
         task = InstructorTask.objects.get(id=task_id)
         assert task.task_state == REVOKED
+        assert json.loads(task.task_output).get("message") == expected_task_output_msg
 
     def test_delete_schedules_schedule_does_not_exist(self):
         """

--- a/lms/djangoapps/instructor_task/rest_api/v1/views.py
+++ b/lms/djangoapps/instructor_task/rest_api/v1/views.py
@@ -16,7 +16,7 @@ from rest_framework import generics, status
 
 from lms.djangoapps.bulk_email.api import update_course_email
 from lms.djangoapps.instructor_task.data import InstructorTaskTypes
-from lms.djangoapps.instructor_task.models import InstructorTaskSchedule, SCHEDULED
+from lms.djangoapps.instructor_task.models import InstructorTask, InstructorTaskSchedule, SCHEDULED
 from lms.djangoapps.instructor_task.rest_api.v1.exceptions import TaskUpdateException
 from lms.djangoapps.instructor_task.rest_api.v1.serializers import ScheduledBulkEmailSerializer
 from lms.djangoapps.instructor_task.rest_api.v1.permissions import CanViewOrModifyScheduledBulkCourseEmailTasks
@@ -106,6 +106,7 @@ class ModifyScheduledBulkEmailInstructorTask(generics.DestroyAPIView, generics.U
         # update the task's status to REVOKED and then delete the task schedule instance
         log.info(f"Revoking instructor task with id '{task.id}' for course '{task.course_id}'")
         task.task_state = REVOKED
+        task.task_output = InstructorTask.create_output_for_revoked()
         task.save()
         schedule.delete()
 


### PR DESCRIPTION
## Description

[MICROBA-1901]
- Update the task_output for (scheduled) bulk emails to include a _little_ more info when they are REVOKED.

<img width="1055" alt="image" src="https://user-images.githubusercontent.com/3229735/181798796-934d973a-c565-4769-b76b-94c306f57d37.png">
(The top row shows output after my changes, the next "revoked" item in the list shows behavior before these changes)