### PR TITLE
feat: update event bus dependencies to bring in schema fix

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -484,7 +484,7 @@ edx-enterprise==3.58.4
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   learner-pathway-progress
-edx-event-bus-kafka==1.3.0
+edx-event-bus-kafka==1.4.3
     # via -r requirements/edx/base.in
 edx-i18n-tools==0.9.2
     # via ora2
@@ -566,7 +566,7 @@ event-tracking==2.1.0
     #   -r requirements/edx/base.in
     #   edx-proctoring
     #   edx-search
-fastavro==1.6.1
+fastavro==1.7.0
     # via openedx-events
 filelock==3.8.0
     # via snowflake-connector-python
@@ -757,7 +757,7 @@ oauthlib==3.0.1
     #   social-auth-core
 openedx-calc==3.0.1
     # via -r requirements/edx/base.in
-openedx-events==3.0.0
+openedx-events==3.0.1
     # via
     #   -r requirements/edx/base.in
     #   edx-event-bus-kafka

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -603,7 +603,7 @@ edx-enterprise==3.58.4
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   learner-pathway-progress
-edx-event-bus-kafka==1.3.0
+edx-event-bus-kafka==1.4.3
     # via -r requirements/edx/testing.txt
 edx-i18n-tools==0.9.2
     # via
@@ -715,7 +715,7 @@ fastapi==0.85.1
     # via
     #   -r requirements/edx/testing.txt
     #   pact-python
-fastavro==1.6.1
+fastavro==1.7.0
     # via
     #   -r requirements/edx/testing.txt
     #   openedx-events
@@ -995,7 +995,7 @@ oauthlib==3.0.1
     #   social-auth-core
 openedx-calc==3.0.1
     # via -r requirements/edx/testing.txt
-openedx-events==3.0.0
+openedx-events==3.0.1
     # via
     #   -r requirements/edx/testing.txt
     #   edx-event-bus-kafka

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -583,7 +583,7 @@ edx-enterprise==3.58.4
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   learner-pathway-progress
-edx-event-bus-kafka==1.3.0
+edx-event-bus-kafka==1.4.3
     # via -r requirements/edx/base.txt
 edx-i18n-tools==0.9.2
     # via
@@ -686,7 +686,7 @@ faker==15.1.1
     # via factory-boy
 fastapi==0.85.1
     # via pact-python
-fastavro==1.6.1
+fastavro==1.7.0
     # via
     #   -r requirements/edx/base.txt
     #   openedx-events
@@ -945,7 +945,7 @@ oauthlib==3.0.1
     #   social-auth-core
 openedx-calc==3.0.1
     # via -r requirements/edx/base.txt
-openedx-events==3.0.0
+openedx-events==3.0.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-event-bus-kafka


### PR DESCRIPTION
## Description
Update openedx-events, edx-event-bus-kafka, and fastavro to get a fix for how event schemas are generated.

This should be done before upgrading these dependencies in course-discovery. Doing it the other way around won't break anything worse than it's already broken but this way it will be easier to verify the fix in discovery.