### PR TITLE
revert: Optimize and reorganize GitHub-hosted dependencies

### DIFF
--- a/requirements/edx-sandbox/py38.txt
+++ b/requirements/edx-sandbox/py38.txt
@@ -18,7 +18,7 @@ cryptography==38.0.1
     # via -r requirements/edx-sandbox/py38.in
 cycler==0.11.0
     # via matplotlib
-joblib==1.2.0
+joblib==1.1.0
     # via nltk
 kiwisolver==1.4.4
     # via matplotlib

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -6,7 +6,7 @@
 #
 -e git+https://github.com/openedx/blockstore.git@1.2.1#egg=blockstore==1.2.1
     # via -r requirements/edx/github.in
--e .
+-e file:///home/runner/work/edx-platform/edx-platform
     # via -r requirements/edx/local.in
 acid-xblock==0.2.1
     # via -r requirements/edx/base.in

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -6,8 +6,18 @@
 #
 -e git+https://github.com/openedx/blockstore.git@1.2.1#egg=blockstore==1.2.1
     # via -r requirements/edx/github.in
--e file:///home/runner/work/edx-platform/edx-platform
+-e git+https://github.com/openedx/codejail.git@3.1.3#egg=codejail==3.1.3
+    # via -r requirements/edx/github.in
+-e git+https://github.com/openedx/django-wiki.git@1.1.1#egg=django-wiki
+    # via -r requirements/edx/github.in
+-e git+https://github.com/openedx/olxcleaner.git@2f0d6c7f126cbd69c9724b7b57a0b2565330a297#egg=olxcleaner
+    # via -r requirements/edx/github.in
+-e .
     # via -r requirements/edx/local.in
+-e git+https://github.com/openedx/RateXBlock.git@2.0.1#egg=rate-xblock
+    # via -r requirements/edx/github.in
+-e git+https://github.com/openedx/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive
+    # via -r requirements/edx/github.in
 acid-xblock==0.2.1
     # via -r requirements/edx/base.in
 aiohttp==3.8.1
@@ -86,7 +96,7 @@ celery==5.2.7
     #   edx-celeryutils
     #   edx-enterprise
     #   event-tracking
-certifi==2022.9.14
+certifi==2022.6.15.1
     # via
     #   -r requirements/edx/paver.txt
     #   elasticsearch
@@ -130,8 +140,6 @@ code-annotations==1.3.0
     # via
     #   edx-enterprise
     #   edx-toggles
-codejail @ git+https://github.com/openedx/codejail.git@3.1.3
-    # via -r requirements/edx/github.in
 codejail-includes==1.0.0
     # via -r requirements/edx/base.in
 contextlib2==21.6.0
@@ -334,7 +342,7 @@ django-pyfs==3.2.0
     # via -r requirements/edx/base.in
 django-ratelimit==3.0.1
     # via -r requirements/edx/base.in
-django-require @ git+https://github.com/openedx/django-require.git@f4f01e4e959adc6210873ae99e7f2c3741afbf35
+django-require @ git+https://github.com/openedx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776
     # via -r requirements/edx/github.in
 django-sekizai==4.0.0
     # via
@@ -377,8 +385,6 @@ django-webpack-loader==0.7.0
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   edx-proctoring
-django-wiki @ git+https://github.com/openedx/django-wiki.git@1.1.1
-    # via -r requirements/edx/github.in
 djangorestframework==3.12.4
     # via
     #   -r requirements/edx/base.in
@@ -601,7 +607,7 @@ html5lib==1.1
     #   ora2
 icalendar==4.1.0
     # via -r requirements/edx/base.in
-idna==3.4
+idna==3.3
     # via
     #   -r requirements/edx/paver.txt
     #   optimizely-sdk
@@ -630,7 +636,7 @@ jmespath==0.10.0
     # via
     #   boto3
     #   botocore
