### PR TITLE
[OldMongo FC-0004] Tests for removing support for children in Old Mongo - part 3

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_users_default_role.py
+++ b/cms/djangoapps/contentstore/tests/test_users_default_role.py
@@ -3,7 +3,9 @@ Unit tests for checking default forum role "Student" of a user when he creates a
 after deleting it creates same course again
 """
 
-from xmodule.modulestore.tests.django_utils import TEST_DATA_MONGO_AMNESTY_MODULESTORE, ModuleStoreTestCase
+from unittest import skip
+
+from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, ModuleStoreTestCase
 
 from cms.djangoapps.contentstore.tests.utils import AjaxEnabledTestClient
 from cms.djangoapps.contentstore.utils import delete_course, reverse_url
@@ -15,7 +17,7 @@ class TestUsersDefaultRole(ModuleStoreTestCase):
     """
     Unit tests for checking enrollment and default forum role "Student" of a logged in user
     """
-    MODULESTORE = TEST_DATA_MONGO_AMNESTY_MODULESTORE
+    MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
 
     def setUp(self):
         """
@@ -92,6 +94,8 @@ class TestUsersDefaultRole(ModuleStoreTestCase):
         # check that user has his default "Student" forum role for this course
         self.assertTrue(self.user.roles.filter(name="Student", course_id=self.course_key))
 
