### PR TITLE
fix: fix make upgrade job failure

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -97,3 +97,7 @@ pyopenssl==22.0.0
 
 # pytz>2022.2.1 causes test failures in edx-platform
 pytz==2022.2.1
+
+# openedx-events>0.13.0 causes test failures due to breaking changes
+# These broken tests will be fixed in a separate PR
+openedx-events==0.13.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -88,3 +88,9 @@ markdown<3.4.0
 # pycodestyle==2.9.0 generates false positive error E275.
 # Constraint can be removed once the issue https://github.com/PyCQA/pycodestyle/issues/1090 is fixed.
 pycodestyle<2.9.0
+
+# pyopenssl>22.0.0 requires cryptography>=38.0 && conflicts with snowflak-connector-python requires cryptography<37
+# which causes the requirements upgrade job to fail due to constraint conflict
+# This constraint can be removed once https://github.com/snowflakedb/snowflake-connector-python/issues/1259 is resolved
+# and snowflake-connector-python>2.8.0 is released.
+pyopenssl==22.0.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -94,3 +94,6 @@ pycodestyle<2.9.0
 # This constraint can be removed once https://github.com/snowflakedb/snowflake-connector-python/issues/1259 is resolved
 # and snowflake-connector-python>2.8.0 is released.
 pyopenssl==22.0.0
+
+# pytz>2022.2.1 causes test failures in edx-platform
+pytz==2022.2.1

--- a/requirements/edx-sandbox/py38.txt
+++ b/requirements/edx-sandbox/py38.txt
@@ -18,7 +18,7 @@ cryptography==38.0.1
     # via -r requirements/edx-sandbox/py38.in
 cycler==0.11.0
     # via matplotlib
-joblib==1.1.0
+joblib==1.2.0
     # via nltk
 kiwisolver==1.4.4
     # via matplotlib
@@ -36,7 +36,7 @@ matplotlib==3.3.4
     #   -r requirements/edx-sandbox/py38.in
 mpmath==1.2.1
     # via sympy
-networkx==2.8.6
+networkx==2.8.7
     # via -r requirements/edx-sandbox/py38.in
 nltk==3.7
     # via

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -18,7 +18,7 @@
     # via -r requirements/edx/github.in
 acid-xblock==0.2.1
     # via -r requirements/edx/base.in
-aiohttp==3.8.1
+aiohttp==3.8.3
     # via geoip2
 aiosignal==1.2.0
     # via aiohttp
@@ -94,7 +94,7 @@ celery==5.2.7
     #   edx-celeryutils
     #   edx-enterprise
     #   event-tracking
-certifi==2022.6.15.1
+certifi==2022.9.24
     # via
     #   -r requirements/edx/paver.txt
     #   elasticsearch
@@ -320,7 +320,7 @@ django-model-utils==4.2.0
     #   ora2
     #   outcome-surveys
     #   super-csv
-django-mptt==0.13.4
+django-mptt==0.14.0
     # via
     #   -r requirements/edx/base.in
     #   django-wiki
@@ -346,7 +346,7 @@ django-sekizai==4.0.0
     # via
     #   -r requirements/edx/base.in
     #   django-wiki
-django-ses==3.1.2
+django-ses==3.2.0
     # via -r requirements/edx/base.in
 django-simple-history==3.0.0
     # via
@@ -417,7 +417,7 @@ drf-jwt==1.19.2
     # via edx-drf-extensions
 drf-nested-routers==0.93.4
     # via blockstore
-drf-yasg==1.21.3
+drf-yasg==1.21.4
     # via edx-api-doc-tools
 edx-ace==1.5.0
     # via -r requirements/edx/base.in
@@ -605,14 +605,14 @@ html5lib==1.1
     #   ora2
 icalendar==4.1.0
     # via -r requirements/edx/base.in
-idna==3.3
+idna==3.4
     # via
     #   -r requirements/edx/paver.txt
     #   optimizely-sdk
     #   requests
     #   snowflake-connector-python
     #   yarl
-importlib-metadata==4.12.0
+importlib-metadata==5.0.0
     # via markdown
 importlib-resources==5.9.0
     # via jsonschema
