### PR TITLE
chore: upgrade name affirmation version

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -495,7 +495,7 @@ edx-i18n-tools==0.9.1
     # via ora2
 edx-milestones==0.4.0
     # via -r requirements/edx/base.in
-edx-name-affirmation==2.3.4
+edx-name-affirmation==2.3.5
     # via -r requirements/edx/base.in
 edx-opaque-keys[django]==2.3.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -613,7 +613,7 @@ edx-lint==5.2.4
     # via -r requirements/edx/testing.txt
 edx-milestones==0.4.0
     # via -r requirements/edx/testing.txt
-edx-name-affirmation==2.3.4
+edx-name-affirmation==2.3.5
     # via -r requirements/edx/testing.txt
 edx-opaque-keys[django]==2.3.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -594,7 +594,7 @@ edx-lint==5.2.4
     # via -r requirements/edx/testing.in
 edx-milestones==0.4.0
     # via -r requirements/edx/base.txt
-edx-name-affirmation==2.3.4
+edx-name-affirmation==2.3.5
     # via -r requirements/edx/base.txt
 edx-opaque-keys[django]==2.3.0
     # via


### PR DESCRIPTION
## Description
The newest version of `edx-name-affirmation` contains a fix for a bug that prevented verified name updates for users with multiple names associated with proctored exam attemps.
