### PR TITLE
build: nudge devs about Olive release in github

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,13 @@
 <!--
 
-🌰🌰
-🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
-    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
-🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
-🌰🌰
+🫒🫒
+🫒🫒🫒🫒         🫒 Note: the Olive master branch has been created.  Please consider whether your change
+    🫒🫒🫒🫒     should also be applied to Olive. If so, make another pull request against the
+🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
+🫒🫒
+
+🌰🌰🌰🌰🌰🌰     🌰 Note: the Nutmeg release is still supported.
+                  Please consider whether your change should be applied to Nutmeg as well.
 
 Please give your pull request a short but descriptive title.
 Use conventional commits to separate and summarize commits logically:


### PR DESCRIPTION
## Description

Remind devs that when they open PRs on edx-platform, that they should backport their bug fixes to the Olive master branch (and think about backporting to Nutmeg as well).