### PR TITLE
feat!: update Drag and Drop v2 XBlock to prevent XSS vulnerabilities

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -1174,7 +1174,7 @@ xblock==1.6.1
     #   xblock-google-drive
     #   xblock-poll
     #   xblock-utils
-xblock-drag-and-drop-v2==2.5.0
+xblock-drag-and-drop-v2==3.0.0
     # via -r requirements/edx/base.in
 xblock-google-drive==0.3.0
     # via -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1667,7 +1667,7 @@ xblock==1.6.1
     #   xblock-google-drive
     #   xblock-poll
     #   xblock-utils
-xblock-drag-and-drop-v2==2.5.0
+xblock-drag-and-drop-v2==3.0.0
     # via -r requirements/edx/testing.txt
 xblock-google-drive==0.3.0
     # via -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1544,7 +1544,7 @@ xblock==1.6.1
     #   xblock-google-drive
     #   xblock-poll
     #   xblock-utils
-xblock-drag-and-drop-v2==2.5.0
+xblock-drag-and-drop-v2==3.0.0
     # via -r requirements/edx/base.txt
 xblock-google-drive==0.3.0
     # via -r requirements/edx/base.txt


### PR DESCRIPTION
BREAKING CHANGE: disallowed HTML tags (e.g. `<script>`) will no longer be rendered in LMS and Studio.

Forum announcement: https://discuss.openedx.org/t/upcoming-security-release-xblock-drag-and-drop-v2/8768/6