### PR TITLE
Optimize and reorganize GitHub-hosted dependencies (attempt 2)

### DIFF
--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -3,6 +3,11 @@
 # See BOM-2721 for more details.
 # Below is the copied and edited version of common_constraints
 
+# This is a temporary solution to override the real common_constraints.txt
+# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
+# See BOM-2721 for more details.
+# Below is the copied and edited version of common_constraints
+
 # A central location for most common version constraints
 # (across edx repos) for pip-installation.
 #

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -4,16 +4,6 @@
 #
 #    make upgrade
 #
--e git+https://github.com/openedx/blockstore.git@1.2.4#egg=blockstore==1.2.4
-    # via -r requirements/edx/github.in
--e git+https://github.com/openedx/codejail.git@3.1.3#egg=codejail==3.1.3
-    # via -r requirements/edx/github.in
--e git+https://github.com/openedx/django-wiki.git@1.1.1#egg=django-wiki
-    # via -r requirements/edx/github.in
--e git+https://github.com/openedx/olxcleaner.git@2f0d6c7f126cbd69c9724b7b57a0b2565330a297#egg=olxcleaner
-    # via -r requirements/edx/github.in
--e git+https://github.com/openedx/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive
-    # via -r requirements/edx/github.in
 acid-xblock==0.2.1
     # via -r requirements/edx/base.in
 aiohttp==3.8.3
@@ -67,6 +57,8 @@ bleach[css]==5.0.1
     #   ora2
     #   xblock-drag-and-drop-v2
     #   xblock-poll
+blockstore @ git+https://github.com/openedx/blockstore.git@1.2.5
+    # via -r requirements/edx/github.in
 boto==2.39.0
     # via
     #   -r requirements/edx/base.in
@@ -137,6 +129,8 @@ code-annotations==1.3.0
     # via
     #   edx-enterprise
     #   edx-toggles
+codejail @ git+https://github.com/openedx/codejail.git@3.1.3
+    # via -r requirements/edx/github.in
 codejail-includes==1.0.0
     # via -r requirements/edx/base.in
 contextlib2==21.6.0
@@ -339,7 +333,7 @@ django-pyfs==3.2.0
     # via -r requirements/edx/base.in
 django-ratelimit==3.0.1
     # via -r requirements/edx/base.in
-django-require @ git+https://github.com/openedx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776
+django-require @ git+https://github.com/openedx/django-require.git@f4f01e4e959adc6210873ae99e7f2c3741afbf35
     # via -r requirements/edx/github.in
 django-sekizai==4.0.0
     # via
@@ -382,6 +376,8 @@ django-webpack-loader==0.7.0
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   edx-proctoring
+django-wiki @ git+https://github.com/openedx/django-wiki.git@1.1.1
+    # via -r requirements/edx/github.in
 djangorestframework==3.12.4
     # via
     #   -r requirements/edx/base.in
@@ -444,6 +440,8 @@ edx-celeryutils==1.2.1
     #   -r requirements/edx/base.in
     #   edx-name-affirmation
     #   super-csv
+edx-codejail @ git+https://github.com/openedx/codejail.git@3.3.0
+    # via -r requirements/edx/github.in
 edx-completion==4.2.0
     # via -r requirements/edx/base.in
 edx-django-release-util==1.2.0
@@ -758,6 +756,8 @@ oauthlib==3.0.1
     #   lti-consumer-xblock
     #   requests-oauthlib
     #   social-auth-core
+olxcleaner @ git+https://github.com/openedx/olxcleaner.git@2f0d6c7f126cbd69c9724b7b57a0b2565330a297
+    # via -r requirements/edx/github.in
 openedx-calc==3.0.1
     # via -r requirements/edx/base.in
 openedx-events==0.13.0
@@ -1032,6 +1032,7 @@ six==1.16.0
     #   edx-ace
     #   edx-auth-backends
     #   edx-ccx-keys
+    #   edx-codejail
     #   edx-django-release-util
     #   edx-drf-extensions
     #   edx-milestones
@@ -1181,6 +1182,8 @@ xblock==1.6.1
     #   xblock-poll
     #   xblock-utils
 xblock-drag-and-drop-v2 @ git+https://github.com/openedx/xblock-drag-and-drop-v2@v2.3.5
+    # via -r requirements/edx/github.in
+xblock-google-drive @ git+https://github.com/openedx/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6
     # via -r requirements/edx/github.in
 xblock-poll @ git+https://github.com/open-craft/xblock-poll@v1.12.0
     # via -r requirements/edx/github.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -4,16 +4,6 @@
 #
 #    make upgrade
 #
