### PR TITLE
fix: hide new provider if flag disabled

### DIFF
--- a/openedx/core/djangoapps/discussions/tests/test_views.py
+++ b/openedx/core/djangoapps/discussions/tests/test_views.py
@@ -424,7 +424,10 @@ class DataTest(AuthorizedApiTest, DataTestMixin):
         with override_waffle_flag(ENABLE_NEW_STRUCTURE_DISCUSSIONS, new_structure_enabled):
             response = self._get()
             data = response.json()
-            for visible_provider in [Provider.OPEN_EDX, Provider.LEGACY]:
+            visible_providers = [Provider.OPEN_EDX, Provider.LEGACY]
+            if not new_structure_enabled:
+                visible_providers = [Provider.LEGACY]
+            for visible_provider in visible_providers:
                 assert visible_provider in data['providers']['available'].keys()
 
     @ddt.data(

--- a/openedx/core/djangoapps/discussions/views.py
+++ b/openedx/core/djangoapps/discussions/views.py
@@ -183,6 +183,11 @@ class DiscussionsProvidersView(APIView):
             else:
                 if configuration.provider_type != Provider.OPEN_EDX:
                     hidden_providers.append(Provider.OPEN_EDX)
+        else:
+            # if new discussions is not enabled, hide the new provider in case it is not already in use
+            if not ENABLE_NEW_STRUCTURE_DISCUSSIONS.is_enabled(course_key):
+                if configuration.provider_type != Provider.OPEN_EDX:
+                    hidden_providers.append(Provider.OPEN_EDX)
 
         serializer = DiscussionsProvidersSerializer(
             {


### PR DESCRIPTION
Hide new discussions provider for global staff if the ENABLE_NEW_STRUCTURE_DISCUSSIONS flag is disabled