### PR TITLE
feat: VAN-1075 - Added country field validation on registration endpoint

### DIFF
--- a/common/djangoapps/student/tests/test_configuration_overrides.py
+++ b/common/djangoapps/student/tests/test_configuration_overrides.py
@@ -68,7 +68,7 @@ class TestSite(TestCase):
             "address1": "foo",
             "city": "foo",
             "state": "foo",
-            "country": "foo",
+            "country": "US",
             "company": "foo",
             "title": "foo"
         }.items()))


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Added country field validation on registration endpoint for AuthN MFE.
Ticket: https://2u-internal.atlassian.net/browse/VAN-1075