### PR TITLE
Feat: new PERSISTENT_GRADE_SUMMARY signal

### DIFF
--- a/lms/djangoapps/grades/models.py
+++ b/lms/djangoapps/grades/models.py
@@ -16,6 +16,8 @@ from hashlib import sha1
 
 from django.apps import apps
 from django.db import models, IntegrityError, transaction
+from openedx_events.learning.data import CourseData, PersistentCourseGradeData
+from openedx_events.learning.signals import PERSISTENT_GRADE_SUMMARY_CHANGED
 
 from django.utils.timezone import now
 from lazy import lazy
@@ -33,7 +35,6 @@ from lms.djangoapps.grades.signals.signals import (
 )
 
 log = logging.getLogger(__name__)
-
 
 BLOCK_RECORD_LIST_VERSION = 1
 
@@ -663,6 +664,7 @@ class PersistentCourseGrade(TimeStampedModel):
 
         cls._emit_grade_calculated_event(grade)
         cls._update_cache(course_id, user_id, grade)
+        cls._emit_openedx_persistent_grade_summary_changed_event(course_id, user_id, grade)
         return grade
 
     @classmethod
@@ -678,6 +680,27 @@ class PersistentCourseGrade(TimeStampedModel):
     @staticmethod
     def _emit_grade_calculated_event(grade):
         events.course_grade_calculated(grade)
+
+    @staticmethod
+    def _emit_openedx_persistent_grade_summary_changed_event(course_id, user_id, grade):
+        """
+        When called emits an event when a persistent grade is created or updated.
+        """
+        # .. event_implemented_name: PERSISTENT_GRADE_SUMMARY_CHANGED
+        PERSISTENT_GRADE_SUMMARY_CHANGED.send_event(
+            grade=PersistentCourseGradeData(
+                user_id=user_id,
+                course=CourseData(
+                    course_key=course_id,
+                ),
+                course_edited_timestamp=grade.course_edited_timestamp,
+                course_version=grade.course_version,
+                grading_policy_hash=grade.grading_policy_hash,
+                percent_grade=grade.percent_grade,
+                letter_grade=grade.letter_grade,
+                passed_timestamp=grade.passed_timestamp,
+            )
+        )
 
 
 class PersistentSubsectionGradeOverride(models.Model):

