### PR TITLE
fix: remove legacy error messages

### DIFF
--- a/common/djangoapps/third_party_auth/tests/specs/base.py
+++ b/common/djangoapps/third_party_auth/tests/specs/base.py
@@ -149,7 +149,7 @@ class HelperMixin:
         assert 409 == response.status_code
         payload = json.loads(response.content.decode('utf-8'))
         assert not payload.get('success')
-        assert 'belongs to an existing account' in payload['username'][0]['user_message']
+        assert 'It looks like this username is already taken' == payload['username'][0]['user_message']
 
     def assert_json_success_response_looks_correct(self, response, verify_redirect_url):
         """Asserts the json response indicates success and redirection."""

--- a/openedx/core/djangoapps/user_api/accounts/__init__.py
+++ b/openedx/core/djangoapps/user_api/accounts/__init__.py
@@ -52,7 +52,6 @@ USERNAME_INVALID_CHARS_UNICODE = _(
 
 # Translators: This message is shown to users who attempt to create a new account using
 # an invalid email format.
-EMAIL_INVALID_MSG = _('"{email}" is not a valid email address.')
 AUTHN_EMAIL_INVALID_MSG = _('Enter a valid email address')
 
 # Translators: This message is shown to users who attempt to create a new

--- a/openedx/core/djangoapps/user_api/accounts/api.py
+++ b/openedx/core/djangoapps/user_api/accounts/api.py
@@ -423,17 +423,16 @@ def get_username_validation_error(username):
     return _validate(_validate_username, errors.AccountUsernameInvalid, username)
 
 
-def get_email_validation_error(email, api_version='v1'):
+def get_email_validation_error(email):
     """Get the built-in validation error message for when
     the email is invalid in some way.
 
     :param email: The proposed email (unicode).
-    :param api_version: registration validation api version
     :param default: The message to default to in case of no error.
     :return: Validation error message.
 
     """
-    return _validate(_validate_email, errors.AccountEmailInvalid, email, api_version)
+    return _validate(_validate_email, errors.AccountEmailInvalid, email)
 
 
 def get_secondary_email_validation_error(email):
@@ -487,30 +486,28 @@ def get_country_validation_error(country):
     return _validate(_validate_country, errors.AccountCountryInvalid, country)
 
 
-def get_username_existence_validation_error(username, api_version='v1'):
+def get_username_existence_validation_error(username):
     """Get the built-in validation error message for when
     the username has an existence conflict.
 
     :param username: The proposed username (unicode).
-    :param api_version: registration validation api version
     :param default: The message to default to in case of no error.
     :return: Validation error message.
 
     """
-    return _validate(_validate_username_doesnt_exist, errors.AccountUsernameAlreadyExists, username, api_version)
+    return _validate(_validate_username_doesnt_exist, errors.AccountUsernameAlreadyExists, username)
 
 
-def get_email_existence_validation_error(email, api_version='v1'):
+def get_email_existence_validation_error(email):
     """Get the built-in validation error message for when
     the email has an existence conflict.
 
     :param email: The proposed email (unicode).
-    :param api_version: registration validation api version
     :param default: The message to default to in case of no error.
     :return: Validation error message.
 
     """
-    return _validate(_validate_email_doesnt_exist, errors.AccountEmailAlreadyExists, email, api_version)
+    return _validate(_validate_email_doesnt_exist, errors.AccountEmailAlreadyExists, email)
 
 
 def _get_user_and_profile(username):
@@ -577,12 +574,11 @@ def _validate_username(username):
         raise errors.AccountUsernameInvalid(validation_err.message)
 
 
-def _validate_email(email, api_version='v1'):
+def _validate_email(email):
     """Validate the format of the email address.
 
     Arguments:
         email (unicode): The proposed email.
-        api_version(str): Validation API version; it is used to determine the error message
 
     Returns:
         None
@@ -595,9 +591,7 @@ def _validate_email(email, api_version='v1'):
         _validate_unicode(email)
         _validate_type(email, str, accounts.EMAIL_BAD_TYPE_MSG)
         _validate_length(email, accounts.EMAIL_MIN_LENGTH, accounts.EMAIL_MAX_LENGTH, accounts.EMAIL_BAD_LENGTH_MSG)
-        validate_email.message = (
-            accounts.EMAIL_INVALID_MSG.format(email=email) if api_version == 'v1' else accounts.AUTHN_EMAIL_INVALID_MSG
-        )
+        validate_email.message = accounts.AUTHN_EMAIL_INVALID_MSG
         validate_email(email)
     except (UnicodeError, errors.AccountDataBadType, errors.AccountDataBadLength) as invalid_email_err:
         raise errors.AccountEmailInvalid(str(invalid_email_err))
@@ -670,34 +664,26 @@ def _validate_country(country):
         raise errors.AccountCountryInvalid(accounts.REQUIRED_FIELD_COUNTRY_MSG)
 
 
-def _validate_username_doesnt_exist(username, api_version='v1'):
+def _validate_username_doesnt_exist(username):
     """Validate that the username is not associated with an existing user.
 
     :param username: The proposed username (unicode).
-    :param api_version: Validation API version; it is used to determine the error message
     :return: None
     :raises: errors.AccountUsernameAlreadyExists
     """
-    if api_version == 'v1':
-        error_message = accounts.USERNAME_CONFLICT_MSG.format(username=username)
-    else:
-        error_message = accounts.AUTHN_USERNAME_CONFLICT_MSG
     if username is not None and username_exists_or_retired(username):
-        raise errors.AccountUsernameAlreadyExists(_(error_message))  # lint-amnesty, pylint: disable=translation-of-non-string
+        # lint-amnesty, pylint: disable=translation-of-non-string
+        raise errors.AccountUsernameAlreadyExists(_(accounts.AUTHN_USERNAME_CONFLICT_MSG))
 
 
-def _validate_email_doesnt_exist(email, api_version='v1'):
+def _validate_email_doesnt_exist(email):
     """Validate that the email is not associated with an existing user.
 
     :param email: The proposed email (unicode).
-    :param api_version: Validation API version; it is used to determine the error message
     :return: None
     :raises: errors.AccountEmailAlreadyExists
     """
-    if api_version == 'v1':
-        error_message = accounts.EMAIL_CONFLICT_MSG.format(email_address=email)
-    else:
-        error_message = accounts.AUTHN_EMAIL_CONFLICT_MSG
+    error_message = accounts.AUTHN_EMAIL_CONFLICT_MSG
 
     if email is not None and email_exists_or_retired(email):
         raise errors.AccountEmailAlreadyExists(_(error_message))  # lint-amnesty, pylint: disable=translation-of-non-string

--- a/openedx/core/djangoapps/user_authn/views/tests/test_register.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_register.py
@@ -25,16 +25,14 @@ from openedx.core.djangoapps.site_configuration.helpers import get_value
 from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration
 from openedx.core.djangoapps.user_api.accounts import (
     AUTHN_EMAIL_CONFLICT_MSG,
+    AUTHN_EMAIL_INVALID_MSG,
     AUTHN_USERNAME_CONFLICT_MSG,
     EMAIL_BAD_LENGTH_MSG,
-    EMAIL_CONFLICT_MSG,
-    EMAIL_INVALID_MSG,
     EMAIL_MAX_LENGTH,
     EMAIL_MIN_LENGTH,
     NAME_MAX_LENGTH,
     REQUIRED_FIELD_CONFIRM_EMAIL_MSG,
     USERNAME_BAD_LENGTH_MSG,
-    USERNAME_CONFLICT_MSG,
     USERNAME_INVALID_CHARS_ASCII,
     USERNAME_INVALID_CHARS_UNICODE,
     USERNAME_MAX_LENGTH,
@@ -158,12 +156,7 @@ class RegistrationViewValidationErrorTest(
             response_json,
             {
                 "email": [{
-                    "user_message": (
-                        "It looks like {} belongs to an existing account. "
-                        "Try again with a different email address."
-                    ).format(
-                        self.EMAIL
-                    )
+                    "user_message": AUTHN_EMAIL_CONFLICT_MSG,
                 }],
                 "error_code": "duplicate-email"
             }
@@ -205,12 +198,7 @@ class RegistrationViewValidationErrorTest(
             response_json,
             {
                 "username": [{
-                    "user_message": (
-                        "It looks like {} belongs to an existing account. "
-                        "Try again with a different username."
-                    ).format(
-                        self.USERNAME
-                    )
+                    "user_message": AUTHN_USERNAME_CONFLICT_MSG,
                 }],
                 "error_code": "duplicate-username"
             }
@@ -243,12 +231,7 @@ class RegistrationViewValidationErrorTest(
             response_json,
             {
                 "email": [{
-                    "user_message": (
-                        "It looks like {} belongs to an existing account. "
-                        "Try again with a different email address."
-                    ).format(
-                        self.EMAIL
-                    )
+                    "user_message": AUTHN_EMAIL_CONFLICT_MSG,
                 }],
                 "error_code": "duplicate-email"
             }
@@ -285,12 +268,7 @@ class RegistrationViewValidationErrorTest(
             response_json,
             {
                 "email": [{
-                    "user_message": (
-                        "It looks like {} belongs to an existing account. "
-                        "Try again with a different email address."
-                    ).format(
-                        account_recovery.secondary_email
-                    )
+                    "user_message": AUTHN_EMAIL_CONFLICT_MSG,
                 }],
                 "error_code": "duplicate-email"
             }
@@ -344,12 +322,7 @@ class RegistrationViewValidationErrorTest(
             response_json,
             {
                 "email": [{
-                    "user_message": (
-                        "It looks like {} belongs to an existing account. "
-                        "Try again with a different email address."
-                    ).format(
-                        self.EMAIL
-                    )
+                    "user_message": AUTHN_EMAIL_CONFLICT_MSG,
                 }],
                 "error_code": "duplicate-email"
             }
@@ -383,12 +356,7 @@ class RegistrationViewValidationErrorTest(
             response_json,
             {
                 "username": [{
-                    "user_message": (
-                        "It looks like {} belongs to an existing account. "
-                        "Try again with a different username."
-                    ).format(
-                        self.USERNAME
-                    )
+                    "user_message": AUTHN_USERNAME_CONFLICT_MSG,
                 }],
                 "error_code": "duplicate-username"
             }
@@ -422,58 +390,10 @@ class RegistrationViewValidationErrorTest(
             response_json,
             {
                 "username": [{
-                    "user_message": (
-                        "It looks like {} belongs to an existing account. "
-                        "Try again with a different username."
-                    ).format(
-                        self.USERNAME
-                    )
-                }],
-                "email": [{
-                    "user_message": (
-                        "It looks like {} belongs to an existing account. "
-                        "Try again with a different email address."
-                    ).format(
-                        self.EMAIL
-                    )
-                }],
-                "error_code": "duplicate-email-username"
-            }
-        )
-
-    def test_duplicate_email_username_error_with_is_authn_check(self):
-        # Register the first user
-        response = self.client.post(self.url, {
-            "email": self.EMAIL,
-            "name": self.NAME,
-            "username": self.USERNAME,
-            "password": self.PASSWORD,
-            "honor_code": "true",
-        })
-        self.assertHttpOK(response)
-
-        # Try to create a second user with the same username and email
-        response = self.client.post(self.url, {
-            "is_authn_mfe": True,
-            "email": self.EMAIL,
-            "name": "Someone Else",
-            "username": self.USERNAME,
-            "password": self.PASSWORD,
-            "honor_code": "true",
-        })
-
-        response_json = json.loads(response.content.decode('utf-8'))
-        assert response.status_code == 409
-        username_suggestions = response_json.pop('username_suggestions')
-        assert len(username_suggestions) == 3
-        self.assertDictEqual(
-            response_json,
-            {
-                "username": [{
                     "user_message": AUTHN_USERNAME_CONFLICT_MSG,
                 }],
                 "email": [{
-                    "user_message": AUTHN_EMAIL_CONFLICT_MSG
+                    "user_message": AUTHN_EMAIL_CONFLICT_MSG,
                 }],
                 "error_code": "duplicate-email-username"
             }
@@ -1651,12 +1571,7 @@ class RegistrationViewTestV1(
             response_json,
             {
                 "email": [{
-                    "user_message": (
-                        "It looks like {} belongs to an existing account. "
-                        "Try again with a different email address."
-                    ).format(
-                        self.EMAIL
-                    )
+                    "user_message": AUTHN_EMAIL_CONFLICT_MSG,
                 }],
                 "error_code": "duplicate-email"
             }
@@ -1690,12 +1605,7 @@ class RegistrationViewTestV1(
             response_json,
             {
                 "username": [{
-                    "user_message": (
-                        "It looks like {} belongs to an existing account. "
-                        "Try again with a different username."
-                    ).format(
-                        self.USERNAME
-                    )
+                    "user_message": AUTHN_USERNAME_CONFLICT_MSG,
                 }],
                 "error_code": "duplicate-username"
             }
@@ -1729,20 +1639,10 @@ class RegistrationViewTestV1(
             response_json,
             {
                 "username": [{
-                    "user_message": (
-                        "It looks like {} belongs to an existing account. "
-                        "Try again with a different username."
-                    ).format(
-                        self.USERNAME
-                    )
+                    "user_message": AUTHN_USERNAME_CONFLICT_MSG,
                 }],
                 "email": [{
-                    "user_message": (
-                        "It looks like {} belongs to an existing account. "
-                        "Try again with a different email address."
-                    ).format(
-                        self.EMAIL
-                    )
+                    "user_message": AUTHN_EMAIL_CONFLICT_MSG,
                 }],
                 "error_code": "duplicate-email-username"
             }
@@ -2371,8 +2271,12 @@ class ThirdPartyRegistrationTestMixin(
         assert response.status_code == 409
         errors = json.loads(response.content.decode('utf-8'))
         for conflict_attribute in ["username", "email"]:
+            if conflict_attribute == 'username':
+                error_message = AUTHN_USERNAME_CONFLICT_MSG
+            else:
+                error_message = AUTHN_EMAIL_CONFLICT_MSG
             assert conflict_attribute in errors
-            assert "belongs to an existing account" in errors[conflict_attribute][0]["user_message"]
+            assert error_message == errors[conflict_attribute][0]["user_message"]
 
     def _assert_access_token_error(self, response, expected_error_message, error_code):
         """Assert that the given response was an error for the access_token field with the given error message."""
@@ -2665,13 +2569,9 @@ class RegistrationValidationViewTests(test_utils.ApiTestCase, OpenEdxEventsTestM
             },
             {
                 # pylint: disable=no-member
-                "username": USERNAME_CONFLICT_MSG.format(
-                    username=user.username
-                ) if username == user.username else '',
+                "username": AUTHN_USERNAME_CONFLICT_MSG if username == user.username else '',
                 # pylint: disable=no-member
-                "email": EMAIL_CONFLICT_MSG.format(
-                    email_address=user.email
-                ) if email == user.email else ''
+                "email": AUTHN_EMAIL_CONFLICT_MSG if email == user.email else ''
             },
             validate_suggestions
         )
@@ -2684,11 +2584,10 @@ class RegistrationValidationViewTests(test_utils.ApiTestCase, OpenEdxEventsTestM
         )
 
     def test_email_generically_invalid_validation_decision(self):
-        email = 'email'
         self.assertValidationDecision(
-            {'email': email},
+            {'email': 'email'},
             # pylint: disable=no-member
-            {'email': EMAIL_INVALID_MSG.format(email=email)}
+            {'email': AUTHN_EMAIL_INVALID_MSG}
         )
 
     def test_confirm_email_matches_email(self):


### PR DESCRIPTION
## Description

As part of Authn MFE redesign, new message copies were added and old were kept to keep back compatibility. These old message copies are not used and are not needed anymore. 

## Supporting information

Ticket: https://2u-internal.atlassian.net/browse/VAN-1069

## Testing instructions

Updated existing tests
