### PR TITLE
Install xblock-drag-and-drop from pypi

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -176,3 +176,4 @@ XBlock                              # Courseware component architecture
 xblock-utils                        # Provides utilities used by the Discussion XBlock
 xss-utils                           # https://github.com/edx/edx-platform/pull/20633 Fix XSS via Translations
 enmerkar-underscore                 # Implements a underscore extractor for django-babel.
+xblock-drag-and-drop-v2             # Drag and Drop XBlock

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -54,6 +54,8 @@ babel==2.10.3
     #   enmerkar-underscore
 backoff==1.10.0
     # via analytics-python
+backports-zoneinfo==0.2.1
+    # via icalendar
 beautifulsoup4==4.11.1
     # via pynliner
 billiard==3.6.4.0
@@ -164,9 +166,7 @@ cryptography==36.0.2
 cssutils==2.6.0
     # via pynliner
 ddt==1.6.0
-    # via
-    #   xblock-drag-and-drop-v2
-    #   xblock-poll
+    # via xblock-poll
 defusedxml==0.7.1
     # via
     #   -r requirements/edx/base.in
@@ -602,7 +602,7 @@ html5lib==1.1
     # via
     #   -r requirements/edx/base.in
     #   ora2
-icalendar==4.1.0
+icalendar==5.0.1
     # via -r requirements/edx/base.in
 idna==3.4
     # via
@@ -664,7 +664,7 @@ lazy==1.5
     #   ora2
 learner-pathway-progress==1.3.3
     # via -r requirements/edx/base.in
-levenshtein==0.20.5
+levenshtein==0.20.7
     # via python-levenshtein
 libsass==0.10.0
     # via
@@ -715,7 +715,6 @@ maxminddb==2.2.0
 mock==4.0.3
     # via
     #   -r requirements/edx/paver.txt
-    #   xblock-drag-and-drop-v2
     #   xblock-poll
 mongodbproxy @ git+https://github.com/openedx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a
     # via -r requirements/edx/github.in
@@ -797,7 +796,7 @@ path-py==12.5.0
     #   staff-graded-xblock
 paver==1.3.4
     # via -r requirements/edx/paver.txt
-pbr==5.10.0
+pbr==5.11.0
     # via
     #   -r requirements/edx/paver.txt
     #   stevedore
@@ -814,7 +813,7 @@ polib==1.1.1
     # via edx-i18n-tools
 prompt-toolkit==3.0.31
     # via click-repl
-psutil==5.9.2
+psutil==5.9.3
     # via
     #   -r requirements/edx/paver.txt
     #   edx-django-utils
@@ -844,7 +843,7 @@ pyjwkest==1.4.2
     #   -r requirements/edx/base.in
     #   edx-drf-extensions
     #   lti-consumer-xblock
-pyjwt[crypto]==2.5.0
+pyjwt[crypto]==2.6.0
     # via
     #   -r requirements/edx/base.in
     #   drf-jwt
@@ -903,7 +902,7 @@ python-dateutil==2.8.2
     #   olxcleaner
     #   ora2
     #   xblock
-python-levenshtein==0.20.5
+python-levenshtein==0.20.7
     # via -r requirements/edx/base.in
 python-memcached==1.59
     # via -r requirements/edx/paver.txt
@@ -991,7 +990,7 @@ requests-oauthlib==1.3.1
     #   social-auth-core
 ruamel-yaml==0.17.21
     # via drf-yasg
-ruamel-yaml-clib==0.2.6
+ruamel-yaml-clib==0.2.7
     # via ruamel-yaml
 rules==3.3
     # via
@@ -1080,7 +1079,7 @@ sqlparse==0.4.3
     #   django
 staff-graded-xblock==2.0.1
     # via -r requirements/edx/base.in
-stevedore==4.0.1
+stevedore==4.1.0
     # via
     #   -r requirements/edx/base.in
     #   -r requirements/edx/paver.txt
@@ -1105,8 +1104,6 @@ tinycss2==1.1.1
     # via bleach
 tqdm==4.64.1
     # via nltk
-types-cryptography==3.3.23
-    # via pyjwt
 typing-extensions==4.4.0
     # via
     #   django-countries
@@ -1179,8 +1176,8 @@ xblock==1.6.1
     #   xblock-google-drive
     #   xblock-poll
     #   xblock-utils
-xblock-drag-and-drop-v2 @ git+https://github.com/openedx/xblock-drag-and-drop-v2@v2.3.5
-    # via -r requirements/edx/github.in
+xblock-drag-and-drop-v2==2.5.0
+    # via -r requirements/edx/base.in
 xblock-poll @ git+https://github.com/open-craft/xblock-poll@v1.12.0
     # via -r requirements/edx/github.in
 xblock-utils==3.0.0
