### PR TITLE
feat: added support to check if active enterprise is same as EnterpriseCourseEnrollment object.

### DIFF
--- a/lms/djangoapps/course_home_api/course_metadata/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/course_metadata/tests/test_views.py
@@ -5,18 +5,22 @@ Tests for the Course Home Course Metadata API in the Course Home API
 import ddt
 import mock
 from django.urls import reverse
-
 from edx_toggles.toggles.testutils import override_waffle_flag
+
 from common.djangoapps.course_modes.models import CourseMode
-from common.djangoapps.student.roles import CourseInstructorRole
-from lms.djangoapps.courseware.toggles import (
-    COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES,
-    COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES_STREAK_CELEBRATION,
-)
 from common.djangoapps.student.models import CourseEnrollment
+from common.djangoapps.student.roles import CourseInstructorRole
 from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.course_home_api.tests.utils import BaseCourseHomeTests
-from lms.djangoapps.courseware.toggles import COURSEWARE_MFE_MILESTONES_STREAK_DISCOUNT
+from lms.djangoapps.courseware.toggles import (
+    COURSEWARE_MFE_MILESTONES_STREAK_DISCOUNT,
+    COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES,
+    COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES_STREAK_CELEBRATION
+)
+from openedx.features.enterprise_support.tests.factories import (
+    EnterpriseCourseEnrollmentFactory,
+    EnterpriseCustomerUserFactory
+)
 
 
 @ddt.ddt
@@ -82,6 +86,16 @@ class CourseHomeMetadataTests(BaseCourseHomeTests):
         response = self.client.get(url)
         assert response.status_code == 404
 
+    def _assert_course_access_response(self, response, expect_course_access, expected_error_code):
+        """
+        Responsible to asset the course_access response with expected values.
+        """
+        assert response.status_code == 200
+        assert response.data['course_access']['has_access'] == expect_course_access
+        assert response.data['course_access']['error_code'] == expected_error_code
+        # Start date is used when handling some errors, so make sure it is present too
+        assert response.data['start'] == self.course.start.isoformat() + 'Z'
+
     def test_streak_data_in_response(self):
         """ Test that metadata endpoint returns data for the streak celebration """
         CourseEnrollment.enroll(self.user, self.course.id, 'audit')
@@ -138,6 +152,15 @@ class CourseHomeMetadataTests(BaseCourseHomeTests):
             'dsc_required': True,
             'expect_course_access': False,
             'error_code': 'data_sharing_access_required'
+        },
+        {
+            # Data sharing Consent required staff should Not have access.
+            'enroll_user': True,
+            'instructor_role': True,
+            'masquerade_role': None,
+            'dsc_required': True,
+            'expect_course_access': False,
+            'error_code': 'data_sharing_access_required'
         }
     )
     @ddt.unpack
@@ -159,8 +182,43 @@ class CourseHomeMetadataTests(BaseCourseHomeTests):
         with mock.patch('openedx.features.enterprise_support.api.get_enterprise_consent_url', return_value=consent_url):
             response = self.client.get(self.url)
 
-        assert response.status_code == 200
-        assert response.data['course_access']['has_access'] == expect_course_access
-        assert response.data['course_access']['error_code'] == error_code
-        # Start date is used when handling some errors, so make sure it is present too
-        assert response.data['start'] == self.course.start.isoformat() + 'Z'
+        self._assert_course_access_response(response, expect_course_access, error_code)
+
+    @ddt.data(True, False)
+    def test_course_access_with_correct_active_enterprise(self, instructor_role):
+        """
+        Test that course_access is calculated correctly based on
+        access to MFE and access to the course itself.
+        """
+        if instructor_role:
+            CourseInstructorRole(self.course.id).add_users(self.user)
+
+        # Test with no EnterpriseCourseEnrollment
+        course_enrollment = CourseEnrollment.enroll(self.user, self.course.id, 'audit')
+        response = self.client.get(self.url)
+        self._assert_course_access_response(response, True, None)
+
+        # Test with EnterpriseCourseEnrollment and having correct active enterprise
+        course = course_enrollment.course
+        enterprise_customer_user = EnterpriseCustomerUserFactory(user_id=self.user.id)
+        EnterpriseCourseEnrollmentFactory(enterprise_customer_user=enterprise_customer_user, course_id=course.id)
+        response = self.client.get(self.url)
+        self._assert_course_access_response(response, True, None)
+
+        # Test with incorrect active enterprise
+        enterprise_customer_user_2 = EnterpriseCustomerUserFactory(user_id=self.user.id, active=True)
+        enterprise_customer_user.refresh_from_db()
+        assert not enterprise_customer_user.active
+        assert enterprise_customer_user_2.active
+        response = self.client.get(self.url)
+        self._assert_course_access_response(response, False, 'incorrect_active_enterprise')
+
+        # test when no active enterprise at all (ideally this should never happen)
+        enterprise_customer_user_2.active = False
+        enterprise_customer_user_2.save()
+        enterprise_customer_user.refresh_from_db()
+        enterprise_customer_user_2.refresh_from_db()
+        assert not enterprise_customer_user.active
+        assert not enterprise_customer_user_2.active
+        response = self.client.get(self.url)
+        self._assert_course_access_response(response, False, 'incorrect_active_enterprise')

--- a/lms/djangoapps/course_home_api/course_metadata/views.py
+++ b/lms/djangoapps/course_home_api/course_metadata/views.py
@@ -88,7 +88,7 @@ class CourseHomeMetadataView(RetrieveAPIView):
             'load',
             check_if_enrolled=True,
             check_if_authenticated=True,
-            check_if_dsc_required=True,
+            apply_enterprise_checks=True,
         )
 
         _, request.user = setup_masquerade(

--- a/lms/djangoapps/courseware/access_response.py
+++ b/lms/djangoapps/courseware/access_response.py
@@ -227,6 +227,22 @@ class EnrollmentRequiredAccessError(AccessError):
         super().__init__(error_code, developer_message, user_message)
 
 
+class IncorrectActiveEnterpriseAccessError(AccessError):
+    """
+    Access denied because the user must login with correct enterprise.
+    """
+    def __init__(self, enrollment_enterprise_name, active_enterprise_name):
+        error_code = "incorrect_active_enterprise"
+        developer_message = "User active enterprise should be same as EnterpriseCourseEnrollment enterprise."
+        user_message = _("You are enrolled in this course with '{enrollment_enterprise_name}'. However, you are "
+                         "currently logged in as a '{active_enterprise_name}' user. Please log in with "
+                         "'{enrollment_enterprise_name}' to access this course.")
+        user_message = user_message.format(
+            enrollment_enterprise_name=enrollment_enterprise_name, active_enterprise_name=active_enterprise_name
+        )
+        super().__init__(error_code, developer_message, user_message)
+
+
 class DataSharingConsentRequiredAccessError(AccessError):
     """
     Access denied because the user must give Data sharing consent before access it.


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-6111

If the active enterprise customer is not equal to the enrollment’s enterprise customer, return the `incorrect_active_enterprise` error from course-home:course-metadata API


<img width="721" alt="Screenshot 2022-08-30 at 2 12 31 PM" src="https://user-images.githubusercontent.com/29247391/187400873-994424f8-3963-4fed-8e01-4c06b45d21f5.png">


<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
