### PR TITLE
[OldMongo FC-0004] Tests for removing support for children in Old Mongo - part 1

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -40,7 +40,6 @@ from openedx.core.djangoapps.discussions.config.waffle import (
 )
 from openedx.core.djangoapps.models.course_details import CourseDetails
 from xmodule.fields import Date  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
@@ -602,10 +601,9 @@ class CourseGradingTest(CourseTestCase):
     @mock.patch('common.djangoapps.track.event_transaction_utils.uuid4')
     @mock.patch('cms.djangoapps.models.settings.course_grading.tracker')
     @mock.patch('cms.djangoapps.contentstore.signals.signals.GRADING_POLICY_CHANGED.send')
-    @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
-    def test_update_from_json(self, store, send_signal, tracker, uuid):
+    def test_update_from_json(self, send_signal, tracker, uuid):
         uuid.return_value = "mockUUID"
-        self.course = CourseFactory.create(default_store=store)
+        self.course = CourseFactory.create()
         test_grader = CourseGradingModel.fetch(self.course.id)
         # there should be no event raised after this call, since nothing got modified
         altered_grader = CourseGradingModel.update_from_json(self.course.id, test_grader.__dict__, self.user)
@@ -660,14 +658,13 @@ class CourseGradingTest(CourseTestCase):
             )
         ])
 
-    @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
-    def test_must_fire_grading_event_and_signal_multiple_type(self, store):
+    def test_must_fire_grading_event_and_signal_multiple_type(self):
         """
         Verifies that 'must_fire_grading_event_and_signal' ignores (returns False) if we modify
         short_label and or name
         use test_must_fire_grading_event_and_signal_multiple_type_2_split to run this test only
         """
-        self.course = CourseFactory.create(default_store=store)
+        self.course = CourseFactory.create()
         # .raw_grader approximates what our UI sends down. It uses decimal representation of percent
         # without it, the  weights would be percentages
         raw_grader_list = modulestore().get_course(self.course.id).raw_grader
@@ -686,14 +683,13 @@ class CourseGradingTest(CourseTestCase):
         self.assertTrue(result)
 
     @override_waffle_flag(MATERIAL_RECOMPUTE_ONLY_FLAG, True)
-    @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
-    def test_must_fire_grading_event_and_signal_multiple_type_waffle_on(self, store):
+    def test_must_fire_grading_event_and_signal_multiple_type_waffle_on(self):
         """
         Verifies that 'must_fire_grading_event_and_signal' ignores (returns False) if we modify
         short_label and or name
         use test_must_fire_grading_event_and_signal_multiple_type_2_split to run this test only
         """
-        self.course = CourseFactory.create(default_store=store)
+        self.course = CourseFactory.create()
         # .raw_grader approximates what our UI sends down. It uses decimal representation of percent
         # without it, the  weights would be percentages
         raw_grader_list = modulestore().get_course(self.course.id).raw_grader
@@ -711,14 +707,13 @@ class CourseGradingTest(CourseTestCase):
         )
         self.assertFalse(result)
 
-    @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
-    def test_must_fire_grading_event_and_signal_return_true(self, store):
+    def test_must_fire_grading_event_and_signal_return_true(self):
         """
         Verifies that 'must_fire_grading_event_and_signal' ignores (returns False) if we modify
         short_label and or name
         use _2_split suffix to run this test only
         """
-        self.course = CourseFactory.create(default_store=store)
+        self.course = CourseFactory.create()
         # .raw_grader approximates what our UI sends down. It uses decimal representation of percent
         # without it, the  weights would be percentages
         raw_grader_list = modulestore().get_course(self.course.id).raw_grader

--- a/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
+++ b/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
@@ -19,7 +19,7 @@ from cms.djangoapps.contentstore.utils import reverse_course_url, reverse_usage_
 from openedx.features.content_type_gating.helpers import CONTENT_GATING_PARTITION_ID
 from openedx.features.content_type_gating.partitions import CONTENT_TYPE_GATING_SCHEME
 from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.partitions.partitions import ENROLLMENT_TRACK_PARTITION_ID, Group, UserPartition  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.validation import StudioValidation, StudioValidationMessage  # lint-amnesty, pylint: disable=wrong-import-order