@@ -634,7 +634,7 @@ jmespath==0.10.0
     # via
     #   boto3
     #   botocore
-joblib==1.1.0
+joblib==1.2.0
     # via nltk
 jsondiff==2.0.0
     # via edx-enterprise
@@ -651,13 +651,13 @@ jsonfield==3.1.0
     #   outcome-surveys
 jsonschema==4.16.0
     # via optimizely-sdk
-jwcrypto==1.3.1
+jwcrypto==1.4.2
     # via pylti1p3
 kombu==5.2.4
     # via celery
 laboratory==1.0.2
     # via -r requirements/edx/base.in
-lazy==1.4
+lazy==1.5
     # via
     #   -r requirements/edx/paver.txt
     #   acid-xblock
@@ -665,6 +665,8 @@ lazy==1.4
     #   ora2
 learner-pathway-progress==1.3.2
     # via -r requirements/edx/base.in
+levenshtein==0.20.5
+    # via python-levenshtein
 libsass==0.10.0
     # via
     #   -r requirements/edx/paver.txt
@@ -685,7 +687,7 @@ lxml==4.9.1
     #   xmlsec
 mailsnake==1.6.4
     # via -r requirements/edx/base.in
-mako==1.2.2
+mako==1.2.3
     # via
     #   -r requirements/edx/base.in
     #   acid-xblock
@@ -734,7 +736,7 @@ mysqlclient==2.1.1
     # via
     #   -r requirements/edx/base.in
     #   blockstore
-newrelic==8.1.0.180
+newrelic==8.2.0.181
     # via
     #   -r requirements/edx/base.in
     #   edx-django-utils
@@ -761,6 +763,7 @@ openedx-calc==3.0.1
     # via -r requirements/edx/base.in
 openedx-events==0.13.0
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   edx-event-bus-kafka
 openedx-filters==0.8.0
@@ -780,9 +783,10 @@ packaging==21.3
     #   drf-yasg
     #   py2neo
     #   redis
+    #   tableauserverclient
 pansi==2020.7.3
     # via py2neo
-path==16.4.0
+path==16.5.0
     # via
     #   -r requirements/edx/base.in
     #   -r requirements/edx/paver.txt
@@ -842,7 +846,7 @@ pyjwkest==1.4.2
     #   -r requirements/edx/base.in
     #   edx-drf-extensions
     #   lti-consumer-xblock
-pyjwt[crypto]==2.4.0
+pyjwt[crypto]==2.5.0
     # via
     #   -r requirements/edx/base.in
     #   drf-jwt
@@ -855,7 +859,7 @@ pyjwt[crypto]==2.4.0
     #   social-auth-core
 pylatexenc==2.10
     # via olxcleaner
-pylti1p3==1.12.0
+pylti1p3==1.12.1
     # via -r requirements/edx/base.in
 pymongo==3.12.3
     # via
@@ -872,6 +876,7 @@ pynliner==0.8.0
     # via -r requirements/edx/base.in
 pyopenssl==22.0.0
     # via
+    #   -c requirements/edx/../constraints.txt
     #   optimizely-sdk
     #   snowflake-connector-python
 pyparsing==3.0.9
@@ -900,7 +905,7 @@ python-dateutil==2.8.2
     #   olxcleaner
     #   ora2
     #   xblock
-python-levenshtein==0.12.2
+python-levenshtein==0.20.5
     # via -r requirements/edx/base.in
 python-memcached==1.59
     # via -r requirements/edx/paver.txt
@@ -918,6 +923,7 @@ python3-saml==1.9.0
     #   -r requirements/edx/base.in
 pytz==2022.2.1
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   babel
     #   blockstore
@@ -950,6 +956,8 @@ pyyaml==6.0
     #   xblock
 random2==1.0.1
     # via -r requirements/edx/base.in
+rapidfuzz==2.11.0
+    # via levenshtein
 recommender-xblock==2.0.1
     # via -r requirements/edx/base.in
 redis==4.3.4
@@ -1048,7 +1056,7 @@ slumber==0.7.1
     #   edx-bulk-grades
     #   edx-enterprise
     #   edx-rest-api-client
