### PR TITLE
chore: upgrades blockstore to 1.2.4

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
--e git+https://github.com/openedx/blockstore.git@1.2.1#egg=blockstore==1.2.1
+-e git+https://github.com/openedx/blockstore.git@1.2.4#egg=blockstore==1.2.4
     # via -r requirements/edx/github.in
 -e git+https://github.com/openedx/codejail.git@3.1.3#egg=codejail==3.1.3
     # via -r requirements/edx/github.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
--e git+https://github.com/openedx/blockstore.git@1.2.1#egg=blockstore==1.2.1
+-e git+https://github.com/openedx/blockstore.git@1.2.4#egg=blockstore==1.2.4
     # via -r requirements/edx/testing.txt
 -e git+https://github.com/openedx/codejail.git@3.1.3#egg=codejail==3.1.3
     # via -r requirements/edx/testing.txt

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -63,7 +63,7 @@ git+https://github.com/openedx/django-require.git@0c54adb167142383b26ea6b3edecc3
 
 
 # Our libraries:
--e git+https://github.com/openedx/blockstore.git@1.2.1#egg=blockstore==1.2.1  # Note: Blockstore 1.2.2 is failing.
+-e git+https://github.com/openedx/blockstore.git@1.2.4#egg=blockstore==1.2.4  # Note: Blockstore 1.2.2 & 1.2.3 are failing.
 -e git+https://github.com/openedx/codejail.git@3.1.3#egg=codejail==3.1.3
 -e git+https://github.com/openedx/RateXBlock.git@2.0.1#egg=rate-xblock
 -e git+https://github.com/openedx/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
--e git+https://github.com/openedx/blockstore.git@1.2.1#egg=blockstore==1.2.1
+-e git+https://github.com/openedx/blockstore.git@1.2.4#egg=blockstore==1.2.4
     # via -r requirements/edx/base.txt
 -e git+https://github.com/openedx/codejail.git@3.1.3#egg=codejail==3.1.3
     # via -r requirements/edx/base.txt


### PR DESCRIPTION
This is simply a rebased version of @pomegranited 's PR over here: https://github.com/openedx/edx-platform/pull/30620 . Please see that PR for details.