### PR TITLE
feat: add check for new video editor waffle flag

### DIFF
--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -26,7 +26,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
 from openedx.features.content_type_gating.models import ContentTypeGatingConfig
 from openedx.features.content_type_gating.partitions import CONTENT_TYPE_GATING_SCHEME
-from cms.djangoapps.contentstore.toggles import use_new_text_editor
+from cms.djangoapps.contentstore.toggles import use_new_text_editor, use_new_video_editor
 from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.exceptions import ItemNotFoundError  # lint-amnesty, pylint: disable=wrong-import-order
@@ -203,7 +203,7 @@ def get_editor_page_base_url(course_locator) -> str:
     Gets course authoring microfrontend URL for links to the new base editors
     """
     editor_url = None
-    if use_new_text_editor():
+    if use_new_text_editor() or use_new_video_editor():
         mfe_base_url = get_course_authoring_url(course_locator)
         course_mfe_url = f'{mfe_base_url}/course/{course_locator}/editor'
         if mfe_base_url:


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This change routes user to the new video editor experience when the `new_core_editors.use_new_video_editor` waffle flag is enabled. Previously the flag exists, but there was no condition that routed to the new experience. This change impacts Developers and Course Authors.

## Supporting information

JIRA Ticket [TNL-10111](https://2u-internal.atlassian.net/browse/TNL-10111)

## Testing instructions

1. Open [Django Admin waffle flags](http://localhost:18010/admin/waffle/flag)
2. Add new flag, `new_core_editors.use_new_video_editor`
3. Enable for Superuser and Unknown for Everyone
4. Open a course outline in Studio
5. Add a video block
6. Edit block
7. Check URL, should match the following pattern
```
http://localhost:2001/course/{course}/editor/video/{blockId}
```
8. Navigate back to [Django Admin waffle flags](http://localhost:18010/admin/waffle/flag)
9. Disable the `new_core_editors.use_new_video_editor`
10. Navigate back to video block
11. Edit block
12. Check that modal appears with no URL change

## Deadline

None