+    @skip("OldMongo Deprecation")
+    # Issue with case-insensitive course keys
     def test_user_role_on_course_recreate_with_change_name_case(self):
         """
         Test that creating same course again with different name case after deleting it gives user

--- a/cms/djangoapps/contentstore/tests/utils.py
+++ b/cms/djangoapps/contentstore/tests/utils.py
@@ -8,15 +8,13 @@ import json
 from django.conf import settings
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.test.client import Client
-from opaque_keys.edx.keys import AssetKey, CourseKey
+from opaque_keys.edx.keys import AssetKey
 from xmodule.contentstore.django import contentstore
-from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.inheritance import own_metadata
 from xmodule.modulestore.split_mongo.split import SplitMongoModuleStore
 from xmodule.modulestore.tests.django_utils import TEST_DATA_MONGO_MODULESTORE, ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 from xmodule.modulestore.tests.utils import ProceduralCourseTestMixin
-from xmodule.modulestore.xml_importer import import_course_from_xml
 from xmodule.tests.test_transcripts_utils import YoutubeVideoHTMLResponse
 
 from cms.djangoapps.contentstore.utils import reverse_url
@@ -124,158 +122,6 @@ class CourseTestCase(ProceduralCourseTestMixin, ModuleStoreTestCase):
     DRAFT_HTML = 'draft_html'
     DRAFT_VIDEO = 'draft_video'
     LOCKED_ASSET_KEY = AssetKey.from_string('/c4x/edX/toy/asset/sample_static.html')
-
-    def import_and_populate_course(self):
-        """
-        Imports the test toy course and populates it with additional test data
-        """
-        content_store = contentstore()
-        import_course_from_xml(self.store, self.user.id, TEST_DATA_DIR, ['toy'], static_content_store=content_store)
-        course_id = CourseKey.from_string('/'.join(['edX', 'toy', '2012_Fall']))
-
-        # create an Orphan
-        # We had a bug where orphaned draft nodes caused export to fail. This is here to cover that case.
-        vertical = self.store.get_item(course_id.make_usage_key('vertical', self.TEST_VERTICAL), depth=1)
-        vertical.location = vertical.location.replace(name='no_references')
-        self.store.update_item(vertical, self.user.id, allow_not_found=True)
-        orphan_vertical = self.store.get_item(vertical.location)
-        self.assertEqual(orphan_vertical.location.block_id, 'no_references')
-        self.assertEqual(len(orphan_vertical.children), len(vertical.children))
-
-        # create an orphan vertical and html; we already don't try to import
-        # the orphaned vertical, but we should make sure we don't import
-        # the orphaned vertical's child html, too
-        orphan_draft_vertical = self.store.create_item(
-            self.user.id, course_id, 'vertical', self.ORPHAN_DRAFT_VERTICAL
-        )
-        orphan_draft_html = self.store.create_item(
-            self.user.id, course_id, 'html', self.ORPHAN_DRAFT_HTML
-        )
-        orphan_draft_vertical.children.append(orphan_draft_html.location)
-        self.store.update_item(orphan_draft_vertical, self.user.id)
-
-        # create a Draft vertical
-        vertical = self.store.get_item(course_id.make_usage_key('vertical', self.TEST_VERTICAL), depth=1)
-        draft_vertical = self.store.convert_to_draft(vertical.location, self.user.id)
-        self.assertTrue(self.store.has_published_version(draft_vertical))
-
-        # create a Private (draft only) vertical
-        private_vertical = self.store.create_item(self.user.id, course_id, 'vertical', self.PRIVATE_VERTICAL)
-        self.assertFalse(self.store.has_published_version(private_vertical))
-
-        # create a Published (no draft) vertical
-        public_vertical = self.store.create_item(self.user.id, course_id, 'vertical', self.PUBLISHED_VERTICAL)
-        public_vertical = self.store.publish(public_vertical.location, self.user.id)
-        self.assertTrue(self.store.has_published_version(public_vertical))
-
-        # add the new private and new public as children of the sequential
-        sequential = self.store.get_item(course_id.make_usage_key('sequential', self.SEQUENTIAL))
-        sequential.children.append(private_vertical.location)
-        sequential.children.append(public_vertical.location)
-        self.store.update_item(sequential, self.user.id)
-
-        # create an html and video component to make drafts:
-        draft_html = self.store.create_item(self.user.id, course_id, 'html', self.DRAFT_HTML)
-        draft_video = self.store.create_item(self.user.id, course_id, 'video', self.DRAFT_VIDEO)
-
-        # add them as children to the public_vertical
-        public_vertical.children.append(draft_html.location)
-        public_vertical.children.append(draft_video.location)
-        self.store.update_item(public_vertical, self.user.id)
-        # publish changes to vertical
-        self.store.publish(public_vertical.location, self.user.id)
-        # convert html/video to draft
-        self.store.convert_to_draft(draft_html.location, self.user.id)
-        self.store.convert_to_draft(draft_video.location, self.user.id)
-
-        # lock an asset
-        content_store.set_attr(self.LOCKED_ASSET_KEY, 'locked', True)
-
-        # create a non-portable link - should be rewritten in new courses
-        html_block = self.store.get_item(course_id.make_usage_key('html', 'nonportable'))
-        new_data = html_block.data = html_block.data.replace(
-            '/static/',
-            f'/c4x/{course_id.org}/{course_id.course}/asset/'
-        )
-        self.store.update_item(html_block, self.user.id)
-
-        html_block = self.store.get_item(html_block.location)
-        self.assertEqual(new_data, html_block.data)
-
-        return course_id
-
-    def check_populated_course(self, course_id):
-        """
-        Verifies the content of the given course, per data that was populated in import_and_populate_course
-        """
-        items = self.store.get_items(
-            course_id,
-            qualifiers={'category': 'vertical'},
-            revision=ModuleStoreEnum.RevisionOption.published_only
-        )
-        self.check_verticals(items)
-
-        def verify_item_publish_state(item, publish_state):
-            """Verifies the publish state of the item is as expected."""
-            self.assertEqual(self.store.has_published_version(item), publish_state)
-
-        def get_and_verify_publish_state(item_type, item_name, publish_state):
-            """
-            Gets the given item from the store and verifies the publish state
-            of the item is as expected.
-            """
-            item = self.store.get_item(course_id.make_usage_key(item_type, item_name))
-            verify_item_publish_state(item, publish_state)
-            return item
-
-        # verify draft vertical has a published version with published children
-        vertical = get_and_verify_publish_state('vertical', self.TEST_VERTICAL, True)
-        for child in vertical.get_children():
-            verify_item_publish_state(child, True)
-
-        # verify that it has a draft too
-        self.assertTrue(getattr(vertical, "is_draft", False))
-
-        # make sure that we don't have a sequential that is in draft mode
-        sequential = get_and_verify_publish_state('sequential', self.SEQUENTIAL, True)
-        self.assertFalse(getattr(sequential, "is_draft", False))
-
-        # verify that we have the private vertical
-        private_vertical = get_and_verify_publish_state('vertical', self.PRIVATE_VERTICAL, False)
-
-        # verify that we have the public vertical
-        public_vertical = get_and_verify_publish_state('vertical', self.PUBLISHED_VERTICAL, True)
-
-        # verify that we have the draft html
-        draft_html = self.store.get_item(course_id.make_usage_key('html', self.DRAFT_HTML))
-        self.assertTrue(getattr(draft_html, 'is_draft', False))
-
-        # verify that we have the draft video
-        draft_video = self.store.get_item(course_id.make_usage_key('video', self.DRAFT_VIDEO))
-        self.assertTrue(getattr(draft_video, 'is_draft', False))
-
-        # verify verticals are children of sequential
-        for vert in [vertical, private_vertical, public_vertical]:
-            self.assertIn(vert.location, sequential.children)
-
-        # verify draft html is the child of the public vertical
-        self.assertIn(draft_html.location, public_vertical.children)
-
-        # verify draft video is the child of the public vertical
-        self.assertIn(draft_video.location, public_vertical.children)
-
-        # verify textbook exists
-        course = self.store.get_course(course_id)
-        self.assertGreater(len(course.textbooks), 0)
-
-        # verify asset attributes of locked asset key
-        self.assertAssetsEqual(self.LOCKED_ASSET_KEY, self.LOCKED_ASSET_KEY.course_key, course_id)
-
-        # verify non-portable links are rewritten
-        html_block = self.store.get_item(course_id.make_usage_key('html', 'nonportable'))
-        self.assertIn('/static/foo.jpg', html_block.data)
-
-        return course
 
     def assertCoursesEqual(self, course1_id, course2_id):
         """