-joblib==1.2.0
+joblib==1.1.0
     # via nltk
 jsondiff==2.0.0
     # via edx-enterprise
@@ -647,13 +653,13 @@ jsonfield==3.1.0
     #   outcome-surveys
 jsonschema==4.16.0
     # via optimizely-sdk
-jwcrypto==1.4.2
+jwcrypto==1.3.1
     # via pylti1p3
 kombu==5.2.4
     # via celery
 laboratory==1.0.2
     # via -r requirements/edx/base.in
-lazy==1.5
+lazy==1.4
     # via
     #   -r requirements/edx/paver.txt
     #   acid-xblock
@@ -753,8 +759,6 @@ oauthlib==3.0.1
     #   lti-consumer-xblock
     #   requests-oauthlib
     #   social-auth-core
-olxcleaner @ git+https://github.com/openedx/olxcleaner.git@2f0d6c7f126cbd69c9724b7b57a0b2565330a297
-    # via -r requirements/edx/github.in
 openedx-calc==3.0.1
     # via -r requirements/edx/base.in
 openedx-events==0.12.0
@@ -840,7 +844,7 @@ pyjwkest==1.4.2
     #   -r requirements/edx/base.in
     #   edx-drf-extensions
     #   lti-consumer-xblock
-pyjwt[crypto]==2.5.0
+pyjwt[crypto]==2.4.0
     # via
     #   -r requirements/edx/base.in
     #   drf-jwt
@@ -853,7 +857,7 @@ pyjwt[crypto]==2.5.0
     #   social-auth-core
 pylatexenc==2.10
     # via olxcleaner
-pylti1p3==1.12.1
+pylti1p3==1.12.0
     # via -r requirements/edx/base.in
 pymongo==3.12.3
     # via
@@ -948,8 +952,6 @@ pyyaml==6.0
     #   xblock
 random2==1.0.1
     # via -r requirements/edx/base.in
-rate-xblock @ git+https://github.com/openedx/RateXBlock.git@2.0.1
-    # via -r requirements/edx/github.in
 recommender-xblock==2.0.1
     # via -r requirements/edx/base.in
 redis==4.3.4
@@ -1099,8 +1101,6 @@ tinycss2==1.1.1
     # via bleach
 tqdm==4.64.1
     # via nltk
-types-cryptography==3.3.23
-    # via pyjwt
 typing-extensions==4.3.0
     # via
     #   django-countries
@@ -1174,8 +1174,6 @@ xblock==1.6.1
     #   xblock-poll
     #   xblock-utils
 xblock-drag-and-drop-v2 @ git+https://github.com/openedx/xblock-drag-and-drop-v2@v2.3.5
-    # via -r requirements/edx/github.in
-xblock-google-drive @ git+https://github.com/openedx/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6
     # via -r requirements/edx/github.in
 xblock-poll @ git+https://github.com/open-craft/xblock-poll@v1.12.0
     # via -r requirements/edx/github.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -6,7 +6,17 @@
 #
 -e git+https://github.com/openedx/blockstore.git@1.2.1#egg=blockstore==1.2.1
     # via -r requirements/edx/testing.txt
--e file:///home/runner/work/edx-platform/edx-platform
+-e git+https://github.com/openedx/codejail.git@3.1.3#egg=codejail==3.1.3
+    # via -r requirements/edx/testing.txt
+-e git+https://github.com/openedx/django-wiki.git@1.1.1#egg=django-wiki
+    # via -r requirements/edx/testing.txt
+-e git+https://github.com/openedx/olxcleaner.git@2f0d6c7f126cbd69c9724b7b57a0b2565330a297#egg=olxcleaner
+    # via -r requirements/edx/testing.txt
+-e .
+    # via -r requirements/edx/testing.txt
+-e git+https://github.com/openedx/RateXBlock.git@2.0.1#egg=rate-xblock
+    # via -r requirements/edx/testing.txt
+-e git+https://github.com/openedx/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive
     # via -r requirements/edx/testing.txt
 acid-xblock==0.2.1
     # via -r requirements/edx/testing.txt
