### PR TITLE
Add openedx-filters hook to account settings before rendering it context

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/settings_views.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
-from django.core.exceptions import ImproperlyConfigured
+from django.http import HttpResponseRedirect
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.translation import gettext as _
@@ -76,9 +76,13 @@ def account_settings(request):
     context = account_settings_context(request)
 
     try:
+        # .. filter_implemented_name: AccountSettingsRenderStarted
+        # .. filter_type: org.openedx.learning.student.settings.render.started.v1
         context = AccountSettingsRenderStarted().run_filter(context=context)
-    except AccountSettingsRenderStarted.ErrorFilteringContext as exc:
-        raise ImproperlyConfigured(f'Pipeline configuration error: {exc}') from exc
+    except AccountSettingsRenderStarted.RedirectToPage as exc:
+        return HttpResponseRedirect(exc.redirect_to)
+    except AccountSettingsRenderStarted.RenderCustomResponse as exc:
+        return exc.response
 
     return render_to_response('student_account/account_settings.html', context)
 

--- a/openedx/core/djangoapps/user_api/accounts/settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/settings_views.py
@@ -75,16 +75,24 @@ def account_settings(request):
 
     context = account_settings_context(request)
 
+    account_settings_template = 'student_account/account_settings.html'
+
     try:
         # .. filter_implemented_name: AccountSettingsRenderStarted
         # .. filter_type: org.openedx.learning.student.settings.render.started.v1
-        context = AccountSettingsRenderStarted().run_filter(context=context)
+        context, account_settings_template = AccountSettingsRenderStarted.run_filter(
+            context=context, account_settings_template=account_settings_template,
+        )
+    except AccountSettingsRenderStarted.RenderInvalidAccountSettings as exc:
+        response = render_to_response(exc.account_settings_template, exc.template_context)
     except AccountSettingsRenderStarted.RedirectToPage as exc:
-        return HttpResponseRedirect(exc.redirect_to)
+        response = HttpResponseRedirect(exc.redirect_to or reverse('dashboard'))
     except AccountSettingsRenderStarted.RenderCustomResponse as exc:
-        return exc.response
+        response = exc.response
+    else:
+        response = render_to_response(account_settings_template, context)
 
-    return render_to_response('student_account/account_settings.html', context)
+    return response
 
 
 def account_settings_context(request):

--- a/openedx/core/djangoapps/user_api/accounts/settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/settings_views.py
@@ -8,12 +8,14 @@ from datetime import datetime
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
+from django.core.exceptions import ImproperlyConfigured
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
 from django_countries import countries
 
+from openedx_filters.learning.filters import AccountSettingsRenderStarted
 from common.djangoapps import third_party_auth
 from common.djangoapps.edxmako.shortcuts import render_to_response
 from common.djangoapps.student.models import UserProfile
@@ -72,6 +74,12 @@ def account_settings(request):
         return redirect(url)
 
     context = account_settings_context(request)
+
+    try:
+        context = AccountSettingsRenderStarted().run_filter(context=context)
+    except AccountSettingsRenderStarted.ErrorFilteringContext as exc:
+        raise ImproperlyConfigured(f'Pipeline configuration error: {exc}') from exc
+
     return render_to_response('student_account/account_settings.html', context)
 
 

--- a/openedx/core/djangoapps/user_api/accounts/settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/settings_views.py
@@ -81,7 +81,7 @@ def account_settings(request):
         # .. filter_implemented_name: AccountSettingsRenderStarted
         # .. filter_type: org.openedx.learning.student.settings.render.started.v1
         context, account_settings_template = AccountSettingsRenderStarted.run_filter(
-            context=context, account_settings_template=account_settings_template,
+            context=context, template_name=account_settings_template,
         )
     except AccountSettingsRenderStarted.RenderInvalidAccountSettings as exc:
         response = render_to_response(exc.account_settings_template, exc.template_context)

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_filters.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_filters.py
@@ -83,11 +83,9 @@ class TestAccountSettingsRender(PipelineStep):
 
     def run_filter(self, context, template_name):  # pylint: disable=arguments-differ
         """Pipeline step that returns a custom response when rendering the account settings page."""
