### PR TITLE
feat: add thumbnail field to video xblock fields

### DIFF
--- a/cms/templates/widgets/tabs/metadata-edit-tab.html
+++ b/cms/templates/widgets/tabs/metadata-edit-tab.html
@@ -1,6 +1,7 @@
 <%namespace name='static' file='../../static_content.html'/>
 <%
   import json
+  import copy
 %>
 
 ## js templates
@@ -13,5 +14,10 @@
         <%static:include path="js/${template_name}.underscore" />
     </script>
 % endfor
-
-<div class="wrapper-comp-settings metadata_edit" id="settings-tab" data-metadata='${json.dumps(editable_metadata_fields) | h}'></div>
+<% metadata_field_copy = copy.copy(editable_metadata_fields) %>
+## Delete 'thumbnail' field (if it exists) so metadata editor view does not attempt to render it.
+% if 'thumbnail' in editable_metadata_fields:
+    ## the new video editor needs access to the 'thumbnail' value, so delete from a copy.
+    <% del metadata_field_copy['thumbnail'] %>
+% endif
+<div class="wrapper-comp-settings metadata_edit" id="settings-tab" data-metadata='${json.dumps(metadata_field_copy) | h}'></div>

--- a/xmodule/video_module/video_xfields.py
+++ b/xmodule/video_module/video_xfields.py
@@ -219,5 +219,4 @@ class VideoFields:
         display_name=_("Thumbnail"),
         scope=Scope.settings,
         default="",
-        disabled=True
     )

--- a/xmodule/video_module/video_xfields.py
+++ b/xmodule/video_module/video_xfields.py
@@ -212,3 +212,12 @@ class VideoFields:
         scope=Scope.settings,
         default=False
     )
+    # thumbnail is need as a field for the new video editor. The field is hidden in
+    # the legacy modal.
+    thumbnail = String(
+        help=_("Add a specific thumbnail for learners to see before playing the video."),
+        display_name=_("Thumbnail"),
+        scope=Scope.settings,
+        default="",
+        disabled=True
+    )


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/openedx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This PR adds a thumbnail field to the video xblock fields. In the new video editor there is a thumbnail field to make it easier for user's to update the video thumbnail for edx videos. By default all fields are rendered in the legacy modal's advanced tab. To prevent confusion in the legacy experience, the thumbnail field is hidden in the advanced tab

This change impact developers and Authors.

## Supporting information

JIRA Ticket: [TNL-9821](https://2u-internal.atlassian.net/browse/TNL-9821)

## Testing instructions

1. Navigate to linked PR from edx/frontend-lib-content-components and switch to the KristinAoki/thumbnail-widget branch
2. Navigate to [Django Admin](http://localhost:18010/admin/waffle/flag) and turn on the new_core_editors.use_new_video_editor waffle flag
4. Open a course in Studio
5. Navigate to the course outline
6. Open a unit to edit
7. Add a "Video" block with a edx Video
8. Scroll to the "Thumbnail" section
9. Upload a thumbnail
10. Click "Save"
11. Navigate to [Django Admin](http://localhost:18010/admin/waffle/flag) and turn off the new_core_editors.use_new_video_editor waffle flag
12. Navigate back to  the unit outline and reload the page
13. Open the "Video" block and switch to the "Advance" tab
14. Scroll through the list of fields and check that thumbnail is not present.

## Deadline

None

## Other information

This PR is connected to the frontend-lib-content-components [PR: 121](https://github.com/edx/frontend-lib-content-components/pull/121)
