### PR TITLE
fix: Use non-yanked version of snowflake-python-connector

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -1021,7 +1021,7 @@ slumber==0.7.1
     #   edx-bulk-grades
     #   edx-enterprise
     #   edx-rest-api-client
-snowflake-connector-python==2.7.10
+snowflake-connector-python==2.7.11
     # via edx-enterprise
 social-auth-app-django==5.0.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1412,7 +1412,7 @@ sniffio==1.2.0
     #   anyio
 snowballstemmer==2.2.0
     # via sphinx
-snowflake-connector-python==2.7.10
+snowflake-connector-python==2.7.11
     # via
     #   -r requirements/edx/testing.txt
     #   edx-enterprise

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1326,7 +1326,7 @@ slumber==0.7.1
     #   edx-rest-api-client
 sniffio==1.2.0
     # via anyio
-snowflake-connector-python==2.7.10
+snowflake-connector-python==2.7.11
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise


### PR DESCRIPTION
2.7.10 was yanked for not having the right dependency constraints:
https://github.com/snowflakedb/snowflake-connector-python/issues/1206#issuecomment-1195840226