### PR TITLE
perf: add lru_cache to improve performance with multiple themes

### DIFF
--- a/lms/djangoapps/courseware/tests/test_comprehensive_theming.py
+++ b/lms/djangoapps/courseware/tests/test_comprehensive_theming.py
@@ -8,6 +8,8 @@ from path import Path
 
 from common.djangoapps import edxmako
 from openedx.core.djangoapps.theming.tests.test_util import with_comprehensive_theme
+from openedx.core.djangoapps.theming.helpers import get_themes
+from openedx.core.djangoapps.theming.helpers_dirs import get_theme_dirs
 from openedx.core.lib.tempdir import create_symlink, delete_symlink, mkdtemp_clean
 
 
@@ -19,6 +21,10 @@ class TestComprehensiveTheming(TestCase):
 
         # Clear the internal staticfiles caches, to get test isolation.
         staticfiles.finders.get_finder.cache_clear()
+
+        # Clear cache on get_theme methods.
+        get_themes.cache_clear()
+        get_theme_dirs.cache_clear()
 
     @with_comprehensive_theme('red-theme')
     def test_red_footer(self):

--- a/openedx/core/djangoapps/theming/helpers.py
+++ b/openedx/core/djangoapps/theming/helpers.py
@@ -23,6 +23,7 @@ from openedx.core.djangoapps.theming.helpers_dirs import (
     get_themes_unchecked
 )
 from openedx.core.lib.cache_utils import request_cached
+from functools import lru_cache
 
 logger = getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -255,6 +256,7 @@ def theme_exists(theme_name, themes_dir=None):
     return False
 
 
+@lru_cache
 def get_themes(themes_dir=None):
     """
     get a list of all themes known to the system.

--- a/openedx/core/djangoapps/theming/helpers_dirs.py
+++ b/openedx/core/djangoapps/theming/helpers_dirs.py
@@ -7,6 +7,7 @@ as the discovery happens during the initial setup of Django settings.
 import os
 
 from path import Path
+from functools import lru_cache
 
 
 def get_theme_base_dirs_from_settings(theme_base_dirs=None):
@@ -49,6 +50,7 @@ def get_themes_unchecked(themes_base_dirs, project_root=None):
     return themes
 
 
+@lru_cache
 def get_theme_dirs(themes_base_dir=None):
     """
     Get all the theme dirs directly under a given base dir.

--- a/openedx/core/djangoapps/theming/tests/test_helpers.py
+++ b/openedx/core/djangoapps/theming/tests/test_helpers.py
@@ -16,12 +16,22 @@ from openedx.core.djangoapps.theming.helpers import (
     get_themes,
     strip_site_theme_templates_path
 )
+from openedx.core.djangoapps.theming.helpers_dirs import get_theme_dirs
 from openedx.core.djangoapps.theming.tests.test_util import with_comprehensive_theme
 from openedx.core.djangolib.testing.utils import skip_unless_cms, skip_unless_lms
 
 
 class TestHelpers(TestCase):
     """Test comprehensive theming helper functions."""
+
+    def setUp(self):
+        """
+        Clear cache on get_theme methods.
+        """
+        super().setUp()
+
+        get_themes.cache_clear()
+        get_theme_dirs.cache_clear()
 
     def test_get_themes(self):
         """


### PR DESCRIPTION
These changes should improve the performance when there are plenty of themes defined in **COMPREHENSIVE_THEME_DIRS**, using lru_cache to reduce the number of calls to the method **is_theme_dir**.

We have a bad response time due to the file I/O when it's **running in docker** the more themes you add to your platform the more slow answer you will have.

We can evidence this in these tests:

Test without comprehensive theming (0 Themes)
```bash
running (10m09.6s), 00/28 VUs, 602 complete and 0 interrupted iterations
http_req_duration..............: avg=553.57ms min=107.08ms med=492.97ms max=3.98s p(90)=1.02s p(95)=1.24s
```

Test with indigo (1 Theme)
```bash
running (10m15.3s), 00/28 VUs, 523 complete and 0 interrupted iterations
http_req_duration..............: avg=1.24s min=132.26ms med=1.23s max=2.95s p(90)=2s p(95)=2.17s
```

Test with multiple themes (5 Themes)
```bash
running (10m12.7s), 00/28 VUs, 313 complete and 3 interrupted iterations
http_req_duration..............: avg=4.56s   min=111.86ms med=5.25s   max=7.57s    p(90)=6.25s    p(95)=6.5s
```

**Finally, we can see the improvement with the changes in this PR (5 Themes)**
```bash
running (10m06.6s), 00/28 VUs, 592 complete and 0 interrupted iterations
http_req_duration..............: avg=633.36ms min=101.13ms med=606.9ms  max=2.15s    p(90)=1.13s    p(95)=1.27s 
```

For a thorough description of the issue, performance tests & solution design, you could refer to [
ISSUE: Comprehensive theming performance](https://discuss.openedx.org/t/issue-comprehensive-theming-performance/8292)

---
We may wish to backport all of these changes to Nutmeg