@@ -125,7 +135,7 @@ celery==5.2.7
     #   edx-celeryutils
     #   edx-enterprise
     #   event-tracking
-certifi==2022.9.14
+certifi==2022.6.15.1
     # via
     #   -r requirements/edx/testing.txt
     #   elasticsearch
@@ -193,8 +203,6 @@ code-annotations==1.3.0
     #   edx-enterprise
     #   edx-lint
     #   edx-toggles
-codejail @ git+https://github.com/openedx/codejail.git@3.1.3
-    # via -r requirements/edx/testing.txt
 codejail-includes==1.0.0
     # via -r requirements/edx/testing.txt
 contextlib2==21.6.0
@@ -437,7 +445,7 @@ django-pyfs==3.2.0
     # via -r requirements/edx/testing.txt
 django-ratelimit==3.0.1
     # via -r requirements/edx/testing.txt
-django-require @ git+https://github.com/openedx/django-require.git@f4f01e4e959adc6210873ae99e7f2c3741afbf35
+django-require @ git+https://github.com/openedx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776
     # via -r requirements/edx/testing.txt
 django-sekizai==4.0.0
     # via
@@ -480,8 +488,6 @@ django-webpack-loader==0.7.0
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   edx-proctoring
-django-wiki @ git+https://github.com/openedx/django-wiki.git@1.1.1
-    # via -r requirements/edx/testing.txt
 djangorestframework==3.12.4
     # via
     #   -r requirements/edx/testing.txt
@@ -601,7 +607,7 @@ edx-i18n-tools==0.9.1
     # via
     #   -r requirements/edx/testing.txt
     #   ora2
-edx-lint==5.3.0
+edx-lint==5.2.5
     # via -r requirements/edx/testing.txt
 edx-milestones==0.4.0
     # via -r requirements/edx/testing.txt
@@ -701,7 +707,7 @@ faker==14.2.0
     # via
     #   -r requirements/edx/testing.txt
     #   factory-boy
-fastapi==0.85.0
+fastapi==0.83.0
     # via
     #   -r requirements/edx/testing.txt
     #   pact-python
@@ -757,7 +763,7 @@ httpretty==1.1.4
     # via -r requirements/edx/testing.txt
 icalendar==4.1.0
     # via -r requirements/edx/testing.txt
-idna==3.4
+idna==3.3
     # via
     #   -r requirements/edx/testing.txt
     #   anyio
@@ -815,7 +821,7 @@ jmespath==0.10.0
     #   -r requirements/edx/testing.txt
     #   boto3
     #   botocore
-joblib==1.2.0
+joblib==1.1.0
     # via
     #   -r requirements/edx/testing.txt
     #   nltk
@@ -839,7 +845,7 @@ jsonschema==4.16.0
     #   -r requirements/edx/testing.txt
     #   optimizely-sdk
     #   sphinxcontrib-openapi
-jwcrypto==1.4.2
+jwcrypto==1.3.1
     # via
     #   -r requirements/edx/testing.txt
     #   pylti1p3
@@ -849,7 +855,7 @@ kombu==5.2.4
     #   celery
 laboratory==1.0.2
     # via -r requirements/edx/testing.txt
-lazy==1.5
+lazy==1.4
     # via
     #   -r requirements/edx/testing.txt
     #   acid-xblock
@@ -980,8 +986,6 @@ oauthlib==3.0.1
     #   lti-consumer-xblock
     #   requests-oauthlib
     #   social-auth-core
-olxcleaner @ git+https://github.com/openedx/olxcleaner.git@2f0d6c7f126cbd69c9724b7b57a0b2565330a297
-    # via -r requirements/edx/testing.txt
 openedx-calc==3.0.1
     # via -r requirements/edx/testing.txt
 openedx-events==0.12.0
