### PR TITLE
feat: one problem type for new problem editor

### DIFF
--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -354,10 +354,13 @@ def get_component_templates(courselike, library=False):  # lint-amnesty, pylint:
                             )
                         )
 
-
+        #If using new problem editor, we select problem type inside the editor
+        # because of this, we only show one problem.
         if category == 'problem' and use_new_problem_editor():
             print('problemma',templates_for_category)
-            templates_for_category = [ template for template in templates_for_category if template['boilerplate_name'] == 'blank_common.yaml' ]
+            templates_for_category = [
+                template for template in templates_for_category if template['boilerplate_name'] == 'blank_common.yaml'
+                ]
 
         # Add any advanced problem types. Note that these are different xblocks being stored as Advanced Problems,
         # currently not supported in libraries .

--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -357,7 +357,6 @@ def get_component_templates(courselike, library=False):  # lint-amnesty, pylint:
         #If using new problem editor, we select problem type inside the editor
         # because of this, we only show one problem.
         if category == 'problem' and use_new_problem_editor():
-            print('problemma',templates_for_category)
             templates_for_category = [
                 template for template in templates_for_category if template['boilerplate_name'] == 'blank_common.yaml'
                 ]

--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -24,6 +24,7 @@ from common.djangoapps.edxmako.shortcuts import render_to_response
 from common.djangoapps.student.auth import has_course_author_access
 from common.djangoapps.xblock_django.api import authorable_xblocks, disabled_xblocks
 from common.djangoapps.xblock_django.models import XBlockStudioConfigurationFlag
+from cms.djangoapps.contentstore.toggles import use_new_problem_editor
 from openedx.core.lib.xblock_utils import get_aside_from_xblock, is_xblock_aside
 from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
@@ -353,9 +354,14 @@ def get_component_templates(courselike, library=False):  # lint-amnesty, pylint:
                             )
                         )
 
+
+        if category == 'problem' and use_new_problem_editor():
+            print('problemma',templates_for_category)
+            templates_for_category = [ template for template in templates_for_category if template['boilerplate_name'] == 'blank_common.yaml' ]
+
         # Add any advanced problem types. Note that these are different xblocks being stored as Advanced Problems,
         # currently not supported in libraries .
-        if category == 'problem' and not library:
+        if category == 'problem' and not library and not use_new_problem_editor():
             disabled_block_names = [block.name for block in disabled_xblocks()]
             advanced_problem_types = [advanced_problem_type for advanced_problem_type in ADVANCED_PROBLEM_TYPES
                                       if advanced_problem_type['component'] not in disabled_block_names]

--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -359,7 +359,7 @@ def get_component_templates(courselike, library=False):  # lint-amnesty, pylint:
         if category == 'problem' and use_new_problem_editor():
             templates_for_category = [
                 template for template in templates_for_category if template['boilerplate_name'] == 'blank_common.yaml'
-                ]
+            ]
 
         # Add any advanced problem types. Note that these are different xblocks being stored as Advanced Problems,
         # currently not supported in libraries .


### PR DESCRIPTION
<!--

🫒🫒
🫒🫒🫒🫒         🫒 Note: the Olive master branch has been created.  Please consider whether your change
    🫒🫒🫒🫒     should also be applied to Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

🌰🌰🌰🌰🌰🌰     🌰 Note: the Nutmeg release is still supported.
                  Please consider whether your change should be applied to Nutmeg as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/openedx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This PR should create the experience that if you are using the new problem editor, problem type selection should be done in the editor.


Useful information to include:
- This PR should only be merged to master **AFTER** we merge the problem editor PR and milestone 1: select problem type screen.

## Supporting information

Check out PR 
navigate to course or library
create a problem
you are brought to the new editor experince.

## Deadline

None
