### PR TITLE
build: run tests for open-release branches on GH hosted runners

### DIFF
--- a/.github/workflows/unit-tests-gh-hosted.yml
+++ b/.github/workflows/unit-tests-gh-hosted.yml
@@ -31,7 +31,7 @@ jobs:
             "cms-2",
             "common-1",
             "common-2",
-            "common-3",
+            "xmodule-1"
         ]
     name: gh-hosted-python-${{ matrix.python-version }},django-${{ matrix.django-version }},${{ matrix.shard_name }}
     steps:

--- a/.github/workflows/unit-tests-gh-hosted.yml
+++ b/.github/workflows/unit-tests-gh-hosted.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run-test:
-    if: github.repository != 'openedx/edx-platform' && github.repository != 'edx/edx-platform-private'
+    if: (github.repository != 'openedx/edx-platform' && github.repository != 'edx/edx-platform-private') || (github.repository == 'openedx/edx-platform' && (startsWith(github.base_ref, 'open-release') == true))
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
@@ -75,7 +75,7 @@ jobs:
         uses: ./.github/actions/unit-tests
 
   collect-and-verify:
-    if: github.repository != 'openedx/edx-platform' && github.repository != 'edx/edx-platform-private'
+    if: (github.repository != 'openedx/edx-platform' && github.repository != 'edx/edx-platform-private') || (github.repository == 'openedx/edx-platform' && (startsWith(github.base_ref, 'open-release') == true))
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -80,7 +80,7 @@ jobs:
   # https://github.com/orgs/community/discussions/33579
   success:
     name: Tests successful
-    if: always()
+    if: (github.repository == 'edx/edx-platform-private') || (github.repository == 'openedx/edx-platform' && (startsWith(github.base_ref, 'open-release') == false))
     needs:
       - run-tests
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   run-tests:
     name: python-${{ matrix.python-version }},django-${{ matrix.django-version }},${{ matrix.shard_name }}
-    if: github.repository == 'openedx/edx-platform' || github.repository == 'edx/edx-platform-private'
+    if: (github.repository == 'edx/edx-platform-private') || (github.repository == 'openedx/edx-platform' && (startsWith(github.base_ref, 'open-release') == false))
     runs-on: [ edx-platform-runner ]
     strategy:
       matrix:

--- a/.github/workflows/verify-gha-unit-tests-count.yml
+++ b/.github/workflows/verify-gha-unit-tests-count.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   collect-and-verify:
-    if: github.repository == 'openedx/edx-platform' || github.repository == 'edx/edx-platform-private'
+    if: (github.repository == 'edx/edx-platform-private') || (github.repository == 'openedx/edx-platform' && (startsWith(github.base_ref, 'open-release') == false))
     runs-on: [ edx-platform-runner ]
     steps:
       - name: sync directory owner


### PR DESCRIPTION
Back-porting https://github.com/openedx/edx-platform/pull/31302 into olive to run tests smoothly on PRs against open releases