@@ -1124,7 +1128,7 @@ pyjwkest==1.4.2
     #   -r requirements/edx/testing.txt
     #   edx-drf-extensions
     #   lti-consumer-xblock
-pyjwt[crypto]==2.5.0
+pyjwt[crypto]==2.4.0
     # via
     #   -r requirements/edx/testing.txt
     #   drf-jwt
@@ -1163,7 +1167,7 @@ pylint-plugin-utils==0.7
     #   pylint-django
 pylint-pytest==0.3.0
     # via -r requirements/edx/testing.txt
-pylti1p3==1.12.1
+pylti1p3==1.12.0
     # via -r requirements/edx/testing.txt
 pymongo==3.12.3
     # via
@@ -1305,8 +1309,6 @@ pyyaml==6.0
     #   sphinxcontrib-openapi
     #   xblock
 random2==1.0.1
-    # via -r requirements/edx/testing.txt
-rate-xblock @ git+https://github.com/openedx/RateXBlock.git@2.0.1
     # via -r requirements/edx/testing.txt
 recommender-xblock==2.0.1
     # via -r requirements/edx/testing.txt
@@ -1492,7 +1494,7 @@ sqlparse==0.4.2
     #   django-debug-toolbar
 staff-graded-xblock==2.0.1
     # via -r requirements/edx/testing.txt
-starlette==0.20.4
+starlette==0.19.1
     # via
     #   -r requirements/edx/testing.txt
     #   fastapi
@@ -1551,10 +1553,6 @@ tqdm==4.64.1
     # via
     #   -r requirements/edx/testing.txt
     #   nltk
-types-cryptography==3.3.23
-    # via
-    #   -r requirements/edx/testing.txt
-    #   pyjwt
 typing-extensions==4.3.0
     # via
     #   -r requirements/edx/testing.txt
@@ -1606,7 +1604,7 @@ voluptuous==0.13.1
     # via
     #   -r requirements/edx/testing.txt
     #   ora2
-vulture==2.6
+vulture==2.5
     # via -r requirements/edx/development.in
 watchdog==2.1.9
     # via -r requirements/edx/testing.txt
@@ -1660,8 +1658,6 @@ xblock==1.6.1
     #   xblock-poll
     #   xblock-utils
 xblock-drag-and-drop-v2 @ git+https://github.com/openedx/xblock-drag-and-drop-v2@v2.3.5
-    # via -r requirements/edx/testing.txt
-xblock-google-drive @ git+https://github.com/openedx/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6
     # via -r requirements/edx/testing.txt
 xblock-poll @ git+https://github.com/open-craft/xblock-poll@v1.12.0
     # via -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -6,7 +6,7 @@
 #
 -e git+https://github.com/openedx/blockstore.git@1.2.1#egg=blockstore==1.2.1
     # via -r requirements/edx/testing.txt
--e .
+-e file:///home/runner/work/edx-platform/edx-platform
     # via -r requirements/edx/testing.txt
 acid-xblock==0.2.1
     # via -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -8,7 +8,7 @@ alabaster==0.7.12
     # via sphinx
 babel==2.10.3
     # via sphinx
-certifi==2022.9.14
+certifi==2022.6.15.1
     # via requests
 charset-normalizer==2.0.12
     # via
@@ -30,7 +30,7 @@ gitdb==4.0.9
     # via gitpython
 gitpython==3.1.27
     # via -r requirements/edx/doc.in
-idna==3.4
+idna==3.3
     # via requests
 imagesize==1.4.1
     # via sphinx

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -63,13 +63,25 @@
 #     re-install the package each time, and can be useful when working with two
 #     repos before picking a version number. Don't use 0.0 on master, only for
 #     tight-loop work in progress.
+
+
+# Python libraries to install directly from github
+
+# Third-party:
 -e git+https://github.com/openedx/django-wiki.git@1.1.1#egg=django-wiki
 -e git+https://github.com/openedx/olxcleaner.git@2f0d6c7f126cbd69c9724b7b57a0b2565330a297#egg=olxcleaner
 git+https://github.com/openedx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2
