### PR TITLE
feat: upgrade lti-consumer-xblock to install proctoring support and LTI 1.1 launch user_id changes

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -670,7 +670,7 @@ libsass==0.10.0
     #   ora2
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==6.1.0
+lti-consumer-xblock==6.4.0
     # via -r requirements/edx/base.in
 lxml==4.9.1
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -884,7 +884,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/testing.txt
     #   ora2
-lti-consumer-xblock==6.1.0
+lti-consumer-xblock==6.4.0
     # via -r requirements/edx/testing.txt
 lxml==4.9.1
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -845,7 +845,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==6.1.0
+lti-consumer-xblock==6.4.0
     # via -r requirements/edx/base.txt
 lxml==4.9.1
     # via


### PR DESCRIPTION
<!--

🫒🫒
🫒🫒🫒🫒         🫒 Note: the Olive master branch has been created.  Please consider whether your change
    🫒🫒🫒🫒     should also be applied to Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

🌰🌰🌰🌰🌰🌰     🌰 Note: the Nutmeg release is still supported.
                  Please consider whether your change should be applied to Nutmeg as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/openedx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This commit upgrades the version of the lti-consumer-xblock library from version 6.1.0 to version 6.4.0. Version 6.3.0 includes support for the Proctoring Assessment Messages of the 1EdTech Proctoring Services Specification (i.e. the in-browser proctoring launch). Version 6.4.0 includes changes to the user_id attribute in the LTI launch message of the LTI 1.1 XBlock launch.

Please see the CHANGELOG entry for these versions for a full description of the changes: https://github.com/openedx/xblock-lti-consumer/blob/master/CHANGELOG.rst#630---2022-11-16 and https://github.com/openedx/xblock-lti-consumer/blob/master/CHANGELOG.rst#640---2022-11-18. The commit messages are included below for convenience.

**6.3.0**

feat: adds support for LTI 1.3 Proctoring Service specification in-browser proctoring launch.

  * Adds an Lti1p3ProctoringLaunchData data class. It should be included as an attribute of the Lti1p3LaunchData data class to provide necessary proctoring data for a proctoring launch.
  * Adds an LtiProctoringConsumer class. This class is used to generate LTI proctoring launch requests and to decode and validate the JWT send back by the Tool with the LtiStartAssessment message.
  * Adds an lti_1p3_proctoring_enabled BooleanField to the LtiConfiguration model. This field controls whether proctoring is enabled for a particular LTI integration.
  * Modifies the launch_gate_endpoint to support LtiStartProctoring and LtiEndAssessment LTI launch messages.
  * Adds an start_proctoring_assessment_endpoint to support LtiStartAssessment messages from the Tool.
  * Adds an LTI_1P3_PROCTORING_ASSESSMENT_STARTED signal. This signal is emitted when the LtiStartAssessment message is sent from the Tool to inform users of the library that the LtiStartAssessment message has been received.

**6.4.0**

feat: add course flag to send external_user_id as user_id in LTI 1.1 XBlock launches

This commit introduces a new CourseWaffleFlag lti_consumer.enable_external_user_id_1p1_launches. When this flag is enabled for a course, LTI 1.1 XBlock launches in that course will send the user's external_user_id as the user_id attribute of the launch. external_user_id is the user's external user ID as defined, created, and stored by the external_user_ids Djangoapp in the edx-platform. When this waffle is not enabled for a course - the default case - LTI 1.1 XBlock launches in that course will continue to send the user's anonymous_user_id as the user_id attribute of the launch, as before.

This provides an opt-in opportunity for courses to send a consistent, static, and opaque user identifier in an LTI 1.1 XBlock launch. This may be necessary for integration with LTI tools that require such an identifier.

Please be aware that toggling this flag in a running course carries the risk of breaking the LTI integrations in the course. This flag should also only be enabled for new courses in which no LTI attempts have been made.

## Supporting information

JIRA: https://2u-internal.atlassian.net/browse/MST-1473
Github: https://github.com/openedx/xblock-lti-consumer/pull/297

JIRA: [MST-1717](https://2u-internal.atlassian.net/browse/MST-1717)
Github: https://github.com/openedx/xblock-lti-consumer/pull/307

## Testing instructions

Please see both pull requests for testing instructions.