--e git+https://github.com/openedx/blockstore.git@1.2.4#egg=blockstore==1.2.4
-    # via -r requirements/edx/testing.txt
--e git+https://github.com/openedx/codejail.git@3.1.3#egg=codejail==3.1.3
-    # via -r requirements/edx/testing.txt
--e git+https://github.com/openedx/django-wiki.git@1.1.1#egg=django-wiki
-    # via -r requirements/edx/testing.txt
--e git+https://github.com/openedx/olxcleaner.git@2f0d6c7f126cbd69c9724b7b57a0b2565330a297#egg=olxcleaner
-    # via -r requirements/edx/testing.txt
--e git+https://github.com/openedx/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive
-    # via -r requirements/edx/testing.txt
 acid-xblock==0.2.1
     # via -r requirements/edx/testing.txt
 aiohttp==3.8.3
@@ -100,6 +90,8 @@ bleach[css]==5.0.1
     #   ora2
     #   xblock-drag-and-drop-v2
     #   xblock-poll
+blockstore @ git+https://github.com/openedx/blockstore.git@1.2.5
+    # via -r requirements/edx/testing.txt
 bok-choy==1.1.1
     # via -r requirements/edx/testing.txt
 boto==2.39.0
@@ -200,6 +192,8 @@ code-annotations==1.3.0
     #   edx-enterprise
     #   edx-lint
     #   edx-toggles
+codejail @ git+https://github.com/openedx/codejail.git@3.1.3
+    # via -r requirements/edx/testing.txt
 codejail-includes==1.0.0
     # via -r requirements/edx/testing.txt
 contextlib2==21.6.0
@@ -442,7 +436,7 @@ django-pyfs==3.2.0
     # via -r requirements/edx/testing.txt
 django-ratelimit==3.0.1
     # via -r requirements/edx/testing.txt
-django-require @ git+https://github.com/openedx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776
+django-require @ git+https://github.com/openedx/django-require.git@f4f01e4e959adc6210873ae99e7f2c3741afbf35
     # via -r requirements/edx/testing.txt
 django-sekizai==4.0.0
     # via
@@ -485,6 +479,8 @@ django-webpack-loader==0.7.0
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   edx-proctoring
+django-wiki @ git+https://github.com/openedx/django-wiki.git@1.1.1
+    # via -r requirements/edx/testing.txt
 djangorestframework==3.12.4
     # via
     #   -r requirements/edx/testing.txt
@@ -560,6 +556,8 @@ edx-celeryutils==1.2.1
     #   -r requirements/edx/testing.txt
     #   edx-name-affirmation
     #   super-csv
+edx-codejail @ git+https://github.com/openedx/codejail.git@3.3.0
+    # via -r requirements/edx/testing.txt
 edx-completion==4.2.0
     # via -r requirements/edx/testing.txt
 edx-django-release-util==1.2.0
@@ -989,6 +987,8 @@ oauthlib==3.0.1
     #   lti-consumer-xblock
     #   requests-oauthlib
     #   social-auth-core
+olxcleaner @ git+https://github.com/openedx/olxcleaner.git@2f0d6c7f126cbd69c9724b7b57a0b2565330a297
+    # via -r requirements/edx/testing.txt
 openedx-calc==3.0.1
     # via -r requirements/edx/testing.txt
 openedx-events==0.13.0
@@ -1417,6 +1417,7 @@ six==1.16.0
     #   edx-ace
     #   edx-auth-backends
     #   edx-ccx-keys
+    #   edx-codejail
     #   edx-django-release-util
     #   edx-drf-extensions
     #   edx-lint
@@ -1673,6 +1674,8 @@ xblock==1.6.1
     #   xblock-poll
     #   xblock-utils
 xblock-drag-and-drop-v2 @ git+https://github.com/openedx/xblock-drag-and-drop-v2@v2.3.5
+    # via -r requirements/edx/testing.txt
+xblock-google-drive @ git+https://github.com/openedx/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6
     # via -r requirements/edx/testing.txt
 xblock-poll @ git+https://github.com/open-craft/xblock-poll@v1.12.0
     # via -r requirements/edx/testing.txt

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -63,12 +63,14 @@
 #     re-install the package each time, and can be useful when working with two
 #     repos before picking a version number. Don't use 0.0 on master, only for
 #     tight-loop work in progress.
