### PR TITLE
feat: add optimizely experiment

### DIFF
--- a/common/djangoapps/track/views/__init__.py
+++ b/common/djangoapps/track/views/__init__.py
@@ -9,6 +9,7 @@ from eventtracking import tracker as eventtracker
 from ipware.ip import get_client_ip
 
 from common.djangoapps.track import contexts, shim, tracker
+from lms.djangoapps.utils import OptimizelyClient
 
 
 def _get_request_header(request, header_name, default=''):
@@ -96,6 +97,13 @@ def user_track(request):
 
     with eventtracker.get_tracker().context('edx.course.browser', context_override):
         eventtracker.emit(name=name, data=data)
+
+    # TODO: VAN-1052: This event is added to track the KPIs for A/B experiment.
+    #  Remove it after the experiment has been paused.
+    if name == 'edx.course.home.resume_course.clicked' and request.user:
+        optimizely_client = OptimizelyClient.get_optimizely_client()
+        if optimizely_client:
+            optimizely_client.track('user_start_course_click', str(request.user.id))
 
     return HttpResponse('success')
 

--- a/lms/djangoapps/course_home_api/outline/views.py
+++ b/lms/djangoapps/course_home_api/outline/views.py
@@ -35,6 +35,7 @@ from lms.djangoapps.courseware.date_summary import TodaysDate
 from lms.djangoapps.courseware.masquerade import is_masquerading, setup_masquerade
 from lms.djangoapps.courseware.views.views import get_cert_data
 from lms.djangoapps.grades.course_grade_factory import CourseGradeFactory
+from lms.djangoapps.utils import OptimizelyClient
 from openedx.core.djangoapps.content.learning_sequences.api import get_user_course_outline
 from openedx.core.djangoapps.content.course_overviews.api import get_course_overview_or_404
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
@@ -390,6 +391,11 @@ def save_course_goal(request):  # pylint: disable=missing-function-docstring
 
     try:
         add_course_goal(request.user, course_id, subscribed_to_reminders, days_per_week)
+        # TODO: VAN-1052: This event is added to track the KPIs for A/B experiment.
+        #  Remove it after the experiment has been paused.
+        optimizely_client = OptimizelyClient.get_optimizely_client()
+        if optimizely_client and request.user:
+            optimizely_client.track('user_goal_setting_click', str(request.user.id))
         return Response({
             'header': _('Your course goal has been successfully set.'),
             'message': _('Course goal updated successfully.'),


### PR DESCRIPTION


<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Added two events to measure optimizely experiment metrics:
- user_goal_setting_click
- user_start_course_click

## Supporting information

[VAN-1052](https://2u-internal.atlassian.net/browse/VAN-1052)

## Testing instructions

No tests added yet because this code is part of A/B experiment. Once it becomes a permanent part of the code base, tests will be added.
