### PR TITLE
chore: disable forum digest subscription section by default

### DIFF
--- a/lms/djangoapps/discussion/config/settings.py
+++ b/lms/djangoapps/discussion/config/settings.py
@@ -5,7 +5,7 @@ from django.conf import settings
 
 # .. toggle_name: FEATURES['ENABLE_FORUM_DAILY_DIGEST']
 # .. toggle_implementation: DjangoSetting
-# .. toggle_default: True
+# .. toggle_default: False
 # .. toggle_description: Settings for forums/discussions to on/off daily digest
 #   feature. Set this to True if you want to enable users to subscribe and unsubscribe
 #   for daily digest. This setting enables deprecation of daily digest.
@@ -16,4 +16,4 @@ ENABLE_FORUM_DAILY_DIGEST = 'enable_forum_daily_digest'
 
 def is_forum_daily_digest_enabled():
     """Returns whether forum notification features should be visible"""
-    return settings.FEATURES.get('ENABLE_FORUM_DAILY_DIGEST', True)
+    return settings.FEATURES.get('ENABLE_FORUM_DAILY_DIGEST', False)

--- a/lms/djangoapps/discussion/notification_prefs/tests.py
+++ b/lms/djangoapps/discussion/notification_prefs/tests.py
@@ -28,6 +28,7 @@ class NotificationPrefViewTest(UrlResetMixin, TestCase):  # lint-amnesty, pylint
     INITIALIZATION_VECTOR = b"\x00" * 16
 
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_FORUM_DAILY_DIGEST": True})
     def setUp(self):
         super().setUp()
         self.user = UserFactory.create(username="testuser")


### PR DESCRIPTION
### Current state of the feature
Initially, this feature used the [Notifier Django app](https://github.com/edx-unsupported/notifier) but was deprecated and [removed from the configuration](https://github.com/openedx/configuration/pull/6098) in favor of [edx-notifications](https://github.com/openedx-unsupported/edx-notifications). More info about this deprecation can be found in the [GitHub issue](https://github.com/openedx/build-test-release-wg/issues/22).

The edx-notifications app was not supported though, so its repository was archived and moved to [GitHub - openedx-unsupported/edx-notifications](https://github.com/openedx-unsupported/edx-notifications). Check the [deprecation ticket](https://github.com/openedx/edx-notifications/issues/253) and corresponding [discussion](https://discuss.openedx.org/t/deprecation-removal-edx-notifications-repository/6748) for details. 

### What remains in the edx-platform
The forum's initial page contains the how-to info with the notification preferences toggle:
![image](https://user-images.githubusercontent.com/47273130/208666502-dab8cc23-3838-4d31-b2ba-3da6aac8dc2d.png)


This section is responsible for toggling the "notification_pref" user preference (aka NOTIFICATION_PREF_KEY). I didn't find any usage of this preference across the platform, so I'm suggesting hiding it by default by setting the ENABLE_FORUM_DAILY_DIGEST setting default value to `False`.

The result will look like 
![image](https://user-images.githubusercontent.com/47273130/208670074-dac31003-8f44-488e-b0ab-b2d6ffbedc9a.png)
