### PR TITLE
feat: added new edit reason code

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -5162,6 +5162,7 @@ DISCUSSION_MODERATION_EDIT_REASON_CODES = {
     "format-change": _("Formatting changes needed"),
     "post-type-change": _("Post type needs change"),
     "contains-pii": _("Contains personally identifiable information"),
+    "violates-guidelines": _("Violates community guidelines"),
 }
 # Provide a list of reason codes for moderators to close posts, as a mapping
 # from the internal reason code representation, to  an internationalizable label


### PR DESCRIPTION
## Description
Added violates-guidelines edit reason code in LMS settings it depends on this PR https://github.com/openedx/frontend-app-discussions/pull/288

## Ticket
https://2u-internal.atlassian.net/browse/INF-538

## Testing instructions
Login with a global staff account and edit other users' posts, observe that in edit reasons Violates community guidelines is selected by default.