### PR TITLE
feat: learner home course provider and grade data

### DIFF
--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -6,10 +6,10 @@ from urllib.parse import urljoin
 
 from django.conf import settings
 from django.urls import reverse
-from common.djangoapps.student.helpers import user_has_passing_grade_in_course
 from rest_framework import serializers
 
 from common.djangoapps.course_modes.models import CourseMode
+from common.djangoapps.student.helpers import user_has_passing_grade_in_course
 from openedx.features.course_experience import course_home_url
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from xmodule.data import CertificatesDisplayBehaviors

--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -12,7 +12,6 @@ from rest_framework import serializers
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.helpers import user_has_passing_grade_in_course
 from openedx.features.course_experience import course_home_url
-from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from xmodule.data import CertificatesDisplayBehaviors
 
 

--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -37,9 +37,9 @@ class PlatformSettingsSerializer(serializers.Serializer):
 
 
 class CourseProviderSerializer(serializers.Serializer):
-    """Info about a course provider (institution/business)"""
+    """Info about a course provider (institution/business) from a CourseOverview"""
 
-    name = serializers.CharField()
+    name = serializers.CharField(source="display_org_with_default")
 
 
 class CourseSerializer(serializers.Serializer):
@@ -359,13 +359,13 @@ class LearnerEnrollmentSerializer(serializers.Serializer):
     requires_context = True
 
     course = CourseSerializer()
+    courseProvider = CourseProviderSerializer(source="course_overview")
     courseRun = CourseRunSerializer(source="*")
     enrollment = EnrollmentSerializer(source="*")
     certificate = CertificateSerializer(source="*")
     entitlement = serializers.SerializerMethodField()
 
     # TODO - remove "allow_null" as each of these are implemented, temp for testing.
-    courseProvider = CourseProviderSerializer(allow_null=True)
     gradeData = GradeDataSerializer(allow_null=True)
     programs = ProgramsSerializer(allow_null=True)
 

--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -6,6 +6,7 @@ from urllib.parse import urljoin
 
 from django.conf import settings
 from django.urls import reverse
+from opaque_keys.edx.keys import CourseKey
 from rest_framework import serializers
 
 from common.djangoapps.course_modes.models import CourseMode
@@ -451,7 +452,14 @@ class UnfulfilledEntitlementSerializer(serializers.Serializer):
         pseudo_session = self.context["unfulfilled_entitlement_pseudo_sessions"].get(
             str(entitlement.uuid)
         )
-        course_overview = CourseOverview.get_from_id(pseudo_session["key"]) or None
+        course_overview = None
+
+        if pseudo_session:
+            course_key = CourseKey.from_string(pseudo_session["key"])
+            course_overview = self.context.get("pseudo_session_course_overviews").get(
+                course_key
+            )
+
         return CourseProviderSerializer(course_overview, allow_null=True).data
 
 

--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -318,8 +318,8 @@ class EntitlementSerializer(serializers.Serializer):
         return bool(instance.expired_at)
 
     def get_availableSessions(self, instance):
-        avaialableSessions = self.context['course_entitlement_available_sessions'].get(str(instance.uuid))
-        return AvailableEntitlementSessionSerializer(avaialableSessions, many=True).data
+        availableSessions = self.context['course_entitlement_available_sessions'].get(str(instance.uuid))
+        return AvailableEntitlementSessionSerializer(availableSessions, many=True).data
 
     def get_expirationDate(self, instance):
         if instance.expired_at is not None:
@@ -410,7 +410,7 @@ class UnfulfilledEntitlementSerializer(serializers.Serializer):
 
     class _PseudoSessionCourseSerializer(serializers.Serializer):
         """
-        'Private' Serilizer for the 'course' key data. This data comes from the pseudo session
+        'Private' Serializer for the 'course' key data. This data comes from the pseudo session
         """
         bannerImgSrc = serializers.URLField(source="image.src")
         courseName = serializers.CharField(source="title")

--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -6,6 +6,7 @@ from urllib.parse import urljoin
 
 from django.conf import settings
 from django.urls import reverse
