### PR TITLE
feat: add feature flag to enable legacy md5 hash for anonymous user id

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -516,6 +516,17 @@ FEATURES = {
     #   in the LMS and CMS.
     # .. toggle_tickets: 'https://github.com/open-craft/edx-platform/pull/429'
     'DISABLE_UNENROLLMENT': False,
+
+    # .. toggle_name: FEATURES['ENABLE_LEGACY_MD5_HASH_FOR_ANONYMOUS_USER_ID']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Whether to enable the legacy MD5 hashing algorithm to generate anonymous user id
+    #   instead of the newer SHAKE128 hashing algorithm
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2022-08-08
+    # .. toggle_target_removal_date: None
+    # .. toggle_tickets: 'https://github.com/openedx/edx-platform/pull/30832'
+    'ENABLE_LEGACY_MD5_HASH_FOR_ANONYMOUS_USER_ID': False,
 }
 
 # .. toggle_name: ENABLE_COPPA_COMPLIANCE

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -215,12 +215,22 @@ def anonymous_id_for_user(user, course_id):
         # function: Rotate at will, since the hashes are stored and
         # will not change.
         # include the secret key as a salt, and to make the ids unique across different LMS installs.
-        hasher = hashlib.shake_128()
+        legacy_hash_enabled = settings.FEATURES.get('ENABLE_LEGACY_MD5_HASH_FOR_ANONYMOUS_USER_ID', False)
+        if legacy_hash_enabled:
+            # Use legacy MD5 algorithm if flag enabled
+            hasher = hashlib.md5()
+        else:
+            hasher = hashlib.shake_128()
+
         hasher.update(settings.SECRET_KEY.encode('utf8'))
         hasher.update(str(user.id).encode('utf8'))
         if course_id:
             hasher.update(str(course_id).encode('utf-8'))
-        anonymous_user_id = hasher.hexdigest(16)  # pylint: disable=too-many-function-args
+
+        if legacy_hash_enabled:
+            anonymous_user_id = hasher.hexdigest()
+        else:
+            anonymous_user_id = hasher.hexdigest(16)  # pylint: disable=too-many-function-args
 
         try:
             AnonymousUserId.objects.create(

--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -1057,6 +1057,17 @@ class AnonymousLookupTable(ModuleStoreTestCase):
             assert anonymous_id != new_anonymous_id
             assert self.user == user_by_anonymous_id(new_anonymous_id)
 
+    def test_enable_legacy_hash_flag(self):
+        """Test that different anonymous id returned if ENABLE_LEGACY_MD5_HASH_FOR_ANONYMOUS_USER_ID enabled."""
+        CourseEnrollment.enroll(self.user, self.course.id)
+        anonymous_id = anonymous_id_for_user(self.user, self.course.id)
+        with patch.dict(settings.FEATURES, ENABLE_LEGACY_MD5_HASH_FOR_ANONYMOUS_USER_ID=True):
+            # Recreate user object to clear cached anonymous id.
+            self.user = User.objects.get(pk=self.user.id)
+            AnonymousUserId.objects.filter(user=self.user).filter(course_id=self.course.id).delete()
+            new_anonymous_id = anonymous_id_for_user(self.user, self.course.id)
+            assert anonymous_id != new_anonymous_id
+
 
 @skip_unless_lms
 @patch('openedx.core.djangoapps.programs.utils.get_programs')

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1018,6 +1018,17 @@ FEATURES = {
     # .. toggle_target_removal_date: None
     # .. toggle_tickets: 'https://openedx.atlassian.net/browse/MST-1458'
     'ENABLE_CERTIFICATES_IDV_REQUIREMENT': False,
+
+    # .. toggle_name: FEATURES['ENABLE_LEGACY_MD5_HASH_FOR_ANONYMOUS_USER_ID']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Whether to enable the legacy MD5 hashing algorithm to generate anonymous user id
+    #   instead of the newer SHAKE128 hashing algorithm
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2022-08-08
+    # .. toggle_target_removal_date: None
+    # .. toggle_tickets: 'https://github.com/openedx/edx-platform/pull/30832'
+    'ENABLE_LEGACY_MD5_HASH_FOR_ANONYMOUS_USER_ID': False,
 }
 
 # Specifies extra XBlock fields that should available when requested via the Course Blocks API


### PR DESCRIPTION
## Description

PR #26198 changed the hash algorithm to generate an anonymous user id from MD5 to SHAKE-128.

However, there are Open edX operators who maintain backward compatibility of anonymous user IDs after past rotations of their Django secret key. For them, altering the hashing algorithm was a breaking change that made their analytics inconsistent.

This PR, introduces a feature flag, to enable Open edX operators to switch back to the legacy MD5 algorithm if they so require.


## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

1. Checkout this branch in devstack
2. Browse any course.
3. Open LMS shell and retrieve the anonymous user id for the user/course using 
```Python
from common.djangoapps.student.models import AnonymousUserId
anonymous_user_ids = AnonymousUserId.objects.filter(user=8).filter(course_id='course-v1:edX+DemoX+Demo_Course').order_by('-id')
```
4. Note this anonymous id down
5. Delete the anonymous user id
```Python
anonymous_user_ids[0].delete()
```
6. Open `/edx/etc/lms.yml`
7. Under `Features` add the new Flag
```yaml
FEATURES:
    ENABLE_LEGACY_MD5_HASH_FOR_ANONYMOUS_USER_ID: true
```
8. Rerun steps 2 to 4.
9. Verify the anonymous user ids are different

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Private Ref: [BB-6533](https://tasks.opencraft.com/browse/BB-6533)
