### PR TITLE
build: aggregated success step to simplify required check configuration

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -34,6 +34,8 @@ jobs:
           - "common-1"
           - "common-2"
           - "xmodule-1"
+    # We expect Django 4.0 to fail, so don't stop when it fails.
+    continue-on-error: ${{ matrix.django-version == '4.0' }}
 
     steps:
       - name: sync directory owner
@@ -73,6 +75,17 @@ jobs:
 
       - name: Setup and run tests
         uses: ./.github/actions/unit-tests
+
+  success:
+    name: Tests successful
+    # A collection step to give a simple name for required status checks.
+    # https://github.com/orgs/community/discussions/33579
+    needs: run-tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Success"
+        run: |
+          echo Tests successful
 
   compile-warnings-report:
     runs-on: [ edx-platform-runner ]

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,34 +8,33 @@ on:
 
 jobs:
   run-tests:
+    name: python-${{ matrix.python-version }},django-${{ matrix.django-version }},${{ matrix.shard_name }}
     if: github.repository == 'openedx/edx-platform' || github.repository == 'edx/edx-platform-private'
     runs-on: [ edx-platform-runner ]
     strategy:
       matrix:
-        python-version: ['3.8']
+        python-version:
+          - "3.8"
         django-version:
           - "pinned"
           #- "4.0"
-        shard_name: [
-            "lms-1",
-            "lms-2",
-            "lms-3",
-            "lms-4",
-            "lms-5",
-            "lms-6",
-            "openedx-1",
-            "openedx-2",
-            "openedx-3",
-            "openedx-4",
-            "cms-1",
-            "cms-2",
-            "common-1",
-            "common-2",
-            "xmodule-1"
-        ]
+        shard_name:
+          - "lms-1"
+          - "lms-2"
+          - "lms-3"
+          - "lms-4"
+          - "lms-5"
+          - "lms-6"
+          - "openedx-1"
+          - "openedx-2"
+          - "openedx-3"
+          - "openedx-4"
+          - "cms-1"
+          - "cms-2"
+          - "common-1"
+          - "common-2"
+          - "xmodule-1"
 
-
-    name: python-${{ matrix.python-version }},django-${{ matrix.django-version }},${{ matrix.shard_name }}
     steps:
       - name: sync directory owner
         run: sudo chown runner:runner -R .*


### PR DESCRIPTION
This is a small change to the unit-tests.yml file to add an aggregation step.  The success of that step depends on the previous run-test matrix steps.  This means we can put just that last step into the configured list of required checks, instead of the matrix steps.  Because we might add Django 4.0 (or other speculative versions) into the matrix in the future, some steps are allowed to fail without blocking the entire action.

Here's an action run that included Django 4.0 to show what it would look like: https://github.com/openedx/edx-platform/actions/runs/3114613801

Once this is merged, we can change the list of required checks in the repo settings.

Note that there's an "xmodule-1" shard_name in the matrix (added 2022-06-20), but it isn't in the list of required checks.  This seems like an oversight.  This change would make the required checks less error prone, and make oversights like this less frequent.