### PR TITLE
build: Clear out stale dependencies when installing requirements

### DIFF
--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -63,7 +63,6 @@ jobs:
 
     - name: Install Required Python Dependencies
       run: |
-        pip install -r requirements/pip.txt
         make base-requirements
 
     - uses: c-hive/gha-npm-cache@v1

--- a/.github/workflows/migrations-check-mysql8.yml
+++ b/.github/workflows/migrations-check-mysql8.yml
@@ -50,7 +50,6 @@ jobs:
 
     - name: Install Python dependencies
       run: |
-        pip install -r requirements/pip.txt
         make dev-requirements
         pip uninstall -y mysqlclient
         pip install --no-binary mysqlclient mysqlclient

--- a/.github/workflows/migrations-check.yml
+++ b/.github/workflows/migrations-check.yml
@@ -60,7 +60,6 @@ jobs:
 
     - name: Install Python dependencies
       run: |
-        pip install -r requirements/pip.txt
         make dev-requirements
         pip uninstall -y mysqlclient
         pip install --no-binary mysqlclient mysqlclient

--- a/.github/workflows/pylint-checks.yml
+++ b/.github/workflows/pylint-checks.yml
@@ -57,7 +57,6 @@ jobs:
 
       - name: Install required Python dependencies
         run: |
-          pip install -r requirements/pip.txt
           make dev-requirements
           pip uninstall -y mysqlclient
           pip install --no-binary mysqlclient mysqlclient

--- a/.github/workflows/static-assets-check.yml
+++ b/.github/workflows/static-assets-check.yml
@@ -49,7 +49,6 @@ jobs:
 
     - name: Install Required Python Dependencies
       run: |
-        pip install -r requirements/pip.txt
         make base-requirements
 
     - name: Initiate Mongo DB Service

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -61,7 +61,6 @@ jobs:
 
       - name: install requirements
         run: |
-          sudo pip install -r requirements/pip.txt
           sudo make test-requirements
           if [[ "${{ matrix.django-version }}" == "pinned" ]]; then
             sudo pip install -r requirements/edx/django.txt

--- a/.github/workflows/verify-gha-unit-tests-count.yml
+++ b/.github/workflows/verify-gha-unit-tests-count.yml
@@ -17,7 +17,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: install requirements
         run: |
-          sudo pip install -r requirements/pip.txt
           sudo make test-requirements
 
       - name: verify unit tests count

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ local-requirements:
 # 	edx-platform installs some Python projects from within the edx-platform repo itself.
 	pip install -e .
 
-dev-requirements: pre-requirements ## install development environment requirements
+dev-requirements: pre-requirements
 	@# The "$(wildcard..)" is to include private.txt if it exists, and make no mention
 	@# of it if it does not.  Shell wildcarding can't do that with default options.
 	pip-sync -q requirements/edx/development.txt $(wildcard requirements/edx/private.txt)
@@ -85,7 +85,7 @@ test-requirements: pre-requirements
 	pip-sync --pip-args="--exists-action=w" requirements/edx/testing.txt
 	make local-requirements
 
-requirements: dev-requirements
+requirements: dev-requirements ## install development environment requirements
 
 shell: ## launch a bash shell in a Docker container with all edx-platform dependencies installed
 	docker run -it -e "NO_PYTHON_UNINSTALL=1" -e "PIP_INDEX_URL=https://pypi.python.org/simple" -e TERM \

--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,10 @@ local-requirements:
 # 	edx-platform installs some Python projects from within the edx-platform repo itself.
 	pip install -e .
 
-dev-requirements: pre-requirements
-	pip-sync requirements/edx/development.txt
+dev-requirements: pre-requirements ## install development environment requirements
+	@# The "$(wildcard..)" is to include private.txt if it exists, and make no mention
+	@# of it if it does not.  Shell wildcarding can't do that with default options.
+	pip-sync -q requirements/edx/development.txt $(wildcard requirements/edx/private.txt)
 	make local-requirements
 
 base-requirements: pre-requirements
@@ -83,11 +85,7 @@ test-requirements: pre-requirements
 	pip-sync --pip-args="--exists-action=w" requirements/edx/testing.txt
 	make local-requirements
 
-requirements: pre-requirements ## install development environment requirements
-	@# The "$(wildcard..)" is to include private.txt if it exists, and make no mention
-	@# of it if it does not.  Shell wildcarding can't do that with default options.
-	pip-sync -q requirements/edx/development.txt $(wildcard requirements/edx/private.txt)
-	pip install -e .
+requirements: dev-requirements
 
 shell: ## launch a bash shell in a Docker container with all edx-platform dependencies installed
 	docker run -it -e "NO_PYTHON_UNINSTALL=1" -e "PIP_INDEX_URL=https://pypi.python.org/simple" -e TERM \


### PR DESCRIPTION
This should help prevent some cross-version caching issues in the edx-platform-runner unit tests, which apparently run on a "dirty" environment. (This results in errors between master and older open-releases but could also prevent us from noticing missing deps.)

Calling `make local-requirements` at the end of each `*-requirements` target rather than making it a prerequisite is necessary for using sync, since otherwise the local reqs would be wiped out.

Adding a prerequisite of `pre-requirements` allows us to simplify some workflow calls slightly.

Also fix leading whitespace issue in Makefile.

----

We may wish to backport some or all of these changes to Nutmeg or maybe even Maple due to the caching issues that led to this PR (see discussion in https://github.com/openedx/edx-platform/pull/30759) but the changes will almost certainly not apply cleanly, and will have to be replayed by hand.