@@ -64,9 +64,9 @@ class HelperMethods:
             parent_location=sequential.location,
             display_name=f'Test Unit {name_suffix}'
         )
-        c0_url = self.course.id.make_usage_key("vertical", "split_test_cond0")
-        c1_url = self.course.id.make_usage_key("vertical", "split_test_cond1")
-        c2_url = self.course.id.make_usage_key("vertical", "split_test_cond2")
+        c0_url = self.course.id.make_usage_key("vertical", f"split_test_cond0_{name_suffix}")
+        c1_url = self.course.id.make_usage_key("vertical", f"split_test_cond1_{name_suffix}")
+        c2_url = self.course.id.make_usage_key("vertical", f"split_test_cond2_{name_suffix}")
         split_test = ItemFactory.create(
             category='split_test',
             parent_location=vertical.location,
@@ -693,6 +693,7 @@ class GroupConfigurationsUsageInfoTestCase(CourseTestCase, HelperMethods):
     """
     Tests for usage information of configurations and content groups.
     """
+    MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
 
     def _get_user_partition(self, scheme):
         """
@@ -770,13 +771,12 @@ class GroupConfigurationsUsageInfoTestCase(CourseTestCase, HelperMethods):
 
         self.assertEqual(actual, expected)
 
-    @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
-    def test_can_get_correct_usage_info_with_orphan(self, module_store_type):
+    def test_can_get_correct_usage_info_with_orphan(self):
         """
         Test if content group json updated successfully with usage information
         even if there is an orphan in content group.
         """
-        self.course = CourseFactory.create(default_store=module_store_type)
+        self.course = CourseFactory.create()
         self._add_user_partitions(count=1, scheme_id='cohort')
         vertical, __ = self._create_problem_with_content_group(cid=0, group_id=1, name_suffix='0', orphan=True)
 
@@ -784,16 +784,8 @@ class GroupConfigurationsUsageInfoTestCase(CourseTestCase, HelperMethods):
         self.assertEqual(len(self.store.get_orphans(self.course.id)), 1)
         self.assertIn(vertical.location, self.store.get_orphans(self.course.id))
 
-        # Get the expected content group information based on module store.
-        if module_store_type == ModuleStoreEnum.Type.mongo:
-            expected = self._get_expected_content_group(usage_for_group=[
-                {
-                    'url': f'/container/{vertical.location}',
-                    'label': 'Test Unit 0 / Test Problem 0'
-                }
-            ])
-        else:
-            expected = self._get_expected_content_group(usage_for_group=[])
+        # Get the expected content group information.
+        expected = self._get_expected_content_group(usage_for_group=[])
 
         # Get the actual content group information
         actual = self._get_user_partition('cohort')
@@ -807,8 +799,8 @@ class GroupConfigurationsUsageInfoTestCase(CourseTestCase, HelperMethods):
         content group.
         """
         self._add_user_partitions(scheme_id='cohort')
-        vertical, __ = self._create_problem_with_content_group(cid=0, group_id=1, name_suffix='0')
         vertical1, __ = self._create_problem_with_content_group(cid=0, group_id=1, name_suffix='1')
+        vertical, __ = self._create_problem_with_content_group(cid=0, group_id=1, name_suffix='0')
 
         actual = self._get_user_partition('cohort')
 
@@ -868,6 +860,7 @@ class GroupConfigurationsUsageInfoTestCase(CourseTestCase, HelperMethods):
             ),
         ]
         self.store.update_item(self.course, ModuleStoreEnum.UserID.test)
+        self.reload_course()
 
         __, split_test, problem = self._create_content_experiment(cid=0, name_suffix='0', group_id=3, cid_for_problem=1)  # lint-amnesty, pylint: disable=unused-variable
 
