### PR TITLE
feat: integrate amplitude API with learner_home frontend [VAN-1124]

### DIFF
--- a/lms/djangoapps/learner_dashboard/api/v0/tests/test_views.py
+++ b/lms/djangoapps/learner_dashboard/api/v0/tests/test_views.py
@@ -252,7 +252,7 @@ class TestCourseRecommendationApiView(SharedModuleStoreTestCase):
             'marketing_url': 'https://www.edx.org/course/introduction-to-computer-science-and-programming-7'
         }
 
-    @mock.patch('lms.djangoapps.learner_dashboard.api.v0.views.get_personalized_course_recommendations', )
+    @mock.patch('lms.djangoapps.learner_dashboard.api.v0.views.get_personalized_course_recommendations')
     @mock.patch('lms.djangoapps.learner_dashboard.api.v0.views.get_course_data')
     def test_no_recommendations_from_amplitude(self, mocked_get_course_data,
                                                mocked_get_personalized_course_recommendations):

--- a/lms/djangoapps/learner_home/urls.py
+++ b/lms/djangoapps/learner_home/urls.py
@@ -12,4 +12,5 @@ urlpatterns = [
     re_path(
         r"^mock/init/?", mock_views.InitializeView.as_view(), name="mock_initialize"
     ),
+    re_path(r"^recommendation/courses/$", views.CourseRecommendationApiView.as_view(), name="courses"),
 ]

--- a/lms/djangoapps/learner_home/utils.py
+++ b/lms/djangoapps/learner_home/utils.py
@@ -1,0 +1,33 @@
+"""API utils"""
+
+import logging
+import requests
+from django.conf import settings
+
+log = logging.getLogger(__name__)
+
+
+def get_personalized_course_recommendations(user_id):
+    """ Get personalize recommendations from Amplitude. """
+    headers = {
+        'Authorization': f'Api-Key {settings.AMPLITUDE_API_KEY}',
+        'Content-Type': 'application/json'
+    }
+    params = {
+        'user_id': user_id,
+        'get_recs': True,
+        'rec_id': settings.REC_ID,
+    }
+    try:
+        response = requests.get(settings.AMPLITUDE_URL, params=params, headers=headers)
+        if response.status_code == 200:
+            response = response.json()
+            recommendations = response.get('userData', {}).get('recommendations', [])
+            if recommendations:
+                is_control = recommendations[0].get('is_control')
+                recommended_course_keys = recommendations[0].get('items')
+                return is_control, recommended_course_keys
+    except Exception as ex:  # pylint: disable=broad-except
+        log.warning(f'Cannot get recommendations from Amplitude: {ex}')
+
+    return True, []


### PR DESCRIPTION
This PR integrates the Amplitude Course Recommendations endpoint with the learner home MFE.

Ticket: https://2u-internal.atlassian.net/browse/VAN-1124