### PR TITLE
fix: readability of course creator access request button text

### DIFF
--- a/cms/static/sass/views/_dashboard.scss
+++ b/cms/static/sass/views/_dashboard.scss
@@ -151,6 +151,7 @@
       .action-primary {
         @extend %btn-primary-blue;
         @extend %t-action3;
+        color: $white;
       }
 
       // specific - request button


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This PR address the readability of the Course Creator Access Request button in the Edge instance of Studio. Currently the button in a dark blue with dark text. This make the button unreadable. This PR overrides the default button text color and sets it to white. This change will impact Course Authors.

## Supporting information

JIRA Ticket: [TNL-9656](https://2u-internal.atlassian.net/browse/TNL-9656)

## Testing instructions

No testing instructions. Fixing error on that is only viewable on the Edge instance of Studio.