@@ -1066,14 +1059,13 @@ class GroupConfigurationsUsageInfoTestCase(CourseTestCase, HelperMethods):
         """
         self._add_user_partitions()
         # Create split test without parent.
-        with modulestore().branch_setting(ModuleStoreEnum.Branch.published_only):
-            orphan = modulestore().create_item(
-                ModuleStoreEnum.UserID.test,
-                self.course.id, 'split_test',
-            )
-            orphan.user_partition_id = 0
-            orphan.display_name = 'Test Content Experiment'
-            modulestore().update_item(orphan, ModuleStoreEnum.UserID.test)
+        orphan = self.store.create_item(
+            ModuleStoreEnum.UserID.test,
+            self.course.id, 'split_test',
+        )
+        orphan.user_partition_id = 0
+        orphan.display_name = 'Test Content Experiment'
+        self.store.update_item(orphan, ModuleStoreEnum.UserID.test)
 
         self.save_course()
         actual = GroupConfiguration.get_content_experiment_usage_info(self.store, self.course)

--- a/cms/djangoapps/contentstore/views/tests/test_preview.py
+++ b/cms/djangoapps/contentstore/views/tests/test_preview.py
@@ -14,11 +14,9 @@ from web_fragments.fragment import Fragment
 from xblock.core import XBlock, XBlockAside
 
 from xmodule.contentstore.django import contentstore
-from xmodule.lti_block import LTIBlock
-from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import (
-    TEST_DATA_MONGO_MODULESTORE, ModuleStoreTestCase, upload_file_to_course,
+    TEST_DATA_SPLIT_MODULESTORE, ModuleStoreTestCase, upload_file_to_course,
 )
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from xmodule.modulestore.tests.test_asides import AsideTestType
@@ -39,13 +37,16 @@ class GetPreviewHtmlTestCase(ModuleStoreTestCase):
     Note that there are other existing test cases in test_contentstore that indirectly execute
     get_preview_fragment via the xblock RESTful API.
     """
+
+    MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
+
     @XBlockAside.register_temp_plugin(AsideTestType, 'test_aside')
     def test_preview_fragment(self):
         """
         Test for calling get_preview_html. Ensures data-usage-id is correctly set and
         asides are correctly included.
         """
