### PR TITLE
fix: force procoring back to 4.10.3

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -93,3 +93,7 @@ markdown<3.4.0
 # pycodestyle==2.9.0 generates false positive error E275.
 # Constraint can be removed once the issue https://github.com/PyCQA/pycodestyle/issues/1090 is fixed.
 pycodestyle<2.9.0
+
+# pinned 8/30/22
+# proctoring 4.11.0 breaks collect static stage of AMI building, can be removed once MST-1622 is resolved
+edx-proctoring==4.10.3

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -518,8 +518,9 @@ edx-opaque-keys[django]==2.3.0
     #   outcome-surveys
 edx-organizations==6.11.1
     # via -r requirements/edx/base.in
-edx-proctoring==4.12.0
+edx-proctoring==4.10.3
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   edx-proctoring-proctortrack
 edx-proctoring-proctortrack==1.0.5

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -635,8 +635,9 @@ edx-opaque-keys[django]==2.3.0
     #   outcome-surveys
 edx-organizations==6.11.1
     # via -r requirements/edx/testing.txt
-edx-proctoring==4.12.0
+edx-proctoring==4.10.3
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   edx-proctoring-proctortrack
 edx-proctoring-proctortrack==1.0.5

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -70,7 +70,6 @@ attrs==22.1.0
     #   edx-ace
     #   jsonschema
     #   openedx-events
-    #   outcome
     #   pytest
 babel==2.10.3
     # via
@@ -616,8 +615,9 @@ edx-opaque-keys[django]==2.3.0
     #   outcome-surveys
 edx-organizations==6.11.1
     # via -r requirements/edx/base.txt
-edx-proctoring==4.12.0
+edx-proctoring==4.10.3
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-proctoring-proctortrack
 edx-proctoring-proctortrack==1.0.5


### PR DESCRIPTION
proctoring 4.11 has changes which mysteriously crash the collect static stage of AMI building