### PR TITLE
feat: adds openedx-filter hook to the course enrollments site

### DIFF
--- a/common/djangoapps/student/tests/test_filters.py
+++ b/common/djangoapps/student/tests/test_filters.py
@@ -4,14 +4,13 @@ Test that various filters are fired for models/views in the student app.
 from django.http import HttpResponse
 from django.test import override_settings
 from django.urls import reverse
-from lms.djangoapps.mobile_api.users.views import UserCourseEnrollmentsList
 from openedx.core.djangoapps.enrollments.data import get_course_enrollments
 from openedx_filters import PipelineStep
 from openedx_filters.learning.filters import (
     DashboardRenderStarted,
     CourseEnrollmentStarted,
     CourseUnenrollmentStarted,
-    CourseEnrollmentQuerysetRequested
+    CourseEnrollmentQuerysetRequested,
 )
 from rest_framework import status
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
@@ -230,6 +229,8 @@ class EnrollmentFiltersTest(ModuleStoreTestCase):
             - CourseEnrollmentQuerysetRequested is triggered and executes TestCourseEnrollmentsPipelineStep.
             - The result is a list of course enrollments queryset filter by org
         """
+
+        from lms.djangoapps.mobile_api.users.views import UserCourseEnrollmentsList
 
         enrollments_list = UserCourseEnrollmentsList()
         enrollments = enrollments_list.get_queryset()

--- a/lms/djangoapps/mobile_api/users/test_filter.py
+++ b/lms/djangoapps/mobile_api/users/test_filter.py
@@ -1,0 +1,112 @@
+"""
+Test that various filters are fired for models/views in the student app.
+"""
+from django.test import override_settings
+
+from lms.djangoapps.mobile_api.users.views import UserCourseEnrollmentsList
+from common.djangoapps.student.models import CourseEnrollment
+from openedx_filters import PipelineStep
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+
+from xmodule.modulestore.tests.factories import CourseFactory
+
+from lms.djangoapps.mobile_api.utils import API_V1
+from lms.djangoapps.mobile_api.testutils import MobileAPITestCase
+from common.djangoapps.student.tests.factories import UserFactory
+from openedx.core.djangolib.testing.utils import skip_unless_lms
+
+
+class TestCourseEnrollmentsPipelineStep(PipelineStep):
+    """
+    Utility function used when getting steps for pipeline.
+    """
+
+    def run_filter(self, enrollments):  # pylint: disable=arguments-differ
+        """Pipeline steps that modifies course enrollments when make a queryset request."""
+
+        enrollments = [enrollment for enrollment in enrollments if enrollment.course_id.org == "demo"]
+        return enrollments
+
+
+@skip_unless_lms
+class EnrollmentFiltersTest(MobileAPITestCase, ModuleStoreTestCase):
+    """
+    Tests for the Open edX Filters associated with the enrollment process through the enroll method.
+
+    This class guarantees that the following filters are triggered during the user's enrollment:
+
+    - CourseEnrollmentQuerysetRequested
+    """
+    REVERSE_INFO = {'name': 'user-info', 'params': ['api_version']}
+
+    def setUp(self):  # pylint: disable=arguments-differ
+        super().setUp()
+        self.user = UserFactory.create(
+            username="test",
+            email="test@example.com",
+            password="password",
+        )
+        demo_course = CourseFactory.create(org='demo', mobile_available=True)
+        test_course = CourseFactory.create(org='test', mobile_available=True)
+        CourseEnrollment.enroll(self.user, demo_course.id)
+        CourseEnrollment.enroll(self.user, test_course.id)
+        request = self.api_response(
+            data={"query_params": {'org': None}},
+            api_version=API_V1,
+            expected_response_code=None
+        )
+        view = UserCourseEnrollmentsList(
+            kwargs={"username": self.user.username, "api_version": API_V1},
+            request=request
+        )
+        self.enrollment = view.get_queryset()
+
+    @override_settings()
+    def test_enrollment_queryset_filter_unexecuted_views(self):
+        """
+        Test filter enrollment queryset when a request is made.
+
+        Expected result:
+            - CourseEnrollmentQuerysetRequested is triggered and executes TestCourseEnrollmentsPipelineStep.
+            - The result is a list of course enrollments queryset filter by org
+        """
+        request = self.api_response(data={'org': ''}, api_version=API_V1)
+        view = UserCourseEnrollmentsList(
+            kwargs={"username": self.user.username, "api_version": API_V1},
+            request=request
+        )
+        enrollments = view.get_queryset()
+
+        self.assertEqual(self.enrollment, "HELO")
+
+    # @override_settings(
+    #     OPEN_EDX_FILTERS_CONFIG={
+    #         "org.openedx.learning.course_enrollment_queryset.requested.v1": {
+    #             "pipeline": [
+    #                 "common.djangoapps.student.tests.test_filters.TestCourseEnrollmentsPipelineStep",
+    #             ],
+    #             "fail_silently": False,
+    #         },
+    #     },
+    # )
+    # def test_enrollment_queryset_filter_executed_views(self):
+    #     """
+    #     Test filter enrollment queryset when a request is made.
+
+    #     Expected result:
+    #         - CourseEnrollmentQuerysetRequested is triggered and executes TestCourseEnrollmentsPipelineStep.
+    #         - The result is a list of course enrollments queryset filter by org
+    #     """
+    #     expected_enrollment = self.enrollment
+    #     expected_enrollment = expected_enrollment[0]['course_details']['course_id']
+
+    #     request = self.api_response(data={'org': ''}, api_version=API_V1)
+    #     view = UserCourseEnrollmentsList(
+    #         kwargs={"username": self.user.username, "api_version": API_V1},
+    #         request=request
+    #     )
+    #     enrollments = view.get_queryset()
+    #     enrollments = enrollments[0]['course_details']['course_id']
+
+    #     self.assertEqual(expected_enrollment, enrollments)
+    #     self.assertAlmostEqual(len(enrollments), len(expected_enrollment), 1)

