### PR TITLE
fix: save scroll position on exit from video xblock fullscreen mode

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -976,7 +976,7 @@ DEFAULT_HASHING_ALGORITHM = 'sha1'
 #################### Python sandbox ############################################
 
 CODE_JAIL = {
-    # from https://github.com/edx/codejail/blob/master/codejail/django_integration.py#L24, '' should be same as None
+    # from https://github.com/openedx/codejail/blob/master/codejail/django_integration.py#L24, '' should be same as None
     'python_bin': '/edx/app/edxapp/venvs/edxapp-sandbox/bin/python',
     # User to run as in the sandbox.
     'user': 'sandbox',

--- a/common/lib/capa/capa/safe_exec/README.rst
+++ b/common/lib/capa/capa/safe_exec/README.rst
@@ -12,10 +12,10 @@ protection on that code.
 If you want to configure sandboxing, you're going to use the `README from
 CodeJail`__, with a few customized tweaks.
 
-__ https://github.com/edx/codejail/blob/master/README.rst
+__ https://github.com/openedx/codejail/blob/master/README.rst
 
 
-1. At the instruction to install packages into the sandboxed code, you'll 
+1. At the instruction to install packages into the sandboxed code, you'll
    need to install the requirements from requirements/edx-sandbox::
 
     $ pip install -r requirements/edx-sandbox/base.txt

--- a/common/lib/xmodule/xmodule/js/src/video/04_video_full_screen.js
+++ b/common/lib/xmodule/xmodule/js/src/video/04_video_full_screen.js
@@ -161,6 +161,20 @@
             return this.videoFullScreen.height;
         }
 
+        function notifyParent(fullscreenOpen) {
+            if (window !== window.parent) {
+                // This is used by the Learning MFE to know about changing fullscreen mode.
+                // The MFE is then able to respond appropriately and scroll window to the previous position.
+                window.parent.postMessage({
+                    type: 'plugin.videoFullScreen',
+                    payload: {
+                        open: fullscreenOpen
+                    }
+                  }, document.referrer
+                );
+            }
+        }
+
     /**
      * Event handler to toggle fullscreen mode.
      * @param {jquery Event} event
@@ -192,6 +206,8 @@
                 this.resizer.delta.reset().setMode('width');
             }
             this.el.trigger('fullscreen', [this.isFullScreen]);
+
+            this.videoFullScreen.notifyParent(false);
         }
 
         function handleEnter() {
@@ -201,6 +217,8 @@
             if (this.isFullScreen === true) {
                 return;
             }
+
+            this.videoFullScreen.notifyParent(true);
 
             this.videoFullScreen.fullScreenState = this.isFullScreen = true;
             fullScreenClassNameEl.addClass('video-fullscreen');
@@ -267,7 +285,8 @@
                 handleFullscreenChange: handleFullscreenChange,
                 toggle: toggle,
                 toggleHandler: toggleHandler,
-                updateControlsHeight: updateControlsHeight
+                updateControlsHeight: updateControlsHeight,
+                notifyParent: notifyParent
             };
 
             state.bindTo(methodsDict, state.videoFullScreen, state);

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1607,7 +1607,7 @@ DEFAULT_HASHING_ALGORITHM = 'sha1'
 #################### Python sandbox ############################################
 
 CODE_JAIL = {
-    # from https://github.com/edx/codejail/blob/master/codejail/django_integration.py#L24, '' should be same as None
+    # from https://github.com/openedx/codejail/blob/master/codejail/django_integration.py#L24, '' should be same as None
     'python_bin': '/edx/app/edxapp/venvs/edxapp-sandbox/bin/python',
     # User to run as in the sandbox.
     'user': 'sandbox',

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -8,7 +8,7 @@
     # via
     #   -r requirements/edx/local.in
     #   xmodule
--e git+https://github.com/edx/codejail.git@3.1.3#egg=codejail==3.1.3
+-e git+https://github.com/openedx/codejail.git@3.1.3#egg=codejail==3.1.3
     # via -r requirements/edx/github.in
 -e git+https://github.com/edx/django-wiki.git@1.0.2#egg=django-wiki
     # via -r requirements/edx/github.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -8,7 +8,7 @@
     # via
     #   -r requirements/edx/testing.txt
     #   xmodule
--e git+https://github.com/edx/codejail.git@3.1.3#egg=codejail==3.1.3
+-e git+https://github.com/openedx/codejail.git@3.1.3#egg=codejail==3.1.3
     # via -r requirements/edx/testing.txt
 -e git+https://github.com/edx/django-wiki.git@1.0.2#egg=django-wiki
     # via -r requirements/edx/testing.txt

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -67,7 +67,7 @@ git+https://github.com/edx/django-ratelimit-backend.git@6e1a0c6ea1d27062c16e9fb9
 git+https://github.com/edx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776#egg=django-require==1.0.12
 
 # Our libraries:
--e git+https://github.com/edx/codejail.git@3.1.3#egg=codejail==3.1.3
+-e git+https://github.com/openedx/codejail.git@3.1.3#egg=codejail==3.1.3
 -e git+https://github.com/edx/RateXBlock.git@2.0.1#egg=rate-xblock
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive
 

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -8,7 +8,7 @@
     # via
     #   -r requirements/edx/base.txt
     #   xmodule
--e git+https://github.com/edx/codejail.git@3.1.3#egg=codejail==3.1.3
+-e git+https://github.com/openedx/codejail.git@3.1.3#egg=codejail==3.1.3
     # via -r requirements/edx/base.txt
 -e git+https://github.com/edx/django-wiki.git@1.0.2#egg=django-wiki
     # via -r requirements/edx/base.txt


### PR DESCRIPTION
This merge request contains a fix for toggling video xblock full-screen mode and saving the previous window top offset position on exit from the full-screen state.

A related bug was found here https://bugs.chromium.org/p/chromium/issues/detail?id=142427 but it still reproduces.

Realised solution: Save the scroll position before the turn on the fullscreen mode and scroll to the previous position on turn off the fullscreen mode.

**Dependent PR to MFE Learning:**
This MR https://github.com/openedx/frontend-app-learning/pull/982 must be merged with this MR.
