### PR TITLE
fix: updated topic sorting for discussions MFE

### DIFF
--- a/lms/djangoapps/discussion/rest_api/tests/test_api.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api.py
@@ -443,7 +443,6 @@ class GetCourseTopicsTest(CommentsServiceMockMixin, ForumsEnableMixin, UrlResetM
                 self.make_expected_tree("non-courseware-2", "B"),
             ],
         }
-        breakpoint()
         assert actual == expected
 
     def test_sort_key_doesnot_work(self):

--- a/lms/djangoapps/discussion/rest_api/tests/test_api.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api.py
@@ -408,17 +408,17 @@ class GetCourseTopicsTest(CommentsServiceMockMixin, ForumsEnableMixin, UrlResetM
                 "B": {"id": "non-courseware-2"},
             }
             self.store.update_item(self.course, self.user.id)
-            self.make_discussion_xblock("courseware-1", "A", "1")
-            self.make_discussion_xblock("courseware-2", "A", "2")
-            self.make_discussion_xblock("courseware-3", "B", "1")
-            self.make_discussion_xblock("courseware-4", "B", "2")
-            self.make_discussion_xblock("courseware-5", "C", "1")
+            self.make_discussion_xblock("courseware-1", "Week 1", "1")
+            self.make_discussion_xblock("courseware-2", "Week 1", "2")
+            self.make_discussion_xblock("courseware-3", "Week 10", "1")
+            self.make_discussion_xblock("courseware-4", "Week 10", "2")
+            self.make_discussion_xblock("courseware-5", "Week 9", "1")
         actual = self.get_course_topics()
         expected = {
             "courseware_topics": [
                 self.make_expected_tree(
                     None,
-                    "A",
+                    "Week 1",
                     [
                         self.make_expected_tree("courseware-1", "1"),
                         self.make_expected_tree("courseware-2", "2"),
@@ -426,16 +426,16 @@ class GetCourseTopicsTest(CommentsServiceMockMixin, ForumsEnableMixin, UrlResetM
                 ),
                 self.make_expected_tree(
                     None,
-                    "B",
+                    "Week 9",
+                    [self.make_expected_tree("courseware-5", "1")]
+                ),
+                self.make_expected_tree(
+                    None,
+                    "Week 10",
                     [
                         self.make_expected_tree("courseware-3", "1"),
                         self.make_expected_tree("courseware-4", "2"),
                     ]
-                ),
-                self.make_expected_tree(
-                    None,
-                    "C",
-                    [self.make_expected_tree("courseware-5", "1")]
                 ),
             ],
             "non_courseware_topics": [
@@ -443,6 +443,7 @@ class GetCourseTopicsTest(CommentsServiceMockMixin, ForumsEnableMixin, UrlResetM
                 self.make_expected_tree("non-courseware-2", "B"),
             ],
         }
+        breakpoint()
         assert actual == expected
 
     def test_sort_key_doesnot_work(self):


### PR DESCRIPTION
## Description
Topics that have alphanumeric categories were being sorted in weird ways i.e 
```python
data = ['week 2', 'week 1', 'week 10', 'week 9']
data = sorted (data)
## returns ['week 1', 'week 10', 'week 2', 'week 9']
```
Created new key mapping that would sort it as expected 

Like this : 
```python
## returns ['week 1', 'week 2', 'week 9', 'week 10']
```
