### PR TITLE
fix: pin LTI xblock to version 5.0.1 while 6 is fixed

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -114,7 +114,7 @@ jsonfield                           # Django model field for validated JSON; use
 laboratory                          # Library for testing that code refactors/infrastructure changes produce identical results
 lxml                                # XML parser
 learner-pathway-progress    # A plugin for lms to track learners progress in pathays
-lti-consumer-xblock>=4.1.1
+lti-consumer-xblock==5.0.1          # version 6 does not work with studio, pinning while that is resolved
 mailsnake                           # Needed for mailchimp (mailing djangoapp)
 mako                                # Primary template language used for server-side page rendering
 Markdown                            # Convert text markup to HTML; used in capa problems, forums, and course wikis

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -670,7 +670,7 @@ libsass==0.10.0
     #   ora2
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==6.0.0
+lti-consumer-xblock==5.0.1
     # via -r requirements/edx/base.in
 lxml==4.9.1
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -884,7 +884,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/testing.txt
     #   ora2
-lti-consumer-xblock==6.0.0
+lti-consumer-xblock==5.0.1
     # via -r requirements/edx/testing.txt
 lxml==4.9.1
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -845,7 +845,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==6.0.0
+lti-consumer-xblock==5.0.1
     # via -r requirements/edx/base.txt
 lxml==4.9.1
     # via


### PR DESCRIPTION
6.0.0 refactored this xblock in a way that does not work with studio leaving blocks partialy broken. While that is being fixed, roll back to 5.0.1.

Bug ticket: MST-1697
