### PR TITLE
build(fix): use alls-green to correctly aggregate earlier steps

### DIFF
--- a/.github/workflows/pylint-checks.yml
+++ b/.github/workflows/pylint-checks.yml
@@ -65,13 +65,18 @@ jobs:
         run: |
           pylint ${{ matrix.path }}
 
+  # This job aggregates test results. It's the required check for branch protection.
+  # https://github.com/marketplace/actions/alls-green#why
+  # https://github.com/orgs/community/discussions/33579
   success:
-    name: Pylint successful
-    # A collection step to give a simple name for required status checks.
-    # https://github.com/orgs/community/discussions/33579
-    needs: run-pylint
+    name: Tests successful
+    if: always()
+    needs:
+      - run-pylint
     runs-on: ubuntu-latest
     steps:
-      - name: "Success"
-        run: |
-          echo Pylint successful
+      - name: Decide whether the needed jobs succeeded or failed
+        # uses: re-actors/alls-green@v1.2.1
+        uses: re-actors/alls-green@13b4244b312e8a314951e03958a2f91519a6a3c9
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -75,16 +75,21 @@ jobs:
       - name: Setup and run tests
         uses: ./.github/actions/unit-tests
 
+  # This job aggregates test results. It's the required check for branch protection.
+  # https://github.com/marketplace/actions/alls-green#why
+  # https://github.com/orgs/community/discussions/33579
   success:
     name: Tests successful
-    # A collection step to give a simple name for required status checks.
-    # https://github.com/orgs/community/discussions/33579
-    needs: run-tests
+    if: always()
+    needs:
+      - run-tests
     runs-on: ubuntu-latest
     steps:
-      - name: "Success"
-        run: |
-          echo Tests successful
+      - name: Decide whether the needed jobs succeeded or failed
+        # uses: re-actors/alls-green@v1.2.1
+        uses: re-actors/alls-green@13b4244b312e8a314951e03958a2f91519a6a3c9
+        with:
+          jobs: ${{ toJSON(needs) }}
 
   compile-warnings-report:
     runs-on: [ edx-platform-runner ]


### PR DESCRIPTION
My earlier action aggregation step wasn't sufficient. If a job "needs" earlier jobs, and one of the earlier jobs fails, then the "needs" job will be marked as Skipped.  A required check that is skipped doesn't block merging.

The alls-green action has the correct logic to fail the aggregation job if any of its required jobs fail.
