### PR TITLE
feat: decouple LtiConsumerXBlock.location from LTI 1.3 views

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -673,7 +673,7 @@ libsass==0.10.0
     #   ora2
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==4.5.0
+lti-consumer-xblock==5.0.0
     # via -r requirements/edx/base.in
 lxml==4.9.1
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -878,7 +878,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/testing.txt
     #   ora2
-lti-consumer-xblock==4.5.0
+lti-consumer-xblock==5.0.0
     # via -r requirements/edx/testing.txt
 lxml==4.9.1
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -841,7 +841,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==4.5.0
+lti-consumer-xblock==5.0.0
     # via -r requirements/edx/base.txt
 lxml==4.9.1
     # via


### PR DESCRIPTION
## Description

This commit upgrades the version of the lti-consumer-xblock library from version 4.5.0 to version 5.0.0. This new version contains breaking changes to the public Python API published by the library, but it mainly contains code refactors that decouple the LtiConsumerXBlock.location field from the basic LTI 1.3 launches.

LTI 1.3 launches should continue to work unaltered.

The only course staff or instructor facing changes are described below. The access token and keyset URLs displayed in Studio have changed in format.

The old format was:

- Access Token URL: `https://courses.edx.org/api/lti_consumer/v1/token/block-v1:edX+999+2022Q3+type@lti_consumer+block@714c10a5e4df452da9d058788acb56be`
- Keyset URL: `https://courses.edx.org/api/lti_consumer/v1/public_keysets/block-v1:edX+999+2022Q3+type@lti_consumer+block@714c10a5e4df452da9d058788acb56be`

The new format is:

- Access Token URL: `https://courses.edx.org/api/lti_consumer/v1/token/c3f6af60-dbf2-4f85-8974-4ff870068d43`
- Keyset URL: `https://courses.edx.org/api/lti_consumer/v1/public_keysets/c3f6af60-dbf2-4f85-8974-4ff870068d43`

The difference is in the slug at the end of the URL. In the old format, the slug was the `UsageKey` of the XBlock associated with the LTI integration. In the new format, the slug is the `config_id` of the `LtiConfiguration` associated with the LTI integration. This is an iterative step toward decoupling the `access_token_endpoint` and the `public_keyset_endpoint` views from the XBlock `location` field. The XBlock `location` field appears as the `usage_key` parameter to both views. We cannot simply remove the `usage_key` parameter from the views, because existing LTI 1.3 integrations may have been created using the old format, and we need to maintain backwards compatibility. This change, however, prevents new integrations from being created that are coupled to the XBlock. In the future, we may address integrations that use the old format to fully decouple the XBlock from the views.