### PR TITLE
build: add import linter check

### DIFF
--- a/.github/workflows/lint-imports.yml
+++ b/.github/workflows/lint-imports.yml
@@ -1,0 +1,48 @@
+name: Lint Python Imports
+
+on: pull_request
+
+jobs:
+
+  lint-imports:
+    name: Lint Python Imports
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Check out branch
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+
+      - name: Install system requirements
+        run: sudo apt update && sudo apt install -y libxmlsec1-dev
+
+      - name: Install pip
+        run: python -m pip install -r requirements/pip.txt
+
+      - name: Get pip cache dir
+        id: pip-cache-dir
+        run: echo "::set-output name=dir::$(pip cache dir)"
+
+      - name: Cache pip dependencies
+        id: cache-dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements/edx/development.txt') }}
+          restore-keys: ${{ runner.os }}-pip-
+
+      - name: Install python dependencies
+        run: pip install -r requirements/edx/development.txt
+
+      # As long there are sub-projects[1] in edx-platform, we analyze each
+      # project separately here, in order to make import-linting errors easier
+      # to pinpoint.
+      #
+      #  [1] https://openedx.atlassian.net/browse/BOM-2579
+
+      - name: Analyze imports (repo root)
+        run: make lint-imports

--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,9 @@ docker_push: docker_tag docker_auth ## push to docker hub
 	docker push "openedx/cms-dev:latest"
 	docker push "openedx/cms-dev:${GITHUB_SHA}"
 
+lint-imports:
+	lint-imports
+
 # WARNING (EXPERIMENTAL):
 # This installs the Ubuntu requirements necessary to make `pip install` and some other basic
 # dev commands to pass. This is not necessarily everything needed to get a working edx-platform.

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -173,6 +173,7 @@ click==8.1.3
     #   code-annotations
     #   edx-django-utils
     #   edx-lint
+    #   import-linter
     #   nltk
     #   pact-python
     #   pip-tools
@@ -750,6 +751,10 @@ geoip2==4.6.0
     # via -r requirements/edx/testing.txt
 glob2==0.7
     # via -r requirements/edx/testing.txt
+grimp==1.3
+    # via
+    #   -r requirements/edx/testing.txt
+    #   import-linter
 gunicorn==20.1.0
     # via -r requirements/edx/testing.txt
 h11==0.14.0
@@ -776,6 +781,8 @@ idna==3.4
     #   yarl
 imagesize==1.4.1
     # via sphinx
+import-linter==1.3.0
+    # via -r requirements/edx/testing.txt
 importlib-metadata==5.0.0
     # via
     #   -r requirements/edx/testing.txt
@@ -1577,6 +1584,7 @@ typing-extensions==4.4.0
     #   -r requirements/edx/testing.txt
     #   astroid
     #   django-countries
+    #   import-linter
     #   mypy
     #   pydantic
     #   pylint

--- a/requirements/edx/testing.in
+++ b/requirements/edx/testing.in
@@ -28,6 +28,7 @@ factory-boy               # Library for creating test fixtures, used in many tes
 # Pinning the freezegun version because 0.3.13 is causing failures which have also been reported on the git repo by public.
 freezegun                 # Allows tests to mock the output of assorted datetime module functions
 httpretty                 # Library for mocking HTTP requests, used in many tests
+import-linter             # Tool for making assertions about which modules can import which others
 isort                     # For checking and fixing the order of imports
 pycodestyle               # Checker for compliance with the Python style guide (PEP 8)
 polib                     # Library for manipulating gettext translation files, used to test paver i18n commands

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -163,6 +163,7 @@ click==8.1.3
     #   code-annotations
     #   edx-django-utils
     #   edx-lint
+    #   import-linter
     #   nltk
     #   pact-python
     #   user-util
@@ -720,6 +721,8 @@ geoip2==4.6.0
     # via -r requirements/edx/base.txt
 glob2==0.7
     # via -r requirements/edx/base.txt
+grimp==1.3
+    # via import-linter
 gunicorn==20.1.0
     # via -r requirements/edx/base.txt
 h11==0.14.0
@@ -742,6 +745,8 @@ idna==3.4
     #   requests
     #   snowflake-connector-python
     #   yarl
+import-linter==1.3.0
+    # via -r requirements/edx/testing.in
 importlib-metadata==5.0.0
     # via
     #   -r requirements/edx/base.txt
@@ -1464,6 +1469,7 @@ typing-extensions==4.4.0
     #   -r requirements/edx/base.txt
     #   astroid
     #   django-countries
+    #   import-linter
     #   pydantic
     #   pylint
     #   snowflake-connector-python

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,3 +47,29 @@ multi_line_output=3
 skip=
     envs
     migrations
+
+[importlinter]
+root_packages =
+    lms
+    cms
+include_external_packages = True
+
+[importlinter:contract:1]
+name = lms and cms are independent
+type = independence
+modules =
+    lms
+    cms
+ignore_imports =
+    # lms side imports that we are ignoring for now
+    lms.djangoapps.course_home_api.outline.tests.test_view -> cms.djangoapps.contentstore.outlines
+    lms.djangoapps.courseware.plugins -> cms.djangoapps.contentstore.utils
+    lms.djangoapps.course_home_api.tests.utils -> cms.djangoapps.contentstore.outlines
+    # cms side imports that we are ignoring for now
+    cms.djangoapps.contentstore.views.tests.test_item -> lms.djangoapps.lms_xblock.mixin
+    cms.envs.common -> lms.envs.common
+    cms.djangoapps.contentstore.signals.handlers -> lms.djangoapps.grades.api
+    cms.djangoapps.contentstore.course_group_config -> lms.lib.utils
+    cms.djangoapps.contentstore.views.preview -> lms.djangoapps.lms_xblock.field_data
+    cms.envs.common -> lms.djangoapps.lms_xblock.mixin
+    cms.envs.test -> lms.envs.test


### PR DESCRIPTION
**Ticket Link:** https://openedx.atlassian.net/browse/BOM-2576

**Description:**
In order to empower refactoring, restructuring, and extraction of edx-platform code, we would like to be able to analyze and make assertions about what code depends on what. One way to do this is by computing the digraph of Python import statements in our codebase, and failing PR builds if unwanted imports exist in the graph. This is exactly what the tool import-linter will allow us to do.

**Note:**
For now, we're ignoring the existing imports which are breaking the check of `independence`.

**Screenshots**
- If there is any forbidden import the check will fail like this
<img width="501" alt="Screen Shot 2022-10-04 at 4 41 31 PM" src="https://user-images.githubusercontent.com/42294172/193814819-579ef95b-1b37-43fc-9102-0b44f8d6278d.png">


