### PR TITLE
feat: add timers / logs for for profiling learner home

### DIFF
--- a/lms/djangoapps/learner_home/utils.py
+++ b/lms/djangoapps/learner_home/utils.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 LH_DEBUG = True
 
 
-def timed(func):
+def exec_time_logged(func):
     """Wrap the function and return result and execution time"""
 
     # IF debugging is on, log function run lengths

--- a/lms/djangoapps/learner_home/utils.py
+++ b/lms/djangoapps/learner_home/utils.py
@@ -21,7 +21,7 @@ def exec_time_logged(func):
         # Display lists / sets as their lengths instead of actual items
         debug_args = []
         for arg in args:
-            if isinstance(arg, list) or isinstance(arg, set):
+            if isinstance(arg, (list, set)):
                 debug_args.append(f"<list: (len {len(arg)})>")
             else:
                 debug_args.append(arg)

--- a/lms/djangoapps/learner_home/utils.py
+++ b/lms/djangoapps/learner_home/utils.py
@@ -2,9 +2,44 @@
 
 import logging
 import requests
+from time import time
+
 from django.conf import settings
 
 log = logging.getLogger(__name__)
+LH_DEBUG = True
+
+
+def timed(func):
+    """Wrap the function and return result and execution time"""
+
+    # IF debugging is on, log function run lengths
+    if LH_DEBUG:
+
+        def wrap_func(*args, **kwargs):
+            # Time the function operation
+            t1 = time()
+            result = func(*args, **kwargs)
+            t2 = time()
+
+            # Display lists / sets as their lengths instead of actual items
+            debug_args = []
+            for arg in args:
+                if isinstance(arg, list) or isinstance(arg, set):
+                    debug_args.append(f"<list: (len {len(arg)})>")
+                else:
+                    debug_args.append(arg)
+
+            # Log the output
+            log.info(f"{func.__name__!r} args:{debug_args} completed in {(t2-t1):.4f}s")
+
+            return result
+
+        return wrap_func
+
+    # If debugging is off, don't do any logging
+    else:
+        return func
 
 
 def get_personalized_course_recommendations(user_id):

--- a/lms/djangoapps/learner_home/utils.py
+++ b/lms/djangoapps/learner_home/utils.py
@@ -7,39 +7,31 @@ from time import time
 from django.conf import settings
 
 log = logging.getLogger(__name__)
-LH_DEBUG = True
 
 
 def exec_time_logged(func):
     """Wrap the function and return result and execution time"""
 
-    # IF debugging is on, log function run lengths
-    if LH_DEBUG:
+    def wrap_func(*args, **kwargs):
+        # Time the function operation
+        t1 = time()
+        result = func(*args, **kwargs)
+        t2 = time()
 
-        def wrap_func(*args, **kwargs):
-            # Time the function operation
-            t1 = time()
-            result = func(*args, **kwargs)
-            t2 = time()
+        # Display lists / sets as their lengths instead of actual items
+        debug_args = []
+        for arg in args:
+            if isinstance(arg, list) or isinstance(arg, set):
+                debug_args.append(f"<list: (len {len(arg)})>")
+            else:
+                debug_args.append(arg)
 
-            # Display lists / sets as their lengths instead of actual items
-            debug_args = []
-            for arg in args:
-                if isinstance(arg, list) or isinstance(arg, set):
-                    debug_args.append(f"<list: (len {len(arg)})>")
-                else:
-                    debug_args.append(arg)
+        # Log the output
+        log.info(f"{func.__name__!r} args:{debug_args} completed in {(t2-t1):.4f}s")
 
-            # Log the output
-            log.info(f"{func.__name__!r} args:{debug_args} completed in {(t2-t1):.4f}s")
+        return result
 
-            return result
-
-        return wrap_func
-
-    # If debugging is off, don't do any logging
-    else:
-        return func
+    return wrap_func
 
 
 def get_personalized_course_recommendations(user_id):

--- a/lms/djangoapps/learner_home/views.py
+++ b/lms/djangoapps/learner_home/views.py
@@ -46,7 +46,7 @@ from lms.djangoapps.courseware.access_utils import (
 from lms.djangoapps.learner_home.serializers import LearnerDashboardSerializer
 from lms.djangoapps.learner_home.utils import (
     get_personalized_course_recommendations,
-    timed,
+    exec_time_logged,
 )
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
@@ -61,7 +61,7 @@ logger = logging.getLogger(__name__)
 User = get_user_model()
 
 
-@timed
+@exec_time_logged
 def get_platform_settings():
     """Get settings used for platform level connections: emails, url routes, etc."""
 
@@ -72,7 +72,7 @@ def get_platform_settings():
     }
 
 
-@timed
+@exec_time_logged
 def get_user_account_confirmation_info(user):
     """Determine if a user needs to verify their account and related URL info"""
 
@@ -91,7 +91,7 @@ def get_user_account_confirmation_info(user):
     return email_confirmation
 
 