--e git+https://github.com/openedx/django-wiki.git@1.1.1#egg=django-wiki
--e git+https://github.com/openedx/olxcleaner.git@2f0d6c7f126cbd69c9724b7b57a0b2565330a297#egg=olxcleaner
-git+https://github.com/openedx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2
-git+https://github.com/openedx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776#egg=django-require==1.0.12
+#
+#   * Alphabetize dependencies by DIST-NAME.
 -e git+https://github.com/openedx/blockstore.git@1.2.4#egg=blockstore==1.2.4  # Note: Blockstore 1.2.2 & 1.2.3 are failing.
 -e git+https://github.com/openedx/codejail.git@3.1.3#egg=codejail==3.1.3
+git+https://github.com/openedx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776#egg=django-require==1.0.12
+-e git+https://github.com/openedx/django-wiki.git@1.1.1#egg=django-wiki
+git+https://github.com/openedx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2
+-e git+https://github.com/openedx/olxcleaner.git@2f0d6c7f126cbd69c9724b7b57a0b2565330a297#egg=olxcleaner
+git+https://github.com/openedx/xblock-drag-and-drop-v2@v2.3.5#egg=xblock-drag-and-drop-v2==2.3.5
 -e git+https://github.com/openedx/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive
 git+https://github.com/open-craft/xblock-poll@v1.12.0#egg=xblock-poll==1.12.0
-git+https://github.com/openedx/xblock-drag-and-drop-v2@v2.3.5#egg=xblock-drag-and-drop-v2==2.3.5

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -65,12 +65,12 @@
 #     tight-loop work in progress.
 #
 #   * Alphabetize dependencies by DIST-NAME.
--e git+https://github.com/openedx/blockstore.git@1.2.4#egg=blockstore==1.2.4  # Note: Blockstore 1.2.2 & 1.2.3 are failing.
--e git+https://github.com/openedx/codejail.git@3.1.3#egg=codejail==3.1.3
-git+https://github.com/openedx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776#egg=django-require==1.0.12
--e git+https://github.com/openedx/django-wiki.git@1.1.1#egg=django-wiki
+git+https://github.com/openedx/blockstore.git@1.2.5#egg=blockstore==1.2.5  # See blockstore comment below.
+git+https://github.com/openedx/codejail.git@3.1.3#egg=codejail==3.1.3
+git+https://github.com/openedx/django-require.git@f4f01e4e959adc6210873ae99e7f2c3741afbf35#egg=django-require==1.0.12
+git+https://github.com/openedx/django-wiki.git@1.1.1#egg=django-wiki
 git+https://github.com/openedx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2
--e git+https://github.com/openedx/olxcleaner.git@2f0d6c7f126cbd69c9724b7b57a0b2565330a297#egg=olxcleaner
+git+https://github.com/openedx/olxcleaner.git@2f0d6c7f126cbd69c9724b7b57a0b2565330a297#egg=olxcleaner
 git+https://github.com/openedx/xblock-drag-and-drop-v2@v2.3.5#egg=xblock-drag-and-drop-v2==2.3.5
--e git+https://github.com/openedx/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive
+git+https://github.com/openedx/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive
 git+https://github.com/open-craft/xblock-poll@v1.12.0#egg=xblock-poll==1.12.0

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -65,7 +65,8 @@
 #     tight-loop work in progress.
 #
 #   * Alphabetize dependencies by DIST-NAME.
-git+https://github.com/openedx/blockstore.git@1.2.5#egg=blockstore==1.2.5  # See blockstore comment below.
+git+https://github.com/openedx/blockstore.git@1.2.5#egg=blockstore==1.2.5
+git+https://github.com/openedx/codejail.git@3.3.0#egg=edx-codejail==3.3.0
 git+https://github.com/openedx/codejail.git@3.1.3#egg=codejail==3.1.3
 git+https://github.com/openedx/django-require.git@f4f01e4e959adc6210873ae99e7f2c3741afbf35#egg=django-require==1.0.12
 git+https://github.com/openedx/django-wiki.git@1.1.1#egg=django-wiki

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -1,15 +1,29 @@
-# DON'T JUST ADD NEW DEPENDENCIES!!!
+# This file holds all GitHub-hosted edx-platform Python dependencies.
+# Such dependencies should be added here, not to base.in.
+# That being said....
 #
