### PR TITLE
refactor: deprecate `static_url` argument from ModuleSystem [BD-13]

### DIFF
--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -207,7 +207,6 @@ def _preview_module_system(request, descriptor, field_data):
             preview_anonymous_user_id = anonymous_id_for_user(request.user, course_id)
 
     return PreviewModuleSystem(
-        static_url=settings.STATIC_URL,
         # TODO (cpennington): Do we want to track how instructors are using the preview problems?
         track_function=lambda event_type, event: None,
         get_module=partial(_load_preview_module, request),

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -680,7 +680,6 @@ def get_module_system_for_user(
 
     system = LmsModuleSystem(
         track_function=track_function,
-        static_url=settings.STATIC_URL,
         get_module=inner_get_module,
         user=user,
         publish=publish,

--- a/lms/djangoapps/lms_xblock/test/test_runtime.py
+++ b/lms/djangoapps/lms_xblock/test/test_runtime.py
@@ -60,7 +60,6 @@ class TestHandlerUrl(TestCase):
         self.block = BlockMock(name='block', scope_ids=ScopeIds(None, None, None, 'dummy'))
         self.course_key = CourseLocator("org", "course", "run")
         self.runtime = LmsModuleSystem(
-            static_url='/static',
             track_function=Mock(),
             get_module=Mock(),
             course_id=self.course_key,
@@ -125,7 +124,6 @@ class TestUserServiceAPI(TestCase):
         self.user = UserFactory.create()
 
         self.runtime = LmsModuleSystem(
-            static_url='/static',
             track_function=Mock(),
             get_module=Mock(),
             user=self.user,
@@ -175,7 +173,6 @@ class TestBadgingService(ModuleStoreTestCase):
         Create the testing runtime.
         """
         return LmsModuleSystem(
-            static_url='/static',
             track_function=Mock(),
             get_module=Mock(),
             course_id=self.course_id,
@@ -229,7 +226,6 @@ class TestI18nService(ModuleStoreTestCase):
         self.course = CourseFactory.create()
         self.test_language = 'dummy language'
         self.runtime = LmsModuleSystem(
-            static_url='/static',
             track_function=Mock(),
             get_module=Mock(),
             course_id=self.course.id,

--- a/openedx/core/djangoapps/xblock/runtime/shims.py
+++ b/openedx/core/djangoapps/xblock/runtime/shims.py
@@ -4,18 +4,16 @@ Code to implement backwards compatibility
 # pylint: disable=no-member
 
 import warnings
-
 from django.conf import settings
 from django.core.cache import cache
 from django.template import TemplateDoesNotExist
 from django.utils.functional import cached_property
 from fs.memoryfs import MemoryFS
 
-from openedx.core.djangoapps.xblock.apps import get_xblock_app_config
-
-from common.djangoapps.static_replace.services import ReplaceURLService
 from common.djangoapps.edxmako.shortcuts import render_to_string
+from common.djangoapps.static_replace.services import ReplaceURLService
 from common.djangoapps.student.models import anonymous_id_for_user
+from openedx.core.djangoapps.xblock.apps import get_xblock_app_config
 
 
 class RuntimeShim:
@@ -235,10 +233,12 @@ class RuntimeShim:
     def STATIC_URL(self):
         """
         Get the django STATIC_URL path.
-
-        Seems only to be used by capa. Remove this if capa can be refactored.
+        Deprecated in favor of the settings.STATIC_URL configuration.
         """
-        # TODO: Refactor capa to access this directly, don't bother the runtime. Then remove it from here.
+        warnings.warn(
+            'runtime.STATIC_URL is deprecated. Please use settings.STATIC_URL instead.',
+            DeprecationWarning, stacklevel=3,
+        )
         static_url = settings.STATIC_URL
         if static_url.startswith('/') and not static_url.startswith('//'):
             # This is not a full URL - should start with https:// to support loading assets from an iframe sandbox

--- a/xmodule/capa/capa_problem.py
+++ b/xmodule/capa/capa_problem.py
@@ -23,6 +23,7 @@ from datetime import datetime
 from xml.sax.saxutils import unescape
 
 import six
+from django.conf import settings
 
 from lxml import etree
 from pytz import UTC
@@ -107,7 +108,6 @@ class LoncapaSystem(object):
         render_template,
         resources_fs,
         seed,      # Why do we do this if we have self.seed?
-        STATIC_URL,
         xqueue,
         matlab_api_key=None
     ):
@@ -121,7 +121,7 @@ class LoncapaSystem(object):
         self.render_template = render_template
         self.resources_fs = resources_fs
         self.seed = seed                     # Why do we do this if we have self.seed?
-        self.STATIC_URL = STATIC_URL                    # pylint: disable=invalid-name
+        self.STATIC_URL = settings.STATIC_URL           # pylint: disable=invalid-name
         self.xqueue = xqueue
         self.matlab_api_key = matlab_api_key
 

--- a/xmodule/capa_module.py
+++ b/xmodule/capa_module.py
@@ -630,7 +630,6 @@ class ProblemBlock(
             render_template=None,
             resources_fs=self.runtime.resources_fs,
             seed=None,
-            STATIC_URL=None,
             xqueue=None,
             matlab_api_key=None,
         )
@@ -691,7 +690,6 @@ class ProblemBlock(
             render_template=None,
             resources_fs=self.runtime.resources_fs,
             seed=1,
-            STATIC_URL=None,
             xqueue=None,
             matlab_api_key=None,
         )
@@ -839,7 +837,6 @@ class ProblemBlock(
             render_template=self.runtime.service(self, 'mako').render_template,
             resources_fs=self.runtime.resources_fs,
             seed=seed,  # Why do we do this if we have self.seed?
-            STATIC_URL=self.runtime.STATIC_URL,
             xqueue=self.runtime.service(self, 'xqueue'),
             matlab_api_key=self.matlab_api_key
         )

--- a/xmodule/tests/__init__.py
+++ b/xmodule/tests/__init__.py
@@ -149,7 +149,6 @@ def get_test_system(
         return descriptor
 
     return TestModuleSystem(
-        static_url='/static',
         track_function=Mock(name='get_test_system.track_function'),
         get_module=get_module,
         services={

--- a/xmodule/x_module.py
+++ b/xmodule/x_module.py
@@ -1705,6 +1705,19 @@ class ModuleSystemShim:
         if rebind_user_service:
             return partial(rebind_user_service.rebind_noauth_module_to_user)
 
+    # noinspection PyPep8Naming
+    @property
+    def STATIC_URL(self):  # pylint: disable=invalid-name
+        """
+        Returns the base URL for static assets.
+        Deprecated in favor of the settings.STATIC_URL configuration.
+        """
+        warnings.warn(
+            'runtime.STATIC_URL is deprecated. Please use settings.STATIC_URL instead.',
+            DeprecationWarning, stacklevel=3,
+        )
+        return settings.STATIC_URL
+
 
 class ModuleSystem(MetricsMixin, ConfigurableFragmentWrapper, ModuleSystemShim, Runtime):
     """
@@ -1721,7 +1734,6 @@ class ModuleSystem(MetricsMixin, ConfigurableFragmentWrapper, ModuleSystemShim, 
 
     def __init__(
         self,
-        static_url,
         track_function,
         get_module,
         descriptor_runtime,
@@ -1731,8 +1743,6 @@ class ModuleSystem(MetricsMixin, ConfigurableFragmentWrapper, ModuleSystemShim, 
     ):
         """
         Create a closure around the system environment.
-
-        static_url - the base URL to static assets
 
         track_function - function of (event_type, event), intended for logging
                          or otherwise tracking the event.
@@ -1754,7 +1764,6 @@ class ModuleSystem(MetricsMixin, ConfigurableFragmentWrapper, ModuleSystemShim, 
         kwargs.setdefault('id_generator', getattr(descriptor_runtime, 'id_generator', AsideKeyGenerator()))
         super().__init__(**kwargs)
 
-        self.STATIC_URL = static_url
         self.track_function = track_function
         self.get_module = get_module
         self.course_id = course_id


### PR DESCRIPTION
## Description

As a part of the ModuleSystem removal, we want to get rid of its `static_url` attribute.

## Supporting information

Sandbox instance: https://pr30046.sandbox.opencraft.hosting/
Use `staff@example.com:edx` to log in.

## Testing instructions

1. This attribute was used only by the CAPA XBlock, so we can test this by checking that [the chemical equation problem](https://app.pr30046.sandbox.opencraft.hosting/learning/course/course-v1:edX+DemoX+Demo_Course/block-v1:edX+DemoX+Demo_Course+type@sequential+block@basic_questions/block-v1:edX+DemoX+Demo_Course+type@vertical+block@vertical_1fef54c2b23b) loads the `chemical_equation_preview.js`.

## Other information

Private-ref: [BB-5518](https://tasks.opencraft.com/browse/BB-5518)