### PR TITLE
feat: create new waffle flag for learner home recommendations [VAN-1138]

### DIFF
--- a/lms/djangoapps/learner_home/test_views.py
+++ b/lms/djangoapps/learner_home/test_views.py
@@ -18,7 +18,6 @@ from rest_framework.test import APITestCase
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.entitlements.tests.factories import CourseEntitlementFactory
-from common.djangoapps.student.toggles import ENABLE_AMPLITUDE_RECOMMENDATIONS
 from common.djangoapps.student.tests.factories import (
     CourseEnrollmentFactory,
     UserFactory,
@@ -40,6 +39,7 @@ from lms.djangoapps.learner_home.views import (
     get_course_share_urls,
 )
 from lms.djangoapps.learner_home.test_serializers import random_url
+from lms.djangoapps.learner_home.waffle import ENABLE_LEARNER_HOME_AMPLITUDE_RECOMMENDATIONS
 from openedx.core.djangoapps.catalog.tests.factories import (
     CourseRunFactory as CatalogCourseRunFactory,
     ProgramFactory,
@@ -841,7 +841,7 @@ class TestCourseRecommendationApiView(SharedModuleStoreTestCase):
             'marketing_url': 'https://www.marketing_url.com'
         }
 
-    @override_waffle_flag(ENABLE_AMPLITUDE_RECOMMENDATIONS, active=False)
+    @override_waffle_flag(ENABLE_LEARNER_HOME_AMPLITUDE_RECOMMENDATIONS, active=False)
     def test_waffle_flag_off(self):
         """
         Verify API returns 400 if waffle flag is off.
@@ -850,7 +850,7 @@ class TestCourseRecommendationApiView(SharedModuleStoreTestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.data, None)
 
-    @override_waffle_flag(ENABLE_AMPLITUDE_RECOMMENDATIONS, active=True)
+    @override_waffle_flag(ENABLE_LEARNER_HOME_AMPLITUDE_RECOMMENDATIONS, active=True)
     @mock.patch('lms.djangoapps.learner_home.views.get_personalized_course_recommendations')
     @mock.patch('lms.djangoapps.learner_home.views.get_course_data')
     def test_no_recommendations_from_amplitude(self, mocked_get_course_data,
@@ -865,7 +865,7 @@ class TestCourseRecommendationApiView(SharedModuleStoreTestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.data, None)
 
-    @override_waffle_flag(ENABLE_AMPLITUDE_RECOMMENDATIONS, active=True)
+    @override_waffle_flag(ENABLE_LEARNER_HOME_AMPLITUDE_RECOMMENDATIONS, active=True)
     @mock.patch('lms.djangoapps.learner_home.views.get_personalized_course_recommendations')
     @mock.patch('lms.djangoapps.learner_home.views.get_course_data')
     def test_get_course_recommendations(self, mocked_get_course_data,
@@ -882,7 +882,7 @@ class TestCourseRecommendationApiView(SharedModuleStoreTestCase):
         self.assertEqual(response.data.get('is_personalized_recommendation'), True)
         self.assertEqual(len(response.data.get('courses')), expected_recommendations_length)
 
-    @override_waffle_flag(ENABLE_AMPLITUDE_RECOMMENDATIONS, active=True)
+    @override_waffle_flag(ENABLE_LEARNER_HOME_AMPLITUDE_RECOMMENDATIONS, active=True)
     @mock.patch('lms.djangoapps.learner_home.views.get_personalized_course_recommendations')
     @mock.patch('lms.djangoapps.learner_home.views.get_course_data')
     def test_get_enrollable_course_recommendations(self, mocked_get_course_data,

--- a/lms/djangoapps/learner_home/views.py
+++ b/lms/djangoapps/learner_home/views.py
@@ -34,7 +34,6 @@ from common.djangoapps.student.models import (
     CourseEnrollment,
     get_user_by_username_or_email,
 )
-from common.djangoapps.student.toggles import should_show_amplitude_recommendations
 from common.djangoapps.student.views.dashboard import (
     complete_course_mode_info,
     get_course_enrollments,
@@ -53,6 +52,7 @@ from lms.djangoapps.courseware.access_utils import (
     check_course_open_for_learner,
 )
 from lms.djangoapps.learner_home.serializers import LearnerDashboardSerializer
+from lms.djangoapps.learner_home.waffle import should_show_learner_home_amplitude_recommendations
 from lms.djangoapps.learner_home.utils import (
     get_personalized_course_recommendations,
     exec_time_logged,
@@ -537,7 +537,7 @@ class CourseRecommendationApiView(APIView):
 
     def get(self, request):
         """ Retrieves course recommendations details of a user in a specified course. """
-        if not should_show_amplitude_recommendations():
+        if not should_show_learner_home_amplitude_recommendations():
             return Response(status=400)
 
         user_id = request.user.id

--- a/lms/djangoapps/learner_home/waffle.py
+++ b/lms/djangoapps/learner_home/waffle.py
@@ -6,6 +6,9 @@ waffle switches for the teams app.
 from edx_toggles.toggles import WaffleFlag
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
+# Namespace for Learner Home MFE waffle flags.
+WAFFLE_FLAG_NAMESPACE = "learner_home_mfe"
+
 # .. toggle_name: learner_home_mfe.enabled
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
@@ -14,7 +17,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 # .. toggle_creation_date: 2022-10-11
 # .. toggle_tickets: AU-879
 ENABLE_LEARNER_HOME_MFE = WaffleFlag(
-    "learner_home_mfe.enabled",
+    f"{WAFFLE_FLAG_NAMESPACE}.enabled",
     __name__,
 )
 
@@ -23,3 +26,22 @@ def should_redirect_to_learner_home_mfe():
     return configuration_helpers.get_value(
         "ENABLE_LEARNER_HOME_MFE", ENABLE_LEARNER_HOME_MFE.is_enabled()
     )
+
+
+# Waffle flag to enable to recommendation panel on learner home mfe
+# .. toggle_name: learner_home_mfe.enable_learner_home_amplitude_recommendations
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Waffle flag to enable to recommendation panel on learner home mfe
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2022-10-28
+# .. toggle_target_removal_date: None
+# .. toggle_warning: None
+# .. toggle_tickets: VAN-1138
+ENABLE_LEARNER_HOME_AMPLITUDE_RECOMMENDATIONS = WaffleFlag(
+    f"{WAFFLE_FLAG_NAMESPACE}.enable_learner_home_amplitude_recommendations", __name__
+)
+
+
+def should_show_learner_home_amplitude_recommendations():
+    return ENABLE_LEARNER_HOME_AMPLITUDE_RECOMMENDATIONS.is_enabled()


### PR DESCRIPTION
Created and Configured a new waffle flag for the learner home page to show amplitude recommendations

[VAN-1138](https://2u-internal.atlassian.net/browse/VAN-1138)

<!--

🫒🫒
🫒🫒🫒🫒         🫒 Note: the Olive master branch has been created.  Please consider whether your change
    🫒🫒🫒🫒     should also be applied to Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

🌰🌰🌰🌰🌰🌰     🌰 Note: the Nutmeg release is still supported.
                  Please consider whether your change should be applied to Nutmeg as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/openedx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