-# If you open a pull request that adds a new dependency, you should:
+# ---->>> DON'T JUST ADD NEW DEPENDENCIES!!! <<<----
+#
+# We are working to move all dependencies here to proper PyPI-hosted
+# projects that can be specified in base.in (or development.in, etc).
+# Every new GitHub-hosted dependency slows down the edx-platform build and
+# subverts our continuous dependency upgrade process. This file should
+# only be added to in exceptional circumstances.
+#
+# "I don't have time to publish my package to PyPI" is **not** an
+# acceptable excuse. You can add a GitHub Action workflow to automatically
+# upload your package to PyPI with the push of a button:
+#
+# * Go to https://github.com/openedx/<YOUR_REPO>/actions/new
+# * Find "Publish Python Package"
+# * Merge the generated PR and push package.
+# * You're done! Add your dependency to base.in, and the requirements
+#   bot will automatically keep it fresh in edx-platform.
+#
+# If you must open a pull request that adds a new git dependency, you should:
 #   * verify that the dependency has a license compatible with AGPLv3
 #   * confirm that it has no system requirements beyond what we already install
 #   * run "make upgrade" to update the detailed requirements files
-#
-# Do *NOT* install Python packages from GitHub unless it's absolutely necessary!
-# "I don't have time to add automatic Travis upload to PyPI." is *not* an
-# acceptable excuse. Non-wheel module installations slow down the dev/building process.
-# Travis/PyPI instructions are here:
-# https://openedx.atlassian.net/wiki/spaces/OpenOPS/pages/41911049/Publishing+a+Package+to+PyPI+using+Travis
 #
 # A correct GitHub reference looks like this:
 #

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -63,25 +63,12 @@
 #     re-install the package each time, and can be useful when working with two
 #     repos before picking a version number. Don't use 0.0 on master, only for
 #     tight-loop work in progress.
-
-
-# Python libraries to install directly from github
-
-# Third-party:
 -e git+https://github.com/openedx/django-wiki.git@1.1.1#egg=django-wiki
 -e git+https://github.com/openedx/olxcleaner.git@2f0d6c7f126cbd69c9724b7b57a0b2565330a297#egg=olxcleaner
 git+https://github.com/openedx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2
-
-# original repo is not maintained any more.
 git+https://github.com/openedx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776#egg=django-require==1.0.12
-
-
-# Our libraries:
 -e git+https://github.com/openedx/blockstore.git@1.2.4#egg=blockstore==1.2.4  # Note: Blockstore 1.2.2 & 1.2.3 are failing.
 -e git+https://github.com/openedx/codejail.git@3.1.3#egg=codejail==3.1.3
 -e git+https://github.com/openedx/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive
-
-# Third Party XBlocks
-
 git+https://github.com/open-craft/xblock-poll@v1.12.0#egg=xblock-poll==1.12.0
 git+https://github.com/openedx/xblock-drag-and-drop-v2@v2.3.5#egg=xblock-drag-and-drop-v2==2.3.5

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -4,16 +4,6 @@
 #
 #    make upgrade
 #
--e git+https://github.com/openedx/blockstore.git@1.2.4#egg=blockstore==1.2.4
-    # via -r requirements/edx/base.txt
--e git+https://github.com/openedx/codejail.git@3.1.3#egg=codejail==3.1.3
-    # via -r requirements/edx/base.txt
--e git+https://github.com/openedx/django-wiki.git@1.1.1#egg=django-wiki
-    # via -r requirements/edx/base.txt
--e git+https://github.com/openedx/olxcleaner.git@2f0d6c7f126cbd69c9724b7b57a0b2565330a297#egg=olxcleaner
-    # via -r requirements/edx/base.txt
--e git+https://github.com/openedx/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive
-    # via -r requirements/edx/base.txt
 acid-xblock==0.2.1
     # via -r requirements/edx/base.txt
 aiohttp==3.8.3
@@ -95,6 +85,8 @@ bleach[css]==5.0.1
     #   ora2
     #   xblock-drag-and-drop-v2
     #   xblock-poll
+blockstore @ git+https://github.com/openedx/blockstore.git@1.2.5
+    # via -r requirements/edx/base.txt
 bok-choy==1.1.1
     # via -r requirements/edx/testing.in
 boto==2.39.0
@@ -188,6 +180,8 @@ code-annotations==1.3.0
     #   edx-enterprise
     #   edx-lint
     #   edx-toggles
+codejail @ git+https://github.com/openedx/codejail.git@3.1.3
+    # via -r requirements/edx/base.txt
 codejail-includes==1.0.0
     # via -r requirements/edx/base.txt
 contextlib2==21.6.0
@@ -423,7 +417,7 @@ django-pyfs==3.2.0
     # via -r requirements/edx/base.txt
 django-ratelimit==3.0.1
     # via -r requirements/edx/base.txt
