### PR TITLE
feat: Send `modified` data of a learner's grade to the Credentials IDA

### DIFF
--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -1508,7 +1508,7 @@ class ProgressPageTests(ProgressPageBaseTests):
 
     @patch.dict(settings.FEATURES, {'ASSUME_ZERO_GRADE_IF_ABSENT_FOR_ALL_TESTS': False})
     @ddt.data(
-        (False, 60, 42),
+        (False, 60, 43),
         (True, 52, 36)
     )
     @ddt.unpack

--- a/lms/djangoapps/grades/tests/test_course_grade_factory.py
+++ b/lms/djangoapps/grades/tests/test_course_grade_factory.py
@@ -130,7 +130,7 @@ class TestCourseGradeFactory(GradeTestBase):
         with self.assertNumQueries(4), mock_get_score(1, 2):
             _assert_read(expected_pass=False, expected_percent=0)  # start off with grade of 0
 
-        num_queries = 43
+        num_queries = 42
         with self.assertNumQueries(num_queries), mock_get_score(1, 2):
             grade_factory.update(self.request.user, self.course, force_update_subsections=True)
 

--- a/lms/djangoapps/grades/tests/test_tasks.py
+++ b/lms/djangoapps/grades/tests/test_tasks.py
@@ -161,10 +161,10 @@ class RecalculateSubsectionGradeTest(HasCourseWithProblemsMixin, ModuleStoreTest
             assert mock_block_structure_create.call_count == 1
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 1, 41, True),
-        (ModuleStoreEnum.Type.mongo, 1, 41, False),
-        (ModuleStoreEnum.Type.split, 2, 41, True),
-        (ModuleStoreEnum.Type.split, 2, 41, False),
+        (ModuleStoreEnum.Type.mongo, 1, 40, True),
+        (ModuleStoreEnum.Type.mongo, 1, 40, False),
+        (ModuleStoreEnum.Type.split, 2, 40, True),
+        (ModuleStoreEnum.Type.split, 2, 40, False),
     )
     @ddt.unpack
     def test_query_counts(self, default_store, num_mongo_calls, num_sql_calls, create_multiple_subsections):
@@ -176,8 +176,8 @@ class RecalculateSubsectionGradeTest(HasCourseWithProblemsMixin, ModuleStoreTest
                     self._apply_recalculate_subsection_grade()
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 1, 41),
-        (ModuleStoreEnum.Type.split, 2, 41),
+        (ModuleStoreEnum.Type.mongo, 1, 40),
+        (ModuleStoreEnum.Type.split, 2, 40),
     )
     @ddt.unpack
     def test_query_counts_dont_change_with_more_content(self, default_store, num_mongo_calls, num_sql_calls):
@@ -223,8 +223,8 @@ class RecalculateSubsectionGradeTest(HasCourseWithProblemsMixin, ModuleStoreTest
         )
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 1, 24),
-        (ModuleStoreEnum.Type.split, 2, 24),
+        (ModuleStoreEnum.Type.mongo, 1, 23),
+        (ModuleStoreEnum.Type.split, 2, 23),
     )
     @ddt.unpack
     def test_persistent_grades_not_enabled_on_course(self, default_store, num_mongo_queries, num_sql_queries):
@@ -238,8 +238,8 @@ class RecalculateSubsectionGradeTest(HasCourseWithProblemsMixin, ModuleStoreTest
             assert len(PersistentSubsectionGrade.bulk_read_grades(self.user.id, self.course.id)) == 0
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 1, 42),
-        (ModuleStoreEnum.Type.split, 2, 42),
+        (ModuleStoreEnum.Type.mongo, 1, 41),
+        (ModuleStoreEnum.Type.split, 2, 41),
     )
     @ddt.unpack
     def test_persistent_grades_enabled_on_course(self, default_store, num_mongo_queries, num_sql_queries):

--- a/lms/djangoapps/grades/tests/utils.py
+++ b/lms/djangoapps/grades/tests/utils.py
@@ -15,7 +15,7 @@ from xmodule.graders import ProblemScore  # lint-amnesty, pylint: disable=wrong-
 
 
 @contextmanager
-def mock_passing_grade(letter_grade='Pass', percent=0.75, ):
+def mock_passing_grade(letter_grade='Pass', percent=0.75, modified=None):
     """
     Mock the grading function to always return a passing grade.
     """
@@ -24,6 +24,7 @@ def mock_passing_grade(letter_grade='Pass', percent=0.75, ):
         percent=percent,
         passed=letter_grade is not None,
         attempted=True,
+        modified=modified,
     )
     with patch('lms.djangoapps.grades.course_grade_factory.CourseGradeFactory.read') as mock_grade_read:
         mock_grade_read.return_value = MagicMock(**passing_grade_fields)

--- a/lms/djangoapps/grades/tests/utils.py
+++ b/lms/djangoapps/grades/tests/utils.py
@@ -15,7 +15,7 @@ from xmodule.graders import ProblemScore  # lint-amnesty, pylint: disable=wrong-
 
 
 @contextmanager
