### PR TITLE
feat: add static full url to asset response

### DIFF
--- a/cms/djangoapps/contentstore/views/assets.py
+++ b/cms/djangoapps/contentstore/views/assets.py
@@ -356,7 +356,8 @@ def _get_assets_in_json_format(assets, course_key):
             asset['uploadDate'],
             asset['asset_key'],
             thumbnail_asset_key,
-            asset_is_locked
+            asset_is_locked,
+            course_key,
         )
 
         assets_in_json_format.append(asset_in_json)
@@ -426,7 +427,8 @@ def _upload_asset(request, course_key):
             readback.last_modified_at,
             content.location,
             content.thumbnail_location,
-            locked
+            locked,
+            course_key,
         ),
         'msg': _('Upload completed')
     })
@@ -588,21 +590,23 @@ def _delete_thumbnail(thumbnail_location, course_key, asset_key):  # lint-amnest
             logging.warning('Could not delete thumbnail: %s', thumbnail_location)
 
 
-def _get_asset_json(display_name, content_type, date, location, thumbnail_location, locked):
+def _get_asset_json(display_name, content_type, date, location, thumbnail_location, locked, course_key):
     '''
     Helper method for formatting the asset information to send to client.
     '''
     asset_url = StaticContent.serialize_asset_key_with_slash(location)
     external_url = urljoin(configuration_helpers.get_value('LMS_ROOT_URL', settings.LMS_ROOT_URL), asset_url)
+    portable_url = StaticContent.get_static_path_from_location(location)
     return {
         'display_name': display_name,
         'content_type': content_type,
         'date_added': get_default_time_display(date),
         'url': asset_url,
         'external_url': external_url,
-        'portable_url': StaticContent.get_static_path_from_location(location),
+        'portable_url': portable_url,
         'thumbnail': StaticContent.serialize_asset_key_with_slash(thumbnail_location) if thumbnail_location else None,
         'locked': locked,
+        'static_full_url': StaticContent.get_canonicalized_asset_path(course_key, portable_url, '', []),
         # needed for Backbone delete/update.
         'id': str(location)
     }

--- a/cms/djangoapps/contentstore/views/tests/test_assets.py
+++ b/cms/djangoapps/contentstore/views/tests/test_assets.py
@@ -420,7 +420,8 @@ class AssetToJsonTestCase(AssetsTestCase):
         thumbnail_location = course_key.make_asset_key('thumbnail', 'my_file_name_thumb.jpg')
 
         # pylint: disable=protected-access
-        output = assets._get_asset_json("my_file", content_type, upload_date, location, thumbnail_location, True, course_key)
+        output = assets._get_asset_json("my_file", content_type, upload_date, location,
+                                        thumbnail_location, True, course_key)
 
         self.assertEqual(output["display_name"], "my_file")
         self.assertEqual(output["date_added"], "Jun 01, 2013 at 10:30 UTC")

--- a/cms/djangoapps/contentstore/views/tests/test_assets.py
+++ b/cms/djangoapps/contentstore/views/tests/test_assets.py
@@ -231,7 +231,8 @@ class PaginationTestCase(AssetsTestCase):
                     "portable_url": "/static/test.jpg",
                     "thumbnail": None,
                     "thumbnail_location": thumbnail_location,
-                    "locked": None
+                    "locked": None,
+                    "static_full_url": "/assets/courseware/v1/asset-v1:org+class+run+type@asset+block@my_file_name.jpg"
                 }
             ],
             1
@@ -419,7 +420,7 @@ class AssetToJsonTestCase(AssetsTestCase):
         thumbnail_location = course_key.make_asset_key('thumbnail', 'my_file_name_thumb.jpg')
 
         # pylint: disable=protected-access
-        output = assets._get_asset_json("my_file", content_type, upload_date, location, thumbnail_location, True)
+        output = assets._get_asset_json("my_file", content_type, upload_date, location, thumbnail_location, True, course_key)
 
         self.assertEqual(output["display_name"], "my_file")
         self.assertEqual(output["date_added"], "Jun 01, 2013 at 10:30 UTC")
@@ -431,8 +432,9 @@ class AssetToJsonTestCase(AssetsTestCase):
         self.assertEqual(output["thumbnail"], "/asset-v1:org+class+run+type@thumbnail+block@my_file_name_thumb.jpg")
         self.assertEqual(output["id"], str(location))
         self.assertEqual(output['locked'], True)
+        self.assertEqual(output['static_full_url'], '/asset-v1:org+class+run+type@asset+block@my_file_name.jpg')
 
