### PR TITLE
docs: Try to explicitly set python 3.8 for docs.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-22.04"
   tools:
     python: "3.8"
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,10 @@
+version: 2
+
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "3.8"
+
+python:
+  install:
+  - requirements: "requirements/edx/doc.txt"


### PR DESCRIPTION
This repo currently builds multiple RTD projects out of it and the yaml
config doesn't really have a way to specify which project it's for so we
keep this minimal.

The hope is that any settings it doesn't find here it will pick up from
the advanced project settings in RTD.

We need to explicitly set the python version because RTD seems to be
defaulting to Python 3.7 otherwise and that's not compatible with some
of the requirements in our docs.txt file which no longer support
python<3.8

We need to explicitly list any extra requirements files we want to
install and that can't be set per project but luckily all the doc
projects share the same requirements file.
