### PR TITLE
fix: make devstack-with-worker behave like actual worker envs

### DIFF
--- a/cms/envs/devstack_with_worker.py
+++ b/cms/envs/devstack_with_worker.py
@@ -20,8 +20,3 @@ from cms.envs.devstack import *
 CELERY_ALWAYS_EAGER = False
 CLEAR_REQUEST_CACHE_ON_TASK_COMPLETION = True
 BROKER_URL = 'redis://:password@edx.devstack.redis:6379/'
-
-# Disable transaction management because we are using a worker. Views
-# that request a task and wait for the result will deadlock otherwise.
-for database_name in DATABASES:
-    DATABASES[database_name]['ATOMIC_REQUESTS'] = False

--- a/lms/envs/devstack_with_worker.py
+++ b/lms/envs/devstack_with_worker.py
@@ -21,7 +21,3 @@ from lms.envs.devstack import *
 CELERY_ALWAYS_EAGER = False
 CLEAR_REQUEST_CACHE_ON_TASK_COMPLETION = True
 BROKER_URL = 'redis://:password@edx.devstack.redis:6379/'
-# Disable transaction management because we are using a worker. Views
-# that request a task and wait for the result will deadlock otherwise.
-for database_name in DATABASES:
-    DATABASES[database_name]['ATOMIC_REQUESTS'] = False


### PR DESCRIPTION
We run atomic-requests in almost all environments (for the lms and cms anyway) EXCEPT devstack_with_worker. Using a different setting means that even if you think you are testing with a worker like real deploys use, you are not actually testing with the data a worker would actually see.

The removed code also claims that if you run with atomic transactions and a worker you will deadlock the system. If so edx.org would be deadlocked at all times and yet is not. The old code was vintage 2015 and its assumptions probably haven't been examined since then.

Tested locally with this setup and the simple studio behavior I was actually fixing, it did not in fact deadlock and with this setup it actually replicates what we see in stage/prod.