-snowflake-connector-python==2.7.12
+snowflake-connector-python==2.8.0
     # via edx-enterprise
 social-auth-app-django==5.0.0
     # via
@@ -1067,7 +1075,7 @@ sortedcontainers==2.4.0
     # via -r requirements/edx/base.in
 soupsieve==2.3.2.post1
     # via beautifulsoup4
-sqlparse==0.4.2
+sqlparse==0.4.3
     # via
     #   -r requirements/edx/base.in
     #   blockstore
@@ -1089,7 +1097,7 @@ super-csv==3.0.1
     #   edx-bulk-grades
 sympy==1.11.1
     # via openedx-calc
-tableauserverclient==0.19.0
+tableauserverclient==0.23
     # via edx-enterprise
 testfixtures==7.0.0
     # via edx-enterprise
@@ -1099,6 +1107,8 @@ tinycss2==1.1.1
     # via bleach
 tqdm==4.64.1
     # via nltk
+types-cryptography==3.3.23
+    # via pyjwt
 typing-extensions==4.3.0
     # via
     #   django-countries
@@ -1119,6 +1129,7 @@ urllib3==1.26.12
     #   py2neo
     #   requests
     #   snowflake-connector-python
+    #   tableauserverclient
 user-util==1.0.0
     # via -r requirements/edx/base.in
 vine==5.0.0

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -6,9 +6,9 @@
 #
 chardet==5.0.0
     # via diff-cover
-coverage==6.4.4
+coverage==6.5.0
     # via -r requirements/edx/coverage.in
-diff-cover==6.5.1
+diff-cover==7.0.1
     # via -r requirements/edx/coverage.in
 jinja2==3.1.2
     # via diff-cover

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -18,7 +18,7 @@
     # via -r requirements/edx/testing.txt
 acid-xblock==0.2.1
     # via -r requirements/edx/testing.txt
-aiohttp==3.8.1
+aiohttp==3.8.3
     # via
     #   -r requirements/edx/testing.txt
     #   geoip2
@@ -133,7 +133,7 @@ celery==5.2.7
     #   edx-celeryutils
     #   edx-enterprise
     #   event-tracking
-certifi==2022.6.15.1
+certifi==2022.9.24
     # via
     #   -r requirements/edx/testing.txt
     #   elasticsearch
@@ -214,7 +214,7 @@ coreschema==0.0.4
     #   -r requirements/edx/testing.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==6.4.4
+coverage[toml]==6.5.0
     # via
     #   -r requirements/edx/testing.txt
     #   pytest-cov
@@ -258,7 +258,7 @@ deprecated==1.2.13
     #   -r requirements/edx/testing.txt
     #   jwcrypto
     #   redis
-diff-cover==6.5.1
+diff-cover==7.0.1
     # via -r requirements/edx/testing.txt
 dill==0.3.5.1
     # via
@@ -370,7 +370,7 @@ django-crum==0.7.9
     #   edx-rbac
     #   edx-toggles
     #   super-csv
-django-debug-toolbar==3.6.0
+django-debug-toolbar==3.7.0
     # via -r requirements/edx/development.in
 django-environ==0.9.0
     # via
@@ -419,7 +419,7 @@ django-model-utils==4.2.0
     #   ora2
     #   outcome-surveys
     #   super-csv
-django-mptt==0.13.4
+django-mptt==0.14.0
     # via
     #   -r requirements/edx/testing.txt
     #   django-wiki
@@ -449,7 +449,7 @@ django-sekizai==4.0.0
     # via
     #   -r requirements/edx/testing.txt
     #   django-wiki
-django-ses==3.1.2
+django-ses==3.2.0
     # via -r requirements/edx/testing.txt
 django-simple-history==3.0.0
     # via
@@ -529,7 +529,7 @@ drf-nested-routers==0.93.4
     # via
     #   -r requirements/edx/testing.txt
     #   blockstore
-drf-yasg==1.21.3
+drf-yasg==1.21.4
     # via
     #   -r requirements/edx/testing.txt
     #   edx-api-doc-tools
@@ -605,7 +605,7 @@ edx-i18n-tools==0.9.1
     # via
     #   -r requirements/edx/testing.txt
     #   ora2
