### PR TITLE
feat: api for block metadata including index_dictionary

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1660,6 +1660,51 @@ paths:
         in: path
         required: true
         type: string
+  /courses/v1/block_metadata/{usage_key_string}:
+    get:
+      operationId: courses_v1_block_metadata_read
+      summary: '**Use Case**'
+      description: |-
+        Returns the block metadata. Data like index_dictionary related to a
+            block should be fetched using this API, because they are too large for
+            the cache used by the course blocks/transformers API.
+
+        **Example requests**:
+
+            GET /api/courses/v1/block_metadata/<usage_id>/?
+                &include=index_dictionary
+
+        **Parameters**:
+
+            * "include": a comma-separated list of keys to include.
+              Valid keys are "index_dictionary".
+
+        **Response Values**
+
+            A dictionary containing:
+            * id (string): Block usage_key_str.
+            * type (string) Block type.
+            * index_dictionary: (dict) The index_dictionary JSON data
+              (usually this is the text content of the block, for search
+              indexing or other purposes) for this block. Returned only if
+              the "index_dictionary" is included in the "include"
+              parameter.
+      parameters:
+        - name: include
+          in: query
+          description: A comma-separated list of keys to include.
+          required: false
+          type: string
+      responses:
+        '200':
+          description: ''
+      tags:
+        - courses
+    parameters:
+      - name: usage_key_string
+        in: path
+        required: true
+        type: string
   /courses/v1/blocks/:
     get:
       operationId: courses_v1_blocks_list

--- a/lms/djangoapps/course_api/blocks/api.py
+++ b/lms/djangoapps/course_api/blocks/api.py
@@ -152,3 +152,22 @@ def get_blocks(
 
     # return serialized data
     return serializer.data
+
+
+def get_block_metadata(block, includes=()):
+    """
+    Get metadata about the specified XBlock.
+
+    Args:
+        block (XModuleDescriptor): block object
+        includes (list|set): list or set of metadata keys to include. Valid keys are:
+            index_dictionary: a dictionary of data used to add this XBlock's content
+                to a search index.
+    """
+    data = {
+        "id": str(block.scope_ids.usage_id),
+        "type": block.scope_ids.block_type,
+    }
+    if "index_dictionary" in includes:
+        data["index_dictionary"] = block.index_dictionary()
+    return data

--- a/lms/djangoapps/course_api/blocks/urls.py
+++ b/lms/djangoapps/course_api/blocks/urls.py
@@ -6,7 +6,7 @@ Course Block API URLs
 from django.conf import settings
 from django.urls import path, re_path
 
-from .views import BlocksInCourseView, BlocksView
+from .views import BlockMetadataView, BlocksInCourseView, BlocksView
 
 urlpatterns = [
     # This endpoint requires the usage_key for the starting block.
@@ -24,6 +24,13 @@ urlpatterns = [
         kwargs={'hide_access_denials': True},
         name="blocks_in_course"
     ),
+    # This endpoint requires the usage_key
+    re_path(
+        fr'^v1/block_metadata/{settings.USAGE_KEY_PATTERN}',
+        BlockMetadataView.as_view(),
+        name="blocks_metadata"
+    ),
+
     # This endpoint requires the usage_key for the starting block.
     re_path(
         fr'^v2/blocks/{settings.USAGE_KEY_PATTERN}',
@@ -36,6 +43,13 @@ urlpatterns = [
         'v2/blocks/',
         BlocksInCourseView.as_view(),
         name="blocks_in_course"
+    ),
+
+    # This endpoint requires the usage_key
+    re_path(
+        fr'^v2/block_metadata/{settings.USAGE_KEY_PATTERN}',
+        BlockMetadataView.as_view(),
+        name="blocks_metadata"
     ),
 ]
 


### PR DESCRIPTION
<!--

🫒🫒
🫒🫒🫒🫒         🫒 Note: the Olive master branch has been created.  Please consider whether your change
    🫒🫒🫒🫒     should also be applied to Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

🌰🌰🌰🌰🌰🌰     🌰 Note: the Nutmeg release is still supported.
                  Please consider whether your change should be applied to Nutmeg as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/openedx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Adds new api to return block metadata which includes [index_dictionary](https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/edx_search.html#which-data-gets-indexed).

**Background:** The text representation of xblock is required in course-discovery/taxonomy-connector to be able to fetch skills/tags related to it using third party API like lightcast.

## Supporting information

`Private-ref`: [BB-6879](https://tasks.opencraft.com/browse/BB-6879)

**Sandbox url:** https://pr31273.sandbox.opencraft.hosting/dashboard

## Testing instructions

- Read through the code
- Use the sandbox to test out API
- Login to the instance with the default `staff` credentials
- Navigate to 
- https://pr31273.sandbox.opencraft.hosting/api/courses/v1/block_metadata/block-v1:edX+DemoX+Demo_Course+type@video+block@0b9e39477cf34507a7a48f74be381fdd?include=index_dictionary

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.