-        output = assets._get_asset_json("name", content_type, upload_date, location, None, False)
+        output = assets._get_asset_json("name", content_type, upload_date, location, None, False, course_key)
         self.assertIsNone(output["thumbnail"])
 
 
@@ -454,6 +456,7 @@ class LockAssetTestCase(AssetsTestCase):
         def post_asset_update(lock, course):
             """ Helper method for posting asset update. """
             content_type = 'application/txt'
+            course_key = CourseLocator('org', 'class', 'run')
             upload_date = datetime(2013, 6, 1, 10, 30, tzinfo=UTC)
             asset_location = course.id.make_asset_key('asset', 'sample_static.html')
             url = reverse_course_url(
@@ -464,7 +467,7 @@ class LockAssetTestCase(AssetsTestCase):
                 url,
                 # pylint: disable=protected-access
                 json.dumps(assets._get_asset_json(
-                    "sample_static.html", content_type, upload_date, asset_location, None, lock)),
+                    "sample_static.html", content_type, upload_date, asset_location, None, lock, course_key)),
                 "application/json"
             )
 

--- a/cms/static/js/models/asset.js
+++ b/cms/static/js/models/asset.js
@@ -11,7 +11,8 @@ define(['backbone'], function(Backbone) {
             url: '',
             external_url: '',
             portable_url: '',
-            locked: false
+            locked: false,
+            static_full_url: '',
         },
         get_extension: function() {
             var name_segments = this.get('display_name').split('.').reverse();

--- a/cms/static/js/spec/views/assets_spec.js
+++ b/cms/static/js/spec/views/assets_spec.js
@@ -40,7 +40,8 @@ define(['jquery', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers', 'URI', 'j
                 date_added: 'date',
                 thumbnail: null,
                 locked: false,
-                id: 'id_1'
+                id: 'id_1',
+                static_full_url: 'static_full_url',
             };
 
             mockEmptyAssetsResponse = {
@@ -64,7 +65,8 @@ define(['jquery', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers', 'URI', 'j
                         portable_url: '/static/test.jpg',
                         thumbnail: '/c4x/A/CS102/thumbnail/test.jpg',
                         locked: false,
-                        external_url: 'localhost:8000/c4x/A/CS102/asset/test.jpg'
+                        external_url: 'localhost:8000/c4x/A/CS102/asset/test.jpg',
+                        static_full_url: '/c4x/A/CS102/asset/test.jpg',
                     },
                     {
                         display_name: 'test.pdf',
@@ -74,7 +76,8 @@ define(['jquery', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers', 'URI', 'j
                         portable_url: '/static/test.pdf',
                         thumbnail: null,
                         locked: false,
-                        external_url: 'localhost:8000/c4x/A/CS102/asset/test.pdf'
+                        external_url: 'localhost:8000/c4x/A/CS102/asset/test.pdf',
+                        static_full_url: '/c4x/A/CS102/asset/test.pdf',
                     },
                     {
                         display_name: 'test.odt',
@@ -84,7 +87,8 @@ define(['jquery', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers', 'URI', 'j
                         portable_url: '/static/test.odt',
                         thumbnail: null,
                         locked: false,
-                        external_url: 'localhost:8000/c4x/A/CS102/asset/test.odt'
+                        external_url: 'localhost:8000/c4x/A/CS102/asset/test.odt',
+                        static_full_url: '/c4x/A/CS102/asset/test.odt',
                     }
                 ],
                 pageSize: 2,
@@ -105,7 +109,8 @@ define(['jquery', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers', 'URI', 'j
                         portable_url: '/static/test.jpg',
                         thumbnail: '/c4x/A/CS102/thumbnail/test.jpg',
                         locked: false,
-                        external_url: 'localhost:8000/c4x/A/CS102/asset/test.jpg'
+                        external_url: 'localhost:8000/c4x/A/CS102/asset/test.jpg',
+                        static_full_url: '/c4x/A/CS102/asset/test.jpg'
                     }
                 ],
                 pageSize: 1,
@@ -373,7 +378,8 @@ define(['jquery', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers', 'URI', 'j
                                     portable_url: '/static/test.jpg',
                                     thumbnail: '/c4x/A/CS102/thumbnail/test.jpg',
                                     locked: false,
-                                    external_url: 'localhost:8000/c4x/A/CS102/asset/test.jpg'
+                                    external_url: 'localhost:8000/c4x/A/CS102/asset/test.jpg',
+                                    static_full_url: '/c4x/A/CS102/asset/test.jpg'
                                 },
                                 {
                                     display_name: 'test.pdf',
@@ -383,7 +389,8 @@ define(['jquery', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers', 'URI', 'j
                                     portable_url: '/static/test.pdf',
                                     thumbnail: null,
                                     locked: false,
-                                    external_url: 'localhost:8000/c4x/A/CS102/asset/test.pdf'
+                                    external_url: 'localhost:8000/c4x/A/CS102/asset/test.pdf',
+                                    static_full_url: '/c4x/A/CS102/asset/test.pdf',
                                 }
                             ],
                             pageSize: 2,
@@ -403,7 +410,8 @@ define(['jquery', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers', 'URI', 'j
                                     portable_url: '/static/test.odt',
                                     thumbnail: null,
                                     locked: false,
-                                    external_url: 'localhost:8000/c4x/A/CS102/asset/test.odt'
+                                    external_url: 'localhost:8000/c4x/A/CS102/asset/test.odt',
+                                    static_full_url: '/c4x/A/CS102/asset/test.odt',
                                 }
                             ],
                             pageSize: 2,

--- a/cms/static/js/spec/views/assets_squire_spec.js
+++ b/cms/static/js/spec/views/assets_squire_spec.js
@@ -38,7 +38,8 @@ function($, AjaxHelpers, Squire) {
                         portable_url: 'portable_url',
                         date_added: 'date',
                         thumbnail: null,
-                        id: 'id'
+                        id: 'id',
+                        static_full_url: 'static_full_url',
                     });
                     spyOn(this.model, "destroy").and.callThrough();
                     spyOn(this.model, "save").and.callThrough();
@@ -175,7 +176,8 @@ function($, AjaxHelpers, Squire) {
                 portable_url: 'portable_url_1',
                 date_added: 'date_1',
                 thumbnail: null,
-                id: 'id_1'
+                id: 'id_1',
+                static_full_url: 'static_full_url_1',
             };
             this.mockAsset2 = {
                 display_name: "test asset 2",
@@ -183,7 +185,8 @@ function($, AjaxHelpers, Squire) {
                 portable_url: 'portable_url_2',
                 date_added: 'date_2',
                 thumbnail: null,
-                id: 'id_2'
+                id: 'id_2',
+                static_full_url: 'static_full_url_2',
             };
             this.mockAssetsResponse = {
                 assets: [ this.mockAsset1, this.mockAsset2 ],
@@ -229,7 +232,8 @@ function($, AjaxHelpers, Squire) {
                 portable_url: 'portable_url',
                 date_added: 'date',
                 thumbnail: null,
-                id: 'idx'
+                id: 'idx',
+                static_full_url: 'static_full_url',
             });
             this.view.addAsset(model);
             return AjaxHelpers.respondWithJson(requests,
@@ -242,7 +246,8 @@ function($, AjaxHelpers, Squire) {
                             portable_url: 'portable_url',
                             date_added: 'date',
                             thumbnail: null,
-                            id: 'idx'
+                            id: 'idx',
+                            static_full_url: 'static_full_url',
                         }
                     ],
                     start: 0,

--- a/cms/static/js/views/asset.js
+++ b/cms/static/js/views/asset.js
@@ -22,6 +22,7 @@ define(['js/views/baseview', 'underscore', 'gettext', 'common/js/components/view
                     url: this.model.get('url'),
                     external_url: this.model.get('external_url'),
                     portable_url: this.model.get('portable_url'),
+                    static_full_url: this.model.get('static_full_url'),
                     asset_type: this.model.get_extension(),
                     uniqueId: uniqueId
                 };


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This changes provides the `/assets/` link to the course-authoring MFE to continue support of `/static/` urls. Previously the course-authoring MFE only had access to the external url for an assets. This link does not update when a course is  re-ran., it maintains its original course reference. However, `/assets/` links update on course re-run and helps prevent the deletion of content based on old courses. This change impacts Developers.

## Supporting information

Jira Ticket: [TNL-10077](https://2u-internal.atlassian.net/browse/TNL-10077)

## Testing instructions

1. Navigate to linked PR from edx/frontend-lib-content-components and switch to the `KristinAoki/change-static-to-usable-url` 
2. Open a course in Studio
3. Navigate to "Files and Images"
4. Pick an images to add to the course
5. Click the "Studio" button to get the `/static/` link 
6. Navigate to the course outline
7. Open a unit to edit
8. Click the "HTML" button to open the source code for the editor
9. Add ```<img src="{studioLink}" />```
10. Save change
11. Check that image appears in editor
12. Click "Save"
13. Check that the image appears in the Studio block preview

## Deadline

None

## Other information

Include anything else that will help reviewers and consumers understand the change.
This ticket is link to frontend-lib-content-components [PR #103](https://github.com/edx/frontend-lib-content-components/pull/103)