-edx-lint==5.2.5
+edx-lint==5.3.0
     # via -r requirements/edx/testing.txt
 edx-milestones==0.4.0
     # via -r requirements/edx/testing.txt
@@ -701,11 +701,11 @@ execnet==1.9.0
     #   pytest-xdist
 factory-boy==3.2.1
     # via -r requirements/edx/testing.txt
-faker==14.2.0
+faker==15.0.0
     # via
     #   -r requirements/edx/testing.txt
     #   factory-boy
-fastapi==0.83.0
+fastapi==0.85.0
     # via
     #   -r requirements/edx/testing.txt
     #   pact-python
@@ -747,7 +747,7 @@ glob2==0.7
     # via -r requirements/edx/testing.txt
 gunicorn==20.1.0
     # via -r requirements/edx/testing.txt
-h11==0.13.0
+h11==0.14.0
     # via
     #   -r requirements/edx/testing.txt
     #   uvicorn
@@ -761,7 +761,7 @@ httpretty==1.1.4
     # via -r requirements/edx/testing.txt
 icalendar==4.1.0
     # via -r requirements/edx/testing.txt
-idna==3.3
+idna==3.4
     # via
     #   -r requirements/edx/testing.txt
     #   anyio
@@ -771,7 +771,7 @@ idna==3.3
     #   yarl
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==4.12.0
+importlib-metadata==5.0.0
     # via
     #   -r requirements/edx/testing.txt
     #   markdown
@@ -819,7 +819,7 @@ jmespath==0.10.0
     #   -r requirements/edx/testing.txt
     #   boto3
     #   botocore
-joblib==1.1.0
+joblib==1.2.0
     # via
     #   -r requirements/edx/testing.txt
     #   nltk
@@ -843,7 +843,7 @@ jsonschema==4.16.0
     #   -r requirements/edx/testing.txt
     #   optimizely-sdk
     #   sphinxcontrib-openapi
-jwcrypto==1.3.1
+jwcrypto==1.4.2
     # via
     #   -r requirements/edx/testing.txt
     #   pylti1p3
@@ -853,7 +853,7 @@ kombu==5.2.4
     #   celery
 laboratory==1.0.2
     # via -r requirements/edx/testing.txt
-lazy==1.4
+lazy==1.5
     # via
     #   -r requirements/edx/testing.txt
     #   acid-xblock
@@ -866,6 +866,10 @@ lazy-object-proxy==1.7.1
     #   astroid
 learner-pathway-progress==1.3.2
     # via -r requirements/edx/testing.txt
+levenshtein==0.20.5
+    # via
+    #   -r requirements/edx/testing.txt
+    #   python-levenshtein
 libsass==0.10.0
     # via
     #   -r requirements/edx/testing.txt
@@ -891,7 +895,7 @@ m2r==0.2.1
     # via sphinxcontrib-openapi
 mailsnake==1.6.4
     # via -r requirements/edx/testing.txt
-mako==1.2.2
+mako==1.2.3
     # via
     #   -r requirements/edx/testing.txt
     #   acid-xblock
@@ -952,7 +956,7 @@ multidict==6.0.2
     #   -r requirements/edx/testing.txt
     #   aiohttp
     #   yarl
-mypy==0.971
+mypy==0.981
     # via -r requirements/edx/development.in
 mypy-extensions==0.4.3
     # via mypy
@@ -960,7 +964,7 @@ mysqlclient==2.1.1
     # via
     #   -r requirements/edx/testing.txt
     #   blockstore
-newrelic==8.1.0.180
+newrelic==8.2.0.181
     # via
     #   -r requirements/edx/testing.txt
     #   edx-django-utils
@@ -988,6 +992,7 @@ openedx-calc==3.0.1
     # via -r requirements/edx/testing.txt
 openedx-events==0.13.0
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   edx-event-bus-kafka
 openedx-filters==0.8.0
@@ -1014,6 +1019,7 @@ packaging==21.3
     #   pytest
     #   redis
     #   sphinx
+    #   tableauserverclient
     #   tox
 pact-python==1.6.0
     # via -r requirements/edx/testing.txt
