### PR TITLE
fix: resolve backend issues in learner home

### DIFF
--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -534,7 +534,10 @@ class EnterpriseDashboardSerializer(serializers.Serializer):
     url = serializers.SerializerMethodField()
 
     def get_url(self, instance):
-        return urljoin(settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL, instance["uuid"])
+        return urljoin(
+            settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL,
+            instance["slug"],
+        )
 
 
 class LearnerDashboardSerializer(serializers.Serializer):

--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -48,7 +48,7 @@ class CourseProviderSerializer(serializers.Serializer):
 class CourseSerializer(serializers.Serializer):
     """Course header information, derived from a CourseOverview"""
 
-    bannerImgSrc = serializers.URLField(source="banner_image_url")
+    bannerImgSrc = serializers.URLField(source="image_urls.small")
     courseName = serializers.CharField(source="display_name_with_default")
     courseNumber = serializers.CharField(source="display_number_with_default")
 

--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -407,9 +407,6 @@ class LearnerEnrollmentSerializer(serializers.Serializer):
     gradeData = GradeDataSerializer(source="*")
     programs = serializers.SerializerMethodField()
 
-    # TODO - remove "allow_null" as each of these are implemented, temp for testing.
-    courseProvider = CourseProviderSerializer(allow_null=True)
-
     def get_entitlement(self, instance):
         """
         If this enrollment is the fulfillment of an entitlement, include information about the entitlement

--- a/lms/djangoapps/learner_home/test_serializers.py
+++ b/lms/djangoapps/learner_home/test_serializers.py
@@ -51,6 +51,7 @@ from lms.djangoapps.learner_home.test_utils import (
     datetime_to_django_format,
     random_bool,
     random_date,
+    random_string,
     random_url,
 )
 from xmodule.data import CertificatesDisplayBehaviors
@@ -991,15 +992,17 @@ class TestEnterpriseDashboardSerializer(TestCase):
     """High-level tests for EnterpriseDashboardSerializer"""
 
     @classmethod
-    def generate_test_data(cls):
+    def generate_test_enterprise_customer(cls):
         return {
+            "name": random_string(),
+            "slug": str(uuid4()),
+            "enable_learner_portal": True,
             "uuid": str(uuid4()),
-            "name": str(uuid4()),
         }
 
     def test_structure(self):
         """Test that nothing breaks and the output fields look correct"""
-        input_data = self.generate_test_data()
+        input_data = self.generate_test_enterprise_customer()
 
         output_data = EnterpriseDashboardSerializer(input_data).data
 
@@ -1007,12 +1010,12 @@ class TestEnterpriseDashboardSerializer(TestCase):
             "label",
             "url",
         ]
-        assert output_data.keys() == set(expected_keys)
+        self.assertEqual(output_data.keys(), set(expected_keys))
 
     def test_happy_path(self):
         """Test that data serializes correctly"""
 
-        input_data = self.generate_test_data()
+        input_data = self.generate_test_enterprise_customer()
 
         output_data = EnterpriseDashboardSerializer(input_data).data
 
@@ -1022,7 +1025,7 @@ class TestEnterpriseDashboardSerializer(TestCase):
                 "label": input_data["name"],
                 "url": settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL
                 + "/"
-                + input_data["uuid"],
+                + input_data["slug"],
             },
         )
 

--- a/lms/djangoapps/learner_home/test_utils.py
+++ b/lms/djangoapps/learner_home/test_utils.py
@@ -15,6 +15,11 @@ from openedx.core.djangoapps.content.course_overviews.tests.factories import (
 from xmodule.modulestore.tests.factories import CourseFactory
 
 
+def random_string():
+    """Test util for generating a random string"""
+    return str(uuid4())
+
+
 def random_bool():
     """Test util for generating a random boolean"""
     return bool(getrandbits(1))


### PR DESCRIPTION
## Description

Resolve first round of issues found in Learner Home bug bash:
1. Fix `courseProvider` accidental nulling.
2. Fix route for `enterpriseDashboard.url`.
3. Fix course `course.bannerImgSrouce` source.

FYI @openedx/content-aurora 