### PR TITLE
fix: course_staff and course_admin added in get_course api

### DIFF
--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -31,7 +31,6 @@ from rest_framework.response import Response
 from common.djangoapps.student.roles import (
     CourseInstructorRole,
     CourseStaffRole,
-    GlobalStaff,
 )
 
 from lms.djangoapps.course_blocks.api import get_course_blocks

--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -28,6 +28,12 @@ from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from common.djangoapps.student.roles import (
+    CourseInstructorRole,
+    CourseStaffRole,
+    GlobalStaff,
+)
+
 from lms.djangoapps.course_blocks.api import get_course_blocks
 from lms.djangoapps.courseware.courses import get_course_with_access
 from lms.djangoapps.courseware.exceptions import CourseAccessRedirect
@@ -340,6 +346,8 @@ def get_course(request, course_key):
         }),
         "is_group_ta": bool(user_roles & {FORUM_ROLE_GROUP_MODERATOR}),
         "is_user_admin": request.user.is_staff,
+        "is_course_staff": CourseStaffRole(course_key).has_user(request.user),
+        "is_course_admin": CourseInstructorRole(course_key).has_user(request.user),
         "provider": course_config.provider_type,
         "enable_in_context": course_config.enable_in_context,
         "group_at_subsection": course_config.plugin_configuration.get("group_at_subsection", False),

--- a/lms/djangoapps/discussion/rest_api/tests/test_api.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api.py
@@ -201,6 +201,8 @@ class GetCourseTest(ForumsEnableMixin, UrlResetMixin, SharedModuleStoreTestCase)
             'group_at_subsection': False,
             'provider': 'legacy',
             'has_moderation_privileges': False,
+            "is_course_staff": False,
+            "is_course_admin": False,
             'is_group_ta': False,
             'is_user_admin': False,
             'user_roles': {'Student'},

--- a/lms/djangoapps/discussion/rest_api/tests/test_views.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views.py
@@ -521,6 +521,8 @@ class CourseViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
                 "allow_anonymous": True,
                 "allow_anonymous_to_peers": False,
                 "has_moderation_privileges": False,
+                'is_course_admin': False,
+                'is_course_staff': False,
                 "is_group_ta": False,
                 'is_user_admin': False,
                 "user_roles": ["Student"],


### PR DESCRIPTION
[INF-628](https://2u-internal.atlassian.net/browse/INF-628)

Course staff and Course Admin roles added in get_course API