@@ -1197,7 +1194,7 @@ xss-utils==0.4.0
     # via -r requirements/edx/base.in
 yarl==1.8.1
     # via aiohttp
-zipp==3.9.0
+zipp==3.10.0
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -36,7 +36,7 @@ aniso8601==9.0.1
     # via
     #   -r requirements/edx/testing.txt
     #   edx-tincan-py35
-anyio==3.6.1
+anyio==3.6.2
     # via
     #   -r requirements/edx/testing.txt
     #   starlette
@@ -83,6 +83,10 @@ backoff==1.10.0
     # via
     #   -r requirements/edx/testing.txt
     #   analytics-python
+backports-zoneinfo==0.2.1
+    # via
+    #   -r requirements/edx/testing.txt
+    #   icalendar
 beautifulsoup4==4.11.1
     # via
     #   -r requirements/edx/testing.txt
@@ -242,7 +246,6 @@ cssutils==2.6.0
 ddt==1.6.0
     # via
     #   -r requirements/edx/testing.txt
-    #   xblock-drag-and-drop-v2
     #   xblock-poll
 defusedxml==0.7.1
     # via
@@ -260,7 +263,7 @@ deprecated==1.2.13
     #   redis
 diff-cover==7.0.1
     # via -r requirements/edx/testing.txt
-dill==0.3.5.1
+dill==0.3.6
     # via
     #   -r requirements/edx/testing.txt
     #   pylint
@@ -706,7 +709,7 @@ faker==15.1.1
     # via
     #   -r requirements/edx/testing.txt
     #   factory-boy
-fastapi==0.85.0
+fastapi==0.85.1
     # via
     #   -r requirements/edx/testing.txt
     #   pact-python
@@ -760,7 +763,7 @@ html5lib==1.1
     #   ora2
 httpretty==1.1.4
     # via -r requirements/edx/testing.txt
-icalendar==4.1.0
+icalendar==5.0.1
     # via -r requirements/edx/testing.txt
 idna==3.4
     # via
@@ -867,7 +870,7 @@ lazy-object-proxy==1.7.1
     #   astroid
 learner-pathway-progress==1.3.3
     # via -r requirements/edx/testing.txt
-levenshtein==0.20.5
+levenshtein==0.20.7
     # via
     #   -r requirements/edx/testing.txt
     #   python-levenshtein
@@ -937,7 +940,6 @@ mistune==0.8.4
 mock==4.0.3
     # via
     #   -r requirements/edx/testing.txt
-    #   xblock-drag-and-drop-v2
     #   xblock-poll
 mongodbproxy @ git+https://github.com/openedx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a
     # via -r requirements/edx/testing.txt
@@ -1040,7 +1042,7 @@ path-py==12.5.0
     #   staff-graded-xblock
 paver==1.3.4
     # via -r requirements/edx/testing.txt
-pbr==5.10.0
+pbr==5.11.0
     # via
     #   -r requirements/edx/testing.txt
     #   stevedore
@@ -1080,7 +1082,7 @@ prompt-toolkit==3.0.31
     # via
     #   -r requirements/edx/testing.txt
     #   click-repl
-psutil==5.9.2
+psutil==5.9.3
     # via
     #   -r requirements/edx/testing.txt
     #   edx-django-utils
@@ -1132,7 +1134,7 @@ pyjwkest==1.4.2
     #   -r requirements/edx/testing.txt
     #   edx-drf-extensions
     #   lti-consumer-xblock
-pyjwt[crypto]==2.5.0
+pyjwt[crypto]==2.6.0
     # via
     #   -r requirements/edx/testing.txt
     #   drf-jwt
@@ -1258,7 +1260,7 @@ python-dateutil==2.8.2
     #   olxcleaner
     #   ora2
     #   xblock
-python-levenshtein==0.20.5
+python-levenshtein==0.20.7
     # via -r requirements/edx/testing.txt
 python-memcached==1.59
     # via -r requirements/edx/testing.txt
@@ -1361,7 +1363,7 @@ ruamel-yaml==0.17.21
     # via
     #   -r requirements/edx/testing.txt
     #   drf-yasg
-ruamel-yaml-clib==0.2.6
+ruamel-yaml-clib==0.2.7
     # via
     #   -r requirements/edx/testing.txt
     #   ruamel-yaml
@@ -1475,7 +1477,7 @@ soupsieve==2.3.2.post1
     # via
     #   -r requirements/edx/testing.txt
     #   beautifulsoup4
-sphinx==5.2.3
+sphinx==5.3.0
     # via
     #   edx-sphinx-theme
     #   sphinxcontrib-httpdomain
@@ -1508,7 +1510,7 @@ starlette==0.20.4
     # via
     #   -r requirements/edx/testing.txt
     #   fastapi
