### PR TITLE
fix: Temporary fix for learners stats api performance issue

### DIFF
--- a/lms/djangoapps/discussion/config/waffle.py
+++ b/lms/djangoapps/discussion/config/waffle.py
@@ -11,8 +11,8 @@ WAFFLE_NAMESPACE = 'discussions'
 # .. toggle_default: False
 # .. toggle_description: Waffle flag to enable learners stats
 # .. toggle_use_cases: temporary, open_edx
-# .. toggle_creation_date: 2022-03-02
-# .. toggle_target_removal_date: 2022-06-02
+# .. toggle_creation_date: 2022-08-12
+# .. toggle_target_removal_date: 2022-10-02
 # .. toggle_warning: When the flag is ON, API will return learners stats with null values.
 # .. This is temporary fix for performance issue in API.
 # .. toggle_tickets: INF-444

--- a/lms/djangoapps/discussion/config/waffle.py
+++ b/lms/djangoapps/discussion/config/waffle.py
@@ -17,6 +17,3 @@ WAFFLE_NAMESPACE = 'discussions'
 # .. This is temporary fix for performance issue in API.
 # .. toggle_tickets: INF-444
 DISABLE_LEARNERS_STATS = CourseWaffleFlag(f'{WAFFLE_NAMESPACE}.disable_learners_stats', __name__)
-
-
-

--- a/lms/djangoapps/discussion/config/waffle.py
+++ b/lms/djangoapps/discussion/config/waffle.py
@@ -13,7 +13,7 @@ WAFFLE_NAMESPACE = 'discussions'
 # .. toggle_use_cases: temporary, open_edx
 # .. toggle_creation_date: 2022-08-12
 # .. toggle_target_removal_date: 2022-10-02
-# .. toggle_warning: When the flag is ON, API will return learners stats with null values.
+# .. toggle_warning: When the flag is ON, API will return learners stats with original values.
 # .. This is temporary fix for performance issue in API.
 # .. toggle_tickets: INF-444
 ENABLE_LEARNERS_STATS = CourseWaffleFlag(f'{WAFFLE_NAMESPACE}.enable_learners_stats', __name__)

--- a/lms/djangoapps/discussion/config/waffle.py
+++ b/lms/djangoapps/discussion/config/waffle.py
@@ -1,0 +1,22 @@
+"""
+This module contains  configuration settings via waffle switches for the discussions.
+"""
+
+from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
+
+WAFFLE_NAMESPACE = 'discussions'
+
+# .. toggle_name: discussions.disable_learners_stats
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Waffle flag to disable learners stats
+# .. toggle_use_cases: temporary, open_edx
+# .. toggle_creation_date: 2022-03-02
+# .. toggle_target_removal_date: 2022-06-02
+# .. toggle_warning: When the flag is ON, API will return learners stats with zero values.
+# .. This is temporary fix for performance issue in API.
+# .. toggle_tickets: INF-444
+DISABLE_LEARNERS_STATS = CourseWaffleFlag(f'{WAFFLE_NAMESPACE}.disable_learners_stats', __name__)
+
+
+

--- a/lms/djangoapps/discussion/config/waffle.py
+++ b/lms/djangoapps/discussion/config/waffle.py
@@ -6,14 +6,14 @@ from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
 WAFFLE_NAMESPACE = 'discussions'
 
-# .. toggle_name: discussions.disable_learners_stats
+# .. toggle_name: discussions.enable_learners_stats
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False
-# .. toggle_description: Waffle flag to disable learners stats
+# .. toggle_description: Waffle flag to enable learners stats
 # .. toggle_use_cases: temporary, open_edx
 # .. toggle_creation_date: 2022-03-02
 # .. toggle_target_removal_date: 2022-06-02
-# .. toggle_warning: When the flag is ON, API will return learners stats with zero values.
+# .. toggle_warning: When the flag is ON, API will return learners stats with null values.
 # .. This is temporary fix for performance issue in API.
 # .. toggle_tickets: INF-444