@@ -1021,7 +1027,7 @@ pansi==2020.7.3
     # via
     #   -r requirements/edx/testing.txt
     #   py2neo
-path==16.4.0
+path==16.5.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-i18n-tools
@@ -1126,7 +1132,7 @@ pyjwkest==1.4.2
     #   -r requirements/edx/testing.txt
     #   edx-drf-extensions
     #   lti-consumer-xblock
-pyjwt[crypto]==2.4.0
+pyjwt[crypto]==2.5.0
     # via
     #   -r requirements/edx/testing.txt
     #   drf-jwt
@@ -1165,7 +1171,7 @@ pylint-plugin-utils==0.7
     #   pylint-django
 pylint-pytest==0.3.0
     # via -r requirements/edx/testing.txt
-pylti1p3==1.12.0
+pylti1p3==1.12.1
     # via -r requirements/edx/testing.txt
 pymongo==3.12.3
     # via
@@ -1183,6 +1189,7 @@ pynliner==0.8.0
     # via -r requirements/edx/testing.txt
 pyopenssl==22.0.0
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   optimizely-sdk
     #   snowflake-connector-python
@@ -1218,7 +1225,7 @@ pytest==7.1.3
     #   pytest-xdist
 pytest-attrib==0.1.3
     # via -r requirements/edx/testing.txt
-pytest-cov==3.0.0
+pytest-cov==4.0.0
     # via -r requirements/edx/testing.txt
 pytest-django==4.5.2
     # via -r requirements/edx/testing.txt
@@ -1251,7 +1258,7 @@ python-dateutil==2.8.2
     #   olxcleaner
     #   ora2
     #   xblock
-python-levenshtein==0.12.2
+python-levenshtein==0.20.5
     # via -r requirements/edx/testing.txt
 python-memcached==1.59
     # via -r requirements/edx/testing.txt
@@ -1273,6 +1280,7 @@ python3-saml==1.9.0
     #   -r requirements/edx/testing.txt
 pytz==2022.2.1
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   babel
     #   blockstore
@@ -1308,6 +1316,10 @@ pyyaml==6.0
     #   xblock
 random2==1.0.1
     # via -r requirements/edx/testing.txt
+rapidfuzz==2.11.0
+    # via
+    #   -r requirements/edx/testing.txt
+    #   levenshtein
 recommender-xblock==2.0.1
     # via -r requirements/edx/testing.txt
 redis==4.3.4
@@ -1440,7 +1452,7 @@ sniffio==1.3.0
     #   anyio
 snowballstemmer==2.2.0
     # via sphinx
-snowflake-connector-python==2.7.12
+snowflake-connector-python==2.8.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
@@ -1484,7 +1496,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlparse==0.4.2
+sqlparse==0.4.3
     # via
     #   -r requirements/edx/testing.txt
     #   blockstore
@@ -1492,7 +1504,7 @@ sqlparse==0.4.2
     #   django-debug-toolbar
 staff-graded-xblock==2.0.1
     # via -r requirements/edx/testing.txt
-starlette==0.19.1
+starlette==0.20.4
     # via
     #   -r requirements/edx/testing.txt
     #   fastapi
@@ -1512,7 +1524,7 @@ sympy==1.11.1
     # via
     #   -r requirements/edx/testing.txt
     #   openedx-calc
-tableauserverclient==0.19.0
+tableauserverclient==0.23
     # via
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
@@ -1551,6 +1563,10 @@ tqdm==4.64.1
     # via
     #   -r requirements/edx/testing.txt
     #   nltk
+types-cryptography==3.3.23
+    # via
+    #   -r requirements/edx/testing.txt
+    #   pyjwt
 typing-extensions==4.3.0
     # via
     #   -r requirements/edx/testing.txt
@@ -1582,6 +1598,7 @@ urllib3==1.26.12
     #   requests
     #   selenium
     #   snowflake-connector-python
+    #   tableauserverclient
 user-util==1.0.0
     # via -r requirements/edx/testing.txt
 uvicorn==0.18.3
@@ -1602,7 +1619,7 @@ voluptuous==0.13.1
     # via
     #   -r requirements/edx/testing.txt
     #   ora2
