### PR TITLE
fix: safe wrapper for no program banner image

### DIFF
--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -345,7 +345,7 @@ class EntitlementSerializer(serializers.Serializer):
 class RelatedProgramSerializer(serializers.Serializer):
     """Related programs information"""
 
-    bannerImgSrc = serializers.URLField(source="banner_image.small.url")
+    bannerImgSrc = serializers.URLField(source="banner_image.small.url", default=None)
     logoImgSrc = serializers.SerializerMethodField()
     numberOfCourses = serializers.SerializerMethodField()
     programType = serializers.CharField(source="type")

--- a/lms/djangoapps/learner_home/test_serializers.py
+++ b/lms/djangoapps/learner_home/test_serializers.py
@@ -752,6 +752,23 @@ class TestProgramsSerializer(TestCase):
             },
         )
 
+    def test_empty_source_programs_serializer(self):
+        """Test the ProgramsSerializer with empty data"""
+        # Given a program with empty test data
+        input_data = self.generate_test_related_program()
+
+        input_data["banner_image"] = None
+        input_data["title"] = None
+        input_data["type"] = None
+
+        # When I serialize the program
+        output_data = RelatedProgramSerializer(input_data).data
+
+        # Test the output
+        self.assertEqual(
+            output_data['bannerImgSrc'], None
+        )
+
     def test_empty_sessions(self):
         input_data = {"relatedPrograms": []}
         output_data = ProgramsSerializer(input_data).data


### PR DESCRIPTION
Safe wrapper for related program serializer incase `banner_image=None`.

## Supporting information

Recieve splunk errors:
`
KeyError: "Got KeyError when attempting to get a value for field "bannerImgSrc" on serializer "RelatedProgramSerializer".\nThe serializer field might be named incorrectly and not match any attribute or key on the "dict" instance.\nOriginal exception text was: 'small'."
`
