### PR TITLE
feat: add static assets to dockerfile

### DIFF
--- a/cms/envs/assets.py
+++ b/cms/envs/assets.py
@@ -1,0 +1,16 @@
+from path import Path as path
+
+from openedx.core.lib.derived import derive_settings
+
+from .common import *
+
+STATIC_ROOT_BASE = os.environ.get('STATIC_ROOT_BASE', STATIC_ROOT_BASE)
+JS_ENV_EXTRA_CONFIG = os.environ.get('JS_ENV_EXTRA_CONFIG', JS_ENV_EXTRA_CONFIG)
+WEBPACK_CONFIG_PATH = os.environ.get('WEBPACK_CONFIG_PATH', WEBPACK_CONFIG_PATH)
+
+if STATIC_ROOT_BASE:
+    STATIC_ROOT = path(STATIC_ROOT_BASE) / 'studio'
+
+derive_settings(__name__)
+
+

--- a/lms/envs/assets.py
+++ b/lms/envs/assets.py
@@ -1,0 +1,15 @@
+from path import Path as path
+
+from openedx.core.lib.derived import derive_settings
+
+from .common import *
+
+STATIC_ROOT_BASE = os.environ.get('STATIC_ROOT_BASE', STATIC_ROOT_BASE)
+WEBPACK_CONFIG_PATH = os.environ.get('WEBPACK_CONFIG_PATH', WEBPACK_CONFIG_PATH)
+
+if STATIC_ROOT_BASE:
+    STATIC_ROOT = path(STATIC_ROOT_BASE)
+
+derive_settings(__name__)
+
+


### PR DESCRIPTION
Related to [MST-1664](https://2u-internal.atlassian.net/browse/MST-1664)

Build static assets within platform dockerfile. 

Separate settings files are necessary to avoid needing a valid LMS_CFG and CMS_CFG file when reading from the production settings file, as those configs are not available at build time. 

Values in the assets.py settings files will first look for environment variables, before falling back on values defined in the common settings files. Relying on environment variables allows these files to be configurable via docker env args. 