### PR TITLE
feat: add related program info to unfulfilled entitlements

### DIFF
--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -467,9 +467,7 @@ class UnfulfilledEntitlementSerializer(serializers.Serializer):
     entitlement = EntitlementSerializer(source="*")
     course = serializers.SerializerMethodField()
     courseProvider = serializers.SerializerMethodField()
-
-    # Change after data is implemented. This data is required
-    programs = ProgramsSerializer(allow_null=True)
+    programs = serializers.SerializerMethodField()
 
     # These fields are literal values that do not change
     courseRun = LiteralField(None)
@@ -499,6 +497,13 @@ class UnfulfilledEntitlementSerializer(serializers.Serializer):
             )
 
         return CourseProviderSerializer(course_overview, allow_null=True).data
+
+    def get_programs(self, instance):
+        """
+        If this entitlement is part of a program, include information about the program and related programs
+        """
+        programs = self.context['programs'].get(str(instance.course_uuid), [])
+        return ProgramsSerializer({"relatedPrograms": programs}, context=self.context).data
 
 
 class SuggestedCourseSerializer(serializers.Serializer):

--- a/lms/djangoapps/learner_home/views.py
+++ b/lms/djangoapps/learner_home/views.py
@@ -246,7 +246,7 @@ def get_course_programs(user, course_enrollments, site):
         }
     }
     """
-    meter = ProgramProgressMeter(site, user, enrollments=course_enrollments)
+    meter = ProgramProgressMeter(site, user, enrollments=course_enrollments, include_course_entitlements=True)
     return meter.invert_programs()
 
 


### PR DESCRIPTION
We missed program info in unfulfilled entitlements. Thankfully, the data was already there and I just had to add the serializer methods and tests