### PR TITLE
Update docutils & Sphinx constraints

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -60,11 +60,6 @@ py2neo<2022
 # pylint==2.14.0 is causing test failures
 pylint==2.13.9
 
-# Sphinx requires docutils<0.18. This pin can be removed once https://github.com/sphinx-doc/sphinx/issues/9777 is closed.
-docutils<0.18
-# Sphinx docs build fails with new version. Will be fixed in https://github.com/openedx/public-engineering/issues/161
-sphinx<5.1.0
-
 # scipy version 1.8 requires numpy>=1.17.3, we've pinned numpy to <1.17.0 in requirements/edx-sandbox/py38.in
 scipy<1.8.0
 

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -96,3 +96,8 @@ pytz==2022.2.1
 # openedx-events>0.13.0 causes test failures due to breaking changes
 # These broken tests will be fixed in a separate PR
 openedx-events==0.13.0
+
+# docutils==0.18.1 fails with sphinxcontrib-openapi package
+# docutils==0.19 has removed the docutils.core.ErrorString which is required by the sphinxcontrib-openapi
+# This constraint can be removed once sphinxcontrib-openapi is updated to resolve this issue.
+docutils<0.19

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -97,7 +97,6 @@ pytz==2022.2.1
 # These broken tests will be fixed in a separate PR
 openedx-events==0.13.0
 
-# docutils==0.18.1 fails with sphinxcontrib-openapi package
 # docutils==0.19 has removed the docutils.core.ErrorString which is required by the sphinxcontrib-openapi
 # This constraint can be removed once sphinxcontrib-openapi is updated to resolve this issue.
 docutils<0.19

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -407,7 +407,7 @@ djangorestframework-xml==2.0.0
     # via edx-enterprise
 docopt==0.6.2
     # via -r requirements/edx/base.in
-docutils==0.19
+docutils==0.18.1
     # via botocore
 done-xblock==2.0.4
     # via -r requirements/edx/base.in

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -407,10 +407,8 @@ djangorestframework-xml==2.0.0
     # via edx-enterprise
 docopt==0.6.2
     # via -r requirements/edx/base.in
-docutils==0.17.1
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   botocore
+docutils==0.19
+    # via botocore
 done-xblock==2.0.4
     # via -r requirements/edx/base.in
 drf-jwt==1.19.2
@@ -1011,7 +1009,7 @@ scipy==1.7.3
     #   openedx-calc
 semantic-version==2.10.0
     # via edx-drf-extensions
-shapely==1.8.4
+shapely==1.8.5
     # via -r requirements/edx/base.in
 simplejson==3.17.6
     # via
@@ -1082,7 +1080,7 @@ sqlparse==0.4.3
     #   django
 staff-graded-xblock==2.0.1
     # via -r requirements/edx/base.in
-stevedore==4.0.0
+stevedore==4.0.1
     # via
     #   -r requirements/edx/base.in
     #   -r requirements/edx/paver.txt

--- a/requirements/edx/development.in
+++ b/requirements/edx/development.in
@@ -18,5 +18,5 @@ django-debug-toolbar                    # A set of panels that display debug inf
 edx-sphinx-theme                        # Documentation theme
 mypy                                    # static type checking
 pywatchman                              # More efficient checking for runserver reload trigger events
-sphinxcontrib-openapi[markdown]==0.6.0  # OpenAPI (fka Swagger) spec renderer for Sphinx; pinned because 0.70 requires Python >=3.6
+sphinxcontrib-openapi[markdown]         # OpenAPI (fka Swagger) spec renderer for Sphinx; pinned because 0.70 requires Python >=3.6
 vulture                                 # Detects possible dead/unused code, used in scripts/find-dead-code.sh

--- a/requirements/edx/development.in
+++ b/requirements/edx/development.in
@@ -18,5 +18,5 @@ django-debug-toolbar                    # A set of panels that display debug inf
 edx-sphinx-theme                        # Documentation theme
 mypy                                    # static type checking
 pywatchman                              # More efficient checking for runserver reload trigger events
-sphinxcontrib-openapi[markdown]         # OpenAPI (fka Swagger) spec renderer for Sphinx; pinned because 0.70 requires Python >=3.6
+sphinxcontrib-openapi[markdown]         # OpenAPI (fka Swagger) spec renderer for Sphinx
 vulture                                 # Detects possible dead/unused code, used in scripts/find-dead-code.sh

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -512,9 +512,8 @@ djangorestframework-xml==2.0.0
     #   edx-enterprise
 docopt==0.6.2
     # via -r requirements/edx/testing.txt
-docutils==0.17.1
+docutils==0.19
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   botocore
     #   m2r
@@ -701,7 +700,7 @@ execnet==1.9.0
     #   pytest-xdist
 factory-boy==3.2.1
     # via -r requirements/edx/testing.txt
-faker==15.0.0
+faker==15.1.0
     # via
     #   -r requirements/edx/testing.txt
     #   factory-boy