--- a/cms/djangoapps/contentstore/views/tests/test_assets.py
+++ b/cms/djangoapps/contentstore/views/tests/test_assets.py
@@ -27,6 +27,7 @@ from xmodule.contentstore.django import contentstore  # lint-amnesty, pylint: di
 from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.xml_importer import import_course_from_xml  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE
 
 TEST_DATA_DIR = settings.COMMON_TEST_DATA_ROOT
 
@@ -41,6 +42,9 @@ class AssetsTestCase(CourseTestCase):
     """
     Parent class for all asset tests.
     """
+
+    MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
+
     def setUp(self):
         super().setUp()
         self.url = reverse_course_url('assets_handler', self.course.id)
@@ -96,6 +100,7 @@ class BasicAssetsTestCase(AssetsTestCase):
             TEST_DATA_DIR,
             ['toy'],
             static_content_store=contentstore(),
+            create_if_not_present=True,
             verbose=True
         )
         course = course_items[0]
@@ -103,8 +108,8 @@ class BasicAssetsTestCase(AssetsTestCase):
 
         # Test valid contentType for pdf asset (textbook.pdf)
         resp = self.client.get(url, HTTP_ACCEPT='application/json')
-        self.assertContains(resp, "/c4x/edX/toy/asset/textbook.pdf")
-        asset_location = AssetKey.from_string('/c4x/edX/toy/asset/textbook.pdf')
+        self.assertContains(resp, "/asset-v1:edX+toy+2012_Fall+type@asset+block@textbook.pdf")
+        asset_location = AssetKey.from_string('asset-v1:edX+toy+2012_Fall+type@asset+block@textbook.pdf')
         content = contentstore().find(asset_location)
         # Check after import textbook.pdf has valid contentType ('application/pdf')
 
