### PR TITLE
temp: constrain newrelic to working version

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -102,6 +102,5 @@ pytz==2022.2.1
 # These broken tests will be fixed in a separate PR
 openedx-events==0.13.0
 
-# newrelic==8.2.0 has broken instrumentation for confluent-kafka. This constraint can be removed once
-# that bug is fixed.
+# newrelic==8.2.0 has broken instrumentation for confluent-kafka. This constraint can be removed once this issue is fixed.
 newrelic<8.2.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -102,5 +102,6 @@ pytz==2022.2.1
 # These broken tests will be fixed in a separate PR
 openedx-events==0.13.0
 
-# newrelic==8.2.0 has broken instrumentation for confluent-kafka. This constraint can be removed once the issue is fixed.
+# newrelic==8.2.0 has broken instrumentation for confluent-kafka. This constraint can be removed once
+# that bug is fixed.
 newrelic<8.2.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -101,3 +101,6 @@ pytz==2022.2.1
 # openedx-events>0.13.0 causes test failures due to breaking changes
 # These broken tests will be fixed in a separate PR
 openedx-events==0.13.0
+
+# newrelic==8.2.0 has broken instrumentation for confluent-kafka. This constraint can be removed once the issue is fixed.
+newrelic<8.2.0

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -736,8 +736,9 @@ mysqlclient==2.1.1
     # via
     #   -r requirements/edx/base.in
     #   blockstore
-newrelic==8.2.0.181
+newrelic==8.1.0.180
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   edx-django-utils
 nltk==3.7

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -68,7 +68,6 @@ attrs==22.1.0
     #   edx-ace
     #   jsonschema
     #   openedx-events
-    #   outcome
     #   pytest
 babel==2.10.3
     # via
@@ -254,6 +253,7 @@ dill==0.3.5.1
     # via pylint
 distlib==0.3.6
     # via virtualenv
+django==3.2.15
     # via
     #   -c requirements/edx/../common_constraints.txt
     #   -r requirements/edx/base.txt
@@ -916,8 +916,9 @@ mysqlclient==2.1.1
     # via
     #   -r requirements/edx/base.txt
     #   blockstore
-newrelic==8.2.0.181
+newrelic==8.1.0.180
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-django-utils
 nltk==3.7

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -68,6 +68,7 @@ attrs==22.1.0
     #   edx-ace
     #   jsonschema
     #   openedx-events
+    #   outcome
     #   pytest
 babel==2.10.3
     # via
@@ -253,7 +254,6 @@ dill==0.3.5.1
     # via pylint
 distlib==0.3.6
     # via virtualenv
-django==3.2.15
     # via
     #   -c requirements/edx/../common_constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
GH Issue: https://github.com/edx/edx-arch-experiments/issues/71

Constrains NewRelic to <8.2.0 to avoid a bug in the Confluent Kafka instrumentation introduced in 8.2. New Relic Changelog: https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes

The issue to remove the constraint is here: https://github.com/edx/edx-arch-experiments/issues/72