### PR TITLE
Revert "fix: filter out discussion topics that have not started yet."

### DIFF
--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -5,13 +5,10 @@ from __future__ import annotations
 
 import itertools
 from collections import defaultdict
-from datetime import datetime
 
 from enum import Enum
 from typing import Dict, Iterable, List, Literal, Optional, Set, Tuple
 from urllib.parse import urlencode, urlunparse
-from pytz import UTC
-
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -381,13 +378,10 @@ def get_courseware_topics(
     courseware_topics = []
     existing_topic_ids = set()
 
-    now = datetime.now(UTC)
-
     discussion_xblocks = get_accessible_discussion_xblocks(course, request.user)
     xblocks_by_category = defaultdict(list)
     for xblock in discussion_xblocks:
-        if xblock.start < now:
-            xblocks_by_category[xblock.discussion_category].append(xblock)
+        xblocks_by_category[xblock.discussion_category].append(xblock)
 
     for category in xblocks_by_category.keys():
         children = []

--- a/lms/djangoapps/discussion/rest_api/tests/test_api.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api.py
@@ -503,6 +503,7 @@ class GetCourseTopicsTest(CommentsServiceMockMixin, ForumsEnableMixin, UrlResetM
         ways in which a user may not have access are:
 
         * Module is visible to staff only
+        * Module has a start date in the future
         * Module is accessible only to a group the user is not in
 
         Also, there is a case that ensures that a category with no accessible
@@ -574,7 +575,12 @@ class GetCourseTopicsTest(CommentsServiceMockMixin, ForumsEnableMixin, UrlResetM
                         self.make_expected_tree("courseware-3", "Cohort B"),
                         self.make_expected_tree("courseware-1", "Everybody"),
                     ]
-                )
+                ),
+                self.make_expected_tree(
+                    None,
+                    "Second",
+                    [self.make_expected_tree("courseware-5", "Future Start Date")]
+                ),
             ],
             "non_courseware_topics": [
                 self.make_expected_tree("non-courseware-topic-id", "Test Topic"),
@@ -599,45 +605,8 @@ class GetCourseTopicsTest(CommentsServiceMockMixin, ForumsEnableMixin, UrlResetM
                     None,
                     "Second",
                     [
+                        self.make_expected_tree("courseware-5", "Future Start Date"),
                         self.make_expected_tree("courseware-4", "Staff Only"),
-                    ]
-                ),
-            ],
-            "non_courseware_topics": [
-                self.make_expected_tree("non-courseware-topic-id", "Test Topic"),
-            ],
-        }
-        assert staff_actual == staff_expected
-
-    def test_un_released_discussion_topic(self):
-        """
-        Test discussion topics that have not yet started
-        """
-        staff = StaffFactory.create(course_key=self.course.id)
-        with self.store.bulk_operations(self.course.id, emit_signals=False):
-            self.store.update_item(self.course, self.user.id)
-            self.make_discussion_xblock(
-                "courseware-2",
-                "First",
-                "Released",
-                start=datetime.now(UTC) - timedelta(days=1)
-            )
-            self.make_discussion_xblock(
-                "courseware-3",
-                "First",
-                "Future release",
-                start=datetime.now(UTC) + timedelta(days=1)
-            )
-
-        self.request.user = staff
-        staff_actual = self.get_course_topics()
-        staff_expected = {
-            "courseware_topics": [
-                self.make_expected_tree(
-                    None,
-                    "First",
-                    [
-                        self.make_expected_tree("courseware-2", "Released"),
                     ]
                 ),
             ],


### PR DESCRIPTION
Reverts openedx/edx-platform#31068

The revert was needed because it caused 16k errors in the last 24 hours and also caused the discussions topics in the discussions MFE to not load