### PR TITLE
fix: intial chatty goals is a bit too chatty

### DIFF
--- a/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
+++ b/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
@@ -159,7 +159,8 @@ class Command(BaseCommand):
         sent_count = 0
         filtered_count = 0
         course_goals = course_goals.exclude(course_key__in=courses_to_exclude).select_related('user').order_by('user')
-        log.info(f'Processing course goals, total goal count {len(course_goals)}')
+        total_goals = len(course_goals)
+        log.info(f'Processing course goals, total goal count {total_goals}')
         for goal in course_goals:
             # emulate a request for waffle's benefit
             with emulate_http_request(site=Site.objects.get_current(), user=goal.user):
@@ -167,10 +168,10 @@ class Command(BaseCommand):
                     sent_count += 1
                 else:
                     filtered_count += 1
-            if (sent_count + filtered_count) % 1000 == 0:
-                log.info(f'Processing course goals: sent {sent_count} filtered {filtered_count}')
+            if (sent_count + filtered_count) % 10000 == 0:
+                log.info(f'Processing course goals: sent {sent_count} filtered {filtered_count} out of {total_goals}')
 
-        log.info(f'Sent {sent_count} emails, filtered out {filtered_count} emails')
+        log.info(f'Processing course goals complete: sent {sent_count} emails, filtered out {filtered_count} emails')
 
     @staticmethod
     def handle_goal(goal, today, sunday_date, monday_date):


### PR DESCRIPTION
it takes 20-30s to run through 1000 goals so this logs too often to read in splunk. Every 10000 will be every few minutes.

also makes a few other useful logging tweaks