### PR TITLE
Revert "feat: update xblock lti library to version 7"

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -669,7 +669,7 @@ libsass==0.10.0
     #   ora2
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==7.0.1
+lti-consumer-xblock==6.4.0
     # via -r requirements/edx/base.in
 lxml==4.9.1
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -883,7 +883,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/testing.txt
     #   ora2
-lti-consumer-xblock==7.0.1
+lti-consumer-xblock==6.4.0
     # via -r requirements/edx/testing.txt
 lxml==4.9.1
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -843,7 +843,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==7.0.1
+lti-consumer-xblock==6.4.0
     # via -r requirements/edx/base.txt
 lxml==4.9.1
     # via


### PR DESCRIPTION
Reverts openedx/edx-platform#31369

## Reason
- This PR may have caused the trigger of error on edx-app-lms `AttributeError: 'OutcomeService' object has no attribute 'service_declaration'`
- Detailed error stack trace: https://one.newrelic.com/nr1-core/errors/overview/ODgxNzh8QVBNfEFQUExJQ0FUSU9OfDMzNDMzMjc?duration=86400000&filters=%28domain%20%3D%20%27APM%27%20AND%20type%20%3D%20%27APPLICATION%27%29&state=8d6d81d1-dae5-bbc0-7f07-546887e0d797