-def mock_passing_grade(letter_grade='Pass', percent=0.75, modified=None):
+def mock_passing_grade(letter_grade='Pass', percent=0.75):
     """
     Mock the grading function to always return a passing grade.
     """
@@ -23,8 +23,7 @@ def mock_passing_grade(letter_grade='Pass', percent=0.75, modified=None):
         letter_grade=letter_grade,
         percent=percent,
         passed=letter_grade is not None,
-        attempted=True,
-        modified=modified,
+        attempted=True
     )
     with patch('lms.djangoapps.grades.course_grade_factory.CourseGradeFactory.read') as mock_grade_read:
         mock_grade_read.return_value = MagicMock(**passing_grade_fields)

--- a/openedx/core/djangoapps/credentials/signals.py
+++ b/openedx/core/djangoapps/credentials/signals.py
@@ -17,6 +17,7 @@ def handle_grade_change(user, course_grade, course_key, **kwargs):
         None,
         course_grade.letter_grade,
         course_grade.percent,
+        course_grade.modified,
         verbose=kwargs.get('verbose', False)
     )
 
@@ -25,4 +26,12 @@ def handle_cert_change(user, course_key, mode, status, **kwargs):
     """
     Notifies the Credentials IDA about certain grades it needs for its records, when a cert changes.
     """
-    send_grade_if_interesting(user, course_key, mode, status, None, None, verbose=kwargs.get('verbose', False))
+    send_grade_if_interesting(
+        user,
+        course_key,
+        mode,
+        status,
+        None,
+        None,
+        None,
+        verbose=kwargs.get('verbose', False))

--- a/openedx/core/djangoapps/credentials/signals.py
+++ b/openedx/core/djangoapps/credentials/signals.py
@@ -17,7 +17,6 @@ def handle_grade_change(user, course_grade, course_key, **kwargs):
         None,
         course_grade.letter_grade,
         course_grade.percent,
-        course_grade.modified,
         verbose=kwargs.get('verbose', False)
     )
 
@@ -26,12 +25,4 @@ def handle_cert_change(user, course_key, mode, status, **kwargs):
     """
     Notifies the Credentials IDA about certain grades it needs for its records, when a cert changes.
     """
-    send_grade_if_interesting(
-        user,
-        course_key,
-        mode,
-        status,
-        None,
-        None,
-        None,
-        verbose=kwargs.get('verbose', False))
+    send_grade_if_interesting(user, course_key, mode, status, None, None, verbose=kwargs.get('verbose', False))

--- a/openedx/core/djangoapps/credentials/tasks/v1/tasks.py
+++ b/openedx/core/djangoapps/credentials/tasks/v1/tasks.py
@@ -49,14 +49,14 @@ MAX_RETRIES = 11
 @shared_task(bind=True, ignore_result=True)
 @set_code_owner_attribute
 def send_grade_to_credentials(
-        self,
-        username,
-        course_run_key,
-        verified,
-        letter_grade,
-        percent_grade,
-        grade_last_modified=None
-    ):
+    self,
+    username,
+    course_run_key,
+    verified,
+    letter_grade,
+    percent_grade,
+    grade_last_modified=None
+):
     """
     Celery task to notify the Credentials IDA of a grade change via POST.
     """

--- a/openedx/core/djangoapps/credentials/tests/test_tasks.py
+++ b/openedx/core/djangoapps/credentials/tests/test_tasks.py
@@ -454,7 +454,7 @@ class TestSendGradeIfInteresting(TestCase):
         mock_is_course_run_in_a_program.return_value = True
 
         # Test direct send
-        tasks.send_grade_if_interesting(self.user, self.key, mode, status, 'A', 1.0, None)
+        tasks.send_grade_if_interesting(self.user, self.key, mode, status, 'A', 1.0)
         assert mock_send_grade_to_credentials.delay.called is called
         mock_send_grade_to_credentials.delay.reset_mock()
 
@@ -465,12 +465,12 @@ class TestSendGradeIfInteresting(TestCase):
             status=status,
             mode=mode
         )
-        tasks.send_grade_if_interesting(self.user, self.key, None, None, 'A', 1.0, None)
+        tasks.send_grade_if_interesting(self.user, self.key, None, None, 'A', 1.0)
         assert mock_send_grade_to_credentials.delay.called is called
         mock_send_grade_to_credentials.delay.reset_mock()
 
     def test_send_grade_missing_cert(self, _, mock_send_grade_to_credentials, _mock_is_learner_issuance_enabled):
-        tasks.send_grade_if_interesting(self.user, self.key, None, None, 'A', 1.0, None)
+        tasks.send_grade_if_interesting(self.user, self.key, None, None, 'A', 1.0)
         assert not mock_send_grade_to_credentials.delay.called
 
     @ddt.data([True], [False])
