### PR TITLE
fix: use timeout from settings

### DIFF
--- a/openedx/core/djangoapps/password_policy/hibp.py
+++ b/openedx/core/djangoapps/password_policy/hibp.py
@@ -6,6 +6,7 @@ import hashlib
 import logging
 
 import requests
+from django.conf import settings
 from requests.exceptions import ReadTimeout
 from rest_framework.status import HTTP_408_REQUEST_TIMEOUT
 
@@ -58,7 +59,8 @@ class PwnedPasswordsAPI:
 
         if ENABLE_PWNED_PASSWORD_API.is_enabled():
             try:
-                response = requests.get(range_url, timeout=5)
+                timeout = getattr(settings, 'PASSWORD_POLICY_COMPLIANCE_API_TIMEOUT', 5)
+                response = requests.get(range_url, timeout=timeout)
                 entries = dict(map(convert_password_tuple, response.text.split("\r\n")))
                 return entries
 

--- a/openedx/core/djangoapps/password_policy/settings/common.py
+++ b/openedx/core/djangoapps/password_policy/settings/common.py
@@ -35,3 +35,4 @@ def plugin_settings(settings):
         # Ex: 2018-04-19 00:00:00+00:00
         'GENERAL_USER_COMPLIANCE_DEADLINE': None,
     }
+    settings.PASSWORD_POLICY_COMPLIANCE_API_TIMEOUT = 5


### PR DESCRIPTION
In hib password policy the timeout value is hardcoded instead of using it from settings. This change is implemented in this PR. The value of timeout is used from settings.

[](https://github.com/openedx/edx-platform/blob/5a3e67d8f4d9725e3a9baeffb6cdc5c371a77f25/openedx/core/djangoapps/password_policy/hibp.py#L61)