-vulture==2.5
+vulture==2.6
     # via -r requirements/edx/development.in
 watchdog==2.1.9
     # via -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -8,7 +8,7 @@ alabaster==0.7.12
     # via sphinx
 babel==2.10.3
     # via sphinx
-certifi==2022.6.15.1
+certifi==2022.9.24
     # via requests
 charset-normalizer==2.0.12
     # via
@@ -30,11 +30,11 @@ gitdb==4.0.9
     # via gitpython
 gitpython==3.1.27
     # via -r requirements/edx/doc.in
-idna==3.3
+idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==4.12.0
+importlib-metadata==5.0.0
     # via sphinx
 jinja2==3.1.2
     # via
@@ -53,7 +53,9 @@ pyparsing==3.0.9
 python-slugify==6.1.2
     # via code-annotations
 pytz==2022.2.1
-    # via babel
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   babel
 pyyaml==6.0
     # via code-annotations
 requests==2.28.1

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-certifi==2022.6.15.1
+certifi==2022.9.24
     # via requests
 charset-normalizer==2.0.12
     # via
@@ -12,9 +12,9 @@ charset-normalizer==2.0.12
     #   requests
 edx-opaque-keys==2.3.0
     # via -r requirements/edx/paver.in
-idna==3.3
+idna==3.4
     # via requests
-lazy==1.4
+lazy==1.5
     # via -r requirements/edx/paver.in
 libsass==0.10.0
     # via -r requirements/edx/paver.in
@@ -22,7 +22,7 @@ markupsafe==2.1.1
     # via -r requirements/edx/paver.in
 mock==4.0.3
     # via -r requirements/edx/paver.in
-path==16.4.0
+path==16.5.0
     # via -r requirements/edx/paver.in
 paver==1.3.4
     # via -r requirements/edx/paver.in

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -18,7 +18,7 @@
     # via -r requirements/edx/base.txt
 acid-xblock==0.2.1
     # via -r requirements/edx/base.txt
-aiohttp==3.8.1
+aiohttp==3.8.3
     # via
     #   -r requirements/edx/base.txt
     #   geoip2
@@ -125,7 +125,7 @@ celery==5.2.7
     #   edx-celeryutils
     #   edx-enterprise
     #   event-tracking
-certifi==2022.6.15.1
+certifi==2022.9.24
     # via
     #   -r requirements/edx/base.txt
     #   elasticsearch
@@ -203,7 +203,7 @@ coreschema==0.0.4
     #   -r requirements/edx/base.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==6.4.4
+coverage[toml]==6.5.0
     # via
     #   -r requirements/edx/coverage.txt
     #   pytest-cov
@@ -248,7 +248,7 @@ deprecated==1.2.13
     #   -r requirements/edx/base.txt
     #   jwcrypto
     #   redis
-diff-cover==6.5.1
+diff-cover==7.0.1
     # via -r requirements/edx/coverage.txt
 dill==0.3.5.1
     # via pylint
@@ -401,7 +401,7 @@ django-model-utils==4.2.0
     #   ora2
     #   outcome-surveys
     #   super-csv
-django-mptt==0.13.4
+django-mptt==0.14.0
     # via
     #   -r requirements/edx/base.txt
     #   django-wiki
@@ -431,7 +431,7 @@ django-sekizai==4.0.0
     # via
     #   -r requirements/edx/base.txt
     #   django-wiki
-django-ses==3.1.2
+django-ses==3.2.0
     # via -r requirements/edx/base.txt
 django-simple-history==3.0.0
     # via
@@ -509,7 +509,7 @@ drf-nested-routers==0.93.4
     # via
     #   -r requirements/edx/base.txt
     #   blockstore
-drf-yasg==1.21.3
+drf-yasg==1.21.4
     # via
     #   -r requirements/edx/base.txt
     #   edx-api-doc-tools
@@ -586,7 +586,7 @@ edx-i18n-tools==0.9.1
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/testing.in
     #   ora2
-edx-lint==5.2.5
+edx-lint==5.3.0
     # via -r requirements/edx/testing.in
 edx-milestones==0.4.0
     # via -r requirements/edx/base.txt
