### PR TITLE
chore: edx-proctoring update

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -518,7 +518,7 @@ edx-opaque-keys[django]==2.3.0
     #   outcome-surveys
 edx-organizations==6.11.1
     # via -r requirements/edx/base.in
-edx-proctoring==4.10.3
+edx-proctoring==4.12.0
     # via
     #   -r requirements/edx/base.in
     #   edx-proctoring-proctortrack

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -635,7 +635,7 @@ edx-opaque-keys[django]==2.3.0
     #   outcome-surveys
 edx-organizations==6.11.1
     # via -r requirements/edx/testing.txt
-edx-proctoring==4.10.3
+edx-proctoring==4.12.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-proctoring-proctortrack

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -616,7 +616,7 @@ edx-opaque-keys[django]==2.3.0
     #   outcome-surveys
 edx-organizations==6.11.1
     # via -r requirements/edx/base.txt
-edx-proctoring==4.10.3
+edx-proctoring==4.12.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring-proctortrack


### PR DESCRIPTION
Update edx-proctoring to 4.12.0

Release Notes: https://github.com/openedx/edx-proctoring/blob/master/CHANGELOG.rst#4120---2022-08-29