### PR TITLE
[BD-38] fix: hide discussion xblock for openedx provider

### DIFF
--- a/lms/djangoapps/courseware/tests/test_discussion_xblock.py
+++ b/lms/djangoapps/courseware/tests/test_discussion_xblock.py
@@ -162,7 +162,10 @@ class TestViews(TestDiscussionXBlock):
         assert fragment.content == self.template_canary
         self.render_template.assert_called_once_with(
             'discussion/_discussion_inline_studio.html',
-            {'discussion_id': self.discussion_id}
+            {
+                'discussion_id': self.discussion_id,
+                'is_visible': True,
+            }
         )
 
     @ddt.data(

--- a/lms/djangoapps/courseware/tests/test_discussion_xblock.py
+++ b/lms/djangoapps/courseware/tests/test_discussion_xblock.py
@@ -14,7 +14,6 @@ from unittest import mock
 import ddt
 from django.urls import reverse
 from opaque_keys.edx.keys import CourseKey
-from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration, Provider
 from web_fragments.fragment import Fragment
 from xblock.field_data import DictFieldData
 from xmodule.discussion_block import DiscussionXBlock, loader
@@ -25,6 +24,7 @@ from xmodule.modulestore.tests.factories import ItemFactory, ToyCourseFactory
 from lms.djangoapps.course_api.blocks.tests.helpers import deserialize_usage_key
 from lms.djangoapps.courseware.module_render import get_module_for_descriptor_internal
 from lms.djangoapps.courseware.tests.helpers import XModuleRenderingTestBase
+from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration, Provider
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
 
 
@@ -427,12 +427,13 @@ class TestXBlockQueryLoad(SharedModuleStoreTestCase):
                 discussion_target='Target Discussion',
             ))
 
-        # 4 queries are required to do first discussion xblock render:
+        # 5 queries are required to do first discussion xblock render:
         # * split_modulestore_django_splitmodulestorecourseindex x2
         # * waffle_utils_waffleorgoverridemodel
         # * django_comment_client_role
+        # * DiscussionsConfiguration
 
-        num_queries = 4
+        num_queries = 5
 
         for discussion in discussions:
             discussion_xblock = get_module_for_descriptor_internal(
@@ -448,7 +449,8 @@ class TestXBlockQueryLoad(SharedModuleStoreTestCase):
 
             # Permissions are cached, so no queries required for subsequent renders
 
-            num_queries = 0
+            # Only query to check for provider_type
+            num_queries = 1
 
             html = fragment.content
             assert 'data-user-create-comment="false"' in html

--- a/lms/djangoapps/courseware/tests/test_discussion_xblock.py
+++ b/lms/djangoapps/courseware/tests/test_discussion_xblock.py
@@ -430,13 +430,14 @@ class TestXBlockQueryLoad(SharedModuleStoreTestCase):
                 discussion_target='Target Discussion',
             ))
 
-        # 5 queries are required to do first discussion xblock render:
+        # 6 queries are required to do first discussion xblock render:
         # * split_modulestore_django_splitmodulestorecourseindex x2
-        # * waffle_utils_waffleorgoverridemodel
+        # * waffle_flag.discussions.enable_new_structure_discussions
+        # * lms_xblock_xblockasidesconfig
         # * django_comment_client_role
         # * DiscussionsConfiguration
 
