### PR TITLE
fix: handle course prise

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1652,7 +1652,7 @@ class CourseEnrollment(models.Model):
                         'partner_image_url': owners[0].get('logo_image_url') if owners else '',
                         'learner_name': self.user.profile.name,
                         'course_run_key': str(self.course_id),
-                        'price': price,
+                        'course_price': price,
                         'lms_base_url': configuration_helpers.get_value('LMS_ROOT_URL', settings.LMS_ROOT_URL),
                         'learning_base_url': configuration_helpers.get_value('LEARNING_MICROFRONTEND_URL',
                                                                              settings.LEARNING_MICROFRONTEND_URL)

--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -726,7 +726,7 @@ class EnrollmentEventTestMixin(EventTestMixin):
             })
             if not studio_request:
                 properties.update({
-                    'price': 0,
+                    'course_price': 0,
                     'goals_enabled': False,
                     'learner_name': user.profile.name,
                     'course_run_key': str(course_key),


### PR DESCRIPTION
course price was not showing in braze because of multiple datatype with same event property.

VAN-1083
