### PR TITLE
revert: redesign enrollment email properties from segment

### DIFF
--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -324,11 +324,11 @@ class ChooseModeView(View):
             # been configured.  However, alternative enrollment workflows have been introduced into the
             # system, such as third-party discovery.  These workflows result in learners arriving
             # directly at this screen, and they will not necessarily be pre-enrolled in the audit mode.
-            CourseEnrollment.enroll(request.user, course_key, CourseMode.AUDIT, request=request)
+            CourseEnrollment.enroll(request.user, course_key, CourseMode.AUDIT)
             return self._redirect_to_course_or_dashboard(course, course_key, user)
 
         if requested_mode == 'honor':
-            CourseEnrollment.enroll(user, course_key, mode=requested_mode, request=request)
+            CourseEnrollment.enroll(user, course_key, mode=requested_mode)
             return self._redirect_to_course_or_dashboard(course, course_key, user)
 
         mode_info = allowed_modes[requested_mode]

--- a/common/djangoapps/student/management/tests/test_transfer_students.py
+++ b/common/djangoapps/student/management/tests/test_transfer_students.py
@@ -20,7 +20,6 @@ from common.djangoapps.student.models import (
 )
 from common.djangoapps.student.signals import UNENROLL_DONE
 from common.djangoapps.student.tests.factories import UserFactory
-from openedx.core.djangoapps.catalog.tests.factories import CourseRunFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
@@ -55,8 +54,7 @@ class TestTransferStudents(ModuleStoreTestCase):
         assert skip_refund
         self.signal_fired = True
 
-    @patch('openedx.core.djangoapps.catalog.api.get_course_run_details')
-    def test_transfer_students(self, mock_get_course_run_details):
+    def test_transfer_students(self):
         """
         Verify the transfer student command works as intended.
         """
@@ -67,12 +65,6 @@ class TestTransferStudents(ModuleStoreTestCase):
         # Original Course
         original_course_location = locator.CourseLocator('Org0', 'Course0', 'Run0')
         course = self._create_course(original_course_location)
-
-        course_run = CourseRunFactory.create(key=course.id)
-        course_run['min_effort'] = 1
-        course_run['enrollment_count'] = 12345
-
-        mock_get_course_run_details.return_value = course_run
         # Enroll the student in 'verified'
         CourseEnrollment.enroll(student, course.id, mode='verified')
 

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -59,7 +59,6 @@ from simple_history.models import HistoricalRecords
 from user_util import user_util
 
 import openedx.core.djangoapps.django_comment_common.comment_client as cc
