### PR TITLE
chore: upgrade edx-braze-client package

### DIFF
--- a/requirements/edx-sandbox/py38.txt
+++ b/requirements/edx-sandbox/py38.txt
@@ -14,7 +14,7 @@ click==8.1.3
     #   nltk
 codejail-includes==1.0.0
     # via -r requirements/edx-sandbox/py38.in
-cryptography==38.0.1
+cryptography==38.0.3
     # via -r requirements/edx-sandbox/py38.in
 cycler==0.11.0
     # via matplotlib
@@ -36,7 +36,7 @@ matplotlib==3.3.4
     #   -r requirements/edx-sandbox/py38.in
 mpmath==1.2.1
     # via sympy
-networkx==2.8.7
+networkx==2.8.8
     # via -r requirements/edx-sandbox/py38.in
 nltk==3.7
     # via
@@ -50,7 +50,7 @@ numpy==1.22.4
     #   scipy
 openedx-calc==3.0.1
     # via -r requirements/edx-sandbox/py38.in
-pillow==9.2.0
+pillow==9.3.0
     # via matplotlib
 pycparser==2.21
     # via cffi
@@ -64,7 +64,7 @@ python-dateutil==2.8.2
     # via matplotlib
 random2==1.0.1
     # via -r requirements/edx-sandbox/py38.in
-regex==2022.9.13
+regex==2022.10.31
     # via nltk
 scipy==1.7.3
     # via

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -45,7 +45,7 @@ attrs==22.1.0
     #   jsonschema
     #   lti-consumer-xblock
     #   openedx-events
-babel==2.10.3
+babel==2.11.0
     # via
     #   -r requirements/edx/base.in
     #   enmerkar
@@ -343,7 +343,7 @@ django-sekizai==4.0.0
     # via
     #   -r requirements/edx/base.in
     #   django-wiki
-django-ses==3.2.0
+django-ses==3.2.2
     # via -r requirements/edx/base.in
 django-simple-history==3.0.0
     # via
@@ -429,7 +429,7 @@ edx-auth-backends==4.1.0
     # via
     #   -r requirements/edx/base.in
     #   blockstore
-edx-braze-client==0.1.4
+edx-braze-client==0.1.5
     # via -r requirements/edx/base.in
 edx-bulk-grades==1.0.0
     # via
@@ -484,7 +484,7 @@ edx-enterprise==3.58.4
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   learner-pathway-progress
-edx-event-bus-kafka==1.4.3
+edx-event-bus-kafka==1.5.0
     # via -r requirements/edx/base.in
 edx-i18n-tools==0.9.2
     # via ora2
@@ -646,7 +646,7 @@ jsonfield==3.1.0
     #   lti-consumer-xblock
     #   ora2
     #   outcome-surveys
-jsonschema==4.16.0
+jsonschema==4.17.0
     # via optimizely-sdk
 jwcrypto==1.4.2
     # via pylti1p3
@@ -662,7 +662,7 @@ lazy==1.5
     #   ora2
 learner-pathway-progress==1.3.3
     # via -r requirements/edx/base.in
-levenshtein==0.20.7
+levenshtein==0.20.8
     # via python-levenshtein
 libsass==0.10.0
     # via
@@ -732,7 +732,7 @@ mysqlclient==2.1.1
     # via
     #   -r requirements/edx/base.in
     #   blockstore
-newrelic==8.3.0
+newrelic==8.4.0
     # via
     #   -r requirements/edx/base.in
     #   edx-django-utils
@@ -800,7 +800,7 @@ pbr==5.11.0
     #   stevedore
 piexif==1.1.3
     # via -r requirements/edx/base.in
-pillow==9.2.0
+pillow==9.3.0
     # via
     #   -r requirements/edx/base.in
     #   edx-enterprise
@@ -856,7 +856,7 @@ pylatexenc==2.10
     # via olxcleaner
 pylti1p3==1.12.1
     # via -r requirements/edx/base.in
-pymongo==3.12.3
+pymongo==3.13.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
@@ -879,7 +879,7 @@ pyparsing==3.0.9
     #   chem
     #   openedx-calc
     #   packaging
-pyrsistent==0.18.1
+pyrsistent==0.19.1
     # via
     #   jsonschema
     #   optimizely-sdk
