### PR TITLE
feat: added organization dropdown in studio

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
+++ b/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
@@ -23,6 +23,7 @@ from xmodule.modulestore.tests.factories import CourseFactory
 from cms.djangoapps.contentstore.tests.utils import AjaxEnabledTestClient, parse_json
 from cms.djangoapps.course_creators.admin import CourseCreatorAdmin
 from cms.djangoapps.course_creators.models import CourseCreator
+from cms.djangoapps.contentstore.views.course import get_allowed_organizations
 from common.djangoapps.student.auth import update_org_role
 from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole, OrgContentCreatorRole
 from common.djangoapps.student.tests.factories import AdminFactory, UserFactory
@@ -216,6 +217,7 @@ class TestCourseListing(ModuleStoreTestCase):
             'description': 'Testing Organization Description',
         })
         update_org_role(self.global_admin, OrgContentCreatorRole, self.user, [self.source_course_key.org])
+        self.assertIn(self.source_course_key.org, get_allowed_organizations(self.user))
         response = self.client.ajax_post(self.course_create_rerun_url, {
             'org': self.source_course_key.org,
             'number': 'CS101',
@@ -241,6 +243,7 @@ class TestCourseListing(ModuleStoreTestCase):
         self.course_creator_entry.all_organizations = True
         self.course_creator_entry.state = CourseCreator.GRANTED
         self.creator_admin.save_model(self.request, self.course_creator_entry, None, True)
+        self.assertIn(self.source_course_key.org, get_allowed_organizations(self.user))
         response = self.client.ajax_post(self.course_create_rerun_url, {
             'org': self.source_course_key.org,
             'number': 'CS101',
@@ -268,6 +271,7 @@ class TestCourseListing(ModuleStoreTestCase):
         self.creator_admin.save_model(self.request, self.course_creator_entry, None, True)
         dc_org_object = Organization.objects.get(name='Test Organization')
         self.course_creator_entry.organizations.add(dc_org_object)
+        self.assertIn(self.source_course_key.org, get_allowed_organizations(self.user))
         response = self.client.ajax_post(self.course_create_rerun_url, {
             'org': self.source_course_key.org,
             'number': 'CS101',
@@ -302,6 +306,7 @@ class TestCourseListing(ModuleStoreTestCase):
         # When the user tries to create course under `Test Organization` it throws a 403.
         dc_org_object = Organization.objects.get(name='DC')
         self.course_creator_entry.organizations.add(dc_org_object)
+        self.assertNotIn(self.source_course_key.org, get_allowed_organizations(self.user))
         response = self.client.ajax_post(self.course_create_rerun_url, {
             'org': self.source_course_key.org,
             'number': 'CS101',

--- a/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
+++ b/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
@@ -23,7 +23,7 @@ from xmodule.modulestore.tests.factories import CourseFactory
 from cms.djangoapps.contentstore.tests.utils import AjaxEnabledTestClient, parse_json
 from cms.djangoapps.course_creators.admin import CourseCreatorAdmin
 from cms.djangoapps.course_creators.models import CourseCreator
-from cms.djangoapps.contentstore.views.course import get_allowed_organizations
+from cms.djangoapps.contentstore.views.course import get_allowed_organizations, user_can_create_organizations
 from common.djangoapps.student.auth import update_org_role
 from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole, OrgContentCreatorRole
 from common.djangoapps.student.tests.factories import AdminFactory, UserFactory
@@ -244,6 +244,7 @@ class TestCourseListing(ModuleStoreTestCase):
         self.course_creator_entry.state = CourseCreator.GRANTED
         self.creator_admin.save_model(self.request, self.course_creator_entry, None, True)
         self.assertIn(self.source_course_key.org, get_allowed_organizations(self.user))
+        self.assertFalse(user_can_create_organizations(self.user))
         response = self.client.ajax_post(self.course_create_rerun_url, {
             'org': self.source_course_key.org,
             'number': 'CS101',
@@ -272,6 +273,7 @@ class TestCourseListing(ModuleStoreTestCase):
         dc_org_object = Organization.objects.get(name='Test Organization')
         self.course_creator_entry.organizations.add(dc_org_object)
         self.assertIn(self.source_course_key.org, get_allowed_organizations(self.user))
+        self.assertFalse(user_can_create_organizations(self.user))
         response = self.client.ajax_post(self.course_create_rerun_url, {
             'org': self.source_course_key.org,
             'number': 'CS101',
@@ -307,6 +309,7 @@ class TestCourseListing(ModuleStoreTestCase):
         dc_org_object = Organization.objects.get(name='DC')
         self.course_creator_entry.organizations.add(dc_org_object)
         self.assertNotIn(self.source_course_key.org, get_allowed_organizations(self.user))
+        self.assertFalse(user_can_create_organizations(self.user))
         response = self.client.ajax_post(self.course_create_rerun_url, {
             'org': self.source_course_key.org,
             'number': 'CS101',

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -1944,11 +1944,13 @@ def get_organizations(user):
     """
     Returns the list of organizations for which the user is allowed to create courses.
     """
-    user = CourseCreator.objects.filter(user=user)
-    if user.count() == 0:
+    course_creator = CourseCreator.objects.filter(user=user)
+    if not course_creator:
         return []
-    elif user[0].all_organizations:
-        # User is defined to be unique, can assume a single entry.
-        return Organization.objects.all().values_list('short_name', flat=True)
+    elif course_creator[0].all_organizations:
+        organizations = Organization.objects.all().values_list('short_name', flat=True)
     else:
-        return user[0].organizations.all().values_list('short_name', flat=True)
+        # User is defined to be unique, can assume a single entry.
+        organizations = course_creator[0].organizations.all().values_list('short_name', flat=True)
+
+    return organizations

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -1944,13 +1944,12 @@ def get_organizations(user):
     """
     Returns the list of organizations for which the user is allowed to create courses.
     """
-    course_creator = CourseCreator.objects.filter(user=user)
+    course_creator = CourseCreator.objects.filter(user=user).first()
     if not course_creator:
         return []
-    elif course_creator[0].all_organizations:
+    elif course_creator.all_organizations:
         organizations = Organization.objects.all().values_list('short_name', flat=True)
     else:
-        # User is defined to be unique, can assume a single entry.
-        organizations = course_creator[0].organizations.all().values_list('short_name', flat=True)
+        organizations = course_creator.organizations.all().values_list('short_name', flat=True)
 
     return organizations

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -35,6 +35,7 @@ from organizations.exceptions import InvalidOrganizationException
 from rest_framework.exceptions import ValidationError
 
 from cms.djangoapps.course_creators.views import add_user_with_status_unrequested, get_course_creator_status
+from cms.djangoapps.course_creators.models import CourseCreator
 from cms.djangoapps.models.settings.course_grading import CourseGradingModel
 from cms.djangoapps.models.settings.course_metadata import CourseMetadata
 from cms.djangoapps.models.settings.encoder import CourseSettingsEncoder
@@ -74,6 +75,7 @@ from openedx.core.lib.courses import course_image_url
 from openedx.features.content_type_gating.models import ContentTypeGatingConfig
 from openedx.features.content_type_gating.partitions import CONTENT_TYPE_GATING_SCHEME
 from openedx.features.course_experience.waffle import ENABLE_COURSE_ABOUT_SIDEBAR_HTML
+from organizations.models import Organization
 from xmodule.contentstore.content import StaticContent  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.course_block import CourseBlock, DEFAULT_START_DATE, CourseFields  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.error_block import ErrorBlock  # lint-amnesty, pylint: disable=wrong-import-order
@@ -588,7 +590,9 @@ def course_listing(request):
         'allow_unicode_course_id': settings.FEATURES.get('ALLOW_UNICODE_COURSE_ID', False),
         'allow_course_reruns': settings.FEATURES.get('ALLOW_COURSE_RERUNS', True),
         'optimization_enabled': optimization_enabled,
-        'active_tab': 'courses'
+        'active_tab': 'courses',
+        'allowed_organizations': get_allowed_organizations(user),
+        'can_create_organizations': user_can_create_organizations(user),
     })
 
 
@@ -1917,3 +1921,34 @@ def _get_course_creator_status(user):
         course_creator_status = 'granted'
 
     return course_creator_status
+
+
+def get_allowed_organizations(user):
+    """
+    Helper method for returning the list of organizations for which the user is allowed to create courses.
+    """
+    if settings.FEATURES.get('ENABLE_CREATOR_GROUP', False):
+        return get_organizations(user)
+    else:
+        return []
+
+
+def user_can_create_organizations(user):
+    """
+    Returns True if the user can create organizations.
+    """
+    return user.is_staff or not settings.FEATURES.get('ENABLE_CREATOR_GROUP', False)
+
+
+def get_organizations(user):
+    """
+    Returns the list of organizations for which the user is allowed to create courses.
+    """
+    user = CourseCreator.objects.filter(user=user)
+    if user.count() == 0:
+        return []
+    elif user[0].all_organizations:
+        # User is defined to be unique, can assume a single entry.
+        return Organization.objects.all().values_list('short_name', flat=True)
+    else:
+        return user[0].organizations.all().values_list('short_name', flat=True)

--- a/cms/static/sass/views/_course-create.scss
+++ b/cms/static/sass/views/_course-create.scss
@@ -68,6 +68,10 @@
       width: 100%;
     }
 
+    .new-course-org{
+      padding: 10px;
+    }
+
     .rerun-course-number,
     .rerun-course-number-label {
       color: #a0a0a0;

--- a/cms/static/sass/views/_dashboard.scss
+++ b/cms/static/sass/views/_dashboard.scss
@@ -681,6 +681,11 @@
       width: 100%;
     }
 
+    .new-course-org,
+    .new-library-org {
+      padding: 10px;
+    }
+
     .course-run-text-direction {
       direction: ltr;
       text-align: right;

--- a/cms/static/sass/views/_dashboard.scss
+++ b/cms/static/sass/views/_dashboard.scss
@@ -676,7 +676,8 @@
     .new-course-org,
     .new-course-number,
     .new-course-name,
-    .new-course-run {
+    .new-course-run,
+    .new-library-org {
       width: 100%;
     }
 

--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -81,7 +81,15 @@ from openedx.core.djangolib.js_utils import (
                   <label for="new-course-org">${_("Organization")}</label>
                   ## Translators: This is an example for the name of the organization sponsoring a course, seen when filling out the form to create a new course. The organization name cannot contain spaces.
                   ## Translators: "e.g. UniversityX or OrganizationX" is a placeholder displayed when user put no data into this field.
-                  <input class="new-course-org" id="new-course-org" type="text" name="new-course-org" required placeholder="${_('e.g. UniversityX or OrganizationX')}" aria-describedby="tip-new-course-org tip-error-new-course-org" />
+                  % if can_create_organizations:
+                    <input class="new-course-org" id="new-course-org" type="text" name="new-course-org" required placeholder="${_('e.g. UniversityX or OrganizationX')}" aria-describedby="tip-new-course-org tip-error-new-course-org" />
+                  % else:
+                    <select style="padding: 10px" class="new-course-org" id="course-language" name="new-course-org" required aria-describedby="tip-new-course-org tip-error-new-course-org">
+                      % for org in allowed_organizations:
+                        <option value="${org}">${org}</option>
+                      % endfor
+                    </select>
+                  % endif
                   <span class="tip" id="tip-new-course-org">${Text(_("The name of the organization sponsoring the course. {strong_start}Note: The organization name is part of the course URL.{strong_end} This cannot be changed, but you can set a different display name in Advanced Settings later.")).format(
                       strong_start=HTML('<strong>'),
                       strong_end=HTML('</strong>'),

--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -166,7 +166,7 @@ from openedx.core.djangolib.js_utils import (
                   % if can_create_organizations:
                     <input class="new-library-org" id="new-library-org" type="text" name="new-library-org" required placeholder="${_('e.g. UniversityX or OrganizationX')}" aria-describedby="tip-new-library-org tip-error-new-library-org" />
                   % else:
-                    <select style="padding: 10px" class="new-library-org" id="new-library-org" name="new-library-org" required aria-describedby="tip-new-library-org tip-error-new-library-org">
+                    <select class="new-library-org" id="new-library-org" name="new-library-org" required aria-describedby="tip-new-library-org tip-error-new-library-org">
                       % for org in allowed_organizations:
                         <option value="${org}">${org}</option>
                       % endfor

--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -84,7 +84,7 @@ from openedx.core.djangolib.js_utils import (
                   % if can_create_organizations:
                     <input class="new-course-org" id="new-course-org" type="text" name="new-course-org" required placeholder="${_('e.g. UniversityX or OrganizationX')}" aria-describedby="tip-new-course-org tip-error-new-course-org" />
                   % else:
-                    <select style="padding: 10px" class="new-course-org" id="course-language" name="new-course-org" required aria-describedby="tip-new-course-org tip-error-new-course-org">
+                    <select class="new-course-org" id="new-course-org" name="new-course-org" required aria-describedby="tip-new-course-org tip-error-new-course-org">
                       % for org in allowed_organizations:
                         <option value="${org}">${org}</option>
                       % endfor

--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -163,7 +163,15 @@ from openedx.core.djangolib.js_utils import (
                 </li>
                 <li class="field text required">
                   <label for="new-library-org">${_("Organization")}</label>
-                  <input class="new-library-org" id="new-library-org" type="text" name="new-library-org" required placeholder="${_('e.g. UniversityX or OrganizationX')}" aria-describedby="tip-new-library-org tip-error-new-library-org" />
+                  % if can_create_organizations:
+                    <input class="new-library-org" id="new-library-org" type="text" name="new-library-org" required placeholder="${_('e.g. UniversityX or OrganizationX')}" aria-describedby="tip-new-library-org tip-error-new-library-org" />
+                  % else:
+                    <select style="padding: 10px" class="new-library-org" id="new-library-org" name="new-library-org" required aria-describedby="tip-new-library-org tip-error-new-library-org">
+                      % for org in allowed_organizations:
+                        <option value="${org}">${org}</option>
+                      % endfor
+                    </select>
+                  % endif
                   <span class="tip" id="tip-new-library-org">${_("The public organization name for your library.")} ${_("This cannot be changed.")}</span>
                   <span class="tip tip-error is-hiding" id="tip-error-new-library-org"></span>
                 </li>


### PR DESCRIPTION
## Description

This PR adds a dropdown to select the organization. The dropdown will only be activated for users with CourseCreator permission to specific organizations in Studio.

Use cases:

When `FEATURES['ENABLE_CREATOR_GROUP'] = True` and the user has CourseCreator permission granted, a dropdown will appear with all specific organizations allowed. In case of `all_organizations` setting is enabled, all organizations will appear in the dropdown.

In case the user is staff, he can create organizations it will work as before:

![image](https://user-images.githubusercontent.com/33465240/194938940-7fdaa7f7-1728-4995-a000-96ebcb286c83.png)

## Testing instructions

1. Enable course creator group in studio.
2. Create a student account and give it CourseCreator permission only for some organizations.
![image](https://user-images.githubusercontent.com/33465240/189672192-df4c5c91-4744-4c6c-ba1f-2fca22185442.png)
3. Login as this user and try to create a new course.

Result:
![image](https://user-images.githubusercontent.com/33465240/194939083-e8154fa4-3489-4960-97bd-aa14787cc938.png)