-@timed
+@exec_time_logged
 def get_enrollments(user, org_allow_list, org_block_list, course_limit=None):
     """Get enrollments and enrollment course modes for user"""
 
@@ -131,7 +131,7 @@ def get_enrollments(user, org_allow_list, org_block_list, course_limit=None):
     return course_enrollments, course_mode_info
 
 
-@timed
+@exec_time_logged
 def get_entitlements(user, org_allow_list, org_block_list):
     """Get entitlements for the user"""
     (
@@ -157,7 +157,7 @@ def get_entitlements(user, org_allow_list, org_block_list):
     )
 
 
-@timed
+@exec_time_logged
 def get_course_overviews_for_pseudo_sessions(unfulfilled_entitlement_pseudo_sessions):
     """
     Get course overviews for entitlement pseudo sessions. This is required for
@@ -195,7 +195,7 @@ def get_email_settings_info(user, course_enrollments):
     return show_email_settings_for, course_optouts
 
 
-@timed
+@exec_time_logged
 def get_enterprise_customer(user, request, is_masquerading):
     """
     If we are not masquerading, try to load the enterprise learner from session data, falling back to the db.
@@ -208,7 +208,7 @@ def get_enterprise_customer(user, request, is_masquerading):
         return enterprise_customer_from_session_or_learner_data(request)
 
 
-@timed
+@exec_time_logged
 def get_ecommerce_payment_page(user):
     """Determine the ecommerce payment page URL if enabled for this user"""
     ecommerce_service = EcommerceService()
@@ -219,7 +219,7 @@ def get_ecommerce_payment_page(user):
     )
 
 
-@timed
+@exec_time_logged
 def get_cert_statuses(user, course_enrollments):
     """Get cert status by course for user enrollments"""
     return {
@@ -228,13 +228,13 @@ def get_cert_statuses(user, course_enrollments):
     }
 
 
-@timed
+@exec_time_logged
 def get_org_block_and_allow_lists():
     """Proxy for get_org_black_and_whitelist_for_site to allow for modification / profiling"""
     return get_org_black_and_whitelist_for_site()
 
 
-@timed
+@exec_time_logged
 def get_resume_urls_for_course_enrollments(user, course_enrollments):
     """Proxy for get_resume_urls_for_enrollments to allow for modification / profiling"""
     return get_resume_urls_for_enrollments(user, course_enrollments)
@@ -260,7 +260,7 @@ def _get_courses_with_unmet_prerequisites(user, course_enrollments):
     return get_pre_requisite_courses_not_completed(user, courses_having_prerequisites)
 
 
-@timed
+@exec_time_logged
 def check_course_access(user, course_enrollments):
     """
     Wrapper for checks surrounding user ability to view courseware
@@ -297,7 +297,7 @@ def check_course_access(user, course_enrollments):
     return course_access_dict
 
 
-@timed
+@exec_time_logged
 def get_course_programs(user, course_enrollments, site):
     """
     Get programs related to the courses the user is enrolled in.
@@ -314,7 +314,7 @@ def get_course_programs(user, course_enrollments, site):
     return meter.invert_programs()
 
 
-@timed
+@exec_time_logged
 def get_suggested_courses():
     """
     Currently just returns general recommendations from settings
@@ -328,7 +328,7 @@ def get_suggested_courses():
     )
 
 
-@timed
+@exec_time_logged
 def get_social_share_settings():
     """Config around social media sharing campaigns"""
 
@@ -354,7 +354,7 @@ def get_social_share_settings():
     }
 
 
-@timed
+@exec_time_logged
 def get_course_share_urls(course_enrollments):
     """Get course URLs for sharing on social media"""
     return {


### PR DESCRIPTION
## Description

- Added a `timed` decorator to tell us how long certain functions are running.
- Also involved proxying some imported functions to be able to use with this decorator.

Example logs:

```
'get_platform_settings' args:[] completed in 2.1996s
'get_org_block_and_allow_lists' args:[] completed in 0.0279s
'get_entitlements' args:[<User: staff>, None, '<list: (len 0)>'] completed in 0.0183s
'get_course_overviews_for_pseudo_sessions' args:[{}] completed in 0.0118s
'get_enrollments' args:[<User: staff>, None, '<list: (len 0)>'] completed in 0.0628s
'get_cert_statuses' args:[<User: staff>, '<list: (len 4)>'] completed in 0.0590s
'check_course_access' args:[<User: staff>, '<list: (len 4)>'] completed in 0.0425s
Failed to get program UUIDs from the cache for site example.com.
'get_course_programs' args:[<User: staff>, '<list: (len 4)>', <Site: example.com>] completed in 0.0198s
'get_ecommerce_payment_page' args:[<User: staff>] completed in 0.0161s
'get_resume_urls_for_course_enrollments' args:[<User: staff>, '<list: (len 4)>'] completed in 0.0395s
'get_suggested_courses' args:[] completed in 0.0002s
'get_course_share_urls' args:['<list: (len 4)>'] completed in 0.0018s
Finished serializing home info for staff in 0.1811s
```

FYI: @openedx/content-aurora 