@@ -900,7 +900,7 @@ python-dateutil==2.8.2
     #   olxcleaner
     #   ora2
     #   xblock
-python-levenshtein==0.20.7
+python-levenshtein==0.20.8
     # via -r requirements/edx/base.in
 python-memcached==1.59
     # via -r requirements/edx/paver.txt
@@ -951,13 +951,13 @@ pyyaml==6.0
     #   xblock
 random2==1.0.1
     # via -r requirements/edx/base.in
-rapidfuzz==2.12.0
+rapidfuzz==2.13.0
     # via levenshtein
 recommender-xblock==2.0.1
     # via -r requirements/edx/base.in
 redis==4.3.4
     # via -r requirements/edx/base.in
-regex==2022.9.13
+regex==2022.10.31
     # via nltk
 requests==2.28.1
     # via
@@ -1094,7 +1094,7 @@ sympy==1.11.1
     # via openedx-calc
 tableauserverclient==0.23
     # via edx-enterprise
-testfixtures==7.0.0
+testfixtures==7.0.2
     # via edx-enterprise
 text-unidecode==1.3
     # via python-slugify

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -51,7 +51,7 @@ asn1crypto==1.5.1
     #   -r requirements/edx/testing.txt
     #   oscrypto
     #   snowflake-connector-python
-astroid==2.12.10
+astroid==2.12.12
     # via
     #   -r requirements/edx/testing.txt
     #   pylint
@@ -71,7 +71,7 @@ attrs==22.1.0
     #   lti-consumer-xblock
     #   openedx-events
     #   pytest
-babel==2.10.3
+babel==2.11.0
     # via
     #   -r requirements/edx/testing.txt
     #   enmerkar
@@ -121,7 +121,7 @@ botocore==1.8.17
     #   s3transfer
 bridgekeeper==0.9
     # via -r requirements/edx/testing.txt
-build==0.8.0
+build==0.9.0
     # via
     #   -r requirements/edx/pip-tools.txt
     #   pip-tools
@@ -233,7 +233,7 @@ cryptography==36.0.2
     #   pyopenssl
     #   snowflake-connector-python
     #   social-auth-core
-cssselect==1.1.0
+cssselect==1.2.0
     # via
     #   -r requirements/edx/testing.txt
     #   pyquery
@@ -449,7 +449,7 @@ django-sekizai==4.0.0
     # via
     #   -r requirements/edx/testing.txt
     #   django-wiki
-django-ses==3.2.0
+django-ses==3.2.2
     # via -r requirements/edx/testing.txt
 django-simple-history==3.0.0
     # via
@@ -548,7 +548,7 @@ edx-auth-backends==4.1.0
     # via
     #   -r requirements/edx/testing.txt
     #   blockstore
-edx-braze-client==0.1.4
+edx-braze-client==0.1.5
     # via -r requirements/edx/testing.txt
 edx-bulk-grades==1.0.0
     # via
@@ -603,7 +603,7 @@ edx-enterprise==3.58.4
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   learner-pathway-progress
-edx-event-bus-kafka==1.4.3
+edx-event-bus-kafka==1.5.0
     # via -r requirements/edx/testing.txt
 edx-i18n-tools==0.9.2
     # via
@@ -697,7 +697,7 @@ event-tracking==2.1.0
     #   -r requirements/edx/testing.txt
     #   edx-proctoring
     #   edx-search
-exceptiongroup==1.0.0rc9
+exceptiongroup==1.0.0
     # via
     #   -r requirements/edx/testing.txt
     #   pytest
@@ -707,11 +707,11 @@ execnet==1.9.0
     #   pytest-xdist
 factory-boy==3.2.1
     # via -r requirements/edx/testing.txt
-faker==15.1.1
+faker==15.1.3
     # via
     #   -r requirements/edx/testing.txt
     #   factory-boy
-fastapi==0.85.1
+fastapi==0.85.2
     # via
     #   -r requirements/edx/testing.txt
     #   pact-python
@@ -844,7 +844,7 @@ jsonfield==3.1.0
     #   lti-consumer-xblock
     #   ora2
     #   outcome-surveys
-jsonschema==4.16.0
+jsonschema==4.17.0
     # via
     #   -r requirements/edx/testing.txt
     #   optimizely-sdk
@@ -866,13 +866,13 @@ lazy==1.5
     #   bok-choy
     #   lti-consumer-xblock
     #   ora2