-        course = CourseFactory.create(default_store=ModuleStoreEnum.Type.split)
+        course = CourseFactory.create()
         html = ItemFactory.create(
             parent_location=course.location,
             category="html",
@@ -93,7 +94,7 @@ class GetPreviewHtmlTestCase(ModuleStoreTestCase):
         Test for calling get_preview_html. Ensures data-usage-id is correctly set and
         asides are correctly excluded because they are not enabled.
         """
-        course = CourseFactory.create(default_store=ModuleStoreEnum.Type.split)
+        course = CourseFactory.create()
         html = ItemFactory.create(
             parent_location=course.location,
             category="html",
@@ -127,52 +128,49 @@ class GetPreviewHtmlTestCase(ModuleStoreTestCase):
         client = Client()
         client.login(username=self.user.username, password=self.user_password)
 
-        with self.store.default_store(ModuleStoreEnum.Type.split):
-            course = CourseFactory.create()
+        course = CourseFactory.create()
 
-            conditional_block = ItemFactory.create(
-                parent_location=course.location,
-                category="conditional"
-            )
+        conditional_block = ItemFactory.create(
+            parent_location=course.location,
+            category="conditional"
+        )
 
-            # child conditional_block
-            ItemFactory.create(
-                parent_location=conditional_block.location,
-                category="conditional"
-            )
+        # child conditional_block
+        ItemFactory.create(
+            parent_location=conditional_block.location,
+            category="conditional"
+        )
 
-            url = reverse_usage_url(
-                'preview_handler',
-                conditional_block.location,
-                kwargs={'handler': 'xmodule_handler/conditional_get'}
-            )
-            response = client.post(url)
-            self.assertEqual(response.status_code, 200)
+        url = reverse_usage_url(
+            'preview_handler',
+            conditional_block.location,
+            kwargs={'handler': 'xmodule_handler/conditional_get'}
+        )
+        response = client.post(url)
+        self.assertEqual(response.status_code, 200)
 
-    @ddt.data(ModuleStoreEnum.Type.split, ModuleStoreEnum.Type.mongo)
-    def test_block_branch_not_changed_by_preview_handler(self, default_store):
+    def test_block_branch_not_changed_by_preview_handler(self):
         """
         Tests preview_handler should not update blocks being previewed
         """
         client = Client()
         client.login(username=self.user.username, password=self.user_password)
 
-        with self.store.default_store(default_store):
-            course = CourseFactory.create()
+        course = CourseFactory.create()
 
-            block = ItemFactory.create(
-                parent_location=course.location,
-                category="problem"
-            )
+        block = ItemFactory.create(
+            parent_location=course.location,
+            category="problem"
+        )
 
-            url = reverse_usage_url(
-                'preview_handler',
-                block.location,
-                kwargs={'handler': 'xmodule_handler/problem_check'}
-            )
-            response = client.post(url)
-            self.assertEqual(response.status_code, 200)
-            self.assertFalse(modulestore().has_changes(modulestore().get_item(block.location)))
+        url = reverse_usage_url(
+            'preview_handler',
+            block.location,
+            kwargs={'handler': 'xmodule_handler/problem_check'}
+        )
+        response = client.post(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(modulestore().has_changes(modulestore().get_item(block.location)))
 
 
 @XBlock.needs("field-data")
@@ -229,8 +227,8 @@ class CmsModuleSystemShimTest(ModuleStoreTestCase):
     """
     Tests that the deprecated attributes in the Module System (XBlock Runtime) return the expected values.
     """
-    MODULESTORE = TEST_DATA_MONGO_MODULESTORE
-    COURSE_ID = 'edX/CmsModuleShimTest/2021_Fall'
+    MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
+    COURSE_ID = 'course-v1:edX+LmsModuleShimTest+2021_Fall'
     PYTHON_LIB_FILENAME = 'test_python_lib.zip'
     PYTHON_LIB_SOURCE_FILE = './common/test/data/uploads/python_lib.zip'
 
@@ -239,20 +237,20 @@ class CmsModuleSystemShimTest(ModuleStoreTestCase):
         Set up the user, course and other fields that will be used to instantiate the runtime.
         """
         super().setUp()
-        org, number, run = self.COURSE_ID.split('/')
-        self.course = CourseFactory.create(org=org, number=number, run=run)
+        course = CourseFactory.create(org='edX', number='LmsModuleShimTest', run='2021_Fall')
         self.user = UserFactory()
         self.request = RequestFactory().get('/dummy-url')
         self.request.user = self.user
         self.request.session = {}
-        self.descriptor = ItemFactory(category="video", parent=self.course)
+        self.descriptor = ItemFactory(category="video", parent=course)
         self.field_data = mock.Mock()
         self.contentstore = contentstore()
         self.runtime = _preview_module_system(
             self.request,
-            descriptor=ItemFactory(category="problem", parent=self.course),
+            descriptor=ItemFactory(category="problem", parent=course),
             field_data=mock.Mock(),
         )
+        self.course = self.store.get_item(course.location)
 
     def test_get_user_role(self):
         assert self.runtime.get_user_role() == 'staff'
@@ -263,7 +261,7 @@ class CmsModuleSystemShimTest(ModuleStoreTestCase):
         html = get_preview_fragment(self.request, descriptor, {'element_id': 142}).content
         assert '<div id="142" ns="main">Testing the MakoService</div>' in html
 
-    @override_settings(COURSES_WITH_UNSAFE_CODE=[COURSE_ID])
+    @override_settings(COURSES_WITH_UNSAFE_CODE=[r'course-v1:edX\+LmsModuleShimTest\+2021_Fall'])
     def test_can_execute_unsafe_code(self):
         assert self.runtime.can_execute_unsafe_code()
 
@@ -318,7 +316,7 @@ class CmsModuleSystemShimTest(ModuleStoreTestCase):
         # Create the runtime with the flag turned on.
         runtime = _preview_module_system(
             self.request,
-            descriptor=ItemFactory(category="lti", parent=self.course, spec=LTIBlock),
+            descriptor=ItemFactory(category="lti", parent=self.course),
             field_data=mock.Mock(),
         )
-        assert runtime.anonymous_student_id == 'cf99fd26f9a41d4d9b4069739cc2be7b'
+        assert runtime.anonymous_student_id == 'ad503f629b55c531fed2e45aa17a3368'

--- a/lms/djangoapps/discussion/tests/test_views.py
+++ b/lms/djangoapps/discussion/tests/test_views.py
@@ -19,7 +19,7 @@ from edx_toggles.toggles.testutils import override_waffle_flag
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import (
-    TEST_DATA_MONGO_AMNESTY_MODULESTORE,
+    TEST_DATA_SPLIT_MODULESTORE,
     ModuleStoreTestCase,
     SharedModuleStoreTestCase
 )
@@ -1905,6 +1905,8 @@ class DividedDiscussionsTestCase(CohortViewsTestCase):  # lint-amnesty, pylint: 
             discussion_target="Discussion",
             start=datetime.now()
         )
