### PR TITLE
Feat  hide library sourced content xblock

### DIFF
--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -47,7 +47,12 @@ ADVANCED_COMPONENT_TYPES = sorted({name for name, class_ in XBlock.load_classes(
 
 ADVANCED_PROBLEM_TYPES = settings.ADVANCED_PROBLEM_TYPES
 
-LIBRARY_BLOCK_TYPES = settings.LIBRARY_BLOCK_TYPES
+
+# NOTE: PER PR #30803 we are setting this value to not include the "Library Sourced Content" xblock on the Olive Release.
+LIBRARY_BLOCK_TYPES =  filter(
+    lambda b: b["component"] != "library_sourced",
+    settings.LIBRARY_BLOCK_TYPES
+)
 
 CONTAINER_TEMPLATES = [
     "basic-modal", "modal-button", "edit-xblock-modal",

--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -47,7 +47,6 @@ ADVANCED_COMPONENT_TYPES = sorted({name for name, class_ in XBlock.load_classes(
 
 ADVANCED_PROBLEM_TYPES = settings.ADVANCED_PROBLEM_TYPES
 
-
 # NOTE: PER PR #30803 we are setting this value to not include the "Library Sourced Content" xblock on the Olive Release.
 LIBRARY_BLOCK_TYPES =  filter(
     lambda b: b["component"] != "library_sourced",


### PR DESCRIPTION
<!--

🫒🫒
🫒🫒🫒🫒         🫒 Note: the Olive master branch has been created.  Please consider whether your change
    🫒🫒🫒🫒     should also be applied to Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

🌰🌰🌰🌰🌰🌰     🌰 Note: the Nutmeg release is still supported.
                  Please consider whether your change should be applied to Nutmeg as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/openedx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

per https://github.com/openedx/edx-platform/pull/30803, we want to remove this feature from view for the Olive release as it is not fully completed.


## Testing instructions

Launch studio. See that the add xblock buttons do not include library sourced content but do include randomized content block.

## Deadline

Olive Release is Friday?