### PR TITLE
build: add a success aggregation job to simplify required check configuration

### DIFF
--- a/.github/workflows/pylint-checks.yml
+++ b/.github/workflows/pylint-checks.yml
@@ -1,11 +1,10 @@
-name: Pylint checks
+name: Pylint Checks
 
 on:
   pull_request:
   push:
     branches:
       - master
-      - open-release/lilac.master
 
 jobs:
   run_pylint:
@@ -32,13 +31,13 @@ jobs:
 
     name: pylint ${{ matrix.module-name }}
     steps:
+    - name: Check out repo
+      uses: actions/checkout@v2
 
-    - uses: actions/checkout@v2
-
-    - name: Install Required System Packages
+    - name: Install required system packages
       run: sudo apt-get update && sudo apt-get install libxmlsec1-dev
 
-    - name: Setup Python
+    - name: Set up Python
       uses: actions/setup-python@v2
       with:
         python-version: 3.8
@@ -56,13 +55,13 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements/edx/development.txt') }}
         restore-keys: ${{ runner.os }}-pip-
 
-    - name: Install Required Python Dependencies
+    - name: Install required Python dependencies
       run: |
         pip install -r requirements/pip.txt
         make dev-requirements
         pip uninstall -y mysqlclient
         pip install --no-binary mysqlclient mysqlclient
 
-    - name: Run Quality Tests
+    - name: Run quality tests
       run: |
-        pylint  ${{ matrix.path }}
+        pylint ${{ matrix.path }}

--- a/.github/workflows/pylint-checks.yml
+++ b/.github/workflows/pylint-checks.yml
@@ -7,7 +7,7 @@ on:
       - master
 
 jobs:
-  run_pylint:
+  run-pylint:
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
@@ -65,3 +65,14 @@ jobs:
       - name: Run quality tests
         run: |
           pylint ${{ matrix.path }}
+
+  success:
+    name: Pylint successful
+    # A collection step to give a simple name for required status checks.
+    # https://github.com/orgs/community/discussions/33579
+    needs: run-pylint
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Success"
+        run: |
+          echo Pylint successful

--- a/.github/workflows/pylint-checks.yml
+++ b/.github/workflows/pylint-checks.yml
@@ -31,37 +31,37 @@ jobs:
 
     name: pylint ${{ matrix.module-name }}
     steps:
-    - name: Check out repo
-      uses: actions/checkout@v2
+      - name: Check out repo
+        uses: actions/checkout@v2
 
-    - name: Install required system packages
-      run: sudo apt-get update && sudo apt-get install libxmlsec1-dev
+      - name: Install required system packages
+        run: sudo apt-get update && sudo apt-get install libxmlsec1-dev
 
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
 
-    - name: Get pip cache dir
-      id: pip-cache-dir
-      run: |
-        echo "::set-output name=dir::$(pip cache dir)"
+      - name: Get pip cache dir
+        id: pip-cache-dir
+        run: |
+          echo "::set-output name=dir::$(pip cache dir)"
 
-    - name: Cache pip dependencies
-      id: cache-dependencies
-      uses: actions/cache@v2
-      with:
-        path: ${{ steps.pip-cache-dir.outputs.dir }}
-        key: ${{ runner.os }}-pip-${{ hashFiles('requirements/edx/development.txt') }}
-        restore-keys: ${{ runner.os }}-pip-
+      - name: Cache pip dependencies
+        id: cache-dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements/edx/development.txt') }}
+          restore-keys: ${{ runner.os }}-pip-
 
-    - name: Install required Python dependencies
-      run: |
-        pip install -r requirements/pip.txt
-        make dev-requirements
-        pip uninstall -y mysqlclient
-        pip install --no-binary mysqlclient mysqlclient
+      - name: Install required Python dependencies
+        run: |
+          pip install -r requirements/pip.txt
+          make dev-requirements
+          pip uninstall -y mysqlclient
+          pip install --no-binary mysqlclient mysqlclient
 
-    - name: Run quality tests
-      run: |
-        pylint ${{ matrix.path }}
+      - name: Run quality tests
+        run: |
+          pylint ${{ matrix.path }}

--- a/openedx/tests/ci/test_ci_matrix.py
+++ b/openedx/tests/ci/test_ci_matrix.py
@@ -31,7 +31,7 @@ def test_quality_matrix_is_complete():
         quality_yaml = yaml.safe_load(fp)
 
         matrix_dirs = []
-        for matrix_item in quality_yaml['jobs']['run_pylint']['strategy']['matrix']['include']:
+        for matrix_item in quality_yaml['jobs']['run-pylint']['strategy']['matrix']['include']:
             matrix_dirs.extend(matrix_item['path'].split(' '))
 
         for module in ['lms', 'lms/djangoapps', 'openedx', 'openedx/core', 'openedx/core/djangoapps']:


### PR DESCRIPTION
## Description

Similar to #31024, this adds a success aggregation job that succeeds only of the full matrix of pylint jobs succeed.  Then this aggregated job can be marked as a required check instead of the individual matrix jobs.
