### PR TITLE
feat: update docker production log settings

### DIFF
--- a/lms/envs/docker-production.py
+++ b/lms/envs/docker-production.py
@@ -2,6 +2,7 @@
 Specific overrides to the base prod settings for a docker production deployment.
 """
 
+from logging.handlers import SysLogHandler
 import platform
 from .production import *  # pylint: disable=wildcard-import, unused-wildcard-import
 
@@ -48,12 +49,24 @@ def get_docker_logger_config(log_dir='/var/tmp',
                 'formatter': 'standard',
                 'stream': sys.stdout,
             },
+            'tracking': {
+                'level': 'DEBUG',
+                'class': 'logging.handlers.SysLogHandler',
+                'address': ('localhost', 5140),
+                'facility': SysLogHandler.LOG_LOCAL1,
+                'formatter': 'raw',
+            }
         },
         'loggers': {
             'django': {
                 'handlers': handlers,
                 'propagate': True,
                 'level': 'INFO'
+            },
+            'tracking': {
+                'handlers': ['tracking'],
+                'level': 'DEBUG',
+                'propagate': False,
             },
             'requests': {
                 'handlers': handlers,


### PR DESCRIPTION
With a containerized platform, we would still like to be able to write tracking logs to other sources. Right now, the docker-production env does not account for tracking logs. The normal production tracking logs are handled via syslog, but that same process cannot be used in a container. 

We would still like to use a SysLogHandler, but are instead using a separate address, which corresponds to a port that a fluentd container is listening to. Fluentd can then process the logs by either outputting to std.out or eventually we can send those logs to S3. 

SysLogHandler was preferable over a FileHandler (which could take up disk space) as well as a SocketHandler (which pickles data). 