### PR TITLE
fix: when making a hasty exit from goals, make sure to get the log out

### DIFF
--- a/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
+++ b/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
@@ -122,6 +122,8 @@ class Command(BaseCommand):
             self._handle_all_goals()
         except BaseException:  # pylint: disable=broad-except
             log.exception("Error while sending course goals emails: ")
+            for h in log.handlers:
+                h.flush()
             raise
 
     def _handle_all_goals(self):


### PR DESCRIPTION
Goals email continues to sometimes exit without providing any information, but I remembered the classic "blowing up before the loggers get onto disk" so let's give that a try.