+from common.djangoapps.student.helpers import user_has_passing_grade_in_course
 from rest_framework import serializers
 
 from common.djangoapps.course_modes.models import CourseMode
@@ -223,7 +224,10 @@ class EnrollmentSerializer(serializers.Serializer):
 class GradeDataSerializer(serializers.Serializer):
     """Info about grades for this enrollment"""
 
-    isPassing = serializers.BooleanField()
+    isPassing = serializers.SerializerMethodField()
+
+    def get_isPassing(self, enrollment):
+        return user_has_passing_grade_in_course(enrollment)
 
 
 class CertificateSerializer(serializers.Serializer):
@@ -364,9 +368,9 @@ class LearnerEnrollmentSerializer(serializers.Serializer):
     enrollment = EnrollmentSerializer(source="*")
     certificate = CertificateSerializer(source="*")
     entitlement = serializers.SerializerMethodField()
+    gradeData = GradeDataSerializer(source="*")
 
     # TODO - remove "allow_null" as each of these are implemented, temp for testing.
-    gradeData = GradeDataSerializer(allow_null=True)
     programs = ProgramsSerializer(allow_null=True)
 
     def get_entitlement(self, instance):

--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -450,11 +450,11 @@ class EmailConfirmationSerializer(serializers.Serializer):
 class EnterpriseDashboardSerializer(serializers.Serializer):
     """Serializer for individual enterprise dashboard data"""
 
-    label = serializers.CharField(source='name')
+    label = serializers.CharField(source="name")
     url = serializers.SerializerMethodField()
 
     def get_url(self, instance):
-        return urljoin(settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL, instance['uuid'])
+        return urljoin(settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL, instance["uuid"])
 
 
 class LearnerDashboardSerializer(serializers.Serializer):

--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -18,6 +18,7 @@ class LiteralField(serializers.Field):
     """
     Custom Field for use with fields that will always intentionally serialize to the same static value.
     """
+
     def __init__(self, literal_value):
         super().__init__()
         self.literal_value = literal_value
@@ -291,9 +292,9 @@ class CertificateSerializer(serializers.Serializer):
 class AvailableEntitlementSessionSerializer(serializers.Serializer):
     """An available entitlement session"""
 
-    startDate = serializers.DateTimeField(source='start')
-    endDate = serializers.DateTimeField(source='end')
-    courseId = serializers.CharField(source='key')
+    startDate = serializers.DateTimeField(source="start")
+    endDate = serializers.DateTimeField(source="end")
+    courseId = serializers.CharField(source="key")
 
 
 class EntitlementSerializer(serializers.Serializer):
@@ -302,7 +303,7 @@ class EntitlementSerializer(serializers.Serializer):
 
     availableSessions = serializers.SerializerMethodField()
     uuid = serializers.UUIDField()
-    isRefundable = serializers.BooleanField(source='is_entitlement_refundable')
+    isRefundable = serializers.BooleanField(source="is_entitlement_refundable")
     isFulfilled = serializers.SerializerMethodField()
     changeDeadline = serializers.SerializerMethodField()
     isExpired = serializers.SerializerMethodField()
@@ -318,7 +319,9 @@ class EntitlementSerializer(serializers.Serializer):
         return bool(instance.expired_at)
 
     def get_availableSessions(self, instance):
-        availableSessions = self.context['course_entitlement_available_sessions'].get(str(instance.uuid))
+        availableSessions = self.context["course_entitlement_available_sessions"].get(
+            str(instance.uuid)
+        )
         return AvailableEntitlementSessionSerializer(availableSessions, many=True).data
 
     def get_expirationDate(self, instance):
@@ -331,7 +334,7 @@ class EntitlementSerializer(serializers.Serializer):
         return self.get_expirationDate(instance)
 
     def get_enrollmentUrl(self, instance):
-        return reverse('entitlements_api:v1:enrollments', args=[str(instance.uuid)])
+        return reverse("entitlements_api:v1:enrollments", args=[str(instance.uuid)])
 
 
 class RelatedProgramSerializer(serializers.Serializer):
