### PR TITLE
fix: VAN-1223 - Add is_control property to recommendations viewed event

### DIFF
--- a/lms/djangoapps/learner_dashboard/api/utils.py
+++ b/lms/djangoapps/learner_dashboard/api/utils.py
@@ -25,9 +25,10 @@ def get_personalized_course_recommendations(user_id):
             recommendations = response.get('userData', {}).get('recommendations', [])
             if recommendations:
                 is_control = recommendations[0].get('is_control')
+                has_is_control = recommendations[0].get('has_is_control')
                 recommended_course_keys = recommendations[0].get('items')
-                return is_control, recommended_course_keys
+                return is_control, has_is_control, recommended_course_keys
     except Exception as ex:  # pylint: disable=broad-except
         log.warning(f'Cannot get recommendations from Amplitude: {ex}')
 
-    return True, []
+    return True, False, []

--- a/lms/djangoapps/learner_dashboard/api/v0/views.py
+++ b/lms/djangoapps/learner_dashboard/api/v0/views.py
@@ -357,22 +357,14 @@ class CourseRecommendationApiView(APIView):
 
     def get(self, request):
         """ Retrieves course recommendations details of a user in a specified course. """
+        recommended_courses = []
         user_id = request.user.id
-        is_control, course_keys = get_personalized_course_recommendations(user_id)
-
-        # Emits an event to track student dashboard page visits.
-        segment.track(
-            user_id,
-            'edx.bi.user.recommendations.viewed',
-            {
-                'is_personalized_recommendation': not is_control,
-            }
-        )
+        is_control, has_is_control, course_keys = get_personalized_course_recommendations(user_id)
 
         if is_control or not course_keys:
+            self._emit_recommendations_viewed_event(user_id, is_control, has_is_control, recommended_courses)
             return Response(status=400)
 
-        recommended_courses = []
         user_enrolled_course_keys = set()
         fields = ['title', 'owners', 'marketing_url']
 
@@ -392,5 +384,18 @@ class CourseRecommendationApiView(APIView):
                     'logo_image_url': course_data['owners'][0]['logo_image_url'],
                     'marketing_url': course_data.get('marketing_url')
                 })
+        self._emit_recommendations_viewed_event(user_id, is_control, has_is_control, recommended_courses)
 
         return Response({'courses': recommended_courses, 'is_personalized_recommendation': not is_control}, status=200)
+
+    def _emit_recommendations_viewed_event(self, user_id, is_control, has_is_control, recommended_courses):
+        """Emits an event to track student dashboard page visits."""
+        segment.track(
+            user_id,
+            'edx.bi.user.recommendations.viewed',
+            {
+                'is_personalized_recommendation': not is_control,
+                'is_control': is_control if has_is_control else None,
+                'course_key_array': [course['course_key'] for course in recommended_courses],
+            }
+        )

--- a/lms/djangoapps/learner_home/recommendations/utils.py
+++ b/lms/djangoapps/learner_home/recommendations/utils.py
@@ -25,7 +25,8 @@ def get_personalized_course_recommendations(user_id):
         recommendations = response.get("userData", {}).get("recommendations", [])
         if recommendations:
             is_control = recommendations[0].get("is_control")
+            has_is_control = recommendations[0].get("has_is_control")
             recommended_course_keys = recommendations[0].get("items")
-            return is_control, recommended_course_keys
+            return is_control, has_is_control, recommended_course_keys
 
-    return True, []
+    return True, False, []


### PR DESCRIPTION
<!--

🎉🎉 Olive has been released! 🎉🎉

🫒🫒
🫒🫒🫒🫒         🫒 Note: Olive is in support. Fixes you make on master may still
    🫒🫒🫒🫒     be needed on Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/openedx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description
Add `is_control` property in recommendations viewed event. This property will show the actual Amplitude API's is_control value only when `has_is_control` is True

Ticket: https://2u-internal.atlassian.net/browse/VAN-1223