-stevedore==4.0.1
+stevedore==4.1.0
     # via
     #   -r requirements/edx/testing.txt
     #   code-annotations
@@ -1563,10 +1565,6 @@ tqdm==4.64.1
     # via
     #   -r requirements/edx/testing.txt
     #   nltk
-types-cryptography==3.3.23
-    # via
-    #   -r requirements/edx/testing.txt
-    #   pyjwt
 typing-extensions==4.4.0
     # via
     #   -r requirements/edx/testing.txt
@@ -1601,7 +1599,7 @@ urllib3==1.26.12
     #   tableauserverclient
 user-util==1.0.0
     # via -r requirements/edx/testing.txt
-uvicorn==0.18.3
+uvicorn==0.19.0
     # via
     #   -r requirements/edx/testing.txt
     #   pact-python
@@ -1671,7 +1669,7 @@ xblock==1.6.1
     #   xblock-google-drive
     #   xblock-poll
     #   xblock-utils
-xblock-drag-and-drop-v2 @ git+https://github.com/openedx/xblock-drag-and-drop-v2@v2.3.5
+xblock-drag-and-drop-v2==2.5.0
     # via -r requirements/edx/testing.txt
 xblock-poll @ git+https://github.com/open-craft/xblock-poll@v1.12.0
     # via -r requirements/edx/testing.txt
@@ -1693,7 +1691,7 @@ yarl==1.8.1
     # via
     #   -r requirements/edx/testing.txt
     #   aiohttp
-zipp==3.9.0
+zipp==3.10.0
     # via
     #   -r requirements/edx/testing.txt
     #   importlib-metadata

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -44,7 +44,7 @@ markupsafe==2.1.1
     # via jinja2
 packaging==21.3
     # via sphinx
-pbr==5.10.0
+pbr==5.11.0
     # via stevedore
 pygments==2.13.0
     # via sphinx
@@ -66,7 +66,7 @@ smmap==5.0.0
     # via gitdb
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==5.2.3
+sphinx==5.3.0
     # via
     #   -r requirements/edx/doc.in
     #   edx-sphinx-theme
@@ -82,11 +82,11 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-stevedore==4.0.1
+stevedore==4.1.0
     # via code-annotations
 text-unidecode==1.3
     # via python-slugify
 urllib3==1.26.12
     # via requests
-zipp==3.9.0
+zipp==3.10.0
     # via importlib-metadata

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -70,4 +70,3 @@ git+https://github.com/openedx/django-require.git@0c54adb167142383b26ea6b3edecc3
 # Third Party XBlocks
 
 git+https://github.com/open-craft/xblock-poll@v1.12.0#egg=xblock-poll==1.12.0
-git+https://github.com/openedx/xblock-drag-and-drop-v2@v2.3.5#egg=xblock-drag-and-drop-v2==2.3.5

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -26,9 +26,9 @@ path==16.5.0
     # via -r requirements/edx/paver.in
 paver==1.3.4
     # via -r requirements/edx/paver.in
-pbr==5.10.0
+pbr==5.11.0
     # via stevedore
-psutil==5.9.2
+psutil==5.9.3
     # via -r requirements/edx/paver.in
 pymongo==3.12.3
     # via
@@ -44,7 +44,7 @@ six==1.16.0
     #   libsass
     #   paver
     #   python-memcached
-stevedore==4.0.1
+stevedore==4.1.0
     # via
     #   -r requirements/edx/paver.in
     #   edx-opaque-keys

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -34,7 +34,7 @@ aniso8601==9.0.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-tincan-py35
-anyio==3.6.1
+anyio==3.6.2
     # via starlette
 appdirs==1.4.4
     # via
@@ -67,6 +67,7 @@ attrs==22.1.0
     #   jsonschema
     #   lti-consumer-xblock
     #   openedx-events
+    #   outcome
     #   pytest
 babel==2.10.3
     # via
@@ -77,6 +78,10 @@ backoff==1.10.0
     # via
     #   -r requirements/edx/base.txt
     #   analytics-python
+backports-zoneinfo==0.2.1
+    # via
+    #   -r requirements/edx/base.txt
+    #   icalendar
 beautifulsoup4==4.11.1
     # via
     #   -r requirements/edx/base.txt
@@ -231,7 +236,6 @@ ddt==1.6.0
     # via
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/testing.in
-    #   xblock-drag-and-drop-v2
     #   xblock-poll
 defusedxml==0.7.1
     # via
@@ -249,7 +253,7 @@ deprecated==1.2.13
     #   redis
 diff-cover==7.0.1
     # via -r requirements/edx/coverage.txt
-dill==0.3.5.1
+dill==0.3.6
     # via pylint
 distlib==0.3.6
     # via virtualenv
@@ -680,7 +684,7 @@ factory-boy==3.2.1
     # via -r requirements/edx/testing.in
 faker==15.1.1
     # via factory-boy
