### PR TITLE
feat: add forum response event for marking responses as answered or endorsed

### DIFF
--- a/lms/djangoapps/discussion/django_comment_client/base/tests.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/tests.py
@@ -269,7 +269,9 @@ class ViewsTestCaseMixin:
         data = {
             "user_id": str(self.student.id),
             "closed": False,
-            "commentable_id": "non_team_dummy_id"
+            "commentable_id": "non_team_dummy_id",
+            "thread_id": "dummy",
+            "thread_type": "discussion"
         }
         if include_depth:
             data["depth"] = 0
@@ -1141,7 +1143,7 @@ class ViewPermissionsTestCase(ForumsEnableMixin, UrlResetMixin, SharedModuleStor
     def test_endorse_response_as_staff(self, mock_request):
         self._set_mock_request_thread_and_comment(
             mock_request,
-            {"type": "thread", "thread_type": "question", "user_id": str(self.student.id)},
+            {"type": "thread", "thread_type": "question", "user_id": str(self.student.id), "commentable_id": "course"},
             {"type": "comment", "thread_id": "dummy"}
         )
         self.client.login(username=self.moderator.username, password=self.password)
@@ -1153,7 +1155,8 @@ class ViewPermissionsTestCase(ForumsEnableMixin, UrlResetMixin, SharedModuleStor
     def test_endorse_response_as_student(self, mock_request):
         self._set_mock_request_thread_and_comment(
             mock_request,
-            {"type": "thread", "thread_type": "question", "user_id": str(self.moderator.id)},
+            {"type": "thread", "thread_type": "question",
+             "user_id": str(self.moderator.id), "commentable_id": "course"},
             {"type": "comment", "thread_id": "dummy"}
         )
         self.client.login(username=self.student.username, password=self.password)
@@ -1165,7 +1168,7 @@ class ViewPermissionsTestCase(ForumsEnableMixin, UrlResetMixin, SharedModuleStor
     def test_endorse_response_as_student_question_author(self, mock_request):
         self._set_mock_request_thread_and_comment(
             mock_request,
-            {"type": "thread", "thread_type": "question", "user_id": str(self.student.id)},
+            {"type": "thread", "thread_type": "question", "user_id": str(self.student.id), "commentable_id": "course"},
             {"type": "comment", "thread_id": "dummy"}
         )
         self.client.login(username=self.student.username, password=self.password)

--- a/lms/djangoapps/discussion/rest_api/serializers.py
+++ b/lms/djangoapps/discussion/rest_api/serializers.py
@@ -16,7 +16,7 @@ from rest_framework import serializers
 from common.djangoapps.student.models import get_user_by_username_or_email
 from common.djangoapps.student.roles import GlobalStaff
 from lms.djangoapps.discussion.django_comment_client.base.views import track_thread_lock_unlock_event, \
-    track_thread_edited_event, track_comment_edited_event
+    track_thread_edited_event, track_comment_edited_event, track_forum_response_mark_event
 from lms.djangoapps.discussion.django_comment_client.utils import (
     course_discussion_division_enabled,
     get_group_id_for_user,
@@ -591,6 +591,7 @@ class CommentSerializer(_ContentSerializer):
             # endorsement_user_id on update
             requesting_user_id = self.context["cc_requester"]["id"]
             if key == "endorsed":
+                track_forum_response_mark_event(self.context['request'], self.context['course'], instance, val)
                 instance["endorsement_user_id"] = requesting_user_id
             if key == "body" and val:
                 instance["editing_user_id"] = requesting_user_id


### PR DESCRIPTION
### [INF-491](https://2u-internal.atlassian.net/browse/INF-491)

### Description

Add following discussions response mark events

- `edx.forum.response.mark`
- `edx.forum.response.unmark`

_NOTE: Coverage for both Legacy and new MFE experience for these events_

### Response mark Event from logs

```python
...
"event": {
    "discussion": {"id": "..."}, 
    "commentable_id": "...", 
    "mark_type": "Endorse",
    "target_username": "edx", 
    "id": "...", 
    "category_name": "Week 1 / Topic-Level Student-Visible Label", 
    "category_id": "...", 
    "url": "http://localhost:2002/", 
    "user_forums_roles": ["Student"],
    "user_course_roles": []
},
"name": "edx.forum.response.mark"
...
```


### Response unmark Event from logs

```python
...
"event":  {
    "discussion": {"id": "..."}, 
    "commentable_id": "course", 
    "mark_type": "Answer", 
    "target_username": "edx", 
    "id": "...", "url": "http://localhost:2002/", 
    "user_forums_roles": ["Student"], 
    "user_course_roles": []
},
"name": "edx.forum.response.unmark"
...
```
