### PR TITLE
feat: force enrollment after enrollment end date

### DIFF
--- a/openedx/core/djangoapps/enrollments/api.py
+++ b/openedx/core/djangoapps/enrollments/api.py
@@ -199,7 +199,16 @@ def get_enrollment(username, course_id):
     return _data_api().get_course_enrollment(username, course_id)
 
 
-def add_enrollment(username, course_id, mode=None, is_active=True, enrollment_attributes=None, enterprise_uuid=None):
+def add_enrollment(
+    username,
+    course_id,
+    mode=None,
+    is_active=True,
+    enrollment_attributes=None,
+    enterprise_uuid=None,
+    force_enrollment=False,
+    include_expired=False
+):
     """Enrolls a user in a course.
 
     Enrolls a user in a course. If the mode is not specified, this will default to `CourseMode.DEFAULT_MODE_SLUG`.
@@ -213,6 +222,8 @@ def add_enrollment(username, course_id, mode=None, is_active=True, enrollment_at
             defaults to True.
         enrollment_attributes (list): Attributes to be set the enrollment.
         enterprise_uuid (str): Add course enterprise uuid
+        force_enrollment (bool): Enroll user even if course enrollment_end date is expired
+        include_expired (bool): Boolean denoting whether expired course modes should be included.
 
     Returns:
         A serializable dictionary of the new course enrollment.
@@ -250,8 +261,10 @@ def add_enrollment(username, course_id, mode=None, is_active=True, enrollment_at
     """
     if mode is None:
         mode = _default_course_mode(course_id)
-    validate_course_mode(course_id, mode, is_active=is_active)
-    enrollment = _data_api().create_course_enrollment(username, course_id, mode, is_active, enterprise_uuid)
+    validate_course_mode(course_id, mode, is_active=is_active, include_expired=include_expired)
+    enrollment = _data_api().create_course_enrollment(
+        username, course_id, mode, is_active, enterprise_uuid, force_enrollment=force_enrollment
+    )
 
     if enrollment_attributes is not None:
         set_enrollment_attributes(username, course_id, enrollment_attributes)

--- a/openedx/core/djangoapps/enrollments/data.py
+++ b/openedx/core/djangoapps/enrollments/data.py
@@ -115,7 +115,7 @@ def get_user_enrollments(course_key):
     ).order_by('created')
 
 
-def create_course_enrollment(username, course_id, mode, is_active, enterprise_uuid=None):
+def create_course_enrollment(username, course_id, mode, is_active, enterprise_uuid=None, force_enrollment=False):
     """Create a new course enrollment for the given user.
 
     Creates a new course enrollment for the specified user username.
@@ -126,6 +126,7 @@ def create_course_enrollment(username, course_id, mode, is_active, enterprise_uu
         mode (str): (Optional) The mode for the new enrollment.
         is_active (boolean): (Optional) Determines if the enrollment is active.
         enterprise_uuid (str): Add course enterprise uuid
+        force_enrollment (bool): Enroll user even if course enrollment_end date is expired
 
     Returns:
         A serializable dictionary representing the new course enrollment.
@@ -147,7 +148,9 @@ def create_course_enrollment(username, course_id, mode, is_active, enterprise_uu
         raise UserNotFoundError(msg)  # lint-amnesty, pylint: disable=raise-missing-from
 
     try:
-        enrollment = CourseEnrollment.enroll(user, course_key, check_access=True, enterprise_uuid=enterprise_uuid)
+        enrollment = CourseEnrollment.enroll(
+            user, course_key, check_access=True, can_upgrade=force_enrollment, enterprise_uuid=enterprise_uuid
+        )
         return _update_enrollment(enrollment, is_active=is_active, mode=mode)
     except NonExistentCourseError as err:
         raise CourseNotFoundError(str(err))  # lint-amnesty, pylint: disable=raise-missing-from

--- a/openedx/core/djangoapps/enrollments/tests/fake_data_api.py
+++ b/openedx/core/djangoapps/enrollments/tests/fake_data_api.py
@@ -36,9 +36,18 @@ def get_course_enrollment(student_id, course_id):
     return _get_fake_enrollment(student_id, course_id)
 
 
-def create_course_enrollment(student_id, course_id, mode='honor', is_active=True, enterprise_uuid=None):
+def create_course_enrollment(
+    student_id, course_id, mode='honor', is_active=True, enterprise_uuid=None, force_enrollment=False
+):
     """Stubbed out Enrollment creation request. """
-    return add_enrollment(student_id, course_id, mode=mode, is_active=is_active, enterprise_uuid=enterprise_uuid)
+    return add_enrollment(
+        student_id,
+        course_id,
+        mode=mode,
+        is_active=is_active,
+        enterprise_uuid=enterprise_uuid,
+        force_enrollment=force_enrollment
+    )
 
 
 def update_course_enrollment(student_id, course_id, mode=None, is_active=None):
@@ -74,7 +83,9 @@ def _get_fake_course_info(course_id, include_expired=False):
             return course
 
 
-def add_enrollment(student_id, course_id, is_active=True, mode='honor', enterprise_uuid=None):
+def add_enrollment(
+    student_id, course_id, is_active=True, mode='honor', enterprise_uuid=None, force_enrollment=False
+):
     """Append an enrollment to the enrollments array."""
     enrollment = {
         "created": datetime.datetime.now(),


### PR DESCRIPTION
<!--

🫒🫒
🫒🫒🫒🫒         🫒 Note: the Olive master branch has been created.  Please consider whether your change
    🫒🫒🫒🫒     should also be applied to Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

🌰🌰🌰🌰🌰🌰     🌰 Note: the Nutmeg release is still supported.
                  Please consider whether your change should be applied to Nutmeg as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/openedx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

It includes support for course enrollment in case of `enrollment_end` date has passed or the `upgrade_deadline` has passed. The `force_enrollment` argument is used to support this functionality, and `can_upgrade` and `include_expired` will be `True` if `force_enrollment` is `True`. Only a user who has `GlobalSupport` access can perform this operation. 
This feature is required because as an admin or support user I need to create verified enrollments sometimes:

- to address customer support issues
- to test the system
- to enroll staff

These verified enrollments need to be accounted for properly, so they should be created with an enrollment code.

Sometimes I need to do this after the `enrollment_end` date has passed, or the `upgrade_deadline` has passed.

## Related Issue
https://github.com/openedx/edx-platform/issues/31308