### PR TITLE
fix: update new `update_certificate_available_date_on_course_update` task to use dedicated credentials queue

### DIFF
--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -1041,6 +1041,8 @@ EXPLICIT_QUEUES = {
         'queue': PROGRAM_CERTIFICATES_ROUTING_KEY},
     'openedx.core.djangoapps.programs.tasks.update_certificate_visible_date_on_course_update': {
         'queue': PROGRAM_CERTIFICATES_ROUTING_KEY},
+    'openedx.core.djangoapps.programs.tasks.update_certificate_available_date_on_course_update': {
+        'queue': PROGRAM_CERTIFICATES_ROUTING_KEY},
     'openedx.core.djangoapps.programs.tasks.award_course_certificate': {
         'queue': PROGRAM_CERTIFICATES_ROUTING_KEY},
 }


### PR DESCRIPTION
[APER-1941]

* update new `update_certificate_available_date_on_course_update` task to use dedicated credentials queue (like the other import Credentials tasks)
