### PR TITLE
fix: broken promise for personalized recommendations

### DIFF
--- a/lms/static/js/learner_dashboard/RecommendationsPanel.jsx
+++ b/lms/static/js/learner_dashboard/RecommendationsPanel.jsx
@@ -40,12 +40,7 @@ class RecommendationsPanel extends React.Component {
         if (response.status === 400) {
           return this.props.generalRecommendations;
         } else {
-          const recommendationsData = response.json();
-          if (recommendationsData.courses.length > 0) {
-            return recommendationsData
-          } else {
-            return this.props.generalRecommendations;
-          }
+          return response.json();
           
         }
       }).catch(() => {


### PR DESCRIPTION
After https://github.com/openedx/edx-platform/pull/30827 merge, the general recommendations are getting rendered even if there are personalized available in API response due to a broken promise.
 
[VAN-1034](https://2u-internal.atlassian.net/browse/VAN-1034)