### PR TITLE
docs: remove a link to a closed pull request

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,9 +12,11 @@ Please give your pull request a short but descriptive title.
 Use conventional commits to separate and summarize commits logically:
 https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html
 
-Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-More details about the template are at https://github.com/openedx/open-edx-proposals/pull/180
-(link will be updated when that document merges)
+Use this template as a guide. Omit sections that don't apply.
+You may link to information rather than copy it, but only if the link is publicly
+readable.  If you must linked information must be private (because it has secrets),
+clearly label the link as private.
+
 -->
 
 ## Description


### PR DESCRIPTION
I had hopes that the OEP would be merged, but it wasn't, so don't use it as a reference anymore.

