### PR TITLE
Feat: Persian language support added

### DIFF
--- a/conf/locale/config.yaml
+++ b/conf/locale/config.yaml
@@ -35,7 +35,7 @@ locales:
     # - et_EE  # Estonian (Estonia)
     - eu_ES  # Basque (Spain)
     # - fa  # Persian
-    # - fa_IR  # Persian (Iran)
+    - fa_IR  # Persian (Iran)
     # - fi_FI  # Finnish (Finland)
     # - fil  # Filipino
     - fr  # French


### PR DESCRIPTION
Hello edx
Since the beginning of my acquaintance with the edx platform, I always wondered, why t doesn't support Farsi.
well, I'm glad to announce that we translated the Persian language (fa_IR) in Transifex. right now both translated and reviewed statuses are at 100%.

I wanted to add `.po` and `.mo` files to the PR but noticed that Jenkins CI is responsible for that.
is there anything else I need to add?