### PR TITLE
fix: Pin newrelic to unreleased version fixing kafka instrumentation

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -120,7 +120,8 @@ mako                                # Primary template language used for server-
 Markdown                            # Convert text markup to HTML; used in capa problems, forums, and course wikis
 mongoengine                         # Object-document mapper for MongoDB, used in the LMS dashboard
 mysqlclient                         # Driver for the default production relational database
-newrelic                            # New Relic agent for performance monitoring
+# 2022-10-06: newrelic is temporarily pinned in github.in, see comment there.
+# newrelic                            # New Relic agent for performance monitoring
 nltk                                # Natural language processing; used by the chem package
 nodeenv                             # Utility for managing Node.js environments; we use this for deployments and testing
 oauthlib                            # OAuth specification support for authenticating via LTI or other Open edX services

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -736,9 +736,9 @@ mysqlclient==2.1.1
     # via
     #   -r requirements/edx/base.in
     #   blockstore
-newrelic==8.2.0.181
+newrelic @ git+https://github.com/newrelic/newrelic-python-agent.git@cf306cea7eed4a6b4a954622438628fd34cd9824
     # via
-    #   -r requirements/edx/base.in
+    #   -r requirements/edx/github.in
     #   edx-django-utils
 nltk==3.7
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -964,7 +964,7 @@ mysqlclient==2.1.1
     # via
     #   -r requirements/edx/testing.txt
     #   blockstore
-newrelic==8.2.0.181
+newrelic @ git+https://github.com/newrelic/newrelic-python-agent.git@cf306cea7eed4a6b4a954622438628fd34cd9824
     # via
     #   -r requirements/edx/testing.txt
     #   edx-django-utils

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -61,6 +61,15 @@ git+https://github.com/openedx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29
 # original repo is not maintained any more.
 git+https://github.com/openedx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776#egg=django-require==1.0.12
 
+# Pinned 2022-10-06: New Relic 8.2.0.181 adds instrumentation for confluent-kafka
+# but causes errors in event production if a dict is used for headers. This is fixed
+# in <https://github.com/newrelic/newrelic-python-agent/pull/645> but NR would like us
+# to test the fix (the pinned commit below) before they make their next release.
+# Once it's released, we should remove this pin and restore the line in base.in.
+# Unpinning is tracked in <https://github.com/openedx/event-bus-kafka/issues/52>.
+git+https://github.com/newrelic/newrelic-python-agent.git@cf306cea7eed4a6b4a954622438628fd34cd9824#egg=newrelic==8.3.0.0
+
+
 # Our libraries:
 -e git+https://github.com/openedx/blockstore.git@1.2.1#egg=blockstore==1.2.1  # Note: Blockstore 1.2.2 is failing.
 -e git+https://github.com/openedx/codejail.git@3.1.3#egg=codejail==3.1.3

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -916,7 +916,7 @@ mysqlclient==2.1.1
     # via
     #   -r requirements/edx/base.txt
     #   blockstore
-newrelic==8.2.0.181
+newrelic @ git+https://github.com/newrelic/newrelic-python-agent.git@cf306cea7eed4a6b4a954622438628fd34cd9824
     # via
     #   -r requirements/edx/base.txt
     #   edx-django-utils


### PR DESCRIPTION
This will allow us to resume producing events with edx-event-bus-kafka and help validate NR's fix. Unpinning is be tracked in <https://github.com/openedx/event-bus-kafka/issues/52>.
