### PR TITLE
fix: VAN-1206 - Resume last course URL defaults to request path for new users with no enrollments

### DIFF
--- a/openedx/core/djangoapps/user_authn/cookies.py
+++ b/openedx/core/djangoapps/user_authn/cookies.py
@@ -251,7 +251,9 @@ def _get_user_info_cookie_data(request, user):
 
     # Add 'resume course' last completed block
     try:
-        header_urls['resume_block'] = retrieve_last_sitewide_block_completed(user)
+        block_url = retrieve_last_sitewide_block_completed(user)
+        if block_url:
+            header_urls['resume_block'] = block_url
     except User.DoesNotExist:
         pass
     except Exception as err:  # pylint: disable=broad-except

--- a/openedx/core/djangoapps/user_authn/tests/test_cookies.py
+++ b/openedx/core/djangoapps/user_authn/tests/test_cookies.py
@@ -57,10 +57,12 @@ class CookieTests(TestCase):
     def _get_expected_header_urls(self):
         expected_header_urls = {
             'logout': reverse('logout'),
-            'resume_block': retrieve_last_sitewide_block_completed(self.user),
             'account_settings': reverse('account_settings'),
             'learner_profile': reverse('learner_profile', kwargs={'username': self.user.username}),
         }
+        block_url = retrieve_last_sitewide_block_completed(self.user)
+        if block_url:
+            expected_header_urls['resume_block'] = block_url
 
         expected_header_urls = self._convert_to_absolute_uris(self.request, expected_header_urls)
 


### PR DESCRIPTION
…

<!--

🫒🫒
🫒🫒🫒🫒         🫒 Note: the Olive master branch has been created.  Please consider whether your change
    🫒🫒🫒🫒     should also be applied to Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

🌰🌰🌰🌰🌰🌰     🌰 Note: the Nutmeg release is still supported.
                  Please consider whether your change should be applied to Nutmeg as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/openedx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

In a customer support ticket, it was reported that the click to 'resume your last course' on the marketing site's user profile dropdown redirects the login/register API endpoint and renders JSON.

After investigation, it was found that the `edx-user-info` Cookie has a `resume_block` property that has a `None` value for a new learner, and upon [build_absolute_uri](https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/user_authn/cookies.py#L263) on None results in default URI which is request path.

This issue is fixed by only calling the request `build_absolute_uri` when there is a valid resume_block value.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information
- https://2u-internal.atlassian.net/browse/CR-5420
- https://2u-internal.atlassian.net/browse/VAN-1206