### PR TITLE
feat: TNL-10051 blockstore API perf instrumentation

### DIFF
--- a/openedx/core/lib/blockstore_api/methods.py
+++ b/openedx/core/lib/blockstore_api/methods.py
@@ -37,6 +37,7 @@ import logging
 
 log = logging.getLogger(__name__)
 
+
 def toggle_blockstore_api(func):
     """
     Decorator function to toggle usage of the Blockstore service

--- a/openedx/core/lib/blockstore_api/methods.py
+++ b/openedx/core/lib/blockstore_api/methods.py
@@ -33,7 +33,9 @@ from blockstore.apps.api.exceptions import (
 import blockstore.apps.api.methods as blockstore_api_methods
 
 from .config import use_blockstore_app
+import logging
 
+log = logging.getLogger(__name__)
 
 def toggle_blockstore_api(func):
     """
@@ -44,7 +46,11 @@ def toggle_blockstore_api(func):
     def wrapper(*args, **kwargs):
         if use_blockstore_app():
             return getattr(blockstore_api_methods, func.__name__)(*args, **kwargs)
-        return func(*args, **kwargs)
+        joined_args = " "
+        log.Info('blockstore ' + func.__name__ + ' API call called with ' + joined_args.join(args) + ' arguments')
+        ret_object = func(*args, **kwargs)
+        log.Info('blockstore ' + func.__name__ + ' API call is done')
+        return ret_object
     return wrapper
 
 

--- a/openedx/core/lib/blockstore_api/methods.py
+++ b/openedx/core/lib/blockstore_api/methods.py
@@ -3,6 +3,7 @@ API Client methods for working with Blockstore bundles and drafts
 """
 
 import base64
+import logging
 from functools import wraps
 from urllib.parse import urlencode
 from uuid import UUID
@@ -33,7 +34,6 @@ from blockstore.apps.api.exceptions import (
 import blockstore.apps.api.methods as blockstore_api_methods
 
 from .config import use_blockstore_app
-import logging
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
Log before & after making blockstore (Django) API calls to get performance from timestamps

This PR is for ticket https://2u-internal.atlassian.net/browse/TNL-10081, intended to instrument Blockstore as a Django app for performance reasons. This comment references TNL-10081, but the feature name references TNL-10051.  TNL-10081 is a subtask of TNL-10051, and, strictly speaking, this PR is for TNL-10081.

The changes contained here will induce logging just before and just after every Blockstore API call. The timestamps on those logs will reveal whether there are any bottlenecks with execution of these API calls.

The syntax of the log messages was tested on an interactive Python shell. There is no automated testing for this logic; confirmation that the tests are as required will occur on the stage environment. 



<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