@@ -450,7 +455,8 @@ class LockAssetTestCase(AssetsTestCase):
         """
         def verify_asset_locked_state(locked):
             """ Helper method to verify lock state in the contentstore """
-            asset_location = StaticContent.get_location_from_path('/c4x/edX/toy/asset/sample_static.html')
+            asset_location = StaticContent.get_location_from_path(
+                'asset-v1:edX+toy+2012_Fall+type@asset+block@sample_static.html')
             content = contentstore().find(asset_location)
             self.assertEqual(content.locked, locked)
 
@@ -483,6 +489,7 @@ class LockAssetTestCase(AssetsTestCase):
             TEST_DATA_DIR,
             ['toy'],
             static_content_store=contentstore(),
+            create_if_not_present=True,
             verbose=True
         )
         course = course_items[0]
@@ -513,15 +520,15 @@ class DeleteAssetTestCase(AssetsTestCase):
 
         response = self.client.post(self.url, {"name": self.asset_name, "file": self.asset})
         self.assertEqual(response.status_code, 200)
-        self.uploaded_url = json.loads(response.content.decode('utf-8'))['asset']['url']
+        self.uploaded_id = json.loads(response.content.decode('utf-8'))['asset']['id']
 
-        self.asset_location = AssetKey.from_string(self.uploaded_url)
+        self.asset_location = AssetKey.from_string(self.uploaded_id)
         self.content = contentstore().find(self.asset_location)
 
     def test_delete_asset(self):
         """ Tests the happy path :) """
         test_url = reverse_course_url(
-            'assets_handler', self.course.id, kwargs={'asset_key_string': str(self.uploaded_url)})
+            'assets_handler', self.course.id, kwargs={'asset_key_string': self.uploaded_id})
         resp = self.client.delete(test_url, HTTP_ACCEPT="application/json")
         self.assertEqual(resp.status_code, 204)
 
@@ -533,7 +540,7 @@ class DeleteAssetTestCase(AssetsTestCase):
         # upload image
         response = self.client.post(self.url, {"name": "delete_image_test", "file": image_asset})
         self.assertEqual(response.status_code, 200)
-        uploaded_image_url = json.loads(response.content.decode('utf-8'))['asset']['url']
+        uploaded_image_url = json.loads(response.content.decode('utf-8'))['asset']['id']
 
         # upload image thumbnail
         response = self.client.post(self.url, {"name": "delete_image_thumb_test", "file": thumbnail_image_asset})
@@ -558,7 +565,7 @@ class DeleteAssetTestCase(AssetsTestCase):
         """ Tests the sad path :( """
         test_url = reverse_course_url(
             'assets_handler',
-            self.course.id, kwargs={'asset_key_string': "/c4x/edX/toy/asset/invalid.pdf"}
+            self.course.id, kwargs={'asset_key_string': "asset-v1:edX+toy+2012_Fall+type@asset+block@invalid.pdf"}
         )
         resp = self.client.delete(test_url, HTTP_ACCEPT="application/json")
         self.assertEqual(resp.status_code, 404)
@@ -566,8 +573,9 @@ class DeleteAssetTestCase(AssetsTestCase):
     def test_delete_asset_with_invalid_thumbnail(self):
         """ Tests the sad path :( """
         test_url = reverse_course_url(
-            'assets_handler', self.course.id, kwargs={'asset_key_string': str(self.uploaded_url)})
-        self.content.thumbnail_location = StaticContent.get_location_from_path('/c4x/edX/toy/asset/invalid')
+            'assets_handler', self.course.id, kwargs={'asset_key_string': self.uploaded_id})
+        self.content.thumbnail_location = StaticContent.get_location_from_path(
+            '/asset-v1:edX+toy+2012_Fall+type@asset+block@invalid.pdf')
         contentstore().save(self.content)
         resp = self.client.delete(test_url, HTTP_ACCEPT="application/json")
         self.assertEqual(resp.status_code, 204)

--- a/cms/lib/xblock/test/test_authoring_mixin.py
+++ b/cms/lib/xblock/test/test_authoring_mixin.py
@@ -6,7 +6,7 @@ Tests for the Studio authoring XBlock mixin.
 from django.conf import settings
 from django.test.utils import override_settings
 from xblock.core import XBlock
-from xmodule.modulestore.tests.django_utils import TEST_DATA_MONGO_AMNESTY_MODULESTORE, ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from xmodule.partitions.partitions import (
     ENROLLMENT_TRACK_PARTITION_ID,
@@ -23,7 +23,7 @@ class AuthoringMixinTestCase(ModuleStoreTestCase):
     """
     Tests the studio authoring XBlock mixin.
     """
-    MODULESTORE = TEST_DATA_MONGO_AMNESTY_MODULESTORE
+    MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
     GROUP_NO_LONGER_EXISTS = "This group no longer exists"
     NO_CONTENT_OR_ENROLLMENT_GROUPS = "Access to this component is not restricted"
     NO_CONTENT_ENROLLMENT_TRACK_ENABLED = "You can restrict access to this component to learners in specific enrollment tracks or content groups"  # lint-amnesty, pylint: disable=line-too-long
@@ -44,27 +44,27 @@ class AuthoringMixinTestCase(ModuleStoreTestCase):
         self.course = CourseFactory.create()
         chapter = ItemFactory.create(
             category='chapter',
-            parent_location=self.course.location,
+            parent=self.course,
             display_name='Test Chapter'
         )
         sequential = ItemFactory.create(
             category='sequential',
-            parent_location=chapter.location,
+            parent=chapter,
             display_name='Test Sequential'
         )
         vertical = ItemFactory.create(
             category='vertical',
-            parent_location=sequential.location,
+            parent=sequential,
             display_name='Test Vertical'
         )
         video = ItemFactory.create(
             category='video',
-            parent_location=vertical.location,
+            parent=vertical,
             display_name='Test Vertical'
         )
         pure = ItemFactory.create(
             category='pure',
-            parent_location=vertical.location,
+            parent=vertical,
             display_name='Test Pure'
         )
         self.vertical_location = vertical.location

--- a/openedx/core/djangoapps/content/course_overviews/tests/test_signals.py
+++ b/openedx/core/djangoapps/content/course_overviews/tests/test_signals.py
@@ -6,10 +6,11 @@ from collections import namedtuple
 
 import pytest
 import ddt
+from pytz import UTC
 
 from xmodule.data import CertificatesDisplayBehaviors
 from xmodule.modulestore import ModuleStoreEnum
-from xmodule.modulestore.tests.django_utils import TEST_DATA_MONGO_AMNESTY_MODULESTORE, ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import TEST_DATA_ONLY_SPLIT_MODULESTORE_DRAFT_PREFERRED, ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, check_mongo_calls
 
 from ..models import CourseOverview
@@ -23,13 +24,12 @@ class CourseOverviewSignalsTestCase(ModuleStoreTestCase):
     """
     Tests for CourseOverview signals.
     """
-    MODULESTORE = TEST_DATA_MONGO_AMNESTY_MODULESTORE
+    MODULESTORE = TEST_DATA_ONLY_SPLIT_MODULESTORE_DRAFT_PREFERRED
     ENABLED_SIGNALS = ['course_deleted', 'course_published']
-    TODAY = datetime.datetime.utcnow()
+    TODAY = datetime.datetime.utcnow().replace(tzinfo=UTC)
     NEXT_WEEK = TODAY + datetime.timedelta(days=7)
 
-    @ddt.data(ModuleStoreEnum.Type.split)
-    def test_caching(self, modulestore_type):
+    def test_caching(self):
         """
         Tests that CourseOverview structures are actually getting cached.
 
@@ -38,14 +38,13 @@ class CourseOverviewSignalsTestCase(ModuleStoreTestCase):
                 course in.
         """
         # Creating a new course will trigger a publish event and the course will be cached
-        course = CourseFactory.create(default_store=modulestore_type, emit_signals=True)
+        course = CourseFactory.create(emit_signals=True)
 
         # The cache will be hit and mongo will not be queried
         with check_mongo_calls(0):
             CourseOverview.get_from_id(course.id)
 
-    @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
-    def test_cache_invalidation(self, modulestore_type):
+    def test_cache_invalidation(self):
         """
         Tests that when a course is published or deleted, the corresponding
         course_overview is removed from the cache.
@@ -54,28 +53,26 @@ class CourseOverviewSignalsTestCase(ModuleStoreTestCase):
             modulestore_type (ModuleStoreEnum.Type): type of store to create the
                 course in.
         """
-        with self.store.default_store(modulestore_type):
+        # Create a course where mobile_available is True.
+        course = CourseFactory.create(mobile_available=True)
+        course_overview_1 = CourseOverview.get_from_id(course.id)
+        assert course_overview_1.mobile_available
 
-            # Create a course where mobile_available is True.
-            course = CourseFactory.create(mobile_available=True, default_store=modulestore_type)
-            course_overview_1 = CourseOverview.get_from_id(course.id)
-            assert course_overview_1.mobile_available
+        # Set mobile_available to False and update the course.
+        # This fires a course_published signal, which should be caught in signals.py, which should in turn
+        # delete the corresponding CourseOverview from the cache.
+        course.mobile_available = False
+        with self.store.branch_setting(ModuleStoreEnum.Branch.draft_preferred):
+            self.store.update_item(course, ModuleStoreEnum.UserID.test)
 
-            # Set mobile_available to False and update the course.
-            # This fires a course_published signal, which should be caught in signals.py, which should in turn
-            # delete the corresponding CourseOverview from the cache.
-            course.mobile_available = False
-            with self.store.branch_setting(ModuleStoreEnum.Branch.draft_preferred):
-                self.store.update_item(course, ModuleStoreEnum.UserID.test)
+        # Make sure that when we load the CourseOverview again, mobile_available is updated.
+        course_overview_2 = CourseOverview.get_from_id(course.id)
+        assert not course_overview_2.mobile_available
 
-            # Make sure that when we load the CourseOverview again, mobile_available is updated.
-            course_overview_2 = CourseOverview.get_from_id(course.id)
-            assert not course_overview_2.mobile_available
-
-            # Verify that when the course is deleted, the corresponding CourseOverview is deleted as well.
-            with pytest.raises(CourseOverview.DoesNotExist):
-                self.store.delete_course(course.id, ModuleStoreEnum.UserID.test)
-                CourseOverview.get_from_id(course.id)
+        # Verify that when the course is deleted, the corresponding CourseOverview is deleted as well.
+        with pytest.raises(CourseOverview.DoesNotExist):
+            self.store.delete_course(course.id, ModuleStoreEnum.UserID.test)
+            CourseOverview.get_from_id(course.id)
 
     def assert_changed_signal_sent(self, changes, mock_signal):  # lint-amnesty, pylint: disable=missing-function-docstring
         course = CourseFactory.create(
@@ -86,7 +83,7 @@ class CourseOverviewSignalsTestCase(ModuleStoreTestCase):
         # changing display name doesn't fire the signal
         with self.captureOnCommitCallbacks(execute=True) as callbacks:
             course.display_name = course.display_name + 'changed'
-            self.store.update_item(course, ModuleStoreEnum.UserID.test)
+            course = self.store.update_item(course, ModuleStoreEnum.UserID.test)
         assert not mock_signal.called
 
         # changing the given field fires the signal

--- a/openedx/core/lib/tests/test_xblock_utils.py
+++ b/openedx/core/lib/tests/test_xblock_utils.py
@@ -13,7 +13,7 @@ from opaque_keys.edx.asides import AsideUsageKeyV1, AsideUsageKeyV2
 from web_fragments.fragment import Fragment
 from xblock.core import XBlockAside
 from xmodule.modulestore import ModuleStoreEnum
-from xmodule.modulestore.tests.django_utils import TEST_DATA_MONGO_AMNESTY_MODULESTORE, SharedModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from xmodule.modulestore.tests.test_asides import AsideTestType
 
@@ -38,13 +38,7 @@ class TestXblockUtils(SharedModuleStoreTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.course_mongo = CourseFactory.create(
-            default_store=ModuleStoreEnum.Type.mongo,
-            org='TestX',
-            number='TS01',
-            run='2015'
-        )
-        cls.course_split = CourseFactory.create(
+        cls.course = CourseFactory.create(
             default_store=ModuleStoreEnum.Type.split,
             org='TestX',
             number='TS02',
@@ -86,21 +80,15 @@ class TestXblockUtils(SharedModuleStoreTestCase):
         test_uuid = uuid.UUID(token, version=1)
         assert token == test_uuid.hex
 
-    @ddt.data(
-        ('course_mongo', 'data-usage-id="i4x:;_;_TestX;_TS01;_course;_2015"'),
-        ('course_split', 'data-usage-id="block-v1:TestX+TS02+2015+type@course+block@course"')
-    )
-    @ddt.unpack
-    def test_wrap_xblock(self, course_id, data_usage_id):
+    def test_wrap_xblock(self):
         """
         Verify that new content is added and the resources are the same.
         """
         fragment = self.create_fragment("<h1>Test!</h1>")
         fragment.initialize_js('BlockMain')  # wrap_block() sets some attributes only if there is JS.
-        course = getattr(self, course_id)
         test_wrap_output = wrap_xblock(
             runtime_class='TestRuntime',
-            block=course,
+            block=self.course,
             view='baseview',
             frag=fragment,
             context={"wrap_xblock_data": {"custom-attribute": "custom-value"}},
@@ -110,7 +98,7 @@ class TestXblockUtils(SharedModuleStoreTestCase):
         assert isinstance(test_wrap_output, Fragment)
         assert 'xblock-baseview' in test_wrap_output.content
         assert 'data-runtime-class="TestRuntime"' in test_wrap_output.content
-        assert data_usage_id in test_wrap_output.content
+        assert 'data-usage-id="block-v1:TestX+TS02+2015+type@course+block@course"' in test_wrap_output.content
         assert '<h1>Test!</h1>' in test_wrap_output.content
         assert 'data-custom-attribute="custom-value"' in test_wrap_output.content
         assert test_wrap_output.resources[0].data == 'body {background-color:red;}'
@@ -170,13 +158,13 @@ class TestXblockUtils(SharedModuleStoreTestCase):
 
 class TestXBlockAside(SharedModuleStoreTestCase):
     """Test the xblock aside function."""
-    MODULESTORE = TEST_DATA_MONGO_AMNESTY_MODULESTORE
+    MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
         cls.course = CourseFactory.create()
-        cls.block = ItemFactory.create(category='aside', parent=cls.course)
+        cls.block = ItemFactory.create(parent=cls.course)
         cls.aside_v2 = AsideUsageKeyV2(cls.block.scope_ids.usage_id, "aside")
         cls.aside_v1 = AsideUsageKeyV1(cls.block.scope_ids.usage_id, "aside")
 


### PR DESCRIPTION
## Description
Should be merged after: https://github.com/openedx/edx-platform/pull/31427
Third part of preparing tests for `Remove support for children in Old Mongo` task (https://github.com/openedx/edx-platform/pull/31134).

* updated test_authoring_mixin.py
* updated test_xblock_utils.py
* updated TestOnboardingView tests (updated default course key)
* updated UsersDefaultRole tests

Useful information to include:
First part: https://github.com/openedx/edx-platform/pull/31422
Second part: https://github.com/openedx/edx-platform/pull/31427
Remove support for children in Old Mongo PR: https://github.com/openedx/edx-platform/pull/31134
https://github.com/openedx/public-engineering/issues/80