### PR TITLE
fix: allow for entitlement with no psuedo-sessions

### DIFF
--- a/lms/djangoapps/learner_home/test_views.py
+++ b/lms/djangoapps/learner_home/test_views.py
@@ -325,6 +325,18 @@ class TestGetCourseOverviewsForPseudoSessions(SharedModuleStoreTestCase):
         # Then I should get an empty dict
         self.assertDictEqual(course_overviews, {})
 
+    def test_entitlement_without_pseudo_session(self):
+        # Given an unfulfilled entitlement which does not have a psuedo session
+        pseudo_sessions = {
+            uuid4(): None,
+        }
+
+        # When I query course overviews
+        course_overviews = get_course_overviews_for_pseudo_sessions(pseudo_sessions)
+
+        # Then I should gracefully return none for that entitlement
+        self.assertDictEqual(course_overviews, {})
+
 
 class TestGetEmailSettingsInfo(SharedModuleStoreTestCase):
     """Tests for get_email_settings_info"""

--- a/lms/djangoapps/learner_home/views.py
+++ b/lms/djangoapps/learner_home/views.py
@@ -182,6 +182,8 @@ def get_course_overviews_for_pseudo_sessions(unfulfilled_entitlement_pseudo_sess
 
     # Get course IDs from unfulfilled entitlement pseudo sessions
     for pseudo_session in unfulfilled_entitlement_pseudo_sessions.values():
+        if not pseudo_session:
+            continue
         course_id = pseudo_session.get("key")
         if course_id:
             course_ids.append(CourseKey.from_string(course_id))


### PR DESCRIPTION
## Description

It is possible to have an entitlement with no available course runs. In this case, the entitlement is filtered out by the view logic but the residual, bad pesudo-session mapping can cause breaks if we don't handle for this case.

JIRA: [AU-969](https://2u-internal.atlassian.net/browse/AU-969)
FIY: @openedx/content-aurora 

## Supporting information

Although the entitlement gathering code [filters out entitlements without available course runs](https://github.com/openedx/edx-platform/blob/master/common/djangoapps/student/views/dashboard.py#L239-L240), the old logic [still populates a pseudo-session lookup for the entitlement](https://github.com/openedx/edx-platform/blob/master/common/djangoapps/student/views/dashboard.py#L228) that, [unless intentionally handled](https://github.com/openedx/edx-platform/blob/master/lms/templates/dashboard.html#L194-L195), can cause us to try to operate on a `None` type and throw exceptions.

## Testing instructions

1. Create an entitlement for a course with no linked course runs.
2. Attempt to load the new Learner Home, or call the `{lms}/api/learner_home/init` endpoint and verify it does not error.
