### PR TITLE
feat: add discussion reported and unreported events

### DIFF
--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -763,31 +763,16 @@ def is_privileged_user(course_key: CourseKey, user: User):
     """
     Returns True if user has one of following course role
     Administrator, Moderator, Group Moderator, Community TA,
-    Global Staff, Course Instructor or Course Staff.
+    or Global Staff.
     """
     forum_roles = [
         FORUM_ROLE_COMMUNITY_TA,
         FORUM_ROLE_GROUP_MODERATOR,
         FORUM_ROLE_MODERATOR,
-        FORUM_ROLE_ADMINISTRATOR
+        FORUM_ROLE_ADMINISTRATOR,
     ]
     has_course_role = Role.user_has_role_for_course(user, course_key, forum_roles)
-    return GlobalStaff().has_user(user) or is_course_staff(course_key, user) or has_course_role
-
-
-def is_user_moderator(course_key: CourseKey, user: User):
-    """
-    Returns True if user has one of following course role
-    Administrator, Moderator, Group Moderator, Community TA.
-    """
-    forum_roles = [
-        FORUM_ROLE_COMMUNITY_TA,
-        FORUM_ROLE_GROUP_MODERATOR,
-        FORUM_ROLE_MODERATOR,
-        FORUM_ROLE_ADMINISTRATOR
-    ]
-    has_course_role = Role.user_has_role_for_course(user, course_key, forum_roles)
-    return has_course_role
+    return GlobalStaff().has_user(user) or has_course_role
 
 
 class DiscussionBoardFragmentView(EdxFragmentView):


### PR DESCRIPTION
### [INF-489](https://2u-internal.atlassian.net/browse/INF-489) 
### [INF-490](https://2u-internal.atlassian.net/browse/INF-490)

### Description

Add following discussion reported events:

- `edx.forum.thread.reported`
- `edx.forum.response.reported`
- `edx.forum.comment.reported`
- `edx.forum.thread.unreported`
- `edx.forum.response.unreported`
- `edx.forum.comment.unreported`

This PR also adds `GlobalStaff` role to roles that can remove all `abuse_flaggers` for a content when they unreport content.