### PR TITLE
[BD-13] refactor: Clean up HTMLSnippet

### DIFF
--- a/xmodule/mako_module.py
+++ b/xmodule/mako_module.py
@@ -41,6 +41,8 @@ class MakoTemplateBlockBase:
     """
     # pylint: disable=no-member
 
+    js_module_name = None
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if getattr(self.runtime, 'render_template', None) is None:

--- a/xmodule/x_module.py
+++ b/xmodule/x_module.py
@@ -14,7 +14,7 @@ from lazy import lazy
 from lxml import etree
 from opaque_keys.edx.asides import AsideDefinitionKeyV2, AsideUsageKeyV2
 from opaque_keys.edx.keys import UsageKey
-from pkg_resources import resource_isdir, resource_string, resource_filename
+from pkg_resources import resource_isdir, resource_filename
 from web_fragments.fragment import Fragment
 from webob import Response
 from webob.multidict import MultiDict
@@ -213,39 +213,11 @@ class HTMLSnippet:
     html snippet, along with associated javascript and css
     """
 
-    js = {}
-    js_module_name = None
-
     preview_view_js = {}
     studio_view_js = {}
 
-    css = {}
     preview_view_css = {}
     studio_view_css = {}
-
-    @classmethod
-    def get_javascript(cls):
-        """
-        Return a dictionary containing some of the following keys:
-
-            coffee: A list of coffeescript fragments that should be compiled and
-                    placed on the page
-
-            js: A list of javascript fragments that should be included on the
-            page
-
-        All of these will be loaded onto the page in the CMS
-        """
-        # cdodge: We've moved the xmodule.coffee script from an outside directory into the xmodule area of common
-        # this means we need to make sure that all xmodules include this dependency which had been previously implicitly
-        # fulfilled in a different area of code
-        coffee = cls.js.setdefault('coffee', [])  # lint-amnesty, pylint: disable=unused-variable
-        js = cls.js.setdefault('js', [])  # lint-amnesty, pylint: disable=unused-variable
-
-        # Added xmodule.js separately to enforce 000 prefix for this only.
-        cls.js.setdefault('xmodule_js', resource_string(__name__, 'js/src/xmodule.js'))
-
-        return cls.js
 
     @classmethod
     def get_preview_view_js(cls):
@@ -262,22 +234,6 @@ class HTMLSnippet:
     @classmethod
     def get_studio_view_js_bundle_name(cls):
         return cls.__name__ + 'Studio'
-
-    @classmethod
-    def get_css(cls):
-        """
-        Return a dictionary containing some of the following keys:
-
-            css: A list of css fragments that should be applied to the html
-                 contents of the snippet
-
-            sass: A list of sass fragments that should be applied to the html
-                  contents of the snippet
-
-            scss: A list of scss fragments that should be applied to the html
-                  contents of the snippet
-        """
-        return cls.css
 
     @classmethod
     def get_preview_view_css(cls):


### PR DESCRIPTION
<!--

🫒🫒
🫒🫒🫒🫒         🫒 Note: the Olive master branch has been created.  Please consider whether your change
    🫒🫒🫒🫒     should also be applied to Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

🌰🌰🌰🌰🌰🌰     🌰 Note: the Nutmeg release is still supported.
                  Please consider whether your change should be applied to Nutmeg as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/openedx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This PR removes code from HTMLSnippets that is no longer needed after the conversion of all the XModules to standard XBlocks.

## Testing instructions

N/A

## Other information

To determine which code can be removed, I checked the commit history and grep'ed through the code. For the code that I removed, I wasn't able to find any places where it was being used, and the commit history showed that the places where it has been used before were removed. E.g. `git log -Gget_javascript -p`.

The remaining code of the `HTMLSnippet` class is being used in `xmodule/static_content.py`, which is used to collect javascript and css for XModules (for example when you run `paver update_assets`).

`Private-ref`: [BB-6731](https://tasks.opencraft.com/browse/BB-6731)