### PR TITLE
feat: hook xblock publish, delete and duplicate openedx-events

### DIFF
--- a/cms/djangoapps/contentstore/signals/handlers.py
+++ b/cms/djangoapps/contentstore/signals/handlers.py
@@ -13,7 +13,12 @@ from django.dispatch import receiver
 from edx_toggles.toggles import SettingToggle
 from opaque_keys.edx.keys import CourseKey
 from openedx_events.content_authoring.data import CourseCatalogData, CourseScheduleData
-from openedx_events.content_authoring.signals import COURSE_CATALOG_INFO_CHANGED
+from openedx_events.content_authoring.signals import (
+    COURSE_CATALOG_INFO_CHANGED,
+    XBLOCK_DELETED,
+    XBLOCK_DUPLICATED,
+    XBLOCK_PUBLISHED,
+)
 from openedx_events.event_bus import get_producer
 from pytz import UTC
 
@@ -162,6 +167,42 @@ def listen_for_course_catalog_info_changed(sender, signal, **kwargs):
     get_producer().send(
         signal=COURSE_CATALOG_INFO_CHANGED, topic='course-catalog-info-changed',
         event_key_field='catalog_info.course_key', event_data={'catalog_info': kwargs['catalog_info']},
+        event_metadata=kwargs['metadata'],
+    )
+
+
+@receiver(XBLOCK_PUBLISHED)
+def listen_for_xblock_published(sender, signal, **kwargs):
+    """
+    Publish XBLOCK_PUBLISHED signals onto the event bus.
+    """
+    get_producer().send(
+        signal=XBLOCK_PUBLISHED, topic='xblock-published',
+        event_key_field='xblock_info.usage_key', event_data={'xblock_info': kwargs['xblock_info']},
+        event_metadata=kwargs['metadata'],
+    )
+
+
+@receiver(XBLOCK_DELETED)
+def listen_for_xblock_deleted(sender, signal, **kwargs):
+    """
+    Publish XBLOCK_DELETED signals onto the event bus.
+    """
+    get_producer().send(
+        signal=XBLOCK_DELETED, topic='xblock-deleted',
+        event_key_field='xblock_info.usage_key', event_data={'xblock_info': kwargs['xblock_info']},
+        event_metadata=kwargs['metadata'],
+    )
+
+
+@receiver(XBLOCK_DUPLICATED)
+def listen_for_xblock_duplicated(sender, signal, **kwargs):
+    """
+    Publish XBLOCK_DUPLICATED signals onto the event bus.
+    """
+    get_producer().send(
+        signal=XBLOCK_DUPLICATED, topic='xblock-duplicated',
+        event_key_field='xblock_info.usage_key', event_data={'xblock_info': kwargs['xblock_info']},
         event_metadata=kwargs['metadata'],
     )
 

