### PR TITLE
fix: handle exception getting cert statuses

### DIFF
--- a/lms/djangoapps/learner_home/views.py
+++ b/lms/djangoapps/learner_home/views.py
@@ -238,10 +238,24 @@ def get_ecommerce_payment_page(user):
 @function_trace("get_cert_statuses")
 def get_cert_statuses(user, course_enrollments):
     """Get cert status by course for user enrollments"""
-    return {
-        enrollment.course_id: cert_info(user, enrollment)
-        for enrollment in course_enrollments
-    }
+
+    cert_statuses = {}
+
+    for enrollment in course_enrollments:
+        # APER-2171 - trying to get a cert for a deleted course can throw an exception
+        # Wrap in exception handling to avoid this issue.
+        try:
+            certificate_for_course = cert_info(user, enrollment)
+
+            if certificate_for_course:
+                cert_statuses[enrollment.course_id] = certificate_for_course
+
+        except Exception as ex:  # pylint: disable=broad-except
+            logger.exception(
+                f"Error getting certificate status for (user, course) ({user}, {enrollment.course_id}): {ex}"
+            )
+
+    return cert_statuses
 
 
 @function_trace("get_org_block_and_allow_lists")


### PR DESCRIPTION
## Description

If a user has a certificate in a deleted course, an issue with how the course is loaded from the cache can cause an exception that breaks our code. This adds a wrapper to fail gracefully and log the exception for future tracking / investigation.

JIRA: [APER-2171](https://2u-internal.atlassian.net/browse/APER-2171) and [AU-952](https://2u-internal.atlassian.net/browse/AU-952).

## Testing instructions

While I'm unable to reproduce locally (I think the root cause is an issue thrown by caching in our STAGE/PROD systems), this is known to fail for a known user on STAGE which will be used to verify the fix (see ticket info).

## Other information

I do expect this issue to still surface other places (e.g. old learner dashboard) but those fixes are out of scope and this should help better identify root causes / courses.