### PR TITLE
fix: TNL-10267 video blocks load wrong editor

### DIFF
--- a/cms/djangoapps/contentstore/toggles.py
+++ b/cms/djangoapps/contentstore/toggles.py
@@ -116,7 +116,9 @@ ENABLE_NEW_VIDEO_EDITOR_FLAG = WaffleFlag('new_core_editors.use_new_video_editor
 
 
 def use_new_video_editor():
-    return True
+    # TODO: Remove next 2 lines
+    # uncomment next line to test new video editor redirect
+    # return True
     """
     Returns a boolean = true if new video editor is enabled
     """

--- a/cms/djangoapps/contentstore/toggles.py
+++ b/cms/djangoapps/contentstore/toggles.py
@@ -116,9 +116,6 @@ ENABLE_NEW_VIDEO_EDITOR_FLAG = WaffleFlag('new_core_editors.use_new_video_editor
 
 
 def use_new_video_editor():
-    # TODO: Remove next 2 lines
-    # uncomment next line to test new video editor redirect
-    # return True
     """
     Returns a boolean = true if new video editor is enabled
     """

--- a/cms/djangoapps/contentstore/toggles.py
+++ b/cms/djangoapps/contentstore/toggles.py
@@ -116,6 +116,7 @@ ENABLE_NEW_VIDEO_EDITOR_FLAG = WaffleFlag('new_core_editors.use_new_video_editor
 
 
 def use_new_video_editor():
+    return True
     """
     Returns a boolean = true if new video editor is enabled
     """

--- a/cms/static/js/views/pages/container.js
+++ b/cms/static/js/views/pages/container.js
@@ -183,8 +183,6 @@ define(['jquery', 'underscore', 'backbone', 'gettext', 'js/views/pages/base_page
             editXBlock: function(event, options) {
                 event.preventDefault();
 
-                debugger;
-
                 if(!options || options.view !== 'visibility_view' ){
                     const primaryHeader = $(event.target).closest('.xblock-header-primary')
 
@@ -192,6 +190,7 @@ define(['jquery', 'underscore', 'backbone', 'gettext', 'js/views/pages/base_page
                     useNewVideoEditor = primaryHeader.attr("use-new-editor-video"),
                     useNewProblemEditor = primaryHeader.attr("use-new-editor-problem"),
                     blockType = primaryHeader.attr("data-block-type");
+
                     if( (useNewTextEditor === "True" && blockType === "html") ||
                         (useNewVideoEditor === "True" && blockType === "video") ||
                         (useNewProblemEditor === "True" && blockType === "problem")

--- a/cms/static/js/views/pages/container.js
+++ b/cms/static/js/views/pages/container.js
@@ -181,25 +181,32 @@ define(['jquery', 'underscore', 'backbone', 'gettext', 'js/views/pages/base_page
             },
 
             editXBlock: function(event, options) {
-                var xblockElement = this.findXBlockElement(event.target),
-                    self = this,
-                    modal = new EditXBlockModal(options);
                 event.preventDefault();
 
+                debugger;
+
                 if(!options || options.view !== 'visibility_view' ){
-                    var useNewTextEditor = this.$('.xblock-header-primary').attr("use-new-editor-text"),
-                    useNewVideoEditor = this.$('.xblock-header-primary').attr("use-new-editor-video"),
-                    useNewProblemEditor = this.$('.xblock-header-primary').attr("use-new-editor-problem"),
-                    blockType = xblockElement.find('.xblock').attr("data-block-type");
+                    const primaryHeader = $(event.target).closest('.xblock-header-primary')
+
+                    var useNewTextEditor = primaryHeader.attr("use-new-editor-text"),
+                    useNewVideoEditor = primaryHeader.attr("use-new-editor-video"),
+                    useNewProblemEditor = primaryHeader.attr("use-new-editor-problem"),
+                    blockType = primaryHeader.attr("data-block-type");
                     if( (useNewTextEditor === "True" && blockType === "html") ||
                         (useNewVideoEditor === "True" && blockType === "video") ||
                         (useNewProblemEditor === "True" && blockType === "problem")
                     ) {
-                        var destinationUrl = this.$('.xblock-header-primary').attr("authoring_MFE_base_url") + '/' + blockType + '/' + encodeURI(xblockElement.find('.xblock').attr("data-usage-id"));
+                        var destinationUrl = primaryHeader.attr("authoring_MFE_base_url") + '/' + blockType + '/' + encodeURI(primaryHeader.attr("data-usage-id"));
                         window.location.href = destinationUrl;
                         return;
                     }
                 }
+
+                // xblockElement is undefined when hiding previews in the Content Library
+                var xblockElement = this.findXBlockElement(event.target),
+                self = this,
+                modal = new EditXBlockModal(options);
+
                 modal.edit(xblockElement, this.model, {
                     readOnlyView: !this.options.canEdit,
                     refresh: function() {

--- a/cms/static/js/views/pages/container.js
+++ b/cms/static/js/views/pages/container.js
@@ -201,7 +201,6 @@ define(['jquery', 'underscore', 'backbone', 'gettext', 'js/views/pages/base_page
                     }
                 }
 
-                // xblockElement is undefined when hiding previews in the Content Library
                 var xblockElement = this.findXBlockElement(event.target),
                 self = this,
                 modal = new EditXBlockModal(options);

--- a/cms/templates/studio_xblock_wrapper.html
+++ b/cms/templates/studio_xblock_wrapper.html
@@ -64,6 +64,8 @@ block_is_unit = is_unit(xblock)
     use-new-editor-video = ${use_new_editor_video}
     use-new-editor-problem = ${use_new_editor_problem}
     authoring_MFE_base_url = ${get_editor_page_base_url(xblock.location.course_key)}
+    data-block-type = ${xblock.scope_ids.block_type}
+    data-usage-id = ${xblock.scope_ids.usage_id}
     >
         <div class="header-details">
             % if show_inline:
@@ -85,7 +87,7 @@ block_is_unit = is_unit(xblock)
                     % if can_edit:
                         % if not show_inline:
                             <li class="action-item action-edit">
-                                <button class="btn-default edit-button action-button">
+                                <button class="btn-default edit-button action-button" data-usage-id=${xblock.scope_ids.usage_id}>
                                     <span class="icon fa fa-pencil" aria-hidden="true"></span>
                                     <span class="action-button-text">${_("Edit")}</span>
                                 </button>


### PR DESCRIPTION
## Description

This fixes https://2u-internal.atlassian.net/browse/TNL-10267, a bug that prevents the edit video settings button in the studio library view to redirect to the new editor when previews are hidden. The problem was that the xblock that has the information for the redirect url is not loaded. I fixed it by adding this information to the xblock-header as well.

## Testing instructions

Steps to reproduce:

1. Go into a content library
2. Add a video block
3. Ensure Previews are shown, click edit
  a. Go to the new video editor
4. Close, and Hide Previews, click edit again
  a. See an old version of the editor
 
The edit button should always take you to the same place, no matter the state of the blocks.

## Other information

- To test locally, uncomment line 121 in toggles.py (see my change - I added a statement for debugging there)
- before merge, remove this debugging statement

## Questions

- Can I add any tests?