### PR TITLE
feat: adds VerticalBlockRenderCompleted filter hook

### DIFF
--- a/docs/guides/hooks/filters.rst
+++ b/docs/guides/hooks/filters.rst
@@ -186,6 +186,6 @@ well as the trigger location in this same repository.
      - org.openedx.learning.veritical_block_child.render.started.v1
      - TODO: Update link `2022-08-18 <https://github.com/openedx/edx-platform/blob/master/xmodule/vertical_block.py#L122>`_
 
-   * - `VerticalBlockChildrenLoaded <https://github.com/openedx/openedx-filters/blob/main/openedx_filters/learning/filters.py#L427>`_
-     - org.openedx.learning.veritical_block.children.loaded.v1
+   * - `VerticalBlockRenderCompleted <https://github.com/openedx/openedx-filters/blob/main/openedx_filters/learning/filters.py#L427>`_
+     - org.openedx.learning.veritical_block.render.completed.v1
      - TODO: Update date and link `2022-08-18 <https://github.com/openedx/edx-platform/blob/master/xmodule/vertical_block.py#L122>`_

--- a/docs/guides/hooks/filters.rst
+++ b/docs/guides/hooks/filters.rst
@@ -182,6 +182,10 @@ well as the trigger location in this same repository.
      - org.openedx.learning.dashboard.render.started.v1
      - `2022-06-14 <https://github.com/eduNEXT/edx-platform/blob/master/common/djangoapps/student/views/dashboard.py#L878>`_
 
-   * - `VerticalChildRenderStarted <https://github.com/openedx/openedx-filters/blob/main/openedx_filters/learning/filters.py#L427>`_
-     - org.openedx.learning.veritical_child_block.render.started.v1
-     - `2022-08-18 <https://github.com/openedx/edx-platform/blob/master/xmodule/vertical_block.py#L122>`_
+   * - `VerticalBlockChildRenderStarted <https://github.com/openedx/openedx-filters/blob/main/openedx_filters/learning/filters.py#L427>`_
+     - org.openedx.learning.veritical_block_child.render.started.v1
+     - TODO: Update link `2022-08-18 <https://github.com/openedx/edx-platform/blob/master/xmodule/vertical_block.py#L122>`_
+
+   * - `VerticalBlockChildrenLoaded <https://github.com/openedx/openedx-filters/blob/main/openedx_filters/learning/filters.py#L427>`_
+     - org.openedx.learning.veritical_block.children.loaded.v1
+     - TODO: Update date and link `2022-08-18 <https://github.com/openedx/edx-platform/blob/master/xmodule/vertical_block.py#L122>`_

--- a/docs/guides/hooks/filters.rst
+++ b/docs/guides/hooks/filters.rst
@@ -184,8 +184,8 @@ well as the trigger location in this same repository.
 
    * - `VerticalBlockChildRenderStarted <https://github.com/openedx/openedx-filters/blob/main/openedx_filters/learning/filters.py#L427>`_
      - org.openedx.learning.veritical_block_child.render.started.v1
-     - TODO: Update link `2022-08-18 <https://github.com/openedx/edx-platform/blob/master/xmodule/vertical_block.py#L122>`_
+     - `2022-08-18 <https://github.com/openedx/edx-platform/blob/master/xmodule/vertical_block.py#L170>`_
 
-   * - `VerticalBlockRenderCompleted <https://github.com/openedx/openedx-filters/blob/main/openedx_filters/learning/filters.py#L427>`_
+   * - `VerticalBlockRenderCompleted <https://github.com/openedx/openedx-filters/blob/main/openedx_filters/learning/filters.py#L476>`_
      - org.openedx.learning.veritical_block.render.completed.v1
-     - TODO: Update date and link `2022-08-18 <https://github.com/openedx/edx-platform/blob/master/xmodule/vertical_block.py#L122>`_
+     - `2022-02-18 <https://github.com/openedx/edx-platform/blob/master/xmodule/vertical_block.py#L121>`_

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -762,7 +762,8 @@ openedx-events==5.0.0
     # via
     #   -r requirements/edx/base.in
     #   edx-event-bus-kafka
