### PR TITLE
fix: delay creation of course topics after course publish [BD-38]

### DIFF
--- a/cms/djangoapps/contentstore/signals/handlers.py
+++ b/cms/djangoapps/contentstore/signals/handlers.py
@@ -142,7 +142,10 @@ def listen_for_course_publish(sender, course_key, **kwargs):  # pylint: disable=
     if CoursewareSearchIndexer.indexing_is_enabled() and CourseAboutSearchIndexer.indexing_is_enabled():
         update_search_index.delay(course_key_str, datetime.now(UTC).isoformat())
 
-    update_discussions_settings_from_course_task.delay(course_key_str)
+    update_discussions_settings_from_course_task.apply_async(
+        args=[course_key_str],
+        countdown=settings.DISCUSSION_SETTINGS['COURSE_PUBLISH_TASK_DELAY'],
+    )
 
     # Send to a signal for catalog info changes as well, but only once we know the transaction is committed.
     transaction.on_commit(lambda: emit_catalog_info_changed_signal(course_key))

--- a/openedx/core/djangoapps/discussions/handlers.py
+++ b/openedx/core/djangoapps/discussions/handlers.py
@@ -61,7 +61,6 @@ def update_course_discussion_config(configuration: CourseDiscussionConfiguration
             lookup_key = topic_link.usage_key or topic_link.external_id
             topic_context = new_topic_map.pop(lookup_key, None)
             if topic_context is None:
-                log.info(f"[DEBUG INF-291] Unit was deleted or discussion disabled: {lookup_key}")
                 topic_link.enabled_in_context = False
                 try:
                     # If the section/subsection/unit a topic is in is deleted, add that context to title.
@@ -70,7 +69,6 @@ def update_course_discussion_config(configuration: CourseDiscussionConfiguration
                     # It's possible the context is empty if the link was created before the context field was added.
                     pass
             else:
-                log.info(f"[DEBUG INF-291] Unit topic already exists, will be updated: {lookup_key}")
                 topic_link.enabled_in_context = True
                 topic_link.ordering = topic_context.ordering
                 topic_link.title = topic_context.title
@@ -79,9 +77,6 @@ def update_course_discussion_config(configuration: CourseDiscussionConfiguration
                 topic_link.context = topic_context.context
             topic_link.save()
         log.info(f"Creating new discussion topic links for {course_key}")
-
-        log.info(f"[DEBUG INF-291] Discovered new units with keys: {[str(key) for key in new_topic_map.keys()]}")
-        log.info(f"[DEBUG INF-291] New unit names: {[topic.title for topic in new_topic_map.values()]}")
 
         DiscussionTopicLink.objects.bulk_create([
             DiscussionTopicLink(

--- a/openedx/core/djangoapps/discussions/tasks.py
+++ b/openedx/core/djangoapps/discussions/tasks.py
@@ -55,7 +55,6 @@ def update_discussions_settings_from_course(course_key: CourseKey) -> CourseDisc
         # This leaves the first 100 slots for the course wide topics, which is only a concern if there are more
         # than that many.
         idx = 99
-        log.info(f"[DEBUG INF-291] Unit-level visibility enabled: {unit_level_visibility}")
         for section in course.get_children():
             if section.location.block_type != "chapter":
                 continue
@@ -65,23 +64,18 @@ def update_discussions_settings_from_course(course_key: CourseKey) -> CourseDisc
                 for unit in subsection.get_children():
                     if unit.location.block_type != 'vertical':
                         continue
-                    log.info(f"[DEBUG INF-291] Processing unit: {unit.location}")
                     # Increment index even for skipped units so that the index is more stable and won't change
                     # if settings change, only if a unit is added or removed.
                     idx += 1
                     # If unit-level visibility is enabled and the unit doesn't have discussion enabled, skip it.
                     if unit_level_visibility and not getattr(unit, "discussion_enabled", False):
-                        log.info(f"[DEBUG INF-291] Skipping unit because discussion is disbled: {unit.location}")
                         continue
                     # If the unit is in a graded section and graded sections aren't enabled skip it.
                     if subsection.graded and not enable_graded_units:
-                        log.info(f"[DEBUG INF-291] Skipping unit because it's in a graded subsection: {unit.location}")
                         continue
                     # If the unit is an exam, skip it.
                     if subsection.is_practice_exam or subsection.is_proctored_enabled or subsection.is_time_limited:
-                        log.info(f"[DEBUG INF-291] Skipping unit because it's in an exam: {unit.location}")
                         continue
-                    log.info(f"[DEBUG INF-291] Topic will be created for unit: {unit.location}")
                     yield DiscussionTopicContext(
                         usage_key=unit.location,
                         title=unit.display_name,


### PR DESCRIPTION
## Description
When running in a sharded MongoDB setup it's possible that querying the
modulestore right after the course publish signal will not return the
latest data.

This commit adds a delay similar to the one used in other places in the
codebase for a similar reason.

## Testing instructions

This needs to be tested in a production-like environment where the delay between
a write to Mongo and it's propagation to a read-replica is significant enough
to have an impact.