-lazy-object-proxy==1.7.1
+lazy-object-proxy==1.8.0
     # via
     #   -r requirements/edx/testing.txt
     #   astroid
 learner-pathway-progress==1.3.3
     # via -r requirements/edx/testing.txt
-levenshtein==0.20.7
+levenshtein==0.20.8
     # via
     #   -r requirements/edx/testing.txt
     #   python-levenshtein
@@ -969,7 +969,7 @@ mysqlclient==2.1.1
     # via
     #   -r requirements/edx/testing.txt
     #   blockstore
-newrelic==8.3.0
+newrelic==8.4.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-django-utils
@@ -1054,7 +1054,7 @@ pep517==0.13.0
     #   build
 piexif==1.1.3
     # via -r requirements/edx/testing.txt
-pillow==9.2.0
+pillow==9.3.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
@@ -1093,7 +1093,6 @@ psutil==5.9.3
 py==1.11.0
     # via
     #   -r requirements/edx/testing.txt
-    #   pytest-forked
     #   tox
 py2neo==2021.2.3
     # via
@@ -1150,7 +1149,7 @@ pylatexenc==2.10
     # via
     #   -r requirements/edx/testing.txt
     #   olxcleaner
-pylint==2.15.3
+pylint==2.15.5
     # via
     #   -r requirements/edx/testing.txt
     #   edx-lint
@@ -1175,7 +1174,7 @@ pylint-pytest==0.3.0
     # via -r requirements/edx/testing.txt
 pylti1p3==1.12.1
     # via -r requirements/edx/testing.txt
-pymongo==3.12.3
+pymongo==3.13.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
@@ -1204,7 +1203,7 @@ pyparsing==3.0.9
     #   packaging
 pyquery==1.4.3
     # via -r requirements/edx/testing.txt
-pyrsistent==0.18.1
+pyrsistent==0.19.1
     # via
     #   -r requirements/edx/testing.txt
     #   jsonschema
@@ -1220,7 +1219,6 @@ pytest==7.2.0
     #   pytest-attrib
     #   pytest-cov
     #   pytest-django
-    #   pytest-forked
     #   pytest-json-report
     #   pytest-metadata
     #   pytest-randomly
@@ -1231,10 +1229,6 @@ pytest-cov==4.0.0
     # via -r requirements/edx/testing.txt
 pytest-django==4.5.2
     # via -r requirements/edx/testing.txt
-pytest-forked==1.4.0
-    # via
-    #   -r requirements/edx/testing.txt
-    #   pytest-xdist
 pytest-json-report==1.5.0
     # via -r requirements/edx/testing.txt
 pytest-metadata==1.8.0
@@ -1243,7 +1237,7 @@ pytest-metadata==1.8.0
     #   pytest-json-report
 pytest-randomly==3.12.0
     # via -r requirements/edx/testing.txt
-pytest-xdist[psutil]==2.5.0
+pytest-xdist[psutil]==3.0.2
     # via -r requirements/edx/testing.txt
 python-dateutil==2.8.2
     # via
@@ -1260,7 +1254,7 @@ python-dateutil==2.8.2
     #   olxcleaner
     #   ora2
     #   xblock
-python-levenshtein==0.20.7
+python-levenshtein==0.20.8
     # via -r requirements/edx/testing.txt
 python-memcached==1.59
     # via -r requirements/edx/testing.txt
@@ -1318,7 +1312,7 @@ pyyaml==6.0
     #   xblock
 random2==1.0.1
     # via -r requirements/edx/testing.txt
-rapidfuzz==2.12.0
+rapidfuzz==2.13.0
     # via
     #   -r requirements/edx/testing.txt
     #   levenshtein
@@ -1326,7 +1320,7 @@ recommender-xblock==2.0.1
     # via -r requirements/edx/testing.txt
 redis==4.3.4
     # via -r requirements/edx/testing.txt
-regex==2022.9.13
+regex==2022.10.31
     # via
     #   -r requirements/edx/testing.txt
     #   nltk
@@ -1530,7 +1524,7 @@ tableauserverclient==0.23
     # via
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
-testfixtures==7.0.0
+testfixtures==7.0.2
     # via
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
@@ -1555,11 +1549,11 @@ tomli==2.0.1
     #   pylint
     #   pytest
     #   tox
