### PR TITLE
fix: update cert requirements

### DIFF
--- a/lms/djangoapps/certificates/docs/decisions/001-allowlist-cert-requirements.rst
+++ b/lms/djangoapps/certificates/docs/decisions/001-allowlist-cert-requirements.rst
@@ -31,7 +31,7 @@ the time the certificate is generated:
   * The enrollment mode must be eligible for a certificate
   * The enrollment does not need to be active
 
-* The user must have an approved, unexpired, ID verification
 * The user must not have an invalidated certificate for the course run (see the *CertificateInvalidation* model)
 * HTML (web) certificates must be globally enabled, and also enabled for the course run
 * The user must be on the allowlist for the course run (see the *CertificateAllowlist* model)
+* If the `ENABLE_CERTIFICATES_IDV_REQUIREMENT` WaffleFlag is enabled, a user must have an approved and unexpired ID verification.

--- a/lms/djangoapps/certificates/docs/decisions/002-cert-requirements.rst
+++ b/lms/djangoapps/certificates/docs/decisions/002-cert-requirements.rst
@@ -24,9 +24,9 @@ be true at the time the certificate is generated:
   * The enrollment mode must be eligible for a certificate
   * The enrollment does not need to be active
 
-* The user must have an approved, unexpired, ID verification
 * The user must not have an invalidated certificate for the course run (see the *CertificateInvalidation* model)
 * HTML (web) certificates must be globally enabled, and also enabled for the course run
 * The user must have passed the course run
 * The user must not be a beta tester in the course run
 * The course run must not be a CCX (custom edX course)
+* If the `ENABLE_CERTIFICATES_IDV_REQUIREMENT` WaffleFlag is enabled, a user must have an approved and unexpired ID verification.


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This pull request updates two ADRs that define requirements a learner must meet to receive a certificate. We no longer require learners to have an unexpired and approved ID verification. We are supporting [Name Affirmation](https://github.com/edx/edx-name-affirmation) to verify which name a user would like on their certificate. ID verification can still be enabled through a WaffleFlag.

JIRA: https://2u-internal.atlassian.net/browse/APER-1969