### PR TITLE
fix: Add default video stream priority

### DIFF
--- a/lms/djangoapps/course_api/blocks/transformers/tests/test_video_stream_priority.py
+++ b/lms/djangoapps/course_api/blocks/transformers/tests/test_video_stream_priority.py
@@ -90,12 +90,20 @@ class TestVideoBlockStreamPriorityTransformer(ModuleStoreTestCase):
                     'url': 'https://1234abc.cloudfront.net/A1234abc.mp4',
                     'file_size': 0
                 },
+                'desktop_webm': {
+                    'url': 'https://123abc.cloudfront.net/A123abc.mp4',
+                    'file_size': 0
+                },
                 'fallback': {
                     'url': 'https://1234abcd.cloudfront.net/A1234abcd.mp4',
                     'file_size': 0
                 },
                 'youtube': {
                     'url': 'https://1234abcde.cloudfront.net/A1234abcde.mp4',
+                    'file_size': 0
+                },
+                'new_video_format': {
+                    'url': 'https://1234abcdef.cloudfront.net/A1234abcdef.mp4',
                     'file_size': 0
                 }
             },
@@ -110,8 +118,12 @@ class TestVideoBlockStreamPriorityTransformer(ModuleStoreTestCase):
         post_transform_data = self.change_encoded_videos_presentation(post_transform_data['encoded_videos'])
 
         for video_format, stream_priority in post_transform_data.items():
-            assert post_transform_data[video_format] == \
-                   VideoBlockStreamPriorityTransformer.DEPRECATE_YOUTUBE_VIDEO_STREAM_PRIORITY[video_format]
+            fetched_stream_priority = VideoBlockStreamPriorityTransformer.\
+                DEPRECATE_YOUTUBE_VIDEO_STREAM_PRIORITY.get(video_format)
+            if fetched_stream_priority is None:
+                assert post_transform_data[video_format] == -1
+            else:
+                assert post_transform_data[video_format] == fetched_stream_priority
 
     @mock.patch('lms.djangoapps.course_blocks.usage_info.CourseUsageInfo')
     @mock.patch('openedx.core.djangoapps.waffle_utils.CourseWaffleFlag.is_enabled')
@@ -139,12 +151,20 @@ class TestVideoBlockStreamPriorityTransformer(ModuleStoreTestCase):
                     'url': 'https://1234abc.cloudfront.net/A1234abc.mp4',
                     'file_size': 0
                 },
+                'desktop_webm': {
+                    'url': 'https://123abc.cloudfront.net/A123abc.mp4',
+                    'file_size': 0
+                },
                 'fallback': {
                     'url': 'https://1234abcd.cloudfront.net/A1234abcd.mp4',
                     'file_size': 0
                 },
                 'youtube': {
                     'url': 'https://1234abcde.cloudfront.net/A1234abcde.mp4',
+                    'file_size': 0
+                },
+                'new_video_format': {
+                    'url': 'https://1234abcdef.cloudfront.net/A1234abcdef.mp4',
                     'file_size': 0
                 }
             },
@@ -159,8 +179,12 @@ class TestVideoBlockStreamPriorityTransformer(ModuleStoreTestCase):
         post_transform_data = self.change_encoded_videos_presentation(post_transform_data['encoded_videos'])
 
         for video_format, stream_priority in post_transform_data.items():
-            assert post_transform_data[video_format] == \
-                   VideoBlockStreamPriorityTransformer.DEFAULT_VIDEO_STREAM_PRIORITY[video_format]
+            fetched_stream_priority = VideoBlockStreamPriorityTransformer.\
+                DEFAULT_VIDEO_STREAM_PRIORITY.get(video_format)
+            if fetched_stream_priority is None:
+                assert post_transform_data[video_format] == -1
+            else:
+                assert post_transform_data[video_format] == fetched_stream_priority
 
     @mock.patch('xmodule.video_module.VideoBlock.student_view_data')
     def test_no_priority_for_web_only_videos(self, mock_video_data):

--- a/lms/djangoapps/course_api/blocks/transformers/video_stream_priority.py
+++ b/lms/djangoapps/course_api/blocks/transformers/video_stream_priority.py
@@ -15,6 +15,7 @@ class VideoBlockStreamPriorityTransformer(BlockStructureTransformer):
     If DEPRECATE_YOUTUBE waffle flag is on for a course, Youtube videos
     have highest priority i.e. 0. Else, the default priority for videos
     is as shown in DEFAULT_VIDEO_STREAM_PRIORITY below.
+    In case video_format not found in given, set stream_priority to -1.
     """
 
     WRITE_VERSION = 1
@@ -24,8 +25,9 @@ class VideoBlockStreamPriorityTransformer(BlockStructureTransformer):
         'mobile_low': 1,
         'mobile_high': 2,
         'desktop_mp4': 3,
-        'fallback': 4,
-        'youtube': 5,
+        'desktop_webm': 4,
+        'fallback': 5,
+        'youtube': 6,
     }
     DEPRECATE_YOUTUBE_VIDEO_STREAM_PRIORITY = {
         'youtube': 0,
@@ -33,7 +35,8 @@ class VideoBlockStreamPriorityTransformer(BlockStructureTransformer):
         'mobile_low': 2,
         'mobile_high': 3,
         'desktop_mp4': 4,
-        'fallback': 5,
+        'desktop_webm': 5,
+        'fallback': 6,
     }
 
     @classmethod
@@ -66,6 +69,6 @@ class VideoBlockStreamPriorityTransformer(BlockStructureTransformer):
             encoded_videos = student_view_data.get('encoded_videos')
             for video_format, video_data in encoded_videos.items():
                 if DEPRECATE_YOUTUBE.is_enabled(usage_info.course_key):
-                    video_data['stream_priority'] = self.DEPRECATE_YOUTUBE_VIDEO_STREAM_PRIORITY[video_format]
+                    video_data['stream_priority'] = self.DEPRECATE_YOUTUBE_VIDEO_STREAM_PRIORITY.get(video_format, -1)
                 else:
-                    video_data['stream_priority'] = self.DEFAULT_VIDEO_STREAM_PRIORITY[video_format]
+                    video_data['stream_priority'] = self.DEFAULT_VIDEO_STREAM_PRIORITY.get(video_format, -1)


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This is a follow-up to https://github.com/openedx/edx-platform/pull/30767. This PR adds a default stream_priority for video formats that are not configured in code.
These formats can be unknown formats or newly added formats to the platform/studio.

Useful information to include:
- This PR is created as a response to an error spike due to video formats causing KeyErrors. NewRelic link in Supporting Information.

## Supporting information

- Link to [Jira ticket](https://2u-internal.atlassian.net/browse/LEARNER-8805)
- Link to [NewRelic Error trace](https://one.newrelic.com/nr1-core/errors/overview/ODgxNzh8QVBNfEFQUExJQ0FUSU9OfDMzNDMzMjc?account=88178&duration=10800000&state=a667a351-d824-2c17-c1a8-b2e457b53126)

## Testing instructions

- Create a token via Postman: `{{domain}}/oauth2/access_token/`
- Fetch blocks via api: `{{domain}}/api/courses/v2/blocks/?depth=all&requested_fields=graded,format,student_view_multi_device,due&student_view_data=video,discussion&block_counts=video&nav_depth=3&username=edx&course_id=course-v1%3AedX%2BDemoX%2BDemo_Course`

## Deadline

Preferably early to fix mentioned Error spike.

