### PR TITLE
fix: Hide course dates block

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1602,6 +1602,7 @@ class CourseEnrollment(models.Model):
                     send_course_enrollment_email.apply_async((self.user.id, str(self.course_id),
                                                               self.course_overview.display_name,
                                                               self.course_overview.short_description,
+                                                              self.course_overview.has_ended(),
                                                               course_pacing_type))
                 segment_properties['email'] = self.user.email
                 # This next property is for an experiment, see method's comments for more information

--- a/common/djangoapps/student/tasks.py
+++ b/common/djangoapps/student/tasks.py
@@ -31,7 +31,7 @@ COUNTDOWN = 60
 
 @shared_task(bind=True, ignore_result=True)
 def send_course_enrollment_email(
-    self, user_id, course_id, course_title, short_description, pacing_type
+    self, user_id, course_id, course_title, short_description, course_ended, pacing_type
 ):
     """
     Send course enrollment email using Braze API.
@@ -74,7 +74,8 @@ def send_course_enrollment_email(
     try:
         user = User.objects.get(id=user_id)
         course_key = CourseKey.from_string(course_id)
-        course_date_blocks = get_course_dates_for_email(user, course_key, request=None)
+        if not course_ended:
+            course_date_blocks = get_course_dates_for_email(user, course_key, request=None)
     except Exception:  # pylint: disable=broad-except
         is_course_date_missing = True
 

--- a/common/djangoapps/student/tests/test_tasks.py
+++ b/common/djangoapps/student/tests/test_tasks.py
@@ -37,6 +37,7 @@ class TestCourseEnrollmentEmailTask(ModuleStoreTestCase):
             "course_id": str(self.course.id),
             "course_title": "Test course",
             "short_description": "Short description of course",
+            "course_ended": False,
             "pacing_type": "self-paced",
         }
 


### PR DESCRIPTION
If course is archived hide the course dates block from email template.

VAN-1176