### PR TITLE
feat: decouple LTI handlers from XBlock and improve LTI error handling for unauthenticated users

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -666,7 +666,7 @@ libsass==0.10.0
     #   ora2
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==4.3.3
+lti-consumer-xblock==4.5.0
     # via -r requirements/edx/base.in
 lxml==4.9.1
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -870,7 +870,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/testing.txt
     #   ora2
-lti-consumer-xblock==4.3.3
+lti-consumer-xblock==4.5.0
     # via -r requirements/edx/testing.txt
 lxml==4.9.1
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -832,7 +832,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==4.3.3
+lti-consumer-xblock==4.5.0
     # via -r requirements/edx/base.txt
 lxml==4.9.1
     # via


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This commit updates the version of the lti-consumer-xblock from 4.3.3 to 4.5.0. This installs the newest version of the lti-consumer-xblock library. This version includes the following changes, from versions 4.4.0 and 4.5.0 of the library.

* Move LTI XBlock Handlers to Django Plugin (4.4.0, https://github.com/openedx/xblock-lti-consumer/pull/254)

1. The functionality of LTI 1.3 Launch Handler is moved from the XBlock to the Django plugin.
2. The functionality of the Access Token endpoint is moved from XBlock to the Django plugin.
3. A new URL format using the LtiConfiguration ID is introduced for the Access Token endpoint and is used when a LTI Consumer is configured without a location allowing LTI integrations to be created without the XBlock context.
4. A new URL format using the LtiConfiguration ID is introduced for the Keyset Endpoint and is used with the location of the XBlock is not available in the configuration.

* Handle LtiError Error During LTI 1.1 Launch for Unauthenticated User (4.5.0, https://github.com/openedx/xblock-lti-consumer/pull/278)

1. Improve error handling for LTI errors raised during LTI 1.1 launch when user is unauthenticated by returning a 400 response instead of falling through to the 500 error.
2. Change the error template to be generic to both LTI 1.1 and LTI 1.3 launches.
3. Revert logging amendments that were made to investigate the nature of the LTI errors. 

## Support Information

[MST-1585](https://2u-internal.atlassian.net/browse/MST-1585)