### PR TITLE
Install xblock-google-drive from pypi

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -177,3 +177,4 @@ xblock-utils                        # Provides utilities used by the Discussion 
 xss-utils                           # https://github.com/edx/edx-platform/pull/20633 Fix XSS via Translations
 enmerkar-underscore                 # Implements a underscore extractor for django-babel.
 xblock-drag-and-drop-v2             # Drag and Drop XBlock
+xblock-google-drive                 # XBlock for google docs and calendar

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -12,8 +12,6 @@
     # via -r requirements/edx/github.in
 -e git+https://github.com/openedx/olxcleaner.git@2f0d6c7f126cbd69c9724b7b57a0b2565330a297#egg=olxcleaner
     # via -r requirements/edx/github.in
--e git+https://github.com/openedx/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive
-    # via -r requirements/edx/github.in
 acid-xblock==0.2.1
     # via -r requirements/edx/base.in
 aiohttp==3.8.3
@@ -734,7 +732,7 @@ mysqlclient==2.1.1
     # via
     #   -r requirements/edx/base.in
     #   blockstore
-newrelic==8.2.1
+newrelic==8.3.0
     # via
     #   -r requirements/edx/base.in
     #   edx-django-utils
@@ -953,7 +951,7 @@ pyyaml==6.0
     #   xblock
 random2==1.0.1
     # via -r requirements/edx/base.in
-rapidfuzz==2.11.1
+rapidfuzz==2.12.0
     # via levenshtein
 recommender-xblock==2.0.1
     # via -r requirements/edx/base.in
@@ -1177,6 +1175,8 @@ xblock==1.6.1
     #   xblock-poll
     #   xblock-utils
 xblock-drag-and-drop-v2==2.5.0
+    # via -r requirements/edx/base.in
+xblock-google-drive==0.3.0
     # via -r requirements/edx/base.in
 xblock-poll @ git+https://github.com/open-craft/xblock-poll@v1.12.0
     # via -r requirements/edx/github.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -12,8 +12,6 @@
     # via -r requirements/edx/testing.txt
 -e git+https://github.com/openedx/olxcleaner.git@2f0d6c7f126cbd69c9724b7b57a0b2565330a297#egg=olxcleaner
     # via -r requirements/edx/testing.txt
--e git+https://github.com/openedx/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive
-    # via -r requirements/edx/testing.txt
 acid-xblock==0.2.1
     # via -r requirements/edx/testing.txt
 aiohttp==3.8.3
@@ -699,6 +697,10 @@ event-tracking==2.1.0
     #   -r requirements/edx/testing.txt
     #   edx-proctoring
     #   edx-search
+exceptiongroup==1.0.0rc9
+    # via
+    #   -r requirements/edx/testing.txt
+    #   pytest
 execnet==1.9.0
     # via
     #   -r requirements/edx/testing.txt
@@ -967,7 +969,7 @@ mysqlclient==2.1.1
     # via
     #   -r requirements/edx/testing.txt
     #   blockstore
-newrelic==8.2.1
+newrelic==8.3.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-django-utils
@@ -1091,7 +1093,6 @@ psutil==5.9.3
 py==1.11.0
     # via
     #   -r requirements/edx/testing.txt
-    #   pytest
     #   pytest-forked
     #   tox
 py2neo==2021.2.3
@@ -1213,7 +1214,7 @@ pysrt==1.1.2
     # via
     #   -r requirements/edx/testing.txt
     #   edxval
-pytest==7.1.3
+pytest==7.2.0
     # via
     #   -r requirements/edx/testing.txt
     #   pylint-pytest
@@ -1318,7 +1319,7 @@ pyyaml==6.0
     #   xblock
 random2==1.0.1
     # via -r requirements/edx/testing.txt
-rapidfuzz==2.11.1
+rapidfuzz==2.12.0
     # via
     #   -r requirements/edx/testing.txt
     #   levenshtein
@@ -1670,6 +1671,8 @@ xblock==1.6.1
     #   xblock-poll
     #   xblock-utils
 xblock-drag-and-drop-v2==2.5.0
+    # via -r requirements/edx/testing.txt
+xblock-google-drive==0.3.0
     # via -r requirements/edx/testing.txt
 xblock-poll @ git+https://github.com/open-craft/xblock-poll@v1.12.0
     # via -r requirements/edx/testing.txt

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -65,7 +65,6 @@ git+https://github.com/openedx/django-require.git@0c54adb167142383b26ea6b3edecc3
 # Our libraries:
 -e git+https://github.com/openedx/blockstore.git@1.2.4#egg=blockstore==1.2.4  # Note: Blockstore 1.2.2 & 1.2.3 are failing.
 -e git+https://github.com/openedx/codejail.git@3.1.3#egg=codejail==3.1.3
--e git+https://github.com/openedx/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive
 
 # Third Party XBlocks
 

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -12,8 +12,6 @@
     # via -r requirements/edx/base.txt
 -e git+https://github.com/openedx/olxcleaner.git@2f0d6c7f126cbd69c9724b7b57a0b2565330a297#egg=olxcleaner
     # via -r requirements/edx/base.txt
--e git+https://github.com/openedx/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive
-    # via -r requirements/edx/base.txt
 acid-xblock==0.2.1
     # via -r requirements/edx/base.txt
 aiohttp==3.8.3
@@ -678,6 +676,8 @@ event-tracking==2.1.0
     #   -r requirements/edx/base.txt
     #   edx-proctoring
     #   edx-search
+exceptiongroup==1.0.0rc9
+    # via pytest
 execnet==1.9.0
     # via pytest-xdist
 factory-boy==3.2.1
@@ -919,7 +919,7 @@ mysqlclient==2.1.1
     # via
     #   -r requirements/edx/base.txt
     #   blockstore
-newrelic==8.2.1
+newrelic==8.3.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-django-utils
@@ -1033,7 +1033,6 @@ psutil==5.9.3
     #   pytest-xdist
 py==1.11.0
     # via
-    #   pytest
     #   pytest-forked
     #   tox
 py2neo==2021.2.3
@@ -1146,7 +1145,7 @@ pysrt==1.1.2
     # via
     #   -r requirements/edx/base.txt
     #   edxval
-pytest==7.1.3
+pytest==7.2.0
     # via
     #   -r requirements/edx/testing.in
     #   pylint-pytest
@@ -1246,7 +1245,7 @@ pyyaml==6.0
     #   xblock
 random2==1.0.1
     # via -r requirements/edx/base.txt
-rapidfuzz==2.11.1
+rapidfuzz==2.12.0
     # via
     #   -r requirements/edx/base.txt
     #   levenshtein
@@ -1550,6 +1549,8 @@ xblock==1.6.1
     #   xblock-poll
     #   xblock-utils
 xblock-drag-and-drop-v2==2.5.0
+    # via -r requirements/edx/base.txt
+xblock-google-drive==0.3.0
     # via -r requirements/edx/base.txt
 xblock-poll @ git+https://github.com/open-craft/xblock-poll@v1.12.0
     # via -r requirements/edx/base.txt


### PR DESCRIPTION
**Sub-task of:** https://github.com/openedx/xblock-google-drive/issues/49

## DESC
This PR removes `xblock-google-drive` from `github.in` and instead uses the PyPI package. 