### PR TITLE
feat: add script to convert toggle/settings data

### DIFF
--- a/docs/technical/conf.py
+++ b/docs/technical/conf.py
@@ -19,7 +19,7 @@ extensions = ["code_annotations.contrib.sphinx.extensions.featuretoggles", "code
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
-edxplatform_repo_url = "https://github.com/edx/edx-platform"
+edxplatform_repo_url = "https://github.com/openedx/edx-platform"
 edxplatform_source_path = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "..")
 )

--- a/docs/technical/xml_to_json.py
+++ b/docs/technical/xml_to_json.py
@@ -1,0 +1,68 @@
+import xml.etree.ElementTree as ET
+import json
+
+
+def parse_desc(n):
+    return n.text
+
+
+def parse_source(n):
+    return n[0].items()[0][1]
+
+
+def parse_def(n):
+    return n[0].text
+
+
+def iter_toggle(section):
+    key = {"name": section[0].text}
+    for item in section[1:]:
+        if item.items()[0][1] == "source":
+            key["source"] = parse_source(item)
+        elif item.items()[0][1] == "default":
+            key["default"] = parse_def(item)
+        elif item.items()[0][1] == "warning":
+            key["warning"] = item[0].text
+        elif item.items()[0][1] == "description":
+            key["desc"] = parse_desc(item)
+        else:
+            key[item.items()[0][1]] = item.text.split(": ")[1]
+    return key
+
+
+result = {}
+
+s = ET.parse("_build/xml/settings.xml")
+s = s.getroot()
+s = s[0]
+
+scms = s.findall("section")[1]
+slms = s.findall("section")[0]
+
+lms_settings = []
+cms_settings = []
+
+for i in scms[1:]:
+    cms_settings.append(iter_toggle(i))
+
+result["cms_settigs"] = cms_settings
+
+for i in slms[1:]:
+    lms_settings.append(iter_toggle(i))
+
+result["lms_settings"] = lms_settings
+
+f = ET.parse("_build/xml/featuretoggles.xml")
+f = f.getroot()
+f = f[1]
+
+f_a = []
+
+for i in f[2:]:
+    f_a.append(iter_toggle(i))
+
+result["features_toggles"] = f_a
+raw_json = json.dumps(result, indent=2, ensure_ascii=False)
+result_file = open("result.json", "wt")
+result_file.write(raw_json)
+result_file.close()


### PR DESCRIPTION
 This PR adds a handy python script to convert data about toggles
 and settings to be in a structural form. It would be used by:
 when in docs/technical `make xml && python xml_to_json`
 the result will be result.json has all data about toggles and
 settings in structural format.

 Note: this depends on: openedx/code-annotations/pull/83 and that
 shall be merged before.

<details><summary>Example of Result</summary>

