### PR TITLE
feat: add rollout waffle flag

### DIFF
--- a/common/djangoapps/student/tests/test_views.py
+++ b/common/djangoapps/student/tests/test_views.py
@@ -235,6 +235,14 @@ class StudentDashboardTests(SharedModuleStoreTestCase, MilestonesTestCaseMixin, 
         response = self.client.get(self.path)
         self.assertRedirects(response, reverse('account_settings'))
 
+    def test_redirect_to_learner_home(self):
+        """
+        if learner home mfe is enabled, redirect to learner home mfe
+        """
+        with patch('lms.djangoapps.learner_home.waffle.ENABLE_LEARNER_HOME_MFE.is_enabled', return_value=True):
+            response = self.client.get(self.path)
+            self.assertRedirects(response, settings.LEARNER_HOME_MICROFRONTEND_URL, fetch_redirect_response=False)
+
     def test_course_cert_available_message_after_course_end(self):
         course_key = CourseKey.from_string('course-v1:edX+DemoX+Demo_Course')
         course = CourseOverviewFactory.create(

--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -30,6 +30,7 @@ from common.djangoapps.edxmako.shortcuts import render_to_response, render_to_st
 from common.djangoapps.entitlements.models import CourseEntitlement
 from lms.djangoapps.commerce.utils import EcommerceService
 from lms.djangoapps.courseware.access import has_access
+from lms.djangoapps.learner_home.waffle import should_redirect_to_learner_home_mfe
 from lms.djangoapps.experiments.utils import get_dashboard_course_info, get_experiment_user_metadata_context
 from lms.djangoapps.verify_student.services import IDVerificationService
 from openedx.core.djangoapps.catalog.utils import (
@@ -517,6 +518,10 @@ def student_dashboard(request):  # lint-amnesty, pylint: disable=too-many-statem
     user = request.user
     if not UserProfile.objects.filter(user=user).exists():
         return redirect(reverse('account_settings'))
+
+    enable_learner_home_mfe = should_redirect_to_learner_home_mfe()
+    if enable_learner_home_mfe:
+        return redirect(settings.LEARNER_HOME_MICROFRONTEND_URL)
 
     platform_name = configuration_helpers.get_value("platform_name", settings.PLATFORM_NAME)
 

--- a/lms/djangoapps/learner_home/waffle.py
+++ b/lms/djangoapps/learner_home/waffle.py
@@ -1,0 +1,24 @@
+"""
+This module contains various configuration settings via
+waffle switches for the teams app.
+"""
+
+from edx_toggles.toggles import WaffleFlag
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+
+# .. toggle_name: learner_home_mfe.enabled
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Waffle flag to enable to redirect user to learner home mfe
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2022-10-11
+# .. toggle_tickets: AU-879
+ENABLE_LEARNER_HOME_MFE = WaffleFlag(
+    'learner_home_mfe.enabled',
+    __name__,
+)
+
+
+def should_redirect_to_learner_home_mfe():
+    return configuration_helpers.get_value('ENABLE_LEARNER_HOME_MFE',
+                                           ENABLE_LEARNER_HOME_MFE.is_enabled())

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -594,6 +594,8 @@ AUTHN_MICROFRONTEND_URL = "http://authn-mfe"
 AUTHN_MICROFRONTEND_DOMAIN = "authn-mfe"
 LEARNING_MICROFRONTEND_URL = "http://learning-mfe"
 DISCUSSIONS_MICROFRONTEND_URL = "http://discussions-mfe"
+LEARNER_HOME_MICROFRONTEND_URL = "http://learner-home-mfe"
+ORA_GRADING_MICROFRONTEND_URL = "http://ora-grading-mfe"
 
 ########################## limiting dashboard courses ######################
 


### PR DESCRIPTION
## Description

TLDR; create waffle flag for rolling out `leaner_home`.

https://2u-internal.atlassian.net/browse/AU-879

1. Create waffle flag on django-admin
2. The flag name is `learner_home_mfe.enabled`
3. Enable "Testing" mode from django-admin to allow for query-based enable

`{dashboard_url}?dwft_learner_home_mfe.enabled=1` will redirect learner to Learner Home. This is sticky unless flag turned off later with `{dashboard_url}?dwft_learner_home_mfe.enabled=0`.
