### PR TITLE
fix: legacy coverage and add missing properties for reported events

### DIFF
--- a/lms/djangoapps/discussion/django_comment_client/base/tests.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/tests.py
@@ -138,7 +138,8 @@ class ThreadActionGroupIdTestCase(
                 "group_id": self.student_cohort.id,
                 "closed": False,
                 "type": "thread",
-                "commentable_id": "non_team_dummy_id"
+                "commentable_id": "non_team_dummy_id",
+                "body": "test body"
             }
         )
         request = RequestFactory().post("dummy_url", post_params or {})
@@ -1663,7 +1664,7 @@ class TeamsPermissionsTestCase(ForumsEnableMixin, UrlResetMixin, SharedModuleSto
         commentable_id = getattr(self, commentable_id)
         self._setup_mock(
             user, mock_request,
-            {"closed": False, "commentable_id": commentable_id, "thread_id": "dummy_thread"},
+            {"closed": False, "commentable_id": commentable_id, "thread_id": "dummy_thread", "body": 'dummy body'},
         )
         for action in ["upvote_comment", "downvote_comment", "un_flag_abuse_for_comment", "flag_abuse_for_comment"]:
             response = self.client.post(
@@ -1684,7 +1685,7 @@ class TeamsPermissionsTestCase(ForumsEnableMixin, UrlResetMixin, SharedModuleSto
         commentable_id = getattr(self, commentable_id)
         self._setup_mock(
             user, mock_request,
-            {"closed": False, "commentable_id": commentable_id},
+            {"closed": False, "commentable_id": commentable_id, "body": "dummy body"},
         )
         for action in ["upvote_thread", "downvote_thread", "un_flag_abuse_for_thread", "flag_abuse_for_thread",
                        "follow_thread", "unfollow_thread"]:

--- a/lms/djangoapps/discussion/rest_api/tests/test_api.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api.py
@@ -2871,6 +2871,9 @@ class UpdateThreadTest(
                 'target_username': self.user.username,
                 'title_truncated': False,
                 'title': 'Original Title',
+                'thread_type': 'discussion',
+                'group_id': None,
+                'truncated': False,
             }
             if not new_flagged:
                 expected_event_data['reported_status_cleared'] = False
@@ -2919,6 +2922,9 @@ class UpdateThreadTest(
             'title_truncated': False,
             'title': 'Original Title',
             'reported_status_cleared': False,
+            'thread_type': 'discussion',
+            'group_id': None,
+            'truncated': False,
         }
 
         actual_event_name, actual_event_data = mock_emit.call_args[0]
@@ -3433,6 +3439,7 @@ class UpdateCommentTest(
                 'content_type': 'Response',
                 'commentable_id': 'dummy',
                 'url': '',
+                'truncated': False,
                 'user_course_roles': [],
                 'user_forums_roles': [FORUM_ROLE_STUDENT],
                 'target_username': self.user.username,
@@ -3477,6 +3484,7 @@ class UpdateCommentTest(
             'id': 'test_comment',
             'content_type': 'Response',
             'commentable_id': 'dummy',
+            'truncated': False,
             'url': '',
             'user_course_roles': [],
             'user_forums_roles': [FORUM_ROLE_STUDENT, FORUM_ROLE_ADMINISTRATOR],


### PR DESCRIPTION
### [INF-655](https://2u-internal.atlassian.net/browse/INF-655)

### Description

This PR addressing some of the missing fields on the `reported content` events. 
This PR also addressing adding event coverage for `reported content` for legacy experience. 