### PR TITLE
feat: point to new discussions MFE on Discussion Tab

### DIFF
--- a/lms/djangoapps/discussion/django_comment_client/tests/test_utils.py
+++ b/lms/djangoapps/discussion/django_comment_client/tests/test_utils.py
@@ -27,7 +27,6 @@ from lms.djangoapps.discussion.django_comment_client.constants import TYPE_ENTRY
 from lms.djangoapps.discussion.django_comment_client.tests.factories import RoleFactory
 from lms.djangoapps.discussion.django_comment_client.tests.unicode import UnicodeTestMixin
 from lms.djangoapps.discussion.django_comment_client.tests.utils import config_course_discussions, topic_name_to_id
-from lms.djangoapps.discussion.toggles import ENABLE_DISCUSSIONS_MFE
 from lms.djangoapps.teams.tests.factories import CourseTeamFactory
 from openedx.core.djangoapps.course_groups import cohorts
 from openedx.core.djangoapps.course_groups.cohorts import set_course_cohorted

--- a/lms/djangoapps/discussion/plugins.py
+++ b/lms/djangoapps/discussion/plugins.py
@@ -4,7 +4,12 @@ Views handling read (GET) requests for the Discussion tab and inline discussions
 
 
 from django.conf import settings
+from django.urls import reverse
 from django.utils.translation import gettext_noop
+
+
+from lms.djangoapps.discussion.toggles import ENABLE_VIEW_MFE_IN_IFRAME
+from openedx.core.djangoapps.discussions.url_helpers import get_discussions_mfe_url
 from xmodule.tabs import TabFragmentViewMixin
 
 import lms.djangoapps.discussion.django_comment_client.utils as utils
@@ -35,3 +40,12 @@ class DiscussionTab(TabFragmentViewMixin, EnrolledTab):
         if DiscussionLtiCourseTab.is_enabled(course, user):
             return False
         return utils.is_discussion_enabled(course.id)
+
+    @property
+    def link_func(self):
+        def _link_func(course, reverse_func):
+            if not ENABLE_VIEW_MFE_IN_IFRAME.is_enabled():
+                return get_discussions_mfe_url(course_key=course.id)
+            return reverse('forum_form_discussion', args=[str(course.id)])
+
+        return _link_func


### PR DESCRIPTION
### [INF-338](https://2u-internal.atlassian.net/browse/INF-338)

### Description

Updated Discussion Tab link to point to new discussion MFE experience when `ENABLE_VIEW_MFE_IN_IFRAME` is disabled.

#### Testing instruction
- Flag enabled
  - add `discussions.enable_view_mfe_in_iframe` flag and enable it
  - Load lms
  - Click on Discussion tab
  - Will be redirected to iframe view on Discussion Tab

![Screen Shot 2022-08-24 at 4 09 26 PM](https://user-images.githubusercontent.com/30112155/186404617-b182386a-e5d8-4bf0-8c9f-cb9989281103.png)

- Flag disabled
  - add `discussions.enable_view_mfe_in_iframe` flag and disable it
  - Load lms
  - Click on Discussion tab
  - Will be redirected to new discussion MFE experience

![Screen Shot 2022-08-24 at 4 11 52 PM](https://user-images.githubusercontent.com/30112155/186404602-a8a6eda7-5eec-45cf-8d4d-086b9ec2ca92.png)
