### PR TITLE
feat: add discussion event coverage for legacy experience.

### DIFF
--- a/lms/djangoapps/discussion/django_comment_client/base/tests.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/tests.py
@@ -139,7 +139,7 @@ class ThreadActionGroupIdTestCase(
                 "closed": False,
                 "type": "thread",
                 "commentable_id": "non_team_dummy_id",
-                "body": "test body"
+                "body": "test body",
             }
         )
         request = RequestFactory().post("dummy_url", post_params or {})
@@ -412,7 +412,7 @@ class ViewsQueryCountTestCase(
         self.create_thread_helper(mock_request)
 
     @ddt.data(
-        (ModuleStoreEnum.Type.split, 3, 6, 38),
+        (ModuleStoreEnum.Type.split, 3, 6, 42),
     )
     @ddt.unpack
     @count_queries
@@ -528,6 +528,7 @@ class ViewsTestCase(
         self._set_mock_request_data(mock_request, {
             "user_id": str(self.student.id),
             "closed": False,
+            "body": "test body",
         })
         test_thread_id = "test_thread_id"
         request = RequestFactory().post("dummy_url", {"id": test_thread_id})
@@ -546,6 +547,7 @@ class ViewsTestCase(
         self._set_mock_request_data(mock_request, {
             "user_id": str(self.student.id),
             "closed": False,
+            "body": "test body",
         })
         test_comment_id = "test_comment_id"
         request = RequestFactory().post("dummy_url", {"id": test_comment_id})
@@ -1595,7 +1597,8 @@ class TeamsPermissionsTestCase(ForumsEnableMixin, UrlResetMixin, SharedModuleSto
             "commentable_id": commentable_id,
             "user_id": str(comment_author.id),
             "username": comment_author.username,
-            "course_id": str(self.course.id)
+            "course_id": str(self.course.id),
+            "body": "test body",
         })
 
         response = self.client.post(

--- a/lms/djangoapps/discussion/django_comment_client/base/views.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/views.py
@@ -524,11 +524,11 @@ def update_thread(request, course_id, thread_id):
     user = request.user
     # The following checks should avoid issues we've seen during deploys, where end users are hitting an updated server
     # while their browser still has the old client code. This will avoid erasing present values in those cases.
+    course = get_course_with_access(user, 'load', course_key)
     if "thread_type" in request.POST:
         thread.thread_type = request.POST["thread_type"]
     if "commentable_id" in request.POST:
         commentable_id = request.POST["commentable_id"]
-        course = get_course_with_access(user, 'load', course_key)
         if thread_context == "course" and not discussion_category_id_access(course, user, commentable_id):
             return JsonError(_("Topic doesn't exist"))
         else:
@@ -538,6 +538,7 @@ def update_thread(request, course_id, thread_id):
 
     thread_edited.send(sender=None, user=user, post=thread)
 
+    track_thread_edited_event(request, course, thread, None)
     if request.is_ajax():
         return ajax_content_response(request, course_key, thread.to_dict())
     else:
@@ -616,9 +617,12 @@ def delete_thread(request, course_id, thread_id):
     this is ajax only
     """
     course_key = CourseKey.from_string(course_id)
+    course = get_course_with_access(request.user, 'load', course_key)
     thread = cc.Thread.find(thread_id)
     thread.delete()
     thread_deleted.send(sender=None, user=request.user, post=thread)
+
+    track_thread_deleted_event(request, course, thread)
     return JsonResponse(prepare_content(thread.to_dict(), course_key))
 
 
@@ -631,6 +635,7 @@ def update_comment(request, course_id, comment_id):
     handles static and ajax submissions
     """
     course_key = CourseKey.from_string(course_id)
+    course = get_course_with_access(request.user, 'load', course_key)
     comment = cc.Comment.find(comment_id)
     if 'body' not in request.POST or not request.POST['body'].strip():
         return JsonError(_("Body can't be empty"))
@@ -639,6 +644,7 @@ def update_comment(request, course_id, comment_id):
 
     comment_edited.send(sender=None, user=request.user, post=comment)
 
+    track_comment_edited_event(request, course, comment, None)
     if request.is_ajax():
         return ajax_content_response(request, course_key, comment.to_dict())
     else:
@@ -672,10 +678,13 @@ def openclose_thread(request, course_id, thread_id):
     ajax only
     """
     course_key = CourseKey.from_string(course_id)
+    course = get_course_with_access(request.user, 'load', course_key)
     thread = cc.Thread.find(thread_id)
-    thread.closed = request.POST.get('closed', 'false').lower() == 'true'
+    close_thread = request.POST.get('closed', 'false').lower() == 'true'
+    thread.closed = close_thread
     thread.save()
 
+    track_thread_lock_unlock_event(request, course, thread, None, close_thread)
     return JsonResponse({
         'content': prepare_content(thread.to_dict(), course_key),
         'ability': get_ability(course_key, thread.to_dict(), request.user),
@@ -704,9 +713,11 @@ def delete_comment(request, course_id, comment_id):
     ajax only
     """
     course_key = CourseKey.from_string(course_id)
+    course = get_course_with_access(request.user, 'load', course_key)
     comment = cc.Comment.find(comment_id)
     comment.delete()
     comment_deleted.send(sender=None, user=request.user, post=comment)
+    track_comment_deleted_event(request, course, comment)
     return JsonResponse(prepare_content(comment.to_dict(), course_key))
 
 
@@ -828,7 +839,7 @@ def flag_abuse_for_comment(request, course_id, comment_id):
     course = get_course_by_id(course_key)
     comment = cc.Comment.find(comment_id)
     comment.flagAbuse(user, comment)
-    track_discussion_unreported_event(request, course, comment)
+    track_discussion_reported_event(request, course, comment)
     return JsonResponse(prepare_content(comment.to_dict(), course_key))
 
 


### PR DESCRIPTION
### [INF-657](https://2u-internal.atlassian.net/browse/INF-657)

### Description

Add legacy coverage for discussion events. The following events have been added for legacy.

- `edx.forum.thread.deleted`
- `edx.forum.response.deleted`
- `edx.forum.comment.deleted`
- `edx.forum.thread.locked`
- `edx.forum.thread.unlocked`
- `edx.forum.thread.edited`
- `edx.forum.response.edited`
- `edx.forum.comment.edited`