### PR TITLE
Youtube scrape transcripts

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
@@ -239,7 +239,7 @@ class TestDownloadYoutubeSubs(TestYoutubeSubsBase):
         with patch('xmodule.video_module.transcripts_utils.requests.get') as mock_get:
             mock_get.side_effect = [
                 YoutubeVideoHTMLResponse.with_caption_link(language_code),
-                { 'status_code': 200, 'text': response, 'content': response.encode('utf-8')},
+                {'status_code': 200, 'text': response, 'content': response.encode('utf-8')},
             ]
             # Check transcripts_utils.GetTranscriptsFromYouTubeException not thrown
             transcripts_utils.download_youtube_subs(good_youtube_sub, self.course, settings)

--- a/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
@@ -287,57 +287,6 @@ class TestDownloadYoutubeSubs(TestYoutubeSubsBase):
 
         self.clear_sub_content(good_youtube_sub)
 
-    @patch('xmodule.video_module.transcripts_utils.requests.get')
-    def test_get_transcript_name_youtube_server_success(self, mock_get):
-        """
-        Get transcript name from transcript_list fetch from youtube server api
-        depends on language code, default language in YOUTUBE Text Api is "en"
-        """
-        youtube_text_api = copy.deepcopy(settings.YOUTUBE['TEXT_API'])
-        youtube_text_api['params']['v'] = 'dummy_video_id'
-        response_success = """
-        <transcript_list>
-            <track id="1" name="Custom" lang_code="en" />
-            <track id="0" name="Custom1" lang_code="en-GB"/>
-        </transcript_list>
-        """
-        mock_get.return_value = Mock(status_code=200, text=response_success, content=response_success.encode('utf-8'))
-
-        transcript_name = transcripts_utils.youtube_video_transcript_name(youtube_text_api)
-        self.assertEqual(transcript_name, 'Custom')
-
-    @patch('xmodule.video_module.transcripts_utils.requests.get')
-    def test_get_transcript_name_youtube_server_no_transcripts(self, mock_get):
-        """
-        When there are no transcripts of video transcript name will be None
-        """
-        youtube_text_api = copy.deepcopy(settings.YOUTUBE['TEXT_API'])
-        youtube_text_api['params']['v'] = 'dummy_video_id'
-        response_success = "<transcript_list></transcript_list>"
-        mock_get.return_value = Mock(status_code=200, text=response_success, content=response_success.encode('utf-8'))
-
-        transcript_name = transcripts_utils.youtube_video_transcript_name(youtube_text_api)
-        self.assertIsNone(transcript_name)
-
-    @patch('xmodule.video_module.transcripts_utils.requests.get')
-    def test_get_transcript_name_youtube_server_language_not_exist(self, mock_get):
-        """
-        When the language does not exist in transcript_list transcript name will be None
-        """
-        youtube_text_api = copy.deepcopy(settings.YOUTUBE['TEXT_API'])
-        youtube_text_api['params']['v'] = 'dummy_video_id'
-        youtube_text_api['params']['lang'] = 'abc'
-        response_success = """
-        <transcript_list>
-            <track id="1" name="Custom" lang_code="en" />
-            <track id="0" name="Custom1" lang_code="en-GB"/>
-        </transcript_list>
-        """
-        mock_get.return_value = Mock(status_code=200, text=response_success, content=response_success.encode('utf-8'))
-
-        transcript_name = transcripts_utils.youtube_video_transcript_name(youtube_text_api)
-        self.assertIsNone(transcript_name)
-
     @patch('xmodule.video_module.transcripts_utils.requests.get', side_effect=mock_requests_get)
     def test_downloading_subs_using_transcript_name(self, mock_get):
         """

--- a/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
@@ -238,7 +238,7 @@ class TestDownloadYoutubeSubs(TestYoutubeSubsBase):
         language_code = 'en'
         with patch('xmodule.video_module.transcripts_utils.requests.get') as mock_get:
             mock_get.side_effect = [
-                {'content': bytearray(YoutubeVideoHTMLResponse.with_caption_link(language_code), 'UTF-8')},
+                YoutubeVideoHTMLResponse.with_caption_link(language_code),
                 { 'status_code': 200, 'text': response, 'content': response.encode('utf-8')},
             ]
             # Check transcripts_utils.GetTranscriptsFromYouTubeException not thrown

--- a/cms/djangoapps/contentstore/tests/utils.py
+++ b/cms/djangoapps/contentstore/tests/utils.py
@@ -4,8 +4,6 @@ Utilities for contentstore tests
 
 
 import json
-import textwrap
-from unittest.mock import Mock
 
 from django.conf import settings
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
@@ -391,6 +389,7 @@ def setup_caption_responses(mock_get, language_code, caption_response_string, tr
         caption_link_response,
         caption_track_response,
     ]
+
 
 def get_url(handler_name, key_value, key_name='usage_key_string', kwargs=None):
     """

