### PR TITLE
feat: get credit statuses for Learner Home

### DIFF
--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -454,7 +454,7 @@ class AccountValidationError(Exception):
         self.error_code = error_code
 
 
-def cert_info(user, enrollment):  # pylint: disable=redefined-outer-name
+def cert_info(user, enrollment):
     """
     Get the certificate info needed to render the dashboard section for the given
     student and course.

--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -454,7 +454,7 @@ class AccountValidationError(Exception):
         self.error_code = error_code
 
 
-def cert_info(user, enrollment):
+def cert_info(user, enrollment):  # pylint: disable=redefined-outer-name
     """
     Get the certificate info needed to render the dashboard section for the given
     student and course.

--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -324,7 +324,7 @@ def reverification_info(statuses):
     return reverifications
 
 
-def credit_statuses(user, course_enrollments):
+def credit_statuses(user, course_enrollments):  # pylint: disable=redefined-outer-name
     """
     Retrieve the status for credit courses.
 

--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -324,7 +324,7 @@ def reverification_info(statuses):
     return reverifications
 
 
-def _credit_statuses(user, course_enrollments):
+def credit_statuses(user, course_enrollments):
     """
     Retrieve the status for credit courses.
 
@@ -353,12 +353,13 @@ def _credit_statuses(user, course_enrollments):
         * purchased (bool): Whether the user has purchased credit for this course.
         * provider_name (string): The display name of the credit provider.
         * provider_status_url (string): A URL the user can visit to check on their credit request status.
+        * provider_id (string): A unique alphanumeric (plus hyphens) string identifying the provider.
         * request_status (string): Either "pending", "approved", or "rejected"
         * error (bool): If true, an unexpected error occurred when retrieving the credit status,
             so the user should contact the support team.
 
     Example:
-    >>> _credit_statuses(user, course_enrollments)
+    >>> credit_statuses(user, course_enrollments)
     {
         CourseKey.from_string("edX/DemoX/Demo_Course"): {
             "course_key": "edX/DemoX/Demo_Course",
@@ -367,6 +368,7 @@ def _credit_statuses(user, course_enrollments):
             "purchased": True,
             "provider_name": "Hogwarts",
             "provider_status_url": "http://example.com/status",
+            "provider_id": "HSWW",
             "request_status": "pending",
             "error": False
         }
@@ -807,7 +809,7 @@ def student_dashboard(request):  # lint-amnesty, pylint: disable=too-many-statem
         'show_courseware_links_for': show_courseware_links_for,
         'all_course_modes': course_mode_info,
         'cert_statuses': cert_statuses,
-        'credit_statuses': _credit_statuses(user, course_enrollments),
+        'credit_statuses': credit_statuses(user, course_enrollments),
         'show_email_settings_for': show_email_settings_for,
         'reverifications': reverifications,
         'verification_display': verification_status['should_display'],

--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -324,7 +324,7 @@ def reverification_info(statuses):
     return reverifications
 
 
-def credit_statuses(user, course_enrollments):  # pylint: disable=redefined-outer-name
+def credit_statuses(user, course_enrollments):
     """
     Retrieve the status for credit courses.
 

--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -507,6 +507,7 @@ class UnfulfilledEntitlementSerializer(serializers.Serializer):
     gradeData = LiteralField(None)
     certificate = LiteralField(None)
     enrollment = LiteralField(STATIC_ENTITLEMENT_ENROLLMENT_DATA)
+    credit = LiteralField({})
 
     def _get_course_overview(self, instance):
         """Look up course provider from CourseOverview matching the pseudo session"""

--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -462,7 +462,7 @@ class LearnerEnrollmentSerializer(serializers.Serializer):
         credit_status = self.context["credit_statuses"].get(str(instance.course_id))
 
         # If user or course is ineligible for credit, return empty
-        if not credit_status or credit_status.get("eligible", False):
+        if not credit_status:
             return {}
         else:
             return CreditSerializer(credit_status).data

--- a/lms/djangoapps/learner_home/test_serializers.py
+++ b/lms/djangoapps/learner_home/test_serializers.py
@@ -986,6 +986,7 @@ class TestUnfulfilledEntitlementSerializer(LearnerDashboardBaseTest):
             "gradeData",
             "certificate",
             "enrollment",
+            "credit",
         ]
 
         assert output_data.keys() == set(expected_keys)
@@ -1360,6 +1361,7 @@ class TestLearnerDashboardSerializer(LearnerDashboardBaseTest):
             "resume_course_urls": resume_course_urls,
             "ecommerce_payment_page": random_url(),
             "course_mode_info": course_mode_info,
+            "credit_statuses": {},
             "fulfilled_entitlements": fulfilled_entitlements,
             "unfulfilled_entitlement_pseudo_sessions": unfulfilled_entitlement_pseudo_sessions,
             "course_entitlement_available_sessions": course_entitlement_available_sessions,

--- a/lms/djangoapps/learner_home/test_serializers.py
+++ b/lms/djangoapps/learner_home/test_serializers.py
@@ -916,22 +916,6 @@ class TestLearnerEnrollmentsSerializer(LearnerDashboardBaseTest):
         # Then I return empty credit info
         self.assertDictEqual(output["credit"], {})
 
-    def test_user_ineligible(self):
-
-        # Given an enrollment
-        enrollment = self.create_test_enrollment()
-        input_data = enrollment
-        input_context = self.create_test_context(enrollment)
-
-        # ... but the user is ineligible
-        input_context["credit_statuses"]["eligible"] = False
-
-        # When I serialize
-        output = LearnerEnrollmentSerializer(input_data, context=input_context).data
-
-        # Then I return empty credit info
-        self.assertDictEqual(output["credit"], {})
-
 
 class TestUnfulfilledEntitlementSerializer(LearnerDashboardBaseTest):
     """High-level tests for UnfulfilledEntitlementSerializer"""

--- a/lms/djangoapps/learner_home/views.py
+++ b/lms/djangoapps/learner_home/views.py
@@ -29,6 +29,7 @@ from common.djangoapps.student.helpers import (
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.views.dashboard import (
     complete_course_mode_info,
+    credit_statuses,
     get_course_enrollments,
     get_filtered_course_entitlements,
     get_org_black_and_whitelist_for_site,
@@ -423,6 +424,18 @@ def get_user_grade_passing_statuses(course_enrollments):
     }
 
 
+@function_trace("get_credit_statuses")
+def get_credit_statuses(user, course_enrollments):
+    """
+    Wrapper for getting credit statuses. Credit statuses are already in a
+    format we can use so this is largely for profiling / testing.
+
+    Returns (only for courses with credit options)
+    - Dict {course_id: <credit_status>}
+    """
+    return credit_statuses(user, course_enrollments)
+
+
 @function_trace("serialize_learner_home_data")
 def serialize_learner_home_data(data, context):
     """Wrapper for serialization so we can profile"""
@@ -517,6 +530,9 @@ class InitializeView(APIView):  # pylint: disable=unused-argument
         # Get social media sharing config
         course_share_urls = get_course_share_urls(course_enrollments)
 
+        # Get credit availability
+        credit_statuses = get_credit_statuses(user, course_enrollments)
+
         learner_dash_data = {
             "emailConfirmation": email_confirmation,
             "enterpriseDashboard": enterprise_customer,
@@ -534,6 +550,7 @@ class InitializeView(APIView):  # pylint: disable=unused-argument
             "course_mode_info": course_mode_info,
             "course_optouts": course_optouts,
             "course_access_checks": course_access_checks,
+            "credit_statuses": credit_statuses,
             "grade_statuses": grade_statuses,
             "resume_course_urls": resume_button_urls,
             "course_share_urls": course_share_urls,

--- a/lms/djangoapps/learner_home/views.py
+++ b/lms/djangoapps/learner_home/views.py
@@ -531,7 +531,7 @@ class InitializeView(APIView):  # pylint: disable=unused-argument
         course_share_urls = get_course_share_urls(course_enrollments)
 
         # Get credit availability
-        credit_statuses = get_credit_statuses(user, course_enrollments)
+        user_credit_statuses = get_credit_statuses(user, course_enrollments)
 
         learner_dash_data = {
             "emailConfirmation": email_confirmation,
@@ -550,7 +550,7 @@ class InitializeView(APIView):  # pylint: disable=unused-argument
             "course_mode_info": course_mode_info,
             "course_optouts": course_optouts,
             "course_access_checks": course_access_checks,
-            "credit_statuses": credit_statuses,
+            "credit_statuses": user_credit_statuses,
             "grade_statuses": grade_statuses,
             "resume_course_urls": resume_button_urls,
             "course_share_urls": course_share_urls,


### PR DESCRIPTION
## Description

Add credit information to Learner Home `init` output.

JIRA: [AU-948](https://2u-internal.atlassian.net/browse/AU-948)
FYI: @openedx/content-aurora

## Supporting Info

Notes & changes:
1. Uses existing logic from Student Dashboard (`_credit_statuses`) by making it public (`credit_statuses`).
2. Returned from Learner Home under new `courses[item].enrollment.credit` field.
3. `credit` is intentionally left empty (`{}`) for courses without a credit option or where the learner is ineligible / not yet eligible to purchase credit.