### PR TITLE
fix: mail goals during the whole day, not just the morning

### DIFF
--- a/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
+++ b/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
@@ -205,10 +205,10 @@ class Command(BaseCommand):
         # Essentially, if today is Sunday, days_left_in_week should be 1 since they have Sunday to hit their goal.
         days_left_in_week = SUNDAY_WEEKDAY - today.weekday() + 1
 
-        # We want to email users in the morning of their timezone
+        # We want to email users during the day of their timezone
         user_timezone = get_user_timezone_or_last_seen_timezone_or_utc(goal.user)
         now_in_users_timezone = datetime.now(user_timezone)
-        if not 9 <= now_in_users_timezone.hour < 12:
+        if not 8 <= now_in_users_timezone.hour < 18:
             return False
 
         if required_days_left == days_left_in_week:

--- a/lms/djangoapps/course_goals/management/commands/tests/test_goal_reminder_email.py
+++ b/lms/djangoapps/course_goals/management/commands/tests/test_goal_reminder_email.py
@@ -110,9 +110,9 @@ class TestGoalReminderEmailCommand(TestCase):
         self.call_command(day=current_day, expect_sent=expect_sent)
 
     def test_will_send_at_the_right_time(self):
-        """ We only send the emails from 9am-12pm in the user's time"""
+        """ We only send the emails during the day in the user's time"""
         self.make_valid_goal()
-        self.call_command(expect_sent=False, time='2021-03-02 8:00:00')
+        self.call_command(expect_sent=False, time='2021-03-02 6:00:00')
         self.call_command(expect_sent=True, time='2021-03-02 10:00:00')
 
     def test_feature_disabled(self):


### PR DESCRIPTION
Goal mail jobs can easily take 4 hours to run and sometimes fail. Restricting the allowable mail window to three morning hours only means many goal mails will be missed.

Extend the window to the whole day so that mails are actually sent. It will still prefer to send mail in the morning because that is the first time it could encounter the goal and it will mark it as sent afterwards.
