### PR TITLE
fix: update enrollment.canUpgrade

### DIFF
--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -156,8 +156,7 @@ class EnrollmentSerializer(serializers.Serializer):
     """
     Info about this particular enrollment.
     Derived from a CourseEnrollment with added context:
-    - "use_ecommerce_payment_flow" (bool): whether or not we use an ecommerce flow to
-      upsell.
+    - "ecommerce_payment_page" (url): ecommerce page, used to determine if we can upgrade.
     - "course_mode_info" (dict): keyed by course ID with the following values:
         - "expiration_datetime" (int): when the verified mode will expire.
         - "show_upsell" (bool): whether or not we offer an upsell for this course.
@@ -201,9 +200,7 @@ class EnrollmentSerializer(serializers.Serializer):
 
     def get_canUpgrade(self, enrollment):
         """Determine if a user can upgrade this enrollment to verified track"""
-        use_ecommerce_payment_flow = self.context.get(
-            "use_ecommerce_payment_flow", False
-        )
+        use_ecommerce_payment_flow = bool(self.context.get("ecommerce_payment_page"))
         course_mode_info = self.context.get("course_mode_info", {}).get(
             enrollment.course_id, {}
         )


### PR DESCRIPTION
## Description

Fixes a bug with Learner Home `enrollment.canUpgrade`. Previously, it copied the original logic and expected us to pass the `use_ecommerce_payment_flow` field, which we forgot to pass as part of context. Instead of providing this, we can simplify the logic to infer from the presence of an `ecommerce_payment_page` URL (which must be present if ecommerce is enabled and will be `None` if disabled).

JIRA: [AU-849](https://2u-internal.atlassian.net/browse/AU-849)
FYI: @openedx/content-aurora 