-tomlkit==0.11.5
+tomlkit==0.11.6
     # via
     #   -r requirements/edx/testing.txt
     #   pylint
-tox==3.26.0
+tox==3.27.0
     # via
     #   -r requirements/edx/testing.txt
     #   tox-battery
@@ -1613,7 +1607,7 @@ vine==5.0.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.16.5
+virtualenv==20.16.6
     # via
     #   -r requirements/edx/testing.txt
     #   tox

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -6,7 +6,7 @@
 #
 alabaster==0.7.12
     # via sphinx
-babel==2.10.3
+babel==2.11.0
     # via sphinx
 certifi==2022.9.24
     # via requests

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -30,7 +30,7 @@ pbr==5.11.0
     # via stevedore
 psutil==5.9.3
     # via -r requirements/edx/paver.in
-pymongo==3.12.3
+pymongo==3.13.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/paver.in

--- a/requirements/edx/pip-tools.txt
+++ b/requirements/edx/pip-tools.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-build==0.8.0
+build==0.9.0
     # via pip-tools
 click==8.1.3
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -47,7 +47,7 @@ asn1crypto==1.5.1
     #   -r requirements/edx/base.txt
     #   oscrypto
     #   snowflake-connector-python
-astroid==2.12.10
+astroid==2.12.12
     # via
     #   pylint
     #   pylint-celery
@@ -67,7 +67,7 @@ attrs==22.1.0
     #   openedx-events
     #   outcome
     #   pytest
-babel==2.10.3
+babel==2.11.0
     # via
     #   -r requirements/edx/base.txt
     #   enmerkar
@@ -222,7 +222,7 @@ cryptography==36.0.2
     #   pyopenssl
     #   snowflake-connector-python
     #   social-auth-core
-cssselect==1.1.0
+cssselect==1.2.0
     # via
     #   -r requirements/edx/testing.in
     #   pyquery
@@ -431,7 +431,7 @@ django-sekizai==4.0.0
     # via
     #   -r requirements/edx/base.txt
     #   django-wiki
-django-ses==3.2.0
+django-ses==3.2.2
     # via -r requirements/edx/base.txt
 django-simple-history==3.0.0
     # via
@@ -528,7 +528,7 @@ edx-auth-backends==4.1.0
     # via
     #   -r requirements/edx/base.txt
     #   blockstore
-edx-braze-client==0.1.4
+edx-braze-client==0.1.5
     # via -r requirements/edx/base.txt
 edx-bulk-grades==1.0.0
     # via
@@ -583,7 +583,7 @@ edx-enterprise==3.58.4
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   learner-pathway-progress
-edx-event-bus-kafka==1.4.3
+edx-event-bus-kafka==1.5.0
     # via -r requirements/edx/base.txt
 edx-i18n-tools==0.9.2
     # via
@@ -676,15 +676,15 @@ event-tracking==2.1.0
     #   -r requirements/edx/base.txt
     #   edx-proctoring
     #   edx-search
-exceptiongroup==1.0.0rc9
+exceptiongroup==1.0.0
     # via pytest
 execnet==1.9.0
     # via pytest-xdist
 factory-boy==3.2.1
     # via -r requirements/edx/testing.in
-faker==15.1.1
+faker==15.1.3
     # via factory-boy
-fastapi==0.85.1
+fastapi==0.85.2
     # via pact-python
 fastavro==1.7.0
     # via
@@ -808,7 +808,7 @@ jsonfield==3.1.0
     #   lti-consumer-xblock
     #   ora2
     #   outcome-surveys
-jsonschema==4.16.0
+jsonschema==4.17.0
     # via
     #   -r requirements/edx/base.txt
     #   optimizely-sdk
@@ -829,11 +829,11 @@ lazy==1.5
     #   bok-choy
     #   lti-consumer-xblock
     #   ora2
-lazy-object-proxy==1.7.1
+lazy-object-proxy==1.8.0
     # via astroid
 learner-pathway-progress==1.3.3
     # via -r requirements/edx/base.txt
-levenshtein==0.20.7
+levenshtein==0.20.8
     # via
     #   -r requirements/edx/base.txt
     #   python-levenshtein
@@ -919,7 +919,7 @@ mysqlclient==2.1.1
     # via
     #   -r requirements/edx/base.txt
     #   blockstore
