### PR TITLE
Created a edx.forum.thread.locked event

### DIFF
--- a/lms/djangoapps/discussion/django_comment_client/base/views.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/views.py
@@ -177,6 +177,20 @@ def track_thread_viewed_event(request, course, thread):
     track_forum_event(request, event_name, course, thread, event_data)
 
 
+def track_thread_lock_unlock_event(request, course, thread, close_reason_code, locked=True):
+    """
+    Triggers edx.forum.thread.locked  and edx.forum.thread.unlocked tracking event
+    """
+    event_name = f'edx.forum.thread.{"locked" if locked else "unlocked"}'
+    event_data = {
+        'target_username': thread.get('username'),
+        'lock_reason': close_reason_code,
+        'commentable_id': thread.get('commentable_id', ''),
+        'team_id': get_team(thread.commentable_id),
+    }
+    track_forum_event(request, event_name, course, thread, event_data)
+
+
 def permitted(func):
     """
     View decorator to verify the user is authorized to access this endpoint.

--- a/lms/djangoapps/discussion/rest_api/serializers.py
+++ b/lms/djangoapps/discussion/rest_api/serializers.py
@@ -458,6 +458,7 @@ class ThreadSerializer(_ContentSerializer):
             }
         )
 
+
 class CommentSerializer(_ContentSerializer):
     """
     A serializer for comment data.

--- a/lms/djangoapps/discussion/rest_api/tests/test_api.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api.py
@@ -2890,41 +2890,50 @@ class UpdateThreadTest(
             assert error.message_dict == {"edit_reason_code": ["This field is not editable."]}
 
     @ddt.data(
-        FORUM_ROLE_ADMINISTRATOR,
-        FORUM_ROLE_MODERATOR,
-        FORUM_ROLE_COMMUNITY_TA,
-        FORUM_ROLE_STUDENT,
+        *itertools.product(
+            [
+                FORUM_ROLE_ADMINISTRATOR,
+                FORUM_ROLE_MODERATOR,
+                FORUM_ROLE_COMMUNITY_TA,
+                FORUM_ROLE_STUDENT,
+            ],
+            [True, False]
+        )
     )
+    @ddt.unpack
     @mock.patch("lms.djangoapps.discussion.rest_api.serializers.CLOSE_REASON_CODES", {
         "test-close-reason": "Test Close Reason",
     })
     @mock.patch("eventtracking.tracker.emit")
-    def test_update_thread_with_close_reason_code(self, role_name, mock_emit):
+    def test_update_thread_with_close_reason_code(self, role_name, closed, mock_emit):
         """
         Test editing comments, specifying and retrieving edit reason codes.
         """
         _assign_role_to_user(user=self.user, course_id=self.course.id, role=role_name)
         self.register_thread()
         try:
+            self.request.META['HTTP_REFERER'] = 'https://example.cop'
             result = update_thread(self.request, "test_thread", {
-                "closed": True,
+                "closed": closed,
                 "close_reason_code": "test-close-reason",
             })
+
             assert role_name != FORUM_ROLE_STUDENT
-            assert result["closed"]
+            assert result["closed"] == closed
             request_body = httpretty.last_request().parsed_body  # pylint: disable=no-member
             assert request_body["close_reason_code"] == ["test-close-reason"]
             assert request_body["closing_user_id"] == [str(self.user.id)]
 
-            expected_event_name = "edx.forum.thread.locked"
+            expected_event_name = f'edx.forum.thread.{"locked" if closed else "unlocked"}'
             expected_event_data = {
                 'id': 'test_thread',
                 'team_id': None,
-                'url': f'/courses/{self.course.id}/discussion/forum/original_topic/threads/test_thread',
+                'url': self.request.META['HTTP_REFERER'],
                 'user_course_roles': [],
                 'user_forums_roles': ['Student', role_name],
                 'target_username': self.user.username,
-                'lock_reason': 'test-close-reason'
+                'lock_reason': 'test-close-reason',
+                'commentable_id': 'original_topic'
             }
 
             actual_event_name, actual_event_data = mock_emit.call_args[0]


### PR DESCRIPTION
# Description :
Added `edx.forum.thread.locked` event to add data in snowflake for tracking. And it would add data like this.

```python
{
        'id': 'test_thread',
        'team_id': '',
        'url': f'/courses/{self.course.id}/discussion/forum/original_topic/threads/test_thread',
        'user_course_roles': [],
        'user_forums_roles': ['Student', 'Moderator'],
        'target_username': 'robot_123'
        'lock_reason': 'test-close-reason'
}
```
## Ticket :
https://2u-internal.atlassian.net/browse/INF-483