-fastapi==0.85.0
+fastapi==0.85.1
     # via pact-python
 fastavro==1.6.1
     # via
@@ -730,7 +734,7 @@ html5lib==1.1
     #   ora2
 httpretty==1.1.4
     # via -r requirements/edx/testing.in
-icalendar==4.1.0
+icalendar==5.0.1
     # via -r requirements/edx/base.txt
 idna==3.4
     # via
@@ -829,7 +833,7 @@ lazy-object-proxy==1.7.1
     # via astroid
 learner-pathway-progress==1.3.3
     # via -r requirements/edx/base.txt
-levenshtein==0.20.5
+levenshtein==0.20.7
     # via
     #   -r requirements/edx/base.txt
     #   python-levenshtein
@@ -892,7 +896,6 @@ mccabe==0.7.0
 mock==4.0.3
     # via
     #   -r requirements/edx/base.txt
-    #   xblock-drag-and-drop-v2
     #   xblock-poll
 mongodbproxy @ git+https://github.com/openedx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a
     # via -r requirements/edx/base.txt
@@ -988,7 +991,7 @@ path-py==12.5.0
     #   staff-graded-xblock
 paver==1.3.4
     # via -r requirements/edx/base.txt
-pbr==5.10.0
+pbr==5.11.0
     # via
     #   -r requirements/edx/base.txt
     #   stevedore
@@ -1022,7 +1025,7 @@ prompt-toolkit==3.0.31
     # via
     #   -r requirements/edx/base.txt
     #   click-repl
-psutil==5.9.2
+psutil==5.9.3
     # via
     #   -r requirements/edx/base.txt
     #   edx-django-utils
@@ -1071,7 +1074,7 @@ pyjwkest==1.4.2
     #   -r requirements/edx/base.txt
     #   edx-drf-extensions
     #   lti-consumer-xblock
-pyjwt[crypto]==2.5.0
+pyjwt[crypto]==2.6.0
     # via
     #   -r requirements/edx/base.txt
     #   drf-jwt
@@ -1188,7 +1191,7 @@ python-dateutil==2.8.2
     #   olxcleaner
     #   ora2
     #   xblock
-python-levenshtein==0.20.5
+python-levenshtein==0.20.7
     # via -r requirements/edx/base.txt
 python-memcached==1.59
     # via -r requirements/edx/base.txt
@@ -1287,7 +1290,7 @@ ruamel-yaml==0.17.21
     # via
     #   -r requirements/edx/base.txt
     #   drf-yasg
-ruamel-yaml-clib==0.2.6
+ruamel-yaml-clib==0.2.7
     # via
     #   -r requirements/edx/base.txt
     #   ruamel-yaml
@@ -1404,7 +1407,7 @@ staff-graded-xblock==2.0.1
     # via -r requirements/edx/base.txt
 starlette==0.20.4
     # via fastapi
-stevedore==4.0.1
+stevedore==4.1.0
     # via
     #   -r requirements/edx/base.txt
     #   code-annotations
@@ -1453,10 +1456,6 @@ tqdm==4.64.1
     # via
     #   -r requirements/edx/base.txt
     #   nltk
-types-cryptography==3.3.23
-    # via
-    #   -r requirements/edx/base.txt
-    #   pyjwt
 typing-extensions==4.4.0
     # via
     #   -r requirements/edx/base.txt
@@ -1490,7 +1489,7 @@ urllib3==1.26.12
     #   tableauserverclient
 user-util==1.0.0
     # via -r requirements/edx/base.txt
-uvicorn==0.18.3
+uvicorn==0.19.0
     # via pact-python
 vine==5.0.0
     # via
@@ -1550,7 +1549,7 @@ xblock==1.6.1
     #   xblock-google-drive
     #   xblock-poll
     #   xblock-utils
-xblock-drag-and-drop-v2 @ git+https://github.com/openedx/xblock-drag-and-drop-v2@v2.3.5
+xblock-drag-and-drop-v2==2.5.0
     # via -r requirements/edx/base.txt
 xblock-poll @ git+https://github.com/open-craft/xblock-poll@v1.12.0
     # via -r requirements/edx/base.txt
@@ -1572,7 +1571,7 @@ yarl==1.8.1
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
-zipp==3.9.0
+zipp==3.10.0
     # via
     #   -r requirements/edx/base.txt
     #   importlib-metadata


### PR DESCRIPTION
## DESC:
This PR removes `xblock-drag-and-drop-v2` from `github.in` as a github dependency and installs it from PyPI. It is now listed in `base.in` requirements file.

**Sub-task of Issue:** https://github.com/openedx/xblock-drag-and-drop-v2/issues/299
**Sandbox**: https://xblock.sandbox.edx.org
