### PR TITLE
fix: added keyword substitution support in edx_ace based bulk course emails

### DIFF
--- a/lms/djangoapps/bulk_email/messages.py
+++ b/lms/djangoapps/bulk_email/messages.py
@@ -8,6 +8,7 @@ from django.core.mail import EmailMultiAlternatives
 from edx_ace import ace
 from edx_ace.recipient import Recipient
 
+from common.djangoapps.util.keyword_substitution import substitute_keywords_with_data
 from lms.djangoapps.bulk_email.message_types import BulkEmail
 from openedx.core.lib.celery.task_utils import emulate_http_request
 
@@ -69,6 +70,14 @@ class ACEEmail(CourseEmailMessage):
         """
         self.site = site
         self.user = User.objects.get(email=email_context['email'])
+        text_message = email_context['course_email'].text_message
+        html_message = email_context['course_email'].html_message
+        formatted_text_message = substitute_keywords_with_data(text_message, email_context)
+        formatted_html_message = substitute_keywords_with_data(html_message, email_context)
+        email_context.update({
+            'formatted_text_message': formatted_text_message,
+            'formatted_html_message': formatted_html_message,
+        })
         message = BulkEmail(context=email_context).personalize(
             recipient=Recipient(email_context['user_id'], email_context['email']),
             language=email_context['course_language'],

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -5144,6 +5144,7 @@ TEAMS_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-runn
 TEXTBOOKS_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_assets/textbooks.html"
 WIKI_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_assets/course_wiki.html"
 CUSTOM_PAGES_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_assets/pages.html#adding-custom-pages"
+COURSE_BULK_EMAIL_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/manage_live_course/bulk_email.html"
 
 ################# Bulk Course Email Settings #################
 # If set, recipients of bulk course email messages will be filtered based on the last_login date of their User account.

--- a/lms/templates/bulk_email/edx_ace/bulkemail/email/body.html
+++ b/lms/templates/bulk_email/edx_ace/bulkemail/email/body.html
@@ -8,7 +8,7 @@
     <td>
       <p style="color: rgba(0,0,0,.75);">
         {% autoescape off %}
-          {{ course_email.html_message }}
+          {{ formatted_html_message }}
         {% endautoescape %}
         <br/>
       </p>

--- a/lms/templates/bulk_email/edx_ace/bulkemail/email/body.txt
+++ b/lms/templates/bulk_email/edx_ace/bulkemail/email/body.txt
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% autoescape off %}
-{{ course_email.text_message }}
+{{ formatted_text_message }}
 {% endautoescape %}
 
 

--- a/lms/templates/instructor/instructor_dashboard_2/send_email.html
+++ b/lms/templates/instructor/instructor_dashboard_2/send_email.html
@@ -1,7 +1,7 @@
 <%page args="section_data" expression_filter="h"/>
 <%!
 from django.utils.translation import ugettext as _
-from openedx.core.djangolib.markup import HTML
+from openedx.core.djangolib.markup import HTML, Text
 %>
 
 
@@ -91,7 +91,16 @@ from openedx.core.djangolib.markup import HTML
         </li>
     </ul>
     <div class="submit-email-action">
-        <p class="copy">${_("We recommend sending learners no more than one email message per week. Before you send your email, review the text carefully and send it to yourself first, so that you can preview the formatting and make sure embedded images and links work correctly.")}</p>
+        <p class="copy">
+            ${_("We recommend sending learners no more than one email message per week. Before you send your email, review the text carefully and send it to yourself first, so that you can preview the formatting and make sure embedded images and links work correctly.")}
+            ${Text(
+                _("You can include keywords in your messages. For list of available keywords see the {start_link}documentation{end_link}."
+                )).format(
+                    start_link=HTML('<a href="{}">').format(settings.COURSE_BULK_EMAIL_HELP_URL),
+                    end_link=HTML('</a>')
+                )
+            }
+        </p>
     </div>
     <div class="submit-email-warning">
         <p class="copy"><span style="color: red;"><b>${_("CAUTION!")}</b></span>


### PR DESCRIPTION
This PR has changes to support keyword substitution in edx_ace based bulk course emails. This issue is reported [here](https://discuss.openedx.org/t/keyword-support-in-course-bulk-emails-with-edx-ace/8339/4).

Testing Instructions.
1. Login as a user having django admin access and enable bulk course email flag
<img width="588" alt="Screen Shot 2022-09-27 at 6 36 32 PM" src="https://user-images.githubusercontent.com/434995/192541599-f1046e6e-a141-4d77-91d8-66ba8e7a1109.png">
 
2. Login as course instructor or staff
3. Open `Email` tab on instructor dashboard of any course
4. Set Myself in `Send To` field, enter anything in `Subject` field. In `Message` field enter the text below and hit `Send Mail` button
```
Hey %%USER_FULLNAME%%

welcome in %%COURSE_DISPLAY_NAME%%
```
5. You should receive email with `%%USER_FULLNAME%%` and `%%COURSE_DISPLAY_NAME%%` replaced with user's full name and the course display name.