+        # get updated course
+        self.course = self.store.get_item(self.course.location)
         # course-wide discussion
         discussion_topics = {
             "Topic B": {"id": "Topic B"},
@@ -1927,7 +1929,7 @@ class CourseDiscussionTopicsTestCase(DividedDiscussionsTestCase):
     """
     Tests the `divide_discussion_topics` view.
     """
-    MODULESTORE = TEST_DATA_MONGO_AMNESTY_MODULESTORE
+    MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
 
     def test_non_staff(self):
         """
@@ -1983,7 +1985,7 @@ class CourseDiscussionsHandlerTestCase(DividedDiscussionsTestCase):
     """
     Tests the course_discussion_settings_handler
     """
-    MODULESTORE = TEST_DATA_MONGO_AMNESTY_MODULESTORE
+    MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
 
     def get_expected_response(self):
         """

--- a/lms/djangoapps/gating/tests/test_integration.py
+++ b/lms/djangoapps/gating/tests/test_integration.py
@@ -11,7 +11,7 @@ from edx_toggles.toggles.testutils import override_waffle_switch
 from milestones import api as milestones_api
 from milestones.tests.utils import MilestonesTestCaseMixin
 from xmodule.modulestore.django import modulestore
-from xmodule.modulestore.tests.django_utils import TEST_DATA_MONGO_AMNESTY_MODULESTORE, SharedModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
 from common.djangoapps.student.tests.factories import UserFactory
@@ -28,7 +28,7 @@ class TestGatedContent(MilestonesTestCaseMixin, SharedModuleStoreTestCase):
     Base TestCase class for setting up a basic course structure
     and testing the gating feature
     """
-    MODULESTORE = TEST_DATA_MONGO_AMNESTY_MODULESTORE
+    MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
 
     @classmethod
     def setUpClass(cls):
@@ -48,14 +48,14 @@ class TestGatedContent(MilestonesTestCaseMixin, SharedModuleStoreTestCase):
         """
         Set up a course for testing gated content.
         """
-        cls.course = CourseFactory.create(
+        course = CourseFactory.create(
             org='edX',
             number='EDX101',
             run='EDX101_RUN1',
             display_name='edX 101'
         )
-        with modulestore().bulk_operations(cls.course.id):
-            cls.course.enable_subsection_gating = True
+        with modulestore().bulk_operations(course.id):
+            course.enable_subsection_gating = True
             grading_policy = {
                 "GRADER": [{
                     "type": "Homework",
@@ -65,34 +65,33 @@ class TestGatedContent(MilestonesTestCaseMixin, SharedModuleStoreTestCase):
                     "weight": 1.0
                 }]
             }
-            cls.course.grading_policy = grading_policy
-            cls.course.save()
-            cls.store.update_item(cls.course, 0)
+            course.grading_policy = grading_policy
+            course.save()
 
             # create chapter
             cls.chapter1 = ItemFactory.create(
-                parent_location=cls.course.location,
+                parent=course,
                 category='chapter',
                 display_name='chapter 1'
             )
 
             # create sequentials
             cls.seq1 = ItemFactory.create(
-                parent_location=cls.chapter1.location,
+                parent=cls.chapter1,
                 category='sequential',
                 display_name='gating sequential 1',
                 graded=True,
                 format='Homework',
             )
             cls.seq2 = ItemFactory.create(
-                parent_location=cls.chapter1.location,
+                parent=cls.chapter1,
                 category='sequential',
                 display_name='gated sequential 2',
                 graded=True,
                 format='Homework',
             )
             cls.seq3 = ItemFactory.create(
-                parent_location=cls.chapter1.location,
+                parent=cls.chapter1,
                 category='sequential',
                 display_name='sequential 3',
                 graded=True,
@@ -101,7 +100,7 @@ class TestGatedContent(MilestonesTestCaseMixin, SharedModuleStoreTestCase):
 
             # create problem
             cls.gating_prob1 = ItemFactory.create(
-                parent_location=cls.seq1.location,
+                parent=cls.seq1,
                 category='problem',
                 display_name='gating problem 1',
             )
@@ -109,7 +108,7 @@ class TestGatedContent(MilestonesTestCaseMixin, SharedModuleStoreTestCase):
             # this should give us ability to test gating with blocks
             # which needs to be excluded from completion tracking
             ItemFactory.create(
-                parent_location=cls.seq1.location,
+                parent=cls.seq1,
                 category="discussion",
                 discussion_id="discussion 1",
                 discussion_category="discussion category",
@@ -117,15 +116,17 @@ class TestGatedContent(MilestonesTestCaseMixin, SharedModuleStoreTestCase):
             )
 
             cls.gated_prob2 = ItemFactory.create(
-                parent_location=cls.seq2.location,
+                parent=cls.seq2,
                 category='problem',
                 display_name='gated problem 2',
             )
             cls.prob3 = ItemFactory.create(
-                parent_location=cls.seq3.location,
+                parent=cls.seq3,
                 category='problem',
                 display_name='problem 3',
             )
+        # get updated course
+        cls.course = cls.store.get_item(course.location)
 
     def setup_gating_milestone(self, min_score, min_completion):
         """

--- a/lms/djangoapps/instructor/tests/test_tools.py
+++ b/lms/djangoapps/instructor/tests/test_tools.py
@@ -19,7 +19,7 @@ from opaque_keys.edx.keys import CourseKey
 from pytz import UTC
 from xmodule.fields import Date
 from xmodule.modulestore.tests.django_utils import (
-    TEST_DATA_MONGO_AMNESTY_MODULESTORE, ModuleStoreTestCase, SharedModuleStoreTestCase,
+    TEST_DATA_SPLIT_MODULESTORE, ModuleStoreTestCase, SharedModuleStoreTestCase,
 )
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
@@ -102,15 +102,18 @@ class TestFindUnit(SharedModuleStoreTestCase):
     """
     Test the find_unit function.
     """
-    MODULESTORE = TEST_DATA_MONGO_AMNESTY_MODULESTORE
+    MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.course = CourseFactory.create()
-        with cls.store.bulk_operations(cls.course.id, emit_signals=False):
-            week1 = ItemFactory.create(parent=cls.course)
-            cls.homework = ItemFactory.create(parent=week1)
+        course = CourseFactory.create()
+        with cls.store.bulk_operations(course.id, emit_signals=False):
+            cls.week1 = ItemFactory.create(parent=course)
+            cls.homework = ItemFactory.create(parent=cls.week1)
+
+        # get updated course
+        cls.course = cls.store.get_item(course.location)
 
     def test_find_unit_success(self):
         """
@@ -133,7 +136,7 @@ class TestGetUnitsWithDueDate(ModuleStoreTestCase):
     """
     Test the get_units_with_due_date function.
     """
-    MODULESTORE = TEST_DATA_MONGO_AMNESTY_MODULESTORE
+    MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
 
     def setUp(self):
         """
@@ -153,7 +156,8 @@ class TestGetUnitsWithDueDate(ModuleStoreTestCase):
             (child.location, {'due': due}),
         ])
 