+
+# original repo is not maintained any more.
 git+https://github.com/openedx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776#egg=django-require==1.0.12
+
+# Our libraries:
 -e git+https://github.com/openedx/blockstore.git@1.2.1#egg=blockstore==1.2.1  # Note: Blockstore 1.2.2 is failing.
 -e git+https://github.com/openedx/codejail.git@3.1.3#egg=codejail==3.1.3
 -e git+https://github.com/openedx/RateXBlock.git@2.0.1#egg=rate-xblock
 -e git+https://github.com/openedx/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive
+
+# Third Party XBlocks
+
 git+https://github.com/open-craft/xblock-poll@v1.12.0#egg=xblock-poll==1.12.0
 git+https://github.com/openedx/xblock-drag-and-drop-v2@v2.3.5#egg=xblock-drag-and-drop-v2==2.3.5

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -65,19 +65,13 @@
 #     tight-loop work in progress.
 #
 #   * Alphabetize dependencies by DIST-NAME.
-#git+https://github.com/openedx/blockstore.git@1.2.5#egg=blockstore==1.2.5  # See blockstore comment below.
-git+https://github.com/openedx/codejail.git@3.1.3#egg=codejail==3.1.3
-git+https://github.com/openedx/django-require.git@f4f01e4e959adc6210873ae99e7f2c3741afbf35#egg=django-require==1.0.12
-git+https://github.com/openedx/django-wiki.git@1.1.1#egg=django-wiki
+-e git+https://github.com/openedx/blockstore.git@1.2.1#egg=blockstore==1.2.1  # Note: Blockstore 1.2.2 is failing.
+-e git+https://github.com/openedx/codejail.git@3.1.3#egg=codejail==3.1.3
+git+https://github.com/openedx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776#egg=django-require==1.0.12
+-e git+https://github.com/openedx/django-wiki.git@1.1.1#egg=django-wiki
 git+https://github.com/openedx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2
-git+https://github.com/openedx/olxcleaner.git@2f0d6c7f126cbd69c9724b7b57a0b2565330a297#egg=olxcleaner
-git+https://github.com/openedx/RateXBlock.git@2.0.1#egg=rate-xblock
+-e git+https://github.com/openedx/olxcleaner.git@2f0d6c7f126cbd69c9724b7b57a0b2565330a297#egg=olxcleaner
+-e git+https://github.com/openedx/RateXBlock.git@2.0.1#egg=rate-xblock
 git+https://github.com/openedx/xblock-drag-and-drop-v2@v2.3.5#egg=xblock-drag-and-drop-v2==2.3.5
-git+https://github.com/openedx/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive
+-e git+https://github.com/openedx/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive
 git+https://github.com/open-craft/xblock-poll@v1.12.0#egg=xblock-poll==1.12.0
-
-# This will be converted to the correct format (git+https://...) soon.
-# We must upgrade to blockstore>=1.2.5 in order to use the correct format, though,
-# which is in progress.
-# Relevant PR: https://github.com/openedx/edx-platform/pull/30620
--e git+https://github.com/openedx/blockstore.git@1.2.1#egg=blockstore==1.2.1

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -63,15 +63,13 @@
 #     re-install the package each time, and can be useful when working with two
 #     repos before picking a version number. Don't use 0.0 on master, only for
 #     tight-loop work in progress.
-#
-#   * Alphabetize dependencies by DIST-NAME.
+-e git+https://github.com/openedx/django-wiki.git@1.1.1#egg=django-wiki
+-e git+https://github.com/openedx/olxcleaner.git@2f0d6c7f126cbd69c9724b7b57a0b2565330a297#egg=olxcleaner
+git+https://github.com/openedx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2
+git+https://github.com/openedx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776#egg=django-require==1.0.12
 -e git+https://github.com/openedx/blockstore.git@1.2.1#egg=blockstore==1.2.1  # Note: Blockstore 1.2.2 is failing.
 -e git+https://github.com/openedx/codejail.git@3.1.3#egg=codejail==3.1.3
