### PR TITLE
Addition of not responded posts filter in fetch threads lists API. 

### DIFF
--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -873,7 +873,7 @@ def get_thread_list(
     }
 
     if view:
-        if view in ["unread", "unanswered"]:
+        if view in ["unread", "unanswered", "unresponded"]:
             query_params[view] = "true"
         else:
             ValidationError({

--- a/lms/djangoapps/discussion/rest_api/forms.py
+++ b/lms/djangoapps/discussion/rest_api/forms.py
@@ -59,7 +59,7 @@ class ThreadListGetForm(_PaginationForm):
     count_flagged = ExtendedNullBooleanField(required=False)
     flagged = ExtendedNullBooleanField(required=False)
     view = ChoiceField(
-        choices=[(choice, choice) for choice in ["unread", "unanswered"]],
+        choices=[(choice, choice) for choice in ["unread", "unanswered", "unresponded"]],
         required=False,
     )
     order_by = ChoiceField(

--- a/lms/djangoapps/discussion/rest_api/tests/test_views.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views.py
@@ -955,7 +955,7 @@ class ThreadViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase, Pro
             "per_page": ["10"],
         })
 
-    @ddt.data("unread", "unanswered")
+    @ddt.data("unread", "unanswered", "unresponded")
     def test_view_query(self, query):
         threads = [make_minimal_cs_thread()]
         self.register_get_user_response(self.user)

--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -361,7 +361,7 @@ class ThreadViewSet(DeveloperErrorViewMixin, ViewSet):
 
         * view: "unread" for threads the requesting user has not read, or
             "unanswered" for question threads with no marked answer. Only one
-            can be selected.
+            can be selected, or unresponded for discussion type posts with no response
 
         * requested_fields: (list) Indicates which additional fields to return
           for each thread. (supports 'profile_image')


### PR DESCRIPTION
Addition of not responded posts filter in fetch threads lists API. 

<!--

🫒🫒
🫒🫒🫒🫒         🫒 Note: the Olive master branch has been created.  Please consider whether your change
    🫒🫒🫒🫒     should also be applied to Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

🌰🌰🌰🌰🌰🌰     🌰 Note: the Nutmeg release is still supported.
                  Please consider whether your change should be applied to Nutmeg as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/openedx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Addition of not responded posts filter in fetch threads lists API. 
Jira ticket: https://2u-internal.atlassian.net/browse/INF-524
related FE PR: https://github.com/openedx/frontend-app-discussions/pull/286

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author".

<img width="1238" alt="Screen Shot 2022-11-10 at 2 26 07 AM" src="https://user-images.githubusercontent.com/67791278/200945087-f422bd15-d8ce-43ca-b61e-55111b557107.png">


## Supporting information

Jira ticket: https://2u-internal.atlassian.net/browse/INF-524
related FE PR: https://github.com/openedx/frontend-app-discussions/pull/286
## Testing instructions

- checkout to this branch and make sure you have the latest changes from cs_comment_service as well
- use **mehak/INF-475** [branch](https://github.com/openedx/frontend-app-discussions/pull/286) of discussions MFE
- run devstack and open the filters section in all posts/ and my posts
- select not responded from the filters section now scroll through the list and. it should display a list of all such discussion posts which have not been responded to.
- Click load more posts to validate no such posts are returned in paginated response as well.
