### PR TITLE
wait for exam block to actually be committed before trying to update off it

### DIFF
--- a/cms/djangoapps/contentstore/signals/handlers.py
+++ b/cms/djangoapps/contentstore/signals/handlers.py
@@ -125,9 +125,9 @@ def listen_for_course_publish(sender, course_key, **kwargs):  # pylint: disable=
         dump_course_to_neo4j
     )
 
-    # register special exams asynchronously
+    # register special exams asynchronously after the data is ready
     course_key_str = str(course_key)
-    update_special_exams_and_publish.delay(course_key_str)
+    transaction.on_commit(lambda: update_special_exams_and_publish.delay(course_key_str))
 
     if key_supports_outlines(course_key):
         # Push the course outline to learning_sequences asynchronously.

--- a/cms/djangoapps/contentstore/tests/test_exams.py
+++ b/cms/djangoapps/contentstore/tests/test_exams.py
@@ -2,7 +2,7 @@
 Test the exams service integration into Studio
 """
 from datetime import datetime, timedelta
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 import ddt
 from django.conf import settings
@@ -19,6 +19,8 @@ from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 @override_waffle_flag(EXAMS_IDA, active=True)
 @patch.dict('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': True})
 @patch('cms.djangoapps.contentstore.exams._patch_course_exams')
+@patch('cms.djangoapps.contentstore.signals.handlers.transaction.on_commit',
+       new=Mock(side_effect=lambda func: func()),)  # run right away
 class TestExamService(ModuleStoreTestCase):
     """
     Test for syncing exams to the exam service

--- a/cms/djangoapps/contentstore/tests/test_proctoring.py
+++ b/cms/djangoapps/contentstore/tests/test_proctoring.py
@@ -4,7 +4,7 @@ Tests for the edx_proctoring integration into Studio
 
 
 from datetime import datetime, timedelta
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 import ddt
 from django.conf import settings
@@ -20,6 +20,8 @@ from common.djangoapps.student.tests.factories import UserFactory
 
 @ddt.ddt
 @patch.dict('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': True})
+@patch('cms.djangoapps.contentstore.signals.handlers.transaction.on_commit',
+       new=Mock(side_effect=lambda func: func()),)  # run right away
 class TestProctoredExams(ModuleStoreTestCase):
     """
     Tests for the publishing of proctored exams


### PR DESCRIPTION
This behavior is modeled off what we are doing for events (wait for commit, then do things that depend on publish) rather than what we are doing for discussion settings (wait 30s after call).

Tested locally in regular devstack where the bug doesn't even happen and using devstack-with-worker with request transactions on which accurately replicates production - in that test I can see the bug on master branch and the fix working on this branch.

https://2u-internal.atlassian.net/browse/MST-1710