### PR TITLE
fix: Made user search function case in-sensitive

### DIFF
--- a/lms/djangoapps/discussion/rest_api/tests/test_views.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views.py
@@ -22,6 +22,7 @@ from rest_framework.parsers import JSONParser
 from rest_framework.test import APIClient, APITestCase
 
 from lms.djangoapps.discussion.config.waffle import ENABLE_LEARNERS_STATS
+from lms.djangoapps.discussion.rest_api.utils import get_usernames_from_search_string
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase
@@ -3021,3 +3022,17 @@ class CourseActivityStatsTest(ForumsEnableMixin, UrlResetMixin, CommentsServiceM
         data = response.json()
         self.assertFalse(data['results'])
         assert data['pagination']['count'] == 0
+
+    @ddt.data(
+        'user-0',
+        'USER-1',
+        'User-2',
+        'UsEr-3'
+    )
+    @mock.patch.dict("django.conf.settings.FEATURES", {'ENABLE_DISCUSSION_SERVICE': True})
+    def test_with_username_param_case(self, username_search_string):
+        """
+        Test user search function is case-insensitive.
+        """
+        response = get_usernames_from_search_string(self.course_key, username_search_string, 1, 1)
+        assert response == (username_search_string.lower(), 1, 1)

--- a/lms/djangoapps/discussion/rest_api/utils.py
+++ b/lms/djangoapps/discussion/rest_api/utils.py
@@ -59,7 +59,7 @@ def get_usernames_from_search_string(course_id, search_string, page_number, page
     """
     matched_users_in_course = User.objects.filter(
         courseenrollment__course_id=course_id,
-        username__contains=search_string).order_by(Length('username').asc()).values_list('username', flat=True)
+        username__icontains=search_string).order_by(Length('username').asc()).values_list('username', flat=True)
     if not matched_users_in_course:
         return '', 0, 0
     matched_users_count = len(matched_users_in_course)


### PR DESCRIPTION
## Description
Search functionality was not case sensitive, This PR resolves this issue by using `icontains` to query usernames.

## Ticket
https://2u-internal.atlassian.net/browse/INF-439

## Testing Instructions:
1. Checkout in this branch
2. Go to the discussions forum MFE
3. Search for the user in the learner's Tab with both caps on and off
4. Observe the same users listed in both cases.