### PR TITLE
feat: Add optional security policy link in the site footer

### DIFF
--- a/lms/djangoapps/branding/api.py
+++ b/lms/djangoapps/branding/api.py
@@ -241,12 +241,20 @@ def _build_help_center_url(language):
     return support_url
 
 
+def _security_url():
+    """
+    Return the security policy page URL.
+    """
+    return settings.SECURITY_PAGE_URL
+
+
 def _footer_connect_links(language=settings.LANGUAGE_CODE):
     """Return the connect links to display in the footer. """
     links = [
         ("blog", (marketing_link("BLOG"), _("Blog"))),
         ("contact", (_build_support_form_url(full_path=True), _("Contact Us"))),
         ("help-center", (_build_help_center_url(language), _("Help Center"))),
+        ("security", (_security_url(), _("Security"))),
     ]
 
     if language == settings.LANGUAGE_CODE:

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3339,6 +3339,13 @@ PASSWORD_RESET_SUPPORT_LINK = ''
 ACTIVATION_EMAIL_SUPPORT_LINK = ''
 LOGIN_ISSUE_SUPPORT_LINK = ''
 
+# .. setting_name: SECURITY_PAGE_URL
+# .. setting_default: None
+# .. setting_description: A link to the site's security disclosure/reporting policy,
+#   to display in the site footer. This will only appear for sites using themes that
+#   use the links produced by ``lms.djangoapps.branding.api.get_footer``.
+SECURITY_PAGE_URL = None
+
 # Days before the expired date that we warn the user
 ENTITLEMENT_EXPIRED_ALERT_PERIOD = 90
 


### PR DESCRIPTION
For edx.org, this will be set to <https://www.edx.org/policy/security>. The only theme that I'm aware of as supporting this is `edx.org-next` but other deployments might use this `get_footer` call as well.

Internal Jira ticket: https://2u-internal.atlassian.net/browse/SEG-76

## Testing instructions

1. Start LMS in devstack
2. Switch to the `edx.org-next` theme as described in <https://github.com/edx/edx-themes/blob/master/docs/guides/local-development.rst>
3. View a page with the theme enabled: http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/about?site_theme=edx.org-next

Test with `SECURITY_URL` still `None` or set to a URL.

## Deadline

None