### PR TITLE
fix: return empty response if no enterprise enrollments exists for a learner

### DIFF
--- a/lms/djangoapps/learner_dashboard/api/v0/views.py
+++ b/lms/djangoapps/learner_dashboard/api/v0/views.py
@@ -96,6 +96,10 @@ class Programs(APIView):
         user = request.user
 
         enrollments = self._get_enterprise_course_enrollments(enterprise_uuid, user)
+        # return empty reponse if no enterprise enrollments exists for a user
+        if not enrollments:
+            return Response([])
+
         meter = ProgramProgressMeter(
             request.site,
             user,


### PR DESCRIPTION
**Description:** Return empty response if no enterprise enrollments exists for a learner.

**JIRA:** https://2u-internal.atlassian.net/browse/ENT-6228
