### PR TITLE
fix: update proctoring library to 4.13.3

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -512,7 +512,7 @@ edx-opaque-keys[django]==2.3.0
     #   outcome-surveys
 edx-organizations==6.11.1
     # via -r requirements/edx/base.in
-edx-proctoring==4.13.2
+edx-proctoring==4.13.3
     # via
     #   -r requirements/edx/base.in
     #   edx-proctoring-proctortrack

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -634,7 +634,7 @@ edx-opaque-keys[django]==2.3.0
     #   outcome-surveys
 edx-organizations==6.11.1
     # via -r requirements/edx/testing.txt
-edx-proctoring==4.13.2
+edx-proctoring==4.13.3
     # via
     #   -r requirements/edx/testing.txt
     #   edx-proctoring-proctortrack

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -614,7 +614,7 @@ edx-opaque-keys[django]==2.3.0
     #   outcome-surveys
 edx-organizations==6.11.1
     # via -r requirements/edx/base.txt
-edx-proctoring==4.13.2
+edx-proctoring==4.13.3
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring-proctortrack


### PR DESCRIPTION
4.13.3 merely brings the proctoring library celery version up to date with the platform celery version, which is already the case when proctoring is deployed since as a plugin it does not control celery
