### PR TITLE
fix: fix routing for mock path in learner home

### DIFF
--- a/lms/djangoapps/learner_home/urls.py
+++ b/lms/djangoapps/learner_home/urls.py
@@ -8,8 +8,8 @@ app_name = "learner_home"
 
 # Learner Dashboard Routing
 urlpatterns = [
-    re_path(r"init/?", views.InitializeView.as_view(), name="initialize"),
+    re_path(r"^init/?", views.InitializeView.as_view(), name="initialize"),
     re_path(
-        r"mock/init/?", mock_views.InitializeView.as_view(), name="mock_initialize"
+        r"^mock/init/?", mock_views.InitializeView.as_view(), name="mock_initialize"
     ),
 ]


### PR DESCRIPTION
## Description

Fix URL routes change introduce during masquerade to re-enable mock API.

FYI: @openedx/content-aurora 