### PR TITLE
chore: bump ORA2 version to 4.5.1

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -769,7 +769,7 @@ openedx-filters==0.8.0
     #   lti-consumer-xblock
 optimizely-sdk==4.1.0
     # via -r requirements/edx/base.in
-ora2==4.5.0
+ora2==4.5.1
     # via -r requirements/edx/base.in
 oscrypto==1.3.0
     # via snowflake-connector-python

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -996,7 +996,7 @@ openedx-filters==0.8.0
     #   lti-consumer-xblock
 optimizely-sdk==4.1.0
     # via -r requirements/edx/testing.txt
-ora2==4.5.0
+ora2==4.5.1
     # via -r requirements/edx/testing.txt
 oscrypto==1.3.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -948,7 +948,7 @@ openedx-filters==0.8.0
     #   lti-consumer-xblock
 optimizely-sdk==4.1.0
     # via -r requirements/edx/base.txt
-ora2==4.5.0
+ora2==4.5.1
     # via -r requirements/edx/base.txt
 oscrypto==1.3.0
     # via


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/openedx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Update version of ORA2 to 4.5.1 

## Supporting information

Update for https://2u-internal.atlassian.net/browse/AU-871 / https://2u-internal.atlassian.net/browse/CR-5246

## Testing instructions

## Deadline

ASAP

## Other information

