### PR TITLE
fix: Only create one StudentModuleHistory record per request

### DIFF
--- a/lms/djangoapps/courseware/tests/test_model_data.py
+++ b/lms/djangoapps/courseware/tests/test_model_data.py
@@ -150,7 +150,7 @@ class TestStudentModuleStorage(OtherUserFailureTestMixin, TestCase):
         # has written to the StudentModule (such as UserStateCache setting the score
         # on the StudentModule).
         with self.assertNumQueries(4, using='default'):
-            with self.assertNumQueries(1, using='student_module_history'):
+            with self.assertNumQueries(2, using='student_module_history'):
                 self.kvs.set(user_state_key('a_field'), 'new_value')
         assert 1 == StudentModule.objects.all().count()
         assert {'b_field': 'b_value', 'a_field': 'new_value'} == json.loads(StudentModule.objects.all()[0].state)
@@ -164,7 +164,7 @@ class TestStudentModuleStorage(OtherUserFailureTestMixin, TestCase):
         # has written to the StudentModule (such as UserStateCache setting the score
         # on the StudentModule).
         with self.assertNumQueries(4, using='default'):
-            with self.assertNumQueries(1, using='student_module_history'):
+            with self.assertNumQueries(2, using='student_module_history'):
                 self.kvs.set(user_state_key('not_a_field'), 'new_value')
         assert 1 == StudentModule.objects.all().count()
         assert {'b_field': 'b_value', 'a_field': 'a_value', 'not_a_field': 'new_value'} == json.loads(StudentModule.objects.all()[0].state)
@@ -178,7 +178,7 @@ class TestStudentModuleStorage(OtherUserFailureTestMixin, TestCase):
         # has written to the StudentModule (such as UserStateCache setting the score
         # on the StudentModule).
         with self.assertNumQueries(2, using='default'):
-            with self.assertNumQueries(1, using='student_module_history'):
+            with self.assertNumQueries(2, using='student_module_history'):
                 self.kvs.delete(user_state_key('a_field'))
         assert 1 == StudentModule.objects.all().count()
         self.assertRaises(KeyError, self.kvs.get, user_state_key('not_a_field'))
@@ -219,7 +219,7 @@ class TestStudentModuleStorage(OtherUserFailureTestMixin, TestCase):
         # DjangoXBlockUserStateClient has written to the StudentModule (such as
         # UserStateCache setting the score on the StudentModule).
         with self.assertNumQueries(4, using="default"):
-            with self.assertNumQueries(1, using="student_module_history"):
+            with self.assertNumQueries(2, using="student_module_history"):
                 self.kvs.set_many(kv_dict)
 
         for key in kv_dict:
@@ -276,7 +276,7 @@ class TestMissingStudentModule(TestCase):  # lint-amnesty, pylint: disable=missi
         # on the StudentModule).
         # Django 1.8 also has a number of other BEGIN and SAVESTATE queries.
         with self.assertNumQueries(4, using='default'):
-            with self.assertNumQueries(1, using='student_module_history'):
+            with self.assertNumQueries(2, using='student_module_history'):
                 self.kvs.set(user_state_key('a_field'), 'a_value')
 
         assert 1 == sum(len(cache) for cache in self.field_data_cache.cache.values())

--- a/lms/djangoapps/courseware/tests/test_submitting_problems.py
+++ b/lms/djangoapps/courseware/tests/test_submitting_problems.py
@@ -497,14 +497,14 @@ class TestCourseGrader(TestSubmittingProblems):
         )
         # count how many state history entries there are
         baseline = BaseStudentModuleHistory.get_history(student_module)
-        assert len(baseline) == 2
+        assert len(baseline) == 1
 
         # now click "show answer"
         self.show_question_answer('p1')
 
         # check that we don't have more state history entries
         csmh = BaseStudentModuleHistory.get_history(student_module)
-        assert len(csmh) == 2
+        assert len(csmh) == 1
 
     def test_grade_with_collected_max_score(self):
         """

--- a/lms/djangoapps/courseware/tests/test_user_state_client.py
+++ b/lms/djangoapps/courseware/tests/test_user_state_client.py
@@ -36,3 +36,21 @@ class TestDjangoUserStateClient(UserStateClientTestBase, ModuleStoreTestCase):
         super().setUp()
         self.client = DjangoXBlockUserStateClient()
         self.users = defaultdict(UserFactory.create)
+
+    def test_history_after_delete(self):
+        """
+        Changes made in the edx-platform repo broke this test in the edx-user-state-client repo.
+        Getting the tests and code in sync is a three step process:
+            1. Override the test here to make it a no-op and merge this code
+            2. Update the test in the other repo to align with the new functionality
+            3. Remove this override to re-enable the working test
+        """
+
+    def test_multiple_history_entries(self):
+        """
+        Changes made in the edx-platform repo broke this test in the edx-user-state-client repo.
+        Getting the tests and code in sync is a three step process:
+            1. Override the test here to make it a no-op and merge this code
+            2. Update the test in the other repo to align with the new functionality
+            3. Remove this override to re-enable the working test
+        """

--- a/lms/djangoapps/coursewarehistoryextended/models.py
+++ b/lms/djangoapps/coursewarehistoryextended/models.py
@@ -46,14 +46,11 @@ class StudentModuleHistoryExtended(BaseStudentModuleHistory):
         StudentModuleHistoryExtended entry if the module_type is one that
         we save.
         """
-        if instance.module_type in StudentModuleHistoryExtended.HISTORY_SAVING_TYPES:
-            history_entry = StudentModuleHistoryExtended(student_module=instance,
-                                                         version=None,
-                                                         created=instance.modified,
-                                                         state=instance.state,
-                                                         grade=instance.grade,
-                                                         max_grade=instance.max_grade)
-            history_entry.save()
+        BaseStudentModuleHistory.save_history_entry(
+            instance,
+            StudentModuleHistoryExtended,
+            "lms.djangoapps.coursewarehistoryextended.models.student_module_history_extended_map"
+        )
 
     @receiver(post_delete, sender=StudentModule)
     def delete_history(sender, instance, **kwargs):  # pylint: disable=no-self-argument, unused-argument


### PR DESCRIPTION
NOTE: THIS SOLUTION IS DEPENDENT ON https://github.com/openedx/edx-platform/pull/31261

Description

When a student submits a problem answer, the state is stored in a StudentModule record containing answer, score, correctness, etc. The record, though, is updated in multiple steps within the single request (first the grade is updated, then the state is updated separately). Each partial save would trigger a separate StudentModuleHistory record to be stored resulting in duplicate and inaccurate historical records.

This solution uses the RequestCache to track within a request thread which StudentModules are updated and a single corresponding StudentModuleHistory id. If multiple update actions occur within the request cycle, then modify the history record that was already generated to ensure that each submission only results in one StudentModuleHistory record.

Supporting information
This issue and its solution were discussed [here](https://discuss.openedx.org/t/extra-history-record-stored-on-each-problem-submission/8081)

Testing instructions
Submit an answer for any problem xblock, then confirm that the courseware_studentmodulehistory table only contains one new row corresponding to the latest submission.

Deadline
None

Other information
None