### PR TITLE
feat: add new template text for raw html editor

### DIFF
--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -331,7 +331,6 @@ def get_component_templates(courselike, library=False):  # lint-amnesty, pylint:
                     support_level_with_template = component_support_level(
                         authorable_variations, category, template_id
                     )
-                    print("PRINTING TEMPLATE ID", template_id)
                     if support_level_with_template:
                         # Tab can be 'common' 'advanced'
                         # Default setting is common/advanced depending on the presence of markdown

--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -20,6 +20,7 @@ from xblock.exceptions import NoSuchHandlerError
 from xblock.plugin import PluginMissingError
 from xblock.runtime import Mixologist
 
+from cms.djangoapps.contentstore.toggles import use_new_text_editor
 from common.djangoapps.edxmako.shortcuts import render_to_response
 from common.djangoapps.student.auth import has_course_author_access
 from common.djangoapps.xblock_django.api import authorable_xblocks, disabled_xblocks
@@ -32,8 +33,6 @@ from xmodule.modulestore.exceptions import ItemNotFoundError  # lint-amnesty, py
 from ..utils import get_lms_link_for_item, get_sibling_urls, reverse_course_url
 from .helpers import get_parent_xblock, is_unit, xblock_type_display_name
 from .item import StudioEditModuleRuntime, add_container_page_publishing_info, create_xblock_info
-
-from cms.djangoapps.contentstore.toggles import use_new_text_editor
 
 __all__ = [
     'container_handler',

--- a/xmodule/templates/html/react_raw.yaml
+++ b/xmodule/templates/html/react_raw.yaml
@@ -1,0 +1,9 @@
+---
+metadata:
+    display_name: Raw HTML
+    editor: raw
+data: |
+      <p>This is a Raw HTML editor that saves your HTML exactly as you enter it.
+      This means that even malformed HTML tags will be saved and rendered as-is.
+      There is no way to switch between Raw and Visual Text editor types, so be
+      sure this is the editor you should be using!</p>


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This PR changes the default text in a Raw HTML Text Editor depending on the value of the  `new_core_editors.use_new_text_editor` waffle flag. The new Text Editor has separate instances for Text and Raw HTML. Therefore the current default text in Raw HTML is no longer applicable. The Course Author will be impacted by this change. 

## Supporting information

Jira Ticket: [TNL-10045](https://2u-internal.atlassian.net/browse/TNL-10045)

## Testing instructions

1. Open a course outline and select a unit to edit
2. Add a new text component
3. Select Raw HTML
4. The default text should be

```      
<p>This template is similar to the Text template. The only difference is 
that this template opens in the Raw HTML editor rather than in the Visual
editor.</p>
<p>The Raw HTML editor saves your HTML exactly as you enter it.
You can switch to the Visual editor by clicking the Settings tab and 
changing the Editor setting to Visual. Note, however, that some of your 
HTML may be modified when you save the component if you switch to the 
Visual editor.</p>
```

5. Turn on the `new_core_editors.use_new_text_editor` waffle flag
6. Re-open course outline and select a unit to edit
7. Add a new text component
8. Select Raw HTML
9. The default text should be

```
<p>This is a Raw HTML editor that saves your HTML exactly as you enter it.
This means that even malformed HTML tags will be saved and rendered as-is.
There is no way to switch between Raw and Visual Text editor types, so be
sure this is the editor you should be using!</p>
```

## Deadline

None
