### PR TITLE
fix: missing exception details in xblock-lti-consumer logs

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -656,7 +656,7 @@ libsass==0.10.0
     #   ora2
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==4.3.2
+lti-consumer-xblock==4.3.3
     # via -r requirements/edx/base.in
 lxml==4.9.1
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -860,7 +860,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/testing.txt
     #   ora2
-lti-consumer-xblock==4.3.2
+lti-consumer-xblock==4.3.3
     # via -r requirements/edx/testing.txt
 lxml==4.9.1
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -818,7 +818,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==4.3.2
+lti-consumer-xblock==4.3.3
     # via -r requirements/edx/base.txt
 lxml==4.9.1
     # via


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This commit updates the version of the lti-consumer-xblock from 4.3.2 to 4.3.3. This installs the newest version of the lti-consumer-xblock library. This version includes the following changes.

The error handler in LtiConsumerXBlock.lti_1p3_launch_callback logs a warning when a select set of exceptions are handled. That log does not contain useful information about the nature of the exception, because the exceptions were not being instantiated with error messages. The try...catch is a large block that contains code that can raise a multitude of errors, so these changes will enable better debugging.

This commit:
* adds helpful messages to the raised exceptions.
* adds the "exc_info=True" argument to include the stack trace of the handled exception.
* adds ValueError and TypeError to the list of handled exceptions, because the code can raise exceptions of these types.