@@ -1392,7 +1391,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-drf-extensions
-shapely==1.8.4
+shapely==1.8.5
     # via -r requirements/edx/testing.txt
 simplejson==3.17.6
     # via
@@ -1475,11 +1474,11 @@ soupsieve==2.3.2.post1
     # via
     #   -r requirements/edx/testing.txt
     #   beautifulsoup4
-sphinx==5.0.2
+sphinx==5.2.3
     # via
-    #   -c requirements/edx/../constraints.txt
     #   edx-sphinx-theme
     #   sphinxcontrib-httpdomain
+    #   sphinxcontrib-openapi
 sphinxcontrib-applehelp==1.0.2
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
@@ -1490,7 +1489,7 @@ sphinxcontrib-httpdomain==1.8.0
     # via sphinxcontrib-openapi
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-openapi[markdown]==0.6.0
+sphinxcontrib-openapi[markdown]==0.7.0
     # via -r requirements/edx/development.in
 sphinxcontrib-qthelp==1.0.3
     # via sphinx
@@ -1508,7 +1507,7 @@ starlette==0.20.4
     # via
     #   -r requirements/edx/testing.txt
     #   fastapi
-stevedore==4.0.0
+stevedore==4.0.1
     # via
     #   -r requirements/edx/testing.txt
     #   code-annotations

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -512,7 +512,7 @@ djangorestframework-xml==2.0.0
     #   edx-enterprise
 docopt==0.6.2
     # via -r requirements/edx/testing.txt
-docutils==0.19
+docutils==0.18.1
     # via
     #   -r requirements/edx/testing.txt
     #   botocore

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -20,10 +20,8 @@ click==8.1.3
     #   code-annotations
 code-annotations==1.3.0
     # via -r requirements/edx/doc.in
-docutils==0.17.1
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   sphinx
+docutils==0.19
+    # via sphinx
 edx-sphinx-theme==3.0.0
     # via -r requirements/edx/doc.in
 gitdb==4.0.9
@@ -66,9 +64,8 @@ smmap==5.0.0
     # via gitdb
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==5.0.2
+sphinx==5.2.3
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.in
     #   edx-sphinx-theme
 sphinxcontrib-applehelp==1.0.2
@@ -83,7 +80,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-stevedore==4.0.0
+stevedore==4.0.1
     # via code-annotations
 text-unidecode==1.3
     # via python-slugify

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -20,7 +20,7 @@ click==8.1.3
     #   code-annotations
 code-annotations==1.3.0
     # via -r requirements/edx/doc.in
-docutils==0.19
+docutils==0.18.1
     # via sphinx
 edx-sphinx-theme==3.0.0
     # via -r requirements/edx/doc.in

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -44,7 +44,7 @@ six==1.16.0
     #   libsass
     #   paver
     #   python-memcached
-stevedore==4.0.0
+stevedore==4.0.1
     # via
     #   -r requirements/edx/paver.in
     #   edx-opaque-keys

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -494,7 +494,7 @@ djangorestframework-xml==2.0.0
     #   edx-enterprise
 docopt==0.6.2
     # via -r requirements/edx/base.txt
-docutils==0.19
+docutils==0.18.1
     # via
     #   -r requirements/edx/base.txt
     #   botocore

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -494,9 +494,8 @@ djangorestframework-xml==2.0.0
     #   edx-enterprise
 docopt==0.6.2
     # via -r requirements/edx/base.txt
-docutils==0.17.1
+docutils==0.19
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   botocore
 done-xblock==2.0.4
@@ -678,7 +677,7 @@ execnet==1.9.0
     # via pytest-xdist
 factory-boy==3.2.1
     # via -r requirements/edx/testing.in
-faker==15.0.0
+faker==15.1.0
     # via factory-boy
 fastapi==0.85.0
     # via pact-python
@@ -1319,7 +1318,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-drf-extensions
-shapely==1.8.4
+shapely==1.8.5
     # via -r requirements/edx/base.txt
 simplejson==3.17.6
     # via
@@ -1405,7 +1404,7 @@ staff-graded-xblock==2.0.1
     # via -r requirements/edx/base.txt
 starlette==0.20.4
     # via fastapi
-stevedore==4.0.0
+stevedore==4.0.1
     # via
     #   -r requirements/edx/base.txt
     #   code-annotations


### PR DESCRIPTION
### Description
- Fixes the [BOM-3369](https://2u-internal.atlassian.net/browse/BOM-3369)(2U-internal) and https://github.com/openedx/public-engineering/issues/161 issues.
- Investigated the `docutils` && `sphinx` constraints and bumped the required constraints.
- `docutils<0.19` constraint is needed due to `sphinxcontrib-openapi` package which hasn't been updated since two years so we'll need to wait for a fix in this package to remove the constraint completely. 
- Community is also facing the same failure and an issue has already been created against the upstream repo: https://github.com/sphinx-contrib/openapi/issues/129