### PR TITLE
chore: upgrade learner-pathway-progress version

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -663,7 +663,7 @@ lazy==1.5
     #   acid-xblock
     #   lti-consumer-xblock
     #   ora2
-learner-pathway-progress==1.3.2
+learner-pathway-progress==1.3.3
     # via -r requirements/edx/base.in
 levenshtein==0.20.5
     # via python-levenshtein

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -864,7 +864,7 @@ lazy-object-proxy==1.7.1
     # via
     #   -r requirements/edx/testing.txt
     #   astroid
-learner-pathway-progress==1.3.2
+learner-pathway-progress==1.3.3
     # via -r requirements/edx/testing.txt
 levenshtein==0.20.5
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -827,7 +827,7 @@ lazy==1.5
     #   ora2
 lazy-object-proxy==1.7.1
     # via astroid
-learner-pathway-progress==1.3.2
+learner-pathway-progress==1.3.3
     # via -r requirements/edx/base.txt
 levenshtein==0.20.5
     # via


### PR DESCRIPTION
## Description

These changes are for enterprise learners. This pull request brings changes from this [PR#16](https://github.com/edx/learner-pathway-progress/pull/16#issue-1403052367) in [learner-pathway-progress](https://github.com/edx/learner-pathway-progress) release [1.3.3](https://github.com/edx/learner-pathway-progress/releases/tag/1.3.3). These changes include a data migration which will remove the data from the `LearnerEnterprisePathwayMembership` and `LearnerPathwayProgress` tables from the plugin `learner-pathway-progress`. 

## Supporting information

JIRA: [ENT-6387](https://2u-internal.atlassian.net/browse/ENT-6387)
The information is repeated here for visibility issues. 

> Description
> 
> This ticket is required to close the [ENT-6280](https://2u-internal.atlassian.net/browse/ENT-6280) ticket. We need to delete data for the learner-pathway-progress plugin from prod and run the management command to backfill the progress of learners, again. 
> 
> Acceptance Criteria
> 
> First, delete data for the learner-pathway-progress tables LearnerEnterprisePathwayMembership and LearnerPathwayProgress from the PROD LMS admin
> 
> Then run the management command update_all_pathways_progress from the learner-pathway-progress plugin


## Other information
- This data migration deletes data so this cannot be reverted but there is a management command that we need to run to refill data
- We need to run this migration and delete data because we need to run the management command to refill tables 