-        num_queries = 5
+        num_queries = 6
 
         for discussion in discussions:
             discussion_xblock = get_module_for_descriptor_internal(
@@ -452,8 +453,9 @@ class TestXBlockQueryLoad(SharedModuleStoreTestCase):
 
             # Permissions are cached, so no queries required for subsequent renders
 
-            # Only query to check for provider_type
-            num_queries = 1
+            # query to check for provider_type
+            # query to check waffle flag discussions.enable_new_structure_discussions
+            num_queries = 2
 
             html = fragment.content
             assert 'data-user-create-comment="false"' in html

--- a/lms/templates/discussion/_discussion_inline_studio.html
+++ b/lms/templates/discussion/_discussion_inline_studio.html
@@ -7,6 +7,9 @@
             <span class="icon fa fa-comment"/>
             ${_("To view live discussions, click Preview or View Live in Unit Settings.")}<br />
             ${_("Discussion ID: {discussion_id}").format(discussion_id=discussion_id)}
+            % if not is_visible:
+            <br /><b>${_('Due to the discussion provider not being set to "legacy", this block will not be visible.')}</b>
+            % endif
         </span>
     </p>
 </div>

--- a/lms/templates/discussion/_discussion_inline_studio.html
+++ b/lms/templates/discussion/_discussion_inline_studio.html
@@ -8,7 +8,7 @@
             ${_("To view live discussions, click Preview or View Live in Unit Settings.")}<br />
             ${_("Discussion ID: {discussion_id}").format(discussion_id=discussion_id)}
             % if not is_visible:
-            <br /><b>${_('Due to the discussion provider not being set to "legacy", this block will not be visible.')}</b>
+            <br /><b>${_('The discussion block is disabled for this course as it is not using a compatible discussion provider.')}</b>
             % endif
         </span>
     </p>

--- a/xmodule/discussion_block.py
+++ b/xmodule/discussion_block.py
@@ -90,7 +90,6 @@ class DiscussionXBlock(XBlock, StudioEditableXBlockMixin, XmlParserMixin):  # li
         provider = DiscussionsConfiguration.get(self.course_key)
         return provider.provider_type == Provider.LEGACY
 
-
     @property
     def django_user(self):
         """

--- a/xmodule/discussion_block.py
+++ b/xmodule/discussion_block.py
@@ -8,6 +8,7 @@ import urllib
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.urls import reverse
 from django.utils.translation import get_language_bidi
+from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration, Provider
 from web_fragments.fragment import Fragment
 from xblock.completable import XBlockCompletionMode
 from xblock.core import XBlock
@@ -162,8 +163,13 @@ class DiscussionXBlock(XBlock, StudioEditableXBlockMixin, XmlParserMixin):  # li
         Renders student view for LMS.
         """
         fragment = Fragment()
-        self.add_resource_urls(fragment)
 
+        # Discussion Xblock does not support new OPEN_EDX provider
+        provider = DiscussionsConfiguration.get(self.course_key)
+        if provider.provider_type == Provider.OPEN_EDX:
+            return fragment
+
+        self.add_resource_urls(fragment)
         login_msg = ''
 
         if not self.django_user.is_authenticated:

--- a/xmodule/discussion_block.py
+++ b/xmodule/discussion_block.py
@@ -83,6 +83,15 @@ class DiscussionXBlock(XBlock, StudioEditableXBlockMixin, XmlParserMixin):  # li
         return getattr(self.scope_ids.usage_id, 'course_key', None)
 
     @property
+    def is_visible(self):
+        """
+        Discussion Xblock does not support new OPEN_EDX provider
+        """
+        provider = DiscussionsConfiguration.get(self.course_key)
+        return provider.provider_type == Provider.LEGACY
+
+
+    @property
     def django_user(self):
         """
         Returns django user associated with user currently interacting
@@ -164,9 +173,7 @@ class DiscussionXBlock(XBlock, StudioEditableXBlockMixin, XmlParserMixin):  # li
         """
         fragment = Fragment()
 
-        # Discussion Xblock does not support new OPEN_EDX provider
-        provider = DiscussionsConfiguration.get(self.course_key)
-        if provider.provider_type == Provider.OPEN_EDX:
+        if not self.is_visible:
             return fragment
 
         self.add_resource_urls(fragment)
@@ -216,7 +223,10 @@ class DiscussionXBlock(XBlock, StudioEditableXBlockMixin, XmlParserMixin):  # li
         fragment = Fragment()
         fragment.add_content(self.runtime.service(self, 'mako').render_template(
             'discussion/_discussion_inline_studio.html',
-            {'discussion_id': self.discussion_id}
+            {
+                'discussion_id': self.discussion_id,
+                'is_visible': self.is_visible,
+            }
         ))
         return fragment
 

--- a/xmodule/discussion_block.py
+++ b/xmodule/discussion_block.py
@@ -8,7 +8,6 @@ import urllib
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.urls import reverse
 from django.utils.translation import get_language_bidi
-from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration, Provider
 from web_fragments.fragment import Fragment
 from xblock.completable import XBlockCompletionMode
 from xblock.core import XBlock
@@ -16,6 +15,7 @@ from xblock.fields import UNIQUE_ID, Scope, String
 from xblockutils.resources import ResourceLoader
 from xblockutils.studio_editable import StudioEditableXBlockMixin
 
+from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration, Provider
 from openedx.core.djangolib.markup import HTML, Text
 from openedx.core.lib.xblock_utils import get_css_dependencies, get_js_dependencies
 from xmodule.xml_module import XmlParserMixin


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Open edX now support multiple discussion providers. One of them is the "legacy" provider and another is the newer "openedx" provider. The Discussion XBlock is only supported for the older legacy provider.

~This MR hides the xblock if provider is set to `openedx`.~
This MR hides the xblock if provider is not set to `legacy` as well as adds a message in studio.

## Testing instructions

1. Setup course with discussion xblock or use demo course which has a discussion xblock added in chapter 3: Be social.
2. First make sure that you can see the discussion xblock
3. Goto http://localhost:18000/admin/discussions/discussionsconfiguration/ and select the course.
4. Change `Discussion provider` to "openedx"
5. Reload the course chapter which contains discussion xblock. It should not visible. 
6. Reload studio and verify that a message appears in discussion block stating that the block will not be visible.

## Other information

`Private-ref:` [BB-6509](https://tasks.opencraft.com/browse/BB-6509)