-git+https://github.com/openedx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776#egg=django-require==1.0.12
--e git+https://github.com/openedx/django-wiki.git@1.1.1#egg=django-wiki
-git+https://github.com/openedx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2
--e git+https://github.com/openedx/olxcleaner.git@2f0d6c7f126cbd69c9724b7b57a0b2565330a297#egg=olxcleaner
 -e git+https://github.com/openedx/RateXBlock.git@2.0.1#egg=rate-xblock
-git+https://github.com/openedx/xblock-drag-and-drop-v2@v2.3.5#egg=xblock-drag-and-drop-v2==2.3.5
 -e git+https://github.com/openedx/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive
 git+https://github.com/open-craft/xblock-poll@v1.12.0#egg=xblock-poll==1.12.0
+git+https://github.com/openedx/xblock-drag-and-drop-v2@v2.3.5#egg=xblock-drag-and-drop-v2==2.3.5

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -1,29 +1,15 @@
-# This file holds all GitHub-hosted edx-platform Python dependencies.
-# Such dependencies should be added here, not to base.in.
-# That being said....
+# DON'T JUST ADD NEW DEPENDENCIES!!!
 #
-# ---->>> DON'T JUST ADD NEW DEPENDENCIES!!! <<<----
-#
-# We are working to move all dependencies here to proper PyPI-hosted
-# projects that can be specified in base.in (or development.in, etc).
-# Every new GitHub-hosted dependency slows down the edx-platform build and
-# subverts our continuous dependency upgrade process. This file should
-# only be added to in exceptional circumstances.
-#
-# "I don't have time to publish my package to PyPI" is **not** an
-# acceptable excuse. You can add a GitHub Action workflow to automatically
-# upload your package to PyPI with the push of a button:
-#
-# * Go to https://github.com/openedx/<YOUR_REPO>/actions/new
-# * Find "Publish Python Package"
-# * Merge the generated PR and push package.
-# * You're done! Add your dependency to base.in, and the requirements
-#   bot will automatically keep it fresh in edx-platform.
-#
-# If you must open a pull request that adds a new git dependency, you should:
+# If you open a pull request that adds a new dependency, you should:
 #   * verify that the dependency has a license compatible with AGPLv3
 #   * confirm that it has no system requirements beyond what we already install
 #   * run "make upgrade" to update the detailed requirements files
+#
+# Do *NOT* install Python packages from GitHub unless it's absolutely necessary!
+# "I don't have time to add automatic Travis upload to PyPI." is *not* an
+# acceptable excuse. Non-wheel module installations slow down the dev/building process.
+# Travis/PyPI instructions are here:
+# https://openedx.atlassian.net/wiki/spaces/OpenOPS/pages/41911049/Publishing+a+Package+to+PyPI+using+Travis
 #
 # A correct GitHub reference looks like this:
 #

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-certifi==2022.9.14
+certifi==2022.6.15.1
     # via requests
 charset-normalizer==2.0.12
     # via
@@ -12,9 +12,9 @@ charset-normalizer==2.0.12
     #   requests
 edx-opaque-keys==2.3.0
     # via -r requirements/edx/paver.in
-idna==3.4
+idna==3.3
     # via requests
-lazy==1.5
+lazy==1.4
     # via -r requirements/edx/paver.in
 libsass==0.10.0
     # via -r requirements/edx/paver.in

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -6,7 +6,7 @@
 #
 -e git+https://github.com/openedx/blockstore.git@1.2.1#egg=blockstore==1.2.1
     # via -r requirements/edx/base.txt