--- a/cms/djangoapps/contentstore/tests/utils.py
+++ b/cms/djangoapps/contentstore/tests/utils.py
@@ -19,6 +19,7 @@ from xmodule.modulestore.tests.django_utils import TEST_DATA_MONGO_MODULESTORE, 
 from xmodule.modulestore.tests.factories import CourseFactory
 from xmodule.modulestore.tests.utils import ProceduralCourseTestMixin
 from xmodule.modulestore.xml_importer import import_course_from_xml
+from xmodule.tests.test_transcripts_utils import YoutubeVideoHTMLResponse
 
 from cms.djangoapps.contentstore.utils import reverse_url
 from common.djangoapps.student.models import Registration
@@ -365,34 +366,31 @@ class CourseTestCase(ProceduralCourseTestMixin, ModuleStoreTestCase):
                 self.assertEqual(value, course2_asset_attrs[key])
 
 
-def mock_requests_get(*args, **kwargs):
+class HTTPGetResponse:
     """
-    Returns mock responses for the youtube API.
+    Generic object used to return results from a mock patch to an HTTP GET request
     """
-    # pylint: disable=unused-argument
-    response_transcript_list = """
-    <transcript_list>
-        <track id="1" name="Custom" lang_code="en" />
-        <track id="0" name="Custom1" lang_code="en-GB"/>
-    </transcript_list>
+    def __init__(self, status_code, response_string):
+        self.status_code = status_code
+        self.text = response_string
+        self.content = response_string.encode('utf-8')
+
+
+def setup_caption_responses(mock_get, language_code, caption_response_string, track_status_code=200):
     """
-    response_transcript = textwrap.dedent("""
-    <transcript>
-        <text start="100" dur="100">subs #1</text>
-        <text start="200" dur="40">subs #2</text>
-        <text start="240" dur="140">subs #3</text>
-    </transcript>
-    """)
+    When fetching youtube captions, two calls to requests.get() are required. The first fetches a
+    captions URL (link) from the video page, applicable to the selected language track. The second
+    fetches caption timing information from that track's captions URL.
 
-    if kwargs == {'params': {'lang': 'en', 'v': 'good_id_2'}}:
-        return Mock(status_code=200, text='')
-    elif kwargs == {'params': {'type': 'list', 'v': 'good_id_2'}}:
-        return Mock(status_code=200, text=response_transcript_list, content=response_transcript_list)
-    elif kwargs == {'params': {'lang': 'en', 'v': 'good_id_2', 'name': 'Custom'}}:
-        return Mock(status_code=200, text=response_transcript, content=response_transcript)
-
-    return Mock(status_code=404, text='')
-
+    This helper method assumes that the two operations are performed in order, and is used in conjunction
+    with mock patch() operations to return appropriate results for each of the two get operations.
+    """
+    caption_link_response = YoutubeVideoHTMLResponse.with_caption_track(language_code)
+    caption_track_response = HTTPGetResponse(track_status_code, caption_response_string)
+    mock_get.side_effect = [
+        caption_link_response,
+        caption_track_response,
+    ]
 
 def get_url(handler_name, key_value, key_name='usage_key_string', kwargs=None):
     """

--- a/cms/djangoapps/contentstore/views/tests/test_transcripts.py
+++ b/cms/djangoapps/contentstore/views/tests/test_transcripts.py
@@ -3,7 +3,6 @@
 
 import copy
 import json
-import re
 import tempfile
 import textwrap
 from codecs import BOM_UTF8

