### PR TITLE
feat: certificate config for old courses is taken from credentials

### DIFF
--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -612,7 +612,7 @@ def render_html_view(request, course_id, certificate=None):  # pylint: disable=t
 
     # Generate the certificate context in the correct language, then render the template.
     with translation.override(certificate_language):
-        context = {'user_language': user_language}
+        context = {'user_language': user_language, 'certificate_type': preview_mode or user_certificate.mode}
 
         _update_context_with_basic_info(context, course_id, platform_name, configuration)
 


### PR DESCRIPTION
Description: This pr offers functionality to take certificate configurations, including signatures, from Credential IDA for courses IDs that are deprecated.

ISSUE: https://github.com/openedx/credentials/issues/1765

Reviewers:

- [ ] @ormsbee


Merge checklist:

- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

Post merge:

- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)