### PR TITLE
[BD-38][BB-6681] feat: add `count_flagged` query param to the learner thread endpoint

### DIFF
--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -892,7 +892,7 @@ def get_learner_active_thread_list(request, course_key, query_params):
     request: The django request objects used for build_absolute_uri
     course_key: The key of the course
     query_params: Parameters to fetch data from comments service. It must contain
-                        user_id, course_id, page, per_page, group_id
+                        user_id, course_id, page, per_page, group_id, count_flagged
 
     Returns:
 

--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -571,6 +571,9 @@ class LearnerThreadView(APIView):
         * page: The (1-indexed) page to retrieve (default is 1)
 
         * page_size: The number of items per page (default is 10)
+
+        * count_flagged: If True, return the count of flagged comments for each thread.
+        (can only be used by moderators or above)
     """
 
     authentication_classes = (
@@ -590,6 +593,7 @@ class LearnerThreadView(APIView):
         course_key = CourseKey.from_string(course_id)
         page_num = request.GET.get('page', 1)
         threads_per_page = request.GET.get('page_size', 10)
+        count_flagged = request.GET.get('count_flagged', False)
         discussion_id = None
         username = request.GET.get('username', None)
         user = get_object_or_404(User, username=username)
@@ -604,7 +608,8 @@ class LearnerThreadView(APIView):
             "per_page": threads_per_page,
             "course_id": str(course_key),
             "user_id": user.id,
-            "group_id": group_id
+            "group_id": group_id,
+            "count_flagged": count_flagged,
         }
         return get_learner_active_thread_list(request, course_key, query_params)
 


### PR DESCRIPTION
## Description

Adds `count_flagged` query parameter to the forum Learner Thread endpoint, which allows platform moderators to see how posts were flagged per given user's thread.

## Supporting information

- Depends on https://github.com/openedx/cs_comments_service/pull/393.

## Testing instructions

1. Install this branch and https://github.com/openedx/cs_comments_service/pull/393 to your devstack.
2. Enroll into some course.
3. As a stuff user, open Discussions, create a thread, and leave a few replies.
4. As a regular user, enroll into the same course, open Discussions, and flag some of the replies.
5. As a stuff user, open `<LMS_URL>/api/discussion/v1/courses/<URL_ENCODED_COURSE_ID>/learner/?username=<STAFF_USERNAME>&page=1&count_flagged=true` — resulting JSON document has to contain `"abuse_flagged_count": <number_of_flagged_replies>`.