### PR TITLE
[OldMongo FC-0004] Support for legacy assets with deprecated keys is removed from uploads

### DIFF
--- a/cms/djangoapps/contentstore/views/assets.py
+++ b/cms/djangoapps/contentstore/views/assets.py
@@ -406,6 +406,9 @@ def _upload_asset(request, course_key):
     if course_exists_error is not None:
         return course_exists_error
 
+    if course_key.deprecated:
+        return JsonResponse({'error': 'Uploading assets for the legacy course is not available.'}, status=400)
+
     # compute a 'filename' which is similar to the location formatting, we're
     # using the 'filename' nomenclature since we're using a FileSystem paradigm
     # here. We're just imposing the Location string formatting expectations to

--- a/cms/djangoapps/contentstore/views/tests/test_assets.py
+++ b/cms/djangoapps/contentstore/views/tests/test_assets.py
@@ -26,6 +26,7 @@ from xmodule.contentstore.content import StaticContent  # lint-amnesty, pylint: 
 from xmodule.contentstore.django import contentstore  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore import ModuleStoreEnum  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory
 from xmodule.modulestore.xml_importer import import_course_from_xml  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE
 
@@ -47,6 +48,7 @@ class AssetsTestCase(CourseTestCase):
 
     def setUp(self):
         super().setUp()
+        self.course = CourseFactory(default_store='split')
         self.url = reverse_course_url('assets_handler', self.course.id)
 
     def upload_asset(self, name="asset-1", asset_type='text'):


### PR DESCRIPTION
Description: This pr prevents loading assets for deprecated courses.

ISSUE: https://github.com/openedx/public-engineering/issues/80

Reviewers:

- [ ] @ormsbee


Merge checklist:

- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed