### PR TITLE
fix: update devstack with worker for cache and proper redis

### DIFF
--- a/cms/envs/devstack_with_worker.py
+++ b/cms/envs/devstack_with_worker.py
@@ -18,6 +18,8 @@ from cms.envs.devstack import *
 
 # Require a separate celery worker
 CELERY_ALWAYS_EAGER = False
+CLEAR_REQUEST_CACHE_ON_TASK_COMPLETION = True
+BROKER_URL = 'redis://:password@edx.devstack.redis:6379/'
 
 # Disable transaction management because we are using a worker. Views
 # that request a task and wait for the result will deadlock otherwise.

--- a/lms/envs/devstack_with_worker.py
+++ b/lms/envs/devstack_with_worker.py
@@ -19,6 +19,7 @@ from lms.envs.devstack import *
 
 # Require a separate celery worker
 CELERY_ALWAYS_EAGER = False
+CLEAR_REQUEST_CACHE_ON_TASK_COMPLETION = True
 BROKER_URL = 'redis://:password@edx.devstack.redis:6379/'
 # Disable transaction management because we are using a worker. Views
 # that request a task and wait for the result will deadlock otherwise.


### PR DESCRIPTION
https://github.com/openedx/edx-platform/pull/31261 fixed celery cache behavior when not running a worker and made sure production would keep the old cache behavior, but missed these secret alternate settings files, bring them up to date.

Also fixes the cms file to have the actual broker URL.

