### PR TITLE
fix: add missing context for discussion events

### DIFF
--- a/lms/djangoapps/discussion/tests/test_views.py
+++ b/lms/djangoapps/discussion/tests/test_views.py
@@ -2186,7 +2186,7 @@ class ThreadViewedEventTestCase(EventTestMixin, ForumsEnableMixin, UrlResetMixin
 
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):  # pylint: disable=arguments-differ
-        super().setUp('eventtracking.tracker')
+        super().setUp('lms.djangoapps.discussion.django_comment_client.base.views.tracker')
 
         self.course = CourseFactory.create(
             teams_configuration=TeamsConfig({


### PR DESCRIPTION
### [INF-539](https://2u-internal.atlassian.net/browse/INF-539)

#### Description

Add missing context to discussion forum events.

For the shared snippet below, please note the `context` dict to notice the change in event structure.

#### Legacy Event Structure

```python
{
    ...
    "context": {
        "course_id": "course-v1:EDX1+DIS101+2022_T2",
        "course_user_tags": {
        },
        "enterprise_uuid": "",
        "org_id": "EDX1",
        "path": "/courses/course-v1:EDX1+DIS101+2022_T2/discussion/course/threads/create",
        "user_id": 3
    },
    "event": {
        "anonymous": false,
        "anonymous_to_peers": false,
        "body": "This is a test post",
        "commentable_id": "course",
        "group_id": null,
        "id": "6333fe8fceb0b100c0b71ac9",
        "options": {
            "followed": true
        },
        "thread_type": "discussion",
        "title": "This is a test post from legacy",
        "title_truncated": false,
        "truncated": false,
        "url": "http://localhost:18000/courses/course-v1:EDX1+DIS101+2022_T2/discussion/forum/",
        "user_course_roles": [
            "instructor",
            "staff"
        ],
        "user_forums_roles": [
            "Student"
        ]
    },
    ...
}
```

#### Event Structure from external source (BEFORE FIX)

```python 
{
    ...
    "context": {
        "course_id": "",
        "enterprise_uuid": "",
        "org_id": "",
        "path": "/api/discussion/v1/threads/",
        "user_id": 3
    },
    "event": {
        "anonymous": false,
        "anonymous_to_peers": false,
        "body": "<p>This is MFE test POST</p>",
        "commentable_id": "course",
        "group_id": null,
        "id": "6333ffbbceb0b100c0b71acb",
        "options": {
            "followed": true
        },
        "thread_type": "discussion",
        "title": "This is a post from MFE",
        "title_truncated": false,
        "truncated": false,
        "url": "http://localhost:2002/",
        "user_course_roles": [
            "instructor"
        ],
        "user_forums_roles": [
            "Moderator",
            "Student"
        ]
    },
    ...
    "username": "edx"
}
```

#### Event Structure from external source (AFTER FIX)

```python
{
    ...
    "context": {
        "course_id": "course-v1:EDX1+DIS111+2022_T2",
        "enterprise_uuid": "",
        "org_id": "EDX1",
        "path": "/api/discussion/v1/threads/",
        "user_id": 3
    },
    "event": {
        "anonymous": false,
        "anonymous_to_peers": false,
        "body": "<p>Here we go again</p>",
        "commentable_id": "course",
        "group_id": null,
        "id": "6334080fceb0b100c0b71acf",
        "options": {
            "followed": true
        },
        "thread_type": "discussion",
        "title": "This is test post number 3 from MFE",
        "title_truncated": false,
        "truncated": false,
        "url": "[http://localhost:2002/](http://localhost:2002/)",
        "user_course_roles": [
            "instructor"
        ],
        "user_forums_roles": [
            "Moderator",
            "Student"
        ]
    },
    ...
    "username": "edx"
}

```