### PR TITLE
fix: registration form population with unicode through tpa

### DIFF
--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -67,8 +67,13 @@ def clean_json(value, of_type):
 
 
 def clean_username(username=''):
-    """ Simple helper method to ensure a username is compatible with our system requirements. """
-    return ('_').join(re.findall(r'[a-zA-Z0-9\-]+', username))[:USERNAME_MAX_LENGTH]
+    """
+    Simple helper method to ensure a username is compatible with our system requirements.
+    """
+    if settings.FEATURES.get("ENABLE_UNICODE_USERNAME"):
+        return ('_').join(re.findall(settings.USERNAME_REGEX_PARTIAL, username))[:USERNAME_MAX_LENGTH]
+    else:
+        return ('_').join(re.findall(r'[a-zA-Z0-9\-]+', username))[:USERNAME_MAX_LENGTH]
 
 
 class AuthNotConfigured(SocialAuthBaseException):


### PR DESCRIPTION
Fixes the registration form username field prefilling with the
third party auth data when Unicode usernames are allowed.

### Preconditions
- settings.FEATURES['ENABLE_UNICODE_USERNAME'] == True
- TPA is configured and provides the username with non-ASCII characters

### Steps to reproduce
- Register via SSO with non-ASCII characters in the username

### Expected Result
- user sees a registration form with the username field prefilled with the data from the SSO provider

### Actual Result
- the username field in the registration form is empty

### Additional Info
- there was previously a fix (https://github.com/openedx/edx-platform/pull/20900) for the TPA with `ENABLE_UNICODE_USERNAME == True`. It added settings to skip the `clean_username` function in the TPA pipeline. The registration form initialization calls it though.