@@ -360,6 +363,7 @@ class LearnerEnrollmentSerializer(serializers.Serializer):
     Info for displaying an enrollment on the learner dashboard.
     Derived from a CourseEnrollment with added context.
     """
+
     requires_context = True
 
     course = CourseSerializer()
@@ -377,7 +381,9 @@ class LearnerEnrollmentSerializer(serializers.Serializer):
         """
         If this enrollment is the fulfillment of an entitlement, include information about the entitlement
         """
-        entitlement = self.context['fulfilled_entitlements'].get(str(instance.course_id))
+        entitlement = self.context["fulfilled_entitlements"].get(
+            str(instance.course_id)
+        )
         if entitlement:
             return EntitlementSerializer(entitlement, context=self.context).data
         else:
@@ -395,23 +401,24 @@ class UnfulfilledEntitlementSerializer(serializers.Serializer):
 
     # This is the static constant data returned as the 'enrollment' key for all unfulfilled enrollments.
     STATIC_ENTITLEMENT_ENROLLMENT_DATA = {
-        'accessExpirationDate': None,
-        'isAudit': False,
-        'hasStarted': False,
-        'hasAccess': True,
-        'isVerified': False,
-        'canUpgrade': False,
-        'isAuditAccessExpired': False,
-        'isEmailEnabled': False,
-        'hasOptedOutOfEmail': False,
-        'lastEnrolled': None,
-        'isEnrolled': False,
+        "accessExpirationDate": None,
+        "isAudit": False,
+        "hasStarted": False,
+        "hasAccess": True,
+        "isVerified": False,
+        "canUpgrade": False,
+        "isAuditAccessExpired": False,
+        "isEmailEnabled": False,
+        "hasOptedOutOfEmail": False,
+        "lastEnrolled": None,
+        "isEnrolled": False,
     }
 
     class _PseudoSessionCourseSerializer(serializers.Serializer):
         """
         'Private' Serializer for the 'course' key data. This data comes from the pseudo session
         """
+
         bannerImgSrc = serializers.URLField(source="image.src")
         courseName = serializers.CharField(source="title")
         courseNumber = serializers.CharField(source="key")
@@ -431,8 +438,12 @@ class UnfulfilledEntitlementSerializer(serializers.Serializer):
     enrollment = LiteralField(STATIC_ENTITLEMENT_ENROLLMENT_DATA)
 
     def get_course(self, instance):
-        pseudo_session = self.context['unfulfilled_entitlement_pseudo_sessions'].get(str(instance.uuid))
-        return UnfulfilledEntitlementSerializer._PseudoSessionCourseSerializer(pseudo_session).data
+        pseudo_session = self.context["unfulfilled_entitlement_pseudo_sessions"].get(
+            str(instance.uuid)
+        )
+        return UnfulfilledEntitlementSerializer._PseudoSessionCourseSerializer(
+            pseudo_session
+        ).data
 
 
 class SuggestedCourseSerializer(serializers.Serializer):

--- a/lms/djangoapps/learner_home/test_serializers.py
+++ b/lms/djangoapps/learner_home/test_serializers.py
@@ -888,7 +888,9 @@ class TestEnterpriseDashboardSerializer(TestCase):
             output_data,
             {
                 "label": input_data["name"],
-                "url": settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL + '/' + input_data["uuid"],
+                "url": settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL
+                + "/"
+                + input_data["uuid"],
             },
         )
 

--- a/lms/djangoapps/learner_home/test_serializers.py
+++ b/lms/djangoapps/learner_home/test_serializers.py
@@ -344,23 +344,29 @@ class TestEnrollmentSerializer(LearnerDashboardBaseTest):
             self.assertFalse(output["hasStarted"])
 
 
-class TestGradeDataSerializer(TestCase):
+@ddt.ddt
+class TestGradeDataSerializer(LearnerDashboardBaseTest):
     """Tests for the GradeDataSerializer"""
 
-    @classmethod
-    def generate_test_grade_data(cls):
-        """Util to generate test grade data"""
-        return {
-            "isPassing": random_bool(),
-        }
+    @mock.patch(
+        "lms.djangoapps.learner_home.serializers.user_has_passing_grade_in_course"
+    )
+    @ddt.data(True, False, None)
+    def test_happy_path(self, is_passing, mock_get_grade_data):
+        # Given a course where I am/not passing
+        input_data = self.create_test_enrollment()
+        mock_get_grade_data.return_value = is_passing
 
-    def test_happy_path(self):
-        input_data = self.generate_test_grade_data()
+        # When I serialize grade data
         output_data = GradeDataSerializer(input_data).data
 
-        assert output_data == {
-            "isPassing": input_data["isPassing"],
-        }
+        # Then I get the correct data shape out
+        self.assertDictEqual(
+            output_data,
+            {
+                "isPassing": is_passing,
+            },
+        )
 
 
 @ddt.ddt

--- a/lms/djangoapps/learner_home/test_serializers.py
+++ b/lms/djangoapps/learner_home/test_serializers.py
@@ -102,7 +102,7 @@ class TestPlatformSettingsSerializer(TestCase):
         }
 
 
-class TestCourseProviderSerializer(TestCase):
+class TestCourseProviderSerializer(LearnerDashboardBaseTest):
     """Tests for the CourseProviderSerializer"""
 
     @classmethod
@@ -113,12 +113,12 @@ class TestCourseProviderSerializer(TestCase):
         }
 
     def test_happy_path(self):
-        input_data = self.generate_test_provider_info()
+        test_enrollment = self.create_test_enrollment()
+
+        input_data = test_enrollment.course_overview
         output_data = CourseProviderSerializer(input_data).data
 
-        assert output_data == {
-            "name": input_data["name"],
-        }
+        self.assertEqual(output_data["name"], test_enrollment.course_overview.org)
 
 
 class TestCourseSerializer(LearnerDashboardBaseTest):

--- a/lms/djangoapps/learner_home/test_serializers.py
+++ b/lms/djangoapps/learner_home/test_serializers.py
@@ -594,7 +594,7 @@ class TestCertificateSerializer(LearnerDashboardBaseTest):
 class TestEntitlementSerializer(TestCase):
     """Tests for the EntitlementSerializer"""
 
-    def _assert_availale_sessions(self, input_sessions, output_sessions):
+    def _assert_available_sessions(self, input_sessions, output_sessions):
         assert len(output_sessions) == len(input_sessions)
         for input_session, output_session in zip(input_sessions, output_sessions):
             assert output_session == {
@@ -627,7 +627,7 @@ class TestEntitlementSerializer(TestCase):
         ).data
 
         output_sessions = output_data.pop("availableSessions")
-        self._assert_availale_sessions(available_sessions, output_sessions)
+        self._assert_available_sessions(available_sessions, output_sessions)
 
         if isExpired:
             expected_expiration_date = entitlement.expired_at
@@ -946,7 +946,7 @@ class TestLearnerDashboardSerializer(LearnerDashboardBaseTest):
         unfulfilled_entitlements=None,
     ):
         """