@@ -478,7 +478,7 @@ class TestSendGradeIfInteresting(TestCase):
     def test_send_grade_if_in_a_program(self, in_program, mock_is_course_run_in_a_program,
                                         mock_send_grade_to_credentials, _mock_is_learner_issuance_enabled):
         mock_is_course_run_in_a_program.return_value = in_program
-        tasks.send_grade_if_interesting(self.user, self.key, 'verified', 'downloadable', 'A', 1.0, None)
+        tasks.send_grade_if_interesting(self.user, self.key, 'verified', 'downloadable', 'A', 1.0)
         assert mock_send_grade_to_credentials.delay.called is in_program
 
     def test_send_grade_queries_grade(self, mock_is_course_run_in_a_program, mock_send_grade_to_credentials,
@@ -486,7 +486,7 @@ class TestSendGradeIfInteresting(TestCase):
         mock_is_course_run_in_a_program.return_value = True
 
         with mock_passing_grade('B', 0.81):
-            tasks.send_grade_if_interesting(self.user, self.key, 'verified', 'downloadable', None, None, None)
+            tasks.send_grade_if_interesting(self.user, self.key, 'verified', 'downloadable', None)
         assert mock_send_grade_to_credentials.delay.called
         assert mock_send_grade_to_credentials.delay.call_args[0] == (
             self.user.username, str(self.key), True, 'B', 0.81, None
@@ -502,6 +502,7 @@ class TestSendGradeIfInteresting(TestCase):
 
         modified_dt = datetime.now()
         modified_dt_utc = modified_dt.replace(tzinfo=pytz.UTC)
+
         with mock_passing_grade('B', 0.81, modified_dt_utc):
             tasks.send_grade_if_interesting(
                 self.user,
@@ -527,13 +528,13 @@ class TestSendGradeIfInteresting(TestCase):
     def test_send_grade_without_grade(self, mock_is_course_run_in_a_program, mock_send_grade_to_credentials,
                                       _mock_is_learner_issuance_enabled):
         mock_is_course_run_in_a_program.return_value = True
-        tasks.send_grade_if_interesting(self.user, self.key, 'verified', 'downloadable', None, None, None)
+        tasks.send_grade_if_interesting(self.user, self.key, 'verified', 'downloadable', None, None)
         assert not mock_send_grade_to_credentials.delay.called
 
     def test_send_grade_without_issuance_enabled(self, _mock_is_course_run_in_a_program,
                                                  mock_send_grade_to_credentials, mock_is_learner_issuance_enabled):
         mock_is_learner_issuance_enabled.return_value = False
-        tasks.send_grade_if_interesting(self.user, self.key, 'verified', 'downloadable', None, None, None)
+        tasks.send_grade_if_interesting(self.user, self.key, 'verified', 'downloadable', None, None)
         assert mock_is_learner_issuance_enabled.called
         assert not mock_send_grade_to_credentials.delay.called
 
@@ -544,14 +545,14 @@ class TestSendGradeIfInteresting(TestCase):
         )
 
         # Correctly sent
-        tasks.send_grade_if_interesting(self.user, self.key, 'verified', 'downloadable', None, None, None)
+        tasks.send_grade_if_interesting(self.user, self.key, 'verified', 'downloadable', None, None)
         assert mock_send_grade_to_credentials.delay.called
         mock_send_grade_to_credentials.delay.reset_mock()
 
         # Correctly not sent
         site_config.site_values['ENABLE_LEARNER_RECORDS'] = False
         site_config.save()
-        tasks.send_grade_if_interesting(self.user, self.key, 'verified', 'downloadable', None, None, None)
+        tasks.send_grade_if_interesting(self.user, self.key, 'verified', 'downloadable', None, None)
         assert not mock_send_grade_to_credentials.delay.called
 
     def test_send_grade_records_disabled_globally(
@@ -561,7 +562,7 @@ class TestSendGradeIfInteresting(TestCase):
         assert is_learner_records_enabled()
         with override_settings(FEATURES={"ENABLE_LEARNER_RECORDS": False}):
             assert not is_learner_records_enabled()
-            tasks.send_grade_if_interesting(self.user, self.key, 'verified', 'downloadable', None, None, None)
+            tasks.send_grade_if_interesting(self.user, self.key, 'verified', 'downloadable', None, None)
         assert not mock_send_grade_to_credentials.delay.called
 
 


### PR DESCRIPTION
## Description

[APER-1968]

We don't have a good way to understand if grade data in Credentials is out of sync with the LMS. Grades are sent to Credentials via a REST API call originating from an asynchronous Celery task on the LMS side. This PR updates our Celery task `send_grade_to_credentials` to include sending the `modified` DateTime value of a grade record to the Credentials IDA. Updates will be made on the Credentials side to accept and store this data as part of the UserGrade instance.

* Updates the `send_grade_to_credentials` task to include passing the grade's `modified` DateTime info as part of the request data to Credentials
* Update existing log statement to use format strings where possible.