### PR TITLE
fix: update problem templates according newer python versions

### DIFF
--- a/xmodule/templates/problem/circuitschematic.yaml
+++ b/xmodule/templates/problem/circuitschematic.yaml
@@ -65,7 +65,7 @@ data: |
         if response[0] == 'ac':
             for node in response[1:]:
                 ac_values = node['NodeA']
-      print "the ac analysis value:", ac_values
+      print("the ac analysis value:", ac_values)
       if ac_values == None:
         correct = ['incorrect']
       elif ac_values[0][1] &lt; ac_values[1][1]:

--- a/xmodule/templates/problem/problem_with_hint_in_latex.yaml
+++ b/xmodule/templates/problem/problem_with_hint_in_latex.yaml
@@ -17,7 +17,7 @@ metadata:
 
         \begin{edXscript}
         def test_str(expect, ans):
-          print expect, ans
+          print(expect, ans)
           ans = ans.strip("'")
           ans = ans.strip('"')
           return expect == ans.lower()
@@ -25,7 +25,7 @@ metadata:
         def hint_fn(answer_ids, student_answers, new_cmap, old_cmap):
           aid = answer_ids[0]
           ans = str(student_answers[aid]).lower()
-          print 'hint_fn called, ans=', ans
+          print('hint_fn called, ans=', ans)
           hint = ''
           if 'java' in ans:
              hint = 'that is only good for drinking'
@@ -56,7 +56,7 @@ data: |
             <customresponse cfn="test_str" expect="python">
         <script type="text/python" system_path="python_lib">
     def test_str(expect, ans):
-      print expect, ans
+      print(expect, ans)
       ans = ans.strip("'")
       ans = ans.strip('"')
       return expect == ans.lower()
@@ -64,7 +64,7 @@ data: |
     def hint_fn(answer_ids, student_answers, new_cmap, old_cmap):
       aid = answer_ids[0]
       ans = str(student_answers[aid]).lower()
-      print 'hint_fn called, ans=', ans
+      print('hint_fn called, ans=', ans)
       hint = ''
       if 'java' in ans:
          hint = 'that is only good for drinking'


### PR DESCRIPTION
<!--

🫒🫒
🫒🫒🫒🫒         🫒 Note: the Olive master branch has been created.  Please consider whether your change
    🫒🫒🫒🫒     should also be applied to Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

🌰🌰🌰🌰🌰🌰     🌰 Note: the Nutmeg release is still supported.
                  Please consider whether your change should be applied to Nutmeg as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/openedx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This PR updates problem templates which use python code to a newer python version.

## Supporting information

This PR fixes some of the issues mentioned in the BTR board: https://github.com/openedx/build-test-release-wg/issues/209

## Testing instructions

1. Create a problem in studio that uses one of these templates.
2. Fill in the problem, hit submit. It shouldn't fail.

Note: some of these problems need codejail so they run smoothly.

### Before
![image](https://user-images.githubusercontent.com/64440265/204536544-6c8aab06-fa7a-442b-a7d8-a9f185e3d73b.png)

### After
![image](https://user-images.githubusercontent.com/64440265/204538441-7408fa67-0878-410e-b277-414d58f96fe6.png)

## Deadline

None. It needs to be added to tutor as a patch for olive.