### PR TITLE
fix: remove edx-val pin

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -46,11 +46,6 @@ python3-saml<1.10.0
 # greater version has breaking changes and requires some migration steps.
 django-webpack-loader==0.7.0
 
-# Release 2.1.0 pulls declares `pact-python` as a base requirement, even though it should be
-# a testing requirement. Installing it would cause a bunch of new tool packages to become base
-# requirements of edx-platform. Pinning temporarily until this is resolved in edx-val.
-edxval<2.1
-
 # At the time of writing this comment, we do not know whether py2neo>=2022
 # will support our currently-deployed Neo4j version (3.5).
 # Feel free to loosen this constraint if/when it is confirmed that a later

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -47,6 +47,7 @@ attrs==22.1.0
     #   blockstore
     #   edx-ace
     #   jsonschema
+    #   lti-consumer-xblock
     #   openedx-events
 babel==2.10.3
     # via
@@ -154,6 +155,7 @@ cryptography==36.0.2
     # via
     #   -r requirements/edx/base.in
     #   django-fernet-fields
+    #   djfernet
     #   edx-enterprise
     #   jwcrypto
     #   optimizely-sdk
@@ -283,7 +285,6 @@ django-fernet-fields==0.6
     # via
     #   -r requirements/edx/base.in
     #   edx-enterprise
-    #   edxval
 django-filter==22.1
     # via
     #   -r requirements/edx/base.in
@@ -405,10 +406,14 @@ djangorestframework==3.12.4
     #   super-csv
 djangorestframework-xml==2.0.0
     # via edx-enterprise
+djfernet==0.8.1
+    # via edxval
 docopt==0.6.2
     # via -r requirements/edx/base.in
 docutils==0.18.1
-    # via botocore
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   botocore
 done-xblock==2.0.4
     # via -r requirements/edx/base.in
 drf-jwt==1.19.2
@@ -483,7 +488,7 @@ edx-enterprise==3.57.2
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   learner-pathway-progress
-edx-event-bus-kafka==1.1.0
+edx-event-bus-kafka==1.2.0
     # via -r requirements/edx/base.in
 edx-i18n-tools==0.9.1
     # via ora2
@@ -550,10 +555,8 @@ edx-when==2.3.0
     # via
     #   -r requirements/edx/base.in
     #   edx-proctoring
-edxval==2.0.3
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/base.in
+edxval==2.2.0
+    # via -r requirements/edx/base.in
 elasticsearch==7.13.4
     # via
     #   -c requirements/edx/../common_constraints.txt
@@ -1009,7 +1012,7 @@ scipy==1.7.3
     #   openedx-calc
 semantic-version==2.10.0
     # via edx-drf-extensions
-shapely==1.8.5
+shapely==1.8.5.post1
     # via -r requirements/edx/base.in
 simplejson==3.17.6
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -72,6 +72,7 @@ attrs==22.1.0
     #   blockstore
     #   edx-ace
     #   jsonschema
+    #   lti-consumer-xblock
     #   openedx-events
     #   pytest
 babel==2.10.3
@@ -224,6 +225,7 @@ cryptography==36.0.2
     # via
     #   -r requirements/edx/testing.txt
     #   django-fernet-fields
+    #   djfernet
     #   edx-enterprise
     #   jwcrypto
     #   optimizely-sdk
@@ -380,7 +382,6 @@ django-fernet-fields==0.6
     # via
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
-    #   edxval
 django-filter==22.1
     # via
     #   -r requirements/edx/testing.txt
@@ -510,10 +511,15 @@ djangorestframework-xml==2.0.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
+djfernet==0.8.1
+    # via
+    #   -r requirements/edx/testing.txt
+    #   edxval
 docopt==0.6.2
     # via -r requirements/edx/testing.txt
 docutils==0.18.1
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   botocore
     #   m2r
@@ -598,7 +604,7 @@ edx-enterprise==3.57.2
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   learner-pathway-progress
-edx-event-bus-kafka==1.1.0
+edx-event-bus-kafka==1.2.0
     # via -r requirements/edx/testing.txt
 edx-i18n-tools==0.9.1
     # via
@@ -674,10 +680,8 @@ edx-when==2.3.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-proctoring
-edxval==2.0.3
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/testing.txt
+edxval==2.2.0
+    # via -r requirements/edx/testing.txt
 elasticsearch==7.13.4
     # via
     #   -c requirements/edx/../common_constraints.txt
@@ -700,7 +704,7 @@ execnet==1.9.0
     #   pytest-xdist
 factory-boy==3.2.1
     # via -r requirements/edx/testing.txt
-faker==15.1.0
+faker==15.1.1
     # via
     #   -r requirements/edx/testing.txt
     #   factory-boy
@@ -1391,7 +1395,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-drf-extensions
-shapely==1.8.5
+shapely==1.8.5.post1
     # via -r requirements/edx/testing.txt
 simplejson==3.17.6
     # via

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -21,7 +21,9 @@ click==8.1.3
 code-annotations==1.3.0
     # via -r requirements/edx/doc.in
 docutils==0.18.1
-    # via sphinx
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   sphinx
 edx-sphinx-theme==3.0.0
     # via -r requirements/edx/doc.in
 gitdb==4.0.9

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -67,6 +67,7 @@ attrs==22.1.0
     #   blockstore
     #   edx-ace
     #   jsonschema
+    #   lti-consumer-xblock
     #   openedx-events
     #   outcome
     #   pytest
@@ -213,6 +214,7 @@ cryptography==36.0.2
     # via
     #   -r requirements/edx/base.txt
     #   django-fernet-fields
+    #   djfernet
     #   edx-enterprise
     #   jwcrypto
     #   optimizely-sdk
@@ -362,7 +364,6 @@ django-fernet-fields==0.6
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-    #   edxval
 django-filter==22.1
     # via
     #   -r requirements/edx/base.txt
@@ -492,10 +493,15 @@ djangorestframework-xml==2.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
+djfernet==0.8.1
+    # via
+    #   -r requirements/edx/base.txt
+    #   edxval
 docopt==0.6.2
     # via -r requirements/edx/base.txt
 docutils==0.18.1
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   botocore
 done-xblock==2.0.4
@@ -578,7 +584,7 @@ edx-enterprise==3.57.2
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   learner-pathway-progress
-edx-event-bus-kafka==1.1.0
+edx-event-bus-kafka==1.2.0
     # via -r requirements/edx/base.txt
 edx-i18n-tools==0.9.1
     # via
@@ -653,10 +659,8 @@ edx-when==2.3.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring
-edxval==2.0.3
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/base.txt
+edxval==2.2.0
+    # via -r requirements/edx/base.txt
 elasticsearch==7.13.4
     # via
     #   -c requirements/edx/../common_constraints.txt
@@ -677,7 +681,7 @@ execnet==1.9.0
     # via pytest-xdist
 factory-boy==3.2.1
     # via -r requirements/edx/testing.in
-faker==15.1.0
+faker==15.1.1
     # via factory-boy
 fastapi==0.85.0
     # via pact-python
@@ -1318,7 +1322,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-drf-extensions
-shapely==1.8.5
+shapely==1.8.5.post1
     # via -r requirements/edx/base.txt
 simplejson==3.17.6
     # via


### PR DESCRIPTION
### Description
- https://github.com/openedx/edx-val/pull/316 resolved the issue with the `edx-val` dependencies.
- Removing the constraint to update `edx-val` to latest version.