### PR TITLE
fix: Youtube has highest default stream priority

### DIFF
--- a/lms/djangoapps/course_api/blocks/transformers/video_stream_priority.py
+++ b/lms/djangoapps/course_api/blocks/transformers/video_stream_priority.py
@@ -13,14 +13,15 @@ class VideoBlockStreamPriorityTransformer(BlockStructureTransformer):
     Transformer to add stream priority for encoded_videos.
 
     If DEPRECATE_YOUTUBE waffle flag is on for a course, Youtube videos
-    have highest priority i.e. 0. Else, the default priority for videos
+    have lowest priority. Else, the default priority for videos
     is as shown in DEFAULT_VIDEO_STREAM_PRIORITY below.
+    With 0 being the highest stream priority.
     In case video_format not found in given, set stream_priority to -1.
     """
 
     WRITE_VERSION = 1
     READ_VERSION = 1
-    DEFAULT_VIDEO_STREAM_PRIORITY = {
+    DEPRECATE_YOUTUBE_VIDEO_STREAM_PRIORITY = {
         'hls': 0,
         'mobile_low': 1,
         'mobile_high': 2,
@@ -29,7 +30,7 @@ class VideoBlockStreamPriorityTransformer(BlockStructureTransformer):
         'fallback': 5,
         'youtube': 6,
     }
-    DEPRECATE_YOUTUBE_VIDEO_STREAM_PRIORITY = {
+    DEFAULT_VIDEO_STREAM_PRIORITY = {
         'youtube': 0,
         'hls': 1,
         'mobile_low': 2,


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/openedx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

For encoded videos in course blocks, videos with format 'youtube' have the highest priority on prod right now by default. This is a change to reflect that in code.
By default youtube will have the highest stream priority. If the course flag `videos.deprecate_youtube` is forced on for a course, youtube will have the lowest stream priority.

## Supporting information

Jira ticket: [LEARNER-9051](https://2u-internal.atlassian.net/browse/LEARNER-9051)
Related PR: https://github.com/openedx/edx-platform/pull/30767

## Testing instructions

- Create a token via Postman: {{domain}}/oauth2/access_token/
- Fetch blocks via api: {{domain}}/api/courses/v2/blocks/?depth=all&requested_fields=graded,format,student_view_multi_device,due&student_view_data=video,discussion&block_counts=video&nav_depth=3&username=edx&course_id=course-v1%3AedX%2BDemoX%2BDemo_Course

## Deadline

September 30th, 2022

## Other information
None