### PR TITLE
feat: show exam info in course outline

### DIFF
--- a/lms/djangoapps/course_api/blocks/transformers/milestones.py
+++ b/lms/djangoapps/course_api/blocks/transformers/milestones.py
@@ -6,12 +6,14 @@ Milestones Transformer
 import logging
 
 from django.conf import settings
+from django.utils.translation import gettext as _
 from edx_proctoring.api import get_attempt_status_summary
 from edx_proctoring.exceptions import ProctoredExamNotFoundException
 
 from common.djangoapps.student.models import EntranceExamConfiguration
 from common.djangoapps.util import milestones_helpers
 from openedx.core.djangoapps.content.block_structure.transformer import BlockStructureTransformer
+from openedx.core.djangoapps.course_apps.toggles import exams_ida_enabled
 
 log = logging.getLogger(__name__)
 
@@ -113,17 +115,14 @@ class MilestonesAndSpecialExamsTransformer(BlockStructureTransformer):
         """
         For special exams, add the special exam information to the course blocks.
         """
-        special_exam_attempt_context = None
-        try:
-            # Calls into edx_proctoring subsystem to get relevant special exam information.
-            # This will return None, if (user, course_id, content_id) is not applicable.
-            special_exam_attempt_context = get_attempt_status_summary(
-                usage_info.user.id,
-                str(block_key.course_key),
-                str(block_key)
-            )
-        except ProctoredExamNotFoundException as ex:
-            log.exception(ex)
+        special_exam_attempt_context = self._generate_special_exam_attempt_context(
+            block_structure.get_xblock_field(block_key, 'is_practice_exam'),
+            block_structure.get_xblock_field(block_key, 'is_proctored_enabled'),
+            block_structure.get_xblock_field(block_key, 'is_timed_exam'),
+            usage_info.user.id,
+            block_key.course_key,
+            str(block_key)
+        )
 
         if special_exam_attempt_context:
             # This user has special exam context for this block so add it.
@@ -172,3 +171,43 @@ class MilestonesAndSpecialExamsTransformer(BlockStructureTransformer):
             return True
 
         return False
+
+    def _generate_special_exam_attempt_context(self, is_practice_exam, is_proctored_enabled,
+                                               is_timed_exam, user_id, course_key, block_key):
+        """
+        Helper method which generates the special exam attempt context.
+        Either calls into proctoring or, if exams ida waffle flag on, then get internally.
+        Note: This method duplicates the method by the same name in:
+        openedx/core/djangoapps/content/learning_sequences/api/processors/special_exams.py
+        For now, both methods exist to avoid importing from different directories. In the future,
+        we could potentially consolidate if there is a good common place to implement.
+        """
+        special_exam_attempt_context = None
+
+        # if exams waffle flag enabled, get exam type internally
+        if exams_ida_enabled(course_key):
+            # add short description based on exam type
+            if is_practice_exam:
+                exam_type = _('Practice Exam')
+            elif is_proctored_enabled:
+                exam_type = _('Proctored Exam')
+            elif is_timed_exam:
+                exam_type = _('Timed Exam')
+            else:  # sets a default, though considered impossible
+                log.info('Using default Exam value for exam type.')
+                exam_type = _('Exam')
+
+            summary = {'short_description': exam_type, }
+            special_exam_attempt_context = summary
+        else:
+            try:
+                # Calls into edx_proctoring subsystem to get relevant special exam information.
+                special_exam_attempt_context = get_attempt_status_summary(
+                    user_id,
+                    str(course_key),
+                    block_key
+                )
+            except ProctoredExamNotFoundException as ex:
+                log.exception(ex)
+
+        return special_exam_attempt_context

--- a/openedx/core/djangoapps/content/learning_sequences/api/processors/special_exams.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/processors/special_exams.py
@@ -16,9 +16,12 @@ from edx_proctoring.api import get_attempt_status_summary
 from edx_proctoring.exceptions import ProctoredExamNotFoundException
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.utils.translation import gettext as _
 
 from ...data import SpecialExamAttemptData, UserCourseOutlineData
 from .base import OutlineProcessor
+from openedx.core.djangoapps.course_apps.toggles import exams_ida_enabled
+
 
 User = get_user_model()
 log = logging.getLogger(__name__)
