### PR TITLE
feat: add serializer for recommendations api

### DIFF
--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -515,6 +515,26 @@ class UnfulfilledEntitlementSerializer(serializers.Serializer):
         ).data
 
 
+class RecommendedCourseSerializer(serializers.Serializer):
+    """Serializer for a recommended course from the recommendation engine"""
+
+    courseKey = serializers.CharField(source="course_key")
+    logoImageUrl = serializers.URLField(source="logo_image_url")
+    marketingUrl = serializers.URLField(source="marketing_url")
+    title = serializers.CharField()
+
+
+class CourseRecommendationSerializer(serializers.Serializer):
+    """Recommended courses by the Amplitude"""
+
+    courses = serializers.ListField(
+        child=RecommendedCourseSerializer(), allow_empty=True
+    )
+    isPersonalizedRecommendation = serializers.BooleanField(
+        source="is_personalized_recommendation"
+    )
+
+
 class SuggestedCourseSerializer(serializers.Serializer):
     """Serializer for a suggested course from recommendation engine"""
 

--- a/lms/djangoapps/learner_home/test_serializers.py
+++ b/lms/djangoapps/learner_home/test_serializers.py
@@ -30,6 +30,7 @@ from openedx.core.djangoapps.content.course_overviews.tests.factories import (
 from lms.djangoapps.learner_home.serializers import (
     CertificateSerializer,
     CourseProviderSerializer,
+    CourseRecommendationSerializer,
     CourseRunSerializer,
     CourseSerializer,
     EmailConfirmationSerializer,
@@ -958,6 +959,81 @@ class TestUnfulfilledEntitlementSerializer(LearnerDashboardBaseTest):
         )
         actual_keys = output_data.keys()
         assert expected_keys == actual_keys
+
+
+class TestCourseRecommendationSerializer(TestCase):
+    """High-level tests for CourseRecommendationSerializer"""
+
+    @classmethod
+    def mock_recommended_courses(cls, courses_count=2):
+        """Sample course data"""
+
+        recommended_courses = []
+
+        for _ in range(courses_count):
+            recommended_courses.append(
+                {
+                    "course_key": str(uuid4()),
+                    "logo_image_url": random_url(),
+                    "marketing_url": random_url(),
+                    "title": str(uuid4()),
+                },
+            )
+
+        return recommended_courses
+
+    def test_no_recommended_courses(self):
+        """That that data serializes correctly for empty courses list"""
+
+        recommended_courses = self.mock_recommended_courses(courses_count=0)
+
+        output_data = CourseRecommendationSerializer(
+            {
+                "courses": recommended_courses,
+                "is_personalized_recommendation": False,
+            }
+        ).data
+
+        self.assertDictEqual(
+            output_data,
+            {
+                "courses": [],
+                "isPersonalizedRecommendation": False,
+            },
+        )
+
+    def test_happy_path(self):
+        """Test that data serializes correctly"""
+
+        recommended_courses = self.mock_recommended_courses()
+
+        output_data = CourseRecommendationSerializer(
+            {
+                "courses": recommended_courses,
+                "is_personalized_recommendation": True,
+            }
+        ).data
+
+        self.assertDictEqual(
+            output_data,
+            {
+                "courses": [
+                    {
+                        "courseKey": recommended_courses[0]["course_key"],
+                        "logoImageUrl": recommended_courses[0]["logo_image_url"],
+                        "marketingUrl": recommended_courses[0]["marketing_url"],
+                        "title": recommended_courses[0]["title"],
+                    },
+                    {
+                        "courseKey": recommended_courses[1]["course_key"],
+                        "logoImageUrl": recommended_courses[1]["logo_image_url"],
+                        "marketingUrl": recommended_courses[1]["marketing_url"],
+                        "title": recommended_courses[1]["title"],
+                    },
+                ],
+                "isPersonalizedRecommendation": True,
+            },
+        )
 
 
 class TestSuggestedCourseSerializer(TestCase):

--- a/lms/djangoapps/learner_home/views.py
+++ b/lms/djangoapps/learner_home/views.py
@@ -48,7 +48,10 @@ from lms.djangoapps.courseware.access import administrative_accesses_to_course_f
 from lms.djangoapps.courseware.access_utils import (
     check_course_open_for_learner,
 )
-from lms.djangoapps.learner_home.serializers import LearnerDashboardSerializer
+from lms.djangoapps.learner_home.serializers import (
+    CourseRecommendationSerializer,
+    LearnerDashboardSerializer,
+)
 from lms.djangoapps.learner_home.waffle import (
     should_show_learner_home_amplitude_recommendations,
 )
@@ -581,10 +584,12 @@ class CourseRecommendationApiView(APIView):
 
         if is_control:
             return Response(
-                {
-                    "courses": settings.GENERAL_RECOMMENDATIONS,
-                    "is_personalized_recommendation": False,
-                },
+                CourseRecommendationSerializer(
+                    {
+                        "courses": settings.GENERAL_RECOMMENDATIONS,
+                        "is_personalized_recommendation": False,
+                    }
+                ).data,
                 status=200,
             )
 
@@ -622,9 +627,11 @@ class CourseRecommendationApiView(APIView):
             {"count": len(recommended_courses)},
         )
         return Response(
-            {
-                "courses": recommended_courses,
-                "is_personalized_recommendation": not is_control,
-            },
+            CourseRecommendationSerializer(
+                {
+                    "courses": recommended_courses,
+                    "is_personalized_recommendation": not is_control,
+                }
+            ).data,
             status=200,
         )


### PR DESCRIPTION
<!--

🫒🫒
🫒🫒🫒🫒         🫒 Note: the Olive master branch has been created.  Please consider whether your change
    🫒🫒🫒🫒     should also be applied to Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

🌰🌰🌰🌰🌰🌰     🌰 Note: the Nutmeg release is still supported.
                  Please consider whether your change should be applied to Nutmeg as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/openedx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Added a serializer for Course Recommendation Api

## Supporting information

Ticket: https://2u-internal.atlassian.net/browse/VAN-1156

## Testing instructions

Added unit tests
