### PR TITLE
chore: update edx-i18n-tools

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -488,7 +488,7 @@ edx-enterprise==3.57.3
     #   learner-pathway-progress
 edx-event-bus-kafka==1.2.0
     # via -r requirements/edx/base.in
-edx-i18n-tools==0.9.1
+edx-i18n-tools==0.9.2
     # via ora2
 edx-milestones==0.4.0
     # via -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -604,7 +604,7 @@ edx-enterprise==3.57.3
     #   learner-pathway-progress
 edx-event-bus-kafka==1.2.0
     # via -r requirements/edx/testing.txt
-edx-i18n-tools==0.9.1
+edx-i18n-tools==0.9.2
     # via
     #   -r requirements/edx/testing.txt
     #   ora2
@@ -1667,7 +1667,6 @@ xblock==1.6.1
     #   edx-when
     #   lti-consumer-xblock
     #   ora2
-    #   rate-xblock
     #   staff-graded-xblock
     #   xblock-drag-and-drop-v2
     #   xblock-google-drive

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -67,7 +67,6 @@ attrs==22.1.0
     #   jsonschema
     #   lti-consumer-xblock
     #   openedx-events
-    #   outcome
     #   pytest
 babel==2.10.3
     # via
@@ -584,7 +583,7 @@ edx-enterprise==3.57.3
     #   learner-pathway-progress
 edx-event-bus-kafka==1.2.0
     # via -r requirements/edx/base.txt
-edx-i18n-tools==0.9.1
+edx-i18n-tools==0.9.2
     # via
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/testing.in
@@ -1547,7 +1546,6 @@ xblock==1.6.1
     #   edx-when
     #   lti-consumer-xblock
     #   ora2
-    #   rate-xblock
     #   staff-graded-xblock
     #   xblock-drag-and-drop-v2
     #   xblock-google-drive


### PR DESCRIPTION
## Description

Update edx-i18n-tools to bring in a fix for the transifex pull command.

## Supporting information

The original issue is here: https://github.com/edx/edx-arch-experiments/issues/77 (private to 2U/OCM)
The fix in edx-i18n-tools is here:  https://github.com/openedx/i18n-tools/pull/119

## Testing instructions
```git clean -fdX conf/locale```
```i18n_tool transifex pull```