### PR TITLE
test: fix hardcoded date of birth (2022)

### DIFF
--- a/common/djangoapps/student/tests/test_models.py
+++ b/common/djangoapps/student/tests/test_models.py
@@ -9,7 +9,6 @@ from crum import set_current_request
 from django.contrib.auth.models import AnonymousUser, User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.core.cache import cache
 from django.conf import settings
-from django.db.models import signals  # pylint: disable=unused-import
 from django.db.models.functions import Lower
 from django.test import TestCase, override_settings
 from edx_toggles.toggles.testutils import override_waffle_flag
@@ -832,7 +831,7 @@ class TestUserPostSaveCallback(SharedModuleStoreTestCase):
             'username': 'some_user',
             'name': 'Student Person',
             'age': -1,
-            'yearOfBirth': 2022,
+            'yearOfBirth': datetime.datetime.today().year,
             'education': None,
             'address': None,
             'gender': 'Male',


### PR DESCRIPTION
## Description

Removes unused import and fixes `test_is_marketable_set_to_false_for_user_created_via_management_command` test, which is failing due to the mismatching `yearOfBirth`:
```
FAILED common/djangoapps/student/tests/test_models.py::TestUserPostSaveCallback::test_is_marketable_set_to_false_for_user_created_via_management_command - AssertionError: assert (1, {'address...': None, ...}) == (1, {'address...': None, ...})
  At index 1 diff: {'email': 'some.user@example.com', 'username': 'some_user', 'name': 'Student Person', 'age': -1, 'yearOfBirth': 2023, 'education': None, 'address': None, 'gender': 'Male', 'country': '', 'is_marketable': False} != {'email': 'some.user@example.com', 'username': 'some_user', 'name': 'Student Person', 'age': -1, 'yearOfBirth': 2022, 'education': None, 'address': None, 'gender': 'Male', 'country': '', 'is_marketable': False}
  Full diff:
    (
     1,
     {'address': None,
      'age': -1,
      'country': '',
      'education': None,
      'email': 'some.user@example.com',
      'gender': 'Male',
      'is_marketable': False,
      'name': 'Student Person',
      'username': 'some_user',
  -   'yearOfBirth': 2022},
  ?                     ^
  +   'yearOfBirth': 2023},
  ?                     ^
    )
===== 1 failed, 997 passed, 825 skipped, 145 warnings in 101.19s (0:01:41) =====
```

## Testing instructions

All pipeline checks should pass.