### PR TITLE
fix: downgrade transifex-client version in requirements

### DIFF
--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1509,7 +1509,7 @@ tqdm==4.64.0
     # via
     #   -r requirements/edx/testing.txt
     #   nltk
-transifex-client==0.14.4
+transifex-client==0.14.3
     # via -r requirements/edx/testing.txt
 typing-extensions==4.1.1
     # via

--- a/requirements/edx/testing.in
+++ b/requirements/edx/testing.in
@@ -45,8 +45,8 @@ singledispatch            # Backport of functools.singledispatch from Python 3.4
 testfixtures              # Provides a LogCapture utility used by several tests
 tox                       # virtualenv management for tests
 tox-battery               # Makes tox aware of requirements file changes
-transifex-client          # Command-line interface for the Transifex localization service
+transifex-client==0.14.3  # Command-line interface for the Transifex localization service
 unidiff                   # Required by coverage_pytest_plugin
 pylint-pytest==0.3.0      # A Pylint plugin to suppress pytest-related false positives.
-pact-python               # Library for contract testing 
+pact-python               # Library for contract testing
 

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1393,7 +1393,7 @@ tqdm==4.64.0
     # via
     #   -r requirements/edx/base.txt
     #   nltk
-transifex-client==0.14.4
+transifex-client==0.14.3
     # via -r requirements/edx/testing.in
 typing-extensions==4.1.1
     # via


### PR DESCRIPTION
Downgrading transifex-client to the previous release 0.14.3 allows for
the Translation files to be pushed to Transifex automatically via the tools we are currently using.