### PR TITLE
fix: error on the course about page when course overview is empty

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -548,6 +548,37 @@ class CourseDetailsViewTest(CourseTestCase, MilestonesTestCaseMixin):
             response = self.client.get_html(settings_details_url)
             self.assertNotContains(response, "Course Short Description")
 
+    def test_empty_course_overview_keep_default_value(self):
+        """
+        Test saving the course with an empty course overview.
+
+        If the overview is empty - the save method should use the default
+        value for the field.
+        """
+        settings_details_url = get_url(self.course.id)
+
+        # add overview with empty value in json request.
+        test_data = {
+            'syllabus': 'none',
+            'short_description': 'test',
+            'overview': '',
+            'effort': '',
+            'intro_video': '',
+            'start_date': '2022-01-01',
+            'end_date': '2022-12-31',
+        }
+
+        response = self.client.post(
+            settings_details_url,
+            data=json.dumps(test_data),
+            content_type='application/json',
+            HTTP_ACCEPT='application/json'
+        )
+        course_details = CourseDetails.fetch(self.course.id)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(course_details.overview, '<p>&nbsp;</p>')
+
     def test_regular_site_fetch(self):
         settings_details_url = get_url(self.course.id)
 

--- a/openedx/core/djangoapps/models/course_details.py
+++ b/openedx/core/djangoapps/models/course_details.py
@@ -208,6 +208,9 @@ class CourseDetails:
         # is what the setter expects as input.
         date = Date()
 
+        if jsondict['overview'] == '':
+            jsondict['overview'] = '<p>&nbsp;</p>'
+
         if 'start_date' in jsondict:
             converted = date.from_json(jsondict['start_date'])
         else:


### PR DESCRIPTION
Fix 500 error on the course About page for course with empty course overview. 

Steps to reproduce:
- go to the studio and create a course (or use existing)
- remove the course overview content and save changes
- go to the LMS's course about page and observe the result

![Default value](https://user-images.githubusercontent.com/98233552/205682583-89ff9f8d-6616-4d2c-a18c-26cf89d31ce5.png)
![Error 500](https://user-images.githubusercontent.com/98233552/205683874-b9b77748-17b2-4111-aee4-2baef633b78e.png)
![fix](https://user-images.githubusercontent.com/98233552/205683523-42aa4d9c-2e8f-4bb9-9ff8-0a9ff7f65f58.png)

Problem cause:
The empty overview is saved as \<p\> element by default (could be checked in the editor), but resulting in saving the empty string. Any other type chosen in the editor (e.g. Heading) with no content will be saved as `<name>&nbsp;</name>` and rendered without a problem.

The Fix:
- save the empty Paragraph element the same way as for any other empty element 

Learner see:
![Screen_15](https://user-images.githubusercontent.com/98233552/217942375-4fd5cf80-3762-4310-b276-b19447b5dd8c.png)