-        self.course = course
+        # get updated course
+        self.course = self.store.get_item(course.location)
         self.week1 = week1
         self.week2 = week2
 
@@ -200,7 +204,7 @@ class TestSetDueDateExtension(ModuleStoreTestCase):
     """
     Test the set_due_date_extensions function.
     """
-    MODULESTORE = TEST_DATA_MONGO_AMNESTY_MODULESTORE
+    MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
 
     def setUp(self):
         """
@@ -219,9 +223,10 @@ class TestSetDueDateExtension(ModuleStoreTestCase):
 
         user = UserFactory.create()
 
-        self.course = course
-        self.week1 = week1
-        self.homework = homework
+        # get updated course
+        self.course = self.store.get_item(course.location)
+        self.week1 = self.store.get_item(week1.location)
+        self.homework = self.store.get_item(homework.location)
         self.assignment = assignment
         self.week2 = week2
         self.week3 = week3
@@ -229,7 +234,7 @@ class TestSetDueDateExtension(ModuleStoreTestCase):
 
         CourseEnrollmentFactory.create(user=self.user, course_id=self.course.id)
 
-        inject_field_data((course, week1, week2, week3, homework, assignment), course, user)
+        inject_field_data((course, self.week1, self.week2, self.week3, self.homework, self.assignment), course, user)
 
     def _clear_field_data_cache(self):
         """
