### PR TITLE
fix: Override Credentials service URLs in Studio devstack.py files

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -291,6 +291,10 @@ SOCIAL_AUTH_REDIRECT_IS_HTTPS = False
 # Devstack is directly exposed to the caller
 CLOSEST_CLIENT_IP_FROM_HEADERS = []
 
+#################### Credentials Settings ####################
+CREDENTIALS_INTERNAL_SERVICE_URL = 'http://localhost:18150'
+CREDENTIALS_PUBLIC_SERVICE_URL = 'http://localhost:18150'
+
 ################# New settings must go ABOVE this line #################
 ########################################################################
 # See if the developer has any local overrides.


### PR DESCRIPTION
## Description

In the `cms/envs/common.py` file the `CREDENTIALS_INTERNAL_SERVICE_URL` and `CREDENTIALS_PUBLIC_SERVICE_URL` settings are set to
`http://localhost:8005` which is incorrect for devstack. In devstack the Credentials IDA runs on port `18150`. This causes
issues with Studio being able to communicate with the Credentials IDA.

I've overriden the service URL settings in devstack.py to point to the correct port.