### PR TITLE
fix: catch even base exceptions when exiting

### DIFF
--- a/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
+++ b/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
@@ -120,7 +120,7 @@ class Command(BaseCommand):
 
         try:
             self._handle_all_goals()
-        except Exception:  # pylint: disable=broad-except
+        except BaseException:  # pylint: disable=broad-except
             log.exception("Error while sending course goals emails: ")
             raise
 


### PR DESCRIPTION
prior exception catch is not triggering in cases where the job blows up, there is one more level of exception available to catch and print
