### PR TITLE
feat: VAN-1120 - Add 2U widget context API endpoint to learner home

### DIFF
--- a/lms/djangoapps/learner_home/twou_widgets/serializers.py
+++ b/lms/djangoapps/learner_home/twou_widgets/serializers.py
@@ -1,0 +1,11 @@
+"""
+Serializers for TwoU widget context.
+"""
+
+from rest_framework import serializers
+
+
+class TwoUWidgetContextSerializer(serializers.Serializer):
+    """Serializer for TwoU widget context."""
+
+    countryCode = serializers.CharField(allow_blank=True)

--- a/lms/djangoapps/learner_home/twou_widgets/test_serializers.py
+++ b/lms/djangoapps/learner_home/twou_widgets/test_serializers.py
@@ -1,0 +1,43 @@
+"""Tests for serializers for the Learner Home"""
+
+from django.test import TestCase
+
+from lms.djangoapps.learner_home.twou_widgets.serializers import (
+    TwoUWidgetContextSerializer,
+)
+
+
+class TestTwoUWidgetContextSerializer(TestCase):
+    """High-level tests for TwoUWidgetContextSerializer"""
+
+    def test_empty(self):
+        """Test that empty input returns the right output"""
+
+        output_data = TwoUWidgetContextSerializer(
+            {
+                "countryCode": "",
+            }
+        ).data
+
+        self.assertDictEqual(
+            output_data,
+            {
+                "countryCode": "",
+            },
+        )
+
+    def test_happy_path(self):
+        """Test that data serializes correctly"""
+
+        output_data = TwoUWidgetContextSerializer(
+            {
+                "countryCode": "US",
+            }
+        ).data
+
+        self.assertDictEqual(
+            output_data,
+            {
+                "countryCode": "US",
+            },
+        )

--- a/lms/djangoapps/learner_home/twou_widgets/test_views.py
+++ b/lms/djangoapps/learner_home/twou_widgets/test_views.py
@@ -1,0 +1,49 @@
+"""
+Tests for TwoU widget context
+"""
+
+import json
+from unittest.mock import patch
+
+import ddt
+from django.urls import reverse_lazy
+from rest_framework.test import APITestCase
+
+from common.djangoapps.student.tests.factories import UserFactory
+
+
+@ddt.ddt
+class TestTwoUWidgetContextView(APITestCase):
+    """Tests for the TwoU widget context."""
+
+    password = "test"
+    view_url = reverse_lazy("learner_home:twou_widget_context")
+
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory()
+
+    @ddt.data("US", "")
+    @patch("lms.djangoapps.learner_home.twou_widgets.views.country_code_from_ip")
+    def test_country_code_from_ip(self, country_code, mock_country_code_from_ip):
+        """Test that country code gets populated correctly."""
+
+        mock_country_code_from_ip.return_value = country_code
+
+        # Given I am logged in.
+        self.client.login(username=self.user.username, password=self.password)
+
+        # When I request for TwoU widget context.
+        response = self.client.get(self.view_url)
+
+        response_data = json.loads(response.content)
+        self.assertEqual(response_data["countryCode"], country_code)
+
+    def test_unauthenticated_request(self):
+        """
+        Test unauthenticated request to TwoU widget context API view.
+        """
+
+        # When I request for TwoU widget context without logging in.
+        response = self.client.get(self.view_url)
+        self.assertEqual(response.status_code, 401)

--- a/lms/djangoapps/learner_home/twou_widgets/urls.py
+++ b/lms/djangoapps/learner_home/twou_widgets/urls.py
@@ -1,0 +1,13 @@
+"""Learner home URL routing configuration"""
+
+from django.urls import path
+
+from lms.djangoapps.learner_home.twou_widgets import views
+
+urlpatterns = [
+    path(
+        "",
+        views.TwoUWidgetContextView.as_view(),
+        name="twou_widget_context",
+    ),
+]

--- a/lms/djangoapps/learner_home/twou_widgets/views.py
+++ b/lms/djangoapps/learner_home/twou_widgets/views.py
@@ -1,0 +1,52 @@
+"""
+Views for TwoU widget context in Learner Home
+"""
+
+from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
+from edx_rest_framework_extensions.auth.session.authentication import (
+    SessionAuthenticationAllowInactiveUser,
+)
+from edx_rest_framework_extensions.permissions import NotJwtRestrictedApplication
+from ipware.ip import get_client_ip
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from lms.djangoapps.learner_home.twou_widgets.serializers import (
+    TwoUWidgetContextSerializer,
+)
+from openedx.core.djangoapps.geoinfo.api import country_code_from_ip
+
+
+class TwoUWidgetContextView(APIView):
+    """
+    API to get the widget context i.e country code from the IP address.
+
+    **Example Request**
+
+    GET /api/learner_home/twou_widget_context/
+    """
+
+    authentication_classes = (
+        JwtAuthentication,
+        SessionAuthenticationAllowInactiveUser,
+    )
+    permission_classes = (IsAuthenticated, NotJwtRestrictedApplication)
+
+    def get(self, request):
+        """
+        Retrieves the TwoU widget context.
+        """
+        user_ip_address = get_client_ip(request)[0]
+
+        # Get country code from user IP address.
+        country_code = country_code_from_ip(user_ip_address)
+
+        return Response(
+            TwoUWidgetContextSerializer(
+                {
+                    "countryCode": country_code,
+                }
+            ).data,
+            status=200,
+        )

--- a/lms/djangoapps/learner_home/urls.py
+++ b/lms/djangoapps/learner_home/urls.py
@@ -15,4 +15,7 @@ urlpatterns = [
     re_path(
         r"^recommendation/", include("lms.djangoapps.learner_home.recommendations.urls")
     ),
+    re_path(
+        r"^twou_widget_context/", include("lms.djangoapps.learner_home.twou_widgets.urls")
+    ),
 ]


### PR DESCRIPTION
<!--

🎉🎉 Olive has been released! 🎉🎉

🫒🫒
🫒🫒🫒🫒         🫒 Note: Olive is in support. Fixes you make on master may still
    🫒🫒🫒🫒     be needed on Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/openedx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This PR fetches the user's country code from the IP address and sends it to the learner home AP. Country code is required for 2U LOBs merchanding work to show boot-camps callout for US-based users only.
Learner dashboard PR: https://github.com/openedx/frontend-app-learner-dashboard/pull/93/files

Ticket: https://2u-internal.atlassian.net/browse/VAN-1120