-        Given enrollments and entitlements, generate a mathing serializer context
+        Given enrollments and entitlements, generate a matching serializer context
         """
         enrollments = enrollments or []
         enrollments_with_entitlements = enrollments_with_entitlements or []
@@ -1069,7 +1069,7 @@ class TestLearnerDashboardSerializer(LearnerDashboardBaseTest):
         self._assert_all_keys_equal(courses)
         # Non-entitlement enrollment should have no entitlement info
         assert not courses[0]['entitlement']
-        # Fulfuilled and Unfulfilled entitlement should have identical keys
+        # Fulfilled and Unfulfilled entitlement should have identical keys
         fulfilled_entitlement = courses[1]['entitlement']
         unfulfilled_entitlement = courses[2]['entitlement']
         assert fulfilled_entitlement

--- a/lms/djangoapps/learner_home/test_views.py
+++ b/lms/djangoapps/learner_home/test_views.py
@@ -10,9 +10,9 @@ import ddt
 from django.conf import settings
 from django.urls import reverse
 from django.utils import timezone
+from opaque_keys.edx.keys import CourseKey
 from rest_framework.test import APITestCase
 
-from lms.djangoapps.learner_home.test_utils import create_test_enrollment
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.entitlements.tests.factories import CourseEntitlementFactory
 from common.djangoapps.student.tests.factories import (
@@ -20,7 +20,9 @@ from common.djangoapps.student.tests.factories import (
     UserFactory,
 )
 from lms.djangoapps.bulk_email.models import Optout
+from lms.djangoapps.learner_home.test_utils import create_test_enrollment
 from lms.djangoapps.learner_home.views import (
+    get_course_overviews_for_pseudo_sessions,
     get_email_settings_info,
     get_enrollments,
     get_platform_settings,
@@ -30,6 +32,9 @@ from lms.djangoapps.learner_home.views import (
 from lms.djangoapps.learner_home.test_serializers import random_url
 from openedx.core.djangoapps.catalog.tests.factories import (
     CourseRunFactory as CatalogCourseRunFactory,
+)
+from openedx.core.djangoapps.content.course_overviews.tests.factories import (
+    CourseOverviewFactory,
 )
 from xmodule.modulestore.tests.django_utils import (
     TEST_DATA_SPLIT_MODULESTORE,
@@ -264,6 +269,43 @@ class TestGetEntitlements(SharedModuleStoreTestCase):
         assert not unfulfulled_entitlements
         assert not course_entitlement_available_sessions
         assert not unfulfilled_entitlement_pseudo_sessions
+
+
+class TestGetCourseOverviewsForPseudoSessions(SharedModuleStoreTestCase):
+    """Tests for get_course_overviews_for_pseudo_sessions"""
+
+    def test_basic(self):
+        # Given several unfulfilled entitlements
+        unfulfilled_entitlement_uuids = [uuid4() for _ in range(3)]
+        pseudo_sessions = {}
+        for uuid in unfulfilled_entitlement_uuids:
+            pseudo_sessions[str(uuid)] = CatalogCourseRunFactory.create()
+
+        # ... that have matching CourseOverviews
+        expected_course_overviews = {}
+        for pseudo_session in pseudo_sessions.values():
+            course_key = CourseKey.from_string(pseudo_session["key"])
+            mock_course = CourseFactory.create(
+                org=course_key.org, run=course_key.run, number=course_key.course
+            )
+            mock_course_overview = CourseOverviewFactory.create(id=mock_course.id)
+            expected_course_overviews[course_key] = mock_course_overview
+
+        # When I try to get course overviews, keyed by course key
+        course_overviews = get_course_overviews_for_pseudo_sessions(pseudo_sessions)
+
+        # Then they map to the correct courses
+        self.assertDictEqual(course_overviews, expected_course_overviews)
+
+    def test_no_pseudo_sessions(self):
+        # Given no pseudo sessions
+        pseudo_sessions = {}
+
+        # When I query course overviews
+        course_overviews = get_course_overviews_for_pseudo_sessions(pseudo_sessions)
+
+        # Then I should get an empty dict
+        self.assertDictEqual(course_overviews, {})
 
 
 class TestGetEmailSettingsInfo(SharedModuleStoreTestCase):

--- a/lms/djangoapps/learner_home/test_views.py
+++ b/lms/djangoapps/learner_home/test_views.py
@@ -36,7 +36,7 @@ from xmodule.modulestore.tests.django_utils import (
 from xmodule.modulestore.tests.factories import CourseFactory
 
 
-ENTERPRISE_ENABLED = 'ENABLE_ENTERPRISE_INTEGRATION'
+ENTERPRISE_ENABLED = "ENABLE_ENTERPRISE_INTEGRATION"
 
 
 class TestGetPlatformSettings(TestCase):

--- a/lms/djangoapps/learner_home/test_views.py
+++ b/lms/djangoapps/learner_home/test_views.py
@@ -28,7 +28,9 @@ from lms.djangoapps.learner_home.views import (
     get_entitlements,
 )
 from lms.djangoapps.learner_home.test_serializers import random_url
-from openedx.core.djangoapps.catalog.tests.factories import CourseRunFactory as CatalogCourseRunFactory
+from openedx.core.djangoapps.catalog.tests.factories import (
+    CourseRunFactory as CatalogCourseRunFactory,
+)
 from xmodule.modulestore.tests.django_utils import (
     TEST_DATA_SPLIT_MODULESTORE,
     SharedModuleStoreTestCase,
@@ -173,7 +175,7 @@ class TestGetEntitlements(SharedModuleStoreTestCase):
         self,
         filtered_entitlements,
         course_entitlement_available_sessions,
-        unfulfilled_entitlement_pseudo_sessions
+        unfulfilled_entitlement_pseudo_sessions,
     ):
         """
         Context manager utility for mocking get_filtered_course_entitlements.
