### PR TITLE
fix: learner home anon user status fix

### DIFF
--- a/lms/djangoapps/learner_home/views.py
+++ b/lms/djangoapps/learner_home/views.py
@@ -17,7 +17,6 @@ from edx_rest_framework_extensions.auth.session.authentication import (
 from opaque_keys.edx.keys import CourseKey
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from rest_framework.generics import RetrieveAPIView
 from rest_framework.views import APIView
 
 from common.djangoapps.course_modes.models import CourseMode
@@ -63,6 +62,7 @@ from openedx.core.djangoapps.content.course_overviews.models import CourseOvervi
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.programs.utils import ProgramProgressMeter
 from openedx.core.djangoapps.catalog.utils import get_course_data
+from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from openedx.features.course_duration_limits.access import (
     get_user_course_expiration_date,
 )
@@ -430,8 +430,15 @@ def serialize_learner_home_data(data, context):
     return LearnerDashboardSerializer(data, context=context).data
 
 
-class InitializeView(RetrieveAPIView):  # pylint: disable=unused-argument
+class InitializeView(APIView):  # pylint: disable=unused-argument
     """List of courses a user is enrolled in or entitled to"""
+
+    authentication_classes = (
+        JwtAuthentication,
+        BearerAuthenticationAllowInactiveUser,
+        SessionAuthenticationAllowInactiveUser,
+    )
+    permission_classes = (IsAuthenticated,)
 
     def get(self, request, *args, **kwargs):  # pylint: disable=unused-argument
         """Get masquerade user and proxy to init request"""

--- a/lms/djangoapps/learner_home/views.py
+++ b/lms/djangoapps/learner_home/views.py
@@ -1,13 +1,13 @@
 """
 Views for the learner dashboard.
 """
-from collections import OrderedDict
 import logging
+from collections import OrderedDict
 
-from django.conf import settings
-from django.urls import reverse
 from completion.exceptions import UnavailableCompletionData
 from completion.utilities import get_key_to_last_completed_block
+from django.conf import settings
+from django.urls import reverse
 from edx_django_utils import monitoring as monitoring_utils
 from edx_django_utils.monitoring import function_trace
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
@@ -45,24 +45,22 @@ from lms.djangoapps.bulk_email.models import Optout
 from lms.djangoapps.bulk_email.models_api import is_bulk_email_feature_enabled
 from lms.djangoapps.commerce.utils import EcommerceService
 from lms.djangoapps.courseware.access import administrative_accesses_to_course_for_user
-from lms.djangoapps.courseware.access_utils import (
-    check_course_open_for_learner,
-)
+from lms.djangoapps.courseware.access_utils import check_course_open_for_learner
 from lms.djangoapps.learner_home.serializers import (
     CourseRecommendationSerializer,
     LearnerDashboardSerializer,
-)
-from lms.djangoapps.learner_home.waffle import (
-    should_show_learner_home_amplitude_recommendations,
 )
 from lms.djangoapps.learner_home.utils import (
     get_masquerade_user,
     get_personalized_course_recommendations,
 )
-from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
-from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-from openedx.core.djangoapps.programs.utils import ProgramProgressMeter
+from lms.djangoapps.learner_home.waffle import (
+    should_show_learner_home_amplitude_recommendations,
+)
 from openedx.core.djangoapps.catalog.utils import get_course_data
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from openedx.core.djangoapps.programs.utils import ProgramProgressMeter
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from openedx.features.course_duration_limits.access import (
     get_user_course_expiration_date,

--- a/lms/djangoapps/learner_home/views.py
+++ b/lms/djangoapps/learner_home/views.py
@@ -14,6 +14,7 @@ from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthenticat
 from edx_rest_framework_extensions.auth.session.authentication import (
     SessionAuthenticationAllowInactiveUser,
 )
+from edx_rest_framework_extensions.permissions import NotJwtRestrictedApplication
 from opaque_keys.edx.keys import CourseKey
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -438,7 +439,7 @@ class InitializeView(APIView):  # pylint: disable=unused-argument
         BearerAuthenticationAllowInactiveUser,
         SessionAuthenticationAllowInactiveUser,
     )
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (IsAuthenticated, NotJwtRestrictedApplication)
 
     def get(self, request, *args, **kwargs):  # pylint: disable=unused-argument
         """Get masquerade user and proxy to init request"""
@@ -564,7 +565,7 @@ class CourseRecommendationApiView(APIView):
         JwtAuthentication,
         SessionAuthenticationAllowInactiveUser,
     )
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (IsAuthenticated, NotJwtRestrictedApplication)
 
     def get(self, request):
         """


### PR DESCRIPTION
## Description

Learner home was showing a high error percentage, largely of `500` errors with the log below:

```
TypeError: Field 'id' expected a number but got <django.contrib.auth.models.AnonymousUser object>
```

Was able to reproduce by attempting to hit the `init` call directly from Postman without logging in. A non-logged in user doesn't have a `None` user object, but an `AnonymousUser` object, which we try to use for lookups later and causes issues.

While end-users will probably not experience the issue (since login redirects will take), important to suppress this noisy error.

Fix adds missing `permission` and  `authentication` config to the `Initialize` endpoint. Specifically, users should be Authenticated but may be inactive (haven't verified email yet). Also allows JWT, bearer, and session authentication (since these are the 3 we appear to have most commonly). 

This correctly returns the clearer `401` error instead of the generic `500` error.

FYI: @openedx/content-aurora 

## Other changes

Additionally:
- Added the missing `NotJwtRestrictedApplication` class which Django was automatically adding anyways but spitting out a warning for.
- Ran some formatting on the imports for `views.py`