@@ -678,9 +678,9 @@ execnet==1.9.0
     # via pytest-xdist
 factory-boy==3.2.1
     # via -r requirements/edx/testing.in
-faker==14.2.0
+faker==15.0.0
     # via factory-boy
-fastapi==0.83.0
+fastapi==0.85.0
     # via pact-python
 fastavro==1.6.1
     # via
@@ -720,7 +720,7 @@ glob2==0.7
     # via -r requirements/edx/base.txt
 gunicorn==20.1.0
     # via -r requirements/edx/base.txt
-h11==0.13.0
+h11==0.14.0
     # via uvicorn
 help-tokens==2.2.0
     # via -r requirements/edx/base.txt
@@ -732,7 +732,7 @@ httpretty==1.1.4
     # via -r requirements/edx/testing.in
 icalendar==4.1.0
     # via -r requirements/edx/base.txt
-idna==3.3
+idna==3.4
     # via
     #   -r requirements/edx/base.txt
     #   anyio
@@ -740,7 +740,7 @@ idna==3.3
     #   requests
     #   snowflake-connector-python
     #   yarl
-importlib-metadata==4.12.0
+importlib-metadata==5.0.0
     # via
     #   -r requirements/edx/base.txt
     #   markdown
@@ -785,7 +785,7 @@ jmespath==0.10.0
     #   -r requirements/edx/base.txt
     #   boto3
     #   botocore
-joblib==1.1.0
+joblib==1.2.0
     # via
     #   -r requirements/edx/base.txt
     #   nltk
@@ -808,7 +808,7 @@ jsonschema==4.16.0
     # via
     #   -r requirements/edx/base.txt
     #   optimizely-sdk
-jwcrypto==1.3.1
+jwcrypto==1.4.2
     # via
     #   -r requirements/edx/base.txt
     #   pylti1p3
@@ -818,7 +818,7 @@ kombu==5.2.4
     #   celery
 laboratory==1.0.2
     # via -r requirements/edx/base.txt
-lazy==1.4
+lazy==1.5
     # via
     #   -r requirements/edx/base.txt
     #   acid-xblock
@@ -829,6 +829,10 @@ lazy-object-proxy==1.7.1
     # via astroid
 learner-pathway-progress==1.3.2
     # via -r requirements/edx/base.txt
+levenshtein==0.20.5
+    # via
+    #   -r requirements/edx/base.txt
+    #   python-levenshtein
 libsass==0.10.0
     # via
     #   -r requirements/edx/base.txt
@@ -852,7 +856,7 @@ lxml==4.9.1
     #   xmlsec
 mailsnake==1.6.4
     # via -r requirements/edx/base.txt
-mako==1.2.2
+mako==1.2.3
     # via
     #   -r requirements/edx/base.txt
     #   acid-xblock
@@ -912,7 +916,7 @@ mysqlclient==2.1.1
     # via
     #   -r requirements/edx/base.txt
     #   blockstore
-newrelic==8.1.0.180
+newrelic==8.2.0.181
     # via
     #   -r requirements/edx/base.txt
     #   edx-django-utils
@@ -940,6 +944,7 @@ openedx-calc==3.0.1
     # via -r requirements/edx/base.txt
 openedx-events==0.13.0
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-event-bus-kafka
 openedx-filters==0.8.0
@@ -963,6 +968,7 @@ packaging==21.3
     #   py2neo
     #   pytest
     #   redis
+    #   tableauserverclient
     #   tox
 pact-python==1.6.0
     # via -r requirements/edx/testing.in
@@ -970,7 +976,7 @@ pansi==2020.7.3
     # via
     #   -r requirements/edx/base.txt
     #   py2neo
-path==16.4.0
+path==16.5.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-i18n-tools
@@ -1066,7 +1072,7 @@ pyjwkest==1.4.2
     #   -r requirements/edx/base.txt
     #   edx-drf-extensions
     #   lti-consumer-xblock
-pyjwt[crypto]==2.4.0
+pyjwt[crypto]==2.5.0
     # via
     #   -r requirements/edx/base.txt
     #   drf-jwt
@@ -1099,7 +1105,7 @@ pylint-plugin-utils==0.7
     #   pylint-django
 pylint-pytest==0.3.0
     # via -r requirements/edx/testing.in
