### PR TITLE
ENT-6234: Upgraded learner-pathway-progress version to 1.3.1

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -668,7 +668,7 @@ lazy==1.4
     #   acid-xblock
     #   lti-consumer-xblock
     #   ora2
-learner-pathway-progress==1.3.0
+learner-pathway-progress==1.3.1
     # via -r requirements/edx/base.in
 libsass==0.10.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -869,7 +869,7 @@ lazy-object-proxy==1.7.1
     # via
     #   -r requirements/edx/testing.txt
     #   astroid
-learner-pathway-progress==1.3.0
+learner-pathway-progress==1.3.1
     # via -r requirements/edx/testing.txt
 libsass==0.10.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -831,7 +831,7 @@ lazy==1.4
     #   ora2
 lazy-object-proxy==1.7.1
     # via astroid
-learner-pathway-progress==1.3.0
+learner-pathway-progress==1.3.1
     # via -r requirements/edx/base.txt
 libsass==0.10.0
     # via


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Upgraded learner-pathway-progress version to 1.3.1, new version of the plugin removed `default` attribute from `LearnerPathwayProgress.learner_pathway_uuid `.
Here is a link to complete change-set https://github.com/edx/learner-pathway-progress/compare/1.3.0...1.3.1

## Supporting information

__Jira Issue:__ [ENT-6234](https://2u-internal.atlassian.net/browse/ENT-6234)

## Testing instructions

1. Open page django admin page for learner pathway progress model at `/admin/learner_pathway_progress/learnerpathwayprogress/`
2. Make sure there is no button to add a new record
3. User should be able to view/edit existing instances.

## Deadline

Need to merge this soon to unblock other tickets that are blocked on this in the current sprint.
