### PR TITLE
fix: update Zoom live configurations to support email for course staff roles.

### DIFF
--- a/openedx/core/djangoapps/course_live/providers.py
+++ b/openedx/core/djangoapps/course_live/providers.py
@@ -87,9 +87,6 @@ class Zoom(LiveProvider):
     """
     id = 'zoom'
     name = 'Zoom LTI PRO'
-    additional_parameters = [
-        'custom_instructor_email'
-    ]
 
     @property
     def is_enabled(self):

--- a/openedx/features/lti_course_tab/tab.py
+++ b/openedx/features/lti_course_tab/tab.py
@@ -57,6 +57,7 @@ class LtiCourseLaunchMixin:
         pii_config = {}
         if lti_config.pii_share_username:
             pii_config['person_sourcedid'] = request.user.username
+
         if lti_config.pii_share_email:
             pii_config['person_contact_email_primary'] = request.user.email
         return pii_config


### PR DESCRIPTION
### [INF-640](https://2u-internal.atlassian.net/browse/INF-640)

### Description

Update Zoom live configuration to add `primary_email` for `CourseStaff` and `CourseInstructor` roles.
`custom_instructor_email` field is also now optional.

Related PR from course-authoring -- https://github.com/openedx/frontend-app-course-authoring/pull/380