### PR TITLE
feat: Adding 'Show Answer' setting argument passing support in XBlock 

### DIFF
--- a/openedx/core/lib/xblock_utils/__init__.py
+++ b/openedx/core/lib/xblock_utils/__init__.py
@@ -149,7 +149,10 @@ def wrap_xblock(
     }
 
     if hasattr(frag, 'json_init_args') and frag.json_init_args is not None:
-        template_context['js_init_parameters'] = frag.json_init_args
+        json_init_args = frag.json_init_args
+        if hasattr(block, "showanswer"):
+            json_init_args["showanswer"] = block.showanswer
+        template_context['js_init_parameters'] = json_init_args
     else:
         template_context['js_init_parameters'] = ""
 


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/openedx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Problem
The global setting for the Show Answer button is not working for the d&dv2 block;

## Fix

Adding 'Show Answer' setting argument passing support in XBlock

This is a part of [xblock-drag-and-drop-v2 #294](https://github.com/openedx/xblock-drag-and-drop-v2/pull/294/files)

```python 
       json_init_args = frag.json_init_args
        if hasattr(block, "showanswer"):
            json_init_args["showanswer"] = block.showanswer
        template_context['js_init_parameters'] = json_init_args
``` 

## Testing instructions

-  creating a new course or using Demo Course created by devstack.
-  go to "Settings" -> "Advanced Settings" in the studio and search for "Show Answer" and set it to "finished".
-  [Enabling Drag and Drop in Studio](https://github.com/open-craft/xblock-drag-and-drop-v2/#enabling-in-studio)
- Go to Studio UI and create a new unit
- Select Problem > Advanced > Drag and Drop, to create a v2 drag and drop XBlock
- Click Edit and change mode to Assessment
- Click Continue twice and Save
- Click on View Live Version
- "showanswer" with value "finished" will be added to the problem init_parameters

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Current PR should unblock  https://github.com/openedx/xblock-drag-and-drop-v2/pull/294
