### PR TITLE
fix: wrap course goals email handle to report on errors

### DIFF
--- a/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
+++ b/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
@@ -112,7 +112,21 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         """
-        Docstring
+        Handle goal emails across all courses.
+
+        This outer layer calls the inner and reports on any exception that
+        occurred.
+        """
+
+        try:
+            self._handle_all_goals()
+        except Exception:  # pylint: disable=broad-except
+            log.exception("Error while sending course goals emails: ")
+            raise
+
+    def _handle_all_goals(self):
+        """
+        Handle goal emails across all courses
 
         Helpful notes for the function:
             weekday() returns an int 0-6 with Monday being 0 and Sunday being 6


### PR DESCRIPTION
currently this is failing many runs but the exception information is lost at some higher level. Report on it immediately.