@@ -184,7 +186,10 @@ class TestGetEntitlements(SharedModuleStoreTestCase):
             course_entitlement_available_sessions,
             unfulfilled_entitlement_pseudo_sessions,
         )
-        with patch('lms.djangoapps.learner_home.views.get_filtered_course_entitlements', return_value=return_value):
+        with patch(
+            "lms.djangoapps.learner_home.views.get_filtered_course_entitlements",
+            return_value=return_value,
+        ):
             yield
 
     def create_test_fulfilled_entitlement(self):
@@ -213,7 +218,9 @@ class TestGetEntitlements(SharedModuleStoreTestCase):
 
         available_sessions = {}
         for entitlement in fulfilled_test_entitlements + unfulfilled_test_entitlements:
-            available_sessions[str(entitlement.uuid)] = CatalogCourseRunFactory.create_batch(3)
+            available_sessions[
+                str(entitlement.uuid)
+            ] = CatalogCourseRunFactory.create_batch(3)
 
         pseudo_sessions = {}
         for entitlement in unfulfilled_test_entitlements:
@@ -222,7 +229,7 @@ class TestGetEntitlements(SharedModuleStoreTestCase):
         with self.mock_get_filtered_course_entitlements(
             fulfilled_test_entitlements + unfulfilled_test_entitlements,
             available_sessions,
-            pseudo_sessions
+            pseudo_sessions,
         ):
             (
                 fulfilled_entitlements_by_course_key,
@@ -231,7 +238,9 @@ class TestGetEntitlements(SharedModuleStoreTestCase):
                 unfulfilled_entitlement_pseudo_sessions,
             ) = get_entitlements(self.user, None, None)
 
