### PR TITLE
feat: add event for content deletion for discussions

### DIFF
--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -73,7 +73,9 @@ from ..config.waffle import ENABLE_LEARNERS_STATS
 
 from ..django_comment_client.base.views import (
     track_comment_created_event,
+    track_comment_deleted_event,
     track_thread_created_event,
+    track_thread_deleted_event,
     track_thread_viewed_event,
     track_voted_event,
 )
@@ -1604,6 +1606,7 @@ def delete_thread(request, thread_id):
     if can_delete(cc_thread, context):
         cc_thread.delete()
         thread_deleted.send(sender=None, user=request.user, post=cc_thread)
+        track_thread_deleted_event(request, context["course"], cc_thread)
     else:
         raise PermissionDenied
 
@@ -1628,6 +1631,7 @@ def delete_comment(request, comment_id):
     if can_delete(cc_comment, context):
         cc_comment.delete()
         comment_deleted.send(sender=None, user=request.user, post=cc_comment)
+        track_comment_deleted_event(request, context["course"], cc_comment)
     else:
         raise PermissionDenied
 


### PR DESCRIPTION
### [INF-486](https://2u-internal.atlassian.net/browse/INF-486)

### Description
We need to create a new event named `edx.forum.content.deleted`. This event will be triggered when a post, response or comment is deleted either by author or by user having moderation privileges.

### Post Event

event_name: `edx.forum.thread.deleted`

```python
{
            'body': 'dummy',
            'content_type': 'Post',
            'own_content': True,
            'commentable_id': 'dummy',
            'target_username': 'dummy',
            'title_truncated': False,
            'title': 'dummy',
            'id': 'test_thread',
            'url': '',
            'user_forums_roles': ['Student'],
            'user_course_roles': []
}
```
### Response Event 

event_name: `edx.forum.response.deleted`

```python
{
            'body': 'dummy',
            'content_type': 'Response',
            'own_content': True,
            'commentable_id': 'dummy',
            'target_username': 'dummy',
            'id': 'test_comment',
            'url': '',
            'user_forums_roles': ['Student'],
            'user_course_roles': []
}
```

### Comment Event 

event_name: `edx.forum.comment.deleted`

```python
{
            'body': 'dummy',
            'content_type': 'Comment',
            'own_content': True,
            'commentable_id': 'dummy',
            'target_username': 'dummy',
            'id': 'test_comment',
            'url': '',
            'user_forums_roles': ['Student'],
            'user_course_roles': []
}
```