--e .
+-e file:///home/runner/work/edx-platform/edx-platform
     # via -r requirements/edx/base.txt
 acid-xblock==0.2.1
     # via -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -6,7 +6,17 @@
 #
 -e git+https://github.com/openedx/blockstore.git@1.2.1#egg=blockstore==1.2.1
     # via -r requirements/edx/base.txt
--e file:///home/runner/work/edx-platform/edx-platform
+-e git+https://github.com/openedx/codejail.git@3.1.3#egg=codejail==3.1.3
+    # via -r requirements/edx/base.txt
+-e git+https://github.com/openedx/django-wiki.git@1.1.1#egg=django-wiki
+    # via -r requirements/edx/base.txt
+-e git+https://github.com/openedx/olxcleaner.git@2f0d6c7f126cbd69c9724b7b57a0b2565330a297#egg=olxcleaner
+    # via -r requirements/edx/base.txt
+-e .
+    # via -r requirements/edx/base.txt
+-e git+https://github.com/openedx/RateXBlock.git@2.0.1#egg=rate-xblock
+    # via -r requirements/edx/base.txt
+-e git+https://github.com/openedx/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive
     # via -r requirements/edx/base.txt
 acid-xblock==0.2.1
     # via -r requirements/edx/base.txt
@@ -117,7 +127,7 @@ celery==5.2.7
     #   edx-celeryutils
     #   edx-enterprise
     #   event-tracking
-certifi==2022.9.14
+certifi==2022.6.15.1
     # via
     #   -r requirements/edx/base.txt
     #   elasticsearch
@@ -182,8 +192,6 @@ code-annotations==1.3.0
     #   edx-enterprise
     #   edx-lint
     #   edx-toggles
-codejail @ git+https://github.com/openedx/codejail.git@3.1.3
-    # via -r requirements/edx/base.txt
 codejail-includes==1.0.0
     # via -r requirements/edx/base.txt
 contextlib2==21.6.0
@@ -419,7 +427,7 @@ django-pyfs==3.2.0
     # via -r requirements/edx/base.txt
 django-ratelimit==3.0.1
     # via -r requirements/edx/base.txt
-django-require @ git+https://github.com/openedx/django-require.git@f4f01e4e959adc6210873ae99e7f2c3741afbf35
+django-require @ git+https://github.com/openedx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776
     # via -r requirements/edx/base.txt
 django-sekizai==4.0.0
     # via
@@ -462,8 +470,6 @@ django-webpack-loader==0.7.0
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-proctoring
-django-wiki @ git+https://github.com/openedx/django-wiki.git@1.1.1
-    # via -r requirements/edx/base.txt
 djangorestframework==3.12.4
     # via
     #   -r requirements/edx/base.txt
@@ -582,7 +588,7 @@ edx-i18n-tools==0.9.1
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/testing.in
     #   ora2
-edx-lint==5.3.0
+edx-lint==5.2.5
     # via -r requirements/edx/testing.in
 edx-milestones==0.4.0
     # via -r requirements/edx/base.txt
@@ -676,7 +682,7 @@ factory-boy==3.2.1
     # via -r requirements/edx/testing.in
 faker==14.2.0
     # via factory-boy
-fastapi==0.85.0
+fastapi==0.83.0
     # via pact-python
 fastavro==1.6.1
     # via
@@ -728,7 +734,7 @@ httpretty==1.1.4
     # via -r requirements/edx/testing.in
 icalendar==4.1.0
     # via -r requirements/edx/base.txt
-idna==3.4
+idna==3.3
     # via
     #   -r requirements/edx/base.txt
     #   anyio
@@ -781,7 +787,7 @@ jmespath==0.10.0
     #   -r requirements/edx/base.txt
     #   boto3
     #   botocore
-joblib==1.2.0
+joblib==1.1.0
     # via
     #   -r requirements/edx/base.txt
     #   nltk
@@ -804,7 +810,7 @@ jsonschema==4.16.0
     # via
     #   -r requirements/edx/base.txt
     #   optimizely-sdk
