### PR TITLE
fix: full post content is returned for preview

### DIFF
--- a/lms/djangoapps/discussion/rest_api/serializers.py
+++ b/lms/djangoapps/discussion/rest_api/serializers.py
@@ -10,7 +10,6 @@ from django.core.exceptions import ValidationError
 from django.db.models import TextChoices
 from django.urls import reverse
 from django.utils.html import strip_tags
-from django.utils.text import Truncator
 from rest_framework import serializers
 
 from common.djangoapps.student.models import get_user_by_username_or_email
@@ -406,7 +405,7 @@ class ThreadSerializer(_ContentSerializer):
         Returns a cleaned and truncated version of the thread's body to display in a
         preview capacity.
         """
-        return Truncator(strip_tags(self.get_rendered_body(obj))).chars(35, ).replace('\n', ' ')
+        return strip_tags(self.get_rendered_body(obj)).replace('\n', ' ')
 
     def get_close_reason(self, obj):
         """

--- a/lms/djangoapps/discussion/rest_api/tests/test_views.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views.py
@@ -1331,7 +1331,7 @@ class ThreadViewSetCreateTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
             "topic_id": "test_topic",
             "type": "discussion",
             "title": "Test Title",
-            "raw_body": "# Test \n This is a very long body that will be truncated for the preview.",
+            "raw_body": "# Test \n This is a very long body but will not be truncated for the preview.",
         }
         response = self.client.post(
             self.url,
@@ -1342,16 +1342,17 @@ class ThreadViewSetCreateTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         response_data = json.loads(response.content.decode('utf-8'))
         assert response_data == self.expected_thread_data({
             "read": True,
-            "raw_body": "# Test \n This is a very long body that will be truncated for the preview.",
-            "preview_body": "Test This is a very long body that…",
-            "rendered_body": "<h1>Test</h1>\n<p>This is a very long body that will be truncated for the preview.</p>",
+            "raw_body": "# Test \n This is a very long body but will not be truncated for the preview.",
+            "preview_body": "Test This is a very long body but will not be truncated for the preview.",
+            "rendered_body": "<h1>Test</h1>\n<p>This is a very long body but will not be truncated for"
+                             " the preview.</p>",
         })
         assert parsed_body(httpretty.last_request()) == {
             'course_id': [str(self.course.id)],
             'commentable_id': ['test_topic'],
             'thread_type': ['discussion'],
             'title': ['Test Title'],
-            'body': ['# Test \n This is a very long body that will be truncated for the preview.'],
+            'body': ['# Test \n This is a very long body but will not be truncated for the preview.'],
             'user_id': [str(self.user.id)],
             'anonymous': ['False'],
             'anonymous_to_peers': ['False'],


### PR DESCRIPTION
### [NF-682](https://2u-internal.atlassian.net/browse/INF-682)

## Description

This is to make preview consistent on frontend truncation is now handled on FE and needs to be removed from the backend