@@ -53,22 +56,14 @@ class SpecialExamsOutlineProcessor(OutlineProcessor):
                     if not bool(sequence.exam):
                         continue
 
-                    special_exam_attempt_context = None
-                    try:
-                        # Calls into edx_proctoring subsystem to get relevant special exam information.
-                        # This will return None, if (user, course_id, content_id) is not applicable.
-                        special_exam_attempt_context = get_attempt_status_summary(
-                            self.user.id,
-                            str(self.course_key),
-                            str(sequence.usage_key)
-                        )
-                    except ProctoredExamNotFoundException:
-                        log.info(
-                            'No exam found for {sequence_key} in {course_key}'.format(
-                                sequence_key=sequence.usage_key,
-                                course_key=self.course_key
-                            )
-                        )
+                    special_exam_attempt_context = self._generate_special_exam_attempt_context(
+                        sequence.exam.is_practice_exam,
+                        sequence.exam.is_proctored_enabled,
+                        sequence.exam.is_time_limited,
+                        self.user.id,
+                        self.course_key,
+                        str(sequence.usage_key)
+                    )
 
                     if special_exam_attempt_context:
                         # Return exactly the same format as the edx_proctoring API response
@@ -77,3 +72,39 @@ class SpecialExamsOutlineProcessor(OutlineProcessor):
         return SpecialExamAttemptData(
             sequences=sequences,
         )
+
+    def _generate_special_exam_attempt_context(self, is_practice_exam, is_proctored_enabled,
+                                               is_timed_exam, user_id, course_key, block_key):
+        """
+        Helper method which generates the special exam attempt context.
+        Either calls into proctoring or, if exams ida waffle flag on, then get internally.
+        """
+        special_exam_attempt_context = None
+
+        # if exams waffle flag enabled, get exam type internally
+        if exams_ida_enabled(course_key):
+            # add short description based on exam type
+            if is_practice_exam:
+                exam_type = _('Practice Exam')
+            elif is_proctored_enabled:
+                exam_type = _('Proctored Exam')
+            elif is_timed_exam:
+                exam_type = _('Timed Exam')
+            else:  # sets a default, though considered impossible
+                log.info('Using default Exam value for exam type.')
+                exam_type = _('Exam')
+
+            summary = {'short_description': exam_type, }
+            special_exam_attempt_context = summary
+        else:
+            try:
+                # Calls into edx_proctoring subsystem to get relevant special exam information.
+                special_exam_attempt_context = get_attempt_status_summary(
+                    user_id,
+                    str(course_key),
+                    block_key
+                )
+            except ProctoredExamNotFoundException as ex:
+                log.exception(ex)
+
+        return special_exam_attempt_context


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/openedx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This pull request includes the changes for [MST-1528](https://2u-internal.atlassian.net/browse/MST-1528). 

Which edX user roles will this change impact? "Learner"

## Supporting information

From the JIRA Ticket:
"The course outline currently displays info about what type of exam, the due date, and certain attempt statuses. This relies on the edx-proctoring api to build this string because it depends on attempt status and not just the exam type.

We should update this to just show messages based on the type of exam and it’s due date when the edx-exams waffle flag is enabled. This is all information the platform already has without needing a call to proctoring/exams."

Context on  code duplication:
The helper method `_generate_special_exam_attempt_context` is used in both `milestones.py` and `special_exams.py` (both implemented the same way). Originally, I was going to refactor such that the method can be implemented in one place and used in both classes. The problem is that both classes are in completely different places (openedx and lms), which could create issues in the future. After discussion with others on the team, there isn't a great place to keep this function/helper method. So I decided to implement both the same way for now and in the future this could be consolidated if there is a good place for it. It seems like there is already similarly duplicated code between these two areas.

## Testing instructions

To enable the Exams waffle flag:
1. Go to LMS django admin for waffle flags at /admin/waffle/flag.
2. Create new waffle flag with name, `course_apps.exams_ida`.
3. Set everyone to be yes.

To test that exam is updated:
1. Go to course
2. (Create exam in studio with special exams enabled)
3. Description should match with exam type and due date.

## Other information

This update makes changes in two places that edx-proctoring is called into, but only milestones.py is currently being used/impacting the frontend. We could potentially break out the special exams piece into a separate ticket.