@@ -293,8 +298,8 @@ class TestSetDueDateExtension(ModuleStoreTestCase):
         extended_hw = datetime.datetime(2013, 10, 25, 0, 0, tzinfo=UTC)
         tools.set_due_date_extension(self.course, self.assignment, self.user, extended_hw)
 
-        assert mock_method.call_count == 2
-        mock_method.assert_called_with(self.course.id, user=self.user, published_version=None, use_cached=False)
+        assert mock_method.call_count == 3
+        mock_method.assert_called_with(self.course.id, user=self.user, use_cached=False)
 
     @patch('edx_when.api.get_dates_for_course', wraps=get_dates_for_course)
     def test_set_due_date_extension_cache_invalidation_with_version(self, mock_method: MagicMock):
@@ -315,7 +320,7 @@ class TestDataDumps(ModuleStoreTestCase):
     """
     Test data dumps for reporting.
     """
-    MODULESTORE = TEST_DATA_MONGO_AMNESTY_MODULESTORE
+    MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
 
     def setUp(self):
         """
@@ -335,7 +340,8 @@ class TestDataDumps(ModuleStoreTestCase):
 
         user1 = UserFactory.create()
         user2 = UserFactory.create()
-        self.course = course
+        # get updated course
+        self.course = self.store.get_item(course.location)
         self.week1 = week1
         self.homework = homework
         self.week2 = week2

--- a/lms/djangoapps/program_enrollments/rest_api/v1/tests/test_views.py
+++ b/lms/djangoapps/program_enrollments/rest_api/v1/tests/test_views.py
@@ -20,7 +20,7 @@ from organizations.tests.factories import OrganizationFactory as LMSOrganization
 from rest_framework import status
 from rest_framework.test import APITestCase
 from social_django.models import UserSocialAuth
-from xmodule.modulestore.tests.django_utils import TEST_DATA_MONGO_AMNESTY_MODULESTORE, SharedModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory as ModulestoreCourseFactory
 from xmodule.modulestore.tests.factories import ItemFactory
 
@@ -96,7 +96,7 @@ class EnrollmentsDataMixin(ProgramCacheMixin):
     Mixin to define some shared test data objects for program/course enrollment
     view tests.
     """
-    MODULESTORE = TEST_DATA_MONGO_AMNESTY_MODULESTORE
+    MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
     view_name = 'SET-ME-IN-SUBCLASS'
 
     @classmethod
@@ -1637,7 +1637,7 @@ class ProgramCourseEnrollmentOverviewGetTests(
     """
     Tests for the ProgramCourseEnrollmentOverview view GET method.
     """
-    MODULESTORE = TEST_DATA_MONGO_AMNESTY_MODULESTORE
+    MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
 
     patch_resume_url = mock.patch(
         _UTILS_PATCH_FORMAT.format('get_resume_urls_for_enrollments'),
@@ -1944,25 +1944,25 @@ class ProgramCourseEnrollmentOverviewGetTests(
                 {
                     'name': section_1.display_name,
                     'url': ('http://testserver/courses/course-v1:edX+ToyX+Toy_Course/'
-                            'jump_to/i4x://edX/ToyX/chapter/section_1'),
+                            'jump_to/block-v1:edX+ToyX+Toy_Course+type@chapter+block@section_1'),
                     'date': '2019-01-02T00:00:00Z',
                 },
                 {
                     'name': subsection_1.display_name,
                     'url': ('http://testserver/courses/course-v1:edX+ToyX+Toy_Course/'
-                            'jump_to/i4x://edX/ToyX/sequential/subsection_1'),
+                            'jump_to/block-v1:edX+ToyX+Toy_Course+type@sequential+block@subsection_1'),
                     'date': '2019-01-02T00:00:00Z',
                 },
                 {
                     'name': subsection_2.display_name,
                     'url': ('http://testserver/courses/course-v1:edX+ToyX+Toy_Course/'
-                            'jump_to/i4x://edX/ToyX/sequential/subsection_2'),
+                            'jump_to/block-v1:edX+ToyX+Toy_Course+type@sequential+block@subsection_2'),
                     'date': '2019-01-01T00:00:00Z',
                 },
                 {
                     'name': unit_1.display_name,
                     'url': ('http://testserver/courses/course-v1:edX+ToyX+Toy_Course/'
-                            'jump_to/i4x://edX/ToyX/vertical/unit_1'),
+                            'jump_to/block-v1:edX+ToyX+Toy_Course+type@vertical+block@unit_1'),
                     'date': '2019-01-04T00:00:00Z',
                 },
             ]

