### PR TITLE
fix: prevent 500 error when course mode currency is not the same as t…

### DIFF
--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -774,7 +774,10 @@ class CourseMode(models.Model):
         If there is no mode found, will return the price of DEFAULT_MODE, which is 0
         """
         modes = cls.modes_for_course(course_id)
-        return min(mode.min_price for mode in modes if mode.currency.lower() == currency.lower())
+        return min(
+            (mode.min_price for mode in modes if mode.currency.lower() == currency.lower()),
+            default=0
+        )
 
     @classmethod
     def is_eligible_for_certificate(cls, mode_slug, status=None):

--- a/common/djangoapps/course_modes/tests/test_models.py
+++ b/common/djangoapps/course_modes/tests/test_models.py
@@ -125,6 +125,11 @@ class CourseModeModelTest(TestCase):
         # no modes, should get 0
         assert 0 == CourseMode.min_course_price_for_currency(self.course_key, 'usd')
 
+        # with mode with other currency, should get 0
+        mode = Mode('audit', 'Audit', 30, '', 'eur', None, None, None, None)
+        self.create_mode(mode.slug, mode.name, mode.min_price, mode.suggested_prices, mode.currency)
+        assert 0 == CourseMode.min_course_price_for_currency(self.course_key, 'usd')
+
         # create some modes
         mode1 = Mode('honor', 'Honor Code Certificate', 10, '', 'usd', None, None, None, None)
         mode2 = Mode('verified', 'Verified Certificate', 20, '', 'usd', None, None, None, None)


### PR DESCRIPTION

## Description

This PR solves the http 500 error when course concurrency is setted different for PAID_COURSE_REGISTRATION_CURRENCY and course modes.

Before:
![image](https://user-images.githubusercontent.com/39854568/202747434-c823bbbf-93a8-4849-98f1-c303a1368986.png)


After:
![image](https://user-images.githubusercontent.com/39854568/202747121-11683399-005e-4470-9245-09415bf6e145.png)


## Testing instructions

1. Create Course Mode for one course with different concurrency in /admin/course_modes/coursemode/ (For the example screenshots i tested with EUR).
2. Go to /courses/[COURSE-KEY]/about and the error now is not displayed.

## Deadline

None