### PR TITLE
Allow overriding TinyMCE config

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1243,6 +1243,8 @@ EMBARGO_SITE_REDIRECT_URL = None
 ##### custom vendor plugin variables #####
 # JavaScript code can access this data using `process.env.JS_ENV_EXTRA_CONFIG`
 # One of the current use cases for this is enabling custom TinyMCE plugins
+# (TINYMCE_ADDITIONAL_PLUGINS) and overriding the TinyMCE configuration
+# (TINYMCE_CONFIG_OVERRIDES).
 JS_ENV_EXTRA_CONFIG = {}
 
 ############################### PIPELINE #######################################

--- a/xmodule/js/src/html/edit.js
+++ b/xmodule/js/src/html/edit.js
@@ -208,6 +208,12 @@
               }
             });
           }
+
+          // apply configuration overrides if have been defined
+          var tinyMceConfigOverrides = process.env.JS_ENV_EXTRA_CONFIG.TINYMCE_CONFIG_OVERRIDES;
+          if (tinyMceConfigOverrides) {
+            Object.assign(tinyMceConfig, tinyMceConfigOverrides);
+          }
         }
 
         this.tiny_mce_textarea = $(".tiny-mce", this.element).tinymce(tinyMceConfig);


### PR DESCRIPTION
## Description

TinyMCE used in WYSWIG edit windows of the XBlocks can be configured with custom plugins by defining them in the Studio settings ([ref](https://github.com/openedx/edx-platform/pull/25695)). This PR extends that functionality to allow overriding the TinyMCE's configuration.

 For eg., using the following configuration, the default set of colors in the color picker can be changed from the default set of 12 colors to a custom set of just 3.

```py
JS_ENV_EXTRA_CONFIG = {
    "TINYMCE_CONFIG_OVERRIDES": {
        "color_map": ["000000", "Black", "FF0000", "Red", "00FF00", "Green"]
    }
}
```

Useful information to include:
- **Which edX user roles will this change impact?**  - Course Authors
- **Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).**
This change allows overriding all of the TinyMCE's initial configuration. The screenshots below show how the colors in the color-picker for text-color has been changed based on the example configuration given above:

**Default**
![image](https://user-images.githubusercontent.com/383862/202752445-e0cef8d8-5d9b-4965-a92f-5e2d2e7e7a4a.png)

**With color_map override**
![image](https://user-images.githubusercontent.com/383862/202752657-3e7625d2-c55d-425a-974c-d0bbcb906501.png)

## Supporting information

* Related previous change - https://github.com/openedx/edx-platform/pull/25695

## Testing instructions (for devstack)

1. Check out to the PR Branch
2. Add some configuration changes to TinyMCE in `cms/envs/private.py` 
    ```
    JS_ENV_EXTRA_CONFIG = {
        "TINYMCE_CONFIG_OVERRIDES": {... your config here ...}
    ```
3. Rebuild the static files for Studio using `make studio-static` or `make dev.static.studio`
4. Open any unit which has editable text content in Studio and verify that the TinyMCE has the overrides applied as expected.

## Deadline

"None"

## Other information

- [TinyMCE v5.x documentation](https://www.tiny.cloud/docs/general-configuration-guide/basic-setup/)
