### PR TITLE
chore: Unpin edx-event-bus-kafka and upgrade

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -298,6 +298,7 @@ CREDENTIALS_PUBLIC_SERVICE_URL = 'http://localhost:18150'
 #################### Event bus backend ########################
 EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL = 'http://edx.devstack.schema-registry:8081'
 EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS = 'edx.devstack.kafka:29092'
+EVENT_BUS_TOPIC_PREFIX = 'dev'
 
 ################# New settings must go ABOVE this line #################
 ########################################################################

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -27,11 +27,6 @@ django-storages<1.9
 # for them.
 edx-enterprise==3.56.9
 
-# As of 2022-08-24, Arch-BOM (at 2U) is changing event-bus-kafka rapidly, with breaking changes.
-# As long as that is happening, Arch-BOM will manually bump this dependency to ensure
-# that any necessary code changes can happen in lockstep.
-edx-event-bus-kafka==0.6.0
-
 # oauthlib>3.0.1 causes test failures ( also remove the django-oauth-toolkit constraint when this is fixed )
 oauthlib==3.0.1
 

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -84,7 +84,8 @@ edx-django-sites-extensions
 edx-django-utils>=5.0.0            # Utilities for cache, monitoring, and plugins
 edx-drf-extensions
 edx-enterprise
-edx-event-bus-kafka                 # Kafka implementation of event bus
+# 0.6.2 introduces topic prefixing
+edx-event-bus-kafka>=0.6.2          # Kafka implementation of event bus
 edx-milestones
 edx-name-affirmation
 edx-opaque-keys

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -481,10 +481,8 @@ edx-enterprise==3.56.9
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   learner-pathway-progress
-edx-event-bus-kafka==0.6.0
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/base.in
+edx-event-bus-kafka==0.7.0
+    # via -r requirements/edx/base.in
 edx-i18n-tools==0.9.1
     # via ora2
 edx-milestones==0.4.0

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -595,10 +595,8 @@ edx-enterprise==3.56.9
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   learner-pathway-progress
-edx-event-bus-kafka==0.6.0
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/testing.txt
+edx-event-bus-kafka==0.7.0
+    # via -r requirements/edx/testing.txt
 edx-i18n-tools==0.9.1
     # via
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -575,10 +575,8 @@ edx-enterprise==3.56.9
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   learner-pathway-progress
-edx-event-bus-kafka==0.6.0
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/base.txt
+edx-event-bus-kafka==0.7.0
+    # via -r requirements/edx/base.txt
 edx-i18n-tools==0.9.1
     # via
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
The producer API is stable enough now.

Make use of new topic prefixing feature for devstack (introduced in 0.6.2)