### PR TITLE
fix: Styling issue in TinyMCE editor in Studio

### DIFF
--- a/xmodule/js/spec/html/edit_spec.js
+++ b/xmodule/js/spec/html/edit_spec.js
@@ -24,7 +24,7 @@ describe('HTMLEditingDescriptor', function() {
     });
     it('Returns data from Raw Editor if text has not changed', function(done) {
       const visualEditorStub =
-        {getContent() { return 'original visual text' }};
+        {getContent() { return '<p>original visual text</p>' }};
       spyOn(this.descriptor, 'getVisualEditor').and.callFake(() => visualEditorStub);
 
       var self = this;

--- a/xmodule/js/src/html/edit.js
+++ b/xmodule/js/src/html/edit.js
@@ -1390,7 +1390,7 @@
       haven't dirtied the Editor. Store the raw content so we can compare it later.
        */
       this.starting_content = visualEditor.getContent({
-        format: "text",
+        format: "raw",
         no_events: 1
       });
       return visualEditor.focus();
@@ -1410,7 +1410,7 @@
       if (this.editor_choice === 'visual') {
         visualEditor = this.getVisualEditor();
         raw_content = visualEditor.getContent({
-          format: "text",
+          format: "raw",
           no_events: 1
         });
         if (this.starting_content !== raw_content) {


### PR DESCRIPTION
<!--

🫒🫒
🫒🫒🫒🫒         🫒 Note: the Olive master branch has been created.  Please consider whether your change
    🫒🫒🫒🫒     should also be applied to Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

🌰🌰🌰🌰🌰🌰     🌰 Note: the Nutmeg release is still supported.
                  Please consider whether your change should be applied to Nutmeg as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/openedx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

- This PR fixes the issue in the TinyMCE editor in Studio.
- TinyMCE was upgraded from v4.0.20 to v5.5.1 under https://github.com/openedx/edx-platform/pull/30335.
- With these changes, we have also changed the way we get the text from the TinyMCE editor. We are passing `text` as format instead of `raw` to get the content from the editor object.
  <img width="1035" alt="Screenshot 2022-10-25 at 3 20 21 PM" src="https://user-images.githubusercontent.com/52656433/198287085-8619e747-a6cc-4ffb-b985-575dce4607b6.png">
- It returns plain text only. In the end, we just check for the plain text changes, and if plain text is not changed then the styling changes like bold, and italic text are not saved. `Hyperlinks` are also not working. 
- Changes will impact course authors.

Before these changes:

https://user-images.githubusercontent.com/52656433/198288326-58be7f45-0ed1-4d21-aae1-732ca27c81bb.mov


After these changes:

https://user-images.githubusercontent.com/52656433/198288964-6efc2b54-1e90-4ed5-91c7-5f77aca38451.mov


## Supporting information

https://github.mit.edu/mitxonline/mitxonline-issues/issues/162

## Testing instructions

- Edit course unit in the studio using the TinyMCE editor as in the supporting videos.
- Edit only the styles of the existing text and save the changes.
- Changes should be saved.

## Deadline

"None"
