### PR TITLE
chore: bumping enterprise package version to latest

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -25,7 +25,7 @@ django-storages<1.9
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==3.60.1
+edx-enterprise==3.60.3
 
 # oauthlib>3.0.1 causes test failures ( also remove the django-oauth-toolkit constraint when this is fixed )
 oauthlib==3.0.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -477,7 +477,7 @@ edx-drf-extensions==8.3.1
     #   edx-when
     #   edxval
     #   learner-pathway-progress
-edx-enterprise==3.60.1
+edx-enterprise==3.60.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -597,7 +597,7 @@ edx-drf-extensions==8.3.1
     #   edx-when
     #   edxval
     #   learner-pathway-progress
-edx-enterprise==3.60.1
+edx-enterprise==3.60.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -577,7 +577,7 @@ edx-drf-extensions==8.3.1
     #   edx-when
     #   edxval
     #   learner-pathway-progress
-edx-enterprise==3.60.1
+edx-enterprise==3.60.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
https://github.com/openedx/edx-enterprise/pull/1695
https://github.com/openedx/edx-enterprise/pull/1694
https://github.com/openedx/edx-enterprise/pull/1692

<!--

🎉🎉 Olive has been released! 🎉🎉

🫒🫒
🫒🫒🫒🫒         🫒 Note: Olive is in support. Fixes you make on master may still
    🫒🫒🫒🫒     be needed on Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/openedx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