--- a/cms/djangoapps/contentstore/views/transcripts_ajax.py
+++ b/cms/djangoapps/contentstore/views/transcripts_ajax.py
@@ -7,12 +7,10 @@ All user changes are saved immediately.
 """
 
 
-import copy
 import json
 import logging
 import os
 
-import requests
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
@@ -42,7 +40,7 @@ from xmodule.video_module.transcripts_utils import (  # lint-amnesty, pylint: di
     get_transcript_for_video,
     get_transcript_from_val,
     get_transcripts_from_youtube,
-    youtube_video_transcript_name
+    get_transcript_link_from_youtube
 )
 
 __all__ = [
@@ -340,15 +338,7 @@ def check_transcripts(request):  # lint-amnesty, pylint: disable=too-many-statem
             except NotFoundError:
                 log.debug("Can't find transcripts in storage for youtube id: %s", youtube_id)
 
-            # youtube server
-            youtube_text_api = copy.deepcopy(settings.YOUTUBE['TEXT_API'])
-            youtube_text_api['params']['v'] = youtube_id
-            youtube_transcript_name = youtube_video_transcript_name(youtube_text_api)
-            if youtube_transcript_name:
-                youtube_text_api['params']['name'] = youtube_transcript_name
-            youtube_response = requests.get('http://' + youtube_text_api['url'], params=youtube_text_api['params'])
-
-            if youtube_response.status_code == 200 and youtube_response.text:
+            if get_transcript_link_from_youtube(youtube_id):
                 transcripts_presence['youtube_server'] = True
             #check youtube local and server transcripts for equality
             if transcripts_presence['youtube_server'] and transcripts_presence['youtube_local']:

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1526,6 +1526,11 @@ YOUTUBE = {
         },
     },
 
+    'TRANSCRIPTS': {
+        'CAPTION_TRACKS_REGEX': r"captionTracks\"\:\[(?P<caption_tracks>[^\]]+)",
+        'YOUTUBE_URL_BASE': 'https://www.youtube.com/watch?v=',
+    },
+
     'IMAGE_API': 'http://img.youtube.com/vi/{youtube_id}/0.jpg',  # /maxresdefault.jpg for 1920*1080
 }
 

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1516,7 +1516,7 @@ YOUTUBE = {
     # URL to get YouTube metadata
     'METADATA_URL': 'https://www.googleapis.com/youtube/v3/videos',
 
-    # Current youtube api for requesting transcripts.
+    # Deprecated youtube api for requesting transcripts.
     # For example: http://video.google.com/timedtext?lang=en&v=j_jEn79vS3g.
     'TEXT_API': {
         'url': 'video.google.com/timedtext',
@@ -1526,6 +1526,7 @@ YOUTUBE = {
         },
     },
 
+    # Current web page mechanism for scraping transcript information from youtube video pages
     'TRANSCRIPTS': {
         'CAPTION_TRACKS_REGEX': r"captionTracks\"\:\[(?P<caption_tracks>[^\]]+)",
         'YOUTUBE_URL_BASE': 'https://www.youtube.com/watch?v=',

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2906,7 +2906,7 @@ YOUTUBE = {
     # URL to get YouTube metadata
     'METADATA_URL': 'https://www.googleapis.com/youtube/v3/videos/',
 
-    # Current youtube api for requesting transcripts.
+    # Deprecated youtube api for requesting transcripts.
     # For example: http://video.google.com/timedtext?lang=en&v=j_jEn79vS3g.
     'TEXT_API': {
         'url': 'video.google.com/timedtext',
@@ -2916,6 +2916,7 @@ YOUTUBE = {
         },
     },
 
+    # Current web page mechanism for scraping transcript information from youtube video pages
     'TRANSCRIPTS': {
         'CAPTION_TRACKS_REGEX': r"captionTracks\"\:\[(?P<caption_tracks>[^\]]+)",
         'YOUTUBE_URL_BASE': 'https://www.youtube.com/watch?v=',

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2916,6 +2916,11 @@ YOUTUBE = {
         },
     },
 
+    'TRANSCRIPTS': {
+        'CAPTION_TRACKS_REGEX': r"captionTracks\"\:\[(?P<caption_tracks>[^\]]+)",
+        'YOUTUBE_URL_BASE': 'https://www.youtube.com/watch?v=',
+    },
+
     'IMAGE_API': 'http://img.youtube.com/vi/{youtube_id}/0.jpg',  # /maxresdefault.jpg for 1920*1080
 }
 YOUTUBE_API_KEY = 'PUT_YOUR_API_KEY_HERE'

--- a/xmodule/tests/test_transcripts_utils.py
+++ b/xmodule/tests/test_transcripts_utils.py
@@ -70,13 +70,15 @@ class YoutubeVideoHTMLResponse:
         '''An object fit to be returned from a an HTTP GET operation, exposing
         a UTF-8 encoded version of the youtube_html input string in its content attribute'''
         def __init__(self, youtube_html):
-            self.content = bytearray(youtube_html, 'UTF-8')
+            self.get_content = bytearray(youtube_html, 'UTF-8')
 
         def content(self):
-            return self.content
+            return self.get_content
 
 
 class TranscriptsUtilsTest(TestCase):
+    ''' Tests utility fucntions for transcripts (in video_module)'''
+
     @mock.patch('requests.get')
     def test_get_transcript_link_from_youtube(self, mock_get):
         '''Happy path test: english caption link returned when video page HTML has one english caption'''

--- a/xmodule/tests/test_transcripts_utils.py
+++ b/xmodule/tests/test_transcripts_utils.py
@@ -1,0 +1,104 @@
+''' Tests mechanism for obtaining language-specific transcript links from youtube video pages
+Note that tests that work with these links are located elsewhere (test_video.py)
+'''
+from ..video_module.transcripts_utils import get_transcript_link_from_youtube
+
+from unittest import mock, TestCase
+
+
+YOUTUBE_VIDEO_ID = "z-LoKnweV6w"
+
+# Use CAPTION_URL_TEMPLATE.format(<youtube_video_ID>, <ampersand_encoding>, <language_code>)
+# to get either the HTML rendition or the json rendition of the link used to obtain a youtube video's subtitles
+#
+# Parameterized with
+# {0} - The youtube video ID whose captions you want
+# {1} - Either \u0026 for use with UTF-8 encoded HTML, or '&' for use with json
+# {2} - Language code (e.g., "en")
+CAPTION_URL_TEMPLATE = "https: //www.youtube.com/api/timedtext?v = {0}{1}caps = asr{1}xoaf = 5{1}hl = {2}{1}\
+ip = 0.0.0.0{1}ipbits = 0{1}expire = 1667281544{1}sparams = ip, ipbits, expire, v, caps, xoaf{1}\
+signature = 3A2A34F0A1FB11B3825FF54D4238B6CC415877E8.058892{1}key = yt8{1}kind = asr{1}lang = {2}"
+
+UTF8_AMPERSAND = '\\u0026'
+
+# These caption link templates have tailored uses and parameterize on the language code only
+#
+# Parameterized with
+# {0} - Language code (e.g., "en")
+CAPTION_URL_UTF8_ENCODED_TEMPLATE = CAPTION_URL_TEMPLATE.format(YOUTUBE_VIDEO_ID, UTF8_AMPERSAND, "{0}")
+CAPTION_URL_UTF8_DECODED_TEMPLATE = CAPTION_URL_TEMPLATE.format(YOUTUBE_VIDEO_ID, "&", "{0}")
+
+# Macro providing the HTML returned by our mock GET operation on the youtube video page
+# This is not valid HTML, but that's OK, as we'll only be using it to confirm the regex
+# search on the 'playerCaptionsTrackListRenderer' subtree.
+#
+# Packed quality (i.e., no spaces) is essential for these tests to work! Introduction
+# of spaces before or after the colon signs causes the regex matching to stop working.
+#
+# Parameterized with
+# {0} - the URL that obtains the selected video's caption
+# {1} - Language code (e.g., "en")
+YOUTUBE_HTML_TEMPLATE = "HTML content that comes before the captions..." \
+                        "\"captions\":{{\"playerCaptionsTracklistRenderer\":" \
+                        "{{\"captionTracks\":[{{\"baseUrl\":\"{0}\"," \
+                        "\"name\":{{\"simpleText\":\"(Caption language name in local language)\"}}," \
+                        "\"vssId\":\".{1}\",\"languageCode\":\"{1}\"," \
+                        "\"isTranslatable\":true}}]}}}}HTML content that comes after the captions..."
+
+
+class YoutubeVideoHTMLResponse:
+    '''Generates substitute HTTP GET responses used when mocking the GET operation to a youtube video page'''
+
+    @classmethod
+    def with_caption_link(cls, language_code):
+        '''Generates a GET response of HTML with a single caption of the specified language code
+            language_code = "en" for english
+        '''
+        caption_link = CAPTION_URL_UTF8_ENCODED_TEMPLATE.format(language_code)
+        html_with_embedded_link = YOUTUBE_HTML_TEMPLATE.format(caption_link, language_code)
+        return cls.MockResponse(html_with_embedded_link)
+
+    @classmethod
+    def with_no_caption_links(cls):
+        '''Generates a GET response of (invalid) HTML lacking any captions within it.
+        This fake HTML is nevered rendered; it's only intended as a source for a regex
+        search
+        '''
+        return cls.MockResponse("No caption URL info for regex to find here")
+
+    class MockResponse:
+        '''An object fit to be returned from a an HTTP GET operation, exposing
+        a UTF-8 encoded version of the youtube_html input string in its content attribute'''
+        def __init__(self, youtube_html):
+            self.content = bytearray(youtube_html, 'UTF-8')
+
+        def content(self):
+            return self.content
+
+
+class TranscriptsUtilsTest(TestCase):
+    @mock.patch('requests.get')
+    def test_get_transcript_link_from_youtube(self, mock_get):
+        '''Happy path test: english caption link returned when video page HTML has one english caption'''
+        language_code = 'en'
+        mock_get.return_value = YoutubeVideoHTMLResponse.with_caption_link(language_code)
+
+        language_specific_caption_link = get_transcript_link_from_youtube(YOUTUBE_VIDEO_ID)
+        self.assertEqual(language_specific_caption_link, CAPTION_URL_UTF8_DECODED_TEMPLATE.format(language_code))
+
+    @ mock.patch('requests.get')
+    def test_get_caption_no_english_caption(self, mock_get):
+        '''No caption link returned when video page HTML contains no caption in English'''
+        language_code = 'fr'
+        mock_get.return_value = YoutubeVideoHTMLResponse.with_caption_link(language_code)
+
+        english_language_caption_link = get_transcript_link_from_youtube(YOUTUBE_VIDEO_ID)
+        self.assertEqual(english_language_caption_link, None)
+
+    @ mock.patch('requests.get')
+    def test_get_caption_no_captions_in_HTML(self, mock_get):
+        ''' No caption link returned when video page HTML contains no captions at all'''
+        mock_get.return_value = YoutubeVideoHTMLResponse.with_no_caption_links()
+
+        english_language_caption_link = get_transcript_link_from_youtube(YOUTUBE_VIDEO_ID)
+        self.assertEqual(english_language_caption_link, None)

--- a/xmodule/tests/test_transcripts_utils.py
+++ b/xmodule/tests/test_transcripts_utils.py
@@ -1,5 +1,11 @@
 ''' Tests mechanism for obtaining language-specific transcript links from youtube video pages
 Note that tests that work with these links are located elsewhere (test_video.py)
+
+These tests follow the following nomenclature:
+ - a youtube video page supports one or more caption languages (aka 'tracks')
+ - embedded in the page's HTML are track descriptors
+ - among the fields found in a track descriptor is a caption URL (aka caption link)
+        - use this link to obtain the track's caption data
 '''
 from ..video_module.transcripts_utils import get_transcript_link_from_youtube
 
@@ -15,7 +21,7 @@ YOUTUBE_VIDEO_ID = "z-LoKnweV6w"
 # {0} - The youtube video ID whose captions you want
 # {1} - Either \u0026 for use with UTF-8 encoded HTML, or '&' for use with json
 # {2} - Language code (e.g., "en")
-CAPTION_URL_TEMPLATE = "https: //www.youtube.com/api/timedtext?v = {0}{1}caps = asr{1}xoaf = 5{1}hl = {2}{1}\
+CAPTION_URL_TEMPLATE = "https://www.youtube.com/api/timedtext?v = {0}{1}caps = asr{1}xoaf = 5{1}hl = {2}{1}\
 ip = 0.0.0.0{1}ipbits = 0{1}expire = 1667281544{1}sparams = ip, ipbits, expire, v, caps, xoaf{1}\
 signature = 3A2A34F0A1FB11B3825FF54D4238B6CC415877E8.058892{1}key = yt8{1}kind = asr{1}lang = {2}"
 
@@ -29,6 +35,9 @@ CAPTION_URL_UTF8_ENCODED_TEMPLATE = CAPTION_URL_TEMPLATE.format(YOUTUBE_VIDEO_ID
 CAPTION_URL_UTF8_DECODED_TEMPLATE = CAPTION_URL_TEMPLATE.format(YOUTUBE_VIDEO_ID, "&", "{0}")
 
 # Macro providing the HTML returned by our mock GET operation on the youtube video page
+#
+# This template is hard-wired for a video with a single language track
+#
 # This is not valid HTML, but that's OK, as we'll only be using it to confirm the regex
 # search on the 'playerCaptionsTrackListRenderer' subtree.
 #
@@ -38,66 +47,105 @@ CAPTION_URL_UTF8_DECODED_TEMPLATE = CAPTION_URL_TEMPLATE.format(YOUTUBE_VIDEO_ID
 # Parameterized with
 # {0} - the URL that obtains the selected video's caption
 # {1} - Language code (e.g., "en")
-YOUTUBE_HTML_TEMPLATE = "HTML content that comes before the captions..." \
+YOUTUBE_HTML_TEMPLATE = "<b>HTML content that comes before the caption tracks...</b>" \
                         "\"captions\":{{\"playerCaptionsTracklistRenderer\":" \
                         "{{\"captionTracks\":[{{\"baseUrl\":\"{0}\"," \
                         "\"name\":{{\"simpleText\":\"(Caption language name in local language)\"}}," \
                         "\"vssId\":\".{1}\",\"languageCode\":\"{1}\"," \
-                        "\"isTranslatable\":true}}]}}}}HTML content that comes after the captions..."
+                        "\"isTranslatable\":true}}]}}}}<b>HTML content that comes after the caption tracks ...</b>"
 
 
 class YoutubeVideoHTMLResponse:
-    '''Generates substitute HTTP GET responses used when mocking the GET operation to a youtube video page'''
+    """
+    Generates substitute HTTP GET responses used when mocking the GET operation to a youtube video page
+    """
 
     @classmethod
-    def with_caption_link(cls, language_code):
-        '''Generates a GET response of HTML with a single caption of the specified language code
-            language_code = "en" for english
-        '''
+    def with_caption_track(cls, language_code):
+        """
+        Generates a GET response of HTML with a single caption track for the specified
+        language code language_code = "en" for english
+        """
         caption_link = CAPTION_URL_UTF8_ENCODED_TEMPLATE.format(language_code)
-        html_with_embedded_link = YOUTUBE_HTML_TEMPLATE.format(caption_link, language_code)
-        return cls.MockResponse(html_with_embedded_link)
+        html_with_single_caption_track = YOUTUBE_HTML_TEMPLATE.format(caption_link, language_code)
+        return cls.MockResponse(html_with_single_caption_track)
 
     @classmethod
-    def with_no_caption_links(cls):
-        '''Generates a GET response of (invalid) HTML lacking any captions within it.
+    def with_no_caption_tracks(cls):
+        """
+        Generates a GET response of (invalid) HTML lacking any caption tracks within it.
         This fake HTML is nevered rendered; it's only intended as a source for a regex
         search
