### PR TITLE
fix: show general recommendations on error or empty list

### DIFF
--- a/lms/djangoapps/learner_dashboard/api/utils.py
+++ b/lms/djangoapps/learner_dashboard/api/utils.py
@@ -22,10 +22,12 @@ def get_personalized_course_recommendations(user_id):
         response = requests.get(settings.AMPLITUDE_URL, params=params, headers=headers)
         if response.status_code == 200:
             response = response.json()
-            is_control = response['userData']['recommendations'][0]['is_control']
-            course_keys = response['userData']['recommendations'][0]['items']
-            return is_control, course_keys
+            recommendations = response.get('userData', {}).get('recommendations', [])
+            if recommendations:
+                is_control = recommendations[0].get('is_control')
+                recommended_course_keys = recommendations[0].get('items')
+                return is_control, recommended_course_keys
     except Exception as ex:  # pylint: disable=broad-except
-        log.exception(f'Cannot get recommendations from Amplitude: {ex}')
+        log.warning(f'Cannot get recommendations from Amplitude: {ex}')
 
     return True, []

--- a/lms/djangoapps/learner_dashboard/api/v0/views.py
+++ b/lms/djangoapps/learner_dashboard/api/v0/views.py
@@ -365,21 +365,18 @@ class CourseRecommendationApiView(APIView):
             }
         )
 
-        if is_control:
+        if is_control or not course_keys:
             return Response(status=400)
 
         recommended_courses = []
-        if course_keys is not None:
-            for course_id in course_keys:
-                course_data = get_course_data(course_id)
-                if course_data:
-                    recommended_courses.append({
-                        'course_key': course_id,
-                        'title': course_data['title'],
-                        'logo_image_url': course_data['owners'][0]['logo_image_url'],
-                        'marketing_url': course_data.get('marketing_url')
-                    })
-                else:
-                    return Response(status=400)
+        for course_id in course_keys:
+            course_data = get_course_data(course_id)
+            if course_data:
+                recommended_courses.append({
+                    'course_key': course_id,
+                    'title': course_data['title'],
+                    'logo_image_url': course_data['owners'][0]['logo_image_url'],
+                    'marketing_url': course_data.get('marketing_url')
+                })
 
         return Response({'courses': recommended_courses, 'is_personalized_recommendation': not is_control}, status=200)

--- a/lms/static/js/learner_dashboard/RecommendationsPanel.jsx
+++ b/lms/static/js/learner_dashboard/RecommendationsPanel.jsx
@@ -40,15 +40,21 @@ class RecommendationsPanel extends React.Component {
         if (response.status === 400) {
           return this.props.generalRecommendations;
         } else {
-          return response.json();
+          const recommendationsData = response.json();
+          if (recommendationsData.courses.length > 0) {
+            return recommendationsData
+          } else {
+            return this.props.generalRecommendations;
+          }
+          
         }
       }).catch(() => {
         return this.props.generalRecommendations;
       });
 
     this.setState({
-      coursesList: coursesRecommendationData['courses'],
-      isPersonalizedRecommendation: coursesRecommendationData['is_personalized_recommendation']
+      coursesList: coursesRecommendationData.courses,
+      isPersonalizedRecommendation: coursesRecommendationData.is_personalized_recommendation
     });
   };
 


### PR DESCRIPTION
## Description
Currently, the loading sign shows indefinitely if the recommendation API response is 200 with an empty recommended courses list. Fix, it by showing the general recommendations.

[VAN-1034](https://2u-internal.atlassian.net/browse/VAN-1034)