### PR TITLE
refactor: remove todo to add tracking for reported content email notification

### DIFF
--- a/lms/djangoapps/discussion/tasks.py
+++ b/lms/djangoapps/discussion/tasks.py
@@ -115,7 +115,6 @@ def send_ace_message_for_reported_content(context):  # lint-amnesty, pylint: dis
             )
             log.info(f'Sending forum reported content email notification with context {message_context}')
             ace.send(message)
-            # TODO: add tracking for reported content email
 
 
 def _track_notification_sent(message, context):


### PR DESCRIPTION
Removing todo for adding tracking for reported content email notification. This is not needed.