### PR TITLE
feat: update xblock lti library to version 7

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -669,7 +669,7 @@ libsass==0.10.0
     #   ora2
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==6.4.0
+lti-consumer-xblock==7.0.1
     # via -r requirements/edx/base.in
 lxml==4.9.1
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -883,7 +883,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/testing.txt
     #   ora2
-lti-consumer-xblock==6.4.0
+lti-consumer-xblock==7.0.1
     # via -r requirements/edx/testing.txt
 lxml==4.9.1
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -843,7 +843,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==6.4.0
+lti-consumer-xblock==7.0.1
     # via -r requirements/edx/base.txt
 lxml==4.9.1
     # via


### PR DESCRIPTION
7 removed use of various deprecated block methods, 7.0.1 includes a minor bugfix