-        context += {
-            'test': 'test',
-        }
+        template_name = 'static_templates/about.html'
         return {
-            'context': context, template_name: template_name,
+            "context": context, "template_name": template_name,
         }
 
 
@@ -124,7 +122,7 @@ class TestAccountSettingsFilters(SharedModuleStoreTestCase):
         """
         response = self.client.get(self.account_settings_url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.context['test'], 'test')
+        self.assertContains(response, "This page left intentionally blank. Feel free to add your own content.")
 
     @override_settings(
         OPEN_EDX_FILTERS_CONFIG={
@@ -217,7 +215,7 @@ class TestAccountSettingsFilters(SharedModuleStoreTestCase):
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)
         self.assertEqual(f"{reverse('dashboard')}", response.url)
 
-@override_settings(OPEN_EDX_FILTERS_CONFIG={})
+    @override_settings(OPEN_EDX_FILTERS_CONFIG={})
     def test_account_settings_render_without_filter_config(self):
         """
         Test whether the course about filter is triggered before the course about
@@ -230,4 +228,4 @@ class TestAccountSettingsFilters(SharedModuleStoreTestCase):
         """
         response = self.client.get(self.course_about_url)
 
-        self.assertNotContains(response, "View About Page in studio", status_code=200)
+        self.assertNotContains(response, "This page left intentionally blank. Feel free to add your own content.")

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_filters.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_filters.py
@@ -1,0 +1,126 @@
+"""
+Test that various filters are fired for views in the certificates app.
+"""
+from django.http import HttpResponse
+from django.test import override_settings
+from openedx_filters import PipelineStep
+from openedx_filters.learning.filters import AccountSettingsRenderStarted
+from rest_framework import status
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
+
+
+class TestRedirectToPageStep(PipelineStep):
+    """
+    Utility class used when getting steps for pipeline.
+    """
+
+    def run_filter(self, context):  # pylint: disable=arguments-differ
+        """Pipeline step that redirects to dashboard before rendering the account settings page."""
+
+        raise AccountSettingsRenderStarted.RedirectToPage(
+            "You can't access this page, redirecting to dashboard.",
+            redirect_to="/dashboard",
+        )
+
+
+class TestRenderCustomResponse(PipelineStep):
+    """
+    Utility class used when getting steps for pipeline.
+    """
+
+    def run_filter(self, context):  # pylint: disable=arguments-differ
+        """Pipeline step that returns a custom response when rendering the account settings page."""
+        response = HttpResponse("Here's the text of the web page.")
+        raise AccountSettingsRenderStarted.RenderCustomResponse(
+            "You can't access this page.",
+            response=response,
+        )
+
+class TestAccountSettingsRenderPipelineStep(PipelineStep):
+    """
+    Utility class used when getting steps for pipeline.
+    """
+
+    def run_filter(self, context):  # pylint: disable=arguments-differ
+        """Pipeline step that returns a custom response when rendering the account settings page."""
+        context += {
+            'test': 'test',
+        }
+        return context
+
+class TestAccountSettingsFilters(SharedModuleStoreTestCase):
+    """
+    Tests for the Open edX Filters associated with the account settings proccess.
+
+    This class guarantees that the following filters are triggered during the user's account settings rendering:
+
+    - AccountSettingsRenderStarted
+    """
+
+    @override_settings(
+        OPEN_EDX_FILTERS_CONFIG={
+            "org.openedx.learning.student.settings.render.started.v1": {
+                "pipeline": [
+                    "openedx.core.djangoapps.user_api.accounts.tests.test_filters.TestAccountSettingsRenderPipelineStep",
+                ],
+                "fail_silently": False,
+            },
+        },
+    )
+    def test_account_settings_render_pipeline_step(self):
+        """
+        Test whether the account settings filter is triggered before the user's
+        account settings page is rendered.
+
+        Expected result:
+            - AccountSettingsRenderStarted is triggered and executes TestAccountSettingsRenderPipelineStep
+        """
+        response = self.client.get('/account/settings')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.context['test'], 'test')
+
+
+    @override_settings(
+        OPEN_EDX_FILTERS_CONFIG={
+            "org.openedx.learning.student.settings.render.started.v1": {
+                "pipeline": [
+                    "openedx.core.djangoapps.user_api.accounts.tests.test_filters.TestRenderCustomResponse",
+                ],
+                "fail_silently": False,
+            },
+        },
+    )
+    def test_account_settings_render_custom_response(self):
+        """
+        Test whether the account settings filter is triggered before the user's
+        account settings page is rendered.
+
+        Expected result:
+            - AccountSettingsRenderStarted is triggered and executes TestRenderCustomResponse
+        """
+        response = self.client.get('/account/settings')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.content, b"Here's the text of the web page.")
+
+
+    @override_settings(
+        OPEN_EDX_FILTERS_CONFIG={
+            "org.openedx.learning.student.settings.render.started.v1": {
+                "pipeline": [
+                    "openedx.core.djangoapps.user_api.accounts.tests.test_filters.TestRedirectToPageStep",
+                ],
+                "fail_silently": False,
+            },
+        },
+    )
+    def test_account_settings_redirect_to_page(self):
+        """
+        Test whether the account settings filter is triggered before the user's
+        account settings page is rendered.
+
+        Expected result:
+            - AccountSettingsRenderStarted is triggered and executes TestRedirectToPageStep
+        """
+        response = self.client.get('/account/settings')
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertEqual(response.url, '/dashboard')

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_filters.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_filters.py
@@ -10,6 +10,7 @@ from rest_framework import status
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 
 from openedx.core.djangolib.testing.utils import skip_unless_lms
+from common.djangoapps.student.tests.factories import UserFactory
 
 
 class TestRenderInvalidAccountSettings(PipelineStep):
@@ -100,6 +101,15 @@ class TestAccountSettingsFilters(SharedModuleStoreTestCase):
     """
     def setUp(self):  # pylint: disable=arguments-differ
         super().setUp()
