### PR TITLE
feat: update template text for raw html editor

### DIFF
--- a/xmodule/templates/html/raw.yaml
+++ b/xmodule/templates/html/raw.yaml
@@ -3,11 +3,7 @@ metadata:
     display_name: Raw HTML
     editor: raw
 data: |
-      <p>This template is similar to the Text template. The only difference is 
-      that this template opens in the Raw HTML editor rather than in the Visual
-      editor.</p>
-      <p>The Raw HTML editor saves your HTML exactly as you enter it.
-      You can switch to the Visual editor by clicking the Settings tab and 
-      changing the Editor setting to Visual. Note, however, that some of your 
-      HTML may be modified when you save the component if you switch to the 
-      Visual editor.</p>
+      <p>This is a Raw HTML editor that saves your HTML exactly as you enter it.
+      This means that even malformed HTML tags will be saved and rendered as-is.
+      There is no way to switch between Raw and Visual Text editor types, so be
+      sure this is the editor you should be using!</p>


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This PR changes the default text in a Raw HTML Text Editor. The new Text Editor has separate instances for Text and Raw HTML. Therefore the current default text in Raw HTML is no longer applicable. This change impacts the Course Author.

## Supporting information

JIRA Ticket: [TNL-10045](https://2u-internal.atlassian.net/browse/TNL-10045)

## Testing instructions

1. Open a course outline and edit a unit.
2. Add a new Raw HTML block.
3. The default text should be: 
```
<p>This is a Raw HTML editor that saves your HTML exactly as you enter it.  
This means that even malformed HTML tags will be saved and rendered as-is.
There is no way to switch between Raw and Visual Text editor types, so be 
sure this is the editor you should be using!</p>
```
4. Click the "Cancel" button and check that the text matches the text above.

## Deadline

None