--- a/cms/djangoapps/contentstore/views/block.py
+++ b/cms/djangoapps/contentstore/views/block.py
@@ -964,8 +964,8 @@ def _duplicate_block(parent_usage_key, duplicate_source_usage_key, user, display
         # .. event_implemented_name: XBLOCK_DUPLICATED
         XBLOCK_DUPLICATED.send_event(
             xblock_info=DuplicatedXBlockData(
-                usage_key=dest_module.location,
-                block_type=dest_module.location.block_type,
+                usage_key=dest_block.location,
+                block_type=dest_block.location.block_type,
                 source_usage_key=duplicate_source_usage_key,
             )
         )

--- a/cms/djangoapps/contentstore/views/block.py
+++ b/cms/djangoapps/contentstore/views/block.py
@@ -11,6 +11,7 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.core.exceptions import PermissionDenied
 from django.http import Http404, HttpResponse, HttpResponseBadRequest
+from django.utils.timezone import timezone
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
 from edx_django_utils.plugins import pluggable_override
@@ -963,6 +964,7 @@ def _duplicate_block(parent_usage_key, duplicate_source_usage_key, user, display
 
         # .. event_implemented_name: XBLOCK_DUPLICATED
         XBLOCK_DUPLICATED.send_event(
+            time=datetime.now(timezone.utc),
             xblock_info=DuplicatedXBlockData(
                 usage_key=dest_block.location,
                 block_type=dest_block.location.block_type,

--- a/cms/djangoapps/contentstore/views/tests/test_block.py
+++ b/cms/djangoapps/contentstore/views/tests/test_block.py
@@ -14,6 +14,7 @@ from django.test.client import RequestFactory
 from django.urls import reverse
 from openedx_events.content_authoring.data import DuplicatedXBlockData
 from openedx_events.content_authoring.signals import XBLOCK_DUPLICATED
+from openedx_events.tests.utils import OpenEdxEventsTestMixin
 from edx_proctoring.exceptions import ProctoredExamNotFoundException
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.asides import AsideUsageKeyV2
@@ -645,7 +646,7 @@ class DuplicateHelper:
         return self.response_usage_key(resp)
 
 
-class TestDuplicateItem(ItemTest, DuplicateHelper):
+class TestDuplicateItem(ItemTest, DuplicateHelper, OpenEdxEventsTestMixin):
     """
     Test the duplicate method.
     """
@@ -653,6 +654,16 @@ class TestDuplicateItem(ItemTest, DuplicateHelper):
     ENABLED_OPENEDX_EVENTS = [
         "org.openedx.content_authoring.xblock.duplicated.v1",
     ]
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Set up class method for the Test class.
+        This method starts manually events isolation. Explanation here:
+        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
+        """
+        super().setUpClass()
+        cls.start_events_isolation()
 
     def setUp(self):
         """ Creates the test course structure and a few components to 'duplicate'. """

--- a/docs/guides/hooks/events.rst
+++ b/docs/guides/hooks/events.rst
@@ -195,3 +195,15 @@ Content Authoring Events
    * - `COURSE_CATALOG_INFO_CHANGED <https://github.com/openedx/openedx-events/blob/main/openedx_events/content_authoring/signals.py#L23>`_
      - org.openedx.content_authoring.course.catalog_info.changed.v1
      - `2022-08-24 <https://github.com/openedx/edx-platform/blob/a8598fa1fac5e26ac212aa588e8527e727581742/cms/djangoapps/contentstore/signals/handlers.py#L111>`_
+
+   * - `XBLOCK_PUBLISHED <https://github.com/openedx/openedx-events/blob/main/openedx_events/content_authoring/signals.py#L30>`_
+     - org.openedx.content_authoring.xblock.published.v1
+     - `2022-12-06 <https://github.com/openedx/edx-platform/blob/master/xmodule/modulestore/mixed.py#L926>`_
+
+   * - `XBLOCK_DELETED <https://github.com/openedx/openedx-events/blob/main/openedx_events/content_authoring/signals.py#L42>`_
+     - org.openedx.content_authoring.xblock.deleted.v1
+     - `2022-12-06 <https://github.com/openedx/edx-platform/blob/master/xmodule/modulestore/mixed.py#L804>`_
+
+   * - `XBLOCK_DUPLICATED <https://github.com/openedx/openedx-events/blob/main/openedx_events/content_authoring/signals.py#L54>`_
+     - org.openedx.content_authoring.xblock.duplicated.v1
+     - `2022-12-06 <https://github.com/openedx/edx-platform/blob/master/cms/djangoapps/contentstore/views/item.py#L965>`_

--- a/xmodule/modulestore/mixed.py
+++ b/xmodule/modulestore/mixed.py
@@ -15,6 +15,7 @@ from opaque_keys.edx.locator import LibraryLocator
 from openedx_events.content_authoring.data import XBlockData
 from openedx_events.content_authoring.signals import XBLOCK_DELETED, XBLOCK_PUBLISHED
 
+from django.utils.timezone import datetime, timezone
 from xmodule.assetstore import AssetMetadata
 
 from . import XMODULE_FIELDS_WITH_USAGE_KEYS, ModuleStoreWriteBase
@@ -802,6 +803,7 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         item = store.delete_item(location, user_id=user_id, **kwargs)
         # .. event_implemented_name: XBLOCK_DELETED
         XBLOCK_DELETED.send_event(
+            time=datetime.now(timezone.utc),
             xblock_info=XBlockData(
                 usage_key=location,
                 block_type=location.block_type,
@@ -924,6 +926,7 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         item = store.publish(location, user_id, **kwargs)
         # .. event_implemented_name: XBLOCK_PUBLISHED
         XBLOCK_PUBLISHED.send_event(
+            time=datetime.now(timezone.utc),
             xblock_info=XBlockData(
                 usage_key=location,
                 block_type=location.block_type,

--- a/xmodule/modulestore/tests/test_mixed_modulestore.py
+++ b/xmodule/modulestore/tests/test_mixed_modulestore.py
@@ -17,6 +17,7 @@ from unittest.mock import Mock, call, patch
 import ddt
 from openedx_events.content_authoring.data import XBlockData
 from openedx_events.content_authoring.signals import XBLOCK_DELETED, XBLOCK_PUBLISHED
+from openedx_events.tests.utils import OpenEdxEventsTestMixin
 import pymongo
 import pytest
 # Mixed modulestore depends on django, so we'll manually configure some django settings
@@ -65,7 +66,7 @@ if not settings.configured:
 log = logging.getLogger(__name__)
 
 
-class CommonMixedModuleStoreSetup(CourseComparisonTest):
+class CommonMixedModuleStoreSetup(CourseComparisonTest, OpenEdxEventsTestMixin):
     """
     Quasi-superclass which tests Location based apps against both split and mongo dbs (Locator and
     Location-based dbs)
@@ -115,6 +116,16 @@ class CommonMixedModuleStoreSetup(CourseComparisonTest):
         "org.openedx.content_authoring.xblock.deleted.v1",
         "org.openedx.content_authoring.xblock.published.v1",
     ]
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Set up class method for the Test class.
+        This method starts manually events isolation. Explanation here:
+        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
+        """
+        super().setUpClass()
+        cls.start_events_isolation()
 
     def setUp(self):
         """


### PR DESCRIPTION
<!--

🫒🫒
🫒🫒🫒🫒         🫒 Note: the Olive master branch has been created.  Please consider whether your change
    🫒🫒🫒🫒     should also be applied to Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

🌰🌰🌰🌰🌰🌰     🌰 Note: the Nutmeg release is still supported.
                  Please consider whether your change should be applied to Nutmeg as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/openedx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

`openedx-events`: `XBLOCK_DELETED`, `XBLOCK_DUPLICATED` and `XBLOCK_PUBLISHED` are hooked into appropriate functions to publish xblock changes.

These signals are implemented in https://github.com/openedx/openedx-events/pull/143 to handle changes to xblocks in taxonomy-connector/course-discovery.

## Supporting information

- https://github.com/openedx/openedx-events/pull/143
- Workflow document: https://github.com/openedx/taxonomy-connector/pull/140

## Testing instructions

1. Add below snippet somewhere, for example in `cms/djangoapps/contentstore/signals/handlers.py`
```python
from openedx_events.content_authoring.signals import XBLOCK_PUBLISHED, XBLOCK_DELETED, XBLOCK_DUPLICATED
XBLOCK_PUBLISHED.connect(lambda **x: print(x))
XBLOCK_DELETED.connect(lambda **x: print(x))
XBLOCK_DUPLICATED.connect(lambda **x: print(x))
```
2. Start lms and studio and monitor studio logs using `make lms-up studio-up studio-logs`
3. Publish, delete and duplicate some xblocks in studio and related signals should be printed in logs.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

**Pre-merge checklist**:

- [x] merge https://github.com/openedx/openedx-events/pull/143
