### PR TITLE
feat: implement missing audit access expired check

### DIFF
--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -176,9 +176,9 @@ class EnrollmentSerializer(serializers.Serializer):
     """
     Info about this particular enrollment.
     Derived from a CourseEnrollment with added context:
+    - "audit_access_deadlines" (dict): when audit access expires for user.
     - "ecommerce_payment_page" (url): ecommerce page, used to determine if we can upgrade.
     - "course_mode_info" (dict): keyed by course ID with the following values:
-        - "expiration_datetime" (int): when the verified mode will expire.
         - "show_upsell" (bool): whether or not we offer an upsell for this course.
         - "verified_sku" (uuid): ID for the verified mode for upgrade.
     - "show_courseware_link": keyed by course ID with added metadata.
@@ -234,9 +234,7 @@ class EnrollmentSerializer(serializers.Serializer):
             enrollment.course_id
         )
 
-        if expiration_date and timezone.now() > expiration_date:
-            return True
-        return False
+        return bool(expiration_date) and timezone.now() > expiration_date
 
     def get_isEmailEnabled(self, enrollment):
         return enrollment.course_id in self.context.get("show_email_settings_for", [])

--- a/lms/djangoapps/learner_home/test_serializers.py
+++ b/lms/djangoapps/learner_home/test_serializers.py
@@ -1,6 +1,6 @@
 """Tests for serializers for the Learner Dashboard"""
 
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from itertools import product
 from random import randint
 from unittest import mock
@@ -325,7 +325,6 @@ class TestEnrollmentSerializer(LearnerDashboardBaseTest):
             },
             "course_optouts": [],
             "show_email_settings_for": [course.id],
-            "show_courseware_link": {course.id: {"has_access": True}},
             "resume_course_urls": {course.id: "some_url"},
             "ecommerce_payment_page": random_url(),
         }
@@ -346,23 +345,33 @@ class TestEnrollmentSerializer(LearnerDashboardBaseTest):
         for key in output:
             assert output[key] is not None
 
-    def test_audit_access_expired(self):
+    @ddt.data(
+        (None, False),  # No expiration date, allowed for non-audit, non-expired.
+        (datetime.max, False),  # Expiration in the far future. Shouldn't be expired.
+        (datetime.min, True),  # Expiration in the far past. Should be expired.
+    )
+    @ddt.unpack
+    def test_audit_access_expired(self, expiration_datetime, should_be_expired):
+        # Given an enrollment
         input_data = self.create_test_enrollment()
         input_context = self.create_test_context(input_data.course)
 
-        # Example audit expired context
+        # With/out an expiration date (made timezone aware, if it exists)
+        expiration_datetime = (
+            expiration_datetime.replace(tzinfo=timezone.utc)
+            if expiration_datetime
+            else None
+        )
         input_context.update(
             {
-                "show_courseware_link": {
-                    input_data.course.id: {"error_code": "audit_expired"}
-                },
+                "audit_access_deadlines": {input_data.course.id: expiration_datetime},
             }
         )
 
-        serializer = EnrollmentSerializer(input_data, context=input_context)
-        output = serializer.data
+        # When I serialize
+        output = EnrollmentSerializer(input_data, context=input_context).data
 
-        assert output["isAuditAccessExpired"] is True
+        self.assertEqual(output["isAuditAccessExpired"], should_be_expired)
 
     @ddt.data(
         (random_url(), True, uuid4(), True),


### PR DESCRIPTION
## Description

Whoops, I forgot to implement the logic behind `isAuditAccessExpired`. Let me do that now...

Instead of the existing behavior which runs a full `has_access` check and checks for an "access expired" error message, I was able to re-implement just the segment of code we care about.

Under the covers, the access check really just runs `check_course_expired` which uses the `get_user_course_expiration_date` which we already leverage for populating the `accessExpirationDate` field. To avoid calling that twice, I can simply reimplement the check in that function which does a simple `datetime` compare between that expiration date and now.

Note that I also checked `get_user_course_expiration_date` is `None` if the user is enrolled in a verified track, so a user who upgrades should never be blocked here.

FYI: @openedx/content-aurora 