### PR TITLE
feat: add enterprise UUID to learner home init data

### DIFF
--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -556,6 +556,7 @@ class EnterpriseDashboardSerializer(serializers.Serializer):
 
     label = serializers.CharField(source="name")
     url = serializers.SerializerMethodField()
+    uuid = serializers.UUIDField()
 
     def get_url(self, instance):
         return urljoin(

--- a/lms/djangoapps/learner_home/test_serializers.py
+++ b/lms/djangoapps/learner_home/test_serializers.py
@@ -1135,10 +1135,7 @@ class TestEnterpriseDashboardSerializer(TestCase):
 
         output_data = EnterpriseDashboardSerializer(input_data).data
 
-        expected_keys = [
-            "label",
-            "url",
-        ]
+        expected_keys = ["label", "url", "uuid"]
         self.assertEqual(output_data.keys(), set(expected_keys))
 
     def test_happy_path(self):
@@ -1155,6 +1152,7 @@ class TestEnterpriseDashboardSerializer(TestCase):
                 "url": settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL
                 + "/"
                 + input_data["slug"],
+                "uuid": input_data["uuid"],
             },
         )
 

--- a/lms/djangoapps/learner_home/test_views.py
+++ b/lms/djangoapps/learner_home/test_views.py
@@ -879,7 +879,7 @@ class TestCourseRecommendationApiView(SharedModuleStoreTestCase):
             "course-v1:BabsonX+EPS03x+Run_0",
             "course-v1:TUMx+QPLS2x+Run_0",
             "course-v1:NYUx+FCS.NET.1+Run_0",
-            "course-v1:MichinX+101x+Run_0"
+            "course-v1:MichinX+101x+Run_0",
         ]
         self.course_data = {
             "course_key": "MITx+6.00.1x",


### PR DESCRIPTION
## Description

Tracking events needed access to enterprise dashboard UUID. Pass that info with the initialize data under `enterpriseDashboard.uuid`.

FYI @openedx/content-aurora 