### PR TITLE
fix: change register button text

### DIFF
--- a/lms/templates/header/navbar-not-authenticated.html
+++ b/lms/templates/header/navbar-not-authenticated.html
@@ -51,11 +51,11 @@ from openedx.core.djangoapps.user_authn.toggles import should_redirect_to_authn_
         % if allow_public_account_creation:
           % if should_redirect_to_authn_mfe:
             <div class="mobile-nav-item hidden-mobile nav-item">
-                <a class="register-btn btn" href="${settings.AUTHN_MICROFRONTEND_URL}/register${login_query()}">${_("Register")}</a>
+                <a class="register-btn btn" href="${settings.AUTHN_MICROFRONTEND_URL}/register${login_query()}">${_("Register for free")}</a>
             </div>
           % else:
             <div class="mobile-nav-item hidden-mobile nav-item">
-                <a class="register-btn btn" href="/register${login_query()}">${_("Register")}</a>
+                <a class="register-btn btn" href="/register${login_query()}">${_("Register for free")}</a>
             </div>
           % endif
         % endif


### PR DESCRIPTION
The “Register” text was changed on the prospectus and authn site to “Register for free”. Reflecting this change on the logout page.

[VAN-1174](https://2u-internal.atlassian.net/browse/VAN-1174)

