### PR TITLE
chore: bump edx-drf-extensions version

### DIFF
--- a/openedx/core/djangoapps/auth_exchange/tests/test_views.py
+++ b/openedx/core/djangoapps/auth_exchange/tests/test_views.py
@@ -242,11 +242,6 @@ class TestLoginWithAccessTokenView(TestCase):
         self.user.save()
 
         response = self._get_response(jwt_token, token_type="JWT")
-        error_msg = {
-            'error_code': 'account_disabled',
-            'developer_message': 'User account is disabled.'
-        }
-        self.assertDictEqual(error_msg, json.loads(response.content))
         assert '_auth_user_id' not in self.client.session
         assert response.status_code == 401
 

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
@@ -45,7 +45,7 @@ from openedx.core.djangoapps.credit.models import (
 from openedx.core.djangoapps.external_user_ids.models import ExternalId, ExternalIdType
 from openedx.core.djangoapps.oauth_dispatch.jwt import create_jwt_for_user
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
-from openedx.core.djangoapps.user_api.accounts.views import AccountRetirementPartnerReportView
+from openedx.core.djangoapps.user_api.accounts.views import AccountRetirementPartnerReportView, DeactivateLogoutView
 from openedx.core.djangoapps.user_api.models import (
     RetirementState,
     UserOrgTag,
@@ -248,8 +248,9 @@ class TestDeactivateLogout(RetirementTestCase):
         """
         self.client.login(username=self.test_user.username, password=self.test_password)
         headers = build_jwt_headers(self.test_user)
-        response = self.client.post(self.url, self.build_post(self.test_password + "xxxx"), **headers)
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        with mock.patch.object(DeactivateLogoutView, 'authentication_classes', new=[]):
+            response = self.client.post(self.url, self.build_post(self.test_password + "xxxx"), **headers)
+            assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_called_twice(self):
         """
@@ -262,8 +263,9 @@ class TestDeactivateLogout(RetirementTestCase):
         assert response.status_code == status.HTTP_204_NO_CONTENT
         self.client.login(username=self.test_user.username, password=self.test_password)
         headers = build_jwt_headers(self.test_user)
-        response = self.client.post(self.url, self.build_post(self.test_password), **headers)
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        with mock.patch.object(DeactivateLogoutView, 'authentication_classes', new=[]):
+            response = self.client.post(self.url, self.build_post(self.test_password), **headers)
+            assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Account APIs are only supported in LMS')

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
@@ -47,7 +47,7 @@ from openedx.core.djangoapps.credit.models import (
 from openedx.core.djangoapps.external_user_ids.models import ExternalId, ExternalIdType
 from openedx.core.djangoapps.oauth_dispatch.jwt import create_jwt_for_user
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
-from openedx.core.djangoapps.user_api.accounts.views import AccountRetirementPartnerReportView, DeactivateLogoutView
+from openedx.core.djangoapps.user_api.accounts.views import AccountRetirementPartnerReportView
 from openedx.core.djangoapps.user_api.models import (
     RetirementState,
     UserOrgTag,

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -470,7 +470,7 @@ edx-django-utils==5.0.0
     #   ora2
     #   outcome-surveys
     #   super-csv
-edx-drf-extensions==8.2.0
+edx-drf-extensions==8.3.0
     # via
     #   -r requirements/edx/base.in
     #   edx-completion

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -584,7 +584,7 @@ edx-django-utils==5.0.0
     #   ora2
     #   outcome-surveys
     #   super-csv
-edx-drf-extensions==8.2.0
+edx-drf-extensions==8.3.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-completion

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -564,7 +564,7 @@ edx-django-utils==5.0.0
     #   ora2
     #   outcome-surveys
     #   super-csv
-edx-drf-extensions==8.2.0
+edx-drf-extensions==8.3.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-completion


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Bump edx-drf-extensions version to 8.3.0.

## Supporting information

Jira ticket: [LEARNER-9001](https://2u-internal.atlassian.net/browse/LEARNER-9001)

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
