### PR TITLE
feat: Send `modified` data of a learner's grade to the Credentials IDA

### DIFF
--- a/lms/djangoapps/grades/course_grade.py
+++ b/lms/djangoapps/grades/course_grade.py
@@ -22,7 +22,16 @@ class CourseGradeBase:
     """
     Base class for Course Grades.
     """
-    def __init__(self, user, course_data, percent=0.0, letter_grade=None, passed=False, force_update_subsections=False):
+    def __init__(
+        self,
+        user,
+        course_data,
+        percent=0.0,
+        letter_grade=None,
+        passed=False,
+        force_update_subsections=False,
+        last_updated=None
+    ):
         self.user = user
         self.course_data = course_data
 
@@ -32,6 +41,8 @@ class CourseGradeBase:
         # Convert empty strings to None when reading from the table
         self.letter_grade = letter_grade or None
         self.force_update_subsections = force_update_subsections
+
+        self.last_updated = last_updated
 
     def __str__(self):
         return 'Course Grade: percent: {}, letter_grade: {}, passed: {}'.format(

--- a/lms/djangoapps/grades/course_grade_factory.py
+++ b/lms/djangoapps/grades/course_grade_factory.py
@@ -143,7 +143,8 @@ class CourseGradeFactory:
             course_data,
             persistent_grade.percent_grade,
             persistent_grade.letter_grade,
-            persistent_grade.letter_grade != ''
+            persistent_grade.letter_grade != '',
+            last_updated=persistent_grade.modified
         )
 
     @staticmethod

--- a/lms/djangoapps/grades/tests/utils.py
+++ b/lms/djangoapps/grades/tests/utils.py
@@ -15,7 +15,7 @@ from xmodule.graders import ProblemScore  # lint-amnesty, pylint: disable=wrong-
 
 
 @contextmanager
-def mock_passing_grade(letter_grade='Pass', percent=0.75, ):
+def mock_passing_grade(letter_grade='Pass', percent=0.75, last_updated=None):
     """
     Mock the grading function to always return a passing grade.
     """
@@ -24,6 +24,7 @@ def mock_passing_grade(letter_grade='Pass', percent=0.75, ):
         percent=percent,
         passed=letter_grade is not None,
         attempted=True,
+        last_updated=last_updated,
     )
     with patch('lms.djangoapps.grades.course_grade_factory.CourseGradeFactory.read') as mock_grade_read:
         mock_grade_read.return_value = MagicMock(**passing_grade_fields)

--- a/openedx/core/djangoapps/credentials/tests/test_tasks.py
+++ b/openedx/core/djangoapps/credentials/tests/test_tasks.py
@@ -51,7 +51,16 @@ class TestSendGradeToCredentialTask(TestCase):
         api_client = mock.MagicMock()
         mock_get_api_client.return_value = api_client
 
-        tasks.send_grade_to_credentials.delay('user', 'course-v1:org+course+run', True, 'A', 1.0).get()
+        last_updated = datetime.now()
+
+        tasks.send_grade_to_credentials.delay(
+            'user',
+            'course-v1:org+course+run',
+            True,
+            'A',
+            1.0,
+            last_updated
+        ).get()
 
         assert mock_get_api_client.call_count == 1
         assert mock_get_api_client.call_args[0] == (self.user,)
@@ -63,6 +72,7 @@ class TestSendGradeToCredentialTask(TestCase):
             'letter_grade': 'A',
             'percent_grade': 1.0,
             'verified': True,
+            'lms_last_updated_at': last_updated.isoformat(),
         })
 
     def test_retry(self, mock_get_api_client):
@@ -71,7 +81,7 @@ class TestSendGradeToCredentialTask(TestCase):
         """
         mock_get_api_client.side_effect = boom
 
-        task = tasks.send_grade_to_credentials.delay('user', 'course-v1:org+course+run', True, 'A', 1.0)
+        task = tasks.send_grade_to_credentials.delay('user', 'course-v1:org+course+run', True, 'A', 1.0, None)
 
         pytest.raises(Exception, task.get)
         assert mock_get_api_client.call_count == (tasks.MAX_RETRIES + 1)
@@ -482,10 +492,13 @@ class TestSendGradeIfInteresting(TestCase):
                                       _mock_is_learner_issuance_enabled):
         mock_is_course_run_in_a_program.return_value = True
 
-        with mock_passing_grade('B', 0.81):
+        last_updated = datetime.now()
+        with mock_passing_grade('B', 0.81, last_updated):
             tasks.send_grade_if_interesting(self.user, self.key, 'verified', 'downloadable', None, None)
         assert mock_send_grade_to_credentials.delay.called
-        assert mock_send_grade_to_credentials.delay.call_args[0] == (self.user.username, str(self.key), True, 'B', 0.81)
+        assert mock_send_grade_to_credentials.delay.call_args[0] == (
+            self.user.username, str(self.key), True, 'B', 0.81, last_updated
+        )
         mock_send_grade_to_credentials.delay.reset_mock()
 
     def test_send_grade_without_issuance_enabled(self, _mock_is_course_run_in_a_program,


### PR DESCRIPTION
## Description

[APER-1968]

We don't have a good way to understand if grade data in Credentials is out of sync with the LMS. Grades are sent to Credentials via a REST API call originating from an asynchronous Celery task on the LMS side. This PR updates our Celery task `send_grade_to_credentials` to include sending the `modified` DateTime value of a grade record to the Credentials IDA. Updates will be made on the Credentials side to accept and store this data as part of the UserGrade instance.

* Updates the `send_grade_to_credentials` task to include passing the grade's `modified` DateTime info as part of the request data to Credentials
* Updates the `CourseGradeBase` class to include an optional `last_updated` field. This will store the `modified` date of a PersistentCourseGrade instance when a grade is read through the CourseGradeFactory.
* Update existing log statement to use format strings where possible.

Related Credentials PR: https://github.com/openedx/credentials/pull/1757

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
