### PR TITLE
fix: allow discussion moderators to unreport their content

### DIFF
--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -23,7 +23,6 @@ from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
 from rest_framework.request import Request
 
-from lms.djangoapps.discussion.views import is_privileged_user
 from xmodule.course_module import CourseBlock
 from xmodule.modulestore.django import modulestore
 from xmodule.tabs import CourseTabList
@@ -34,6 +33,7 @@ from lms.djangoapps.courseware.exceptions import CourseAccessRedirect
 from lms.djangoapps.discussion.toggles import ENABLE_LEARNERS_TAB_IN_DISCUSSIONS_MFE, \
     ENABLE_DISCUSSIONS_MFE_FOR_EVERYONE
 from lms.djangoapps.discussion.toggles_utils import reported_content_email_notification_enabled
+from lms.djangoapps.discussion.views import is_user_moderator
 from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration, DiscussionTopicLink, Provider
 from openedx.core.djangoapps.discussions.utils import get_accessible_discussion_xblocks
 from openedx.core.djangoapps.django_comment_common import comment_client
@@ -1190,8 +1190,7 @@ def _handle_abuse_flagged_field(form_value, user, cc_content):
             else:
                 comment_flagged.send(sender='flag_abuse_for_comment', user=user, post=cc_content)
     else:
-        remove_all = bool(user.id != cc_content["user_id"] and is_privileged_user(course_key,
-                                                                                  User.objects.get(id=user.id)))
+        remove_all = bool(is_user_moderator(course_key, User.objects.get(id=user.id)))
         cc_content.unFlagAbuse(user, cc_content, remove_all)
 
 

--- a/lms/djangoapps/discussion/rest_api/tests/test_api.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api.py
@@ -2826,7 +2826,7 @@ class UpdateThreadTest(
 
     @ddt.data(
         (False, True),
-        (True, False),
+        (True, True),
     )
     @ddt.unpack
     def test_thread_un_abuse_flag_for_moderator_role(self, is_author, remove_all):
@@ -2837,10 +2837,6 @@ class UpdateThreadTest(
         pass the "all" flag to the api. This will indicate
         to the api to clear all abuse_flaggers, and mark the
         thread as unreported.
-        If moderator is author of a thread, we want to restrict
-        the usage of the remove_all flag, so it cant be used
-        to remove all abuse_flaggers from a moderator post
-        by the moderator itself.
         """
         _assign_role_to_user(user=self.user, course_id=self.course.id, role=FORUM_ROLE_ADMINISTRATOR)
         self.register_get_user_response(self.user)
@@ -3311,7 +3307,7 @@ class UpdateCommentTest(
 
     @ddt.data(
         (False, True),
-        (True, False),
+        (True, True),
     )
     @ddt.unpack
     def test_comment_un_abuse_flag_for_moderator_role(self, is_author, remove_all):
@@ -3322,10 +3318,6 @@ class UpdateCommentTest(
         pass the "all" flag to the api. This will indicate
         to the api to clear all abuse_flaggers, and mark the
         comment as unreported.
-        If moderator is author of a comment, we want to restrict
-        the usage of the remove_all flag, so it cant be used
-        to remove all abuse_flaggers from a moderator post
-        by the moderator itself.
         """
         _assign_role_to_user(user=self.user, course_id=self.course.id, role=FORUM_ROLE_ADMINISTRATOR)
         self.register_get_user_response(self.user)

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -829,7 +829,8 @@ def is_course_staff(course_key: CourseKey, user: User):
 def is_privileged_user(course_key: CourseKey, user: User):
     """
     Returns True if user has one of following course role
-    Administrator, Moderator, Group Moderator, Community TA
+    Administrator, Moderator, Group Moderator, Community TA,
+    Global Staff, Course Instructor or Course Staff.
     """
     forum_roles = [
         FORUM_ROLE_COMMUNITY_TA,
@@ -839,6 +840,21 @@ def is_privileged_user(course_key: CourseKey, user: User):
     ]
     has_course_role = Role.user_has_role_for_course(user, course_key, forum_roles)
     return GlobalStaff().has_user(user) or is_course_staff(course_key, user) or has_course_role
+
+
+def is_user_moderator(course_key: CourseKey, user: User):
+    """
+    Returns True if user has one of following course role
+    Administrator, Moderator, Group Moderator, Community TA.
+    """
+    forum_roles = [
+        FORUM_ROLE_COMMUNITY_TA,
+        FORUM_ROLE_GROUP_MODERATOR,
+        FORUM_ROLE_MODERATOR,
+        FORUM_ROLE_ADMINISTRATOR
+    ]
+    has_course_role = Role.user_has_role_for_course(user, course_key, forum_roles)
+    return has_course_role
 
 
 class DiscussionBoardFragmentView(EdxFragmentView):


### PR DESCRIPTION
### [INF-508](https://2u-internal.atlassian.net/browse/INF-508)

### Description

Allow discussions moderators to unreport their own content.
This is a change to the initial implementation we had where moderators were restricted from unreporting their own content. This was done in this [PR](https://github.com/openedx/edx-platform/pull/30777/) 