### PR TITLE
fix: update free tier validation rule

### DIFF
--- a/openedx/core/djangoapps/course_live/serializers.py
+++ b/openedx/core/djangoapps/course_live/serializers.py
@@ -32,7 +32,7 @@ class LtiSerializer(serializers.ModelSerializer):
         """
         Validates if lti_config contains all required data i.e. custom_instructor_email
         """
-        additional_parameters = value.get('additional_parameters', None)
+        additional_parameters = value.get('additional_parameters', {})
         custom_instructor_email = additional_parameters.get('custom_instructor_email', None)
         requires_email = self.context.get('provider').requires_custom_email()
 

--- a/openedx/core/djangoapps/course_live/serializers.py
+++ b/openedx/core/djangoapps/course_live/serializers.py
@@ -140,6 +140,8 @@ class CourseLiveConfigurationSerializer(serializers.ModelSerializer):
         instance = self._update_course_live_instance(instance, validated_data)
         if not validated_data.get('free_tier', False):
             instance = self._update_lti(instance, lti_config)
+        else:
+            instance.lti_configuration = None
         instance.save()
         return instance
 
@@ -151,6 +153,8 @@ class CourseLiveConfigurationSerializer(serializers.ModelSerializer):
         instance = self._update_course_live_instance(instance, validated_data)
         if not validated_data.get('free_tier', False):
             instance = self._update_lti(instance, lti_config)
+        else:
+            instance.lti_configuration = None
         instance.save()
         return instance
 

--- a/openedx/core/djangoapps/course_live/serializers.py
+++ b/openedx/core/djangoapps/course_live/serializers.py
@@ -118,12 +118,14 @@ class CourseLiveConfigurationSerializer(serializers.ModelSerializer):
             self.context['provider_type'] = self.data.get('provider_type', '')
 
     def validate_free_tier(self, value):
+        """
+        Validates free_tier attribute
+        """
         if value:
             if value == self.context['provider'].has_free_tier:
                 return value
             raise serializers.ValidationError('Provider does not support free tier')
-        else:
-            return value
+        return value
 
     def get_pii_sharing_allowed(self, instance):
         return self.context['pii_sharing_allowed']

--- a/openedx/core/djangoapps/course_live/serializers.py
+++ b/openedx/core/djangoapps/course_live/serializers.py
@@ -118,7 +118,7 @@ class CourseLiveConfigurationSerializer(serializers.ModelSerializer):
             self.context['provider_type'] = self.data.get('provider_type', '')
 
     def validate_free_tier(self, value):
-        if value == self.context['provider'].has_free_tier:
+        if value and value == self.context['provider'].has_free_tier:
             return value
         raise serializers.ValidationError('Provider does not support free tier')
 

--- a/openedx/core/djangoapps/course_live/serializers.py
+++ b/openedx/core/djangoapps/course_live/serializers.py
@@ -118,9 +118,12 @@ class CourseLiveConfigurationSerializer(serializers.ModelSerializer):
             self.context['provider_type'] = self.data.get('provider_type', '')
 
     def validate_free_tier(self, value):
-        if value and value == self.context['provider'].has_free_tier:
+        if value:
+            if value == self.context['provider'].has_free_tier:
+                return value
+            raise serializers.ValidationError('Provider does not support free tier')
+        else:
             return value
-        raise serializers.ValidationError('Provider does not support free tier')
 
     def get_pii_sharing_allowed(self, instance):
         return self.context['pii_sharing_allowed']

--- a/openedx/core/djangoapps/course_live/tests/test_views.py
+++ b/openedx/core/djangoapps/course_live/tests/test_views.py
@@ -271,6 +271,7 @@ class TestCourseLiveConfigurationView(ModuleStoreTestCase, APITestCase):
         """
         Create and test POST request response data
         """
+        self.create_course_live_config()
         providers = ProviderManager().get_enabled_providers()
         if providers.get(provider).requires_pii_sharing():
             CourseAllowPIISharingInLTIFlag.objects.create(course_id=self.course.id, enabled=True)

--- a/openedx/core/djangoapps/course_live/views.py
+++ b/openedx/core/djangoapps/course_live/views.py
@@ -113,7 +113,6 @@ class CourseLiveConfigurationView(APIView):
         """
         Handle HTTP/POST requests
         """
-        data = request.data
         pii_sharing_allowed = get_lti_pii_sharing_state_for_course(course_id)
         provider = ProviderManager().get_enabled_providers().get(request.data.get('provider_type', ''), None)
         if not pii_sharing_allowed and provider.requires_pii_sharing():
@@ -121,13 +120,13 @@ class CourseLiveConfigurationView(APIView):
                 "pii_sharing_allowed": pii_sharing_allowed,
                 "message": "PII sharing is not allowed on this course"
             })
-        if provider and not provider.additional_parameters and data.get('lti_configuration', False):
+        if provider and not provider.additional_parameters and request.data.get('lti_configuration', False):
             # Add empty lti config if none is provided in case additional params are not required
-            data['lti_configuration']['lti_config'] = {'additional_parameters': {}}
+            request.data['lti_configuration']['lti_config'] = {'additional_parameters': {}}
         configuration = CourseLiveConfiguration.get(course_id)
         serializer = CourseLiveConfigurationSerializer(
             configuration,
-            data=data,
+            data=request.data,
             context={
                 "pii_sharing_allowed": pii_sharing_allowed,
                 "course_id": course_id,

--- a/openedx/core/djangoapps/course_live/views.py
+++ b/openedx/core/djangoapps/course_live/views.py
@@ -113,6 +113,7 @@ class CourseLiveConfigurationView(APIView):
         """
         Handle HTTP/POST requests
         """
+        data = request.data
         pii_sharing_allowed = get_lti_pii_sharing_state_for_course(course_id)
         provider = ProviderManager().get_enabled_providers().get(request.data.get('provider_type', ''), None)
         if not pii_sharing_allowed and provider.requires_pii_sharing():
@@ -120,11 +121,13 @@ class CourseLiveConfigurationView(APIView):
                 "pii_sharing_allowed": pii_sharing_allowed,
                 "message": "PII sharing is not allowed on this course"
             })
-
+        if provider and not provider.additional_parameters and data.get('lti_configuration', False):
+            # Add empty lti config if none is provided in case additional params are not required
+            data['lti_configuration']['lti_config'] = {'additional_parameters': {}}
         configuration = CourseLiveConfiguration.get(course_id)
         serializer = CourseLiveConfigurationSerializer(
             configuration,
-            data=request.data,
+            data=data,
             context={
                 "pii_sharing_allowed": pii_sharing_allowed,
                 "course_id": course_id,


### PR DESCRIPTION
## Description 
We do not want to validate if free_tier is available or not if free_tier is not required by the client, and remove lit_config from free tier provider

## Ticket 
https://2u-internal.atlassian.net/browse/INF-487 
