### PR TITLE
fix: studio submit handler (nutmeg backport)

### DIFF
--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -504,6 +504,12 @@ def component_handler(request, usage_key_string, handler, suffix=''):
     """
     usage_key = UsageKey.from_string(usage_key_string)
 
+
+    # Addendum:
+    # TNL 101-62 studio write permission is also checked for editing content.
+
+    if handler == 'submit_studio_edits' and not has_course_author_access(request.user, usage_key.course_key):
+        raise PermissionDenied("No studio write Permissions")
     # Let the module handle the AJAX
     req = django_to_webob_request(request)
 

--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -504,7 +504,6 @@ def component_handler(request, usage_key_string, handler, suffix=''):
     """
     usage_key = UsageKey.from_string(usage_key_string)
 
-
     # Addendum:
     # TNL 101-62 studio write permission is also checked for editing content.
 

--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock, PropertyMock, patch
 
 import ddt
 from django.conf import settings
+from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from django.test import TestCase
 from django.test.client import RequestFactory
@@ -2196,6 +2197,15 @@ class TestComponentHandler(TestCase):
 
         self.assertEqual(component_handler(self.request, self.usage_key_string, 'dummy_handler').status_code,
                          status_code)
+
+    def test_submit_studio_edits_checks_author_permission(self):
+        with self.assertRaises(PermissionDenied):
+            with patch(
+                'common.djangoapps.student.auth.has_course_author_access',
+                return_value=False
+            ) as mocked_has_course_author_access:
+                component_handler(self.request, self.usage_key_string, 'submit_studio_edits')
+                assert mocked_has_course_author_access.called is True
 
     @ddt.data((True, True), (False, False),)
     @ddt.unpack


### PR DESCRIPTION
## Description

This solves https://2u-internal.atlassian.net/browse/TNL-10162 for olive. Backport to Olive also coming.
You can see the change in master here:  https://github.com/openedx/edx-platform/pull/31218

It appears that it’s possible for a student with no special studio access
rights to POST to the studio_submit_edits xblock handler on the CMS with no
restrictions. This is what we fix here. Being terse as this is newly public security fix we will post about more widely once these backports have been merged.