--- a/lms/djangoapps/grades/tests/test_events.py
+++ b/lms/djangoapps/grades/tests/test_events.py
@@ -1,0 +1,98 @@
+"""
+Test that various events are fired for models in the grades app.
+"""
+
+from unittest import mock
+
+from django.utils.timezone import now
+from openedx_events.learning.data import (
+    CourseData,
+    PersistentCourseGradeData
+)
+from openedx_events.learning.signals import PERSISTENT_GRADE_SUMMARY_CHANGED
+from openedx_events.tests.utils import OpenEdxEventsTestMixin
+
+from common.djangoapps.student.tests.factories import UserFactory
+from lms.djangoapps.grades.models import PersistentCourseGrade
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
+
+
+class PersistentGradeEventsTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin):
+    """
+    Tests for the Open edX Events associated with the persistant grade process through the update_or_create method.
+
+    This class guarantees that the following events are sent during the user updates their grade, with
+    the exact Data Attributes as the event definition stated:
+
+        - PERSISTENT_GRADE_SUMMARY_CHANGED: sent after the user updates or creates the grade.
+    """
+    ENABLED_OPENEDX_EVENTS = [
+        "org.openedx.learning.course.persistent_grade_summary.changed.v1",
+    ]
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Set up class method for the Test class.
+
+        This method starts manually events isolation. Explanation here:
+        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
+        """
+        super().setUpClass()
+        cls.start_events_isolation()
+
+    def setUp(self):  # pylint: disable=arguments-differ
+        super().setUp()
+        self.course = CourseFactory.create()
+        self.user = UserFactory.create()
+        self.params = {
+            "user_id": self.user.id,
+            "course_id": self.course.id,
+            "course_version": self.course.number,
+            "course_edited_timestamp": now(),
+            "percent_grade": 77.7,
+            "letter_grade": "Great job",
+            "passed": True,
+        }
+        self.receiver_called = False
+
+    def _event_receiver_side_effect(self, **kwargs):  # pylint: disable=unused-argument
+        """
+        Used show that the Open edX Event was called by the Django signal handler.
+        """
+        self.receiver_called = True
+
+    def test_persistent_grade_event_emitted(self):
+        """
+        Test whether the persistent grade updated event is sent after the user updates creates or updates their grade.
+
+        Expected result:
+            - PERSISTENT_GRADE_SUMMARY_CHANGED is sent and received by the mocked receiver.
+            - The arguments that the receiver gets are the arguments sent by the event
+            except the metadata generated on the fly.
+        """
+        event_receiver = mock.Mock(side_effect=self._event_receiver_side_effect)
+
+        PERSISTENT_GRADE_SUMMARY_CHANGED.connect(event_receiver)
+        grade = PersistentCourseGrade.update_or_create(**self.params)
+        self.assertTrue(self.receiver_called)
+        self.assertDictContainsSubset(
+            {
+                "signal": PERSISTENT_GRADE_SUMMARY_CHANGED,
+                "sender": None,
+                "grade": PersistentCourseGradeData(
+                    user_id=self.params["user_id"],
+                    course=CourseData(
+                        course_key=self.params["course_id"],
+                    ),
+                    course_edited_timestamp=self.params["course_edited_timestamp"],
+                    course_version=self.params["course_version"],
+                    grading_policy_hash='',
+                    percent_grade=self.params["percent_grade"],
+                    letter_grade=self.params["letter_grade"],
+                    passed_timestamp=grade.passed_timestamp
+                )
+            },
+            event_receiver.call_args.kwargs
+        )

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -761,7 +761,7 @@ oauthlib==3.0.1
     #   social-auth-core
 openedx-calc==3.0.1
     # via -r requirements/edx/base.in
-openedx-events==0.12.0
+openedx-events==0.13.0
     # via
     #   -r requirements/edx/base.in
     #   edx-event-bus-kafka

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -988,7 +988,7 @@ oauthlib==3.0.1
     #   social-auth-core
 openedx-calc==3.0.1
     # via -r requirements/edx/testing.txt
-openedx-events==0.12.0
+openedx-events==0.13.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-event-bus-kafka

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -940,7 +940,7 @@ oauthlib==3.0.1
     #   social-auth-core
 openedx-calc==3.0.1
     # via -r requirements/edx/base.txt
-openedx-events==0.12.0
+openedx-events==0.13.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-event-bus-kafka


### PR DESCRIPTION
**Description:** 

This PR adds a new signal with its respective unit test. It will be triggered when a persistent grade is created or updated, it is mandatory that you have the event defined in openedx-events.

**Dependencies:**

This PR requires the following PR  [#99](https://github.com/openedx/openedx-events/pull/99)

**Merge deadline:** 

As soon as possible

**Testing instructions:**

if you want to test this event you can use the following repository.

https://github.com/eduNEXT/openedx-events-2-zapier

For more details on how to install the repositories in your tutor installation, you can follow the following documentation:

https://docs.tutor.overhang.io/dev.html#xblock-and-edx-platform-plugin-development

Then you can create a small plugin in tutor to add the following variable `ZAPIER_PERSISTENT_GRADE_COURSE_WEBHOOK` to your lms env with the URL of your Zapier account.

```yaml
name: event-to-webhook
version: 0.1.0
patches:
 lms-env: |
  "ZAPIER_PERSISTENT_GRADE_COURSE_WEBHOOK": "url-zapier-or-webhook"
```

if you don't have a zapier account you can try it with the following site:

https://webhook.site

Additionally, run the unit test:
example: pytest lms/djangoapps/grades/tests/test_events.py

**Reviewers:**

- [x]  @felipemontoya 
- [x] @mariajgrimaldi 

**Merge checklist:**

- [x] All reviewers approved
- [x] CI build is green
- [x] Update openedx-events version
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**

- [ ] Create a tag
- [ ] Delete working branch (if not needed anymore)