### PR TITLE
build: fix syntax error in GH-hosted tests workflow

### DIFF
--- a/.github/workflows/unit-tests-gh-hosted.yml
+++ b/.github/workflows/unit-tests-gh-hosted.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
             pip install -r requirements/pip.txt
             pip install -r requirements/edx/development.txt --src ${{ runner.temp }}
-#            edx-platform installs some Python projects from within the edx-platform repo itself.
+            # edx-platform installs some Python projects from within the edx-platform repo itself.
             pip install -e .
             pip install "django~=${{ matrix.django-version }}.0"
 


### PR DESCRIPTION
## Description

See commit message

## Supporting information

introduced in: https://github.com/openedx/edx-platform/pull/30890

example failure: https://github.com/timmc-edx/edx-platform/actions/runs/3178176565

## Testing instructions

A green build here will be sufficient

## Deadline

N/A

## Other information

FYI @usamasadiq