-        assert len(fulfilled_entitlements_by_course_key) == len(fulfilled_test_entitlements)
+        assert len(fulfilled_entitlements_by_course_key) == len(
+            fulfilled_test_entitlements
+        )
         assert len(unfulfilled_entitlements) == len(unfulfilled_test_entitlements)
         assert set(unfulfilled_entitlements) == set(unfulfilled_test_entitlements)
         assert course_entitlement_available_sessions is available_sessions

--- a/lms/djangoapps/learner_home/views.py
+++ b/lms/djangoapps/learner_home/views.py
@@ -4,7 +4,6 @@ Views for the learner dashboard.
 from django.conf import settings
 from edx_django_utils import monitoring as monitoring_utils
 from opaque_keys.edx.keys import CourseKey
-from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from rest_framework.response import Response
 from rest_framework.generics import RetrieveAPIView
 
@@ -28,6 +27,7 @@ from lms.djangoapps.courseware.access_utils import (
     check_course_open_for_learner,
 )
 from lms.djangoapps.learner_home.serializers import LearnerDashboardSerializer
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.features.enterprise_support.api import (
     enterprise_customer_from_session_or_learner_data,

--- a/lms/djangoapps/learner_home/views.py
+++ b/lms/djangoapps/learner_home/views.py
@@ -27,7 +27,9 @@ from lms.djangoapps.courseware.access_utils import (
 )
 from lms.djangoapps.learner_home.serializers import LearnerDashboardSerializer
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-from openedx.features.enterprise_support.api import enterprise_customer_from_session_or_learner_data
+from openedx.features.enterprise_support.api import (
+    enterprise_customer_from_session_or_learner_data,
+)
 
 
 def get_platform_settings():

--- a/lms/djangoapps/learner_home/views.py
+++ b/lms/djangoapps/learner_home/views.py
@@ -100,25 +100,25 @@ def get_enrollments(user, org_allow_list, org_block_list, course_limit=None):
 
 
 def get_entitlements(user, org_allow_list, org_block_list):
-    """Get entitlments for the user"""
+    """Get entitlements for the user"""
     (
         filtered_entitlements,
         course_entitlement_available_sessions,
         unfulfilled_entitlement_pseudo_sessions,
     ) = get_filtered_course_entitlements(user, org_allow_list, org_block_list)
     fulfilled_entitlements_by_course_key = {}
-    unfulfulled_entitlements = []
+    unfulfilled_entitlements = []
 
     for course_entitlement in filtered_entitlements:
         if course_entitlement.enrollment_course_run:
             course_id = str(course_entitlement.enrollment_course_run.course.id)
             fulfilled_entitlements_by_course_key[course_id] = course_entitlement
         else:
-            unfulfulled_entitlements.append(course_entitlement)
+            unfulfilled_entitlements.append(course_entitlement)
 
     return (
         fulfilled_entitlements_by_course_key,
-        unfulfulled_entitlements,
+        unfulfilled_entitlements,
         course_entitlement_available_sessions,
         unfulfilled_entitlement_pseudo_sessions,
     )
@@ -234,7 +234,7 @@ class InitializeView(RetrieveAPIView):  # pylint: disable=unused-argument
         # Get entitlements
         (
             fulfilled_entitlements_by_course_key,
-            unfulfulled_entitlements,
+            unfulfilled_entitlements,
             course_entitlement_available_sessions,
             unfulfilled_entitlement_pseudo_sessions,
         ) = get_entitlements(user, site_org_whitelist, site_org_blacklist)
@@ -268,7 +268,7 @@ class InitializeView(RetrieveAPIView):  # pylint: disable=unused-argument
             "enterpriseDashboard": enterprise_customer,
             "platformSettings": get_platform_settings(),
             "enrollments": course_enrollments,
-            "unfulfilledEntitlements": unfulfulled_entitlements,
+            "unfulfilledEntitlements": unfulfilled_entitlements,
             "suggestedCourses": [],
         }
 

