### PR TITLE
fix: use language specified in SiteConfiguration

### DIFF
--- a/openedx/core/djangoapps/dark_lang/middleware.py
+++ b/openedx/core/djangoapps/dark_lang/middleware.py
@@ -17,7 +17,6 @@ from django.utils.deprecation import MiddlewareMixin
 from openedx.core.djangoapps.dark_lang import DARK_LANGUAGE_KEY
 from openedx.core.djangoapps.dark_lang.models import DarkLangConfig
 from openedx.core.djangoapps.lang_pref.helpers import set_language_cookie
-from openedx.core.djangoapps.site_configuration.helpers import get_value
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preference
 
 # If django 1.7 or higher is used, the right-side can be updated with new-style codes.
@@ -98,19 +97,9 @@ class DarkLangMiddleware(MiddlewareMixin):
         Apply user's dark lang preference as a cookie for future requests.
         """
         if DarkLangConfig.current().enabled:
-            self._set_site_or_microsite_language(request, response)
             self._activate_preview_language(request, response)
 
         return response
-
-    def _set_site_or_microsite_language(self, request, response):
-        """
-        Apply language specified in site configuration.
-        """
-        language = get_value('LANGUAGE_CODE', None)
-        if language:
-            request.session[LANGUAGE_SESSION_KEY] = language
-            set_language_cookie(request, response, language)
 
     def _fuzzy_match(self, lang_code):
         """Returns a fuzzy match for lang_code"""


### PR DESCRIPTION
## Context
This feature was implemented in #27696 to replace the session's language in the request.
#28796 moved the process from the request to the response, which made this feature unusable (because the request was already processed). #28796 also made this feature set the language cookie. However, it is overwritten by user preferences.

## Description

To fix the described problem, this ignores user preferences and alters the cookie of a request instead of setting the cookie in the response. It also moves this feature from `dark_lang` to `lang_pref` middleware. It fits better here because it directly overwrites the language from user preferences.

Additionally, we are removing setting the session language by this feature. As mentioned in [the release notes](https://docs.djangoproject.com/en/3.2/releases/3.0/#miscellaneous), Django 3.2 no longer checks it in the `LocalMiddleware`. You can find the related code [here](https://github.com/django/django/blob/stable/3.2.x/django/utils/translation/trans_real.py#L530).

## Testing instructions

1. Visit https://pr31408.sandbox.opencraft.hosting/dashboard. The page should be in English.
2. Visit https://fr.pr31408.sandbox.opencraft.hosting/dashboard (ignore the SSL warning). The page should be in French.
3. Visit https://pl.pr31408.sandbox.opencraft.hosting/dashboard (ignore the SSL warning). The page should be in Polish.
4. On any of the Sites, go to the [/update_lang/ page](https://fr.pr31408.sandbox.opencraft.hosting/update_lang/) and select a different language (e.g., `de`). This should change the language of the page. It does not affect the "Started - Feb 5, 2013" text on the dashboard, but this is an upstream bug (not related to this PR).

Note: if you would like to test this locally, you should add `SITE_CACHE_TTL = 0` to your `lms/envs/private.py`. Otherwise, you will need to wait for the SiteConfiguration cache to be invalidated.

## Deadline

"None"

## Other information
Alternatively, we could overwrite the cookie of the response after it's set from user preferences. However, it is not an ideal solution because when users switch between Sites with different languages, the first response will use the language of the previous page.

Sandbox: https://pr31408.sandbox.opencraft.hosting/
Private-ref: [BB-6930](https://tasks.opencraft.com/browse/BB-6930)