-pylti1p3==1.12.0
+pylti1p3==1.12.1
     # via -r requirements/edx/base.txt
 pymongo==3.12.3
     # via
@@ -1117,6 +1123,7 @@ pynliner==0.8.0
     # via -r requirements/edx/base.txt
 pyopenssl==22.0.0
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   optimizely-sdk
     #   snowflake-connector-python
@@ -1151,7 +1158,7 @@ pytest==7.1.3
     #   pytest-xdist
 pytest-attrib==0.1.3
     # via -r requirements/edx/testing.in
-pytest-cov==3.0.0
+pytest-cov==4.0.0
     # via -r requirements/edx/testing.in
 pytest-django==4.5.2
     # via -r requirements/edx/testing.in
@@ -1182,7 +1189,7 @@ python-dateutil==2.8.2
     #   olxcleaner
     #   ora2
     #   xblock
-python-levenshtein==0.12.2
+python-levenshtein==0.20.5
     # via -r requirements/edx/base.txt
 python-memcached==1.59
     # via -r requirements/edx/base.txt
@@ -1204,6 +1211,7 @@ python3-saml==1.9.0
     #   -r requirements/edx/base.txt
 pytz==2022.2.1
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   babel
     #   blockstore
@@ -1236,6 +1244,10 @@ pyyaml==6.0
     #   xblock
 random2==1.0.1
     # via -r requirements/edx/base.txt
+rapidfuzz==2.11.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   levenshtein
 recommender-xblock==2.0.1
     # via -r requirements/edx/base.txt
 redis==4.3.4
@@ -1361,7 +1373,7 @@ slumber==0.7.1
     #   edx-rest-api-client
 sniffio==1.3.0
     # via anyio
-snowflake-connector-python==2.7.12
+snowflake-connector-python==2.8.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -1384,14 +1396,14 @@ soupsieve==2.3.2.post1
     # via
     #   -r requirements/edx/base.txt
     #   beautifulsoup4
-sqlparse==0.4.2
+sqlparse==0.4.3
     # via
     #   -r requirements/edx/base.txt
     #   blockstore
     #   django
 staff-graded-xblock==2.0.1
     # via -r requirements/edx/base.txt
-starlette==0.19.1
+starlette==0.20.4
     # via fastapi
 stevedore==4.0.0
     # via
@@ -1409,7 +1421,7 @@ sympy==1.11.1
     # via
     #   -r requirements/edx/base.txt
     #   openedx-calc
-tableauserverclient==0.19.0
+tableauserverclient==0.23
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -1442,6 +1454,10 @@ tqdm==4.64.1
     # via
     #   -r requirements/edx/base.txt
     #   nltk
+types-cryptography==3.3.23
+    # via
+    #   -r requirements/edx/base.txt
+    #   pyjwt
 typing-extensions==4.3.0
     # via
     #   -r requirements/edx/base.txt
@@ -1472,6 +1488,7 @@ urllib3==1.26.12
     #   requests
     #   selenium
     #   snowflake-connector-python
+    #   tableauserverclient
 user-util==1.0.0
     # via -r requirements/edx/base.txt
 uvicorn==0.18.3

--- a/scripts/xblock/requirements.txt
+++ b/scripts/xblock/requirements.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-certifi==2022.6.15.1
+certifi==2022.9.24
     # via requests
 charset-normalizer==2.1.1
     # via requests
-idna==3.3
+idna==3.4
     # via requests
 requests==2.28.1
     # via -r scripts/xblock/requirements.in


### PR DESCRIPTION
### Details
- `pyopenssl>22.0.0` requires `cryptography>=38.0` && conflicts with `snowflak-connector-python` requires `cryptography<37` which causes the requirements upgrade job to fail due to constraint conflict.
- This constraint can be removed once https://github.com/snowflakedb/snowflake-connector-python/issues/1259 is resolved
 and `snowflake-connector-python>2.8.0` is released.

- `pytz>2022.2.1` causes test failures in edx-platform so pinned `pytz==2022.2.1` for now.
- `openedx-events>0.13.0` causes test failures due to breaking changes so pinned openedx-events==0.13.0` for now