--- a/lms/djangoapps/mobile_api/users/test_filter.py
+++ b/lms/djangoapps/mobile_api/users/test_filter.py
@@ -2,6 +2,7 @@
 Test that various filters are fired for models/views in the student app.
 """
 from django.test import override_settings
+from unittest.mock import MagicMock
 
 from lms.djangoapps.mobile_api.users.views import UserCourseEnrollmentsList
 from common.djangoapps.student.models import CourseEnrollment
@@ -24,7 +25,7 @@ class TestCourseEnrollmentsPipelineStep(PipelineStep):
     def run_filter(self, enrollments):  # pylint: disable=arguments-differ
         """Pipeline steps that modifies course enrollments when make a queryset request."""
 
-        enrollments = [enrollment for enrollment in enrollments if enrollment.course_id.org == "demo"]
+        enrollments = [enrollment for enrollment in enrollments if enrollment.course.org == "demo"]
         return enrollments
 
 
@@ -50,15 +51,12 @@ class EnrollmentFiltersTest(MobileAPITestCase, ModuleStoreTestCase):
         test_course = CourseFactory.create(org='test', mobile_available=True)
         CourseEnrollment.enroll(self.user, demo_course.id)
         CourseEnrollment.enroll(self.user, test_course.id)
-        request = self.api_response(
-            data={"query_params": {'org': None}},
-            api_version=API_V1,
-            expected_response_code=None
-        )
+        self.mock_request = MagicMock()
+        self.mock_request.query_params.get.return_value = ''
         view = UserCourseEnrollmentsList(
-            kwargs={"username": self.user.username, "api_version": API_V1},
-            request=request
+            kwargs={"username": self.user.username, "api_version": API_V1}
         )
+        view.request = self.mock_request
         self.enrollment = view.get_queryset()
 
     @override_settings()
@@ -70,43 +68,39 @@ class EnrollmentFiltersTest(MobileAPITestCase, ModuleStoreTestCase):
             - CourseEnrollmentQuerysetRequested is triggered and executes TestCourseEnrollmentsPipelineStep.
             - The result is a list of course enrollments queryset filter by org
         """
