### PR TITLE
build: run tests for open-release branches on GH hosted runners

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   run-tests:
-    if: (github.repository == 'edx/edx-platform-private') || (github.repository == 'openedx/edx-plastform' && (startsWith(github.base_ref, 'open-release') == false))
+    if: (github.repository == 'edx/edx-platform-private') || (github.repository == 'openedx/edx-platform' && (startsWith(github.base_ref, 'open-release') == false))
     runs-on: [ edx-platform-runner ]
     strategy:
       matrix:

--- a/.github/workflows/verify-gha-unit-tests-count.yml
+++ b/.github/workflows/verify-gha-unit-tests-count.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   collect-and-verify:
-    if: github.repository == 'openedx/edx-platform' || github.repository == 'edx/edx-platform-private'
+    if: (github.repository == 'edx/edx-platform-private') || (github.repository == 'openedx/edx-platform' && (startsWith(github.base_ref, 'open-release') == false))
     runs-on: [ edx-platform-runner ]
     steps:
       - name: sync directory owner


### PR DESCRIPTION
Back-porting https://github.com/openedx/edx-platform/pull/31302 into nutmeg to run tests smoothly on PRs against open releases