### PR TITLE
fix: learner home fixes

### DIFF
--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -462,7 +462,7 @@ class UnfulfilledEntitlementSerializer(serializers.Serializer):
         'Private' Serializer for the 'course' key data. This data comes from the pseudo session
         """
 
-        bannerImgSrc = serializers.URLField(source="image.src")
+        bannerImgSrc = serializers.URLField(source="image.src", default=None)
         courseName = serializers.CharField(source="title")
         courseNumber = serializers.CharField(source="key")
 

--- a/lms/djangoapps/learner_home/test_serializers.py
+++ b/lms/djangoapps/learner_home/test_serializers.py
@@ -765,9 +765,7 @@ class TestProgramsSerializer(TestCase):
         output_data = RelatedProgramSerializer(input_data).data
 
         # Test the output
-        self.assertEqual(
-            output_data['bannerImgSrc'], None
-        )
+        self.assertEqual(output_data["bannerImgSrc"], None)
 
     def test_empty_sessions(self):
         input_data = {"relatedPrograms": []}

--- a/lms/djangoapps/learner_home/test_serializers.py
+++ b/lms/djangoapps/learner_home/test_serializers.py
@@ -883,6 +883,36 @@ class TestUnfulfilledEntitlementSerializer(LearnerDashboardBaseTest):
         assert output_data["courseProvider"] is not None
         assert output_data["programs"] == {"relatedPrograms": []}
 
+    def test_no_image(self):
+        # Given entitlements
+        (
+            unfulfilled_entitlement,
+            pseudo_sessions,
+            available_sessions,
+        ) = self.make_unfulfilled_entitlement()
+
+        # where pseudo sessions don't have images
+        for course_uuid in pseudo_sessions:
+            pseudo_session = pseudo_sessions[course_uuid]
+            pseudo_session["image"] = None
+
+        pseudo_session_course_overviews = self.make_pseudo_session_course_overviews(
+            unfulfilled_entitlement, pseudo_sessions
+        )
+
+        context = {
+            "unfulfilled_entitlement_pseudo_sessions": pseudo_sessions,
+            "course_entitlement_available_sessions": available_sessions,
+            "pseudo_session_course_overviews": pseudo_session_course_overviews,
+            "programs": {},
+        }
+
+        # When I serialize
+        UnfulfilledEntitlementSerializer(unfulfilled_entitlement, context=context).data
+
+        # Then I get None for bannerImgSrc instead of throwing an exception
+        pass
+
     def test_programs(self):
         (
             unfulfilled_entitlement,

--- a/lms/djangoapps/learner_home/test_serializers.py
+++ b/lms/djangoapps/learner_home/test_serializers.py
@@ -908,10 +908,12 @@ class TestUnfulfilledEntitlementSerializer(LearnerDashboardBaseTest):
         }
 
         # When I serialize
-        UnfulfilledEntitlementSerializer(unfulfilled_entitlement, context=context).data
+        output_data = UnfulfilledEntitlementSerializer(
+            unfulfilled_entitlement, context=context
+        ).data
 
         # Then I get None for bannerImgSrc instead of throwing an exception
-        pass
+        self.assertIsNone(output_data["course"]["bannerImgSrc"])
 
     def test_programs(self):
         (


### PR DESCRIPTION
## Description

Fixes from bug bash of learner home:
1. Add fallback for entitlement image when image is not supplied. Keeps serializer from breaking.
2. Run `black`

JIRA: [AU-849](https://2u-internal.atlassian.net/browse/AU-849)
FYI: @openedx/content-aurora 