### PR TITLE
feat!: Add ability to track sent follow up events via a boolean field

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -778,7 +778,7 @@ ora2==4.4.7
     # via -r requirements/edx/base.in
 oscrypto==1.3.0
     # via snowflake-connector-python
-outcome-surveys==1.1.0
+outcome-surveys==1.1.1
     # via -r requirements/edx/base.in
 packaging==21.3
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1007,7 +1007,7 @@ oscrypto==1.3.0
     # via
     #   -r requirements/edx/testing.txt
     #   snowflake-connector-python
-outcome-surveys==1.1.0
+outcome-surveys==1.1.1
     # via -r requirements/edx/testing.txt
 packaging==21.3
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -958,7 +958,7 @@ oscrypto==1.3.0
     # via
     #   -r requirements/edx/base.txt
     #   snowflake-connector-python
-outcome-surveys==1.1.0
+outcome-surveys==1.1.1
     # via -r requirements/edx/base.txt
 packaging==21.3
     # via


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description
This will add an `already_sent` boolean field in `LearnerCourseEvent` model to store the state for sent events. In the management command we will set `already_sent` to `True` for each triggered event.




## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
