### PR TITLE
Bszabo/caption link unit testing

### DIFF
--- a/cms/djangoapps/contentstore/views/transcripts_ajax.py
+++ b/cms/djangoapps/contentstore/views/transcripts_ajax.py
@@ -7,12 +7,10 @@ All user changes are saved immediately.
 """
 
 
-import copy
 import json
 import logging
 import os
 
-import requests
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
@@ -42,7 +40,7 @@ from xmodule.video_module.transcripts_utils import (  # lint-amnesty, pylint: di
     get_transcript_for_video,
     get_transcript_from_val,
     get_transcripts_from_youtube,
-    youtube_video_transcript_name
+    get_transcript_link_from_youtube
 )
 
 __all__ = [
@@ -340,15 +338,7 @@ def check_transcripts(request):  # lint-amnesty, pylint: disable=too-many-statem
             except NotFoundError:
                 log.debug("Can't find transcripts in storage for youtube id: %s", youtube_id)
 
-            # youtube server
-            youtube_text_api = copy.deepcopy(settings.YOUTUBE['TEXT_API'])
-            youtube_text_api['params']['v'] = youtube_id
-            youtube_transcript_name = youtube_video_transcript_name(youtube_text_api)
-            if youtube_transcript_name:
-                youtube_text_api['params']['name'] = youtube_transcript_name
-            youtube_response = requests.get('http://' + youtube_text_api['url'], params=youtube_text_api['params'])
-
-            if youtube_response.status_code == 200 and youtube_response.text:
+            if get_transcript_link_from_youtube(youtube_id):
                 transcripts_presence['youtube_server'] = True
             #check youtube local and server transcripts for equality
             if transcripts_presence['youtube_server'] and transcripts_presence['youtube_local']:

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1527,6 +1527,11 @@ YOUTUBE = {
         },
     },
 
+    'TRANSCRIPTS': {
+        'CAPTION_TRACKS_REGEX': r"captionTracks\"\:\[(?P<caption_tracks>[^\]]+)",
+        'YOUTUBE_URL_BASE': 'https://www.youtube.com/watch?v=',
+    },
+
     'IMAGE_API': 'http://img.youtube.com/vi/{youtube_id}/0.jpg',  # /maxresdefault.jpg for 1920*1080
 }
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2925,6 +2925,11 @@ YOUTUBE = {
         },
     },
 
+    'TRANSCRIPTS': {
+        'CAPTION_TRACKS_REGEX': r"captionTracks\"\:\[(?P<caption_tracks>[^\]]+)",
+        'YOUTUBE_URL_BASE': 'https://www.youtube.com/watch?v=',
+    },
+
     'IMAGE_API': 'http://img.youtube.com/vi/{youtube_id}/0.jpg',  # /maxresdefault.jpg for 1920*1080
 }
 YOUTUBE_API_KEY = 'PUT_YOUR_API_KEY_HERE'

--- a/xmodule/tests/test_transcripts_utils.py
+++ b/xmodule/tests/test_transcripts_utils.py
@@ -1,0 +1,104 @@
+''' Tests mechanism for obtaining language-specific transcript links from youtube video pages
+Note that tests that work with these links are located elsewhere (test_video.py)
+'''
+from ..video_module.transcripts_utils import get_transcript_link_from_youtube
+
+from unittest import mock, TestCase
+
+
+YOUTUBE_VIDEO_ID = "z-LoKnweV6w"
+
+# Use CAPTION_URL_TEMPLATE.format(<youtube_video_ID>, <ampersand_encoding>, <language_code>)
+# to get either the HTML rendition or the json rendition of the link used to obtain a youtube video's subtitles
+#
+# Parameterized with
+# {0} - The youtube video ID whose captions you want
+# {1} - Either \u0026 for use with UTF-8 encoded HTML, or '&' for use with json
+# {2} - Language code (e.g., "en")
+CAPTION_URL_TEMPLATE = "https: //www.youtube.com/api/timedtext?v = {0}{1}caps = asr{1}xoaf = 5{1}hl = {2}{1}\
+ip = 0.0.0.0{1}ipbits = 0{1}expire = 1667281544{1}sparams = ip, ipbits, expire, v, caps, xoaf{1}\
+signature = 3A2A34F0A1FB11B3825FF54D4238B6CC415877E8.058892{1}key = yt8{1}kind = asr{1}lang = {2}"
+
+UTF8_AMPERSAND = '\\u0026'
+
+# These caption link templates have tailored uses and parameterize on the language code only
+#
+# Parameterized with
+# {0} - Language code (e.g., "en")
+CAPTION_URL_UTF8_ENCODED_TEMPLATE = CAPTION_URL_TEMPLATE.format(YOUTUBE_VIDEO_ID, UTF8_AMPERSAND, "{0}")
+CAPTION_URL_UTF8_DECODED_TEMPLATE = CAPTION_URL_TEMPLATE.format(YOUTUBE_VIDEO_ID, "&", "{0}")
+
+# Macro providing the HTML returned by our mock GET operation on the youtube video page
+# This is not valid HTML, but that's OK, as we'll only be using it to confirm the regex
+# search on the 'playerCaptionsTrackListRenderer' subtree.
+#
+# Packed quality (i.e., no spaces) is essential for these tests to work! Introduction
+# of spaces before or after the colon signs causes the regex matching to stop working.
+#
+# Parameterized with
+# {0} - the URL that obtains the selected video's caption
+# {1} - Language code (e.g., "en")
+YOUTUBE_HTML_TEMPLATE = "HTML content that comes before the captions..." \
+                        "\"captions\":{{\"playerCaptionsTracklistRenderer\":" \
+                        "{{\"captionTracks\":[{{\"baseUrl\":\"{0}\"," \
+                        "\"name\":{{\"simpleText\":\"(Caption language name in local language)\"}}," \
+                        "\"vssId\":\".{1}\",\"languageCode\":\"{1}\"," \
+                        "\"isTranslatable\":true}}]}}}}HTML content that comes after the captions..."
+
+
+class YoutubeVideoHTMLResponse:
+    '''Generates substitute HTTP GET responses used when mocking the GET operation to a youtube video page'''
+
+    @classmethod
+    def with_caption_link(cls, language_code):
+        '''Generates a GET response of HTML with a single caption of the specified language code
+            language_code = "en" for english
+        '''
+        caption_link = CAPTION_URL_UTF8_ENCODED_TEMPLATE.format(language_code)
+        html_with_embedded_link = YOUTUBE_HTML_TEMPLATE.format(caption_link, language_code)
+        return cls.MockResponse(html_with_embedded_link)
+
+    @classmethod
+    def with_no_caption_links(cls):
+        '''Generates a GET response of (invalid) HTML lacking any captions within it.
+        This fake HTML is nevered rendered; it's only intended as a source for a regex
+        search
+        '''
+        return cls.MockResponse("No caption URL info for regex to find here")
+
+    class MockResponse:
+        '''An object fit to be returned from a an HTTP GET operation, exposing
+        a UTF-8 encoded version of the youtube_html input string in its content attribute'''
+        def __init__(self, youtube_html):
+            self.content = bytearray(youtube_html, 'UTF-8')
+
+        def content(self):
+            return self.content
+
+
+class TranscriptsUtilsTest(TestCase):
+    @mock.patch('requests.get')
+    def test_get_transcript_link_from_youtube(self, mock_get):
+        '''Happy path test: english caption link returned when video page HTML has one english caption'''
+        language_code = 'en'
+        mock_get.return_value = YoutubeVideoHTMLResponse.with_caption_link(language_code)
+
+        language_specific_caption_link = get_transcript_link_from_youtube(YOUTUBE_VIDEO_ID)
+        self.assertEqual(language_specific_caption_link, CAPTION_URL_UTF8_DECODED_TEMPLATE.format(language_code))
+
+    @ mock.patch('requests.get')
+    def test_get_caption_no_english_caption(self, mock_get):
+        '''No caption link returned when video page HTML contains no caption in English'''
+        language_code = 'fr'
+        mock_get.return_value = YoutubeVideoHTMLResponse.with_caption_link(language_code)
+
+        english_language_caption_link = get_transcript_link_from_youtube(YOUTUBE_VIDEO_ID)
+        self.assertEqual(english_language_caption_link, None)
+
+    @ mock.patch('requests.get')
+    def test_get_caption_no_captions_in_HTML(self, mock_get):
+        ''' No caption link returned when video page HTML contains no captions at all'''
+        mock_get.return_value = YoutubeVideoHTMLResponse.with_no_caption_links()
+
+        english_language_caption_link = get_transcript_link_from_youtube(YOUTUBE_VIDEO_ID)
+        self.assertEqual(english_language_caption_link, None)


### PR DESCRIPTION
Adds unit tests associated with scraping subtitle links from youtube video page HTML. 

Intended to supplement work being carried out under this [PR](https://github.com/openedx/edx-platform/pull/30643).
<!--

🫒🫒
🫒🫒🫒🫒         🫒 Note: the Olive master branch has been created.  Please consider whether your change
    🫒🫒🫒🫒     should also be applied to Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

🌰🌰🌰🌰🌰🌰     🌰 Note: the Nutmeg release is still supported.
                  Please consider whether your change should be applied to Nutmeg as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/openedx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
