### PR TITLE
fix: video captions skip to end and skip to start

### DIFF
--- a/lms/templates/courseware/courseware-chromeless.html
+++ b/lms/templates/courseware/courseware-chromeless.html
@@ -133,20 +133,31 @@ ${HTML(fragment.foot_html())}
         if (!isLoadEvent && newWidth === lastWidth && newHeight === lastHeight) {
             // Monitor when any anchor tag is clicked, it is checked to make sure
             // it is referencing an element's id or name (not an external website). If
-            // the href attribute is an id or name, the location of the selected focus
-            // element is sent through its offset attribute. The offset will
-            // allow the page to scroll to the location of the focus element so
-            // that it is at the top of the page. Unique ids and names are
-            // required for proper scrolling.
+            // the href attribute is an id or name, the page will scroll the id or name.
             $('a').on("click", function(event){
-              if ($(this).attr('href')[0] === "#") {
+              if ($(this).attr('href')[0] === '#') {
                 var targetId = $(this).attr('href');
-                var targetName = $(this).attr('href').slice(1);
-                // Checks if the target uses an id or name to focus and gets offset.
-                var targetOffset = $(targetId).offset() || $(document.getElementsByName(targetName)[0]).offset();
-                if (targetOffset) {
+                // Checks if the href attribute is auto scrolling video transcripts.
+                // The scroll behavior for transcript scrolling requires the viewport
+                // to stay in relatively the same position so viewing of the video
+                // is not disrupted.
+                if ($(this).attr('class') === 'transcript-start'||$(this).attr('class') === 'transcript-end') {
                   event.preventDefault();
-                  window.parent.postMessage({"offset": targetOffset.top}, document.referrer);
+                  $(targetId)[0].scrollIntoView({
+                    block: 'nearest',
+                  });
+                } else {
+                  var targetName = $(this).attr('href').slice(1);
+                  // Checks if the target uses an id or name.
+                  var target = $(targetId)[0] || document.getElementsByName(targetName)[0];
+                  // The scroll behavior fro all other types of href's will scroll
+                  // the target to the top of the page
+                  if (target) {
+                    event.preventDefault();
+                    target.scrollIntoView({
+                      block: 'start',
+                    });
+                  }
                 }
               }
             })


### PR DESCRIPTION
<!--

🫒🫒
🫒🫒🫒🫒         🫒 Note: the Olive master branch has been created.  Please consider whether your change
    🫒🫒🫒🫒     should also be applied to Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

🌰🌰🌰🌰🌰🌰     🌰 Note: the Nutmeg release is still supported.
                  Please consider whether your change should be applied to Nutmeg as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/openedx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This pull request changes fixes how video captions scroll. Previously, when users clicked "Skip to end" or "Skip to start" the page would scroll to the bottom of the page or the top of the page. This would cause the video to scroll out of the viewport and would not scroll the video captions. Now when users click "Skip to end" or "Skip to start" the video will remain in view and the captions will scroll appropriately. Addition, the general scroll behavior for anchor tags that focus on another element on the page was simplified to use the `.scrollIntoView` javascript function instead of relying on messages between the MFE and LMS iFrame. This change impacts "Learners".

## Supporting information

JIRA Ticket: [TNL-7985](https://2u-internal.atlassian.net/browse/TNL-7985)

## Testing instructions

TESTING VIDEO CAPTION SCROLL

1. In Studio view, a video block with a transcript.
2.Publish the changes and click "View Live Version".
3. Click "Start of transcript. Skip to end."
4. The captions will scroll to the text "End of transcript. Skip to start." on page.
5. Click "End of transcript. Skip to start."
6. The captions will scroll to the text "Start of transcript. Skip to end." on page.

TESTING OTHER ANCHOR TAGS (checking functionality remains the same)

1. In Studio view, create a raw HTML block with a large amount of text.
2. At the beginning of the block create an anchor tag like below:
```<a href="#test">test scroll</a>```
4. Someplace lower in the block, add a header (or similar element like paragraph, span, div, etc.) tag like below:
```<h1 id="test">Heading 1</h1>```
6. Publish the changes and click "View Live Version".
7. Locate the anchor tag and click on it.
8. The page will scroll to the text "Heading 1" on page.

## Deadline

None
