### PR TITLE
fix: Fixed broken HiddenContentTransformer when course pacing is self_paced

### DIFF
--- a/lms/djangoapps/course_blocks/transformers/hidden_content.py
+++ b/lms/djangoapps/course_blocks/transformers/hidden_content.py
@@ -10,7 +10,7 @@ from pytz import utc
 from openedx.core.djangoapps.content.block_structure.transformer import BlockStructureTransformer
 from xmodule.seq_module import SequenceBlock  # lint-amnesty, pylint: disable=wrong-import-order
 
-from .utils import collect_merged_boolean_field
+from .utils import collect_merged_boolean_field, collect_merged_date_field
 
 MAXIMUM_DATE = utc.localize(datetime.max)
 
@@ -31,9 +31,10 @@ class HiddenContentTransformer(BlockStructureTransformer):
     IMPORTANT: Must be run _after_ the DateOverrideTransformer from edx-when
     in case the 'due' date on a block has been shifted for a user.
     """
-    WRITE_VERSION = 3
+    WRITE_VERSION = 4
     READ_VERSION = 3
     MERGED_HIDE_AFTER_DUE = 'merged_hide_after_due'
+    MERGED_END_DATE = 'merged_end_date'
 
     @classmethod
     def name(cls):
@@ -65,6 +66,13 @@ class HiddenContentTransformer(BlockStructureTransformer):
             transformer=cls,
             xblock_field_name='hide_after_due',
             merged_field_name=cls.MERGED_HIDE_AFTER_DUE,
+        )
+        collect_merged_date_field(
+            block_structure,
+            transformer=cls,
+            xblock_field_name='end',
+            merged_field_name=cls.MERGED_END_DATE,
+            default_date=MAXIMUM_DATE
         )
 
         block_structure.request_xblock_fields('self_paced', 'end', 'due')


### PR DESCRIPTION
This PR has changes to fix a [issue](https://discuss.openedx.org/t/attributeerror-field-end-does-not-exist-on-get-block-api-request/7481) reported on openedx forum.

Step to reproduce issue.
1. Create a course with course pacing set to self paced
2. Added few sections, subsection, units and few components in those units
3. Set course start date, enrollment date in past 
4. Create a learner account and enroll in the newly created course
5. Try to access course block using course blocks API
http://localhost:18000/api/courses/v1/blocks/{block_usage_key}/?username={learner_username}&depth=all
6. It should throw `AttributeError: Field end does not exist`

In case of self paced course we are relying on course end date to determine if a block is visible or not. However, when course blocks API is called with a block_key it breaks since blocks do not have `end` field instead only course block has `end` field. Changes in this PR fetch `end` date of block from parent or ancestors blocks.

Part 1/2 - Updating collect method + updating Write version
see also #30589