-jwcrypto==1.4.2
+jwcrypto==1.3.1
     # via
     #   -r requirements/edx/base.txt
     #   pylti1p3
@@ -814,7 +820,7 @@ kombu==5.2.4
     #   celery
 laboratory==1.0.2
     # via -r requirements/edx/base.txt
-lazy==1.5
+lazy==1.4
     # via
     #   -r requirements/edx/base.txt
     #   acid-xblock
@@ -932,8 +938,6 @@ oauthlib==3.0.1
     #   lti-consumer-xblock
     #   requests-oauthlib
     #   social-auth-core
-olxcleaner @ git+https://github.com/openedx/olxcleaner.git@2f0d6c7f126cbd69c9724b7b57a0b2565330a297
-    # via -r requirements/edx/base.txt
 openedx-calc==3.0.1
     # via -r requirements/edx/base.txt
 openedx-events==0.12.0
@@ -1064,7 +1068,7 @@ pyjwkest==1.4.2
     #   -r requirements/edx/base.txt
     #   edx-drf-extensions
     #   lti-consumer-xblock
-pyjwt[crypto]==2.5.0
+pyjwt[crypto]==2.4.0
     # via
     #   -r requirements/edx/base.txt
     #   drf-jwt
@@ -1097,7 +1101,7 @@ pylint-plugin-utils==0.7
     #   pylint-django
 pylint-pytest==0.3.0
     # via -r requirements/edx/testing.in
-pylti1p3==1.12.1
+pylti1p3==1.12.0
     # via -r requirements/edx/base.txt
 pymongo==3.12.3
     # via
@@ -1233,8 +1237,6 @@ pyyaml==6.0
     #   edx-i18n-tools
     #   xblock
 random2==1.0.1
-    # via -r requirements/edx/base.txt
-rate-xblock @ git+https://github.com/openedx/RateXBlock.git@2.0.1
     # via -r requirements/edx/base.txt
 recommender-xblock==2.0.1
     # via -r requirements/edx/base.txt
@@ -1391,7 +1393,7 @@ sqlparse==0.4.2
     #   django
 staff-graded-xblock==2.0.1
     # via -r requirements/edx/base.txt
-starlette==0.20.4
+starlette==0.19.1
     # via fastapi
 stevedore==4.0.0
     # via
@@ -1442,10 +1444,6 @@ tqdm==4.64.1
     # via
     #   -r requirements/edx/base.txt
     #   nltk
-types-cryptography==3.3.23
-    # via
-    #   -r requirements/edx/base.txt
-    #   pyjwt
 typing-extensions==4.3.0
     # via
     #   -r requirements/edx/base.txt
@@ -1540,8 +1538,6 @@ xblock==1.6.1
     #   xblock-poll
     #   xblock-utils
 xblock-drag-and-drop-v2 @ git+https://github.com/openedx/xblock-drag-and-drop-v2@v2.3.5
-    # via -r requirements/edx/base.txt
-xblock-google-drive @ git+https://github.com/openedx/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6
     # via -r requirements/edx/base.txt
 xblock-poll @ git+https://github.com/open-craft/xblock-poll@v1.12.0
     # via -r requirements/edx/base.txt

--- a/scripts/xblock/requirements.txt
+++ b/scripts/xblock/requirements.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-certifi==2022.9.14
+certifi==2022.6.15.1
     # via requests
 charset-normalizer==2.1.1
     # via requests
-idna==3.4
+idna==3.3
     # via requests
 requests==2.28.1
     # via -r scripts/xblock/requirements.in


### PR DESCRIPTION
Reverts openedx/edx-platform#30719 , which caused codejail to fail on edX.org due to the changed codejail installation URL.

I am out on PTO this week, so I will not merge this, but feel free to merge it if helpful.

FYI @UsamaSadiq @openedx/teaching-and-learning 