### PR TITLE
fix: filter out discussion topics that have not started yet for instructor paced courses

### DIFF
--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -6,9 +6,13 @@ from __future__ import annotations
 import itertools
 import re
 from collections import defaultdict
+from datetime import datetime
+
 from enum import Enum
 from typing import Dict, Iterable, List, Literal, Optional, Set, Tuple
 from urllib.parse import urlencode, urlunparse
+from pytz import UTC
+
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -379,10 +383,13 @@ def get_courseware_topics(
     courseware_topics = []
     existing_topic_ids = set()
 
+    now = datetime.now(UTC)
+
     discussion_xblocks = get_accessible_discussion_xblocks(course, request.user)
     xblocks_by_category = defaultdict(list)
     for xblock in discussion_xblocks:
-        xblocks_by_category[xblock.discussion_category].append(xblock)
+        if course.self_paced or (xblock.start and xblock.start < now):
+            xblocks_by_category[xblock.discussion_category].append(xblock)
 
     def sort_categories(category_list):
         """

--- a/lms/djangoapps/discussion/rest_api/tests/test_api.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api.py
@@ -503,7 +503,6 @@ class GetCourseTopicsTest(CommentsServiceMockMixin, ForumsEnableMixin, UrlResetM
         ways in which a user may not have access are:
 
         * Module is visible to staff only
-        * Module has a start date in the future
         * Module is accessible only to a group the user is not in
 
         Also, there is a case that ensures that a category with no accessible
@@ -575,12 +574,7 @@ class GetCourseTopicsTest(CommentsServiceMockMixin, ForumsEnableMixin, UrlResetM
                         self.make_expected_tree("courseware-3", "Cohort B"),
                         self.make_expected_tree("courseware-1", "Everybody"),
                     ]
-                ),
-                self.make_expected_tree(
-                    None,
-                    "Second",
-                    [self.make_expected_tree("courseware-5", "Future Start Date")]
-                ),
+                )
             ],
             "non_courseware_topics": [
                 self.make_expected_tree("non-courseware-topic-id", "Test Topic"),
@@ -605,8 +599,45 @@ class GetCourseTopicsTest(CommentsServiceMockMixin, ForumsEnableMixin, UrlResetM
                     None,
                     "Second",
                     [
-                        self.make_expected_tree("courseware-5", "Future Start Date"),
                         self.make_expected_tree("courseware-4", "Staff Only"),
+                    ]
+                ),
+            ],
+            "non_courseware_topics": [
+                self.make_expected_tree("non-courseware-topic-id", "Test Topic"),
+            ],
+        }
+        assert staff_actual == staff_expected
+
+    def test_un_released_discussion_topic(self):
+        """
+        Test discussion topics that have not yet started
+        """
+        staff = StaffFactory.create(course_key=self.course.id)
+        with self.store.bulk_operations(self.course.id, emit_signals=False):
+            self.store.update_item(self.course, self.user.id)
+            self.make_discussion_xblock(
+                "courseware-2",
+                "First",
+                "Released",
+                start=datetime.now(UTC) - timedelta(days=1)
+            )
+            self.make_discussion_xblock(
+                "courseware-3",
+                "First",
+                "Future release",
+                start=datetime.now(UTC) + timedelta(days=1)
+            )
+
+        self.request.user = staff
+        staff_actual = self.get_course_topics()
+        staff_expected = {
+            "courseware_topics": [
+                self.make_expected_tree(
+                    None,
+                    "First",
+                    [
+                        self.make_expected_tree("courseware-2", "Released"),
                     ]
                 ),
             ],


### PR DESCRIPTION
### [INF-551](https://2u-internal.atlassian.net/browse/INF-551)

### Description

Discussion topics of xblocks belonging to units, that are part of section that has not been released should not be visible in topics list.

Currently, all discussion topics are fetched based on user access. There is no filter to filter out discussion topics for units to be released in future.
This only affects users with Global Staff or Staff or Instructor Roles (discussion topics for unreleased units is only visible to them).

Followup PR created for earlier revert -- https://github.com/openedx/edx-platform/pull/31128

**Context:**
The revert was needed because it caused 16k errors in the last 24 hours and also caused the discussions topics in the discussions MFE to not load.

The issue was related to `self paced` courses, that do not have a start date associated to blocks.
