### PR TITLE
fix: update docker build command now that image targets have changed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,10 +151,10 @@ check-types: ## run static type-checking tests
 	mypy
 
 docker_build:
-	docker build . -f Dockerfile --target lms     -t openedx/lms
-	docker build . -f Dockerfile --target lms-dev -t openedx/lms-dev
-	docker build . -f Dockerfile --target cms     -t openedx/cms
-	docker build . -f Dockerfile --target cms-dev -t openedx/cms-dev
+	DOCKER_BUILDKIT=1 docker build . --build-arg SERVICE_VARIANT=lms --build-arg SERVICE_PORT=8000 --target development -t openedx/lms-dev
+	DOCKER_BUILDKIT=1 docker build . --build-arg SERVICE_VARIANT=lms --build-arg SERVICE_PORT=8000 --target production -t openedx/lms
+	DOCKER_BUILDKIT=1 docker build . --build-arg SERVICE_VARIANT=cms --build-arg SERVICE_PORT=8010 --target development -t openedx/cms-dev
+	DOCKER_BUILDKIT=1 docker build . --build-arg SERVICE_VARIANT=cms --build-arg SERVICE_PORT=8010 --target production -t openedx/cms
 
 docker_tag: docker_build
 	docker tag openedx/lms     openedx/lms:${GITHUB_SHA}


### PR DESCRIPTION
## Description

https://github.com/openedx/edx-platform/commit/d0fad59306f99277c109d6be5dc52a99c858f4ad is causing the docker publish github action to fail because the targets were updated in the dockerfile. We should also update the docker_build command in the makefile to account for the changes to the dockerfile.