### PR TITLE
feat: Update the cache when active enterprise is changed.

### DIFF
--- a/openedx/features/enterprise_support/utils.py
+++ b/openedx/features/enterprise_support/utils.py
@@ -329,17 +329,22 @@ def get_enterprise_learner_portal(request):
     # Only cache this if a learner is authenticated (AnonymousUser exists and should not be tracked)
 
     learner_portal_session_key = 'enterprise_learner_portal'
-
+    enterprise_customer_session_key = 'enterprise_customer'
     if enterprise_enabled() and ENTERPRISE_HEADER_LINKS.is_enabled() and user and user.id:
         # If the key exists return that value
-        if learner_portal_session_key in request.session:
-            return json.loads(request.session[learner_portal_session_key])
+        if learner_portal_session_key in request.session and enterprise_customer_session_key in request.session:
+            learner_portal_session = json.loads(request.session[learner_portal_session_key])
+            if request.session[enterprise_customer_session_key].get('slug') == learner_portal_session.get('slug'):
+                return learner_portal_session
 
         kwargs = {
             'user_id': user.id,
             'enterprise_customer__enable_learner_portal': True,
         }
-        enterprise_customer_uuid = enterprise_customer_uuid_for_request(request)
+        if enterprise_customer_session_key in request.session:
+            enterprise_customer_uuid = request.session[enterprise_customer_session_key].get('uuid')
+        else:
+            enterprise_customer_uuid = enterprise_customer_uuid_for_request(request)
         if enterprise_customer_uuid:
             kwargs['enterprise_customer__uuid'] = enterprise_customer_uuid
 


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Issue:
If a user is attached to multiple enterprises then he is always shown the enterprise logo and link on the platform of the enterprise he has selected the very first time because it is cached.
Now:
If a user switched his enterprise in the current session then he will be shown the logo and link of the current active enterprise.

https://2u-internal.atlassian.net/browse/ENT-6103
http://localhost:18000/enterprise/select/active 

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