```json
{
  "cms_settigs": [
    {
      "name": "BLOCKSTORE_BUNDLE_CACHE_TIMEOUT",
      "default": "3000",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/envs/common.py#L2505",
      "desc": "Maximum time-to-live of cached Bundles fetched from\n                         Blockstore, in seconds. When the values returned from Blockstore have\n                         TTLs of their own (such as signed S3 URLs), the maximum TTL of this cache\n                         must be lower than the minimum TTL of those values.\n                         We use a default of 3000s (50mins) because temporary URLs are often\n                         configured to expire after one hour."
    },
    {
      "name": "CODE_JAIL_REST_SERVICE_CONNECT_TIMEOUT",
      "default": "0.5",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/envs/common.py#L1097",
      "desc": "Set the number of seconds CMS will wait to establish an internal\n                       connection to the codejail remote service."
    },
    {
      "name": "CODE_JAIL_REST_SERVICE_HOST",
      "default": "\"'http://127.0.0.1:8550'\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/envs/common.py#L1093",
      "desc": "Set the codejail remote service host"
    },
    {
      "name": "CODE_JAIL_REST_SERVICE_READ_TIMEOUT",
      "default": "3.5",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/envs/common.py#L1101",
      "desc": "Set the number of seconds CMS will wait for a response from the\n                       codejail remote service endpoint."
    },
    {
      "name": "CODE_JAIL_REST_SERVICE_REMOTE_EXEC",
      "default": "\"'common.lib.capa.capa.safe_exec.remote_exec.send_safe_exec_request_v0'\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/envs/common.py#L1088",
      "desc": "Set the python package.module.function that is reponsible of\n                       calling the remote service in charge of jailed code execution"
    },
    {
      "name": "COMPREHENSIVE_THEME_DIRS",
      "default": "\"[]\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/envs/common.py#L2078",
      "desc": "See LMS annotation."
    },
    {
      "name": "COMPREHENSIVE_THEME_LOCALE_PATHS",
      "default": "\"[]\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/envs/common.py#L2083",
      "desc": "See LMS annotation.\n                       “COMPREHENSIVE_THEME_LOCALE_PATHS” : [“/edx/src/edx-themes/conf/locale”]."
    },
    {
      "name": "COURSEGRAPH_CONNECTION",
      "default": "\"'bolt+s://localhost:7687', in dictionary form.\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/envs/common.py#L2272",
      "desc": "Dictionary specifying Neo4j connection parameters for\n                          CourseGraph refresh. Accepted keys are protocol (‘bolt’ or ‘http’),\n                          secure (bool), host (str), port (int), user (str), and password (str).\n                          See https://py2neo.org/2021.1/profiles.html#individual-settings for a\n                          a description of each of those keys."
    },
    {
      "name": "COURSEGRAPH_JOB_QUEUE",
      "default": "\"value of LOW_PRIORITY_QUEUE\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/envs/common.py#L2266",
      "desc": "The name of the Celery queue to which CourseGraph refresh\n                          tasks will be sent"
    },
    {
      "name": "DEFAULT_SITE_THEME",
      "default": "None",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/envs/common.py#L2095",
      "desc": "See LMS annotation."
    },
    {
      "name": "GIT_EXPORT_DEFAULT_IDENT",
      "default": "\"{'name': 'STUDIO_EXPORT_TO_GIT', 'email': 'STUDIO_EXPORT_TO_GIT@example.com'}\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/envs/common.py#L1140",
      "desc": "When courses are exported to git, commits are signed with this name/email git identity."
    },
    {
      "name": "GIT_REPO_EXPORT_DIR",
      "default": "\"'/edx/var/edxapp/export_course_repos'\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/envs/common.py#L1134",
      "desc": "When courses are exported to git, either with the export_git management command or the git\n                       export view from the studio (when FEATURES[‘ENABLE_EXPORT_GIT’] is True), they are stored in this directory, which\n                       must exist at the time of the export."
    },
    {
      "name": "PREPEND_LOCALE_PATHS",
      "default": "\"[]\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/envs/common.py#L2089",
      "desc": "A list of the paths to locale directories to load first e.g.\n                       “PREPEND_LOCALE_PATHS” : [“/edx/my-locales/”]."
    },
    {
      "name": "STUDIO_NAME",
      "default": "\"Your Platform Studio\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/envs/common.py#L176",
      "desc": "The name that will appear on the landing page of Studio, as well as in various emails and\n                       templates."
    }
  ],
  "lms_settings": [
    {
      "name": "ACCOUNT_MICROFRONTEND_URL",
      "default": "None",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L4799",
      "desc": "Base URL of the micro-frontend-based account settings page.",
      "warning": "Also set site’s ENABLE_ACCOUNT_MICROFRONTEND and\n                             account.redirect_to_microfrontend waffle flag"
    },
    {
      "name": "BADGING_BACKEND",
      "default": "\"'lms.djangoapps.badges.backends.badgr.BadgrBackend'\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L3544",
      "desc": "The backend service class (or callable) for creating OpenBadges. It must implement\n                        the interface provided by lms.djangoapps.badges.backends.base.BadgeBackend",
      "warning": "Review FEATURES[‘ENABLE_OPENBADGES’] for further context."
    },
    {
      "name": "BADGR_BASE_URL",
      "default": "\"'http://localhost:8005'\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L3551",
      "desc": "The base URL for the Badgr server.",
      "warning": "DO NOT include a trailing slash. Review FEATURES[‘ENABLE_OPENBADGES’] for further context."
    },
    {
      "name": "BADGR_ISSUER_SLUG",
      "default": "\"'example-issuer'\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L3557",
      "desc": "A string that is the slug for the Badgr issuer. The slug can be obtained from the URL of\n                        the Badgr Server page that displays the issuer. For example, in the URL\n                        http://exampleserver.com/issuer/test-issuer, the issuer slug is “test-issuer”.",
      "warning": "Review FEATURES[‘ENABLE_OPENBADGES’] for further context."
    },
    {
      "name": "BADGR_PASSWORD",
      "default": "None",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L3573",
      "desc": "The password for Badgr. You should set up an issuer application with Badgr\n                        (https://badgr.org/app-developers/). The username and password will then be used to create or renew\n                        OAuth2 tokens.",
      "warning": "Review FEATURES[‘ENABLE_OPENBADGES’] for further context."
    },
    {
      "name": "BADGR_TIMEOUT",
      "default": "10",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L3588",
      "desc": "Number of seconds to wait on the badging server when contacting it before giving up.",
      "warning": "Review FEATURES[‘ENABLE_OPENBADGES’] for further context."
    },
    {
      "name": "BADGR_TOKENS_CACHE_KEY",
      "default": "None",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L3581",
      "desc": "The cache key for Badgr API tokens. Once created, the tokens will be stored in cache.\n                        Define the key here for setting and retrieveing the tokens.",
      "warning": "Review FEATURES[‘ENABLE_OPENBADGES’] for further context."
    },
    {
      "name": "BADGR_USERNAME",
      "default": "None",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L3565",
      "desc": "The username for Badgr. You should set up an issuer application with Badgr\n                        (https://badgr.org/app-developers/). The username and password will then be used to create or renew\n                        OAuth2 tokens.",
      "warning": "Review FEATURES[‘ENABLE_OPENBADGES’] for further context."
    },
    {
      "name": "BLOCKSTORE_BUNDLE_CACHE_TIMEOUT",
      "default": "3000",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L4967",
      "desc": "Maximum time-to-live of cached Bundles fetched from\n                         Blockstore, in seconds. When the values returned from Blockstore have\n                         TTLs of their own (such as signed S3 URLs), the maximum TTL of this cache\n                         must be lower than the minimum TTL of those values.\n                         We use a default of 3000s (50mins) because temporary URLs are often\n                         configured to expire after one hour."
    },
    {
      "name": "BLOCK_STRUCTURES_SETTINGS",
      "default": "\"dict of settings\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L2778",
      "desc": "Stores all the settings used by block structures and block structure\n                       related tasks. See BLOCK_STRUCTURES_SETTINGS[XXX] documentation for details of each setting.\n                       For more information, check https://github.com/edx/edx-platform/pull/13388."
    },
    {
      "name": "BLOCK_STRUCTURES_SETTINGS[‘COURSE_PUBLISH_TASK_DELAY’]",
      "default": "30",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L2784",
      "desc": "Delay, in seconds, after a new edit of a course is published before\n                       updating the block structures cache. This is needed for a better chance at getting\n                       the latest changes when there are secondary reads in sharded mongoDB clusters.\n                       For more information, check https://github.com/edx/edx-platform/pull/13388 and\n                       https://github.com/edx/edx-platform/pull/14571."
    },
    {
      "name": "BLOCK_STRUCTURES_SETTINGS[‘TASK_DEFAULT_RETRY_DELAY’]",
      "default": "30",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L2793",
      "desc": "Delay, in seconds, between retry attempts if a block structure task\n                       fails. For more information, check https://github.com/edx/edx-platform/pull/13388 and\n                       https://github.com/edx/edx-platform/pull/14571."
    },
    {
      "name": "BLOCK_STRUCTURES_SETTINGS[‘TASK_MAX_RETRIES’]",
      "default": "5",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L2800",
      "desc": "Maximum number of retries per block structure task.\n                       If the maximum number of retries is exceeded, then you can attempt to either manually run\n                       the celery task, or wait for it to be triggered again.\n                       For more information, check https://github.com/edx/edx-platform/pull/13388 and\n                       https://github.com/edx/edx-platform/pull/14571."
    },
    {
      "name": "BUNDLE_ASSET_STORAGE_SETTINGS",
      "default": "\"dict, appropriate for file system storage.\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L4995",
      "desc": "When this is set, `BUNDLE_ASSET_URL_STORAGE_KEY` is"
    },
    {
      "name": "BUNDLE_ASSET_URL_STORAGE_KEY",
      "default": "None",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L4977",
      "desc": "When this is set, `BUNDLE_ASSET_URL_STORAGE_SECRET` is"
    },
    {
      "name": "BUNDLE_ASSET_URL_STORAGE_SECRET",
      "default": "None",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L4986",
      "desc": "When this is set, `BUNDLE_ASSET_URL_STORAGE_KEY` is"
    },
    {
      "name": "CCX_MAX_STUDENTS_ALLOWED",
      "default": "200",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L4330",
      "desc": "Maximum number of students allowed in a CCX (Custom Courses for edX), This is an arbitrary\n                       hard limit, chosen so that a CCX does not compete with public MOOCs."
    },
    {
      "name": "CODE_JAIL_REST_SERVICE_CONNECT_TIMEOUT",
      "default": "0.5",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L1689",
      "desc": "Set the number of seconds LMS will wait to establish an internal\n                       connection to the codejail remote service."
    },
    {
      "name": "CODE_JAIL_REST_SERVICE_HOST",
      "default": "\"'http://127.0.0.1:8550'\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L1685",
      "desc": "Set the codejail remote service host"
    },
    {
      "name": "CODE_JAIL_REST_SERVICE_READ_TIMEOUT",
      "default": "3.5",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L1693",
      "desc": "Set the number of seconds LMS will wait for a response from the\n                       codejail remote service endpoint."
    },
    {
      "name": "CODE_JAIL_REST_SERVICE_REMOTE_EXEC",
      "default": "\"'common.lib.capa.capa.safe_exec.remote_exec.send_safe_exec_request_v0'\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L1680",
      "desc": "Set the python package.module.function that is reponsible of\n                       calling the remote service in charge of jailed code execution"
    },
    {
      "name": "COMPREHENSIVE_THEME_DIRS",
      "default": "\"[]\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L4383",
      "desc": "A list of directories containing themes folders,\n                       each entry should be a full path to the directory containing the theme folder."
    },
    {
      "name": "COMPREHENSIVE_THEME_LOCALE_PATHS",
      "default": "\"[]\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L4389",
      "desc": "A list of the paths to themes locale directories e.g.\n                       “COMPREHENSIVE_THEME_LOCALE_PATHS” : [“/edx/src/edx-themes/conf/locale”]."
    },
    {
      "name": "COURSE_MEMBER_API_ENROLLMENT_LIMIT",
      "default": "1000",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L4206",
      "desc": "This limits the response size of the `get_course_members` API, throwing an exception\n                        if the number of Enrolled users is greater than this number. This is needed to limit the dataset size\n                        since the API does most of the calculation in Python to avoid expensive database queries."
    },
    {
      "name": "DEFAULT_SITE_THEME",
      "default": "None",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L4402",
      "desc": "Theme to use when no site or site theme is defined, for example\n                       “dark-theme”. Set to None if you want to use openedx default theme.",
      "warning": "The theme folder needs to be in ‘edx-platform/themes’ or define the path\n                           to the theme folder in COMPREHENSIVE_THEME_DIRS. To be effective, ENABLE_COMPREHENSIVE_THEMING\n                           has to be enabled."
    },
    {
      "name": "DISCUSSIONS_MFE_FEEDBACK_URL = None",
      "default": "None",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L4824",
      "desc": "Base URL of the discussions micro-frontend google form based feedback."
    },
    {
      "name": "DISCUSSIONS_MICROFRONTEND_URL",
      "default": "None",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L4819",
      "desc": "Base URL of the micro-frontend-based discussions page.",
      "warning": "Also set site’s courseware.discussions_mfe waffle flag."
    },
    {
      "name": "EDXNOTES_CLIENT_NAME",
      "default": "\"edx-notes\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L2013",
      "desc": "Set the name of the Oauth client used by LMS to authenticate with\n                         the edx_notes_api service.",
      "warning": "The Oauth client must be created in the platform Django admin in the\n                             path /admin/oauth2_provider/application/, setting the name field of the client as the\n                             value of this setting."
    },
    {
      "name": "EDXNOTES_CONNECT_TIMEOUT",
      "default": "0.5",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L2021",
      "desc": "Set the number of seconds LMS will wait to establish an internal\n                         connection to the edx_notes_api service."
    },
    {
      "name": "EDXNOTES_INTERNAL_API",
      "default": "\"http://localhost:18120/api/v1\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L2004",
      "desc": "Set the internal API endpoint LMS will use in the backend to\n                         interact with the edx_notes_api service.",
      "warning": "Normally set to the same value of EDXNOTES_PUBLIC_API. It is not\n                             mandatory for this setting to be a publicly accessible endpoint, but to be accessible\n                             by the LMS service. It is only used when the setting FEATURES[‘ENABLE_EDXNOTES’] is\n                             activated."
    },
    {
      "name": "EDXNOTES_PUBLIC_API",
      "default": "\"http://localhost:18120/api/v1\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L1996",
      "desc": "Set the public API endpoint LMS will use in the frontend to\n                         interact with the edx_notes_api service.",
      "warning": "This setting must be a publicly accessible endpoint. It is only used\n                             when the setting FEATURES[‘ENABLE_EDXNOTES’] is activated."
    },
    {
      "name": "EDXNOTES_READ_TIMEOUT",
      "default": "1.5",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L2025",
      "desc": "Set the number of seconds LMS will wait for a response from the\n                         edx_notes_api service internal endpoint."
    },
    {
      "name": "LEARNING_MICROFRONTEND_URL",
      "default": "None",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L4808",
      "desc": "Base URL of the micro-frontend-based courseware page."
    },
    {
      "name": "LOGIN_REDIRECT_WHITELIST",
      "default": "\"empty list ([])\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L3478",
      "desc": "While logout, if logout request has a redirect-url as query strings,\n                       then the redirect-url is validated through LOGIN_REDIRECT_WHITELIST."
    },
    {
      "name": "MAINTENANCE_BANNER_TEXT",
      "default": "\"'Sample banner message'\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L1344",
      "desc": "Specifies the text that is rendered on the maintenance banner.",
      "warning": "Depends on the `open_edx_util.display_maintenance_warning` waffle switch.\n                           The banner is only rendered when the switch is activated."
    },
    {
      "name": "MAX_FAILED_LOGIN_ATTEMPTS_ALLOWED",
      "default": "6",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L3667",
      "desc": "Specifies the maximum failed login attempts allowed to users. Once the user reaches this\n                       failure threshold then the account will be locked for a configurable amount of seconds (30 minutes) which will\n                       prevent additional login attempts until this time period has passed. This setting is related with\n                       MAX_FAILED_LOGIN_ATTEMPTS_LOCKOUT_PERIOD_SECS and only used when ENABLE_MAX_FAILED_LOGIN_ATTEMPTS is enabled."
    },
    {
      "name": "MAX_FAILED_LOGIN_ATTEMPTS_LOCKOUT_PERIOD_SECS",
      "default": "\"30 * 60\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L3676",
      "desc": "Specifies the lockout period in seconds for consecutive failed login attempts. Once the user\n                       reaches the threshold of the login failure, then the account will be locked for the given amount of seconds\n                       (30 minutes) which will prevent additional login attempts until this time period has passed. This setting is\n                       related with MAX_FAILED_LOGIN_ATTEMPTS_ALLOWED and only used when ENABLE_MAX_FAILED_LOGIN_ATTEMPTS is enabled."
    },
    {
      "name": "ORA_GRADING_MICROFRONTEND_URL",
      "default": "None",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L4812",
      "desc": "Base URL of the micro-frontend-based openassessment grading page.\n                         This is will be show in the open response tab list data.",
      "warning": "Also set site’s openresponseassessment.enhanced_staff_grader\n                             waffle flag."
    },
    {
      "name": "PLATFORM_NAME",
      "default": "\"Your Platform Name Here\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L57",
      "desc": "The display name of the platform to be used in\n                         templates/emails/etc."
    },
    {
      "name": "PREPEND_LOCALE_PATHS",
      "default": "\"[]\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L4396",
      "desc": "A list of the paths to locale directories to load first e.g.\n                       “PREPEND_LOCALE_PATHS” : [“/edx/my-locales/”]."
    },
    {
      "name": "PROFILE_MICROFRONTEND_URL",
      "default": "None",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L4792",
      "desc": "Base URL of the micro-frontend-based profile page.",
      "warning": "Also set site’s ENABLE_PROFILE_MICROFRONTEND and\n                             learner_profile.redirect_to_microfrontend waffle flag"
    },
    {
      "name": "RATELIMIT_RATE",
      "default": "\"120/m\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L4657",
      "desc": "Due to some reports about attack on /oauth2/access_token/ which took LMS down,\n                        this setting was introduced to rate-limit all endpoints of AccessTokenView up to\n                        120 requests per IP Address in a minute by default.",
      "warning": "RATELIMIT_ENABLE flag must also be enabled/set to True to use this RATELIMIT_RATE setting."
    },
    {
      "name": "REGISTRATION_EXTRA_FIELDS",
      "default": "\"{'confirm_email': 'hidden', 'level_of_education': 'optional', 'gender': 'optional',\n   'year_of_birth': 'optional', 'mailing_address': 'optional', 'goals': 'optional', 'honor_code': 'required',\n   'terms_of_service': 'hidden', 'city': 'hidden', 'country': 'hidden'}\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L3486",
      "desc": "The signup form may contain extra fields that are presented to every user. For every field, we\n                       can specifiy whether it should be “required”: to display the field, and make it mandatory; “optional”: to display\n                       the optional field as part of a toggled input field list; “optional-exposed”: to display the optional fields among\n                       the required fields, and make it non-mandatory; “hidden”: to not display the field.\n                       When the terms of service are not visible and agreement to the honor code is required (the default), the signup page\n                       includes a paragraph that links to the honor code page (defined my MKTG_URLS[“HONOR”]). This page might not be\n                       available for all Open edX platforms. In such cases, the “honor_code” registration field should be “hidden”."
    },
    {
      "name": "REGISTRATION_RATELIMIT",
      "default": "\"60/7d\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L3270",
      "desc": "New users are registered on edx via RegistrationView.\n                        It’s POST end-point is rate-limited up to 60 requests per IP Address in a week by default.\n                        Purpose of this setting is to restrict an attacker from registering numerous fake accounts."
    },
    {
      "name": "REGISTRATION_VALIDATION_RATELIMIT",
      "default": "\"30/7d\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L3261",
      "desc": "Whenver a user tries to register on edx, the data entered during registration\n                        is validated via RegistrationValidationView.\n                        It’s POST endpoint is rate-limited up to 30 requests per IP Address in a week by default.\n                        It was introduced because an attacker can guess or brute force a series of names to enumerate valid users."
    },
    {
      "name": "RETIRED_EMAIL_DOMAIN",
      "default": "\"retired.invalid\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L4699",
      "desc": "Set the domain part of hashed emails for retired users. Used by the derived\n                         setting RETIRED_EMAIL_FMT."
    },
    {
      "name": "RETIRED_EMAIL_FMT",
      "default": "\"retired__user_{}@retired.invalid\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L4710",
      "desc": "Set the format a retired user email field gets transformed into, where {} is\n                         replaced with the hash of the original email. This is a derived setting that depends on\n                         RETIRED_EMAIL_PREFIX and RETIRED_EMAIL_DOMAIN values."
    },
    {
      "name": "RETIRED_EMAIL_PREFIX",
      "default": "\"retired__user_\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L4694",
      "desc": "Set the prefix part of hashed emails for retired users. Used by the derived\n                         setting RETIRED_EMAIL_FMT."
    },
    {
      "name": "RETIRED_USERNAME_FMT",
      "default": "\"retired__user_{}\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L4704",
      "desc": "Set the format a retired user username field gets transformed into, where {}\n                         is replaced with the hash of the original username. This is a derived setting that depends on\n                         RETIRED_USERNAME_PREFIX value."
    },
    {
      "name": "RETIRED_USERNAME_PREFIX",
      "default": "\"retired__user_\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L4688",
      "desc": "Set the prefix part of hashed usernames for retired users. Used by the derived\n                         setting RETIRED_USERNAME_FMT."
    },
    {
      "name": "RETIRED_USER_SALTS",
      "default": "\"['abc', '123']\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L4717",
      "desc": "Set a list of salts used for hashing usernames and emails on users retirement.",
      "warning": "Only the last item in this list is used as a salt for all new retirements, but\n                             historical salts are preserved in order to guarantee that all hashed usernames and emails can still\n                             be checked."
    },
    {
      "name": "RETIREMENT_SERVICE_WORKER_USERNAME",
      "default": "\"RETIREMENT_SERVICE_USER\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L4724",
      "desc": "Set the username of the retirement service worker user. Retirement scripts\n                         authenticate with LMS as this user with oauth client credentials."
    },
    {
      "name": "RETIREMENT_STATES",
      "default": "\"[\n         'PENDING',\n         'LOCKING_ACCOUNT',\n         'LOCKING_COMPLETE',\n         'RETIRING_FORUMS',\n         'FORUMS_COMPLETE',\n         'RETIRING_EMAIL_LISTS',\n         'EMAIL_LISTS_COMPLETE',\n         'RETIRING_ENROLLMENTS',\n         'ENROLLMENTS_COMPLETE',\n         'RETIRING_NOTES',\n         'NOTES_COMPLETE',\n         'RETIRING_LMS',\n         'LMS_COMPLETE',\n         'ERRORED',\n         'ABORTED',\n         'COMPLETE',\n     ]\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L4730",
      "desc": "Set a list that defines the name and order of states for the retirement\n                         workflow.",
      "warning": "These states are stored in the database and it is the responsibility of the\n                             administrator to populate the state list since the states can vary across different installations.\n                             There must be, at minimum, a PENDING state at the beginning, and COMPLETED, ERRORED, and ABORTED\n                             states at the end of the list."
    },
    {
      "name": "XBLOCK_FIELD_DATA_WRAPPERS",
      "default": "\"()\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L1513",
      "desc": "Paths to wrapper methods which should be applied to every XBlock’s FieldData."
    },
    {
      "name": "XBLOCK_RUNTIME_V2_EPHEMERAL_DATA_CACHE",
      "default": "\"default\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L4962",
      "desc": "The django cache key of the cache to use for storing anonymous user state for XBlocks."
    },
    {
      "name": "XBLOCK_SELECT_FUNCTION",
      "default": "\"prefer_xmodules\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L1505",
      "desc": "Function used to select an XBlock from the python package EntryPoints.\n                         Some alternatives are `prefer_xmodules` and `default_select`. The `prefer_modules` function\n                         will choose the first “xmodule” if there is one, otherwise, it will act like `default_select`.\n                         The `default_select` function will simply choose the first match found."
    },
    {
      "name": "XBLOCK_SETTINGS",
      "default": "\"{}\"",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L1521",
      "desc": "Dictionary containing server-wide configuration of XBlocks on a per-type basis.\n                         By default, keys should match the XBlock `block_settings_key` attribute/property. If the attribute/property\n                         is not defined, use the XBlock class name. Check `xmodule.services.SettingsService`\n                         for more reference."
    }
  ],
  "features_toggles": [
    {
      "name": "ALLOW_HIDING_DISCUSSION_TAB",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/discussion/settings/common.py#L6",
      "desc": "Desc: If True, it adds an option to show/hide the discussions tab.",
      "creation_date": "2015-06-15",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "BADGR_ENABLE_NOTIFICATIONS",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L3594",
      "desc": "Desc: Optional setting for enabling email notifications. When set to “True”,\n                    learners will be notified by email when they earn a badge.",
      "creation_date": "2021-07-29",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "BLOCK_STRUCTURES_SETTINGS[‘PRUNING_ACTIVE’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L2809",
      "desc": "Desc: When `True`, only a specified number of versions of block structure\n                   files are kept for each structure, and the rest are cleaned up. The number of versions that\n                   are kept can be specified in the `BlockStructureConfiguration`, which can be edited in\n                   Django Admin. The default number of versions that are kept is `5`.",
      "creation_date": "2018-03-22",
      "target_removal_date": "2018-06-22",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘temporary’]"
    },
    {
      "name": "BULK_EMAIL_SEND_USING_EDX_ACE",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/bulk_email/toggles.py#L20",
      "desc": "Desc: If True, use edx-ace to send bulk email messages",
      "creation_date": "2022-02-10",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "COOKIE_NAME_CHANGE_ACTIVATE",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/core/djangoapps/cookie_metadata/middleware.py#L60",
      "desc": "Desc: Used to enable CookieNameChange middleware which changes a cookie name in request.COOKIES",
      "creation_date": "2021-08-04",
      "target_removal_date": "2021-10-01",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘temporary’]"
    },
    {
      "name": "COURSEGRAPH_DUMP_COURSE_ON_PUBLISH",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/envs/common.py#L2288",
      "desc": "Desc: Whether, upon publish, a course should automatically\n                      be exported to Neo4j via the connection parameters specified in\n                      `COURSEGRAPH_CONNECTION`.",
      "creation_date": "2022-01-27",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "COURSES_INVITE_ONLY",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/courseware/toggles.py#L117",
      "desc": "Desc: Setting this sets the default value of INVITE_ONLY across all courses in a given deployment",
      "creation_date": "2019-05-16",
      "implementation": "[‘SettingToggle’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "CUSTOM_COURSES_EDX",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L299",
      "desc": "Desc: Set to True to enable Custom Courses for edX, a feature that is more commonly known as\n                   CCX. Documentation for configuring and using this feature is available at\n                   https://edx.readthedocs.io/projects/open-edx-ca/en/latest/set_up_course/custom_courses.html",
      "creation_date": "2015-04-10",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘opt_in’, ‘circuit_breaker’]"
    },
    {
      "name": "CourseDurationLimitConfig.enabled",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/features/course_duration_limits/models.py#L16",
      "desc": "Desc: When enabled, users will have a limited time to complete and audit the course. The exact\n                       duration is given by the “weeks_to_complete” course detail. When enabled, it is necessary to also define the\n                       “enabled_as_of” flag: only enrollments created after this date will be affected.",
      "creation_date": "2018-11-02",
      "implementation": "[‘ConfigurationModel’]",
      "use_cases": "[‘opt_in’]"
    },
    {
      "name": "CourseHLSPlaybackEnabledFlag.course_id",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/core/djangoapps/video_config/models.py#L67",
      "desc": "Desc: Add the “hls” profile to all displayed videos for a single course.",
      "creation_date": "2017-04-19",
      "implementation": "[‘ConfigurationModel’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "CourseVideoUploadsEnabledByDefault.course_id",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/core/djangoapps/video_pipeline/models.py#L105",
      "desc": "Desc: Allow video uploads for a specific course. This enables the\n                      “Video Uploads” menu in the CMS.",
      "creation_date": "2017-11-10",
      "implementation": "[‘ConfigurationModel’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "DEFAULT_MOBILE_AVAILABLE",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L3998",
      "desc": "Desc: This specifies if the courses are available for mobile by default. To make any individual\n                   course available for mobile one can set the value of Mobile Course Available to true in Advanced Settings from the\n                   studio when this is False.",
      "creation_date": "2021-01-26",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "DISABLE_DEPRECATED_SIGNIN_URL",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/envs/common.py#L2552",
      "desc": "Desc: Toggle for removing the deprecated /signin url.",
      "creation_date": "2019-12-02",
      "target_removal_date": "2020-06-01",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘temporary’]"
    },
    {
      "name": "DISABLE_DEPRECATED_SIGNUP_URL",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/envs/common.py#L2563",
      "desc": "Desc: Toggle for removing the deprecated /signup url.",
      "creation_date": "2019-12-02",
      "target_removal_date": "2020-06-01",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘temporary’]"
    },
    {
      "name": "ENABLE_AUTHN_LOGIN_BLOCK_HIBP_POLICY",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/envs/common.py#L561",
      "desc": "Desc: When enabled, this toggle activates the use of the password validation\n                   on Authn MFE’s login.",
      "creation_date": "2022-03-29",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘temporary’]"
    },
    {
      "name": "ENABLE_AUTHN_LOGIN_NUDGE_HIBP_POLICY",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/envs/common.py#L549",
      "desc": "Desc: When enabled, this toggle activates the use of the password validation\n                   on Authn MFE’s login.",
      "creation_date": "2022-03-29",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘temporary’]"
    },
    {
      "name": "ENABLE_AUTHN_REGISTER_HIBP_POLICY",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/envs/common.py#L538",
      "desc": "Desc: When enabled, this toggle activates the use of the password validation\n                   HIBP Policy on Authn MFE’s registration.",
      "creation_date": "2022-03-25",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "ENABLE_AUTHN_RESET_PASSWORD_HIBP_POLICY",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/envs/common.py#L529",
      "desc": "Desc: When enabled, this toggle activates the use of the password validation\n                   HIBP Policy.",
      "creation_date": "2021-12-03",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "ENABLE_CODEJAIL_REST_SERVICE",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/common/lib/capa/capa/safe_exec/remote_exec.py#L21",
      "desc": "Desc: Set this to True if you want to run Codejail code using\n                   a separate VM or container and communicate with edx-platform using REST API.",
      "creation_date": "2021-08-19",
      "implementation": "[‘SettingToggle’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "ENABLE_COMPREHENSIVE_THEMING",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/envs/common.py#L2100",
      "desc": "Desc: See LMS annotation.",
      "creation_date": "2016-06-30",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "ENABLE_COPPA_COMPLIANCE",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/envs/common.py#L506",
      "desc": "Desc: When True, inforces COPPA compliance and removes YOB field from registration form and accounnt",
      "creation_date": "2021-10-27",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "ENABLE_REQUIRE_THIRD_PARTY_AUTH",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/core/djangoapps/user_authn/toggles.py#L11",
      "desc": "Desc: Set to True to prevent using username/password login and registration and only allow\n                   authentication with third party auth",
      "creation_date": "2020-09-16",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "ENFORCE_SAFE_SESSIONS",
      "default": "True",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/core/djangoapps/safe_sessions/middleware.py#L136",
      "desc": "Desc: Invalidate session and response if mismatch detected.\n                   That is, when the `user` attribute of the request object gets changed or\n                   no longer matches the session, the session will be invalidated and the\n                   response cancelled (changed to an error). This is intended as a backup\n                   safety measure in case an attacker (or bug) is able to change the user\n                   on a session in an unexpected way.",
      "creation_date": "2021-12-01",
      "implementation": "[‘SettingToggle’]",
      "use_cases": "[‘opt_out’]"
    },
    {
      "name": "EXPECTED_ERRORS[N][‘IS_IGNORED’]",
      "default": "True",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/core/lib/request_utils.py#L147",
      "desc": "Desc: Set this to False if the errors are not ignored by monitoring, but only expected, like\n                      for temporary problems that may take some time to fix. If True, adds the custom attributes\n                      ``error_ignored_class`` and ``error_ignored_message`` to help diagnose issues with ignored errors, since\n                      this data is not otherwise available. For example of ignoring errors in New Relic, see:\n                      https://docs.newrelic.com/docs/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected/#ignore  pylint: disable=line-too-long,useless-suppression\n                      To query for ignored errors, you would use ``error_ignored_class IS NOT NULL``.\n                      Note: This is defaulted to True because it will be easier for us to detect if True is not the correct value, by\n                      seeing that these errors aren’t actually ignored.",
      "warning": "At this time, this toggle does not actually configure the error to be ignored. It is meant to match\n                         the ignored error configuration found elsewhere. When monitoring, no errors should ever have the attribute\n                         ``error_ignored_class``. Only Transactions should have this custom attribute. If found for an error, it means we\n                         are stating an error should be ignored when it is not actually configured as such, or the configuration is not\n                         working.",
      "creation_date": "2021-03-11",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘opt_out’]"
    },
    {
      "name": "EXPECTED_ERRORS[N][‘LOG_ERROR’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/core/lib/request_utils.py#L166",
      "desc": "Desc: If True, the error will be logged with a message like: “Expected error …”.",
      "creation_date": "2021-03-11",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘opt_in’]"
    },
    {
      "name": "EXPECTED_ERRORS[N][‘LOG_STACK_TRACE’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/core/lib/request_utils.py#L173",
      "desc": "Desc: If True, the stacktrace will be included with the logging message.",
      "creation_date": "2021-03-11",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘opt_in’]"
    },
    {
      "name": "FEATURES[‘ALLOW_ADMIN_ENTERPRISE_COURSE_ENROLLMENT_DELETION’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L920",
      "desc": "Desc: If true, allows for the deletion of EnterpriseCourseEnrollment records via Django Admin.",
      "creation_date": "2021-01-27",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘opt_in’]"
    },
    {
      "name": "FEATURES[‘ALLOW_AUTOMATED_SIGNUPS’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/instructor/settings/common.py#L63",
      "desc": "Desc: Enable to show a section in the membership tab of the instructor\n                   dashboard to allow an upload of a CSV file that contains a list of new accounts to create\n                   and register for course.",
      "creation_date": "2014-10-21",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘opt_in’]"
    },
    {
      "name": "FEATURES[‘ALLOW_COURSE_RERUNS’]",
      "default": "True",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/envs/common.py#L296",
      "desc": "Desc: This will allow staff member to re-run the course from the studio home page and will\n                   always use the split modulestore. When this is set to False, the Re-run Course link will not be available on\n                   the studio home page.",
      "creation_date": "2015-02-13",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ALLOW_COURSE_STAFF_GRADE_DOWNLOADS’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/instructor/settings/common.py#L53",
      "desc": "Desc: Enable to give course staff unrestricted access to grade downloads;\n                   if set to False, only edX superusers can perform the downloads.",
      "creation_date": "2018-03-26",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘opt_in’]"
    },
    {
      "name": "FEATURES[‘ALLOW_EMAIL_ADDRESS_CHANGE’]",
      "default": "True",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L785",
      "desc": "Desc: Allow users to change their email address on the Account Settings page. If this is\n                   disabled, users will not be able to change their email address.",
      "creation_date": "2017-06-26",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ALLOW_PUBLIC_ACCOUNT_CREATION’]",
      "default": "True",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L758",
      "desc": "Desc: Allow public account creation. If this is disabled, users will no longer have access to\n                   the signup page.",
      "creation_date": "2017-04-12",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ALWAYS_REDIRECT_HOMEPAGE_TO_DASHBOARD_FOR_AUTHENTICATED_USER’]",
      "default": "True",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L469",
      "desc": "Desc: When a logged in user goes to the homepage (‘/’) the user will be redirected to the\n                   dashboard page when this flag is set to True - this is default Open edX behavior. Set to False to not redirect\n                   the user.",
      "creation_date": "2014-09-16",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘AUTOMATIC_AUTH_FOR_TESTING’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L329",
      "desc": "Desc: Set to True to perform acceptance and load test. Auto auth view is responsible for load\n                   testing and is controlled by this feature flag. Auto-auth causes issues in Bok Choy tests because it resets the\n                   requesting user. Session verification (of CacheBackedAuthenticationMiddleware) is a security feature, but it\n                   can be turned off by enabling this feature flag.",
      "creation_date": "2013-07-25",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L384",
      "desc": "Desc: If set to True, then we want to skip posting anything to Software Secure. Bypass posting\n                   anything to Software Secure if the auto verify feature for testing is enabled. We actually don’t even create\n                   the message because that would require encryption and message signing that rely on settings.VERIFY_STUDENT\n                   values that aren’t set in dev. So we just pretend like we successfully posted and automatically approve student\n                   identity verification attempts.",
      "creation_date": "2013-10-03",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘BATCH_ENROLLMENT_NOTIFY_USERS_DEFAULT’]",
      "default": "True",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/instructor/settings/common.py#L95",
      "desc": "Desc: Controls if the “Notify users by email” checkbox in the batch\n                   enrollment form on the instructor dashboard is already checked on page load or not.",
      "creation_date": "2017-07-05",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘opt_out’]"
    },
    {
      "name": "FEATURES[‘CERTIFICATES_HTML_VIEW’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L613",
      "desc": "Desc: Set to True to enable course certificates on your instance of Open edX.",
      "creation_date": "2015-03-13",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘CERTIFICATES_INSTRUCTOR_GENERATION’]  # lint-amnesty, pylint: disable=annotation-missing-token",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/instructor/settings/common.py#L86",
      "desc": "Desc: Enable to allow batch generation of certificates from the instructor dashboard.\n                   In case of self-paced courses, the certificate generation button is hidden if certificate\n                   generation is not explicitly enabled globally or for the specific course.",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘opt_in’]"
    },
    {
      "name": "FEATURES[‘COURSES_ARE_BROWSABLE’]",
      "default": "True",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L233",
      "desc": "Desc: When this is set to True, all the courses will be listed on the /courses page and Explore\n                   Courses link will be visible. Set to False if courses list and Explore Courses link need to be hidden.",
      "creation_date": "2013-09-28",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘CUSTOM_CERTIFICATE_TEMPLATES_ENABLED’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L626",
      "desc": "Desc: Set to True to enable custom certificate templates which are configured via Django admin.",
      "creation_date": "2015-08-13",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘DEPRECATE_OLD_COURSE_KEYS_IN_STUDIO’]",
      "default": "True",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/envs/common.py#L419",
      "desc": "Desc: Warn about removing support for deprecated course keys.\n                      To enable, set to True.\n                      To disable, set to False.\n                      To enable with a custom support deadline, set to an ISO-8601 date string:\n                        eg: ‘2020-09-01’",
      "creation_date": "2020-06-12",
      "target_removal_date": "2021-04-01",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘temporary’]"
    },
    {
      "name": "FEATURES[‘DISABLE_COURSE_CREATION’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/envs/common.py#L447",
      "desc": "Desc: If set to True, it disables the course creation functionality and hides the “New Course”\n                   button in studio.\n                   It is important to note that the value of this flag only affects if the user doesn’t have a staff role,\n                   otherwise the course creation functionality will work as it should.",
      "creation_date": "2013-12-02",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘DISABLE_HONOR_CERTIFICATES’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L317",
      "desc": "Desc: Set to True to disable honor certificates. Typically used when your installation only\n                   allows verified certificates, like courses.edx.org.",
      "creation_date": "2019-05-14",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘DISABLE_LOGIN_BUTTON’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L198",
      "desc": "Desc: Removes the display of the login button in the navigation bar.\n                   Change is only at the UI level. Used in systems where login is automatic, eg MIT SSL",
      "creation_date": "2013-12-03",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘DISABLE_MOBILE_COURSE_AVAILABLE’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/envs/common.py#L373",
      "desc": "Desc: Set to True to remove Mobile Course Available UI Flag from Studio’s Advanced Settings\n                   page else Mobile Course Available UI Flag will be available on Studio side.",
      "creation_date": "2020-02-14",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘DISABLE_START_DATES’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L104",
      "desc": "Desc: When True, all courses will be active, regardless of start\n                   date.",
      "creation_date": "2012-07-24",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘DISPLAY_ANALYTICS_ENROLLMENTS’]",
      "default": "True",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/instructor/settings/common.py#L13",
      "desc": "Desc: Enable display of enrollment counts in instructor dashboard and\n                   analytics section.",
      "creation_date": "2014-11-12",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘opt_out’]"
    },
    {
      "name": "FEATURES[‘DISPLAY_DEBUG_INFO_TO_STAFF’]",
      "default": "True",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L81",
      "desc": "Desc: Add a “Staff Debug” button to course modules for debugging\n                   by course staff.",
      "creation_date": "2015-09-04",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘DISPLAY_HISTOGRAMS_TO_STAFF’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L91",
      "desc": "Desc: This displays histograms in the Staff Debug Info panel to course staff.",
      "creation_date": "2014-02-13",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘EDITABLE_SHORT_DESCRIPTION’]",
      "default": "True",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/envs/common.py#L218",
      "desc": "Desc: This feature flag allows editing of short descriptions on the Schedule & Details page in\n                   Open edX Studio. Set to False if you want to disable the editing of the course short description.",
      "creation_date": "2014-02-13",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘EMBARGO’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L426",
      "desc": "Desc: Turns on embargo functionality, which blocks users from\n                   the site or courses based on their location. Embargo can restrict users by states\n                   and whitelist/blacklist (IP Addresses (ie. 10.0.0.0), Networks (ie. 10.0.0.0/24)), or the user profile country.",
      "creation_date": "2014-02-27",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_ACCOUNT_DELETION’]",
      "default": "True",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L835",
      "desc": "Desc: Whether to display the account deletion section on Account Settings page. Set to False to\n                   hide this section.",
      "creation_date": "2018-06-01",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_ANNOUNCEMENTS’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/features/announcements/settings/common.py#L5",
      "desc": "Desc: This feature can be enabled to show system wide announcements\n                       on the sidebar of the learner dashboard. Announcements can be created by Global Staff\n                       users on maintenance dashboard of studio. Maintenance dashboard can accessed at\n                       https://{studio.domain}/maintenance",
      "creation_date": "2017-11-08",
      "implementation": "[‘SettingDictToggle’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_AUTHN_MICROFRONTEND’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L859",
      "desc": "Desc: Supports staged rollout of a new micro-frontend-based implementation of the logistration.",
      "creation_date": "2020-09-08",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘temporary’, ‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_AUTOMATED_SIGNUPS_EXTRA_FIELDS’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/instructor/settings/common.py#L74",
      "desc": "Desc: When True, the CSV file that contains a list of\n                   new accounts to create and register for a course in the membership\n                   tab of the instructor dashboard will accept the cohort name to\n                   assign the new user and the enrollment course mode.",
      "creation_date": "2021-10-26",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_BULK_ENROLLMENT_VIEW’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L795",
      "desc": "Desc: When set to True the bulk enrollment view is enabled and one can use it to enroll multiple\n                   users in a course using bulk enrollment API endpoint (/api/bulk_enroll/v1/bulk_enroll).",
      "creation_date": "2017-07-15",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_BULK_USER_RETIREMENT’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L929",
      "desc": "Desc: Set to True to enable bulk user retirement through REST API. This is disabled by\n                   default.",
      "creation_date": "2021-03-11",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_CCX_ANALYTICS_DASHBOARD_URL’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/instructor/settings/common.py#L23",
      "desc": "Desc: Display the ‘Analytics’ tab in the instructor dashboard for CCX courses.\n                   Note: This has no effect unless ANALYTICS_DASHBOARD_URL is already set, because without that\n                   setting, the tab does not show up for any courses.",
      "creation_date": "2016-10-07",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘opt_in’]"
    },
    {
      "name": "FEATURES[‘ENABLE_CHANGE_USER_PASSWORD_ADMIN’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/envs/common.py#L383",
      "desc": "Desc: Set to True to enable changing a user password through django admin. This is disabled by\n                   default because enabling allows a method to bypass password policy.",
      "creation_date": "2020-02-21",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_COMBINED_LOGIN_REGISTRATION_FOOTER’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L506",
      "desc": "Desc: Display the standard footer in the login page. This feature can be overridden by a site-\n                   specific configuration.",
      "creation_date": "2016-06-24",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_CONTENT_LIBRARIES_LTI_TOOL’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/envs/common.py#L265",
      "desc": "Desc: When set to True, Content Libraries in\n                    Studio can be used as an LTI 1.3 tool by external LTI platforms.",
      "creation_date": "2021-08-17",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_COOKIE_CONSENT’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L768",
      "desc": "Desc: Enable header banner for cookie consent using this service:\n                   https://cookieconsent.insites.com/",
      "creation_date": "2017-03-03",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_COSMETIC_DISPLAY_PRICE’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L373",
      "desc": "Desc: Enable the display of “cosmetic_display_price”, set in a course advanced settings. This\n                   cosmetic price is used when there is no registration price associated to the course.",
      "creation_date": "2014-10-10",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_COURSEWARE_SEARCH’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L562",
      "desc": "Desc: When enabled, this adds a Search the course widget on the course outline and courseware\n                   pages for searching courseware data.",
      "creation_date": "2015-01-29",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_COURSEWARE_SEARCH_FOR_COURSE_STAFF’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L575",
      "desc": "Desc: When enabled, this adds a Search the course widget on the course outline and courseware\n                   pages for searching courseware data but for course staff users only.",
      "creation_date": "2019-12-06",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_COURSE_ASSESSMENT_GRADE_CHANGE_SIGNAL’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L909",
      "desc": "Desc: Set to True to start sending signals for assessment level grade updates. Notably, the only\n                   handler of this signal at the time of this writing sends assessment updates to enterprise integrated channels.",
      "creation_date": "2020-12-09",
      "target_removal_date": "2021-02-01",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘temporary’]"
    },
    {
      "name": "FEATURES[‘ENABLE_COURSE_DISCOVERY’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L637",
      "desc": "Desc: Add a course search widget to the LMS for searching courses. When this is enabled, the\n                   latest courses are no longer displayed on the LMS landing page. Also, an “Explore Courses” item is added to the\n                   navbar.",
      "creation_date": "2015-04-23",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_COURSE_FILENAME_CCX_SUFFIX’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L650",
      "desc": "Desc: If set to True, CCX ID will be included in the generated filename for CCX courses.",
      "creation_date": "2021-03-16",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_COURSE_HOME_REDIRECT’]",
      "default": "True",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L491",
      "desc": "Desc: When enabled, along with the ENABLE_MKTG_SITE feature toggle, users who attempt to access a\n                   course “about” page will be redirected to the course home url. This url might be the course “info” page or the\n                   unified course tab (when the DISABLE_UNIFIED_COURSE_TAB_FLAG waffle is not enabled).",
      "creation_date": "2019-01-15",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_COURSE_SORTING_BY_START_DATE’]",
      "default": "True",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L480",
      "desc": "Desc: When a user goes to the homepage (‘/’) the user sees the courses listed in the\n                   announcement dates order - this is default Open edX behavior. Set to True to change the course sorting behavior\n                   by their start dates, latest first.",
      "creation_date": "2015-03-27",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_CREDIT_ELIGIBILITY’]",
      "default": "True",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L3452",
      "desc": "Desc: When enabled, it is possible to define a credit eligibility criteria in the CMS. A “Credit\n                   Eligibility” section then appears for those courses in the LMS.",
      "creation_date": "2015-06-17",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_CSMH_EXTENDED’]",
      "default": "True",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L737",
      "desc": "Desc: Write Courseware Student Module History (CSMH) to the extended table: this logs all\n                   student activities to MySQL, in a separate database.",
      "creation_date": "2020-11-05",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_DASHBOARD_SEARCH’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L588",
      "desc": "Desc: When enabled, this adds a Search Your Courses widget on the dashboard page for searching\n                   courseware data.",
      "creation_date": "2015-01-29",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_DISCUSSION_EMAIL_DIGEST’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L152",
      "desc": "Desc: Set this to True if you want the discussion digest emails\n                   enabled automatically for new users. This will be set on all new account\n                   registrations.",
      "creation_date": "2014-08-19",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_DISCUSSION_HOME_PANEL’]",
      "default": "True",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L141",
      "desc": "Desc: Hides or displays a welcome panel under the Discussion tab, which includes a subscription\n                   on/off setting for discussion digest emails.",
      "creation_date": "2013-07-30",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_DISCUSSION_SERVICE’]",
      "default": "True",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L117",
      "desc": "Desc: When True, it will enable the Discussion tab in courseware for all courses. Setting this\n                   to False will not contain inline discussion components and discussion tab in any courses.",
      "creation_date": "2012-08-14",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_DJANGO_ADMIN_SITE’]",
      "default": "True",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L178",
      "desc": "Desc: Set to False if you want to disable Django’s admin site.",
      "creation_date": "2013-09-26",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_EDXNOTES’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L532",
      "desc": "Desc: This toggle enables the students to save and manage their annotations in the\n                   course using the notes service. The bulk of the actual work in storing the notes is done by\n                   a separate service (see the edx-notes-api repo).",
      "creation_date": "2015-01-04",
      "implementation": "[‘SettingToggle’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_EXAM_SETTINGS_HTML_VIEW’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/djangoapps/contentstore/toggles.py#L67",
      "desc": "Desc: When enabled, users can access the new course authoring view for proctoring exams",
      "creation_date": "2020-07-23",
      "implementation": "[‘SettingDictToggle’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_EXPORT_GIT’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/djangoapps/contentstore/toggles.py#L6",
      "desc": "Desc: When enabled, a “Export to Git” menu item is added to the course studio for courses that have a\n                   valid “giturl” attribute. Exporting a course to git causes the course to be exported in the directory indicated by\n                   the GIT_REPO_EXPORT_DIR setting. Note that when this feature is disabled, courses can still be exported to git with\n                   the git_export management command.",
      "creation_date": "2014-02-13",
      "implementation": "[‘SettingDictToggle’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_FOOTER_MOBILE_APP_LINKS’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L519",
      "desc": "Desc: Set to True if you want show the mobile app links (Apple App Store & Google Play Store) in\n                   the footer.",
      "creation_date": "2015-01-13",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_FORUM_DAILY_DIGEST’]",
      "default": "True",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/discussion/config/settings.py#L6",
      "desc": "Desc: Settings for forums/discussions to on/off daily digest\n                   feature. Set this to True if you want to enable users to subscribe and unsubscribe\n                   for daily digest. This setting enables deprecation of daily digest.",
      "creation_date": "2020-03-09",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_GRADE_DOWNLOADS’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/instructor/settings/common.py#L42",
      "desc": "Desc: Enable grade CSV downloads from the instructor dashboard. Grade\n                   calculation started from the instructor dashboard will write grades CSV files to the\n                   configured storage backend and give links for downloads.",
      "creation_date": "2016-07-06",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘opt_in’]"
    },
    {
      "name": "FEATURES[‘ENABLE_HELP_LINK’]",
      "default": "True",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/envs/common.py#L459",
      "desc": "Desc: When True, a help link is displayed on the main navbar. Set False to hide it.",
      "creation_date": "2021-03-05",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_HTML_XBLOCK_STUDENT_VIEW_DATA’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L808",
      "desc": "Desc: Whether HTML Block returns HTML content with the Course Blocks API when the API\n                   is called with student_view_data=html query parameter.",
      "creation_date": "2017-08-28",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_INTEGRITY_SIGNATURE’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/envs/common.py#L480",
      "desc": "Desc: Whether to replace ID verification course/certificate requirement",
      "creation_date": "2022-02-15",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_LEARNER_RECORDS’]",
      "default": "True",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/core/djangoapps/credentials/helpers.py#L9",
      "desc": "Desc: Enable learner records for the whole platform. This setting may be overridden by site- and\n                   org-specific site configurations with the same name.",
      "creation_date": "2020-10-01",
      "implementation": "[‘SettingDictToggle’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_LIBRARY_AUTHORING_MICROFRONTEND’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/envs/common.py#L435",
      "desc": "Desc: Set to True to enable the Library Authoring MFE",
      "creation_date": "2020-06-20",
      "target_removal_date": "2020-12-31",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘temporary’]"
    },
    {
      "name": "FEATURES[‘ENABLE_LOGIN_MICROFRONTEND’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L354",
      "desc": "Desc: Enable the login micro frontend.",
      "creation_date": "2018-05-07",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_LTI_PROVIDER’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L698",
      "desc": "Desc: When set to True, Open edX site can be used as an LTI Provider to other systems\n                    and applications.",
      "creation_date": "2015-04-24",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_MASQUERADE’]",
      "default": "True",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L190",
      "desc": "Desc: None",
      "creation_date": "2013-04-13",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_MAX_FAILED_LOGIN_ATTEMPTS’]",
      "default": "True",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L408",
      "desc": "Desc: This feature will keep track of the number of failed login attempts on a given user’s\n                   email. If the number of consecutive failed login attempts - without a successful login at some point - reaches\n                   a configurable threshold (default 6), then the account will be locked for a configurable amount of seconds\n                   (30 minutes) which will prevent additional login attempts until this time period has passed. If a user\n                   successfully logs in, all the counter which tracks the number of failed attempts will be reset back to 0. If\n                   set to False then account locking will be disabled for failed login attempts.",
      "creation_date": "2014-01-30",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_MKTG_SITE’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L456",
      "desc": "Desc: Toggle to enable alternate urls for marketing links.",
      "creation_date": "2014-03-24",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_NEW_BULK_EMAIL_EXPERIENCE’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L964",
      "desc": "Desc: When true, replaces the bulk email tool found on the\n                   instructor dashboard with a link to the new communications MFE version instead.\n                   Stting the tool to false will leave the old bulk email tool experience in place.",
      "creation_date": "2022-03-21",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘opt_in’]"
    },
    {
      "name": "FEATURES[‘ENABLE_OAUTH2_PROVIDER’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L207",
      "desc": "Desc: Enable this feature to allow this Open edX platform to be an OAuth2 authentication\n                   provider. This is necessary to enable some other features, such as the REST API for the mobile application.",
      "creation_date": "2014-09-09",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘temporary’]"
    },
    {
      "name": "FEATURES[‘ENABLE_OPENBADGES’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L685",
      "desc": "Desc: Enables support for the creation of OpenBadges as a method of awarding credentials.",
      "creation_date": "2015-04-30",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_ORA_ALL_FILE_URLS’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/envs/common.py#L393",
      "desc": "Desc: A “work-around” feature toggle meant to help in cases where some file uploads are not\n                   discoverable. If enabled, will iterate through all possible file key suffixes up to the max for displaying file\n                   metadata in staff assessments.",
      "creation_date": "2020-03-03",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘temporary’]"
    },
    {
      "name": "FEATURES[‘ENABLE_ORA_TEAM_SUBMISSIONS’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/teams/toggles.py#L12",
      "desc": "Desc: Set to True to enable team-based ORA submissions.",
      "creation_date": "2020-03-03",
      "implementation": "[‘SettingDictToggle’]",
      "use_cases": "[‘temporary’]"
    },
    {
      "name": "FEATURES[‘ENABLE_ORA_USERNAMES_ON_DATA_EXPORT’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L897",
      "desc": "Desc: Set to True to add deanonymized usernames to ORA data\n                   report.",
      "creation_date": "2020-06-11",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘temporary’]"
    },
    {
      "name": "FEATURES[‘ENABLE_ORA_USER_STATE_UPLOAD_DATA’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/envs/common.py#L407",
      "desc": "Desc: A “work-around” feature toggle meant to help in cases where some file uploads are not\n                   discoverable. If enabled, will pull file metadata from StudentModule.state for display in staff assessments.",
      "creation_date": "2020-03-03",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘temporary’]"
    },
    {
      "name": "FEATURES[‘ENABLE_PASSWORD_RESET_FAILURE_EMAIL’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L820",
      "desc": "Desc: Whether to send an email for failed password reset attempts or not. This happens when a\n                   user asks for a password reset but they don’t have an account associated to their email. This is useful for\n                   notifying users that they don’t have an account associated with email addresses they believe they’ve registered\n                   with. This setting can be overridden by a site-specific configuration.",
      "creation_date": "2017-07-20",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_SPECIAL_EXAMS’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L676",
      "desc": "Desc: Enable to use special exams, aka timed and proctored exams.",
      "creation_date": "2015-09-04",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_STUDENT_HISTORY_VIEW’]",
      "default": "True",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L265",
      "desc": "Desc: This provides a UI to show a student’s submission history in a problem by the Staff Debug\n                   tool. Set to False if you want to hide Submission History from the courseware page.",
      "creation_date": "2013-02-15",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_TEXTBOOK’]",
      "default": "True",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L130",
      "desc": "Desc: Add PDF and HTML textbook tabs to the courseware.",
      "creation_date": "2014-03-27",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_THIRD_PARTY_AUTH’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L445",
      "desc": "Desc: Turn on third-party auth. Disabled for now because full mplementations are not yet\n                   available. Remember to run migrations if you enable this; we don’t create tables by default. This feature can\n                   be enabled on a per-site basis. When enabling this feature, remember to define the allowed authentication\n                   backends with the AUTHENTICATION_BACKENDS setting.",
      "creation_date": "2014-09-15",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_UNICODE_USERNAME’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L167",
      "desc": "Desc: Set this to True to allow unicode characters in username. Enabling this will also\n                   automatically enable SOCIAL_AUTH_CLEAN_USERNAMES. When this is enabled, usernames will have to match the\n                   regular expression defined by USERNAME_REGEX_PARTIAL.",
      "creation_date": "2017-06-27",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENABLE_V2_CERT_DISPLAY_SETTINGS’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/envs/common.py#L469",
      "desc": "Desc: Whether to use the reimagined certificates_display_behavior and certificate_available_date",
      "creation_date": "2021-07-26",
      "target_removal_date": "2021-10-01",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘temporary’]"
    },
    {
      "name": "FEATURES[‘ENABLE_XBLOCK_VIEW_ENDPOINT’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L218",
      "desc": "Desc: Enable an API endpoint, named “xblock_view”, to serve rendered XBlock views. This might be\n                   used by external applications. See for instance jquery-xblock (now unmaintained):\n                   https://github.com/edx-solutions/jquery-xblock",
      "creation_date": "2014-03-14",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘ENTRANCE_EXAMS’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/core/toggles.py#L7",
      "desc": "Desc: Enable entrance exams feature. When enabled, students see an exam xblock as the first unit\n                   of the course.",
      "creation_date": "2015-12-01",
      "implementation": "[‘SettingDictToggle’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘HIDE_DASHBOARD_COURSES_UNTIL_ACTIVATED’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L255",
      "desc": "Desc: When set, it hides the Courses list on the Learner Dashboard page if the learner has not\n                   yet activated the account and not enrolled in any courses.",
      "creation_date": "2018-05-18",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘LICENSING’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L603",
      "desc": "Desc: Toggle platform-wide course licensing. The course.license attribute is then used to append\n                   license information to the courseware.",
      "creation_date": "2015-05-14",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘MILESTONES_APP’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/common/djangoapps/util/milestones_helpers.py#L25",
      "desc": "Desc: Enable the milestones application, which manages significant Course and/or Student events in\n                   the Open edX platform. (see https://github.com/edx/edx-milestones) Note that this feature is required to enable\n                   course pre-requisites.",
      "creation_date": "2014-11-21",
      "implementation": "[‘SettingDictToggle’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘RESTRICT_AUTOMATIC_AUTH’]",
      "default": "True",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L342",
      "desc": "Desc: Prevent auto auth from creating superusers or modifying existing users. Auto auth is a\n                   mechanism where superusers can simply modify attributes of other users by accessing the “/auto_auth url” with\n                   the right\n                   querystring parameters.",
      "creation_date": "2018-05-07",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘SHOW_FOOTER_LANGUAGE_SELECTOR’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L727",
      "desc": "Desc: When set to True, language selector will be visible in the footer.",
      "creation_date": "2017-05-25",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘SHOW_HEADER_LANGUAGE_SELECTOR’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L711",
      "desc": "Desc: When set to True, language selector will be visible in the header.",
      "creation_date": "2017-05-25",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘SHOW_PROGRESS_BAR’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/common/lib/xmodule/xmodule/seq_module.py#L68",
      "desc": "Desc: Set to True to show progress bar.",
      "creation_date": "2022-02-09",
      "implementation": "[‘SettingDictToggle’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "FEATURES[‘SKIP_EMAIL_VALIDATION’]",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L363",
      "desc": "Desc: Turn this on to skip sending emails for user validation.\n                   Beware, as this leaves the door open to potential spam abuse.",
      "creation_date": "2018-05-07",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "GLOBAL_NOTICE_ENABLED",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/core/djangoapps/util/user_messages.py#L187",
      "desc": "Desc: When enabled, show the contents of GLOBAL_NOTICE_MESSAGE\n                   as a message on every page. This is intended to be used as a way of\n                   communicating an upcoming or currently active maintenance window or to\n                   warn of known site issues. HTML is not supported for the message content,\n                   only plaintext. Message styling can be controlled with GLOBAL_NOTICE_TYPE,\n                   set to one of INFO, SUCCESS, WARNING, or ERROR (defaulting to INFO). Also\n                   see openedx.core.djangoapps.util.maintenance_banner.add_maintenance_banner\n                   for a variation that only shows a message on specific views.",
      "creation_date": "2021-09-08",
      "implementation": "[‘SettingToggle’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "HLSPlaybackEnabledFlag.enabled_for_all_courses",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/core/djangoapps/video_config/models.py#L16",
      "desc": "Desc: Add the “hls” profile to all displayed videos on the platform.",
      "creation_date": "2017-04-19",
      "implementation": "[‘ConfigurationModel’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "LOG_REQUEST_USER_CHANGES",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/core/djangoapps/safe_sessions/middleware.py#L101",
      "desc": "Desc: Turn this toggle on to provide additional debugging information in the case of a user\n                      verification error. It will track anytime the `user` attribute of a request object is changed and store this\n                      information on the request. This will also track the location where the change is coming from to quickly find\n                      issues. If user verification fails at response time, all of the information about these\n                      changes will be logged.",
      "creation_date": "2021-03-25",
      "implementation": "[‘SettingToggle’]",
      "use_cases": "[‘opt_in’]"
    },
    {
      "name": "LOG_REQUEST_USER_CHANGE_HEADERS",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/core/djangoapps/safe_sessions/middleware.py#L116",
      "desc": "Desc: Turn this toggle on to log all request headers, for all requests, for all user ids involved in\n                      any user id change detected by safe sessions. The headers will provide additional debugging information. The\n                      headers will be logged for all requests up until LOG_REQUEST_USER_CHANGE_HEADERS_DURATION seconds after\n                      the time of the last mismatch. The header details will be encrypted, and only available with the private key.",
      "creation_date": "2021-12-22",
      "implementation": "[‘SettingToggle’]",
      "use_cases": "[‘opt_in’]"
    },
    {
      "name": "MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/envs/common.py#L492",
      "desc": "Desc: If enabled, the Library Content Block is marked as complete when users view it.\n                   Otherwise (by default), all children of this block must be completed.",
      "creation_date": "2022-03-22",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "ORGANIZATIONS_AUTOCREATE",
      "default": "True",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/envs/common.py#L2603",
      "desc": "Desc: When enabled, creating a course run or content library with\n                   an “org slug” that does not map to an Organization in the database will trigger the\n                   creation of a new Organization, with its name and short_name set to said org slug.\n                   When disabled, creation of such content with an unknown org slug will instead\n                   result in a validation error.\n                   If you want the Organization table to be an authoritative information source in\n                   Studio, then disable this; however, if you want the table to just be a reflection of\n                   the orgs referenced in Studio content, then leave it enabled.",
      "creation_date": "2020-11-02",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "PersistentGradesEnabledFlag.enabled",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/grades/config/models.py#L17",
      "desc": "Desc: When enabled, grades are persisted. This means that PersistentCourseGrade objects are\n                       created for student grades. In order for this to take effect, CoursePersistentGradesFlag objects must also be\n                       created individually for each course. Alternatively, the PersistentGradesEnabledFlag.enabled_for_all_courses\n                       waffle flag or the PERSISTENT_GRADES_ENABLED_FOR_ALL_TESTS feature flag can be set to True to enable this\n                       feature for all courses.",
      "creation_date": "2016-08-26",
      "implementation": "[‘ConfigurationModel’]",
      "use_cases": "[‘temporary’]"
    },
    {
      "name": "RATELIMIT_ENABLE",
      "default": "True",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L4647",
      "desc": "Desc: When enabled, RATELIMIT_RATE is applied.\n                    When disabled, RATELIMIT_RATE is not applied.",
      "creation_date": "2018-01-08",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "SEARCH_SKIP_INVITATION_ONLY_FILTERING",
      "default": "True",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L4039",
      "desc": "Desc: If enabled, invitation-only courses will appear in search results.",
      "creation_date": "2021-08-27",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "SEARCH_SKIP_SHOW_IN_CATALOG_FILTERING",
      "default": "True",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L4046",
      "desc": "Desc: If enabled, courses with a catalog_visibility set to “none” will still\n                    appear in search results.",
      "creation_date": "2021-08-27",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "SOME_FEATURE_NAME",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L5047",
      "desc": "Desc: Flag would be used to show account activation popup after the registration",
      "creation_date": "2021-06-10",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "VEMPipelineIntegration.enabled",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/core/djangoapps/video_pipeline/models.py#L14",
      "desc": "Desc: Send videos to the Video Encode Manager (VEM) as part of the\n                      video pipeline.",
      "creation_date": "2020-06-04",
      "implementation": "[‘ConfigurationModel’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "VideoUploadsEnabledByDefault.enabled_for_all_courses",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/core/djangoapps/video_pipeline/models.py#L55",
      "desc": "Desc: Allow video uploads for all courses of the platform. This\n                      enables the “Video Uploads” menu in the CMS.",
      "creation_date": "2017-11-10",
      "implementation": "[‘ConfigurationModel’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "WIKI_ACCOUNT_HANDLING",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L1929",
      "desc": "Desc: We recommend you leave this as ‘False’ for an Open edX installation\n                   to get the proper behavior for register, login and logout. For the original docs see:\n                   https://github.com/edx/django-wiki/blob/edx_release/wiki/conf/settings.py",
      "creation_date": "2012-08-13",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "WIKI_ANONYMOUS",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L1939",
      "desc": "Desc: Enabling this allows access to anonymous users.\n                   For the original docs, see:\n                   https://github.com/edx/django-wiki/blob/edx_release/wiki/conf/settings.py",
      "creation_date": "2012-08-21",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "WIKI_ENABLED",
      "default": "True",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L1365",
      "desc": "Desc: This setting allows us to have a collaborative tool to contribute or\n                   modify content of course related materials.",
      "creation_date": "2012-07-13",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "WIKI_LINK_LIVE_LOOKUPS",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L1964",
      "desc": "Desc: This setting is defined in the original docs:\n                   https://github.com/edx/django-wiki/blob/edx_release/wiki/conf/settings.py",
      "creation_date": "2012-08-23",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "WIKI_USE_BOOTSTRAP_SELECT_WIDGET",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/envs/common.py#L1955",
      "desc": "Desc: Enabling this will use the bootstrap select widget.\n                   For the original docs, see:\n                   https://github.com/edx/django-wiki/blob/edx_release/wiki/conf/settings.py",
      "creation_date": "2012-08-22",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "account.redirect_to_microfrontend",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/core/djangoapps/user_api/accounts/toggles.py#L28",
      "desc": "Desc: Supports staged rollout of a new micro-frontend-based implementation of the account page.\n                   Its action can be overridden using site’s ENABLE_ACCOUNT_MICROFRONTEND setting.",
      "creation_date": "2019-04-30",
      "target_removal_date": "2021-12-31",
      "implementation": "[‘WaffleFlag’]",
      "use_cases": "[‘temporary’, ‘open_edx’]"
    },
    {
      "name": "block_structure.invalidate_cache_on_publish",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/core/djangoapps/content/block_structure/config/__init__.py#L12",
      "desc": "Desc: When enabled, the block structure cache is invalidated when changes to\n                   courses are published. If `block_structure.storage_backing_for_cache` is active, all block\n                   structures related to the published course are also cleared from storage.",
      "creation_date": "2017-02-23",
      "target_removal_date": "2017-05-23",
      "implementation": "[‘WaffleSwitch’]",
      "use_cases": "[‘temporary’]"
    },
    {
      "name": "block_structure.raise_error_when_not_found",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/core/djangoapps/content/block_structure/config/__init__.py#L51",
      "desc": "Desc: Raises an error if the requested block structure does not exist in block\n                   structure store, or if it is outdated. Block structure store refers to both cache and storage,\n                   if enabled.",
      "creation_date": "2017-02-23",
      "target_removal_date": "2017-05-23",
      "implementation": "[‘WaffleSwitch’]",
      "use_cases": "[‘temporary’]"
    },
    {
      "name": "block_structure.storage_backing_for_cache",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/core/djangoapps/content/block_structure/config/__init__.py#L30",
      "desc": "Desc: When enabled, block structures are stored in a more permanent storage,\n                   like a database, which provides an additional backup for cache misses, instead having them\n                   regenerated. The regenration of block structures is a time consuming process. Therefore,\n                   enabling this switch is recommended for Production.",
      "creation_date": "2017-02-23",
      "target_removal_date": "2017-05-23",
      "implementation": "[‘WaffleSwitch’]",
      "use_cases": "[‘temporary’]"
    },
    {
      "name": "blockstore.use_blockstore_app_api",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/core/lib/blockstore_api/config/waffle.py#L7",
      "desc": "Desc: Enable to use the installed blockstore app’s Python API directly instead of the\n                   external blockstore service REST API.\n                   The blockstore REST API is used by default.",
      "creation_date": "2022-01-13",
      "implementation": "[‘WaffleSwitch’]",
      "use_cases": "[‘temporary’, ‘open_edx’]"
    },
    {
      "name": "bulk_email.EMAIL_USE_COURSE_ID_FROM_FOR_BULK",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/bulk_email/toggles.py#L8",
      "desc": "Desc: If False, use the same BULK_EMAIL_DEFAULT_FROM_EMAIL or DEFAULT_FROM_EMAIL as the from_addr for all bulk email, to avoid issues with spam filtering",
      "creation_date": "2020-10-01",
      "implementation": "[‘DjangoSetting’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "bypass_olx_failure",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/djangoapps/contentstore/toggles.py#L38",
      "desc": "Desc: Enables bypassing olx validation failures during course import.",
      "creation_date": "2021-04-15",
      "target_removal_date": "2021-05-15",
      "implementation": "[‘WaffleFlag’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "certificates.auto_certificate_generation",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/certificates/config.py#L11",
      "desc": "Desc: This toggle will enable certificates to be automatically generated",
      "creation_date": "2017-09-14",
      "implementation": "[‘WaffleSwitch’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "contentstore.library_authoring_mfe",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/djangoapps/contentstore/config/waffle.py#L55",
      "desc": "Desc: Toggles the new micro-frontend-based implementation of the library authoring experience.",
      "creation_date": "2020-08-03",
      "target_removal_date": "2020-12-31",
      "implementation": "[‘WaffleFlag’]",
      "use_cases": "[‘temporary’, ‘open_edx’]"
    },
    {
      "name": "course_apps.proctoring_settings_modal_view",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/core/djangoapps/course_apps/toggles.py#L11",
      "desc": "Desc: When enabled, users will be directed to a new proctoring settings\n                    modal on the Pages and Resources view when accessing proctored exam settings.",
      "creation_date": "2021-08-17",
      "implementation": "[‘CourseWaffleFlag’]",
      "use_cases": "[‘temporary’]"
    },
    {
      "name": "course_blocks_api.hide_access_denials",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/course_api/blocks/toggles.py#L10",
      "desc": "Desc: Waffle flag to hide access denial messages in the course blocks.",
      "creation_date": "2019-09-27",
      "implementation": "[‘WaffleFlag’]",
      "use_cases": "[‘temporary’, ‘open_edx’]"
    },
    {
      "name": "course_experience.calendar_sync",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/features/course_experience/__init__.py#L82",
      "desc": "Desc: This course flag enables a course tool (which is a tool that is added on a course home page)\n                   that sends course assignment calendars to course students, whenever they click on the “Subscribe to calendar\n                   updates” button. The email contains an ics attachment that students can then use to sync with their own calendar\n                   apps.",
      "creation_date": "2021-01-26",
      "target_removal_date": "2021-04-26",
      "implementation": "[‘CourseWaffleFlag’]",
      "use_cases": "[‘temporary’]"
    },
    {
      "name": "course_experience.enable_about_sidebar_html",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/features/course_experience/waffle.py#L11",
      "desc": "Desc: Used to determine whether to show custom HTML in the sidebar on the internal course about page.",
      "creation_date": "2018-01-26",
      "implementation": "[‘WaffleSwitch’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "course_experience.enable_course_goals",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/features/course_experience/__init__.py#L34",
      "desc": "Desc: Used to determine whether or not to use course goals for the particular course.",
      "creation_date": "2017-09-11",
      "implementation": "[‘CourseWaffleFlag’]",
      "use_cases": "[‘opt_out’, ‘temporary’]"
    },
    {
      "name": "course_experience.latest_update",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/features/course_experience/__init__.py#L50",
      "desc": "Desc: Used to switch between ‘welcome message’ and ‘latest update’ on the course home page.",
      "creation_date": "2017-09-11",
      "implementation": "[‘CourseWaffleFlag’]",
      "use_cases": "[‘opt_out’, ‘temporary’]"
    },
    {
      "name": "course_experience.relative_dates",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/features/course_experience/__init__.py#L70",
      "desc": "Desc: Waffle flag to enable relative dates for course content. A ‘Dates’ tab will be visible in the\n                   course view showing key course dates. Was previously an ExperimentWaffleFlag with experiment_id=17.",
      "creation_date": "2020-02-10",
      "implementation": "[‘CourseWaffleFlag’]",
      "use_cases": "[‘opt_in’]"
    },
    {
      "name": "course_home.course_home_use_legacy_frontend",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/course_home_api/toggles.py#L14",
      "desc": "Desc: This flag enables the use of the legacy view of course home as the default course frontend.",
      "creation_date": "2021-06-11",
      "target_removal_date": "2022-05-15",
      "implementation": "[‘CourseWaffleFlag’]",
      "use_cases": "[‘temporary’]"
    },
    {
      "name": "course_list_api_rate_limit.rate_limit_10",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/course_api/__init__.py#L17",
      "desc": "Desc: Waffle switch to enable the throttling of 10 requests/minute to the course API. For staff\n                   users, this limit is 20 requests/minute.",
      "creation_date": "2018-06-12",
      "implementation": "[‘WaffleSwitch’]",
      "use_cases": "[‘circuit_breaker’]"
    },
    {
      "name": "course_list_api_rate_limit.rate_limit_2",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/course_api/__init__.py#L8",
      "desc": "Desc: Waffle switch to enable the throttling of 2 requests/minute to the course API. For staff\n                   users, this limit is 10 requests/minute.",
      "creation_date": "2018-06-12",
      "implementation": "[‘WaffleSwitch’]",
      "use_cases": "[‘circuit_breaker’]"
    },
    {
      "name": "course_live.enable_course_live",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/core/djangoapps/course_live/config/waffle.py#L12",
      "desc": "Desc: Waffle flag to enable the course live app plugin",
      "creation_date": "2022-03-02",
      "target_removal_date": "2022-06-02",
      "implementation": "[‘CourseWaffleFlag’]",
      "use_cases": "[‘temporary’, ‘open_edx’]"
    },
    {
      "name": "course_modes.use_new_track_selection",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/common/djangoapps/course_modes/views.py#L50",
      "desc": "Desc: This flag enables the use of the new track selection template for testing purposes before full rollout",
      "creation_date": "2021-8-23",
      "implementation": "[‘WaffleFlag’]",
      "use_cases": "[‘temporary’]"
    },
    {
      "name": "courseware.enable_new_financial_assistance_flow",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/courseware/config.py#L9",
      "desc": "Desc: enables new internal only financial assistance flow, when active.",
      "creation_date": "2022-03-25",
      "implementation": "[‘WaffleSwitch’]",
      "use_cases": "[‘opt_in’]"
    },
    {
      "name": "courseware.mfe_progress_milestones",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/courseware/toggles.py#L58",
      "desc": "Desc: Waffle flag to display learner progress milestones in a course. Supports staged\n                   rollout to students for a new micro-frontend-based implementation of the courseware page.",
      "creation_date": "2020-10-07",
      "target_removal_date": "none",
      "implementation": "[‘CourseWaffleFlag’]",
      "use_cases": "[‘temporary’, ‘open_edx’]"
    },
    {
      "name": "courseware.mfe_progress_milestones_streak_celebration",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/courseware/toggles.py#L72",
      "desc": "Desc: Waffle flag to display a celebration modal when learner completes a configurable streak\n                   Supports staged rollout to students for a new micro-frontend-based implementation of the\n                   courseware page.",
      "creation_date": "2021-02-16",
      "implementation": "[‘CourseWaffleFlag’]",
      "use_cases": "[‘temporary’, ‘open_edx’]"
    },
    {
      "name": "courseware.mfe_progress_milestones_streak_discount_enabled",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/courseware/toggles.py#L88",
      "desc": "Desc: This flag enables an engagement discount incentive message.",
      "creation_date": "2021-08-26",
      "implementation": "[‘CourseWaffleFlag’]",
      "use_cases": "[‘opt_out’, ‘open_edx’]"
    },
    {
      "name": "courseware.microfrontend_course_exit_page",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/courseware/toggles.py#L43",
      "desc": "Desc: Supports staged rollout of the new micro-frontend-based implementation of the course exit page.",
      "creation_date": "2020-10-02",
      "implementation": "[‘CourseWaffleFlag’]",
      "use_cases": "[‘open_edx’, ‘temporary’]"
    },
    {
      "name": "courseware.microfrontend_course_team_preview",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/courseware/toggles.py#L28",
      "desc": "Desc: Waffle flag to display a link for the new learner experience to course teams without\n                   redirecting students. Supports staged rollout to course teams of a new micro-frontend-based implementation of the\n                   courseware page.",
      "creation_date": "2020-03-09",
      "target_removal_date": "2020-12-31",
      "implementation": "[‘CourseWaffleFlag’]",
      "use_cases": "[‘temporary’, ‘open_edx’]"
    },
    {
      "name": "courseware.optimized_render_xblock",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/courseware/toggles.py#L103",
      "desc": "Desc: Waffle flag that determines whether we speed up the render_xblock for browsers by\n                   removing unnecessary JavaScript and CSS. It is possible that this could introduce edge cases with content\n                   that relies on these assets, so being a CourseWaffleFlag will give us the flexibility to exempt courses\n                   from these optimizations.",
      "creation_date": "2021-02-09",
      "target_removal_date": "2021-05-01",
      "implementation": "[‘CourseWaffleFlag’]",
      "use_cases": "[‘temporary’]"
    },
    {
      "name": "courseware.use_legacy_frontend",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/courseware/toggles.py#L14",
      "desc": "Desc: Waffle flag to direct learners to the legacy courseware experience - the default behavior\n                   directs to the new MFE-based courseware in frontend-app-learning. Supports the ability to globally flip back to\n                   the legacy courseware experience.",
      "creation_date": "2021-06-03",
      "target_removal_date": "2021-10-09",
      "implementation": "[‘CourseWaffleFlag’]",
      "use_cases": "[‘temporary’, ‘open_edx’]"
    },
    {
      "name": "discounts.enable_discounting",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/features/discounts/applicability.py#L31",
      "desc": "Desc: Toggle discounts always being disabled",
      "creation_date": "2019-4-16",
      "implementation": "[‘WaffleFlag’]",
      "use_cases": "[‘temporary’]"
    },
    {
      "name": "discussions.enable_discussions_mfe",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/discussion/toggles.py#L8",
      "desc": "Desc: Waffle flag to use the new MFE experience for discussions in the course tab and in-context",
      "creation_date": "2021-11-05",
      "target_removal_date": "2022-03-05",
      "implementation": "[‘CourseWaffleFlag’]",
      "use_cases": "[‘temporary’, ‘open_edx’]"
    },
    {
      "name": "discussions.enable_learners_tab_in_discussions_mfe",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/discussion/toggles.py#L26",
      "desc": "Desc: Waffle flag to enable learners tab in the new MFE experience for discussions",
      "creation_date": "2022-02-21",
      "target_removal_date": "2022-05-21",
      "implementation": "[‘CourseWaffleFlag’]",
      "use_cases": "[‘temporary’, ‘open_edx’]"
    },
    {
      "name": "discussions.enable_moderation_reason_codes",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/discussion/toggles.py#L36",
      "desc": "Desc: Waffle flag to toggle support for the new edit and post close reason codes",
      "creation_date": "2022-02-22",
      "target_removal_date": "2022-09-22",
      "implementation": "[‘CourseWaffleFlag’]",
      "use_cases": "[‘temporary’, ‘open_edx’]"
    },
    {
      "name": "discussions.enable_new_structure_discussions",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/discussion/toggles.py#L17",
      "desc": "Desc: Waffle flag to toggle on the new structure for in context discussions",
      "creation_date": "2022-02-22",
      "target_removal_date": "2022-09-22",
      "implementation": "[‘CourseWaffleFlag’]",
      "use_cases": "[‘temporary’, ‘open_edx’]"
    },
    {
      "name": "discussions.override_discussion_legacy_settings",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/core/djangoapps/discussions/config/waffle.py#L13",
      "desc": "Desc: Waffle flag to override visibility of discussion settings for legacy experience.",
      "creation_date": "2021-06-15",
      "target_removal_date": "2021-12-31",
      "implementation": "[‘CourseWaffleFlag’]",
      "use_cases": "[‘temporary’, ‘open_edx’]"
    },
    {
      "name": "discussions.pages_and_resources_mfe",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/core/djangoapps/discussions/config/waffle.py#L29",
      "desc": "Desc: Waffle flag to enable new Pages and Resources experience for course.",
      "creation_date": "2021-05-24",
      "target_removal_date": "2021-12-31",
      "implementation": "[‘CourseWaffleFlag’]",
      "use_cases": "[‘temporary’, ‘open_edx’]"
    },
    {
      "name": "effort_estimation.disabled",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/features/effort_estimation/toggles.py#L12",
      "desc": "Desc: If effort estimations are confusing for a given course (e.g. the course team has added manual\n                   estimates), you can turn them off case by case here.",
      "creation_date": "2021-07-27",
      "implementation": "[‘CourseWaffleFlag’]",
      "use_cases": "[‘opt_out’]"
    },
    {
      "name": "experiments.add_dashboard_info",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/experiments/utils.py#L44",
      "desc": "Desc: Toggle for adding info about each course to the dashboard metadata",
      "creation_date": "2019-3-28",
      "implementation": "[‘WaffleFlag’]",
      "use_cases": "[‘temporary’]"
    },
    {
      "name": "experiments.add_programs",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/experiments/utils.py#L29",
      "desc": "Desc: Toggle for adding the current course’s program information to user metadata",
      "creation_date": "2019-2-25",
      "implementation": "[‘WaffleFlag’]",
      "use_cases": "[‘temporary’]"
    },
    {
      "name": "experiments.add_upsell_tracking",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/experiments/utils.py#L56",
      "desc": "Desc: Make sure upsell tracking JS works as expected.",
      "creation_date": "2020-7-7",
      "implementation": "[‘WaffleFlag’]",
      "use_cases": "[‘temporary’]"
    },
    {
      "name": "experiments.mobile_upsell_rev934",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/experiments/views_custom.py#L27",
      "desc": "Desc: Toggle mobile upsell enabled",
      "creation_date": "2019-09-05",
      "implementation": "[‘WaffleFlag’]",
      "use_cases": "[‘temporary’]"
    },
    {
      "name": "export_course_metadata",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/djangoapps/export_course_metadata/toggles.py#L7",
      "desc": "Desc: Export of course metadata (initially to s3 for use by braze)",
      "creation_date": "2021-03-01",
      "implementation": "[‘WaffleFlag’]",
      "use_cases": "[‘temporary’]"
    },
    {
      "name": "grades.assume_zero_grade_if_absent",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/grades/config/waffle.py#L16",
      "desc": "Desc: When enabled, an absent grade is assumed to be zero. Alternatively, defining the\n                   `settings.FEATURES[“ASSUME_ZERO_GRADE_IF_ABSENT_FOR_ALL_TESTS”]` feature flag in the LMS will enable this feature\n                   for all courses.",
      "creation_date": "2017-04-11",
      "implementation": "[‘WaffleSwitch’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "grades.bulk_management",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/grades/config/waffle.py#L73",
      "desc": "Desc: When enabled, bulk features are visible for management in masters course. As far\n                   as we understand, this feature is now unused and obsolete.",
      "creation_date": "2019-08-20",
      "implementation": "[‘CourseWaffleFlag’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "grades.disable_regrade_on_policy_change",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/grades/config/waffle.py#L28",
      "desc": "Desc: When enabled, a change in grading policy will not trigger re-grading.",
      "creation_date": "2017-08-03",
      "implementation": "[‘WaffleSwitch’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "grades.rejected_exam_overrides_grade",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/grades/config/waffle.py#L50",
      "desc": "Desc: When enabled, grades can no longer be updated 30 days after a course has ended. Note that this\n                   is only valid for courses which actually have an end date.",
      "creation_date": "2018-10-01",
      "implementation": "[‘CourseWaffleFlag’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "grades.writable_gradebook",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/grades/config/waffle.py#L61",
      "desc": "Desc: When enabled, add GET/POST endpoints for updating gradebook entries in bulk. Also, a link to\n                   the writable gradebook is added to the instructor dashboard.",
      "creation_date": "2018-10-03",
      "implementation": "[‘CourseWaffleFlag’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "instructor.enable_data_download_v2",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/instructor/toggles.py#L11",
      "desc": "Desc: instructor",
      "creation_date": "2020-07-8",
      "implementation": "[‘WaffleFlag’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "ip.legacy",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/core/djangoapps/util/ip.py#L176",
      "desc": "Desc: Emergency switch to revert to use the older, less secure method for\n                   IP determination. When enabled, instructs switch’s callers to revert to using the *leftmost*\n                   IP from the X-Forwarded-For header. When disabled (the default), callers should use the new\n                   code path for IP determination, which has callers retrieve the entire external chain or pick\n                   the leftmost or rightmost IP from it. The construction of the external chain is configurable\n                   via ``CLOSEST_CLIENT_IP_FROM_HEADERS``.\n                     This toggle, as well as any other legacy IP references, should be deleted (in the off\n                   position) when the new IP code is well-tested and all IP-reliant code has been switched over.",
      "warning": "This switch does not control the behavior of this module. Callers must\n                       opt into querying this switch, and can call ``get_legacy_ip`` if the switch is enabled.",
      "creation_date": "2022-03-24",
      "target_removal_date": "2022-07-01",
      "implementation": "[‘WaffleSwitch’]",
      "use_cases": "[‘temporary’]"
    },
    {
      "name": "learner_dashboard.enable_masters_program_tab_view",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/learner_dashboard/config/waffle.py#L25",
      "desc": "Desc: Waffle flag to enable new Masters Program discussion experience for masters program.\n                    This flag is used to decide weather we need to render master program data in “tab” view or simple view.\n                    In the new tab view, we have tabs like “journey”, “live”, “discussions”",
      "creation_date": "2021-10-19",
      "target_removal_date": "2021-12-31",
      "implementation": "[‘WaffleFlag’]",
      "use_cases": "[‘temporary’, ‘open_edx’]"
    },
    {
      "name": "learner_dashboard.enable_program_tab_view",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/learner_dashboard/config/waffle.py#L8",
      "desc": "Desc: Waffle flag to enable new Program discussion experience in tab view for course.\n                    This flag is used to decide weather we need to render program data in “tab” view or simple view.\n                    In the new tab view, we have tabs like “journey”, “live”, “discussions”",
      "creation_date": "2021-08-25",
      "target_removal_date": "2021-12-31",
      "implementation": "[‘WaffleFlag’]",
      "use_cases": "[‘temporary’, ‘open_edx’]"
    },
    {
      "name": "learner_profile.redirect_to_microfrontend",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/features/learner_profile/toggles.py#L12",
      "desc": "Desc: Supports staged rollout of a new micro-frontend-based implementation of the profile page.",
      "creation_date": "2019-02-19",
      "target_removal_date": "2020-12-31",
      "implementation": "[‘WaffleFlag’]",
      "use_cases": "[‘temporary’, ‘open_edx’]"
    },
    {
      "name": "new_core_editors.use_new_problem_editor",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/djangoapps/contentstore/toggles.py#L124",
      "desc": "Desc: This flag enables the use of the new core problem xblock editor",
      "creation_date": "2021-12-1",
      "target_removal_date": "2022-1-30",
      "implementation": "[‘WaffleFlag’]",
      "use_cases": "[‘temporary’]"
    },
    {
      "name": "new_core_editors.use_new_text_editor",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/djangoapps/contentstore/toggles.py#L86",
      "desc": "Desc: This flag enables the use of the new core text xblock editor",
      "creation_date": "2021-12-1",
      "target_removal_date": "2022-1-30",
      "implementation": "[‘WaffleFlag’]",
      "use_cases": "[‘temporary’]"
    },
    {
      "name": "new_core_editors.use_new_video_editor",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/djangoapps/contentstore/toggles.py#L105",
      "desc": "Desc: This flag enables the use of the new core video xblock editor",
      "creation_date": "2021-12-1",
      "target_removal_date": "2022-1-30",
      "implementation": "[‘WaffleFlag’]",
      "use_cases": "[‘temporary’]"
    },
    {
      "name": "open_edx_util.display_maintenance_warning",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/core/djangoapps/util/waffle.py#L8",
      "desc": "Desc: Displays the maintenance warning, when active.",
      "creation_date": "2018-03-20",
      "implementation": "[‘WaffleSwitch’]",
      "use_cases": "[‘opt_in’]"
    },
    {
      "name": "order_history.redirect_to_microfrontend",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/core/djangoapps/user_api/accounts/toggles.py#L8",
      "desc": "Desc: Supports staged rollout of a new micro-frontend-based implementation of the order history page.",
      "creation_date": "2019-04-11",
      "target_removal_date": "2020-12-31",
      "implementation": "[‘WaffleFlag’]",
      "use_cases": "[‘temporary’, ‘open_edx’]"
    },
    {
      "name": "registration.enable_failure_logging",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/core/djangoapps/user_authn/views/register.py#L110",
      "desc": "Desc: Enable verbose logging of registration failure messages",
      "creation_date": "2020-04-30",
      "target_removal_date": "2020-06-01",
      "implementation": "[‘WaffleFlag’]",
      "use_cases": "[‘temporary’]"
    },
    {
      "name": "require_course_email_auth",
      "default": "True",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/bulk_email/models.py#L497",
      "desc": "Desc: If the flag is enabled, course-specific authorization is\n                      required, and the course_id is either not provided or not authorized, the feature\n                      is not available.",
      "creation_date": "2016-05-05",
      "implementation": "[‘ConfigurationModel’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "schedules.enable_debugging",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/core/djangoapps/schedules/config.py#L14",
      "desc": "Desc: Enable debug level of logging for schedules messages.",
      "creation_date": "2017-09-17",
      "implementation": "[‘WaffleFlag’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "split_library_on_studio_dashboard",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/djangoapps/contentstore/toggles.py#L25",
      "desc": "Desc: Enables data new view for library on studio dashboard.",
      "creation_date": "2020-07-8",
      "implementation": "[‘WaffleFlag’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "student.courseenrollment_admin",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/common/djangoapps/student/admin.py#L53",
      "desc": "Desc: This toggle will enable the rendering of the admin view of the CourseEnrollment model.",
      "creation_date": "2018-08-01",
      "implementation": "[‘WaffleSwitch’]",
      "use_cases": "[‘opt_in’, ‘open_edx’]"
    },
    {
      "name": "studio.custom_relative_dates",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/cms/djangoapps/contentstore/config/waffle.py#L72",
      "desc": "Desc: Waffle flag to enable custom pacing input for Personalized Learner Schedule (PLS).",
      "creation_date": "2021-07-12",
      "target_removal_date": "2021-12-31",
      "implementation": "[‘CourseWaffleFlag’]",
      "use_cases": "[‘temporary’]"
    },
    {
      "name": "teams.enable_teams_app",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/teams/waffle.py#L8",
      "desc": "Desc: Waffle flag to enable teams app for a course",
      "creation_date": "2021-10-07",
      "target_removal_date": "2021-11-01",
      "implementation": "[‘WaffleFlag’]",
      "use_cases": "[‘temporary’, ‘open_edx’]"
    },
    {
      "name": "user_authn.enable_login_using_thirdparty_auth_only",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/core/djangoapps/user_authn/config/waffle.py#L11",
      "desc": "Desc: When enabled, users must be sign in using their allowed domain SSO account. This includes sign-\n                   ins to the Django admin dashboard at “/admin”.",
      "creation_date": "2019-11-20",
      "target_removal_date": "2020-01-31",
      "implementation": "[‘WaffleSwitch’]",
      "use_cases": "[‘temporary’]"
    },
    {
      "name": "user_authn.enable_pwned_password_api",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/core/djangoapps/user_authn/config/waffle.py#L27",
      "desc": "Desc: When enabled, user password’s vulnerability would be checked via pwned password database",
      "creation_date": "2021-09-22",
      "target_removal_date": "2021-12-31",
      "implementation": "[‘WaffleSwitch’]",
      "use_cases": "[‘temporary’]"
    },
    {
      "name": "verify_student.optimised_is_small_course",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/instructor/toggles.py#L25",
      "desc": "Desc: Supports staged rollout to improved is_small_course method.",
      "creation_date": "2020-07-02",
      "implementation": "[‘WaffleFlag’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "verify_student.use_new_email_templates",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/lms/djangoapps/verify_student/toggles.py#L10",
      "desc": "Desc: Supports staged rollout to students for a new email templates\n                   implementation for ID verification.",
      "creation_date": "2020-06-25",
      "implementation": "[‘WaffleFlag’]",
      "use_cases": "[‘temporary’, ‘open_edx’]"
    },
    {
      "name": "videos.deprecate_youtube",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/core/djangoapps/video_pipeline/config/waffle.py#L12",
      "desc": "Desc: Waffle flag telling whether youtube is deprecated. When enabled, videos are no longer uploaded\n                   to YouTube as part of the video pipeline.",
      "creation_date": "2018-08-03",
      "implementation": "[‘CourseWaffleFlag’]",
      "use_cases": "[‘open_edx’]"
    },
    {
      "name": "videos.enable_devstack_video_uploads",
      "default": "False",
      "source": "https://github.com/openedx/edx-platform/blob/1d618055dc5a44b94a1da63ef4017a2015aad018/openedx/core/djangoapps/video_pipeline/config/waffle.py#L22",
      "desc": "Desc: When enabled, use Multi-Factor Authentication (MFA) for authenticating to AWS. These short-\n                   lived access tokens are well suited for development (probably?). [At the time of annotation, the exact consequences\n                   of enabling this feature toggle are uncertain.]",
      "creation_date": "2020-03-12",
      "implementation": "[‘WaffleFlag’]",
      "use_cases": "[‘open_edx’]"
    }
  ]
}
```
</details>
