### PR TITLE
[WIP] JWT auth enhancement

### DIFF
--- a/openedx/core/djangoapps/oauth_dispatch/jwt.py
+++ b/openedx/core/djangoapps/oauth_dispatch/jwt.py
@@ -10,6 +10,7 @@ from edx_django_utils.monitoring import set_custom_attribute
 from edx_rbac.utils import create_role_auth_claim_for_user
 from jwkest import jwk
 from jwkest.jws import JWS
+from rest_framework.exceptions import AuthenticationFailed
 
 from common.djangoapps.student.models import UserProfile, anonymous_id_for_user
 
@@ -65,6 +66,10 @@ def create_jwt_token_dict(token_dict, oauth_adapter, use_asymmetric_key=None):
     """
     access_token = oauth_adapter.get_access_token(token_dict['access_token'])
     client = oauth_adapter.get_client_for_token(access_token)
+
+    user = access_token.user
+    if not user.has_usable_password():
+        raise AuthenticationFailed()
 
     jwt_expires_in = _get_jwt_access_token_expire_seconds()
     try:

--- a/openedx/core/djangoapps/oauth_dispatch/views.py
+++ b/openedx/core/djangoapps/oauth_dispatch/views.py
@@ -13,6 +13,7 @@ from edx_django_utils import monitoring as monitoring_utils
 from oauth2_provider import views as dot_views
 from ratelimit import ALL
 from ratelimit.decorators import ratelimit
+from rest_framework.exceptions import AuthenticationFailed
 
 from openedx.core.djangoapps.auth_exchange import views as auth_exchange_views
 from openedx.core.djangoapps.oauth_dispatch import adapters
@@ -106,7 +107,10 @@ class AccessTokenView(_DispatchingView):
         token_type = _get_token_type(request)
 
         if response.status_code == 200 and token_type == 'jwt':
-            response.content = self._get_jwt_content_from_access_token_content(request, response)
+            try:
+                response.content = self._get_jwt_content_from_access_token_content(request, response)
+            except AuthenticationFailed:
+                response.content = '' # TODO: Add appropriate response content
 
         return response
 


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Add additional checks when updating a JWT token.
[LEARNER-9001](https://2u-internal.atlassian.net/browse/LEARNER-9001)

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
