### PR TITLE
fix: empty signature added after every certificate saving

### DIFF
--- a/cms/static/js/certificates/models/certificate.js
+++ b/cms/static/js/certificates/models/certificate.js
@@ -43,7 +43,7 @@ define([
             initialize: function(attributes, options) {
                 // Set up the initial state of the attributes set for this model instance
                 this.canBeEmpty = options && options.canBeEmpty;
-                if (options.add) {
+                if (options.add && !attributes.signatories) {
                     // Ensure at least one child Signatory model is defined for any new Certificate model
                     attributes.signatories = new SignatoryModel({certificate: this});
                 }


### PR DESCRIPTION
## The Problem

After every certificate signature saving - a new empty signature is added which leads to empty signatures in the certificate.

## Steps To Reproduce

- Add a new certificate for a course in the cms
- An empty signature is added by default
- Refresh the page (or activate the certificate which refreshes the page too) - you'll see the second signature was added to the certificate form. In this step, it's only added on the Backbone model level and not saved on the backend.
- Click the "Preview Certificate" button - you'll see one signature, which is OK so far.
- Edit the first signature and save it. After the page refresh, you'll see a third signature appearing in the certificate form.
- Recheck the certificate preview - **the second empty signature is present**
![signatures_issue](https://user-images.githubusercontent.com/47273130/187208980-0baf327f-376d-4ba4-892f-856fc8840da4.gif)


## Expected Result

- When a new certificate is added - it has a signature by default (at least one)
- When at least one signature exists - no additional empty signatures are added

## After the fix is applied:

- Empty signature is still added when initially creating a certificate;
- Empty signature isn't added when the certificate has at least one signature.