-django-require @ git+https://github.com/openedx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776
+django-require @ git+https://github.com/openedx/django-require.git@f4f01e4e959adc6210873ae99e7f2c3741afbf35
     # via -r requirements/edx/base.txt
 django-sekizai==4.0.0
     # via
@@ -466,6 +460,8 @@ django-webpack-loader==0.7.0
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-proctoring
+django-wiki @ git+https://github.com/openedx/django-wiki.git@1.1.1
+    # via -r requirements/edx/base.txt
 djangorestframework==3.12.4
     # via
     #   -r requirements/edx/base.txt
@@ -539,6 +535,8 @@ edx-celeryutils==1.2.1
     #   -r requirements/edx/base.txt
     #   edx-name-affirmation
     #   super-csv
+edx-codejail @ git+https://github.com/openedx/codejail.git@3.3.0
+    # via -r requirements/edx/base.txt
 edx-completion==4.2.0
     # via -r requirements/edx/base.txt
 edx-django-release-util==1.2.0
@@ -940,6 +938,8 @@ oauthlib==3.0.1
     #   lti-consumer-xblock
     #   requests-oauthlib
     #   social-auth-core
+olxcleaner @ git+https://github.com/openedx/olxcleaner.git@2f0d6c7f126cbd69c9724b7b57a0b2565330a297
+    # via -r requirements/edx/base.txt
 openedx-calc==3.0.1
     # via -r requirements/edx/base.txt
 openedx-events==0.13.0
@@ -1343,6 +1343,7 @@ six==1.16.0
     #   edx-ace
     #   edx-auth-backends
     #   edx-ccx-keys
+    #   edx-codejail
     #   edx-django-release-util
     #   edx-drf-extensions
     #   edx-lint
@@ -1552,6 +1553,8 @@ xblock==1.6.1
     #   xblock-poll
     #   xblock-utils
 xblock-drag-and-drop-v2 @ git+https://github.com/openedx/xblock-drag-and-drop-v2@v2.3.5
+    # via -r requirements/edx/base.txt
+xblock-google-drive @ git+https://github.com/openedx/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6
     # via -r requirements/edx/base.txt
 xblock-poll @ git+https://github.com/open-craft/xblock-poll@v1.12.0
     # via -r requirements/edx/base.txt


### PR DESCRIPTION
## Description

This PR cleans up edx-platform's github.in file, notably:
* It updates the documentation on when (answer: very rarely) & how to add GitHub-hosted dependencies. This should encourage folks to add PyPI-hosted-dependencies instead, which install **significantly** faster.
* It makes sure that every GitHub-hosted dependency is installed in the same way: as a pre-built Python wheel, *not* an editable package. Our PyPI-hosted dependencies are always installed as wheels, so installing GitHub-hosted dependencies the same way will be slightly more performant and, more importantly, more consistent from a packaging standpoint.
* It runs `make upgrade` to ensure that the updates to github.in are propagated out to all the requirement `.txt` files. This also pulls in some unrelated but harmless-looking version pin upgrades.

See the commit messages for more details.

I worked on this as part of the [Tutor DevEnv Adoption project](https://github.com/orgs/overhangio/projects/3), because edx-platform build time is one of the major pain points for `tutor dev` users. However, the change should help improve the build story for all edx-platform developers whether or not they use Tutor.

## Supporting information

This PR re-merges https://github.com/openedx/edx-platform/pull/30719, which was reverted in https://github.com/openedx/edx-platform/pull/31021 due to an issue with codejail's setup scripts.

Codejail was fixed here: https://github.com/openedx/codejail/pull/140. This PR includes an additional commit to upgrade codejail to the fixed version.

## Testing instructions

The PR checks should be sufficient to test that these dependencies are correctly installed.

## Deadline

No specific deadline, but we are touching the requirements files which are ripe for merge conflicts, so I'm hoping to get it merged sooner than later!

## Other information

Part of https://github.com/openedx/wg-developer-experience/issues/153

This PR was blocked by edx-platform upgrading its blockstore pin to 1.2.4: https://github.com/openedx/edx-platform/pull/30620 . We needed that to happen so that we could install blockstore 1.2.5 (which has a fixed setup.py) without taking the risk of jumping all the way from 1.2.1 to 1.2.5.

### Merge considerations

I don't expect this PR to cause any problems in edx.org production, but I didn't expect that the [last PR](https://github.com/openedx/edx-platform/pull/30719) would either. So, as soon as this merges, I'll queue up a revert PR for myself or someone at 2U to merge if necessary.