### PR TITLE
fix: allow inactive (email unverified users) to add and refund entitlements

### DIFF
--- a/common/djangoapps/entitlements/rest_api/v1/views.py
+++ b/common/djangoapps/entitlements/rest_api/v1/views.py
@@ -9,11 +9,11 @@ from django.db.models import Q
 from django.http import HttpResponseBadRequest
 from django_filters.rest_framework import DjangoFilterBackend
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
+from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
 from edx_rest_framework_extensions.paginators import DefaultPagination
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from rest_framework import permissions, status, viewsets
-from rest_framework.authentication import SessionAuthentication
 from rest_framework.response import Response
 
 from common.djangoapps.course_modes.models import CourseMode
@@ -315,7 +315,10 @@ class EntitlementEnrollmentViewSet(viewsets.GenericViewSet):
         - Unenroll
         - Switch Enrollment
     """
-    authentication_classes = (JwtAuthentication, SessionAuthentication,)
+    authentication_classes = (
+        JwtAuthentication,
+        SessionAuthenticationAllowInactiveUser,
+    )
     # TODO: ARCH-91
     # This view is excluded from Swagger doc generation because it
     # does not specify a serializer class.


### PR DESCRIPTION
## Description

The default behavior of `SessionAuthentication` is to deny inactive users [[source](https://github.com/encode/django-rest-framework/blob/655e803adfb19b8cb5b94a4895f1baffed55a958/rest_framework/authentication.py#L127)]. Open edX considers a user inactive until they have verified their email. Unfortunately, this means that users with unverified emails may not be able to use functionality gated by `SessionAuthentication`. In this case, this means a user is unable to add or refund entitlements without email verification.

This PR switches to using `SessionAuthenticationAllowInactiveUser` [[source](https://github.com/openedx/edx-drf-extensions/blob/21d98067fb450dacbe8a0e4b7b3ffe95eba5170c/edx_rest_framework_extensions/auth/session/authentication.py#L6)] so inactive users will be able to use and refund their course entitlements.

This does not change any permissions as is_active is not checked for `JwtAuthentication` [[source](https://github.com/openedx/edx-drf-extensions/blob/master/edx_rest_framework_extensions/auth/jwt/authentication.py#L93)].

## Supporting information

* Jira:
  * [REV-2517](https://2u-internal.atlassian.net/browse/REV-2517) Un-confirmed learners (previously called unactivated) blocked from applying entitlements
  * [REV-3166](https://2u-internal.atlassian.net/browse/REV-3166) Error on program refunds for Stripe payments for unverified users
* Special thanks to @robrap for advice regarding JwtAuthentication.

## Testing instructions

* On stage:
  * [ ] As an unverified user, purchase and attempt a refund of a program.