-        request = self.api_response(data={'org': ''}, api_version=API_V1)
         view = UserCourseEnrollmentsList(
-            kwargs={"username": self.user.username, "api_version": API_V1},
-            request=request
+            kwargs={"username": self.user.username, "api_version": API_V1}
         )
+        view.request = self.mock_request
         enrollments = view.get_queryset()
 
-        self.assertEqual(self.enrollment, "HELO")
+        self.assertEqual(self.enrollment, enrollments)
 
-    # @override_settings(
-    #     OPEN_EDX_FILTERS_CONFIG={
-    #         "org.openedx.learning.course_enrollment_queryset.requested.v1": {
-    #             "pipeline": [
-    #                 "common.djangoapps.student.tests.test_filters.TestCourseEnrollmentsPipelineStep",
-    #             ],
-    #             "fail_silently": False,
-    #         },
-    #     },
-    # )
-    # def test_enrollment_queryset_filter_executed_views(self):
-    #     """
-    #     Test filter enrollment queryset when a request is made.
+    @override_settings(
+        OPEN_EDX_FILTERS_CONFIG={
+            "org.openedx.learning.course_enrollment_queryset.requested.v1": {
+                "pipeline": [
+                    "common.djangoapps.student.tests.test_filters.TestCourseEnrollmentsPipelineStep",
+                ],
+                "fail_silently": False,
+            },
+        },
+    )
+    def test_enrollment_queryset_filter_executed_views(self):
+        """
+        Test filter enrollment queryset when a request is made.
 
-    #     Expected result:
-    #         - CourseEnrollmentQuerysetRequested is triggered and executes TestCourseEnrollmentsPipelineStep.
-    #         - The result is a list of course enrollments queryset filter by org
-    #     """
-    #     expected_enrollment = self.enrollment
-    #     expected_enrollment = expected_enrollment[0]['course_details']['course_id']
+        Expected result:
+            - CourseEnrollmentQuerysetRequested is triggered and executes TestCourseEnrollmentsPipelineStep.
+            - The result is a list of course enrollments queryset filter by org
+        """
+        expected_enrollment = self.enrollment
 
-    #     request = self.api_response(data={'org': ''}, api_version=API_V1)
-    #     view = UserCourseEnrollmentsList(
-    #         kwargs={"username": self.user.username, "api_version": API_V1},
-    #         request=request
-    #     )
-    #     enrollments = view.get_queryset()
-    #     enrollments = enrollments[0]['course_details']['course_id']
+        view = UserCourseEnrollmentsList(
+            kwargs={"username": self.user.username, "api_version": API_V1}
+        )
+        view.request = self.mock_request
+        enrollments = view.get_queryset()
 
-    #     self.assertEqual(expected_enrollment, enrollments)
-    #     self.assertAlmostEqual(len(enrollments), len(expected_enrollment), 1)
+        self.assertAlmostEqual(len(enrollments), len(expected_enrollment), 1)
+        self.assertEqual(expected_enrollment.course.org, "helo")

--- a/lms/djangoapps/mobile_api/users/views.py
+++ b/lms/djangoapps/mobile_api/users/views.py
@@ -342,9 +342,12 @@ class UserCourseEnrollmentsList(generics.ListAPIView):
         ).order_by('created').reverse()
         org = self.request.query_params.get('org', None)
 
-        ## .. filter_implemented_name: CourseEnrollmentQuerysetRequested
-        ## .. filter_type: org.openedx.learning.course_enrollment_queryset.requested.v1
-        enrollments = CourseEnrollmentQuerysetRequested.run_filter(context=enrollments)
+        try:
+            ## .. filter_implemented_name: CourseEnrollmentQuerysetRequested
+            ## .. filter_type: org.openedx.learning.course_enrollment_queryset.requested.v1
+            enrollments = CourseEnrollmentQuerysetRequested.run_filter(enrollments=enrollments)
+        except CourseEnrollmentQuerysetRequested.PreventEnrollmentQuerysetRequest as exc:
+            raise EnrollmentRequestNotAllowed(str(exc)) from exc
 
         same_org = (
             enrollment for enrollment in enrollments
@@ -378,6 +381,14 @@ class UserCourseEnrollmentsList(generics.ListAPIView):
             return Response(enrollment_data)
 
         return response
+
+
+class EnrollmentRequestException(Exception):
+    pass
+
+
+class EnrollmentRequestNotAllowed(EnrollmentRequestException):
+    pass
 
 
 @api_view(["GET"])

--- a/lms/djangoapps/mobile_api/users/views.py
+++ b/lms/djangoapps/mobile_api/users/views.py
@@ -13,6 +13,7 @@ from django.utils import dateparse
 from django.utils.decorators import method_decorator
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import UsageKey
+from openedx_filters.learning.filters import CourseEnrollmentSiteFilterRequested
 from rest_framework import generics, views
 from rest_framework.decorators import api_view
 from rest_framework.permissions import SAFE_METHODS
@@ -340,6 +341,10 @@ class UserCourseEnrollmentsList(generics.ListAPIView):
             is_active=True
         ).order_by('created').reverse()
         org = self.request.query_params.get('org', None)
+
+        ## .. filter_implemented_name: CourseEnrollmentSiteFilterRequested
+        ## .. filter_type: org.openedx.learning.course_enrollments_site.filter.requested.v1
+        enrollments = CourseEnrollmentSiteFilterRequested.run_filter(context=enrollments)
 
         same_org = (
             enrollment for enrollment in enrollments

--- a/lms/djangoapps/mobile_api/users/views.py
+++ b/lms/djangoapps/mobile_api/users/views.py
@@ -13,7 +13,7 @@ from django.utils import dateparse
 from django.utils.decorators import method_decorator
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import UsageKey
-from openedx_filters.learning.filters import CourseEnrollmentSiteFilterRequested
+from openedx_filters.learning.filters import CourseEnrollmentQuerysetRequested
 from rest_framework import generics, views
 from rest_framework.decorators import api_view
 from rest_framework.permissions import SAFE_METHODS
@@ -342,9 +342,9 @@ class UserCourseEnrollmentsList(generics.ListAPIView):
         ).order_by('created').reverse()
         org = self.request.query_params.get('org', None)
 
-        ## .. filter_implemented_name: CourseEnrollmentSiteFilterRequested
-        ## .. filter_type: org.openedx.learning.course_enrollments_site.filter.requested.v1
-        enrollments = CourseEnrollmentSiteFilterRequested.run_filter(context=enrollments)
+        ## .. filter_implemented_name: CourseEnrollmentQuerysetRequested
+        ## .. filter_type: org.openedx.learning.course_enrollment_queryset.requested.v1
+        enrollments = CourseEnrollmentQuerysetRequested.run_filter(context=enrollments)
 
         same_org = (
             enrollment for enrollment in enrollments

--- a/openedx/core/djangoapps/enrollments/data.py
+++ b/openedx/core/djangoapps/enrollments/data.py
@@ -55,9 +55,12 @@ def get_course_enrollments(username, include_inactive=False):
     if not include_inactive:
         qset = qset.filter(is_active=True)
 
-    ## .. filter_implemented_name: CourseEnrollmentQuerysetRequested
-    ## .. filter_type: org.openedx.learning.course_enrollment_queryset.requested.v1
-    qset = CourseEnrollmentQuerysetRequested.run_filter(enrollments=qset)
+    try:
+        ## .. filter_implemented_name: CourseEnrollmentQuerysetRequested
+        ## .. filter_type: org.openedx.learning.course_enrollment_queryset.requested.v1
+        qset = CourseEnrollmentQuerysetRequested.run_filter(enrollments=qset)
+    except CourseEnrollmentQuerysetRequested.PreventEnrollmentQuerysetRequest as exc:
+        raise EnrollmentRequestNotAllowed(str(exc)) from exc
 
     enrollments = CourseEnrollmentSerializer(qset, many=True).data
 
@@ -79,6 +82,14 @@ def get_course_enrollments(username, include_inactive=False):
         )
 
     return valid
+
+
+class EnrollmentRequestException(Exception):
+    pass
+
+
+class EnrollmentRequestNotAllowed(EnrollmentRequestException):
+    pass
 
 
 def get_course_enrollment(username, course_id):

--- a/openedx/core/djangoapps/enrollments/data.py
+++ b/openedx/core/djangoapps/enrollments/data.py
@@ -9,6 +9,7 @@ import logging
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.db import transaction
 from opaque_keys.edx.keys import CourseKey
+from openedx_filters.learning.filters import CourseEnrollmentSiteFilterRequested
 
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.enrollments.errors import (
@@ -53,6 +54,10 @@ def get_course_enrollments(username, include_inactive=False):
 
     if not include_inactive:
         qset = qset.filter(is_active=True)
+
+    ## .. filter_implemented_name: CourseEnrollmentSiteFilterRequested
+    ## .. filter_type: org.openedx.learning.course_enrollments_site.filter.requested.v1
+    qset = CourseEnrollmentSiteFilterRequested.run_filter(context=qset)
 
     enrollments = CourseEnrollmentSerializer(qset, many=True).data
 

--- a/openedx/core/djangoapps/enrollments/data.py
+++ b/openedx/core/djangoapps/enrollments/data.py
@@ -9,7 +9,7 @@ import logging
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.db import transaction
 from opaque_keys.edx.keys import CourseKey
-from openedx_filters.learning.filters import CourseEnrollmentSiteFilterRequested
+from openedx_filters.learning.filters import CourseEnrollmentQuerysetRequested
 
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.enrollments.errors import (
@@ -55,9 +55,9 @@ def get_course_enrollments(username, include_inactive=False):
     if not include_inactive:
         qset = qset.filter(is_active=True)
 
-    ## .. filter_implemented_name: CourseEnrollmentSiteFilterRequested
-    ## .. filter_type: org.openedx.learning.course_enrollments_site.filter.requested.v1
-    qset = CourseEnrollmentSiteFilterRequested.run_filter(context=qset)
+    ## .. filter_implemented_name: CourseEnrollmentQuerysetRequested
+    ## .. filter_type: org.openedx.learning.course_enrollment_queryset.requested.v1
+    qset = CourseEnrollmentQuerysetRequested.run_filter(enrollments=qset)
 
     enrollments = CourseEnrollmentSerializer(qset, many=True).data
 


### PR DESCRIPTION
<!--

🫒🫒
🫒🫒🫒🫒         🫒 Note: the Olive master branch has been created.  Please consider whether your change
    🫒🫒🫒🫒     should also be applied to Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

🌰🌰🌰🌰🌰🌰     🌰 Note: the Nutmeg release is still supported.
                  Please consider whether your change should be applied to Nutmeg as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/openedx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This PR introduces a new [openedx-filters](https://github.com/openedx/openedx-filters) event ``org.openedx.learning.course_enrollment_queryset.requested.v1``. This is implemented to guaranty multi tenancy in [eox-tenant](https://github.com/eduNEXT/eox-tenant) in course enrollments request, but eox-tenant is only an example would consider use.

Impact by the change on GET request:
- http://{lms_custom_site}/api/enrollment/v1/enrollment
- http://{lms_custom_site}/api/mobile/v1/users/{username}/course_enrollments/

## Supporting information

There are not openedx related tickets. The related PR are:

- https://github.com/openedx/openedx-filters/pull/47
- https://github.com/eduNEXT/eox-tenant/pull/156 

## Testing instructions

The change can be tested with testing instructions in [eox-tenant plugin](https://github.com/eduNEXT/eox-tenant/pull/156).

## Deadline

"None"

## Other information

**Warning**: Once accepted this PR, it has to be merged only after [openedx/openedx-filters#47](https://github.com/openedx/openedx-filters/pull/47) is merged and the requirements in this PR are updated.

### Settings

```bash
EDXAPP_EXTRA_REQUIREMENTS:
  - name: git+https://github.com/eduNEXT/eox-tenant.git@v3.6.0
```