### PR TITLE
refactor: unify XBlock naming: item [BD-13]

### DIFF
--- a/cms/djangoapps/contentstore/api/tests/base.py
+++ b/cms/djangoapps/contentstore/api/tests/base.py
@@ -6,7 +6,7 @@ Base test case for the course API views.
 from django.urls import reverse
 from rest_framework.test import APITestCase
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
 from common.djangoapps.student.tests.factories import StaffFactory
 from common.djangoapps.student.tests.factories import UserFactory
@@ -40,44 +40,44 @@ class BaseCourseViewTest(SharedModuleStoreTestCase, APITestCase):
         course.self_paced = True
         cls.store.update_item(course, cls.staff.id)
 
-        cls.section = ItemFactory.create(
+        cls.section = BlockFactory.create(
             parent_location=course.location,
             category="chapter",
         )
-        cls.subsection1 = ItemFactory.create(
+        cls.subsection1 = BlockFactory.create(
             parent_location=cls.section.location,
             category="sequential",
         )
-        unit1 = ItemFactory.create(
+        unit1 = BlockFactory.create(
             parent_location=cls.subsection1.location,
             category="vertical",
         )
-        ItemFactory.create(
+        BlockFactory.create(
             parent_location=unit1.location,
             category="video",
         )
-        ItemFactory.create(
+        BlockFactory.create(
             parent_location=unit1.location,
             category="problem",
         )
 
-        cls.subsection2 = ItemFactory.create(
+        cls.subsection2 = BlockFactory.create(
             parent_location=cls.section.location,
             category="sequential",
         )
-        unit2 = ItemFactory.create(
+        unit2 = BlockFactory.create(
             parent_location=cls.subsection2.location,
             category="vertical",
         )
-        unit3 = ItemFactory.create(
+        unit3 = BlockFactory.create(
             parent_location=cls.subsection2.location,
             category="vertical",
         )
-        ItemFactory.create(
+        BlockFactory.create(
             parent_location=unit3.location,
             category="video",
         )
-        ItemFactory.create(
+        BlockFactory.create(
             parent_location=unit3.location,
             category="video",
         )

--- a/cms/djangoapps/contentstore/api/tests/test_validation.py
+++ b/cms/djangoapps/contentstore/api/tests/test_validation.py
@@ -10,7 +10,7 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
 from common.djangoapps.student.tests.factories import StaffFactory
 from common.djangoapps.student.tests.factories import UserFactory
@@ -57,11 +57,11 @@ class CourseValidationViewTest(SharedModuleStoreTestCase, APITestCase):
             fields=dict(data="<ol><li><h2>Date</h2>Hello world!</li></ol>"),
         )
 
-        section = ItemFactory.create(
+        section = BlockFactory.create(
             parent_location=course.location,
             category="chapter",
         )
-        ItemFactory.create(
+        BlockFactory.create(
             parent_location=section.location,
             category="sequential",
         )

--- a/cms/djangoapps/contentstore/management/commands/tests/test_backfill_course_outlines.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_backfill_course_outlines.py
@@ -7,7 +7,7 @@ from opaque_keys.edx.keys import CourseKey
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.content.learning_sequences.api import get_course_keys_with_outlines
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 from ....outlines import update_outline_from_modulestore
 
@@ -53,22 +53,22 @@ class BackfillCourseOutlinesTest(SharedModuleStoreTestCase):
                 display_name=f"Outline Backfill Test Course {course_key.run}"
             )
             with cls.store.bulk_operations(course_key):
-                section = ItemFactory.create(
+                section = BlockFactory.create(
                     parent=course,
                     category="chapter",
                     display_name="A Section"
                 )
-                sequence = ItemFactory.create(
+                sequence = BlockFactory.create(
                     parent=section,
                     category="sequential",
                     display_name="A Sequence"
                 )
-                unit = ItemFactory.create(
+                unit = BlockFactory.create(
                     parent=sequence,
                     category="vertical",
                     display_name="A Unit"
                 )
-                ItemFactory.create(
+                BlockFactory.create(
                     parent=unit,
                     category="html",
                     display_name="An HTML Block"

--- a/cms/djangoapps/contentstore/management/commands/tests/test_fix_not_found.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_fix_not_found.py
@@ -7,7 +7,7 @@ from django.core.management import CommandError, call_command
 
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
 
 class TestFixNotFound(ModuleStoreTestCase):
@@ -33,7 +33,7 @@ class TestFixNotFound(ModuleStoreTestCase):
 
     def test_fix_not_found(self):
         course = CourseFactory.create(default_store=ModuleStoreEnum.Type.split)
-        ItemFactory.create(category='chapter', parent_location=course.location)
+        BlockFactory.create(category='chapter', parent_location=course.location)
 
         # get course again in order to update its children list
         course = self.store.get_course(course.id)

--- a/cms/djangoapps/contentstore/management/commands/tests/test_force_publish.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_force_publish.py
@@ -11,7 +11,7 @@ from cms.djangoapps.contentstore.management.commands.force_publish import Comman
 from cms.djangoapps.contentstore.management.commands.utils import get_course_versions
 from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 
 class TestForcePublish(SharedModuleStoreTestCase):
@@ -85,7 +85,7 @@ class TestForcePublishModifications(ModuleStoreTestCase):
         Test 'force_publish' command
         """
         # Add some changes to course
-        chapter = ItemFactory.create(category='chapter', parent_location=self.course.location)
+        chapter = BlockFactory.create(category='chapter', parent_location=self.course.location)
         self.store.create_child(
             self.test_user_id,
             chapter.location,

--- a/cms/djangoapps/contentstore/rest_api/v0/tests/test_tabs.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/tests/test_tabs.py
@@ -8,7 +8,7 @@ from urllib.parse import urlencode
 
 import ddt
 from django.urls import reverse
-from xmodule.modulestore.tests.factories import ItemFactory
+from xmodule.modulestore.tests.factories import BlockFactory
 from xmodule.tabs import CourseTabList
 
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
@@ -43,7 +43,7 @@ class TabsAPITests(CourseTestCase):
         )
 
         # add a static tab to the course, for code coverage
-        self.test_tab = ItemFactory.create(
+        self.test_tab = BlockFactory.create(
             parent_location=self.course.location,
             category="static_tab",
             display_name="Static_1",

--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -37,7 +37,7 @@ from xmodule.modulestore.exceptions import ItemNotFoundError
 from xmodule.modulestore.inheritance import own_metadata
 from xmodule.modulestore.split_mongo import BlockKey
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, check_mongo_calls
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory, check_mongo_calls
 from xmodule.modulestore.xml_exporter import export_course_to_xml
 from xmodule.modulestore.xml_importer import import_course_from_xml, perform_xlint
 from xmodule.seq_block import SequenceBlock
@@ -321,7 +321,7 @@ class ImportRequiredTestCases(ContentStoreTestCase):
 
         parent = verticals[0]
 
-        ItemFactory.create(parent_location=parent.location, category="video", display_name="untitled")
+        BlockFactory.create(parent_location=parent.location, category="video", display_name="untitled")
 
         root_dir = path(mkdtemp_clean())
 
@@ -347,7 +347,7 @@ class ImportRequiredTestCases(ContentStoreTestCase):
 
         parent = verticals[0]
 
-        ItemFactory.create(parent_location=parent.location, category="word_cloud", display_name="untitled")
+        BlockFactory.create(parent_location=parent.location, category="word_cloud", display_name="untitled")
 
         root_dir = path(mkdtemp_clean())
 
@@ -401,7 +401,8 @@ class ImportRequiredTestCases(ContentStoreTestCase):
         parent = verticals[0]
 
         # Create a module, and ensure that its `data` field is empty
-        word_cloud = ItemFactory.create(parent_location=parent.location, category="word_cloud", display_name="untitled")
+        word_cloud = BlockFactory.create(
+            parent_location=parent.location, category="word_cloud", display_name="untitled")
         del word_cloud.data
         self.assertEqual(word_cloud.data, '')
 
@@ -487,7 +488,7 @@ class ImportRequiredTestCases(ContentStoreTestCase):
         vertical = verticals[0]
 
         # create OpenAssessmentBlock:
-        open_assessment = ItemFactory.create(
+        open_assessment = BlockFactory.create(
             parent_location=vertical.location,
             category="openassessment",
             display_name="untitled",
@@ -1362,7 +1363,7 @@ class ContentStoreTest(ContentStoreTestCase):
     def test_item_factory(self):
         """Test that the item factory works correctly."""
         course = CourseFactory.create()
-        item = ItemFactory.create(parent_location=course.location)
+        item = BlockFactory.create(parent_location=course.location)
         self.assertIsInstance(item, SequenceBlock)
 
     def test_course_overview_view_with_course(self):
@@ -1630,7 +1631,7 @@ class ContentStoreTest(ContentStoreTestCase):
 
     def test_default_metadata_inheritance(self):
         course = CourseFactory.create()
-        vertical = ItemFactory.create(parent_location=course.location)
+        vertical = BlockFactory.create(parent_location=course.location)
         course.children.append(vertical)
         # in memory
         self.assertIsNotNone(course.start)
@@ -1712,7 +1713,7 @@ class MetadataSaveTestCase(ContentStoreTestCase):
         """
         video_data = VideoBlock.parse_video_xml(video_sample_xml)
         video_data.pop('source')
-        self.video_descriptor = ItemFactory.create(
+        self.video_descriptor = BlockFactory.create(
             parent_location=course.location, category='video',
             **video_data
         )
@@ -2046,7 +2047,7 @@ class ContentLicenseTest(ContentStoreTestCase):
     def test_video_license_export(self):
         content_store = contentstore()
         root_dir = path(mkdtemp_clean())
-        video_descriptor = ItemFactory.create(
+        video_descriptor = BlockFactory.create(
             parent_location=self.course.location, category='video',
             license="all-rights-reserved"
         )

--- a/cms/djangoapps/contentstore/tests/test_courseware_index.py
+++ b/cms/djangoapps/contentstore/tests/test_courseware_index.py
@@ -35,7 +35,7 @@ from xmodule.modulestore.tests.django_utils import (  # lint-amnesty, pylint: di
     TEST_DATA_SPLIT_MODULESTORE,
     SharedModuleStoreTestCase,
 )
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, LibraryFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory, LibraryFactory  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.partitions.partitions import UserPartition  # lint-amnesty, pylint: disable=wrong-import-order
 
 COURSE_CHILD_STRUCTURE = {
@@ -50,7 +50,7 @@ def create_children(store, parent, category, load_factor):
     """ create load_factor children within the given parent; recursively call to insert children when appropriate """
     created_count = 0
     for child_index in range(load_factor):
-        child_object = ItemFactory.create(
+        child_object = BlockFactory.create(
             parent_location=parent.location,
             category=category,
             display_name=f"{category} {child_index} {time.clock()}",  # lint-amnesty, pylint: disable=no-member
@@ -152,7 +152,7 @@ class TestCoursewareSearchIndexer(MixedWithOptionsTestCase):
             display_name="Search Index Test Course"
         )
 
-        self.chapter = ItemFactory.create(
+        self.chapter = BlockFactory.create(
             parent_location=self.course.location,
             category='chapter',
             display_name="Week 1",
@@ -160,7 +160,7 @@ class TestCoursewareSearchIndexer(MixedWithOptionsTestCase):
             publish_item=True,
             start=datetime(2015, 3, 1, tzinfo=UTC),
         )
-        self.sequential = ItemFactory.create(
+        self.sequential = BlockFactory.create(
             parent_location=self.chapter.location,
             category='sequential',
             display_name="Lesson 1",
@@ -168,7 +168,7 @@ class TestCoursewareSearchIndexer(MixedWithOptionsTestCase):
             publish_item=True,
             start=datetime(2015, 3, 1, tzinfo=UTC),
         )
-        self.vertical = ItemFactory.create(
+        self.vertical = BlockFactory.create(
             parent_location=self.sequential.location,
             category='vertical',
             display_name='Subsection 1',
@@ -177,7 +177,7 @@ class TestCoursewareSearchIndexer(MixedWithOptionsTestCase):
             start=datetime(2015, 4, 1, tzinfo=UTC),
         )
         # unspecified start - should inherit from container
-        self.html_unit = ItemFactory.create(
+        self.html_unit = BlockFactory.create(
             parent_location=self.vertical.location,
             category="html",
             display_name="Html Content",
@@ -227,7 +227,7 @@ class TestCoursewareSearchIndexer(MixedWithOptionsTestCase):
         self.assertEqual(response["total"], 4)
 
         # Now add a new unit to the existing vertical
-        ItemFactory.create(
+        BlockFactory.create(
             parent_location=self.vertical.location,
             category="html",
             display_name="Some other content",
@@ -316,7 +316,7 @@ class TestCoursewareSearchIndexer(MixedWithOptionsTestCase):
         self.assertEqual(indexed_count, 4)
 
         # Add a new sequential
-        sequential2 = ItemFactory.create(
+        sequential2 = BlockFactory.create(
             parent_location=self.chapter.location,
             category='sequential',
             display_name='Section 2',
@@ -326,14 +326,14 @@ class TestCoursewareSearchIndexer(MixedWithOptionsTestCase):
         )
 
         # add a new vertical
-        vertical2 = ItemFactory.create(
+        vertical2 = BlockFactory.create(
             parent_location=sequential2.location,
             category='vertical',
             display_name='Subsection 2',
             modulestore=store,
             publish_item=True,
         )
-        ItemFactory.create(
+        BlockFactory.create(
             parent_location=vertical2.location,
             category="html",
             display_name="Some other content",
@@ -426,7 +426,7 @@ class TestCoursewareSearchIndexer(MixedWithOptionsTestCase):
 
     def _test_course_location_null(self, store):
         """ Test that course location information is added to index """
-        sequential2 = ItemFactory.create(
+        sequential2 = BlockFactory.create(
             parent_location=self.chapter.location,
             category='sequential',
             display_name=None,
@@ -435,14 +435,14 @@ class TestCoursewareSearchIndexer(MixedWithOptionsTestCase):
             start=datetime(2015, 3, 1, tzinfo=UTC),
         )
         # add a new vertical
-        vertical2 = ItemFactory.create(
+        vertical2 = BlockFactory.create(
             parent_location=sequential2.location,
             category='vertical',
             display_name='Subsection 2',
             modulestore=store,
             publish_item=True,
         )
-        ItemFactory.create(
+        BlockFactory.create(
             parent_location=vertical2.location,
             category="html",
             display_name="Find Me",
@@ -600,21 +600,21 @@ class TestTaskExecution(SharedModuleStoreTestCase):
         SignalHandler.library_updated.disconnect(listen_for_library_update)
         cls.course = CourseFactory.create(start=datetime(2015, 3, 1, tzinfo=UTC))
 
-        cls.chapter = ItemFactory.create(
+        cls.chapter = BlockFactory.create(
             parent_location=cls.course.location,
             category='chapter',
             display_name="Week 1",
             publish_item=True,
             start=datetime(2015, 3, 1, tzinfo=UTC),
         )
-        cls.sequential = ItemFactory.create(
+        cls.sequential = BlockFactory.create(
             parent_location=cls.chapter.location,
             category='sequential',
             display_name="Lesson 1",
             publish_item=True,
             start=datetime(2015, 3, 1, tzinfo=UTC),
         )
-        cls.vertical = ItemFactory.create(
+        cls.vertical = BlockFactory.create(
             parent_location=cls.sequential.location,
             category='vertical',
             display_name='Subsection 1',
@@ -622,7 +622,7 @@ class TestTaskExecution(SharedModuleStoreTestCase):
             start=datetime(2015, 4, 1, tzinfo=UTC),
         )
         # unspecified start - should inherit from container
-        cls.html_unit = ItemFactory.create(
+        cls.html_unit = BlockFactory.create(
             parent_location=cls.vertical.location,
             category="html",
             display_name="Html Content",
@@ -631,14 +631,14 @@ class TestTaskExecution(SharedModuleStoreTestCase):
 
         cls.library = LibraryFactory.create()
 
-        cls.library_block1 = ItemFactory.create(
+        cls.library_block1 = BlockFactory.create(
             parent_location=cls.library.location,
             category="html",
             display_name="Html Content",
             publish_item=False,
         )
 
-        cls.library_block2 = ItemFactory.create(
+        cls.library_block2 = BlockFactory.create(
             parent_location=cls.library.location,
             category="html",
             display_name="Html Content 2",
@@ -719,7 +719,7 @@ class TestLibrarySearchIndexer(MixedWithOptionsTestCase):
         """
         self.library = LibraryFactory.create(modulestore=store)
 
-        self.html_unit1 = ItemFactory.create(
+        self.html_unit1 = BlockFactory.create(
             parent_location=self.library.location,
             category="html",
             display_name="Html Content",
@@ -727,7 +727,7 @@ class TestLibrarySearchIndexer(MixedWithOptionsTestCase):
             publish_item=False,
         )
 
-        self.html_unit2 = ItemFactory.create(
+        self.html_unit2 = BlockFactory.create(
             parent_location=self.library.location,
             category="html",
             display_name="Html Content 2",
@@ -768,7 +768,7 @@ class TestLibrarySearchIndexer(MixedWithOptionsTestCase):
 
         # updating a library item causes immediate reindexing
         data = "Some data"
-        ItemFactory.create(
+        BlockFactory.create(
             parent_location=self.library.location,
             category="html",
             display_name="Html Content 3",
@@ -868,7 +868,7 @@ class GroupConfigurationSearchSplit(CourseTestCase, MixedWithOptionsTestCase):
         """
         Set up course with html content in it.
         """
-        self.chapter = ItemFactory.create(
+        self.chapter = BlockFactory.create(
             parent_location=self.course.location,
             category='chapter',
             display_name="Week 1",
@@ -877,7 +877,7 @@ class GroupConfigurationSearchSplit(CourseTestCase, MixedWithOptionsTestCase):
             start=datetime(2015, 3, 1, tzinfo=UTC),
         )
 
-        self.sequential = ItemFactory.create(
+        self.sequential = BlockFactory.create(
             parent_location=self.chapter.location,
             category='sequential',
             display_name="Lesson 1",
@@ -886,7 +886,7 @@ class GroupConfigurationSearchSplit(CourseTestCase, MixedWithOptionsTestCase):
             start=datetime(2015, 3, 1, tzinfo=UTC),
         )
 
-        self.sequential2 = ItemFactory.create(
+        self.sequential2 = BlockFactory.create(
             parent_location=self.chapter.location,
             category='sequential',
             display_name="Lesson 2",
@@ -895,7 +895,7 @@ class GroupConfigurationSearchSplit(CourseTestCase, MixedWithOptionsTestCase):
             start=datetime(2015, 3, 1, tzinfo=UTC),
         )
 
-        self.vertical = ItemFactory.create(
+        self.vertical = BlockFactory.create(
             parent_location=self.sequential.location,
             category='vertical',
             display_name='Subsection 1',
@@ -904,7 +904,7 @@ class GroupConfigurationSearchSplit(CourseTestCase, MixedWithOptionsTestCase):
             start=datetime(2015, 4, 1, tzinfo=UTC),
         )
 
-        self.vertical2 = ItemFactory.create(
+        self.vertical2 = BlockFactory.create(
             parent_location=self.sequential.location,
             category='vertical',
             display_name='Subsection 2',
@@ -913,7 +913,7 @@ class GroupConfigurationSearchSplit(CourseTestCase, MixedWithOptionsTestCase):
             start=datetime(2015, 4, 1, tzinfo=UTC),
         )
 
-        self.vertical3 = ItemFactory.create(
+        self.vertical3 = BlockFactory.create(
             parent_location=self.sequential2.location,
             category='vertical',
             display_name='Subsection 3',
@@ -923,7 +923,7 @@ class GroupConfigurationSearchSplit(CourseTestCase, MixedWithOptionsTestCase):
         )
 
         # unspecified start - should inherit from container
-        self.html_unit1 = ItemFactory.create(
+        self.html_unit1 = BlockFactory.create(
             parent_location=self.vertical.location,
             category="html",
             display_name="Html Content 1",
@@ -932,7 +932,7 @@ class GroupConfigurationSearchSplit(CourseTestCase, MixedWithOptionsTestCase):
         )
         self.html_unit1.parent = self.vertical
 
-        self.html_unit2 = ItemFactory.create(
+        self.html_unit2 = BlockFactory.create(
             parent_location=self.vertical2.location,
             category="html",
             display_name="Html Content 2",
@@ -941,7 +941,7 @@ class GroupConfigurationSearchSplit(CourseTestCase, MixedWithOptionsTestCase):
         )
         self.html_unit2.parent = self.vertical2
 
-        self.html_unit3 = ItemFactory.create(
+        self.html_unit3 = BlockFactory.create(
             parent_location=self.vertical2.location,
             category="html",
             display_name="Html Content 3",
@@ -958,7 +958,7 @@ class GroupConfigurationSearchSplit(CourseTestCase, MixedWithOptionsTestCase):
         c1_url = self.course.id.make_usage_key("vertical", "condition_1_vertical")
         c2_url = self.course.id.make_usage_key("vertical", "condition_2_vertical")
 
-        self.split_test_unit = ItemFactory.create(
+        self.split_test_unit = BlockFactory.create(
             parent_location=self.vertical3.location,
             category='split_test',
             user_partition_id=0,
@@ -966,7 +966,7 @@ class GroupConfigurationSearchSplit(CourseTestCase, MixedWithOptionsTestCase):
             group_id_to_child={"2": c0_url, "3": c1_url, "4": c2_url}
         )
 
-        self.condition_0_vertical = ItemFactory.create(
+        self.condition_0_vertical = BlockFactory.create(
             parent_location=self.split_test_unit.location,
             category="vertical",
             display_name="Group ID 2",
@@ -974,7 +974,7 @@ class GroupConfigurationSearchSplit(CourseTestCase, MixedWithOptionsTestCase):
         )
         self.condition_0_vertical.parent = self.vertical3
 
-        self.condition_1_vertical = ItemFactory.create(
+        self.condition_1_vertical = BlockFactory.create(
             parent_location=self.split_test_unit.location,
             category="vertical",
             display_name="Group ID 3",
@@ -982,7 +982,7 @@ class GroupConfigurationSearchSplit(CourseTestCase, MixedWithOptionsTestCase):
         )
         self.condition_1_vertical.parent = self.vertical3
 
-        self.condition_2_vertical = ItemFactory.create(
+        self.condition_2_vertical = BlockFactory.create(
             parent_location=self.split_test_unit.location,
             category="vertical",
             display_name="Group ID 4",
@@ -990,7 +990,7 @@ class GroupConfigurationSearchSplit(CourseTestCase, MixedWithOptionsTestCase):
         )
         self.condition_2_vertical.parent = self.vertical3
 
-        self.html_unit4 = ItemFactory.create(
+        self.html_unit4 = BlockFactory.create(
             parent_location=self.condition_0_vertical.location,
             category="html",
             display_name="Split A",
@@ -998,7 +998,7 @@ class GroupConfigurationSearchSplit(CourseTestCase, MixedWithOptionsTestCase):
         )
         self.html_unit4.parent = self.condition_0_vertical
 
-        self.html_unit5 = ItemFactory.create(
+        self.html_unit5 = BlockFactory.create(
             parent_location=self.condition_1_vertical.location,
             category="html",
             display_name="Split B",
@@ -1006,7 +1006,7 @@ class GroupConfigurationSearchSplit(CourseTestCase, MixedWithOptionsTestCase):
         )
         self.html_unit5.parent = self.condition_1_vertical
 
-        self.html_unit6 = ItemFactory.create(
+        self.html_unit6 = BlockFactory.create(
             parent_location=self.condition_2_vertical.location,
             category="html",
             display_name="Split C",

--- a/cms/djangoapps/contentstore/tests/test_crud.py
+++ b/cms/djangoapps/contentstore/tests/test_crud.py
@@ -8,7 +8,7 @@ from xmodule.html_block import HtmlBlock
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.exceptions import DuplicateCourseError
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 from xmodule.seq_block import SequenceBlock
 
 
@@ -61,7 +61,7 @@ class TemplateTests(ModuleStoreTestCase):
         self.assertEqual(course_from_store.id.course, 'course')
         self.assertEqual(course_from_store.id.run, '2014')
 
-        test_chapter = ItemFactory.create(
+        test_chapter = BlockFactory.create(
             parent_location=test_course.location,
             category='chapter',
             display_name='chapter 1'
@@ -117,7 +117,7 @@ class TemplateTests(ModuleStoreTestCase):
             display_name='doomed test course',
             user_id=ModuleStoreEnum.UserID.test,
         )
-        ItemFactory.create(
+        BlockFactory.create(
             parent_location=test_course.location,
             category='chapter',
             display_name='chapter 1'

--- a/cms/djangoapps/contentstore/tests/test_exams.py
+++ b/cms/djangoapps/contentstore/tests/test_exams.py
@@ -12,7 +12,7 @@ from pytz import UTC
 from cms.djangoapps.contentstore.signals.handlers import listen_for_course_publish
 from openedx.core.djangoapps.course_apps.toggles import EXAMS_IDA
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
 
 @ddt.ddt
@@ -40,12 +40,12 @@ class TestExamService(ModuleStoreTestCase):
             enable_proctored_exams=True,
             proctoring_provider='null',
         )
-        self.chapter = ItemFactory.create(parent=self.course, category='chapter', display_name='Test Section')
+        self.chapter = BlockFactory.create(parent=self.course, category='chapter', display_name='Test Section')
         self.course_key = str(self.course.id)
 
         # create one non-exam sequence
-        chapter2 = ItemFactory.create(parent=self.course, category='chapter', display_name='Test Homework')
-        ItemFactory.create(
+        chapter2 = BlockFactory.create(parent=self.course, category='chapter', display_name='Test Homework')
+        BlockFactory.create(
             parent=chapter2,
             category='sequential',
             display_name='Homework 1',
@@ -72,7 +72,7 @@ class TestExamService(ModuleStoreTestCase):
         default_time_limit_minutes = 10
         due_date = datetime.now(UTC) + timedelta(minutes=default_time_limit_minutes + 1)
 
-        sequence = ItemFactory.create(
+        sequence = BlockFactory.create(
             parent=self.chapter,
             category='sequential',
             display_name='Test Proctored Exam',
@@ -113,7 +113,7 @@ class TestExamService(ModuleStoreTestCase):
         """
         Make sure we filter out all dangling items
         """
-        ItemFactory.create(
+        BlockFactory.create(
             parent=self.chapter,
             category='sequential',
             display_name='Test Proctored Exam',
@@ -133,7 +133,7 @@ class TestExamService(ModuleStoreTestCase):
         """
         Make sure the feature flag is honored
         """
-        ItemFactory.create(
+        BlockFactory.create(
             parent=self.chapter,
             category='sequential',
             display_name='Test Proctored Exam',
@@ -150,7 +150,7 @@ class TestExamService(ModuleStoreTestCase):
     def test_self_paced_no_due_dates(self, mock_patch_course_exams):
         self.course.self_paced = True
         self.course = self.update_course(self.course, 1)
-        ItemFactory.create(
+        BlockFactory.create(
             parent=self.chapter,
             category='sequential',
             display_name='Test Proctored Exam',

--- a/cms/djangoapps/contentstore/tests/test_gating.py
+++ b/cms/djangoapps/contentstore/tests/test_gating.py
@@ -10,7 +10,7 @@ from milestones.tests.utils import MilestonesTestCaseMixin
 from cms.djangoapps.contentstore.signals.handlers import handle_item_deleted
 from openedx.core.lib.gating import api as gating_api
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 
 class TestHandleItemDeleted(ModuleStoreTestCase, MilestonesTestCaseMixin):
@@ -28,17 +28,17 @@ class TestHandleItemDeleted(ModuleStoreTestCase, MilestonesTestCaseMixin):
         self.course = CourseFactory.create()
         self.course.enable_subsection_gating = True
         self.course.save()
-        self.chapter = ItemFactory.create(
+        self.chapter = BlockFactory.create(
             parent=self.course,
             category="chapter",
             display_name="Chapter"
         )
-        self.open_seq = ItemFactory.create(
+        self.open_seq = BlockFactory.create(
             parent=self.chapter,
             category='sequential',
             display_name="Open Sequential"
         )
-        self.gated_seq = ItemFactory.create(
+        self.gated_seq = BlockFactory.create(
             parent=self.chapter,
             category='sequential',
             display_name="Gated Sequential"

--- a/cms/djangoapps/contentstore/tests/test_i18n.py
+++ b/cms/djangoapps/contentstore/tests/test_i18n.py
@@ -11,7 +11,7 @@ from django.utils.translation import get_language
 from xblock.core import XBlock
 from xmodule.modulestore.django import ModuleI18nService
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 from xmodule.tests.test_export import PureXBlock
 
 from cms.djangoapps.contentstore.tests.utils import AjaxEnabledTestClient
@@ -69,7 +69,7 @@ class TestModuleI18nService(ModuleStoreTestCase):
         self.request = mock.Mock()
         self.course = CourseFactory.create()
         self.field_data = mock.Mock()
-        self.descriptor = ItemFactory(category="pure", parent=self.course)
+        self.descriptor = BlockFactory(category="pure", parent=self.course)
         self.runtime = _preview_module_system(
             self.request,
             self.descriptor,

--- a/cms/djangoapps/contentstore/tests/test_libraries.py
+++ b/cms/djangoapps/contentstore/tests/test_libraries.py
@@ -11,7 +11,7 @@ from opaque_keys.edx.locator import CourseKey, LibraryLocator
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import TEST_DATA_MONGO_MODULESTORE, ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 from xmodule.x_module import STUDIO_VIEW
 
 from cms.djangoapps.contentstore.tests.utils import AjaxEnabledTestClient, parse_json
@@ -80,7 +80,7 @@ class LibraryTestCase(ModuleStoreTestCase):
         specified by library_key.
         other_settings can be a dict of Scope.settings fields to set on the block.
         """
-        return ItemFactory.create(
+        return BlockFactory.create(
             category='library_content',
             parent_location=course.location,
             user_id=self.user.id,
@@ -91,7 +91,7 @@ class LibraryTestCase(ModuleStoreTestCase):
 
     def _add_simple_content_block(self):
         """ Adds simple HTML block to library """
-        return ItemFactory.create(
+        return BlockFactory.create(
             category="html", parent_location=self.library.location,
             user_id=self.user.id, publish_item=False
         )
@@ -188,7 +188,7 @@ class TestLibraries(LibraryTestCase):
         """
         # Create many blocks in the library and add them to a course:
         for num in range(8):
-            ItemFactory.create(
+            BlockFactory.create(
                 data=f"This is #{num + 1}",
                 category="html", parent_location=self.library.location, user_id=self.user.id, publish_item=False
             )
@@ -264,7 +264,7 @@ class TestLibraries(LibraryTestCase):
         """
         data_value = "A Scope.content value"
         name_value = "A Scope.settings value"
-        lib_block = ItemFactory.create(
+        lib_block = BlockFactory.create(
             category="html",
             parent_location=self.library.location,
             user_id=self.user.id,
@@ -294,13 +294,13 @@ class TestLibraries(LibraryTestCase):
         data_value = "A Scope.content value"
         name_value = "A Scope.settings value"
         # In the library, create a vertical block with a child:
-        vert_block = ItemFactory.create(
+        vert_block = BlockFactory.create(
             category="vertical",
             parent_location=self.library.location,
             user_id=self.user.id,
             publish_item=False,
         )
-        child_block = ItemFactory.create(
+        child_block = BlockFactory.create(
             category="html",
             parent_location=vert_block.location,
             user_id=self.user.id,
@@ -334,7 +334,7 @@ class TestLibraries(LibraryTestCase):
         """
         # Add a block to the library:
         data_value = "Hello world!"
-        ItemFactory.create(
+        BlockFactory.create(
             category="html",
             parent_location=self.library.location,
             user_id=self.user.id,
@@ -367,7 +367,7 @@ class TestLibraries(LibraryTestCase):
         library2key = self._create_library("org2", "lib2", "Library2")
         library2 = modulestore().get_library(library2key)
         data1, data2 = "Hello world!", "Hello other world!"
-        ItemFactory.create(
+        BlockFactory.create(
             category="html",
             parent_location=self.library.location,
             user_id=self.user.id,
@@ -376,7 +376,7 @@ class TestLibraries(LibraryTestCase):
             data=data1,
         )
 
-        ItemFactory.create(
+        BlockFactory.create(
             category="html",
             parent_location=library2.location,
             user_id=self.user.id,
@@ -410,7 +410,7 @@ class TestLibraries(LibraryTestCase):
     def test_refreshes_children_if_capa_type_change(self):
         """ Tests that children are automatically refreshed if capa type field changes """
         name1, name2 = "Option Problem", "Multiple Choice Problem"
-        ItemFactory.create(
+        BlockFactory.create(
             category="problem",
             parent_location=self.library.location,
             user_id=self.user.id,
@@ -418,7 +418,7 @@ class TestLibraries(LibraryTestCase):
             display_name=name1,
             data="<problem><optionresponse></optionresponse></problem>",
         )
-        ItemFactory.create(
+        BlockFactory.create(
             category="problem",
             parent_location=self.library.location,
             user_id=self.user.id,
@@ -791,7 +791,7 @@ class TestLibraryAccess(LibraryTestCase):
         instructor_role = CourseInstructorRole(course.id)
         auth.add_users(self.user, instructor_role, self.non_staff_user)
 
-        lib_block = ItemFactory.create(
+        lib_block = BlockFactory.create(
             category='library_content',
             parent_location=course.location,
             user_id=self.non_staff_user.id,
@@ -842,7 +842,7 @@ class TestOverrides(LibraryTestCase):
         self.original_weight = 1
 
         # Create a problem block in the library:
-        self.problem = ItemFactory.create(
+        self.problem = BlockFactory.create(
             category="problem",
             parent_location=self.library.location,
             display_name=self.original_display_name,  # display_name is a Scope.settings field
@@ -982,7 +982,7 @@ class TestOverrides(LibraryTestCase):
         self.problem.display_name = "--changed in library--"
         store.update_item(self.problem, self.user.id)
         # Create an additional problem block in the library:
-        ItemFactory.create(
+        BlockFactory.create(
             category="problem",
             parent_location=self.library.location,
             user_id=self.user.id,

--- a/cms/djangoapps/contentstore/tests/test_outlines.py
+++ b/cms/djangoapps/contentstore/tests/test_outlines.py
@@ -10,7 +10,7 @@ from openedx.core.djangoapps.content.learning_sequences.api import get_course_ou
 from openedx.core.djangoapps.content.learning_sequences.data import CourseOutlineData, ExamData, VisibilityData
 from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 from ..outlines import get_outline_from_modulestore
 
@@ -135,18 +135,18 @@ class OutlineFromModuleStoreTestCase(ModuleStoreTestCase):
     def test_multiple_sections(self):
         """Make sure sequences go into the right places."""
         with self.store.bulk_operations(self.course_key):
-            section_1 = ItemFactory.create(
+            section_1 = BlockFactory.create(
                 parent=self.draft_course,
                 category='chapter',
                 display_name="Section 1 - Three Sequences",
             )
-            ItemFactory.create(
+            BlockFactory.create(
                 parent=self.draft_course,
                 category='chapter',
                 display_name="Section 2 - Empty",
             )
             for i in range(3):
-                ItemFactory.create(
+                BlockFactory.create(
                     parent=section_1,
                     category='sequential',
                     display_name=f"Seq_1_{i}",
@@ -163,23 +163,23 @@ class OutlineFromModuleStoreTestCase(ModuleStoreTestCase):
 
     def test_duplicate_children(self):
         with self.store.bulk_operations(self.course_key):
-            section_1 = ItemFactory.create(
+            section_1 = BlockFactory.create(
                 parent=self.draft_course,
                 category='chapter',
                 display_name="Section",
             )
-            seq = ItemFactory.create(
+            seq = BlockFactory.create(
                 parent=section_1,
                 category='sequential',
                 display_name="standard_seq"
             )
-            section_2 = ItemFactory.create(
+            section_2 = BlockFactory.create(
                 parent=self.draft_course,
                 category='chapter',
                 display_name="Section 2",
                 children=[seq.location]
             )
-            section_3 = ItemFactory.create(
+            section_3 = BlockFactory.create(
                 parent=self.draft_course,
                 category='chapter',
                 display_name="Section 3",
@@ -214,42 +214,42 @@ class OutlineFromModuleStoreTestCase(ModuleStoreTestCase):
         """
         # Course -> Section -> Unit (No Sequence)
         with self.store.bulk_operations(self.course_key):
-            section_1 = ItemFactory.create(
+            section_1 = BlockFactory.create(
                 parent=self.draft_course,
                 category='chapter',
                 display_name="Section",
             )
             # This Unit should be skipped
-            ItemFactory.create(
+            BlockFactory.create(
                 parent=section_1,
                 category='vertical',
                 display_name="u1"
             )
-            ItemFactory.create(
+            BlockFactory.create(
                 parent=section_1,
                 category='sequential',
                 display_name="standard_seq"
             )
-            ItemFactory.create(
+            BlockFactory.create(
                 parent=section_1,
                 category='sequential',
                 display_name="pset_seq"
             )
-            ItemFactory.create(
+            BlockFactory.create(
                 parent=section_1,
                 category='sequential',
                 display_name="video_seq"
             )
 
             # This should work fine
-            section_2 = ItemFactory.create(
+            section_2 = BlockFactory.create(
                 parent=self.draft_course,
                 category='chapter',
                 display_name="Section 2",
             )
 
             # Second error message here
-            ItemFactory.create(
+            BlockFactory.create(
                 parent=section_2,
                 category='vertical',
                 display_name="u2"
@@ -277,12 +277,12 @@ class OutlineFromModuleStoreTestCase(ModuleStoreTestCase):
         """
         # Course -> Sequence (No Section)
         with self.store.bulk_operations(self.course_key):
-            seq = ItemFactory.create(
+            seq = BlockFactory.create(
                 parent=self.draft_course,
                 category='sequential',
                 display_name="Sequence",
             )
-            ItemFactory.create(
+            BlockFactory.create(
                 parent=seq,
                 category='vertical',
                 display_name="Unit",
@@ -301,12 +301,12 @@ class OutlineFromModuleStoreTestCase(ModuleStoreTestCase):
         When display_names are empty, it should fallback on url_names.
         """
         with self.store.bulk_operations(self.course_key):
-            section = ItemFactory.create(
+            section = BlockFactory.create(
                 parent=self.draft_course,
                 category='chapter',
                 display_name=None,
             )
-            sequence = ItemFactory.create(
+            sequence = BlockFactory.create(
                 parent=section,
                 category='sequential',
                 display_name=None,
@@ -324,7 +324,7 @@ class OutlineFromModuleStoreTestCase(ModuleStoreTestCase):
         seen by any student.
         """
         with self.store.bulk_operations(self.course_key):
-            section = ItemFactory.create(
+            section = BlockFactory.create(
                 parent=self.draft_course,
                 category='chapter',
                 display_name='Ch 1',
@@ -334,7 +334,7 @@ class OutlineFromModuleStoreTestCase(ModuleStoreTestCase):
                     51: [],
                 }
             )
-            ItemFactory.create(
+            BlockFactory.create(
                 parent=section,
                 category='sequential',
                 display_name='Seq 1',
@@ -353,14 +353,14 @@ class OutlineFromModuleStoreTestCase(ModuleStoreTestCase):
     def test_bubbled_up_user_partition_groups_no_children(self):
         """Testing empty case to make sure bubble-up code doesn't break."""
         with self.store.bulk_operations(self.course_key):
-            section = ItemFactory.create(
+            section = BlockFactory.create(
                 parent=self.draft_course,
                 category='chapter',
                 display_name='Ch 0',
             )
 
             # Bubble up with no children (nothing happens)
-            ItemFactory.create(
+            BlockFactory.create(
                 parent=section,
                 category='sequential',
                 display_name='Seq 0',
@@ -374,20 +374,20 @@ class OutlineFromModuleStoreTestCase(ModuleStoreTestCase):
     def test_bubbled_up_user_partition_groups_one_child(self):
         """Group settings should bubble up from Unit to Seq. if only one unit"""
         with self.store.bulk_operations(self.course_key):
-            section = ItemFactory.create(
+            section = BlockFactory.create(
                 parent=self.draft_course,
                 category='chapter',
                 display_name='Ch 0',
             )
 
             # Bubble up with 1 child (grabs the setting from child)
-            seq_1 = ItemFactory.create(
+            seq_1 = BlockFactory.create(
                 parent=section,
                 category='sequential',
                 display_name='Seq 1',
                 group_access={}
             )
-            ItemFactory.create(
+            BlockFactory.create(
                 parent=seq_1,
                 category='vertical',
                 display_name='Single Vertical',
@@ -405,27 +405,27 @@ class OutlineFromModuleStoreTestCase(ModuleStoreTestCase):
     def test_bubbled_up_user_partition_groups_multiple_children(self):
         """If all Units have the same group_access, bubble up to Sequence."""
         with self.store.bulk_operations(self.course_key):
-            section = ItemFactory.create(
+            section = BlockFactory.create(
                 parent=self.draft_course,
                 category='chapter',
                 display_name='Ch 0',
             )
 
             # Bubble up with n children, all matching for one group
-            seq_n = ItemFactory.create(
+            seq_n = BlockFactory.create(
                 parent=section,
                 category='sequential',
                 display_name='Seq N',
                 group_access={}
             )
             for i in range(4):
-                ItemFactory.create(
+                BlockFactory.create(
                     parent=seq_n,
                     category='vertical',
                     display_name=f'vertical {i}',
                     group_access={50: [3, 4], 51: [i]}  # Only 50 should get bubbled up
                 )
-            ItemFactory.create(
+            BlockFactory.create(
                 parent=seq_n,
                 category='vertical',
                 display_name='vertical 5',
@@ -440,20 +440,20 @@ class OutlineFromModuleStoreTestCase(ModuleStoreTestCase):
     def test_not_bubbled_up(self):
         """Don't bubble up from Unit if Seq has a conflicting group_access."""
         with self.store.bulk_operations(self.course_key):
-            section = ItemFactory.create(
+            section = BlockFactory.create(
                 parent=self.draft_course,
                 category='chapter',
                 display_name='Ch 0',
             )
 
             # Bubble up with 1 child (grabs the setting from child)
-            seq_1 = ItemFactory.create(
+            seq_1 = BlockFactory.create(
                 parent=section,
                 category='sequential',
                 display_name='Seq 1',
                 group_access={50: [3, 4]}
             )
-            ItemFactory.create(
+            BlockFactory.create(
                 parent=seq_1,
                 category='vertical',
                 display_name='Single Vertical',
@@ -493,12 +493,12 @@ class OutlineFromModuleStoreTestCase(ModuleStoreTestCase):
         over."
         """
         with self.store.bulk_operations(self.course_key):
-            section = ItemFactory.create(
+            section = BlockFactory.create(
                 parent=self.draft_course,
                 category='chapter',
                 display_name="Generated Section",
             )
-            sequence = ItemFactory.create(
+            sequence = BlockFactory.create(
                 parent=section,
                 category='sequential',
                 **kwargs,
@@ -526,17 +526,17 @@ class OutlineFromModuleStoreTaskTestCase(ModuleStoreTestCase):
             run=course_key.run,
             default_store=ModuleStoreEnum.Type.split,
         )
-        section = ItemFactory.create(
+        section = BlockFactory.create(
             parent_location=course.location,
             category="chapter",
             display_name="First Section"
         )
-        ItemFactory.create(
+        BlockFactory.create(
             parent_location=section.location,
             category="sequential",
             display_name="First Sequence"
         )
-        ItemFactory.create(
+        BlockFactory.create(
             parent_location=section.location,
             category="sequential",
             display_name="Second Sequence"

--- a/cms/djangoapps/contentstore/tests/test_proctoring.py
+++ b/cms/djangoapps/contentstore/tests/test_proctoring.py
@@ -12,7 +12,7 @@ from edx_proctoring.api import get_all_exams_for_course, get_review_policy_by_ex
 from pytz import UTC
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
 from cms.djangoapps.contentstore.signals.handlers import listen_for_course_publish
 from common.djangoapps.student.tests.factories import UserFactory
@@ -87,8 +87,8 @@ class TestProctoredExams(ModuleStoreTestCase):
         default_time_limit_minutes = 10
         is_proctored_exam = True
 
-        chapter = ItemFactory.create(parent=self.course, category='chapter', display_name='Test Section')
-        sequence = ItemFactory.create(
+        chapter = BlockFactory.create(parent=self.course, category='chapter', display_name='Test Section')
+        sequence = BlockFactory.create(
             parent=chapter,
             category='sequential',
             display_name='Test Proctored Exam',
@@ -122,8 +122,8 @@ class TestProctoredExams(ModuleStoreTestCase):
         """
         default_time_limit_minutes = 10
 
-        chapter = ItemFactory.create(parent=self.course, category='chapter', display_name='Test Section')
-        sequence = ItemFactory.create(
+        chapter = BlockFactory.create(parent=self.course, category='chapter', display_name='Test Section')
+        sequence = BlockFactory.create(
             parent=chapter,
             category='sequential',
             display_name='Test Proctored Exam',
@@ -158,8 +158,8 @@ class TestProctoredExams(ModuleStoreTestCase):
         Make sure that if we publish and then unpublish a proctored exam,
         the exam record stays, but is marked as is_active=False
         """
-        chapter = ItemFactory.create(parent=self.course, category='chapter', display_name='Test Section')
-        sequence = ItemFactory.create(
+        chapter = BlockFactory.create(parent=self.course, category='chapter', display_name='Test Section')
+        sequence = BlockFactory.create(
             parent=chapter,
             category='sequential',
             display_name='Test Proctored Exam',
@@ -190,8 +190,8 @@ class TestProctoredExams(ModuleStoreTestCase):
         Make sure we filter out all dangling items
         """
 
-        chapter = ItemFactory.create(parent=self.course, category='chapter', display_name='Test Section')
-        ItemFactory.create(
+        chapter = BlockFactory.create(parent=self.course, category='chapter', display_name='Test Section')
+        BlockFactory.create(
             parent=chapter,
             category='sequential',
             display_name='Test Proctored Exam',
@@ -225,8 +225,8 @@ class TestProctoredExams(ModuleStoreTestCase):
         """
         Make sure the feature flag is honored
         """
-        chapter = ItemFactory.create(parent=self.course, category='chapter', display_name='Test Section')
-        ItemFactory.create(
+        chapter = BlockFactory.create(parent=self.course, category='chapter', display_name='Test Section')
+        BlockFactory.create(
             parent=chapter,
             category='sequential',
             display_name='Test Proctored Exam',
@@ -261,8 +261,8 @@ class TestProctoredExams(ModuleStoreTestCase):
             enable_timed_exams=enable_timed_exams
         )
 
-        chapter = ItemFactory.create(parent=self.course, category='chapter', display_name='Test Section')
-        ItemFactory.create(
+        chapter = BlockFactory.create(parent=self.course, category='chapter', display_name='Test Section')
+        BlockFactory.create(
             parent=chapter,
             category='sequential',
             display_name='Test Proctored Exam',
@@ -290,8 +290,8 @@ class TestProctoredExams(ModuleStoreTestCase):
             enable_timed_exams=True,
             self_paced=True,
         )
-        chapter = ItemFactory.create(parent=self.course, category='chapter', display_name='Test Section')
-        ItemFactory.create(
+        chapter = BlockFactory.create(parent=self.course, category='chapter', display_name='Test Section')
+        BlockFactory.create(
             parent=chapter,
             category='sequential',
             display_name='Test Proctored Exam',
@@ -319,8 +319,8 @@ class TestProctoredExams(ModuleStoreTestCase):
         assert exams[0]['due_date'] is not None
 
     def test_async_waffle_flag_publishes(self):
-        chapter = ItemFactory.create(parent=self.course, category='chapter', display_name='Test Section')
-        sequence = ItemFactory.create(
+        chapter = BlockFactory.create(parent=self.course, category='chapter', display_name='Test Section')
+        sequence = BlockFactory.create(
             parent=chapter,
             category='sequential',
             display_name='Test Proctored Exam',
@@ -340,8 +340,8 @@ class TestProctoredExams(ModuleStoreTestCase):
         self._verify_exam_data(sequence, True)
 
     def test_async_waffle_flag_task(self):
-        chapter = ItemFactory.create(parent=self.course, category='chapter', display_name='Test Section')
-        ItemFactory.create(
+        chapter = BlockFactory.create(parent=self.course, category='chapter', display_name='Test Section')
+        BlockFactory.create(
             parent=chapter,
             category='sequential',
             display_name='Test Proctored Exam',

--- a/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
@@ -21,7 +21,7 @@ from xmodule.contentstore.content import StaticContent  # lint-amnesty, pylint: 
 from xmodule.contentstore.django import contentstore  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.exceptions import NotFoundError  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.video_block import transcripts_utils  # lint-amnesty, pylint: disable=wrong-import-order
 
 TEST_DATA_CONTENTSTORE = copy.deepcopy(settings.CONTENTSTORE)
@@ -725,8 +725,8 @@ class TestGetTranscript(SharedModuleStoreTestCase):
         self.sjson_mime_type = transcripts_utils.Transcript.mime_types[transcripts_utils.Transcript.SJSON]
 
         self.user = UserFactory.create()
-        self.vertical = ItemFactory.create(category='vertical', parent_location=self.course.location)
-        self.video = ItemFactory.create(
+        self.vertical = BlockFactory.create(category='vertical', parent_location=self.course.location)
+        self.video = BlockFactory.create(
             category='video',
             parent_location=self.vertical.location,
             edx_video_id='1234-5678-90'
@@ -741,7 +741,7 @@ class TestGetTranscript(SharedModuleStoreTestCase):
             transcripts = {language: filename}
 
         html5_sources = html5_sources or []
-        self.video = ItemFactory.create(
+        self.video = BlockFactory.create(
             category='video',
             parent_location=self.vertical.location,
             sub=subs_id,

--- a/cms/djangoapps/contentstore/tests/test_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_utils.py
@@ -25,7 +25,7 @@ from xmodule.modulestore.tests.django_utils import (  # lint-amnesty, pylint: di
     ModuleStoreTestCase,
     SharedModuleStoreTestCase
 )
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.partitions.partitions import Group, UserPartition  # lint-amnesty, pylint: disable=wrong-import-order
 
 
@@ -180,9 +180,9 @@ class ReleaseDateSourceTest(CourseTestCase):
     def setUp(self):
         super().setUp()
 
-        self.chapter = ItemFactory.create(category='chapter', parent_location=self.course.location)
-        self.sequential = ItemFactory.create(category='sequential', parent_location=self.chapter.location)
-        self.vertical = ItemFactory.create(category='vertical', parent_location=self.sequential.location)
+        self.chapter = BlockFactory.create(category='chapter', parent_location=self.course.location)
+        self.sequential = BlockFactory.create(category='sequential', parent_location=self.chapter.location)
+        self.vertical = BlockFactory.create(category='vertical', parent_location=self.sequential.location)
 
         # Read again so that children lists are accurate
         self.chapter = self.store.get_item(self.chapter.location)
@@ -234,10 +234,10 @@ class StaffLockTest(CourseTestCase):
     def setUp(self):
         super().setUp()
 
-        self.chapter = ItemFactory.create(category='chapter', parent_location=self.course.location)
-        self.sequential = ItemFactory.create(category='sequential', parent_location=self.chapter.location)
-        self.vertical = ItemFactory.create(category='vertical', parent_location=self.sequential.location)
-        self.orphan = ItemFactory.create(category='vertical', parent_location=self.sequential.location)
+        self.chapter = BlockFactory.create(category='chapter', parent_location=self.course.location)
+        self.sequential = BlockFactory.create(category='sequential', parent_location=self.chapter.location)
+        self.vertical = BlockFactory.create(category='vertical', parent_location=self.sequential.location)
+        self.orphan = BlockFactory.create(category='vertical', parent_location=self.sequential.location)
 
         # Read again so that children lists are accurate
         self.chapter = self.store.get_item(self.chapter.location)
@@ -345,11 +345,11 @@ class GroupVisibilityTest(CourseTestCase):
 
     def setUp(self):
         super().setUp()
-        chapter = ItemFactory.create(category='chapter', parent=self.course)
-        sequential = ItemFactory.create(category='sequential', parent=chapter)
-        vertical = ItemFactory.create(category='vertical', parent=sequential)
-        html = ItemFactory.create(category='html', parent=vertical)
-        problem = ItemFactory.create(
+        chapter = BlockFactory.create(category='chapter', parent=self.course)
+        sequential = BlockFactory.create(category='sequential', parent=chapter)
+        vertical = BlockFactory.create(category='vertical', parent=sequential)
+        html = BlockFactory.create(category='html', parent=vertical)
+        problem = BlockFactory.create(
             category='problem', parent=vertical, data="<problem></problem>"
         )
         self.sequential = self.store.get_item(sequential.location)
@@ -449,7 +449,7 @@ class GetUserPartitionInfoTest(ModuleStoreTestCase):
         """Create a dummy course. """
         super().setUp()
         self.course = CourseFactory()
-        self.block = ItemFactory.create(category="problem", parent_location=self.course.location)
+        self.block = BlockFactory.create(category="problem", parent_location=self.course.location)
 
         # Set up some default partitions
         self._set_partitions([

--- a/cms/djangoapps/contentstore/views/tests/test_container_page.py
+++ b/cms/djangoapps/contentstore/views/tests/test_container_page.py
@@ -16,7 +16,7 @@ import cms.djangoapps.contentstore.views.component as views
 from cms.djangoapps.contentstore.tests.test_libraries import LibraryTestCase
 from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 from .utils import StudioPageTestCase
 
@@ -181,7 +181,7 @@ class ContainerPageTestCase(StudioPageTestCase, LibraryTestCase):
         """
         creates an item in the module store, without publishing it.
         """
-        return ItemFactory.create(
+        return BlockFactory.create(
             parent_location=parent_location,
             category=category,
             display_name=display_name,

--- a/cms/djangoapps/contentstore/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_index.py
@@ -35,7 +35,7 @@ from openedx.core.djangoapps.content.course_overviews.tests.factories import Cou
 from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.exceptions import ItemNotFoundError  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, LibraryFactory, check_mongo_calls  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory, LibraryFactory, check_mongo_calls  # lint-amnesty, pylint: disable=wrong-import-order
 
 from ..course import _deprecated_blocks_info, course_outline_initial_state, reindex_course_and_check_access
 from ..item import VisibilityState, create_xblock_info
@@ -136,14 +136,14 @@ class TestCourseIndex(CourseTestCase):
     def test_json_responses(self):
 
         outline_url = reverse_course_url('course_handler', self.course.id)
-        chapter = ItemFactory.create(parent_location=self.course.location, category='chapter', display_name="Week 1")
-        lesson = ItemFactory.create(parent_location=chapter.location, category='sequential', display_name="Lesson 1")
-        subsection = ItemFactory.create(
+        chapter = BlockFactory.create(parent_location=self.course.location, category='chapter', display_name="Week 1")
+        lesson = BlockFactory.create(parent_location=chapter.location, category='sequential', display_name="Lesson 1")
+        subsection = BlockFactory.create(
             parent_location=lesson.location,
             category='vertical',
             display_name='Subsection 1'
         )
-        ItemFactory.create(parent_location=subsection.location, category="video", display_name="My Video")
+        BlockFactory.create(parent_location=subsection.location, category="video", display_name="My Video")
 
         resp = self.client.get(outline_url, HTTP_ACCEPT='application/json')
 
@@ -460,16 +460,16 @@ class TestCourseOutline(CourseTestCase):
         """
         super().setUp()
 
-        self.chapter = ItemFactory.create(
+        self.chapter = BlockFactory.create(
             parent_location=self.course.location, category='chapter', display_name="Week 1"
         )
-        self.sequential = ItemFactory.create(
+        self.sequential = BlockFactory.create(
             parent_location=self.chapter.location, category='sequential', display_name="Lesson 1"
         )
-        self.vertical = ItemFactory.create(
+        self.vertical = BlockFactory.create(
             parent_location=self.sequential.location, category='vertical', display_name='Subsection 1'
         )
-        self.video = ItemFactory.create(
+        self.video = BlockFactory.create(
             parent_location=self.vertical.location, category="video", display_name="My Video"
         )
 
@@ -549,7 +549,7 @@ class TestCourseOutline(CourseTestCase):
         """
         if create_blocks:
             for block_type in block_types:
-                ItemFactory.create(
+                BlockFactory.create(
                     parent_location=self.vertical.location,
                     category=block_type,
                     display_name=f'{block_type} Problem'
@@ -669,20 +669,20 @@ class TestCourseReIndex(CourseTestCase):
         self.course.start = datetime.datetime(2014, 1, 1, tzinfo=pytz.utc)
         modulestore().update_item(self.course, self.user.id)
 
-        self.chapter = ItemFactory.create(
+        self.chapter = BlockFactory.create(
             parent_location=self.course.location, category='chapter', display_name="Week 1"
         )
-        self.sequential = ItemFactory.create(
+        self.sequential = BlockFactory.create(
             parent_location=self.chapter.location, category='sequential', display_name="Lesson 1"
         )
-        self.vertical = ItemFactory.create(
+        self.vertical = BlockFactory.create(
             parent_location=self.sequential.location, category='vertical', display_name='Subsection 1'
         )
-        self.video = ItemFactory.create(
+        self.video = BlockFactory.create(
             parent_location=self.vertical.location, category="video", display_name="My Video"
         )
 
-        self.html = ItemFactory.create(
+        self.html = BlockFactory.create(
             parent_location=self.vertical.location, category="html", display_name="My HTML",
             data="<div>This is my unique HTML content</div>",
 
@@ -748,7 +748,7 @@ class TestCourseReIndex(CourseTestCase):
         """
         Test json response with real data
         """
-        # results are indexed because they are published from ItemFactory
+        # results are indexed because they are published from BlockFactory
         response = perform_search(
             "unique",
             user=self.user,
@@ -774,7 +774,7 @@ class TestCourseReIndex(CourseTestCase):
         """
         Test json response with mocked error data for video
         """
-        # results are indexed because they are published from ItemFactory
+        # results are indexed because they are published from BlockFactory
         response = perform_search(
             "unique",
             user=self.user,
@@ -796,7 +796,7 @@ class TestCourseReIndex(CourseTestCase):
         """
         Test json response with mocked error data for html
         """
-        # results are indexed because they are published from ItemFactory
+        # results are indexed because they are published from BlockFactory
         response = perform_search(
             "unique",
             user=self.user,
@@ -818,7 +818,7 @@ class TestCourseReIndex(CourseTestCase):
         """
         Test json response with mocked error data for sequence
         """
-        # results are indexed because they are published from ItemFactory
+        # results are indexed because they are published from BlockFactory
         response = perform_search(
             "unique",
             user=self.user,
@@ -858,7 +858,7 @@ class TestCourseReIndex(CourseTestCase):
         """
         Test do_course_reindex response with real data
         """
-        # results are indexed because they are published from ItemFactory
+        # results are indexed because they are published from BlockFactory
         response = perform_search(
             "unique",
             user=self.user,
@@ -884,7 +884,7 @@ class TestCourseReIndex(CourseTestCase):
         """
         Test do_course_reindex response with mocked error data for video
         """
-        # results are indexed because they are published from ItemFactory
+        # results are indexed because they are published from BlockFactory
         response = perform_search(
             "unique",
             user=self.user,
@@ -906,7 +906,7 @@ class TestCourseReIndex(CourseTestCase):
         """
         Test do_course_reindex response with mocked error data for html
         """
-        # results are indexed because they are published from ItemFactory
+        # results are indexed because they are published from BlockFactory
         response = perform_search(
             "unique",
             user=self.user,
@@ -928,7 +928,7 @@ class TestCourseReIndex(CourseTestCase):
         """
         Test do_course_reindex response with mocked error data for sequence
         """
-        # results are indexed because they are published from ItemFactory
+        # results are indexed because they are published from BlockFactory
         response = perform_search(
             "unique",
             user=self.user,

--- a/cms/djangoapps/contentstore/views/tests/test_discussion_enabled.py
+++ b/cms/djangoapps/contentstore/views/tests/test_discussion_enabled.py
@@ -5,7 +5,7 @@ Test module to test the discussion enabled flag.
 
 import json
 
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
 from cms.djangoapps.contentstore.utils import reverse_usage_url
@@ -32,25 +32,25 @@ class TestDiscussionEnabled(CourseTestCase):
             run="2020_T2",
             modulestore=self.store
         )
-        self.chapter = ItemFactory(
+        self.chapter = BlockFactory(
             parent_location=self.course.location,
             category="chapter",
             display_name="What is SHIELD?",
             modulestore=self.store
         )
-        self.sequential = ItemFactory(
+        self.sequential = BlockFactory(
             parent_location=self.chapter.location,
             category="sequential",
             display_name="HQ",
             modulestore=self.store
         )
-        self.vertical = ItemFactory(
+        self.vertical = BlockFactory(
             parent_location=self.sequential.location,
             category="vertical",
             display_name="Triskelion",
             modulestore=self.store
         )
-        self.vertical_1 = ItemFactory(
+        self.vertical_1 = BlockFactory(
             parent_location=self.sequential.location,
             category="vertical",
             display_name="Helicarrier",

--- a/cms/djangoapps/contentstore/views/tests/test_gating.py
+++ b/cms/djangoapps/contentstore/views/tests/test_gating.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 import ddt
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE
-from xmodule.modulestore.tests.factories import ItemFactory
+from xmodule.modulestore.tests.factories import BlockFactory
 
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
 from cms.djangoapps.contentstore.utils import reverse_usage_url
@@ -36,21 +36,21 @@ class TestSubsectionGating(CourseTestCase):
         self.save_course()
 
         # create a chapter
-        self.chapter = ItemFactory.create(
+        self.chapter = BlockFactory.create(
             parent_location=self.course.location,
             category='chapter',
             display_name='untitled chapter'
         )
 
         # create 2 sequentials
-        self.seq1 = ItemFactory.create(
+        self.seq1 = BlockFactory.create(
             parent_location=self.chapter.location,
             category='sequential',
             display_name='untitled sequential 1'
         )
         self.seq1_url = reverse_usage_url('xblock_handler', self.seq1.location)
 
-        self.seq2 = ItemFactory.create(
+        self.seq2 = BlockFactory.create(
             parent_location=self.chapter.location,
             category='sequential',
             display_name='untitled sequential 2'
@@ -150,7 +150,7 @@ class TestSubsectionGating(CourseTestCase):
     @patch('cms.djangoapps.contentstore.signals.handlers.gating_api.set_required_content')
     @patch('cms.djangoapps.contentstore.signals.handlers.gating_api.remove_prerequisite')
     def test_delete_item_signal_handler_called(self, mock_remove_prereq, mock_set_required):
-        seq3 = ItemFactory.create(
+        seq3 = BlockFactory.create(
             parent_location=self.chapter.location,
             category='sequential',
             display_name='untitled sequential 3'

--- a/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
+++ b/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
@@ -20,7 +20,7 @@ from openedx.features.content_type_gating.helpers import CONTENT_GATING_PARTITIO
 from openedx.features.content_type_gating.partitions import CONTENT_TYPE_GATING_SCHEME
 from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.partitions.partitions import ENROLLMENT_TRACK_PARTITION_ID, Group, UserPartition  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.validation import StudioValidation, StudioValidationMessage  # lint-amnesty, pylint: disable=wrong-import-order
 
@@ -54,12 +54,12 @@ class HelperMethods:
         Assign Group Configuration to the experiment if cid is provided.
         Assigns a problem to the first group in the split test if group_id and cid_for_problem is provided.
         """
-        sequential = ItemFactory.create(
+        sequential = BlockFactory.create(
             category='sequential',
             parent_location=self.course.location,
             display_name=f'Test Subsection {name_suffix}'
         )
-        vertical = ItemFactory.create(
+        vertical = BlockFactory.create(
             category='vertical',
             parent_location=sequential.location,
             display_name=f'Test Unit {name_suffix}'
@@ -67,26 +67,26 @@ class HelperMethods:
         c0_url = self.course.id.make_usage_key("vertical", f"split_test_cond0_{name_suffix}")
         c1_url = self.course.id.make_usage_key("vertical", f"split_test_cond1_{name_suffix}")
         c2_url = self.course.id.make_usage_key("vertical", f"split_test_cond2_{name_suffix}")
-        split_test = ItemFactory.create(
+        split_test = BlockFactory.create(
             category='split_test',
             parent_location=vertical.location,
             user_partition_id=cid,
             display_name=f"Test Content Experiment {name_suffix}{special_characters}",
             group_id_to_child={"0": c0_url, "1": c1_url, "2": c2_url}
         )
-        ItemFactory.create(
+        BlockFactory.create(
             parent_location=split_test.location,
             category="vertical",
             display_name="Condition 0 vertical",
             location=c0_url,
         )
-        c1_vertical = ItemFactory.create(
+        c1_vertical = BlockFactory.create(
             parent_location=split_test.location,
             category="vertical",
             display_name="Condition 1 vertical",
             location=c1_url,
         )
-        ItemFactory.create(
+        BlockFactory.create(
             parent_location=split_test.location,
             category="vertical",
             display_name="Condition 2 vertical",
@@ -95,7 +95,7 @@ class HelperMethods:
 
         problem = None
         if group_id and cid_for_problem:
-            problem = ItemFactory.create(
+            problem = BlockFactory.create(
                 category='problem',
                 parent_location=c1_vertical.location,
                 display_name="Test Problem"
@@ -123,20 +123,20 @@ class HelperMethods:
         """
         vertical_parent_location = self.course.location
         if not orphan:
-            subsection = ItemFactory.create(
+            subsection = BlockFactory.create(
                 category='sequential',
                 parent_location=self.course.location,
                 display_name=f"Test Subsection {name_suffix}"
             )
             vertical_parent_location = subsection.location
 
-        vertical = ItemFactory.create(
+        vertical = BlockFactory.create(
             category='vertical',
             parent_location=vertical_parent_location,
             display_name=f"Test Unit {name_suffix}"
         )
 
-        problem = ItemFactory.create(
+        problem = BlockFactory.create(
             category='problem',
             parent_location=vertical.location,
             display_name=f"Test Problem {name_suffix}{special_characters}"

--- a/cms/djangoapps/contentstore/views/tests/test_helpers.py
+++ b/cms/djangoapps/contentstore/views/tests/test_helpers.py
@@ -6,7 +6,7 @@ Unit tests for helpers.py.
 from django.utils import http
 
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
-from xmodule.modulestore.tests.factories import ItemFactory, LibraryFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import BlockFactory, LibraryFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 from ..helpers import xblock_studio_url, xblock_type_display_name
 
@@ -23,34 +23,34 @@ class HelpersTestCase(CourseTestCase):
         self.assertEqual(xblock_studio_url(self.course), course_url)
 
         # Verify chapter URL
-        chapter = ItemFactory.create(parent_location=self.course.location, category='chapter',
-                                     display_name="Week 1")
+        chapter = BlockFactory.create(parent_location=self.course.location, category='chapter',
+                                      display_name="Week 1")
         self.assertEqual(
             xblock_studio_url(chapter),
             f'{course_url}?show={http.urlquote(str(chapter.location).encode())}'
         )
 
         # Verify sequential URL
-        sequential = ItemFactory.create(parent_location=chapter.location, category='sequential',
-                                        display_name="Lesson 1")
+        sequential = BlockFactory.create(parent_location=chapter.location, category='sequential',
+                                         display_name="Lesson 1")
         self.assertEqual(
             xblock_studio_url(sequential),
             f'{course_url}?show={http.urlquote(str(sequential.location).encode())}'
         )
 
         # Verify unit URL
-        vertical = ItemFactory.create(parent_location=sequential.location, category='vertical',
-                                      display_name='Unit')
+        vertical = BlockFactory.create(parent_location=sequential.location, category='vertical',
+                                       display_name='Unit')
         self.assertEqual(xblock_studio_url(vertical), f'/container/{vertical.location}')
 
         # Verify child vertical URL
-        child_vertical = ItemFactory.create(parent_location=vertical.location, category='vertical',
-                                            display_name='Child Vertical')
+        child_vertical = BlockFactory.create(parent_location=vertical.location, category='vertical',
+                                             display_name='Child Vertical')
         self.assertEqual(xblock_studio_url(child_vertical), f'/container/{child_vertical.location}')
 
         # Verify video URL
-        video = ItemFactory.create(parent_location=child_vertical.location, category="video",
-                                   display_name="My Video")
+        video = BlockFactory.create(parent_location=child_vertical.location, category="video",
+                                    display_name="My Video")
         self.assertIsNone(xblock_studio_url(video))
 
         # Verify library URL
@@ -61,31 +61,31 @@ class HelpersTestCase(CourseTestCase):
     def test_xblock_type_display_name(self):
 
         # Verify chapter type display name
-        chapter = ItemFactory.create(parent_location=self.course.location, category='chapter')
+        chapter = BlockFactory.create(parent_location=self.course.location, category='chapter')
         self.assertEqual(xblock_type_display_name(chapter), 'Section')
         self.assertEqual(xblock_type_display_name('chapter'), 'Section')
 
         # Verify sequential type display name
-        sequential = ItemFactory.create(parent_location=chapter.location, category='sequential')
+        sequential = BlockFactory.create(parent_location=chapter.location, category='sequential')
         self.assertEqual(xblock_type_display_name(sequential), 'Subsection')
         self.assertEqual(xblock_type_display_name('sequential'), 'Subsection')
 
         # Verify unit type display names
-        vertical = ItemFactory.create(parent_location=sequential.location, category='vertical')
+        vertical = BlockFactory.create(parent_location=sequential.location, category='vertical')
         self.assertEqual(xblock_type_display_name(vertical), 'Unit')
         self.assertEqual(xblock_type_display_name('vertical'), 'Unit')
 
         # Verify child vertical type display name
-        child_vertical = ItemFactory.create(parent_location=vertical.location, category='vertical',
-                                            display_name='Child Vertical')
+        child_vertical = BlockFactory.create(parent_location=vertical.location, category='vertical',
+                                             display_name='Child Vertical')
         self.assertEqual(xblock_type_display_name(child_vertical), 'Vertical')
 
         # Verify video type display names
-        video = ItemFactory.create(parent_location=vertical.location, category="video")
+        video = BlockFactory.create(parent_location=vertical.location, category="video")
         self.assertEqual(xblock_type_display_name(video), 'Video')
         self.assertEqual(xblock_type_display_name('video'), 'Video')
 
         # Verify split test type display names
-        split_test = ItemFactory.create(parent_location=vertical.location, category="split_test")
+        split_test = BlockFactory.create(parent_location=vertical.location, category="split_test")
         self.assertEqual(xblock_type_display_name(split_test), 'Content Experiment')
         self.assertEqual(xblock_type_display_name('split_test'), 'Content Experiment')

--- a/cms/djangoapps/contentstore/views/tests/test_import_export.py
+++ b/cms/djangoapps/contentstore/views/tests/test_import_export.py
@@ -43,7 +43,7 @@ from xmodule.contentstore.django import contentstore  # lint-amnesty, pylint: di
 from xmodule.modulestore import LIBRARY_ROOT, ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.exceptions import DuplicateCourseError, InvalidProctoringProvider  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, LibraryFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory, LibraryFactory  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.utils import SPLIT_MODULESTORE_SETUP, TEST_DATA_DIR, MongoContentstoreBuilder  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.xml_exporter import export_course_to_xml, export_library_to_xml  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.xml_importer import (  # lint-amnesty, pylint: disable=wrong-import-order
@@ -407,13 +407,13 @@ class ImportTestCase(CourseTestCase):
         # Create some blocks to overwrite
         library = LibraryFactory.create(modulestore=self.store)
         lib_key = library.location.library_key
-        test_block = ItemFactory.create(
+        test_block = BlockFactory.create(
             category="vertical",
             parent_location=library.location,
             user_id=self.user.id,
             publish_item=False,
         )
-        test_block2 = ItemFactory.create(
+        test_block2 = BlockFactory.create(
             category="vertical",
             parent_location=library.location,
             user_id=self.user.id,
@@ -422,13 +422,13 @@ class ImportTestCase(CourseTestCase):
         # Create a library and blocks that should remain unmolested.
         unchanged_lib = LibraryFactory.create()
         unchanged_key = unchanged_lib.location.library_key
-        test_block3 = ItemFactory.create(
+        test_block3 = BlockFactory.create(
             category="vertical",
             parent_location=unchanged_lib.location,
             user_id=self.user.id,
             publish_item=False
         )
-        test_block4 = ItemFactory.create(
+        test_block4 = BlockFactory.create(
             category="vertical",
             parent_location=unchanged_lib.location,
             user_id=self.user.id,
@@ -749,7 +749,7 @@ class ExportTestCase(CourseTestCase):
         """
         Export unknown XBlock type (i.e. we uninstalled the XBlock), top level.
         """
-        fake_xblock = ItemFactory.create(
+        fake_xblock = BlockFactory.create(
             parent_location=self.course.location,
             category='not_a_real_block_type'
         )
@@ -784,12 +784,12 @@ class ExportTestCase(CourseTestCase):
         """
         Export unknown XBlock type deeper in the course.
         """
-        vertical = ItemFactory.create(
+        vertical = BlockFactory.create(
             parent_location=self.course.location,
             category='vertical',
             display_name='sample_vertical',
         )
-        fake_xblock = ItemFactory.create(
+        fake_xblock = BlockFactory.create(
             parent_location=vertical.location,
             category='not_a_real_block_type',
         )
@@ -849,7 +849,7 @@ class ExportTestCase(CourseTestCase):
         """
         youtube_id = "qS4NO9MNC6w"
         library = LibraryFactory.create(modulestore=self.store)
-        video_block = ItemFactory.create(
+        video_block = BlockFactory.create(
             category="video",
             parent_location=library.location,
             user_id=self.user.id,
@@ -880,10 +880,10 @@ class ExportTestCase(CourseTestCase):
         Verify that course export with customtag
         """
         xml_string = '<impl>slides</impl>'
-        vertical = ItemFactory.create(
+        vertical = BlockFactory.create(
             parent_location=self.course.location, category='vertical', display_name='foo'
         )
-        ItemFactory.create(
+        BlockFactory.create(
             parent_location=vertical.location,
             category='customtag',
             display_name='custom_tag_foo',
@@ -1078,7 +1078,7 @@ class TestCourseExportImport(LibraryTestCase):
         self.export_dir = tempfile.mkdtemp()
 
         # Create a problem in library
-        ItemFactory.create(
+        BlockFactory.create(
             category="problem",
             parent_location=self.library.location,
             user_id=self.user.id,
@@ -1095,17 +1095,17 @@ class TestCourseExportImport(LibraryTestCase):
         """
         Sets up course with library content.
         """
-        chapter = ItemFactory.create(
+        chapter = BlockFactory.create(
             parent_location=self.source_course.location,
             category='chapter',
             display_name='Test Section'
         )
-        sequential = ItemFactory.create(
+        sequential = BlockFactory.create(
             parent_location=chapter.location,
             category='sequential',
             display_name='Test Sequential'
         )
-        vertical = ItemFactory.create(
+        vertical = BlockFactory.create(
             category='vertical',
             parent_location=sequential.location,
             display_name='Test Unit'
@@ -1213,23 +1213,23 @@ class TestCourseExportImportProblem(CourseTestCase):
         """
         Sets up course with problem content.
         """
-        chapter = ItemFactory.create(
+        chapter = BlockFactory.create(
             parent_location=self.source_course.location,
             category='chapter',
             display_name='Test Section'
         )
-        sequential = ItemFactory.create(
+        sequential = BlockFactory.create(
             parent_location=chapter.location,
             category='sequential',
             display_name='Test Sequential'
         )
-        vertical = ItemFactory.create(
+        vertical = BlockFactory.create(
             category='vertical',
             parent_location=sequential.location,
             display_name='Test Unit'
         )
 
-        ItemFactory.create(
+        BlockFactory.create(
             parent=vertical,
             category='problem',
             display_name='Test Problem',

--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -33,7 +33,7 @@ from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, LibraryFactory, check_mongo_calls
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory, LibraryFactory, check_mongo_calls
 from xmodule.partitions.partitions import (
     ENROLLMENT_TRACK_PARTITION_ID,
     MINIMUM_STATIC_PARTITION_ID,
@@ -2543,17 +2543,17 @@ class TestXBlockInfo(ItemTest):
     def setUp(self):
         super().setUp()
         user_id = self.user.id
-        self.chapter = ItemFactory.create(
+        self.chapter = BlockFactory.create(
             parent_location=self.course.location, category='chapter', display_name="Week 1", user_id=user_id,
             highlights=['highlight'],
         )
-        self.sequential = ItemFactory.create(
+        self.sequential = BlockFactory.create(
             parent_location=self.chapter.location, category='sequential', display_name="Lesson 1", user_id=user_id
         )
-        self.vertical = ItemFactory.create(
+        self.vertical = BlockFactory.create(
             parent_location=self.sequential.location, category='vertical', display_name='Unit 1', user_id=user_id
         )
-        self.video = ItemFactory.create(
+        self.video = BlockFactory.create(
             parent_location=self.vertical.location, category='video', display_name='My Video', user_id=user_id
         )
 
@@ -2571,18 +2571,18 @@ class TestXBlockInfo(ItemTest):
     def test_xblock_outline_handler_mongo_calls(self, store_type, chapter_queries, chapter_queries_1):
         with self.store.default_store(store_type):
             course = CourseFactory.create()
-            chapter = ItemFactory.create(
+            chapter = BlockFactory.create(
                 parent_location=course.location, category='chapter', display_name='Week 1'
             )
             outline_url = reverse_usage_url('xblock_outline_handler', chapter.location)
             with check_mongo_calls(chapter_queries):
                 self.client.get(outline_url, HTTP_ACCEPT='application/json')
 
-            sequential = ItemFactory.create(
+            sequential = BlockFactory.create(
                 parent_location=chapter.location, category='sequential', display_name='Sequential 1'
             )
 
-            ItemFactory.create(
+            BlockFactory.create(
                 parent_location=sequential.location, category='vertical', display_name='Vertical 1'
             )
             # calls should be same after adding two new children for split only.
@@ -2590,7 +2590,7 @@ class TestXBlockInfo(ItemTest):
                 self.client.get(outline_url, HTTP_ACCEPT='application/json')
 
     def test_entrance_exam_chapter_xblock_info(self):
-        chapter = ItemFactory.create(
+        chapter = BlockFactory.create(
             parent_location=self.course.location, category='chapter', display_name="Entrance Exam",
             user_id=self.user.id, is_entrance_exam=True
         )
@@ -2609,7 +2609,7 @@ class TestXBlockInfo(ItemTest):
         self.assertIsNone(xblock_info.get('is_header_visible', None))
 
     def test_none_entrance_exam_chapter_xblock_info(self):
-        chapter = ItemFactory.create(
+        chapter = BlockFactory.create(
             parent_location=self.course.location, category='chapter', display_name="Test Chapter",
             user_id=self.user.id
         )
@@ -2629,12 +2629,12 @@ class TestXBlockInfo(ItemTest):
         self.assertIsNone(xblock_info.get('is_header_visible', None))
 
     def test_entrance_exam_sequential_xblock_info(self):
-        chapter = ItemFactory.create(
+        chapter = BlockFactory.create(
             parent_location=self.course.location, category='chapter', display_name="Entrance Exam",
             user_id=self.user.id, is_entrance_exam=True, in_entrance_exam=True
         )
 
-        subsection = ItemFactory.create(
+        subsection = BlockFactory.create(
             parent_location=chapter.location, category='sequential', display_name="Subsection - Entrance Exam",
             user_id=self.user.id, in_entrance_exam=True
         )
@@ -2649,7 +2649,7 @@ class TestXBlockInfo(ItemTest):
         self.assertEqual(xblock_info['display_name'], 'Subsection - Entrance Exam')
 
     def test_none_entrance_exam_sequential_xblock_info(self):
-        subsection = ItemFactory.create(
+        subsection = BlockFactory.create(
             parent_location=self.chapter.location, category='sequential', display_name="Subsection - Exam",
             user_id=self.user.id
         )
@@ -2710,7 +2710,7 @@ class TestXBlockInfo(ItemTest):
         """
         with self.store.default_store(store_type):
             course = CourseFactory.create()
-            chapter = ItemFactory.create(
+            chapter = BlockFactory.create(
                 parent_location=course.location, category='chapter', display_name='Week 1'
             )
 
@@ -2868,7 +2868,7 @@ class TestSpecialExamXBlockInfo(ItemTest):
     def setUp(self):
         super().setUp()
         user_id = self.user.id
-        self.chapter = ItemFactory.create(
+        self.chapter = BlockFactory.create(
             parent_location=self.course.location, category='chapter', display_name="Week 1", user_id=user_id,
             highlights=['highlight'],
         )
@@ -2895,7 +2895,7 @@ class TestSpecialExamXBlockInfo(ItemTest):
             _mock_does_backend_support_onboarding,
             mock_get_exam_configuration_dashboard_url,
     ):
-        sequential = ItemFactory.create(
+        sequential = BlockFactory.create(
             parent_location=self.chapter.location,
             category='sequential',
             display_name="Test Lesson 1",
@@ -2937,7 +2937,7 @@ class TestSpecialExamXBlockInfo(ItemTest):
             _mock_does_backend_support_onboarding_patch,
             _mock_get_exam_configuration_dashboard_url,
     ):
-        sequential = ItemFactory.create(
+        sequential = BlockFactory.create(
             parent_location=self.chapter.location,
             category='sequential',
             display_name="Test Lesson 1",
@@ -2965,7 +2965,7 @@ class TestSpecialExamXBlockInfo(ItemTest):
             _mock_does_backend_support_onboarding_patch,
             _mock_get_exam_configuration_dashboard_url,
     ):
-        sequential = ItemFactory.create(
+        sequential = BlockFactory.create(
             parent_location=self.chapter.location,
             category='sequential',
             display_name="Test Lesson 1",
@@ -2993,13 +2993,13 @@ class TestLibraryXBlockInfo(ModuleStoreTestCase):
         super().setUp()
         user_id = self.user.id
         self.library = LibraryFactory.create()
-        self.top_level_html = ItemFactory.create(
+        self.top_level_html = BlockFactory.create(
             parent_location=self.library.location, category='html', user_id=user_id, publish_item=False
         )
-        self.vertical = ItemFactory.create(
+        self.vertical = BlockFactory.create(
             parent_location=self.library.location, category='vertical', user_id=user_id, publish_item=False
         )
-        self.child_html = ItemFactory.create(
+        self.child_html = BlockFactory.create(
             parent_location=self.vertical.location, category='html', display_name='Test HTML Child Block',
             user_id=user_id, publish_item=False
         )
@@ -3083,7 +3083,7 @@ class TestXBlockPublishingInfo(ItemTest):
         """
         Creates a child xblock for the given parent.
         """
-        child = ItemFactory.create(
+        child = BlockFactory.create(
             parent_location=parent.location, category=category, display_name=display_name,
             user_id=self.user.id, publish_item=publish_item
         )

--- a/cms/djangoapps/contentstore/views/tests/test_preview.py
+++ b/cms/djangoapps/contentstore/views/tests/test_preview.py
@@ -18,7 +18,7 @@ from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import (
     TEST_DATA_SPLIT_MODULESTORE, ModuleStoreTestCase, upload_file_to_course,
 )
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 from xmodule.modulestore.tests.test_asides import AsideTestType
 from cms.djangoapps.contentstore.utils import reverse_usage_url
 from cms.djangoapps.contentstore.toggles import INDIVIDUALIZE_ANONYMOUS_USER_ID
@@ -47,7 +47,7 @@ class GetPreviewHtmlTestCase(ModuleStoreTestCase):
         asides are correctly included.
         """
         course = CourseFactory.create()
-        html = ItemFactory.create(
+        html = BlockFactory.create(
             parent_location=course.location,
             category="html",
             data={'data': "<html>foobar</html>"}
@@ -95,7 +95,7 @@ class GetPreviewHtmlTestCase(ModuleStoreTestCase):
         asides are correctly excluded because they are not enabled.
         """
         course = CourseFactory.create()
-        html = ItemFactory.create(
+        html = BlockFactory.create(
             parent_location=course.location,
             category="html",
             data={'data': "<html>foobar</html>"}
@@ -130,13 +130,13 @@ class GetPreviewHtmlTestCase(ModuleStoreTestCase):
 
         course = CourseFactory.create()
 
-        conditional_block = ItemFactory.create(
+        conditional_block = BlockFactory.create(
             parent_location=course.location,
             category="conditional"
         )
 
         # child conditional_block
-        ItemFactory.create(
+        BlockFactory.create(
             parent_location=conditional_block.location,
             category="conditional"
         )
@@ -158,7 +158,7 @@ class GetPreviewHtmlTestCase(ModuleStoreTestCase):
 
         course = CourseFactory.create()
 
-        block = ItemFactory.create(
+        block = BlockFactory.create(
             parent_location=course.location,
             category="problem"
         )
@@ -213,7 +213,7 @@ class StudioXBlockServiceBindingTest(ModuleStoreTestCase):
         """
         Tests that the 'user' and 'i18n' services are provided by the Studio runtime.
         """
-        descriptor = ItemFactory(category="pure", parent=self.course)
+        descriptor = BlockFactory(category="pure", parent=self.course)
         runtime = _preview_module_system(
             self.request,
             descriptor,
@@ -242,12 +242,12 @@ class CmsModuleSystemShimTest(ModuleStoreTestCase):
         self.request = RequestFactory().get('/dummy-url')
         self.request.user = self.user
         self.request.session = {}
-        self.descriptor = ItemFactory(category="video", parent=course)
+        self.descriptor = BlockFactory(category="video", parent=course)
         self.field_data = mock.Mock()
         self.contentstore = contentstore()
         self.runtime = _preview_module_system(
             self.request,
-            descriptor=ItemFactory(category="problem", parent=course),
+            descriptor=BlockFactory(category="problem", parent=course),
             field_data=mock.Mock(),
         )
         self.course = self.store.get_item(course.location)
@@ -257,7 +257,7 @@ class CmsModuleSystemShimTest(ModuleStoreTestCase):
 
     @XBlock.register_temp_plugin(PureXBlock, identifier='pure')
     def test_render_template(self):
-        descriptor = ItemFactory(category="pure", parent=self.course)
+        descriptor = BlockFactory(category="pure", parent=self.course)
         html = get_preview_fragment(self.request, descriptor, {'element_id': 142}).content
         assert '<div id="142" ns="main">Testing the MakoService</div>' in html
 
@@ -305,7 +305,7 @@ class CmsModuleSystemShimTest(ModuleStoreTestCase):
         # Create the runtime with the flag turned on.
         runtime = _preview_module_system(
             self.request,
-            descriptor=ItemFactory(category="problem", parent=self.course),
+            descriptor=BlockFactory(category="problem", parent=self.course),
             field_data=mock.Mock(),
         )
         assert runtime.anonymous_student_id == '26262401c528d7c4a6bbeabe0455ec46'
@@ -316,7 +316,7 @@ class CmsModuleSystemShimTest(ModuleStoreTestCase):
         # Create the runtime with the flag turned on.
         runtime = _preview_module_system(
             self.request,
-            descriptor=ItemFactory(category="lti", parent=self.course),
+            descriptor=BlockFactory(category="lti", parent=self.course),
             field_data=mock.Mock(),
         )
         assert runtime.anonymous_student_id == 'ad503f629b55c531fed2e45aa17a3368'

--- a/cms/djangoapps/contentstore/views/tests/test_tabs.py
+++ b/cms/djangoapps/contentstore/views/tests/test_tabs.py
@@ -10,7 +10,7 @@ from cms.djangoapps.contentstore.utils import reverse_course_url
 from cms.djangoapps.contentstore.views import tabs
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.tabs import CourseTabList  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.x_module import STUDENT_VIEW  # lint-amnesty, pylint: disable=wrong-import-order
 
@@ -28,7 +28,7 @@ class TabsPageTests(CourseTestCase):
         self.url = reverse_course_url('tabs_handler', self.course.id)
 
         # add a static tab to the course, for code coverage
-        self.test_tab = ItemFactory.create(
+        self.test_tab = BlockFactory.create(
             parent_location=self.course.location,
             category="static_tab",
             display_name="Static_1"

--- a/cms/djangoapps/contentstore/views/tests/test_unit_page.py
+++ b/cms/djangoapps/contentstore/views/tests/test_unit_page.py
@@ -4,7 +4,7 @@ Unit tests for the unit page.
 
 
 from xmodule.modulestore.django import modulestore
-from xmodule.modulestore.tests.factories import ItemFactory
+from xmodule.modulestore.tests.factories import BlockFactory
 from xmodule.x_module import STUDENT_VIEW
 
 from .utils import StudioPageTestCase
@@ -17,10 +17,10 @@ class UnitPageTestCase(StudioPageTestCase):
 
     def setUp(self):
         super().setUp()
-        self.vertical = ItemFactory.create(parent_location=self.sequential.location,
-                                           category='vertical', display_name='Unit')
-        self.video = ItemFactory.create(parent_location=self.vertical.location,
-                                        category="video", display_name="My Video")
+        self.vertical = BlockFactory.create(parent_location=self.sequential.location,
+                                            category='vertical', display_name='Unit')
+        self.video = BlockFactory.create(parent_location=self.vertical.location,
+                                         category="video", display_name="My Video")
         self.store = modulestore()
 
     def test_public_component_preview_html(self):
@@ -41,10 +41,10 @@ class UnitPageTestCase(StudioPageTestCase):
         Verify that a public child container rendering on the unit page (which shows a View arrow
         to the container page) returns the expected HTML.
         """
-        child_container = ItemFactory.create(parent_location=self.vertical.location,
-                                             category='split_test', display_name='Split Test')
-        ItemFactory.create(parent_location=child_container.location,
-                           category='html', display_name='grandchild')
+        child_container = BlockFactory.create(parent_location=self.vertical.location,
+                                              category='split_test', display_name='Split Test')
+        BlockFactory.create(parent_location=child_container.location,
+                            category='html', display_name='grandchild')
         published_child_container = self.store.publish(child_container.location, self.user.id)
         self.validate_preview_html(published_child_container, STUDENT_VIEW, can_add=False)
 
@@ -53,9 +53,9 @@ class UnitPageTestCase(StudioPageTestCase):
         Verify that a draft child container rendering on the unit page (which shows a View arrow
         to the container page) returns the expected HTML.
         """
-        child_container = ItemFactory.create(parent_location=self.vertical.location,
-                                             category='split_test', display_name='Split Test')
-        ItemFactory.create(parent_location=child_container.location,
-                           category='html', display_name='grandchild')
+        child_container = BlockFactory.create(parent_location=self.vertical.location,
+                                              category='split_test', display_name='Split Test')
+        BlockFactory.create(parent_location=child_container.location,
+                            category='html', display_name='grandchild')
         draft_child_container = self.store.get_item(child_container.location)
         self.validate_preview_html(draft_child_container, STUDENT_VIEW, can_add=False)

--- a/cms/djangoapps/contentstore/views/tests/utils.py
+++ b/cms/djangoapps/contentstore/views/tests/utils.py
@@ -6,7 +6,7 @@ Utilities for view tests.
 import json
 
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
-from xmodule.modulestore.tests.factories import ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 from ..helpers import xblock_studio_url
 
@@ -18,10 +18,10 @@ class StudioPageTestCase(CourseTestCase):
 
     def setUp(self):
         super().setUp()
-        self.chapter = ItemFactory.create(parent_location=self.course.location,
-                                          category='chapter', display_name="Week 1")
-        self.sequential = ItemFactory.create(parent_location=self.chapter.location,
-                                             category='sequential', display_name="Lesson 1")
+        self.chapter = BlockFactory.create(parent_location=self.course.location,
+                                           category='chapter', display_name="Week 1")
+        self.sequential = BlockFactory.create(parent_location=self.chapter.location,
+                                              category='sequential', display_name="Lesson 1")
 
     def get_page_html(self, xblock):
         """

--- a/cms/djangoapps/coursegraph/management/commands/tests/test_dump_to_neo4j.py
+++ b/cms/djangoapps/coursegraph/management/commands/tests/test_dump_to_neo4j.py
@@ -11,7 +11,7 @@ from django.core.management import call_command
 from django.test.utils import override_settings
 from edx_toggles.toggles.testutils import override_waffle_switch
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
 import openedx.core.djangoapps.content.block_structure.config as block_structure_config
 from openedx.core.djangoapps.content.block_structure.signals import update_block_structure_on_course_publish
@@ -60,13 +60,13 @@ class TestDumpToNeo4jCommandBase(SharedModuleStoreTestCase):
         """
         super().setUpClass()
         cls.course = CourseFactory.create()
-        cls.chapter = ItemFactory.create(parent=cls.course, category='chapter')
-        cls.sequential = ItemFactory.create(parent=cls.chapter, category='sequential')
-        cls.vertical = ItemFactory.create(parent=cls.sequential, category='vertical', display_name='subject')
-        cls.html = ItemFactory.create(parent=cls.vertical, category='html')
-        cls.problem = ItemFactory.create(parent=cls.vertical, category='problem')
-        cls.video = ItemFactory.create(parent=cls.vertical, category='video', display_name='subject')
-        cls.video2 = ItemFactory.create(parent=cls.vertical, category='video')
+        cls.chapter = BlockFactory.create(parent=cls.course, category='chapter')
+        cls.sequential = BlockFactory.create(parent=cls.chapter, category='sequential')
+        cls.vertical = BlockFactory.create(parent=cls.sequential, category='vertical', display_name='subject')
+        cls.html = BlockFactory.create(parent=cls.vertical, category='html')
+        cls.problem = BlockFactory.create(parent=cls.vertical, category='problem')
+        cls.video = BlockFactory.create(parent=cls.vertical, category='video', display_name='subject')
+        cls.video2 = BlockFactory.create(parent=cls.vertical, category='video')
 
         cls.course2 = CourseFactory.create()
 

--- a/cms/djangoapps/export_course_metadata/test_signals.py
+++ b/cms/djangoapps/export_course_metadata/test_signals.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 from edx_toggles.toggles.testutils import override_waffle_flag
 from xmodule.modulestore.django import SignalHandler
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
 from .signals import export_course_metadata
 from .toggles import EXPORT_COURSE_METADATA_FLAG
@@ -31,7 +31,7 @@ class TestExportCourseMetadata(SharedModuleStoreTestCase):
         SignalHandler.course_published.disconnect(export_course_metadata)
 
     def _create_chapter(self, **kwargs):
-        ItemFactory.create(
+        BlockFactory.create(
             parent=self.course,
             category='chapter',
             **kwargs

--- a/cms/djangoapps/maintenance/tests.py
+++ b/cms/djangoapps/maintenance/tests.py
@@ -14,7 +14,7 @@ from common.djangoapps.student.tests.factories import AdminFactory, UserFactory
 from openedx.features.announcements.models import Announcement
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 from .views import COURSE_KEY_ERROR_MESSAGES, MAINTENANCE_VIEWS
 
@@ -141,7 +141,7 @@ class TestForcePublish(MaintenanceViewTestCase):
         """
         course = CourseFactory.create()
         # Add some changes to course
-        chapter = ItemFactory.create(category='chapter', parent_location=course.location)
+        chapter = BlockFactory.create(category='chapter', parent_location=course.location)
         self.store.create_child(
             self.user.id,
             chapter.location,

--- a/cms/lib/xblock/tagging/test.py
+++ b/cms/lib/xblock/tagging/test.py
@@ -26,7 +26,7 @@ from common.djangoapps.student.tests.factories import UserFactory
 from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 
 @ddt.ddt
@@ -46,33 +46,33 @@ class StructuredTagsAsideTestCase(ModuleStoreTestCase):
         self.aside_tag_lo = 'learning_outcome'
 
         course = CourseFactory.create(default_store=ModuleStoreEnum.Type.split)
-        self.course = ItemFactory.create(
+        self.course = BlockFactory.create(
             parent_location=course.location,
             category="course",
             display_name="Test course",
         )
-        self.chapter = ItemFactory.create(
+        self.chapter = BlockFactory.create(
             parent_location=self.course.location,
             category='chapter',
             display_name="Week 1",
             publish_item=True,
             start=datetime(2015, 3, 1, tzinfo=UTC),
         )
-        self.sequential = ItemFactory.create(
+        self.sequential = BlockFactory.create(
             parent_location=self.chapter.location,
             category='sequential',
             display_name="Lesson 1",
             publish_item=True,
             start=datetime(2015, 3, 1, tzinfo=UTC),
         )
-        self.vertical = ItemFactory.create(
+        self.vertical = BlockFactory.create(
             parent_location=self.sequential.location,
             category='vertical',
             display_name='Subsection 1',
             publish_item=True,
             start=datetime(2015, 4, 1, tzinfo=UTC),
         )
-        self.problem = ItemFactory.create(
+        self.problem = BlockFactory.create(
             category="problem",
             parent_location=self.vertical.location,
             display_name="A Problem Block",
@@ -80,7 +80,7 @@ class StructuredTagsAsideTestCase(ModuleStoreTestCase):
             user_id=self.user.id,
             publish_item=False,
         )
-        self.video = ItemFactory.create(
+        self.video = BlockFactory.create(
             parent_location=self.vertical.location,
             category='video',
             display_name='My Video',

--- a/cms/lib/xblock/test/test_authoring_mixin.py
+++ b/cms/lib/xblock/test/test_authoring_mixin.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.test.utils import override_settings
 from xblock.core import XBlock
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 from xmodule.partitions.partitions import (
     ENROLLMENT_TRACK_PARTITION_ID,
     MINIMUM_STATIC_PARTITION_ID,
@@ -42,27 +42,27 @@ class AuthoringMixinTestCase(ModuleStoreTestCase):
         """
         super().setUp()
         self.course = CourseFactory.create()
-        chapter = ItemFactory.create(
+        chapter = BlockFactory.create(
             category='chapter',
             parent=self.course,
             display_name='Test Chapter'
         )
-        sequential = ItemFactory.create(
+        sequential = BlockFactory.create(
             category='sequential',
             parent=chapter,
             display_name='Test Sequential'
         )
-        vertical = ItemFactory.create(
+        vertical = BlockFactory.create(
             category='vertical',
             parent=sequential,
             display_name='Test Vertical'
         )
-        video = ItemFactory.create(
+        video = BlockFactory.create(
             category='video',
             parent=vertical,
             display_name='Test Vertical'
         )
-        pure = ItemFactory.create(
+        pure = BlockFactory.create(
             category='pure',
             parent=vertical,
             display_name='Test Pure'

--- a/common/djangoapps/course_modes/tests/test_signals.py
+++ b/common/djangoapps/course_modes/tests/test_signals.py
@@ -14,7 +14,7 @@ from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.signals import _listen_for_course_publish
 from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.partitions.partitions import ENROLLMENT_TRACK_PARTITION_ID  # lint-amnesty, pylint: disable=wrong-import-order
 
 
@@ -97,15 +97,15 @@ class CourseModeSignalTest(ModuleStoreTestCase):
         AUDIT_ID = settings.COURSE_ENROLLMENT_MODES['audit']['id']
         VERIFIED_ID = settings.COURSE_ENROLLMENT_MODES['verified']['id']
         MASTERS_ID = settings.COURSE_ENROLLMENT_MODES['masters']['id']
-        verified_section = ItemFactory.create(
+        verified_section = BlockFactory.create(
             category="sequential",
             metadata={'group_access': {ENROLLMENT_TRACK_PARTITION_ID: [VERIFIED_ID]}}
         )
         # and a section with no restriction
-        section2 = ItemFactory.create(
+        section2 = BlockFactory.create(
             category="sequential",
         )
-        section3 = ItemFactory.create(
+        section3 = BlockFactory.create(
             category='sequential',
             metadata={'group_access': {ENROLLMENT_TRACK_PARTITION_ID: [AUDIT_ID]}}
         )

--- a/common/djangoapps/student/tests/test_enrollment.py
+++ b/common/djangoapps/student/tests/test_enrollment.py
@@ -12,7 +12,7 @@ from django.conf import settings
 from django.urls import reverse
 from openedx_events.tests.utils import OpenEdxEventsTestMixin
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
@@ -78,10 +78,10 @@ class EnrollmentTest(UrlResetMixin, ModuleStoreTestCase, OpenEdxEventsTestMixin)
         """
         Helper function to create a proctored exam for a given course
         """
-        chapter = ItemFactory.create(
+        chapter = BlockFactory.create(
             parent=course, category='chapter', display_name='Test Section', publish_item=True
         )
-        ItemFactory.create(
+        BlockFactory.create(
             parent=chapter, category='sequential', display_name='Test Proctored Exam',
             graded=True, is_time_limited=True, default_time_limit_minutes=10,
             is_proctored_enabled=True, publish_item=True

--- a/common/djangoapps/student/tests/test_views.py
+++ b/common/djangoapps/student/tests/test_views.py
@@ -46,7 +46,7 @@ from openedx.features.course_duration_limits.models import CourseDurationLimitCo
 from openedx.features.course_experience.tests.views.helpers import add_course_mode
 from xmodule.data import CertificatesDisplayBehaviors  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 PASSWORD = 'test'
 TOMORROW = now() + timedelta(days=1)
@@ -754,7 +754,7 @@ class StudentDashboardTests(SharedModuleStoreTestCase, MilestonesTestCaseMixin, 
 
         course_key = course.id
         block_keys = [
-            ItemFactory.create(
+            BlockFactory.create(
                 category='video',
                 parent_location=course.location,
                 display_name=f'Video {str(number)}'
@@ -854,7 +854,7 @@ class StudentDashboardTests(SharedModuleStoreTestCase, MilestonesTestCaseMixin, 
             # Submit completed course blocks in even-numbered courses.
             if isEven(i):
                 block_keys = [
-                    ItemFactory.create(
+                    BlockFactory.create(
                         category='video',
                         parent_location=course.location,
                         display_name=f'Video {str(number)}'

--- a/lms/djangoapps/ccx/tests/test_ccx_modulestore.py
+++ b/lms/djangoapps/ccx/tests/test_ccx_modulestore.py
@@ -11,7 +11,7 @@ import pytz
 from ccx_keys.locator import CCXLocator
 from six.moves import zip_longest
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
 from common.djangoapps.student.tests.factories import AdminFactory, UserFactory
 from lms.djangoapps.ccx.models import CustomCourseForEdX
@@ -28,18 +28,18 @@ class TestCCXModulestoreWrapper(SharedModuleStoreTestCase):
         due = datetime.datetime(2010, 7, 7, 0, 0, tzinfo=pytz.UTC)
         # Create a course outline
         cls.chapters = chapters = [
-            ItemFactory.create(start=start, parent=cls.course) for _ in range(2)
+            BlockFactory.create(start=start, parent=cls.course) for _ in range(2)
         ]
         cls.sequentials = sequentials = [
-            ItemFactory.create(parent=c) for _ in range(2) for c in chapters
+            BlockFactory.create(parent=c) for _ in range(2) for c in chapters
         ]
         cls.verticals = verticals = [
-            ItemFactory.create(
+            BlockFactory.create(
                 due=due, parent=s, graded=True, format='Homework'
             ) for _ in range(2) for s in sequentials
         ]
         cls.blocks = [
-            ItemFactory.create(parent=v, category='html') for _ in range(2) for v in verticals
+            BlockFactory.create(parent=v, category='html') for _ in range(2) for v in verticals
         ]
 
     @classmethod

--- a/lms/djangoapps/ccx/tests/test_overrides.py
+++ b/lms/djangoapps/ccx/tests/test_overrides.py
@@ -11,7 +11,7 @@ from ccx_keys.locator import CCXLocator
 from django.test.utils import override_settings
 from edx_django_utils.cache import RequestCache
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
 from common.djangoapps.student.tests.factories import AdminFactory
 from lms.djangoapps.ccx.models import CustomCourseForEdX
@@ -43,16 +43,16 @@ class TestFieldOverrides(FieldOverrideTestMixin, SharedModuleStoreTestCase):
         # Create a course outline
         start = datetime.datetime(2010, 5, 12, 2, 42, tzinfo=pytz.UTC)
         due = datetime.datetime(2010, 7, 7, 0, 0, tzinfo=pytz.UTC)
-        chapters = [ItemFactory.create(start=start, parent=cls.course)
+        chapters = [BlockFactory.create(start=start, parent=cls.course)
                     for _ in range(2)]
         sequentials = flatten([
-            [ItemFactory.create(parent=chapter) for _ in range(2)]
+            [BlockFactory.create(parent=chapter) for _ in range(2)]
             for chapter in chapters])
         verticals = flatten([
-            [ItemFactory.create(due=due, parent=sequential) for _ in range(2)]
+            [BlockFactory.create(due=due, parent=sequential) for _ in range(2)]
             for sequential in sequentials])
         blocks = flatten([  # pylint: disable=unused-variable
-            [ItemFactory.create(parent=vertical) for _ in range(2)]
+            [BlockFactory.create(parent=vertical) for _ in range(2)]
             for vertical in verticals])
 
     def setUp(self):

--- a/lms/djangoapps/ccx/tests/test_views.py
+++ b/lms/djangoapps/ccx/tests/test_views.py
@@ -22,7 +22,7 @@ from pytz import UTC
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, SampleCourseFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory, SampleCourseFactory
 from xmodule.x_module import XModuleMixin
 from xmodule.capa.tests.response_xml_factory import StringResponseXMLFactory
 from common.djangoapps.edxmako.shortcuts import render_to_response
@@ -179,15 +179,15 @@ class TestCCXProgressChanges(CcxTestCase, LoginEnrollmentTestCase):
         due = datetime.datetime(2016, 7, 8, 0, 0, tzinfo=UTC)
 
         cls.course = course = CourseFactory.create(enable_ccx=True, start=start)
-        chapter = ItemFactory.create(start=start, parent=course, category='chapter')
-        sequential = ItemFactory.create(
+        chapter = BlockFactory.create(start=start, parent=course, category='chapter')
+        sequential = BlockFactory.create(
             parent=chapter,
             start=start,
             due=due,
             category='sequential',
             metadata={'graded': True, 'format': 'Homework'}
         )
-        vertical = ItemFactory.create(
+        vertical = BlockFactory.create(
             parent=sequential,
             start=start,
             due=due,
@@ -198,7 +198,7 @@ class TestCCXProgressChanges(CcxTestCase, LoginEnrollmentTestCase):
         # Trying to wrap the whole thing in a bulk operation fails because it
         # doesn't find the parents. But we can at least wrap this part...
         with cls.store.bulk_operations(course.id, emit_signals=False):
-            flatten([ItemFactory.create(
+            flatten([BlockFactory.create(
                 parent=vertical,
                 start=start,
                 due=due,
@@ -811,16 +811,16 @@ class TestCoachDashboardSchedule(CcxTestCase, LoginEnrollmentTestCase, ModuleSto
         )
 
         self.chapters = [
-            ItemFactory.create(start=start, parent=course) for _ in range(2)
+            BlockFactory.create(start=start, parent=course) for _ in range(2)
         ]
         self.sequentials = flatten([
             [
-                ItemFactory.create(parent=chapter) for _ in range(2)
+                BlockFactory.create(parent=chapter) for _ in range(2)
             ] for chapter in self.chapters
         ])
         self.verticals = flatten([
             [
-                ItemFactory.create(
+                BlockFactory.create(
                     start=start, due=due, parent=sequential, graded=True, format='Homework', category='vertical'
                 ) for _ in range(2)
             ] for sequential in self.sequentials
@@ -831,7 +831,7 @@ class TestCoachDashboardSchedule(CcxTestCase, LoginEnrollmentTestCase, ModuleSto
         with self.store.bulk_operations(course.id, emit_signals=False):
             blocks = flatten([  # pylint: disable=unused-variable
                 [
-                    ItemFactory.create(parent=vertical) for _ in range(2)
+                    BlockFactory.create(parent=vertical) for _ in range(2)
                 ] for vertical in self.verticals
             ])
 
@@ -951,11 +951,11 @@ class TestCCXGrades(FieldOverrideTestMixin, SharedModuleStoreTestCase, LoginEnro
         cls.mooc_start = start = datetime.datetime(
             2010, 5, 12, 2, 42, tzinfo=UTC
         )
-        chapter = ItemFactory.create(
+        chapter = BlockFactory.create(
             start=start, parent=course, category='sequential'
         )
         cls.sections = sections = [
-            ItemFactory.create(
+            BlockFactory.create(
                 parent=chapter,
                 category="sequential",
                 metadata={'graded': True, 'format': 'Homework'})
@@ -964,7 +964,7 @@ class TestCCXGrades(FieldOverrideTestMixin, SharedModuleStoreTestCase, LoginEnro
         # making problems available at class level for possible future use in tests
         cls.problems = [
             [
-                ItemFactory.create(
+                BlockFactory.create(
                     parent=section,
                     category="problem",
                     data=StringResponseXMLFactory().build_xml(answer='foo'),

--- a/lms/djangoapps/ccx/tests/utils.py
+++ b/lms/djangoapps/ccx/tests/utils.py
@@ -9,7 +9,7 @@ import pytz
 from django.conf import settings
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
 from common.djangoapps.student.roles import CourseCcxCoachRole, CourseInstructorRole, CourseStaffRole
 from common.djangoapps.student.tests.factories import UserFactory
@@ -38,16 +38,16 @@ class CcxTestCase(EmailTemplateTagMixin, SharedModuleStoreTestCase):
         )
 
         cls.chapters = [
-            ItemFactory.create(start=start, parent=course) for _ in range(2)
+            BlockFactory.create(start=start, parent=course) for _ in range(2)
         ]
         cls.sequentials = flatten([
             [
-                ItemFactory.create(parent=chapter) for _ in range(2)
+                BlockFactory.create(parent=chapter) for _ in range(2)
             ] for chapter in cls.chapters
         ])
         cls.verticals = flatten([
             [
-                ItemFactory.create(
+                BlockFactory.create(
                     start=start, due=due, parent=sequential, graded=True, format='Homework', category='vertical'
                 ) for _ in range(2)
             ] for sequential in cls.sequentials
@@ -58,7 +58,7 @@ class CcxTestCase(EmailTemplateTagMixin, SharedModuleStoreTestCase):
         with cls.store.bulk_operations(course.id, emit_signals=False):
             blocks = flatten([  # pylint: disable=unused-variable
                 [
-                    ItemFactory.create(parent=vertical) for _ in range(2)
+                    BlockFactory.create(parent=vertical) for _ in range(2)
                 ] for vertical in cls.verticals
             ])
 

--- a/lms/djangoapps/course_api/blocks/transformers/tests/test_block_completion.py
+++ b/lms/djangoapps/course_api/blocks/transformers/tests/test_block_completion.py
@@ -12,7 +12,7 @@ from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.course_api.blocks.transformers.block_completion import BlockCompletionTransformer
 from lms.djangoapps.course_blocks.api import get_course_blocks
 from lms.djangoapps.course_blocks.transformers.tests.helpers import ModuleStoreTestCase, TransformerRegistryTestMixin
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 
 class StubAggregatorXBlock(XBlock):
@@ -66,14 +66,14 @@ class BlockCompletionTransformerTestCase(TransformerRegistryTestMixin, Completio
         """
         course = CourseFactory.create()
         # Have to have at least one complete block to trigger entering the marking 'complete' flow
-        filled_aggregator = ItemFactory.create(category='aggregator', parent=course)
-        block = ItemFactory.create(category='comp', parent=filled_aggregator)
+        filled_aggregator = BlockFactory.create(category='aggregator', parent=course)
+        block = BlockFactory.create(category='comp', parent=filled_aggregator)
         BlockCompletion.objects.submit_completion(
             user=self.user,
             block_key=block.location,
             completion=self.COMPLETION_TEST_VALUE,
         )
-        empty_aggregator = ItemFactory.create(category='aggregator', parent=course)
+        empty_aggregator = BlockFactory.create(category='aggregator', parent=course)
         block_structure = get_course_blocks(self.user, course.location, self.transformers)
 
         self._assert_block_has_proper_completion_values(
@@ -92,7 +92,7 @@ class BlockCompletionTransformerTestCase(TransformerRegistryTestMixin, Completio
         Excluded blocks always receive None for 'completion' and False for 'complete'
         """
         course = CourseFactory.create()
-        block = ItemFactory.create(category='excluded', parent=course)
+        block = BlockFactory.create(category='excluded', parent=course)
         block_structure = get_course_blocks(self.user, course.location, self.transformers)
 
         self._assert_block_has_proper_completion_values(block_structure, block.location, None, False)
@@ -104,7 +104,7 @@ class BlockCompletionTransformerTestCase(TransformerRegistryTestMixin, Completio
         'completion' should have the value and 'complete' should be True in these cases.
         """
         course = CourseFactory.create()
-        block = ItemFactory.create(category='comp', parent=course)
+        block = BlockFactory.create(category='comp', parent=course)
         BlockCompletion.objects.submit_completion(
             user=self.user,
             block_key=block.location,
@@ -122,7 +122,7 @@ class BlockCompletionTransformerTestCase(TransformerRegistryTestMixin, Completio
         'html' blocks end up receiving a 'completion' of 1.0 after being viewed.
         """
         course = CourseFactory.create()
-        block = ItemFactory.create(category='html', parent=course)
+        block = BlockFactory.create(category='html', parent=course)
         block_structure = get_course_blocks(self.user, course.location, self.transformers)
 
         self._assert_block_has_proper_completion_values(block_structure, block.location, 0.0, False)

--- a/lms/djangoapps/course_api/tests/test_api.py
+++ b/lms/djangoapps/course_api/tests/test_api.py
@@ -18,7 +18,7 @@ from rest_framework.test import APIRequestFactory
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from xmodule.modulestore.exceptions import ItemNotFoundError  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import ItemFactory, check_mongo_calls  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import BlockFactory, check_mongo_calls  # lint-amnesty, pylint: disable=wrong-import-order
 
 from ..api import (
     UNKNOWN_BLOCK_DISPLAY_NAME, course_detail, get_due_dates, list_courses, get_course_members, get_course_run_url,
@@ -287,7 +287,7 @@ class TestGetCourseDates(CourseDetailTestMixin, SharedModuleStoreTestCase):
         cls.yesterday = cls.today - timedelta(days=1)
         cls.tomorrow = cls.today + timedelta(days=1)
 
-        cls.section_1 = ItemFactory.create(
+        cls.section_1 = BlockFactory.create(
             category='chapter',
             start=cls.yesterday,
             due=cls.tomorrow,
@@ -295,7 +295,7 @@ class TestGetCourseDates(CourseDetailTestMixin, SharedModuleStoreTestCase):
             display_name='section 1'
         )
 
-        cls.subsection_1 = ItemFactory.create(
+        cls.subsection_1 = BlockFactory.create(
             category='sequential',
             parent=cls.section_1,
             display_name='subsection 1'

--- a/lms/djangoapps/course_blocks/transformers/tests/helpers.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/helpers.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
@@ -76,7 +76,7 @@ class CourseStructureTestCase(TransformerRegistryTestMixin, ModuleStoreTestCase)
         """
         block_type = block_hierarchy['#type']
         block_ref = block_hierarchy['#ref']
-        factory = (CourseFactory if block_type == 'course' else ItemFactory)
+        factory = (CourseFactory if block_type == 'course' else BlockFactory)
         kwargs = {key: value for key, value in block_hierarchy.items() if key[0] != '#'}
 
         if block_type != 'course':
@@ -239,7 +239,7 @@ class BlockParentsMapTestCase(TransformerRegistryTestMixin, ModuleStoreTestCase)
                 continue  # course already created
 
             self.xblock_keys.append(
-                ItemFactory.create(
+                BlockFactory.create(
                     parent=self.get_block(parents_index[0]),
                     category="vertical",
                 ).location

--- a/lms/djangoapps/course_goals/tests/test_user_activity.py
+++ b/lms/djangoapps/course_goals/tests/test_user_activity.py
@@ -14,7 +14,7 @@ from edx_toggles.toggles.testutils import override_waffle_flag
 from freezegun import freeze_time
 from mock import patch
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
 from common.djangoapps.edxmako.shortcuts import render_to_response
 from common.djangoapps.student.models import CourseEnrollment
@@ -45,8 +45,8 @@ class UserActivityTests(UrlResetMixin, ModuleStoreTestCase):
             modulestore=self.store,
             discussion_topics={"Test Topic": {"id": "test_topic"}},
         )
-        chapter = ItemFactory(parent=self.course, category='chapter')
-        ItemFactory(parent=chapter, category='sequential')
+        chapter = BlockFactory(parent=self.course, category='chapter')
+        BlockFactory(parent=chapter, category='sequential')
 
         self.client.login(username=self.user.username, password=self.user_password)
         CourseEnrollment.enroll(self.user, self.course.id)

--- a/lms/djangoapps/course_home_api/outline/tests/test_view.py
+++ b/lms/djangoapps/course_home_api/outline/tests/test_view.py
@@ -34,7 +34,7 @@ from openedx.features.course_experience import (
 )
 from openedx.features.discounts.applicability import DISCOUNT_APPLICABILITY_FLAG
 from xmodule.course_block import COURSE_VISIBILITY_PUBLIC, COURSE_VISIBILITY_PUBLIC_OUTLINE  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 
 @ddt.ddt
@@ -244,8 +244,8 @@ class OutlineTabTestViews(BaseCourseHomeTests):
             enable_proctored_exams=True,
             proctoring_provider=settings.PROCTORING_BACKENDS['DEFAULT'],
         )
-        chapter = ItemFactory.create(parent=course, category='chapter', display_name='Test Section')
-        sequence = ItemFactory.create(
+        chapter = BlockFactory.create(parent=course, category='chapter', display_name='Test Section')
+        sequence = BlockFactory.create(
             parent=chapter,
             category='sequential',
             display_name='Test Proctored Exam',
@@ -280,14 +280,14 @@ class OutlineTabTestViews(BaseCourseHomeTests):
     def test_assignment(self):
         course = CourseFactory.create()
         with self.store.bulk_operations(course.id):
-            chapter = ItemFactory.create(category='chapter', parent_location=course.location)
-            sequential = ItemFactory.create(display_name='Test', category='sequential', graded=True, has_score=True,
-                                            parent_location=chapter.location)
-            ItemFactory.create(category='problem', graded=True, has_score=True, parent_location=sequential.location)
-            ItemFactory.create(category='problem', graded=True, has_score=True, parent_location=sequential.location)
-            sequential2 = ItemFactory.create(display_name='Ungraded', category='sequential',
+            chapter = BlockFactory.create(category='chapter', parent_location=course.location)
+            sequential = BlockFactory.create(display_name='Test', category='sequential', graded=True, has_score=True,
                                              parent_location=chapter.location)
-            ItemFactory.create(category='problem', parent_location=sequential2.location)
+            BlockFactory.create(category='problem', graded=True, has_score=True, parent_location=sequential.location)
+            BlockFactory.create(category='problem', graded=True, has_score=True, parent_location=sequential.location)
+            sequential2 = BlockFactory.create(display_name='Ungraded', category='sequential',
+                                              parent_location=chapter.location)
+            BlockFactory.create(category='problem', parent_location=sequential2.location)
         update_outline_from_modulestore(course.id)
         url = reverse('course-home:outline-tab', args=[course.id])
 

--- a/lms/djangoapps/course_home_api/tests/utils.py
+++ b/lms/djangoapps/course_home_api/tests/utils.py
@@ -7,7 +7,7 @@ from datetime import datetime
 
 from django.conf import settings
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
 from cms.djangoapps.contentstore.outlines import update_outline_from_modulestore
 from common.djangoapps.course_modes.models import CourseMode
@@ -35,8 +35,8 @@ class BaseCourseHomeTests(ModuleStoreTestCase, MasqueradeMixin):
             emit_signals=True,
             modulestore=self.store,
         )
-        chapter = ItemFactory(parent=self.course, category='chapter')
-        ItemFactory(parent=chapter, category='sequential')
+        chapter = BlockFactory(parent=self.course, category='chapter')
+        BlockFactory(parent=chapter, category='sequential')
 
         CourseModeFactory(course_id=self.course.id, mode_slug=CourseMode.AUDIT)
         CourseModeFactory(

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -912,7 +912,7 @@ def get_current_child(xmodule, min_depth=None, requested_child=None):
         else:
             content_children = [
                 child for child in child_modules
-                if child.has_children_at_depth(min_depth - 1) and child.get_display_items()
+                if child.has_children_at_depth(min_depth - 1) and child.get_display_blocks()
             ]
             return _get_child(content_children) if content_children else None
 
@@ -926,7 +926,7 @@ def get_current_child(xmodule, min_depth=None, requested_child=None):
         return child
 
     if has_position:
-        children = xmodule.get_display_items()
+        children = xmodule.get_display_blocks()
         if len(children) > 0:
             if xmodule.position is not None and not requested_child:
                 pos = int(xmodule.position) - 1  # position is 1-indexed

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -912,7 +912,7 @@ def get_current_child(xmodule, min_depth=None, requested_child=None):
         else:
             content_children = [
                 child for child in child_modules
-                if child.has_children_at_depth(min_depth - 1) and child.get_display_blocks()
+                if child.has_children_at_depth(min_depth - 1) and child.get_children()
             ]
             return _get_child(content_children) if content_children else None
 
@@ -926,7 +926,7 @@ def get_current_child(xmodule, min_depth=None, requested_child=None):
         return child
 
     if has_position:
-        children = xmodule.get_display_blocks()
+        children = xmodule.get_children()
         if len(children) > 0:
             if xmodule.position is not None and not requested_child:
                 pos = int(xmodule.position) - 1  # position is 1-indexed

--- a/lms/djangoapps/courseware/management/commands/tests/test_dump_course.py
+++ b/lms/djangoapps/courseware/management/commands/tests/test_dump_course.py
@@ -17,7 +17,7 @@ from xmodule.modulestore.tests.django_utils import (
     TEST_DATA_SPLIT_MODULESTORE,
     SharedModuleStoreTestCase
 )
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 from xmodule.modulestore.xml_importer import import_course_from_xml
 
 DATA_DIR = settings.COMMON_TEST_DATA_ROOT
@@ -63,7 +63,7 @@ class CommandsTestBase(SharedModuleStoreTestCase):
             end=TEST_COURSE_END,
         )
 
-        cls.discussion = ItemFactory.create(
+        cls.discussion = BlockFactory.create(
             category='discussion', parent_location=cls.course.location
         )
 

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -162,7 +162,7 @@ def toc_for_course(user, request, course, active_chapter, active_section, field_
             return None, None, None
 
         toc_chapters = []
-        chapters = course_block.get_display_blocks()
+        chapters = course_block.get_children()
 
         # Check for content which needs to be completed
         # before the rest of the content is made available
@@ -190,7 +190,7 @@ def toc_for_course(user, request, course, active_chapter, active_section, field_
                 continue
 
             sections = []
-            for section in chapter.get_display_blocks():
+            for section in chapter.get_children():
                 # skip the section if it is hidden from the user
                 if section.hide_from_toc:
                     continue

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -162,7 +162,7 @@ def toc_for_course(user, request, course, active_chapter, active_section, field_
             return None, None, None
 
         toc_chapters = []
-        chapters = course_block.get_display_items()
+        chapters = course_block.get_display_blocks()
 
         # Check for content which needs to be completed
         # before the rest of the content is made available
@@ -190,7 +190,7 @@ def toc_for_course(user, request, course, active_chapter, active_section, field_
                 continue
 
             sections = []
-            for section in chapter.get_display_items():
+            for section in chapter.get_display_blocks():
                 # skip the section if it is hidden from the user
                 if section.hide_from_toc:
                     continue

--- a/lms/djangoapps/courseware/tests/helpers.py
+++ b/lms/djangoapps/courseware/tests/helpers.py
@@ -32,7 +32,7 @@ from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, U
 from common.djangoapps.util.date_utils import strftime_localized_html
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.django_utils import TEST_DATA_MONGO_MODULESTORE, ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.tests import get_test_descriptor_system, get_test_system  # lint-amnesty, pylint: disable=wrong-import-order
 
 
@@ -83,7 +83,7 @@ class BaseTestXmodule(ModuleStoreTestCase):
             'category': self.CATEGORY
         })
 
-        self.item_descriptor = ItemFactory.create(**kwargs)
+        self.item_descriptor = BlockFactory.create(**kwargs)
 
         self.runtime = self.new_descriptor_runtime()
 
@@ -105,11 +105,11 @@ class BaseTestXmodule(ModuleStoreTestCase):
         modulestore().request_cache = None
         modulestore().metadata_inheritance_cache_subsystem = None
 
-        chapter = ItemFactory.create(
+        chapter = BlockFactory.create(
             parent_location=self.course.location,
             category="sequential",
         )
-        self.section = ItemFactory.create(
+        self.section = BlockFactory.create(
             parent_location=chapter.location,
             category="sequential"
         )

--- a/lms/djangoapps/courseware/tests/pacts/views.py
+++ b/lms/djangoapps/courseware/tests/pacts/views.py
@@ -8,7 +8,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from opaque_keys.edx.keys import CourseKey
 from xmodule.modulestore.tests.django_utils import ModuleStoreIsolationMixin
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
 
 class ProviderState(ModuleStoreIsolationMixin):
@@ -37,12 +37,12 @@ class ProviderState(ModuleStoreIsolationMixin):
             modulestore=self.store
         )
 
-        section = ItemFactory.create(
+        section = BlockFactory.create(
             parent_location=demo_course.location,
             category="chapter",
         )
 
-        ItemFactory.create(
+        BlockFactory.create(
             parent_location=section.location,
             category="sequential",
             display_name="basic_questions",

--- a/lms/djangoapps/courseware/tests/test_about.py
+++ b/lms/djangoapps/courseware/tests/test_about.py
@@ -22,7 +22,7 @@ from xmodule.course_block import (
     COURSE_VISIBILITY_PUBLIC_OUTLINE,
 )
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 from xmodule.modulestore.tests.utils import TEST_DATA_DIR
 from xmodule.modulestore.xml_importer import import_course_from_xml
 
@@ -397,7 +397,7 @@ class AboutSidebarHTMLTestCase(SharedModuleStoreTestCase):
     def test_html_sidebar_enabled(self, itemfactory_display_name, itemfactory_data, waffle_switch_value):
         with override_waffle_switch(ENABLE_COURSE_ABOUT_SIDEBAR_HTML, active=waffle_switch_value):
             if itemfactory_display_name:
-                ItemFactory.create(
+                BlockFactory.create(
                     category="about",
                     parent_location=self.course.location,
                     display_name=itemfactory_display_name,

--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -55,7 +55,7 @@ from xmodule.modulestore.tests.django_utils import (  # lint-amnesty, pylint: di
     ModuleStoreTestCase,
     SharedModuleStoreTestCase
 )
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.partitions.partitions import MINIMUM_STATIC_PARTITION_ID, Group, UserPartition  # lint-amnesty, pylint: disable=wrong-import-order
 
 QUERY_COUNT_TABLE_IGNORELIST = WAFFLE_TABLES
@@ -235,7 +235,7 @@ class AccessTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, MilestonesTes
         Tests course student have right access to content w/o preview.
         """
         course_key = self.course.id
-        chapter = ItemFactory.create(category="chapter", parent_location=self.course.location)
+        chapter = BlockFactory.create(category="chapter", parent_location=self.course.location)
         overview = CourseOverview.get_from_id(course_key)
 
         # Enroll student to the course
@@ -291,7 +291,7 @@ class AccessTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, MilestonesTes
         self.course.user_partitions.append(user_partition)
         self.course.cohort_config = {'cohorted': True}
 
-        chapter = ItemFactory.create(category="chapter", parent_location=self.course.location)
+        chapter = BlockFactory.create(category="chapter", parent_location=self.course.location)
         chapter.group_access = {partition_id: [group_0_id]}
 
         modulestore().update_item(self.course, ModuleStoreEnum.UserID.test)

--- a/lms/djangoapps/courseware/tests/test_courses.py
+++ b/lms/djangoapps/courseware/tests/test_courses.py
@@ -166,7 +166,7 @@ class CoursesTest(ModuleStoreTestCase):
         assert get_current_child(mock_xmodule) is None
 
         mock_xmodule.position = -1
-        mock_xmodule.get_display_items.return_value = ['one', 'two', 'three']
+        mock_xmodule.get_display_blocks.return_value = ['one', 'two', 'three']
         assert get_current_child(mock_xmodule) == 'one'
 
         mock_xmodule.position = 2
@@ -175,7 +175,7 @@ class CoursesTest(ModuleStoreTestCase):
         assert get_current_child(mock_xmodule, requested_child='last') == 'three'
 
         mock_xmodule.position = 3
-        mock_xmodule.get_display_items.return_value = []
+        mock_xmodule.get_display_blocks.return_value = []
         assert get_current_child(mock_xmodule) is None
 
 

--- a/lms/djangoapps/courseware/tests/test_courses.py
+++ b/lms/djangoapps/courseware/tests/test_courses.py
@@ -166,7 +166,7 @@ class CoursesTest(ModuleStoreTestCase):
         assert get_current_child(mock_xmodule) is None
 
         mock_xmodule.position = -1
-        mock_xmodule.get_display_blocks.return_value = ['one', 'two', 'three']
+        mock_xmodule.get_children.return_value = ['one', 'two', 'three']
         assert get_current_child(mock_xmodule) == 'one'
 
         mock_xmodule.position = 2
@@ -175,7 +175,7 @@ class CoursesTest(ModuleStoreTestCase):
         assert get_current_child(mock_xmodule, requested_child='last') == 'three'
 
         mock_xmodule.position = 3
-        mock_xmodule.get_display_blocks.return_value = []
+        mock_xmodule.get_children.return_value = []
         assert get_current_child(mock_xmodule) is None
 
 

--- a/lms/djangoapps/courseware/tests/test_date_summary.py
+++ b/lms/djangoapps/courseware/tests/test_date_summary.py
@@ -14,7 +14,7 @@ from freezegun import freeze_time
 from pytz import utc
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
@@ -132,8 +132,8 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
         now = datetime.now(utc)
         assignment_title_html = ['<a href=', '</a>']
         with self.store.bulk_operations(course.id):
-            section = ItemFactory.create(category='chapter', parent_location=course.location)
-            ItemFactory.create(
+            section = BlockFactory.create(category='chapter', parent_location=course.location)
+            BlockFactory.create(
                 category='sequential',
                 display_name='Released',
                 parent_location=section.location,
@@ -142,7 +142,7 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
                 graded=True,
                 format='Homework',
             )
-            ItemFactory.create(
+            BlockFactory.create(
                 category='sequential',
                 display_name='Not released',
                 parent_location=section.location,
@@ -151,7 +151,7 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
                 graded=True,
                 format='Homework',
             )
-            ItemFactory.create(
+            BlockFactory.create(
                 category='sequential',
                 display_name='Third nearest assignment',
                 parent_location=section.location,
@@ -160,7 +160,7 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
                 graded=True,
                 format='Exam',
             )
-            ItemFactory.create(
+            BlockFactory.create(
                 category='sequential',
                 display_name='Past due date',
                 parent_location=section.location,
@@ -169,7 +169,7 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
                 graded=True,
                 format='Exam',
             )
-            ItemFactory.create(
+            BlockFactory.create(
                 category='sequential',
                 display_name='Not returned since we do not get non-graded subsections',
                 parent_location=section.location,
@@ -177,7 +177,7 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
                 due=now - timedelta(days=7),
                 graded=False,
             )
-            ItemFactory.create(
+            BlockFactory.create(
                 category='sequential',
                 display_name='No start date',
                 parent_location=section.location,
@@ -186,7 +186,7 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
                 graded=True,
                 format='Speech',
             )
-            ItemFactory.create(
+            BlockFactory.create(
                 category='sequential',
                 # Setting display name to None should set the assignment title to 'Assignment'
                 display_name=None,
@@ -196,7 +196,7 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
                 graded=True,
                 format=None,
             )
-            dummy_subsection = ItemFactory.create(category='sequential', graded=True, due=now + timedelta(days=11))
+            dummy_subsection = BlockFactory.create(category='sequential', graded=True, due=now + timedelta(days=11))
 
         # We are deleting this subsection right after creating it because we need to pass in a real
         # location object (dummy_subsection.location), but do not want this to exist inside of the modulestore
@@ -320,20 +320,20 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
         CourseEnrollmentFactory(course_id=course.id, user=user, mode=CourseMode.VERIFIED)
         now = datetime.now(utc)
 
-        chapter = ItemFactory.create(
+        chapter = BlockFactory.create(
             parent=course,
             category="chapter",
             graded=True,
         )
-        section = ItemFactory.create(
+        section = BlockFactory.create(
             parent=chapter,
             category="sequential",
         )
-        vertical = ItemFactory.create(
+        vertical = BlockFactory.create(
             parent=section,
             category="vertical",
         )
-        ItemFactory.create(
+        BlockFactory.create(
             parent=vertical,
             category="openassessment",
             rubric_assessments=rubric_assessments,

--- a/lms/djangoapps/courseware/tests/test_discussion_xblock.py
+++ b/lms/djangoapps/courseware/tests/test_discussion_xblock.py
@@ -18,7 +18,7 @@ from web_fragments.fragment import Fragment
 from xblock.field_data import DictFieldData
 from xmodule.discussion_block import DiscussionXBlock, loader
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import ItemFactory, ToyCourseFactory
+from xmodule.modulestore.tests.factories import BlockFactory, ToyCourseFactory
 
 from lms.djangoapps.course_api.blocks.tests.helpers import deserialize_usage_key
 from lms.djangoapps.courseware.module_render import get_module_for_descriptor_internal
@@ -273,7 +273,7 @@ class TestXBlockInCourse(SharedModuleStoreTestCase):
         cls.course_key = cls.course.id
         cls.course_usage_key = cls.store.make_course_usage_key(cls.course_key)
         cls.discussion_id = "test_discussion_xblock_id"
-        cls.discussion = ItemFactory.create(
+        cls.discussion = BlockFactory.create(
             parent_location=cls.course_usage_key,
             category='discussion',
             discussion_id=cls.discussion_id,
@@ -419,7 +419,7 @@ class TestXBlockQueryLoad(SharedModuleStoreTestCase):
 
         for counter in range(5):
             discussion_id = f'test_discussion_{counter}'
-            discussions.append(ItemFactory.create(
+            discussions.append(BlockFactory.create(
                 parent_location=course_usage_key,
                 category='discussion',
                 discussion_id=discussion_id,

--- a/lms/djangoapps/courseware/tests/test_entrance_exam.py
+++ b/lms/djangoapps/courseware/tests/test_entrance_exam.py
@@ -14,7 +14,7 @@ from lms.djangoapps.courseware.entrance_exams import (
     user_has_passed_entrance_exam
 )
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 from xmodule.capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
 from lms.djangoapps.courseware.model_data import FieldDataCache
 from lms.djangoapps.courseware.module_render import get_module, handle_xblock_callback, toc_for_course
@@ -55,55 +55,55 @@ class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase, Milest
                 'entrance_exam_enabled': True,
             }
         )
-        self.chapter = ItemFactory.create(
+        self.chapter = BlockFactory.create(
             parent=self.course,
             display_name='Overview'
         )
-        self.welcome = ItemFactory.create(
+        self.welcome = BlockFactory.create(
             parent=self.chapter,
             display_name='Welcome'
         )
-        ItemFactory.create(
+        BlockFactory.create(
             parent=self.course,
             category='chapter',
             display_name="Week 1"
         )
-        self.chapter_subsection = ItemFactory.create(
+        self.chapter_subsection = BlockFactory.create(
             parent=self.chapter,
             category='sequential',
             display_name="Lesson 1"
         )
-        chapter_vertical = ItemFactory.create(
+        chapter_vertical = BlockFactory.create(
             parent=self.chapter_subsection,
             category='vertical',
             display_name='Lesson 1 Vertical - Unit 1'
         )
-        ItemFactory.create(
+        BlockFactory.create(
             parent=chapter_vertical,
             category="problem",
             display_name="Problem - Unit 1 Problem 1"
         )
-        ItemFactory.create(
+        BlockFactory.create(
             parent=chapter_vertical,
             category="problem",
             display_name="Problem - Unit 1 Problem 2"
         )
 
-        self.entrance_exam = ItemFactory.create(
+        self.entrance_exam = BlockFactory.create(
             parent=self.course,
             category="chapter",
             display_name="Entrance Exam Section - Chapter 1",
             is_entrance_exam=True,
             in_entrance_exam=True
         )
-        self.exam_1 = ItemFactory.create(
+        self.exam_1 = BlockFactory.create(
             parent=self.entrance_exam,
             category='sequential',
             display_name="Exam Sequential - Subsection 1",
             graded=True,
             in_entrance_exam=True
         )
-        subsection = ItemFactory.create(
+        subsection = BlockFactory.create(
             parent=self.exam_1,
             category='vertical',
             display_name='Exam Vertical - Unit 1'
@@ -113,13 +113,13 @@ class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase, Milest
             choices=[False, False, True, False],
             choice_names=['choice_0', 'choice_1', 'choice_2', 'choice_3']
         )
-        self.problem_1 = ItemFactory.create(
+        self.problem_1 = BlockFactory.create(
             parent=subsection,
             category="problem",
             display_name="Exam Problem - Problem 1",
             data=problem_xml
         )
-        self.problem_2 = ItemFactory.create(
+        self.problem_2 = BlockFactory.create(
             parent=subsection,
             category="problem",
             display_name="Exam Problem - Problem 2"

--- a/lms/djangoapps/courseware/tests/test_group_access.py
+++ b/lms/djangoapps/courseware/tests/test_group_access.py
@@ -8,7 +8,7 @@ import ddt
 from stevedore.extension import Extension, ExtensionManager
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 from xmodule.partitions.partitions import USER_PARTITION_SCHEME_NAMESPACE, Group, UserPartition
 
 from common.djangoapps.student.tests.factories import StaffFactory
@@ -128,10 +128,10 @@ class GroupAccessTestCase(ModuleStoreTestCase):
             user_partitions=[self.animal_partition, self.color_partition],
         )
         with self.store.bulk_operations(self.course.id, emit_signals=False):
-            chapter = ItemFactory.create(category='chapter', parent=self.course)
-            section = ItemFactory.create(category='sequential', parent=chapter)
-            vertical = ItemFactory.create(category='vertical', parent=section)
-            component = ItemFactory.create(category='problem', parent=vertical)
+            chapter = BlockFactory.create(category='chapter', parent=self.course)
+            section = BlockFactory.create(category='sequential', parent=chapter)
+            vertical = BlockFactory.create(category='vertical', parent=section)
+            component = BlockFactory.create(category='problem', parent=vertical)
 
             self.chapter_location = chapter.location
             self.section_location = section.location

--- a/lms/djangoapps/courseware/tests/test_lti_integration.py
+++ b/lms/djangoapps/courseware/tests/test_lti_integration.py
@@ -15,7 +15,7 @@ from lms.djangoapps.courseware.tests.helpers import BaseTestXmodule
 from lms.djangoapps.courseware.views.views import get_course_lti_endpoints
 from openedx.core.lib.url_utils import quote_slashes
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.x_module import STUDENT_VIEW  # lint-amnesty, pylint: disable=wrong-import-order
 
 
@@ -137,31 +137,31 @@ class TestLTIBlockListing(SharedModuleStoreTestCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.course = CourseFactory.create(display_name=cls.COURSE_NAME, number=cls.COURSE_SLUG)
-        cls.chapter1 = ItemFactory.create(
+        cls.chapter1 = BlockFactory.create(
             parent_location=cls.course.location,
             display_name="chapter1",
             category='chapter')
-        cls.section1 = ItemFactory.create(
+        cls.section1 = BlockFactory.create(
             parent_location=cls.chapter1.location,
             display_name="section1",
             category='sequential')
-        cls.chapter2 = ItemFactory.create(
+        cls.chapter2 = BlockFactory.create(
             parent_location=cls.course.location,
             display_name="chapter2",
             category='chapter')
-        cls.section2 = ItemFactory.create(
+        cls.section2 = BlockFactory.create(
             parent_location=cls.chapter2.location,
             display_name="section2",
             category='sequential')
 
         # creates one draft and one published lti block, in different sections
-        cls.lti_published = ItemFactory.create(
+        cls.lti_published = BlockFactory.create(
             parent_location=cls.section1.location,
             display_name="lti published",
             category="lti",
             location=cls.course.id.make_usage_key('lti', 'lti_published'),
         )
-        cls.lti_draft = ItemFactory.create(
+        cls.lti_draft = BlockFactory.create(
             parent_location=cls.section2.location,
             display_name="lti draft",
             category="lti",

--- a/lms/djangoapps/courseware/tests/test_masquerade.py
+++ b/lms/djangoapps/courseware/tests/test_masquerade.py
@@ -36,7 +36,7 @@ from common.djangoapps.student.tests.factories import StaffFactory
 from common.djangoapps.student.tests.factories import UserFactory
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.partitions.partitions import Group, UserPartition  # lint-amnesty, pylint: disable=wrong-import-order
 
 
@@ -49,22 +49,22 @@ class MasqueradeTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase, Mas
     def setUpClass(cls):
         super().setUpClass()
         cls.course = CourseFactory.create(number='masquerade-test', metadata={'start': datetime.now(UTC)})
-        cls.info_page = ItemFactory.create(
+        cls.info_page = BlockFactory.create(
             category="course_info", parent_location=cls.course.location,
             data="OOGIE BLOOGIE", display_name="updates"
         )
-        cls.chapter = ItemFactory.create(
+        cls.chapter = BlockFactory.create(
             parent_location=cls.course.location,
             category="chapter",
             display_name="Test Section",
         )
         cls.sequential_display_name = "Test Masquerade Subsection"
-        cls.sequential = ItemFactory.create(
+        cls.sequential = BlockFactory.create(
             parent_location=cls.chapter.location,
             category="sequential",
             display_name=cls.sequential_display_name,
         )
-        cls.vertical = ItemFactory.create(
+        cls.vertical = BlockFactory.create(
             parent_location=cls.sequential.location,
             category="vertical",
             display_name="Test Unit",
@@ -77,7 +77,7 @@ class MasqueradeTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase, Mas
             correct_option='Correct'
         )
         cls.problem_display_name = "TestMasqueradeProblem"
-        cls.problem = ItemFactory.create(
+        cls.problem = BlockFactory.create(
             parent_location=cls.vertical.location,
             category='problem',
             data=problem_xml,

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -54,7 +54,7 @@ from xmodule.modulestore.tests.django_utils import (
     SharedModuleStoreTestCase,
     upload_file_to_course,
 )
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, ToyCourseFactory, check_mongo_calls  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory, ToyCourseFactory, check_mongo_calls  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.test_asides import AsideTestType  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.services import RebindUserServiceError
 from xmodule.video_block import VideoBlock  # lint-amnesty, pylint: disable=wrong-import-order
@@ -411,7 +411,7 @@ class ModuleRenderTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         request = self.request_factory.get('')
         request.user = self.mock_user
         course = CourseFactory()
-        descriptor = ItemFactory(category=block_type, parent=course)
+        descriptor = BlockFactory(category=block_type, parent=course)
         field_data_cache = FieldDataCache([self.toy_course, descriptor], self.toy_course.id, self.mock_user)
         # This is verifying that caching doesn't cause an error during get_module_for_descriptor, which
         # is why it calls the method twice identically.
@@ -467,7 +467,7 @@ class ModuleRenderTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         request.user = self.mock_user
         course = CourseFactory.create()
 
-        descriptor = ItemFactory(category="html", parent=course)
+        descriptor = BlockFactory(category="html", parent=course)
         if block_category == 'test_aside':
             descriptor = create_aside(descriptor, "test_aside")
 
@@ -713,7 +713,7 @@ class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCas
     @XBlock.register_temp_plugin(GradedStatelessXBlock, identifier='stateless_scorer')
     def test_score_without_student_state(self):
         course = CourseFactory.create()
-        block = ItemFactory.create(category='stateless_scorer', parent=course)
+        block = BlockFactory.create(category='stateless_scorer', parent=course)
 
         request = self.request_factory.post(
             'dummy_url',
@@ -746,7 +746,7 @@ class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCas
     def test_completion_events_with_completion_disabled(self, signal, data):
         with override_waffle_switch(ENABLE_COMPLETION_TRACKING_SWITCH, False):
             course = CourseFactory.create()
-            block = ItemFactory.create(category='comp', parent=course)
+            block = BlockFactory.create(category='comp', parent=course)
             request = self.request_factory.post(
                 '/',
                 data=json.dumps(data),
@@ -768,7 +768,7 @@ class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCas
     def test_completion_signal_for_completable_xblock(self):
         with override_waffle_switch(ENABLE_COMPLETION_TRACKING_SWITCH, True):
             course = CourseFactory.create()
-            block = ItemFactory.create(category='comp', parent=course)
+            block = BlockFactory.create(category='comp', parent=course)
 
             response = self.make_xblock_callback_response(
                 {'completion': 0.625}, course, block, 'complete'
@@ -786,7 +786,7 @@ class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCas
         test get_aside_from_xblock called
         """
         course = CourseFactory.create()
-        block = ItemFactory.create(category='comp', parent=course)
+        block = BlockFactory.create(category='comp', parent=course)
         request = self.request_factory.post(
             '/',
             data=json.dumps({'completion': 0.625}),
@@ -848,7 +848,7 @@ class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCas
     def test_progress_signal_ignored_for_completable_xblock(self):
         with override_waffle_switch(ENABLE_COMPLETION_TRACKING_SWITCH, True):
             course = CourseFactory.create()
-            block = ItemFactory.create(category='comp', parent=course)
+            block = BlockFactory.create(category='comp', parent=course)
 
             response = self.make_xblock_callback_response(
                 {}, course, block, 'progress'
@@ -861,7 +861,7 @@ class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCas
     def test_progress_signal_processed_for_xblock_without_completion_api(self):
         with override_waffle_switch(ENABLE_COMPLETION_TRACKING_SWITCH, True):
             course = CourseFactory.create()
-            block = ItemFactory.create(category='no_comp', parent=course)
+            block = BlockFactory.create(category='no_comp', parent=course)
 
             response = self.make_xblock_callback_response(
                 {}, course, block, 'progress'
@@ -875,7 +875,7 @@ class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCas
     def test_skip_handlers_for_masquerading_staff(self):
         with override_waffle_switch(ENABLE_COMPLETION_TRACKING_SWITCH, True):
             course = CourseFactory.create()
-            block = ItemFactory.create(category='comp', parent=course)
+            block = BlockFactory.create(category='comp', parent=course)
             request = self.request_factory.post(
                 '/',
                 data=json.dumps({'completion': 0.8}),
@@ -908,7 +908,7 @@ class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCas
         }
         request = self.request_factory.get('/')
         request.user = AnonymousUser()
-        descriptor = ItemFactory.create(**descriptor_kwargs)
+        descriptor = BlockFactory.create(**descriptor_kwargs)
 
         render.handle_xblock_callback(
             request,
@@ -933,7 +933,7 @@ class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCas
             'category': 'sequential',
             'parent': course,
         }
-        descriptor = ItemFactory.create(**descriptor_kwargs)
+        descriptor = BlockFactory.create(**descriptor_kwargs)
         usage_id = str(descriptor.location)
 
         # Send no special parameters, which will be invalid, but we don't care
@@ -1421,17 +1421,17 @@ class TestGatedSubsectionRendering(ModuleStoreTestCase, MilestonesTestCaseMixin)
         super().setUp()
 
         self.course = CourseFactory.create(enable_subsection_gating=True)
-        self.chapter = ItemFactory.create(
+        self.chapter = BlockFactory.create(
             parent=self.course,
             category="chapter",
             display_name="Chapter"
         )
-        self.open_seq = ItemFactory.create(
+        self.open_seq = BlockFactory.create(
             parent=self.chapter,
             category='sequential',
             display_name="Open Sequential"
         )
-        self.gated_seq = ItemFactory.create(
+        self.gated_seq = BlockFactory.create(
             parent=self.chapter,
             category='sequential',
             display_name="Gated Sequential"
@@ -1504,7 +1504,7 @@ class TestHtmlModifiers(ModuleStoreTestCase):
         self.rewrite_link = '<a href="/static/foo/content">Test rewrite</a>'
         self.rewrite_bad_link = '<img src="/static//file.jpg" />'
         self.course_link = '<a href="/course/bar/content">Test course rewrite</a>'
-        self.descriptor = ItemFactory.create(
+        self.descriptor = BlockFactory.create(
             category='html',
             data=self.content_string + self.rewrite_link + self.rewrite_bad_link + self.course_link
         )
@@ -1649,7 +1649,7 @@ class JsonInitDataTest(ModuleStoreTestCase):
         mock_request = MagicMock()
         mock_request.user = mock_user
         course = CourseFactory()
-        descriptor = ItemFactory(category='withjson', parent=course)
+        descriptor = BlockFactory(category='withjson', parent=course)
         field_data_cache = FieldDataCache([course, descriptor], course.id, mock_user)
         module = render.get_module_for_descriptor(
             mock_user,
@@ -1704,7 +1704,7 @@ class TestStaffDebugInfo(SharedModuleStoreTestCase):
             options=['Correct', 'Incorrect'],
             correct_option='Correct'
         )
-        self.descriptor = ItemFactory.create(
+        self.descriptor = BlockFactory.create(
             category='problem',
             data=problem_xml,
             display_name='Option Response Problem'
@@ -1757,7 +1757,7 @@ class TestStaffDebugInfo(SharedModuleStoreTestCase):
             </optionresponse>
         </problem>
         """
-        problem_descriptor = ItemFactory.create(
+        problem_descriptor = BlockFactory.create(
             category='problem',
             data=problem_xml
         )
@@ -1781,7 +1781,7 @@ class TestStaffDebugInfo(SharedModuleStoreTestCase):
     def test_staff_debug_info_disabled_for_detached_blocks(self):
         """Staff markup should not be present on detached blocks."""
 
-        descriptor = ItemFactory.create(
+        descriptor = BlockFactory.create(
             category='detached-block',
             display_name='Detached Block'
         )
@@ -1813,7 +1813,7 @@ class TestStaffDebugInfo(SharedModuleStoreTestCase):
     def test_histogram_enabled_for_unscored_xmodules(self):
         """Histograms should not display for xmodules which are not scored."""
 
-        html_descriptor = ItemFactory.create(
+        html_descriptor = BlockFactory.create(
             category='html',
             data='Here are some course details.'
         )
@@ -2020,7 +2020,7 @@ class TestModuleTrackingContext(SharedModuleStoreTestCase):
         if problem_display_name:
             descriptor_kwargs['display_name'] = problem_display_name
 
-        descriptor = ItemFactory.create(**descriptor_kwargs)
+        descriptor = BlockFactory.create(**descriptor_kwargs)
         mock_tracker_for_context = MagicMock()
         with patch('lms.djangoapps.courseware.module_render.tracker', mock_tracker_for_context), patch(
             'xmodule.services.tracker', mock_tracker_for_context
@@ -2157,8 +2157,8 @@ class TestRebindModule(TestSubmittingProblems):
     def setUp(self):
         super().setUp()
         self.homework = self.add_graded_section_to_course('homework')
-        self.lti = ItemFactory.create(category='lti', parent=self.homework)
-        self.problem = ItemFactory.create(category='problem', parent=self.homework)
+        self.lti = BlockFactory.create(category='lti', parent=self.homework)
+        self.problem = BlockFactory.create(category='problem', parent=self.homework)
         self.user = UserFactory.create()
         self.anon_user = AnonymousUser()
 
@@ -2247,7 +2247,7 @@ class TestEventPublishing(ModuleStoreTestCase, LoginEnrollmentTestCase):
         request = self.request_factory.get('')
         request.user = self.mock_user
         course = CourseFactory()
-        descriptor = ItemFactory(category='xblock', parent=course)
+        descriptor = BlockFactory(category='xblock', parent=course)
         field_data_cache = FieldDataCache([course, descriptor], course.id, self.mock_user)
         block = render.get_module(self.mock_user, request, descriptor.location, field_data_cache)
 
@@ -2290,7 +2290,7 @@ class LMSXBlockServiceMixin(SharedModuleStoreTestCase):
         self.student_data = Mock()
         self.track_function = Mock()
         self.request_token = Mock()
-        self.descriptor = ItemFactory(category="pure", parent=self.course)
+        self.descriptor = BlockFactory(category="pure", parent=self.course)
         self._prepare_runtime()
 
 
@@ -2524,11 +2524,11 @@ class TestFilteredChildren(SharedModuleStoreTestCase):
         """
         Instantiate an XBlock with the appropriate set of children.
         """
-        self.parent = ItemFactory(category='xblock', parent=self.course)
+        self.parent = BlockFactory(category='xblock', parent=self.course)
 
         # Create a child for each user
         self.children_for_user = {
-            user: ItemFactory(category='xblock', parent=self.parent).scope_ids.usage_id  # lint-amnesty, pylint: disable=no-member
+            user: BlockFactory(category='xblock', parent=self.parent).scope_ids.usage_id  # lint-amnesty, pylint: disable=no-member
             for user in self.users.values()
         }
 
@@ -2625,7 +2625,7 @@ class TestDisabledXBlockTypes(ModuleStoreTestCase):
         Returns the item's usage_id.
         """
         if not item_id:
-            item = ItemFactory(category=category, parent=course)
+            item = BlockFactory(category=category, parent=course)
             item_id = item.scope_ids.usage_id  # lint-amnesty, pylint: disable=no-member
 
         item = self.store.get_item(item_id)
@@ -2653,8 +2653,8 @@ class LmsModuleSystemShimTest(SharedModuleStoreTestCase):
         number = 'LmsModuleShimTest'
         run = '2021_Fall'
         cls.course = CourseFactory.create(org=org, number=number, run=run)
-        cls.descriptor = ItemFactory(category="vertical", parent=cls.course)
-        cls.problem_descriptor = ItemFactory(category="problem", parent=cls.course)
+        cls.descriptor = BlockFactory(category="vertical", parent=cls.course)
+        cls.problem_descriptor = BlockFactory(category="problem", parent=cls.course)
 
     def setUp(self):
         """
@@ -2883,7 +2883,7 @@ class LmsModuleSystemShimTest(SharedModuleStoreTestCase):
     @XBlock.register_temp_plugin(PureXBlock, 'pure')
     @XBlock.register_temp_plugin(PureXBlockWithChildren, identifier='xblock')
     def test_course_id(self):
-        descriptor = ItemFactory(category="pure", parent=self.course)
+        descriptor = BlockFactory(category="pure", parent=self.course)
 
         block = render.get_module(self.user, Mock(), descriptor.location, None)
         assert str(block.runtime.course_id) == self.COURSE_ID

--- a/lms/djangoapps/courseware/tests/test_navigation.py
+++ b/lms/djangoapps/courseware/tests/test_navigation.py
@@ -12,7 +12,7 @@ from django.urls import reverse
 from edx_toggles.toggles.testutils import override_waffle_flag
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase, set_preview_mode
@@ -34,38 +34,38 @@ class TestNavigation(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
 
     @classmethod
     def setUpTestData(cls):  # lint-amnesty, pylint: disable=super-method-not-called
-        cls.chapter0 = ItemFactory.create(parent=cls.course,
-                                          display_name='Overview')
-        cls.chapter9 = ItemFactory.create(parent=cls.course,
-                                          display_name='factory_chapter')
-        cls.section0 = ItemFactory.create(parent=cls.chapter0,
-                                          display_name='Welcome')
-        cls.section9 = ItemFactory.create(parent=cls.chapter9,
-                                          display_name='factory_section')
-        cls.unit0 = ItemFactory.create(parent=cls.section0,
-                                       display_name='New Unit 0')
+        cls.chapter0 = BlockFactory.create(parent=cls.course,
+                                           display_name='Overview')
+        cls.chapter9 = BlockFactory.create(parent=cls.course,
+                                           display_name='factory_chapter')
+        cls.section0 = BlockFactory.create(parent=cls.chapter0,
+                                           display_name='Welcome')
+        cls.section9 = BlockFactory.create(parent=cls.chapter9,
+                                           display_name='factory_section')
+        cls.unit0 = BlockFactory.create(parent=cls.section0,
+                                        display_name='New Unit 0')
 
-        cls.chapterchrome = ItemFactory.create(parent=cls.course,
-                                               display_name='Chrome')
-        cls.chromelesssection = ItemFactory.create(parent=cls.chapterchrome,
-                                                   display_name='chromeless',
-                                                   chrome='none')
-        cls.accordionsection = ItemFactory.create(parent=cls.chapterchrome,
-                                                  display_name='accordion',
-                                                  chrome='accordion')
-        cls.tabssection = ItemFactory.create(parent=cls.chapterchrome,
-                                             display_name='tabs',
-                                             chrome='tabs')
-        cls.defaultchromesection = ItemFactory.create(
+        cls.chapterchrome = BlockFactory.create(parent=cls.course,
+                                                display_name='Chrome')
+        cls.chromelesssection = BlockFactory.create(parent=cls.chapterchrome,
+                                                    display_name='chromeless',
+                                                    chrome='none')
+        cls.accordionsection = BlockFactory.create(parent=cls.chapterchrome,
+                                                   display_name='accordion',
+                                                   chrome='accordion')
+        cls.tabssection = BlockFactory.create(parent=cls.chapterchrome,
+                                              display_name='tabs',
+                                              chrome='tabs')
+        cls.defaultchromesection = BlockFactory.create(
             parent=cls.chapterchrome,
             display_name='defaultchrome',
         )
-        cls.fullchromesection = ItemFactory.create(parent=cls.chapterchrome,
-                                                   display_name='fullchrome',
-                                                   chrome='accordion,tabs')
-        cls.tabtest = ItemFactory.create(parent=cls.chapterchrome,
-                                         display_name='pdf_textbooks_tab',
-                                         default_tab='progress')
+        cls.fullchromesection = BlockFactory.create(parent=cls.chapterchrome,
+                                                    display_name='fullchrome',
+                                                    chrome='accordion,tabs')
+        cls.tabtest = BlockFactory.create(parent=cls.chapterchrome,
+                                          display_name='pdf_textbooks_tab',
+                                          default_tab='progress')
 
         cls.user = GlobalStaffFactory(password='test')
 
@@ -206,7 +206,7 @@ class TestNavigation(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         response = self.assert_request_status_code(200, url)
         self.assertContains(response, "No content has been added to this course")
 
-        section = ItemFactory.create(
+        section = BlockFactory.create(
             parent_location=self.test_course.location,
             display_name='New Section'
         )
@@ -218,7 +218,7 @@ class TestNavigation(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         self.assertNotContains(response, "No content has been added to this course")
         self.assertContains(response, "New Section")
 
-        subsection = ItemFactory.create(
+        subsection = BlockFactory.create(
             parent_location=section.location,
             display_name='New Subsection',
         )
@@ -230,7 +230,7 @@ class TestNavigation(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         self.assertContains(response, "New Subsection")
         self.assertNotContains(response, "sequence-nav")
 
-        ItemFactory.create(
+        BlockFactory.create(
             parent_location=subsection.location,
             display_name='New Unit',
         )

--- a/lms/djangoapps/courseware/tests/test_self_paced_overrides.py
+++ b/lms/djangoapps/courseware/tests/test_self_paced_overrides.py
@@ -12,7 +12,7 @@ from lms.djangoapps.ccx.tests.test_overrides import inject_field_overrides
 from lms.djangoapps.courseware.field_overrides import OverrideFieldData, OverrideModulestoreFieldData
 from openedx.core.djangoapps.discussions.utils import get_accessible_discussion_xblocks
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 
 @override_settings(
@@ -54,13 +54,13 @@ class SelfPacedDateOverrideTest(ModuleStoreTestCase):
         overrides are correctly applied for both blocks.
         """
         course = CourseFactory.create(**course_kwargs)
-        section = ItemFactory.create(parent=course, due=self.now)
+        section = BlockFactory.create(parent=course, due=self.now)
         inject_field_overrides((course, section), course, self.user)
         return (course, section)
 
     def create_discussion_xblocks(self, parent):  # lint-amnesty, pylint: disable=missing-function-docstring
         # Create a released discussion xblock
-        ItemFactory.create(
+        BlockFactory.create(
             parent=parent,
             category='discussion',
             display_name='released',
@@ -68,7 +68,7 @@ class SelfPacedDateOverrideTest(ModuleStoreTestCase):
         )
 
         # Create a scheduled discussion xblock
-        ItemFactory.create(
+        BlockFactory.create(
             parent=parent,
             category='discussion',
             display_name='scheduled',

--- a/lms/djangoapps/courseware/tests/test_services.py
+++ b/lms/djangoapps/courseware/tests/test_services.py
@@ -12,7 +12,7 @@ from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.courseware.services import UserStateService
 from lms.djangoapps.courseware.tests.factories import StudentModuleFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 
 @ddt.ddt
@@ -28,22 +28,22 @@ class TestUserStateService(ModuleStoreTestCase):
         super().setUp()
         self.user = UserFactory.create()
         self.course = CourseFactory.create()
-        chapter = ItemFactory.create(
+        chapter = BlockFactory.create(
             category='chapter',
             parent=self.course,
             display_name='Test Chapter'
         )
-        sequential = ItemFactory.create(
+        sequential = BlockFactory.create(
             category='sequential',
             parent=chapter,
             display_name='Test Sequential'
         )
-        vertical = ItemFactory.create(
+        vertical = BlockFactory.create(
             category='vertical',
             parent=sequential,
             display_name='Test Vertical'
         )
-        self.problem = ItemFactory.create(
+        self.problem = BlockFactory.create(
             category='problem',
             parent=vertical,
             display_name='Test Problem'

--- a/lms/djangoapps/courseware/tests/test_split_module.py
+++ b/lms/djangoapps/courseware/tests/test_split_module.py
@@ -6,7 +6,7 @@ Test for split test XModule
 from unittest.mock import MagicMock
 from django.urls import reverse
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 from xmodule.partitions.partitions import Group, UserPartition
 
 from lms.djangoapps.courseware.model_data import FieldDataCache
@@ -46,12 +46,12 @@ class SplitTestBase(ModuleStoreTestCase):
             number=self.COURSE_NUMBER,
             user_partitions=[self.partition]
         )
-        self.chapter = ItemFactory.create(
+        self.chapter = BlockFactory.create(
             parent_location=self.course.location,
             category="chapter",
             display_name="test chapter",
         )
-        self.sequential = ItemFactory.create(
+        self.sequential = BlockFactory.create(
             parent_location=self.chapter.location,
             category="sequential",
             display_name="Split Test Tests",
@@ -69,7 +69,7 @@ class SplitTestBase(ModuleStoreTestCase):
         Returns a video component with parent ``parent``
         that is intended to be displayed to group ``group``.
         """
-        return ItemFactory.create(
+        return BlockFactory.create(
             parent_location=parent.location,
             category="video",
             display_name=f"Group {group} Sees This Video",
@@ -80,7 +80,7 @@ class SplitTestBase(ModuleStoreTestCase):
         Returns a problem component with parent ``parent``
         that is intended to be displayed to group ``group``.
         """
-        return ItemFactory.create(
+        return BlockFactory.create(
             parent_location=parent.location,
             category="problem",
             display_name=f"Group {group} Sees This Problem",
@@ -92,7 +92,7 @@ class SplitTestBase(ModuleStoreTestCase):
         Returns an html component with parent ``parent``
         that is intended to be displayed to group ``group``.
         """
-        return ItemFactory.create(
+        return BlockFactory.create(
             parent_location=parent.location,
             category="html",
             display_name=f"Group {group} Sees This HTML",
@@ -166,7 +166,7 @@ class TestSplitTestVert(SplitTestBase):
         c0_url = self.course.id.make_usage_key("vertical", "split_test_cond0")
         c1_url = self.course.id.make_usage_key("vertical", "split_test_cond1")
 
-        split_test = ItemFactory.create(
+        split_test = BlockFactory.create(
             parent_location=self.sequential.location,
             category="split_test",
             display_name="Split test",
@@ -174,7 +174,7 @@ class TestSplitTestVert(SplitTestBase):
             group_id_to_child={"0": c0_url, "1": c1_url},
         )
 
-        cond0vert = ItemFactory.create(
+        cond0vert = BlockFactory.create(
             parent_location=split_test.location,
             category="vertical",
             display_name="Condition 0 vertical",
@@ -183,7 +183,7 @@ class TestSplitTestVert(SplitTestBase):
         video0 = self._video(cond0vert, 0)
         problem0 = self._problem(cond0vert, 0)
 
-        cond1vert = ItemFactory.create(
+        cond1vert = BlockFactory.create(
             parent_location=split_test.location,
             category="vertical",
             display_name="Condition 1 vertical",
@@ -231,7 +231,7 @@ class TestVertSplitTestVert(SplitTestBase):
         # We define problem compenents that we need but don't explicitly call elsewhere.
         super().setUp()
 
-        vert1 = ItemFactory.create(
+        vert1 = BlockFactory.create(
             parent_location=self.sequential.location,
             category="vertical",
             display_name="Split test vertical",
@@ -239,7 +239,7 @@ class TestVertSplitTestVert(SplitTestBase):
         c0_url = self.course.id.make_usage_key("vertical", "split_test_cond0")
         c1_url = self.course.id.make_usage_key("vertical", "split_test_cond1")
 
-        split_test = ItemFactory.create(
+        split_test = BlockFactory.create(
             parent_location=vert1.location,
             category="split_test",
             display_name="Split test",
@@ -247,7 +247,7 @@ class TestVertSplitTestVert(SplitTestBase):
             group_id_to_child={"0": c0_url, "1": c1_url},
         )
 
-        cond0vert = ItemFactory.create(
+        cond0vert = BlockFactory.create(
             parent_location=split_test.location,
             category="vertical",
             display_name="Condition 0 Vertical",
@@ -256,7 +256,7 @@ class TestVertSplitTestVert(SplitTestBase):
         video0 = self._video(cond0vert, 0)
         problem0 = self._problem(cond0vert, 0)
 
-        cond1vert = ItemFactory.create(
+        cond1vert = BlockFactory.create(
             parent_location=split_test.location,
             category="vertical",
             display_name="Condition 1 Vertical",
@@ -298,7 +298,7 @@ class SplitTestPosition(SharedModuleStoreTestCase):
             user_partitions=[cls.partition]
         )
 
-        cls.chapter = ItemFactory.create(
+        cls.chapter = BlockFactory.create(
             parent_location=cls.course.location,
             category="chapter",
             display_name="test chapter",

--- a/lms/djangoapps/courseware/tests/test_submitting_problems.py
+++ b/lms/djangoapps/courseware/tests/test_submitting_problems.py
@@ -39,7 +39,7 @@ from openedx.core.djangoapps.user_api.tests.factories import UserCourseTagFactor
 from openedx.core.lib.url_utils import quote_slashes
 from common.djangoapps.student.models import CourseEnrollment, anonymous_id_for_user
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.partitions.partitions import Group, UserPartition  # lint-amnesty, pylint: disable=wrong-import-order
 
 
@@ -181,7 +181,7 @@ class TestSubmittingProblems(ModuleStoreTestCase, LoginEnrollmentTestCase, Probl
             correct_option='Correct'
         )
 
-        problem = ItemFactory.create(
+        problem = BlockFactory.create(
             parent_location=section_location,
             category='problem',
             data=prob_xml,
@@ -200,13 +200,13 @@ class TestSubmittingProblems(ModuleStoreTestCase, LoginEnrollmentTestCase, Probl
 
         # if we don't already have a chapter create a new one
         if not hasattr(self, 'chapter'):
-            self.chapter = ItemFactory.create(
+            self.chapter = BlockFactory.create(
                 parent_location=self.course.location,
                 category='chapter'
             )
 
         if late:
-            section = ItemFactory.create(
+            section = BlockFactory.create(
                 parent_location=self.chapter.location,
                 display_name=name,
                 category='sequential',
@@ -217,7 +217,7 @@ class TestSubmittingProblems(ModuleStoreTestCase, LoginEnrollmentTestCase, Probl
                 },
             )
         elif reset:
-            section = ItemFactory.create(
+            section = BlockFactory.create(
                 parent_location=self.chapter.location,
                 display_name=name,
                 category='sequential',
@@ -229,7 +229,7 @@ class TestSubmittingProblems(ModuleStoreTestCase, LoginEnrollmentTestCase, Probl
             )
 
         elif showanswer:
-            section = ItemFactory.create(
+            section = BlockFactory.create(
                 parent_location=self.chapter.location,
                 display_name=name,
                 category='sequential',
@@ -241,7 +241,7 @@ class TestSubmittingProblems(ModuleStoreTestCase, LoginEnrollmentTestCase, Probl
             )
 
         else:
-            section = ItemFactory.create(
+            section = BlockFactory.create(
                 parent_location=self.chapter.location,
                 display_name=name,
                 category='sequential',
@@ -773,7 +773,7 @@ class ProblemWithUploadedFilesTest(TestSubmittingProblems):
         xmldata = CodeResponseXMLFactory().build_xml(
             allowed_files=files, required_files=files,
         )
-        ItemFactory.create(
+        BlockFactory.create(
             parent_location=self.section.location,
             category='problem',
             display_name=name,
@@ -919,7 +919,7 @@ class TestPythonGradedResponse(TestSubmittingProblems):
         script = self.SCHEMATIC_SCRIPT
 
         xmldata = SchematicResponseXMLFactory().build_xml(answer=script)
-        ItemFactory.create(
+        BlockFactory.create(
             parent_location=self.section.location,
             category='problem',
             boilerplate='circuitschematic.yaml',
@@ -943,7 +943,7 @@ class TestPythonGradedResponse(TestSubmittingProblems):
         expect = self.CUSTOM_RESPONSE_CORRECT
         cfn_problem_xml = CustomResponseXMLFactory().build_xml(script=test_csv, cfn='test_csv', expect=expect)
 
-        ItemFactory.create(
+        BlockFactory.create(
             parent_location=self.section.location,
             category='problem',
             boilerplate='customgrader.yaml',
@@ -967,7 +967,7 @@ class TestPythonGradedResponse(TestSubmittingProblems):
 
         computed_xml = CustomResponseXMLFactory().build_xml(answer=script)
 
-        ItemFactory.create(
+        BlockFactory.create(
             parent_location=self.section.location,
             category='problem',
             boilerplate='customgrader.yaml',
@@ -1120,7 +1120,7 @@ class TestConditionalContent(TestSubmittingProblems):
         for index, url in enumerate([vertical_0_url, vertical_1_url]):
             group_id_to_child[str(index)] = url
 
-        split_test = ItemFactory.create(
+        split_test = BlockFactory.create(
             parent_location=self.homework_conditional.location,
             category="split_test",
             display_name="Split test",
@@ -1128,14 +1128,14 @@ class TestConditionalContent(TestSubmittingProblems):
             group_id_to_child=group_id_to_child,
         )
 
-        vertical_0 = ItemFactory.create(
+        vertical_0 = BlockFactory.create(
             parent_location=split_test.location,
             category="vertical",
             display_name="Condition 0 vertical",
             location=vertical_0_url,
         )
 
-        vertical_1 = ItemFactory.create(
+        vertical_1 = BlockFactory.create(
             parent_location=split_test.location,
             category="vertical",
             display_name="Condition 1 vertical",

--- a/lms/djangoapps/courseware/tests/test_tabs.py
+++ b/lms/djangoapps/courseware/tests/test_tabs.py
@@ -42,7 +42,7 @@ from xmodule.modulestore.tests.django_utils import (  # lint-amnesty, pylint: di
     ModuleStoreTestCase,
     SharedModuleStoreTestCase
 )
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.utils import TEST_DATA_DIR  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.xml_importer import import_course_from_xml  # lint-amnesty, pylint: disable=wrong-import-order
 
@@ -242,7 +242,7 @@ class StaticTabDateTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.course = CourseFactory.create()
-        cls.page = ItemFactory.create(
+        cls.page = BlockFactory.create(
             category="static_tab", parent_location=cls.course.location,
             data="OOGIE BLOOGIE", display_name="new_tab"
         )
@@ -346,11 +346,11 @@ class EntranceExamsTabsTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, Mi
         super().setUp()
 
         self.course = CourseFactory.create()
-        self.extra_tab_2 = ItemFactory.create(
+        self.extra_tab_2 = BlockFactory.create(
             category="static_tab", parent_location=self.course.location,
             data="Extra Tab", display_name="Extra Tab 2"
         )
-        self.extra_tab_3 = ItemFactory.create(
+        self.extra_tab_3 = BlockFactory.create(
             category="static_tab", parent_location=self.course.location,
             data="Extra Tab", display_name="Extra Tab 3"
         )
@@ -364,7 +364,7 @@ class EntranceExamsTabsTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, Mi
         """
         Unit Test: test_get_course_tabs_list_entrance_exam_enabled
         """
-        entrance_exam = ItemFactory.create(
+        entrance_exam = BlockFactory.create(
             category="chapter",
             parent_location=self.course.location,
             display_name="Entrance Exam",

--- a/lms/djangoapps/courseware/tests/test_video_xml.py
+++ b/lms/djangoapps/courseware/tests/test_video_xml.py
@@ -9,7 +9,7 @@ You can search for usages of this in the cms and lms tests for examples.
 You use this so that it will do things like point the modulestore
 setting to mongo, flush the contentstore before and after, load the
 templates, etc.
-You can then use the CourseFactory and XModuleItemFactory as defined in
+You can then use the CourseFactory and BlockFactory as defined in
 xmodule/modulestore/tests/factories.py to create the
 course, section, subsection, unit, etc.
 """

--- a/lms/djangoapps/courseware/tests/test_view_authentication.py
+++ b/lms/djangoapps/courseware/tests/test_view_authentication.py
@@ -10,7 +10,7 @@ import pytz
 from django.urls import reverse
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
 from common.djangoapps.student.tests.factories import BetaTesterFactory
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
@@ -117,16 +117,16 @@ class TestViewAuth(EnterpriseTestConsentRequired, ModuleStoreTestCase, LoginEnro
         super().setUp()
 
         self.course = CourseFactory.create(number='999', display_name='Robot_Super_Course')
-        self.courseware_chapter = ItemFactory.create(display_name='courseware')
-        self.overview_chapter = ItemFactory.create(
+        self.courseware_chapter = BlockFactory.create(display_name='courseware')
+        self.overview_chapter = BlockFactory.create(
             parent_location=self.course.location,
             display_name='Super Overview'
         )
-        self.welcome_section = ItemFactory.create(
+        self.welcome_section = BlockFactory.create(
             parent_location=self.overview_chapter.location,
             display_name='Super Welcome'
         )
-        self.welcome_unit = ItemFactory.create(
+        self.welcome_unit = BlockFactory.create(
             parent_location=self.welcome_section.location,
             display_name='Super Unit'
         )
@@ -134,19 +134,19 @@ class TestViewAuth(EnterpriseTestConsentRequired, ModuleStoreTestCase, LoginEnro
 
         self.test_course = CourseFactory.create(org=self.course.id.org)
         self.other_org_course = CourseFactory.create(org='Other_Org_Course')
-        self.sub_courseware_chapter = ItemFactory.create(
+        self.sub_courseware_chapter = BlockFactory.create(
             parent_location=self.test_course.location,
             display_name='courseware'
         )
-        self.sub_overview_chapter = ItemFactory.create(
+        self.sub_overview_chapter = BlockFactory.create(
             parent_location=self.sub_courseware_chapter.location,
             display_name='Overview'
         )
-        self.sub_welcome_section = ItemFactory.create(
+        self.sub_welcome_section = BlockFactory.create(
             parent_location=self.sub_overview_chapter.location,
             display_name='Welcome'
         )
-        self.sub_welcome_unit = ItemFactory.create(
+        self.sub_welcome_unit = BlockFactory.create(
             parent_location=self.sub_welcome_section.location,
             display_name='New Unit'
         )
@@ -423,7 +423,7 @@ class TestBetatesterAccess(ModuleStoreTestCase, CourseAccessTestMixin):
         tomorrow = now + datetime.timedelta(days=1)
 
         self.course = CourseFactory(days_early_for_beta=2, start=tomorrow)
-        self.content = ItemFactory(parent=self.course)
+        self.content = BlockFactory(parent=self.course)
 
         self.normal_student = UserFactory()
         self.beta_tester = BetaTesterFactory(course_key=self.course.id)  # lint-amnesty, pylint: disable=no-member

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -37,7 +37,7 @@ from xmodule.graders import ShowCorrectness
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import CourseUserType, ModuleStoreTestCase, SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, check_mongo_calls
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory, check_mongo_calls
 
 import lms.djangoapps.courseware.views.views as views
 from common.djangoapps.course_modes.models import CourseMode
@@ -123,7 +123,7 @@ class TestJumpTo(ModuleStoreTestCase):
         Can be removed when the MFE supports a preview mode.
         """
         course = CourseFactory.create()
-        chapter = ItemFactory.create(category='chapter', parent_location=course.location)
+        chapter = BlockFactory.create(category='chapter', parent_location=course.location)
         if expect_mfe:
             expected_url = f'http://learning-mfe/course/{course.id}/{chapter.location}'
         else:
@@ -170,8 +170,8 @@ class TestJumpTo(ModuleStoreTestCase):
     def test_jump_to_legacy_from_sequence(self):
         with self.store.default_store(ModuleStoreEnum.Type.split):
             course = CourseFactory.create()
-            chapter = ItemFactory.create(category='chapter', parent_location=course.location)
-            sequence = ItemFactory.create(category='sequential', parent_location=chapter.location)
+            chapter = BlockFactory.create(category='chapter', parent_location=course.location)
+            sequence = BlockFactory.create(category='sequential', parent_location=chapter.location)
         activate_block_id = urlencode({'activate_block_id': str(sequence.location)})
         expected_redirect_url = (
             f'/courses/{course.id}/courseware/{chapter.url_name}/{sequence.url_name}/?{activate_block_id}'
@@ -183,8 +183,8 @@ class TestJumpTo(ModuleStoreTestCase):
     @set_preview_mode(False)
     def test_jump_to_mfe_from_sequence(self):
         course = CourseFactory.create()
-        chapter = ItemFactory.create(category='chapter', parent_location=course.location)
-        sequence = ItemFactory.create(category='sequential', parent_location=chapter.location)
+        chapter = BlockFactory.create(category='chapter', parent_location=course.location)
+        sequence = BlockFactory.create(category='sequential', parent_location=chapter.location)
         expected_redirect_url = (
             f'http://learning-mfe/course/{course.id}/{sequence.location}'
         )
@@ -197,12 +197,12 @@ class TestJumpTo(ModuleStoreTestCase):
     def test_jump_to_legacy_from_module(self):
         with self.store.default_store(ModuleStoreEnum.Type.split):
             course = CourseFactory.create()
-            chapter = ItemFactory.create(category='chapter', parent_location=course.location)
-            sequence = ItemFactory.create(category='sequential', parent_location=chapter.location)
-            vertical1 = ItemFactory.create(category='vertical', parent_location=sequence.location)
-            vertical2 = ItemFactory.create(category='vertical', parent_location=sequence.location)
-            module1 = ItemFactory.create(category='html', parent_location=vertical1.location)
-            module2 = ItemFactory.create(category='html', parent_location=vertical2.location)
+            chapter = BlockFactory.create(category='chapter', parent_location=course.location)
+            sequence = BlockFactory.create(category='sequential', parent_location=chapter.location)
+            vertical1 = BlockFactory.create(category='vertical', parent_location=sequence.location)
+            vertical2 = BlockFactory.create(category='vertical', parent_location=sequence.location)
+            module1 = BlockFactory.create(category='html', parent_location=vertical1.location)
+            module2 = BlockFactory.create(category='html', parent_location=vertical2.location)
 
         activate_block_id = urlencode({'activate_block_id': str(module1.location)})
         expected_redirect_url = (
@@ -223,12 +223,12 @@ class TestJumpTo(ModuleStoreTestCase):
     @set_preview_mode(False)
     def test_jump_to_mfe_from_module(self):
         course = CourseFactory.create()
-        chapter = ItemFactory.create(category='chapter', parent_location=course.location)
-        sequence = ItemFactory.create(category='sequential', parent_location=chapter.location)
-        vertical1 = ItemFactory.create(category='vertical', parent_location=sequence.location)
-        vertical2 = ItemFactory.create(category='vertical', parent_location=sequence.location)
-        module1 = ItemFactory.create(category='html', parent_location=vertical1.location)
-        module2 = ItemFactory.create(category='html', parent_location=vertical2.location)
+        chapter = BlockFactory.create(category='chapter', parent_location=course.location)
+        sequence = BlockFactory.create(category='sequential', parent_location=chapter.location)
+        vertical1 = BlockFactory.create(category='vertical', parent_location=sequence.location)
+        vertical2 = BlockFactory.create(category='vertical', parent_location=sequence.location)
+        module1 = BlockFactory.create(category='html', parent_location=vertical1.location)
+        module2 = BlockFactory.create(category='html', parent_location=vertical2.location)
 
         expected_redirect_url = (
             f'http://learning-mfe/course/{course.id}/{sequence.location}/{vertical1.location}'
@@ -252,15 +252,15 @@ class TestJumpTo(ModuleStoreTestCase):
     def test_jump_to_legacy_from_nested_module(self):
         with self.store.default_store(ModuleStoreEnum.Type.split):
             course = CourseFactory.create()
-            chapter = ItemFactory.create(category='chapter', parent_location=course.location)
-            sequence = ItemFactory.create(category='sequential', parent_location=chapter.location)
-            vertical = ItemFactory.create(category='vertical', parent_location=sequence.location)
-            nested_sequence = ItemFactory.create(category='sequential', parent_location=vertical.location)
-            nested_vertical1 = ItemFactory.create(category='vertical', parent_location=nested_sequence.location)
+            chapter = BlockFactory.create(category='chapter', parent_location=course.location)
+            sequence = BlockFactory.create(category='sequential', parent_location=chapter.location)
+            vertical = BlockFactory.create(category='vertical', parent_location=sequence.location)
+            nested_sequence = BlockFactory.create(category='sequential', parent_location=vertical.location)
+            nested_vertical1 = BlockFactory.create(category='vertical', parent_location=nested_sequence.location)
             # put a module into nested_vertical1 for completeness
-            ItemFactory.create(category='html', parent_location=nested_vertical1.location)
-            nested_vertical2 = ItemFactory.create(category='vertical', parent_location=nested_sequence.location)
-            module2 = ItemFactory.create(category='html', parent_location=nested_vertical2.location)
+            BlockFactory.create(category='html', parent_location=nested_vertical1.location)
+            nested_vertical2 = BlockFactory.create(category='vertical', parent_location=nested_sequence.location)
+            module2 = BlockFactory.create(category='html', parent_location=nested_vertical2.location)
 
         # internal position of module2 will be 1_2 (2nd item withing 1st item)
         activate_block_id = urlencode({'activate_block_id': str(module2.location)})
@@ -303,12 +303,12 @@ class TestJumpTo(ModuleStoreTestCase):
             request.user = UserFactory(is_staff=is_staff_user, username="staff")
             request.session = {}
             course_key = CourseKey.from_string(str(course.id))
-            chapter = ItemFactory.create(category='chapter', parent_location=course.location)
-            sequence = ItemFactory.create(category='sequential', parent_location=chapter.location)
-            __ = ItemFactory.create(category='vertical', parent_location=sequence.location)
-            staff_only_vertical = ItemFactory.create(category='vertical', parent_location=sequence.location,
-                                                     metadata=dict(visible_to_staff_only=True))
-            __ = ItemFactory.create(category='vertical', parent_location=sequence.location)
+            chapter = BlockFactory.create(category='chapter', parent_location=course.location)
+            sequence = BlockFactory.create(category='sequential', parent_location=chapter.location)
+            __ = BlockFactory.create(category='vertical', parent_location=sequence.location)
+            staff_only_vertical = BlockFactory.create(category='vertical', parent_location=sequence.location,
+                                                      metadata=dict(visible_to_staff_only=True))
+            __ = BlockFactory.create(category='vertical', parent_location=sequence.location)
 
         usage_key = UsageKey.from_string(str(staff_only_vertical.location)).replace(course_key=course_key)
         expected_url = reverse(
@@ -337,11 +337,11 @@ class IndexQueryTestCase(ModuleStoreTestCase):
         with self.store.default_store(ModuleStoreEnum.Type.split):
             course = CourseFactory.create()
             with self.store.bulk_operations(course.id):
-                chapter = ItemFactory.create(category='chapter', parent_location=course.location)
-                section = ItemFactory.create(category='sequential', parent_location=chapter.location)
-                vertical = ItemFactory.create(category='vertical', parent_location=section.location)
+                chapter = BlockFactory.create(category='chapter', parent_location=course.location)
+                section = BlockFactory.create(category='sequential', parent_location=chapter.location)
+                vertical = BlockFactory.create(category='vertical', parent_location=section.location)
                 for _ in range(self.NUM_PROBLEMS):
-                    ItemFactory.create(category='problem', parent_location=vertical.location)
+                    BlockFactory.create(category='problem', parent_location=vertical.location)
 
         self.client.login(username=self.user.username, password=self.user_password)
         CourseEnrollment.enroll(self.user, course.id)
@@ -368,40 +368,40 @@ class BaseViewsTestCase(ModuleStoreTestCase, MasqueradeMixin):
         super().setUp()
         self.course = CourseFactory.create(display_name='teꜱᴛ course', run="Testing_course")
         with self.store.bulk_operations(self.course.id):
-            self.chapter = ItemFactory.create(
+            self.chapter = BlockFactory.create(
                 category='chapter',
                 parent_location=self.course.location,
                 display_name="Chapter 1",
             )
-            self.section = ItemFactory.create(
+            self.section = BlockFactory.create(
                 category='sequential',
                 parent_location=self.chapter.location,
                 due=datetime(2013, 9, 18, 11, 30, 00),
                 display_name='Sequential 1',
                 format='Homework'
             )
-            self.vertical = ItemFactory.create(
+            self.vertical = BlockFactory.create(
                 category='vertical',
                 parent_location=self.section.location,
                 display_name='Vertical 1',
             )
-            self.problem = ItemFactory.create(
+            self.problem = BlockFactory.create(
                 category='problem',
                 parent_location=self.vertical.location,
                 display_name='Problem 1',
             )
 
-            self.section2 = ItemFactory.create(
+            self.section2 = BlockFactory.create(
                 category='sequential',
                 parent_location=self.chapter.location,
                 display_name='Sequential 2',
             )
-            self.vertical2 = ItemFactory.create(
+            self.vertical2 = BlockFactory.create(
                 category='vertical',
                 parent_location=self.section2.location,
                 display_name='Vertical 2',
             )
-            self.problem2 = ItemFactory.create(
+            self.problem2 = BlockFactory.create(
                 category='problem',
                 parent_location=self.vertical2.location,
                 display_name='Problem 2',
@@ -1084,15 +1084,15 @@ class BaseDueDateTests(ModuleStoreTestCase):
         """
         course = CourseFactory.create(**course_kwargs)
         with self.store.bulk_operations(course.id):
-            chapter = ItemFactory.create(category='chapter', parent_location=course.location)
-            section = ItemFactory.create(
+            chapter = BlockFactory.create(category='chapter', parent_location=course.location)
+            section = BlockFactory.create(
                 category='sequential',
                 parent_location=chapter.location,
                 due=datetime(2013, 9, 18, 11, 30, 00),
                 format='homework'
             )
-            vertical = ItemFactory.create(category='vertical', parent_location=section.location)
-            ItemFactory.create(category='problem', parent_location=vertical.location)
+            vertical = BlockFactory.create(category='vertical', parent_location=section.location)
+            BlockFactory.create(category='problem', parent_location=vertical.location)
 
         course = modulestore().get_course(course.id)
         assert course.get_children()[0].get_children()[0].due is not None
@@ -1263,9 +1263,9 @@ class ProgressPageBaseTests(ModuleStoreTestCase):
         """Create the test course and content, and enroll the user."""
         self.create_course(**course_options, grading_policy={'GRADE_CUTOFFS': {'çü†øƒƒ': 0.75, 'Pass': 0.5}})
         with self.store.bulk_operations(self.course.id):
-            self.chapter = ItemFactory.create(category='chapter', parent_location=self.course.location)
-            self.section = ItemFactory.create(category='sequential', parent_location=self.chapter.location)
-            self.vertical = ItemFactory.create(category='vertical', parent_location=self.section.location)
+            self.chapter = BlockFactory.create(category='chapter', parent_location=self.course.location)
+            self.section = BlockFactory.create(category='sequential', parent_location=self.chapter.location)
+            self.vertical = BlockFactory.create(category='vertical', parent_location=self.section.location)
 
         CourseEnrollmentFactory(user=self.user, course_id=self.course.id, mode=CourseMode.HONOR)
 
@@ -1307,7 +1307,7 @@ class ProgressPageTests(ProgressPageBaseTests):
         self.assertNotContains(resp, malicious_code)
 
     def test_pure_ungraded_xblock(self):
-        ItemFactory.create(category='acid', parent_location=self.vertical.location)
+        BlockFactory.create(category='acid', parent_location=self.vertical.location)
         self._get_progress_page()
 
     def test_student_progress_with_valid_and_invalid_id(self):
@@ -1901,11 +1901,11 @@ class ProgressPageShowCorrectnessTests(ProgressPageBaseTests):
             metadata['format'] = self.GRADER_TYPE
 
         with self.store.bulk_operations(self.course.id):
-            self.chapter = ItemFactory.create(category='chapter', parent_location=self.course.location,
-                                              display_name="Section 1")
-            self.section = ItemFactory.create(category='sequential', parent_location=self.chapter.location,
-                                              display_name="Subsection 1", metadata=metadata)
-            self.vertical = ItemFactory.create(category='vertical', parent_location=self.section.location)
+            self.chapter = BlockFactory.create(category='chapter', parent_location=self.course.location,
+                                               display_name="Section 1")
+            self.section = BlockFactory.create(category='sequential', parent_location=self.chapter.location,
+                                               display_name="Subsection 1", metadata=metadata)
+            self.vertical = BlockFactory.create(category='vertical', parent_location=self.section.location)
 
         CourseEnrollmentFactory(user=self.user, course_id=self.course.id, mode=CourseMode.HONOR)
 
@@ -1918,8 +1918,8 @@ class ProgressPageShowCorrectnessTests(ProgressPageBaseTests):
             choices=[True, False],
             choice_names=['choice_0', 'choice_1']
         )
-        self.problem = ItemFactory.create(category='problem', parent_location=self.vertical.location,  # lint-amnesty, pylint: disable=attribute-defined-outside-init
-                                          data=problem_xml, display_name='Problem 1')
+        self.problem = BlockFactory.create(category='problem', parent_location=self.vertical.location,  # lint-amnesty, pylint: disable=attribute-defined-outside-init
+                                           data=problem_xml, display_name='Problem 1')
         # Re-fetch the course from the database
         self.course = self.store.get_course(self.course.id)  # lint-amnesty, pylint: disable=attribute-defined-outside-init
 
@@ -2382,13 +2382,13 @@ class TestIndexView(ModuleStoreTestCase):
         """
         with modulestore().default_store(ModuleStoreEnum.Type.split):
             course = CourseFactory.create()
-            chapter = ItemFactory.create(parent_location=course.location, category='chapter')
-            section = ItemFactory.create(parent_location=chapter.location, category='view_checker',
-                                         display_name="Sequence Checker")
-            vertical = ItemFactory.create(parent_location=section.location, category='view_checker',
-                                          display_name="Vertical Checker")
-            block = ItemFactory.create(parent_location=vertical.location, category='view_checker',
-                                       display_name="Block Checker")
+            chapter = BlockFactory.create(parent_location=course.location, category='chapter')
+            section = BlockFactory.create(parent_location=chapter.location, category='view_checker',
+                                          display_name="Sequence Checker")
+            vertical = BlockFactory.create(parent_location=section.location, category='view_checker',
+                                           display_name="Vertical Checker")
+            block = BlockFactory.create(parent_location=vertical.location, category='view_checker',
+                                        display_name="Block Checker")
 
         for item in (section, vertical, block):
             StudentModuleFactory.create(
@@ -2419,10 +2419,10 @@ class TestIndexView(ModuleStoreTestCase):
     def test_activate_block_id(self):
         course = CourseFactory.create()
         with self.store.bulk_operations(course.id):
-            chapter = ItemFactory.create(parent=course, category='chapter')
-            section = ItemFactory.create(parent=chapter, category='sequential', display_name="Sequence")
-            vertical = ItemFactory.create(parent=section, category='vertical', display_name="Vertical")
-            ItemFactory.create(parent=vertical, category='id_checker', display_name="ID Checker")
+            chapter = BlockFactory.create(parent=course, category='chapter')
+            section = BlockFactory.create(parent=chapter, category='sequential', display_name="Sequence")
+            vertical = BlockFactory.create(parent=section, category='vertical', display_name="Vertical")
+            BlockFactory.create(parent=vertical, category='id_checker', display_name="ID Checker")
 
         CourseOverview.load_from_module_store(course.id)
         CourseEnrollmentFactory(user=self.user, course_id=course.id)
@@ -2543,35 +2543,35 @@ class TestIndexViewCompleteOnView(ModuleStoreTestCase, CompletionWaffleTestMixin
 
             with self.store.bulk_operations(self.course.id):
 
-                self.chapter = ItemFactory.create(
+                self.chapter = BlockFactory.create(
                     parent_location=self.course.location, category='chapter', display_name='Week 1'
                 )
-                self.section_1 = ItemFactory.create(
+                self.section_1 = BlockFactory.create(
                     parent_location=self.chapter.location, category='sequential', display_name='Lesson 1'
                 )
-                self.vertical_1 = ItemFactory.create(
+                self.vertical_1 = BlockFactory.create(
                     parent_location=self.section_1.location, category='vertical', display_name='Subsection 1'
                 )
-                self.html_1_1 = ItemFactory.create(
+                self.html_1_1 = BlockFactory.create(
                     parent_location=self.vertical_1.location, category='html', display_name="HTML 1_1"
                 )
-                self.problem_1 = ItemFactory.create(
+                self.problem_1 = BlockFactory.create(
                     parent_location=self.vertical_1.location, category='problem', display_name="Problem 1"
                 )
-                self.html_1_2 = ItemFactory.create(
+                self.html_1_2 = BlockFactory.create(
                     parent_location=self.vertical_1.location, category='html', display_name="HTML 1_2"
                 )
 
-                self.section_2 = ItemFactory.create(
+                self.section_2 = BlockFactory.create(
                     parent_location=self.chapter.location, category='sequential', display_name='Lesson 2'
                 )
-                self.vertical_2 = ItemFactory.create(
+                self.vertical_2 = BlockFactory.create(
                     parent_location=self.section_2.location, category='vertical', display_name='Subsection 2'
                 )
-                self.video_2 = ItemFactory.create(
+                self.video_2 = BlockFactory.create(
                     parent_location=self.vertical_2.location, category='video', display_name="Video 2"
                 )
-                self.problem_2 = ItemFactory.create(
+                self.problem_2 = BlockFactory.create(
                     parent_location=self.vertical_2.location, category='problem', display_name="Problem 2"
                 )
 
@@ -2675,12 +2675,12 @@ class TestIndexViewWithVerticalPositions(ModuleStoreTestCase):
         # create course with 3 positions
         self.course = CourseFactory.create()
         with self.store.bulk_operations(self.course.id):
-            self.chapter = ItemFactory.create(parent_location=self.course.location, category='chapter')
-            self.section = ItemFactory.create(parent_location=self.chapter.location, category='sequential',
-                                              display_name="Sequence")
-            ItemFactory.create(parent_location=self.section.location, category='vertical', display_name="Vertical1")
-            ItemFactory.create(parent_location=self.section.location, category='vertical', display_name="Vertical2")
-            ItemFactory.create(parent_location=self.section.location, category='vertical', display_name="Vertical3")
+            self.chapter = BlockFactory.create(parent_location=self.course.location, category='chapter')
+            self.section = BlockFactory.create(parent_location=self.chapter.location, category='sequential',
+                                               display_name="Sequence")
+            BlockFactory.create(parent_location=self.section.location, category='vertical', display_name="Vertical1")
+            BlockFactory.create(parent_location=self.section.location, category='vertical', display_name="Vertical2")
+            BlockFactory.create(parent_location=self.section.location, category='vertical', display_name="Vertical3")
 
         CourseOverview.load_from_module_store(self.course.id)
 
@@ -2808,24 +2808,24 @@ class TestRenderXBlock(RenderXBlockTestMixin, ModuleStoreTestCase, CompletionWaf
         with self.store.default_store(ModuleStoreEnum.Type.split):
             # pylint:disable=attribute-defined-outside-init
             self.course = CourseFactory.create(**self.course_options())
-            self.chapter = ItemFactory.create(parent=self.course, category='chapter')
-            self.sequence = ItemFactory.create(
+            self.chapter = BlockFactory.create(parent=self.course, category='chapter')
+            self.sequence = BlockFactory.create(
                 parent=self.chapter,
                 category='sequential',
                 display_name='Sequence',
                 is_time_limited=True,
             )
-            self.vertical_block = ItemFactory.create(
+            self.vertical_block = BlockFactory.create(
                 parent=self.sequence,
                 category='vertical',
                 display_name="Vertical",
             )
-            self.html_block = ItemFactory.create(
+            self.html_block = BlockFactory.create(
                 parent=self.vertical_block,
                 category='html',
                 data="<p>Test HTML Content<p>"
             )
-            self.problem_block = ItemFactory.create(
+            self.problem_block = BlockFactory.create(
                 parent=self.vertical_block,
                 category='problem',
                 display_name='Problem'
@@ -2851,24 +2851,24 @@ class TestRenderXBlock(RenderXBlockTestMixin, ModuleStoreTestCase, CompletionWaf
         with self.store.default_store(ModuleStoreEnum.Type.split):
             # pylint:disable=attribute-defined-outside-init
             self.course = CourseFactory.create(**self.course_options())
-            self.chapter = ItemFactory.create(parent=self.course, category='chapter')
-            self.sequence = ItemFactory.create(
+            self.chapter = BlockFactory.create(parent=self.course, category='chapter')
+            self.sequence = BlockFactory.create(
                 parent=self.chapter,
                 category='sequential',
                 display_name='Sequence',
                 is_time_limited=True,
             )
-            self.vertical_block = ItemFactory.create(
+            self.vertical_block = BlockFactory.create(
                 parent=self.sequence,
                 category='vertical',
                 display_name="Vertical",
             )
-            self.html_block = ItemFactory.create(
+            self.html_block = BlockFactory.create(
                 parent=self.vertical_block,
                 category='html',
                 data="<p>Test HTML Content<p>"
             )
-            self.problem_block = ItemFactory.create(
+            self.problem_block = BlockFactory.create(
                 parent=self.vertical_block,
                 category='problem',
                 display_name='Problem'
@@ -2936,24 +2936,24 @@ class TestRenderPublicVideoXBlock(ModuleStoreTestCase):
         """
         with self.store.default_store(self.store.default_modulestore.get_modulestore_type()):
             course = CourseFactory.create(**{'start': datetime.now() - timedelta(days=1)})
-            chapter = ItemFactory.create(parent=course, category='chapter')
-            vertical_block = ItemFactory.create(
+            chapter = BlockFactory.create(parent=course, category='chapter')
+            vertical_block = BlockFactory.create(
                 parent_location=chapter.location,
                 category='vertical',
                 display_name="Vertical"
             )
-            self.html_block = ItemFactory.create(  # pylint: disable=attribute-defined-outside-init
+            self.html_block = BlockFactory.create(  # pylint: disable=attribute-defined-outside-init
                 parent=vertical_block,
                 category='html',
                 data="<p>Test HTML Content<p>"
             )
-            self.video_block_public = ItemFactory.create(  # pylint: disable=attribute-defined-outside-init
+            self.video_block_public = BlockFactory.create(  # pylint: disable=attribute-defined-outside-init
                 parent=vertical_block,
                 category='video',
                 display_name='Video with public access',
                 metadata={'public_access': True}
             )
-            self.video_block_not_public = ItemFactory.create(  # pylint: disable=attribute-defined-outside-init
+            self.video_block_not_public = BlockFactory.create(  # pylint: disable=attribute-defined-outside-init
                 parent=vertical_block,
                 category='video',
                 display_name='Video with private access'
@@ -3029,9 +3029,9 @@ class TestIndexViewCrawlerStudentStateWrites(SharedModuleStoreTestCase):
         with super().setUpClassAndTestData():
             cls.course = CourseFactory.create()
             with cls.store.bulk_operations(cls.course.id):
-                cls.chapter = ItemFactory.create(category='chapter', parent_location=cls.course.location)
-                cls.section = ItemFactory.create(category='sequential', parent_location=cls.chapter.location)
-                cls.vertical = ItemFactory.create(category='vertical', parent_location=cls.section.location)
+                cls.chapter = BlockFactory.create(category='chapter', parent_location=cls.course.location)
+                cls.section = BlockFactory.create(category='sequential', parent_location=cls.chapter.location)
+                cls.vertical = BlockFactory.create(category='vertical', parent_location=cls.section.location)
 
     @classmethod
     def setUpTestData(cls):  # lint-amnesty, pylint: disable=super-method-not-called
@@ -3214,24 +3214,24 @@ class ContentOptimizationTestCase(ModuleStoreTestCase):
         with self.store.default_store(ModuleStoreEnum.Type.split):
             self.course = CourseFactory.create(display_name='teꜱᴛ course', run="Testing_course")
             with self.store.bulk_operations(self.course.id):
-                chapter = ItemFactory.create(
+                chapter = BlockFactory.create(
                     category='chapter',
                     parent_location=self.course.location,
                     display_name="Chapter 1",
                 )
-                section = ItemFactory.create(
+                section = BlockFactory.create(
                     category='sequential',
                     parent_location=chapter.location,
                     due=datetime(2013, 9, 18, 11, 30, 00),
                     display_name='Sequential 1',
                     format='Homework'
                 )
-                self.math_vertical = ItemFactory.create(
+                self.math_vertical = BlockFactory.create(
                     category='vertical',
                     parent_location=section.location,
                     display_name='Vertical with Mathjax HTML',
                 )
-                self.no_math_vertical = ItemFactory.create(
+                self.no_math_vertical = BlockFactory.create(
                     category='vertical',
                     parent_location=section.location,
                     display_name='Vertical with No Mathjax HTML',
@@ -3243,7 +3243,7 @@ class ContentOptimizationTestCase(ModuleStoreTestCase):
                     ("[mathjax]", "[/mathjax]"),
                 ]
                 for (i, (start_tag, end_tag)) in enumerate(MATHJAX_TAG_PAIRS):
-                    math_html_block = ItemFactory.create(
+                    math_html_block = BlockFactory.create(
                         category='html',
                         parent_location=self.math_vertical.location,
                         display_name=f"HTML With Mathjax {i}",
@@ -3251,7 +3251,7 @@ class ContentOptimizationTestCase(ModuleStoreTestCase):
                     )
                     self.math_html_usage_keys.append(math_html_block.location)
 
-                self.html_without_mathjax = ItemFactory.create(
+                self.html_without_mathjax = BlockFactory.create(
                     category='html',
                     parent_location=self.no_math_vertical.location,
                     display_name="HTML Without Mathjax",
@@ -3329,8 +3329,8 @@ class TestCourseWideResources(ModuleStoreTestCase):
         css = ['https://testcdn.com/css/lib.min.css', '//testcdn.com/css/lib2.css', '/test.css']
 
         course = CourseFactory.create(course_wide_js=js, course_wide_css=css)
-        chapter = ItemFactory.create(parent_location=course.location, category='chapter')
-        sequence = ItemFactory.create(parent_location=chapter.location, category='sequential', display_name='Sequence')
+        chapter = BlockFactory.create(parent_location=course.location, category='chapter')
+        sequence = BlockFactory.create(parent_location=chapter.location, category='sequential', display_name='Sequence')
 
         CourseOverview.load_from_module_store(course.id)
         CourseEnrollmentFactory(user=user, course_id=course.id)

--- a/lms/djangoapps/courseware/testutils.py
+++ b/lms/djangoapps/courseware/testutils.py
@@ -21,7 +21,7 @@ from common.djangoapps.course_modes.tests.factories import CourseModeFactory
 from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, check_mongo_calls  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory, check_mongo_calls  # lint-amnesty, pylint: disable=wrong-import-order
 
 from .field_overrides import OverrideModulestoreFieldData
 from .tests.helpers import MasqueradeMixin
@@ -101,23 +101,23 @@ class RenderXBlockTestMixin(MasqueradeMixin, metaclass=ABCMeta):
             default_store = self.store.default_modulestore.get_modulestore_type()
         with self.store.default_store(default_store):
             self.course = CourseFactory.create(**self.course_options())
-            chapter = ItemFactory.create(parent=self.course, category='chapter')
-            self.vertical_block = ItemFactory.create(
+            chapter = BlockFactory.create(parent=self.course, category='chapter')
+            self.vertical_block = BlockFactory.create(
                 parent_location=chapter.location,
                 category='vertical',
                 display_name="Vertical"
             )
-            self.html_block = ItemFactory.create(
+            self.html_block = BlockFactory.create(
                 parent=self.vertical_block,
                 category='html',
                 data="<p>Test HTML Content<p>"
             )
-            self.problem_block = ItemFactory.create(
+            self.problem_block = BlockFactory.create(
                 parent=self.vertical_block,
                 category='problem',
                 display_name='Problem'
             )
-            self.video_block = ItemFactory.create(
+            self.video_block = BlockFactory.create(
                 parent=self.vertical_block,
                 category='video',
                 display_name='Video'

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -491,7 +491,7 @@ class CoursewareIndex(View):
         exceeds the length of the displayable items, default the position
         to the first element.
         """
-        display_items = self.section.get_display_items()
+        display_items = self.section.get_display_blocks()
         if not display_items:
             return
         if self.section.position > len(display_items):
@@ -565,7 +565,7 @@ def save_child_position(seq_block, child_name):
     """
     child_name: url_name of the child
     """
-    for position, child in enumerate(seq_block.get_display_items(), start=1):
+    for position, child in enumerate(seq_block.get_display_blocks(), start=1):
         if child.location.block_id == child_name:
             # Only save if position changed
             if position != seq_block.position:

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -491,7 +491,7 @@ class CoursewareIndex(View):
         exceeds the length of the displayable items, default the position
         to the first element.
         """
-        display_items = self.section.get_display_blocks()
+        display_items = self.section.get_children()
         if not display_items:
             return
         if self.section.position > len(display_items):
@@ -565,7 +565,7 @@ def save_child_position(seq_block, child_name):
     """
     child_name: url_name of the child
     """
-    for position, child in enumerate(seq_block.get_display_blocks(), start=1):
+    for position, child in enumerate(seq_block.get_children(), start=1):
         if child.location.block_id == child_name:
             # Only save if position changed
             if position != seq_block.position:

--- a/lms/djangoapps/discussion/django_comment_client/base/tests.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/tests.py
@@ -55,7 +55,7 @@ from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import (
     TEST_DATA_SPLIT_MODULESTORE, ModuleStoreTestCase, SharedModuleStoreTestCase,
 )
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, check_mongo_calls
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory, check_mongo_calls
 
 from .event_transformers import ForumThreadViewedEventTransformer
 
@@ -225,7 +225,7 @@ class ViewsTestCaseMixin:
 
         # add some discussion modules
         for i in range(module_count):
-            ItemFactory.create(
+            BlockFactory.create(
                 parent_location=self.course.location,
                 category='discussion',
                 discussion_id=f'id_module_{i}',
@@ -2064,14 +2064,14 @@ class ForumThreadViewedEventTransformerTestCase(ForumsEnableMixin, UrlResetMixin
         self.staff = UserFactory.create(is_staff=True)
         UserBasedRole(user=self.staff, role=CourseStaffRole.ROLE).add_course(self.course.id)
         CourseEnrollmentFactory.create(user=self.student, course_id=self.course.id)
-        self.category = ItemFactory.create(
+        self.category = BlockFactory.create(
             parent_location=self.course.location,
             category='discussion',
             discussion_id=self.CATEGORY_ID,
             discussion_category=self.PARENT_CATEGORY_NAME,
             discussion_target=self.CATEGORY_NAME,
         )
-        self.team_category = ItemFactory.create(
+        self.team_category = BlockFactory.create(
             parent_location=self.course.location,
             category='discussion',
             discussion_id=self.TEAM_CATEGORY_ID,

--- a/lms/djangoapps/discussion/django_comment_client/tests/test_utils.py
+++ b/lms/djangoapps/discussion/django_comment_client/tests/test_utils.py
@@ -51,7 +51,7 @@ from openedx.core.djangoapps.django_comment_common.utils import seed_permissions
 from openedx.core.djangoapps.util.testing import ContentGroupTestCase
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, ToyCourseFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory, ToyCourseFactory
 
 
 class DictionaryTestCase(TestCase):
@@ -135,14 +135,14 @@ class CoursewareContextTestCase(ModuleStoreTestCase):
     def setUp(self):
         super().setUp()
         self.course = CourseFactory.create(org="TestX", number="101", display_name="Test Course")
-        self.discussion1 = ItemFactory.create(
+        self.discussion1 = BlockFactory.create(
             parent_location=self.course.location,
             category="discussion",
             discussion_id="discussion1",
             discussion_category="Chapter",
             discussion_target="Discussion 1"
         )
-        self.discussion2 = ItemFactory.create(
+        self.discussion2 = BlockFactory.create(
             parent_location=self.course.location,
             category="discussion",
             discussion_id="discussion2",
@@ -180,7 +180,7 @@ class CoursewareContextTestCase(ModuleStoreTestCase):
         Test that for empty subcategory inline discussion modules,
         the divider " / " is not rendered on a post or inline discussion topic label.
         """
-        discussion = ItemFactory.create(
+        discussion = BlockFactory.create(
             parent_location=self.course.location,
             category="discussion",
             discussion_id="discussion",
@@ -228,21 +228,21 @@ class CachedDiscussionIdMapTestCase(ModuleStoreTestCase):
         super().setUp()
 
         self.course = CourseFactory.create(org='TestX', number='101', display_name='Test Course')
-        self.discussion = ItemFactory.create(
+        self.discussion = BlockFactory.create(
             parent_location=self.course.location,
             category='discussion',
             discussion_id='test_discussion_id',
             discussion_category='Chapter',
             discussion_target='Discussion 1'
         )
-        self.discussion2 = ItemFactory.create(
+        self.discussion2 = BlockFactory.create(
             parent_location=self.course.location,
             category='discussion',
             discussion_id='test_discussion_id_2',
             discussion_category='Chapter 2',
             discussion_target='Discussion 2'
         )
-        self.private_discussion = ItemFactory.create(
+        self.private_discussion = BlockFactory.create(
             parent_location=self.course.location,
             category='discussion',
             discussion_id='private_discussion_id',
@@ -251,7 +251,7 @@ class CachedDiscussionIdMapTestCase(ModuleStoreTestCase):
             visible_to_staff_only=True
         )
         RequestCache.clear_all_namespaces()  # clear the cache before the last course publish
-        self.bad_discussion = ItemFactory.create(
+        self.bad_discussion = BlockFactory.create(
             parent_location=self.course.location,
             category='discussion',
             discussion_id='bad_discussion_id',
@@ -376,7 +376,7 @@ class CategoryMapTestCase(CategoryMapTestMixin, ModuleStoreTestCase):
 
     def create_discussion(self, discussion_category, discussion_target, **kwargs):
         self.discussion_num += 1
-        return ItemFactory.create(
+        return BlockFactory.create(
             parent_location=self.course.location,
             category="discussion",
             discussion_id=f"discussion{self.discussion_num}",

--- a/lms/djangoapps/discussion/rest_api/tests/test_api.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api.py
@@ -25,7 +25,7 @@ from rest_framework.exceptions import PermissionDenied
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 from xmodule.partitions.partitions import Group, UserPartition
 
 from common.djangoapps.student.tests.factories import (
@@ -319,7 +319,7 @@ class GetCourseTopicsTest(CommentsServiceMockMixin, ForumsEnableMixin, UrlResetM
         """
         Build a discussion xblock in self.course.
         """
-        ItemFactory.create(
+        BlockFactory.create(
             parent_location=self.course.location,
             category="discussion",
             discussion_id=topic_id,
@@ -4014,20 +4014,20 @@ class CourseTopicsV2Test(ModuleStoreTestCase):
         self.course = CourseFactory.create(
             discussion_topics={f"Course Wide Topic {idx}": {"id": f'course-wide-topic-{idx}'} for idx in range(10)}
         )
-        self.chapter = ItemFactory.create(
+        self.chapter = BlockFactory.create(
             parent_location=self.course.location,
             category='chapter',
             display_name="Week 1",
             start=datetime(2015, 3, 1, tzinfo=UTC),
         )
-        self.sequential = ItemFactory.create(
+        self.sequential = BlockFactory.create(
             parent_location=self.chapter.location,
             category='sequential',
             display_name="Lesson 1",
             start=datetime(2015, 3, 1, tzinfo=UTC),
         )
         self.verticals = [
-            ItemFactory.create(
+            BlockFactory.create(
                 parent_location=self.sequential.location,
                 category='vertical',
                 display_name=f'vertical-{idx}',
@@ -4035,7 +4035,7 @@ class CourseTopicsV2Test(ModuleStoreTestCase):
             )
             for idx in range(10)
         ]
-        staff_only_unit = ItemFactory.create(
+        staff_only_unit = BlockFactory.create(
             parent_location=self.sequential.location,
             category='vertical',
             display_name='staff-vertical-1',

--- a/lms/djangoapps/discussion/rest_api/tests/test_views.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views.py
@@ -26,7 +26,7 @@ from lms.djangoapps.discussion.rest_api.utils import get_usernames_from_search_s
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, check_mongo_calls
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory, check_mongo_calls
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
@@ -746,7 +746,7 @@ class CourseTopicsViewTest(DiscussionAPIViewTestMixin, CommentsServiceMockMixin,
         course_url = reverse("course_topics", kwargs={"course_id": str(course.id)})
         # add some discussion xblocks
         for i in range(modules_count):
-            ItemFactory.create(
+            BlockFactory.create(
                 parent_location=course.location,
                 category='discussion',
                 discussion_id=f'id_module_{i}',
@@ -760,7 +760,7 @@ class CourseTopicsViewTest(DiscussionAPIViewTestMixin, CommentsServiceMockMixin,
         """
         Build a discussion xblock in self.course
         """
-        ItemFactory.create(
+        BlockFactory.create(
             parent_location=self.course.location,
             category="discussion",
             discussion_id=topic_id,
@@ -882,19 +882,19 @@ class CourseTopicsViewTest(DiscussionAPIViewTestMixin, CommentsServiceMockMixin,
         Tests whether the new structure is available on old topics API
         (For mobile compatibility)
         """
-        chapter = ItemFactory.create(
+        chapter = BlockFactory.create(
             parent_location=self.course.location,
             category='chapter',
             display_name="Week 1",
             start=datetime(2015, 3, 1, tzinfo=UTC),
         )
-        sequential = ItemFactory.create(
+        sequential = BlockFactory.create(
             parent_location=chapter.location,
             category='sequential',
             display_name="Lesson 1",
             start=datetime(2015, 3, 1, tzinfo=UTC),
         )
-        ItemFactory.create(
+        BlockFactory.create(
             parent_location=sequential.location,
             category='vertical',
             display_name='vertical',
@@ -942,20 +942,20 @@ class CourseTopicsViewV3Test(DiscussionAPIViewTestMixin, CommentsServiceMockMixi
                 "usage_key": None,
             }}
         )
-        self.chapter = ItemFactory.create(
+        self.chapter = BlockFactory.create(
             parent_location=self.course.location,
             category='chapter',
             display_name="Week 1",
             start=datetime(2015, 3, 1, tzinfo=UTC),
         )
-        self.sequential = ItemFactory.create(
+        self.sequential = BlockFactory.create(
             parent_location=self.chapter.location,
             category='sequential',
             display_name="Lesson 1",
             start=datetime(2015, 3, 1, tzinfo=UTC),
         )
         self.verticals = [
-            ItemFactory.create(
+            BlockFactory.create(
                 parent_location=self.sequential.location,
                 category='vertical',
                 display_name='vertical',
@@ -2747,7 +2747,7 @@ class CourseDiscussionSettingsAPIViewTest(APITestCase, UrlResetMixin, ModuleStor
         divided_course_wide_discussions = ['Topic B', ]
         divided_discussions = divided_inline_discussions + divided_course_wide_discussions
 
-        ItemFactory.create(
+        BlockFactory.create(
             parent=self.course,
             category='discussion',
             discussion_id=topic_name_to_id(self.course, 'Topic A'),
@@ -2971,7 +2971,7 @@ class CourseDiscussionSettingsAPIViewTest(APITestCase, UrlResetMixin, ModuleStor
         self._assert_current_settings(expected_response)
 
         now = datetime.now()
-        ItemFactory.create(
+        BlockFactory.create(
             parent_location=self.course.location,
             category='discussion',
             discussion_id='Topic_A',

--- a/lms/djangoapps/discussion/tests/test_signals.py
+++ b/lms/djangoapps/discussion/tests/test_signals.py
@@ -8,7 +8,7 @@ from edx_django_utils.cache import RequestCache
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import (
     CourseFactory,
-    ItemFactory
+    BlockFactory
 )
 
 from lms.djangoapps.discussion.signals.handlers import ENABLE_FORUM_NOTIFICATIONS_FOR_SITE_KEY
@@ -86,7 +86,7 @@ class CoursePublishHandlerTestCase(ModuleStoreTestCase):
         # create discussion block
         RequestCache().clear()
         discussion_id = 'discussion1'
-        discussion_block = ItemFactory.create(
+        discussion_block = BlockFactory.create(
             parent_location=course.location,
             category="discussion",
             discussion_id=discussion_id,

--- a/lms/djangoapps/discussion/tests/test_views.py
+++ b/lms/djangoapps/discussion/tests/test_views.py
@@ -25,7 +25,7 @@ from xmodule.modulestore.tests.django_utils import (
 )
 from xmodule.modulestore.tests.factories import (
     CourseFactory,
-    ItemFactory,
+    BlockFactory,
     check_mongo_calls
 )
 
@@ -1357,7 +1357,7 @@ class InlineDiscussionTestCase(ForumsEnableMixin, ModuleStoreTestCase):  # lint-
         )
         self.student = UserFactory.create()
         CourseEnrollmentFactory(user=self.student, course_id=self.course.id)
-        self.discussion1 = ItemFactory.create(
+        self.discussion1 = BlockFactory.create(
             parent_location=self.course.location,
             category="discussion",
             discussion_id="discussion1",
@@ -1897,7 +1897,7 @@ class DividedDiscussionsTestCase(CohortViewsTestCase):  # lint-amnesty, pylint: 
         divided_discussions = divided_inline_discussions + divided_course_wide_discussions
 
         # inline discussion
-        ItemFactory.create(
+        BlockFactory.create(
             parent_location=self.course.location,
             category="discussion",
             discussion_id=topic_name_to_id(self.course, "Topic A"),
@@ -2068,7 +2068,7 @@ class CourseDiscussionsHandlerTestCase(DividedDiscussionsTestCase):
         RequestCache.clear_all_namespaces()
         now = datetime.now()
         # inline discussion
-        ItemFactory.create(
+        BlockFactory.create(
             parent_location=self.course.location,
             category="discussion",
             discussion_id="Topic_A",
@@ -2208,7 +2208,7 @@ class ThreadViewedEventTestCase(EventTestMixin, ForumsEnableMixin, UrlResetMixin
         self.staff = UserFactory.create(is_staff=True)
         UserBasedRole(user=self.staff, role=CourseStaffRole.ROLE).add_course(self.course.id)
 
-        self.category = ItemFactory.create(
+        self.category = BlockFactory.create(
             parent_location=self.course.location,
             category='discussion',
             discussion_id=self.CATEGORY_ID,

--- a/lms/djangoapps/edxnotes/tests.py
+++ b/lms/djangoapps/edxnotes/tests.py
@@ -819,7 +819,7 @@ class EdxNotesHelpersTest(ModuleStoreTestCase):
         """
         mock_course_block = MagicMock()
         mock_course_block.position = 3
-        mock_course_block.get_display_blocks.return_value = []
+        mock_course_block.get_children.return_value = []
         assert helpers.get_course_position(mock_course_block) is None
 
     def test_get_course_position_to_chapter(self):
@@ -833,7 +833,7 @@ class EdxNotesHelpersTest(ModuleStoreTestCase):
         mock_chapter.url_name = 'chapter_url_name'
         mock_chapter.display_name_with_default = 'Test Chapter Display Name'
 
-        mock_course_block.get_display_blocks.return_value = [mock_chapter]
+        mock_course_block.get_children.return_value = [mock_chapter]
 
         assert helpers.get_course_position(mock_course_block) == {
             'display_name': 'Test Chapter Display Name',
@@ -845,7 +845,7 @@ class EdxNotesHelpersTest(ModuleStoreTestCase):
         Returns `None` if no section found.
         """
         mock_course_block = MagicMock(id=self.course.id, position=None)
-        mock_course_block.get_display_blocks.return_value = [MagicMock()]
+        mock_course_block.get_children.return_value = [MagicMock()]
         assert helpers.get_course_position(mock_course_block) is None
 
     def test_get_course_position_to_section(self):
@@ -857,14 +857,14 @@ class EdxNotesHelpersTest(ModuleStoreTestCase):
 
         mock_chapter = MagicMock()
         mock_chapter.url_name = 'chapter_url_name'
-        mock_course_block.get_display_blocks.return_value = [mock_chapter]
+        mock_course_block.get_children.return_value = [mock_chapter]
 
         mock_section = MagicMock()
         mock_section.url_name = 'section_url_name'
         mock_section.display_name_with_default = 'Test Section Display Name'
 
-        mock_chapter.get_display_blocks.return_value = [mock_section]
-        mock_section.get_display_blocks.return_value = [MagicMock()]
+        mock_chapter.get_children.return_value = [mock_section]
+        mock_section.get_children.return_value = [MagicMock()]
 
         assert helpers.get_course_position(mock_course_block) == {
             'display_name': 'Test Section Display Name',

--- a/lms/djangoapps/edxnotes/tests.py
+++ b/lms/djangoapps/edxnotes/tests.py
@@ -31,7 +31,7 @@ from openedx.core.djangoapps.user_api.models import RetirementState, UserRetirem
 from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.tabs import CourseTab  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.tests.helpers import StubUserService  # lint-amnesty, pylint: disable=wrong-import-order
 
@@ -205,19 +205,20 @@ class EdxNotesHelpersTest(ModuleStoreTestCase):
         with self.store.default_store(ModuleStoreEnum.Type.split):
             ApplicationFactory(name="edx-notes")
             self.course = CourseFactory.create()
-            self.chapter = ItemFactory.create(category="chapter", parent_location=self.course.location)
-            self.chapter_2 = ItemFactory.create(category="chapter", parent_location=self.course.location)
-            self.sequential = ItemFactory.create(category="sequential", parent_location=self.chapter.location)
-            self.vertical = ItemFactory.create(category="vertical", parent_location=self.sequential.location)
-            self.html_block_1 = ItemFactory.create(category="html", parent_location=self.vertical.location)
-            self.html_block_2 = ItemFactory.create(category="html", parent_location=self.vertical.location)
-            self.vertical_with_container = ItemFactory.create(
+            self.chapter = BlockFactory.create(category="chapter", parent_location=self.course.location)
+            self.chapter_2 = BlockFactory.create(category="chapter", parent_location=self.course.location)
+            self.sequential = BlockFactory.create(category="sequential", parent_location=self.chapter.location)
+            self.vertical = BlockFactory.create(category="vertical", parent_location=self.sequential.location)
+            self.html_block_1 = BlockFactory.create(category="html", parent_location=self.vertical.location)
+            self.html_block_2 = BlockFactory.create(category="html", parent_location=self.vertical.location)
+            self.vertical_with_container = BlockFactory.create(
                 category='vertical', parent_location=self.sequential.location
             )
-            self.child_container = ItemFactory.create(
+            self.child_container = BlockFactory.create(
                 category='split_test', parent_location=self.vertical_with_container.location)
-            self.child_vertical = ItemFactory.create(category='vertical', parent_location=self.child_container.location)
-            self.child_html_block = ItemFactory.create(category="html", parent_location=self.child_vertical.location)
+            self.child_vertical = BlockFactory.create(
+                category='vertical', parent_location=self.child_container.location)
+            self.child_html_block = BlockFactory.create(category="html", parent_location=self.child_vertical.location)
 
             # Read again so that children lists are accurate
             self.course = self.store.get_item(self.course.location)

--- a/lms/djangoapps/edxnotes/tests.py
+++ b/lms/djangoapps/edxnotes/tests.py
@@ -819,7 +819,7 @@ class EdxNotesHelpersTest(ModuleStoreTestCase):
         """
         mock_course_block = MagicMock()
         mock_course_block.position = 3
-        mock_course_block.get_display_items.return_value = []
+        mock_course_block.get_display_blocks.return_value = []
         assert helpers.get_course_position(mock_course_block) is None
 
     def test_get_course_position_to_chapter(self):
@@ -833,7 +833,7 @@ class EdxNotesHelpersTest(ModuleStoreTestCase):
         mock_chapter.url_name = 'chapter_url_name'
         mock_chapter.display_name_with_default = 'Test Chapter Display Name'
 
-        mock_course_block.get_display_items.return_value = [mock_chapter]
+        mock_course_block.get_display_blocks.return_value = [mock_chapter]
 
         assert helpers.get_course_position(mock_course_block) == {
             'display_name': 'Test Chapter Display Name',
@@ -845,7 +845,7 @@ class EdxNotesHelpersTest(ModuleStoreTestCase):
         Returns `None` if no section found.
         """
         mock_course_block = MagicMock(id=self.course.id, position=None)
-        mock_course_block.get_display_items.return_value = [MagicMock()]
+        mock_course_block.get_display_blocks.return_value = [MagicMock()]
         assert helpers.get_course_position(mock_course_block) is None
 
     def test_get_course_position_to_section(self):
@@ -857,14 +857,14 @@ class EdxNotesHelpersTest(ModuleStoreTestCase):
 
         mock_chapter = MagicMock()
         mock_chapter.url_name = 'chapter_url_name'
-        mock_course_block.get_display_items.return_value = [mock_chapter]
+        mock_course_block.get_display_blocks.return_value = [mock_chapter]
 
         mock_section = MagicMock()
         mock_section.url_name = 'section_url_name'
         mock_section.display_name_with_default = 'Test Section Display Name'
 
-        mock_chapter.get_display_items.return_value = [mock_section]
-        mock_section.get_display_items.return_value = [MagicMock()]
+        mock_chapter.get_display_blocks.return_value = [mock_section]
+        mock_section.get_display_blocks.return_value = [MagicMock()]
 
         assert helpers.get_course_position(mock_course_block) == {
             'display_name': 'Test Section Display Name',

--- a/lms/djangoapps/gating/tests/test_api.py
+++ b/lms/djangoapps/gating/tests/test_api.py
@@ -13,7 +13,7 @@ from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from lms.djangoapps.gating.api import evaluate_prerequisite
 from openedx.core.lib.gating import api as gating_api
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 
 class GatingTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
@@ -40,19 +40,19 @@ class GatingTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
         self.update_course(self.course, 0)
 
         # create chapter
-        self.chapter1 = ItemFactory.create(
+        self.chapter1 = BlockFactory.create(
             parent_location=self.course.location,
             category='chapter',
             display_name='untitled chapter 1'
         )
 
         # create sequentials
-        self.seq1 = ItemFactory.create(
+        self.seq1 = BlockFactory.create(
             parent_location=self.chapter1.location,
             category='sequential',
             display_name='gating sequential'
         )
-        self.seq2 = ItemFactory.create(
+        self.seq2 = BlockFactory.create(
             parent_location=self.chapter1.location,
             category='sequential',
             display_name='gated sequential'

--- a/lms/djangoapps/gating/tests/test_integration.py
+++ b/lms/djangoapps/gating/tests/test_integration.py
@@ -12,7 +12,7 @@ from milestones import api as milestones_api
 from milestones.tests.utils import MilestonesTestCaseMixin
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
 from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.courseware.access import has_access
@@ -69,28 +69,28 @@ class TestGatedContent(MilestonesTestCaseMixin, SharedModuleStoreTestCase):
             course.save()
 
             # create chapter
-            cls.chapter1 = ItemFactory.create(
+            cls.chapter1 = BlockFactory.create(
                 parent=course,
                 category='chapter',
                 display_name='chapter 1'
             )
 
             # create sequentials
-            cls.seq1 = ItemFactory.create(
+            cls.seq1 = BlockFactory.create(
                 parent=cls.chapter1,
                 category='sequential',
                 display_name='gating sequential 1',
                 graded=True,
                 format='Homework',
             )
-            cls.seq2 = ItemFactory.create(
+            cls.seq2 = BlockFactory.create(
                 parent=cls.chapter1,
                 category='sequential',
                 display_name='gated sequential 2',
                 graded=True,
                 format='Homework',
             )
-            cls.seq3 = ItemFactory.create(
+            cls.seq3 = BlockFactory.create(
                 parent=cls.chapter1,
                 category='sequential',
                 display_name='sequential 3',
@@ -99,7 +99,7 @@ class TestGatedContent(MilestonesTestCaseMixin, SharedModuleStoreTestCase):
             )
 
             # create problem
-            cls.gating_prob1 = ItemFactory.create(
+            cls.gating_prob1 = BlockFactory.create(
                 parent=cls.seq1,
                 category='problem',
                 display_name='gating problem 1',
@@ -107,7 +107,7 @@ class TestGatedContent(MilestonesTestCaseMixin, SharedModuleStoreTestCase):
             # add a discussion block to the prerequisite subsection
             # this should give us ability to test gating with blocks
             # which needs to be excluded from completion tracking
-            ItemFactory.create(
+            BlockFactory.create(
                 parent=cls.seq1,
                 category="discussion",
                 discussion_id="discussion 1",
@@ -115,12 +115,12 @@ class TestGatedContent(MilestonesTestCaseMixin, SharedModuleStoreTestCase):
                 discussion_target="discussion target",
             )
 
-            cls.gated_prob2 = ItemFactory.create(
+            cls.gated_prob2 = BlockFactory.create(
                 parent=cls.seq2,
                 category='problem',
                 display_name='gated problem 2',
             )
-            cls.prob3 = ItemFactory.create(
+            cls.prob3 = BlockFactory.create(
                 parent=cls.seq3,
                 category='problem',
                 display_name='problem 3',

--- a/lms/djangoapps/grades/rest_api/v1/tests/mixins.py
+++ b/lms/djangoapps/grades/rest_api/v1/tests/mixins.py
@@ -7,7 +7,7 @@ from datetime import datetime
 
 from pytz import UTC
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
@@ -127,7 +127,7 @@ class GradeViewTestMixin(SharedModuleStoreTestCase):
         course = CourseFactory.create(display_name=display_name, run=run)
         _ = CourseOverviewFactory.create(id=course.id)
 
-        chapter = ItemFactory.create(
+        chapter = BlockFactory.create(
             category='chapter',
             parent_location=course.location,
             display_name="Chapter 1",
@@ -136,7 +136,7 @@ class GradeViewTestMixin(SharedModuleStoreTestCase):
         # A section is not considered if the student answers less than "min_count" problems
         for grading_type, min_count in (("Homework", 12), ("Lab", 12), ("Midterm Exam", 1), ("Final Exam", 1)):
             for num in range(min_count):
-                section = ItemFactory.create(
+                section = BlockFactory.create(
                     category='sequential',
                     parent_location=chapter.location,
                     due=datetime(2017, 12, 18, 11, 30, 00),
@@ -144,12 +144,12 @@ class GradeViewTestMixin(SharedModuleStoreTestCase):
                     format=grading_type,
                     graded=True,
                 )
-                vertical = ItemFactory.create(
+                vertical = BlockFactory.create(
                     category='vertical',
                     parent_location=section.location,
                     display_name=f'Vertical {grading_type} {num}',
                 )
-                ItemFactory.create(
+                BlockFactory.create(
                     category='problem',
                     parent_location=vertical.location,
                     display_name=f'Problem {grading_type} {num}',

--- a/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
@@ -19,7 +19,7 @@ from pytz import UTC
 from rest_framework import status
 from rest_framework.test import APITestCase
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.roles import (
@@ -80,54 +80,54 @@ class CourseGradingViewTest(SharedModuleStoreTestCase, APITestCase):
         course.grade_cutoffs = {
             "Pass": 0.5,
         }
-        cls.section = ItemFactory.create(
+        cls.section = BlockFactory.create(
             parent_location=course.location,
             category="chapter",
         )
-        cls.subsection1 = ItemFactory.create(
+        cls.subsection1 = BlockFactory.create(
             parent_location=cls.section.location,
             category="sequential",
         )
-        unit1 = ItemFactory.create(
+        unit1 = BlockFactory.create(
             parent_location=cls.subsection1.location,
             category="vertical",
         )
-        ItemFactory.create(
+        BlockFactory.create(
             parent_location=unit1.location,
             category="video",
         )
-        ItemFactory.create(
+        BlockFactory.create(
             parent_location=unit1.location,
             category="problem",
         )
 
-        cls.subsection2 = ItemFactory.create(
+        cls.subsection2 = BlockFactory.create(
             parent_location=cls.section.location,
             category="sequential",
         )
-        unit2 = ItemFactory.create(
+        unit2 = BlockFactory.create(
             parent_location=cls.subsection2.location,
             category="vertical",
         )
-        unit3 = ItemFactory.create(
+        unit3 = BlockFactory.create(
             parent_location=cls.subsection2.location,
             category="vertical",
         )
-        ItemFactory.create(
+        BlockFactory.create(
             parent_location=unit3.location,
             category="video",
         )
-        ItemFactory.create(
+        BlockFactory.create(
             parent_location=unit3.location,
             category="video",
         )
-        cls.homework = ItemFactory.create(
+        cls.homework = BlockFactory.create(
             parent_location=cls.section.location,
             category="sequential",
             graded=True,
             format='Homework',
         )
-        cls.midterm = ItemFactory.create(
+        cls.midterm = BlockFactory.create(
             parent_location=cls.section.location,
             category="sequential",
             graded=True,
@@ -296,19 +296,19 @@ class GradebookViewTestBase(GradeViewTestMixin, APITestCase):
         cls.course_key = cls.course.id
         cls.course_overview = CourseOverviewFactory.create(id=cls.course.id)
 
-        cls.chapter_1 = ItemFactory.create(
+        cls.chapter_1 = BlockFactory.create(
             category='chapter',
             parent_location=cls.course.location,
             display_name="Chapter 1",
         )
-        cls.chapter_2 = ItemFactory.create(
+        cls.chapter_2 = BlockFactory.create(
             category='chapter',
             parent_location=cls.course.location,
             display_name="Chapter 2",
         )
         cls.subsections = {
             cls.chapter_1.location: [
-                ItemFactory.create(
+                BlockFactory.create(
                     category='sequential',
                     parent_location=cls.chapter_1.location,
                     due=datetime(2017, 12, 18, 11, 30, 00),
@@ -316,7 +316,7 @@ class GradebookViewTestBase(GradeViewTestMixin, APITestCase):
                     format='Homework',
                     graded=True,
                 ),
-                ItemFactory.create(
+                BlockFactory.create(
                     category='sequential',
                     parent_location=cls.chapter_1.location,
                     due=datetime(2017, 12, 18, 11, 30, 00),
@@ -326,7 +326,7 @@ class GradebookViewTestBase(GradeViewTestMixin, APITestCase):
                 ),
             ],
             cls.chapter_2.location: [
-                ItemFactory.create(
+                BlockFactory.create(
                     category='sequential',
                     parent_location=cls.chapter_2.location,
                     due=datetime(2017, 12, 18, 11, 30, 00),
@@ -334,7 +334,7 @@ class GradebookViewTestBase(GradeViewTestMixin, APITestCase):
                     format='Homework',
                     graded=True,
                 ),
-                ItemFactory.create(
+                BlockFactory.create(
                     category='sequential',
                     parent_location=cls.chapter_2.location,
                     due=datetime(2017, 12, 18, 11, 30, 00),
@@ -347,7 +347,7 @@ class GradebookViewTestBase(GradeViewTestMixin, APITestCase):
 
         # Data about graded subsections visible to staff only
         # should not be exposed via the gradebook API
-        cls.hidden_subsection = ItemFactory.create(
+        cls.hidden_subsection = BlockFactory.create(
             parent_location=cls.chapter_1.location,
             category='sequential',
             graded=True,
@@ -2175,7 +2175,7 @@ class SubsectionGradeViewTest(GradebookViewTestBase):
     @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
     def test_get_override_for_unreleased_block(self):
         self.login_course_staff()
-        unreleased_subsection = ItemFactory.create(
+        unreleased_subsection = BlockFactory.create(
             parent_location=self.chapter_1.location,
             category='sequential',
             graded=True,

--- a/lms/djangoapps/grades/rest_api/v1/tests/test_grading_policy_view.py
+++ b/lms/djangoapps/grades/rest_api/v1/tests/test_grading_policy_view.py
@@ -10,7 +10,7 @@ from django.urls import reverse
 from pytz import UTC
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 from xmodule.capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from common.djangoapps.student.tests.factories import StaffFactory
@@ -42,7 +42,7 @@ class GradingPolicyTestMixin:
         )
         cls.course_id = str(cls.course.id)
         with cls.store.bulk_operations(cls.course.id, emit_signals=False):
-            cls.sequential = ItemFactory.create(
+            cls.sequential = BlockFactory.create(
                 category="sequential",
                 parent_location=cls.course.location,
                 display_name="Lesson 1",
@@ -53,7 +53,7 @@ class GradingPolicyTestMixin:
             factory = MultipleChoiceResponseXMLFactory()
             args = {'choices': [False, True, False]}
             problem_xml = factory.build_xml(**args)
-            cls.problem = ItemFactory.create(
+            cls.problem = BlockFactory.create(
                 category="problem",
                 parent_location=cls.sequential.location,
                 display_name="Problem 1",
@@ -61,13 +61,13 @@ class GradingPolicyTestMixin:
                 data=problem_xml,
             )
 
-            cls.video = ItemFactory.create(
+            cls.video = BlockFactory.create(
                 category="video",
                 parent_location=cls.sequential.location,
                 display_name="Video 1",
             )
 
-            cls.html = ItemFactory.create(
+            cls.html = BlockFactory.create(
                 category="html",
                 parent_location=cls.sequential.location,
                 display_name="HTML 1",

--- a/lms/djangoapps/grades/tests/base.py
+++ b/lms/djangoapps/grades/tests/base.py
@@ -5,7 +5,7 @@ Base file for Grades tests
 
 from crum import set_current_request
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
 from xmodule.capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
 from common.djangoapps.student.models import CourseEnrollment
@@ -26,19 +26,19 @@ class GradeTestBase(SharedModuleStoreTestCase):
         super().setUpClass()
         cls.course = CourseFactory.create()
         with cls.store.bulk_operations(cls.course.id):
-            cls.chapter = ItemFactory.create(
+            cls.chapter = BlockFactory.create(
                 parent=cls.course,
                 category="chapter",
                 display_name="Test Chapter"
             )
-            cls.sequence = ItemFactory.create(
+            cls.sequence = BlockFactory.create(
                 parent=cls.chapter,
                 category='sequential',
                 display_name="Test Sequential X with an & Ampersand",
                 graded=True,
                 format="Homework"
             )
-            cls.vertical = ItemFactory.create(
+            cls.vertical = BlockFactory.create(
                 parent=cls.sequence,
                 category='vertical',
                 display_name='Test Vertical 1'
@@ -48,20 +48,20 @@ class GradeTestBase(SharedModuleStoreTestCase):
                 choices=[False, False, True, False],
                 choice_names=['choice_0', 'choice_1', 'choice_2', 'choice_3']
             )
-            cls.problem = ItemFactory.create(
+            cls.problem = BlockFactory.create(
                 parent=cls.vertical,
                 category="problem",
                 display_name="Test Problem",
                 data=problem_xml
             )
-            cls.sequence2 = ItemFactory.create(
+            cls.sequence2 = BlockFactory.create(
                 parent=cls.chapter,
                 category='sequential',
                 display_name="Test Sequential A",
                 graded=True,
                 format="Homework"
             )
-            cls.problem2 = ItemFactory.create(
+            cls.problem2 = BlockFactory.create(
                 parent=cls.sequence2,
                 category="problem",
                 display_name="Test Problem 2",
@@ -69,7 +69,7 @@ class GradeTestBase(SharedModuleStoreTestCase):
             )
             # AED 2017-06-19: make cls.sequence belong to multiple parents,
             # so we can test that DAGs with this shape are handled correctly.
-            cls.chapter_2 = ItemFactory.create(
+            cls.chapter_2 = BlockFactory.create(
                 parent=cls.course,
                 category='chapter',
                 display_name='Test Chapter 2'

--- a/lms/djangoapps/grades/tests/integration/test_access.py
+++ b/lms/djangoapps/grades/tests/integration/test_access.py
@@ -14,7 +14,7 @@ from openedx.core.djangolib.testing.utils import get_mock_request
 from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 from ...subsection_grade_factory import SubsectionGradeFactory
 
@@ -30,19 +30,19 @@ class GradesAccessIntegrationTest(ProblemSubmissionTestMixin, SharedModuleStoreT
         super().setUpClass()
         cls.store = modulestore()
         cls.course = CourseFactory.create()
-        cls.chapter = ItemFactory.create(
+        cls.chapter = BlockFactory.create(
             parent=cls.course,
             category="chapter",
             display_name="Test Chapter"
         )
-        cls.sequence = ItemFactory.create(
+        cls.sequence = BlockFactory.create(
             parent=cls.chapter,
             category='sequential',
             display_name="Test Sequential 1",
             graded=True,
             format="Homework"
         )
-        cls.vertical = ItemFactory.create(
+        cls.vertical = BlockFactory.create(
             parent=cls.sequence,
             category='vertical',
             display_name='Test Vertical 1'
@@ -52,7 +52,7 @@ class GradesAccessIntegrationTest(ProblemSubmissionTestMixin, SharedModuleStoreT
             choices=[False, False, True, False],
             choice_names=['choice_0', 'choice_1', 'choice_2', 'choice_3']
         )
-        cls.problem = ItemFactory.create(
+        cls.problem = BlockFactory.create(
             parent=cls.vertical,
             category="problem",
             display_name="p1",
@@ -60,7 +60,7 @@ class GradesAccessIntegrationTest(ProblemSubmissionTestMixin, SharedModuleStoreT
             metadata={'weight': 2}
         )
 
-        cls.problem_2 = ItemFactory.create(
+        cls.problem_2 = BlockFactory.create(
             parent=cls.vertical,
             category="problem",
             display_name="p2",

--- a/lms/djangoapps/grades/tests/integration/test_events.py
+++ b/lms/djangoapps/grades/tests/integration/test_events.py
@@ -15,7 +15,7 @@ from lms.djangoapps.instructor_task.api import submit_rescore_problem_for_studen
 from openedx.core.djangolib.testing.utils import get_mock_request
 from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 from ... import events
 
@@ -34,19 +34,19 @@ class GradesEventIntegrationTest(ProblemSubmissionTestMixin, SharedModuleStoreTe
         """
         with cls.store.default_store(ModuleStoreEnum.Type.split):
             cls.course = CourseFactory.create()
-            cls.chapter = ItemFactory.create(
+            cls.chapter = BlockFactory.create(
                 parent=cls.course,
                 category="chapter",
                 display_name="Test Chapter"
             )
-            cls.sequence = ItemFactory.create(
+            cls.sequence = BlockFactory.create(
                 parent=cls.chapter,
                 category='sequential',
                 display_name="Test Sequential 1",
                 graded=True,
                 format="Homework"
             )
-            cls.vertical = ItemFactory.create(
+            cls.vertical = BlockFactory.create(
                 parent=cls.sequence,
                 category='vertical',
                 display_name='Test Vertical 1'
@@ -56,7 +56,7 @@ class GradesEventIntegrationTest(ProblemSubmissionTestMixin, SharedModuleStoreTe
                 choices=[False, False, True, False],
                 choice_names=['choice_0', 'choice_1', 'choice_2', 'choice_3']
             )
-            cls.problem = ItemFactory.create(
+            cls.problem = BlockFactory.create(
                 parent=cls.vertical,
                 category="problem",
                 display_name="p1",

--- a/lms/djangoapps/grades/tests/integration/test_problems.py
+++ b/lms/djangoapps/grades/tests/integration/test_problems.py
@@ -10,7 +10,7 @@ from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import (
     TEST_DATA_SPLIT_MODULESTORE, ModuleStoreTestCase, SharedModuleStoreTestCase,
 )
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 from xmodule.modulestore.tests.utils import TEST_DATA_DIR
 from xmodule.modulestore.xml_importer import import_course_from_xml
 from xmodule.capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
@@ -118,18 +118,18 @@ class TestVariedMetadata(ProblemSubmissionTestMixin, ModuleStoreTestCase):
         super().setUp()
         self.course = CourseFactory.create()
         with self.store.bulk_operations(self.course.id):
-            self.chapter = ItemFactory.create(
+            self.chapter = BlockFactory.create(
                 parent=self.course,
                 category="chapter",
                 display_name="Test Chapter"
             )
-            self.sequence = ItemFactory.create(
+            self.sequence = BlockFactory.create(
                 parent=self.chapter,
                 category='sequential',
                 display_name="Test Sequential 1",
                 graded=True
             )
-            self.vertical = ItemFactory.create(
+            self.vertical = BlockFactory.create(
                 parent=self.sequence,
                 category='vertical',
                 display_name='Test Vertical 1'
@@ -162,7 +162,7 @@ class TestVariedMetadata(ProblemSubmissionTestMixin, ModuleStoreTestCase):
         """
 
         metadata = self._get_altered_metadata(alterations)
-        ItemFactory.create(
+        BlockFactory.create(
             parent=self.vertical,
             category="problem",
             display_name="problem",
@@ -223,14 +223,14 @@ class TestWeightedProblems(SharedModuleStoreTestCase):
         super().setUpClass()
         cls.course = CourseFactory.create()
         with cls.store.bulk_operations(cls.course.id):
-            cls.chapter = ItemFactory.create(parent=cls.course, category="chapter", display_name="chapter")
-            cls.sequential = ItemFactory.create(parent=cls.chapter, category="sequential", display_name="sequential")
-            cls.vertical = ItemFactory.create(parent=cls.sequential, category="vertical", display_name="vertical1")
+            cls.chapter = BlockFactory.create(parent=cls.course, category="chapter", display_name="chapter")
+            cls.sequential = BlockFactory.create(parent=cls.chapter, category="sequential", display_name="sequential")
+            cls.vertical = BlockFactory.create(parent=cls.sequential, category="vertical", display_name="vertical1")
             problem_xml = cls._create_problem_xml()
             cls.problems = []
             for i in range(2):
                 cls.problems.append(
-                    ItemFactory.create(
+                    BlockFactory.create(
                         parent=cls.vertical,
                         category="problem",
                         display_name=f"problem_{i}",

--- a/lms/djangoapps/grades/tests/test_api.py
+++ b/lms/djangoapps/grades/tests/test_api.py
@@ -9,7 +9,7 @@ from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.grades import api
 from lms.djangoapps.grades.models import PersistentSubsectionGrade, PersistentSubsectionGradeOverride
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 
 @ddt.ddt
@@ -41,7 +41,7 @@ class OverrideSubsectionGradeTests(ModuleStoreTestCase):
     def setUp(self):
         super().setUp()
         self.course = CourseFactory.create(org='edX', number='DemoX', display_name='Demo_Course', run='Spring2019')
-        self.subsection = ItemFactory.create(parent=self.course, category="sequential", display_name="Subsection")
+        self.subsection = BlockFactory.create(parent=self.course, category="sequential", display_name="Subsection")
         self.grade = PersistentSubsectionGrade.update_or_create_grade(
             user_id=self.user.id,
             course_id=self.course.id,

--- a/lms/djangoapps/grades/tests/test_course_grade.py
+++ b/lms/djangoapps/grades/tests/test_course_grade.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import ddt
 from crum import set_current_request
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import UserFactory
@@ -74,20 +74,20 @@ class TestScoreForModule(SharedModuleStoreTestCase):
         super().setUpClass()
         cls.course = CourseFactory.create()
         with cls.store.bulk_operations(cls.course.id):
-            cls.a = ItemFactory.create(parent=cls.course, category="chapter", display_name="a")
-            cls.b = ItemFactory.create(parent=cls.a, category="sequential", display_name="b")
-            cls.c = ItemFactory.create(parent=cls.a, category="sequential", display_name="c")
-            cls.d = ItemFactory.create(parent=cls.b, category="vertical", display_name="d")
-            cls.e = ItemFactory.create(parent=cls.b, category="vertical", display_name="e")
-            cls.f = ItemFactory.create(parent=cls.b, category="vertical", display_name="f")
-            cls.g = ItemFactory.create(parent=cls.c, category="vertical", display_name="g")
-            cls.h = ItemFactory.create(parent=cls.d, category="problem", display_name="h")
-            cls.i = ItemFactory.create(parent=cls.d, category="problem", display_name="i")
-            cls.j = ItemFactory.create(parent=cls.e, category="problem", display_name="j")
-            cls.k = ItemFactory.create(parent=cls.e, category="html", display_name="k")
-            cls.l = ItemFactory.create(parent=cls.e, category="problem", display_name="l")
-            cls.m = ItemFactory.create(parent=cls.f, category="html", display_name="m")
-            cls.n = ItemFactory.create(parent=cls.g, category="problem", display_name="n")
+            cls.a = BlockFactory.create(parent=cls.course, category="chapter", display_name="a")
+            cls.b = BlockFactory.create(parent=cls.a, category="sequential", display_name="b")
+            cls.c = BlockFactory.create(parent=cls.a, category="sequential", display_name="c")
+            cls.d = BlockFactory.create(parent=cls.b, category="vertical", display_name="d")
+            cls.e = BlockFactory.create(parent=cls.b, category="vertical", display_name="e")
+            cls.f = BlockFactory.create(parent=cls.b, category="vertical", display_name="f")
+            cls.g = BlockFactory.create(parent=cls.c, category="vertical", display_name="g")
+            cls.h = BlockFactory.create(parent=cls.d, category="problem", display_name="h")
+            cls.i = BlockFactory.create(parent=cls.d, category="problem", display_name="i")
+            cls.j = BlockFactory.create(parent=cls.e, category="problem", display_name="j")
+            cls.k = BlockFactory.create(parent=cls.e, category="html", display_name="k")
+            cls.l = BlockFactory.create(parent=cls.e, category="problem", display_name="l")
+            cls.m = BlockFactory.create(parent=cls.f, category="html", display_name="m")
+            cls.n = BlockFactory.create(parent=cls.g, category="problem", display_name="n")
 
         cls.request = get_mock_request(UserFactory())
         CourseEnrollment.enroll(cls.request.user, cls.course.id)

--- a/lms/djangoapps/grades/tests/test_services.py
+++ b/lms/djangoapps/grades/tests/test_services.py
@@ -15,7 +15,7 @@ from lms.djangoapps.grades.constants import GradeOverrideFeatureEnum
 from lms.djangoapps.grades.models import PersistentSubsectionGrade, PersistentSubsectionGradeOverride
 from lms.djangoapps.grades.services import GradesService
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 from ..constants import ScoreDatabaseTableEnum
 
@@ -42,8 +42,8 @@ class GradesServiceTests(ModuleStoreTestCase):
         super().setUp()
         self.service = GradesService()
         self.course = CourseFactory.create(org='edX', number='DemoX', display_name='Demo_Course', run='Spring2019')
-        self.subsection = ItemFactory.create(parent=self.course, category="sequential", display_name="Subsection")
-        self.subsection_without_grade = ItemFactory.create(
+        self.subsection = BlockFactory.create(parent=self.course, category="sequential", display_name="Subsection")
+        self.subsection_without_grade = BlockFactory.create(
             parent=self.course,
             category="sequential",
             display_name="Subsection without grade"

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -35,7 +35,7 @@ from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import (
     TEST_DATA_SPLIT_MODULESTORE, ModuleStoreTestCase, SharedModuleStoreTestCase,
 )
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
@@ -360,14 +360,14 @@ class TestInstructorAPIDenyLevels(SharedModuleStoreTestCase, LoginEnrollmentTest
     def setUpClass(cls):
         super().setUpClass()
         cls.course = CourseFactory.create()
-        cls.chapter = ItemFactory.create(
+        cls.chapter = BlockFactory.create(
             parent=cls.course,
             category='chapter',
             display_name="Chapter",
             publish_item=True,
             start=datetime.datetime(2018, 3, 10, tzinfo=UTC),
         )
-        cls.sequential = ItemFactory.create(
+        cls.sequential = BlockFactory.create(
             parent=cls.chapter,
             category='sequential',
             display_name="Lesson",
@@ -375,14 +375,14 @@ class TestInstructorAPIDenyLevels(SharedModuleStoreTestCase, LoginEnrollmentTest
             start=datetime.datetime(2018, 3, 10, tzinfo=UTC),
             metadata={'graded': True, 'format': 'Homework'},
         )
-        cls.vertical = ItemFactory.create(
+        cls.vertical = BlockFactory.create(
             parent=cls.sequential,
             category='vertical',
             display_name='Subsection',
             publish_item=True,
             start=datetime.datetime(2018, 3, 10, tzinfo=UTC),
         )
-        cls.problem = ItemFactory.create(
+        cls.problem = BlockFactory.create(
             category="problem",
             parent=cls.vertical,
             display_name="A Problem Block",
@@ -3105,27 +3105,27 @@ class TestEntranceExamInstructorAPIRegradeTask(SharedModuleStoreTestCase, LoginE
         cls.course_with_invalid_ee = CourseFactory.create(entrance_exam_id='invalid_exam')
 
         with cls.store.bulk_operations(cls.course.id, emit_signals=False):
-            cls.entrance_exam = ItemFactory.create(
+            cls.entrance_exam = BlockFactory.create(
                 parent=cls.course,
                 category='chapter',
                 display_name='Entrance exam'
             )
-            subsection = ItemFactory.create(
+            subsection = BlockFactory.create(
                 parent=cls.entrance_exam,
                 category='sequential',
                 display_name='Subsection 1'
             )
-            vertical = ItemFactory.create(
+            vertical = BlockFactory.create(
                 parent=subsection,
                 category='vertical',
                 display_name='Vertical 1'
             )
-            cls.ee_problem_1 = ItemFactory.create(
+            cls.ee_problem_1 = BlockFactory.create(
                 parent=vertical,
                 category="problem",
                 display_name="Exam Problem - Problem 1"
             )
-            cls.ee_problem_2 = ItemFactory.create(
+            cls.ee_problem_2 = BlockFactory.create(
                 parent=vertical,
                 category="problem",
                 display_name="Exam Problem - Problem 2"
@@ -3938,15 +3938,15 @@ class TestDueDateExtensions(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         cls.due = datetime.datetime(2010, 5, 12, 2, 42, tzinfo=UTC)
 
         with cls.store.bulk_operations(cls.course.id, emit_signals=False):
-            cls.week1 = ItemFactory.create(due=cls.due)
-            cls.week2 = ItemFactory.create(due=cls.due)
-            cls.week3 = ItemFactory.create()  # No due date
+            cls.week1 = BlockFactory.create(due=cls.due)
+            cls.week2 = BlockFactory.create(due=cls.due)
+            cls.week3 = BlockFactory.create()  # No due date
             cls.course.children = [
                 str(cls.week1.location),
                 str(cls.week2.location),
                 str(cls.week3.location)
             ]
-            cls.homework = ItemFactory.create(
+            cls.homework = BlockFactory.create(
                 parent_location=cls.week1.location,
                 due=cls.due
             )
@@ -4120,15 +4120,15 @@ class TestDueDateExtensionsDeletedDate(ModuleStoreTestCase, LoginEnrollmentTestC
         self.due = datetime.datetime(2010, 5, 12, 2, 42, tzinfo=UTC)
 
         with self.store.bulk_operations(self.course.id, emit_signals=False):
-            self.week1 = ItemFactory.create(due=self.due)
-            self.week2 = ItemFactory.create(due=self.due)
-            self.week3 = ItemFactory.create()  # No due date
+            self.week1 = BlockFactory.create(due=self.due)
+            self.week2 = BlockFactory.create(due=self.due)
+            self.week3 = BlockFactory.create()  # No due date
             self.course.children = [
                 self.week1.location,
                 self.week2.location,
                 self.week3.location
             ]
-            self.homework = ItemFactory.create(
+            self.homework = BlockFactory.create(
                 parent_location=self.week1.location,
                 due=self.due
             )

--- a/lms/djangoapps/instructor/tests/test_enrollment.py
+++ b/lms/djangoapps/instructor/tests/test_enrollment.py
@@ -18,7 +18,7 @@ from opaque_keys.edx.locator import CourseLocator
 from submissions import api as sub_api
 
 from xmodule.modulestore.tests.django_utils import TEST_DATA_MONGO_AMNESTY_MODULESTORE, SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 from xmodule.capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
 from common.djangoapps.student.models import CourseEnrollment, CourseEnrollmentAllowed, anonymous_id_for_user
 from common.djangoapps.student.roles import CourseCcxCoachRole
@@ -380,22 +380,22 @@ class TestInstructorEnrollmentStudentModule(SharedModuleStoreTestCase):
         )
         cls.course_key = cls.course.location.course_key  # lint-amnesty, pylint: disable=no-member
         with cls.store.bulk_operations(cls.course.id, emit_signals=False):  # lint-amnesty, pylint: disable=no-member
-            cls.parent = ItemFactory(
+            cls.parent = BlockFactory(
                 category="library_content",
                 parent=cls.course,
                 publish_item=True,
             )
-            cls.child = ItemFactory(
+            cls.child = BlockFactory(
                 category="html",
                 parent=cls.parent,
                 publish_item=True,
             )
-            cls.unrelated = ItemFactory(
+            cls.unrelated = BlockFactory(
                 category="html",
                 parent=cls.course,
                 publish_item=True,
             )
-            cls.team_enabled_ora = ItemFactory.create(
+            cls.team_enabled_ora = BlockFactory.create(
                 parent=cls.parent,
                 category="openassessment",
                 teams_enabled=True,
@@ -712,18 +712,18 @@ class TestStudentModuleGrading(SharedModuleStoreTestCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.course = CourseFactory.create()
-        cls.chapter = ItemFactory.create(
+        cls.chapter = BlockFactory.create(
             parent=cls.course,
             category="chapter",
             display_name="Test Chapter"
         )
-        cls.sequence = ItemFactory.create(
+        cls.sequence = BlockFactory.create(
             parent=cls.chapter,
             category='sequential',
             display_name="Test Sequential 1",
             graded=True
         )
-        cls.vertical = ItemFactory.create(
+        cls.vertical = BlockFactory.create(
             parent=cls.sequence,
             category='vertical',
             display_name='Test Vertical 1'
@@ -733,7 +733,7 @@ class TestStudentModuleGrading(SharedModuleStoreTestCase):
             choices=[False, False, True, False],
             choice_names=['choice_0', 'choice_1', 'choice_2', 'choice_3']
         )
-        cls.problem = ItemFactory.create(
+        cls.problem = BlockFactory.create(
             parent=cls.vertical,
             category="problem",
             display_name="Test Problem",

--- a/lms/djangoapps/instructor/tests/test_services.py
+++ b/lms/djangoapps/instructor/tests/test_services.py
@@ -16,7 +16,7 @@ from lms.djangoapps.courseware.models import StudentModule
 from lms.djangoapps.instructor.access import allow_access
 from lms.djangoapps.instructor.services import InstructorService
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.partitions.partitions import Group, UserPartition  # lint-amnesty, pylint: disable=wrong-import-order
 
 
@@ -30,12 +30,12 @@ class InstructorServiceTests(SharedModuleStoreTestCase):
         super().setUpClass()
         cls.email = 'escalation@test.com'
         cls.course = CourseFactory.create(proctoring_escalation_email=cls.email)
-        cls.section = ItemFactory.create(parent=cls.course, category='chapter')
-        cls.subsection = ItemFactory.create(parent=cls.section, category='sequential')
-        cls.unit = ItemFactory.create(parent=cls.subsection, category='vertical')
-        cls.problem = ItemFactory.create(parent=cls.unit, category='problem')
-        cls.unit_2 = ItemFactory.create(parent=cls.subsection, category='vertical')
-        cls.problem_2 = ItemFactory.create(parent=cls.unit_2, category='problem')
+        cls.section = BlockFactory.create(parent=cls.course, category='chapter')
+        cls.subsection = BlockFactory.create(parent=cls.section, category='sequential')
+        cls.unit = BlockFactory.create(parent=cls.subsection, category='vertical')
+        cls.problem = BlockFactory.create(parent=cls.unit, category='problem')
+        cls.unit_2 = BlockFactory.create(parent=cls.subsection, category='vertical')
+        cls.problem_2 = BlockFactory.create(parent=cls.unit_2, category='problem')
         cls.complete_error_prefix = ('Error occurred while attempting to complete student attempt for '
                                      'user {user} for content_id {content_id}. ')
 
@@ -128,16 +128,16 @@ class InstructorServiceTests(SharedModuleStoreTestCase):
         """
         # Section, subsection, and unit are all aggregators and not completable so should
         # not be submitted.
-        section = ItemFactory.create(parent=self.course, category='chapter')
-        subsection = ItemFactory.create(parent=section, category='sequential')
-        unit = ItemFactory.create(parent=subsection, category='vertical')
+        section = BlockFactory.create(parent=self.course, category='chapter')
+        subsection = BlockFactory.create(parent=section, category='sequential')
+        unit = BlockFactory.create(parent=subsection, category='vertical')
 
         # should both be submitted
-        video = ItemFactory.create(parent=unit, category='video')
-        problem = ItemFactory.create(parent=unit, category='problem')
+        video = BlockFactory.create(parent=unit, category='video')
+        problem = BlockFactory.create(parent=unit, category='problem')
 
         # Not a completable block
-        ItemFactory.create(parent=unit, category='discussion')
+        BlockFactory.create(parent=unit, category='discussion')
 
         with override_waffle_switch(ENABLE_COMPLETION_TRACKING_SWITCH, True):
             self.service.complete_student_attempt(self.student.username, str(subsection.location))
@@ -167,25 +167,25 @@ class InstructorServiceTests(SharedModuleStoreTestCase):
             ]
         )
         course = CourseFactory.create(user_partitions=[partition])
-        section = ItemFactory.create(parent=course, category='chapter')
-        subsection = ItemFactory.create(parent=section, category='sequential')
+        section = BlockFactory.create(parent=course, category='chapter')
+        subsection = BlockFactory.create(parent=section, category='sequential')
 
         c0_url = course.id.make_usage_key('vertical', 'split_test_cond0')
         c1_url = course.id.make_usage_key('vertical', 'split_test_cond1')
-        split_test = ItemFactory.create(
+        split_test = BlockFactory.create(
             parent=subsection,
             category='split_test',
             user_partition_id=0,
             group_id_to_child={'0': c0_url, '1': c1_url},
         )
 
-        cond0vert = ItemFactory.create(parent=split_test, category='vertical', location=c0_url)
-        ItemFactory.create(parent=cond0vert, category='video')
-        ItemFactory.create(parent=cond0vert, category='problem')
+        cond0vert = BlockFactory.create(parent=split_test, category='vertical', location=c0_url)
+        BlockFactory.create(parent=cond0vert, category='video')
+        BlockFactory.create(parent=cond0vert, category='problem')
 
-        cond1vert = ItemFactory.create(parent=split_test, category='vertical', location=c1_url)
-        ItemFactory.create(parent=cond1vert, category='video')
-        ItemFactory.create(parent=cond1vert, category='html')
+        cond1vert = BlockFactory.create(parent=split_test, category='vertical', location=c1_url)
+        BlockFactory.create(parent=cond1vert, category='video')
+        BlockFactory.create(parent=cond1vert, category='html')
 
         with override_waffle_switch(ENABLE_COMPLETION_TRACKING_SWITCH, True):
             self.service.complete_student_attempt(self.student.username, str(subsection.location))

--- a/lms/djangoapps/instructor/tests/test_spoc_gradebook.py
+++ b/lms/djangoapps/instructor/tests/test_spoc_gradebook.py
@@ -8,7 +8,7 @@ from common.djangoapps.student.tests.factories import AdminFactory, CourseEnroll
 from lms.djangoapps.courseware.tests.factories import StudentModuleFactory
 from lms.djangoapps.grades.api import task_compute_all_grades_for_course
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 USER_COUNT = 11
 
@@ -33,17 +33,17 @@ class TestGradebook(SharedModuleStoreTestCase):
 
         # Now give it some content
         with cls.store.bulk_operations(cls.course.id, emit_signals=False):
-            chapter = ItemFactory.create(
+            chapter = BlockFactory.create(
                 parent_location=cls.course.location,
                 category="sequential",
             )
-            section = ItemFactory.create(
+            section = BlockFactory.create(
                 parent_location=chapter.location,
                 category="sequential",
                 metadata={'graded': True, 'format': 'Homework'}
             )
             cls.items = [
-                ItemFactory.create(
+                BlockFactory.create(
                     parent_location=section.location,
                     category="problem",
                     data=StringResponseXMLFactory().build_xml(answer='foo'),

--- a/lms/djangoapps/instructor/tests/test_tools.py
+++ b/lms/djangoapps/instructor/tests/test_tools.py
@@ -21,7 +21,7 @@ from xmodule.fields import Date
 from xmodule.modulestore.tests.django_utils import (
     TEST_DATA_SPLIT_MODULESTORE, ModuleStoreTestCase, SharedModuleStoreTestCase,
 )
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
 from openedx.core.djangoapps.course_date_signals import handlers
@@ -109,8 +109,8 @@ class TestFindUnit(SharedModuleStoreTestCase):
         super().setUpClass()
         course = CourseFactory.create()
         with cls.store.bulk_operations(course.id, emit_signals=False):
-            cls.week1 = ItemFactory.create(parent=course)
-            cls.homework = ItemFactory.create(parent=cls.week1)
+            cls.week1 = BlockFactory.create(parent=course)
+            cls.homework = BlockFactory.create(parent=cls.week1)
 
         # get updated course
         cls.course = cls.store.get_item(course.location)
@@ -145,9 +145,9 @@ class TestGetUnitsWithDueDate(ModuleStoreTestCase):
         super().setUp()
 
         course = CourseFactory.create()
-        week1 = ItemFactory.create(parent=course)
-        week2 = ItemFactory.create(parent=course)
-        child = ItemFactory.create(parent=week1)
+        week1 = BlockFactory.create(parent=course)
+        week2 = BlockFactory.create(parent=course)
+        child = BlockFactory.create(parent=week1)
 
         due = datetime.datetime(2010, 5, 12, 2, 42, tzinfo=UTC)
         set_dates_for_course(course.id, [
@@ -214,11 +214,11 @@ class TestSetDueDateExtension(ModuleStoreTestCase):
 
         self.due = due = datetime.datetime(2010, 5, 12, 2, 42, tzinfo=UTC)
         course = CourseFactory.create()
-        week1 = ItemFactory.create(due=due, parent=course)
-        week2 = ItemFactory.create(due=due, parent=course)
-        week3 = ItemFactory.create(parent=course)
-        homework = ItemFactory.create(parent=week1)
-        assignment = ItemFactory.create(parent=homework, due=due)
+        week1 = BlockFactory.create(due=due, parent=course)
+        week2 = BlockFactory.create(due=due, parent=course)
+        week3 = BlockFactory.create(parent=course)
+        homework = BlockFactory.create(parent=week1)
+        assignment = BlockFactory.create(parent=homework, due=due)
         handlers.extract_dates(None, course.id)
 
         user = UserFactory.create()
@@ -330,10 +330,10 @@ class TestDataDumps(ModuleStoreTestCase):
 
         due = datetime.datetime(2010, 5, 12, 2, 42, tzinfo=UTC)
         course = CourseFactory.create()
-        week1 = ItemFactory.create(due=due, parent=course)
-        week2 = ItemFactory.create(due=due, parent=course)
+        week1 = BlockFactory.create(due=due, parent=course)
+        week2 = BlockFactory.create(due=due, parent=course)
 
-        homework = ItemFactory.create(
+        homework = BlockFactory.create(
             parent=week1,
             due=due
         )

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -16,7 +16,7 @@ from pyquery import PyQuery as pq
 from pytz import UTC
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, check_mongo_calls
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory, check_mongo_calls
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.edxmako.shortcuts import render_to_response
@@ -557,7 +557,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         response = self.client.get(self.url)
         self.assertNotContains(response, ora_section)
 
-        ItemFactory.create(parent_location=self.course.location, category="openassessment")
+        BlockFactory.create(parent_location=self.course.location, category="openassessment")
         response = self.client.get(self.url)
         self.assertContains(response, ora_section)
 
@@ -567,7 +567,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         orphaned openassessment block
         """
         # create non-orphaned openassessment block
-        ItemFactory.create(
+        BlockFactory.create(
             parent_location=self.course.location,
             category="openassessment",
         )
@@ -627,7 +627,7 @@ class TestInstructorDashboardPerformance(ModuleStoreTestCase, LoginEnrollmentTes
         Test that the MongoDB cache is used in API to return grades
         """
         # prepare course structure
-        course = ItemFactory.create(
+        course = BlockFactory.create(
             parent_location=self.course.location,
             category="course",
             display_name="Test course",
@@ -640,14 +640,14 @@ class TestInstructorDashboardPerformance(ModuleStoreTestCase, LoginEnrollmentTes
             CourseEnrollmentFactory.create(user=student, course_id=self.course.id)
             students.append(student)
 
-        chapter = ItemFactory.create(
+        chapter = BlockFactory.create(
             parent=course,
             category='chapter',
             display_name="Chapter",
             publish_item=True,
             start=datetime.datetime(2015, 3, 1, tzinfo=UTC),
         )
-        sequential = ItemFactory.create(
+        sequential = BlockFactory.create(
             parent=chapter,
             category='sequential',
             display_name="Lesson",
@@ -655,7 +655,7 @@ class TestInstructorDashboardPerformance(ModuleStoreTestCase, LoginEnrollmentTes
             start=datetime.datetime(2015, 3, 1, tzinfo=UTC),
             metadata={'graded': True, 'format': 'Homework'},
         )
-        vertical = ItemFactory.create(
+        vertical = BlockFactory.create(
             parent=sequential,
             category='vertical',
             display_name='Subsection',
@@ -663,7 +663,7 @@ class TestInstructorDashboardPerformance(ModuleStoreTestCase, LoginEnrollmentTes
             start=datetime.datetime(2015, 4, 1, tzinfo=UTC),
         )
         for i in range(10):
-            problem = ItemFactory.create(
+            problem = BlockFactory.create(
                 category="problem",
                 parent=vertical,
                 display_name="A Problem Block %d" % i,

--- a/lms/djangoapps/instructor_task/tests/test_base.py
+++ b/lms/djangoapps/instructor_task/tests/test_base.py
@@ -22,7 +22,7 @@ from opaque_keys.edx.locations import Location
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 from xmodule.capa.tests.response_xml_factory import OptionResponseXMLFactory
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
 from lms.djangoapps.courseware.model_data import StudentModule
@@ -138,13 +138,13 @@ class InstructorTaskCourseTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase)
         Add a chapter and a sequential to the current course.
         """
         # Add a chapter to the course
-        self.chapter = ItemFactory.create(
+        self.chapter = BlockFactory.create(
             parent_location=self.course.location,
             display_name=TEST_CHAPTER_NAME,
         )
 
         # add a sequence to the course to which the problems can be added
-        self.problem_section = ItemFactory.create(
+        self.problem_section = BlockFactory.create(
             parent_location=self.chapter.location,
             category='sequential',
             metadata={'graded': True, 'format': 'Homework'},
@@ -235,12 +235,12 @@ class InstructorTaskModuleTestCase(InstructorTaskCourseTestCase):
         factory = OptionResponseXMLFactory()
         factory_args = self._option_problem_factory_args()
         problem_xml = factory.build_xml(**factory_args)
-        return ItemFactory.create(parent_location=parent.location,
-                                  parent=parent,
-                                  category="problem",
-                                  display_name=problem_url_name,
-                                  data=problem_xml,
-                                  **kwargs)
+        return BlockFactory.create(parent_location=parent.location,
+                                   parent=parent,
+                                   category="problem",
+                                   display_name=problem_url_name,
+                                   data=problem_xml,
+                                   **kwargs)
 
     def redefine_option_problem(self, problem_url_name, correct_answer=OPTION_1, num_inputs=1, num_responses=2):
         """Change the problem definition so the answer is Option 2"""

--- a/lms/djangoapps/instructor_task/tests/test_integration.py
+++ b/lms/djangoapps/instructor_task/tests/test_integration.py
@@ -42,7 +42,7 @@ from lms.djangoapps.instructor_task.tests.test_base import (
 from openedx.core.djangoapps.util.testing import TestConditionalContent
 from openedx.core.lib.url_utils import quote_slashes
 from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 log = logging.getLogger(__name__)
 
@@ -322,10 +322,10 @@ class TestRescoringTask(TestIntegrationTask):
                                         answer_display="answer",
                                         grader_payload=grader_payload,
                                         num_responses=2)
-        ItemFactory.create(parent_location=self.problem_section.location,
-                           category="problem",
-                           display_name=str(problem_url_name),
-                           data=problem_xml)
+        BlockFactory.create(parent_location=self.problem_section.location,
+                            category="problem",
+                            display_name=str(problem_url_name),
+                            data=problem_xml)
 
     def test_rescoring_code_problem(self):
         """Run rescore scenario on problem with code submission"""
@@ -378,11 +378,11 @@ class TestRescoringTask(TestIntegrationTask):
             # correct answer, and call a second time with that answer to confirm it's graded as correct.
             # Per-student rerandomization will at least generate different seeds for different users, so
             # we get a little more test coverage.
-            ItemFactory.create(parent_location=self.problem_section.location,
-                               category="problem",
-                               display_name=str(problem_url_name),
-                               data=problem_xml,
-                               metadata={"rerandomize": "per_student"})
+            BlockFactory.create(parent_location=self.problem_section.location,
+                                category="problem",
+                                display_name=str(problem_url_name),
+                                data=problem_xml,
+                                metadata={"rerandomize": "per_student"})
 
     def test_rescoring_randomized_problem(self):
         """Run rescore scenario on custom problem that uses randomize"""

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -68,7 +68,7 @@ from openedx.core.djangoapps.user_api.partition_schemes import RandomUserPartiti
 from openedx.core.djangoapps.util.testing import ContentGroupTestCase, TestConditionalContent
 from openedx.core.lib.teams_config import TeamsConfig
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, check_mongo_calls  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory, check_mongo_calls  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.partitions.partitions import Group, UserPartition  # lint-amnesty, pylint: disable=wrong-import-order
 
 from ..models import ReportStore
@@ -689,7 +689,7 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
         """
         for idx in range(1, 6):
             self.define_option_problem(f'Problem{idx}')
-            item = ItemFactory.create(
+            item = BlockFactory.create(
                 parent_location=self.problem_section.location,
                 parent=self.problem_section,
                 display_name=f"Item{idx}",
@@ -828,7 +828,7 @@ class TestProblemGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
     @patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task')
     @ddt.data(True, False)
     def test_single_problem(self, use_tempfile, _):
-        vertical = ItemFactory.create(
+        vertical = BlockFactory.create(
             parent_location=self.problem_section.location,
             category='vertical',
             metadata={'graded': True},
@@ -873,7 +873,7 @@ class TestProblemGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
             return_value=True,
         ):
             student_verified = self.create_student('user_verified', mode='verified')
-            vertical = ItemFactory.create(
+            vertical = BlockFactory.create(
                 parent_location=self.problem_section.location,
                 category='vertical',
                 metadata={'graded': True},
@@ -896,7 +896,7 @@ class TestProblemGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
         Students with inactive enrollments in a course should be included in Problem Grade Report.
         """
         inactive_student = self.create_student('inactive-student', 'inactive@example.com', enrollment_active=False)
-        vertical = ItemFactory.create(
+        vertical = BlockFactory.create(
             parent_location=self.problem_section.location,
             category='vertical',
             metadata={'graded': True},
@@ -1045,18 +1045,18 @@ class TestProblemReportSplitTestContent(TestReportMixin, TestConditionalContent,
             problem_section_format = 'Homework %d' % i
             problem_vertical_name = 'Problem Unit %d' % i
 
-            chapter = ItemFactory.create(parent_location=self.course.location,
-                                         display_name=chapter_name)
+            chapter = BlockFactory.create(parent_location=self.course.location,
+                                          display_name=chapter_name)
 
             # Add a sequence to the course to which the problems can be added
-            problem_section = ItemFactory.create(parent_location=chapter.location,
-                                                 category='sequential',
-                                                 metadata={'graded': True,
-                                                           'format': problem_section_format},
-                                                 display_name=problem_section_name)
+            problem_section = BlockFactory.create(parent_location=chapter.location,
+                                                  category='sequential',
+                                                  metadata={'graded': True,
+                                                            'format': problem_section_format},
+                                                  display_name=problem_section_name)
 
             # Create a vertical
-            problem_vertical = ItemFactory.create(
+            problem_vertical = BlockFactory.create(
                 parent_location=problem_section.location,
                 category='vertical',
                 display_name=problem_vertical_name
@@ -1088,7 +1088,7 @@ class TestProblemReportCohortedContent(TestReportMixin, ContentGroupTestCase, In
         super().setUp()
         # construct cohorted problems to work on.
         self.add_course_content()
-        vertical = ItemFactory.create(
+        vertical = BlockFactory.create(
             parent_location=self.problem_section.location,
             category='vertical',
             metadata={'graded': True},
@@ -1757,16 +1757,16 @@ class TestGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
             },
             metadata={"start": in_the_past}
         )
-        self.chapter = ItemFactory.create(parent=self.course, category='chapter')
+        self.chapter = BlockFactory.create(parent=self.course, category='chapter')
 
-        self.problem_section = ItemFactory.create(
+        self.problem_section = BlockFactory.create(
             parent=self.chapter,
             category='sequential',
             metadata={'graded': True, 'format': 'Homework'},
             display_name='Subsection'
         )
         self.define_option_problem('Problem1', parent=self.problem_section)
-        self.hidden_section = ItemFactory.create(
+        self.hidden_section = BlockFactory.create(
             parent=self.chapter,
             category='sequential',
             metadata={'graded': True, 'format': 'Homework'},
@@ -1774,20 +1774,20 @@ class TestGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
             display_name='Hidden',
         )
         self.define_option_problem('Problem2', parent=self.hidden_section)
-        self.unattempted_section = ItemFactory.create(
+        self.unattempted_section = BlockFactory.create(
             parent=self.chapter,
             category='sequential',
             metadata={'graded': True, 'format': 'Homework'},
             display_name='Unattempted',
         )
         self.define_option_problem('Problem3', parent=self.unattempted_section)
-        self.empty_section = ItemFactory.create(
+        self.empty_section = BlockFactory.create(
             parent=self.chapter,
             category='sequential',
             metadata={'graded': True, 'format': 'Homework'},
             display_name='Empty',
         )
-        self.unreleased_section = ItemFactory.create(
+        self.unreleased_section = BlockFactory.create(
             parent=self.chapter,
             category='sequential',
             metadata={'graded': True, 'format': 'Homework', 'start': in_the_future},
@@ -1893,7 +1893,7 @@ class TestGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
         ):
             student_1 = self.create_student('user_honor')
             student_verified = self.create_student('user_verified', mode='verified')
-            vertical = ItemFactory.create(
+            vertical = BlockFactory.create(
                 parent_location=self.problem_section.location,
                 category='vertical',
                 metadata={'graded': True},
@@ -1958,7 +1958,7 @@ class TestGradeReportEnrollmentAndCertificateInfo(TestReportMixin, InstructorTas
         factory = MultipleChoiceResponseXMLFactory()
         args = {'choices': [False, True, False]}
         problem_xml = factory.build_xml(**args)
-        ItemFactory.create(
+        BlockFactory.create(
             parent_location=parent.location,
             parent=parent,
             category="problem",

--- a/lms/djangoapps/lti_provider/tests/test_outcomes.py
+++ b/lms/djangoapps/lti_provider/tests/test_outcomes.py
@@ -9,7 +9,7 @@ from django.test import TestCase
 from lxml import etree
 from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator
 from xmodule.modulestore.tests.django_utils import TEST_DATA_MONGO_AMNESTY_MODULESTORE, ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, check_mongo_calls
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory, check_mongo_calls
 
 import lms.djangoapps.lti_provider.outcomes as outcomes
 from common.djangoapps.student.tests.factories import UserFactory
@@ -306,9 +306,9 @@ class TestAssignmentsForProblem(ModuleStoreTestCase):
         self.outcome_service = self.create_outcome_service('outcomes')
         self.course = CourseFactory.create()
         with self.store.bulk_operations(self.course.id, emit_signals=False):
-            self.chapter = ItemFactory.create(parent=self.course, category="chapter")
-            self.vertical = ItemFactory.create(parent=self.chapter, category="vertical")
-            self.unit = ItemFactory.create(parent=self.vertical, category="unit")
+            self.chapter = BlockFactory.create(parent=self.course, category="chapter")
+            self.vertical = BlockFactory.create(parent=self.chapter, category="vertical")
+            self.unit = BlockFactory.create(parent=self.vertical, category="unit")
 
     def create_outcome_service(self, id_suffix):
         """

--- a/lms/djangoapps/mobile_api/tests/test_milestones.py
+++ b/lms/djangoapps/mobile_api/tests/test_milestones.py
@@ -12,7 +12,7 @@ from common.djangoapps.util.milestones_helpers import add_prerequisite_course, f
 from lms.djangoapps.courseware.access_response import MilestoneAccessError
 from lms.djangoapps.courseware.tests.test_entrance_exam import add_entrance_exam_milestone, answer_entrance_exam_problem
 from openedx.core.djangolib.testing.utils import get_mock_request
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 
 class MobileAPIMilestonesMixin:
@@ -89,21 +89,21 @@ class MobileAPIMilestonesMixin:
         with self.store.bulk_operations(self.course.id):
             self.course.entrance_exam_enabled = True
 
-            self.entrance_exam = ItemFactory.create(
+            self.entrance_exam = BlockFactory.create(
                 parent=self.course,
                 category="chapter",
                 display_name="Entrance Exam Chapter",
                 is_entrance_exam=True,
                 in_entrance_exam=True,
             )
-            self.subsection_1 = ItemFactory.create(
+            self.subsection_1 = BlockFactory.create(
                 parent=self.entrance_exam,
                 category='sequential',
                 display_name="The Only Exam Sequential",
                 graded=True,
                 in_entrance_exam=True,
             )
-            self.problem_1 = ItemFactory.create(
+            self.problem_1 = BlockFactory.create(
                 parent=self.subsection_1,
                 category='problem',
                 display_name="The Only Exam Problem",

--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -39,7 +39,7 @@ from openedx.core.lib.courses import course_image_url
 from openedx.features.course_duration_limits.models import CourseDurationLimitConfig
 from openedx.features.course_experience.tests.views.helpers import add_course_mode
 from xmodule.course_block import DEFAULT_START_DATE  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 from .. import errors
 from .serializers import CourseEnrollmentSerializer, CourseEnrollmentSerializerv05
@@ -457,23 +457,23 @@ class CourseStatusAPITestCase(MobileAPITestCase):
         """
         super().setUp()
 
-        self.section = ItemFactory.create(
+        self.section = BlockFactory.create(
             parent=self.course,
             category='chapter',
         )
-        self.sub_section = ItemFactory.create(
+        self.sub_section = BlockFactory.create(
             parent=self.section,
             category='sequential',
         )
-        self.unit = ItemFactory.create(
+        self.unit = BlockFactory.create(
             parent=self.sub_section,
             category='vertical',
         )
-        self.other_sub_section = ItemFactory.create(
+        self.other_sub_section = BlockFactory.create(
             parent=self.section,
             category='sequential',
         )
-        self.other_unit = ItemFactory.create(
+        self.other_unit = BlockFactory.create(
             parent=self.other_sub_section,
             category='vertical',
         )

--- a/lms/djangoapps/ora_staff_grader/tests/test_views.py
+++ b/lms/djangoapps/ora_staff_grader/tests/test_views.py
@@ -14,7 +14,7 @@ from xmodule.modulestore.tests.django_utils import (
     SharedModuleStoreTestCase,
 )
 from xmodule.modulestore.tests.factories import CourseFactory
-from xmodule.modulestore.tests.factories import ItemFactory
+from xmodule.modulestore.tests.factories import BlockFactory
 
 from common.djangoapps.student.tests.factories import StaffFactory
 from lms.djangoapps.ora_staff_grader.constants import (
@@ -51,7 +51,7 @@ class BaseViewTest(SharedModuleStoreTestCase, APITestCase):
         cls.course = CourseFactory.create()
         cls.course_key = cls.course.location.course_key
 
-        cls.ora_block = ItemFactory.create(
+        cls.ora_block = BlockFactory.create(
             category="openassessment",
             parent_location=cls.course.location,
             display_name="test",

--- a/lms/djangoapps/program_enrollments/rest_api/v1/tests/test_views.py
+++ b/lms/djangoapps/program_enrollments/rest_api/v1/tests/test_views.py
@@ -22,7 +22,7 @@ from rest_framework.test import APITestCase
 from social_django.models import UserSocialAuth
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory as ModulestoreCourseFactory
-from xmodule.modulestore.tests.factories import ItemFactory
+from xmodule.modulestore.tests.factories import BlockFactory
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.models import CourseEnrollment
@@ -1891,7 +1891,7 @@ class ProgramCourseEnrollmentOverviewGetTests(
     )
     @ddt.unpack
     def test_due_dates(self, now_time, course_in_progress):
-        section_1 = ItemFactory.create(
+        section_1 = BlockFactory.create(
             category='chapter',
             start=self.yesterday,
             due=self.tomorrow,
@@ -1899,27 +1899,27 @@ class ProgramCourseEnrollmentOverviewGetTests(
             display_name='section 1'
         )
 
-        subsection_1 = ItemFactory.create(
+        subsection_1 = BlockFactory.create(
             category='sequential',
             due=self.tomorrow,
             parent=section_1,
             display_name='subsection 1'
         )
 
-        subsection_2 = ItemFactory.create(
+        subsection_2 = BlockFactory.create(
             category='sequential',
             due=self.tomorrow - timedelta(1),
             parent=section_1,
             display_name='subsection 2'
         )
 
-        subsection_3 = ItemFactory.create(
+        subsection_3 = BlockFactory.create(
             category='sequential',
             parent=section_1,
             display_name='subsection 3'
         )
 
-        unit_1 = ItemFactory.create(
+        unit_1 = BlockFactory.create(
             category='vertical',
             due=self.tomorrow + timedelta(2),
             parent=subsection_3,

--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -32,7 +32,7 @@ from openedx.core.djangoapps.django_comment_common.models import FORUM_ROLE_COMM
 from openedx.core.djangoapps.django_comment_common.utils import seed_permissions_roles
 from openedx.core.lib.teams_config import TeamsConfig
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 from .factories import CourseTeamFactory, LAST_ACTIVITY_AT
 from ..models import CourseTeamMembership
 from ..search_indexes import CourseTeam, CourseTeamIndexer, course_team_post_save_callback
@@ -1687,30 +1687,30 @@ class TestTeamAssignmentsView(TeamAPITestCase):
         teamset_id = cls.solar_team.topic_id
         other_teamset_id = cls.wind_team.topic_id
 
-        section = ItemFactory.create(
+        section = BlockFactory.create(
             parent=course,
             category='chapter',
             display_name='Test Section'
         )
-        subsection = ItemFactory.create(
+        subsection = BlockFactory.create(
             parent=section,
             category="sequential"
         )
-        unit_1 = ItemFactory.create(
+        unit_1 = BlockFactory.create(
             parent=subsection,
             category="vertical"
         )
-        open_assessment = ItemFactory.create(
+        open_assessment = BlockFactory.create(
             parent=unit_1,
             category="openassessment",
             teams_enabled=True,
             selected_teamset_id=teamset_id
         )
-        unit_2 = ItemFactory.create(
+        unit_2 = BlockFactory.create(
             parent=subsection,
             category="vertical"
         )
-        off_team_open_assessment = ItemFactory.create(  # pylint: disable=unused-variable
+        off_team_open_assessment = BlockFactory.create(  # pylint: disable=unused-variable
             parent=unit_2,
             category="openassessment",
             teams_enabled=True,

--- a/lms/lib/courseware_search/test/test_lms_filter_generator.py
+++ b/lms/lib/courseware_search/test/test_lms_filter_generator.py
@@ -7,7 +7,7 @@ from lms.lib.courseware_search.lms_filter_generator import LmsSearchFilterGenera
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 
 class LmsSearchFilterGeneratorTestCase(ModuleStoreTestCase):
@@ -34,14 +34,14 @@ class LmsSearchFilterGeneratorTestCase(ModuleStoreTestCase):
             )
         ]
 
-        self.chapter = ItemFactory.create(
+        self.chapter = BlockFactory.create(
             parent_location=self.courses[0].location,
             category='chapter',
             display_name="Week 1",
             publish_item=True,
         )
 
-        self.chapter2 = ItemFactory.create(
+        self.chapter2 = BlockFactory.create(
             parent_location=self.courses[1].location,
             category='chapter',
             display_name="Week 1",

--- a/lms/lib/courseware_search/test/test_lms_result_processor.py
+++ b/lms/lib/courseware_search/test/test_lms_result_processor.py
@@ -6,7 +6,7 @@ import pytest
 from common.djangoapps.student.tests.factories import UserFactory
 from lms.lib.courseware_search.lms_result_processor import LmsSearchResultProcessor
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 
 class LmsSearchResultProcessorTestCase(ModuleStoreTestCase):
@@ -24,37 +24,37 @@ class LmsSearchResultProcessorTestCase(ModuleStoreTestCase):
             run='test_run',
             display_name='Elasticsearch test course',
         )
-        self.section = ItemFactory.create(
+        self.section = BlockFactory.create(
             parent=self.course,
             category='chapter',
             display_name='Test Section',
         )
-        self.subsection = ItemFactory.create(
+        self.subsection = BlockFactory.create(
             parent=self.section,
             category='sequential',
             display_name='Test Subsection',
         )
-        self.vertical = ItemFactory.create(
+        self.vertical = BlockFactory.create(
             parent=self.subsection,
             category='vertical',
             display_name='Test Unit',
         )
-        self.html = ItemFactory.create(
+        self.html = BlockFactory.create(
             parent=self.vertical,
             category='html',
             display_name='Test Html control',
         )
-        self.ghost_subsection = ItemFactory.create(
+        self.ghost_subsection = BlockFactory.create(
             parent=self.section,
             category='sequential',
             display_name=None,
         )
-        self.ghost_vertical = ItemFactory.create(
+        self.ghost_vertical = BlockFactory.create(
             parent=self.ghost_subsection,
             category='vertical',
             display_name=None,
         )
-        self.ghost_html = ItemFactory.create(
+        self.ghost_html = BlockFactory.create(
             parent=self.ghost_vertical,
             category='html',
             display_name='Ghost Html control',

--- a/lms/lib/tests/test_utils.py
+++ b/lms/lib/tests/test_utils.py
@@ -5,7 +5,7 @@ Tests for the LMS/lib utils
 
 from lms.lib import utils
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 
 class LmsUtilsTest(ModuleStoreTestCase):
@@ -20,17 +20,17 @@ class LmsUtilsTest(ModuleStoreTestCase):
         super().setUp()
 
         self.course = CourseFactory.create()
-        self.chapter = ItemFactory.create(category="chapter", parent_location=self.course.location)
-        self.sequential = ItemFactory.create(category="sequential", parent_location=self.chapter.location)
-        self.vertical = ItemFactory.create(category="vertical", parent_location=self.sequential.location)
-        self.html_block_1 = ItemFactory.create(category="html", parent_location=self.vertical.location)
-        self.vertical_with_container = ItemFactory.create(
+        self.chapter = BlockFactory.create(category="chapter", parent_location=self.course.location)
+        self.sequential = BlockFactory.create(category="sequential", parent_location=self.chapter.location)
+        self.vertical = BlockFactory.create(category="vertical", parent_location=self.sequential.location)
+        self.html_block_1 = BlockFactory.create(category="html", parent_location=self.vertical.location)
+        self.vertical_with_container = BlockFactory.create(
             category="vertical", parent_location=self.sequential.location
         )
-        self.child_container = ItemFactory.create(
+        self.child_container = BlockFactory.create(
             category="split_test", parent_location=self.vertical_with_container.location)
-        self.child_vertical = ItemFactory.create(category="vertical", parent_location=self.child_container.location)
-        self.child_html_block = ItemFactory.create(category="html", parent_location=self.child_vertical.location)
+        self.child_vertical = BlockFactory.create(category="vertical", parent_location=self.child_container.location)
+        self.child_html_block = BlockFactory.create(category="html", parent_location=self.child_vertical.location)
 
         # Read again so that children lists are accurate
         self.course = self.store.get_item(self.course.location)

--- a/lms/lib/xblock/test/test_mixin.py
+++ b/lms/lib/xblock/test/test_mixin.py
@@ -15,7 +15,7 @@ from lms.djangoapps.lms_xblock.mixin import (
 )
 from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, ToyCourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory, ToyCourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.partitions.partitions import Group, UserPartition  # lint-amnesty, pylint: disable=wrong-import-order
 
 
@@ -41,13 +41,13 @@ class LmsXBlockMixinTestCase(ModuleStoreTestCase):
         self.group1 = self.user_partition.groups[0]
         self.group2 = self.user_partition.groups[1]
         self.course = CourseFactory.create(user_partitions=[self.user_partition])
-        section = ItemFactory.create(parent=self.course, category='chapter', display_name='Test Section')
-        subsection = ItemFactory.create(parent=section, category='sequential', display_name='Test Subsection')
-        vertical = ItemFactory.create(parent=subsection, category='vertical', display_name='Test Unit')
-        video = ItemFactory.create(parent=vertical, category='video', display_name='Test Video 1')
-        split_test = ItemFactory.create(parent=vertical, category='split_test', display_name='Test Content Experiment')
-        child_vertical = ItemFactory.create(parent=split_test, category='vertical')
-        child_html_block = ItemFactory.create(parent=child_vertical, category='html')
+        section = BlockFactory.create(parent=self.course, category='chapter', display_name='Test Section')
+        subsection = BlockFactory.create(parent=section, category='sequential', display_name='Test Subsection')
+        vertical = BlockFactory.create(parent=subsection, category='vertical', display_name='Test Unit')
+        video = BlockFactory.create(parent=vertical, category='video', display_name='Test Video 1')
+        split_test = BlockFactory.create(parent=vertical, category='split_test', display_name='Test Content Experiment')
+        child_vertical = BlockFactory.create(parent=split_test, category='vertical')
+        child_html_block = BlockFactory.create(parent=child_vertical, category='html')
         self.section_location = section.location
         self.subsection_location = subsection.location
         self.vertical_location = vertical.location
@@ -282,8 +282,8 @@ class OpenAssessmentBlockMixinTestCase(ModuleStoreTestCase):
     def setUp(self):
         super().setUp()
         self.course = CourseFactory.create()
-        self.section = ItemFactory.create(parent=self.course, category='chapter', display_name='Test Section')
-        self.open_assessment = ItemFactory.create(
+        self.section = BlockFactory.create(parent=self.course, category='chapter', display_name='Test Section')
+        self.open_assessment = BlockFactory.create(
             parent=self.section,
             category="openassessment",
             display_name="untitled",
@@ -333,7 +333,7 @@ class XBlockGetParentTest(LmsXBlockMixinTestCase):
         with self.store.default_store(ModuleStoreEnum.Type.split):
             self.build_course()
             subsection = self.store.get_item(self.subsection_location)
-            new_vertical = ItemFactory.create(parent=subsection, category='vertical', display_name='New Test Unit')
+            new_vertical = BlockFactory.create(parent=subsection, category='vertical', display_name='New Test Unit')
             child_to_move_location = self.video_location.for_branch(None)
             new_parent_location = new_vertical.location.for_branch(None)
             old_parent_location = self.vertical_location.for_branch(None)

--- a/openedx/core/djangoapps/bookmarks/tests/test_models.py
+++ b/openedx/core/djangoapps/bookmarks/tests/test_models.py
@@ -15,7 +15,7 @@ from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, check_mongo_calls
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory, check_mongo_calls
 
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 from common.djangoapps.student.tests.factories import AdminFactory, UserFactory
@@ -57,31 +57,31 @@ class BookmarksTestsBase(ModuleStoreTestCase):
             self.course = CourseFactory.create(display_name='An Introduction to API Testing')
             self.course_id = str(self.course.id)
 
-            self.chapter_1 = ItemFactory.create(
+            self.chapter_1 = BlockFactory.create(
                 parent=self.course, category='chapter', display_name='Week 1'
             )
-            self.chapter_2 = ItemFactory.create(
+            self.chapter_2 = BlockFactory.create(
                 parent=self.course, category='chapter', display_name='Week 2'
             )
 
-            self.sequential_1 = ItemFactory.create(
+            self.sequential_1 = BlockFactory.create(
                 parent=self.chapter_1, category='sequential', display_name='Lesson 1'
             )
-            self.sequential_2 = ItemFactory.create(
+            self.sequential_2 = BlockFactory.create(
                 parent=self.chapter_1, category='sequential', display_name='Lesson 2'
             )
 
-            self.vertical_1 = ItemFactory.create(
+            self.vertical_1 = BlockFactory.create(
                 parent=self.sequential_1, category='vertical', display_name='Subsection 1'
             )
-            self.vertical_2 = ItemFactory.create(
+            self.vertical_2 = BlockFactory.create(
                 parent=self.sequential_2, category='vertical', display_name='Subsection 2'
             )
-            self.vertical_3 = ItemFactory.create(
+            self.vertical_3 = BlockFactory.create(
                 parent=self.sequential_2, category='vertical', display_name='Subsection 3'
             )
 
-            self.html_1 = ItemFactory.create(
+            self.html_1 = BlockFactory.create(
                 parent=self.vertical_2, category='html', display_name='Details 1'
             )
 
@@ -131,19 +131,19 @@ class BookmarksTestsBase(ModuleStoreTestCase):
 
         with self.store.bulk_operations(self.other_course.id):
 
-            self.other_chapter_1 = ItemFactory.create(
+            self.other_chapter_1 = BlockFactory.create(
                 parent=self.other_course, category='chapter', display_name='Other Week 1'
             )
-            self.other_sequential_1 = ItemFactory.create(
+            self.other_sequential_1 = BlockFactory.create(
                 parent=self.other_chapter_1, category='sequential', display_name='Other Lesson 1'
             )
-            self.other_sequential_2 = ItemFactory.create(
+            self.other_sequential_2 = BlockFactory.create(
                 parent=self.other_chapter_1, category='sequential', display_name='Other Lesson 2'
             )
-            self.other_vertical_1 = ItemFactory.create(
+            self.other_vertical_1 = BlockFactory.create(
                 parent=self.other_sequential_1, category='vertical', display_name='Other Subsection 1'
             )
-            self.other_vertical_2 = ItemFactory.create(
+            self.other_vertical_2 = BlockFactory.create(
                 parent=self.other_sequential_1, category='vertical', display_name='Other Subsection 2'
             )
 
@@ -179,7 +179,7 @@ class BookmarksTestsBase(ModuleStoreTestCase):
 
                 for block in blocks_at_current_level:
                     for __ in range(children_per_block):
-                        blocks_at_next_level += [ItemFactory.create(
+                        blocks_at_next_level += [BlockFactory.create(
                             parent_location=block.location, display_name=str(display_name)
                         )]
                         display_name += 1
@@ -195,7 +195,7 @@ class BookmarksTestsBase(ModuleStoreTestCase):
 
             course = CourseFactory.create()
 
-            blocks = [ItemFactory.create(
+            blocks = [BlockFactory.create(
                 parent=course, category='chapter', display_name=str(index)
             ) for index in range(count)]
 
@@ -251,7 +251,7 @@ class BookmarkModelTests(BookmarksTestsBase):
     def setUp(self):
         super().setUp()
 
-        self.vertical_4 = ItemFactory.create(
+        self.vertical_4 = BlockFactory.create(
             parent=self.sequential_2,
             category='vertical',
             display_name=None
@@ -344,7 +344,7 @@ class BookmarkModelTests(BookmarksTestsBase):
         block_path = [PathItem(UsageKey.from_string(EXAMPLE_USAGE_KEY_1), '1')]
         mock_get_path.return_value = block_path
 
-        html = ItemFactory.create(
+        html = BlockFactory.create(
             parent=self.other_chapter_1, category='html', display_name='Other Lesson 1'
         )
 

--- a/openedx/core/djangoapps/bookmarks/tests/test_tasks.py
+++ b/openedx/core/djangoapps/bookmarks/tests/test_tasks.py
@@ -6,7 +6,7 @@ Tests for tasks.
 import ddt
 
 from xmodule.modulestore import ModuleStoreEnum
-from xmodule.modulestore.tests.factories import ItemFactory, check_mongo_calls
+from xmodule.modulestore.tests.factories import BlockFactory, check_mongo_calls
 
 from ..models import XBlockCache
 from ..tasks import _calculate_course_xblocks_data, _update_xblocks_cache
@@ -164,7 +164,7 @@ class XBlockCacheTaskTests(BookmarksTestsBase):
         """
         Test that the xblocks data is persisted correctly with display_name=None.
         """
-        block_with_display_name_none = ItemFactory.create(
+        block_with_display_name_none = BlockFactory.create(
             parent=self.sequential_2,
             category='vertical', display_name=None
         )

--- a/openedx/core/djangoapps/ccxcon/tests/test_api.py
+++ b/openedx/core/djangoapps/ccxcon/tests/test_api.py
@@ -10,7 +10,7 @@ import pytz
 from opaque_keys.edx.keys import CourseKey
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
 from openedx.core.djangoapps.ccxcon import api as ccxconapi
 from common.djangoapps.student.tests.factories import AdminFactory
@@ -51,16 +51,16 @@ class APIsTestCase(SharedModuleStoreTestCase):
         )
 
         cls.chapters = [
-            ItemFactory.create(start=start, parent=course) for _ in range(2)
+            BlockFactory.create(start=start, parent=course) for _ in range(2)
         ]
         cls.sequentials = flatten([
             [
-                ItemFactory.create(parent=chapter) for _ in range(2)
+                BlockFactory.create(parent=chapter) for _ in range(2)
             ] for chapter in cls.chapters
         ])
         cls.verticals = flatten([
             [
-                ItemFactory.create(
+                BlockFactory.create(
                     start=start, due=due, parent=sequential, graded=True, format='Homework', category='vertical'
                 ) for _ in range(2)
             ] for sequential in cls.sequentials
@@ -71,7 +71,7 @@ class APIsTestCase(SharedModuleStoreTestCase):
         with cls.store.bulk_operations(course.id, emit_signals=False):
             blocks = flatten([  # pylint: disable=unused-variable
                 [
-                    ItemFactory.create(parent=vertical) for _ in range(2)
+                    BlockFactory.create(parent=vertical) for _ in range(2)
                 ] for vertical in cls.verticals
             ])
 

--- a/openedx/core/djangoapps/courseware_api/tests/pacts/views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/pacts/views.py
@@ -9,7 +9,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from opaque_keys.edx.keys import CourseKey, UsageKey
 from xmodule.modulestore.tests.django_utils import ModuleStoreIsolationMixin
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, ToyCourseFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory, ToyCourseFactory
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
@@ -90,19 +90,19 @@ class ProviderState(ModuleStoreIsolationMixin):
             enrollment_start=datetime(2020, 1, 1, 1, 1, 1),
             enrollment_end=datetime(2028, 1, 1, 1, 1, 1),
         )
-        section = ItemFactory.create(
+        section = BlockFactory.create(
             parent=demo_course,
             category="chapter",
             display_name="Example Week 1: Getting Started"
         )
-        subsection = ItemFactory.create(
+        subsection = BlockFactory.create(
             location=UsageKey.from_string('block-v1:edX+DemoX+Demo_Course+type@sequential+block@basic_questions'),
             parent=section,
             category="sequential",
             display_name="Homework - Question Styles",
             metadata={'graded': True, 'format': 'Homework'}
         )
-        ItemFactory.create(
+        BlockFactory.create(
             location=UsageKey.from_string(
                 'block-v1:edX+DemoX+Demo_Course+type@vertical+block@2152d4a4aadc4cb0af5256394a3d1fc7'
             ),

--- a/openedx/core/djangoapps/courseware_api/tests/test_views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/test_views.py
@@ -18,7 +18,7 @@ from edx_toggles.toggles.testutils import override_waffle_flag
 from xmodule.data import CertificatesDisplayBehaviors
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import ItemFactory, ToyCourseFactory
+from xmodule.modulestore.tests.factories import BlockFactory, ToyCourseFactory
 from xmodule.partitions.partitions import ENROLLMENT_TRACK_PARTITION_ID
 
 from common.djangoapps.course_modes.models import CourseMode
@@ -68,9 +68,9 @@ class BaseCoursewareTests(SharedModuleStoreTestCase):
             certificate_available_date=_NEXT_WEEK,
             certificates_display_behavior=CertificatesDisplayBehaviors.END_WITH_DATE
         )
-        cls.chapter = ItemFactory(parent=cls.course, category='chapter')
-        cls.sequence = ItemFactory(parent=cls.chapter, category='sequential', display_name='sequence')
-        cls.unit = ItemFactory.create(parent=cls.sequence, category='vertical', display_name="Vertical")
+        cls.chapter = BlockFactory(parent=cls.course, category='chapter')
+        cls.sequence = BlockFactory(parent=cls.chapter, category='sequential', display_name='sequence')
+        cls.unit = BlockFactory.create(parent=cls.sequence, category='vertical', display_name="Vertical")
 
         cls.user = UserFactory(
             username='student',
@@ -467,7 +467,7 @@ class SequenceApiTestViews(MasqueradeMixin, BaseCoursewareTests):
     def test_hidden_after_due(self, is_past_due, masquerade_config, expected_hidden, expected_banner):
         """Validate the metadata when hide-after-due is set for a sequence"""
         due = datetime.now() + timedelta(days=-1 if is_past_due else 1)
-        sequence = ItemFactory(
+        sequence = BlockFactory(
             parent_location=self.chapter.location,
             # ^ It is very important that we use parent_location=self.chapter.location (and not parent=self.chapter), as
             # chapter is a class attribute and passing it by value will update its .children=[] which will then leak

--- a/openedx/core/djangoapps/credit/tests/test_tasks.py
+++ b/openedx/core/djangoapps/credit/tests/test_tasks.py
@@ -13,7 +13,7 @@ from openedx.core.djangoapps.credit.exceptions import InvalidCreditRequirements
 from openedx.core.djangoapps.credit.models import CreditCourse
 from openedx.core.djangoapps.credit.signals import on_course_publish
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 
 class TestTaskExecution(ModuleStoreTestCase):
@@ -35,9 +35,10 @@ class TestTaskExecution(ModuleStoreTestCase):
         super().setUp()
 
         self.course = CourseFactory.create(start=datetime(2015, 3, 1))
-        self.section = ItemFactory.create(parent=self.course, category='chapter', display_name='Test Section')
-        self.subsection = ItemFactory.create(parent=self.section, category='sequential', display_name='Test Subsection')
-        self.vertical = ItemFactory.create(parent=self.subsection, category='vertical', display_name='Test Unit')
+        self.section = BlockFactory.create(parent=self.course, category='chapter', display_name='Test Section')
+        self.subsection = BlockFactory.create(
+            parent=self.section, category='sequential', display_name='Test Subsection')
+        self.vertical = BlockFactory.create(parent=self.subsection, category='vertical', display_name='Test Unit')
 
     def test_task_adding_requirements_invalid_course(self):
         """
@@ -182,7 +183,7 @@ class TestTaskExecution(ModuleStoreTestCase):
         """
 
         self.add_credit_course(self.course.id)
-        subsection = ItemFactory.create(parent=self.section, category='sequential', display_name='Dummy Subsection')
+        subsection = BlockFactory.create(parent=self.section, category='sequential', display_name='Dummy Subsection')
         create_exam(
             course_id=str(self.course.id),
             content_id=str(subsection.location),

--- a/openedx/core/djangoapps/discussions/tests/test_tasks.py
+++ b/openedx/core/djangoapps/discussions/tests/test_tasks.py
@@ -13,7 +13,7 @@ from openedx.core.djangoapps.discussions.tasks import (
     update_unit_discussion_state_from_discussion_blocks,
 )
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
 
 class DiscussionConfigUpdateMixin:
@@ -69,46 +69,46 @@ class UpdateDiscussionsSettingsFromCourseTestCase(ModuleStoreTestCase, Discussio
         )
         self.course_key = course_key = self.course.id
         with self.store.bulk_operations(course_key):
-            self.section = ItemFactory.create(parent=course, category="chapter", display_name="Section")
-            self.sequence = ItemFactory.create(parent=self.section, category="sequential", display_name="Sequence")
-            self.unit = ItemFactory.create(parent=self.sequence, category="vertical", display_name="Unit")
-            ItemFactory.create(
+            self.section = BlockFactory.create(parent=course, category="chapter", display_name="Section")
+            self.sequence = BlockFactory.create(parent=self.section, category="sequential", display_name="Sequence")
+            self.unit = BlockFactory.create(parent=self.sequence, category="vertical", display_name="Unit")
+            BlockFactory.create(
                 parent=self.sequence,
                 category="vertical",
                 display_name="Discussable Unit",
                 discussion_enabled=True,
             )
-            ItemFactory.create(
+            BlockFactory.create(
                 parent=self.sequence,
                 category="vertical",
                 display_name="Non-Discussable Unit",
                 discussion_enabled=False,
             )
-            ItemFactory.create(parent=self.unit, category="html", display_name="An HTML Block")
-            graded_sequence = ItemFactory.create(
+            BlockFactory.create(parent=self.unit, category="html", display_name="An HTML Block")
+            graded_sequence = BlockFactory.create(
                 parent=self.section,
                 category="sequential",
                 display_name="Graded Sequence",
                 graded=True,
             )
-            graded_unit = ItemFactory.create(
+            graded_unit = BlockFactory.create(
                 parent=graded_sequence,
                 category="vertical",
                 display_name="Graded Unit",
             )
-            ItemFactory.create(
+            BlockFactory.create(
                 parent=graded_sequence,
                 category="vertical",
                 display_name="Discussable Graded Unit",
                 discussion_enabled=True,
             )
-            ItemFactory.create(
+            BlockFactory.create(
                 parent=graded_sequence,
                 category="vertical",
                 display_name="Non-Discussable Graded Unit",
                 discussion_enabled=False,
             )
-            ItemFactory.create(
+            BlockFactory.create(
                 parent=graded_unit,
                 category="html",
                 display_name="Graded HTML Block",
@@ -195,35 +195,35 @@ class MigrateUnitDiscussionStateFromXBlockTestCase(ModuleStoreTestCase, Discussi
         self.course = course = CourseFactory.create()
         self.course_key = course_key = self.course.id
         with self.store.bulk_operations(course_key):
-            section = ItemFactory.create(
+            section = BlockFactory.create(
                 parent=course, category="chapter", display_name="Section"
             )
-            sequence = ItemFactory.create(
+            sequence = BlockFactory.create(
                 parent=section, category="sequential", display_name="Sequence"
             )
-            self.unit_discussible = unit_discussible = ItemFactory.create(
+            self.unit_discussible = unit_discussible = BlockFactory.create(
                 parent=sequence,
                 category="vertical",
                 display_name="Discussable Unit",
             )
-            unit_non_discussible = ItemFactory.create(
+            unit_non_discussible = BlockFactory.create(
                 parent=sequence,
                 category="vertical",
                 display_name="Non-Discussable Unit",
                 discussion_enabled=False,
             )
-            graded_sequence = ItemFactory.create(
+            graded_sequence = BlockFactory.create(
                 parent=section,
                 category="sequential",
                 display_name="Graded Sequence",
                 graded=True,
             )
-            self.graded_unit_discussible = graded_unit_discussible = ItemFactory.create(
+            self.graded_unit_discussible = graded_unit_discussible = BlockFactory.create(
                 parent=graded_sequence,
                 category="vertical",
                 display_name="Discussable Graded Unit",
             )
-            graded_unit_non_discussible = ItemFactory.create(
+            graded_unit_non_discussible = BlockFactory.create(
                 parent=graded_sequence,
                 category="vertical",
                 display_name="Non-Discussable Graded Unit",
@@ -243,7 +243,7 @@ class MigrateUnitDiscussionStateFromXBlockTestCase(ModuleStoreTestCase, Discussi
         Add a discussion block to the specified units.
         """
         for unit in units:
-            ItemFactory.create(
+            BlockFactory.create(
                 parent=unit,
                 category='discussion',
                 discussion_id=f'id-{unit.location}',

--- a/openedx/core/djangoapps/discussions/tests/test_transformer.py
+++ b/openedx/core/djangoapps/discussions/tests/test_transformer.py
@@ -3,7 +3,7 @@ Tests for discussions course block transformer
 """
 
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
 from lms.djangoapps.course_blocks.api import get_course_blocks
 from lms.djangoapps.course_blocks.transformers.tests.helpers import TransformerRegistryTestMixin
@@ -24,15 +24,15 @@ class DiscussionsTopicLinkTransformerTestCase(TransformerRegistryTestMixin, Modu
         super().setUp()
         self.test_topic_id = 'test-topic-id'
         self.course = CourseFactory.create()
-        section = ItemFactory.create(
+        section = BlockFactory.create(
             parent_location=self.course.location,
             category="chapter",
         )
-        subsection1 = ItemFactory.create(
+        subsection1 = BlockFactory.create(
             parent_location=section.location,
             category="sequential",
         )
-        self.discussable_unit = ItemFactory.create(
+        self.discussable_unit = BlockFactory.create(
             parent_location=subsection1.location,
             category="vertical",
             # This won't really be used, but set it anyway
@@ -45,7 +45,7 @@ class DiscussionsTopicLinkTransformerTestCase(TransformerRegistryTestMixin, Modu
             provider_id=get_default_provider_type(),
             external_id=self.test_topic_id,
         )
-        self.non_discussable_unit = ItemFactory.create(
+        self.non_discussable_unit = BlockFactory.create(
             parent_location=subsection1.location,
             category="vertical",
             discussion_enabled=False,

--- a/openedx/core/djangoapps/schedules/management/commands/tests/test_send_course_update.py
+++ b/openedx/core/djangoapps/schedules/management/commands/tests/test_send_course_update.py
@@ -22,7 +22,7 @@ from openedx.core.djangoapps.schedules.models import ScheduleExperience
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 
 @ddt.ddt
@@ -65,7 +65,7 @@ class TestSendCourseUpdate(ScheduleUpsellTestMixin, ScheduleSendEmailTestMixin, 
 
         course = CourseFactory(highlights_enabled_for_messaging=True, self_paced=is_self_paced)
         with self.store.bulk_operations(course.id):
-            ItemFactory.create(parent=course, category='chapter', highlights=['highlights'])
+            BlockFactory.create(parent=course, category='chapter', highlights=['highlights'])
 
         enrollment = CourseEnrollmentFactory(course_id=course.id, user=self.user, mode='audit')
         assert enrollment.schedule.get_experience_type() == ScheduleExperience.EXPERIENCES.course_updates

--- a/openedx/core/djangoapps/schedules/tests/test_content_highlights.py
+++ b/openedx/core/djangoapps/schedules/tests/test_content_highlights.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
 from openedx.core.djangoapps.schedules.content_highlights import (
     course_has_highlights_from_store,
@@ -36,7 +36,7 @@ class TestContentHighlights(ModuleStoreTestCase):  # lint-amnesty, pylint: disab
         CourseEnrollment.enroll(self.user, self.course_key)
 
     def _create_chapter(self, **kwargs):
-        ItemFactory.create(
+        BlockFactory.create(
             parent=self.course,
             category='chapter',
             **kwargs

--- a/openedx/core/djangoapps/schedules/tests/test_resolvers.py
+++ b/openedx/core/djangoapps/schedules/tests/test_resolvers.py
@@ -15,7 +15,7 @@ from django.test.utils import override_settings
 from edx_toggles.toggles.testutils import override_waffle_switch
 from testfixtures import LogCapture
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
@@ -144,7 +144,7 @@ class TestCourseUpdateResolver(SchedulesResolverTestMixin, ModuleStoreTestCase):
         super().setUp()
         self.course = CourseFactory.create(highlights_enabled_for_messaging=True)
         with self.store.bulk_operations(self.course.id):
-            ItemFactory.create(parent=self.course, category='chapter', highlights=['good stuff'])
+            BlockFactory.create(parent=self.course, category='chapter', highlights=['good stuff'])
 
     def create_resolver(self):
         """
@@ -244,10 +244,10 @@ class TestCourseNextSectionUpdateResolver(SchedulesResolverTestMixin, ModuleStor
         )
 
         with self.store.bulk_operations(self.course.id):
-            ItemFactory.create(parent=self.course, category='chapter', highlights=['good stuff 1'])
-            ItemFactory.create(parent=self.course, category='chapter', highlights=['good stuff 2'])
-            ItemFactory.create(parent=self.course, category='chapter', highlights=['good stuff 3'])
-            ItemFactory.create(parent=self.course, category='chapter', highlights=['good stuff 4'])
+            BlockFactory.create(parent=self.course, category='chapter', highlights=['good stuff 1'])
+            BlockFactory.create(parent=self.course, category='chapter', highlights=['good stuff 2'])
+            BlockFactory.create(parent=self.course, category='chapter', highlights=['good stuff 3'])
+            BlockFactory.create(parent=self.course, category='chapter', highlights=['good stuff 4'])
 
     def create_resolver(self, user_start_date_offset=8):
         """

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_utils.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_utils.py
@@ -12,7 +12,7 @@ from openedx.core.djangolib.testing.utils import skip_unless_lms
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 from ..utils import format_social_link, validate_social_link
 
@@ -84,10 +84,10 @@ class CompletionUtilsTestCase(SharedModuleStoreTestCase, CompletionWaffleTestMix
         """
         course = CourseFactory.create()
         with self.store.bulk_operations(course.id):
-            self.chapter = ItemFactory.create(category='chapter', parent=course)
-            self.sequential = ItemFactory.create(category='sequential', parent=self.chapter)
-            self.vertical1 = ItemFactory.create(category='vertical', parent=self.sequential)
-            self.vertical2 = ItemFactory.create(category='vertical', parent=self.sequential)
+            self.chapter = BlockFactory.create(category='chapter', parent=course)
+            self.sequential = BlockFactory.create(category='sequential', parent=self.chapter)
+            self.vertical1 = BlockFactory.create(category='vertical', parent=self.sequential)
+            self.vertical2 = BlockFactory.create(category='vertical', parent=self.sequential)
 
         if hasattr(self, 'user_one'):
             CourseEnrollment.enroll(self.engaged_user, course.id)

--- a/openedx/core/djangoapps/util/testing.py
+++ b/openedx/core/djangoapps/util/testing.py
@@ -13,7 +13,7 @@ from openedx.core.djangoapps.user_api.tests.factories import UserCourseTagFactor
 from openedx.core.lib.teams_config import TeamsConfig
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.partitions.partitions import Group, UserPartition  # lint-amnesty, pylint: disable=wrong-import-order
 
 
@@ -99,21 +99,21 @@ class ContentGroupTestCase(ModuleStoreTestCase):
             partition_id=self.course.user_partitions[0].id,
             group_id=self.course.user_partitions[0].groups[1].id
         )
-        self.alpha_module = ItemFactory.create(
+        self.alpha_module = BlockFactory.create(
             parent_location=self.course.location,
             category='discussion',
             discussion_id='alpha_group_discussion',
             discussion_target='Visible to Alpha',
             group_access={self.course.user_partitions[0].id: [self.course.user_partitions[0].groups[0].id]}
         )
-        self.beta_module = ItemFactory.create(
+        self.beta_module = BlockFactory.create(
             parent_location=self.course.location,
             category='discussion',
             discussion_id='beta_group_discussion',
             discussion_target='Visible to Beta',
             group_access={self.course.user_partitions[0].id: [self.course.user_partitions[0].groups[1].id]}
         )
-        self.global_module = ItemFactory.create(
+        self.global_module = BlockFactory.create(
             parent_location=self.course.location,
             category='discussion',
             discussion_id='global_group_discussion',
@@ -172,14 +172,14 @@ class TestConditionalContent(ModuleStoreTestCase):
                 }]
             }
         )
-        chapter = ItemFactory.create(parent_location=self.course.location,
-                                     display_name='Chapter')
+        chapter = BlockFactory.create(parent_location=self.course.location,
+                                      display_name='Chapter')
 
         # add a sequence to the course to which the problems can be added
-        self.problem_section = ItemFactory.create(parent_location=chapter.location,
-                                                  category='sequential',
-                                                  metadata={'graded': True, 'format': 'Homework'},
-                                                  display_name=self.TEST_SECTION_NAME)
+        self.problem_section = BlockFactory.create(parent_location=chapter.location,
+                                                   category='sequential',
+                                                   metadata={'graded': True, 'format': 'Homework'},
+                                                   display_name=self.TEST_SECTION_NAME)
 
         # Create users and partition them
         self.student_a = UserFactory.create(username='student_a', email='student_a@example.com')
@@ -201,7 +201,7 @@ class TestConditionalContent(ModuleStoreTestCase):
         )
 
         # Create a vertical to contain our split test
-        problem_vertical = ItemFactory.create(
+        problem_vertical = BlockFactory.create(
             parent_location=self.problem_section.location,
             category='vertical',
             display_name='Problem Unit'
@@ -210,20 +210,20 @@ class TestConditionalContent(ModuleStoreTestCase):
         # Create the split test and child vertical containers
         vertical_a_url = self.course.id.make_usage_key('vertical', 'split_test_vertical_a')
         vertical_b_url = self.course.id.make_usage_key('vertical', 'split_test_vertical_b')
-        self.split_test = ItemFactory.create(
+        self.split_test = BlockFactory.create(
             parent_location=problem_vertical.location,
             category='split_test',
             display_name='Split Test',
             user_partition_id=self.partition.id,
             group_id_to_child={str(index): url for index, url in enumerate([vertical_a_url, vertical_b_url])}
         )
-        self.vertical_a = ItemFactory.create(
+        self.vertical_a = BlockFactory.create(
             parent_location=self.split_test.location,
             category='vertical',
             display_name='Group A problem container',
             location=vertical_a_url
         )
-        self.vertical_b = ItemFactory.create(
+        self.vertical_b = BlockFactory.create(
             parent_location=self.split_test.location,
             category='vertical',
             display_name='Group B problem container',

--- a/openedx/core/djangoapps/xblock/runtime/shims.py
+++ b/openedx/core/djangoapps/xblock/runtime/shims.py
@@ -394,21 +394,3 @@ class XBlockShim:
         student when the module is created. This is deprecated and discouraged.
         """
         return False
-
-    def get_display_blocks(self):
-        """
-        Returns a list of descendent XBlock instances that will display
-        immediately inside this module.
-        """
-        warnings.warn("get_display_blocks() is deprecated.", DeprecationWarning, stacklevel=2)
-        blocks = []
-        for child in self.get_children():
-            blocks.append(child)
-        return blocks
-
-    def displayable_items(self):
-        """
-        Returns list of displayable modules contained by this XBlock. If this
-        module is visible, should return [self].
-        """
-        return [self]

--- a/openedx/core/djangoapps/xblock/runtime/shims.py
+++ b/openedx/core/djangoapps/xblock/runtime/shims.py
@@ -395,16 +395,16 @@ class XBlockShim:
         """
         return False
 
-    def get_display_items(self):
+    def get_display_blocks(self):
         """
         Returns a list of descendent XBlock instances that will display
         immediately inside this module.
         """
-        warnings.warn("get_display_items() is deprecated.", DeprecationWarning, stacklevel=2)
-        items = []
+        warnings.warn("get_display_blocks() is deprecated.", DeprecationWarning, stacklevel=2)
+        blocks = []
         for child in self.get_children():
-            items.extend(child.displayable_items())
-        return items
+            blocks.extend(child.displayable_blocks())
+        return blocks
 
     def displayable_items(self):
         """

--- a/openedx/core/djangoapps/xblock/runtime/shims.py
+++ b/openedx/core/djangoapps/xblock/runtime/shims.py
@@ -403,7 +403,7 @@ class XBlockShim:
         warnings.warn("get_display_blocks() is deprecated.", DeprecationWarning, stacklevel=2)
         blocks = []
         for child in self.get_children():
-            blocks.extend(child.displayable_blocks())
+            blocks.append(child)
         return blocks
 
     def displayable_items(self):

--- a/openedx/core/lib/gating/tests/test_api.py
+++ b/openedx/core/lib/gating/tests/test_api.py
@@ -12,7 +12,7 @@ from django.conf import settings
 from milestones import api as milestones_api
 from milestones.tests.utils import MilestonesTestCaseMixin
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
 from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.gating import api as lms_gating_api
@@ -46,26 +46,26 @@ class TestGatingApi(ModuleStoreTestCase, MilestonesTestCaseMixin):
         self.course.save()
 
         # create chapter
-        self.chapter1 = ItemFactory.create(
+        self.chapter1 = BlockFactory.create(
             parent_location=self.course.location,
             category='chapter',
             display_name='untitled chapter 1'
         )
 
         # create sequentials
-        self.seq1 = ItemFactory.create(
+        self.seq1 = BlockFactory.create(
             parent_location=self.chapter1.location,
             category='sequential',
             display_name='untitled sequential 1'
         )
-        self.seq2 = ItemFactory.create(
+        self.seq2 = BlockFactory.create(
             parent_location=self.chapter1.location,
             category='sequential',
             display_name='untitled sequential 2'
         )
 
         # create vertical
-        self.vertical = ItemFactory.create(
+        self.vertical = BlockFactory.create(
             parent_location=self.seq1.location,
             category='vertical',
             display_name='untitled vertical 1'
@@ -248,12 +248,12 @@ class TestGatingApi(ModuleStoreTestCase, MilestonesTestCaseMixin):
 
         """
         student = UserFactory(is_staff=False)
-        problem_block = ItemFactory.create(
+        problem_block = BlockFactory.create(
             parent_location=self.vertical.location,
             category='problem',
             display_name='some problem'
         )
-        html_block = ItemFactory.create(
+        html_block = BlockFactory.create(
             parent_location=self.vertical.location,
             category='html',
             display_name='some html block'
@@ -293,7 +293,7 @@ class TestGatingApi(ModuleStoreTestCase, MilestonesTestCaseMixin):
         """
         student = UserFactory(is_staff=False)
 
-        component = ItemFactory.create(
+        component = BlockFactory.create(
             parent_location=self.vertical.location,
             category=component_type,
             display_name=f'{component_type} block'

--- a/openedx/core/lib/tests/test_xblock_utils.py
+++ b/openedx/core/lib/tests/test_xblock_utils.py
@@ -14,7 +14,7 @@ from web_fragments.fragment import Fragment
 from xblock.core import XBlockAside
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 from xmodule.modulestore.tests.test_asides import AsideTestType
 
 from openedx.core.lib.url_utils import quote_slashes
@@ -164,7 +164,7 @@ class TestXBlockAside(SharedModuleStoreTestCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.course = CourseFactory.create()
-        cls.block = ItemFactory.create(parent=cls.course)
+        cls.block = BlockFactory.create(parent=cls.course)
         cls.aside_v2 = AsideUsageKeyV2(cls.block.scope_ids.usage_id, "aside")
         cls.aside_v1 = AsideUsageKeyV1(cls.block.scope_ids.usage_id, "aside")
 

--- a/openedx/features/content_type_gating/tests/test_access.py
+++ b/openedx/features/content_type_gating/tests/test_access.py
@@ -16,7 +16,7 @@ from pyquery import PyQuery as pq
 from xmodule.modulestore.tests.django_utils import (
     TEST_DATA_SPLIT_MODULESTORE, ModuleStoreTestCase, SharedModuleStoreTestCase,
 )
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 from xmodule.partitions.partitions import ENROLLMENT_TRACK_PARTITION_ID
 
 from lms.djangoapps.course_api.blocks.api import get_blocks
@@ -220,9 +220,9 @@ class TestProblemTypeAccess(SharedModuleStoreTestCase, MasqueradeMixin):  # pyli
                 block_args['weight'] = weight
             if graded and has_score and weight:
                 block_args['metadata'] = METADATA
-            block = ItemFactory.create(**block_args)
+            block = BlockFactory.create(**block_args)
             # Intersperse HTML so that the content-gating renders in all blocks
-            ItemFactory.create(
+            BlockFactory.create(
                 parent=cls.blocks_dict['vertical'],
                 category='html',
                 graded=False,
@@ -240,7 +240,7 @@ class TestProblemTypeAccess(SharedModuleStoreTestCase, MasqueradeMixin):  # pyli
         scored_lti_metadata.update(METADATA)
 
         # add LTI blocks to default course
-        cls.blocks_dict['lti_block'] = ItemFactory.create(
+        cls.blocks_dict['lti_block'] = BlockFactory.create(
             parent=cls.blocks_dict['vertical'],
             category='lti_consumer',
             has_score=True,
@@ -248,12 +248,12 @@ class TestProblemTypeAccess(SharedModuleStoreTestCase, MasqueradeMixin):  # pyli
             metadata=scored_lti_metadata,
         )
         # Intersperse HTML so that the content-gating renders in all blocks
-        ItemFactory.create(
+        BlockFactory.create(
             parent=cls.blocks_dict['vertical'],
             category='html',
             graded=False,
         )
-        cls.blocks_dict['lti_block_not_scored'] = ItemFactory.create(
+        cls.blocks_dict['lti_block_not_scored'] = BlockFactory.create(
             parent=cls.blocks_dict['vertical'],
             category='lti_consumer',
             has_score=False,
@@ -261,14 +261,14 @@ class TestProblemTypeAccess(SharedModuleStoreTestCase, MasqueradeMixin):  # pyli
         )
 
         # Intersperse HTML so that the content-gating renders in all blocks
-        ItemFactory.create(
+        BlockFactory.create(
             parent=cls.blocks_dict['vertical'],
             category='html',
             graded=False,
         )
 
         # add ungraded problem for xblock_handler test
-        cls.blocks_dict['graded_problem'] = ItemFactory.create(
+        cls.blocks_dict['graded_problem'] = BlockFactory.create(
             parent=cls.blocks_dict['vertical'],
             category='problem',
             graded=True,
@@ -276,26 +276,26 @@ class TestProblemTypeAccess(SharedModuleStoreTestCase, MasqueradeMixin):  # pyli
         )
 
         # Intersperse HTML so that the content-gating renders in all blocks
-        ItemFactory.create(
+        BlockFactory.create(
             parent=cls.blocks_dict['vertical'],
             category='html',
             graded=False,
         )
 
-        cls.blocks_dict['ungraded_problem'] = ItemFactory.create(
+        cls.blocks_dict['ungraded_problem'] = BlockFactory.create(
             parent=cls.blocks_dict['vertical'],
             category='problem',
             graded=False,
         )
 
         # Intersperse HTML so that the content-gating renders in all blocks
-        ItemFactory.create(
+        BlockFactory.create(
             parent=cls.blocks_dict['vertical'],
             category='html',
             graded=False,
         )
 
-        cls.blocks_dict['audit_visible_graded_problem'] = ItemFactory.create(
+        cls.blocks_dict['audit_visible_graded_problem'] = BlockFactory.create(
             parent=cls.blocks_dict['vertical'],
             category='problem',
             graded=True,
@@ -308,7 +308,7 @@ class TestProblemTypeAccess(SharedModuleStoreTestCase, MasqueradeMixin):  # pyli
         )
 
         # Intersperse HTML so that the content-gating renders in all blocks
-        ItemFactory.create(
+        BlockFactory.create(
             parent=cls.blocks_dict['vertical'],
             category='html',
             graded=False,
@@ -409,28 +409,28 @@ class TestProblemTypeAccess(SharedModuleStoreTestCase, MasqueradeMixin):  # pyli
 
         with cls.store.bulk_operations(course.id):
             blocks_dict = {}
-            chapter = ItemFactory.create(
+            chapter = BlockFactory.create(
                 parent=course,
                 display_name='Overview',
             )
-            blocks_dict['chapter'] = ItemFactory.create(
+            blocks_dict['chapter'] = BlockFactory.create(
                 parent=course,
                 category='chapter',
                 display_name='Week 1',
             )
-            blocks_dict['sequential'] = ItemFactory.create(
+            blocks_dict['sequential'] = BlockFactory.create(
                 parent=chapter,
                 category='sequential',
                 display_name='Lesson 1',
             )
-            blocks_dict['vertical'] = ItemFactory.create(
+            blocks_dict['vertical'] = BlockFactory.create(
                 parent=blocks_dict['sequential'],
                 category='vertical',
                 display_name='Lesson 1 Vertical - Unit 1',
             )
 
             for component_type in component_types:
-                block = ItemFactory.create(
+                block = BlockFactory.create(
                     parent=blocks_dict['vertical'],
                     category=component_type,
                     graded=True,
@@ -438,7 +438,7 @@ class TestProblemTypeAccess(SharedModuleStoreTestCase, MasqueradeMixin):  # pyli
                 )
                 blocks_dict[component_type] = block
                 # Intersperse HTML so that the content-gating renders in all blocks
-                ItemFactory.create(
+                BlockFactory.create(
                     parent=blocks_dict['vertical'],
                     category='html',
                     graded=False,
@@ -834,12 +834,12 @@ class TestConditionalContentAccess(TestConditionalContent):
             value='1',
         )
         # Create blocks to go into the verticals
-        self.block_a = ItemFactory.create(
+        self.block_a = BlockFactory.create(
             category='problem',
             parent=self.vertical_a,
             metadata=METADATA,
         )
-        self.block_b = ItemFactory.create(
+        self.block_b = BlockFactory.create(
             category='problem',
             parent=self.vertical_b,
             metadata=METADATA,
@@ -918,17 +918,17 @@ class TestMessageDeduplication(ModuleStoreTestCase):
         CourseModeFactory.create(course_id=course.id, mode_slug='verified')
         blocks_dict = {}
         with self.store.bulk_operations(course.id):
-            blocks_dict['chapter'] = ItemFactory.create(
+            blocks_dict['chapter'] = BlockFactory.create(
                 parent=course,
                 category='chapter',
                 display_name='Week 1'
             )
-            blocks_dict['sequential'] = ItemFactory.create(
+            blocks_dict['sequential'] = BlockFactory.create(
                 parent=blocks_dict['chapter'],
                 category='sequential',
                 display_name='Lesson 1'
             )
-            blocks_dict['vertical'] = ItemFactory.create(
+            blocks_dict['vertical'] = BlockFactory.create(
                 parent=blocks_dict['sequential'],
                 category='vertical',
                 display_name='Lesson 1 Vertical - Unit 1'
@@ -947,7 +947,7 @@ class TestMessageDeduplication(ModuleStoreTestCase):
             course_id=course['course'].id,
             mode='audit'
         )
-        blocks_dict['graded_1'] = ItemFactory.create(
+        blocks_dict['graded_1'] = BlockFactory.create(
             parent_location=blocks_dict['vertical'].location,
             category='problem',
             graded=True,
@@ -966,13 +966,13 @@ class TestMessageDeduplication(ModuleStoreTestCase):
         ''' First graded problem should show message, second shouldn't '''
         course = self._create_course()
         blocks_dict = course['blocks']
-        blocks_dict['graded_1'] = ItemFactory.create(
+        blocks_dict['graded_1'] = BlockFactory.create(
             parent=blocks_dict['vertical'],
             category='problem',
             graded=True,
             metadata=METADATA,
         )
-        blocks_dict['graded_2'] = ItemFactory.create(
+        blocks_dict['graded_2'] = BlockFactory.create(
             parent=blocks_dict['vertical'],
             category='problem',
             graded=True,
@@ -1003,25 +1003,25 @@ class TestMessageDeduplication(ModuleStoreTestCase):
         ''' First graded problem should show message, all that follow shouldn't '''
         course = self._create_course()
         blocks_dict = course['blocks']
-        blocks_dict['graded_1'] = ItemFactory.create(
+        blocks_dict['graded_1'] = BlockFactory.create(
             parent=blocks_dict['vertical'],
             category='problem',
             graded=True,
             metadata=METADATA,
         )
-        blocks_dict['graded_2'] = ItemFactory.create(
+        blocks_dict['graded_2'] = BlockFactory.create(
             parent=blocks_dict['vertical'],
             category='problem',
             graded=True,
             metadata=METADATA,
         )
-        blocks_dict['graded_3'] = ItemFactory.create(
+        blocks_dict['graded_3'] = BlockFactory.create(
             parent=blocks_dict['vertical'],
             category='problem',
             graded=True,
             metadata=METADATA,
         )
-        blocks_dict['graded_4'] = ItemFactory.create(
+        blocks_dict['graded_4'] = BlockFactory.create(
             parent=blocks_dict['vertical'],
             category='problem',
             graded=True,
@@ -1066,18 +1066,18 @@ class TestMessageDeduplication(ModuleStoreTestCase):
         ''' Multiple graded content with ungraded between it should show message on either end '''
         course = self._create_course()
         blocks_dict = course['blocks']
-        blocks_dict['graded_1'] = ItemFactory.create(
+        blocks_dict['graded_1'] = BlockFactory.create(
             parent=blocks_dict['vertical'],
             category='problem',
             graded=True,
             metadata=METADATA,
         )
-        blocks_dict['ungraded_2'] = ItemFactory.create(
+        blocks_dict['ungraded_2'] = BlockFactory.create(
             parent=blocks_dict['vertical'],
             category='problem',
             graded=False,
         )
-        blocks_dict['graded_3'] = ItemFactory.create(
+        blocks_dict['graded_3'] = BlockFactory.create(
             parent=blocks_dict['vertical'],
             category='problem',
             graded=True,
@@ -1138,17 +1138,17 @@ class TestContentTypeGatingService(ModuleStoreTestCase):
         CourseModeFactory.create(course_id=course.id, mode_slug='verified')
         blocks_dict = {}
         with self.store.bulk_operations(course.id):
-            blocks_dict['chapter'] = ItemFactory.create(
+            blocks_dict['chapter'] = BlockFactory.create(
                 parent=course,
                 category='chapter',
                 display_name='Week 1'
             )
-            blocks_dict['sequential'] = ItemFactory.create(
+            blocks_dict['sequential'] = BlockFactory.create(
                 parent=blocks_dict['chapter'],
                 category='sequential',
                 display_name='Lesson 1'
             )
-            blocks_dict['vertical'] = ItemFactory.create(
+            blocks_dict['vertical'] = BlockFactory.create(
                 parent=blocks_dict['sequential'],
                 category='vertical',
                 display_name='Lesson 1 Vertical - Unit 1'
@@ -1169,13 +1169,13 @@ class TestContentTypeGatingService(ModuleStoreTestCase):
             course_id=course['course'].id,
             mode='audit'
         )
-        blocks_dict['graded_1'] = ItemFactory.create(
+        blocks_dict['graded_1'] = BlockFactory.create(
             parent=blocks_dict['vertical'],
             category='problem',
             graded=True,
             metadata=METADATA,
         )
-        blocks_dict['not_graded_1'] = ItemFactory.create(
+        blocks_dict['not_graded_1'] = BlockFactory.create(
             parent=blocks_dict['vertical'],
             category='problem',
             graded=False,
@@ -1202,7 +1202,7 @@ class TestContentTypeGatingService(ModuleStoreTestCase):
             course_id=course['course'].id,
             mode='audit'
         )
-        blocks_dict['not_graded_1'] = ItemFactory.create(
+        blocks_dict['not_graded_1'] = BlockFactory.create(
             parent=blocks_dict['vertical'],
             category='problem',
             graded=False,
@@ -1217,7 +1217,7 @@ class TestContentTypeGatingService(ModuleStoreTestCase):
             blocks_dict['vertical'], course['course'].id
         ) is None
 
-        blocks_dict['graded_1'] = ItemFactory.create(
+        blocks_dict['graded_1'] = BlockFactory.create(
             parent=blocks_dict['vertical'],
             category='problem',
             graded=True,

--- a/openedx/features/course_bookmarks/tests/test_course_bookmarks.py
+++ b/openedx/features/course_bookmarks/tests/test_course_bookmarks.py
@@ -8,7 +8,7 @@ from django.test import RequestFactory
 
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import CourseUserType, SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
 from ..plugins import CourseBookmarksTool
 
@@ -29,9 +29,9 @@ class TestCourseBookmarksTool(SharedModuleStoreTestCase):
                 cls.course = CourseFactory.create()
                 with cls.store.bulk_operations(cls.course.id):
                     # Create a basic course structure
-                    chapter = ItemFactory.create(category='chapter', parent_location=cls.course.location)
-                    section = ItemFactory.create(category='sequential', parent_location=chapter.location)
-                    ItemFactory.create(category='vertical', parent_location=section.location)
+                    chapter = BlockFactory.create(category='chapter', parent_location=cls.course.location)
+                    section = BlockFactory.create(category='sequential', parent_location=chapter.location)
+                    BlockFactory.create(category='vertical', parent_location=section.location)
 
     @ddt.data(
         [CourseUserType.ANONYMOUS, False],

--- a/openedx/features/course_duration_limits/tests/test_course_expiration.py
+++ b/openedx/features/course_duration_limits/tests/test_course_expiration.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.urls import reverse
 from django.utils.timezone import now
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 from xmodule.partitions.partitions import ENROLLMENT_TRACK_PARTITION_ID
 
 from common.djangoapps.course_modes.models import CourseMode
@@ -49,17 +49,17 @@ class CourseExpirationTestCase(ModuleStoreTestCase, MasqueradeMixin):
         self.course = CourseFactory(
             start=now() - timedelta(weeks=10),
         )
-        self.chapter = ItemFactory.create(
+        self.chapter = BlockFactory.create(
             category='chapter',
             parent_location=self.course.location,
             display_name='Test Chapter'
         )
-        self.sequential = ItemFactory.create(
+        self.sequential = BlockFactory.create(
             category='sequential',
             parent_location=self.chapter.location,
             display_name='Test Sequential'
         )
-        ItemFactory.create(
+        BlockFactory.create(
             category='vertical',
             parent_location=self.sequential.location,
             display_name='Test Vertical'

--- a/openedx/features/course_experience/tests/__init__.py
+++ b/openedx/features/course_experience/tests/__init__.py
@@ -9,7 +9,7 @@ from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.exceptions import ItemNotFoundError  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 
 class BaseCourseUpdatesTestCase(SharedModuleStoreTestCase):
@@ -23,9 +23,9 @@ class BaseCourseUpdatesTestCase(SharedModuleStoreTestCase):
                 cls.course = CourseFactory.create()
                 with cls.store.bulk_operations(cls.course.id):
                     # Create a basic course structure
-                    chapter = ItemFactory.create(category='chapter', parent_location=cls.course.location)
-                    section = ItemFactory.create(category='sequential', parent_location=chapter.location)
-                    ItemFactory.create(category='vertical', parent_location=section.location)
+                    chapter = BlockFactory.create(category='chapter', parent_location=cls.course.location)
+                    section = BlockFactory.create(category='sequential', parent_location=chapter.location)
+                    BlockFactory.create(category='vertical', parent_location=section.location)
 
     @classmethod
     def setUpTestData(cls):

--- a/openedx/features/course_experience/tests/test_url_helpers.py
+++ b/openedx/features/course_experience/tests/test_url_helpers.py
@@ -9,7 +9,7 @@ from django.test.client import RequestFactory
 from django.test.utils import override_settings
 
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
 from .. import url_helpers
 
@@ -90,22 +90,22 @@ class GetCoursewareUrlTests(SharedModuleStoreTestCase):
             display_name='URL Helpers Test Course',
         )
         with cls.store.bulk_operations(course_run.id):
-            section = ItemFactory.create(
+            section = BlockFactory.create(
                 parent_location=course_run.location,
                 category='chapter',
                 display_name="Generated Section",
             )
-            subsection = ItemFactory.create(
+            subsection = BlockFactory.create(
                 parent_location=section.location,
                 category='sequential',
                 display_name="Generated Subsection",
             )
-            unit = ItemFactory.create(
+            unit = BlockFactory.create(
                 parent_location=subsection.location,
                 category='vertical',
                 display_name="Generated Unit",
             )
-            component = ItemFactory.create(
+            component = BlockFactory.create(
                 parent_location=unit.location,
                 category='problem',
                 display_name="Generated Problem Component",

--- a/openedx/features/enterprise_support/tests/test_utils.py
+++ b/openedx/features/enterprise_support/tests/test_utils.py
@@ -47,7 +47,7 @@ from openedx.features.enterprise_support.utils import (
     update_third_party_auth_context_for_enterprise
 )
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 TEST_PASSWORD = 'test'
 
@@ -569,16 +569,16 @@ class TestCourseAccessed(SharedModuleStoreTestCase, CompletionWaffleTestMixin):
         """
         course = CourseFactory.create()
         with cls.store.bulk_operations(course.id):
-            chapter = ItemFactory.create(category='chapter', parent_location=course.location)
-            chapter2 = ItemFactory.create(category='chapter', parent_location=course.location)
-            sequential = ItemFactory.create(category='sequential', parent_location=chapter.location)
-            sequential2 = ItemFactory.create(category='sequential', parent_location=chapter.location)
-            sequential3 = ItemFactory.create(category='sequential', parent_location=chapter2.location)
-            sequential4 = ItemFactory.create(category='sequential', parent_location=chapter2.location)
-            vertical = ItemFactory.create(category='vertical', parent_location=sequential.location)
-            vertical2 = ItemFactory.create(category='vertical', parent_location=sequential2.location)
-            vertical3 = ItemFactory.create(category='vertical', parent_location=sequential3.location)
-            vertical4 = ItemFactory.create(category='vertical', parent_location=sequential4.location)
+            chapter = BlockFactory.create(category='chapter', parent_location=course.location)
+            chapter2 = BlockFactory.create(category='chapter', parent_location=course.location)
+            sequential = BlockFactory.create(category='sequential', parent_location=chapter.location)
+            sequential2 = BlockFactory.create(category='sequential', parent_location=chapter.location)
+            sequential3 = BlockFactory.create(category='sequential', parent_location=chapter2.location)
+            sequential4 = BlockFactory.create(category='sequential', parent_location=chapter2.location)
+            vertical = BlockFactory.create(category='vertical', parent_location=sequential.location)
+            vertical2 = BlockFactory.create(category='vertical', parent_location=sequential2.location)
+            vertical3 = BlockFactory.create(category='vertical', parent_location=sequential3.location)
+            vertical4 = BlockFactory.create(category='vertical', parent_location=sequential4.location)
         course.children = [chapter, chapter2]
         chapter.children = [sequential, sequential2]
         chapter2.children = [sequential3, sequential4]

--- a/openedx/features/personalized_learner_schedules/call_to_action.py
+++ b/openedx/features/personalized_learner_schedules/call_to_action.py
@@ -57,7 +57,7 @@ class PersonalizedLearnerScheduleCallToAction:
         elif category == self.VERTICAL_BANNER and not completed and missed_deadlines:
             # xblock is a vertical, so we'll check all the problems inside it. If there are any that will show a
             # a "shift dates" CTA under CAPA_SUBMIT_DISABLED, then we'll also show the same CTA as a vertical banner.
-            if any(self._is_block_shiftable(item, category) for item in xblock.get_display_blocks()):
+            if any(self._is_block_shiftable(item, category) for item in xblock.get_children()):
                 ctas.append(self._make_reset_deadlines_cta(xblock, category, is_learning_mfe))
 
         return ctas

--- a/openedx/features/personalized_learner_schedules/call_to_action.py
+++ b/openedx/features/personalized_learner_schedules/call_to_action.py
@@ -57,7 +57,7 @@ class PersonalizedLearnerScheduleCallToAction:
         elif category == self.VERTICAL_BANNER and not completed and missed_deadlines:
             # xblock is a vertical, so we'll check all the problems inside it. If there are any that will show a
             # a "shift dates" CTA under CAPA_SUBMIT_DISABLED, then we'll also show the same CTA as a vertical banner.
-            if any(self._is_block_shiftable(item, category) for item in xblock.get_display_items()):
+            if any(self._is_block_shiftable(item, category) for item in xblock.get_display_blocks()):
                 ctas.append(self._make_reset_deadlines_cta(xblock, category, is_learning_mfe))
 
         return ctas

--- a/openedx/tests/completion_integration/test_services.py
+++ b/openedx/tests/completion_integration/test_services.py
@@ -12,7 +12,7 @@ from django.test import override_settings
 from opaque_keys.edx.keys import CourseKey
 from xmodule.library_tools import LibraryToolsService
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, LibraryFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory, LibraryFactory
 from xmodule.tests import get_test_system
 
 from openedx.core.djangolib.testing.utils import skip_unless_lms
@@ -30,47 +30,47 @@ class CompletionServiceTestCase(CompletionWaffleTestMixin, SharedModuleStoreTest
         super().setUpClass()
         cls.course = CourseFactory.create()
         with cls.store.bulk_operations(cls.course.id):
-            cls.chapter = ItemFactory.create(
+            cls.chapter = BlockFactory.create(
                 parent=cls.course,
                 category="chapter",
                 publish_item=False,
             )
-            cls.sequence = ItemFactory.create(
+            cls.sequence = BlockFactory.create(
                 parent=cls.chapter,
                 category='sequential',
                 publish_item=False,
             )
-            cls.vertical = ItemFactory.create(
+            cls.vertical = BlockFactory.create(
                 parent=cls.sequence,
                 category='vertical',
                 publish_item=False,
             )
-            cls.html = ItemFactory.create(
+            cls.html = BlockFactory.create(
                 parent=cls.vertical,
                 category='html',
                 publish_item=False,
             )
-            cls.problem = ItemFactory.create(
+            cls.problem = BlockFactory.create(
                 parent=cls.vertical,
                 category="problem",
                 publish_item=False,
             )
-            cls.problem2 = ItemFactory.create(
+            cls.problem2 = BlockFactory.create(
                 parent=cls.vertical,
                 category="problem",
                 publish_item=False,
             )
-            cls.problem3 = ItemFactory.create(
+            cls.problem3 = BlockFactory.create(
                 parent=cls.vertical,
                 category="problem",
                 publish_item=False,
             )
-            cls.problem4 = ItemFactory.create(
+            cls.problem4 = BlockFactory.create(
                 parent=cls.vertical,
                 category="problem",
                 publish_item=False,
             )
-            cls.problem5 = ItemFactory.create(
+            cls.problem5 = BlockFactory.create(
                 parent=cls.vertical,
                 category="problem",
                 publish_item=False,
@@ -186,8 +186,8 @@ class CompletionServiceTestCase(CompletionWaffleTestMixin, SharedModuleStoreTest
     @override_settings(FEATURES={**settings.FEATURES, 'MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW': True})
     def test_can_mark_library_content_complete_on_view(self):
         library = LibraryFactory.create(modulestore=self.store)
-        lib_vertical = ItemFactory.create(parent=self.sequence, category='vertical', publish_item=False)
-        library_content_block = ItemFactory.create(
+        lib_vertical = BlockFactory.create(parent=self.sequence, category='vertical', publish_item=False)
+        library_content_block = BlockFactory.create(
             parent=lib_vertical,
             category='library_content',
             max_count=1,
@@ -198,19 +198,19 @@ class CompletionServiceTestCase(CompletionWaffleTestMixin, SharedModuleStoreTest
 
     def test_vertical_completion_with_library_content(self):
         library = LibraryFactory.create(modulestore=self.store)
-        ItemFactory.create(parent=library, category='problem', publish_item=False, user_id=self.user.id)
-        ItemFactory.create(parent=library, category='problem', publish_item=False, user_id=self.user.id)
-        ItemFactory.create(parent=library, category='problem', publish_item=False, user_id=self.user.id)
+        BlockFactory.create(parent=library, category='problem', publish_item=False, user_id=self.user.id)
+        BlockFactory.create(parent=library, category='problem', publish_item=False, user_id=self.user.id)
+        BlockFactory.create(parent=library, category='problem', publish_item=False, user_id=self.user.id)
         # Create a new vertical to hold the library content block
         # It is very important that we use parent_location=self.sequence.location (and not parent=self.sequence), since
         # sequence is a class attribute and passing it by value will update its .children=[] which will then leak into
         # other tests and cause errors if the children no longer exist.
-        lib_vertical = ItemFactory.create(
+        lib_vertical = BlockFactory.create(
             parent_location=self.sequence.location,
             category='vertical',
             publish_item=False,
         )
-        library_content_block = ItemFactory.create(
+        library_content_block = BlockFactory.create(
             parent=lib_vertical,
             category='library_content',
             max_count=1,
@@ -262,9 +262,9 @@ class CompletionServiceTestCase(CompletionWaffleTestMixin, SharedModuleStoreTest
         # It is very important that we use parent_location=self.sequence.location (and not parent=self.sequence), since
         # sequence is a class attribute and passing it by value will update its .children=[] which will then leak into
         # other tests and cause errors if the children no longer exist.
-        parent_vertical = ItemFactory(parent_location=self.sequence.location, category='vertical')
-        extra_vertical = ItemFactory(parent=parent_vertical, category='vertical')
-        problem = ItemFactory(parent=extra_vertical, category='problem')
+        parent_vertical = BlockFactory(parent_location=self.sequence.location, category='vertical')
+        extra_vertical = BlockFactory(parent=parent_vertical, category='vertical')
+        problem = BlockFactory(parent=extra_vertical, category='problem')
         parent_vertical = self.store.get_item(parent_vertical.location)
 
         # Nothing is complete

--- a/openedx/tests/completion_integration/test_views.py
+++ b/openedx/tests/completion_integration/test_views.py
@@ -14,7 +14,7 @@ from openedx.core.djangolib.testing.utils import skip_unless_lms
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 
 @ddt.ddt
@@ -45,7 +45,7 @@ class CompletionBatchTestCase(CompletionWaffleTestMixin, ModuleStoreTestCase):
             default_store=ModuleStoreEnum.Type.split,
         )
         assert str(self.course.id) == self.COURSE_KEY
-        self.problem = ItemFactory.create(
+        self.problem = BlockFactory.create(
             parent=self.course, category="problem", display_name="Test Problem", publish_item=False,
         )
         assert str(self.problem.location) == self.BLOCK_KEY

--- a/openedx/tests/xblock_integration/test_crowdsource_hinter.py
+++ b/openedx/tests/xblock_integration/test_crowdsource_hinter.py
@@ -9,7 +9,7 @@ import simplejson as json
 from django.conf import settings
 from django.urls import reverse
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
@@ -39,16 +39,16 @@ class TestCrowdsourceHinter(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
             display_name='CrowdsourceHinter_Test_Course'
         )
         with cls.store.bulk_operations(cls.course.id, emit_signals=False):
-            cls.chapter = ItemFactory.create(
+            cls.chapter = BlockFactory.create(
                 parent=cls.course, display_name='Overview'
             )
-            cls.section = ItemFactory.create(
+            cls.section = BlockFactory.create(
                 parent=cls.chapter, display_name='Welcome'
             )
-            cls.unit = ItemFactory.create(
+            cls.unit = BlockFactory.create(
                 parent=cls.section, display_name='New Unit'
             )
-            cls.xblock = ItemFactory.create(
+            cls.xblock = BlockFactory.create(
                 parent=cls.unit,
                 category='crowdsourcehinter',
                 display_name='crowdsourcehinter'

--- a/openedx/tests/xblock_integration/test_recommender.py
+++ b/openedx/tests/xblock_integration/test_recommender.py
@@ -15,7 +15,7 @@ from ddt import data, ddt
 from django.conf import settings
 from django.urls import reverse
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
 from common.djangoapps.student.tests.factories import GlobalStaffFactory
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
@@ -45,21 +45,21 @@ class TestRecommender(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
             display_name='Recommender_Test_Course'
         )
         with cls.store.bulk_operations(cls.course.id, emit_signals=False):
-            cls.chapter = ItemFactory.create(
+            cls.chapter = BlockFactory.create(
                 parent=cls.course, display_name='Overview'
             )
-            cls.section = ItemFactory.create(
+            cls.section = BlockFactory.create(
                 parent=cls.chapter, display_name='Welcome'
             )
-            cls.unit = ItemFactory.create(
+            cls.unit = BlockFactory.create(
                 parent=cls.section, display_name='New Unit'
             )
-            cls.xblock = ItemFactory.create(
+            cls.xblock = BlockFactory.create(
                 parent=cls.unit,
                 category='recommender',
                 display_name='recommender'
             )
-            cls.xblock2 = ItemFactory.create(
+            cls.xblock2 = BlockFactory.create(
                 parent=cls.unit,
                 category='recommender',
                 display_name='recommender_second'

--- a/openedx/tests/xblock_integration/xblock_testcase.py
+++ b/openedx/tests/xblock_integration/xblock_testcase.py
@@ -52,7 +52,7 @@ from xblock.plugin import Plugin
 
 import xmodule.services
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 
@@ -240,17 +240,17 @@ class XBlockScenarioTestCaseMixin:
         cls.xblocks = {}
         with cls.store.bulk_operations(cls.course.id, emit_signals=False):
             for chapter_config in cls.test_configuration:
-                chapter = ItemFactory.create(
+                chapter = BlockFactory.create(
                     parent_location=cls.course.location,
                     display_name="ch_" + chapter_config['urlname'],
                     category='chapter'
                 )
-                section = ItemFactory.create(
+                section = BlockFactory.create(
                     parent=chapter,
                     display_name="sec_" + chapter_config['urlname'],
                     category='sequential'
                 )
-                unit = ItemFactory.create(
+                unit = BlockFactory.create(
                     parent=section,
                     display_name='unit_' + chapter_config['urlname'],
                     category='vertical'
@@ -264,7 +264,7 @@ class XBlockScenarioTestCaseMixin:
                     )
 
                 for xblock_config in chapter_config['xblocks']:
-                    xblock = ItemFactory.create(
+                    xblock = BlockFactory.create(
                         parent=unit,
                         category=xblock_config['blocktype'],
                         display_name=xblock_config['urlname'],

--- a/xmodule/conditional_block.py
+++ b/xmodule/conditional_block.py
@@ -287,7 +287,7 @@ class ConditionalBlock(
             html = self.runtime.service(self, 'mako').render_template('conditional_block.html', context)
             return json.dumps({'fragments': [{'content': html}], 'message': bool(self.conditional_message)})
 
-        fragments = [child.render(STUDENT_VIEW).to_dict() for child in self.get_display_blocks()]
+        fragments = [child.render(STUDENT_VIEW).to_dict() for child in self.get_children()]
 
         return json.dumps({'fragments': fragments})
 

--- a/xmodule/conditional_block.py
+++ b/xmodule/conditional_block.py
@@ -287,7 +287,7 @@ class ConditionalBlock(
             html = self.runtime.service(self, 'mako').render_template('conditional_block.html', context)
             return json.dumps({'fragments': [{'content': html}], 'message': bool(self.conditional_message)})
 
-        fragments = [child.render(STUDENT_VIEW).to_dict() for child in self.get_display_items()]
+        fragments = [child.render(STUDENT_VIEW).to_dict() for child in self.get_display_blocks()]
 
         return json.dumps({'fragments': fragments})
 

--- a/xmodule/conditional_block.py
+++ b/xmodule/conditional_block.py
@@ -326,7 +326,7 @@ class ConditionalBlock(
         descriptors = []
         for location in self.sources_list:
             try:
-                descriptor = self.system.load_item(location)
+                descriptor = self.system.get_block(location)
                 descriptors.append(descriptor)
             except ItemNotFoundError:
                 msg = "Invalid module by location."

--- a/xmodule/conditional_block.py
+++ b/xmodule/conditional_block.py
@@ -326,7 +326,7 @@ class ConditionalBlock(
         descriptors = []
         for location in self.sources_list:
             try:
-                descriptor = self.system.get_block(location)
+                descriptor = self.runtime.get_block(location)
                 descriptors.append(descriptor)
             except ItemNotFoundError:
                 msg = "Invalid module by location."

--- a/xmodule/library_content_block.py
+++ b/xmodule/library_content_block.py
@@ -399,7 +399,7 @@ class LibraryContentBlock(
                 # 500-response.
                 logger.error('Skipping display for child block that is None')
                 continue
-            for displayable in child.displayable_items():
+            for displayable in child.displayable_blocks():
                 rendered_child = displayable.render(STUDENT_VIEW, child_context)
                 fragment.add_fragment_resources(rendered_child)
                 contents.append({

--- a/xmodule/library_content_block.py
+++ b/xmodule/library_content_block.py
@@ -399,13 +399,13 @@ class LibraryContentBlock(
                 # 500-response.
                 logger.error('Skipping display for child block that is None')
                 continue
-            for displayable in child.displayable_blocks():
-                rendered_child = displayable.render(STUDENT_VIEW, child_context)
-                fragment.add_fragment_resources(rendered_child)
-                contents.append({
-                    'id': str(displayable.location),
-                    'content': rendered_child.content,
-                })
+
+            rendered_child = child.render(STUDENT_VIEW, child_context)
+            fragment.add_fragment_resources(rendered_child)
+            contents.append({
+                'id': str(child.location),
+                'content': rendered_child.content,
+            })
 
         fragment.add_content(self.runtime.service(self, 'mako').render_template('vert_module.html', {
             'items': contents,

--- a/xmodule/modulestore/mongo/base.py
+++ b/xmodule/modulestore/mongo/base.py
@@ -824,7 +824,7 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
             system = using_descriptor_system
             system.module_data.update(data_cache)
 
-        item = system.load_item(location, for_parent=for_parent)
+        item = system.get_block(location, for_parent=for_parent)
 
         # TODO Once TNL-5092 is implemented, we can remove the following line
         # of code. Until then, set the course_version field on the block to be

--- a/xmodule/modulestore/tests/django_utils.py
+++ b/xmodule/modulestore/tests/django_utils.py
@@ -511,7 +511,7 @@ class ModuleStoreTestCase(
                    MODULESTORE = mixed_store_config(data_dir, mappings)
                    # ...
 
-        3. Use factories (e.g. `CourseFactory`, `ItemFactory`) to populate
+        3. Use factories (e.g. `CourseFactory`, `BlockFactory`) to populate
            the modulestore with test data.
 
     NOTE:

--- a/xmodule/modulestore/tests/factories.py
+++ b/xmodule/modulestore/tests/factories.py
@@ -279,7 +279,7 @@ class LibraryFactory(XModuleFactory):
             return new_library
 
 
-class ItemFactory(XModuleFactory):
+class BlockFactory(XModuleFactory):
     """
     Factory for XModule items.
     """

--- a/xmodule/modulestore/tests/test_libraries.py
+++ b/xmodule/modulestore/tests/test_libraries.py
@@ -10,7 +10,7 @@ from bson.objectid import ObjectId
 from opaque_keys.edx.locator import LibraryLocator
 
 from xmodule.modulestore.exceptions import DuplicateCourseError
-from xmodule.modulestore.tests.factories import ItemFactory, LibraryFactory, check_mongo_calls
+from xmodule.modulestore.tests.factories import BlockFactory, LibraryFactory, check_mongo_calls
 from xmodule.modulestore.tests.utils import MixedSplitTestCase
 
 
@@ -80,14 +80,14 @@ class TestLibraries(MixedSplitTestCase):
         library = LibraryFactory.create(modulestore=self.store)
 
         # In the library, create a vertical block with a child:
-        vert_block = ItemFactory.create(
+        vert_block = BlockFactory.create(
             category="vertical",
             parent_location=library.location,
             user_id=self.user_id,
             publish_item=False,
             modulestore=self.store,
         )
-        child_block = ItemFactory.create(
+        child_block = BlockFactory.create(
             category="html",
             parent_location=vert_block.location,
             user_id=self.user_id,
@@ -103,7 +103,7 @@ class TestLibraries(MixedSplitTestCase):
         """
         library = LibraryFactory.create(modulestore=self.store)
 
-        block = ItemFactory.create(
+        block = BlockFactory.create(
             category="html",
             parent_location=library.location,
             user_id=self.user_id,
@@ -128,7 +128,7 @@ class TestLibraries(MixedSplitTestCase):
         """
         library = LibraryFactory.create(modulestore=self.store)
         lib_key = library.location.library_key
-        block = ItemFactory.create(
+        block = BlockFactory.create(
             category="html",
             parent_location=library.location,
             user_id=self.user_id,
@@ -191,7 +191,7 @@ class TestLibraries(MixedSplitTestCase):
 
     def test_xblock_in_lib_have_published_version_returns_false(self):
         library = LibraryFactory.create(modulestore=self.store)
-        block = ItemFactory.create(
+        block = BlockFactory.create(
             category="html",
             parent_location=library.location,
             user_id=self.user_id,

--- a/xmodule/modulestore/tests/test_mixed_modulestore.py
+++ b/xmodule/modulestore/tests/test_mixed_modulestore.py
@@ -448,7 +448,7 @@ class TestMixedModuleStore(CommonMixedModuleStoreSetup):
             assert block.course_version == course_version
             # ensure that when the block is retrieved from the runtime cache,
             # the course version is still present
-            cached_block = course.runtime.load_item(block.location)
+            cached_block = course.runtime.get_block(block.location)
             assert cached_block.course_version == block.course_version
 
     @ddt.data((ModuleStoreEnum.Type.split, 2, False), (ModuleStoreEnum.Type.mongo, 3, True))

--- a/xmodule/modulestore/tests/test_publish.py
+++ b/xmodule/modulestore/tests/test_publish.py
@@ -20,7 +20,7 @@ from openedx.core.lib.tests import attr
 from xmodule.exceptions import InvalidVersionError
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.exceptions import ItemNotFoundError
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, check_mongo_calls
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory, check_mongo_calls
 from xmodule.modulestore.tests.test_split_w_old_mongo import SplitWMongoCourseBootstrapper
 from xmodule.modulestore.tests.utils import (
     DRAFT_MODULESTORE_SETUP,
@@ -217,7 +217,7 @@ class DraftPublishedOpTestCourseSetup(unittest.TestCase):
                     parent_id = _make_block_id(parent_type, idx // 2)
                 parent_item = getattr(self, parent_id)
                 block_id = _make_block_id(block_type, idx)
-                setattr(self, block_id, ItemFactory.create(
+                setattr(self, block_id, BlockFactory.create(
                     parent_location=parent_item.location,
                     category=block_type,
                     modulestore=store,

--- a/xmodule/modulestore/tests/utils.py
+++ b/xmodule/modulestore/tests/utils.py
@@ -19,7 +19,7 @@ from xmodule.modulestore.mongo.base import ModuleStoreEnum
 from xmodule.modulestore.mongo.draft import DraftModuleStore
 from xmodule.modulestore.split_mongo.split_draft import DraftVersioningModuleStore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, TEST_DATA_ONLY_SPLIT_MODULESTORE_DRAFT_PREFERRED
-from xmodule.modulestore.tests.factories import ItemFactory
+from xmodule.modulestore.tests.factories import BlockFactory
 from xmodule.modulestore.tests.mongo_connection import MONGO_HOST, MONGO_PORT_NUM
 from xmodule.modulestore.xml import XMLModuleStore
 from xmodule.tests import DATA_DIR
@@ -109,7 +109,7 @@ class MixedSplitTestCase(ModuleStoreTestCase):
         """
         extra = {"publish_item": False, "user_id": self.user_id}
         extra.update(kwargs)
-        return ItemFactory.create(
+        return BlockFactory.create(
             category=category,
             parent=parent_block,
             parent_location=parent_block.location,
@@ -135,7 +135,7 @@ class ProceduralCourseTestMixin:
 
             xblock_type = stack[0]
             for _ in range(branching):
-                child = ItemFactory.create(
+                child = BlockFactory.create(
                     category=xblock_type,
                     parent=parent,
                     user_id=user_id

--- a/xmodule/modulestore/xml.py
+++ b/xmodule/modulestore/xml.py
@@ -639,7 +639,7 @@ class XMLModuleStore(ModuleStoreReadBase):
                         else:
                             try:
                                 # get and update data field in xblock runtime
-                                module = system.load_item(loc)
+                                module = system.get_block(loc)
                                 for key, value in data_content.items():
                                     setattr(module, key, value)
                                 module.save()
@@ -653,7 +653,7 @@ class XMLModuleStore(ModuleStoreReadBase):
                         # html file with html data content
                         html = f.read()
                         try:
-                            module = system.load_item(loc)
+                            module = system.get_block(loc)
                             module.data = html
                             module.save()
                         except ItemNotFoundError:

--- a/xmodule/seq_block.py
+++ b/xmodule/seq_block.py
@@ -379,7 +379,7 @@ class SequenceBlock(
         prereq_met = True
         prereq_meta_info = {}
         banner_text = None
-        display_blocks = self.get_display_blocks()
+        display_blocks = self.get_children()
         course = self._get_course()
         is_hidden_after_due = False
 
@@ -606,7 +606,7 @@ class SequenceBlock(
         content.
         """
         _ = self.runtime.service(self, "i18n").ugettext
-        display_blocks = self.get_display_blocks()
+        display_blocks = self.get_children()
         self._update_position(context, len(display_blocks))
 
         fragment = Fragment()

--- a/xmodule/seq_block.py
+++ b/xmodule/seq_block.py
@@ -379,7 +379,7 @@ class SequenceBlock(
         prereq_met = True
         prereq_meta_info = {}
         banner_text = None
-        display_items = self.get_display_items()
+        display_blocks = self.get_display_blocks()
         course = self._get_course()
         is_hidden_after_due = False
 
@@ -399,7 +399,7 @@ class SequenceBlock(
             else:
                 is_hidden_after_due = True
 
-        meta = self._get_render_metadata(context, display_items, prereq_met, prereq_meta_info, banner_text, view)
+        meta = self._get_render_metadata(context, display_blocks, prereq_met, prereq_meta_info, banner_text, view)
         meta['display_name'] = self.display_name_with_default
         meta['format'] = getattr(self, 'format', '')
         meta['is_hidden_after_due'] = is_hidden_after_due
@@ -567,7 +567,7 @@ class SequenceBlock(
         # NOTE (CCB): We default to true to maintain the behavior in place prior to allowing anonymous access access.
         return context.get('user_authenticated', True)
 
-    def _get_render_metadata(self, context, display_items, prereq_met, prereq_meta_info, banner_text=None,
+    def _get_render_metadata(self, context, display_blocks, prereq_met, prereq_meta_info, banner_text=None,
                              view=STUDENT_VIEW, fragment=None):
         """Returns a dictionary of sequence metadata, used by render methods and for the courseware API"""
         if prereq_met and not self._is_gate_fulfilled():
@@ -576,10 +576,10 @@ class SequenceBlock(
                 'This section is a prerequisite. You must complete this section in order to unlock additional content.'
             )
 
-        items = self._render_student_view_for_items(context, display_items, fragment, view) if prereq_met else []
+        blocks = self._render_student_view_for_blocks(context, display_blocks, fragment, view) if prereq_met else []
 
         params = {
-            'items': items,
+            'items': blocks,
             'element_id': self.location.html_id(),
             'item_id': str(self.location),
             'is_time_limited': self.is_time_limited,
@@ -606,19 +606,19 @@ class SequenceBlock(
         content.
         """
         _ = self.runtime.service(self, "i18n").ugettext
-        display_items = self.get_display_items()
-        self._update_position(context, len(display_items))
+        display_blocks = self.get_display_blocks()
+        self._update_position(context, len(display_blocks))
 
         fragment = Fragment()
-        params = self._get_render_metadata(context, display_items, prereq_met, prereq_meta_info, banner_text, view, fragment)  # lint-amnesty, pylint: disable=line-too-long
+        params = self._get_render_metadata(context, display_blocks, prereq_met, prereq_meta_info, banner_text, view, fragment)  # lint-amnesty, pylint: disable=line-too-long
         if SHOW_PROGRESS_BAR.is_enabled() and getattr(settings, 'COMPLETION_AGGREGATOR_URL', ''):
             parent_block_id = self.get_parent().scope_ids.usage_id.block_id
             params['chapter_completion_aggregator_url'] = '/'.join(
                 [settings.COMPLETION_AGGREGATOR_URL, str(self.scope_ids.usage_id.context_key), parent_block_id]) + '/'
         fragment.add_content(self.runtime.service(self, 'mako').render_template("seq_block.html", params))
 
-        self._capture_full_seq_item_metrics(display_items)
-        self._capture_current_unit_metrics(display_items)
+        self._capture_full_seq_item_metrics(display_blocks)
+        self._capture_current_unit_metrics(display_blocks)
 
         add_webpack_to_fragment(fragment, 'SequenceBlockPreview')
         shim_xmodule_js(fragment, 'Sequence')
@@ -740,10 +740,10 @@ class SequenceBlock(
 
         return True, {}
 
-    def _update_position(self, context, number_of_display_items):
+    def _update_position(self, context, number_of_display_blocks):
         """
         Update the user's sequential position given the context and the
-        number_of_display_items
+        number_of_display_blocks
         """
 
         position = context.get('position')
@@ -751,25 +751,25 @@ class SequenceBlock(
             self.position = position
 
         # If we're rendering this sequence, but no position is set yet,
-        # or exceeds the length of the displayable items,
+        # or exceeds the length of the displayable blocks,
         # default the position to the first element
         if context.get('requested_child') == 'first':
             self.position = 1
         elif context.get('requested_child') == 'last':
-            self.position = number_of_display_items or 1
-        elif self.position is None or self.position > number_of_display_items:
+            self.position = number_of_display_blocks or 1
+        elif self.position is None or self.position > number_of_display_blocks:
             self.position = 1
 
-    def _render_student_view_for_items(self, context, display_items, fragment, view=STUDENT_VIEW):
+    def _render_student_view_for_blocks(self, context, display_blocks, fragment, view=STUDENT_VIEW):
         """
         Updates the given fragment with rendered student views of the given
-        display_items.  Returns a list of dict objects with information about
-        the given display_items.
+        display_blocks.  Returns a list of dict objects with information about
+        the given display_blocks.
         """
         # Avoid circular imports.
         from openedx.core.lib.xblock_utils import get_icon
 
-        render_items = not context.get('exclude_units', False)
+        render_blocks = not context.get('exclude_units', False)
         is_user_authenticated = self.is_user_authenticated(context)
         completion_service = self.runtime.service(self, 'completion')
         try:
@@ -784,9 +784,9 @@ class SequenceBlock(
             self.display_name_with_default
         ]
         contents = []
-        for item in display_items:
-            item_type = get_icon(item)
-            usage_id = item.scope_ids.usage_id
+        for block in display_blocks:
+            item_type = get_icon(block)
+            usage_id = block.scope_ids.usage_id
 
             show_bookmark_button = False
             is_bookmarked = False
@@ -799,10 +799,10 @@ class SequenceBlock(
             context['bookmarked'] = is_bookmarked
             context['format'] = getattr(self, 'format', '')
 
-            if render_items:
-                rendered_item = item.render(view, context)
-                fragment.add_fragment_resources(rendered_item)
-                content = rendered_item.content
+            if render_blocks:
+                rendered_block = block.render(view, context)
+                fragment.add_fragment_resources(rendered_block)
+                content = rendered_block.content
             else:
                 content = ''
 
@@ -810,27 +810,27 @@ class SequenceBlock(
             contains_content_type_gated_content = False
             if content_type_gating_service:
                 contains_content_type_gated_content = content_type_gating_service.check_children_for_content_type_gating_paywall(  # pylint:disable=line-too-long
-                    item, self.scope_ids.usage_id.context_key
+                    block, self.scope_ids.usage_id.context_key
                 ) is not None
-            iteminfo = {
+            block_info = {
                 'content': content,
-                'page_title': getattr(item, 'tooltip_title', ''),
+                'page_title': getattr(block, 'tooltip_title', ''),
                 'type': item_type,
                 'id': str(usage_id),
                 'bookmarked': is_bookmarked,
-                'path': " > ".join(display_names + [item.display_name_with_default]),
-                'graded': item.graded,
+                'path': " > ".join(display_names + [block.display_name_with_default]),
+                'graded': block.graded,
                 'contains_content_type_gated_content': contains_content_type_gated_content,
             }
-            if not render_items:
+            if not render_blocks:
                 # The item url format can be defined in the template context like so:
                 # context['item_url'] = '/my/item/path/{usage_key}/whatever'
-                iteminfo['href'] = context.get('item_url', '').format(usage_key=usage_id)
+                block_info['href'] = context.get('item_url', '').format(usage_key=usage_id)
             if is_user_authenticated:
-                if item.location.block_type == 'vertical' and completion_service:
-                    iteminfo['complete'] = completion_service.vertical_is_complete(item)
+                if block.location.block_type == 'vertical' and completion_service:
+                    block_info['complete'] = completion_service.vertical_is_complete(block)
 
-            contents.append(iteminfo)
+            contents.append(block_info)
 
         return contents
 
@@ -862,7 +862,7 @@ class SequenceBlock(
         newrelic.agent.add_custom_parameter('seq.position', self.position)
         newrelic.agent.add_custom_parameter('seq.is_time_limited', self.is_time_limited)
 
-    def _capture_full_seq_item_metrics(self, display_items):
+    def _capture_full_seq_item_metrics(self, display_blocks):
         """
         Capture information about the number and types of XBlock content in
         the sequence as a whole. We send this information to New Relic so that
@@ -872,7 +872,7 @@ class SequenceBlock(
             return
         # Basic count of the number of Units (a.k.a. VerticalBlocks) we have in
         # this learning sequence
-        newrelic.agent.add_custom_parameter('seq.num_units', len(display_items))
+        newrelic.agent.add_custom_parameter('seq.num_units', len(display_blocks))
 
         # Count of all modules (leaf nodes) in this sequence (e.g. videos,
         # problems, etc.) The units (verticals) themselves are not counted.
@@ -884,7 +884,7 @@ class SequenceBlock(
         for block_type, count in block_counts.items():
             newrelic.agent.add_custom_parameter(f'seq.block_counts.{block_type}', count)
 
-    def _capture_current_unit_metrics(self, display_items):
+    def _capture_current_unit_metrics(self, display_blocks):
         """
         Capture information about the current selected Unit within the Sequence.
         """
@@ -893,13 +893,13 @@ class SequenceBlock(
         # Positions are stored with indexing starting at 1. If we get into a
         # weird state where the saved position is out of bounds (e.g. the
         # content was changed), avoid going into any details about this unit.
-        if 1 <= self.position <= len(display_items):
+        if 1 <= self.position <= len(display_blocks):
             # Basic info about the Unit...
-            current = display_items[self.position - 1]
+            current = display_blocks[self.position - 1]
             newrelic.agent.add_custom_parameter('seq.current.block_id', str(current.location))
             newrelic.agent.add_custom_parameter('seq.current.display_name', current.display_name or '')
 
-            # Examining all items inside the Unit (or split_test, conditional, etc.)
+            # Examining all blocks inside the Unit (or split_test, conditional, etc.)
             child_locs = self._locations_in_subtree(current)
             newrelic.agent.add_custom_parameter('seq.current.num_items', len(child_locs))
             curr_block_counts = collections.Counter(usage_key.block_type for usage_key in child_locs)

--- a/xmodule/template_block.py
+++ b/xmodule/template_block.py
@@ -111,7 +111,7 @@ class CustomTagBlock(CustomTagTemplateBlock):  # pylint: disable=abstract-method
         # cdodge: look up the template as a module
         template_loc = self.location.replace(category='custom_tag_template', name=template_name)
 
-        template_block = system.load_item(template_loc)
+        template_block = system.get_block(template_loc)
         template_block_data = template_block.data
         template = Template(template_block_data)
         return template.safe_substitute(params)

--- a/xmodule/tests/test_conditional.py
+++ b/xmodule/tests/test_conditional.py
@@ -91,7 +91,6 @@ class ConditionalFactory:
         child_descriptor.visible_to_staff_only = False
         child_descriptor._xmodule.student_view.return_value = Fragment(content='<p>This is a secret</p>')  # lint-amnesty, pylint: disable=protected-access
         child_descriptor.student_view = child_descriptor._xmodule.student_view  # lint-amnesty, pylint: disable=protected-access
-        child_descriptor.displayable_blocks.return_value = [child_descriptor]
         child_descriptor.runtime = descriptor_system
         child_descriptor.xmodule_runtime = get_test_system()
         child_descriptor.render = lambda view, context=None: descriptor_system.render(child_descriptor, view, context)

--- a/xmodule/tests/test_conditional.py
+++ b/xmodule/tests/test_conditional.py
@@ -91,7 +91,7 @@ class ConditionalFactory:
         child_descriptor.visible_to_staff_only = False
         child_descriptor._xmodule.student_view.return_value = Fragment(content='<p>This is a secret</p>')  # lint-amnesty, pylint: disable=protected-access
         child_descriptor.student_view = child_descriptor._xmodule.student_view  # lint-amnesty, pylint: disable=protected-access
-        child_descriptor.displayable_items.return_value = [child_descriptor]
+        child_descriptor.displayable_blocks.return_value = [child_descriptor]
         child_descriptor.runtime = descriptor_system
         child_descriptor.xmodule_runtime = get_test_system()
         child_descriptor.render = lambda view, context=None: descriptor_system.render(child_descriptor, view, context)

--- a/xmodule/tests/test_library_root.py
+++ b/xmodule/tests/test_library_root.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 from web_fragments.fragment import Fragment
 from xblock.runtime import Runtime as VanillaRuntime
 
-from xmodule.modulestore.tests.factories import ItemFactory, LibraryFactory
+from xmodule.modulestore.tests.factories import BlockFactory, LibraryFactory
 from xmodule.modulestore.tests.utils import MixedSplitTestCase
 from xmodule.x_module import AUTHOR_VIEW
 
@@ -35,7 +35,7 @@ class TestLibraryRoot(MixedSplitTestCase):
         message = "Hello world"
         library = LibraryFactory.create(modulestore=self.store)
         # Add one HTML block to the library:
-        ItemFactory.create(
+        BlockFactory.create(
             category="html",
             parent_location=library.location,
             user_id=self.user_id,
@@ -60,7 +60,7 @@ class TestLibraryRoot(MixedSplitTestCase):
         library = LibraryFactory.create(modulestore=self.store)
         # Add five HTML blocks to the library:
         blocks = [
-            ItemFactory.create(
+            BlockFactory.create(
                 category="html",
                 parent_location=library.location,
                 user_id=self.user_id,

--- a/xmodule/tests/test_library_sourced_block.py
+++ b/xmodule/tests/test_library_sourced_block.py
@@ -5,7 +5,7 @@ Tests for Source from Library XBlock
 from openedx.core.djangoapps.content_libraries.tests.base import ContentLibrariesRestApiTest
 from common.djangoapps.student.roles import CourseInstructorRole
 from xmodule.modulestore.django import modulestore
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 from xmodule.tests import get_test_system
 from xmodule.x_module import STUDENT_VIEW  # lint-amnesty, pylint: disable=unused-import
 
@@ -21,7 +21,7 @@ class LibrarySourcedBlockTestCase(ContentLibrariesRestApiTest):
         course = CourseFactory.create(modulestore=self.store, user_id=self.user.id)
         CourseInstructorRole(course.id).add_users(self.user)
         # Add a "Source from Library" block to the course
-        self.source_block = ItemFactory.create(
+        self.source_block = BlockFactory.create(
             category="library_sourced",
             parent=course,
             parent_location=course.location,

--- a/xmodule/tests/test_video.py
+++ b/xmodule/tests/test_video.py
@@ -7,7 +7,7 @@ xmodule/modulestore/tests/django_utils.py. You can
 search for usages of this in the cms and lms tests for examples. You use
 this so that it will do things like point the modulestore setting to mongo,
 flush the contentstore before and after, load the templates, etc.
-You can then use the CourseFactory and XModuleItemFactory as defined
+You can then use the CourseFactory and BlockFactory as defined
 in xmodule/modulestore/tests/factories.py to create
 the course, section, subsection, unit, etc.
 """

--- a/xmodule/vertical_block.py
+++ b/xmodule/vertical_block.py
@@ -95,7 +95,7 @@ class VerticalBlock(
                     'edx-platform.username'
                 )
 
-        child_blocks = self.get_display_blocks()  # lint-amnesty, pylint: disable=no-member
+        child_blocks = self.get_children()  # lint-amnesty, pylint: disable=no-member
 
         child_blocks_to_complete_on_view = set()
         completion_service = self.runtime.service(self, 'completion')

--- a/xmodule/vertical_block.py
+++ b/xmodule/vertical_block.py
@@ -95,7 +95,7 @@ class VerticalBlock(
                     'edx-platform.username'
                 )
 
-        child_blocks = self.get_display_items()  # lint-amnesty, pylint: disable=no-member
+        child_blocks = self.get_display_blocks()  # lint-amnesty, pylint: disable=no-member
 
         child_blocks_to_complete_on_view = set()
         completion_service = self.runtime.service(self, 'completion')

--- a/xmodule/x_module.py
+++ b/xmodule/x_module.py
@@ -524,18 +524,18 @@ class XModuleMixin(XModuleFields, XBlock):
         not children of this module"""
         return []
 
-    def get_display_items(self):
+    def get_display_blocks(self):
         """
         Returns a list of descendent module instances that will display
         immediately inside this module.
         """
-        items = []
+        blocks = []
         for child in self.get_children():
-            items.extend(child.displayable_items())
+            blocks.extend(child.displayable_blocks())
 
-        return items
+        return blocks
 
-    def displayable_items(self):
+    def displayable_blocks(self):
         """
         Returns list of displayable modules contained by this module. If this
         module is visible, should return [self].

--- a/xmodule/x_module.py
+++ b/xmodule/x_module.py
@@ -524,17 +524,6 @@ class XModuleMixin(XModuleFields, XBlock):
         not children of this module"""
         return []
 
-    def get_display_blocks(self):
-        """
-        Returns a list of descendent module instances that will display
-        immediately inside this module.
-        """
-        blocks = []
-        for child in self.get_children():
-            blocks.append(child)
-
-        return blocks
-
     def get_child_by(self, selector):
         """
         Return a child XBlock that matches the specified selector

--- a/xmodule/x_module.py
+++ b/xmodule/x_module.py
@@ -531,16 +531,9 @@ class XModuleMixin(XModuleFields, XBlock):
         """
         blocks = []
         for child in self.get_children():
-            blocks.extend(child.displayable_blocks())
+            blocks.append(child)
 
         return blocks
-
-    def displayable_blocks(self):
-        """
-        Returns list of displayable modules contained by this module. If this
-        module is visible, should return [self].
-        """
-        return [self]
 
     def get_child_by(self, selector):
         """


### PR DESCRIPTION
## Description

Currently, there are various terms used to refer to XBlocks: xblocks (or blocks), descriptors, modules, or items. This makes the code a lot less approachable and understandable. Since we are getting rid of a lot of tech debt it is a good time to do a quick update of the terminology in the edx-platform to make it consistent.

In this PR:

Convert references using `item` to refer to XBlocks to use `block` (e.g. in ItemFactory). 


## Supporting information

This ticket was created from the work started with https://github.com/openedx/edx-platform/pull/31113

## Testing instructions

There is nothing specific to be tested, as we are not adding or changing any functionality. However, we can just perform a general testing of LMS and Studio using the following sandbox.

**Sandbox LMS:** https://pr31384.sandbox.opencraft.hosting/
**Sandbox Studio:** https://studio.pr31384.sandbox.opencraft.hosting/

## Deadline

"None" 

## Other information
Related PR: https://github.com/mitodl/edx-sga/pull/332 (it's not a blocker, as these integration tests do not seem to be used anywhere).
