### PR TITLE
feat: Use new configurable producer API for event bus

### DIFF
--- a/cms/djangoapps/contentstore/signals/handlers.py
+++ b/cms/djangoapps/contentstore/signals/handlers.py
@@ -11,10 +11,10 @@ from django.core.cache import cache
 from django.db import transaction
 from django.dispatch import receiver
 from edx_toggles.toggles import SettingToggle
-from edx_event_bus_kafka import get_producer
 from opaque_keys.edx.keys import CourseKey
 from openedx_events.content_authoring.data import CourseCatalogData, CourseScheduleData
 from openedx_events.content_authoring.signals import COURSE_CATALOG_INFO_CHANGED
+from openedx_events.event_bus import get_producer
 from pytz import UTC
 
 from cms.djangoapps.contentstore.courseware_index import (

--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -301,6 +301,7 @@ CREDENTIALS_INTERNAL_SERVICE_URL = 'http://localhost:18150'
 CREDENTIALS_PUBLIC_SERVICE_URL = 'http://localhost:18150'
 
 #################### Event bus backend ########################
+EVENT_BUS_PRODUCER = 'edx_event_bus_kafka.create_producer'
 EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL = 'http://edx.devstack.schema-registry:8081'
 EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS = 'edx.devstack.kafka:29092'
 EVENT_BUS_TOPIC_PREFIX = 'dev'

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -84,8 +84,8 @@ edx-django-sites-extensions
 edx-django-utils>=5.1.0             # Utilities for cache, monitoring, and plugins
 edx-drf-extensions
 edx-enterprise
-# 0.6.2 introduces topic prefixing
-edx-event-bus-kafka>=0.6.2          # Kafka implementation of event bus
+# edx-event-bus-kafka 2.0.0 adds support for configurable producer API
+edx-event-bus-kafka>=2.0.0          # Kafka implementation of event bus
 edx-milestones
 edx-name-affirmation
 edx-opaque-keys
@@ -125,7 +125,8 @@ nltk                                # Natural language processing; used by the c
 nodeenv                             # Utility for managing Node.js environments; we use this for deployments and testing
 oauthlib                            # OAuth specification support for authenticating via LTI or other Open edX services
 openedx-calc                        # Library supporting mathematical calculations for Open edX
-openedx-events>=0.12.0              # Open edX Events from Hooks Extension Framework (OEP-50)
+# openedx-events 3.1.0 introduces producer API
+openedx-events>=3.1.0               # Open edX Events from Hooks Extension Framework (OEP-50)
 openedx-filters                     # Open edX Filters from Hooks Extension Framework (OEP-50)
 optimizely-sdk                      # Optimizely full stack SDK for Python
 ora2>=4.5.0

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -484,7 +484,7 @@ edx-enterprise==3.58.12
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   learner-pathway-progress
-edx-event-bus-kafka==1.5.0
+edx-event-bus-kafka==2.0.0
     # via -r requirements/edx/base.in
 edx-i18n-tools==0.9.2
     # via ora2
@@ -757,7 +757,7 @@ oauthlib==3.0.1
     #   social-auth-core
 openedx-calc==3.0.1
     # via -r requirements/edx/base.in
-openedx-events==3.0.1
+openedx-events==3.1.0
     # via
     #   -r requirements/edx/base.in
     #   edx-event-bus-kafka

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -603,7 +603,7 @@ edx-enterprise==3.58.12
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   learner-pathway-progress
-edx-event-bus-kafka==1.5.0
+edx-event-bus-kafka==2.0.0
     # via -r requirements/edx/testing.txt
 edx-i18n-tools==0.9.2
     # via
@@ -995,7 +995,7 @@ oauthlib==3.0.1
     #   social-auth-core
 openedx-calc==3.0.1
     # via -r requirements/edx/testing.txt
-openedx-events==3.0.1
+openedx-events==3.1.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-event-bus-kafka

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -583,7 +583,7 @@ edx-enterprise==3.58.12
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   learner-pathway-progress
-edx-event-bus-kafka==1.5.0
+edx-event-bus-kafka==2.0.0
     # via -r requirements/edx/base.txt
 edx-i18n-tools==0.9.2
     # via
@@ -945,7 +945,7 @@ oauthlib==3.0.1
     #   social-auth-core
 openedx-calc==3.0.1
     # via -r requirements/edx/base.txt
-openedx-events==3.0.1
+openedx-events==3.1.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-event-bus-kafka


### PR DESCRIPTION
This involves a breaking-change update to edx-event-bus-kafka 2.0.0.

- [x] Config changes must go out first: https://github.com/edx/edx-internal/pull/7439