### PR TITLE
fix: allow user to save/update custom email

### DIFF
--- a/openedx/core/djangoapps/course_live/providers.py
+++ b/openedx/core/djangoapps/course_live/providers.py
@@ -87,6 +87,9 @@ class Zoom(LiveProvider):
     """
     id = 'zoom'
     name = 'Zoom LTI PRO'
+    additional_parameters = [
+        'custom_instructor_email'
+    ]
 
     @property
     def is_enabled(self):

--- a/openedx/core/djangoapps/course_live/serializers.py
+++ b/openedx/core/djangoapps/course_live/serializers.py
@@ -44,12 +44,7 @@ class LtiSerializer(serializers.ModelSerializer):
                 validate_email(custom_instructor_email)
             except ValidationError as error:
                 raise serializers.ValidationError(f'{custom_instructor_email} is not valid email address') from error
-            return value
-
-        if not requires_email:
-            return value
-
-        raise serializers.ValidationError('custom_instructor_email is required value in additional_parameters')
+        return value
 
     def create(self, validated_data):
         lti_config = validated_data.pop('lti_config', None)


### PR DESCRIPTION
## Ticket 
https://2u-internal.atlassian.net/browse/INF-680

## Description
Users were unable to save/update custom_instructor_email for zoom LTI provider , this PR resolves this issue by making  custom_instructor_email optional 