+        self.user = UserFactory.create(
+            username="somestudent",
+            first_name="Student",
+            last_name="Person",
+            email="robot@robot.org",
+            is_active=True,
+            password="password",
+        )
+        self.client.login(username=self.user.username, password="password")
         self.account_settings_url = '/account/settings'
 
     @override_settings(
@@ -226,6 +236,6 @@ class TestAccountSettingsFilters(SharedModuleStoreTestCase):
             modification comparing it with the effects of TestAccountSettingsRender.
             - The view response is HTTP_200_OK.
         """
-        response = self.client.get(self.course_about_url)
+        response = self.client.get(self.account_settings_url)
 
         self.assertNotContains(response, "This page left intentionally blank. Feel free to add your own content.")

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -761,7 +761,7 @@ openedx-events==5.1.0
     # via
     #   -r requirements/edx/base.in
     #   edx-event-bus-kafka
-openedx-filters==1.1.0
+openedx-filters==1.2.0
     # via
     #   -r requirements/edx/base.in
     #   lti-consumer-xblock

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1021,7 +1021,7 @@ openedx-events==5.1.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-event-bus-kafka
-openedx-filters==1.1.0
+openedx-filters==1.2.0
     # via
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -969,7 +969,7 @@ openedx-events==5.1.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-event-bus-kafka
-openedx-filters==1.1.0
+openedx-filters==1.2.0
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock


### PR DESCRIPTION
## Description

This PR introduces a new [openedx-filters](https://github.com/openedx/openedx-filters) hook:
 
1. `org.openedx.learning.student.settings.render.started.v1` hook in the platform at openedx/core/djangoapps/user_api/accounts/settings_views.py. This is implemented to hook the account settings context.

Users impacted by the change:
- Users: Allow to get customized account settings.

## Supporting information

openedx-filter: In this PR [#46](https://github.com/openedx/openedx-filters/pull/46) is implemented this filter.

## Testing instructions

You can have an example of this filter with its hook working in [edunext-platform](https://github.com/eduNEXT/edunext-platform/pull/691)

You also have an example in openedx-filters-samples in this PR: https://github.com/eduNEXT/openedx-filters-samples/pull/1

## Deadline

None

## Other information

Once accepted, this should be merged only after https://github.com/openedx/openedx-filters/pull/46 is merged and the requirements are updated.