-newrelic==8.3.0
+newrelic==8.4.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-django-utils
@@ -997,7 +997,7 @@ pbr==5.11.0
     #   stevedore
 piexif==1.1.3
     # via -r requirements/edx/base.txt
-pillow==9.2.0
+pillow==9.3.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -1032,9 +1032,7 @@ psutil==5.9.3
     #   pact-python
     #   pytest-xdist
 py==1.11.0
-    # via
-    #   pytest-forked
-    #   tox
+    # via tox
 py2neo==2021.2.3
     # via
     #   -c requirements/edx/../constraints.txt
@@ -1088,7 +1086,7 @@ pylatexenc==2.10
     # via
     #   -r requirements/edx/base.txt
     #   olxcleaner
-pylint==2.15.3
+pylint==2.15.5
     # via
     #   edx-lint
     #   pylint-celery
@@ -1107,7 +1105,7 @@ pylint-pytest==0.3.0
     # via -r requirements/edx/testing.in
 pylti1p3==1.12.1
     # via -r requirements/edx/base.txt
-pymongo==3.12.3
+pymongo==3.13.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
@@ -1135,7 +1133,7 @@ pyparsing==3.0.9
     #   packaging
 pyquery==1.4.3
     # via -r requirements/edx/testing.in
-pyrsistent==0.18.1
+pyrsistent==0.19.1
     # via
     #   -r requirements/edx/base.txt
     #   jsonschema
@@ -1151,7 +1149,6 @@ pytest==7.2.0
     #   pytest-attrib
     #   pytest-cov
     #   pytest-django
-    #   pytest-forked
     #   pytest-json-report
     #   pytest-metadata
     #   pytest-randomly
@@ -1162,8 +1159,6 @@ pytest-cov==4.0.0
     # via -r requirements/edx/testing.in
 pytest-django==4.5.2
     # via -r requirements/edx/testing.in
-pytest-forked==1.4.0
-    # via pytest-xdist
 pytest-json-report==1.5.0
     # via -r requirements/edx/testing.in
 pytest-metadata==1.8.0
@@ -1172,7 +1167,7 @@ pytest-metadata==1.8.0
     #   pytest-json-report
 pytest-randomly==3.12.0
     # via -r requirements/edx/testing.in
-pytest-xdist[psutil]==2.5.0
+pytest-xdist[psutil]==3.0.2
     # via -r requirements/edx/testing.in
 python-dateutil==2.8.2
     # via
@@ -1189,7 +1184,7 @@ python-dateutil==2.8.2
     #   olxcleaner
     #   ora2
     #   xblock
-python-levenshtein==0.20.7
+python-levenshtein==0.20.8
     # via -r requirements/edx/base.txt
 python-memcached==1.59
     # via -r requirements/edx/base.txt
@@ -1244,7 +1239,7 @@ pyyaml==6.0
     #   xblock
 random2==1.0.1
     # via -r requirements/edx/base.txt
-rapidfuzz==2.12.0
+rapidfuzz==2.13.0
     # via
     #   -r requirements/edx/base.txt
     #   levenshtein
@@ -1252,7 +1247,7 @@ recommender-xblock==2.0.1
     # via -r requirements/edx/base.txt
 redis==4.3.4
     # via -r requirements/edx/base.txt
-regex==2022.9.13
+regex==2022.10.31
     # via
     #   -r requirements/edx/base.txt
     #   nltk
@@ -1425,7 +1420,7 @@ tableauserverclient==0.23
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-testfixtures==7.0.0
+testfixtures==7.0.2
     # via
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/testing.in
@@ -1444,9 +1439,9 @@ tomli==2.0.1
     #   pylint
     #   pytest
     #   tox
-tomlkit==0.11.5
+tomlkit==0.11.6
     # via pylint
-tox==3.26.0
+tox==3.27.0
     # via
     #   -r requirements/edx/testing.in
     #   tox-battery
@@ -1497,7 +1492,7 @@ vine==5.0.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.16.5
+virtualenv==20.16.6
     # via tox
 voluptuous==0.13.1
     # via


### PR DESCRIPTION
Before that the only way to send messages/emails by braze was using campaign_id. Now, this package has an implementation of sending messages/emails using canvas_id.

Package PR: https://github.com/edx/braze-client/pull/10

Ticket: https://2u-internal.atlassian.net/browse/VAN-1147