### PR TITLE
feat: learner home contract updates

### DIFF
--- a/lms/djangoapps/learner_home/mock_data.json
+++ b/lms/djangoapps/learner_home/mock_data.json
@@ -16,7 +16,6 @@
             "enrollment": {
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": true,
-                "hasFinished": false,
                 "hasStarted": false,
                 "isAudit": true,
                 "isAuditAccessExpired": false,
@@ -103,7 +102,6 @@
             "enrollment": {
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": true,
-                "hasFinished": false,
                 "hasStarted": false,
                 "isAudit": true,
                 "isAuditAccessExpired": false,
@@ -158,7 +156,6 @@
             "enrollment": {
                 "accessExpirationDate": "11/11/2000",
                 "canUpgrade": true,
-                "hasFinished": false,
                 "hasStarted": false,
                 "isAudit": true,
                 "isAuditAccessExpired": true,
@@ -205,7 +202,6 @@
             "enrollment": {
                 "accessExpirationDate": "11/11/2000",
                 "canUpgrade": false,
-                "hasFinished": false,
                 "hasStarted": false,
                 "isAudit": true,
                 "isAuditAccessExpired": true,
@@ -278,7 +274,6 @@
             "enrollment": {
                 "accessExpirationDate": "11/11/2000",
                 "canUpgrade": true,
-                "hasFinished": false,
                 "hasStarted": false,
                 "isAudit": true,
                 "isAuditAccessExpired": true,
@@ -340,7 +335,6 @@
             "enrollment": {
                 "accessExpirationDate": "11/11/2000",
                 "canUpgrade": true,
-                "hasFinished": false,
                 "hasStarted": false,
                 "isAudit": true,
                 "isAuditAccessExpired": true,
@@ -387,7 +381,6 @@
             "enrollment": {
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": true,
-                "hasFinished": false,
                 "hasStarted": false,
                 "isAudit": true,
                 "isAuditAccessExpired": false,
@@ -464,7 +457,6 @@
             "enrollment": {
                 "accessExpirationDate": "11/11/2000",
                 "canUpgrade": true,
-                "hasFinished": false,
                 "hasStarted": false,
                 "isAudit": true,
                 "isAuditAccessExpired": true,
@@ -530,7 +522,6 @@
             "enrollment": {
                 "accessExpirationDate": "11/11/2000",
                 "canUpgrade": false,
-                "hasFinished": false,
                 "hasStarted": false,
                 "isAudit": true,
                 "isAuditAccessExpired": true,
@@ -582,7 +573,6 @@
             "enrollment": {
                 "accessExpirationDate": "11/11/2000",
                 "canUpgrade": false,
-                "hasFinished": false,
                 "hasStarted": false,
                 "isAudit": true,
                 "isAuditAccessExpired": true,
@@ -664,7 +654,6 @@
             "enrollment": {
                 "accessExpirationDate": "11/11/2000",
                 "canUpgrade": false,
-                "hasFinished": false,
                 "hasStarted": false,
                 "isAudit": true,
                 "isAuditAccessExpired": true,
@@ -716,7 +705,6 @@
             "enrollment": {
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": null,
-                "hasFinished": false,
                 "hasStarted": false,
                 "isAudit": false,
                 "isAuditAccessExpired": null,
@@ -777,7 +765,6 @@
             "enrollment": {
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": null,
-                "hasFinished": false,
                 "hasStarted": false,
                 "isAudit": false,
                 "isAuditAccessExpired": null,
@@ -850,7 +837,6 @@
             "enrollment": {
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": null,
-                "hasFinished": false,
                 "hasStarted": true,
                 "isAudit": false,
                 "isAuditAccessExpired": null,
@@ -912,7 +898,6 @@
             "enrollment": {
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": null,
-                "hasFinished": false,
                 "hasStarted": true,
                 "isAudit": false,
                 "isAuditAccessExpired": null,
@@ -945,7 +930,6 @@
             "enrollment": {
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": null,
-                "hasFinished": true,
                 "hasStarted": true,
                 "isAudit": false,
                 "isAuditAccessExpired": null,
@@ -1018,7 +1002,6 @@
             "enrollment": {
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": null,
-                "hasFinished": true,
                 "hasStarted": true,
                 "isAudit": false,
                 "isAuditAccessExpired": null,
@@ -1081,7 +1064,6 @@
             "enrollment": {
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": null,
-                "hasFinished": true,
                 "hasStarted": true,
                 "isAudit": false,
                 "isAuditAccessExpired": null,
@@ -1128,7 +1110,6 @@
             "enrollment": {
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": null,
-                "hasFinished": true,
                 "hasStarted": true,
                 "isAudit": false,
                 "isAuditAccessExpired": null,
@@ -1202,7 +1183,6 @@
             "enrollment": {
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": null,
-                "hasFinished": true,
                 "hasStarted": true,
                 "isAudit": false,
                 "isAuditAccessExpired": null,
@@ -1265,7 +1245,6 @@
             "enrollment": {
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": null,
-                "hasFinished": true,
                 "hasStarted": true,
                 "isAudit": false,
                 "isAuditAccessExpired": null,
@@ -1348,7 +1327,6 @@
             "enrollment": {
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": null,
-                "hasFinished": false,
                 "hasStarted": false,
                 "isAudit": false,
                 "isAuditAccessExpired": null,
@@ -1456,7 +1434,6 @@
             "enrollment": {
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": null,
-                "hasFinished": false,
                 "hasStarted": false,
                 "isAudit": false,
                 "isAuditAccessExpired": null,
@@ -1553,7 +1530,6 @@
             "enrollment": {
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": null,
-                "hasFinished": false,
                 "hasStarted": true,
                 "isAudit": false,
                 "isAuditAccessExpired": null,
@@ -1635,7 +1611,6 @@
             "enrollment": {
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": null,
-                "hasFinished": false,
                 "hasStarted": true,
                 "isAudit": false,
                 "isAuditAccessExpired": null,
@@ -1717,7 +1692,6 @@
             "enrollment": {
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": null,
-                "hasFinished": false,
                 "hasStarted": false,
                 "isAudit": false,
                 "isAuditAccessExpired": null,
@@ -1788,7 +1762,6 @@
             "enrollment": {
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": null,
-                "hasFinished": false,
                 "hasStarted": false,
                 "isAudit": false,
                 "isAuditAccessExpired": null,
@@ -1845,7 +1818,6 @@
             "enrollment": {
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": null,
-                "hasFinished": false,
                 "hasStarted": false,
                 "isAudit": false,
                 "isAuditAccessExpired": null,
@@ -1927,7 +1899,6 @@
             "enrollment": {
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": null,
-                "hasFinished": false,
                 "hasStarted": false,
                 "isAudit": false,
                 "isAuditAccessExpired": null,
@@ -1986,7 +1957,6 @@
             "enrollment": {
                 "accessExpirationDate": null,
                 "canUpgrade": false,
-                "hasFinished": false,
                 "hasStarted": false,
                 "isAudit": false,
                 "isAuditAccessExpired": false,
@@ -2074,7 +2044,6 @@
             "enrollment": {
                 "accessExpirationDate": null,
                 "canUpgrade": false,
-                "hasFinished": false,
                 "hasStarted": false,
                 "isAudit": false,
                 "isAuditAccessExpired": false,
@@ -2151,7 +2120,6 @@
             "enrollment": {
                 "accessExpirationDate": null,
                 "canUpgrade": false,
-                "hasFinished": false,
                 "hasStarted": false,
                 "isAudit": false,
                 "isAuditAccessExpired": false,
@@ -2213,7 +2181,6 @@
             "enrollment": {
                 "accessExpirationDate": null,
                 "canUpgrade": false,
-                "hasFinished": false,
                 "hasStarted": false,
                 "isAudit": false,
                 "isAuditAccessExpired": false,

--- a/lms/djangoapps/learner_home/mock_data.json
+++ b/lms/djangoapps/learner_home/mock_data.json
@@ -17,6 +17,11 @@
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": true,
                 "hasStarted": false,
+                "hasAccess": {
+                    "hasUnmetPrerequisites": false,
+                    "isTooEarly": false,
+                    "isStaff": false
+                },
                 "isAudit": true,
                 "isAuditAccessExpired": false,
                 "isEmailEnabled": false,
@@ -103,6 +108,11 @@
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": true,
                 "hasStarted": false,
+                "hasAccess": {
+                    "hasUnmetPrerequisites": false,
+                    "isTooEarly": false,
+                    "isStaff": false
+                },
                 "isAudit": true,
                 "isAuditAccessExpired": false,
                 "isEmailEnabled": false,
@@ -157,6 +167,11 @@
                 "accessExpirationDate": "11/11/2000",
                 "canUpgrade": true,
                 "hasStarted": false,
+                "hasAccess": {
+                    "hasUnmetPrerequisites": false,
+                    "isTooEarly": false,
+                    "isStaff": false
+                },
                 "isAudit": true,
                 "isAuditAccessExpired": true,
                 "isEmailEnabled": false,
@@ -203,6 +218,11 @@
                 "accessExpirationDate": "11/11/2000",
                 "canUpgrade": false,
                 "hasStarted": false,
+                "hasAccess": {
+                    "hasUnmetPrerequisites": false,
+                    "isTooEarly": false,
+                    "isStaff": false
+                },
                 "isAudit": true,
                 "isAuditAccessExpired": true,
                 "isEmailEnabled": false,
@@ -275,6 +295,11 @@
                 "accessExpirationDate": "11/11/2000",
                 "canUpgrade": true,
                 "hasStarted": false,
+                "hasAccess": {
+                    "hasUnmetPrerequisites": false,
+                    "isTooEarly": false,
+                    "isStaff": false
+                },
                 "isAudit": true,
                 "isAuditAccessExpired": true,
                 "isEmailEnabled": false,
@@ -336,6 +361,11 @@
                 "accessExpirationDate": "11/11/2000",
                 "canUpgrade": true,
                 "hasStarted": false,
+                "hasAccess": {
+                    "hasUnmetPrerequisites": false,
+                    "isTooEarly": false,
+                    "isStaff": false
+                },
                 "isAudit": true,
                 "isAuditAccessExpired": true,
                 "isEmailEnabled": false,
@@ -382,6 +412,11 @@
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": true,
                 "hasStarted": false,
+                "hasAccess": {
+                    "hasUnmetPrerequisites": false,
+                    "isTooEarly": false,
+                    "isStaff": false
+                },
                 "isAudit": true,
                 "isAuditAccessExpired": false,
                 "isEmailEnabled": false,
@@ -458,6 +493,11 @@
                 "accessExpirationDate": "11/11/2000",
                 "canUpgrade": true,
                 "hasStarted": false,
+                "hasAccess": {
+                    "hasUnmetPrerequisites": false,
+                    "isTooEarly": true,
+                    "isStaff": false
+                },
                 "isAudit": true,
                 "isAuditAccessExpired": true,
                 "isEmailEnabled": false,
@@ -523,6 +563,11 @@
                 "accessExpirationDate": "11/11/2000",
                 "canUpgrade": false,
                 "hasStarted": false,
+                "hasAccess": {
+                    "hasUnmetPrerequisites": false,
+                    "isTooEarly": true,
+                    "isStaff": false
+                },
                 "isAudit": true,
                 "isAuditAccessExpired": true,
                 "isEmailEnabled": false,
@@ -574,6 +619,11 @@
                 "accessExpirationDate": "11/11/2000",
                 "canUpgrade": false,
                 "hasStarted": false,
+                "hasAccess": {
+                    "hasUnmetPrerequisites": false,
+                    "isTooEarly": true,
+                    "isStaff": false
+                },
                 "isAudit": true,
                 "isAuditAccessExpired": true,
                 "isEmailEnabled": false,
@@ -655,6 +705,11 @@
                 "accessExpirationDate": "11/11/2000",
                 "canUpgrade": false,
                 "hasStarted": false,
+                "hasAccess": {
+                    "hasUnmetPrerequisites": false,
+                    "isTooEarly": true,
+                    "isStaff": false
+                },
                 "isAudit": true,
                 "isAuditAccessExpired": true,
                 "isEmailEnabled": false,
@@ -706,6 +761,11 @@
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": null,
                 "hasStarted": false,
+                "hasAccess": {
+                    "hasUnmetPrerequisites": false,
+                    "isTooEarly": true,
+                    "isStaff": false
+                },
                 "isAudit": false,
                 "isAuditAccessExpired": null,
                 "isEmailEnabled": false,
@@ -766,6 +826,11 @@
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": null,
                 "hasStarted": false,
+                "hasAccess": {
+                    "hasUnmetPrerequisites": false,
+                    "isTooEarly": false,
+                    "isStaff": false
+                },
                 "isAudit": false,
                 "isAuditAccessExpired": null,
                 "isEmailEnabled": false,
@@ -838,6 +903,11 @@
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": null,
                 "hasStarted": true,
+                "hasAccess": {
+                    "hasUnmetPrerequisites": false,
+                    "isTooEarly": false,
+                    "isStaff": false
+                },
                 "isAudit": false,
                 "isAuditAccessExpired": null,
                 "isEmailEnabled": false,
@@ -899,6 +969,11 @@
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": null,
                 "hasStarted": true,
+                "hasAccess": {
+                    "hasUnmetPrerequisites": false,
+                    "isTooEarly": false,
+                    "isStaff": false
+                },
                 "isAudit": false,
                 "isAuditAccessExpired": null,
                 "isEmailEnabled": false,
@@ -931,6 +1006,11 @@
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": null,
                 "hasStarted": true,
+                "hasAccess": {
+                    "hasUnmetPrerequisites": false,
+                    "isTooEarly": false,
+                    "isStaff": false
+                },
                 "isAudit": false,
                 "isAuditAccessExpired": null,
                 "isEmailEnabled": false,
@@ -1003,6 +1083,11 @@
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": null,
                 "hasStarted": true,
+                "hasAccess": {
+                    "hasUnmetPrerequisites": false,
+                    "isTooEarly": false,
+                    "isStaff": false
+                },
                 "isAudit": false,
                 "isAuditAccessExpired": null,
                 "isEmailEnabled": false,
@@ -1065,6 +1150,11 @@
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": null,
                 "hasStarted": true,
+                "hasAccess": {
+                    "hasUnmetPrerequisites": false,
+                    "isTooEarly": false,
+                    "isStaff": false
+                },
                 "isAudit": false,
                 "isAuditAccessExpired": null,
                 "isEmailEnabled": false,
@@ -1111,6 +1201,11 @@
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": null,
                 "hasStarted": true,
+                "hasAccess": {
+                    "hasUnmetPrerequisites": false,
+                    "isTooEarly": false,
+                    "isStaff": false
+                },
                 "isAudit": false,
                 "isAuditAccessExpired": null,
                 "isEmailEnabled": false,
@@ -1184,6 +1279,11 @@
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": null,
                 "hasStarted": true,
+                "hasAccess": {
+                    "hasUnmetPrerequisites": false,
+                    "isTooEarly": false,
+                    "isStaff": false
+                },
                 "isAudit": false,
                 "isAuditAccessExpired": null,
                 "isEmailEnabled": false,
@@ -1246,6 +1346,11 @@
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": null,
                 "hasStarted": true,
+                "hasAccess": {
+                    "hasUnmetPrerequisites": false,
+                    "isTooEarly": false,
+                    "isStaff": false
+                },
                 "isAudit": false,
                 "isAuditAccessExpired": null,
                 "isEmailEnabled": false,
@@ -1328,6 +1433,11 @@
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": null,
                 "hasStarted": false,
+                "hasAccess": {
+                    "hasUnmetPrerequisites": false,
+                    "isTooEarly": false,
+                    "isStaff": false
+                },
                 "isAudit": false,
                 "isAuditAccessExpired": null,
                 "isEmailEnabled": false,
@@ -1435,6 +1545,11 @@
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": null,
                 "hasStarted": false,
+                "hasAccess": {
+                    "hasUnmetPrerequisites": false,
+                    "isTooEarly": false,
+                    "isStaff": false
+                },
                 "isAudit": false,
                 "isAuditAccessExpired": null,
                 "isEmailEnabled": false,
@@ -1531,6 +1646,11 @@
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": null,
                 "hasStarted": true,
+                "hasAccess": {
+                    "hasUnmetPrerequisites": false,
+                    "isTooEarly": false,
+                    "isStaff": false
+                },
                 "isAudit": false,
                 "isAuditAccessExpired": null,
                 "isEmailEnabled": false,
@@ -1612,6 +1732,11 @@
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": null,
                 "hasStarted": true,
+                "hasAccess": {
+                    "hasUnmetPrerequisites": false,
+                    "isTooEarly": false,
+                    "isStaff": false
+                },
                 "isAudit": false,
                 "isAuditAccessExpired": null,
                 "isEmailEnabled": false,
@@ -1693,6 +1818,11 @@
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": null,
                 "hasStarted": false,
+                "hasAccess": {
+                    "hasUnmetPrerequisites": false,
+                    "isTooEarly": false,
+                    "isStaff": false
+                },
                 "isAudit": false,
                 "isAuditAccessExpired": null,
                 "isEmailEnabled": false,
@@ -1763,6 +1893,11 @@
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": null,
                 "hasStarted": false,
+                "hasAccess": {
+                    "hasUnmetPrerequisites": false,
+                    "isTooEarly": false,
+                    "isStaff": false
+                },
                 "isAudit": false,
                 "isAuditAccessExpired": null,
                 "isEmailEnabled": false,
@@ -1819,6 +1954,11 @@
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": null,
                 "hasStarted": false,
+                "hasAccess": {
+                    "hasUnmetPrerequisites": false,
+                    "isTooEarly": false,
+                    "isStaff": false
+                },
                 "isAudit": false,
                 "isAuditAccessExpired": null,
                 "isEmailEnabled": false,
@@ -1900,6 +2040,11 @@
                 "accessExpirationDate": "11/11/3030",
                 "canUpgrade": null,
                 "hasStarted": false,
+                "hasAccess": {
+                    "hasUnmetPrerequisites": false,
+                    "isTooEarly": false,
+                    "isStaff": false
+                },
                 "isAudit": false,
                 "isAuditAccessExpired": null,
                 "isEmailEnabled": false,
@@ -1958,6 +2103,11 @@
                 "accessExpirationDate": null,
                 "canUpgrade": false,
                 "hasStarted": false,
+                "hasAccess": {
+                    "hasUnmetPrerequisites": false,
+                    "isTooEarly": false,
+                    "isStaff": false
+                },
                 "isAudit": false,
                 "isAuditAccessExpired": false,
                 "isEmailEnabled": false,
@@ -2045,6 +2195,11 @@
                 "accessExpirationDate": null,
                 "canUpgrade": false,
                 "hasStarted": false,
+                "hasAccess": {
+                    "hasUnmetPrerequisites": false,
+                    "isTooEarly": false,
+                    "isStaff": false
+                },
                 "isAudit": false,
                 "isAuditAccessExpired": false,
                 "isEmailEnabled": false,
@@ -2121,6 +2276,11 @@
                 "accessExpirationDate": null,
                 "canUpgrade": false,
                 "hasStarted": false,
+                "hasAccess": {
+                    "hasUnmetPrerequisites": false,
+                    "isTooEarly": false,
+                    "isStaff": false
+                },
                 "isAudit": false,
                 "isAuditAccessExpired": false,
                 "isEmailEnabled": false,
@@ -2182,6 +2342,11 @@
                 "accessExpirationDate": null,
                 "canUpgrade": false,
                 "hasStarted": false,
+                "hasAccess": {
+                    "hasUnmetPrerequisites": false,
+                    "isTooEarly": false,
+                    "isStaff": false
+                },
                 "isAudit": false,
                 "isAuditAccessExpired": false,
                 "isEmailEnabled": false,

--- a/lms/djangoapps/learner_home/mock_data.json
+++ b/lms/djangoapps/learner_home/mock_data.json
@@ -2242,21 +2242,9 @@
         "isNeeded": true,
         "sendEmailUrl": "sendConfirmation@edx.org"
     },
-    "enterpriseDashboards": {
-        "availableDashboards": [
-            {
-                "label": "edX, Inc.",
-                "url": "/edx-dashboard"
-            },
-            {
-                "label": "Harvard",
-                "url": "/harvard-dashboard"
-            }
-        ],
-        "mostRecentDashboard": {
-            "label": "edX, Inc.",
-            "url": "/edx-dashboard"
-        }
+    "enterpriseDashboard": {
+        "label": "edX, Inc.",
+        "url": "/edx-dashboard"
     },
     "platformSettings": {
         "supportEmail": "support@example.com",

--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -115,7 +115,10 @@ class HasAccessSerializer(serializers.Serializer):
         pass
 
     def get_isStaff(self, enrollment):
-        pass
+        """Determine whether a user has staff access to this course"""
+        return self.context.get("courses_with_staff_access", {}).get(
+            enrollment.course_id, False
+        )
 
 
 class EnrollmentSerializer(serializers.Serializer):

--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -112,7 +112,10 @@ class HasAccessSerializer(serializers.Serializer):
         )
 
     def get_isTooEarly(self, enrollment):
-        pass
+        """Determine if the course is open to a learner (course has started or user has early beta access)"""
+        return not self.context.get("courses_open_for_learner", {}).get(
+            enrollment.course_id, False
+        )
 
     def get_isStaff(self, enrollment):
         """Determine whether a user has staff access to this course"""

--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -330,7 +330,7 @@ class LearnerDashboardSerializer(serializers.Serializer):
     requires_context = True
 
     emailConfirmation = EmailConfirmationSerializer()
-    enterpriseDashboard = EnterpriseDashboardSerializer()
+    enterpriseDashboard = EnterpriseDashboardSerializer(allow_null=True)
     platformSettings = PlatformSettingsSerializer()
     courses = serializers.SerializerMethodField()
     suggestedCourses = serializers.ListField(

--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -329,22 +329,13 @@ class EnterpriseDashboardSerializer(serializers.Serializer):
     url = serializers.URLField()
 
 
-class EnterpriseDashboardsSerializer(serializers.Serializer):
-    """Listing of available enterprise dashboards"""
-
-    availableDashboards = serializers.ListField(
-        child=EnterpriseDashboardSerializer(), allow_empty=True
-    )
-    mostRecentDashboard = EnterpriseDashboardSerializer()
-
-
 class LearnerDashboardSerializer(serializers.Serializer):
     """Serializer for all info required to render the Learner Dashboard"""
 
     requires_context = True
 
     emailConfirmation = EmailConfirmationSerializer()
-    enterpriseDashboards = EnterpriseDashboardsSerializer()
+    enterpriseDashboard = EnterpriseDashboardSerializer()
     platformSettings = PlatformSettingsSerializer()
     courses = serializers.SerializerMethodField()
     suggestedCourses = serializers.ListField(

--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -94,6 +94,30 @@ class CourseRunSerializer(serializers.Serializer):
         return self.context.get("resume_course_urls", {}).get(instance.course_id)
 
 
+class HasAccessSerializer(serializers.Serializer):
+    """
+    Info determining whether a user should be able to view course material.
+    Mirrors logic in "show_courseware_links_for" from old dashboard.py
+    """
+
+    hasUnmetPrerequisites = serializers.SerializerMethodField()
+    isTooEarly = serializers.SerializerMethodField()
+    isStaff = serializers.SerializerMethodField()
+
+    def get_hasUnmetPrerequisites(self, enrollment):
+        """Whether or not a course has unmet prerequisites"""
+
+        return enrollment.course_id in self.context.get(
+            "courses_requirements_not_met", []
+        )
+
+    def get_isTooEarly(self, enrollment):
+        pass
+
+    def get_isStaff(self, enrollment):
+        pass
+
+
 class EnrollmentSerializer(serializers.Serializer):
     """
     Info about this particular enrollment.
@@ -112,6 +136,7 @@ class EnrollmentSerializer(serializers.Serializer):
     accessExpirationDate = serializers.SerializerMethodField()
     isAudit = serializers.SerializerMethodField()
     hasStarted = serializers.SerializerMethodField()
+    hasAccess = HasAccessSerializer(source="*")
     isVerified = serializers.SerializerMethodField()
     canUpgrade = serializers.SerializerMethodField()
     isAuditAccessExpired = serializers.SerializerMethodField()

--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -112,7 +112,6 @@ class EnrollmentSerializer(serializers.Serializer):
     accessExpirationDate = serializers.SerializerMethodField()
     isAudit = serializers.SerializerMethodField()
     hasStarted = serializers.SerializerMethodField()
-    hasFinished = serializers.SerializerMethodField()
     isVerified = serializers.SerializerMethodField()
     canUpgrade = serializers.SerializerMethodField()
     isAuditAccessExpired = serializers.SerializerMethodField()
@@ -137,10 +136,6 @@ class EnrollmentSerializer(serializers.Serializer):
             enrollment.course_id
         )
         return resume_button_url is not None
-
-    def get_hasFinished(self, enrollment):
-        # TODO - AU-796
-        return False
 
     def get_isVerified(self, enrollment):
         return enrollment.is_verified_enrollment()

--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -104,23 +104,28 @@ class HasAccessSerializer(serializers.Serializer):
     isTooEarly = serializers.SerializerMethodField()
     isStaff = serializers.SerializerMethodField()
 
+    def _get_course_access_checks(self, enrollment):
+        """Internal helper to unpack access object for this particular enrollment"""
+        return self.context.get("course_access_checks", {}).get(
+            enrollment.course_id, {}
+        )
+
     def get_hasUnmetPrerequisites(self, enrollment):
         """Whether or not a course has unmet prerequisites"""
-
-        return enrollment.course_id in self.context.get(
-            "courses_requirements_not_met", []
+        return self._get_course_access_checks(enrollment).get(
+            "has_unmet_prerequisites", False
         )
 
     def get_isTooEarly(self, enrollment):
         """Determine if the course is open to a learner (course has started or user has early beta access)"""
-        return not self.context.get("courses_open_for_learner", {}).get(
-            enrollment.course_id, False
+        return self._get_course_access_checks(enrollment).get(
+            "is_too_early_to_view", False
         )
 
     def get_isStaff(self, enrollment):
         """Determine whether a user has staff access to this course"""
-        return self.context.get("courses_with_staff_access", {}).get(
-            enrollment.course_id, False
+        return self._get_course_access_checks(enrollment).get(
+            "user_has_staff_access", False
         )
 
 

--- a/lms/djangoapps/learner_home/test_serializers.py
+++ b/lms/djangoapps/learner_home/test_serializers.py
@@ -225,6 +225,27 @@ class TestHasAccessSerializer(LearnerDashboardBaseTest):
         # Then "isStaff" serializes properly
         self.assertEqual(output_data["isStaff"], is_staff)
 
+    @ddt.data(True, False)
+    def test_is_too_early(self, is_too_early):
+        # Given an enrollment
+        input_data = self.create_test_enrollment()
+        input_context = self.create_test_context(input_data.course)
+
+        # Where the course is/n't yet open for a learner
+        input_context.update(
+            {
+                "courses_open_for_learner": {
+                    input_data.course.id: not is_too_early,
+                }
+            }
+        )
+
+        # When I serialize
+        output_data = HasAccessSerializer(input_data, context=input_context).data
+
+        # Then "isTooEarly" serializes properly
+        self.assertEqual(output_data["isTooEarly"], is_too_early)
+
 
 @ddt.ddt
 class TestEnrollmentSerializer(LearnerDashboardBaseTest):

--- a/lms/djangoapps/learner_home/test_serializers.py
+++ b/lms/djangoapps/learner_home/test_serializers.py
@@ -159,7 +159,15 @@ class TestHasAccessSerializer(LearnerDashboardBaseTest):
     """Tests for the HasAccessSerializer"""
 
     def create_test_context(self, course):
-        return {"courses_requirements_not_met": {}}
+        return {
+            "course_access_checks": {
+                course.id: {
+                    "has_unmet_prerequisites": False,
+                    "is_too_early_to_view": False,
+                    "user_has_staff_access": False,
+                }
+            }
+        }
 
     @ddt.data(True, False)
     def test_unmet_prerequisites(self, has_unmet_prerequisites):
@@ -173,14 +181,9 @@ class TestHasAccessSerializer(LearnerDashboardBaseTest):
             prerequisite_course = CourseFactory()
             input_context.update(
                 {
-                    "courses_requirements_not_met": {
+                    "course_access_checks": {
                         input_data.course.id: {
-                            "courses": [
-                                {
-                                    "key": prerequisite_course.id,
-                                    "display": prerequisite_course.display_name,
-                                }
-                            ]
+                            "has_unmet_prerequisites": has_unmet_prerequisites,
                         }
                     }
                 }
@@ -201,8 +204,10 @@ class TestHasAccessSerializer(LearnerDashboardBaseTest):
         # Where user has/hasn't staff access
         input_context.update(
             {
-                "courses_with_staff_access": {
-                    input_data.course.id: is_staff,
+                "course_access_checks": {
+                    input_data.course.id: {
+                        "user_has_staff_access": is_staff,
+                    }
                 }
             }
         )
@@ -222,8 +227,10 @@ class TestHasAccessSerializer(LearnerDashboardBaseTest):
         # Where the course is/n't yet open for a learner
         input_context.update(
             {
-                "courses_open_for_learner": {
-                    input_data.course.id: not is_too_early,
+                "course_access_checks": {
+                    input_data.course.id: {
+                        "is_too_early_to_view": is_too_early,
+                    }
                 }
             }
         )

--- a/lms/djangoapps/learner_home/test_serializers.py
+++ b/lms/djangoapps/learner_home/test_serializers.py
@@ -22,7 +22,7 @@ from lms.djangoapps.learner_home.serializers import (
     CourseSerializer,
     EmailConfirmationSerializer,
     EnrollmentSerializer,
-    EnterpriseDashboardsSerializer,
+    EnterpriseDashboardSerializer,
     EntitlementSerializer,
     GradeDataSerializer,
     LearnerEnrollmentSerializer,
@@ -759,36 +759,25 @@ class TestEmailConfirmationSerializer(TestCase):
         )
 
 
-class TestEnterpriseDashboardsSerializer(TestCase):
-    """High-level tests for EnterpriseDashboardsSerializer"""
-
-    @classmethod
-    def generate_test_dashboard(cls):
-        return {
-            "label": f"{uuid4()}",
-            "url": random_url(),
-        }
+class TestEnterpriseDashboardSerializer(TestCase):
+    """High-level tests for EnterpriseDashboardSerializer"""
 
     @classmethod
     def generate_test_data(cls):
         return {
-            "availableDashboards": [
-                cls.generate_test_dashboard() for _ in range(randint(0, 3))
-            ],
-            "mostRecentDashboard": cls.generate_test_dashboard()
-            if random_bool()
-            else None,
+            "label": f"{uuid4()}",
+            "url": random_url(),
         }
 
     def test_structure(self):
         """Test that nothing breaks and the output fields look correct"""
         input_data = self.generate_test_data()
 
-        output_data = EnterpriseDashboardsSerializer(input_data).data
+        output_data = EnterpriseDashboardSerializer(input_data).data
 
         expected_keys = [
-            "availableDashboards",
-            "mostRecentDashboard",
+            "label",
+            "url",
         ]
         assert output_data.keys() == set(expected_keys)
 
@@ -797,13 +786,13 @@ class TestEnterpriseDashboardsSerializer(TestCase):
 
         input_data = self.generate_test_data()
 
-        output_data = EnterpriseDashboardsSerializer(input_data).data
+        output_data = EnterpriseDashboardSerializer(input_data).data
 
         self.assertDictEqual(
             output_data,
             {
-                "availableDashboards": input_data["availableDashboards"],
-                "mostRecentDashboard": input_data["mostRecentDashboard"],
+                "label": input_data["label"],
+                "url": input_data["url"],
             },
         )
 
@@ -819,7 +808,7 @@ class TestLearnerDashboardSerializer(LearnerDashboardBaseTest):
 
         input_data = {
             "emailConfirmation": None,
-            "enterpriseDashboards": None,
+            "enterpriseDashboard": None,
             "platformSettings": None,
             "enrollments": [],
             "unfulfilledEntitlements": [],
@@ -831,7 +820,7 @@ class TestLearnerDashboardSerializer(LearnerDashboardBaseTest):
             output_data,
             {
                 "emailConfirmation": None,
-                "enterpriseDashboards": None,
+                "enterpriseDashboard": None,
                 "platformSettings": None,
                 "courses": [],
                 "suggestedCourses": [],
@@ -857,7 +846,7 @@ class TestLearnerDashboardSerializer(LearnerDashboardBaseTest):
 
         input_data = {
             "emailConfirmation": None,
-            "enterpriseDashboards": None,
+            "enterpriseDashboard": None,
             "platformSettings": None,
             "enrollments": enrollments,
             "unfulfilledEntitlements": [],
@@ -889,7 +878,7 @@ class TestLearnerDashboardSerializer(LearnerDashboardBaseTest):
         "lms.djangoapps.learner_home.serializers.PlatformSettingsSerializer.to_representation"
     )
     @mock.patch(
-        "lms.djangoapps.learner_home.serializers.EnterpriseDashboardsSerializer.to_representation"
+        "lms.djangoapps.learner_home.serializers.EnterpriseDashboardSerializer.to_representation"
     )
     @mock.patch(
         "lms.djangoapps.learner_home.serializers.EmailConfirmationSerializer.to_representation"
@@ -897,7 +886,7 @@ class TestLearnerDashboardSerializer(LearnerDashboardBaseTest):
     def test_linkage(
         self,
         mock_email_confirmation_serializer,
-        mock_enterprise_dashboards_serializer,
+        mock_enterprise_dashboard_serializer,
         mock_platform_settings_serializer,
         mock_learner_enrollment_serializer,
         mock_entitlements_serializer,
@@ -906,8 +895,8 @@ class TestLearnerDashboardSerializer(LearnerDashboardBaseTest):
         mock_email_confirmation_serializer.return_value = (
             mock_email_confirmation_serializer
         )
-        mock_enterprise_dashboards_serializer.return_value = (
-            mock_enterprise_dashboards_serializer
+        mock_enterprise_dashboard_serializer.return_value = (
+            mock_enterprise_dashboard_serializer
         )
         mock_platform_settings_serializer.return_value = (
             mock_platform_settings_serializer
@@ -920,7 +909,7 @@ class TestLearnerDashboardSerializer(LearnerDashboardBaseTest):
 
         input_data = {
             "emailConfirmation": {},
-            "enterpriseDashboards": [{}],
+            "enterpriseDashboard": {},
             "platformSettings": {},
             "enrollments": [{}],
             "unfulfilledEntitlements": [{}],
@@ -932,7 +921,7 @@ class TestLearnerDashboardSerializer(LearnerDashboardBaseTest):
             output_data,
             {
                 "emailConfirmation": mock_email_confirmation_serializer,
-                "enterpriseDashboards": mock_enterprise_dashboards_serializer,
+                "enterpriseDashboard": mock_enterprise_dashboard_serializer,
                 "platformSettings": mock_platform_settings_serializer,
                 "courses": [
                     mock_learner_enrollment_serializer,

--- a/lms/djangoapps/learner_home/test_serializers.py
+++ b/lms/djangoapps/learner_home/test_serializers.py
@@ -204,6 +204,27 @@ class TestHasAccessSerializer(LearnerDashboardBaseTest):
         # Then "hasUnmetPrerequisites" is outputs correctly
         self.assertEqual(output_data["hasUnmetPrerequisites"], has_unmet_prerequisites)
 
+    @ddt.data(True, False)
+    def test_is_staff(self, is_staff):
+        # Given an enrollment
+        input_data = self.create_test_enrollment()
+        input_context = self.create_test_context(input_data.course)
+
+        # Where user has/hasn't staff access
+        input_context.update(
+            {
+                "courses_with_staff_access": {
+                    input_data.course.id: is_staff,
+                }
+            }
+        )
+
+        # When I serialize
+        output_data = HasAccessSerializer(input_data, context=input_context).data
+
+        # Then "isStaff" serializes properly
+        self.assertEqual(output_data["isStaff"], is_staff)
+
 
 @ddt.ddt
 class TestEnrollmentSerializer(LearnerDashboardBaseTest):

--- a/lms/djangoapps/learner_home/test_serializers.py
+++ b/lms/djangoapps/learner_home/test_serializers.py
@@ -69,18 +69,6 @@ class LearnerDashboardBaseTest(SharedModuleStoreTestCase):
 
         return test_enrollment
 
-    @classmethod
-    def generate_base_test_context(cls):
-        """Base context object that can be used across tests"""
-        return {
-            "ecommerce_payment_page": random_url(),
-            "cert_statuses": {},
-            "course_mode_info": {},
-            "course_optouts": {},
-            "resume_course_urls": {},
-            "show_email_settings_for": {},
-        }
-
 
 class TestPlatformSettingsSerializer(TestCase):
     """Tests for the PlatformSettingsSerializer"""

--- a/lms/djangoapps/learner_home/test_views.py
+++ b/lms/djangoapps/learner_home/test_views.py
@@ -232,7 +232,7 @@ class TestDashboardView(SharedModuleStoreTestCase, APITestCase):
         expected_keys = set(
             [
                 "emailConfirmation",
-                "enterpriseDashboards",
+                "enterpriseDashboard",
                 "platformSettings",
                 "courses",
                 "suggestedCourses",

--- a/lms/djangoapps/learner_home/views.py
+++ b/lms/djangoapps/learner_home/views.py
@@ -125,6 +125,18 @@ def get_cert_statuses(user, course_enrollments):
     }
 
 
+def get_courses_with_unmet_prerequisites(user, course_enrollments):
+    """Determine which courses have unmetprerequisites"""
+
+    courses_having_prerequisites = frozenset(
+        enrollment.course_id
+        for enrollment in course_enrollments
+        if enrollment.course_overview.pre_requisite_courses
+    )
+
+    return get_pre_requisite_courses_not_completed(user, courses_having_prerequisites)
+
+
 class InitializeView(RetrieveAPIView):  # pylint: disable=unused-argument
     """List of courses a user is enrolled in or entitled to"""
 
@@ -152,6 +164,13 @@ class InitializeView(RetrieveAPIView):  # pylint: disable=unused-argument
         # Get cert status by course
         cert_statuses = get_cert_statuses(user, course_enrollments)
 
+        # Get enrollments with unmet prerequisites
+        courses_requirements_not_met = get_courses_with_unmet_prerequisites(
+            user, course_enrollments
+        )
+
+        # TODO - Get verification status by course (do we still need this?)
+
         # TODO - Determine view access for courses (for showing courseware link or not)
 
         # TODO - Get related programs
@@ -178,6 +197,7 @@ class InitializeView(RetrieveAPIView):  # pylint: disable=unused-argument
             "cert_statuses": cert_statuses,
             "course_mode_info": course_mode_info,
             "course_optouts": course_optouts,
+            "courses_requirements_not_met": courses_requirements_not_met,
             "resume_course_urls": resume_button_urls,
             "show_email_settings_for": show_email_settings_for,
         }

--- a/lms/djangoapps/learner_home/views.py
+++ b/lms/djangoapps/learner_home/views.py
@@ -14,6 +14,9 @@ from common.djangoapps.student.views.dashboard import (
     get_course_enrollments,
     get_org_black_and_whitelist_for_site,
 )
+from common.djangoapps.util.milestones_helpers import (
+    get_pre_requisite_courses_not_completed,
+)
 from lms.djangoapps.bulk_email.models import Optout
 from lms.djangoapps.bulk_email.models_api import is_bulk_email_feature_enabled
 from lms.djangoapps.commerce.utils import EcommerceService


### PR DESCRIPTION
## Description

Update contract based on [recent changes](https://2u-internal.atlassian.net/wiki/pages/diffpagesbyversion.action?pageId=15438335&selectedPageVersions=33&selectedPageVersions=34).
- Update `enterpriseDashboards` to be a single `enterpriseDashboard` object
- Remove `enrollment.hasFinished`
- Add `enrollment.hasAccess` object with reasons a course may/not allow view/resume access to a user.

JIRA: https://2u-internal.atlassian.net/browse/AU-837
FYI: @openedx/content-aurora 