### PR TITLE
refactor: course resume URL speed enhancements

### DIFF
--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -130,10 +130,7 @@ class CourseRunSerializer(serializers.Serializer):
             return f"{ecommerce_payment_page}?sku={verified_sku}"
 
     def get_resumeUrl(self, instance):
-        resumeUrl = self.context.get("resume_course_urls", {}).get(instance.course_id)
-
-        # Return None if missing or empty string
-        return resumeUrl if bool(resumeUrl) else None
+        return self.context.get("resume_course_urls", {}).get(instance.course_id)
 
 
 class CoursewareAccessSerializer(serializers.Serializer):
@@ -492,17 +489,15 @@ class UnfulfilledEntitlementSerializer(serializers.Serializer):
         )
         if pseudo_session:
             course_key = CourseKey.from_string(pseudo_session["key"])
-            return self.context.get("pseudo_session_course_overviews").get(
-                course_key
-            )
+            return self.context.get("pseudo_session_course_overviews").get(course_key)
 
     def get_course(self, instance):
-        """ Serialize course info from a course overview """
+        """Serialize course info from a course overview"""
         course_overview = self._get_course_overview(instance)
         return CourseSerializer(course_overview, context=self.context).data
 
     def get_courseProvider(self, instance):
-        """ Serialize course provider info from a course overview """
+        """Serialize course provider info from a course overview"""
         course_overview = self._get_course_overview(instance)
         return CourseProviderSerializer(course_overview, allow_null=True).data
 

--- a/lms/djangoapps/learner_home/test_serializers.py
+++ b/lms/djangoapps/learner_home/test_serializers.py
@@ -217,12 +217,12 @@ class TestCourseRunSerializer(LearnerDashboardBaseTest):
         input_context = self.create_test_context(input_data.course.id)
 
         # ... where a user hasn't started
-        input_context["resume_course_urls"][input_data.course.id] = ""
+        input_context["resume_course_urls"][input_data.course.id] = None
 
         # When I serialize
         output_data = CourseRunSerializer(input_data, context=input_context).data
 
-        # Then the resumeUrl is None
+        # Then the resumeUrl is None, which is allowed
         self.assertIsNone(output_data["resumeUrl"])
 
 

--- a/lms/djangoapps/learner_home/urls.py
+++ b/lms/djangoapps/learner_home/urls.py
@@ -12,5 +12,9 @@ urlpatterns = [
     re_path(
         r"^mock/init/?", mock_views.InitializeView.as_view(), name="mock_initialize"
     ),
-    re_path(r"^recommendation/courses/$", views.CourseRecommendationApiView.as_view(), name="courses"),
+    re_path(
+        r"^recommendation/courses/$",
+        views.CourseRecommendationApiView.as_view(),
+        name="courses",
+    ),
 ]

--- a/lms/djangoapps/learner_home/views.py
+++ b/lms/djangoapps/learner_home/views.py
@@ -15,6 +15,10 @@ from common.djangoapps.util.course import (
     get_link_for_about_page,
 )
 from edx_django_utils import monitoring as monitoring_utils
+from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
+from edx_rest_framework_extensions.auth.session.authentication import (
+    SessionAuthenticationAllowInactiveUser,
+)
 from opaque_keys.edx.keys import CourseKey
 from rest_framework.exceptions import PermissionDenied, NotFound
 from rest_framework.permissions import IsAuthenticated
@@ -22,12 +26,13 @@ from rest_framework.response import Response
 from rest_framework.generics import RetrieveAPIView
 from rest_framework.views import APIView
 
-from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
-from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.edxmako.shortcuts import marketing_link
 from common.djangoapps.student.helpers import cert_info, get_resume_urls_for_enrollments
-from common.djangoapps.student.models import CourseEnrollment, get_user_by_username_or_email
+from common.djangoapps.student.models import (
+    CourseEnrollment,
+    get_user_by_username_or_email,
+)
 from common.djangoapps.student.toggles import should_show_amplitude_recommendations
 from common.djangoapps.student.views.dashboard import (
     complete_course_mode_info,

--- a/lms/djangoapps/learner_home/views.py
+++ b/lms/djangoapps/learner_home/views.py
@@ -8,6 +8,7 @@ from time import time
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import MultipleObjectsReturned
+from django.urls import reverse
 from completion.exceptions import UnavailableCompletionData
 from completion.utilities import get_key_to_last_completed_block
 from common.djangoapps.util.course import (

--- a/lms/djangoapps/learner_home/views.py
+++ b/lms/djangoapps/learner_home/views.py
@@ -29,7 +29,7 @@ from rest_framework.views import APIView
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.edxmako.shortcuts import marketing_link
-from common.djangoapps.student.helpers import cert_info, get_resume_urls_for_enrollments
+from common.djangoapps.student.helpers import cert_info
 from common.djangoapps.student.models import (
     CourseEnrollment,
     get_user_by_username_or_email,

--- a/lms/djangoapps/learner_home/waffle.py
+++ b/lms/djangoapps/learner_home/waffle.py
@@ -14,11 +14,12 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 # .. toggle_creation_date: 2022-10-11
 # .. toggle_tickets: AU-879
 ENABLE_LEARNER_HOME_MFE = WaffleFlag(
-    'learner_home_mfe.enabled',
+    "learner_home_mfe.enabled",
     __name__,
 )
 
 
 def should_redirect_to_learner_home_mfe():
-    return configuration_helpers.get_value('ENABLE_LEARNER_HOME_MFE',
-                                           ENABLE_LEARNER_HOME_MFE.is_enabled())
+    return configuration_helpers.get_value(
+        "ENABLE_LEARNER_HOME_MFE", ENABLE_LEARNER_HOME_MFE.is_enabled()
+    )


### PR DESCRIPTION
## Description

Current implementation of getting `course_resume_urls` (used for jumping a user back into last-visited block for a course from the dashboard) works as follows:
1. Query `completion` for most recently completed block
2. Load existing course structure and verify that the block exists
3. If block isn't found or user hasn't started course return `''`
4. If block is found, generate the "jump link" to go back to that block.

This ends up being the **vast** majority of processing time for the new dashboard for users with huge course numbers. As a first performance increase, implement a new version of this function that removes the "load existing course and verify block exists" check.

If the jump link ends up going to a bad block, this is fine: Learning MFE will jump to beginning of course instead, so there is low risk of removing this check.

Additional refactors:
- Return `None` for missing URL instead of `''`. Simplifies serialization logic.
- Reorder some dependencies which were out of order.
- Some style fixes from running `black`

Part of investigation into Learner Home timeouts ([AU-905](https://2u-internal.atlassian.net/browse/AU-905))
FYI @openedx/content-aurora 
