### PR TITLE
[BD-13][BB-6442] refactor: remove `field_data` usage by all `DescriptorSystem` subclasses

### DIFF
--- a/xmodule/modulestore/mongo/base.py
+++ b/xmodule/modulestore/mongo/base.py
@@ -204,7 +204,6 @@ class CachingDescriptorSystem(MakoDescriptorSystem, EditInfoRuntimeMixin):  # li
         kwargs.setdefault('id_reader', id_manager)
         kwargs.setdefault('id_generator', id_manager)
         super().__init__(
-            field_data=None,
             load_item=self.load_item,
             **kwargs
         )

--- a/xmodule/modulestore/split_mongo/caching_descriptor_system.py
+++ b/xmodule/modulestore/split_mongo/caching_descriptor_system.py
@@ -60,7 +60,6 @@ class CachingDescriptorSystem(MakoDescriptorSystem, EditInfoRuntimeMixin):  # li
         kwargs.setdefault('id_generator', id_manager)
 
         super().__init__(
-            field_data=None,
             load_item=self._load_item,
             resources_fs=OSFS(root),
             **kwargs

--- a/xmodule/modulestore/xml.py
+++ b/xmodule/modulestore/xml.py
@@ -493,7 +493,9 @@ class XMLModuleStore(ModuleStoreReadBase):
                 """
                 return policy.get(policy_key(usage_id), {})
 
-            services = {}
+            services = {
+                'field-data': self.field_data
+            }
             if self.i18n_service:
                 services['i18n'] = self.i18n_service
 
@@ -513,7 +515,6 @@ class XMLModuleStore(ModuleStoreReadBase):
                 mixins=self.xblock_mixins,
                 default_class=self.default_class,
                 select=self.xblock_select,
-                field_data=self.field_data,
                 services=services,
                 target_course_id=target_course_id,
             )

--- a/xmodule/modulestore/xml_importer.py
+++ b/xmodule/modulestore/xml_importer.py
@@ -954,7 +954,7 @@ def _import_course_draft(
         error_tracker=errorlog.tracker,
         load_error_modules=False,
         mixins=xml_module_store.xblock_mixins,
-        field_data=KvsFieldData(kvs=DictKeyValueStore()),
+        services={'field-data': KvsFieldData(kvs=DictKeyValueStore())},
         target_course_id=target_id,
     )
 

--- a/xmodule/tests/__init__.py
+++ b/xmodule/tests/__init__.py
@@ -182,7 +182,6 @@ def get_test_descriptor_system(render_template=None):
         error_tracker=Mock(name='get_test_descriptor_system.error_tracker'),
         render_template=render_template or mock_render_template,
         mixins=(InheritanceMixin, XModuleMixin),
-        field_data=field_data,
         services={'field-data': field_data},
     )
     descriptor_system.get_asides = lambda block: []

--- a/xmodule/tests/test_course_module.py
+++ b/xmodule/tests/test_course_module.py
@@ -55,7 +55,7 @@ class DummySystem(ImportSystem):  # lint-amnesty, pylint: disable=abstract-metho
             course_dir=course_dir,
             error_tracker=error_tracker,
             load_error_modules=load_error_modules,
-            field_data=KvsFieldData(DictKeyValueStore()),
+            services={'field-data': KvsFieldData(DictKeyValueStore())},
         )
 
 

--- a/xmodule/tests/test_import.py
+++ b/xmodule/tests/test_import.py
@@ -49,7 +49,7 @@ class DummySystem(ImportSystem):  # lint-amnesty, pylint: disable=abstract-metho
             error_tracker=error_tracker,
             load_error_modules=load_error_modules,
             mixins=(InheritanceMixin, XModuleMixin),
-            field_data=KvsFieldData(DictKeyValueStore()),
+            services={'field-data': KvsFieldData(DictKeyValueStore())},
         )
 
     def render_template(self, _template, _context):  # lint-amnesty, pylint: disable=method-hidden

--- a/xmodule/tests/xml/__init__.py
+++ b/xmodule/tests/xml/__init__.py
@@ -38,7 +38,7 @@ class InMemorySystem(XMLParsingSystem, MakoDescriptorSystem):  # pylint: disable
             mixins=xml_import_data.xblock_mixins,
             select=xml_import_data.xblock_select,
             render_template=lambda template, context: pprint.pformat((template, context)),
-            field_data=KvsFieldData(DictKeyValueStore()),
+            services={'field-data': KvsFieldData(DictKeyValueStore())},
         )
 
     def process_xml(self, xml):  # pylint: disable=method-hidden


### PR DESCRIPTION
## Description

Removes `field_data` usage by all `DescriptorSystem` subclasses in favor of Runtime's `field-data` service. See [this PR](https://github.com/openedx/edx-platform/pull/30644)'s description for more details on why this change is safe:
>So, to summarize: unless there is at least one runtime, which is using field_data or _deprecated_per_instance_field_data, we're safe to remove this property from ModuleSystem and other Runtime subclasses. For instance, [xblock-sdk](https://github.com/openedx/xblock-sdk)'s runtime never used old field_data, only runtime service.

## Testing instructions

Test that the platform generally works as expected, including course export and import.
Sandbox: https://extpr30811.sandbox.opencraft.hosting.
Credentials: `staff@example.com;edx`.