### PR TITLE
fix: preview mode navigation previous button (that uses legacy UI)

### DIFF
--- a/xmodule/js/src/sequence/display.js
+++ b/xmodule/js/src/sequence/display.js
@@ -364,7 +364,7 @@
 
             if ((direction === 'next') && (this.position >= this.contents.length)) {
                 targetUrl = this.nextUrl;
-            } else if ((direction === 'previous')) {
+            } else if ((direction === 'previous') && (this.position === 1 || this.contents.length === 0)) {
                 targetUrl = this.prevUrl;
             }
 


### PR DESCRIPTION
## Description
Makes `Previous` and `Next` button in lms preview mode consistent, i.e. 
- clicking on next button takes you to next chapter if there are any chapters left in current subsection else takes you to first chapter 
of next subsection
- clicking on previous button takes you to previous chapter if there are any chapters present before the current chapter in current subsection else takes you to the last chapter of the previous subsection.

Previous button should use prev_url if it in first position. In studio UI, it should always use prev_url. To make this possible we checking length of contents which is always zero for studio and more than 0 for legacy UI.


## Supporting information

`Private ref`: [Jira: BB-6820](https://tasks.opencraft.com/browse/BB-6820)

## Sandbox

- https://pr31193.sandbox.opencraft.hosting/ 

## Testing instructions

- Test `next` and `previous` buttons in lms preview mode.
