### PR TITLE
Revert "feat: Update the cache when active enterprise is changed."

### DIFF
--- a/openedx/features/enterprise_support/tests/test_utils.py
+++ b/openedx/features/enterprise_support/tests/test_utils.py
@@ -336,30 +336,29 @@ class TestEnterpriseUtils(TestCase):
         Test that only an enabled enterprise portal is returned,
         and that it matches the customer UUID provided in the request.
         """
-        old_active_enterprise_customer_user = EnterpriseCustomerUserFactory(active=True, user_id=self.user.id)
-        old_active_enterprise_customer_user.enable_learner_portal = True
-        old_active_enterprise_customer_user.save()
-
-        current_active_enterprise_customer_user = EnterpriseCustomerUserFactory(active=True, user_id=self.user.id)
-        current_active_enterprise_customer = current_active_enterprise_customer_user.enterprise_customer
+        enterprise_customer_user = EnterpriseCustomerUserFactory(active=True, user_id=self.user.id)
         EnterpriseCustomerBrandingConfigurationFactory(
-            enterprise_customer=current_active_enterprise_customer,
+            enterprise_customer=enterprise_customer_user.enterprise_customer,
         )
-        current_active_enterprise_customer.enable_learner_portal = True
-        current_active_enterprise_customer.save()
+        enterprise_customer_user.enterprise_customer.enable_learner_portal = True
+        enterprise_customer_user.enterprise_customer.save()
 
         request = mock.MagicMock(session={}, user=self.user)
+        # Indicate the "preferred" customer in the request
+        request.GET = {'enterprise_customer': enterprise_customer_user.enterprise_customer.uuid}
+
         # Create another enterprise customer association for the same user.
-        # There should be data returned for the latest enterprise association.
-        with mock.patch(
-                'openedx.features.enterprise_support.api.enterprise_customer_uuid_for_request',
-                return_value=str(current_active_enterprise_customer.uuid),
-        ):
-            portal = get_enterprise_learner_portal(request)
+        # There should be no data returned for this customer's portal,
+        # because we filter for only the enterprise customer uuid found in the request.
+        other_enterprise_customer_user = EnterpriseCustomerUserFactory(active=True, user_id=self.user.id)
+        other_enterprise_customer_user.enable_learner_portal = True
+        other_enterprise_customer_user.save()
+
+        portal = get_enterprise_learner_portal(request)
         self.assertDictEqual(portal, {
-            'name': current_active_enterprise_customer.name,
-            'slug': current_active_enterprise_customer.slug,
-            'logo': current_active_enterprise_customer.safe_branding_configuration.safe_logo_url,
+            'name': enterprise_customer_user.enterprise_customer.name,
+            'slug': enterprise_customer_user.enterprise_customer.slug,
+            'logo': enterprise_customer_user.enterprise_customer.safe_branding_configuration.safe_logo_url,
         })
 
     @override_waffle_flag(ENTERPRISE_HEADER_LINKS, True)
@@ -426,46 +425,10 @@ class TestEnterpriseUtils(TestCase):
             'logo': 'https://logo.url',
         }
         request = mock.MagicMock(session={
-            'enterprise_learner_portal': json.dumps(enterprise_customer_data),
-            'enterprise_customer': enterprise_customer_data,
+            'enterprise_learner_portal': json.dumps(enterprise_customer_data)
         }, user=self.user)
         portal = get_enterprise_learner_portal(request)
         self.assertDictEqual(portal, enterprise_customer_data)
-
-    @override_waffle_flag(ENTERPRISE_HEADER_LINKS, True)
-    def test_get_enterprise_learner_portal_of_updated_enterprise(self):
-        """
-        Test that when active enterprise changes, only current active enterprise portal is returned.
-        """
-        current_active_enterprise_customer_user = EnterpriseCustomerUserFactory(user_id=self.user.id)
-        current_active_enterprise_customer = current_active_enterprise_customer_user.enterprise_customer
-        EnterpriseCustomerBrandingConfigurationFactory(
-            enterprise_customer=current_active_enterprise_customer,
-        )
-        current_active_enterprise_customer.enable_learner_portal = True
-        current_active_enterprise_customer.save()
-
-        old_active_enterprise_customer_user = EnterpriseCustomerUserFactory(user_id=self.user.id)
-        old_active_enterprise_customer_data = {
-            'name': old_active_enterprise_customer_user.enterprise_customer.name,
-            'slug': old_active_enterprise_customer_user.enterprise_customer.slug,
-            'logo': 'https://logo.url',
-        }
-        current_active_enterprise_customer_data_updated = {
-            'name': current_active_enterprise_customer.name,
-            'slug': current_active_enterprise_customer.slug,
-            'logo': current_active_enterprise_customer.safe_branding_configuration.safe_logo_url,
-        }
-        request = mock.MagicMock(session={
-            'enterprise_learner_portal': json.dumps(old_active_enterprise_customer_data),
-            'enterprise_customer': current_active_enterprise_customer_data_updated,
-        }, user=self.user)
-        portal = get_enterprise_learner_portal(request)
-        self.assertDictEqual(portal, {
-            'name': current_active_enterprise_customer.name,
-            'slug': current_active_enterprise_customer.slug,
-            'logo': current_active_enterprise_customer.safe_branding_configuration.safe_logo_url,
-        })
 
     @override_waffle_flag(ENTERPRISE_HEADER_LINKS, True)
     def test_get_enterprise_learner_portal_no_enterprise_user(self):

--- a/openedx/features/enterprise_support/utils.py
+++ b/openedx/features/enterprise_support/utils.py
@@ -329,22 +329,17 @@ def get_enterprise_learner_portal(request):
     # Only cache this if a learner is authenticated (AnonymousUser exists and should not be tracked)
 
     learner_portal_session_key = 'enterprise_learner_portal'
-    enterprise_customer_session_key = 'enterprise_customer'
+
     if enterprise_enabled() and ENTERPRISE_HEADER_LINKS.is_enabled() and user and user.id:
         # If the key exists return that value
-        if learner_portal_session_key in request.session and enterprise_customer_session_key in request.session:
-            learner_portal_session = json.loads(request.session[learner_portal_session_key])
-            if request.session[enterprise_customer_session_key].get('slug') == learner_portal_session.get('slug'):
-                return learner_portal_session
+        if learner_portal_session_key in request.session:
+            return json.loads(request.session[learner_portal_session_key])
 
         kwargs = {
             'user_id': user.id,
             'enterprise_customer__enable_learner_portal': True,
         }
-        if enterprise_customer_session_key in request.session:
-            enterprise_customer_uuid = request.session[enterprise_customer_session_key].get('uuid')
-        else:
-            enterprise_customer_uuid = enterprise_customer_uuid_for_request(request)
+        enterprise_customer_uuid = enterprise_customer_uuid_for_request(request)
         if enterprise_customer_uuid:
             kwargs['enterprise_customer__uuid'] = enterprise_customer_uuid
 


### PR DESCRIPTION
Reverts openedx/edx-platform#30866

This caused a number of errors on edx.org that looked like:

```
builtins:AttributeError: 'NoneType' object has no attribute 'get'
Traceback(most recent call last):
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/exception.py", line 47, in inner
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/deprecation.py", line 117, in __call__
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/newrelic/hooks/framework_django.py", line 1195, in _wrapper
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/newrelic/api/function_trace.py", line 166, in literal_wrapper
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/exception.py", line 47, in inner
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/deprecation.py", line 117, in __call__
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/newrelic/hooks/framework_django.py", line 1195, in _wrapper
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/newrelic/api/function_trace.py", line 166, in literal_wrapper
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/exception.py", line 47, in inner
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/deprecation.py", line 117, in __call__
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/newrelic/hooks/framework_django.py", line 1195, in _wrapper
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/newrelic/api/function_trace.py", line 166, in literal_wrapper
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/exception.py", line 47, in inner
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/deprecation.py", line 117, in __call__
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/newrelic/hooks/framework_django.py", line 1195, in _wrapper
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/newrelic/api/function_trace.py", line 166, in literal_wrapper
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/exception.py", line 47, in inner
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/deprecation.py", line 117, in __call__
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/newrelic/hooks/framework_django.py", line 1195, in _wrapper
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/newrelic/api/function_trace.py", line 166, in literal_wrapper
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/exception.py", line 47, in inner
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/deprecation.py", line 117, in __call__
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/newrelic/hooks/framework_django.py", line 1195, in _wrapper
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/newrelic/api/function_trace.py", line 166, in literal_wrapper
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/exception.py", line 47, in inner
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/deprecation.py", line 117, in __call__
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/newrelic/hooks/framework_django.py", line 1195, in _wrapper
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/newrelic/api/function_trace.py", line 166, in literal_wrapper
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/exception.py", line 49, in inner
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/exception.py", line 59, in response_for_exception
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/exception.py", line 132, in get_exception_response
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/newrelic/hooks/framework_django.py", line 552, in wrapper
File "/edx/app/edxapp/edx-platform/common/djangoapps/util/views.py", line 95, in wrapper
File "/edx/app/edxapp/edx-platform/lms/djangoapps/static_template_view/views.py", line 111, in render_404
File "/edx/app/edxapp/edx-platform/common/djangoapps/edxmako/shortcuts.py", line 178, in render_to_string
File "/edx/app/edxapp/edx-platform/common/djangoapps/edxmako/template.py", line 82, in render
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/mako/template.py", line 444, in render_unicode
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/newrelic/hooks/template_mako.py", line 37, in __call__
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/newrelic/api/function_trace.py", line 166, in literal_wrapper
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/mako/runtime.py", line 874, in _render
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/mako/runtime.py", line 916, in _render_context
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/mako/runtime.py", line 943, in _exec_template
File "/tmp/mako_lms/6f79637247faff419ef55a8128bc53da/main.html.py", line 352, in render_body
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/mako/runtime.py", line 793, in _include_file
File "/tmp/mako_lms/6f79637247faff419ef55a8128bc53da/edx.org-next/lms/templates/header.html.py", line 34, in render_body
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/mako/runtime.py", line 793, in _include_file
File "/tmp/mako_lms/6f79637247faff419ef55a8128bc53da/header/header.html.py", line 93, in render_body
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/mako/runtime.py", line 793, in _include_file
File "/tmp/mako_lms/6f79637247faff419ef55a8128bc53da/header/navbar-logo-header.html.py", line 55, in render_body
File "/edx/app/edxapp/edx-platform/openedx/features/enterprise_support/utils.py", line 345, in get_enterprise_learner_portal
```