### PR TITLE
fix: Remove non-working teams from the CODEOWNERS file.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,21 +21,21 @@ lms/djangoapps/discussion/
 lms/djangoapps/edxnotes
 
 # Analytics
-common/djangoapps/track/                   @edx/edx-data-engineering
+common/djangoapps/track/
 
 # Credentials
-lms/djangoapps/certificates/               @edx/platform-credentials
+lms/djangoapps/certificates/
 
 # Discovery
-common/djangoapps/course_modes/            @edx/platform-discovery
-common/djangoapps/enrollment/              @edx/platform-discovery
-lms/djangoapps/commerce/                   @edx/rev-team
-lms/djangoapps/experiments/                @edx/rev-team
-lms/djangoapps/learner_dashboard/          @edx/platform-discovery
-lms/djangoapps/learner_home/               @edx/content-aurora
-openedx/features/content_type_gating/      @edx/rev-team
-openedx/features/course_duration_limits/   @edx/rev-team
-openedx/features/discounts/                @edx/rev-team
+common/djangoapps/course_modes/
+common/djangoapps/enrollment/
+lms/djangoapps/commerce/
+lms/djangoapps/experiments/
+lms/djangoapps/learner_dashboard/
+lms/djangoapps/learner_home/
+openedx/features/content_type_gating/
+openedx/features/course_duration_limits/
+openedx/features/discounts/
 
 # Ping tCRIL On-call if someone uses the QuickStart
 # https://docs.openedx.org/en/latest/developers/quickstarts/first_openedx_pr.html


### PR DESCRIPTION
The teams stopped working when we moved the repo to the openedx org.
Also, things have been re-organized at 2U so it's unclear if these
ownership mappings are still relevant.  I'm removing them for now and
I've posted on the forums to let people know if they want to add back in
more relevant teams.

Relevant Link: https://discuss.openedx.org/t/edx-platform-codeowners/8649