-from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
 from common.djangoapps.course_modes.models import CourseMode, get_cosmetic_verified_display_price
 from common.djangoapps.student.email_helpers import (
     generate_proctoring_requirements_email_context,
@@ -77,7 +76,6 @@ from lms.djangoapps.courseware.models import (
     OrgDynamicUpgradeDeadlineConfiguration,
 )
 from lms.djangoapps.courseware.toggles import streak_celebration_is_active
-from lms.djangoapps.utils import OptimizelyClient
 from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.enrollments.api import (
@@ -1426,7 +1424,7 @@ class CourseEnrollment(models.Model):
         from openedx.core.djangoapps.enrollments.permissions import ENROLL_IN_COURSE
         return not user.has_perm(ENROLL_IN_COURSE, course)
 
-    def update_enrollment(self, mode=None, is_active=None, skip_refund=False, enterprise_uuid=None, request=None):
+    def update_enrollment(self, mode=None, is_active=None, skip_refund=False, enterprise_uuid=None):
         """
         Updates an enrollment for a user in a class.  This includes options
         like changing the mode, toggling is_active True/False, etc.
@@ -1491,10 +1489,10 @@ class CourseEnrollment(models.Model):
 
         if activation_changed:
             if self.is_active:
-                self.emit_event(EVENT_NAME_ENROLLMENT_ACTIVATED, enterprise_uuid=enterprise_uuid, request=request)
+                self.emit_event(EVENT_NAME_ENROLLMENT_ACTIVATED, enterprise_uuid=enterprise_uuid)
             else:
                 UNENROLL_DONE.send(sender=None, course_enrollment=self, skip_refund=skip_refund)
-                self.emit_event(EVENT_NAME_ENROLLMENT_DEACTIVATED, enterprise_uuid=enterprise_uuid, request=request)
+                self.emit_event(EVENT_NAME_ENROLLMENT_DEACTIVATED, enterprise_uuid=enterprise_uuid)
                 self.send_signal(EnrollStatusChange.unenroll)
 
                 # .. event_implemented_name: COURSE_UNENROLLMENT_COMPLETED
@@ -1554,20 +1552,11 @@ class CourseEnrollment(models.Model):
                                   mode=mode, course_id=course_id,
                                   cost=cost, currency=currency)
 
-    def emit_event(self, event_name, enterprise_uuid=None, request=None):  # pylint: disable=too-many-statements
+    def emit_event(self, event_name, enterprise_uuid=None):
         """
         Emits an event to explicitly track course enrollment and unenrollment.
         """
-        from common.djangoapps.student.helpers import get_course_dates_for_email, get_instructors
-        from common.djangoapps.student.toggles import should_send_redesign_email
         from openedx.core.djangoapps.schedules.config import set_up_external_updates_for_enrollment
-        from openedx.core.djangoapps.catalog.api import get_course_run_details
-        from openedx.core.djangoapps.catalog.utils import get_owners_for_course, get_course_uuid_for_course
-        from openedx.features.course_experience import ENABLE_COURSE_GOALS
-        from openedx.core.djangoapps.user_api.preferences.api import get_user_preference
-        from openedx.features.enterprise_support.utils import is_enterprise_learner
-
-        optimizely_client = OptimizelyClient.get_optimizely_client()
 
         segment_properties = {
             'category': 'conversion',
@@ -1606,64 +1595,6 @@ class CourseEnrollment(models.Model):
             segment_traits['email'] = self.user.email
 
             if event_name == EVENT_NAME_ENROLLMENT_ACTIVATED:
-                studio_request = settings.ROOT_URLCONF == 'cms.urls'
-                extra_segment_properties = {
-                    'studio_request': studio_request
-                }
-                exception_raised = False
-                if not studio_request and should_send_redesign_email():
-                    if not request:
-                        request = crum.get_current_request()
-
-                    marketing_root_url = settings.MKTG_URLS.get('ROOT')
-                    course_run_fields = [
-                        'key', 'title', 'short_description', 'marketing_url', 'pacing_type', 'min_effort',
-                        'max_effort', 'weeks_to_complete', 'enrollment_count', 'image', 'staff',
-                    ]
-                    owners, course_run, course_dates_list = None, None, []
-                    try:
-                        course_dates_list = get_course_dates_for_email(self.user, self.course.id, request)
-                        course_uuid = get_course_uuid_for_course(str(self.course_id))
-                        owners = get_owners_for_course(course_uuid=course_uuid)
-                        course_run = get_course_run_details(str(self.course_id), course_run_fields)
-                    except Exception:   # pylint: disable=broad-except
-                        exception_raised = True
-                        log.exception(
-                            'Unable to send extra properties for %s event, user %s and course %s',
-                            event_name,
-                            self.user.id,
-                            self.course_id,
-                        )
-
-                    if course_run:
-                        instructors = get_instructors(course_run, marketing_root_url)
-                        extra_segment_properties.update({
-                            'instructors': instructors,
-                            'instructors_count': 'even' if len(instructors) % 2 == 0 else 'odd',
-                            'pacing_type': course_run.get('pacing_type'),
-                            'min_effort': course_run.get('min_effort'),
-                            'max_effort': course_run.get('max_effort'),
-                            'weeks_to_complete': course_run.get('weeks_to_complete'),
-                            'learners_count': '{:,}'.format(course_run.get('enrollment_count')),
-                            'course_title': course_run.get('title'),
-                            'short_description': course_run.get('short_description'),
-                            'marketing_url': course_run.get('marketing_url'),
-                            'banner_image_url': course_run.get('image').get('src') if course_run.get('image') else ''
-                        })
-                    price = CourseMode.min_course_price_for_currency(course_id=str(self.course_id), currency='USD')
-                    extra_segment_properties.update({
-                        'goals_enabled': ENABLE_COURSE_GOALS.is_enabled(self.course_id),
-                        'course_date_blocks': course_dates_list,
-                        'partner_image_url': owners[0].get('logo_image_url') if owners else '',
-                        'learner_name': self.user.profile.name,
-                        'course_run_key': str(self.course_id),
-                        'course_price': price,
-                        'lms_base_url': configuration_helpers.get_value('LMS_ROOT_URL', settings.LMS_ROOT_URL),
-                        'learning_base_url': configuration_helpers.get_value('LEARNING_MICROFRONTEND_URL',
-                                                                             settings.LEARNING_MICROFRONTEND_URL)
-                    })
-                segment_properties.update(extra_segment_properties)
-                segment_properties['exception_raised'] = exception_raised
                 segment_properties['email'] = self.user.email
                 # This next property is for an experiment, see method's comments for more information
                 segment_properties['external_course_updates'] = set_up_external_updates_for_enrollment(self.user,
@@ -1675,26 +1606,6 @@ class CourseEnrollment(models.Model):
                 is_personalized_recommendation = is_personalized_recommendation_for_user(course_key)
                 if is_personalized_recommendation is not None:
                     segment_properties['is_personalized_recommendation'] = is_personalized_recommendation
-
-                # TODO: VAN-1052 - This is Optimizely's A/B experimentation block to test welcome email redesign.
-                #  Remove this temporary block after pausing the experiment.
-                optimizely_experiment_variation = None
-                if optimizely_client and not studio_request:
-                    optimizely_experiment_variation = optimizely_client.activate(
-                        'welcome_email_redesign_experiment',
-                        str(self.user.id),
-                        {
-                            'lang_preference': get_user_preference(self.user, LANGUAGE_KEY),
-                            'is_enterprise_user': is_enterprise_learner(self.user),
-                        }
-                    )
-                    optimizely_client.track('welcome_email_sent', str(self.user.id))
-                    if exception_raised and optimizely_experiment_variation == 'redesign_email_enabled':
-                        optimizely_client.track('welcome_email_not_sent', str(self.user.id))
-
-                # Set this property to True only if the welcome email redesign Optimizely experiment is running
-                # and user_id falls in required variation.
-                segment_properties['redesign_email'] = optimizely_experiment_variation == 'redesign_email_enabled'
 
             with tracker.get_tracker().context(event_name, context):
                 tracker.emit(event_name, data)
@@ -1710,8 +1621,7 @@ class CourseEnrollment(models.Model):
                 )
 
     @classmethod
-    def enroll(cls, user, course_key, mode=None, check_access=False, can_upgrade=False,
-               enterprise_uuid=None, request=None):
+    def enroll(cls, user, course_key, mode=None, check_access=False, can_upgrade=False, enterprise_uuid=None):
         """
         Enroll a user in a course. This saves immediately.
 
@@ -1806,7 +1716,7 @@ class CourseEnrollment(models.Model):
 
         # User is allowed to enroll if they've reached this point.
         enrollment = cls.get_or_create_enrollment(user, course_key)
-        enrollment.update_enrollment(is_active=True, mode=mode, enterprise_uuid=enterprise_uuid, request=request)
+        enrollment.update_enrollment(is_active=True, mode=mode, enterprise_uuid=enterprise_uuid)
         enrollment.send_signal(EnrollStatusChange.enroll)
 
         # .. event_implemented_name: COURSE_ENROLLMENT_CREATED

--- a/common/djangoapps/student/tests/test_enrollment.py
+++ b/common/djangoapps/student/tests/test_enrollment.py
@@ -26,7 +26,6 @@ from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRol
 from common.djangoapps.student.tests.factories import CourseEnrollmentAllowedFactory, UserFactory
 from common.djangoapps.util.testing import UrlResetMixin
 from openedx.core.djangoapps.embargo.test_utils import restrict_course
-from openedx.core.djangoapps.catalog.tests.factories import CourseRunFactory
 
 
 @ddt.ddt
@@ -74,17 +73,6 @@ class EnrollmentTest(UrlResetMixin, ModuleStoreTestCase, OpenEdxEventsTestMixin)
         ]
         # Set up proctored exam
         self._create_proctored_exam(self.proctored_course)
-
-        course_run = CourseRunFactory.create(key=self.course.id)
-        course_run.update({
-            'min_effort': 1,
-            'enrollment_count': 12345
-        })
-
-        patch_course_data = patch('openedx.core.djangoapps.catalog.api.get_course_run_details')
-        course_data = patch_course_data.start()
-        course_data.return_value = course_run
-        self.addCleanup(patch_course_data.stop)
 
     def _create_proctored_exam(self, course):
         """

--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -21,7 +21,6 @@ from markupsafe import escape
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locations import CourseLocator
 from pyquery import PyQuery as pq
-from edx_toggles.toggles.testutils import override_waffle_flag
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
@@ -39,7 +38,6 @@ from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, U
 from common.djangoapps.student.views import complete_course_mode_info
 from common.djangoapps.util.model_utils import USER_SETTINGS_CHANGED_EVENT_NAME
 from common.djangoapps.util.testing import EventTestMixin
-from common.djangoapps.student.toggles import ENROLLMENT_CONFIRMATION_EMAIL_REDESIGN
 from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
 from lms.djangoapps.verify_student.tests import TestVerificationBase
@@ -49,7 +47,6 @@ from openedx.core.djangoapps.content.course_overviews.tests.factories import Cou
 from openedx.core.djangoapps.programs.tests.mixins import ProgramsApiConfigMixin
 from openedx.core.djangoapps.site_configuration.tests.mixins import SiteMixin
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_unless_lms
-from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.factories import CourseFactory, check_mongo_calls  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.data import CertificatesDisplayBehaviors  # lint-amnesty, pylint: disable=wrong-import-order
@@ -286,11 +283,6 @@ class DashboardTest(ModuleStoreTestCase, TestVerificationBase):
         self.user = UserFactory.create(username="jack", email="jack@fake.edx.org", password='test')
         self.client = Client()
         cache.clear()
-
-        patch_context = patch('common.djangoapps.student.helpers.get_course_dates_for_email')
-        get_course = patch_context.start()
-        get_course.return_value = []
-        self.addCleanup(patch_context.stop)
 
     @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
     def _check_verification_status_on(self, mode, value):
@@ -654,7 +646,7 @@ class EnrollmentEventTestMixin(EventTestMixin):
         )
         self.mock_segment_tracker.reset_mock()
 
-    def assert_enrollment_event_was_emitted(self, user, course_key, course, enrollment, course_run=None):
+    def assert_enrollment_event_was_emitted(self, user, course_key, course, enrollment):
         """Ensures an enrollment event was emitted since the last event related assertion"""
         self.mock_tracker.emit.assert_called_once_with(
             'edx.course.enrollment.activated',
@@ -665,8 +657,7 @@ class EnrollmentEventTestMixin(EventTestMixin):
             }
         )
         self.mock_tracker.reset_mock()
-        properties, traits = self._build_segment_properties_and_traits(user, course_key, course,
-                                                                       enrollment, True, course_run)
+        properties, traits = self._build_segment_properties_and_traits(user, course_key, course, enrollment, True)
         self.mock_segment_tracker.track.assert_called_once_with(
             user.id, 'edx.course.enrollment.activated', properties, traits=traits
         )
@@ -689,8 +680,7 @@ class EnrollmentEventTestMixin(EventTestMixin):
         )
         self.mock_segment_tracker.reset_mock()
 
-    def _build_segment_properties_and_traits(self, user, course_key, course, enrollment,
-                                             activated=False, course_run=None):
+    def _build_segment_properties_and_traits(self, user, course_key, course, enrollment, activated=False):
         """ Builds the segment properties and traits that are sent during enrollment events """
         properties = {
             'category': 'conversion',
@@ -703,10 +693,6 @@ class EnrollmentEventTestMixin(EventTestMixin):
         traits = properties.copy()
         traits.update({'course_title': course.display_name, 'email': user.email})
 
-        lms_root_url = configuration_helpers.get_value('LMS_ROOT_URL', settings.LMS_ROOT_URL)
-        learning_base_url = configuration_helpers.get_value('LEARNING_MICROFRONTEND_URL',
-                                                            settings.LEARNING_MICROFRONTEND_URL)
-        studio_request = settings.ROOT_URLCONF == 'cms.urls'
         if activated:
             properties.update({
                 'email': user.email,
@@ -715,68 +701,12 @@ class EnrollmentEventTestMixin(EventTestMixin):
                 'external_course_updates': -1,
                 'course_start': course.start,
                 'course_pacing': course.pacing,
-                'redesign_email': False,
-                'studio_request': studio_request,
-                'exception_raised': False
             })
-            if not studio_request:
-                properties.update({
-                    'course_price': 0,
-                    'goals_enabled': False,
-                    'learner_name': user.profile.name,
-                    'course_run_key': str(course_key),
-                    'lms_base_url': lms_root_url,
-                    'learning_base_url': learning_base_url,
-                    'course_title': course_run.get('title'),
-                    'short_description': course_run.get('short_description'),
-                    'marketing_url': course_run.get('marketing_url'),
-                    'pacing_type': course_run.get('pacing_type'),
-                    'partner_image_url': '',
-                    'banner_image_url': course_run.get('image').get('src'),
-                    'instructors': [],
-                    'instructors_count': 'even',
-                    'min_effort': course_run.get('min_effort'),
-                    'max_effort': course_run.get('max_effort'),
-                    'weeks_to_complete': course_run.get('weeks_to_complete'),
-                    'learners_count': '{:,}'.format(course_run.get('enrollment_count')),
-                    'course_date_blocks': [],
-                })
-
         return properties, traits
 
 
-@override_waffle_flag(ENROLLMENT_CONFIRMATION_EMAIL_REDESIGN, active=True)
-@override_settings(PAID_COURSE_REGISTRATION_CURRENCY=["USD", "$"])
-class EnrollInCourseTest(EnrollmentEventTestMixin, CacheIsolationTestCase, ModuleStoreTestCase):
+class EnrollInCourseTest(EnrollmentEventTestMixin, CacheIsolationTestCase):
     """Tests enrolling and unenrolling in courses."""
-
-    def setUp(self):
-        """
-        Set up tests
-        """
-        super().setUp()
-
-        patch_context = patch('common.djangoapps.student.helpers.get_course_dates_for_email')
-        get_course = patch_context.start()
-        get_course.return_value = []
-        self.addCleanup(patch_context.stop)
-
-    @staticmethod
-    def _create_course_run(course_id, course):
-        """
-        Discovery course run
-        """
-        course_run = CourseRunFactory.create(key=course_id)
-        course_run.update({
-            'title': course.display_name,
-            'short_description': course.short_description,
-            'marketing_url': course.marketing_url,
-            'pacing_type': 'self_paced' if course.self_paced else 'instructor_paced',
-            'banner_image_url': course.banner_image_url,
-            'min_effort': 1,
-            'enrollment_count': 12345
-        })
-        return course_run
 
     @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
     def test_enrollment(self):
@@ -784,11 +714,6 @@ class EnrollInCourseTest(EnrollmentEventTestMixin, CacheIsolationTestCase, Modul
         course_id = CourseKey.from_string("edX/Test101/2013")
         course_id_partial = CourseKey.from_string("edX/Test101/")
         course = CourseOverviewFactory.create(id=course_id)
-        course_run = self._create_course_run(course_id, course)
-
-        patch_course_data = patch('openedx.core.djangoapps.catalog.api.get_course_run_details')
-        course_data = patch_course_data.start()
-        course_data.return_value = course_run
 
         # Test basic enrollment
         assert not CourseEnrollment.is_enrolled(user, course_id)
@@ -796,7 +721,7 @@ class EnrollInCourseTest(EnrollmentEventTestMixin, CacheIsolationTestCase, Modul
         enrollment = CourseEnrollment.enroll(user, course_id)
         assert CourseEnrollment.is_enrolled(user, course_id)
         assert CourseEnrollment.is_enrolled_by_partial(user, course_id_partial)
-        self.assert_enrollment_event_was_emitted(user, course_id, course, enrollment, course_run)
+        self.assert_enrollment_event_was_emitted(user, course_id, course, enrollment)
 
         # Enrolling them again should be harmless
         enrollment = CourseEnrollment.enroll(user, course_id)
@@ -830,19 +755,12 @@ class EnrollInCourseTest(EnrollmentEventTestMixin, CacheIsolationTestCase, Modul
         enrollment = CourseEnrollment.enroll(user, course_id, "audit")
         assert CourseEnrollment.is_enrolled(user, course_id)
         assert enrollment.mode == 'audit'
-        self.addCleanup(patch_course_data.stop)
 
-    @override_settings(LEARNING_MICROFRONTEND_URL='https://learningmfe.openedx.org')
     def test_enrollment_non_existent_user(self):
         # Testing enrollment of newly unsaved user (i.e. no database entry)
         user = UserFactory(username="rusty", email="rusty@fake.edx.org")
         course_id = CourseLocator("edX", "Test101", "2013")
         course = CourseOverviewFactory.create(id=course_id)
-        course_run = self._create_course_run(course_id, course)
-
-        patch_course_data = patch('openedx.core.djangoapps.catalog.api.get_course_run_details')
-        course_data = patch_course_data.start()
-        course_data.return_value = course_run
 
         assert not CourseEnrollment.is_enrolled(user, course_id)
 
@@ -854,23 +772,17 @@ class EnrollInCourseTest(EnrollmentEventTestMixin, CacheIsolationTestCase, Modul
         # should still work
         enrollment = CourseEnrollment.enroll(user, course_id)
         assert CourseEnrollment.is_enrolled(user, course_id)
-        self.assert_enrollment_event_was_emitted(user, course_id, course, enrollment, course_run)
-        self.addCleanup(patch_course_data.stop)
+        self.assert_enrollment_event_was_emitted(user, course_id, course, enrollment)
 
     @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
     def test_enrollment_by_email(self):
         user = UserFactory.create(username="jack", email="jack@fake.edx.org")
         course_id = CourseLocator("edX", "Test101", "2013")
         course = CourseOverviewFactory.create(id=course_id)
-        course_run = self._create_course_run(course_id, course)
-
-        patch_course_data = patch('openedx.core.djangoapps.catalog.api.get_course_run_details')
-        course_data = patch_course_data.start()
-        course_data.return_value = course_run
 
         enrollment = CourseEnrollment.enroll_by_email("jack@fake.edx.org", course_id)
         assert CourseEnrollment.is_enrolled(user, course_id)
-        self.assert_enrollment_event_was_emitted(user, course_id, course, enrollment, course_run)
+        self.assert_enrollment_event_was_emitted(user, course_id, course, enrollment)
 
         # This won't throw an exception, even though the user is not found
         assert CourseEnrollment.enroll_by_email('not_jack@fake.edx.org', course_id) is None
@@ -898,7 +810,6 @@ class EnrollInCourseTest(EnrollmentEventTestMixin, CacheIsolationTestCase, Modul
         # Unenroll on non-existent user shouldn't throw an error
         CourseEnrollment.unenroll_by_email("not_jack@fake.edx.org", course_id)
         self.assert_no_events_were_emitted()
-        self.addCleanup(patch_course_data.stop)
 
     @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
     def test_enrollment_multiple_classes(self):
@@ -907,24 +818,11 @@ class EnrollInCourseTest(EnrollmentEventTestMixin, CacheIsolationTestCase, Modul
         course_id2 = CourseLocator("MITx", "6.003z", "2012")
         course1 = CourseOverviewFactory.create(id=course_id1)
         course2 = CourseOverviewFactory.create(id=course_id2)
-        course_run1 = self._create_course_run(course_id1, course1)
-        course_run2 = self._create_course_run(course_id2, course2)
-
-        patch_course_data1 = patch('openedx.core.djangoapps.catalog.api.get_course_run_details')
-        course_data1 = patch_course_data1.start()
-        course_data1.return_value = course_run1
 
         enrollment1 = CourseEnrollment.enroll(user, course_id1)
-        self.assert_enrollment_event_was_emitted(user, course_id1, course1, enrollment1, course_run1)
-        self.addCleanup(course_data1.stop)
-
-        patch_course_data2 = patch('openedx.core.djangoapps.catalog.api.get_course_run_details')
-        course_data2 = patch_course_data2.start()
-        course_data2.return_value = course_run2
-
+        self.assert_enrollment_event_was_emitted(user, course_id1, course1, enrollment1)
         enrollment2 = CourseEnrollment.enroll(user, course_id2)
-        self.assert_enrollment_event_was_emitted(user, course_id2, course2, enrollment2, course_run2)
-        self.addCleanup(course_data2.stop)
+        self.assert_enrollment_event_was_emitted(user, course_id2, course2, enrollment2)
         assert CourseEnrollment.is_enrolled(user, course_id1)
         assert CourseEnrollment.is_enrolled(user, course_id2)
 
@@ -943,11 +841,6 @@ class EnrollInCourseTest(EnrollmentEventTestMixin, CacheIsolationTestCase, Modul
         user = UserFactory.create(username="jack", email="jack@fake.edx.org")
         course_id = CourseLocator("edX", "Test101", "2013")
         course = CourseOverviewFactory.create(id=course_id)
-        course_run = self._create_course_run(course_id, course)
-
-        patch_course_data = patch('openedx.core.djangoapps.catalog.api.get_course_run_details')
-        course_data = patch_course_data.start()
-        course_data.return_value = course_run
         assert not CourseEnrollment.is_enrolled(user, course_id)
 
         # Creating an enrollment doesn't actually enroll a student
@@ -959,7 +852,7 @@ class EnrollInCourseTest(EnrollmentEventTestMixin, CacheIsolationTestCase, Modul
         # Until you explicitly activate it
         enrollment.activate()
         assert CourseEnrollment.is_enrolled(user, course_id)
-        self.assert_enrollment_event_was_emitted(user, course_id, course, enrollment, course_run)
+        self.assert_enrollment_event_was_emitted(user, course_id, course, enrollment)
 
         # Activating something that's already active does nothing
         enrollment.activate()
@@ -980,22 +873,15 @@ class EnrollInCourseTest(EnrollmentEventTestMixin, CacheIsolationTestCase, Modul
         # for that user/course_id combination
         CourseEnrollment.enroll(user, course_id)
         assert CourseEnrollment.is_enrolled(user, course_id)
-        self.assert_enrollment_event_was_emitted(user, course_id, course, enrollment, course_run)
-        self.addCleanup(course_data.stop)
+        self.assert_enrollment_event_was_emitted(user, course_id, course, enrollment)
 
-    @override_settings(LEARNING_MICROFRONTEND_URL='https://learningmfe.openedx.org')
     def test_change_enrollment_modes(self):
         user = UserFactory.create(username="justin", email="jh@fake.edx.org")
         course_id = CourseLocator("edX", "Test101", "2013")
         course = CourseOverviewFactory.create(id=course_id)
-        course_run = self._create_course_run(course_id, course)
-
-        patch_course_data = patch('openedx.core.djangoapps.catalog.api.get_course_run_details')
-        course_data = patch_course_data.start()
-        course_data.return_value = course_run
 
         enrollment = CourseEnrollment.enroll(user, course_id, "audit")
-        self.assert_enrollment_event_was_emitted(user, course_id, course, enrollment, course_run)
+        self.assert_enrollment_event_was_emitted(user, course_id, course, enrollment)
 
         enrollment = CourseEnrollment.enroll(user, course_id, "honor")
         self.assert_enrollment_mode_change_event_was_emitted(user, course_id, "honor", course, enrollment)
@@ -1006,7 +892,6 @@ class EnrollInCourseTest(EnrollmentEventTestMixin, CacheIsolationTestCase, Modul
 
         enrollment = CourseEnrollment.enroll(user, course_id, "audit")
         self.assert_enrollment_mode_change_event_was_emitted(user, course_id, "audit", course, enrollment)
-        self.addCleanup(course_data.stop)
 
 
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -387,8 +387,7 @@ def change_enrollment(request, check_access=True):
             try:
                 enroll_mode = CourseMode.auto_enroll_mode(course_id, available_modes)
                 if enroll_mode:
-                    CourseEnrollment.enroll(user, course_id, check_access=check_access,
-                                            mode=enroll_mode, request=request)
+                    CourseEnrollment.enroll(user, course_id, check_access=check_access, mode=enroll_mode)
             except Exception:  # pylint: disable=broad-except
                 return HttpResponseBadRequest(_("Could not enroll"))
 

--- a/lms/djangoapps/ccx/tests/test_field_override_performance.py
+++ b/lms/djangoapps/ccx/tests/test_field_override_performance.py
@@ -76,11 +76,6 @@ class FieldOverridePerformanceTestCase(FieldOverrideTestMixin, ProceduralCourseT
         self.course = None
         self.ccx = None
 
-        patch_context = mock.patch('common.djangoapps.student.helpers.get_course_dates_for_email')
-        get_course = patch_context.start()
-        get_course.return_value = []
-        self.addCleanup(patch_context.stop)
-
     def setup_course(self, size, enable_ccx, view_as_ccx):
         """
         Build a gradable course where each node has `size` children.

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -331,10 +331,8 @@ class IndexQueryTestCase(ModuleStoreTestCase):
     """
     NUM_PROBLEMS = 20
 
-    @patch('common.djangoapps.student.helpers.get_course_dates_for_email')
-    def test_index_query_counts(self, mock_course_dates_for_email):
+    def test_index_query_counts(self):
         # TODO: decrease query count as part of REVO-28
-        mock_course_dates_for_email.return_value = []
         ContentTypeGatingConfig.objects.create(enabled=True, enabled_as_of=datetime(2018, 1, 1))
         with self.store.default_store(ModuleStoreEnum.Type.split):
             course = CourseFactory.create()
@@ -344,20 +342,6 @@ class IndexQueryTestCase(ModuleStoreTestCase):
                 vertical = ItemFactory.create(category='vertical', parent_location=section.location)
                 for _ in range(self.NUM_PROBLEMS):
                     ItemFactory.create(category='problem', parent_location=vertical.location)
-
-        course_run = CourseRunFactory.create(key=course.id)
-        course_run['title'] = course.display_name
-        course_run['short_description'] = None
-        course_run['marketing_url'] = 'www.edx.org'
-        course_run['pacing_type'] = 'self_paced'
-        course_run['banner_image_url'] = ''
-        course_run['min_effort'] = 1
-        course_run['enrollment_count'] = 12345
-
-        patch_course_data = patch('openedx.core.djangoapps.catalog.api.get_course_run_details')
-        course_data = patch_course_data.start()
-        course_data.return_value = course_run
-        self.addCleanup(patch_course_data.stop)
 
         self.client.login(username=self.user.username, password=self.user_password)
         CourseEnrollment.enroll(self.user, course.id)


### PR DESCRIPTION
- revert changes of redesign course enrolment email PR.

**Reference for revert PR:**
https://github.com/openedx/edx-platform/pull/30919/files

VAN-1157


