### PR TITLE
chore: bumping enterprise requirements to 3.56.1

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -25,7 +25,7 @@ django-storages<1.9
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==3.56.0
+edx-enterprise==3.56.1
 
 # oauthlib>3.0.1 causes test failures ( also remove the django-oauth-toolkit constraint when this is fixed )
 oauthlib==3.0.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -475,7 +475,7 @@ edx-drf-extensions==8.0.1
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.56.0
+edx-enterprise==3.56.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -590,7 +590,7 @@ edx-drf-extensions==8.0.1
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.56.0
+edx-enterprise==3.56.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -569,7 +569,7 @@ edx-drf-extensions==8.0.1
     #   edx-rbac
     #   edx-when
     #   edxval
-edx-enterprise==3.56.0
+edx-enterprise==3.56.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

https://github.com/openedx/edx-enterprise/pull/1615
