### PR TITLE
Upgrade lti-consumer-xblock to Install Fixes to Basic Outcomes Service and Result Service

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -669,7 +669,7 @@ libsass==0.10.0
     #   ora2
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==6.4.0
+lti-consumer-xblock==7.0.2
     # via -r requirements/edx/base.in
 lxml==4.9.1
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -883,7 +883,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/testing.txt
     #   ora2
-lti-consumer-xblock==6.4.0
+lti-consumer-xblock==7.0.2
     # via -r requirements/edx/testing.txt
 lxml==4.9.1
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -843,7 +843,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==6.4.0
+lti-consumer-xblock==7.0.2
     # via -r requirements/edx/base.txt
 lxml==4.9.1
     # via


### PR DESCRIPTION
<!--

🫒🫒
🫒🫒🫒🫒         🫒 Note: the Olive master branch has been created.  Please consider whether your change
    🫒🫒🫒🫒     should also be applied to Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

🌰🌰🌰🌰🌰🌰     🌰 Note: the Nutmeg release is still supported.
                  Please consider whether your change should be applied to Nutmeg as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/openedx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This commit upgrades the version of the lti-consumer-xblock library from version 6.4.0 to version 7.0.2. This includes versions 7.0.0, 7.0.1, and 7.0.2.

Version 7.0.0 includes refactoring to remove deprecated method calls to `rebind_noauth_module_to_user`, `get_real_user`, `runtime.hostname`, and `runtime.course_id`.

Version 7.0.1 includes a fix to the `clean` method of the `LtiConfiguration` model. The fix changes the way we look up the course ID so that we can access the course ID without needing to load the XBlock.

Version 7.0.2 includes fixes to LTI 1.1 Basic Outcomes Services and LTI 2.0 Result Service when using an `external_user_id` as a user identifier.

Note that version 7.0.1 was originally deployed in https://github.com/openedx/edx-platform/pull/31369. It was reverted soon after in https://github.com/openedx/edx-platform/pull/31377. The issue occurred in version 7.0.0, in the following line https://github.com/openedx/xblock-lti-consumer/pull/249/files#diff-ab027143adc95b9776c12e973e28f025a21b0d88112937af93645829686527fdL186. self in the call to the service is an instance of the OutcomeService. self should be an instance of an XBlock (i.e. `LtiConsumerXBlock`). Version 7.0.2 fixes this bug by moving the call to the service to the `LtiConsumerXBlock`, where self is an instance of an XBlock. Therefore, we are deploying this version to fix forward.

Please see the CHANGELOG entries for these versions for a full description of the changes.

**Version 7.0.0**: https://github.com/openedx/xblock-lti-consumer/blob/master/CHANGELOG.rst#700---2022-11-29
**Version 7.0.1**: https://github.com/openedx/xblock-lti-consumer/blob/master/CHANGELOG.rst#701---2022-11-29
**Version 7.0.2**: https://github.com/openedx/xblock-lti-consumer/blob/master/CHANGELOG.rst#702---2022-11-29.

In #307, we added the ability to send a stable, static user identifier (i.e. external user ID) to fix failed launches with the QwikLabs tool. This is because the QwikLabs tool did not work with the course-anonymized user IDs we used to send (i.e. anonymous user IDs). Inadvertently, this change broke the LTI 1.1 Basic Outcomes Service and the LTI 2.0 Result Service for courses that use the external user ID (i.e. they have the `lti_consumer.enable_external_user_id_1p1_launches` `CourseWaffleFlag` enabled). The Basic Outcomes Service and Result Service handle grade pass backs. Because we now have two ways to identify a user in LTI 1.1/2.0, we must update the Basic Outcomes Service and Result Service to support both. This commit fixes this bug.

## Supporting information

* https://github.com/openedx/xblock-lti-consumer/pull/310
* https://github.com/openedx/edx-platform/pull/31369
* https://github.com/openedx/edx-platform/pull/31377

## Testing instructions

Please see the pull request description for detailed testing instructions.
