### PR TITLE
Fix PII sharing bugs and enable PII sharing in LTI 1.3

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -668,7 +668,7 @@ libsass==0.10.0
     #   ora2
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==7.1.0
+lti-consumer-xblock==7.2.0
     # via -r requirements/edx/base.in
 lxml==4.9.1
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -889,7 +889,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/testing.txt
     #   ora2
-lti-consumer-xblock==7.1.0
+lti-consumer-xblock==7.2.0
     # via -r requirements/edx/testing.txt
 lxml==4.9.1
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -848,7 +848,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==7.1.0
+lti-consumer-xblock==7.2.0
     # via -r requirements/edx/base.txt
 lxml==4.9.1
     # via


### PR DESCRIPTION
<!--

🫒🫒
🫒🫒🫒🫒         🫒 Note: the Olive master branch has been created.  Please consider whether your change
    🫒🫒🫒🫒     should also be applied to Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

🌰🌰🌰🌰🌰🌰     🌰 Note: the Nutmeg release is still supported.
                  Please consider whether your change should be applied to Nutmeg as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/openedx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This commit upgrades the version of the lti-consumer-xblock library from version 7.1.0 to version 7.2.0. Version 7.2.0 includes a number of fixes to bugs relating to personally identifiable information (PII) sharing in LTI launches in both LTI 1.1 and LTI 1.3. Version 7.2.0 also enables PII sharing (username and email) in LTI 1.3 launches.

Please see the CHANGELOG entry for these versions for a full description of the changes: https://github.com/openedx/xblock-lti-consumer/blob/master/CHANGELOG.rst#720---2022-12-15.