--- a/openedx/features/content_type_gating/tests/test_access.py
+++ b/openedx/features/content_type_gating/tests/test_access.py
@@ -14,7 +14,7 @@ from django.utils import timezone
 from django.contrib.auth import get_user_model
 from pyquery import PyQuery as pq
 from xmodule.modulestore.tests.django_utils import (
-    TEST_DATA_MONGO_AMNESTY_MODULESTORE, ModuleStoreTestCase, SharedModuleStoreTestCase,
+    TEST_DATA_SPLIT_MODULESTORE, ModuleStoreTestCase, SharedModuleStoreTestCase,
 )
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from xmodule.partitions.partitions import ENROLLMENT_TRACK_PARTITION_ID
@@ -1123,7 +1123,7 @@ class TestContentTypeGatingService(ModuleStoreTestCase):
     to check whether a sequence contains content type gated blocks
     The content_type_gate_for_block can be used to return the content type gate for a given block
     """
-    MODULESTORE = TEST_DATA_MONGO_AMNESTY_MODULESTORE
+    MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
 
     def setUp(self):
         super().setUp()
@@ -1153,6 +1153,8 @@ class TestContentTypeGatingService(ModuleStoreTestCase):
                 category='vertical',
                 display_name='Lesson 1 Vertical - Unit 1'
             )
+        # get updated course
+        course = self.store.get_item(course.location)
         return {
             'course': course,
             'blocks': blocks_dict,
@@ -1206,6 +1208,9 @@ class TestContentTypeGatingService(ModuleStoreTestCase):
             graded=False,
             metadata=METADATA,
         )
+        # get updated course
+        course['course'] = self.store.get_item(course['course'].location)
+        blocks_dict['vertical'] = self.store.get_item(blocks_dict['vertical'].location)
 
         # The method returns a content type gate for blocks that should be gated
         assert ContentTypeGatingService().check_children_for_content_type_gating_paywall(
@@ -1218,6 +1223,9 @@ class TestContentTypeGatingService(ModuleStoreTestCase):
             graded=True,
             metadata=METADATA,
         )
+        # get updated course
+        course['course'] = self.store.get_item(course['course'].location)
+        blocks_dict['vertical'] = self.store.get_item(blocks_dict['vertical'].location)
 
         # The method returns None for blocks that should not be gated
         assert 'content-paywall' in ContentTypeGatingService().check_children_for_content_type_gating_paywall(

--- a/xmodule/modulestore/tests/utils.py
+++ b/xmodule/modulestore/tests/utils.py
@@ -137,7 +137,7 @@ class ProceduralCourseTestMixin:
             for _ in range(branching):
                 child = ItemFactory.create(
                     category=xblock_type,
-                    parent_location=parent.location,
+                    parent=parent,
                     user_id=user_id
                 )
                 self.populated_usage_keys.setdefault(xblock_type, []).append(


### PR DESCRIPTION
## Description
First part of preparing tests for `Remove support for children in Old Mongo` task (https://github.com/openedx/edx-platform/pull/31134).
Fixed problem with .get_children() in tests for split modulestore.
Problem: If we create some CourseItem with some parent, we must get the updated parent item before using that parent item.

Useful information to include:
Remove support for children in Old Mongo PR: https://github.com/openedx/edx-platform/pull/31134
https://github.com/openedx/public-engineering/issues/80