--- a/lms/djangoapps/learner_home/views.py
+++ b/lms/djangoapps/learner_home/views.py
@@ -104,10 +104,8 @@ def get_entitlements(user, org_allow_list, org_block_list):
     (
         filtered_entitlements,
         course_entitlement_available_sessions,
-        unfulfilled_entitlement_pseudo_sessions
-    ) = get_filtered_course_entitlements(
-        user, org_allow_list, org_block_list
-    )
+        unfulfilled_entitlement_pseudo_sessions,
+    ) = get_filtered_course_entitlements(user, org_allow_list, org_block_list)
     fulfilled_entitlements_by_course_key = {}
     unfulfulled_entitlements = []
 
@@ -238,7 +236,7 @@ class InitializeView(RetrieveAPIView):  # pylint: disable=unused-argument
             fulfilled_entitlements_by_course_key,
             unfulfulled_entitlements,
             course_entitlement_available_sessions,
-            unfulfilled_entitlement_pseudo_sessions
+            unfulfilled_entitlement_pseudo_sessions,
         ) = get_entitlements(user, site_org_whitelist, site_org_blacklist)
 
         # Get enrollments


### PR DESCRIPTION
## Description

Fill out `courseProvider` and `gradeData` serializers. Also standardizes some formatting (thanks, `black`).

**Note:** for getting the course provider of an unfulfilled entitlement we have to find `CourseOverviews` based off the psuedo sessions which is gross but 🤷 

JIRA: [AU-845](https://2u-internal.atlassian.net/browse/AU-845)
FYI: @openedx/content-aurora 