-DISABLE_LEARNERS_STATS = CourseWaffleFlag(f'{WAFFLE_NAMESPACE}.disable_learners_stats', __name__)
+ENABLE_LEARNERS_STATS = CourseWaffleFlag(f'{WAFFLE_NAMESPACE}.enable_learners_stats', __name__)

--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -543,9 +543,9 @@ def get_course_topics_v2(
     _get_course(course_key, user=user, check_tab=False)
     course_blocks = get_course_blocks(user, store.make_course_usage_key(course_key))
     accessible_vertical_keys = [
-                                   block for block in course_blocks.get_block_keys()
-                                   if block.category == 'vertical'
-                               ] + [None]
+        block for block in course_blocks.get_block_keys()
+        if block.category == 'vertical'
+    ] + [None]
     topics_query = DiscussionTopicLink.objects.filter(
         context_key=course_key,
         provider_id=provider_type,
@@ -1184,7 +1184,7 @@ def _handle_abuse_flagged_field(form_value, user, cc_content):
     if form_value:
         cc_content.flagAbuse(user, cc_content)
         if ENABLE_DISCUSSIONS_MFE_FOR_EVERYONE.is_enabled(course_key) and reported_content_email_notification_enabled(
-            course_key):
+                course_key):
             if cc_content.type == 'thread':
                 thread_flagged.send(sender='flag_abuse_for_thread', user=user, post=cc_content)
             else:

--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -1651,7 +1651,7 @@ def get_course_discussion_user_stats(
         order_by = order_by or UserOrdering.BY_ACTIVITY
         if order_by != UserOrdering.BY_ACTIVITY:
             raise ValidationError({"order_by": "Invalid value"})
-    breakpoint()
+
     if not ENABLE_LEARNERS_STATS.is_enabled(course_key):
         return get_users_without_stats(
             username_search_string,

--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -6,11 +6,9 @@ from __future__ import annotations
 import itertools
 from collections import defaultdict
 
-from analytics import page
 from enum import Enum
 from typing import Dict, Iterable, List, Literal, Optional, Set, Tuple
 from urllib.parse import urlencode, urlunparse
-from django.db.models.functions import Length
 
 from django.conf import settings
 from django.contrib.auth import get_user_model

--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -1714,7 +1714,7 @@ def get_users_without_stats(
 ):
     """
     This return users with no user stats.
-    This function will be deprecated when this ticket is resolved
+    This function will be deprecated when this ticket DOS-3414 is resolved
     """
     if username_search_string:
         comma_separated_usernames, matched_users_count, matched_users_pages = get_usernames_from_search_string(

--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -66,7 +66,7 @@ from openedx.core.djangoapps.django_comment_common.signals import (
 )
 from openedx.core.djangoapps.user_api.accounts.api import get_account_settings
 from openedx.core.lib.exceptions import CourseNotFoundError, DiscussionNotFoundError, PageNotFoundError
-from ..config.waffle import DISABLE_LEARNERS_STATS
+from ..config.waffle import ENABLE_LEARNERS_STATS
 
 from ..django_comment_client.base.views import (
     track_comment_created_event,
@@ -1651,8 +1651,8 @@ def get_course_discussion_user_stats(
         order_by = order_by or UserOrdering.BY_ACTIVITY
         if order_by != UserOrdering.BY_ACTIVITY:
             raise ValidationError({"order_by": "Invalid value"})
-
-    if DISABLE_LEARNERS_STATS.is_enabled():
+    breakpoint()
+    if not ENABLE_LEARNERS_STATS.is_enabled(course_key):
         return get_users_without_stats(
             username_search_string,
             course_key,
@@ -1736,7 +1736,7 @@ def get_users_without_stats(
         serializer = UserStatsSerializer(updated_course_stats, context={"is_privileged": is_privileged}, many=True)
         paginator = DiscussionAPIPagination(
             request,
-            1,
+            page_number,
             matched_users_pages,
             matched_users_count,
         )

--- a/lms/djangoapps/discussion/rest_api/tests/test_views.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views.py
@@ -14,11 +14,14 @@ import httpretty
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import override_settings
 from django.urls import reverse
+from edx_toggles.toggles.testutils import override_waffle_flag
 from opaque_keys.edx.keys import CourseKey
 from pytz import UTC
 from rest_framework import status
 from rest_framework.parsers import JSONParser
 from rest_framework.test import APIClient, APITestCase
+
+from lms.djangoapps.discussion.config.waffle import ENABLE_LEARNERS_STATS
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase
@@ -2890,6 +2893,7 @@ class CourseDiscussionRolesAPIViewTest(APITestCase, UrlResetMixin, ModuleStoreTe
 
 @ddt.ddt
 @httpretty.activate
+@override_waffle_flag(ENABLE_LEARNERS_STATS, True)
 class CourseActivityStatsTest(ForumsEnableMixin, UrlResetMixin, CommentsServiceMockMixin, APITestCase,
                               SharedModuleStoreTestCase):
     """

--- a/lms/djangoapps/discussion/rest_api/utils.py
+++ b/lms/djangoapps/discussion/rest_api/utils.py
@@ -69,6 +69,32 @@ def get_usernames_from_search_string(course_id, search_string, page_number, page
     return ','.join(page_matched_users), matched_users_count, matched_users_pages
 
 
+def get_usernames_for_course(course_id, page_number, page_size):
+    """
+    Gets usernames for all users in course.
+
+    Args:
+            course_id (CourseKey): Course to check discussions for
+            page_number (int): Page numbers to fetch
+            page_size (int): Number of items in each page
+
+    Returns:
+            page_matched_users (str): comma seperated usernames for the page
+            matched_users_count (int): count of matched users in course
+            matched_users_pages (int): pages of matched users in course
+    """
+    matched_users_in_course = User.objects.filter(
+        courseenrollment__course_id=course_id,
+       ).order_by(Length('username').asc()).values_list('username', flat=True)
+    if not matched_users_in_course:
+        return '', 0, 0
+    matched_users_count = len(matched_users_in_course)
+    paginator = Paginator(matched_users_in_course, page_size)
+    page_matched_users = paginator.page(page_number)
+    matched_users_pages = int(matched_users_count / page_size)
+    return ','.join(page_matched_users), matched_users_count, matched_users_pages
+
+
 def add_stats_for_users_with_no_discussion_content(course_stats, users_in_course):
     """
     Update users stats for users with no discussion stats available in course

--- a/lms/djangoapps/discussion/rest_api/utils.py
+++ b/lms/djangoapps/discussion/rest_api/utils.py
@@ -83,9 +83,8 @@ def get_usernames_for_course(course_id, page_number, page_size):
             matched_users_count (int): count of matched users in course
             matched_users_pages (int): pages of matched users in course
     """
-    matched_users_in_course = User.objects.filter(
-        courseenrollment__course_id=course_id,
-       ).order_by(Length('username').asc()).values_list('username', flat=True)
+    matched_users_in_course = User.objects.filter(courseenrollment__course_id=course_id,)\
+        .order_by(Length('username').asc()).values_list('username', flat=True)
     if not matched_users_in_course:
         return '', 0, 0
     matched_users_count = len(matched_users_in_course)


### PR DESCRIPTION
## Description

This PR patches performance issues by not including user stats in API response. 
This change is behind `discussions.disable_learners_stats`  waffle flag


## Testing instructions

- enable `discussions.disable_learners_stats` waffle flag.
- Observe learner's stats values are now 0.

## Ticket:
https://2u-internal.atlassian.net/browse/INF-444

## Related PR: 

https://github.com/openedx/frontend-app-discussions/pull/245