### PR TITLE
feat: learner home certs

### DIFF
--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -4,7 +4,6 @@ Serializers for the Learner Dashboard
 
 from django.conf import settings
 from django.urls import reverse
-from common.djangoapps.student.helpers import cert_info
 from rest_framework import serializers
 
 from common.djangoapps.course_modes.models import CourseMode

--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -2,11 +2,14 @@
 Serializers for the Learner Dashboard
 """
 
+from django.conf import settings
 from django.urls import reverse
+from common.djangoapps.student.helpers import cert_info
 from rest_framework import serializers
 
 from common.djangoapps.course_modes.models import CourseMode
 from openedx.features.course_experience import course_home_url
+from xmodule.data import CertificatesDisplayBehaviors
 
 
 class PlatformSettingsSerializer(serializers.Serializer):
@@ -179,11 +182,59 @@ class GradeDataSerializer(serializers.Serializer):
 class CertificateSerializer(serializers.Serializer):
     """Certificate availability info"""
 
-    availableDate = serializers.DateTimeField(allow_null=True)
-    isRestricted = serializers.BooleanField()
-    isEarned = serializers.BooleanField()
-    isDownloadable = serializers.BooleanField()
-    certPreviewUrl = serializers.URLField(allow_null=True)
+    availableDate = serializers.SerializerMethodField()
+    isRestricted = serializers.SerializerMethodField()
+    isEarned = serializers.SerializerMethodField()
+    isDownloadable = serializers.SerializerMethodField()
+    certPreviewUrl = serializers.SerializerMethodField()
+
+    def get_cert_info(self, enrollment):
+        """Utility to grab certificate info for this enrollment or empty object"""
+        return self.context.get("cert_statuses", {}).get(enrollment.course.id, {})
+
+    def get_availableDate(self, enrollment):
+        """Available date changes based off of Certificate display behavior"""
+        course_overview = enrollment.course_overview
+        available_date = course_overview.certificate_available_date
+
+        if settings.FEATURES.get("ENABLE_V2_CERT_DISPLAY_SETTINGS", False):
+            if (
+                course_overview.certificates_display_behavior
+                == CertificatesDisplayBehaviors.END_WITH_DATE
+                and course_overview.certificate_available_date
+            ):
+                available_date = course_overview.certificate_available_date
+            elif (
+                course_overview.certificates_display_behavior
+                == CertificatesDisplayBehaviors.END
+                and course_overview.end
+            ):
+                available_date = course_overview.end
+        else:
+            available_date = course_overview.certificate_available_date
+
+        return serializers.DateTimeField().to_representation(available_date)
+
+    def get_isRestricted(self, enrollment):
+        """Cert is considered restricted based on certificate status"""
+        return self.get_cert_info(enrollment).get("status") == "restricted"
+
+    def get_isEarned(self, enrollment):
+        """Cert is considered earned based on certificate status"""
+        is_earned_states = ("downloadable", "certificate_earned_but_not_available")
+        return self.get_cert_info(enrollment).get("status") in is_earned_states
+
+    def get_isDownloadable(self, enrollment):
+        """Cert is considered downloadable based on certificate status"""
+        return self.get_cert_info(enrollment).get("status") == "downloadable"
+
+    def get_certPreviewUrl(self, enrollment):
+        """Cert preview URL comes from certificate info"""
+        cert_info = self.get_cert_info(enrollment)
+        if not cert_info.get("show_cert_web_view", False):
+            return None
+        else:
+            return cert_info.get("cert_web_view_url")
 
 
 class AvailableEntitlementSessionSerializer(serializers.Serializer):
@@ -238,11 +289,11 @@ class LearnerEnrollmentSerializer(serializers.Serializer):
     course = CourseSerializer()
     courseRun = CourseRunSerializer(source="*")
     enrollment = EnrollmentSerializer(source="*")
+    certificate = CertificateSerializer(source="*")
 
     # TODO - remove "allow_null" as each of these are implemented, temp for testing.
     courseProvider = CourseProviderSerializer(allow_null=True)
     gradeData = GradeDataSerializer(allow_null=True)
-    certificate = CertificateSerializer(allow_null=True)
     entitlements = EntitlementSerializer(allow_null=True)
     programs = ProgramsSerializer(allow_null=True)
 

--- a/lms/djangoapps/learner_home/test_serializers.py
+++ b/lms/djangoapps/learner_home/test_serializers.py
@@ -64,6 +64,7 @@ class LearnerDashboardBaseTest(SharedModuleStoreTestCase):
         # Add extra info to exercise serialization
         test_enrollment.course_overview.marketing_url = random_url()
         test_enrollment.course_overview.end = random_date()
+        test_enrollment.course_overview.certificate_available_date = random_date()
 
         return test_enrollment
 
@@ -364,7 +365,7 @@ class TestCertificateSerializer(LearnerDashboardBaseTest):
 
         # Then the available date is the course end date
         expected_available_date = datetime_to_django_format(
-            input_data.course.certificate_available_date
+            input_data.course.end
         )
         self.assertEqual(output_data["availableDate"], expected_available_date)
 

--- a/lms/djangoapps/learner_home/test_serializers.py
+++ b/lms/djangoapps/learner_home/test_serializers.py
@@ -48,17 +48,15 @@ class LearnerDashboardBaseTest(SharedModuleStoreTestCase):
         super().setUpClass()
         cls.user = UserFactory()
 
-    def create_test_enrollment(self):
+    def create_test_enrollment(self, course_mode=CourseMode.AUDIT):
         """Create a test user, course, and enrollment. Return the enrollment."""
         course = CourseFactory(self_paced=True)
         CourseModeFactory(
             course_id=course.id,
-            mode_slug=CourseMode.AUDIT,
+            mode_slug=course_mode,
         )
 
-        test_enrollment = CourseEnrollmentFactory(
-            course_id=course.id, mode=CourseMode.AUDIT
-        )
+        test_enrollment = CourseEnrollmentFactory(course_id=course.id, mode=course_mode)
 
         # Add extra info to exercise serialization
         test_enrollment.course_overview.marketing_url = random_url()

--- a/lms/djangoapps/learner_home/test_serializers.py
+++ b/lms/djangoapps/learner_home/test_serializers.py
@@ -369,7 +369,7 @@ class TestCertificateSerializer(LearnerDashboardBaseTest):
         self.assertEqual(output_data["availableDate"], expected_available_date)
 
     @mock.patch.dict(settings.FEATURES, ENABLE_V2_CERT_DISPLAY_SETTINGS=True)
-    def test_available_date_course_end(self):
+    def test_available_date_specific_end(self):
         # Given new cert display settings are enabled
         input_data = self.create_test_enrollment(course_mode=CourseMode.VERIFIED)
         input_context = self.create_test_context(input_data.course)

--- a/lms/djangoapps/learner_home/test_utils.py
+++ b/lms/djangoapps/learner_home/test_utils.py
@@ -6,6 +6,11 @@ from random import choice, getrandbits, randint
 from time import time
 from uuid import uuid4
 
+from common.djangoapps.course_modes.models import CourseMode
+from common.djangoapps.course_modes.tests.factories import CourseModeFactory
+from common.djangoapps.student.tests.factories import CourseEnrollmentFactory
+from xmodule.modulestore.tests.factories import CourseFactory
+
 
 def random_bool():
     """Test util for generating a random boolean"""
@@ -48,3 +53,17 @@ def datetime_to_django_format(datetime_obj):
     """Util for matching serialized Django datetime format for comparison"""
     if datetime_obj:
         return datetime_obj.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def create_test_enrollment(user, course_mode=CourseMode.AUDIT):
+    """Create a course and enrollment for the test user. Returns a CourseEnrollment"""
+    course = CourseFactory(self_paced=True)
+
+    CourseModeFactory(
+        course_id=course.id,
+        mode_slug=course_mode,
+    )
+
+    return CourseEnrollmentFactory(
+        course_id=course.id, mode=course_mode, user_id=user.id
+    )

--- a/lms/djangoapps/learner_home/test_utils.py
+++ b/lms/djangoapps/learner_home/test_utils.py
@@ -9,6 +9,9 @@ from uuid import uuid4
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory
+from openedx.core.djangoapps.content.course_overviews.tests.factories import (
+    CourseOverviewFactory,
+)
 from xmodule.modulestore.tests.factories import CourseFactory
 
 
@@ -56,7 +59,7 @@ def datetime_to_django_format(datetime_obj):
 
 
 def create_test_enrollment(user, course_mode=CourseMode.AUDIT):
-    """Create a course and enrollment for the test user. Returns a CourseEnrollment"""
+    """Create a test user, course, course overview, and enrollment. Return the enrollment."""
     course = CourseFactory(self_paced=True)
 
     CourseModeFactory(
@@ -64,6 +67,16 @@ def create_test_enrollment(user, course_mode=CourseMode.AUDIT):
         mode_slug=course_mode,
     )
 
-    return CourseEnrollmentFactory(
+    course_overview = CourseOverviewFactory(id=course.id)
+
+    # extra info for exercising serializers
+    course_overview.certificate_available_date = random_date()
+
+    test_enrollment = CourseEnrollmentFactory(
         course_id=course.id, mode=course_mode, user_id=user.id
     )
+
+    test_enrollment.course_overview.marketing_url = random_url()
+    test_enrollment.course_overview.end = random_date()
+
+    return test_enrollment

--- a/lms/djangoapps/learner_home/test_views.py
+++ b/lms/djangoapps/learner_home/test_views.py
@@ -7,9 +7,9 @@ from uuid import uuid4
 
 import ddt
 from django.urls import reverse
-from lms.djangoapps.learner_home.test_utils import create_test_enrollment
 from rest_framework.test import APITestCase
 
+from lms.djangoapps.learner_home.test_utils import create_test_enrollment
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.tests.factories import (
     CourseEnrollmentFactory,

--- a/lms/djangoapps/learner_home/test_views.py
+++ b/lms/djangoapps/learner_home/test_views.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 
 import ddt
 from django.urls import reverse
+from lms.djangoapps.learner_home.test_utils import create_test_enrollment
 from rest_framework.test import APITestCase
 
 from common.djangoapps.course_modes.models import CourseMode
@@ -126,22 +127,9 @@ class TestGetEnrollments(SharedModuleStoreTestCase):
         super().setUp()
         self.user = UserFactory()
 
-    def create_test_enrollment(self, course_mode=CourseMode.AUDIT):
-        """Create a course and enrollment for the test user. Returns a CourseEnrollment"""
-        course = CourseFactory(self_paced=True)
-
-        CourseModeFactory(
-            course_id=course.id,
-            mode_slug=course_mode,
-        )
-
-        return CourseEnrollmentFactory(
-            course_id=course.id, mode=course_mode, user_id=self.user.id
-        )
-
     def test_basic(self):
         # Given a set of enrollments
-        test_enrollments = [self.create_test_enrollment() for i in range(3)]
+        test_enrollments = [create_test_enrollment(self.user) for i in range(3)]
 
         # When I request my enrollments
         returned_enrollments, course_mode_info = get_enrollments(self.user, None, None)

--- a/lms/djangoapps/learner_home/test_views.py
+++ b/lms/djangoapps/learner_home/test_views.py
@@ -11,7 +11,6 @@ from lms.djangoapps.learner_home.test_utils import create_test_enrollment
 from rest_framework.test import APITestCase
 
 from common.djangoapps.course_modes.models import CourseMode
-from common.djangoapps.course_modes.tests.factories import CourseModeFactory
 from common.djangoapps.student.tests.factories import (
     CourseEnrollmentFactory,
     UserFactory,

--- a/lms/djangoapps/learner_home/views.py
+++ b/lms/djangoapps/learner_home/views.py
@@ -8,7 +8,7 @@ from rest_framework.generics import RetrieveAPIView
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.edxmako.shortcuts import marketing_link
-from common.djangoapps.student.helpers import get_resume_urls_for_enrollments
+from common.djangoapps.student.helpers import cert_info, get_resume_urls_for_enrollments
 from common.djangoapps.student.views.dashboard import (
     complete_course_mode_info,
     get_course_enrollments,
@@ -117,6 +117,14 @@ def get_ecommerce_payment_page(user):
     )
 
 
+def get_cert_statuses(user, course_enrollments):
+    """Get cert status by course for user enrollments"""
+    return {
+        enrollment.course_id: cert_info(user, enrollment)
+        for enrollment in course_enrollments
+    }
+
+
 class InitializeView(RetrieveAPIView):  # pylint: disable=unused-argument
     """List of courses a user is enrolled in or entitled to"""
 
@@ -141,7 +149,8 @@ class InitializeView(RetrieveAPIView):  # pylint: disable=unused-argument
             user, course_enrollments
         )
 
-        # TODO - Get verification status by course (do we still need this?)
+        # Get cert status by course
+        cert_statuses = get_cert_statuses(user, course_enrollments)
 
         # TODO - Determine view access for courses (for showing courseware link or not)
 
@@ -166,6 +175,7 @@ class InitializeView(RetrieveAPIView):  # pylint: disable=unused-argument
 
         context = {
             "ecommerce_payment_page": ecommerce_payment_page,
+            "cert_statuses": cert_statuses,
             "course_mode_info": course_mode_info,
             "course_optouts": course_optouts,
             "resume_course_urls": resume_button_urls,


### PR DESCRIPTION
## Description

Get certificate info for a user's enrollments for `learner_home`

JIRA: https://2u-internal.atlassian.net/browse/AU-792
FYI: @openedx/content-aurora 

Additional refactors:
- Move `create_test_enrollment` to `test_utils.py` for reuse