### PR TITLE
build: remove accidental duplicate codejail installation

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -129,8 +129,6 @@ code-annotations==1.3.0
     # via
     #   edx-enterprise
     #   edx-toggles
-codejail @ git+https://github.com/openedx/codejail.git@3.1.3
-    # via -r requirements/edx/github.in
 codejail-includes==1.0.0
     # via -r requirements/edx/base.in
 contextlib2==21.6.0
@@ -1026,7 +1024,6 @@ six==1.16.0
     #   bleach
     #   chem
     #   click-repl
-    #   codejail
     #   codejail-includes
     #   crowdsourcehinter-xblock
     #   edx-ace

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -192,8 +192,6 @@ code-annotations==1.3.0
     #   edx-enterprise
     #   edx-lint
     #   edx-toggles
-codejail @ git+https://github.com/openedx/codejail.git@3.1.3
-    # via -r requirements/edx/testing.txt
 codejail-includes==1.0.0
     # via -r requirements/edx/testing.txt
 contextlib2==21.6.0
@@ -1411,7 +1409,6 @@ six==1.16.0
     #   bok-choy
     #   chem
     #   click-repl
-    #   codejail
     #   codejail-includes
     #   crowdsourcehinter-xblock
     #   edx-ace

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -67,7 +67,6 @@
 #   * Alphabetize dependencies by DIST-NAME.
 git+https://github.com/openedx/blockstore.git@1.2.5#egg=blockstore==1.2.5
 git+https://github.com/openedx/codejail.git@3.3.0#egg=edx-codejail==3.3.0
-git+https://github.com/openedx/codejail.git@3.1.3#egg=codejail==3.1.3
 git+https://github.com/openedx/django-require.git@f4f01e4e959adc6210873ae99e7f2c3741afbf35#egg=django-require==1.0.12
 git+https://github.com/openedx/django-wiki.git@1.1.1#egg=django-wiki
 git+https://github.com/openedx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -180,8 +180,6 @@ code-annotations==1.3.0
     #   edx-enterprise
     #   edx-lint
     #   edx-toggles
-codejail @ git+https://github.com/openedx/codejail.git@3.1.3
-    # via -r requirements/edx/base.txt
 codejail-includes==1.0.0
     # via -r requirements/edx/base.txt
 contextlib2==21.6.0
@@ -1337,7 +1335,6 @@ six==1.16.0
     #   bok-choy
     #   chem
     #   click-repl
-    #   codejail
     #   codejail-includes
     #   crowdsourcehinter-xblock
     #   edx-ace


### PR DESCRIPTION
We are accidentally installing both codejail==3.1.3 and edx-codejail==3.3.0
which are different versions of the same respository.
This was the the result of a botched rebase in
https://github.com/openedx/edx-platform/pull/31104

This PR fixes github.in and re-runs `make compile-requirements`
to fix the generated .txt requirement pins file.

Reviewers, see https://github.com/openedx/edx-platform/pull/31188#discussion_r1000988717

