### PR TITLE
feat: learner home enterprise dash data

### DIFF
--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -356,8 +356,13 @@ class EmailConfirmationSerializer(serializers.Serializer):
 class EnterpriseDashboardSerializer(serializers.Serializer):
     """Serializer for individual enterprise dashboard data"""
 
-    label = serializers.CharField()
-    url = serializers.URLField()
+    requires_context = True
+
+    label = serializers.CharField(source='name')
+    url = serializers.SerializerMethodField()
+
+    def get_url(self, instance):
+        return f"{self.context['enterprise_learner_portal_base_url']}/{instance['uuid']}"
 
 
 class LearnerDashboardSerializer(serializers.Serializer):

--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -1,6 +1,7 @@
 """
 Serializers for the Learner Dashboard
 """
+from urllib.parse import urljoin
 
 from django.conf import settings
 from django.urls import reverse
@@ -356,13 +357,11 @@ class EmailConfirmationSerializer(serializers.Serializer):
 class EnterpriseDashboardSerializer(serializers.Serializer):
     """Serializer for individual enterprise dashboard data"""
 
-    requires_context = True
-
     label = serializers.CharField(source='name')
     url = serializers.SerializerMethodField()
 
     def get_url(self, instance):
-        return f"{self.context['enterprise_learner_portal_base_url']}/{instance['uuid']}"
+        return urljoin(settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL, instance['uuid'])
 
 
 class LearnerDashboardSerializer(serializers.Serializer):

--- a/lms/djangoapps/learner_home/test_serializers.py
+++ b/lms/djangoapps/learner_home/test_serializers.py
@@ -844,18 +844,11 @@ class TestEnterpriseDashboardSerializer(TestCase):
             "name": str(uuid4()),
         }
 
-    @classmethod
-    def generate_test_context(cls):
-        return {
-            'enterprise_learner_portal_base_url': random_url()
-        }
-
     def test_structure(self):
         """Test that nothing breaks and the output fields look correct"""
         input_data = self.generate_test_data()
-        input_context = self.generate_test_context()
 
-        output_data = EnterpriseDashboardSerializer(input_data, context=input_context).data
+        output_data = EnterpriseDashboardSerializer(input_data).data
 
         expected_keys = [
             "label",
@@ -867,15 +860,14 @@ class TestEnterpriseDashboardSerializer(TestCase):
         """Test that data serializes correctly"""
 
         input_data = self.generate_test_data()
-        input_context = self.generate_test_context()
 
-        output_data = EnterpriseDashboardSerializer(input_data, context=input_context).data
+        output_data = EnterpriseDashboardSerializer(input_data).data
 
         self.assertDictEqual(
             output_data,
             {
                 "label": input_data["name"],
-                "url": input_context['enterprise_learner_portal_base_url'] + '/' + input_data["uuid"],
+                "url": settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL + '/' + input_data["uuid"],
             },
         )
 

--- a/lms/djangoapps/learner_home/test_serializers.py
+++ b/lms/djangoapps/learner_home/test_serializers.py
@@ -840,15 +840,22 @@ class TestEnterpriseDashboardSerializer(TestCase):
     @classmethod
     def generate_test_data(cls):
         return {
-            "label": f"{uuid4()}",
-            "url": random_url(),
+            "uuid": str(uuid4()),
+            "name": str(uuid4()),
+        }
+
+    @classmethod
+    def generate_test_context(cls):
+        return {
+            'enterprise_learner_portal_base_url': random_url()
         }
 
     def test_structure(self):
         """Test that nothing breaks and the output fields look correct"""
         input_data = self.generate_test_data()
+        input_context = self.generate_test_context()
 
-        output_data = EnterpriseDashboardSerializer(input_data).data
+        output_data = EnterpriseDashboardSerializer(input_data, context=input_context).data
 
         expected_keys = [
             "label",
@@ -860,14 +867,15 @@ class TestEnterpriseDashboardSerializer(TestCase):
         """Test that data serializes correctly"""
 
         input_data = self.generate_test_data()
+        input_context = self.generate_test_context()
 
-        output_data = EnterpriseDashboardSerializer(input_data).data
+        output_data = EnterpriseDashboardSerializer(input_data, context=input_context).data
 
         self.assertDictEqual(
             output_data,
             {
-                "label": input_data["label"],
-                "url": input_data["url"],
+                "label": input_data["name"],
+                "url": input_context['enterprise_learner_portal_base_url'] + '/' + input_data["uuid"],
             },
         )
 

--- a/lms/djangoapps/learner_home/test_views.py
+++ b/lms/djangoapps/learner_home/test_views.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 from uuid import uuid4
 
 import ddt
+from django.conf import settings
 from django.urls import reverse
 from rest_framework.test import APITestCase
 
@@ -28,6 +29,9 @@ from xmodule.modulestore.tests.django_utils import (
     SharedModuleStoreTestCase,
 )
 from xmodule.modulestore.tests.factories import CourseFactory
+
+
+ENTERPRISE_ENABLED = 'ENABLE_ENTERPRISE_INTEGRATION'
 
 
 class TestGetPlatformSettings(TestCase):
@@ -216,6 +220,7 @@ class TestDashboardView(SharedModuleStoreTestCase, APITestCase):
         super().setUp()
         self.log_in()
 
+    @patch.dict(settings.FEATURES, ENTERPRISE_ENABLED=False)
     def test_response_structure(self):
         """Basic test for correct response structure"""
 
@@ -241,6 +246,7 @@ class TestDashboardView(SharedModuleStoreTestCase, APITestCase):
 
         assert expected_keys == response_data.keys()
 
+    @patch.dict(settings.FEATURES, ENTERPRISE_ENABLED=False)
     @patch("lms.djangoapps.learner_home.views.get_user_account_confirmation_info")
     def test_email_confirmation(self, mock_user_conf_info):
         """Test that email confirmation info passes through correctly"""
@@ -269,6 +275,7 @@ class TestDashboardView(SharedModuleStoreTestCase, APITestCase):
             },
         )
 