-        '''
-        return cls.MockResponse("No caption URL info for regex to find here")
+        """
+        html_with_no_caption_tracks = "<b>No caption URL info for regex to find here</b>"
+        return cls.MockResponse(html_with_no_caption_tracks)
+
+    @classmethod
+    def with_malformed_caption_track(cls, language_code):
+        """
+        Generates a GET response of HTML with a single caption of the specified
+        language code language_code = "en" for english
+        """
+        caption_link = CAPTION_URL_UTF8_ENCODED_TEMPLATE.format(language_code)
+        html_with_single_valid_caption_track = YOUTUBE_HTML_TEMPLATE.format(caption_link, language_code)
+        html_with_single_malformed_caption_track = \
+            html_with_single_valid_caption_track.replace('languageCode', 'bogus_key')
+        return cls.MockResponse(html_with_single_malformed_caption_track)
 
     class MockResponse:
-        '''An object fit to be returned from a an HTTP GET operation, exposing
-        a UTF-8 encoded version of the youtube_html input string in its content attribute'''
+        """
+        An object fit to be returned from a an HTTP GET operation, exposing
+        a UTF-8 encoded version of the youtube_html input string in its content attribute
+        """
         def __init__(self, youtube_html):
+            self.status_code = 200
             self.content = bytearray(youtube_html, 'UTF-8')
 
 
 class TranscriptsUtilsTest(TestCase):
-    ''' Tests utility fucntions for transcripts (in video_module)'''
+    """
+    Tests utility fucntions for transcripts (in video_module)
+    """
 
     @mock.patch('requests.get')
     def test_get_transcript_link_from_youtube(self, mock_get):
-        '''Happy path test: english caption link returned when video page HTML has one english caption'''
+        """
+        Happy path test: english caption link returned when video page HTML has one english caption
+        """
         language_code = 'en'
-        mock_get.return_value = YoutubeVideoHTMLResponse.with_caption_link(language_code)
+        mock_get.return_value = YoutubeVideoHTMLResponse.with_caption_track(language_code)
 
         language_specific_caption_link = get_transcript_link_from_youtube(YOUTUBE_VIDEO_ID)
         self.assertEqual(language_specific_caption_link, CAPTION_URL_UTF8_DECODED_TEMPLATE.format(language_code))
 
     @ mock.patch('requests.get')
     def test_get_caption_no_english_caption(self, mock_get):
-        '''No caption link returned when video page HTML contains no caption in English'''
+        """
+        No caption link returned when video page HTML contains no caption in English
+        """
         language_code = 'fr'
-        mock_get.return_value = YoutubeVideoHTMLResponse.with_caption_link(language_code)
+        mock_get.return_value = YoutubeVideoHTMLResponse.with_caption_track(language_code)
+
+        english_language_caption_link = get_transcript_link_from_youtube(YOUTUBE_VIDEO_ID)
+        self.assertIsNone(english_language_caption_link)
+
+    @ mock.patch('requests.get')
+    def test_get_caption_no_captions_in_HTML(self, mock_get):
+        """
+        No caption link returned when video page HTML contains no captions at all
+        """
+        mock_get.return_value = YoutubeVideoHTMLResponse.with_no_caption_tracks()
 
         english_language_caption_link = get_transcript_link_from_youtube(YOUTUBE_VIDEO_ID)
         self.assertEqual(english_language_caption_link, None)
 
     @ mock.patch('requests.get')
-    def test_get_caption_no_captions_in_HTML(self, mock_get):
-        ''' No caption link returned when video page HTML contains no captions at all'''
-        mock_get.return_value = YoutubeVideoHTMLResponse.with_no_caption_links()
+    def test_get_caption_malformed_caption_locator(self, mock_get):
+        """
+        Caption track provided on video page for the selected language, but with broken syntax
+        """
+        language_code = 'en'
+        mock_get.return_value = YoutubeVideoHTMLResponse.with_malformed_caption_track(language_code)
 
         english_language_caption_link = get_transcript_link_from_youtube(YOUTUBE_VIDEO_ID)
-        self.assertEqual(english_language_caption_link, None)
+        self.assertIsNone(english_language_caption_link)

--- a/xmodule/tests/test_transcripts_utils.py
+++ b/xmodule/tests/test_transcripts_utils.py
@@ -70,10 +70,7 @@ class YoutubeVideoHTMLResponse:
         '''An object fit to be returned from a an HTTP GET operation, exposing
         a UTF-8 encoded version of the youtube_html input string in its content attribute'''
         def __init__(self, youtube_html):
-            self.get_content = bytearray(youtube_html, 'UTF-8')
-
-        def content(self):
-            return self.get_content
+            self.content = bytearray(youtube_html, 'UTF-8')
 
 
 class TranscriptsUtilsTest(TestCase):

--- a/xmodule/tests/test_video.py
+++ b/xmodule/tests/test_video.py
@@ -916,6 +916,12 @@ class VideoBlockStudentViewDataTestCase(unittest.TestCase):
             'v': 'set_youtube_id_of_11_symbols_here',
         },
     },
+
+    # Current web page mechanism for scraping transcript information from youtube video pages
+    'TRANSCRIPTS': {
+        'CAPTION_TRACKS_REGEX': r"captionTracks\"\:\[(?P<caption_tracks>[^\]]+)",
+        'YOUTUBE_URL_BASE': 'https://www.youtube.com/watch?v=',
+    }
 })
 @patch.object(settings, 'CONTENTSTORE', create=True, new={
     'ENGINE': 'xmodule.contentstore.mongo.MongoContentStore',
@@ -959,7 +965,6 @@ class VideoBlockIndexingTestCase(unittest.TestCase):
         descriptor = instantiate_descriptor(data=xml_data)
         assert descriptor.index_dictionary() == {'content': {'display_name': 'Test Video'}, 'content_type': 'Video'}
 
-    @unittest.skip("API for youtube captions no longer supported")
     @httpretty.activate
     def test_video_with_youtube_subs_index_dictionary(self):
         """
@@ -993,7 +998,6 @@ class VideoBlockIndexingTestCase(unittest.TestCase):
         assert descriptor.index_dictionary() ==\
                {'content': {'display_name': 'Test Video', 'transcript_en': YOUTUBE_SUBTITLES}, 'content_type': 'Video'}
 
-    @unittest.skip("API for youtube captions no longer supported")
     @httpretty.activate
     def test_video_with_subs_and_transcript_index_dictionary(self):
         """

--- a/xmodule/tests/test_video.py
+++ b/xmodule/tests/test_video.py
@@ -959,6 +959,7 @@ class VideoBlockIndexingTestCase(unittest.TestCase):
         descriptor = instantiate_descriptor(data=xml_data)
         assert descriptor.index_dictionary() == {'content': {'display_name': 'Test Video'}, 'content_type': 'Video'}
 
+    @unittest.skip("API for youtube captions no longer supported")
     @httpretty.activate
     def test_video_with_youtube_subs_index_dictionary(self):
         """
@@ -992,6 +993,7 @@ class VideoBlockIndexingTestCase(unittest.TestCase):
         assert descriptor.index_dictionary() ==\
                {'content': {'display_name': 'Test Video', 'transcript_en': YOUTUBE_SUBTITLES}, 'content_type': 'Video'}
 
+    @unittest.skip("API for youtube captions no longer supported")
     @httpretty.activate
     def test_video_with_subs_and_transcript_index_dictionary(self):
         """
@@ -1006,6 +1008,7 @@ class VideoBlockIndexingTestCase(unittest.TestCase):
                    sub="OEoXaMPEzfM"
                    start_time="00:00:01"
                    download_video="false"
+                   end_time="00:01:00">
                    end_time="00:01:00">
               <source src="http://www.example.com/source.mp4"/>
               <track src="http://www.example.com/track"/>

--- a/xmodule/video_module/transcripts_utils.py
+++ b/xmodule/video_module/transcripts_utils.py
@@ -131,29 +131,6 @@ def save_subs_to_store(subs, subs_id, item, language='en'):
     return save_to_store(filedata, filename, 'application/json', item.location)
 
 
-def youtube_video_transcript_name(youtube_text_api):
-    """
-    Get the transcript name from available transcripts of video
-    with respect to language from youtube server
-    """
-    utf8_parser = etree.XMLParser(encoding='utf-8')
-
-    transcripts_param = {'type': 'list', 'v': youtube_text_api['params']['v']}
-    lang = youtube_text_api['params']['lang']
-    # get list of transcripts of specific video
-    # url-form
-    # http://video.google.com/timedtext?type=list&v={VideoId}
-    youtube_response = requests.get('http://' + youtube_text_api['url'], params=transcripts_param)
-    if youtube_response.status_code == 200 and youtube_response.text:
-        youtube_data = etree.fromstring(youtube_response.text.encode('utf-8'), parser=utf8_parser)
-        # iterate all transcripts information from youtube server
-        for element in youtube_data:
-            # search specific language code such as 'en' in transcripts info list
-            if element.tag == 'track' and element.get('lang_code', '') == lang:
-                return element.get('name')
-    return None
-
-
 def get_transcript_link_from_youtube(youtube_id):
     """
     Get the link for YouTube transcript by parsing the source of the YouTube webpage.

--- a/xmodule/video_module/transcripts_utils.py
+++ b/xmodule/video_module/transcripts_utils.py
@@ -207,6 +207,7 @@ def get_transcripts_from_youtube(youtube_id, settings, i18n, youtube_transcript_
     utf8_parser = etree.XMLParser(encoding='utf-8')
 
     transcript_link = get_transcript_link_from_youtube(youtube_id)
+    log.info('transcript_link = {0}'.format(transcript_link))
 
     if not transcript_link:
         msg = _("Can't get transcript link from Youtube for {youtube_id}.").format(
@@ -215,6 +216,7 @@ def get_transcripts_from_youtube(youtube_id, settings, i18n, youtube_transcript_
         raise GetTranscriptsFromYouTubeException(msg)
 
     data = requests.get(transcript_link)
+    log.info('data = {0}'.format(data))
 
     if data.status_code != 200 or not data.text:
         msg = _("Can't receive transcripts from Youtube for {youtube_id}. Status code: {status_code}.").format(

--- a/xmodule/video_module/transcripts_utils.py
+++ b/xmodule/video_module/transcripts_utils.py
@@ -186,7 +186,7 @@ def get_transcript_link_from_youtube(youtube_id):
         if caption_matched:
             caption_tracks = json.loads(f'[{caption_matched.group("caption_tracks")}]')
             for caption in caption_tracks:
-                if caption["languageCode"] == "en":
+                if "languageCode" in caption.keys() and caption["languageCode"] == "en":
                     return caption["baseUrl"]
         return None
     except ConnectionError:
@@ -207,7 +207,6 @@ def get_transcripts_from_youtube(youtube_id, settings, i18n, youtube_transcript_
     utf8_parser = etree.XMLParser(encoding='utf-8')
 
     transcript_link = get_transcript_link_from_youtube(youtube_id)
-    log.info('transcript_link = {0}'.format(transcript_link))
 
     if not transcript_link:
         msg = _("Can't get transcript link from Youtube for {youtube_id}.").format(
@@ -216,7 +215,6 @@ def get_transcripts_from_youtube(youtube_id, settings, i18n, youtube_transcript_
         raise GetTranscriptsFromYouTubeException(msg)
 
     data = requests.get(transcript_link)
-    log.info('data = {0}'.format(data))
 
     if data.status_code != 200 or not data.text:
         msg = _("Can't receive transcripts from Youtube for {youtube_id}. Status code: {status_code}.").format(

--- a/xmodule/video_module/transcripts_utils.py
+++ b/xmodule/video_module/transcripts_utils.py
@@ -205,7 +205,7 @@ def get_transcript_link_from_youtube(youtube_id):
     try:
         youtube_html = requests.get(f"{youtube_url_base}{youtube_id}")
         caption_re = settings.YOUTUBE['TRANSCRIPTS']['CAPTION_TRACKS_REGEX']
-        caption_matched = caption_re.search(youtube_html.content.decode("utf-8"))
+        caption_matched = re.search(caption_re, youtube_html.content.decode("utf-8"))
         if caption_matched:
             caption_tracks = json.loads(f'[{caption_matched.group("caption_tracks")}]')
             for caption in caption_tracks:


### PR DESCRIPTION
This PR picks up where [work](https://github.com/openedx/edx-platform/pull/30643) conducted by Crist Ye left off.

Specifically, this feature branch contains modifications to access captions from YouTube videos post-December '21. At or around that time, a non-supported API that had been used to retrieve such captions stopped working. Crist Ye provided a work-around that leverages inclusion of URLs in the video page itself that can then be used to locate the captions.

The files changed here come from two branches in the repo used by Crist Ye's original development. One was his `fix-youtube` branch, holding the scraping logic. The other is the `caption-link-unit-testing branch`, with unit tests for the new logic.

@iamCristYe -- Please have a look here