-openedx-filters==1.0.0
+# openedx-filters==1.0.0
+openedx-filters @ git+https://github.com/open-craft/openedx-filters.git@ae45fdf1a5d96b766ed5c2dba3680fc691ac118a
     # via
     #   -r requirements/edx/base.in
     #   lti-consumer-xblock

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -762,8 +762,7 @@ openedx-events==5.0.0
     # via
     #   -r requirements/edx/base.in
     #   edx-event-bus-kafka
-# openedx-filters==1.0.0
-openedx-filters @ git+https://github.com/open-craft/openedx-filters.git@ae45fdf1a5d96b766ed5c2dba3680fc691ac118a
+openedx-filters==1.1.0
     # via
     #   -r requirements/edx/base.in
     #   lti-consumer-xblock

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1009,7 +1009,8 @@ openedx-events==5.0.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-event-bus-kafka
-openedx-filters==1.0.0
+# openedx-filters==0.8.0
+openedx-filters @ git+https://github.com/open-craft/openedx-filters.git@984f734f82bffff08e14757ed770a8b1663265be
     # via
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1010,7 +1010,7 @@ openedx-events==5.0.0
     #   -r requirements/edx/testing.txt
     #   edx-event-bus-kafka
 # openedx-filters==0.8.0
-openedx-filters @ git+https://github.com/open-craft/openedx-filters.git@984f734f82bffff08e14757ed770a8b1663265be
+openedx-filters @ git+https://github.com/open-craft/openedx-filters.git@d0206cf84f2e5e22b1a99d06566d88839d40b9fe
     # via
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1009,8 +1009,7 @@ openedx-events==5.0.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-event-bus-kafka
-# openedx-filters==0.8.0
-openedx-filters @ git+https://github.com/open-craft/openedx-filters.git@ae45fdf1a5d96b766ed5c2dba3680fc691ac118a
+openedx-filters==1.1.0
     # via
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1010,7 +1010,7 @@ openedx-events==5.0.0
     #   -r requirements/edx/testing.txt
     #   edx-event-bus-kafka
 # openedx-filters==0.8.0
-openedx-filters @ git+https://github.com/open-craft/openedx-filters.git@d0206cf84f2e5e22b1a99d06566d88839d40b9fe
+openedx-filters @ git+https://github.com/open-craft/openedx-filters.git@ae45fdf1a5d96b766ed5c2dba3680fc691ac118a
     # via
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -960,7 +960,7 @@ openedx-events==5.0.0
     #   -r requirements/edx/base.txt
     #   edx-event-bus-kafka
 # openedx-filters==0.8.0
-openedx-filters @ git+https://github.com/open-craft/openedx-filters.git@d0206cf84f2e5e22b1a99d06566d88839d40b9fe
+openedx-filters @ git+https://github.com/open-craft/openedx-filters.git@ae45fdf1a5d96b766ed5c2dba3680fc691ac118a
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -959,8 +959,7 @@ openedx-events==5.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-event-bus-kafka
-# openedx-filters==0.8.0
-openedx-filters @ git+https://github.com/open-craft/openedx-filters.git@ae45fdf1a5d96b766ed5c2dba3680fc691ac118a
+openedx-filters==1.1.0
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -959,7 +959,8 @@ openedx-events==5.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-event-bus-kafka
-openedx-filters==1.0.0
+# openedx-filters==0.8.0
+openedx-filters @ git+https://github.com/open-craft/openedx-filters.git@984f734f82bffff08e14757ed770a8b1663265be
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -960,7 +960,7 @@ openedx-events==5.0.0
     #   -r requirements/edx/base.txt
     #   edx-event-bus-kafka
 # openedx-filters==0.8.0
-openedx-filters @ git+https://github.com/open-craft/openedx-filters.git@984f734f82bffff08e14757ed770a8b1663265be
+openedx-filters @ git+https://github.com/open-craft/openedx-filters.git@d0206cf84f2e5e22b1a99d06566d88839d40b9fe
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock

--- a/xmodule/vertical_block.py
+++ b/xmodule/vertical_block.py
@@ -13,7 +13,7 @@ from lxml import etree
 from web_fragments.fragment import Fragment
 from xblock.core import XBlock  # lint-amnesty, pylint: disable=wrong-import-order
 from xblock.fields import Boolean, Scope
-from openedx_filters.learning.filters import VerticalBlockChildRenderStarted
+from openedx_filters.learning.filters import VerticalBlockChildRenderStarted, VerticalBlockChildrenLoaded
 from xmodule.mako_block import MakoTemplateBlockBase
 from xmodule.progress import Progress
 from xmodule.seq_block import SequenceFields
@@ -96,6 +96,12 @@ class VerticalBlock(
                 )
 
         child_blocks = self.get_children()  # lint-amnesty, pylint: disable=no-member
+
+        # .. filter_implemented_name: VerticalBlockChildrenLoaded
+        # .. filter_type: org.openedx.learning.vertical_block.children.loaded.v1
+        child_blocks, context, view = VerticalBlockChildrenLoaded.run_filter(
+            children=child_blocks, context=context, view=view
+        )
 
         child_blocks_to_complete_on_view = set()
         completion_service = self.runtime.service(self, 'completion')

--- a/xmodule/vertical_block.py
+++ b/xmodule/vertical_block.py
@@ -72,7 +72,7 @@ class VerticalBlock(
 
     show_in_read_only_mode = True
 
-    def _student_or_public_view(self, context, view):
+    def _student_or_public_view(self, context, view):  # lint-amnesty, pylint: disable=too-many-statements
         """
         Renders the requested view type of the block in the LMS.
         """

--- a/xmodule/vertical_block.py
+++ b/xmodule/vertical_block.py
@@ -13,7 +13,7 @@ from lxml import etree
 from web_fragments.fragment import Fragment
 from xblock.core import XBlock  # lint-amnesty, pylint: disable=wrong-import-order
 from xblock.fields import Boolean, Scope
-from openedx_filters.learning.filters import VerticalBlockChildRenderStarted, VerticalBlockChildrenLoaded
+from openedx_filters.learning.filters import VerticalBlockChildRenderStarted, VerticalBlockRenderCompleted
 from xmodule.mako_block import MakoTemplateBlockBase
 from xmodule.progress import Progress
 from xmodule.seq_block import SequenceFields
@@ -97,12 +97,6 @@ class VerticalBlock(
 
         child_blocks = self.get_children()  # lint-amnesty, pylint: disable=no-member
 
-        # .. filter_implemented_name: VerticalBlockChildrenLoaded
-        # .. filter_type: org.openedx.learning.vertical_block.children.loaded.v1
-        child_blocks, context, view = VerticalBlockChildrenLoaded.run_filter(
-            children=child_blocks, context=context, view=view
-        )
-
         child_blocks_to_complete_on_view = set()
         completion_service = self.runtime.service(self, 'completion')
         if completion_service and completion_service.completion_tracking_enabled():
@@ -167,6 +161,12 @@ class VerticalBlock(
 
         add_webpack_to_fragment(fragment, 'VerticalStudentView')
         fragment.initialize_js('VerticalStudentView')
+
+        # .. filter_implemented_name: VerticalBlockRenderCompleted
+        # .. filter_type: org.openedx.learning.vertical_block.render.completed.v1
+        fragment, context, view = VerticalBlockRenderCompleted.run_filter(
+            fragment=fragment, context=context, view=view
+        )
 
         return fragment
 

--- a/xmodule/vertical_block.py
+++ b/xmodule/vertical_block.py
@@ -164,8 +164,8 @@ class VerticalBlock(
 
         # .. filter_implemented_name: VerticalBlockRenderCompleted
         # .. filter_type: org.openedx.learning.vertical_block.render.completed.v1
-        fragment, context, view = VerticalBlockRenderCompleted.run_filter(
-            fragment=fragment, context=context, view=view
+        _, fragment, context, view = VerticalBlockRenderCompleted.run_filter(
+            block=self, fragment=fragment, context=context, view=view
         )
 
         return fragment


### PR DESCRIPTION
## Description

This introduces the [VerticalBlockRenderCompleted](https://github.com/openedx/openedx-filters/pull/52) filter that will be called after a VerticalBlock's rendering is completed. This filter is passed the instance of the `VerticalBlock`, web fragment that has been created after the rendering, the context dictionary and the view name.

The applications implementing the filter can modify the content that will be presented to the learner based on its own parameters. Some example scenarios:

1. Add extra HTML to ask for feedback about the unit's content
2. Embed an external service using IFrame
3. Replace the VerticalBlock completely for specific users based on some criteria...etc.,

#### Which edX user roles will this change impact?

*  Learner

#### Configuration


The filter can be configured as given below

```py
OPEN_EDX_FILTERS_CONFIG = {
    "org.openedx.learning.vertical_block.render.completed.v1": {
        "fail_silently": False,
        "pipeline": [
            "my-package.pipeline.ActionStep"
        ]
    }
}
```

## Supporting information

This relies on the `VerticalBlockRenderCompleted` introduced in this PR - https://github.com/openedx/openedx-filters/pull/52 - and should be merged after the openedx-filters package is released.

## Testing instructions

The testing instructions assuming you have working devstack setup.

1. Pull the PR branch
2. Install the dependencies
    ```sh
    make lms-shell
    # To install openedx-events branch with the VerticalBlockRenderCompleted filter implemented
    pip install -r requirements/edx/development.txt
    # A simple openedx plugin for testing and development
    pip install git+https://github.com/open-craft/openedx-filter-demos.git 
    ```
3. Edit/Add the file `lms/envs/private.py` and include the following contents
    ```py
    OPEN_EDX_FILTERS_CONFIG = {
        "org.openedx.learning.vertical_block.render.completed.v1": {
            "fail_silently": False,
            "pipeline": [
                "openedx_filter_demos.pipeline.AddDebugInfoBlock",
                "openedx_filter_demos.pipeline.AddAJAXButtonBlock" # OPTIONAL - to test JSON Handler of XBlock
            ]
        }
    }
    ```
4. OPTIONAL - Add the following dummy handler to `class VerticalBlock`  to test the AJAX Calls.
    ```diff
    diff --git a/xmodule/vertical_block.py b/xmodule/vertical_block.py
    index a6d79a543e..a0542fd73a 100644
    --- a/xmodule/vertical_block.py
    +++ b/xmodule/vertical_block.py
    @@ -72,6 +72,15 @@ class VerticalBlock(
 
         show_in_read_only_mode = True
 
    +    @XBlock.json_handler
    +    def dummy_json(self, data, suffix=""):
    +        """
    +        Dummy JSON Handler to test the veritical block render filter
    +        """
    +        print("[DUMMY JSON Handler]")
    +        print(f"Data passed to the endpoint: {data}")
    +        return {"status": "success"}
    +
    ```
4. Restart the LMS `make lms-restart`

Now when any unit is opened in the LMS, the bottom should have 2 red boxeslike the one below (only 1 if the AJAX Button Block was skipped). This is injected by the pipeline steps of the the [openedx_filter_demos](https://github.com/open-craft/openedx-filter-demos) via the `VerticalBlockRenderCompleted` filter.

![image](https://user-images.githubusercontent.com/383862/208677652-671a4220-ef56-4d0d-864e-3a466f74b420.png)

Corresponding logs like the example below can also be see in the LMS logs `make lms-logs`.

```log
pipeline.py:43 - =========== AddDebugInfoBlock Pipeline Step Start ==========
pipeline.py:44 - Fragment: <web_fragments.fragment.Fragment object at 0x7ff3f01d22b0>
pipeline.py:45 - Context: {'show_title': False, 'show_bookmark_button': False, 'recheck_access': '1', 'view': 'student_view', 'hide_access_error_blocks': True, 'is_mobile_app': False}
pipeline.py:46 - View: student_view
pipeline.py:47 - =========== AddDebugInfoBlock Pipeline Step Stop ==========
```

OPTIONAL - If you have added the AJAX Button block in config and added the `dummy_json` handler, then clicking the button should populate the *Response* block with `{"status": "success"}`. 

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Similar prior work: https://github.com/openedx/edx-platform/pull/30773