+    @patch.dict(settings.FEATURES, ENTERPRISE_ENABLED=False)
     @patch("lms.djangoapps.learner_home.views.cert_info")
     def test_get_cert_statuses(self, mock_get_cert_info):
         """Test that cert information gets loaded correctly"""

--- a/lms/djangoapps/learner_home/views.py
+++ b/lms/djangoapps/learner_home/views.py
@@ -26,6 +26,7 @@ from lms.djangoapps.courseware.access_utils import (
 )
 from lms.djangoapps.learner_home.serializers import LearnerDashboardSerializer
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from openedx.features.enterprise_support.api import enterprise_customer_from_session_or_learner_data
 
 
 def get_platform_settings():
@@ -196,6 +197,9 @@ class InitializeView(RetrieveAPIView):  # pylint: disable=unused-argument
         user = request.user
         email_confirmation = get_user_account_confirmation_info(user)
 
+        # Gather info for enterprise dashboard
+        enterprise_customer = enterprise_customer_from_session_or_learner_data(request)
+
         # Get the org whitelist or the org blacklist for the current site
         site_org_whitelist, site_org_blacklist = get_org_black_and_whitelist_for_site()
 
@@ -228,7 +232,7 @@ class InitializeView(RetrieveAPIView):  # pylint: disable=unused-argument
 
         learner_dash_data = {
             "emailConfirmation": email_confirmation,
-            "enterpriseDashboards": None,
+            "enterpriseDashboard": enterprise_customer,
             "platformSettings": get_platform_settings(),
             "enrollments": course_enrollments,
             "unfulfilledEntitlements": [],
@@ -243,6 +247,7 @@ class InitializeView(RetrieveAPIView):  # pylint: disable=unused-argument
             "course_access_checks": course_access_checks,
             "resume_course_urls": resume_button_urls,
             "show_email_settings_for": show_email_settings_for,
+            'enterprise_learner_portal_base_url': settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL,
         }
 
         response_data = LearnerDashboardSerializer(

--- a/lms/djangoapps/learner_home/views.py
+++ b/lms/djangoapps/learner_home/views.py
@@ -247,7 +247,6 @@ class InitializeView(RetrieveAPIView):  # pylint: disable=unused-argument
             "course_access_checks": course_access_checks,
             "resume_course_urls": resume_button_urls,
             "show_email_settings_for": show_email_settings_for,
-            'enterprise_learner_portal_base_url': settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL,
         }
 
         response_data = LearnerDashboardSerializer(


### PR DESCRIPTION
Add Enterprise Dash info to learner home endpoint and serializer

[AU-795](https://2u-internal.atlassian.net/browse/AU-795
)

Merging into the learner contract branch for now, since this is on top of work from that branch

@openedx/content-aurora 