### PR TITLE
[BD-13][BB-6927] Unify xblock naming descriptor

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/edit_course_tabs.py
+++ b/cms/djangoapps/contentstore/management/commands/edit_course_tabs.py
@@ -25,7 +25,7 @@ def print_course(course):
         print('num type name')
         for index, item in enumerate(course.tabs):
             print(index + 1, '"' + item.get('type') + '"', '"' + item.get('name', '') + '"')
-    # If a course is bad we will get an error descriptor here, dump it and die instead of
+    # If a course is bad we will get an error here, dump it and die instead of
     # just sending up the error that .id doesn't exist.
     except AttributeError:
         print(course)

--- a/cms/djangoapps/contentstore/signals/handlers.py
+++ b/cms/djangoapps/contentstore/signals/handlers.py
@@ -28,7 +28,7 @@ from cms.djangoapps.contentstore.courseware_index import (
     LibrarySearchIndexer,
 )
 from common.djangoapps.track.event_transaction_utils import get_event_transaction_id, get_event_transaction_type
-from common.djangoapps.util.block_utils import yield_dynamic_descriptor_descendants
+from common.djangoapps.util.block_utils import yield_dynamic_block_descendants
 from lms.djangoapps.grades.api import task_compute_all_grades_for_course
 from openedx.core.djangoapps.content.learning_sequences.api import key_supports_outlines
 from openedx.core.djangoapps.discussions.tasks import update_discussions_settings_from_course_task
@@ -252,7 +252,7 @@ def handle_item_deleted(**kwargs):
         usage_key = usage_key.for_branch(None)
         course_key = usage_key.course_key
         deleted_block = modulestore().get_item(usage_key)
-        for block in yield_dynamic_descriptor_descendants(deleted_block, kwargs.get('user_id')):
+        for block in yield_dynamic_block_descendants(deleted_block, kwargs.get('user_id')):
             # Remove prerequisite milestone data
             gating_api.remove_prerequisite(block.location)
             # Remove any 'requires' course content milestone relationships

--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -1713,17 +1713,17 @@ class MetadataSaveTestCase(ContentStoreTestCase):
         """
         video_data = VideoBlock.parse_video_xml(video_sample_xml)
         video_data.pop('source')
-        self.video_descriptor = BlockFactory.create(
+        self.video_block = BlockFactory.create(
             parent_location=course.location, category='video',
             **video_data
         )
 
     def test_metadata_not_persistence(self):
         """
-        Test that descriptors which set metadata fields in their
+        Test that blocks which set metadata fields in their
         constructor are correctly deleted.
         """
-        self.assertIn('html5_sources', own_metadata(self.video_descriptor))
+        self.assertIn('html5_sources', own_metadata(self.video_block))
         attrs_to_strip = {
             'show_captions',
             'youtube_id_1_0',
@@ -1736,13 +1736,13 @@ class MetadataSaveTestCase(ContentStoreTestCase):
             'track'
         }
 
-        location = self.video_descriptor.location
+        location = self.video_block.location
 
         for field_name in attrs_to_strip:
-            delattr(self.video_descriptor, field_name)
+            delattr(self.video_block, field_name)
 
-        self.assertNotIn('html5_sources', own_metadata(self.video_descriptor))
-        self.store.update_item(self.video_descriptor, self.user.id)
+        self.assertNotIn('html5_sources', own_metadata(self.video_block))
+        self.store.update_item(self.video_block, self.user.id)
         block = self.store.get_item(location)
 
         self.assertNotIn('html5_sources', own_metadata(block))
@@ -2047,12 +2047,12 @@ class ContentLicenseTest(ContentStoreTestCase):
     def test_video_license_export(self):
         content_store = contentstore()
         root_dir = path(mkdtemp_clean())
-        video_descriptor = BlockFactory.create(
+        video_block = BlockFactory.create(
             parent_location=self.course.location, category='video',
             license="all-rights-reserved"
         )
         export_course_to_xml(self.store, content_store, self.course.id, root_dir, 'test_license')
-        fname = f"{video_descriptor.scope_ids.usage_id.block_id}.xml"
+        fname = f"{video_block.scope_ids.usage_id.block_id}.xml"
         video_file_path = root_dir / "test_license" / "video" / fname
         with video_file_path.open() as f:
             video_xml = etree.parse(f)

--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -885,33 +885,33 @@ class CourseGradingTest(CourseTestCase):
     @mock.patch('cms.djangoapps.contentstore.signals.signals.GRADING_POLICY_CHANGED.send')
     def test_update_section_grader_type(self, send_signal, tracker, uuid):
         uuid.return_value = 'mockUUID'
-        # Get the descriptor and the section_grader_type and assert they are the default values
-        descriptor = modulestore().get_item(self.course.location)
+        # Get the block and the section_grader_type and assert they are the default values
+        block = modulestore().get_item(self.course.location)
         section_grader_type = CourseGradingModel.get_section_grader_type(self.course.location)
 
         self.assertEqual('notgraded', section_grader_type['graderType'])
-        self.assertEqual(None, descriptor.format)
-        self.assertEqual(False, descriptor.graded)
+        self.assertEqual(None, block.format)
+        self.assertEqual(False, block.graded)
 
         # Change the default grader type to Homework, which should also mark the section as graded
         CourseGradingModel.update_section_grader_type(self.course, 'Homework', self.user)
-        descriptor = modulestore().get_item(self.course.location)
+        block = modulestore().get_item(self.course.location)
         section_grader_type = CourseGradingModel.get_section_grader_type(self.course.location)
         grading_policy_1 = self._grading_policy_hash_for_course()
 
         self.assertEqual('Homework', section_grader_type['graderType'])
-        self.assertEqual('Homework', descriptor.format)
-        self.assertEqual(True, descriptor.graded)
+        self.assertEqual('Homework', block.format)
+        self.assertEqual(True, block.graded)
 
         # Change the grader type back to notgraded, which should also unmark the section as graded
         CourseGradingModel.update_section_grader_type(self.course, 'notgraded', self.user)
-        descriptor = modulestore().get_item(self.course.location)
+        block = modulestore().get_item(self.course.location)
         section_grader_type = CourseGradingModel.get_section_grader_type(self.course.location)
         grading_policy_2 = self._grading_policy_hash_for_course()
 
         self.assertEqual('notgraded', section_grader_type['graderType'])
-        self.assertEqual(None, descriptor.format)
-        self.assertEqual(False, descriptor.graded)
+        self.assertEqual(None, block.format)
+        self.assertEqual(False, block.graded)
 
         # one for each call to update_section_grader_type()
         send_signal.assert_has_calls([

--- a/cms/djangoapps/contentstore/tests/test_i18n.py
+++ b/cms/djangoapps/contentstore/tests/test_i18n.py
@@ -69,19 +69,19 @@ class TestXBlockI18nService(ModuleStoreTestCase):
         self.request = mock.Mock()
         self.course = CourseFactory.create()
         self.field_data = mock.Mock()
-        self.descriptor = BlockFactory(category="pure", parent=self.course)
+        self.block = BlockFactory(category="pure", parent=self.course)
         _prepare_runtime_for_preview(
             self.request,
-            self.descriptor,
+            self.block,
             self.field_data,
         )
         self.addCleanup(translation.deactivate)
 
-    def get_block_i18n_service(self, descriptor):
+    def get_block_i18n_service(self, block):
         """
         return the block i18n service.
         """
-        i18n_service = self.descriptor.runtime.service(descriptor, 'i18n')
+        i18n_service = self.block.runtime.service(block, 'i18n')
         self.assertIsNotNone(i18n_service)
         self.assertIsInstance(i18n_service, XBlockI18nService)
         return i18n_service
@@ -113,7 +113,7 @@ class TestXBlockI18nService(ModuleStoreTestCase):
                 self.module.ugettext = self.old_ugettext
                 self.module.gettext = self.old_ugettext
 
-        i18n_service = self.get_block_i18n_service(self.descriptor)
+        i18n_service = self.get_block_i18n_service(self.block)
 
         # Activate french, so that if the fr files haven't been loaded, they will be loaded now.
         with translation.override("fr"):
@@ -150,13 +150,13 @@ class TestXBlockI18nService(ModuleStoreTestCase):
         translation.activate("es")
         with mock.patch('gettext.translation', return_value=_translator(domain='text', localedir=localedir,
                                                                         languages=[get_language()])):
-            i18n_service = self.get_block_i18n_service(self.descriptor)
+            i18n_service = self.get_block_i18n_service(self.block)
             self.assertEqual(i18n_service.ugettext('Hello'), 'es-hello-world')
 
         translation.activate("ar")
         with mock.patch('gettext.translation', return_value=_translator(domain='text', localedir=localedir,
                                                                         languages=[get_language()])):
-            i18n_service = self.get_block_i18n_service(self.descriptor)
+            i18n_service = self.get_block_i18n_service(self.block)
             self.assertEqual(get_gettext(i18n_service)('Hello'), 'Hello')
             self.assertNotEqual(get_gettext(i18n_service)('Hello'), 'fr-hello-world')
             self.assertNotEqual(get_gettext(i18n_service)('Hello'), 'es-hello-world')
@@ -164,14 +164,14 @@ class TestXBlockI18nService(ModuleStoreTestCase):
         translation.activate("fr")
         with mock.patch('gettext.translation', return_value=_translator(domain='text', localedir=localedir,
                                                                         languages=[get_language()])):
-            i18n_service = self.get_block_i18n_service(self.descriptor)
+            i18n_service = self.get_block_i18n_service(self.block)
             self.assertEqual(i18n_service.ugettext('Hello'), 'fr-hello-world')
 
     def test_i18n_service_callable(self):
         """
         Test: i18n service should be callable in studio.
         """
-        self.assertTrue(callable(self.descriptor.runtime._services.get('i18n')))  # pylint: disable=protected-access
+        self.assertTrue(callable(self.block.runtime._services.get('i18n')))  # pylint: disable=protected-access
 
 
 class InternationalizationTest(ModuleStoreTestCase):

--- a/cms/djangoapps/contentstore/tests/test_libraries.py
+++ b/cms/djangoapps/contentstore/tests/test_libraries.py
@@ -114,7 +114,7 @@ class LibraryTestCase(ModuleStoreTestCase):
         self.assertEqual(response.status_code, status_code_expected)
         return modulestore().get_item(lib_content_block.location)
 
-    def _bind_block(self, descriptor, user=None):
+    def _bind_block(self, block, user=None):
         """
         Helper to use the CMS's module system so we can access student-specific fields.
         """
@@ -123,7 +123,7 @@ class LibraryTestCase(ModuleStoreTestCase):
         if user not in self.session_data:
             self.session_data[user] = {}
         request = Mock(user=user, session=self.session_data[user])
-        _load_preview_block(request, descriptor)
+        _load_preview_block(request, block)
 
     def _update_block(self, usage_key, metadata):
         """
@@ -174,13 +174,13 @@ class TestLibraries(LibraryTestCase):
         lc_block = self._refresh_children(lc_block)
 
         # Now, we want to make sure that .children has the total # of potential
-        # children, and that get_child_descriptors() returns the actual children
+        # children, and that get_child_blocks() returns the actual children
         # chosen for a given student.
-        # In order to be able to call get_child_descriptors(), we must first
+        # In order to be able to call get_child_blocks(), we must first
         # call bind_for_student:
         self._bind_block(lc_block)
         self.assertEqual(len(lc_block.children), num_to_create)
-        self.assertEqual(len(lc_block.get_child_descriptors()), num_expected)
+        self.assertEqual(len(lc_block.get_child_blocks()), num_expected)
 
     def test_consistent_children(self):
         """
@@ -204,7 +204,7 @@ class TestLibraries(LibraryTestCase):
             """
             Fetch the child shown to the current user.
             """
-            children = block.get_child_descriptors()
+            children = block.get_child_blocks()
             self.assertEqual(len(children), 1)
             return children[0]
 

--- a/cms/djangoapps/contentstore/tests/test_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_utils.py
@@ -620,7 +620,7 @@ class GetUserPartitionInfoTest(ModuleStoreTestCase):
         self.assertEqual(partitions[0]["scheme"], "random")
 
     def _set_partitions(self, partitions):
-        """Set the user partitions of the course descriptor. """
+        """Set the user partitions of the course block. """
         self.course.user_partitions = partitions
         self.course = self.store.update_item(self.course, ModuleStoreEnum.UserID.test)
 

--- a/cms/djangoapps/contentstore/tests/utils.py
+++ b/cms/djangoapps/contentstore/tests/utils.py
@@ -191,8 +191,8 @@ class CourseTestCase(ProceduralCourseTestMixin, ModuleStoreTestCase):
         """ Test getting the editing HTML for each vertical. """
         # assert is here to make sure that the course being tested actually has verticals (units) to check.
         self.assertGreater(len(items), 0, "Course has no verticals (units) to check")
-        for descriptor in items:
-            resp = self.client.get_html(get_url('container_handler', descriptor.location))
+        for block in items:
+            resp = self.client.get_html(get_url('container_handler', block.location))
             self.assertEqual(resp.status_code, 200)
 
     def assertAssetsEqual(self, asset_son, course1_id, course2_id):

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -372,7 +372,7 @@ def get_split_group_display_name(xblock, course):
 
     Arguments:
         xblock (XBlock): The courseware component.
-        course (XBlock): The course descriptor.
+        course (XBlock): The course block.
 
     Returns:
         group name (String): Group name of the matching group xblock.
@@ -399,14 +399,14 @@ def get_user_partition_info(xblock, schemes=None, course=None):
         schemes (iterable of str): If provided, filter partitions to include only
             schemes with the provided names.
 
-        course (XBlock): The course descriptor.  If provided, uses this to look up the user partitions
+        course (XBlock): The course block.  If provided, uses this to look up the user partitions
             instead of loading the course.  This is useful if we're calling this function multiple
             times for the same course want to minimize queries to the modulestore.
 
     Returns: list
 
     Example Usage:
-    >>> get_user_partition_info(block, schemes=["cohort", "verification"])
+    >>> get_user_partition_info(xblock, schemes=["cohort", "verification"])
     [
         {
             "id": 12345,
@@ -509,7 +509,7 @@ def get_visibility_partition_info(xblock, course=None):
     Arguments:
         xblock (XBlock): The component being edited.
 
-        course (XBlock): The course descriptor.  If provided, uses this to look up the user partitions
+        course (XBlock): The course block.  If provided, uses this to look up the user partitions
             instead of loading the course.  This is useful if we're calling this function multiple
             times for the same course want to minimize queries to the modulestore.
 
@@ -569,8 +569,8 @@ def get_xblock_aside_instance(usage_key):
     :param usage_key: Usage key of aside xblock
     """
     try:
-        descriptor = modulestore().get_item(usage_key.usage_key)
-        for aside in descriptor.runtime.get_asides(descriptor):
+        xblock = modulestore().get_item(usage_key.usage_key)
+        for aside in xblock.runtime.get_asides(xblock):
             if aside.scope_ids.block_type == usage_key.aside_type:
                 return aside
     except ItemNotFoundError:

--- a/cms/djangoapps/contentstore/views/certificates.py
+++ b/cms/djangoapps/contentstore/views/certificates.py
@@ -128,7 +128,7 @@ class CertificateValidationError(CertificateException):
 class CertificateManager:
     """
     The CertificateManager is responsible for storage, retrieval, and manipulation of Certificates
-    Certificates are not stored in the Django ORM, they are a field/setting on the course descriptor
+    Certificates are not stored in the Django ORM, they are a field/setting on the course block
     """
     @staticmethod
     def parse(json_string):

--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -552,18 +552,18 @@ def component_handler(request, usage_key_string, handler, suffix=''):
 
     try:
         if is_xblock_aside(usage_key):
-            # Get the descriptor for the block being wrapped by the aside (not the aside itself)
-            descriptor = modulestore().get_item(usage_key.usage_key)
-            handler_descriptor = get_aside_from_xblock(descriptor, usage_key.aside_type)
-            asides = [handler_descriptor]
+            # Get the block being wrapped by the aside (not the aside itself)
+            block = modulestore().get_item(usage_key.usage_key)
+            handler_block = get_aside_from_xblock(block, usage_key.aside_type)
+            asides = [handler_block]
         else:
-            descriptor = modulestore().get_item(usage_key)
-            handler_descriptor = descriptor
+            block = modulestore().get_item(usage_key)
+            handler_block = block
             asides = []
-        load_services_for_studio(handler_descriptor.runtime, request.user)
-        resp = handler_descriptor.handle(handler, req, suffix)
+        load_services_for_studio(handler_block.runtime, request.user)
+        resp = handler_block.handle(handler, req, suffix)
     except NoSuchHandlerError:
-        log.info("XBlock %s attempted to access missing handler %r", handler_descriptor, handler, exc_info=True)
+        log.info("XBlock %s attempted to access missing handler %r", handler_block, handler, exc_info=True)
         raise Http404  # lint-amnesty, pylint: disable=raise-missing-from
 
     # unintentional update to handle any side effects of handle call
@@ -572,7 +572,7 @@ def component_handler(request, usage_key_string, handler, suffix=''):
     # TNL 101-62 studio write permission is also checked for editing content.
 
     if has_course_author_access(request.user, usage_key.course_key):
-        modulestore().update_item(descriptor, request.user.id, asides=asides)
+        modulestore().update_item(block, request.user.id, asides=asides)
     else:
         #fail quietly if user is not course author.
         log.warning(

--- a/cms/djangoapps/contentstore/views/entrance_exam.py
+++ b/cms/djangoapps/contentstore/views/entrance_exam.py
@@ -176,9 +176,9 @@ def _get_entrance_exam(request, course_key):
     except InvalidKeyError:
         return HttpResponse(status=404)
     try:
-        exam_descriptor = modulestore().get_item(exam_key)
+        exam_block = modulestore().get_item(exam_key)
         return HttpResponse(  # lint-amnesty, pylint: disable=http-response-with-content-type-json
-            dump_js_escaped_json({'locator': str(exam_descriptor.location)}),
+            dump_js_escaped_json({'locator': str(exam_block.location)}),
             status=200, content_type='application/json')
     except ItemNotFoundError:
         return HttpResponse(status=404)

--- a/cms/djangoapps/contentstore/views/tests/test_block.py
+++ b/cms/djangoapps/contentstore/views/tests/test_block.py
@@ -2159,10 +2159,10 @@ class TestComponentHandler(TestCase):
         self.modulestore = patcher.start()
         self.addCleanup(patcher.stop)
 
-        # component_handler calls modulestore.get_item to get the descriptor of the requested xBlock.
+        # component_handler calls modulestore.get_item to get the requested xBlock.
         # Here, we mock the return value of modulestore.get_item so it can be used to mock the handler
-        # of the xBlock descriptor.
-        self.descriptor = self.modulestore.return_value.get_item.return_value
+        # of the xBlock.
+        self.block = self.modulestore.return_value.get_item.return_value
 
         self.usage_key = BlockUsageLocator(
             CourseLocator('dummy_org', 'dummy_course', 'dummy_run'), 'dummy_category', 'dummy_name'
@@ -2173,7 +2173,7 @@ class TestComponentHandler(TestCase):
         self.request.user = self.user
 
     def test_invalid_handler(self):
-        self.descriptor.handle.side_effect = NoSuchHandlerError
+        self.block.handle.side_effect = NoSuchHandlerError
 
         with self.assertRaises(Http404):
             component_handler(self.request, self.usage_key_string, 'invalid_handler')
@@ -2185,7 +2185,7 @@ class TestComponentHandler(TestCase):
             self.assertEqual(request.method, method)
             return Response()
 
-        self.descriptor.handle = check_handler
+        self.block.handle = check_handler
 
         # Have to use the right method to create the request to get the HTTP method that we want
         req_factory_method = getattr(self.request_factory, method.lower())
@@ -2198,7 +2198,7 @@ class TestComponentHandler(TestCase):
         def create_response(handler, request, suffix):  # lint-amnesty, pylint: disable=unused-argument
             return Response(status_code=status_code)
 
-        self.descriptor.handle = create_response
+        self.block.handle = create_response
 
         self.assertEqual(component_handler(self.request, self.usage_key_string, 'dummy_handler').status_code,
                          status_code)
@@ -2219,7 +2219,7 @@ class TestComponentHandler(TestCase):
         self.request.user = UserFactory()
         mock_handler = 'dummy_handler'
 
-        self.descriptor.handle = create_response
+        self.block.handle = create_response
 
         with patch(
             'cms.djangoapps.contentstore.views.component.is_xblock_aside',
@@ -2253,7 +2253,7 @@ class TestComponentHandler(TestCase):
                 else self.usage_key_string
             )
 
-        self.descriptor.handle = create_response
+        self.block.handle = create_response
 
         with patch(
             'cms.djangoapps.contentstore.views.component.is_xblock_aside',

--- a/cms/djangoapps/contentstore/views/tests/test_preview.py
+++ b/cms/djangoapps/contentstore/views/tests/test_preview.py
@@ -213,13 +213,13 @@ class StudioXBlockServiceBindingTest(ModuleStoreTestCase):
         """
         Tests that the 'user' and 'i18n' services are provided by the Studio runtime.
         """
-        descriptor = BlockFactory(category="pure", parent=self.course)
+        block = BlockFactory(category="pure", parent=self.course)
         _prepare_runtime_for_preview(
             self.request,
-            descriptor,
+            block,
             self.field_data,
         )
-        service = descriptor.runtime.service(descriptor, expected_service)
+        service = block.runtime.service(block, expected_service)
         self.assertIsNotNone(service)
 
 
@@ -242,32 +242,31 @@ class CmsModuleSystemShimTest(ModuleStoreTestCase):
         self.request = RequestFactory().get('/dummy-url')
         self.request.user = self.user
         self.request.session = {}
-        self.descriptor = BlockFactory(category="video", parent=course)
         self.field_data = mock.Mock()
         self.contentstore = contentstore()
-        self.descriptor = BlockFactory(category="problem", parent=course)
+        self.block = BlockFactory(category="problem", parent=course)
         _prepare_runtime_for_preview(
             self.request,
-            block=self.descriptor,
+            block=self.block,
             field_data=mock.Mock(),
         )
         self.course = self.store.get_item(course.location)
 
     def test_get_user_role(self):
-        assert self.descriptor.runtime.get_user_role() == 'staff'
+        assert self.block.runtime.get_user_role() == 'staff'
 
     @XBlock.register_temp_plugin(PureXBlock, identifier='pure')
     def test_render_template(self):
-        descriptor = BlockFactory(category="pure", parent=self.course)
-        html = get_preview_fragment(self.request, descriptor, {'element_id': 142}).content
+        block = BlockFactory(category="pure", parent=self.course)
+        html = get_preview_fragment(self.request, block, {'element_id': 142}).content
         assert '<div id="142" ns="main">Testing the MakoService</div>' in html
 
     @override_settings(COURSES_WITH_UNSAFE_CODE=[r'course-v1:edX\+LmsModuleShimTest\+2021_Fall'])
     def test_can_execute_unsafe_code(self):
-        assert self.descriptor.runtime.can_execute_unsafe_code()
+        assert self.block.runtime.can_execute_unsafe_code()
 
     def test_cannot_execute_unsafe_code(self):
-        assert not self.descriptor.runtime.can_execute_unsafe_code()
+        assert not self.block.runtime.can_execute_unsafe_code()
 
     @override_settings(PYTHON_LIB_FILENAME=PYTHON_LIB_FILENAME)
     def test_get_python_lib_zip(self):
@@ -277,7 +276,7 @@ class CmsModuleSystemShimTest(ModuleStoreTestCase):
             source_file=self.PYTHON_LIB_SOURCE_FILE,
             target_filename=self.PYTHON_LIB_FILENAME,
         )
-        assert self.descriptor.runtime.get_python_lib_zip() == zipfile
+        assert self.block.runtime.get_python_lib_zip() == zipfile
 
     def test_no_get_python_lib_zip(self):
         zipfile = upload_file_to_course(
@@ -286,40 +285,40 @@ class CmsModuleSystemShimTest(ModuleStoreTestCase):
             source_file=self.PYTHON_LIB_SOURCE_FILE,
             target_filename=self.PYTHON_LIB_FILENAME,
         )
-        assert self.descriptor.runtime.get_python_lib_zip() is None
+        assert self.block.runtime.get_python_lib_zip() is None
 
     def test_cache(self):
-        assert hasattr(self.descriptor.runtime.cache, 'get')
-        assert hasattr(self.descriptor.runtime.cache, 'set')
+        assert hasattr(self.block.runtime.cache, 'get')
+        assert hasattr(self.block.runtime.cache, 'set')
 
     def test_replace_urls(self):
         html = '<a href="/static/id">'
-        assert self.descriptor.runtime.replace_urls(html) == \
+        assert self.block.runtime.replace_urls(html) == \
             static_replace.replace_static_urls(html, course_id=self.course.id)
 
     def test_anonymous_user_id_preview(self):
-        assert self.descriptor.runtime.anonymous_student_id == 'student'
+        assert self.block.runtime.anonymous_student_id == 'student'
 
     @override_waffle_flag(INDIVIDUALIZE_ANONYMOUS_USER_ID, active=True)
     def test_anonymous_user_id_individual_per_student(self):
         """Test anonymous_user_id on a block which uses per-student anonymous IDs"""
         # Create the runtime with the flag turned on.
-        descriptor = BlockFactory(category="problem", parent=self.course)
+        block = BlockFactory(category="problem", parent=self.course)
         _prepare_runtime_for_preview(
             self.request,
-            block=descriptor,
+            block=block,
             field_data=mock.Mock(),
         )
-        assert descriptor.runtime.anonymous_student_id == '26262401c528d7c4a6bbeabe0455ec46'
+        assert block.runtime.anonymous_student_id == '26262401c528d7c4a6bbeabe0455ec46'
 
     @override_waffle_flag(INDIVIDUALIZE_ANONYMOUS_USER_ID, active=True)
     def test_anonymous_user_id_individual_per_course(self):
         """Test anonymous_user_id on a block which uses per-course anonymous IDs"""
         # Create the runtime with the flag turned on.
-        descriptor = BlockFactory(category="lti", parent=self.course)
+        block = BlockFactory(category="lti", parent=self.course)
         _prepare_runtime_for_preview(
             self.request,
-            block=descriptor,
+            block=block,
             field_data=mock.Mock(),
         )
-        assert descriptor.runtime.anonymous_student_id == 'ad503f629b55c531fed2e45aa17a3368'
+        assert block.runtime.anonymous_student_id == 'ad503f629b55c531fed2e45aa17a3368'

--- a/cms/djangoapps/contentstore/views/tests/test_transcripts.py
+++ b/cms/djangoapps/contentstore/views/tests/test_transcripts.py
@@ -364,7 +364,7 @@ class TestUploadTranscripts(BaseTranscripts):
     def test_transcript_upload_with_non_existant_edx_video_id(self):
         """
         Test that transcript upload works as expected if `edx_video_id` set on
-        video descriptor is different from `edx_video_id` received in POST request.
+        video block is different from `edx_video_id` received in POST request.
         """
         non_existant_edx_video_id = '1111-2222-3333-4444'
 

--- a/cms/djangoapps/contentstore/views/transcripts_ajax.py
+++ b/cms/djangoapps/contentstore/views/transcripts_ajax.py
@@ -71,7 +71,7 @@ def link_video_to_component(video_component, user):
     Links a VAL video to the video component.
 
     Arguments:
-        video_component: video descriptor item.
+        video_component: video block.
         user: A requesting user.
 
     Returns:
@@ -134,7 +134,7 @@ def validate_video_block(request, locator):
         locator: video locator.
 
     Returns:
-        A tuple containing error(or None) and video descriptor(i.e. if validation succeeds).
+        A tuple containing error(or None) and video block(i.e. if validation succeeds).
 
     Raises:
         PermissionDenied: if requesting user does not have access to author the video component.

--- a/cms/djangoapps/models/settings/course_grading.py
+++ b/cms/djangoapps/models/settings/course_grading.py
@@ -25,21 +25,21 @@ class CourseGradingModel:
     """
     # Within this class, allow access to protected members of client classes.
     # This comes up when accessing kvs data and caches during kvs saves and modulestore writes.
-    def __init__(self, course_descriptor):
+    def __init__(self, course):
         self.graders = [
-            CourseGradingModel.jsonize_grader(i, grader) for i, grader in enumerate(course_descriptor.raw_grader)
+            CourseGradingModel.jsonize_grader(i, grader) for i, grader in enumerate(course.raw_grader)
         ]  # weights transformed to ints [0..100]
-        self.grade_cutoffs = course_descriptor.grade_cutoffs
-        self.grace_period = CourseGradingModel.convert_set_grace_period(course_descriptor)
-        self.minimum_grade_credit = course_descriptor.minimum_grade_credit
+        self.grade_cutoffs = course.grade_cutoffs
+        self.grace_period = CourseGradingModel.convert_set_grace_period(course)
+        self.minimum_grade_credit = course.minimum_grade_credit
 
     @classmethod
     def fetch(cls, course_key):
         """
         Fetch the course grading policy for the given course from persistence and return a CourseGradingModel.
         """
-        descriptor = modulestore().get_course(course_key)
-        model = cls(descriptor)
+        course = modulestore().get_course(course_key)
+        model = cls(course)
         return model
 
     @staticmethod
@@ -48,10 +48,10 @@ class CourseGradingModel:
         Fetch the course's nth grader
         Returns an empty dict if there's no such grader.
         """
-        descriptor = modulestore().get_course(course_key)
+        course = modulestore().get_course(course_key)
         index = int(index)
-        if len(descriptor.raw_grader) > index:
-            return CourseGradingModel.jsonize_grader(index, descriptor.raw_grader[index])
+        if len(course.raw_grader) > index:
+            return CourseGradingModel.jsonize_grader(index, course.raw_grader[index])
 
         # return empty model
         else:
@@ -69,27 +69,27 @@ class CourseGradingModel:
         Decode the json into CourseGradingModel and save any changes. Returns the modified model.
         Probably not the usual path for updates as it's too coarse grained.
         """
-        descriptor = modulestore().get_course(course_key)
-        previous_grading_policy_hash = str(hash_grading_policy(descriptor.grading_policy))
+        course = modulestore().get_course(course_key)
+        previous_grading_policy_hash = str(hash_grading_policy(course.grading_policy))
 
         graders_parsed = [CourseGradingModel.parse_grader(jsonele) for jsonele in jsondict['graders']]
         fire_signal = CourseGradingModel.must_fire_grading_event_and_signal(
             course_key,
             graders_parsed,
-            descriptor,
+            course,
             jsondict
         )
-        descriptor.raw_grader = graders_parsed
-        descriptor.grade_cutoffs = jsondict['grade_cutoffs']
+        course.raw_grader = graders_parsed
+        course.grade_cutoffs = jsondict['grade_cutoffs']
 
-        modulestore().update_item(descriptor, user.id)
+        modulestore().update_item(course, user.id)
 
         CourseGradingModel.update_grace_period_from_json(course_key, jsondict['grace_period'], user)
 
         CourseGradingModel.update_minimum_grade_credit_from_json(course_key, jsondict['minimum_grade_credit'], user)
 
-        descriptor = modulestore().get_course(course_key)
-        new_grading_policy_hash = str(hash_grading_policy(descriptor.grading_policy))
+        course = modulestore().get_course(course_key)
+        new_grading_policy_hash = str(hash_grading_policy(course.grading_policy))
         log.info(
             "Updated course grading policy for course %s from %s to %s. fire_signal = %s",
             str(course_key),
@@ -153,28 +153,28 @@ class CourseGradingModel:
         Create or update the grader of the given type (string key) for the given course. Returns the modified
         grader which is a full model on the client but not on the server (just a dict)
         """
-        descriptor = modulestore().get_course(course_key)
-        previous_grading_policy_hash = str(hash_grading_policy(descriptor.grading_policy))
+        course = modulestore().get_course(course_key)
+        previous_grading_policy_hash = str(hash_grading_policy(course.grading_policy))
 
         # parse removes the id; so, grab it before parse
-        index = int(grader.get('id', len(descriptor.raw_grader)))
+        index = int(grader.get('id', len(course.raw_grader)))
         grader = CourseGradingModel.parse_grader(grader)
 
         fire_signal = True
-        if index < len(descriptor.raw_grader):
+        if index < len(course.raw_grader):
             fire_signal = CourseGradingModel.must_fire_grading_event_and_signal_single_grader(
                 course_key,
                 grader,
-                descriptor.raw_grader[index]
+                course.raw_grader[index]
             )
-            descriptor.raw_grader[index] = grader
+            course.raw_grader[index] = grader
         else:
-            descriptor.raw_grader.append(grader)
+            course.raw_grader.append(grader)
 
-        modulestore().update_item(descriptor, user.id)
+        modulestore().update_item(course, user.id)
 
-        descriptor = modulestore().get_course(course_key)
-        new_grading_policy_hash = str(hash_grading_policy(descriptor.grading_policy))
+        course = modulestore().get_course(course_key)
+        new_grading_policy_hash = str(hash_grading_policy(course.grading_policy))
         log.info(
             "Updated grader for course %s. Grading policy has changed from %s to %s. fire_signal = %s",
             str(course_key),
@@ -185,7 +185,7 @@ class CourseGradingModel:
         if fire_signal:
             _grading_event_and_signal(course_key, user.id)
 
-        return CourseGradingModel.jsonize_grader(index, descriptor.raw_grader[index])
+        return CourseGradingModel.jsonize_grader(index, course.raw_grader[index])
 
     @staticmethod
     def update_cutoffs_from_json(course_key, cutoffs, user):
@@ -193,10 +193,10 @@ class CourseGradingModel:
         Create or update the grade cutoffs for the given course. Returns sent in cutoffs (ie., no extra
         db fetch).
         """
-        descriptor = modulestore().get_course(course_key)
-        descriptor.grade_cutoffs = cutoffs
+        course = modulestore().get_course(course_key)
+        course.grade_cutoffs = cutoffs
 
-        modulestore().update_item(descriptor, user.id)
+        modulestore().update_item(course, user.id)
         _grading_event_and_signal(course_key, user.id)
         return cutoffs
 
@@ -207,7 +207,7 @@ class CourseGradingModel:
         grace_period entry in an enclosing dict. It is also safe to call this method with a value of
         None for graceperiodjson.
         """
-        descriptor = modulestore().get_course(course_key)
+        course = modulestore().get_course(course_key)
 
         # Before a graceperiod has ever been created, it will be None (once it has been
         # created, it cannot be set back to None).
@@ -216,9 +216,9 @@ class CourseGradingModel:
                 graceperiodjson = graceperiodjson['grace_period']
 
             grace_timedelta = timedelta(**graceperiodjson)
-            descriptor.graceperiod = grace_timedelta
+            course.graceperiod = grace_timedelta
 
-            modulestore().update_item(descriptor, user.id)
+            modulestore().update_item(course, user.id)
 
     @staticmethod
     def update_minimum_grade_credit_from_json(course_key, minimum_grade_credit, user):
@@ -230,29 +230,29 @@ class CourseGradingModel:
             user(User): The user object
 
         """
-        descriptor = modulestore().get_course(course_key)
+        course = modulestore().get_course(course_key)
 
         # 'minimum_grade_credit' cannot be set to None
         if minimum_grade_credit is not None:
             minimum_grade_credit = minimum_grade_credit  # lint-amnesty, pylint: disable=self-assigning-variable
 
-            descriptor.minimum_grade_credit = minimum_grade_credit
-            modulestore().update_item(descriptor, user.id)
+            course.minimum_grade_credit = minimum_grade_credit
+            modulestore().update_item(course, user.id)
 
     @staticmethod
     def delete_grader(course_key, index, user):
         """
         Delete the grader of the given type from the given course.
         """
-        descriptor = modulestore().get_course(course_key)
+        course = modulestore().get_course(course_key)
 
         index = int(index)
-        if index < len(descriptor.raw_grader):
-            del descriptor.raw_grader[index]
+        if index < len(course.raw_grader):
+            del course.raw_grader[index]
             # force propagation to definition
-            descriptor.raw_grader = descriptor.raw_grader
+            course.raw_grader = course.raw_grader
 
-        modulestore().update_item(descriptor, user.id)
+        modulestore().update_item(course, user.id)
         _grading_event_and_signal(course_key, user.id)
 
     @staticmethod
@@ -260,37 +260,37 @@ class CourseGradingModel:
         """
         Delete the course's grace period.
         """
-        descriptor = modulestore().get_course(course_key)
+        course = modulestore().get_course(course_key)
 
-        del descriptor.graceperiod
+        del course.graceperiod
 
-        modulestore().update_item(descriptor, user.id)
+        modulestore().update_item(course, user.id)
 
     @staticmethod
     def get_section_grader_type(location):
-        descriptor = modulestore().get_item(location)
+        block = modulestore().get_item(location)
         return {
-            "graderType": descriptor.format if descriptor.format is not None else 'notgraded',
+            "graderType": block.format if block.format is not None else 'notgraded',
             "location": str(location),
         }
 
     @staticmethod
-    def update_section_grader_type(descriptor, grader_type, user):  # lint-amnesty, pylint: disable=missing-function-docstring
+    def update_section_grader_type(block, grader_type, user):  # lint-amnesty, pylint: disable=missing-function-docstring
         if grader_type is not None and grader_type != 'notgraded':
-            descriptor.format = grader_type
-            descriptor.graded = True
+            block.format = grader_type
+            block.graded = True
         else:
-            del descriptor.format
-            del descriptor.graded
+            del block.format
+            del block.graded
 
-        modulestore().update_item(descriptor, user.id)
-        _grading_event_and_signal(descriptor.location.course_key, user.id)
+        modulestore().update_item(block, user.id)
+        _grading_event_and_signal(block.location.course_key, user.id)
         return {'graderType': grader_type}
 
     @staticmethod
-    def convert_set_grace_period(descriptor):  # lint-amnesty, pylint: disable=missing-function-docstring
+    def convert_set_grace_period(course):  # lint-amnesty, pylint: disable=missing-function-docstring
         # 5 hours 59 minutes 59 seconds => converted to iso format
-        rawgrace = descriptor.graceperiod
+        rawgrace = course.graceperiod
         if rawgrace:
             hours_from_days = rawgrace.days * 24
             seconds = rawgrace.seconds

--- a/cms/djangoapps/xblock_config/apps.py
+++ b/cms/djangoapps/xblock_config/apps.py
@@ -19,9 +19,9 @@ class XBlockConfig(AppConfig):
     def ready(self):
         from openedx.core.lib.xblock_utils import xblock_local_resource_url
 
-        # In order to allow descriptors to use a handler url, we need to
+        # In order to allow blocks to use a handler url, we need to
         # monkey-patch the x_module library.
         # TODO: Remove this code when Runtimes are no longer created by modulestores
         # https://openedx.atlassian.net/wiki/display/PLAT/Convert+from+Storage-centric+runtimes+to+Application-centric+runtimes
-        xmodule.x_module.descriptor_global_handler_url = cms.lib.xblock.runtime.handler_url
-        xmodule.x_module.descriptor_global_local_resource_url = xblock_local_resource_url
+        xmodule.x_module.block_global_handler_url = cms.lib.xblock.runtime.handler_url
+        xmodule.x_module.block_global_local_resource_url = xblock_local_resource_url

--- a/common/djangoapps/util/block_utils.py
+++ b/common/djangoapps/util/block_utils.py
@@ -3,34 +3,34 @@ Utility library containing operations used/shared by multiple CourseBlocks.
 """
 
 
-def yield_dynamic_descriptor_descendants(descriptor, user_id, block_creator=None):
+def yield_dynamic_block_descendants(block, user_id, block_creator=None):
     """
-    This returns all of the descendants of a descriptor. If the descriptor
+    This returns all of the descendants of a block. If the block
     has dynamic children, the block will be created using block_creator
-    and the children (as descriptors) of that module will be returned.
+    and the children (as blocks) of that module will be returned.
     """
-    stack = [descriptor]
+    stack = [block]
 
     while len(stack) > 0:
-        next_descriptor = stack.pop()
-        stack.extend(get_dynamic_descriptor_children(next_descriptor, user_id, block_creator))
-        yield next_descriptor
+        next_block = stack.pop()
+        stack.extend(get_dynamic_block_children(next_block, user_id, block_creator))
+        yield next_block
 
 
-def get_dynamic_descriptor_children(descriptor, user_id, block_creator=None, usage_key_filter=None):
+def get_dynamic_block_children(block, user_id, block_creator=None, usage_key_filter=None):
     """
-    Returns the children of the given descriptor, while supporting descriptors with dynamic children.
+    Returns the children of the given block, while supporting blocks with dynamic children.
     """
     block_children = []
-    if descriptor.has_dynamic_children():
-        block = None
-        if descriptor.scope_ids.user_id and user_id == descriptor.scope_ids.user_id:
+    if block.has_dynamic_children():
+        parent_block = None
+        if block.scope_ids.user_id and user_id == block.scope_ids.user_id:
             # do not rebind the block if it's already bound to a user.
-            block = descriptor
+            parent_block = block
         elif block_creator:
-            block = block_creator(descriptor)
-        if block:
-            block_children = block.get_child_descriptors()
+            parent_block = block_creator(block)
+        if parent_block:
+            block_children = parent_block.get_child_blocks()
     else:
-        block_children = descriptor.get_children(usage_key_filter)
+        block_children = block.get_children(usage_key_filter)
     return block_children

--- a/common/djangoapps/util/course.py
+++ b/common/djangoapps/util/course.py
@@ -40,7 +40,7 @@ def get_encoded_course_sharing_utm_params():
 def get_link_for_about_page(course):
     """
     Arguments:
-        course: This can be either a course overview object or a course descriptor.
+        course: This can be either a course overview object or a course block.
 
     Returns the course sharing url, this can be one of course's social sharing url, marketing url, or
     lms course about url.
@@ -65,7 +65,7 @@ def get_link_for_about_page(course):
 def has_certificates_enabled(course):
     """
     Arguments:
-        course: This can be either a course overview object or a course descriptor.
+        course: This can be either a course overview object or a course block.
     Returns a boolean if the course has enabled certificates
     """
     if not settings.FEATURES.get('CERTIFICATES_HTML_VIEW', False):

--- a/common/djangoapps/util/milestones_helpers.py
+++ b/common/djangoapps/util/milestones_helpers.py
@@ -150,35 +150,35 @@ def get_pre_requisite_courses_not_completed(user, enrolled_courses):
     return pre_requisite_courses
 
 
-def get_prerequisite_courses_display(course_descriptor):
+def get_prerequisite_courses_display(course_block):
     """
     It would retrieve pre-requisite courses, make display strings
     and return list of dictionary with course key as 'key' field
     and course display name as `display` field.
     """
     pre_requisite_courses = []
-    if is_prerequisite_courses_enabled() and course_descriptor.pre_requisite_courses:
-        for course_id in course_descriptor.pre_requisite_courses:
+    if is_prerequisite_courses_enabled() and course_block.pre_requisite_courses:
+        for course_id in course_block.pre_requisite_courses:
             course_key = CourseKey.from_string(course_id)
-            required_course_descriptor = modulestore().get_course(course_key)
+            required_course_block = modulestore().get_course(course_key)
             prc = {
                 'key': course_key,
-                'display': get_course_display_string(required_course_descriptor)
+                'display': get_course_display_string(required_course_block)
             }
             pre_requisite_courses.append(prc)
     return pre_requisite_courses
 
 
-def get_course_display_string(descriptor):
+def get_course_display_string(block):
     """
     Returns a string to display for a course or course overview.
 
     Arguments:
-        descriptor (CourseBlock|CourseOverview): a course or course overview.
+        block (CourseBlock|CourseOverview): a course or course overview.
     """
     return ' '.join([
-        descriptor.display_org_with_default,
-        descriptor.display_number_with_default
+        block.display_org_with_default,
+        block.display_number_with_default
     ])
 
 

--- a/common/djangoapps/util/tests/test_course.py
+++ b/common/djangoapps/util/tests/test_course.py
@@ -44,7 +44,7 @@ class TestCourseSharingLinks(ModuleStoreTestCase):
             enable_mktg_site(Boolean): A feature flag to decide activation of marketing site.
 
         Keyword Arguments:
-            use_overview: indicates whether course overview or course descriptor should get
+            use_overview: indicates whether course overview or course block should get
             past to get_link_for_about_page.
 
         Returns course sharing url.
@@ -115,10 +115,10 @@ class TestCourseSharingLinks(ModuleStoreTestCase):
         ),
     )
     @ddt.unpack
-    def test_sharing_link_with_course_descriptor(self, enable_social_sharing, expected_course_sharing_link):
+    def test_sharing_link_with_course_block(self, enable_social_sharing, expected_course_sharing_link):
         """
         Verify the method gives correct course sharing url on passing
-        course descriptor as a parameter.
+        course block as a parameter.
         """
         actual_course_sharing_link = self.get_course_sharing_link(
             enable_social_sharing=enable_social_sharing,

--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -610,7 +610,7 @@ def certificates_viewable_for_course(course):
     Returns True if certificates are viewable for any student enrolled in the course, False otherwise.
 
     Arguments:
-        course (CourseOverview or course descriptor): The course to check if certificates are viewable
+        course (CourseOverview or course block): The course to check if certificates are viewable
 
     Returns:
         boolean: whether the certificates are viewable or not
@@ -879,7 +879,7 @@ def available_date_for_certificate(course, certificate):
     Returns the available date to use with a certificate
 
     Arguments:
-        course (CourseOverview or course descriptor): The course we're checking
+        course (CourseOverview or course block): The course we're checking
         certificate (GeneratedCertificate): The certificate we're getting the date for
     """
     if _course_uses_available_date(course):
@@ -892,7 +892,7 @@ def display_date_for_certificate(course, certificate):
     Returns the display date that a certificate should display.
 
     Arguments:
-        course (CourseOverview or course descriptor): The course we're getting the date for
+        course (CourseOverview or course block): The course we're getting the date for
     Returns:
         datetime.date
     """

--- a/lms/djangoapps/certificates/tests/test_webview_views.py
+++ b/lms/djangoapps/certificates/tests/test_webview_views.py
@@ -747,7 +747,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
     def test_course_display_name_not_override_with_course_title(self):
-        # if certificate in descriptor has not course_title then course name should not be overridden with this title.
+        # if certificate in block has not course_title then course name should not be overridden with this title.
         test_certificates = [
             {
                 'id': 0,

--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -349,8 +349,8 @@ def _get_user_certificate(request, user, course_key, course_overview, preview_mo
     Returns None if there is no certificate generated for given user
     otherwise returns `GeneratedCertificate` instance.
 
-    We use the course_overview instead of the course descriptor here, so we get the certificate_available_date and
-    certificates_display_behavior validation logic, rather than the raw data from the course descriptor.
+    We use the course_overview instead of the course block here, so we get the certificate_available_date and
+    certificates_display_behavior validation logic, rather than the raw data from the course block.
     """
     user_certificate = None
     if preview_mode:

--- a/lms/djangoapps/course_api/blocks/api.py
+++ b/lms/djangoapps/course_api/blocks/api.py
@@ -159,7 +159,7 @@ def get_block_metadata(block, includes=()):
     Get metadata about the specified XBlock.
 
     Args:
-        block (XModuleDescriptor): block object
+        block (XBlock): block object
         includes (list|set): list or set of metadata keys to include. Valid keys are:
             index_dictionary: a dictionary of data used to add this XBlock's content
                 to a search index.

--- a/lms/djangoapps/course_api/blocks/transformers/student_view.py
+++ b/lms/djangoapps/course_api/blocks/transformers/student_view.py
@@ -33,7 +33,7 @@ class StudentViewTransformer(BlockStructureTransformer):
         for block_key in block_structure.topological_traversal():
             block = block_structure.get_xblock(block_key)
 
-            # We're iterating through descriptors (not bound to a user) that are
+            # We're iterating through blocks (not bound to a user) that are
             # given to us by the modulestore. The reason we look at
             # block.__class__ is to avoid the XModuleDescriptor -> XModule
             # proxying that would happen if we just examined block directly,

--- a/lms/djangoapps/course_api/tests/test_serializers.py
+++ b/lms/djangoapps/course_api/tests/test_serializers.py
@@ -163,8 +163,8 @@ class TestCourseDetailSerializer(TestCourseSerializer):  # lint-amnesty, pylint:
         super().setUp()
 
         # update the expected_data to include the 'overview' data.
-        about_descriptor = XBlock.load_class('about')
-        overview_template = about_descriptor.get_template('overview.yaml')
+        about_block = XBlock.load_class('about')
+        overview_template = about_block.get_template('overview.yaml')
         self.expected_data['overview'] = overview_template.get('data')
 
     # override test case

--- a/lms/djangoapps/course_home_api/progress/views.py
+++ b/lms/djangoapps/course_home_api/progress/views.py
@@ -226,8 +226,8 @@ class ProgressTabView(RetrieveAPIView):
             user_grade = course_grade.percent
             user_has_passing_grade = user_grade >= course.lowest_passing_grade
 
-        descriptor = modulestore().get_course(course_key)
-        grading_policy = descriptor.grading_policy
+        block = modulestore().get_course(course_key)
+        grading_policy = block.grading_policy
         verification_status = IDVerificationService.user_status(student)
         verification_link = None
         if verification_status['status'] is None or verification_status['status'] == 'expired':

--- a/lms/djangoapps/courseware/block_render.py
+++ b/lms/djangoapps/courseware/block_render.py
@@ -297,7 +297,7 @@ def get_block(user, request, usage_key, field_data_cache, position=None, log_if_
                                 XModule javascript to be bound correctly
       - depth                 : number of levels of descendents to cache when loading this module.
                                 None means cache all descendents
-      - static_asset_path     : static asset path to use (overrides descriptor's value); needed
+      - static_asset_path     : static asset path to use (overrides block's value); needed
                                 by get_course_info_section, because info section modules
                                 do not have a course as the parent module, and thus do not
                                 inherit this lms key value.
@@ -310,8 +310,8 @@ def get_block(user, request, usage_key, field_data_cache, position=None, log_if_
     if possible.  If not possible, return None.
     """
     try:
-        descriptor = modulestore().get_item(usage_key, depth=depth)
-        return get_block_for_descriptor(user, request, descriptor, field_data_cache, usage_key.course_key,
+        block = modulestore().get_item(usage_key, depth=depth)
+        return get_block_for_descriptor(user, request, block, field_data_cache, usage_key.course_key,
                                         position=position,
                                         wrap_xblock_display=wrap_xblock_display,
                                         grade_bucket_type=grade_bucket_type,
@@ -365,7 +365,7 @@ def display_access_messages(user, block, view, frag, context):  # pylint: disabl
 
 
 # pylint: disable=too-many-statements
-def get_block_for_descriptor(user, request, descriptor, field_data_cache, course_key,
+def get_block_for_descriptor(user, request, block, field_data_cache, course_key,
                              position=None, wrap_xblock_display=True, grade_bucket_type=None,
                              static_asset_path='', disable_staff_debug_info=False,
                              course=None, will_recheck_access=False):
@@ -387,7 +387,7 @@ def get_block_for_descriptor(user, request, descriptor, field_data_cache, course
 
     return get_block_for_descriptor_internal(
         user=user,
-        descriptor=descriptor,
+        block=block,
         student_data=student_data,
         course_id=course_key,
         track_function=track_function,
@@ -469,17 +469,17 @@ def prepare_runtime_for_user(
         waittime=settings.XQUEUE_WAITTIME_BETWEEN_REQUESTS,
     )
 
-    def inner_get_block(descriptor):
+    def inner_get_block(block):
         """
-        Delegate to get_block_for_descriptor_internal() with all values except `descriptor` set.
+        Delegate to get_block_for_descriptor_internal() with all values except `block` set.
 
         Because it does an access check, it may return None.
         """
-        # TODO: fix this so that make_xqueue_callback uses the descriptor passed into
+        # TODO: fix this so that make_xqueue_callback uses the block passed into
         # inner_get_block, not the parent's callback.  Add it as an argument....
         return get_block_for_descriptor_internal(
             user=user,
-            descriptor=descriptor,
+            block=block,
             student_data=student_data,
             course_id=course_id,
             track_function=track_function,
@@ -648,7 +648,7 @@ def prepare_runtime_for_user(
 
 # TODO: Find all the places that this method is called and figure out how to
 # get a loaded course passed into it
-def get_block_for_descriptor_internal(user, descriptor, student_data, course_id, track_function, request_token,
+def get_block_for_descriptor_internal(user, block, student_data, course_id, track_function, request_token,
                                       position=None, wrap_xblock_display=True, grade_bucket_type=None,
                                       static_asset_path='', user_location=None, disable_staff_debug_info=False,
                                       course=None, will_recheck_access=False):
@@ -664,7 +664,7 @@ def get_block_for_descriptor_internal(user, descriptor, student_data, course_id,
     student_data = prepare_runtime_for_user(
         user=user,
         student_data=student_data,  # These have implicit user bindings, the rest of args are considered not to
-        block=descriptor,
+        block=block,
         course_id=course_id,
         track_function=track_function,
         position=position,
@@ -678,7 +678,7 @@ def get_block_for_descriptor_internal(user, descriptor, student_data, course_id,
         will_recheck_access=will_recheck_access,
     )
 
-    descriptor.bind_for_student(
+    block.bind_for_student(
         user.id,
         [
             partial(DateLookupFieldData, course_id=course_id, user=user),
@@ -687,16 +687,16 @@ def get_block_for_descriptor_internal(user, descriptor, student_data, course_id,
         ],
     )
 
-    descriptor.scope_ids = descriptor.scope_ids._replace(user_id=user.id)
+    block.scope_ids = block.scope_ids._replace(user_id=user.id)
 
     # Do not check access when it's a noauth request.
-    # Not that the access check needs to happen after the descriptor is bound
+    # Not that the access check needs to happen after the block is bound
     # for the student, since there may be field override data for the student
     # that affects xblock visibility.
     user_needs_access_check = getattr(user, 'known', True) and not isinstance(user, SystemUser)
     if user_needs_access_check:
-        access = has_access(user, 'load', descriptor, course_id)
-        # A descriptor should only be returned if either the user has access, or the user doesn't have access, but
+        access = has_access(user, 'load', block, course_id)
+        # A block should only be returned if either the user has access, or the user doesn't have access, but
         # the failed access has a message for the user and the caller of this function specifies it will check access
         # again. This allows blocks to show specific error message or upsells when access is denied.
         caller_will_handle_access_error = (
@@ -705,10 +705,10 @@ def get_block_for_descriptor_internal(user, descriptor, student_data, course_id,
             and (access.user_message or access.user_fragment)
         )
         if access or caller_will_handle_access_error:
-            descriptor.has_access_error = bool(caller_will_handle_access_error)
-            return descriptor
+            block.has_access_error = bool(caller_will_handle_access_error)
+            return block
         return None
-    return descriptor
+    return block
 
 
 def load_single_xblock(request, user_id, course_id, usage_key_string, course=None, will_recheck_access=False):
@@ -719,7 +719,7 @@ def load_single_xblock(request, user_id, course_id, usage_key_string, course=Non
     course_key = CourseKey.from_string(course_id)
     usage_key = usage_key.map_into_course(course_key)
     user = User.objects.get(id=user_id)
-    field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
+    field_data_cache = FieldDataCache.cache_for_block_descendents(
         course_key,
         user,
         modulestore().get_item(usage_key),
@@ -873,15 +873,15 @@ def _get_usage_key_for_course(course_key, usage_id) -> UsageKey:
         raise Http404("Invalid location") from exc
 
 
-def _get_descriptor_by_usage_key(usage_key):
+def _get_block_by_usage_key(usage_key):
     """
-    Gets a descriptor instance based on a mapped-to-course usage_key
+    Gets a block instance based on a mapped-to-course usage_key
 
     Returns (instance, tracking_context)
     """
     try:
-        descriptor = modulestore().get_item(usage_key)
-        descriptor_orig_usage_key, descriptor_orig_version = modulestore().get_block_original_usage(usage_key)
+        block = modulestore().get_item(usage_key)
+        block_orig_usage_key, block_orig_version = modulestore().get_block_original_usage(usage_key)
     except ItemNotFoundError as exc:
         log.warning(
             "Invalid location for course id %s: %s",
@@ -893,17 +893,17 @@ def _get_descriptor_by_usage_key(usage_key):
     tracking_context = {
         'module': {
             # xss-lint: disable=python-deprecated-display-name
-            'display_name': descriptor.display_name_with_default_escaped,
-            'usage_key': str(descriptor.location),
+            'display_name': block.display_name_with_default_escaped,
+            'usage_key': str(block.location),
         }
     }
 
     # For blocks that are inherited from a content library, we add some additional metadata:
-    if descriptor_orig_usage_key is not None:
-        tracking_context['module']['original_usage_key'] = str(descriptor_orig_usage_key)
-        tracking_context['module']['original_usage_version'] = str(descriptor_orig_version)
+    if block_orig_usage_key is not None:
+        tracking_context['module']['original_usage_key'] = str(block_orig_usage_key)
+        tracking_context['module']['original_usage_version'] = str(block_orig_version)
 
-    return descriptor, tracking_context
+    return block, tracking_context
 
 
 def get_block_by_usage_id(request, course_id, usage_id, disable_staff_debug_info=False, course=None,
@@ -915,19 +915,19 @@ def get_block_by_usage_id(request, course_id, usage_id, disable_staff_debug_info
     """
     course_key = CourseKey.from_string(course_id)
     usage_key = _get_usage_key_for_course(course_key, usage_id)
-    descriptor, tracking_context = _get_descriptor_by_usage_key(usage_key)
+    block, tracking_context = _get_block_by_usage_key(usage_key)
 
-    _, user = setup_masquerade(request, course_key, has_access(request.user, 'staff', descriptor, course_key))
-    field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
+    _, user = setup_masquerade(request, course_key, has_access(request.user, 'staff', block, course_key))
+    field_data_cache = FieldDataCache.cache_for_block_descendents(
         course_key,
         user,
-        descriptor,
+        block,
         read_only=CrawlersConfig.is_crawler(request),
     )
     instance = get_block_for_descriptor(
         user,
         request,
-        descriptor,
+        block,
         field_data_cache,
         usage_key.course_key,
         disable_staff_debug_info=disable_staff_debug_info,
@@ -978,13 +978,13 @@ def _invoke_xblock_handler(request, course_id, usage_id, handler, suffix, course
             block_usage_key = usage_key
 
         # Peek at the handler method to see if it actually wants to check access itself. (The handler may not want
-        # inaccessible blocks stripped from the tree.) This ends up doing two modulestore lookups for the descriptor,
+        # inaccessible blocks stripped from the tree.) This ends up doing two modulestore lookups for the block,
         # but the blocks should be available in the request cache the second time.
         # At the time of writing, this is only used by one handler. If this usage grows, we may want to re-evaluate
         # how we do this to something more elegant. If you are the author of a third party block that decides it wants
         # to set this too, please let us know so we can consider making this easier / better-documented.
-        descriptor, _ = _get_descriptor_by_usage_key(block_usage_key)
-        handler_method = getattr(descriptor, handler, False)
+        block, _ = _get_block_by_usage_key(block_usage_key)
+        handler_method = getattr(block, handler, False)
         will_recheck_access = handler_method and getattr(handler_method, 'will_recheck_access', False)
 
         instance, tracking_context = get_block_by_usage_id(

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -76,7 +76,7 @@ _Assignment = namedtuple(
 
 def get_course(course_id, depth=0):
     """
-    Given a course id, return the corresponding course descriptor.
+    Given a course id, return the corresponding course block.
 
     If the course does not exist, raises a CourseRunNotFound. This is appropriate
     for internal use.
@@ -92,9 +92,9 @@ def get_course(course_id, depth=0):
 
 def get_course_with_access(user, action, course_key, depth=0, check_if_enrolled=False, check_survey_complete=True, check_if_authenticated=False):  # lint-amnesty, pylint: disable=line-too-long
     """
-    Given a course_key, look up the corresponding course descriptor,
+    Given a course_key, look up the corresponding course block,
     check that the user has the access to perform the specified action
-    on the course, and return the descriptor.
+    on the course, and return the block.
 
     Raises a 404 if the course_key is invalid, or the user doesn't have access.
 
@@ -857,26 +857,26 @@ def get_problems_in_section(section):
     """
     This returns a dict having problems in a section.
     Returning dict has problem location as keys and problem
-    descriptor as values.
+    block as values.
     """
 
-    problem_descriptors = defaultdict()
+    problem_blocks = defaultdict()
     if not isinstance(section, UsageKey):
         section_key = UsageKey.from_string(section)
     else:
         section_key = section
     # it will be a Mongo performance boost, if you pass in a depth=3 argument here
     # as it will optimize round trips to the database to fetch all children for the current node
-    section_descriptor = modulestore().get_item(section_key, depth=3)
+    section_block = modulestore().get_item(section_key, depth=3)
 
     # iterate over section, sub-section, vertical
-    for subsection in section_descriptor.get_children():
+    for subsection in section_block.get_children():
         for vertical in subsection.get_children():
             for component in vertical.get_children():
                 if component.location.block_type == 'problem' and getattr(component, 'has_score', False):
-                    problem_descriptors[str(component.location)] = component
+                    problem_blocks[str(component.location)] = component
 
-    return problem_descriptors
+    return problem_blocks
 
 
 def get_current_child(xblock, min_depth=None, requested_child=None):

--- a/lms/djangoapps/courseware/management/commands/clean_xml.py
+++ b/lms/djangoapps/courseware/management/commands/clean_xml.py
@@ -17,7 +17,7 @@ from xmodule.modulestore.xml import XMLModuleStore
 
 def traverse_tree(course):
     """
-    Load every descriptor in course.  Return bool success value.
+    Load every block in course.  Return bool success value.
     """
     queue = [course]
     while len(queue) > 0:

--- a/lms/djangoapps/courseware/masquerade.py
+++ b/lms/djangoapps/courseware/masquerade.py
@@ -112,8 +112,8 @@ class MasqueradeView(View):
             group_id=None,
             user_name=None,
         )
-        descriptor = modulestore().get_course(course_key)
-        partitions = get_all_partitions_for_course(descriptor, active_only=True)
+        block = modulestore().get_course(course_key)
+        partitions = get_all_partitions_for_course(block, active_only=True)
         data = {
             'success': True,
             'active': {

--- a/lms/djangoapps/courseware/tests/helpers.py
+++ b/lms/djangoapps/courseware/tests/helpers.py
@@ -85,20 +85,20 @@ class BaseTestXmodule(ModuleStoreTestCase):
             'category': self.CATEGORY
         })
 
-        self.item_descriptor = BlockFactory.create(**kwargs)
+        self.block = BlockFactory.create(**kwargs)
 
         self.runtime = self.new_descriptor_runtime()
 
         field_data = {}
         field_data.update(self.MODEL_DATA)
         student_data = DictFieldData(field_data)
-        self.item_descriptor._field_data = LmsFieldData(self.item_descriptor._field_data, student_data)  # lint-amnesty, pylint: disable=protected-access
+        self.block._field_data = LmsFieldData(self.block._field_data, student_data)  # lint-amnesty, pylint: disable=protected-access
 
         if runtime_kwargs is None:
             runtime_kwargs = {}
-        self.new_module_runtime(runtime=self.item_descriptor.runtime, **runtime_kwargs)
+        self.new_module_runtime(runtime=self.block.runtime, **runtime_kwargs)
 
-        self.item_url = str(self.item_descriptor.location)
+        self.item_url = str(self.block.location)
 
     def setup_course(self):  # lint-amnesty, pylint: disable=missing-function-docstring
         self.course = CourseFactory.create(data=self.COURSE_DATA)

--- a/lms/djangoapps/courseware/tests/test_block_render.py
+++ b/lms/djangoapps/courseware/tests/test_block_render.py
@@ -251,7 +251,7 @@ class BlockRenderTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
 
         course = get_course_with_access(self.mock_user, 'load', self.course_key)
 
-        field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
+        field_data_cache = FieldDataCache.cache_for_block_descendents(
             self.course_key, self.mock_user, course, depth=2)
 
         block = render.get_block(
@@ -411,14 +411,14 @@ class BlockRenderTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         request = self.request_factory.get('')
         request.user = self.mock_user
         course = CourseFactory()
-        descriptor = BlockFactory(category=block_type, parent=course)
-        field_data_cache = FieldDataCache([self.toy_course, descriptor], self.toy_course.id, self.mock_user)
+        block = BlockFactory(category=block_type, parent=course)
+        field_data_cache = FieldDataCache([self.toy_course, block], self.toy_course.id, self.mock_user)
         # This is verifying that caching doesn't cause an error during get_block_for_descriptor, which
         # is why it calls the method twice identically.
         render.get_block_for_descriptor(
             self.mock_user,
             request,
-            descriptor,
+            block,
             field_data_cache,
             self.toy_course.id,
             course=self.toy_course
@@ -426,7 +426,7 @@ class BlockRenderTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         render.get_block_for_descriptor(
             self.mock_user,
             request,
-            descriptor,
+            block,
             field_data_cache,
             self.toy_course.id,
             course=self.toy_course
@@ -442,7 +442,7 @@ class BlockRenderTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     @ddt.data('regular', 'test_aside')
     def test_rebind_different_users(self, block_category):
         """
-        This tests the rebinding a descriptor to a student does not result
+        This tests the rebinding a block to a student does not result
         in overly nested _field_data.
         """
         def create_aside(item, block_type):
@@ -467,33 +467,33 @@ class BlockRenderTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         request.user = self.mock_user
         course = CourseFactory.create()
 
-        descriptor = BlockFactory(category="html", parent=course)
+        block = BlockFactory(category="html", parent=course)
         if block_category == 'test_aside':
-            descriptor = create_aside(descriptor, "test_aside")
+            block = create_aside(block, "test_aside")
 
         field_data_cache = FieldDataCache(
-            [course, descriptor], course.id, self.mock_user
+            [course, block], course.id, self.mock_user
         )
 
         # grab what _field_data was originally set to
-        original_field_data = descriptor._field_data  # lint-amnesty, pylint: disable=no-member, protected-access
+        original_field_data = block._field_data  # lint-amnesty, pylint: disable=no-member, protected-access
 
         render.get_block_for_descriptor(
-            self.mock_user, request, descriptor, field_data_cache, course.id, course=course
+            self.mock_user, request, block, field_data_cache, course.id, course=course
         )
 
         # check that _unwrapped_field_data is the same as the original
         # _field_data, but now _field_data as been reset.
         # pylint: disable=protected-access
-        assert descriptor._unwrapped_field_data is original_field_data  # lint-amnesty, pylint: disable=no-member
-        assert descriptor._unwrapped_field_data is not descriptor._field_data  # lint-amnesty, pylint: disable=no-member
+        assert block._unwrapped_field_data is original_field_data  # lint-amnesty, pylint: disable=no-member
+        assert block._unwrapped_field_data is not block._field_data  # lint-amnesty, pylint: disable=no-member
 
         # now bind this block to a few other students
         for user in [UserFactory(), UserFactory(), self.mock_user]:
             render.get_block_for_descriptor(
                 user,
                 request,
-                descriptor,
+                block,
                 field_data_cache,
                 course.id,
                 course=course
@@ -501,14 +501,14 @@ class BlockRenderTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
 
         # _field_data should now be wrapped by LmsFieldData
         # pylint: disable=protected-access
-        assert isinstance(descriptor._field_data, LmsFieldData)  # lint-amnesty, pylint: disable=no-member
+        assert isinstance(block._field_data, LmsFieldData)  # lint-amnesty, pylint: disable=no-member
 
         # the LmsFieldData should now wrap OverrideFieldData
-        assert isinstance(descriptor._field_data._authored_data._source, OverrideFieldData)   # lint-amnesty, pylint: disable=no-member, line-too-long
+        assert isinstance(block._field_data._authored_data._source, OverrideFieldData)   # lint-amnesty, pylint: disable=no-member, line-too-long
 
         # the OverrideFieldData should point to the date FieldData
-        assert isinstance(descriptor._field_data._authored_data._source.fallback, DateLookupFieldData)    # lint-amnesty, pylint: disable=no-member, line-too-long
-        assert descriptor._field_data._authored_data._source.fallback._defaults is descriptor._unwrapped_field_data    # lint-amnesty, pylint: disable=no-member, line-too-long
+        assert isinstance(block._field_data._authored_data._source.fallback, DateLookupFieldData)    # lint-amnesty, pylint: disable=no-member, line-too-long
+        assert block._field_data._authored_data._source.fallback._defaults is block._unwrapped_field_data    # lint-amnesty, pylint: disable=no-member, line-too-long
 
     def test_hash_resource(self):
         """
@@ -903,17 +903,17 @@ class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCas
     @patch('xmodule.services.grades_signals.SCORE_PUBLISHED.send')
     def test_anonymous_user_not_be_graded(self, mock_score_signal):
         course = CourseFactory.create()
-        descriptor_kwargs = {
+        block_kwargs = {
             'category': 'problem',
         }
         request = self.request_factory.get('/')
         request.user = AnonymousUser()
-        descriptor = BlockFactory.create(**descriptor_kwargs)
+        block = BlockFactory.create(**block_kwargs)
 
         render.handle_xblock_callback(
             request,
             str(course.id),
-            quote_slashes(str(descriptor.location)),
+            quote_slashes(str(block.location)),
             'xmodule_handler',
             'problem_check',
         )
@@ -929,12 +929,12 @@ class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCas
     def test_will_recheck_access_handler_attribute(self, handler, will_recheck_access, mock_get_block):
         """Confirm that we pay attention to any 'will_recheck_access' attributes on handler methods"""
         course = CourseFactory.create()
-        descriptor_kwargs = {
+        block_kwargs = {
             'category': 'sequential',
             'parent': course,
         }
-        descriptor = BlockFactory.create(**descriptor_kwargs)
-        usage_id = str(descriptor.location)
+        block = BlockFactory.create(**block_kwargs)
+        usage_id = str(block.location)
 
         # Send no special parameters, which will be invalid, but we don't care
         request = self.request_factory.post('/', data='{}', content_type='application/json')
@@ -1021,7 +1021,7 @@ class TestTOC(ModuleStoreTestCase):
         with self.modulestore.bulk_operations(self.course_key):
             with check_mongo_calls(num_finds, num_sends):
                 self.toy_course = self.store.get_course(self.course_key, depth=2)  # pylint: disable=attribute-defined-outside-init
-                self.field_data_cache = FieldDataCache.cache_for_descriptor_descendents(  # lint-amnesty, pylint: disable=attribute-defined-outside-init
+                self.field_data_cache = FieldDataCache.cache_for_block_descendents(  # lint-amnesty, pylint: disable=attribute-defined-outside-init
                     self.course_key, self.request.user, self.toy_course, depth=2
                 )
 
@@ -1113,7 +1113,7 @@ class TestProctoringRendering(ModuleStoreTestCase):
         self.modulestore = self.store._get_modulestore_for_courselike(self.course_key)  # pylint: disable=protected-access
         with self.modulestore.bulk_operations(self.course_key):
             self.toy_course = self.store.get_course(self.course_key, depth=2)
-            self.field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
+            self.field_data_cache = FieldDataCache.cache_for_block_descendents(
                 self.course_key, self.request.user, self.toy_course, depth=2
             )
 
@@ -1348,7 +1348,7 @@ class TestProctoringRendering(ModuleStoreTestCase):
         self.toy_course = self.update_course(self.toy_course, self.user.id)
 
         # refresh cache after update
-        self.field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
+        self.field_data_cache = FieldDataCache.cache_for_block_descendents(
             self.course_key, self.request.user, self.toy_course, depth=2
         )
 
@@ -1440,7 +1440,7 @@ class TestGatedSubsectionRendering(ModuleStoreTestCase, MilestonesTestCaseMixin)
 
         self.request = RequestFactoryNoCsrf().get(f'/courses/{self.course.id}/{self.chapter.display_name}')
         self.request.user = UserFactory()
-        self.field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
+        self.field_data_cache = FieldDataCache.cache_for_block_descendents(
             self.course.id, self.request.user, self.course, depth=2
         )
         gating_api.add_prerequisite(self.course.id, self.open_seq.location)
@@ -1504,15 +1504,15 @@ class TestHtmlModifiers(ModuleStoreTestCase):
         self.rewrite_link = '<a href="/static/foo/content">Test rewrite</a>'
         self.rewrite_bad_link = '<img src="/static//file.jpg" />'
         self.course_link = '<a href="/course/bar/content">Test course rewrite</a>'
-        self.descriptor = BlockFactory.create(
+        self.block = BlockFactory.create(
             category='html',
             data=self.content_string + self.rewrite_link + self.rewrite_bad_link + self.course_link
         )
-        self.location = self.descriptor.location
-        self.field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
+        self.location = self.block.location
+        self.field_data_cache = FieldDataCache.cache_for_block_descendents(
             self.course.id,
             self.user,
-            self.descriptor
+            self.block
         )
 
     def test_xblock_display_wrapper_enabled(self):
@@ -1649,12 +1649,12 @@ class JsonInitDataTest(ModuleStoreTestCase):
         mock_request = MagicMock()
         mock_request.user = mock_user
         course = CourseFactory()
-        descriptor = BlockFactory(category='withjson', parent=course)
-        field_data_cache = FieldDataCache([course, descriptor], course.id, mock_user)
+        block = BlockFactory(category='withjson', parent=course)
+        field_data_cache = FieldDataCache([course, block], course.id, mock_user)
         block = render.get_block_for_descriptor(
             mock_user,
             mock_request,
-            descriptor,
+            block,
             field_data_cache,
             course.id,
             course=course
@@ -1704,17 +1704,17 @@ class TestStaffDebugInfo(SharedModuleStoreTestCase):
             options=['Correct', 'Incorrect'],
             correct_option='Correct'
         )
-        self.descriptor = BlockFactory.create(
+        self.block = BlockFactory.create(
             category='problem',
             data=problem_xml,
             display_name='Option Response Problem'
         )
 
-        self.location = self.descriptor.location
-        self.field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
+        self.location = self.block.location
+        self.field_data_cache = FieldDataCache.cache_for_block_descendents(
             self.course.id,
             self.user,
-            self.descriptor
+            self.block
         )
 
     @patch.dict('django.conf.settings.FEATURES', {'DISPLAY_DEBUG_INFO_TO_STAFF': False})
@@ -1757,14 +1757,14 @@ class TestStaffDebugInfo(SharedModuleStoreTestCase):
             </optionresponse>
         </problem>
         """
-        problem_descriptor = BlockFactory.create(
+        problem_block = BlockFactory.create(
             category='problem',
             data=problem_xml
         )
         block = render.get_block(
             self.user,
             self.request,
-            problem_descriptor.location,
+            problem_block.location,
             self.field_data_cache
         )
         html_fragment = block.render(STUDENT_VIEW)
@@ -1774,26 +1774,26 @@ class TestStaffDebugInfo(SharedModuleStoreTestCase):
         <label for="sd_fs_{block_id}"> / 0</label>
       </div>""")
 
-        assert expected_score_override_html.format(block_id=problem_descriptor.location.block_id) in\
+        assert expected_score_override_html.format(block_id=problem_block.location.block_id) in\
                html_fragment.content
 
     @XBlock.register_temp_plugin(DetachedXBlock, identifier='detached-block')
     def test_staff_debug_info_disabled_for_detached_blocks(self):
         """Staff markup should not be present on detached blocks."""
 
-        descriptor = BlockFactory.create(
+        detached_block = BlockFactory.create(
             category='detached-block',
             display_name='Detached Block'
         )
-        field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
+        field_data_cache = FieldDataCache.cache_for_block_descendents(
             self.course.id,
             self.user,
-            descriptor
+            detached_block
         )
         block = render.get_block(
             self.user,
             self.request,
-            descriptor.location,
+            detached_block.location,
             field_data_cache,
         )
         result_fragment = block.render(STUDENT_VIEW)
@@ -1813,21 +1813,21 @@ class TestStaffDebugInfo(SharedModuleStoreTestCase):
     def test_histogram_enabled_for_unscored_xblocks(self):
         """Histograms should not display for xblocks which are not scored."""
 
-        html_descriptor = BlockFactory.create(
+        html_block = BlockFactory.create(
             category='html',
             data='Here are some course details.'
         )
-        field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
+        field_data_cache = FieldDataCache.cache_for_block_descendents(
             self.course.id,
             self.user,
-            self.descriptor
+            self.block
         )
         with patch('openedx.core.lib.xblock_utils.grade_histogram') as mock_grade_histogram:
             mock_grade_histogram.return_value = []
             block = render.get_block(
                 self.user,
                 self.request,
-                html_descriptor.location,
+                html_block.location,
                 field_data_cache,
             )
             block.render(STUDENT_VIEW)
@@ -1888,7 +1888,7 @@ class TestAnonymousStudentId(SharedModuleStoreTestCase, LoginEnrollmentTestCase)
     @patch('lms.djangoapps.courseware.block_render.has_access', Mock(return_value=True, autospec=True))
     def _get_anonymous_id(self, course_id, xblock_class):  # lint-amnesty, pylint: disable=missing-function-docstring
         location = course_id.make_usage_key('dummy_category', 'dummy_name')
-        descriptor = Mock(
+        block = Mock(
             spec=xblock_class,
             _field_data=Mock(spec=FieldData, name='field_data'),
             location=location,
@@ -1901,36 +1901,36 @@ class TestAnonymousStudentId(SharedModuleStoreTestCase, LoginEnrollmentTestCase)
                 name='runtime',
             ),
             scope_ids=Mock(spec=ScopeIds),
-            name='descriptor',
+            name='block',
             _field_data_cache={},
             _dirty_fields={},
             fields={},
             days_early_for_beta=None,
         )
-        descriptor.runtime = DescriptorSystem(None, None, None)
+        block.runtime = DescriptorSystem(None, None, None)
         # Use the xblock_class's bind_for_student method
-        descriptor.bind_for_student = partial(xblock_class.bind_for_student, descriptor)
+        block.bind_for_student = partial(xblock_class.bind_for_student, block)
 
         if hasattr(xblock_class, 'module_class'):
-            descriptor.module_class = xblock_class.module_class
+            block.module_class = xblock_class.module_class
 
-        block = render.get_block_for_descriptor_internal(
+        rendered_block = render.get_block_for_descriptor_internal(
             user=self.user,
-            descriptor=descriptor,
+            block=block,
             student_data=Mock(spec=FieldData, name='student_data'),
             course_id=course_id,
             track_function=Mock(name='track_function'),  # Track Function
             request_token='request_token',
             course=self.course,
         )
-        current_user = block.runtime.service(block, 'user').get_current_user()
+        current_user = rendered_block.runtime.service(rendered_block, 'user').get_current_user()
         return current_user.opt_attrs.get(ATTR_KEY_ANONYMOUS_USER_ID)
 
     @ddt.data(*PER_STUDENT_ANONYMIZED_XBLOCKS)
-    def test_per_student_anonymized_id(self, descriptor_class):
+    def test_per_student_anonymized_id(self, block_class):
         for course_id in ('MITx/6.00x/2012_Fall', 'MITx/6.00x/2013_Spring'):
             assert 'de619ab51c7f4e9c7216b4644c24f3b5' == \
-                   self._get_anonymous_id(CourseKey.from_string(course_id), descriptor_class)
+                   self._get_anonymous_id(CourseKey.from_string(course_id), block_class)
 
     @ddt.data(*PER_COURSE_ANONYMIZED_XBLOCKS)
     def test_per_course_anonymized_id(self, xblock_class):
@@ -2014,14 +2014,14 @@ class TestModuleTrackingContext(SharedModuleStoreTestCase):
         metadata from the emitted problem_check event.
         """
 
-        descriptor_kwargs = {
+        block_kwargs = {
             'category': 'problem',
             'data': self.problem_xml
         }
         if problem_display_name:
-            descriptor_kwargs['display_name'] = problem_display_name
+            block_kwargs['display_name'] = problem_display_name
 
-        descriptor = BlockFactory.create(**descriptor_kwargs)
+        block = BlockFactory.create(**block_kwargs)
         mock_tracker_for_context = MagicMock()
         with patch('lms.djangoapps.courseware.block_render.tracker', mock_tracker_for_context), patch(
             'xmodule.services.tracker', mock_tracker_for_context
@@ -2029,7 +2029,7 @@ class TestModuleTrackingContext(SharedModuleStoreTestCase):
             render.handle_xblock_callback(
                 self.request,
                 str(self.course.id),
-                quote_slashes(str(descriptor.location)),
+                quote_slashes(str(block.location)),
                 'xmodule_handler',
                 'problem_check',
             )
@@ -2096,7 +2096,7 @@ class TestXBlockRuntimeEvent(TestSubmittingProblems):
         """Helper function to get useful block at self.location in self.course_id for user"""
         mock_request = MagicMock()
         mock_request.user = user
-        field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
+        field_data_cache = FieldDataCache.cache_for_block_descendents(
             self.course.id, user, self.course, depth=2)
 
         return render.get_block(
@@ -2167,7 +2167,7 @@ class TestRebindBlock(TestSubmittingProblems):
         """Helper function to get useful block at self.location in self.course_id for user"""
         mock_request = MagicMock()
         mock_request.user = user
-        field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
+        field_data_cache = FieldDataCache.cache_for_block_descendents(
             self.course.id, user, self.course, depth=2)
 
         if item is None:
@@ -2248,9 +2248,9 @@ class TestEventPublishing(ModuleStoreTestCase, LoginEnrollmentTestCase):
         request = self.request_factory.get('')
         request.user = self.mock_user
         course = CourseFactory()
-        descriptor = BlockFactory(category='xblock', parent=course)
-        field_data_cache = FieldDataCache([course, descriptor], course.id, self.mock_user)
-        block = render.get_block(self.mock_user, request, descriptor.location, field_data_cache)
+        block = BlockFactory(category='xblock', parent=course)
+        field_data_cache = FieldDataCache([course, block], course.id, self.mock_user)
+        block = render.get_block(self.mock_user, request, block.location, field_data_cache)
 
         event_type = 'event_type'
         event = {'event': 'data'}
@@ -2273,7 +2273,7 @@ class LMSXBlockServiceMixin(SharedModuleStoreTestCase):
         _ = render.prepare_runtime_for_user(
             self.user,
             self.student_data,
-            self.descriptor,
+            self.block,
             self.course.id,
             self.track_function,
             self.request_token,
@@ -2291,7 +2291,7 @@ class LMSXBlockServiceMixin(SharedModuleStoreTestCase):
         self.student_data = Mock()
         self.track_function = Mock()
         self.request_token = Mock()
-        self.descriptor = BlockFactory(category="pure", parent=self.course)
+        self.block = BlockFactory(category="pure", parent=self.course)
         self._prepare_runtime()
 
 
@@ -2334,19 +2334,19 @@ class LMSXBlockServiceBindingTest(LMSXBlockServiceMixin):
         """
         Tests that the 'user', 'i18n', and 'fs' services are provided by the LMS runtime.
         """
-        service = self.descriptor.runtime.service(self.descriptor, expected_service)
+        service = self.block.runtime.service(self.block, expected_service)
         assert service is not None
 
     def test_beta_tester_fields_added(self):
         """
         Tests that the beta tester fields are set on LMS runtime.
         """
-        self.descriptor.days_early_for_beta = 5
+        self.block.days_early_for_beta = 5
         self._prepare_runtime()
 
         # pylint: disable=no-member
-        assert not self.descriptor.runtime.user_is_beta_tester
-        assert self.descriptor.runtime.days_early_for_beta == 5
+        assert not self.block.runtime.user_is_beta_tester
+        assert self.block.runtime.days_early_for_beta == 5
 
     def test_get_set_tag(self):
         """
@@ -2356,23 +2356,23 @@ class LMSXBlockServiceBindingTest(LMSXBlockServiceMixin):
         key = 'key1'
 
         # test for when we haven't set the tag yet
-        tag = self.descriptor.runtime.service(self.descriptor, 'user_tags').get_tag(scope, key)
+        tag = self.block.runtime.service(self.block, 'user_tags').get_tag(scope, key)
         assert tag is None
 
         # set the tag
         set_value = 'value'
-        self.descriptor.runtime.service(self.descriptor, 'user_tags').set_tag(scope, key, set_value)
-        tag = self.descriptor.runtime.service(self.descriptor, 'user_tags').get_tag(scope, key)
+        self.block.runtime.service(self.block, 'user_tags').set_tag(scope, key, set_value)
+        tag = self.block.runtime.service(self.block, 'user_tags').get_tag(scope, key)
 
         assert tag == set_value
 
         # Try to set tag in wrong scope
         with pytest.raises(ValueError):
-            self.descriptor.runtime.service(self.descriptor, 'user_tags').set_tag('fake_scope', key, set_value)
+            self.block.runtime.service(self.block, 'user_tags').set_tag('fake_scope', key, set_value)
 
         # Try to get tag in wrong scope
         with pytest.raises(ValueError):
-            self.descriptor.runtime.service(self.descriptor, 'user_tags').get_tag('fake_scope', key)
+            self.block.runtime.service(self.block, 'user_tags').get_tag('fake_scope', key)
 
 
 @ddt.ddt
@@ -2382,23 +2382,23 @@ class TestBadgingService(LMSXBlockServiceMixin):
     @patch.dict(settings.FEATURES, {'ENABLE_OPENBADGES': True})
     def test_service_rendered(self):
         self._prepare_runtime()
-        assert self.descriptor.runtime.service(self.descriptor, 'badging')
+        assert self.block.runtime.service(self.block, 'badging')
 
     def test_no_service_rendered(self):
         with pytest.raises(NoSuchServiceError):
-            self.descriptor.runtime.service(self.descriptor, 'badging')
+            self.block.runtime.service(self.block, 'badging')
 
     @ddt.data(True, False)
     @patch.dict(settings.FEATURES, {'ENABLE_OPENBADGES': True})
     def test_course_badges_toggle(self, toggle):
         self.course = CourseFactory.create(metadata={'issue_badges': toggle})
         self._prepare_runtime()
-        assert self.descriptor.runtime.service(self.descriptor, 'badging').course_badges_enabled is toggle
+        assert self.block.runtime.service(self.block, 'badging').course_badges_enabled is toggle
 
     @patch.dict(settings.FEATURES, {'ENABLE_OPENBADGES': True})
     def test_get_badge_class(self):
         self._prepare_runtime()
-        badge_service = self.descriptor.runtime.service(self.descriptor, 'badging')
+        badge_service = self.block.runtime.service(self.block, 'badging')
         premade_badge_class = BadgeClassFactory.create()
         # Ignore additional parameters. This class already exists.
         # We should get back the first class we created, rather than a new one.
@@ -2422,7 +2422,7 @@ class TestI18nService(LMSXBlockServiceMixin):
         """
         Test: module i18n service in LMS
         """
-        i18n_service = self.descriptor.runtime.service(self.descriptor, 'i18n')
+        i18n_service = self.block.runtime.service(self.block, 'i18n')
         assert i18n_service is not None
         assert isinstance(i18n_service, XBlockI18nService)
 
@@ -2430,32 +2430,32 @@ class TestI18nService(LMSXBlockServiceMixin):
         """
         Test: NoSuchServiceError should be raised block declaration returns none
         """
-        self.descriptor.service_declaration = Mock(return_value=None)
+        self.block.service_declaration = Mock(return_value=None)
         with pytest.raises(NoSuchServiceError):
-            self.descriptor.runtime.service(self.descriptor, 'i18n')
+            self.block.runtime.service(self.block, 'i18n')
 
     def test_no_service_exception_(self):
         """
         Test: NoSuchServiceError should be raised if i18n service is none.
         """
-        i18nService = self.descriptor.runtime._services['i18n']  # pylint: disable=protected-access
-        self.descriptor.runtime._runtime_services['i18n'] = None  # pylint: disable=protected-access
-        self.descriptor.runtime._services['i18n'] = None  # pylint: disable=protected-access
+        i18nService = self.block.runtime._services['i18n']  # pylint: disable=protected-access
+        self.block.runtime._runtime_services['i18n'] = None  # pylint: disable=protected-access
+        self.block.runtime._services['i18n'] = None  # pylint: disable=protected-access
         with pytest.raises(NoSuchServiceError):
-            self.descriptor.runtime.service(self.descriptor, 'i18n')
-        self.descriptor.runtime._services['i18n'] = i18nService  # pylint: disable=protected-access
+            self.block.runtime.service(self.block, 'i18n')
+        self.block.runtime._services['i18n'] = i18nService  # pylint: disable=protected-access
 
     def test_i18n_service_callable(self):
         """
         Test: _services dict should contain the callable i18n service in LMS.
         """
-        assert callable(self.descriptor.runtime._services.get('i18n'))  # pylint: disable=protected-access
+        assert callable(self.block.runtime._services.get('i18n'))  # pylint: disable=protected-access
 
     def test_i18n_service_not_callable(self):
         """
         Test: i18n service should not be callable in LMS after initialization.
         """
-        assert not callable(self.descriptor.runtime.service(self.descriptor, 'i18n'))
+        assert not callable(self.block.runtime.service(self.block, 'i18n'))
 
 
 class PureXBlockWithChildren(PureXBlock):
@@ -2492,27 +2492,10 @@ class TestFilteredChildren(SharedModuleStoreTestCase):
 
     @ddt.data(*USER_NUMBERS)
     @XBlock.register_temp_plugin(PureXBlockWithChildren, identifier='xblock')
-    def test_unbound_then_bound_as_descriptor(self, user_number):
-        user = self.users[user_number]
-        block = self._load_block()
-        self.assertUnboundChildren(block)
-        self._bind_block(block, user)
-        self.assertBoundChildren(block, user)
-
-    @ddt.data(*USER_NUMBERS)
-    @XBlock.register_temp_plugin(PureXBlockWithChildren, identifier='xblock')
     def test_unbound_then_bound_as_xblock(self, user_number):
         user = self.users[user_number]
         block = self._load_block()
         self.assertUnboundChildren(block)
-        self._bind_block(block, user)
-        self.assertBoundChildren(block, user)
-
-    @ddt.data(*USER_NUMBERS)
-    @XBlock.register_temp_plugin(PureXBlockWithChildren, identifier='xblock')
-    def test_bound_only_as_descriptor(self, user_number):
-        user = self.users[user_number]
-        block = self._load_block()
         self._bind_block(block, user)
         self.assertBoundChildren(block, user)
 
@@ -2545,7 +2528,7 @@ class TestFilteredChildren(SharedModuleStoreTestCase):
         Bind `block` to the supplied `user`.
         """
         course_id = self.course.id
-        field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
+        field_data_cache = FieldDataCache.cache_for_block_descendents(
             course_id,
             user,
             block,
@@ -2606,25 +2589,25 @@ class TestDisabledXBlockTypes(ModuleStoreTestCase):
 
     def test_get_item(self):
         course = CourseFactory()
-        self._verify_descriptor('video', course, 'HiddenBlockWithMixins')
+        self._verify_block('video', course, 'HiddenBlockWithMixins')
 
     def test_dynamic_updates(self):
         """Tests that the list of disabled xblocks can dynamically update."""
         course = CourseFactory()
-        item_usage_id = self._verify_descriptor('problem', course, 'ProblemBlockWithMixins')
+        item_usage_id = self._verify_block('problem', course, 'ProblemBlockWithMixins')
         XBlockConfiguration(name='problem', enabled=False).save()
 
         # First verify that the cached value is used until there is a new request cache.
-        self._verify_descriptor('problem', course, 'ProblemBlockWithMixins', item_usage_id)
+        self._verify_block('problem', course, 'ProblemBlockWithMixins', item_usage_id)
 
         # Now simulate a new request cache.
         self.store.request_cache.data.clear()
-        self._verify_descriptor('problem', course, 'HiddenBlockWithMixins', item_usage_id)
+        self._verify_block('problem', course, 'HiddenBlockWithMixins', item_usage_id)
 
-    def _verify_descriptor(self, category, course, descriptor, item_id=None):
+    def _verify_block(self, category, course, block, item_id=None):
         """
         Helper method that gets an item with the specified category from the
-        modulestore and verifies that it has the expected descriptor name.
+        modulestore and verifies that it has the expected block name.
 
         Returns the item's usage_id.
         """
@@ -2633,7 +2616,7 @@ class TestDisabledXBlockTypes(ModuleStoreTestCase):
             item_id = item.scope_ids.usage_id  # lint-amnesty, pylint: disable=no-member
 
         item = self.store.get_item(item_id)
-        assert item.__class__.__name__ == descriptor
+        assert item.__class__.__name__ == block
         return item_id
 
 
@@ -2650,15 +2633,15 @@ class LmsModuleSystemShimTest(SharedModuleStoreTestCase):
     @classmethod
     def setUpClass(cls):
         """
-        Set up the course and descriptor used to instantiate the runtime.
+        Set up the course and block used to instantiate the runtime.
         """
         super().setUpClass()
         org = 'edX'
         number = 'LmsModuleShimTest'
         run = '2021_Fall'
         cls.course = CourseFactory.create(org=org, number=number, run=run)
-        cls.descriptor = BlockFactory(category="vertical", parent=cls.course)
-        cls.problem_descriptor = BlockFactory(category="problem", parent=cls.course)
+        cls.block = BlockFactory(category="vertical", parent=cls.course)
+        cls.problem_block = BlockFactory(category="problem", parent=cls.course)
 
     def setUp(self):
         """
@@ -2673,7 +2656,7 @@ class LmsModuleSystemShimTest(SharedModuleStoreTestCase):
         _ = render.prepare_runtime_for_user(
             self.user,
             self.student_data,
-            self.descriptor,
+            self.block,
             self.course.id,
             self.track_function,
             self.request_token,
@@ -2690,37 +2673,37 @@ class LmsModuleSystemShimTest(SharedModuleStoreTestCase):
         """
         Tests that the deprecated attributes provided by the user service match expected values.
         """
-        assert getattr(self.descriptor.runtime, attribute) == expected_value
+        assert getattr(self.block.runtime, attribute) == expected_value
 
     @patch('lms.djangoapps.courseware.block_render.has_access', Mock(return_value=True, autospec=True))
     def test_user_is_staff(self):
         _ = render.prepare_runtime_for_user(
             self.user,
             self.student_data,
-            self.descriptor,
+            self.block,
             self.course.id,
             self.track_function,
             self.request_token,
             course=self.course,
         )
-        assert self.descriptor.runtime.user_is_staff
-        assert self.descriptor.runtime.get_user_role() == 'student'
+        assert self.block.runtime.user_is_staff
+        assert self.block.runtime.get_user_role() == 'student'
 
     @patch('lms.djangoapps.courseware.block_render.get_user_role', Mock(return_value='instructor', autospec=True))
     def test_get_user_role(self):
         _ = render.prepare_runtime_for_user(
             self.user,
             self.student_data,
-            self.descriptor,
+            self.block,
             self.course.id,
             self.track_function,
             self.request_token,
             course=self.course,
         )
-        assert self.descriptor.runtime.get_user_role() == 'instructor'
+        assert self.block.runtime.get_user_role() == 'instructor'
 
     def test_anonymous_student_id(self):
-        assert self.descriptor.runtime.anonymous_student_id == anonymous_id_for_user(self.user, self.course.id)
+        assert self.block.runtime.anonymous_student_id == anonymous_id_for_user(self.user, self.course.id)
 
     def test_anonymous_student_id_bug(self):
         """
@@ -2730,76 +2713,76 @@ class LmsModuleSystemShimTest(SharedModuleStoreTestCase):
         _ = render.prepare_runtime_for_user(
             self.user,
             self.student_data,
-            self.problem_descriptor,
+            self.problem_block,
             self.course.id,
             self.track_function,
             self.request_token,
             course=self.course,
         )
         # Ensure the problem block returns a per-user anonymous id
-        assert self.problem_descriptor.runtime.anonymous_student_id == anonymous_id_for_user(self.user, None)
+        assert self.problem_block.runtime.anonymous_student_id == anonymous_id_for_user(self.user, None)
 
         _ = render.prepare_runtime_for_user(
             self.user,
             self.student_data,
-            self.descriptor,
+            self.block,
             self.course.id,
             self.track_function,
             self.request_token,
             course=self.course,
         )
         # Ensure the vertical block returns a per-course+user anonymous id
-        assert self.descriptor.runtime.anonymous_student_id == anonymous_id_for_user(self.user, self.course.id)
+        assert self.block.runtime.anonymous_student_id == anonymous_id_for_user(self.user, self.course.id)
 
         # Ensure the problem runtime's anonymous student ID is unchanged after the above call.
-        assert self.problem_descriptor.runtime.anonymous_student_id == anonymous_id_for_user(self.user, None)
+        assert self.problem_block.runtime.anonymous_student_id == anonymous_id_for_user(self.user, None)
 
     def test_user_service_with_anonymous_user(self):
         _ = render.prepare_runtime_for_user(
             AnonymousUser(),
             self.student_data,
-            self.descriptor,
+            self.block,
             self.course.id,
             self.track_function,
             self.request_token,
             course=self.course,
         )
-        assert self.descriptor.runtime.anonymous_student_id is None
-        assert self.descriptor.runtime.seed == 0
-        assert self.descriptor.runtime.user_id is None
-        assert not self.descriptor.runtime.user_is_staff
-        assert not self.descriptor.runtime.get_user_role()
+        assert self.block.runtime.anonymous_student_id is None
+        assert self.block.runtime.seed == 0
+        assert self.block.runtime.user_id is None
+        assert not self.block.runtime.user_is_staff
+        assert not self.block.runtime.get_user_role()
 
     def test_get_real_user(self):
         _ = render.prepare_runtime_for_user(
             self.user,
             self.student_data,
-            self.descriptor,
+            self.block,
             self.course.id,
             self.track_function,
             self.request_token,
             course=self.course,
         )
         course_anonymous_student_id = anonymous_id_for_user(self.user, self.course.id)
-        assert self.descriptor.runtime.get_real_user(course_anonymous_student_id) == self.user  # pylint: disable=not-callable
+        assert self.block.runtime.get_real_user(course_anonymous_student_id) == self.user  # pylint: disable=not-callable
 
         no_course_anonymous_student_id = anonymous_id_for_user(self.user, None)
-        assert self.descriptor.runtime.get_real_user(no_course_anonymous_student_id) == self.user  # pylint: disable=not-callable
+        assert self.block.runtime.get_real_user(no_course_anonymous_student_id) == self.user  # pylint: disable=not-callable
 
         # Tests that the default is to use the user service's anonymous_student_id
-        assert self.descriptor.runtime.get_real_user() == self.user  # pylint: disable=not-callable
+        assert self.block.runtime.get_real_user() == self.user  # pylint: disable=not-callable
 
     def test_render_template(self):
-        rendered = self.descriptor.runtime.render_template('templates/edxmako.html', {'element_id': 'hi'})  # pylint: disable=not-callable
+        rendered = self.block.runtime.render_template('templates/edxmako.html', {'element_id': 'hi'})  # pylint: disable=not-callable
         assert rendered == '<div id="hi" ns="main">Testing the MakoService</div>\n'
 
     def test_xqueue(self):
-        xqueue = self.descriptor.runtime.xqueue
+        xqueue = self.block.runtime.xqueue
         assert isinstance(xqueue['interface'], XQueueInterface)
         assert xqueue['interface'].url == 'http://sandbox-xqueue.edx.org'
         assert xqueue['default_queuename'] == 'edX-LmsModuleShimTest'
         assert xqueue['waittime'] == 5
-        callback_url = f'http://localhost:8000/courses/{self.course.id}/xqueue/232/{self.descriptor.location}'
+        callback_url = f'http://localhost:8000/courses/{self.course.id}/xqueue/232/{self.block.location}'
         assert xqueue['construct_callback']() == f'{callback_url}/score_update'
         assert xqueue['construct_callback']('mock_dispatch') == f'{callback_url}/mock_dispatch'
 
@@ -2819,31 +2802,31 @@ class LmsModuleSystemShimTest(SharedModuleStoreTestCase):
         _ = render.prepare_runtime_for_user(
             self.user,
             self.student_data,
-            self.descriptor,
+            self.block,
             self.course.id,
             self.track_function,
             self.request_token,
             course=self.course,
         )
-        xqueue = self.descriptor.runtime.xqueue
+        xqueue = self.block.runtime.xqueue
         assert isinstance(xqueue['interface'], XQueueInterface)
         assert xqueue['interface'].url == 'http://xqueue.url'
         assert xqueue['default_queuename'] == 'edX-LmsModuleShimTest'
         assert xqueue['waittime'] == 15
-        callback_url = f'http://alt.url/courses/{self.course.id}/xqueue/232/{self.descriptor.location}'
+        callback_url = f'http://alt.url/courses/{self.course.id}/xqueue/232/{self.block.location}'
         assert xqueue['construct_callback']() == f'{callback_url}/score_update'
         assert xqueue['construct_callback']('mock_dispatch') == f'{callback_url}/mock_dispatch'
 
     @override_settings(COURSES_WITH_UNSAFE_CODE=[r'course-v1:edX\+LmsModuleShimTest\+2021_Fall'])
     def test_can_execute_unsafe_code_when_allowed(self):
-        assert self.descriptor.runtime.can_execute_unsafe_code()
+        assert self.block.runtime.can_execute_unsafe_code()
 
     @override_settings(COURSES_WITH_UNSAFE_CODE=[r'course-v1:edX\+full\+2021_Fall'])
     def test_cannot_execute_unsafe_code_when_disallowed(self):
-        assert not self.descriptor.runtime.can_execute_unsafe_code()
+        assert not self.block.runtime.can_execute_unsafe_code()
 
     def test_cannot_execute_unsafe_code(self):
-        assert not self.descriptor.runtime.can_execute_unsafe_code()
+        assert not self.block.runtime.can_execute_unsafe_code()
 
     @override_settings(PYTHON_LIB_FILENAME=PYTHON_LIB_FILENAME)
     def test_get_python_lib_zip(self):
@@ -2853,7 +2836,7 @@ class LmsModuleSystemShimTest(SharedModuleStoreTestCase):
             source_file=self.PYTHON_LIB_SOURCE_FILE,
             target_filename=self.PYTHON_LIB_FILENAME,
         )
-        assert self.descriptor.runtime.get_python_lib_zip() == zipfile
+        assert self.block.runtime.get_python_lib_zip() == zipfile
 
     def test_no_get_python_lib_zip(self):
         zipfile = upload_file_to_course(
@@ -2862,32 +2845,32 @@ class LmsModuleSystemShimTest(SharedModuleStoreTestCase):
             source_file=self.PYTHON_LIB_SOURCE_FILE,
             target_filename=self.PYTHON_LIB_FILENAME,
         )
-        assert self.descriptor.runtime.get_python_lib_zip() is None
+        assert self.block.runtime.get_python_lib_zip() is None
 
     def test_cache(self):
-        assert hasattr(self.descriptor.runtime.cache, 'get')
-        assert hasattr(self.descriptor.runtime.cache, 'set')
+        assert hasattr(self.block.runtime.cache, 'get')
+        assert hasattr(self.block.runtime.cache, 'set')
 
     def test_replace_urls(self):
         html = '<a href="/static/id">'
-        assert self.descriptor.runtime.replace_urls(html) == \
+        assert self.block.runtime.replace_urls(html) == \
             static_replace.replace_static_urls(html, course_id=self.course.id)
 
     def test_replace_course_urls(self):
         html = '<a href="/course/id">'
-        assert self.descriptor.runtime.replace_course_urls(html) == \
+        assert self.block.runtime.replace_course_urls(html) == \
             static_replace.replace_course_urls(html, course_key=self.course.id)
 
     def test_replace_jump_to_id_urls(self):
         html = '<a href="/jump_to_id/id">'
         jump_to_id_base_url = reverse('jump_to_id', kwargs={'course_id': str(self.course.id), 'module_id': ''})
-        assert self.descriptor.runtime.replace_jump_to_id_urls(html) == \
+        assert self.block.runtime.replace_jump_to_id_urls(html) == \
             static_replace.replace_jump_to_id_urls(html, self.course.id, jump_to_id_base_url)
 
     @XBlock.register_temp_plugin(PureXBlock, 'pure')
     @XBlock.register_temp_plugin(PureXBlockWithChildren, identifier='xblock')
     def test_course_id(self):
-        descriptor = BlockFactory(category="pure", parent=self.course)
+        block = BlockFactory(category="pure", parent=self.course)
 
-        block = render.get_block(self.user, Mock(), descriptor.location, None)
-        assert str(block.runtime.course_id) == self.COURSE_ID
+        rendered_block = render.get_block(self.user, Mock(), block.location, None)
+        assert str(rendered_block.runtime.course_id) == self.COURSE_ID

--- a/lms/djangoapps/courseware/tests/test_courses.py
+++ b/lms/djangoapps/courseware/tests/test_courses.py
@@ -382,7 +382,7 @@ class CourseInstantiationTests(ModuleStoreTestCase):
         course = modulestore().get_course(course.id, depth=course_depth)
 
         for _ in range(loops):
-            field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
+            field_data_cache = FieldDataCache.cache_for_block_descendents(
                 course.id, self.user, course, depth=course_depth
             )
             course_block = get_block_for_descriptor(

--- a/lms/djangoapps/courseware/tests/test_discussion_xblock.py
+++ b/lms/djangoapps/courseware/tests/test_discussion_xblock.py
@@ -295,7 +295,7 @@ class TestXBlockInCourse(SharedModuleStoreTestCase):
         """
         discussion_xblock = get_block_for_descriptor_internal(
             user=self.user,
-            descriptor=self.discussion,
+            block=self.discussion,
             student_data=mock.Mock(name='student_data'),
             course_id=self.course.id,
             track_function=mock.Mock(name='track_function'),
@@ -335,10 +335,10 @@ class TestXBlockInCourse(SharedModuleStoreTestCase):
         assert orphan_sequential.location.block_type == root.location.block_type
         assert orphan_sequential.location.block_id == root.location.block_id
 
-        # Get xblock bound to a user and a descriptor.
+        # Get xblock bound to a user and a block.
         discussion_xblock = get_block_for_descriptor_internal(
             user=self.user,
-            descriptor=discussion,
+            block=discussion,
             student_data=mock.Mock(name='student_data'),
             course_id=self.course.id,
             track_function=mock.Mock(name='track_function'),
@@ -388,7 +388,7 @@ class TestXBlockInCourse(SharedModuleStoreTestCase):
 
         discussion_xblock = get_block_for_descriptor_internal(
             user=self.user,
-            descriptor=self.discussion,
+            block=self.discussion,
             student_data=mock.Mock(name='student_data'),
             course_id=self.course.id,
             track_function=mock.Mock(name='track_function'),
@@ -438,7 +438,7 @@ class TestXBlockQueryLoad(SharedModuleStoreTestCase):
         for discussion in discussions:
             discussion_xblock = get_block_for_descriptor_internal(
                 user=user,
-                descriptor=discussion,
+                block=discussion,
                 student_data=mock.Mock(name='student_data'),
                 course_id=course.id,
                 track_function=mock.Mock(name='track_function'),

--- a/lms/djangoapps/courseware/tests/test_entrance_exam.py
+++ b/lms/djangoapps/courseware/tests/test_entrance_exam.py
@@ -340,7 +340,7 @@ class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase, Milest
         Returns the table of contents for course self.course, for chapter
         self.entrance_exam, and for section self.exam1
         """
-        self.field_data_cache = FieldDataCache.cache_for_descriptor_descendents(  # pylint: disable=attribute-defined-outside-init
+        self.field_data_cache = FieldDataCache.cache_for_block_descendents(  # pylint: disable=attribute-defined-outside-init
             self.course.id,
             self.request.user,
             self.entrance_exam
@@ -372,7 +372,7 @@ def answer_entrance_exam_problem(course, request, problem, user=None, value=1, m
         user = request.user
 
     grade_dict = {'value': value, 'max_value': max_value, 'user_id': user.id}
-    field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
+    field_data_cache = FieldDataCache.cache_for_block_descendents(
         course.id,
         user,
         course,

--- a/lms/djangoapps/courseware/tests/test_lti_integration.py
+++ b/lms/djangoapps/courseware/tests/test_lti_integration.py
@@ -40,11 +40,11 @@ class TestLTI(BaseTestXmodule):
         mocked_decoded_signature = 'my_signature='
 
         # Note: this course_id is actually a course_key
-        context_id = str(self.item_descriptor.course_id)
-        user_service = self.item_descriptor.runtime.service(self.item_descriptor, 'user')
+        context_id = str(self.block.course_id)
+        user_service = self.block.runtime.service(self.block, 'user')
         user_id = str(user_service.get_current_user().opt_attrs.get(ATTR_KEY_ANONYMOUS_USER_ID))
         hostname = settings.LMS_BASE
-        resource_link_id = str(urllib.parse.quote(f'{hostname}-{self.item_descriptor.location.html_id()}'))
+        resource_link_id = str(urllib.parse.quote(f'{hostname}-{self.block.location.html_id()}'))
 
         sourcedId = "{context}:{resource_link}:{user_id}".format(
             context=urllib.parse.quote(context_id),
@@ -75,14 +75,14 @@ class TestLTI(BaseTestXmodule):
         saved_sign = oauthlib.oauth1.Client.sign
 
         self.expected_context = {
-            'display_name': self.item_descriptor.display_name,
+            'display_name': self.block.display_name,
             'input_fields': self.correct_headers,
-            'element_class': self.item_descriptor.category,
-            'element_id': self.item_descriptor.location.html_id(),
+            'element_class': self.block.category,
+            'element_id': self.block.location.html_id(),
             'launch_url': 'http://www.example.com',  # default value
             'open_in_a_new_page': True,
-            'form_url': self.item_descriptor.runtime.handler_url(
-                self.item_descriptor,
+            'form_url': self.block.runtime.handler_url(
+                self.block,
                 'preview_handler'
             ).rstrip('/?'),
             'hide_launch': False,
@@ -90,11 +90,11 @@ class TestLTI(BaseTestXmodule):
             'module_score': None,
             'comment': '',
             'weight': 1.0,
-            'ask_to_send_username': self.item_descriptor.ask_to_send_username,
-            'ask_to_send_email': self.item_descriptor.ask_to_send_email,
-            'description': self.item_descriptor.description,
-            'button_text': self.item_descriptor.button_text,
-            'accept_grades_past_due': self.item_descriptor.accept_grades_past_due,
+            'ask_to_send_username': self.block.ask_to_send_username,
+            'ask_to_send_email': self.block.ask_to_send_email,
+            'description': self.block.description,
+            'button_text': self.block.button_text,
+            'accept_grades_past_due': self.block.accept_grades_past_due,
         }
 
         def mocked_sign(self, *args, **kwargs):
@@ -117,12 +117,12 @@ class TestLTI(BaseTestXmodule):
         self.addCleanup(patcher.stop)
 
     def test_lti_constructor(self):
-        generated_content = self.item_descriptor.render(STUDENT_VIEW).content
+        generated_content = self.block.render(STUDENT_VIEW).content
         expected_content = self.runtime.render_template('lti.html', self.expected_context)
         assert generated_content == expected_content
 
     def test_lti_preview_handler(self):
-        generated_content = self.item_descriptor.preview_handler(None, None).body
+        generated_content = self.block.preview_handler(None, None).body
         expected_content = self.runtime.render_template('lti_form.html', self.expected_context)
         assert generated_content.decode('utf-8') == expected_content
 

--- a/lms/djangoapps/courseware/tests/test_model_data.py
+++ b/lms/djangoapps/courseware/tests/test_model_data.py
@@ -35,13 +35,13 @@ def mock_field(scope, name):
     return field
 
 
-def mock_descriptor(fields=[]):  # lint-amnesty, pylint: disable=dangerous-default-value, missing-function-docstring
-    descriptor = Mock(entry_point=XBlock.entry_point)
-    descriptor.scope_ids = ScopeIds('user1', 'mock_problem', LOCATION('def_id'), LOCATION('usage_id'))
-    descriptor.module_class.fields.values.return_value = fields
-    descriptor.fields.values.return_value = fields
-    descriptor.module_class.__name__ = 'MockProblemModule'
-    return descriptor
+def mock_block(fields=[]):  # lint-amnesty, pylint: disable=dangerous-default-value, missing-function-docstring
+    block = Mock(entry_point=XBlock.entry_point)
+    block.scope_ids = ScopeIds('user1', 'mock_problem', LOCATION('def_id'), LOCATION('usage_id'))
+    block.module_class.fields.values.return_value = fields
+    block.fields.values.return_value = fields
+    block.module_class.__name__ = 'MockProblemModule'
+    return block
 
 # The user ids here are 1 because we make a student in the setUp functions, and
 # they get an id of 1.  There's an assertion in setUp to ensure that assumption
@@ -63,7 +63,7 @@ class TestInvalidScopes(TestCase):  # lint-amnesty, pylint: disable=missing-clas
         super().setUp()
         self.user = UserFactory.create(username='user')
         self.field_data_cache = FieldDataCache(
-            [mock_descriptor([mock_field(Scope.user_state, 'a_field')])],
+            [mock_block([mock_field(Scope.user_state, 'a_field')])],
             COURSE_KEY,
             self.user,
         )
@@ -120,10 +120,10 @@ class TestStudentModuleStorage(OtherUserFailureTestMixin, TestCase):
         assert self.user.id == 1
         # check our assumption hard-coded in the key functions above.
 
-        # There should be only one query to load a single descriptor with a single user_state field
+        # There should be only one query to load a single block with a single user_state field
         with self.assertNumQueries(1):
             self.field_data_cache = FieldDataCache(
-                [mock_descriptor([mock_field(Scope.user_state, 'a_field')])],
+                [mock_block([mock_field(Scope.user_state, 'a_field')])],
                 COURSE_KEY,
                 self.user,
             )
@@ -250,10 +250,10 @@ class TestMissingStudentModule(TestCase):  # lint-amnesty, pylint: disable=missi
         assert self.user.id == 1
         # check our assumption hard-coded in the key functions above.
 
-        # The descriptor has no fields, so FDC shouldn't send any queries
+        # The block has no fields, so FDC shouldn't send any queries
         with self.assertNumQueries(0):
             self.field_data_cache = FieldDataCache(
-                [mock_descriptor()],
+                [mock_block()],
                 COURSE_KEY,
                 self.user,
             )
@@ -318,14 +318,14 @@ class StorageTestBase:
             self.user = field_storage.student
         else:
             self.user = UserFactory.create()
-        self.mock_descriptor = mock_descriptor([
+        self.mock_block = mock_block([
             mock_field(self.scope, 'existing_field'),
             mock_field(self.scope, 'other_existing_field')])
         # Each field is stored as a separate row in the table,
         # but we can query them in a single query
         with self.assertNumQueries(1):
             self.field_data_cache = FieldDataCache(
-                [self.mock_descriptor],
+                [self.mock_block],
                 COURSE_KEY,
                 self.user,
             )

--- a/lms/djangoapps/courseware/tests/test_video_handlers.py
+++ b/lms/djangoapps/courseware/tests/test_video_handlers.py
@@ -172,12 +172,12 @@ class TestVideo(BaseTestVideoXBlock):
         assert status_codes.pop() == 404
 
     def test_handle_ajax_for_speed_with_nan(self):
-        self.item_descriptor.handle_ajax('save_user_state', {'speed': json.dumps(1.0)})
-        assert self.item_descriptor.speed == 1.0
-        assert self.item_descriptor.global_speed == 1.0
+        self.block.handle_ajax('save_user_state', {'speed': json.dumps(1.0)})
+        assert self.block.speed == 1.0
+        assert self.block.global_speed == 1.0
 
         # try to set NaN value for speed.
-        response = self.item_descriptor.handle_ajax(
+        response = self.block.handle_ajax(
             'save_user_state', {'speed': json.dumps(float('NaN'))}
         )
 
@@ -186,8 +186,8 @@ class TestVideo(BaseTestVideoXBlock):
         assert json.loads(response)['error'] == expected_error
 
         # verify that the speed and global speed are still 1.0
-        assert self.item_descriptor.speed == 1.0
-        assert self.item_descriptor.global_speed == 1.0
+        assert self.block.speed == 1.0
+        assert self.block.global_speed == 1.0
 
     def test_handle_ajax(self):
 
@@ -206,41 +206,41 @@ class TestVideo(BaseTestVideoXBlock):
                 HTTP_X_REQUESTED_WITH='XMLHttpRequest')
             assert response.status_code == 200
 
-        assert self.item_descriptor.speed is None
-        self.item_descriptor.handle_ajax('save_user_state', {'speed': json.dumps(2.0)})
-        assert self.item_descriptor.speed == 2.0
-        assert self.item_descriptor.global_speed == 2.0
+        assert self.block.speed is None
+        self.block.handle_ajax('save_user_state', {'speed': json.dumps(2.0)})
+        assert self.block.speed == 2.0
+        assert self.block.global_speed == 2.0
 
-        assert self.item_descriptor.saved_video_position == timedelta(0)
-        self.item_descriptor.handle_ajax('save_user_state', {'saved_video_position': "00:00:10"})
-        assert self.item_descriptor.saved_video_position == timedelta(0, 10)
+        assert self.block.saved_video_position == timedelta(0)
+        self.block.handle_ajax('save_user_state', {'saved_video_position': "00:00:10"})
+        assert self.block.saved_video_position == timedelta(0, 10)
 
-        assert self.item_descriptor.transcript_language == 'en'
-        self.item_descriptor.handle_ajax('save_user_state', {'transcript_language': "uk"})
-        assert self.item_descriptor.transcript_language == 'uk'
+        assert self.block.transcript_language == 'en'
+        self.block.handle_ajax('save_user_state', {'transcript_language': "uk"})
+        assert self.block.transcript_language == 'uk'
 
-        assert self.item_descriptor.bumper_do_not_show_again is False
-        self.item_descriptor.handle_ajax('save_user_state', {'bumper_do_not_show_again': True})
-        assert self.item_descriptor.bumper_do_not_show_again is True
+        assert self.block.bumper_do_not_show_again is False
+        self.block.handle_ajax('save_user_state', {'bumper_do_not_show_again': True})
+        assert self.block.bumper_do_not_show_again is True
 
         with freezegun.freeze_time(now()):
-            assert self.item_descriptor.bumper_last_view_date is None
-            self.item_descriptor.handle_ajax('save_user_state', {'bumper_last_view_date': True})
-            assert self.item_descriptor.bumper_last_view_date == now()
+            assert self.block.bumper_last_view_date is None
+            self.block.handle_ajax('save_user_state', {'bumper_last_view_date': True})
+            assert self.block.bumper_last_view_date == now()
 
-        response = self.item_descriptor.handle_ajax('save_user_state', {'demoo�': "sample"})
+        response = self.block.handle_ajax('save_user_state', {'demoo�': "sample"})
         assert json.loads(response)['success'] is True
 
     def get_handler_url(self, handler, suffix):
         """
-        Return the URL for the specified handler on self.item_descriptor.
+        Return the URL for the specified handler on self.block.
         """
-        return self.item_descriptor.runtime.handler_url(
-            self.item_descriptor, handler, suffix
+        return self.block.runtime.handler_url(
+            self.block, handler, suffix
         ).rstrip('/?')
 
     def tearDown(self):
-        _clear_assets(self.item_descriptor.location)
+        _clear_assets(self.block.location)
         super().tearDown()
 
 
@@ -268,24 +268,23 @@ class TestTranscriptAvailableTranslationsDispatch(TestVideo):  # lint-amnesty, p
 
     def setUp(self):
         super().setUp()
-        self.item_descriptor.render(STUDENT_VIEW)
-        self.item = self.item_descriptor
+        self.block.render(STUDENT_VIEW)
         self.subs = {"start": [10], "end": [100], "text": ["Hi, welcome to Edx."]}
 
     def test_available_translation_en(self):
         good_sjson = _create_file(json.dumps(self.subs))
-        _upload_sjson_file(good_sjson, self.item_descriptor.location)
-        self.item.sub = _get_subs_id(good_sjson.name)
+        _upload_sjson_file(good_sjson, self.block.location)
+        self.block.sub = _get_subs_id(good_sjson.name)
 
         request = Request.blank('/available_translations')
-        response = self.item.transcript(request=request, dispatch='available_translations')
+        response = self.block.transcript(request=request, dispatch='available_translations')
         assert json.loads(response.body.decode('utf-8')) == ['en']
 
     def test_available_translation_non_en(self):
-        _upload_file(_create_srt_file(), self.item_descriptor.location, os.path.split(self.srt_file.name)[1])
+        _upload_file(_create_srt_file(), self.block.location, os.path.split(self.srt_file.name)[1])
 
         request = Request.blank('/available_translations')
-        response = self.item.transcript(request=request, dispatch='available_translations')
+        response = self.block.transcript(request=request, dispatch='available_translations')
         assert json.loads(response.body.decode('utf-8')) == ['uk']
 
     @patch('xmodule.video_block.transcripts_utils.get_video_transcript_content')
@@ -302,16 +301,16 @@ class TestTranscriptAvailableTranslationsDispatch(TestVideo):  # lint-amnesty, p
         good_sjson = _create_file(json.dumps(self.subs))
 
         # Upload english transcript.
-        _upload_sjson_file(good_sjson, self.item_descriptor.location)
+        _upload_sjson_file(good_sjson, self.block.location)
 
         # Upload non-english transcript.
-        _upload_file(self.srt_file, self.item_descriptor.location, os.path.split(self.srt_file.name)[1])
+        _upload_file(self.srt_file, self.block.location, os.path.split(self.srt_file.name)[1])
 
-        self.item.sub = _get_subs_id(good_sjson.name)
-        self.item.edx_video_id = 'an-edx-video-id'
+        self.block.sub = _get_subs_id(good_sjson.name)
+        self.block.edx_video_id = 'an-edx-video-id'
 
         request = Request.blank('/available_translations')
-        response = self.item.transcript(request=request, dispatch='available_translations')
+        response = self.block.transcript(request=request, dispatch='available_translations')
         assert sorted(json.loads(response.body.decode('utf-8'))) == sorted(['en', 'uk'])
 
     @patch('xmodule.video_block.transcripts_utils.get_video_transcript_content')
@@ -365,13 +364,13 @@ class TestTranscriptAvailableTranslationsDispatch(TestVideo):  # lint-amnesty, p
         for lang_code, in_content_store in dict(transcripts).items():
             if in_content_store:
                 file_name, __ = os.path.split(self.srt_file.name)
-                _upload_file(self.srt_file, self.item_descriptor.location, file_name)
+                _upload_file(self.srt_file, self.block.location, file_name)
                 transcripts[lang_code] = file_name
             else:
                 transcripts[lang_code] = 'non_existent.srt.sjson'
         if sub:
             sjson_transcript = _create_file(json.dumps(self.subs))
-            _upload_sjson_file(sjson_transcript, self.item_descriptor.location)
+            _upload_sjson_file(sjson_transcript, self.block.location)
             sub = _get_subs_id(sjson_transcript.name)
 
         mock_get_video_transcript_content.return_value = {
@@ -383,12 +382,12 @@ class TestTranscriptAvailableTranslationsDispatch(TestVideo):  # lint-amnesty, p
             'file_name': 'edx.sjson'
         }
         mock_get_transcript_languages.return_value = val_transcripts
-        self.item.transcripts = transcripts
-        self.item.sub = sub
-        self.item.edx_video_id = 'an-edx-video-id'
+        self.block.transcripts = transcripts
+        self.block.sub = sub
+        self.block.edx_video_id = 'an-edx-video-id'
         # Make request to available translations dispatch.
         request = Request.blank('/available_translations')
-        response = self.item.transcript(request=request, dispatch='available_translations')
+        response = self.block.transcript(request=request, dispatch='available_translations')
         self.assertCountEqual(json.loads(response.body.decode('utf-8')), result)
 
     @patch('xmodule.video_block.transcripts_utils.edxval_api.get_available_transcript_languages')
@@ -398,7 +397,7 @@ class TestTranscriptAvailableTranslationsDispatch(TestVideo):  # lint-amnesty, p
         """
         mock_get_available_transcript_languages.return_value = ['en', 'de', 'ro']
         request = Request.blank('/available_translations')
-        response = self.item.transcript(request=request, dispatch='available_translations')
+        response = self.block.transcript(request=request, dispatch='available_translations')
         assert response.status_code == 404
 
 
@@ -426,19 +425,18 @@ class TestTranscriptAvailableTranslationsBumperDispatch(TestVideo):  # lint-amne
 
     def setUp(self):
         super().setUp()
-        self.item_descriptor.render(STUDENT_VIEW)
-        self.item = self.item_descriptor
+        self.block.render(STUDENT_VIEW)
         self.dispatch = "available_translations/?is_bumper=1"
-        self.item.video_bumper = {"transcripts": {"en": ""}}
+        self.block.video_bumper = {"transcripts": {"en": ""}}
 
     @ddt.data("en", "uk")
     def test_available_translation_en_and_non_en(self, lang):
         filename = os.path.split(self.srt_file.name)[1]
-        _upload_file(self.srt_file, self.item_descriptor.location, filename)
-        self.item.video_bumper["transcripts"][lang] = filename
+        _upload_file(self.srt_file, self.block.location, filename)
+        self.block.video_bumper["transcripts"][lang] = filename
 
         request = Request.blank('/' + self.dispatch)
-        response = self.item.transcript(request=request, dispatch=self.dispatch)
+        response = self.block.transcript(request=request, dispatch=self.dispatch)
         assert json.loads(response.body.decode('utf-8')) == [lang]
 
     @patch('xmodule.video_block.transcripts_utils.get_available_transcript_languages')
@@ -453,16 +451,16 @@ class TestTranscriptAvailableTranslationsBumperDispatch(TestVideo):  # lint-amne
         en_translation_filename = os.path.split(en_translation.name)[1]
         uk_translation_filename = os.path.split(self.srt_file.name)[1]
         # Upload english transcript.
-        _upload_file(en_translation, self.item_descriptor.location, en_translation_filename)
+        _upload_file(en_translation, self.block.location, en_translation_filename)
 
         # Upload non-english transcript.
-        _upload_file(self.srt_file, self.item_descriptor.location, uk_translation_filename)
+        _upload_file(self.srt_file, self.block.location, uk_translation_filename)
 
-        self.item.video_bumper["transcripts"]["en"] = en_translation_filename
-        self.item.video_bumper["transcripts"]["uk"] = uk_translation_filename
+        self.block.video_bumper["transcripts"]["en"] = en_translation_filename
+        self.block.video_bumper["transcripts"]["uk"] = uk_translation_filename
 
         request = Request.blank('/' + self.dispatch)
-        response = self.item.transcript(request=request, dispatch=self.dispatch)
+        response = self.block.transcript(request=request, dispatch=self.dispatch)
         # Assert that bumper only get its own translations.
         assert sorted(json.loads(response.body.decode('utf-8'))) == sorted(['en', 'uk'])
 
@@ -492,12 +490,11 @@ class TestTranscriptDownloadDispatch(TestVideo):  # lint-amnesty, pylint: disabl
 
     def setUp(self):
         super().setUp()
-        self.item_descriptor.render(STUDENT_VIEW)
-        self.item = self.item_descriptor
+        self.block.render(STUDENT_VIEW)
 
     def test_download_transcript_not_exist(self):
         request = Request.blank('/download')
-        response = self.item.transcript(request=request, dispatch='download')
+        response = self.block.transcript(request=request, dispatch='download')
         assert response.status == '404 Not Found'
 
     @patch(
@@ -506,7 +503,7 @@ class TestTranscriptDownloadDispatch(TestVideo):  # lint-amnesty, pylint: disabl
     )
     def test_download_srt_exist(self, __):
         request = Request.blank('/download')
-        response = self.item.transcript(request=request, dispatch='download')
+        response = self.block.transcript(request=request, dispatch='download')
         assert response.body.decode('utf-8') == 'Subs!'
         assert response.headers['Content-Type'] == 'application/x-subrip; charset=utf-8'
         assert response.headers['Content-Language'] == 'en'
@@ -516,19 +513,19 @@ class TestTranscriptDownloadDispatch(TestVideo):  # lint-amnesty, pylint: disabl
         return_value=('Subs!', 'txt', 'text/plain; charset=utf-8')
     )
     def test_download_txt_exist(self, __):
-        self.item.transcript_format = 'txt'
+        self.block.transcript_format = 'txt'
         request = Request.blank('/download')
-        response = self.item.transcript(request=request, dispatch='download')
+        response = self.block.transcript(request=request, dispatch='download')
         assert response.body.decode('utf-8') == 'Subs!'
         assert response.headers['Content-Type'] == 'text/plain; charset=utf-8'
         assert response.headers['Content-Language'] == 'en'
 
     def test_download_en_no_sub(self):
         request = Request.blank('/download')
-        response = self.item.transcript(request=request, dispatch='download')
+        response = self.block.transcript(request=request, dispatch='download')
         assert response.status == '404 Not Found'
         with pytest.raises(NotFoundError):
-            get_transcript(self.item)
+            get_transcript(self.block)
 
     @patch(
         'xmodule.video_block.transcripts_utils.get_transcript_for_video',
@@ -536,7 +533,7 @@ class TestTranscriptDownloadDispatch(TestVideo):  # lint-amnesty, pylint: disabl
     )
     def test_download_non_en_non_ascii_filename(self, __):
         request = Request.blank('/download')
-        response = self.item.transcript(request=request, dispatch='download')
+        response = self.block.transcript(request=request, dispatch='download')
         assert response.body.decode('utf-8') == 'Subs!'
         assert response.headers['Content-Type'] == 'application/x-subrip; charset=utf-8'
         assert response.headers['Content-Disposition'] == 'attachment; filename="en_塞.srt"'
@@ -558,7 +555,7 @@ class TestTranscriptDownloadDispatch(TestVideo):  # lint-amnesty, pylint: disabl
 
         # Make request to XModule transcript handler
         request = Request.blank('/download')
-        response = self.item.transcript(request=request, dispatch='download')
+        response = self.block.transcript(request=request, dispatch='download')
 
         # Expected response
         expected_content = '0\n00:00:00,010 --> 00:00:00,100\nHi, welcome to Edx.\n\n'
@@ -602,9 +599,8 @@ class TestTranscriptTranslationGetDispatch(TestVideo):  # lint-amnesty, pylint: 
 
     def setUp(self):
         super().setUp()
-        self.item_descriptor.render(STUDENT_VIEW)
-        self.item = self.item_descriptor
-        self.item.video_bumper = {"transcripts": {"en": ""}}
+        self.block.render(STUDENT_VIEW)
+        self.block.video_bumper = {"transcripts": {"en": ""}}
 
     @ddt.data(
         # No language
@@ -623,7 +619,7 @@ class TestTranscriptTranslationGetDispatch(TestVideo):  # lint-amnesty, pylint: 
     @ddt.unpack
     def test_translation_fails(self, url, dispatch, status_code):
         request = Request.blank(url)
-        response = self.item.transcript(request=request, dispatch=dispatch)
+        response = self.block.transcript(request=request, dispatch=dispatch)
         assert response.status == status_code
 
     @ddt.data(
@@ -633,12 +629,12 @@ class TestTranscriptTranslationGetDispatch(TestVideo):  # lint-amnesty, pylint: 
     def test_translaton_en_youtube_success(self, url, dispatch, attach):
         subs = {"start": [10], "end": [100], "text": ["Hi, welcome to Edx."]}
         good_sjson = _create_file(json.dumps(subs))
-        _upload_sjson_file(good_sjson, self.item_descriptor.location)
+        _upload_sjson_file(good_sjson, self.block.location)
         subs_id = _get_subs_id(good_sjson.name)
 
-        attach(self.item, subs_id)
+        attach(self.block, subs_id)
         request = Request.blank(url.format(subs_id))
-        response = self.item.transcript(request=request, dispatch=dispatch)
+        response = self.block.transcript(request=request, dispatch=dispatch)
         self.assertDictEqual(json.loads(response.body.decode('utf-8')), subs)
 
     def test_translation_non_en_youtube_success(self):
@@ -650,20 +646,20 @@ class TestTranscriptTranslationGetDispatch(TestVideo):  # lint-amnesty, pylint: 
             ]
         }
         self.srt_file.seek(0)
-        _upload_file(self.srt_file, self.item_descriptor.location, os.path.split(self.srt_file.name)[1])
+        _upload_file(self.srt_file, self.block.location, os.path.split(self.srt_file.name)[1])
         subs_id = _get_subs_id(self.srt_file.name)
 
         # youtube 1_0 request, will generate for all speeds for existing ids
-        self.item.youtube_id_1_0 = subs_id
-        self.item.youtube_id_0_75 = '0_75'
-        self.store.update_item(self.item, self.user.id)
+        self.block.youtube_id_1_0 = subs_id
+        self.block.youtube_id_0_75 = '0_75'
+        self.store.update_item(self.block, self.user.id)
         request = Request.blank(f'/translation/uk?videoId={subs_id}')
-        response = self.item.transcript(request=request, dispatch='translation/uk')
+        response = self.block.transcript(request=request, dispatch='translation/uk')
         self.assertDictEqual(json.loads(response.body.decode('utf-8')), subs)
 
         # 0_75 subs are exist
         request = Request.blank('/translation/uk?videoId={}'.format('0_75'))
-        response = self.item.transcript(request=request, dispatch='translation/uk')
+        response = self.block.transcript(request=request, dispatch='translation/uk')
         calculated_0_75 = {
             'end': [75],
             'start': [9],
@@ -674,10 +670,10 @@ class TestTranscriptTranslationGetDispatch(TestVideo):  # lint-amnesty, pylint: 
 
         self.assertDictEqual(json.loads(response.body.decode('utf-8')), calculated_0_75)
         # 1_5 will be generated from 1_0
-        self.item.youtube_id_1_5 = '1_5'
-        self.store.update_item(self.item, self.user.id)
+        self.block.youtube_id_1_5 = '1_5'
+        self.store.update_item(self.block, self.user.id)
         request = Request.blank('/translation/uk?videoId={}'.format('1_5'))
-        response = self.item.transcript(request=request, dispatch='translation/uk')
+        response = self.block.transcript(request=request, dispatch='translation/uk')
         calculated_1_5 = {
             'end': [150],
             'start': [18],
@@ -693,13 +689,13 @@ class TestTranscriptTranslationGetDispatch(TestVideo):  # lint-amnesty, pylint: 
     @ddt.unpack
     def test_translaton_en_html5_success(self, url, dispatch, attach):
         good_sjson = _create_file(json.dumps(TRANSCRIPT))
-        _upload_sjson_file(good_sjson, self.item_descriptor.location)
+        _upload_sjson_file(good_sjson, self.block.location)
         subs_id = _get_subs_id(good_sjson.name)
 
-        attach(self.item, subs_id)
-        self.store.update_item(self.item, self.user.id)
+        attach(self.block, subs_id)
+        self.store.update_item(self.block, self.user.id)
         request = Request.blank(url)
-        response = self.item.transcript(request=request, dispatch=dispatch)
+        response = self.block.transcript(request=request, dispatch=dispatch)
         self.assertDictEqual(json.loads(response.body.decode('utf-8')), TRANSCRIPT)
 
     def test_translaton_non_en_html5_success(self):
@@ -711,12 +707,12 @@ class TestTranscriptTranslationGetDispatch(TestVideo):  # lint-amnesty, pylint: 
             ]
         }
         self.srt_file.seek(0)
-        _upload_file(self.srt_file, self.item_descriptor.location, os.path.split(self.srt_file.name)[1])
+        _upload_file(self.srt_file, self.block.location, os.path.split(self.srt_file.name)[1])
 
         # manually clean youtube_id_1_0, as it has default value
-        self.item.youtube_id_1_0 = ""
+        self.block.youtube_id_1_0 = ""
         request = Request.blank('/translation/uk')
-        response = self.item.transcript(request=request, dispatch='translation/uk')
+        response = self.block.transcript(request=request, dispatch='translation/uk')
         self.assertDictEqual(json.loads(response.body.decode('utf-8')), subs)
 
     def test_translation_static_transcript_xml_with_data_dirc(self):
@@ -730,25 +726,25 @@ class TestTranscriptTranslationGetDispatch(TestVideo):  # lint-amnesty, pylint: 
         test_modulestore = MagicMock()
         attrs = {'get_course.return_value': Mock(data_dir='dummy/static', static_asset_path='')}
         test_modulestore.configure_mock(**attrs)
-        self.item_descriptor.runtime.modulestore = test_modulestore
+        self.block.runtime.modulestore = test_modulestore
 
         # Test youtube style en
         request = Request.blank('/translation/en?videoId=12345')
-        response = self.item.transcript(request=request, dispatch='translation/en')
+        response = self.block.transcript(request=request, dispatch='translation/en')
         assert response.status == '307 Temporary Redirect'
         assert ('Location', '/static/dummy/static/subs_12345.srt.sjson') in response.headerlist
 
         # Test HTML5 video style
-        self.item.sub = 'OEoXaMPEzfM'
+        self.block.sub = 'OEoXaMPEzfM'
         request = Request.blank('/translation/en')
-        response = self.item.transcript(request=request, dispatch='translation/en')
+        response = self.block.transcript(request=request, dispatch='translation/en')
         assert response.status == '307 Temporary Redirect'
         assert ('Location', '/static/dummy/static/subs_OEoXaMPEzfM.srt.sjson') in response.headerlist
 
         # Test different language to ensure we are just ignoring it since we can't
         # translate with static fallback
         request = Request.blank('/translation/uk')
-        response = self.item.transcript(request=request, dispatch='translation/uk')
+        response = self.block.transcript(request=request, dispatch='translation/uk')
         assert response.status == '404 Not Found'
 
     @ddt.data(
@@ -774,9 +770,9 @@ class TestTranscriptTranslationGetDispatch(TestVideo):  # lint-amnesty, pylint: 
         self._set_static_asset_path()
 
         if attach:
-            attach(self.item, sub)
+            attach(self.block, sub)
         request = Request.blank(url)
-        response = self.item.transcript(request=request, dispatch=dispatch)
+        response = self.block.transcript(request=request, dispatch=dispatch)
         assert response.status == status_code
         if sub:
             assert ('Location', f'/static/dummy/static/subs_{sub}.srt.sjson') in response.headerlist
@@ -791,7 +787,7 @@ class TestTranscriptTranslationGetDispatch(TestVideo):  # lint-amnesty, pylint: 
 
         # When course_id is not mocked out, these values would result in 307, as tested above.
         request = Request.blank('/translation/en?videoId=12345')
-        response = self.item.transcript(request=request, dispatch='translation/en')
+        response = self.block.transcript(request=request, dispatch='translation/en')
         assert response.status == '404 Not Found'
 
     def _set_static_asset_path(self):
@@ -821,7 +817,7 @@ class TestTranscriptTranslationGetDispatch(TestVideo):  # lint-amnesty, pylint: 
         mock_get_video_transcript_data.return_value = transcript
 
         # Make request to XModule transcript handler
-        response = self.item.transcript(request=Request.blank('/translation/en'), dispatch='translation/en')
+        response = self.block.transcript(request=Request.blank('/translation/en'), dispatch='translation/en')
 
         # Expected headers
         expected_headers = {
@@ -842,7 +838,7 @@ class TestTranscriptTranslationGetDispatch(TestVideo):  # lint-amnesty, pylint: 
         Verify that val transcript is not returned when its feature is disabled.
         """
         # Make request to XModule transcript handler
-        response = self.item.transcript(request=Request.blank('/translation/en'), dispatch='translation/en')
+        response = self.block.transcript(request=Request.blank('/translation/en'), dispatch='translation/en')
         # Assert the actual response
         assert response.status_code == 404
 
@@ -870,20 +866,20 @@ class TestStudioTranscriptTranslationGetDispatch(TestVideo):  # lint-amnesty, py
     def test_translation_fails(self):
         # No language
         request = Request.blank("")
-        response = self.item_descriptor.studio_transcript(request=request, dispatch="translation")
+        response = self.block.studio_transcript(request=request, dispatch="translation")
         assert response.status == '400 Bad Request'
 
         # No language_code param in request.GET
         request = Request.blank("")
-        response = self.item_descriptor.studio_transcript(request=request, dispatch="translation")
+        response = self.block.studio_transcript(request=request, dispatch="translation")
         assert response.status == '400 Bad Request'
         assert response.json['error'] == 'Language is required.'
 
         # Correct case:
         filename = os.path.split(self.srt_file.name)[1]
-        _upload_file(self.srt_file, self.item_descriptor.location, filename)
+        _upload_file(self.srt_file, self.block.location, filename)
         request = Request.blank("translation?language_code=uk")
-        response = self.item_descriptor.studio_transcript(request=request, dispatch="translation?language_code=uk")
+        response = self.block.studio_transcript(request=request, dispatch="translation?language_code=uk")
         self.srt_file.seek(0)
         assert response.body == self.srt_file.read()
         assert response.headers['Content-Type'] == 'application/x-subrip; charset=utf-8'
@@ -892,9 +888,9 @@ class TestStudioTranscriptTranslationGetDispatch(TestVideo):  # lint-amnesty, py
 
         # Non ascii file name download:
         self.srt_file.seek(0)
-        _upload_file(self.srt_file, self.item_descriptor.location, "塞.srt")
+        _upload_file(self.srt_file, self.block.location, "塞.srt")
         request = Request.blank("translation?language_code=zh")
-        response = self.item_descriptor.studio_transcript(request=request, dispatch="translation?language_code=zh")
+        response = self.block.studio_transcript(request=request, dispatch="translation?language_code=zh")
         self.srt_file.seek(0)
         assert response.body == self.srt_file.read()
         assert response.headers['Content-Type'] == 'application/x-subrip; charset=utf-8'
@@ -945,9 +941,9 @@ class TestStudioTranscriptTranslationPostDispatch(TestVideo):  # lint-amnesty, p
         Verify that POST request validations works as expected.
         """
         # mock available_translations method
-        self.item_descriptor.available_translations = lambda transcripts, verify_assets: ['ur']
+        self.block.available_translations = lambda transcripts, verify_assets: ['ur']
         request = Request.blank('/translation', POST=post_data)
-        response = self.item_descriptor.studio_transcript(request=request, dispatch='translation')
+        response = self.block.studio_transcript(request=request, dispatch='translation')
         assert response.json['error'] == error_message
 
     @ddt.data(
@@ -981,11 +977,11 @@ class TestStudioTranscriptTranslationPostDispatch(TestVideo):  # lint-amnesty, p
             })
 
         request = Request.blank('/translation', POST=post_data)
-        response = self.item_descriptor.studio_transcript(request=request, dispatch='translation')
+        response = self.block.studio_transcript(request=request, dispatch='translation')
         assert response.status == '201 Created'
         response = json.loads(response.text)
         assert response['language_code'], 'uk'
-        self.assertDictEqual(self.item_descriptor.transcripts, {})
+        self.assertDictEqual(self.block.transcripts, {})
         assert edxval_api.get_video_transcript_data(video_id=response['edx_video_id'], language_code='uk')
 
     def test_studio_transcript_post_bad_content(self):
@@ -1000,7 +996,7 @@ class TestStudioTranscriptTranslationPostDispatch(TestVideo):  # lint-amnesty, p
         }
 
         request = Request.blank("/translation", POST=post_data)
-        response = self.item_descriptor.studio_transcript(request=request, dispatch="translation")
+        response = self.block.studio_transcript(request=request, dispatch="translation")
         assert response.status_code == 400
         assert response.json['error'] == 'There is a problem with this transcript file. Try to upload a different file.'
 
@@ -1033,7 +1029,7 @@ class TestStudioTranscriptTranslationDeleteDispatch(TestVideo):  # lint-amnesty,
         Verify that DELETE dispatch works as expected when required args are missing from request
         """
         request = Request(self.REQUEST_META, body=json.dumps(params).encode('utf-8'))
-        response = self.item_descriptor.studio_transcript(request=request, dispatch='translation')
+        response = self.block.studio_transcript(request=request, dispatch='translation')
         assert response.status_code == 400
 
     def test_translation_delete_w_edx_video_id(self):
@@ -1060,8 +1056,8 @@ class TestStudioTranscriptTranslationDeleteDispatch(TestVideo):  # lint-amnesty,
         assert api.get_video_transcript_data(video_id=self.EDX_VIDEO_ID, language_code=self.LANGUAGE_CODE_UK)
 
         request = Request(self.REQUEST_META, body=request_body.encode('utf-8'))
-        self.item_descriptor.edx_video_id = self.EDX_VIDEO_ID
-        response = self.item_descriptor.studio_transcript(request=request, dispatch='translation')
+        self.block.edx_video_id = self.EDX_VIDEO_ID
+        response = self.block.studio_transcript(request=request, dispatch='translation')
         assert response.status_code == 200
 
         # verify that a video transcript dose not exist for expected data
@@ -1076,20 +1072,20 @@ class TestStudioTranscriptTranslationDeleteDispatch(TestVideo):  # lint-amnesty,
         request = Request(self.REQUEST_META, body=request_body.encode('utf-8'))
 
         # upload and verify that srt file exists in assets
-        _upload_file(self.SRT_FILE, self.item_descriptor.location, srt_file_name_uk)
-        assert _check_asset(self.item_descriptor.location, srt_file_name_uk)
+        _upload_file(self.SRT_FILE, self.block.location, srt_file_name_uk)
+        assert _check_asset(self.block.location, srt_file_name_uk)
 
         # verify transcripts field
-        assert self.item_descriptor.transcripts != {}
-        assert self.LANGUAGE_CODE_UK in self.item_descriptor.transcripts
+        assert self.block.transcripts != {}
+        assert self.LANGUAGE_CODE_UK in self.block.transcripts
 
         # make request and verify response
-        response = self.item_descriptor.studio_transcript(request=request, dispatch='translation')
+        response = self.block.studio_transcript(request=request, dispatch='translation')
         assert response.status_code == 200
 
         # verify that srt file is deleted
-        assert self.item_descriptor.transcripts == {}
-        assert not _check_asset(self.item_descriptor.location, srt_file_name_uk)
+        assert self.block.transcripts == {}
+        assert not _check_asset(self.block.location, srt_file_name_uk)
 
     def test_translation_delete_w_english_lang(self):
         """
@@ -1097,45 +1093,45 @@ class TestStudioTranscriptTranslationDeleteDispatch(TestVideo):  # lint-amnesty,
         """
         request_body = json.dumps({'lang': self.LANGUAGE_CODE_EN, 'edx_video_id': ''})
         srt_file_name_en = subs_filename('english_translation.srt', lang=self.LANGUAGE_CODE_EN)
-        self.item_descriptor.transcripts['en'] = 'english_translation.srt'
+        self.block.transcripts['en'] = 'english_translation.srt'
         request = Request(self.REQUEST_META, body=request_body.encode('utf-8'))
 
         # upload and verify that srt file exists in assets
-        _upload_file(self.SRT_FILE, self.item_descriptor.location, srt_file_name_en)
-        assert _check_asset(self.item_descriptor.location, srt_file_name_en)
+        _upload_file(self.SRT_FILE, self.block.location, srt_file_name_en)
+        assert _check_asset(self.block.location, srt_file_name_en)
 
         # make request and verify response
-        response = self.item_descriptor.studio_transcript(request=request, dispatch='translation')
+        response = self.block.studio_transcript(request=request, dispatch='translation')
         assert response.status_code == 200
 
         # verify that srt file is deleted
-        assert self.LANGUAGE_CODE_EN not in self.item_descriptor.transcripts
-        assert not _check_asset(self.item_descriptor.location, srt_file_name_en)
+        assert self.LANGUAGE_CODE_EN not in self.block.transcripts
+        assert not _check_asset(self.block.location, srt_file_name_en)
 
     def test_translation_delete_w_sub(self):
         """
         Verify that DELETE dispatch works as expected when translation is present against `sub` field
         """
         request_body = json.dumps({'lang': self.LANGUAGE_CODE_EN, 'edx_video_id': ''})
-        sub_file_name = subs_filename(self.item_descriptor.sub, lang=self.LANGUAGE_CODE_EN)
+        sub_file_name = subs_filename(self.block.sub, lang=self.LANGUAGE_CODE_EN)
         request = Request(self.REQUEST_META, body=request_body.encode('utf-8'))
 
         # sub should not be empy
-        assert not self.item_descriptor.sub == ''
+        assert not self.block.sub == ''
         # lint-amnesty, pylint: disable=wrong-assert-type
 
         # upload and verify that srt file exists in assets
-        _upload_file(self.SRT_FILE, self.item_descriptor.location, sub_file_name)
-        assert _check_asset(self.item_descriptor.location, sub_file_name)
+        _upload_file(self.SRT_FILE, self.block.location, sub_file_name)
+        assert _check_asset(self.block.location, sub_file_name)
 
         # make request and verify response
-        response = self.item_descriptor.studio_transcript(request=request, dispatch='translation')
+        response = self.block.studio_transcript(request=request, dispatch='translation')
         assert response.status_code == 200
 
         # verify that sub is empty and transcript is deleted also
-        assert self.item_descriptor.sub == ''
+        assert self.block.sub == ''
         # lint-amnesty, pylint: disable=wrong-assert-type
-        assert not _check_asset(self.item_descriptor.location, sub_file_name)
+        assert not _check_asset(self.block.location, sub_file_name)
 
 
 class TestGetTranscript(TestVideo):  # lint-amnesty, pylint: disable=test-inherits-tests
@@ -1161,8 +1157,7 @@ class TestGetTranscript(TestVideo):  # lint-amnesty, pylint: disable=test-inheri
 
     def setUp(self):
         super().setUp()
-        self.item_descriptor.render(STUDENT_VIEW)
-        self.item = self.item_descriptor
+        self.block.render(STUDENT_VIEW)
 
     def test_good_transcript(self):
         """
@@ -1185,10 +1180,10 @@ class TestGetTranscript(TestVideo):  # lint-amnesty, pylint: disable=test-inheri
                 }
             """))
 
-        _upload_sjson_file(good_sjson, self.item.location)
-        self.item.sub = _get_subs_id(good_sjson.name)
+        _upload_sjson_file(good_sjson, self.block.location)
+        self.block.sub = _get_subs_id(good_sjson.name)
 
-        text, filename, mime_type = get_transcript(self.item)
+        text, filename, mime_type = get_transcript(self.block)
 
         expected_text = textwrap.dedent("""\
             0
@@ -1202,7 +1197,7 @@ class TestGetTranscript(TestVideo):  # lint-amnesty, pylint: disable=test-inheri
             """)
 
         assert text == expected_text
-        assert filename[:(- 4)] == ('en_' + self.item.sub)
+        assert filename[:(- 4)] == ('en_' + self.block.sub)
         assert mime_type == 'application/x-subrip; charset=utf-8'
 
     def test_good_txt_transcript(self):
@@ -1223,29 +1218,29 @@ class TestGetTranscript(TestVideo):  # lint-amnesty, pylint: disable=test-inheri
                 }
             """))
 
-        _upload_sjson_file(good_sjson, self.item.location)
-        self.item.sub = _get_subs_id(good_sjson.name)
-        text, filename, mime_type = get_transcript(self.item, output_format=Transcript.TXT)
+        _upload_sjson_file(good_sjson, self.block.location)
+        self.block.sub = _get_subs_id(good_sjson.name)
+        text, filename, mime_type = get_transcript(self.block, output_format=Transcript.TXT)
         expected_text = textwrap.dedent("""\
             Hi, welcome to Edx.
             Let's start with what is on your screen right now.""")
 
         assert text == expected_text
-        assert filename == (('en_' + self.item.sub) + '.txt')
+        assert filename == (('en_' + self.block.sub) + '.txt')
         assert mime_type == 'text/plain; charset=utf-8'
 
     def test_en_with_empty_sub(self):
 
-        self.item.sub = ""
-        self.item.transcripts = None
+        self.block.sub = ""
+        self.block.transcripts = None
         # no self.sub, self.youttube_1_0 exist, but no file in assets
         with pytest.raises(NotFoundError):
-            get_transcript(self.item)
+            get_transcript(self.block)
 
         # no self.sub and no self.youtube_1_0, no non-en transcritps
-        self.item.youtube_id_1_0 = None
+        self.block.youtube_id_1_0 = None
         with pytest.raises(NotFoundError):
-            get_transcript(self.item)
+            get_transcript(self.block)
 
         # no self.sub but youtube_1_0 exists with file in assets
         good_sjson = _create_file(content=textwrap.dedent("""\
@@ -1264,10 +1259,10 @@ class TestGetTranscript(TestVideo):  # lint-amnesty, pylint: disable=test-inheri
                   ]
                 }
             """))
-        _upload_sjson_file(good_sjson, self.item.location)
-        self.item.youtube_id_1_0 = _get_subs_id(good_sjson.name)
+        _upload_sjson_file(good_sjson, self.block.location)
+        self.block.youtube_id_1_0 = _get_subs_id(good_sjson.name)
 
-        text, filename, mime_type = get_transcript(self.item)
+        text, filename, mime_type = get_transcript(self.block)
         expected_text = textwrap.dedent("""\
             0
             00:00:00,270 --> 00:00:02,720
@@ -1280,16 +1275,16 @@ class TestGetTranscript(TestVideo):  # lint-amnesty, pylint: disable=test-inheri
             """)
 
         assert text == expected_text
-        assert filename == (('en_' + self.item.youtube_id_1_0) + '.srt')
+        assert filename == (('en_' + self.block.youtube_id_1_0) + '.srt')
         assert mime_type == 'application/x-subrip; charset=utf-8'
 
     def test_non_en_with_non_ascii_filename(self):
-        self.item.transcript_language = 'zh'
+        self.block.transcript_language = 'zh'
         self.srt_file.seek(0)
-        _upload_file(self.srt_file, self.item_descriptor.location, "塞.srt")
+        _upload_file(self.srt_file, self.block.location, "塞.srt")
 
-        transcripts = self.item.get_transcripts_info()  # lint-amnesty, pylint: disable=unused-variable
-        text, filename, mime_type = get_transcript(self.item)
+        transcripts = self.block.get_transcripts_info()  # lint-amnesty, pylint: disable=unused-variable
+        text, filename, mime_type = get_transcript(self.block)
         expected_text = textwrap.dedent("""
         0
         00:00:00,12 --> 00:00:00,100
@@ -1302,12 +1297,12 @@ class TestGetTranscript(TestVideo):  # lint-amnesty, pylint: disable=test-inheri
     def test_value_error_handled(self):
         good_sjson = _create_file(content='bad content')
 
-        _upload_sjson_file(good_sjson, self.item.location)
-        self.item.sub = _get_subs_id(good_sjson.name)
+        _upload_sjson_file(good_sjson, self.block.location)
+        self.block.sub = _get_subs_id(good_sjson.name)
 
-        transcripts = self.item.get_transcripts_info()  # lint-amnesty, pylint: disable=unused-variable
+        transcripts = self.block.get_transcripts_info()  # lint-amnesty, pylint: disable=unused-variable
         error_transcript = {"start": [], "end": [], "text": ["An error occured obtaining the transcript."]}
-        content, _, _ = get_transcript(self.item)
+        content, _, _ = get_transcript(self.block)
         assert error_transcript["text"][0] in content
 
     def test_key_error(self):
@@ -1324,9 +1319,9 @@ class TestGetTranscript(TestVideo):  # lint-amnesty, pylint: disable=test-inheri
                 }
             """)
 
-        _upload_sjson_file(good_sjson, self.item.location)
-        self.item.sub = _get_subs_id(good_sjson.name)
+        _upload_sjson_file(good_sjson, self.block.location)
+        self.block.sub = _get_subs_id(good_sjson.name)
 
-        transcripts = self.item.get_transcripts_info()  # lint-amnesty, pylint: disable=unused-variable
+        transcripts = self.block.get_transcripts_info()  # lint-amnesty, pylint: disable=unused-variable
         with pytest.raises(KeyError):
-            get_transcript(self.item)
+            get_transcript(self.block)

--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -81,7 +81,7 @@ class TestVideoYouTube(TestVideo):  # lint-amnesty, pylint: disable=missing-clas
 
     def test_video_constructor(self):
         """Make sure that all parameters extracted correctly from xml"""
-        context = self.item_descriptor.render(STUDENT_VIEW).content
+        context = self.block.render(STUDENT_VIEW).content
         sources = ['example.mp4', 'example.webm']
 
         expected_context = {
@@ -95,12 +95,12 @@ class TestVideoYouTube(TestVideo):  # lint-amnesty, pylint: disable=missing-clas
             'download_video_link': 'example.mp4',
             'handout': None,
             'hide_downloads': False,
-            'id': self.item_descriptor.location.html_id(),
+            'id': self.block.location.html_id(),
             'is_embed': False,
             'metadata': json.dumps(OrderedDict({
                 'autoAdvance': False,
                 'saveStateEnabled': True,
-                'saveStateUrl': self.item_descriptor.ajax_url + '/save_user_state',
+                'saveStateUrl': self.block.ajax_url + '/save_user_state',
                 'autoplay': False,
                 'streams': '0.75:jNCf2gIqpeE,1.00:ZwkTiUPN0mg,1.25:rsq9auxASqI,1.50:kMyNdzVHHgg',
                 'sources': sources,
@@ -138,7 +138,7 @@ class TestVideoYouTube(TestVideo):  # lint-amnesty, pylint: disable=missing-clas
             'public_video_url': None,
         }
 
-        mako_service = self.item_descriptor.runtime.service(self.item_descriptor, 'mako')
+        mako_service = self.block.runtime.service(self.block, 'mako')
         assert get_context_dict_from_string(context) ==\
                get_context_dict_from_string(mako_service.render_template('video.html', expected_context))
 
@@ -165,7 +165,7 @@ class TestVideoNonYouTube(TestVideo):  # pylint: disable=test-inherits-tests
         """Make sure that if the 'youtube' attribute is omitted in XML, then
             the template generates an empty string for the YouTube streams.
         """
-        context = self.item_descriptor.render(STUDENT_VIEW).content
+        context = self.block.render(STUDENT_VIEW).content
         sources = ['example.mp4', 'example.webm']
 
         expected_context = {
@@ -180,11 +180,11 @@ class TestVideoNonYouTube(TestVideo):  # pylint: disable=test-inherits-tests
             'handout': None,
             'hide_downloads': False,
             'is_embed': False,
-            'id': self.item_descriptor.location.html_id(),
+            'id': self.block.location.html_id(),
             'metadata': json.dumps(OrderedDict({
                 'autoAdvance': False,
                 'saveStateEnabled': True,
-                'saveStateUrl': self.item_descriptor.ajax_url + '/save_user_state',
+                'saveStateUrl': self.block.ajax_url + '/save_user_state',
                 'autoplay': False,
                 'streams': '1.00:3_yD_cEKoCk',
                 'sources': sources,
@@ -222,7 +222,7 @@ class TestVideoNonYouTube(TestVideo):  # pylint: disable=test-inherits-tests
             'public_video_url': None,
         }
 
-        mako_service = self.item_descriptor.runtime.service(self.item_descriptor, 'mako')
+        mako_service = self.block.runtime.service(self.block, 'mako')
         expected_result = get_context_dict_from_string(
             mako_service.render_template('video.html', expected_context)
         )
@@ -249,11 +249,11 @@ class TestVideoPublicAccess(BaseTestVideoXBlock):
     @ddt.unpack
     def test_public_video_url(self, is_lms_platform, enable_public_share):
         """Test public video url."""
-        assert self.item_descriptor.public_access is True
+        assert self.block.public_access is True
         if not is_lms_platform:
-            self.item_descriptor.runtime.is_author_mode = True
+            self.block.runtime.is_author_mode = True
         with patch.object(PUBLIC_VIDEO_SHARE, 'is_enabled', return_value=enable_public_share):
-            context = self.item_descriptor.render(STUDENT_VIEW).content
+            context = self.block.render(STUDENT_VIEW).content
             # public video url iif PUBLIC_VIDEO_SHARE waffle and is_lms_platform, public_access are true
             assert bool(get_context_dict_from_string(context)['public_video_url']) \
                 is (is_lms_platform and enable_public_share)
@@ -307,10 +307,10 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
     def get_handler_url(self, handler, suffix):
         """
         Return the URL for the specified handler on the block represented by
-        self.item_descriptor.
+        self.block.
         """
-        return self.item_descriptor.runtime.handler_url(
-            self.item_descriptor, handler, suffix
+        return self.block.runtime.handler_url(
+            self.block, handler, suffix
         ).rstrip('/?')
 
     def test_get_html_track(self):
@@ -379,7 +379,7 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
             'download_video_link': 'example.mp4',
             'handout': None,
             'hide_downloads': False,
-            'id': self.item_descriptor.location.html_id(),
+            'id': self.block.location.html_id(),
             'is_embed': False,
             'metadata': '',
             'track': None,
@@ -406,27 +406,27 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
             self.initialize_block(data=DATA)
             track_url = self.get_handler_url('transcript', 'download')
 
-            context = self.item_descriptor.render(STUDENT_VIEW).content
+            context = self.block.render(STUDENT_VIEW).content
             metadata.update({
                 'transcriptLanguages': {"en": "English"} if not data['transcripts'] else {"uk": 'Українська'},
                 'transcriptLanguage': 'en' if not data['transcripts'] or data.get('sub') else 'uk',
                 'transcriptTranslationUrl': self.get_handler_url('transcript', 'translation/__lang__'),
                 'transcriptAvailableTranslationsUrl': self.get_handler_url('transcript', 'available_translations'),
                 'publishCompletionUrl': self.get_handler_url('publish_completion', ''),
-                'saveStateUrl': self.item_descriptor.ajax_url + '/save_user_state',
+                'saveStateUrl': self.block.ajax_url + '/save_user_state',
             })
             expected_context.update({
                 'transcript_download_format': (
-                    None if self.item_descriptor.track and self.item_descriptor.download_track else 'srt'
+                    None if self.block.track and self.block.download_track else 'srt'
                 ),
                 'track': (
                     track_url if data['expected_track_url'] == 'a_sub_file.srt.sjson' else data['expected_track_url']
                 ),
-                'id': self.item_descriptor.location.html_id(),
+                'id': self.block.location.html_id(),
                 'metadata': json.dumps(metadata)
             })
 
-            mako_service = self.item_descriptor.runtime.service(self.item_descriptor, 'mako')
+            mako_service = self.block.runtime.service(self.block, 'mako')
             assert get_context_dict_from_string(context) ==\
                    get_context_dict_from_string(mako_service.render_template('video.html', expected_context))
 
@@ -500,7 +500,7 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
             'download_video_link': 'example.mp4',
             'handout': None,
             'hide_downloads': False,
-            'id': self.item_descriptor.location.html_id(),
+            'id': self.block.location.html_id(),
             'is_embed': False,
             'metadata': self.default_metadata_dict,
             'track': None,
@@ -521,23 +521,23 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
                 sources=data['sources']
             )
             self.initialize_block(data=DATA)
-            context = self.item_descriptor.render(STUDENT_VIEW).content
+            context = self.block.render(STUDENT_VIEW).content
 
             expected_context = dict(initial_context)
             expected_context['metadata'].update({
                 'transcriptTranslationUrl': self.get_handler_url('transcript', 'translation/__lang__'),
                 'transcriptAvailableTranslationsUrl': self.get_handler_url('transcript', 'available_translations'),
                 'publishCompletionUrl': self.get_handler_url('publish_completion', ''),
-                'saveStateUrl': self.item_descriptor.ajax_url + '/save_user_state',
+                'saveStateUrl': self.block.ajax_url + '/save_user_state',
                 'sources': data['result'].get('sources', []),
             })
             expected_context.update({
-                'id': self.item_descriptor.location.html_id(),
+                'id': self.block.location.html_id(),
                 'download_video_link': data['result'].get('download_video_link'),
                 'metadata': json.dumps(expected_context['metadata'])
             })
 
-            mako_service = self.item_descriptor.runtime.service(self.item_descriptor, 'mako')
+            mako_service = self.block.runtime.service(self.block, 'mako')
             assert get_context_dict_from_string(context) ==\
                    get_context_dict_from_string(mako_service.render_template('video.html', expected_context))
 
@@ -581,7 +581,7 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
 
         # Referencing a non-existent VAL ID in courseware won't cause an error --
         # it'll just fall back to the values in the VideoBlock.
-        assert 'example.mp4' in self.item_descriptor.render(STUDENT_VIEW).content
+        assert 'example.mp4' in self.block.render(STUDENT_VIEW).content
 
     def test_get_html_with_mocked_edx_video_id(self):
         # lint-amnesty, pylint: disable=invalid-name, redefined-outer-name
@@ -629,7 +629,7 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
             'handout': None,
             'hide_downloads': False,
             'is_embed': False,
-            'id': self.item_descriptor.location.html_id(),
+            'id': self.block.location.html_id(),
             'track': None,
             'transcript_download_format': 'srt',
             'transcript_download_formats_list': [
@@ -664,23 +664,23 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
                     }
                 ]
             }
-            context = self.item_descriptor.render(STUDENT_VIEW).content
+            context = self.block.render(STUDENT_VIEW).content
 
         expected_context = dict(initial_context)
         expected_context['metadata'].update({
             'transcriptTranslationUrl': self.get_handler_url('transcript', 'translation/__lang__'),
             'transcriptAvailableTranslationsUrl': self.get_handler_url('transcript', 'available_translations'),
             'publishCompletionUrl': self.get_handler_url('publish_completion', ''),
-            'saveStateUrl': self.item_descriptor.ajax_url + '/save_user_state',
+            'saveStateUrl': self.block.ajax_url + '/save_user_state',
             'sources': data['result']['sources'],
         })
         expected_context.update({
-            'id': self.item_descriptor.location.html_id(),
+            'id': self.block.location.html_id(),
             'download_video_link': data['result']['download_video_link'],
             'metadata': json.dumps(expected_context['metadata'])
         })
 
-        mako_service = self.item_descriptor.runtime.service(self.item_descriptor, 'mako')
+        mako_service = self.block.runtime.service(self.block, 'mako')
         assert get_context_dict_from_string(context) ==\
                get_context_dict_from_string(mako_service.render_template('video.html', expected_context))
 
@@ -708,7 +708,7 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
         # context returned by get_html when provided with above data
         # expected_context, a dict to assert with context
         context, expected_context = self.helper_get_html_with_edx_video_id(data)
-        mako_service = self.item_descriptor.runtime.service(self.item_descriptor, 'mako')
+        mako_service = self.block.runtime.service(self.block, 'mako')
         assert get_context_dict_from_string(context) ==\
                get_context_dict_from_string(mako_service.render_template('video.html', expected_context))
 
@@ -739,7 +739,7 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
         # expected_context, a dict to assert with context
         context, expected_context = self.helper_get_html_with_edx_video_id(data)
 
-        mako_service = self.item_descriptor.runtime.service(self.item_descriptor, 'mako')
+        mako_service = self.block.runtime.service(self.block, 'mako')
         assert get_context_dict_from_string(context) ==\
                get_context_dict_from_string(mako_service.render_template('video.html', expected_context))
 
@@ -803,7 +803,7 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
             'handout': None,
             'hide_downloads': False,
             'is_embed': False,
-            'id': self.item_descriptor.location.html_id(),
+            'id': self.block.location.html_id(),
             'track': None,
             'transcript_download_format': 'srt',
             'transcript_download_formats_list': [
@@ -824,7 +824,7 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
         )
         self.initialize_block(data=DATA)
         # context returned by get_html
-        context = self.item_descriptor.render(STUDENT_VIEW).content
+        context = self.block.render(STUDENT_VIEW).content
 
         # expected_context, expected context to be returned by get_html
         expected_context = dict(initial_context)
@@ -832,11 +832,11 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
             'transcriptTranslationUrl': self.get_handler_url('transcript', 'translation/__lang__'),
             'transcriptAvailableTranslationsUrl': self.get_handler_url('transcript', 'available_translations'),
             'publishCompletionUrl': self.get_handler_url('publish_completion', ''),
-            'saveStateUrl': self.item_descriptor.ajax_url + '/save_user_state',
+            'saveStateUrl': self.block.ajax_url + '/save_user_state',
             'sources': data['result']['sources'],
         })
         expected_context.update({
-            'id': self.item_descriptor.location.html_id(),
+            'id': self.block.location.html_id(),
             'download_video_link': data['result']['download_video_link'],
             'metadata': json.dumps(expected_context['metadata'])
         })
@@ -940,25 +940,25 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
             self.initialize_block(data=DATA, runtime_kwargs={
                 'user_location': 'CN',
             })
-            user_service = self.item_descriptor.runtime.service(self.item_descriptor, 'user')
+            user_service = self.block.runtime.service(self.block, 'user')
             user_location = user_service.get_current_user().opt_attrs[ATTR_KEY_REQUEST_COUNTRY_CODE]
             assert user_location == 'CN'
-            context = self.item_descriptor.render('student_view').content
+            context = self.block.render('student_view').content
             expected_context = dict(initial_context)
             expected_context['metadata'].update({
                 'transcriptTranslationUrl': self.get_handler_url('transcript', 'translation/__lang__'),
                 'transcriptAvailableTranslationsUrl': self.get_handler_url('transcript', 'available_translations'),
                 'publishCompletionUrl': self.get_handler_url('publish_completion', ''),
-                'saveStateUrl': self.item_descriptor.ajax_url + '/save_user_state',
+                'saveStateUrl': self.block.ajax_url + '/save_user_state',
                 'sources': data['result'].get('sources', []),
             })
             expected_context.update({
-                'id': self.item_descriptor.location.html_id(),
+                'id': self.block.location.html_id(),
                 'download_video_link': data['result'].get('download_video_link'),
                 'metadata': json.dumps(expected_context['metadata'])
             })
 
-            mako_service = self.item_descriptor.runtime.service(self.item_descriptor, 'mako')
+            mako_service = self.block.runtime.service(self.block, 'mako')
             assert get_context_dict_from_string(context) ==\
                    get_context_dict_from_string(mako_service.render_template('video.html', expected_context))
 
@@ -1048,22 +1048,22 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
                     'client_video_id': 'external video',
                     'encoded_videos': {}
                 }
-                context = self.item_descriptor.render(STUDENT_VIEW).content
+                context = self.block.render(STUDENT_VIEW).content
             expected_context = dict(initial_context)
             expected_context['metadata'].update({
                 'transcriptTranslationUrl': self.get_handler_url('transcript', 'translation/__lang__'),
                 'transcriptAvailableTranslationsUrl': self.get_handler_url('transcript', 'available_translations'),
                 'publishCompletionUrl': self.get_handler_url('publish_completion', ''),
-                'saveStateUrl': self.item_descriptor.ajax_url + '/save_user_state',
+                'saveStateUrl': self.block.ajax_url + '/save_user_state',
                 'sources': data['result'].get('sources', []),
             })
             expected_context.update({
-                'id': self.item_descriptor.location.html_id(),
+                'id': self.block.location.html_id(),
                 'download_video_link': data['result'].get('download_video_link'),
                 'metadata': json.dumps(expected_context['metadata'])
             })
 
-            mako_service = self.item_descriptor.runtime.service(self.item_descriptor, 'mako')
+            mako_service = self.block.runtime.service(self.block, 'mako')
             assert get_context_dict_from_string(context) ==\
                    get_context_dict_from_string(mako_service.render_template('video.html', expected_context))
 
@@ -1087,9 +1087,9 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
                 feature_enabled.return_value = hls_feature_enabled
                 video_xml = '<video display_name="Video" download_video="true" edx_video_id="12345-67890">[]</video>'
                 self.initialize_block(data=video_xml)
-                self.item_descriptor.render(STUDENT_VIEW)
+                self.block.render(STUDENT_VIEW)
                 get_urls_for_profiles.assert_called_with(
-                    self.item_descriptor.edx_video_id,
+                    self.block.edx_video_id,
                     expected_val_profiles,
                 )
 
@@ -1112,7 +1112,7 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
         }
 
         self.initialize_block(data=video_xml)
-        context = self.item_descriptor.render(STUDENT_VIEW).content
+        context = self.block.render(STUDENT_VIEW).content
 
         assert "'download_video_link': 'https://mp4.com/dm.mp4'" in context
         assert '"streams": "1.00:https://yt.com/?v=v0TFmdO4ZP0"' in context
@@ -1130,7 +1130,7 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
         """
 
         self.initialize_block(data=video_xml)
-        context = self.item_descriptor.render(STUDENT_VIEW).content
+        context = self.block.render(STUDENT_VIEW).content
         assert "'download_video_link': None" in context
 
     def test_get_html_non_hls_video_download(self):
@@ -1146,7 +1146,7 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
         """
 
         self.initialize_block(data=video_xml)
-        context = self.item_descriptor.render(STUDENT_VIEW).content
+        context = self.block.render(STUDENT_VIEW).content
         assert "'download_video_link': 'http://example.com/example.mp4'" in context
 
     def test_html_student_public_view(self):
@@ -1160,9 +1160,9 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
         """
 
         self.initialize_block(data=video_xml)
-        context = self.item_descriptor.render(STUDENT_VIEW).content
+        context = self.block.render(STUDENT_VIEW).content
         assert '"saveStateEnabled": true' in context
-        context = self.item_descriptor.render(PUBLIC_VIEW).content
+        context = self.block.render(PUBLIC_VIEW).content
         assert '"saveStateEnabled": false' in context
 
     @patch('xmodule.video_block.video_block.edxval_api.get_course_video_image_url')
@@ -1174,7 +1174,7 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
         get_course_video_image_url.return_value = '/media/video-images/poster.png'
 
         self.initialize_block(data=video_xml)
-        context = self.item_descriptor.render(STUDENT_VIEW).content
+        context = self.block.render(STUDENT_VIEW).content
 
         assert '"poster": "/media/video-images/poster.png"' in context
 
@@ -1187,7 +1187,7 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
         get_course_video_image_url.return_value = '/media/video-images/poster.png'
 
         self.initialize_block(data=video_xml)
-        context = self.item_descriptor.render(STUDENT_VIEW).content
+        context = self.block.render(STUDENT_VIEW).content
 
         assert "'poster': 'null'" in context
 
@@ -1198,7 +1198,7 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
         """
         video_xml = '<video display_name="Video" download_video="true" edx_video_id="12345-67890">[]</video>'
         self.initialize_block(data=video_xml)
-        context = self.item_descriptor.render(STUDENT_VIEW).content
+        context = self.block.render(STUDENT_VIEW).content
         assert '"prioritizeHls": false' in context
 
     @ddt.data(
@@ -1252,7 +1252,7 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
         with patch.object(WaffleFlagCourseOverrideModel, 'override_value', return_value=data['course_override']):
             with override_waffle_flag(DEPRECATE_YOUTUBE, active=data['waffle_enabled']):
                 self.initialize_block(data=video_xml, metadata=metadata)
-                context = self.item_descriptor.render(STUDENT_VIEW).content
+                context = self.block.render(STUDENT_VIEW).content
                 assert '"prioritizeHls": {}'.format(data['result']) in context
 
 
@@ -1316,7 +1316,7 @@ class TestVideoBlockInitialization(BaseTestVideoXBlock):
             self.initialize_block(
                 data='<video display_name="Video" download_video="true" edx_video_id="12345-67890">[]</video>'
             )
-            context = self.item_descriptor.get_context()
+            context = self.block.get_context()
         assert context['transcripts_basic_tab_metadata']['video_url']['value'] == video_url
 
     @ddt.data(
@@ -1354,7 +1354,7 @@ class TestVideoBlockInitialization(BaseTestVideoXBlock):
             self.initialize_block(
                 data='<video display_name="Video" youtube_id_1_0="" download_video="true" edx_video_id="12345-67890">[]</video>'
             )
-            context = self.item_descriptor.get_context()
+            context = self.block.get_context()
         assert context['transcripts_basic_tab_metadata']['video_url']['value'] == video_url
 
 
@@ -1388,7 +1388,7 @@ class TestEditorSavedMethod(BaseTestVideoXBlock):
         """
         self.MODULESTORE = MODULESTORES[default_store]  # pylint: disable=invalid-name
         self.initialize_block(metadata=self.metadata)
-        item = self.store.get_item(self.item_descriptor.location)
+        item = self.store.get_item(self.block.location)
         with open(self.file_path, "rb") as myfile:  # lint-amnesty, pylint: disable=bad-option-value, open-builtin
             save_to_store(myfile.read(), self.file_name, 'text/sjson', item.location)
         item.sub = "3_yD_cEKoCk"
@@ -1408,7 +1408,7 @@ class TestEditorSavedMethod(BaseTestVideoXBlock):
         """
         self.MODULESTORE = MODULESTORES[default_store]
         self.initialize_block(metadata=self.metadata)
-        item = self.store.get_item(self.item_descriptor.location)
+        item = self.store.get_item(self.block.location)
         with open(self.file_path, "rb") as myfile:  # lint-amnesty, pylint: disable=bad-option-value, open-builtin
             save_to_store(myfile.read(), self.file_name, 'text/sjson', item.location)
             save_to_store(myfile.read(), 'subs_video.srt.sjson', 'text/sjson', item.location)
@@ -1433,7 +1433,7 @@ class TestEditorSavedMethod(BaseTestVideoXBlock):
             'edx_video_id': unstripped_video_id
         })
         self.initialize_block(metadata=self.metadata)
-        item = self.store.get_item(self.item_descriptor.location)
+        item = self.store.get_item(self.block.location)
         assert item.edx_video_id == unstripped_video_id
 
         # Now, modifying and saving the video block should strip the video id.
@@ -1451,7 +1451,7 @@ class TestEditorSavedMethod(BaseTestVideoXBlock):
         """
         self.MODULESTORE = MODULESTORES[default_store]
         self.initialize_block(metadata=self.metadata)
-        item = self.store.get_item(self.item_descriptor.location)
+        item = self.store.get_item(self.block.location)
         assert item.youtube_id_1_0 == '3_yD_cEKoCk'
 
         # Now, modify `edx_video_id` and save should override `youtube_id_1_0`.
@@ -1493,7 +1493,7 @@ class TestVideoBlockStudentViewJson(BaseTestVideoXBlock, CacheIsolationTestCase)
         )
         self.transcript_url = "transcript_url"
         self.initialize_block(data=sample_xml)
-        self.video = self.item_descriptor
+        self.video = self.block
         self.video.runtime.handler_url = Mock(return_value=self.transcript_url)
 
     def setup_val_video(self, associate_course_in_val=False):
@@ -1595,7 +1595,7 @@ class TestVideoBlockStudentViewJson(BaseTestVideoXBlock, CacheIsolationTestCase)
         ])
         self.transcript_url = "transcript_url"
         self.initialize_block(data=sample_xml)
-        self.video = self.item_descriptor
+        self.video = self.block
         self.video.runtime.handler_url = Mock(return_value=self.transcript_url)
         result = self.get_result()
         self.verify_result_with_youtube_url(result)
@@ -1659,11 +1659,11 @@ class TestVideoBlockStudentViewJson(BaseTestVideoXBlock, CacheIsolationTestCase)
 @ddt.ddt
 class VideoBlockTest(TestCase, VideoBlockTestBase):
     """
-    Tests for video descriptor that requires access to django settings.
+    Tests for video block that requires access to django settings.
     """
     def setUp(self):
         super().setUp()
-        self.descriptor.runtime.handler_url = MagicMock()
+        self.block.runtime.handler_url = MagicMock()
         self.temp_dir = mkdtemp()
         file_system = OSFS(self.temp_dir)
         self.file_system = file_system.makedir(EXPORT_IMPORT_COURSE_DIR, recreate=True)
@@ -1695,12 +1695,12 @@ class VideoBlockTest(TestCase, VideoBlockTestBase):
                 'template': 'tabs/metadata-edit-tab.html'
             }
         ]
-        rendered_context = self.descriptor.get_context()
+        rendered_context = self.block.get_context()
         self.assertListEqual(rendered_context['tabs'], correct_tabs)
 
         # Assert that the Video ID field is present in basic tab metadata context.
         assert rendered_context['transcripts_basic_tab_metadata']['edx_video_id'] ==\
-               self.descriptor.editable_metadata_fields['edx_video_id']
+               self.block.editable_metadata_fields['edx_video_id']
 
     def test_export_val_data_with_internal(self):
         """
@@ -1712,11 +1712,11 @@ class VideoBlockTest(TestCase, VideoBlockTestBase):
             combine(self.temp_dir, EXPORT_IMPORT_COURSE_DIR),
             combine(EXPORT_IMPORT_STATIC_DIR, transcript_file_name)
         )
-        self.descriptor.edx_video_id = 'test_edx_video_id'
+        self.block.edx_video_id = 'test_edx_video_id'
 
         create_profile('mobile')
         create_video({
-            'edx_video_id': self.descriptor.edx_video_id,
+            'edx_video_id': self.block.edx_video_id,
             'client_video_id': 'test_client_video_id',
             'duration': 111.0,
             'status': 'dummy',
@@ -1728,7 +1728,7 @@ class VideoBlockTest(TestCase, VideoBlockTestBase):
             }],
         })
         create_or_update_video_transcript(
-            video_id=self.descriptor.edx_video_id,
+            video_id=self.block.edx_video_id,
             language_code=language_code,
             metadata={
                 'provider': 'Cielo24',
@@ -1737,7 +1737,7 @@ class VideoBlockTest(TestCase, VideoBlockTestBase):
             file_data=ContentFile(TRANSCRIPT_FILE_SRT_DATA)
         )
 
-        actual = self.descriptor.definition_to_xml(resource_fs=self.file_system)
+        actual = self.block.definition_to_xml(resource_fs=self.file_system)
         expected_str = """
             <video youtube="1.00:3_yD_cEKoCk" url_name="SampleProblem" transcripts='{transcripts}'>
                 <video_asset client_video_id="test_client_video_id" duration="111.0" image="">
@@ -1763,7 +1763,7 @@ class VideoBlockTest(TestCase, VideoBlockTestBase):
         # Also verify the content of created transcript file.
         with open(expected_transcript_path) as transcript_path:
             expected_transcript_content = File(transcript_path).read()
-            transcript = get_video_transcript_data(video_id=self.descriptor.edx_video_id, language_code=language_code)
+            transcript = get_video_transcript_data(video_id=self.block.edx_video_id, language_code=language_code)
             assert transcript['content'].decode('utf-8') == expected_transcript_content
 
     @ddt.data(
@@ -1775,13 +1775,13 @@ class VideoBlockTest(TestCase, VideoBlockTestBase):
         """
         Tests new transcripts export for backward compatibility.
         """
-        self.descriptor.edx_video_id = 'test_video_id'
-        self.descriptor.sub = sub
+        self.block.edx_video_id = 'test_video_id'
+        self.block.sub = sub
 
         # Setup VAL encode profile, video and transcripts
         create_profile('mobile')
         create_video({
-            'edx_video_id': self.descriptor.edx_video_id,
+            'edx_video_id': self.block.edx_video_id,
             'client_video_id': 'test_client_video_id',
             'duration': 111.0,
             'status': 'dummy',
@@ -1795,21 +1795,21 @@ class VideoBlockTest(TestCase, VideoBlockTestBase):
 
         for language in languages:
             create_video_transcript(
-                video_id=self.descriptor.edx_video_id,
+                video_id=self.block.edx_video_id,
                 language_code=language,
                 file_format=Transcript.SRT,
                 content=ContentFile(TRANSCRIPT_FILE_SRT_DATA)
             )
 
         # Export the video block into xml
-        video_xml = self.descriptor.definition_to_xml(resource_fs=self.file_system)
+        video_xml = self.block.definition_to_xml(resource_fs=self.file_system)
 
         # Assert `sub` and `transcripts` attribute in the xml
         assert video_xml.get('sub') == expected_sub
 
         expected_transcripts = {
             language: "{edx_video_id}-{language}.srt".format(
-                edx_video_id=self.descriptor.edx_video_id,
+                edx_video_id=self.block.edx_video_id,
                 language=language
             )
             for language in languages
@@ -1824,15 +1824,15 @@ class VideoBlockTest(TestCase, VideoBlockTestBase):
             )
             with open(expected_transcript_path) as transcript_path:
                 expected_transcript_content = File(transcript_path).read()
-                transcript = get_video_transcript_data(video_id=self.descriptor.edx_video_id, language_code=language)
+                transcript = get_video_transcript_data(video_id=self.block.edx_video_id, language_code=language)
                 assert transcript['content'].decode('utf-8') == expected_transcript_content
 
     def test_export_val_data_not_found(self):
         """
         Tests that external video export works as expected.
         """
-        self.descriptor.edx_video_id = 'nonexistent'
-        actual = self.descriptor.definition_to_xml(resource_fs=self.file_system)
+        self.block.edx_video_id = 'nonexistent'
+        actual = self.block.definition_to_xml(resource_fs=self.file_system)
         expected_str = """<video youtube="1.00:3_yD_cEKoCk" url_name="SampleProblem"/>"""
         parser = etree.XMLParser(remove_blank_text=True)
         expected = etree.XML(expected_str, parser=parser)
@@ -1845,7 +1845,7 @@ class VideoBlockTest(TestCase, VideoBlockTestBase):
         """
         mock_get_video_ids_info.return_value = True, []
 
-        actual = self.descriptor.definition_to_xml(resource_fs=self.file_system)
+        actual = self.block.definition_to_xml(resource_fs=self.file_system)
         expected_str = '<video youtube="1.00:3_yD_cEKoCk" url_name="SampleProblem"></video>'
 
         parser = etree.XMLParser(remove_blank_text=True)
@@ -1883,7 +1883,7 @@ class VideoBlockTest(TestCase, VideoBlockTestBase):
         # Create self.sub and self.transcripts transcript.
         create_file_in_fs(
             TRANSCRIPT_FILE_SRT_DATA,
-            subs_filename(sub_id, self.descriptor.transcript_language),
+            subs_filename(sub_id, self.block.transcript_language),
             module_system.resources_fs,
             EXPORT_IMPORT_STATIC_DIR
         )
@@ -1913,7 +1913,7 @@ class VideoBlockTest(TestCase, VideoBlockTestBase):
         xml_object = etree.fromstring(xml_data)
         id_generator = Mock()
         id_generator.target_course_id = "test_course_id"
-        video = self.descriptor.parse_xml(xml_object, module_system, None, id_generator)
+        video = self.block.parse_xml(xml_object, module_system, None, id_generator)
 
         assert video.edx_video_id == 'test_edx_video_id'
         video_data = get_video_info(video.edx_video_id)
@@ -1940,9 +1940,9 @@ class VideoBlockTest(TestCase, VideoBlockTestBase):
         self.assertDictContainsSubset(
             self.get_video_transcript_data(
                 edx_video_id,
-                language_code=self.descriptor.transcript_language
+                language_code=self.block.transcript_language
             ),
-            get_video_transcript(video.edx_video_id, self.descriptor.transcript_language)
+            get_video_transcript(video.edx_video_id, self.block.transcript_language)
         )
 
         # Verify that transcript from transcript field is imported.
@@ -1964,9 +1964,9 @@ class VideoBlockTest(TestCase, VideoBlockTestBase):
         id_generator = Mock()
 
         # Verify edx_video_id is empty before.
-        assert self.descriptor.edx_video_id == ''
+        assert self.block.edx_video_id == ''
 
-        video = self.descriptor.parse_xml(xml_object, module_system, None, id_generator)
+        video = self.block.parse_xml(xml_object, module_system, None, id_generator)
 
         # Verify edx_video_id is populated after the import.
         assert video.edx_video_id != ''
@@ -2012,9 +2012,9 @@ class VideoBlockTest(TestCase, VideoBlockTestBase):
         )
 
         # Verify edx_video_id is empty before.
-        assert self.descriptor.edx_video_id == ''
+        assert self.block.edx_video_id == ''
 
-        video = self.descriptor.parse_xml(xml_object, module_system, None, id_generator)
+        video = self.block.parse_xml(xml_object, module_system, None, id_generator)
 
         # Verify edx_video_id is populated after the import.
         assert video.edx_video_id != ''
@@ -2154,9 +2154,9 @@ class VideoBlockTest(TestCase, VideoBlockTestBase):
         xml_object = etree.fromstring(xml_data)
 
         # Verify edx_video_id is empty before import.
-        assert self.descriptor.edx_video_id == ''
+        assert self.block.edx_video_id == ''
 
-        video = self.descriptor.parse_xml(xml_object, module_system, None, id_generator)
+        video = self.block.parse_xml(xml_object, module_system, None, id_generator)
 
         # Verify edx_video_id is not empty after import.
         assert video.edx_video_id != ''
@@ -2215,12 +2215,12 @@ class TestVideoWithBumper(TestVideo):  # pylint: disable=test-inherits-tests
             "transcripts": {},
         }
         with override_settings(FEATURES=self.FEATURES):
-            assert bumper_utils.is_bumper_enabled(self.item_descriptor)
+            assert bumper_utils.is_bumper_enabled(self.block)
 
         self.FEATURES.update({"ENABLE_VIDEO_BUMPER": False})
 
         with override_settings(FEATURES=self.FEATURES):
-            assert not bumper_utils.is_bumper_enabled(self.item_descriptor)
+            assert not bumper_utils.is_bumper_enabled(self.block)
 
     @patch('xmodule.video_block.bumper_utils.is_bumper_enabled')
     @patch('xmodule.video_block.bumper_utils.get_bumper_settings')
@@ -2241,14 +2241,14 @@ class TestVideoWithBumper(TestVideo):  # pylint: disable=test-inherits-tests
 
         is_bumper_enabled.return_value = True
 
-        content = self.item_descriptor.render(STUDENT_VIEW).content
+        content = self.block.render(STUDENT_VIEW).content
         sources = ['example.mp4', 'example.webm']
         expected_context = {
             'autoadvance_enabled': False,
             'branding_info': None,
             'license': None,
             'bumper_metadata': json.dumps(OrderedDict({
-                'saveStateUrl': self.item_descriptor.ajax_url + '/save_user_state',
+                'saveStateUrl': self.block.ajax_url + '/save_user_state',
                 'showCaptions': 'true',
                 'sources': ['http://test_bumper.mp4'],
                 'streams': '',
@@ -2271,11 +2271,11 @@ class TestVideoWithBumper(TestVideo):  # pylint: disable=test-inherits-tests
             'handout': None,
             'hide_downloads': False,
             'is_embed': False,
-            'id': self.item_descriptor.location.html_id(),
+            'id': self.block.location.html_id(),
             'metadata': json.dumps(OrderedDict({
                 'autoAdvance': False,
                 'saveStateEnabled': True,
-                'saveStateUrl': self.item_descriptor.ajax_url + '/save_user_state',
+                'saveStateUrl': self.block.ajax_url + '/save_user_state',
                 'autoplay': False,
                 'streams': '0.75:jNCf2gIqpeE,1.00:ZwkTiUPN0mg,1.25:rsq9auxASqI,1.50:kMyNdzVHHgg',
                 'sources': sources,
@@ -2316,7 +2316,7 @@ class TestVideoWithBumper(TestVideo):  # pylint: disable=test-inherits-tests
             }))
         }
 
-        mako_service = self.item_descriptor.runtime.service(self.item_descriptor, 'mako')
+        mako_service = self.block.runtime.service(self.block, 'mako')
         expected_content = mako_service.render_template('video.html', expected_context)
         assert get_context_dict_from_string(content) == get_context_dict_from_string(expected_content)
 
@@ -2348,12 +2348,12 @@ class TestAutoAdvanceVideo(TestVideo):  # lint-amnesty, pylint: disable=test-inh
             'handout': None,
             'hide_downloads': False,
             'is_embed': False,
-            'id': self.item_descriptor.location.html_id(),
+            'id': self.block.location.html_id(),
             'bumper_metadata': 'null',
             'metadata': json.dumps(OrderedDict({
                 'autoAdvance': autoadvance_flag,
                 'saveStateEnabled': True,
-                'saveStateUrl': self.item_descriptor.ajax_url + '/save_user_state',
+                'saveStateUrl': self.block.ajax_url + '/save_user_state',
                 'autoplay': False,
                 'streams': '0.75:jNCf2gIqpeE,1.00:ZwkTiUPN0mg,1.25:rsq9auxASqI,1.50:kMyNdzVHHgg',
                 'sources': ['example.mp4', 'example.webm'],
@@ -2372,11 +2372,11 @@ class TestAutoAdvanceVideo(TestVideo):  # lint-amnesty, pylint: disable=test-inh
                 'ytTestTimeout': 1500,
                 'ytApiUrl': 'https://www.youtube.com/iframe_api',
                 'lmsRootURL': settings.LMS_ROOT_URL,
-                'transcriptTranslationUrl': self.item_descriptor.runtime.handler_url(
-                    self.item_descriptor, 'transcript', 'translation/__lang__'
+                'transcriptTranslationUrl': self.block.runtime.handler_url(
+                    self.block, 'transcript', 'translation/__lang__'
                 ).rstrip('/?'),
-                'transcriptAvailableTranslationsUrl': self.item_descriptor.runtime.handler_url(
-                    self.item_descriptor, 'transcript', 'available_translations'
+                'transcriptAvailableTranslationsUrl': self.block.runtime.handler_url(
+                    self.block, 'transcript', 'available_translations'
                 ).rstrip('/?'),
                 'autohideHtml5': False,
                 'recordedYoutubeIsAvailable': True,
@@ -2404,14 +2404,14 @@ class TestAutoAdvanceVideo(TestVideo):  # lint-amnesty, pylint: disable=test-inh
         """
 
         with override_settings(FEATURES=self.FEATURES):
-            content = self.item_descriptor.render(STUDENT_VIEW).content
+            content = self.block.render(STUDENT_VIEW).content
 
         expected_context = self.prepare_expected_context(
             autoadvanceenabled_flag=autoadvanceenabled_must_be,
             autoadvance_flag=autoadvance_must_be,
         )
 
-        mako_service = self.item_descriptor.runtime.service(self.item_descriptor, 'mako')
+        mako_service = self.block.runtime.service(self.block, 'mako')
         with override_settings(FEATURES=self.FEATURES):
             expected_content = mako_service.render_template('video.html', expected_context)
 
@@ -2424,11 +2424,11 @@ class TestAutoAdvanceVideo(TestVideo):  # lint-amnesty, pylint: disable=test-inh
         Based on test code for video_bumper setting.
         """
         # This first render is done to initialize the instance
-        self.item_descriptor.render(STUDENT_VIEW)
-        self.item_descriptor.video_auto_advance = new_value
-        self.item_descriptor._reset_dirty_field(self.item_descriptor.fields['video_auto_advance'])  # pylint: disable=protected-access
+        self.block.render(STUDENT_VIEW)
+        self.block.video_auto_advance = new_value
+        self.block._reset_dirty_field(self.block.fields['video_auto_advance'])  # pylint: disable=protected-access
         # After this step, render() should see the new value
-        # e.g. use self.item_descriptor.render(STUDENT_VIEW).content
+        # e.g. use self.block.render(STUDENT_VIEW).content
 
     @ddt.data(
         (False, False),

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -1936,7 +1936,7 @@ class ProgressPageShowCorrectnessTests(ProgressPageBaseTests):
         Submit the given score to the problem on behalf of the user
         """
         # Get the block for the problem, as viewed by the user
-        field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
+        field_data_cache = FieldDataCache.cache_for_block_descendents(
             self.course.id,
             self.user,
             self.course,

--- a/lms/djangoapps/courseware/tests/test_word_cloud.py
+++ b/lms/djangoapps/courseware/tests/test_word_cloud.py
@@ -18,15 +18,6 @@ class TestWordCloud(BaseTestXmodule):
     """Integration test for Word Cloud Block."""
     CATEGORY = "word_cloud"
 
-    def _get_resource_url(self, item):
-        """
-        Creates a resource URL for a given asset that is compatible with this old XModule testing stuff.
-        """
-        display_name = self.item_descriptor.display_name.replace(' ', '_')
-        return "resource/i4x://{}/{}/word_cloud/{}/{}".format(
-            self.course.id.org, self.course.id.course, display_name, item
-        )
-
     def _get_users_state(self):
         """Return current state for each user:
 
@@ -227,13 +218,13 @@ class TestWordCloud(BaseTestXmodule):
         """
         Make sure that all parameters extracted correctly from xml.
         """
-        fragment = self.runtime.render(self.item_descriptor, STUDENT_VIEW)
+        fragment = self.runtime.render(self.block, STUDENT_VIEW)
         expected_context = {
-            'ajax_url': self.item_descriptor.ajax_url,
-            'display_name': self.item_descriptor.display_name,
-            'instructions': self.item_descriptor.instructions,
-            'element_class': self.item_descriptor.location.block_type,
-            'element_id': self.item_descriptor.location.html_id(),
+            'ajax_url': self.block.ajax_url,
+            'display_name': self.block.display_name,
+            'instructions': self.block.instructions,
+            'element_class': self.block.location.block_type,
+            'element_id': self.block.location.html_id(),
             'num_inputs': 5,  # default value
             'submitted': False,  # default value,
         }

--- a/lms/djangoapps/courseware/tests/tests.py
+++ b/lms/djangoapps/courseware/tests/tests.py
@@ -63,32 +63,32 @@ class PageLoaderTestCase(LoginEnrollmentTestCase):
             self.fail('Could not retrieve any items from course')
 
         # Try to load each item in the course
-        for descriptor in items:
+        for block in items:
 
-            if descriptor.location.category == 'about':
+            if block.location.category == 'about':
                 self._assert_loads('about_course',
                                    {'course_id': str(course_key)},
-                                   descriptor)
+                                   block)
 
-            elif descriptor.location.category == 'static_tab':
+            elif block.location.category == 'static_tab':
                 kwargs = {'course_id': str(course_key),
-                          'tab_slug': descriptor.location.name}
-                self._assert_loads('static_tab', kwargs, descriptor)
+                          'tab_slug': block.location.name}
+                self._assert_loads('static_tab', kwargs, block)
 
-            elif descriptor.location.category == 'course_info':
+            elif block.location.category == 'course_info':
                 self._assert_loads('info', {'course_id': str(course_key)},
-                                   descriptor)
+                                   block)
 
             else:
 
                 kwargs = {'course_id': str(course_key),
-                          'location': str(descriptor.location)}
+                          'location': str(block.location)}
 
-                self._assert_loads('jump_to', kwargs, descriptor,
+                self._assert_loads('jump_to', kwargs, block,
                                    expect_redirect=True,
                                    check_content=True)
 
-    def _assert_loads(self, django_url, kwargs, descriptor,
+    def _assert_loads(self, django_url, kwargs, block,
                       expect_redirect=False,
                       check_content=False):
         """
@@ -103,14 +103,14 @@ class PageLoaderTestCase(LoginEnrollmentTestCase):
 
         if response.status_code != 200:
             self.fail('Status %d for page %s' %
-                      (response.status_code, descriptor.location))
+                      (response.status_code, block.location))
 
         if expect_redirect:
             assert response.redirect_chain[0][1] == 302
 
         if check_content:
             self.assertNotContains(response, "this module is temporarily unavailable")
-            assert not isinstance(descriptor, ErrorBlock)
+            assert not isinstance(block, ErrorBlock)
 
 
 class TestMongoCoursesLoad(ModuleStoreTestCase, PageLoaderTestCase):
@@ -156,7 +156,7 @@ class TestLmsFieldData(TestCase):
         # Verify that if an LmsFieldData is passed into LmsFieldData as the
         # authored_data, that it doesn't produced a nested field data.
         #
-        # This fixes a bug where re-use of the same descriptor for many modules
+        # This fixes a bug where re-use of the same block for many modules
         # would cause more and more nesting, until the recursion depth would be
         # reached on any attribute access
 

--- a/lms/djangoapps/courseware/user_state_client.py
+++ b/lms/djangoapps/courseware/user_state_client.py
@@ -107,7 +107,7 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
 
     def _nr_attribute_name(self, function_name, stat_name, block_type=None):
         """
-        Return an attribute name (string) representing the provided descriptors.
+        Return an attribute name (string) representing the provided blocks.
         The return value is directly usable for New Relic custom attributes.
         """
         if block_type is None:

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -349,7 +349,7 @@ class CoursewareIndex(View):
         Prefetches all descendant data for the requested section and
         sets up the runtime, which binds the request user to the section.
         """
-        self.field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
+        self.field_data_cache = FieldDataCache.cache_for_block_descendents(
             self.course_key,
             self.effective_user,
             self.course,
@@ -374,7 +374,7 @@ class CoursewareIndex(View):
         """
         # Pre-fetch all descendant data
         self.section = modulestore().get_item(self.section.location, depth=None, lazy=False)
-        self.field_data_cache.add_descriptor_descendents(self.section, depth=None)
+        self.field_data_cache.add_block_descendents(self.section, depth=None)
 
         # Bind section to user
         self.section = get_block_for_descriptor(
@@ -585,11 +585,11 @@ def save_positions_recursively_up(user, request, field_data_cache, xmodule, cour
         parent_location = modulestore().get_parent_location(current_block.location)
         parent = None
         if parent_location:
-            parent_descriptor = modulestore().get_item(parent_location)
+            parent_block = modulestore().get_item(parent_location)
             parent = get_block_for_descriptor(
                 user,
                 request,
-                parent_descriptor,
+                parent_block,
                 field_data_cache,
                 current_block.location.course_key,
                 course=course

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1262,7 +1262,7 @@ def get_static_tab_fragment(request, course, tab):
         tab.type,
         tab.url_slug,
     )
-    field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
+    field_data_cache = FieldDataCache.cache_for_block_descendents(
         course.id, request.user, modulestore().get_item(loc), depth=0
     )
     tab_block = get_block(
@@ -1309,23 +1309,23 @@ def get_course_lti_endpoints(request, course_id):
 
     anonymous_user = AnonymousUser()
     anonymous_user.known = False  # make these "noauth" requests like block_render.handle_xblock_callback_noauth
-    lti_descriptors = modulestore().get_items(course.id, qualifiers={'category': 'lti'})
-    lti_descriptors.extend(modulestore().get_items(course.id, qualifiers={'category': 'lti_consumer'}))
+    lti_blocks = modulestore().get_items(course.id, qualifiers={'category': 'lti'})
+    lti_blocks.extend(modulestore().get_items(course.id, qualifiers={'category': 'lti_consumer'}))
 
     lti_noauth_blocks = [
         get_block_for_descriptor(
             anonymous_user,
             request,
-            descriptor,
-            FieldDataCache.cache_for_descriptor_descendents(
+            block,
+            FieldDataCache.cache_for_block_descendents(
                 course_key,
                 anonymous_user,
-                descriptor
+                block
             ),
             course_key,
             course=course
         )
-        for descriptor in lti_descriptors
+        for block in lti_blocks
     ]
 
     endpoints = [

--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -166,7 +166,7 @@ class DiscussionEntity(Enum):
 
 def _get_course(course_key: CourseKey, user: User, check_tab: bool = True) -> CourseBlock:
     """
-    Get the course descriptor, raising CourseNotFoundError if the course is not found or
+    Get the course block, raising CourseNotFoundError if the course is not found or
     the user cannot access forums for the course, and DiscussionDisabledError if the
     discussion tab is disabled for the course.
 

--- a/lms/djangoapps/edxnotes/decorators.py
+++ b/lms/djangoapps/edxnotes/decorators.py
@@ -29,12 +29,12 @@ def edxnotes(cls):
         if not settings.FEATURES.get("ENABLE_EDXNOTES"):
             return original_get_html(self, *args, **kwargs)
 
-        runtime = getattr(self, 'descriptor', self).runtime
+        runtime = getattr(self, 'block', self).runtime
         if not hasattr(runtime, 'modulestore'):
             return original_get_html(self, *args, **kwargs)
 
         is_studio = getattr(self.runtime, "is_author_mode", False)
-        course = getattr(self, 'descriptor', self).runtime.modulestore.get_course(self.scope_ids.usage_id.context_key)
+        course = getattr(self, 'block', self).runtime.modulestore.get_course(self.scope_ids.usage_id.context_key)
 
         # Must be disabled when:
         # - in Studio

--- a/lms/djangoapps/edxnotes/helpers.py
+++ b/lms/djangoapps/edxnotes/helpers.py
@@ -323,7 +323,7 @@ def get_notes(request, course, page=DEFAULT_PAGE, page_size=DEFAULT_PAGE_SIZE, t
 
     Arguments:
         request: HTTP request object
-        course: Course descriptor
+        course: Course block
         page: requested or default page number
         page_size: requested or default page size
         text: text to search. If None then return all results for the current logged in user.

--- a/lms/djangoapps/edxnotes/tests.py
+++ b/lms/djangoapps/edxnotes/tests.py
@@ -83,8 +83,8 @@ class TestProblem:
         user = user or UserFactory()
         user_service = StubUserService(user)
         self.runtime = MagicMock(service=lambda _a, _b: user_service, is_author_mode=False)
-        self.descriptor = MagicMock()
-        self.descriptor.runtime.modulestore.get_course.return_value = course
+        self.block = MagicMock()
+        self.block.runtime.modulestore.get_course.return_value = course
 
     def get_html(self):
         """
@@ -171,7 +171,7 @@ class EdxNotesDecoratorTest(ModuleStoreTestCase):
         """
         Tests that get_html is not wrapped when problem is rendered by Blockstore runtime.
         """
-        del self.problem.descriptor.runtime.modulestore
+        del self.problem.block.runtime.modulestore
         assert 'original_get_html' == self.problem.get_html()
 
     def test_edxnotes_harvard_notes_enabled(self):

--- a/lms/djangoapps/edxnotes/views.py
+++ b/lms/djangoapps/edxnotes/views.py
@@ -71,7 +71,7 @@ def edxnotes(request, course_id):
     }
 
     if not has_notes:
-        field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
+        field_data_cache = FieldDataCache.cache_for_block_descendents(
             course.id, request.user, course, depth=2
         )
         course_block = get_block_for_descriptor(

--- a/lms/djangoapps/grades/context.py
+++ b/lms/djangoapps/grades/context.py
@@ -50,7 +50,7 @@ def grading_context(course, course_structure):
     all_graded_blocks - This contains a list of all blocks that can
         affect grading a student. This is used to efficiently fetch
         all the xmodule state for a FieldDataCache without walking
-        the descriptor tree again.
+        the block tree again.
 
     """
     count_all_graded_blocks = 0

--- a/lms/djangoapps/grades/rest_api/v1/gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/gradebook_views.py
@@ -442,7 +442,7 @@ class GradebookView(GradeViewMixin, PaginatedAPIView):
         returns a list of grade data broken down by subsection.
 
         Args:
-            course: A Course Descriptor object
+            course: A CourseBlock object
             graded_subsections: A list of graded subsection objects in the given course.
             course_grade: A CourseGrade object.
         """
@@ -494,7 +494,7 @@ class GradebookView(GradeViewMixin, PaginatedAPIView):
 
         Args:
             user: A User object.
-            course: A Course Descriptor object.
+            course: A CourseBlock object.
             graded_subsections: A list of graded subsections in the given course.
             course_grade: A CourseGrade object.
         """

--- a/lms/djangoapps/grades/tests/utils.py
+++ b/lms/djangoapps/grades/tests/utils.py
@@ -73,7 +73,7 @@ def answer_problem(course, request, problem, score=1, max_value=1):
 
     user = request.user
     grade_dict = {'value': score, 'max_value': max_value, 'user_id': user.id}
-    field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
+    field_data_cache = FieldDataCache.cache_for_block_descendents(
         course.id,
         user,
         course,

--- a/lms/djangoapps/instructor/tasks.py
+++ b/lms/djangoapps/instructor/tasks.py
@@ -45,7 +45,7 @@ def update_exam_completion_task(user_identifier: str, content_id: str, completio
     try:
         user = get_user_by_username_or_email(user_identifier)
         block_key = UsageKey.from_string(content_id)
-        root_descriptor = modulestore().get_item(block_key)
+        root_block = modulestore().get_item(block_key)
     except ObjectDoesNotExist:
         err_msg = err_msg_prefix + 'User does not exist!'
     except InvalidKeyError:
@@ -66,13 +66,13 @@ def update_exam_completion_task(user_identifier: str, content_id: str, completio
     request = get_request_or_stub()
     request.user = user
 
-    # Now evil modulestore magic to inflate our descriptor with user state and
+    # Now evil modulestore magic to inflate our block with user state and
     # permissions checks.
-    field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
-        root_descriptor.scope_ids.usage_id.context_key, user, root_descriptor, read_only=True,
+    field_data_cache = FieldDataCache.cache_for_block_descendents(
+        root_block.scope_ids.usage_id.context_key, user, root_block, read_only=True,
     )
     root_block = get_block_for_descriptor(
-        user, request, root_descriptor, field_data_cache, root_descriptor.scope_ids.usage_id.context_key,
+        user, request, root_block, field_data_cache, root_block.scope_ids.usage_id.context_key,
     )
     if not root_block:
         err_msg = err_msg_prefix + 'Block unable to be created from descriptor!'
@@ -89,11 +89,11 @@ def update_exam_completion_task(user_identifier: str, content_id: str, completio
         elif mode == XBlockCompletionMode.AGGREGATOR:
             # I know this looks weird, but at the time of writing at least, there isn't a good
             # single way to get the children assigned for a partcular user. Some blocks define the
-            # child descriptors method, but others don't and with blocks like Randomized Content
+            # child blocks method, but others don't and with blocks like Randomized Content
             # (Library Content), the get_children method returns all children and not just assigned
             # children. So this is our way around situations like that. See also Split Test Block
-            # for another use case where user state has to be taken into account via get_child_descriptors
-            block_children = ((hasattr(block, 'get_child_descriptors') and block.get_child_descriptors())
+            # for another use case where user state has to be taken into account via get_child_blocks
+            block_children = ((hasattr(block, 'get_child_blocks') and block.get_child_blocks())
                               or (hasattr(block, 'get_children') and block.get_children())
                               or [])
             for child in block_children:

--- a/lms/djangoapps/instructor_task/api.py
+++ b/lms/djangoapps/instructor_task/api.py
@@ -210,7 +210,7 @@ def submit_reset_problem_attempts_for_all_students(request, usage_key):  # pylin
     if the problem is already being reset.
     """
     # check arguments:  make sure that the usage_key is defined
-    # (since that's currently typed in).  If the corresponding module descriptor doesn't exist,
+    # (since that's currently typed in).  If the corresponding block doesn't exist,
     # an exception will be raised.  Let it pass up to the caller.
     modulestore().get_item(usage_key)
 
@@ -256,7 +256,7 @@ def submit_delete_problem_state_for_all_students(request, usage_key):  # pylint:
     if the particular problem's state is already being deleted.
     """
     # check arguments:  make sure that the usage_key is defined
-    # (since that's currently typed in).  If the corresponding module descriptor doesn't exist,
+    # (since that's currently typed in).  If the corresponding block doesn't exist,
     # an exception will be raised.  Let it pass up to the caller.
     modulestore().get_item(usage_key)
 
@@ -270,7 +270,7 @@ def submit_delete_entrance_exam_state_for_student(request, usage_key, student): 
     """
     Requests reset of state for entrance exam as a background task.
 
-    Module state for all problems in entrance exam will be deleted
+    Block state for all problems in entrance exam will be deleted
     for specified student.
 
     All User Milestones of entrance exam will be removed for the specified student

--- a/lms/djangoapps/instructor_task/api_helper.py
+++ b/lms/djangoapps/instructor_task/api_helper.py
@@ -149,14 +149,14 @@ def _get_xblock_instance_args(request, task_id):
     return xblock_instance_args
 
 
-def _supports_rescore(descriptor):
+def _supports_rescore(block):
     """
     Helper method to determine whether a given item supports rescoring.
     In order to accommodate both XModules and XBlocks, we have to check
-    the descriptor itself then fall back on its module class.
+    the block itself then fall back on its module class.
     """
-    return hasattr(descriptor, 'rescore') or (
-        hasattr(descriptor, 'module_class') and hasattr(descriptor.module_class, 'rescore')
+    return hasattr(block, 'rescore') or (
+        hasattr(block, 'module_class') and hasattr(block.module_class, 'rescore')
     )
 
 
@@ -343,49 +343,49 @@ def get_status_from_instructor_task(instructor_task):
 
 def check_arguments_for_rescoring(usage_key):
     """
-    Do simple checks on the descriptor to confirm that it supports rescoring.
+    Do simple checks on the block to confirm that it supports rescoring.
 
     Confirms first that the usage_key is defined (since that's currently typed
     in).  An ItemNotFoundException is raised if the corresponding module
-    descriptor doesn't exist.  NotImplementedError is raised if the
+    block doesn't exist.  NotImplementedError is raised if the
     corresponding module doesn't support rescoring calls.
 
     Note: the string returned here is surfaced as the error
     message on the instructor dashboard when a rescore is
     submitted for a non-rescorable block.
     """
-    descriptor = modulestore().get_item(usage_key)
-    if not _supports_rescore(descriptor):
+    block = modulestore().get_item(usage_key)
+    if not _supports_rescore(block):
         msg = _("This component cannot be rescored.")
         raise NotImplementedError(msg)
 
 
 def check_arguments_for_overriding(usage_key, score):
     """
-    Do simple checks on the descriptor to confirm that it supports overriding
+    Do simple checks on the block to confirm that it supports overriding
     the problem score and the score passed in is not greater than the value of
     the problem or less than 0.
     """
-    descriptor = modulestore().get_item(usage_key)
+    block = modulestore().get_item(usage_key)
     score = float(score)
 
-    # some weirdness around initializing the descriptor requires this
-    if not hasattr(descriptor.__class__, 'set_score'):
+    # some weirdness around initializing the block requires this
+    if not hasattr(block.__class__, 'set_score'):
         msg = _("This component does not support score override.")
         raise NotImplementedError(msg)
 
-    if score < 0 or score > descriptor.max_score():
+    if score < 0 or score > block.max_score():
         msg = _("Scores must be between 0 and the value of the problem.")
         raise ValueError(msg)
 
 
 def check_entrance_exam_problems_for_rescoring(exam_key):  # pylint: disable=invalid-name
     """
-    Grabs all problem descriptors in exam and checks each descriptor to
+    Grabs all problem blocks in exam and checks each block to
     confirm that it supports re-scoring.
 
     An ItemNotFoundException is raised if the corresponding module
-    descriptor doesn't exist for exam_key. NotImplementedError is raised if
+    block doesn't exist for exam_key. NotImplementedError is raised if
     any of the problem in entrance exam doesn't support re-scoring calls.
     """
     problems = list(get_problems_in_section(exam_key).values())

--- a/lms/djangoapps/instructor_task/tasks.py
+++ b/lms/djangoapps/instructor_task/tasks.py
@@ -4,7 +4,7 @@ running state of a course.
 
 At present, these tasks all operate on StudentModule objects in one way or another,
 so they share a visitor architecture.  Each task defines an "update function" that
-takes a module_descriptor, a particular StudentModule object, and xblock_instance_args.
+takes a block, a particular StudentModule object, and xblock_instance_args.
 
 A task may optionally specify a "filter function" that takes a query for StudentModule
 objects, and adds additional filter clauses.

--- a/lms/djangoapps/instructor_task/tests/test_base.py
+++ b/lms/djangoapps/instructor_task/tests/test_base.py
@@ -254,12 +254,12 @@ class InstructorTaskModuleTestCase(InstructorTaskCourseTestCase):
             self.module_store.update_item(item, self.user.id)
             self.module_store.publish(location, self.user.id)
 
-    def get_student_module(self, username, descriptor):
-        """Get StudentModule object for test course, given the `username` and the problem's `descriptor`."""
+    def get_student_module(self, username, block):
+        """Get StudentModule object for test course, given the `username` and the problem's `block`."""
         return StudentModule.objects.get(course_id=self.course.id,
                                          student=User.objects.get(username=username),
-                                         module_type=descriptor.location.block_type,
-                                         module_state_key=descriptor.location,
+                                         module_type=block.location.block_type,
+                                         module_state_key=block.location,
                                          )
 
     def submit_student_answer(self, username, problem_url_name, responses):

--- a/lms/djangoapps/instructor_task/tests/test_integration.py
+++ b/lms/djangoapps/instructor_task/tests/test_integration.py
@@ -110,15 +110,15 @@ class TestRescoringTask(TestIntegrationTask):
         resp = self.client.post(modx_url, {})
         return resp
 
-    def check_state(self, user, descriptor, expected_score, expected_max_score, expected_attempts=1):
+    def check_state(self, user, block, expected_score, expected_max_score, expected_attempts=1):
         """
         Check that the StudentModule state contains the expected values.
 
-        The student module is found for the test course, given the `username` and problem `descriptor`.
+        The student module is found for the test course, given the `username` and problem `block`.
 
         Values checked include the number of attempts, the score, and the max score for a problem.
         """
-        module = self.get_student_module(user.username, descriptor)
+        module = self.get_student_module(user.username, block)
         assert module.grade == expected_score
         assert module.max_grade == expected_max_score
         state = json.loads(module.state)
@@ -160,11 +160,11 @@ class TestRescoringTask(TestIntegrationTask):
         Common helper to verify the results of rescoring for a single
         student and all students are as expected.
         """
-        # get descriptor:
+        # get block:
         problem_url_name = 'H1P1'
         self.define_option_problem(problem_url_name)
         location = InstructorTaskModuleTestCase.problem_location(problem_url_name)
-        descriptor = self.module_store.get_item(location)
+        block = self.module_store.get_item(location)
 
         # first store answers for each of the separate users:
         self.submit_student_answer('u1', problem_url_name, [OPTION_1, OPTION_1])
@@ -176,25 +176,25 @@ class TestRescoringTask(TestIntegrationTask):
         expected_original_scores = (2, 1, 1, 0)
         expected_original_max = 2
         for i, user in enumerate(self.users):
-            self.check_state(user, descriptor, expected_original_scores[i], expected_original_max)
+            self.check_state(user, block, expected_original_scores[i], expected_original_max)
 
         # update the data in the problem definition so the answer changes.
         self.redefine_option_problem(problem_url_name, **problem_edit)
 
         # confirm that simply rendering the problem again does not change the grade
         self.render_problem('u1', problem_url_name)
-        self.check_state(self.user1, descriptor, expected_original_scores[0], expected_original_max)
+        self.check_state(self.user1, block, expected_original_scores[0], expected_original_max)
 
         # rescore the problem for only one student -- only that student's grade should change:
         self.submit_rescore_one_student_answer('instructor', problem_url_name, self.user1, rescore_if_higher)
-        self.check_state(self.user1, descriptor, new_expected_scores[0], new_expected_max)
+        self.check_state(self.user1, block, new_expected_scores[0], new_expected_max)
         for i, user in enumerate(self.users[1:], start=1):  # everyone other than user1
-            self.check_state(user, descriptor, expected_original_scores[i], expected_original_max)
+            self.check_state(user, block, expected_original_scores[i], expected_original_max)
 
         # rescore the problem for all students
         self.submit_rescore_all_student_answers('instructor', problem_url_name, rescore_if_higher)
         for i, user in enumerate(self.users):
-            self.check_state(user, descriptor, new_expected_scores[i], new_expected_max)
+            self.check_state(user, block, new_expected_scores[i], new_expected_max)
 
     RescoreTestData = namedtuple('RescoreTestData', 'edit, new_expected_scores, new_expected_max')
 
@@ -240,31 +240,31 @@ class TestRescoringTask(TestIntegrationTask):
         problem_url_name = 'H1P1'
         self.define_option_problem(problem_url_name)
         location = InstructorTaskModuleTestCase.problem_location(problem_url_name)
-        descriptor = self.module_store.get_item(location)
+        block = self.module_store.get_item(location)
 
         # first store answers for each of the separate users:
         self.submit_student_answer('u1', problem_url_name, [OPTION_1, OPTION_1])
         self.submit_student_answer('u2', problem_url_name, [OPTION_2, OPTION_2])
 
         # verify each user's grade
-        self.check_state(self.user1, descriptor, 2, 2)  # user 1 has a 2/2
-        self.check_state(self.user2, descriptor, 0, 2)  # user 2 has a 0/2
+        self.check_state(self.user1, block, 2, 2)  # user 1 has a 2/2
+        self.check_state(self.user2, block, 0, 2)  # user 2 has a 0/2
 
         # update the data in the problem definition so the answer changes.
         self.redefine_option_problem(problem_url_name, **problem_edit)
 
         # confirm that simply rendering the problem again does not change the grade
         self.render_problem('u1', problem_url_name)
-        self.check_state(self.user1, descriptor, 2, 2)
-        self.check_state(self.user2, descriptor, 0, 2)
+        self.check_state(self.user1, block, 2, 2)
+        self.check_state(self.user2, block, 0, 2)
 
         # rescore the problem for all students
         self.submit_rescore_all_student_answers('instructor', problem_url_name, True)
 
         # user 1's score would go down, so it remains 2/2. user 2's score was 0/2, which is equivalent to the new score
         # of 0/4, so user 2's score changes to 0/4.
-        self.check_state(self.user1, descriptor, 2, unchanged_max)
-        self.check_state(self.user2, descriptor, 0, new_max)
+        self.check_state(self.user1, block, 2, unchanged_max)
+        self.check_state(self.user2, block, 0, new_max)
 
     def test_rescoring_failure(self):
         """Simulate a failure in rescoring a problem"""
@@ -365,13 +365,13 @@ class TestRescoringTask(TestIntegrationTask):
             """ % ('!=' if redefine else '=='))
         problem_xml = factory.build_xml(script=script, cfn="check_func", expect="42", num_responses=1)
         if redefine:
-            descriptor = self.module_store.get_item(
+            block = self.module_store.get_item(
                 InstructorTaskModuleTestCase.problem_location(problem_url_name)
             )
-            descriptor.data = problem_xml
-            with self.module_store.branch_setting(ModuleStoreEnum.Branch.draft_preferred, descriptor.location.course_key):  # lint-amnesty, pylint: disable=line-too-long
-                self.module_store.update_item(descriptor, self.user.id)
-                self.module_store.publish(descriptor.location, self.user.id)
+            block.data = problem_xml
+            with self.module_store.branch_setting(ModuleStoreEnum.Branch.draft_preferred, block.location.course_key):  # lint-amnesty, pylint: disable=line-too-long
+                self.module_store.update_item(block, self.user.id)
+                self.module_store.publish(block.location, self.user.id)
         else:
             # Use "per-student" rerandomization so that check-problem can be called more than once.
             # Using "always" means we cannot check a problem twice, but we want to call once to get the
@@ -390,7 +390,7 @@ class TestRescoringTask(TestIntegrationTask):
         problem_url_name = 'H1P1'
         self.define_randomized_custom_response_problem(problem_url_name)
         location = InstructorTaskModuleTestCase.problem_location(problem_url_name)
-        descriptor = self.module_store.get_item(location)
+        block = self.module_store.get_item(location)
         # run with more than one user
         for user in self.users:
             # first render the problem, so that a seed will be created for this user
@@ -399,9 +399,9 @@ class TestRescoringTask(TestIntegrationTask):
             dummy_answer = "1000"
             self.submit_student_answer(user.username, problem_url_name, [dummy_answer, dummy_answer])
             # we should have gotten the problem wrong, since we're way out of range:
-            self.check_state(user, descriptor, 0, 1, expected_attempts=1)
+            self.check_state(user, block, 0, 1, expected_attempts=1)
             # dig the correct answer out of the problem's message
-            module = self.get_student_module(user.username, descriptor)
+            module = self.get_student_module(user.username, block)
             state = json.loads(module.state)
             correct_map = state['correct_map']
             log.info("Correct Map: %s", correct_map)
@@ -409,28 +409,28 @@ class TestRescoringTask(TestIntegrationTask):
             answer = list(correct_map.values())[0]['msg']
             self.submit_student_answer(user.username, problem_url_name, [answer, answer])
             # we should now get the problem right, with a second attempt:
-            self.check_state(user, descriptor, 1, 1, expected_attempts=2)
+            self.check_state(user, block, 1, 1, expected_attempts=2)
 
         # redefine the problem (as stored in Mongo) so that the definition of correct changes
         self.define_randomized_custom_response_problem(problem_url_name, redefine=True)
         # confirm that simply rendering the problem again does not result in a change
         # in the grade (or the attempts):
         self.render_problem('u1', problem_url_name)
-        self.check_state(self.user1, descriptor, 1, 1, expected_attempts=2)
+        self.check_state(self.user1, block, 1, 1, expected_attempts=2)
 
         # rescore the problem for only one student -- only that student's grade should change
         # (and none of the attempts):
         self.submit_rescore_one_student_answer('instructor', problem_url_name, User.objects.get(username='u1'))
         for user in self.users:
             expected_score = 0 if user.username == 'u1' else 1
-            self.check_state(user, descriptor, expected_score, 1, expected_attempts=2)
+            self.check_state(user, block, expected_score, 1, expected_attempts=2)
 
         # rescore the problem for all students
         self.submit_rescore_all_student_answers('instructor', problem_url_name)
 
         # all grades should change to being wrong (with no change in attempts)
         for user in self.users:
-            self.check_state(user, descriptor, 0, 1, expected_attempts=2)
+            self.check_state(user, block, 0, 1, expected_attempts=2)
 
 
 @override_settings(RATELIMIT_ENABLE=False)
@@ -450,9 +450,9 @@ class TestResetAttemptsTask(TestIntegrationTask):
             self.create_student(username)
         self.logout()
 
-    def get_num_attempts(self, username, descriptor):
-        """returns number of attempts stored for `username` on problem `descriptor` for test course"""
-        module = self.get_student_module(username, descriptor)
+    def get_num_attempts(self, username, block):
+        """returns number of attempts stored for `username` on problem `block` for test course"""
+        module = self.get_student_module(username, block)
         state = json.loads(module.state)
         return state['attempts']
 
@@ -463,11 +463,11 @@ class TestResetAttemptsTask(TestIntegrationTask):
 
     def test_reset_attempts_on_problem(self):
         """Run reset-attempts scenario on option problem"""
-        # get descriptor:
+        # get block:
         problem_url_name = 'H1P1'
         self.define_option_problem(problem_url_name)
         location = InstructorTaskModuleTestCase.problem_location(problem_url_name)
-        descriptor = self.module_store.get_item(location)
+        block = self.module_store.get_item(location)
         num_attempts = 3
         # first store answers for each of the separate users:
         for _ in range(num_attempts):
@@ -475,12 +475,12 @@ class TestResetAttemptsTask(TestIntegrationTask):
                 self.submit_student_answer(username, problem_url_name, [OPTION_1, OPTION_1])
 
         for username in self.userlist:
-            assert self.get_num_attempts(username, descriptor) == num_attempts
+            assert self.get_num_attempts(username, block) == num_attempts
 
         self.reset_problem_attempts('instructor', location)
 
         for username in self.userlist:
-            assert self.get_num_attempts(username, descriptor) == 0
+            assert self.get_num_attempts(username, block) == 0
 
     def test_reset_failure(self):
         """Simulate a failure in resetting attempts on a problem"""
@@ -528,23 +528,23 @@ class TestDeleteProblemTask(TestIntegrationTask):
 
     def test_delete_problem_state(self):
         """Run delete-state scenario on option problem"""
-        # get descriptor:
+        # get block:
         problem_url_name = 'H1P1'
         self.define_option_problem(problem_url_name)
         location = InstructorTaskModuleTestCase.problem_location(problem_url_name)
-        descriptor = self.module_store.get_item(location)
+        block = self.module_store.get_item(location)
         # first store answers for each of the separate users:
         for username in self.userlist:
             self.submit_student_answer(username, problem_url_name, [OPTION_1, OPTION_1])
         # confirm that state exists:
         for username in self.userlist:
-            assert self.get_student_module(username, descriptor) is not None
+            assert self.get_student_module(username, block) is not None
         # run delete task:
         self.delete_problem_state('instructor', location)
         # confirm that no state can be found:
         for username in self.userlist:
             with pytest.raises(StudentModule.DoesNotExist):
-                self.get_student_module(username, descriptor)
+                self.get_student_module(username, block)
 
     def test_delete_failure(self):
         """Simulate a failure in deleting state of a problem"""

--- a/lms/djangoapps/instructor_task/tests/test_tasks.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks.py
@@ -283,7 +283,7 @@ class TestOverrideScoreInstructorTask(TestInstructorTasks):
 
     def test_overriding_non_scorable(self):
         """
-        Tests that override problem score raises an error if module descriptor has not `set_score` method.
+        Tests that override problem score raises an error if block has not `set_score` method.
         """
         input_state = json.dumps({'done': True})
         num_students = 1

--- a/lms/djangoapps/lms_xblock/apps.py
+++ b/lms/djangoapps/lms_xblock/apps.py
@@ -22,5 +22,5 @@ class LMSXBlockConfig(AppConfig):
         # monkey-patch the x_module library.
         # TODO: Remove this code when Runtimes are no longer created by modulestores
         # https://openedx.atlassian.net/wiki/display/PLAT/Convert+from+Storage-centric+runtimes+to+Application-centric+runtimes
-        xmodule.x_module.descriptor_global_handler_url = handler_url
-        xmodule.x_module.descriptor_global_local_resource_url = local_resource_url
+        xmodule.x_module.block_global_handler_url = handler_url
+        xmodule.x_module.block_global_local_resource_url = local_resource_url

--- a/lms/djangoapps/lms_xblock/runtime.py
+++ b/lms/djangoapps/lms_xblock/runtime.py
@@ -28,7 +28,7 @@ def handler_url(block, handler_name, suffix='', query='', thirdparty=False):
         # Be sure this is really a handler.
         #
         # We're checking the .__class__ instead of the block itself to avoid
-        # auto-proxying from Descriptor -> Module, in case descriptors want
+        # auto-proxying from Descriptor -> XBlock, in case descriptors want
         # to ask for handler URLs without a student context.
         func = getattr(block.__class__, handler_name, None)
         if not func:

--- a/lms/djangoapps/lti_provider/outcomes.py
+++ b/lms/djangoapps/lti_provider/outcomes.py
@@ -97,7 +97,7 @@ def generate_replace_result_xml(result_sourcedid, score):
     return etree.tostring(xml, xml_declaration=True, encoding='UTF-8')
 
 
-def get_assignments_for_problem(problem_descriptor, user_id, course_key):
+def get_assignments_for_problem(problem_block, user_id, course_key):
     """
     Trace the parent hierarchy from a given problem to find all blocks that
     correspond to graded assignment launches for this user. A problem may
@@ -107,13 +107,13 @@ def get_assignments_for_problem(problem_descriptor, user_id, course_key):
     problem and as a problem in a vertical, for example).
 
     Returns a list of GradedAssignment objects that are associated with the
-    given descriptor for the current user.
+    given block for the current user.
     """
     locations = []
-    current_descriptor = problem_descriptor
-    while current_descriptor:
-        locations.append(current_descriptor.location)
-        current_descriptor = current_descriptor.get_parent()
+    current_block = problem_block
+    while current_block:
+        locations.append(current_block.location)
+        current_block = current_block.get_parent()
     assignments = GradedAssignment.objects.filter(
         user=user_id, course_key=course_key, usage_key__in=locations
     )

--- a/lms/djangoapps/lti_provider/signals.py
+++ b/lms/djangoapps/lti_provider/signals.py
@@ -22,13 +22,13 @@ def increment_assignment_versions(course_key, usage_key, user_id):
     Update the version numbers for all assignments that are affected by a score
     change event. Returns a list of all affected assignments.
     """
-    problem_descriptor = modulestore().get_item(usage_key)
+    problem_block = modulestore().get_item(usage_key)
     # Get all assignments involving the current problem for which the campus LMS
     # is expecting a grade. There may be many possible graded assignments, if
     # a problem has been added several times to a course at different
     # granularities (such as the unit or the vertical).
     assignments = outcomes.get_assignments_for_problem(
-        problem_descriptor, user_id, course_key
+        problem_block, user_id, course_key
     )
     for assignment in assignments:
         assignment.version_number += 1

--- a/lms/djangoapps/lti_provider/tests/test_tasks.py
+++ b/lms/djangoapps/lti_provider/tests/test_tasks.py
@@ -97,8 +97,8 @@ class SendCompositeOutcomeTest(BaseOutcomeTest):
 
     def setUp(self):
         super().setUp()
-        self.descriptor = MagicMock()
-        self.descriptor.location = BlockUsageLocator(
+        self.block = MagicMock()
+        self.block.location = BlockUsageLocator(
             course_key=self.course_key,
             block_type='problem',
             block_id='problem',
@@ -108,7 +108,7 @@ class SendCompositeOutcomeTest(BaseOutcomeTest):
             'lms.djangoapps.lti_provider.tasks.CourseGradeFactory.read', self.course_grade
         )
         self.module_store = MagicMock()
-        self.module_store.get_item = MagicMock(return_value=self.descriptor)
+        self.module_store.get_item = MagicMock(return_value=self.block)
         self.check_result_mock = self.setup_patch(
             'lms.djangoapps.lti_provider.tasks.modulestore',
             self.module_store

--- a/lms/djangoapps/mobile_api/decorators.py
+++ b/lms/djangoapps/mobile_api/decorators.py
@@ -29,7 +29,7 @@ def mobile_course_access(depth=0):
         def _wrapper(self, request, *args, **kwargs):
             """
             Expects kwargs to contain 'course_id'.
-            Passes the course descriptor to the given decorated function.
+            Passes the course block to the given decorated function.
             Raises 404 if access to course is disallowed.
             """
             course_id = CourseKey.from_string(kwargs.pop('course_id'))

--- a/lms/djangoapps/mobile_api/models.py
+++ b/lms/djangoapps/mobile_api/models.py
@@ -93,7 +93,7 @@ class IgnoreMobileAvailableFlagConfig(ConfigurationModel):
     Configuration for the mobile_available flag. Default is false.
 
     Enabling this configuration will cause the mobile_available flag check in
-    access.py._is_descriptor_mobile_available to ignore the mobile_available
+    access.py._is_block_mobile_available to ignore the mobile_available
     flag.
 
     .. no_pii:

--- a/lms/djangoapps/mobile_api/users/views.py
+++ b/lms/djangoapps/mobile_api/users/views.py
@@ -140,7 +140,7 @@ class UserCourseStatus(views.APIView):
         the course block. If there is no such visit, the first item deep enough down the course
         tree is used.
         """
-        field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
+        field_data_cache = FieldDataCache.cache_for_block_descendents(
             course.id, request.user, course, depth=2)
 
         course_block = get_block_for_descriptor(
@@ -173,14 +173,14 @@ class UserCourseStatus(views.APIView):
         """
         Saves the module id if the found modification_date is less recent than the passed modification date
         """
-        field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
+        field_data_cache = FieldDataCache.cache_for_block_descendents(
             course.id, request.user, course, depth=2)
         try:
-            block_descriptor = modulestore().get_item(module_key)
+            descriptor = modulestore().get_item(module_key)
         except ItemNotFoundError:
             return Response(errors.ERROR_INVALID_MODULE_ID, status=400)
         block = get_block_for_descriptor(
-            request.user, request, block_descriptor, field_data_cache, course.id, course=course
+            request.user, request, descriptor, field_data_cache, course.id, course=course
         )
 
         if modification_date:

--- a/lms/djangoapps/survey/tests/test_utils.py
+++ b/lms/djangoapps/survey/tests/test_utils.py
@@ -64,7 +64,7 @@ class SurveyModelsTests(ModuleStoreTestCase):
     def test_is_survey_required_for_course(self):
         """
         Assert the a requried course survey is when both the flags is set and a survey name
-        is set on the course descriptor
+        is set on the course block
         """
         assert is_survey_required_for_course(self.course)
 

--- a/lms/djangoapps/survey/utils.py
+++ b/lms/djangoapps/survey/utils.py
@@ -21,20 +21,20 @@ class SurveyRequiredAccessError(AccessError):
         super().__init__(error_code, developer_message, user_message)
 
 
-def is_survey_required_for_course(course_descriptor):
+def is_survey_required_for_course(course_block):
     """
     Returns whether a Survey is required for this course
     """
 
     # Check to see that the survey is required in the CourseBlock.
-    if not getattr(course_descriptor, 'course_survey_required', False):
+    if not getattr(course_block, 'course_survey_required', False):
         return SurveyRequiredAccessError()
 
     # Check that the specified Survey for the course exists.
-    return SurveyForm.get(course_descriptor.course_survey_name, throw_if_not_found=False)
+    return SurveyForm.get(course_block.course_survey_name, throw_if_not_found=False)
 
 
-def check_survey_required_and_unanswered(user, course_descriptor):
+def check_survey_required_and_unanswered(user, course_block):
     """
     Checks whether a user is required to answer the survey and has yet to do so.
 
@@ -42,7 +42,7 @@ def check_survey_required_and_unanswered(user, course_descriptor):
         AccessResponse: Either ACCESS_GRANTED or SurveyRequiredAccessError.
     """
 
-    if not is_survey_required_for_course(course_descriptor):
+    if not is_survey_required_for_course(course_block):
         return ACCESS_GRANTED
 
     # anonymous users do not need to answer the survey
@@ -50,12 +50,12 @@ def check_survey_required_and_unanswered(user, course_descriptor):
         return ACCESS_GRANTED
 
     # course staff do not need to answer survey
-    has_staff_access = has_access(user, 'staff', course_descriptor)
+    has_staff_access = has_access(user, 'staff', course_block)
     if has_staff_access:
         return ACCESS_GRANTED
 
     # survey is required and it exists, let's see if user has answered the survey
-    survey = SurveyForm.get(course_descriptor.course_survey_name)
+    survey = SurveyForm.get(course_block.course_survey_name)
     answered_survey = SurveyAnswer.do_survey_answers_exist(survey, user)
     if answered_survey:
         return ACCESS_GRANTED

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -159,7 +159,7 @@ class CourseOverview(TimeStampedModel):
         from the given course.
 
         Arguments:
-            course (CourseBlock): any course descriptor object
+            course (CourseBlock): any course block object
 
         Returns:
             CourseOverview: created or updated overview extracted from the given course

--- a/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
+++ b/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
@@ -1064,7 +1064,7 @@ class CourseOverviewImageSetTestCase(ModuleStoreTestCase):
         assert image_urls['small'].endswith('src_course_image-png-{}x{}.jpg'.format(*config.small))
         assert image_urls['large'].endswith('src_course_image-png-{}x{}.jpg'.format(*config.large))
 
-        # Update course image on the course descriptor This fires a
+        # Update course image on the course block. This fires a
         # course_published signal, this will be caught in signals.py,
         # which should in turn load CourseOverview from modulestore.
         course.course_image = 'src_course_image1.png'
@@ -1126,7 +1126,7 @@ class CourseOverviewTabTestCase(ModuleStoreTestCase):
         ) as course_overview_tabs_bulk_create:
             course_overview_tabs_bulk_create.side_effect = IntegrityError
 
-            # Update display name on the course descriptor
+            # Update display name on the course block
             # This fires a course_published signal, which should be caught in signals.py,
             # which should in turn load CourseOverview from modulestore.
             course.display_name = 'Updated display name'

--- a/openedx/core/djangoapps/course_groups/tests/helpers.py
+++ b/openedx/core/djangoapps/course_groups/tests/helpers.py
@@ -70,7 +70,7 @@ def config_course_cohorts_legacy(
 ):
     """
     Given a course with no discussion set up, add the discussions and set
-    the cohort config on the course descriptor.
+    the cohort config on the course block.
 
     Since cohort settings are now stored in models.CourseCohortSettings,
     this is only used for testing data migration from the CourseBlock

--- a/openedx/core/djangoapps/enrollments/serializers.py
+++ b/openedx/core/djangoapps/enrollments/serializers.py
@@ -33,7 +33,7 @@ class StringListField(serializers.CharField):
 
 class CourseSerializer(serializers.Serializer):  # pylint: disable=abstract-method
     """
-    Serialize a course descriptor and related information.
+    Serialize a course block and related information.
     """
 
     course_id = serializers.CharField(source="id")
@@ -79,7 +79,7 @@ class CourseEnrollmentSerializer(serializers.ModelSerializer):
     """Serializes CourseEnrollment models
 
     Aggregates all data from the Course Enrollment table, and pulls in the serialization for
-    the Course Descriptor and course modes, to give a complete representation of course enrollment.
+    the Course block and course modes, to give a complete representation of course enrollment.
 
     """
     course_details = CourseSerializer(source="course_overview")

--- a/openedx/core/djangoapps/models/course_details.py
+++ b/openedx/core/djangoapps/models/course_details.py
@@ -103,36 +103,36 @@ class CourseDetails:
         return cls.populate(modulestore().get_course(course_key))
 
     @classmethod
-    def populate(cls, course_descriptor):
+    def populate(cls, block):
         """
-        Returns a fully populated CourseDetails model given the course descriptor
+        Returns a fully populated CourseDetails model given the course block
         """
-        course_key = course_descriptor.id
+        course_key = block.id
         course_details = cls(course_key.org, course_key.course, course_key.run)
-        course_details.start_date = course_descriptor.start
-        course_details.end_date = course_descriptor.end
+        course_details.start_date = block.start
+        course_details.end_date = block.end
         updated_available_date, updated_display_behavior = cls.validate_certificate_settings(
-            course_descriptor.certificate_available_date,
-            course_descriptor.certificates_display_behavior
+            block.certificate_available_date,
+            block.certificates_display_behavior
         )
         course_details.certificate_available_date = updated_available_date
         course_details.certificates_display_behavior = updated_display_behavior
-        course_details.enrollment_start = course_descriptor.enrollment_start
-        course_details.enrollment_end = course_descriptor.enrollment_end
-        course_details.pre_requisite_courses = course_descriptor.pre_requisite_courses
-        course_details.course_image_name = course_descriptor.course_image
-        course_details.course_image_asset_path = course_image_url(course_descriptor, 'course_image')
-        course_details.banner_image_name = course_descriptor.banner_image
-        course_details.banner_image_asset_path = course_image_url(course_descriptor, 'banner_image')
-        course_details.video_thumbnail_image_name = course_descriptor.video_thumbnail_image
-        course_details.video_thumbnail_image_asset_path = course_image_url(course_descriptor, 'video_thumbnail_image')
-        course_details.language = course_descriptor.language
-        course_details.self_paced = course_descriptor.self_paced
-        course_details.learning_info = course_descriptor.learning_info
-        course_details.instructor_info = course_descriptor.instructor_info
+        course_details.enrollment_start = block.enrollment_start
+        course_details.enrollment_end = block.enrollment_end
+        course_details.pre_requisite_courses = block.pre_requisite_courses
+        course_details.course_image_name = block.course_image
+        course_details.course_image_asset_path = course_image_url(block, 'course_image')
+        course_details.banner_image_name = block.banner_image
+        course_details.banner_image_asset_path = course_image_url(block, 'banner_image')
+        course_details.video_thumbnail_image_name = block.video_thumbnail_image
+        course_details.video_thumbnail_image_asset_path = course_image_url(block, 'video_thumbnail_image')
+        course_details.language = block.language
+        course_details.self_paced = block.self_paced
+        course_details.learning_info = block.learning_info
+        course_details.instructor_info = block.instructor_info
 
         # Default course license is "All Rights Reserved"
-        course_details.license = getattr(course_descriptor, "license", "all-rights-reserved")
+        course_details.license = getattr(block, "license", "all-rights-reserved")
 
         course_details.intro_video = cls.fetch_youtube_video_id(course_key)
 
@@ -197,11 +197,11 @@ class CourseDetails:
         Decode the json into CourseDetails and save any changed attrs to the db
         """
         module_store = modulestore()
-        descriptor = module_store.get_course(course_key)
+        block = module_store.get_course(course_key)
 
         dirty = False
 
-        # In the descriptor's setter, the date is converted to JSON
+        # In the block's setter, the date is converted to JSON
         # using Date's to_json method. Calling to_json on something that
         # is already JSON doesn't work. Since reaching directly into the
         # model is nasty, convert the JSON Date to a Python date, which
@@ -215,95 +215,95 @@ class CourseDetails:
             converted = date.from_json(jsondict['start_date'])
         else:
             converted = None
-        if converted != descriptor.start:
+        if converted != block.start:
             dirty = True
-            descriptor.start = converted
+            block.start = converted
 
         if 'end_date' in jsondict:
             converted = date.from_json(jsondict['end_date'])
         else:
             converted = None
 
-        if converted != descriptor.end:
+        if converted != block.end:
             dirty = True
-            descriptor.end = converted
+            block.end = converted
 
         if 'enrollment_start' in jsondict:
             converted = date.from_json(jsondict['enrollment_start'])
         else:
             converted = None
 
-        if converted != descriptor.enrollment_start:
+        if converted != block.enrollment_start:
             dirty = True
-            descriptor.enrollment_start = converted
+            block.enrollment_start = converted
 
         if 'enrollment_end' in jsondict:
             converted = date.from_json(jsondict['enrollment_end'])
         else:
             converted = None
 
-        if converted != descriptor.enrollment_end:
+        if converted != block.enrollment_end:
             dirty = True
-            descriptor.enrollment_end = converted
+            block.enrollment_end = converted
 
         if 'certificate_available_date' in jsondict:
             converted = date.from_json(jsondict['certificate_available_date'])
         else:
             converted = None
 
-        if converted != descriptor.certificate_available_date:
+        if converted != block.certificate_available_date:
             dirty = True
-            descriptor.certificate_available_date = converted
+            block.certificate_available_date = converted
 
         if (
             'certificates_display_behavior' in jsondict
-            and jsondict['certificates_display_behavior'] != descriptor.certificates_display_behavior
+            and jsondict['certificates_display_behavior'] != block.certificates_display_behavior
         ):
-            descriptor.certificates_display_behavior = jsondict['certificates_display_behavior']
+            block.certificates_display_behavior = jsondict['certificates_display_behavior']
             dirty = True
 
-        if 'course_image_name' in jsondict and jsondict['course_image_name'] != descriptor.course_image:
-            descriptor.course_image = jsondict['course_image_name']
+        if 'course_image_name' in jsondict and jsondict['course_image_name'] != block.course_image:
+            block.course_image = jsondict['course_image_name']
             dirty = True
 
-        if 'banner_image_name' in jsondict and jsondict['banner_image_name'] != descriptor.banner_image:
-            descriptor.banner_image = jsondict['banner_image_name']
+        if 'banner_image_name' in jsondict and jsondict['banner_image_name'] != block.banner_image:
+            block.banner_image = jsondict['banner_image_name']
             dirty = True
 
         if 'video_thumbnail_image_name' in jsondict \
-                and jsondict['video_thumbnail_image_name'] != descriptor.video_thumbnail_image:
-            descriptor.video_thumbnail_image = jsondict['video_thumbnail_image_name']
+                and jsondict['video_thumbnail_image_name'] != block.video_thumbnail_image:
+            block.video_thumbnail_image = jsondict['video_thumbnail_image_name']
             dirty = True
 
         if 'pre_requisite_courses' in jsondict \
-                and sorted(jsondict['pre_requisite_courses']) != sorted(descriptor.pre_requisite_courses):
-            descriptor.pre_requisite_courses = jsondict['pre_requisite_courses']
+                and sorted(jsondict['pre_requisite_courses']) != sorted(block.pre_requisite_courses):
+            block.pre_requisite_courses = jsondict['pre_requisite_courses']
             dirty = True
 
         if 'license' in jsondict:
-            descriptor.license = jsondict['license']
+            block.license = jsondict['license']
             dirty = True
 
         if 'learning_info' in jsondict:
-            descriptor.learning_info = jsondict['learning_info']
+            block.learning_info = jsondict['learning_info']
             dirty = True
 
         if 'instructor_info' in jsondict:
-            descriptor.instructor_info = jsondict['instructor_info']
+            block.instructor_info = jsondict['instructor_info']
             dirty = True
 
-        if 'language' in jsondict and jsondict['language'] != descriptor.language:
-            descriptor.language = jsondict['language']
+        if 'language' in jsondict and jsondict['language'] != block.language:
+            block.language = jsondict['language']
             dirty = True
 
-        if (descriptor.can_toggle_course_pacing
+        if (block.can_toggle_course_pacing
                 and 'self_paced' in jsondict
-                and jsondict['self_paced'] != descriptor.self_paced):
-            descriptor.self_paced = jsondict['self_paced']
+                and jsondict['self_paced'] != block.self_paced):
+            block.self_paced = jsondict['self_paced']
             dirty = True
 
         if dirty:
-            module_store.update_item(descriptor, user.id)
+            module_store.update_item(block, user.id)
 
         # NOTE: below auto writes to the db w/o verifying that any of
         # the fields actually changed to make faster, could compare
@@ -311,9 +311,9 @@ class CourseDetails:
         # fields changed.
         for attribute in ABOUT_ATTRIBUTES:
             if attribute in jsondict:
-                cls.update_about_item(descriptor, attribute, jsondict[attribute], user.id)
+                cls.update_about_item(block, attribute, jsondict[attribute], user.id)
 
-        cls.update_about_video(descriptor, jsondict['intro_video'], user.id)
+        cls.update_about_video(block, jsondict['intro_video'], user.id)
 
         # Could just return jsondict w/o doing any db reads, but I put
         # the reads in as a means to confirm it persisted correctly

--- a/openedx/core/djangoapps/programs/utils.py
+++ b/openedx/core/djangoapps/programs/utils.py
@@ -984,9 +984,9 @@ class ProgramMarketingDataExtender(ProgramDataExtender):
         """
         module_store = modulestore()
         course_run_key = CourseKey.from_string(course_run['key'])
-        course_descriptor = module_store.get_course(course_run_key)
-        if course_descriptor:
-            course_instructors = getattr(course_descriptor, 'instructor_info', {})
+        course_block = module_store.get_course(course_run_key)
+        if course_block:
+            course_instructors = getattr(course_block, 'instructor_info', {})
 
             # Deduplicate program instructors using instructor name
             curr_instructors_names = [instructor.get('name', '').strip() for instructor in self.instructors]

--- a/openedx/core/djangoapps/schedules/content_highlights.py
+++ b/openedx/core/djangoapps/schedules/content_highlights.py
@@ -37,7 +37,7 @@ def course_has_highlights(course):
     inaccessible content.
 
     Arguments:
-        course (CourseDescriptor): course object to check
+        course (CourseBlock): course block to check
     """
     if not course.highlights_enabled_for_messaging:
         return False
@@ -106,7 +106,7 @@ def get_next_section_highlights(user, course_key, start_date, target_date):
 
 
 def _get_course_with_highlights(course_key):
-    """ Gets Course descriptor iff highlights are enabled for the course """
+    """ Gets Course descriptor if highlights are enabled for the course """
     course_descriptor = _get_course_descriptor(course_key)
     if not course_descriptor.highlights_enabled_for_messaging:
         raise CourseUpdateDoesNotExist(
@@ -118,12 +118,12 @@ def _get_course_with_highlights(course_key):
 
 def _get_course_descriptor(course_key):
     """ Gets course descriptor from modulestore """
-    course_descriptor = modulestore().get_course(course_key, depth=1)
-    if course_descriptor is None:
+    descriptor = modulestore().get_course(course_key, depth=1)
+    if descriptor is None:
         raise CourseUpdateDoesNotExist(
             f'Course {course_key} not found.'
         )
-    return course_descriptor
+    return descriptor
 
 
 def _get_course_block(course_descriptor, user):
@@ -137,9 +137,9 @@ def _get_course_block(course_descriptor, user):
     request = get_request_or_stub()
     request.user = user
 
-    # Now evil modulestore magic to inflate our descriptor with user state and
+    # Now evil modulestore magic to inflate our block with user state and
     # permissions checks.
-    field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
+    field_data_cache = FieldDataCache.cache_for_block_descendents(
         course_descriptor.id, user, course_descriptor, depth=1, read_only=True,
     )
     course_block = get_block_for_descriptor(

--- a/openedx/core/djangoapps/xblock/runtime/runtime.py
+++ b/openedx/core/djangoapps/xblock/runtime/runtime.py
@@ -304,7 +304,7 @@ class XBlockRuntime(RuntimeShim, Runtime):
                 self.django_field_data_caches[context_key] = field_data_cache
             else:
                 field_data_cache = self.django_field_data_caches[context_key]
-                field_data_cache.add_descriptors_to_cache([block])
+                field_data_cache.add_blocks_to_cache([block])
             student_data_store = KvsFieldData(kvs=DjangoKeyValueStore(field_data_cache))
 
         return SplitFieldData({

--- a/openedx/core/lib/courses.py
+++ b/openedx/core/lib/courses.py
@@ -87,7 +87,7 @@ def clean_course_id(model_form, is_required=True):
 
 def get_course_by_id(course_key, depth=0):
     """
-    Given a course id, return the corresponding course descriptor.
+    Given a course id, return the corresponding course block.
 
     If such a course does not exist, raises a 404.
 

--- a/openedx/core/lib/xblock_utils/__init__.py
+++ b/openedx/core/lib/xblock_utils/__init__.py
@@ -307,7 +307,7 @@ def add_staff_markup(user, disable_staff_debug_info, block, view, frag, context)
     source_file = block.source_file  # source used to generate the problem XML, eg latex or word
 
     # Useful to indicate to staff if problem has been released or not.
-    # TODO (ichuang): use _has_access_descriptor.can_load in lms.courseware.access,
+    # TODO (ichuang): use _has_access_block.can_load in lms.courseware.access,
     # instead of now>mstart comparison here.
     now = datetime.datetime.now(UTC)
     is_released = "unknown"

--- a/openedx/features/content_type_gating/tests/test_access.py
+++ b/openedx/features/content_type_gating/tests/test_access.py
@@ -61,7 +61,7 @@ def _get_content_from_fragment(_store, block, user_id, course, request_factory, 
     """
     Returns the content from the rendered fragment of a block
     Arguments:
-        block: some sort of xblock descriptor, must implement .scope_ids.usage_id
+        block: some sort of XBlock, must implement .scope_ids.usage_id
         user_id (int): id of user
         course_id (CourseLocator): id of course
     """
@@ -86,7 +86,7 @@ def _get_content_from_lms_index(store, block, user_id, _course, _request_factory
     """
     Returns the content from the lms index view of the block
     Arguments:
-        block: some sort of xblock descriptor, must implement .scope_ids.usage_id
+        block: some sort of XBlock, must implement .scope_ids.usage_id
         user_id (int): id of user
     """
     client = Client()
@@ -109,7 +109,7 @@ def _assert_block_is_gated(store, block, is_gated, user, course, request_factory
     """
     Asserts that a block in a specific course is gated for a specific user
     Arguments:
-        block: some sort of xblock descriptor, must implement .scope_ids.usage_id
+        block: some sort of XBlock, must implement .scope_ids.usage_id
         is_gated (bool): if True, this user is expected to be gated from this block
         user (int): user
         course_id (CourseLocator): id of course
@@ -151,7 +151,7 @@ def _assert_block_is_empty(store, block, user_id, course, request_factory):
     """
     Asserts that a block in a specific course is empty for a specific user
     Arguments:
-        block: some sort of xblock descriptor, must implement .scope_ids.usage_id
+        block: some sort of XBlock, must implement .scope_ids.usage_id
         is_gated (bool): if True, this user is expected to be gated from this block
         user_id (int): id of user
         course_id (CourseLocator): id of course

--- a/openedx/tests/completion_integration/test_services.py
+++ b/openedx/tests/completion_integration/test_services.py
@@ -226,13 +226,13 @@ class CompletionServiceTestCase(CompletionWaffleTestMixin, SharedModuleStoreTest
                                  if child.scope_ids.block_type == 'library_content'][0]
 
         ## Ensure the library_content_block is properly set up
-        # This is needed so we can call get_child_descriptors
+        # This is needed so we can call get_child_blocks
         self._bind_course_block(library_content_block)
         # Make sure the runtime knows that the block's children vary per-user:
         assert library_content_block.has_dynamic_children()
         assert len(library_content_block.children) == 3
         # Check how many children each user will see:
-        assert len(library_content_block.get_child_descriptors()) == 1
+        assert len(library_content_block.get_child_blocks()) == 1
 
         # No problems are complete yet
         assert not self.completion_service.vertical_is_complete(lib_vertical)
@@ -246,7 +246,7 @@ class CompletionServiceTestCase(CompletionWaffleTestMixin, SharedModuleStoreTest
         # Library content problems aren't complete yet
         assert not self.completion_service.vertical_is_complete(lib_vertical)
 
-        for child in library_content_block.get_child_descriptors():
+        for child in library_content_block.get_child_blocks():
             BlockCompletion.objects.submit_completion(
                 user=self.user,
                 block_key=child.scope_ids.usage_id,

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -442,7 +442,7 @@ edx-celeryutils==1.2.2
     #   super-csv
 edx-codejail==3.3.3
     # via -r requirements/edx/base.in
-edx-completion==4.2.0
+edx-completion==4.2.1
     # via -r requirements/edx/base.in
 edx-django-release-util==1.2.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -567,7 +567,7 @@ edx-celeryutils==1.2.2
     #   super-csv
 edx-codejail==3.3.3
     # via -r requirements/edx/testing.txt
-edx-completion==4.2.0
+edx-completion==4.2.1
     # via -r requirements/edx/testing.txt
 edx-django-release-util==1.2.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -545,7 +545,7 @@ edx-celeryutils==1.2.2
     #   super-csv
 edx-codejail==3.3.3
     # via -r requirements/edx/base.txt
-edx-completion==4.2.0
+edx-completion==4.2.1
     # via -r requirements/edx/base.txt
 edx-django-release-util==1.2.0
     # via

--- a/xmodule/block_metadata_utils.py
+++ b/xmodule/block_metadata_utils.py
@@ -34,7 +34,7 @@ def display_name_with_default(block):
     a name based on the URL.
 
     Unlike the rest of this module's functions, this function takes an entire
-    course descriptor/overview as a parameter. This is because a few test cases
+    course block/overview as a parameter. This is because a few test cases
     (specifically, {Text|Image|Video}AnnotationModuleTestCase.test_student_view)
     create scenarios where course.display_name is not None but course.location
     is None, which causes calling course.url_name to fail. So, although we'd

--- a/xmodule/conditional_block.py
+++ b/xmodule/conditional_block.py
@@ -213,8 +213,8 @@ class ConditionalBlock(
             for block in self.get_required_blocks:
                 if not hasattr(block, attr_name):
                     # We don't throw an exception here because it is possible for
-                    # the descriptor of a required block to have a property but
-                    # for the resulting module to be a (flavor of) ErrorBlock.
+                    # the required block to have a property but
+                    # for the resulting block to be a (flavor of) ErrorBlock.
                     # So just log and return false.
                     if block is not None:
                         # We do not want to log when block is None, and it is when requester
@@ -244,7 +244,7 @@ class ConditionalBlock(
         return fragment
 
     def get_html(self):
-        required_html_ids = [descriptor.location.html_id() for descriptor in self.get_required_blocks]
+        required_html_ids = [block.location.html_id() for block in self.get_required_blocks]
         return self.runtime.service(self, 'mako').render_template('conditional_ajax.html', {
             'element_id': self.location.html_id(),
             'ajax_url': self.ajax_url,
@@ -298,7 +298,7 @@ class ConditionalBlock(
         class_priority = ['video', 'problem']
 
         child_classes = [
-            child_descriptor.get_icon_class() for child_descriptor in self.get_children()
+            child_block.get_icon_class() for child_block in self.get_children()
         ]
         for c in class_priority:
             if c in child_classes:
@@ -318,24 +318,24 @@ class ConditionalBlock(
         Returns a list of bound XBlocks instances upon which XBlock depends.
         """
         return [
-            self.runtime.get_block_for_descriptor(descriptor) for descriptor in self.get_required_block_descriptors()
+            self.runtime.get_block_for_descriptor(block) for block in self.get_required_block_descriptors()
         ]
 
     def get_required_block_descriptors(self):
         """
         Returns a list of unbound XBlocks instances upon which this XBlock depends.
         """
-        descriptors = []
+        blocks = []
         for location in self.sources_list:
             try:
-                descriptor = self.runtime.get_block(location)
-                descriptors.append(descriptor)
+                block = self.runtime.get_block(location)
+                blocks.append(block)
             except ItemNotFoundError:
                 msg = "Invalid module by location."
                 log.exception(msg)
                 self.runtime.error_tracker(msg)
 
-        return descriptors
+        return blocks
 
     @classmethod
     def definition_from_xml(cls, xml_object, system):
@@ -357,8 +357,8 @@ class ConditionalBlock(
                     show_tag_list.append(location)
             else:
                 try:
-                    descriptor = system.process_xml(etree.tostring(child, encoding='unicode'))
-                    children.append(descriptor.scope_ids.usage_id)
+                    block = system.process_xml(etree.tostring(child, encoding='unicode'))
+                    children.append(block.scope_ids.usage_id)
                 except:  # lint-amnesty, pylint: disable=bare-except
                     msg = "Unable to load child when parsing Conditional."
                     log.exception(msg)

--- a/xmodule/error_block.py
+++ b/xmodule/error_block.py
@@ -97,8 +97,8 @@ class ErrorBlock(
         if location.block_type == 'error':
             location = location.replace(
                 # Pick a unique url_name -- the sha1 hash of the contents.
-                # NOTE: We could try to pull out the url_name of the errored descriptor,
-                # but url_names aren't guaranteed to be unique between descriptor types,
+                # NOTE: We could try to pull out the url_name of the errored block,
+                # but url_names aren't guaranteed to be unique between block types,
                 # and ErrorBlock can wrap any type.  When the wrapped block is fixed,
                 # it will be written out with the original url_name.
                 name=hashlib.sha1(contents.encode('utf8')).hexdigest()
@@ -141,19 +141,19 @@ class ErrorBlock(
         )
 
     @classmethod
-    def from_descriptor(cls, descriptor, error_msg=None):
+    def from_block(cls, block, error_msg=None):
         return cls._construct(
-            descriptor.runtime,
-            str(descriptor),
+            block.runtime,
+            str(block),
             error_msg,
-            location=descriptor.location,
-            for_parent=descriptor.get_parent() if descriptor.has_cached_parent else None
+            location=block.location,
+            for_parent=block.get_parent() if block.has_cached_parent else None
         )
 
     @classmethod
     def from_xml(cls, xml_data, system, id_generator,  # pylint: disable=arguments-differ
                  error_msg=None):
-        '''Create an instance of this descriptor from the supplied data.
+        '''Create an instance of this block from the supplied data.
 
         Does not require that xml_data be parseable--just stores it and exports
         as-is if not.

--- a/xmodule/library_content_block.py
+++ b/xmodule/library_content_block.py
@@ -468,7 +468,7 @@ class LibraryContentBlock(
         shim_xmodule_js(fragment, self.studio_js_module_name)
         return fragment
 
-    def get_child_descriptors(self):
+    def get_child_blocks(self):
         """
         Return only the subset of our children relevant to the current student.
         """
@@ -701,7 +701,7 @@ class LibraryContentBlock(
     def has_dynamic_children(self):
         """
         Inform the runtime that our children vary per-user.
-        See get_child_descriptors() above
+        See get_child_blocks() above
         """
         return True
 
@@ -714,7 +714,7 @@ class LibraryContentBlock(
         This overwrites the get_content_titles method included in x_module by default.
         """
         titles = []
-        for child in self.get_child_descriptors():
+        for child in self.get_child_blocks():
             titles.extend(child.get_content_titles())
         return titles
 

--- a/xmodule/library_tools.py
+++ b/xmodule/library_tools.py
@@ -125,9 +125,9 @@ class LibraryToolsService:
         if usage_key.block_type != "problem":
             return False
 
-        descriptor = self.store.get_item(usage_key, depth=0)
-        assert isinstance(descriptor, ProblemBlock)
-        return capa_type in descriptor.problem_types
+        block = self.store.get_item(usage_key, depth=0)
+        assert isinstance(block, ProblemBlock)
+        return capa_type in block.problem_types
 
     def can_use_library_content(self, block):
         """

--- a/xmodule/modulestore/__init__.py
+++ b/xmodule/modulestore/__init__.py
@@ -922,7 +922,7 @@ class ModuleStoreRead(ModuleStoreAssetBase, metaclass=ABCMeta):
     def get_course(self, course_id, depth=0, **kwargs):
         '''
         Look for a specific course by its id (:class:`CourseKey`).
-        Returns the course descriptor, or None if not found.
+        Returns the course block, or None if not found.
         '''
         pass  # lint-amnesty, pylint: disable=unnecessary-pass
 
@@ -1286,8 +1286,8 @@ class ModuleStoreWriteBase(ModuleStoreReadBase, ModuleStoreWrite):
         # clone a default 'about' overview block as well
         about_location = self.make_course_key(org, course, run).make_usage_key('about', 'overview')
 
-        about_descriptor = XBlock.load_class('about')
-        overview_template = about_descriptor.get_template('overview.yaml')
+        about_block = XBlock.load_class('about')
+        overview_template = about_block.get_template('overview.yaml')
         self.create_item(
             user_id,
             about_location.course_key,

--- a/xmodule/modulestore/inheritance.py
+++ b/xmodule/modulestore/inheritance.py
@@ -272,27 +272,27 @@ class InheritanceMixin(XBlockMixin):
         return self.is_past_due()
 
 
-def compute_inherited_metadata(descriptor):
-    """Given a descriptor, traverse all of its descendants and do metadata
+def compute_inherited_metadata(block):
+    """Given a block, traverse all of its descendants and do metadata
     inheritance.  Should be called on a CourseBlock after importing a
     course.
 
     NOTE: This means that there is no such thing as lazy loading at the
     moment--this accesses all the children."""
-    if descriptor.has_children:
-        parent_metadata = descriptor.xblock_kvs.inherited_settings.copy()
-        # add any of descriptor's explicitly set fields to the inheriting list
+    if block.has_children:
+        parent_metadata = block.xblock_kvs.inherited_settings.copy()
+        # add any of block's explicitly set fields to the inheriting list
         for field in InheritanceMixin.fields.values():  # lint-amnesty, pylint: disable=no-member
-            if field.is_set_on(descriptor):
+            if field.is_set_on(block):
                 # inherited_settings values are json repr
-                parent_metadata[field.name] = field.read_json(descriptor)
+                parent_metadata[field.name] = field.read_json(block)
 
-        for child in descriptor.get_children():
+        for child in block.get_children():
             inherit_metadata(child, parent_metadata)
             compute_inherited_metadata(child)
 
 
-def inherit_metadata(descriptor, inherited_data):
+def inherit_metadata(block, inherited_data):
     """
     Updates this block with metadata inherited from a containing block.
     Only metadata specified in self.inheritable_metadata will
@@ -302,7 +302,7 @@ def inherit_metadata(descriptor, inherited_data):
         they should inherit
     """
     try:
-        descriptor.xblock_kvs.inherited_settings = inherited_data
+        block.xblock_kvs.inherited_settings = inherited_data
     except AttributeError:  # the kvs doesn't have inherited_settings probably b/c it's an error block
         pass
 

--- a/xmodule/modulestore/split_mongo/split.py
+++ b/xmodule/modulestore/split_mongo/split.py
@@ -781,7 +781,7 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
 
     def _get_cache(self, course_version_guid):
         """
-        Find the descriptor cache for this course if it exists
+        Find the block cache for this course if it exists
         :param course_version_guid:
         """
         if self.request_cache is None:
@@ -956,7 +956,7 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
     @autoretry_read()
     def get_courses(self, branch, **kwargs):  # lint-amnesty, pylint: disable=arguments-differ
         """
-        Returns a list of course descriptors matching any given qualifiers.
+        Returns a list of course blocks matching any given qualifiers.
 
         qualifiers should be a dict of keywords matching the db fields or any
         legal query for mongo to use against the active_versions collection.
@@ -1098,7 +1098,7 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
 
     def get_course(self, course_id, depth=0, **kwargs):
         """
-        Gets the course descriptor for the course identified by the locator
+        Gets the course block for the course identified by the locator
         """
         if not isinstance(course_id, CourseLocator) or course_id.deprecated:
             # The supplied CourseKey is of the wrong type, so it can't possibly be stored in this modulestore.
@@ -1423,7 +1423,7 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
         index = self.get_course_index(course_key)
         return index
 
-    # TODO figure out a way to make this info accessible from the course descriptor
+    # TODO figure out a way to make this info accessible from the course block
     def get_course_history_info(self, course_key):
         """
         Because xblocks doesn't give a means to separate the course structure's meta information from
@@ -1490,7 +1490,7 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
 
     def create_definition_from_data(self, course_key, new_def_data, category, user_id):
         """
-        Pull the definition fields out of descriptor and save to the db as a new definition
+        Pull the definition fields out of block and save to the db as a new definition
         w/o a predecessor and return the new id.
 
         :param user_id: request.user object
@@ -1529,7 +1529,7 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
                     return True
 
         # if this looks in cache rather than fresh fetches, then it will probably not detect
-        # actual change b/c the descriptor and cache probably point to the same objects
+        # actual change b/c the block and cache probably point to the same objects
         old_definition = self.get_definition(course_key, definition_locator.definition_id)
         if old_definition is None:
             raise ItemNotFoundError(definition_locator)
@@ -1579,7 +1579,7 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
     def create_item(self, user_id, course_key, block_type, block_id=None, definition_locator=None, fields=None,  # lint-amnesty, pylint: disable=arguments-differ
                     asides=None, force=False, **kwargs):
         """
-        Add a descriptor to persistence as an element
+        Add a block to persistence as an element
         of the course. Return the resulting post saved version with populated locators.
 
         :param course_key: If it has a version_guid and a course org + course + run + branch, this
@@ -1937,26 +1937,26 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
         locator = LibraryLocator(org=org, library=library, branch=kwargs["master_branch"])
         return self._create_courselike(locator, user_id, **kwargs)
 
-    def update_item(self, descriptor, user_id, allow_not_found=False, force=False, **kwargs):  # lint-amnesty, pylint: disable=arguments-differ
+    def update_item(self, block, user_id, allow_not_found=False, force=False, **kwargs):  # lint-amnesty, pylint: disable=arguments-differ
         """
-        Save the descriptor's fields. it doesn't descend the course dag to save the children.
-        Return the new descriptor (updated location).
+        Save the block's fields. it doesn't descend the course dag to save the children.
+        Return the new block (updated location).
 
         raises ItemNotFoundError if the location does not exist.
 
-        Creates a new course version. If the descriptor's location has a org and course and run, it moves the course head  # lint-amnesty, pylint: disable=line-too-long
-        pointer. If the version_guid of the descriptor points to a non-head version and there's been an intervening
+        Creates a new course version. If the block's location has a org and course and run, it moves the course head  # lint-amnesty, pylint: disable=line-too-long
+        pointer. If the version_guid of the block points to a non-head version and there's been an intervening
         change to this item, it raises a VersionConflictError unless force is True. In the force case, it forks
         the course but leaves the head pointer where it is (this change will not be in the course head).
 
         The implementation tries to detect which, if any changes, actually need to be saved and thus won't version
         the definition, structure, nor course if they didn't change.
         """
-        partitioned_fields = self.partition_xblock_fields_by_scope(descriptor)
+        partitioned_fields = self.partition_xblock_fields_by_scope(block)
         return self._update_item_from_fields(
-            user_id, descriptor.location.course_key, BlockKey.from_usage_key(descriptor.location),
-            partitioned_fields, descriptor.definition_locator, allow_not_found, force, **kwargs
-        ) or descriptor
+            user_id, block.location.course_key, BlockKey.from_usage_key(block.location),
+            partitioned_fields, block.definition_locator, allow_not_found, force, **kwargs
+        ) or block
 
     def _update_item_from_fields(self, user_id, course_key, block_key, partitioned_fields,    # pylint: disable=too-many-statements
                                  definition_locator, allow_not_found, force, asides=None, **kwargs):
@@ -2519,8 +2519,8 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
         raises ItemNotFoundError if the location does not exist.
         raises ValueError if usage_locator points to the structure root
 
-        Creates a new course version. If the descriptor's location has a org, a course, and a run, it moves the course head  # lint-amnesty, pylint: disable=line-too-long
-        pointer. If the version_guid of the descriptor points to a non-head version and there's been an intervening
+        Creates a new course version. If the block's location has a org, a course, and a run, it moves the course head  # lint-amnesty, pylint: disable=line-too-long
+        pointer. If the version_guid of the block points to a non-head version and there's been an intervening
         change to this item, it raises a VersionConflictError unless force is True. In the force case, it forks
         the course but leaves the head pointer where it is (this change will not be in the course head).
         """

--- a/xmodule/modulestore/split_mongo/split_draft.py
+++ b/xmodule/modulestore/split_mongo/split_draft.py
@@ -140,15 +140,15 @@ class DraftVersioningModuleStore(SplitMongoModuleStore, ModuleStoreDraftAndPubli
                         keys_to_check.extend(children)
         return new_keys
 
-    def update_item(self, descriptor, user_id, allow_not_found=False, force=False, asides=None, **kwargs):  # lint-amnesty, pylint: disable=arguments-differ
-        old_descriptor_locn = descriptor.location
-        descriptor.location = self._map_revision_to_branch(old_descriptor_locn)
-        emit_signals = descriptor.location.branch == ModuleStoreEnum.BranchName.published \
-            or descriptor.location.block_type in DIRECT_ONLY_CATEGORIES
+    def update_item(self, block, user_id, allow_not_found=False, force=False, asides=None, **kwargs):  # lint-amnesty, pylint: disable=arguments-differ
+        old_block_locn = block.location
+        block.location = self._map_revision_to_branch(old_block_locn)
+        emit_signals = block.location.branch == ModuleStoreEnum.BranchName.published \
+            or block.location.block_type in DIRECT_ONLY_CATEGORIES
 
-        with self.bulk_operations(descriptor.location.course_key, emit_signals=emit_signals):
+        with self.bulk_operations(block.location.course_key, emit_signals=emit_signals):
             item = super().update_item(
-                descriptor,
+                block,
                 user_id,
                 allow_not_found=allow_not_found,
                 force=force,
@@ -156,7 +156,7 @@ class DraftVersioningModuleStore(SplitMongoModuleStore, ModuleStoreDraftAndPubli
                 **kwargs
             )
             self._auto_publish_no_children(item.location, item.location.block_type, user_id, **kwargs)
-            descriptor.location = old_descriptor_locn
+            block.location = old_block_locn
             return item
 
     def create_item(self, user_id, course_key, block_type, block_id=None,     # pylint: disable=W0221

--- a/xmodule/modulestore/tests/test_split_modulestore.py
+++ b/xmodule/modulestore/tests/test_split_modulestore.py
@@ -514,7 +514,7 @@ class SplitModuleTest(unittest.TestCase):
 
     def findByIdInResult(self, collection, _id):  # pylint: disable=invalid-name
         """
-        Result is a collection of descriptors. Find the one whose block id
+        Result is a collection of blocks. Find the one whose block id
         matches the _id.
         """
         for element in collection:
@@ -576,7 +576,7 @@ class SplitModuleCourseTests(SplitModuleTest):
         assert course.display_name == 'The Ancient Greek Hero', 'wrong display name'
         assert course.advertised_start == 'Fall 2013', 'advertised_start'
         assert len(course.children) == 4, 'children'
-        # check dates and graders--forces loading of descriptor
+        # check dates and graders--forces loading of block
         assert course.edited_by == TEST_ASSISTANT_USER_ID
         self.assertDictEqual(course.grade_cutoffs, {"Pass": 0.45})
 
@@ -662,7 +662,7 @@ class SplitModuleCourseTests(SplitModuleTest):
         assert course.advertised_start is None
         assert len(course.children) == 0
         assert course.definition_locator.definition_id != head_course.definition_locator.definition_id
-        # check dates and graders--forces loading of descriptor
+        # check dates and graders--forces loading of block
         assert course.edited_by == TEST_ASSISTANT_USER_ID
         self.assertDictEqual(course.grade_cutoffs, {"Pass": 0.55})
 
@@ -676,7 +676,7 @@ class SplitModuleCourseTests(SplitModuleTest):
         assert course.display_name == 'The Ancient Greek Hero'
         assert course.advertised_start == 'Fall 2013'
         assert len(course.children) == 4
-        # check dates and graders--forces loading of descriptor
+        # check dates and graders--forces loading of block
         assert course.edited_by == TEST_ASSISTANT_USER_ID
         self.assertDictEqual(course.grade_cutoffs, {"Pass": 0.45})
 
@@ -928,7 +928,7 @@ class SplitModuleItemTests(SplitModuleTest):
             assert block.display_name == 'The Ancient Greek Hero'
             assert block.advertised_start == 'Fall 2013'
             assert len(block.children) == 4
-            # check dates and graders--forces loading of descriptor
+            # check dates and graders--forces loading of block
             assert block.edited_by == TEST_ASSISTANT_USER_ID
             self.assertDictEqual(
                 block.grade_cutoffs, {"Pass": 0.45},
@@ -1061,7 +1061,7 @@ class SplitModuleItemTests(SplitModuleTest):
 
     def test_get_children(self):
         """
-        Test the existing get_children method on xdescriptors
+        Test the existing get_children method on xblocks
         """
         locator = BlockUsageLocator(
             CourseLocator(org='testx', course='GreekHero', run="run", branch=BRANCH_NAME_DRAFT), 'course', 'head12345'
@@ -1080,7 +1080,7 @@ class SplitModuleItemTests(SplitModuleTest):
 
 def version_agnostic(children):
     """
-    children: list of descriptors
+    children: list of blocks
     Returns the `children` list with each member version-agnostic
     """
     return [child.version_agnostic() for child in children]

--- a/xmodule/modulestore/xml.py
+++ b/xmodule/modulestore/xml.py
@@ -160,7 +160,7 @@ class ImportSystem(XMLParsingSystem, MakoDescriptorSystem):  # lint-amnesty, pyl
             try:
                 xml_data = etree.fromstring(xml)
                 make_name_unique(xml_data)
-                descriptor = self.xblock_from_node(
+                block = self.xblock_from_node(
                     xml_data,
                     None,  # parent_id
                     id_manager,
@@ -170,7 +170,7 @@ class ImportSystem(XMLParsingSystem, MakoDescriptorSystem):  # lint-amnesty, pyl
                     raise
 
                 # Didn't load properly.  Fall back on loading as an error
-                # descriptor.  This should never error due to formatting.
+                # block.  This should never error due to formatting.
 
                 msg = "Error loading from xml. %s"
                 log.warning(
@@ -186,34 +186,34 @@ class ImportSystem(XMLParsingSystem, MakoDescriptorSystem):  # lint-amnesty, pyl
 
                 self.error_tracker(msg)
                 err_msg = msg + "\n" + exc_info_to_str(sys.exc_info())
-                descriptor = ErrorBlock.from_xml(
+                block = ErrorBlock.from_xml(
                     xml,
                     self,
                     id_manager,
                     err_msg
                 )
 
-            descriptor.data_dir = course_dir
+            block.data_dir = course_dir
 
-            if descriptor.scope_ids.usage_id in xmlstore.modules[course_id]:
+            if block.scope_ids.usage_id in xmlstore.modules[course_id]:
                 # keep the parent pointer if any but allow everything else to overwrite
-                other_copy = xmlstore.modules[course_id][descriptor.scope_ids.usage_id]
-                descriptor.parent = other_copy.parent
-                if descriptor != other_copy:
-                    log.warning("%s has more than one definition", descriptor.scope_ids.usage_id)
-            xmlstore.modules[course_id][descriptor.scope_ids.usage_id] = descriptor
+                other_copy = xmlstore.modules[course_id][block.scope_ids.usage_id]
+                block.parent = other_copy.parent
+                if block != other_copy:
+                    log.warning("%s has more than one definition", block.scope_ids.usage_id)
+            xmlstore.modules[course_id][block.scope_ids.usage_id] = block
 
-            if descriptor.has_children:
-                for child in descriptor.get_children():
+            if block.has_children:
+                for child in block.get_children():
                     # parent is alphabetically least
-                    if child.parent is None or child.parent > descriptor.scope_ids.usage_id:
-                        child.parent = descriptor.location
+                    if child.parent is None or child.parent > block.scope_ids.usage_id:
+                        child.parent = block.location
                         child.save()
 
-            # After setting up the descriptor, save any changes that we have
-            # made to attributes on the descriptor to the underlying KeyValueStore.
-            descriptor.save()
-            return descriptor
+            # After setting up the block, save any changes that we have
+            # made to attributes on the block to the underlying KeyValueStore.
+            block.save()
+            return block
 
         render_template = lambda template, context: ''
 
@@ -313,7 +313,7 @@ class XMLModuleStore(ModuleStoreReadBase):
         Args:
             data_dir (str): path to data directory containing the course directories
 
-            default_class (str): dot-separated string defining the default descriptor
+            default_class (str): dot-separated string defining the default block
                 class to use if none is specified in entry_points
 
             source_dirs or course_ids (list of str): If specified, the list of source_dirs or course_ids to load.
@@ -376,9 +376,9 @@ class XMLModuleStore(ModuleStoreReadBase):
         # So, make a tracker to track load-time errors, then put in the right
         # place after the course loads and we have its location
         errorlog = make_error_tracker()
-        course_descriptor = None
+        course_block = None
         try:
-            course_descriptor = self.load_course(course_dir, course_ids, errorlog.tracker, target_course_id)
+            course_block = self.load_course(course_dir, course_ids, errorlog.tracker, target_course_id)
         except Exception as exc:  # pylint: disable=broad-except
             msg = f'Course import {target_course_id}: ERROR: Failed to load courselike "{course_dir}": {str(exc)}'
             log.exception(msg)
@@ -387,15 +387,15 @@ class XMLModuleStore(ModuleStoreReadBase):
             monitor_import_failure(target_course_id, 'Updating', exception=exc)
             raise exc
         finally:
-            if course_descriptor is None:
+            if course_block is None:
                 pass
-            elif isinstance(course_descriptor, ErrorBlock):
+            elif isinstance(course_block, ErrorBlock):
                 # Didn't load course.  Instead, save the errors elsewhere.
                 self.errored_courses[course_dir] = errorlog
             else:
-                self.courses[course_dir] = course_descriptor
-                course_descriptor.parent = None
-                course_id = self.id_from_descriptor(course_descriptor)
+                self.courses[course_dir] = course_block
+                course_block.parent = None
+                course_id = self.id_from_block(course_block)
                 self._course_errors[course_id] = errorlog
 
     def __str__(self):
@@ -407,11 +407,11 @@ class XMLModuleStore(ModuleStoreReadBase):
         )
 
     @staticmethod
-    def id_from_descriptor(descriptor):
+    def id_from_block(block):
         """
-        Grab the course ID from the descriptor
+        Grab the course ID from the block
         """
-        return descriptor.id
+        return block.id
 
     def load_policy(self, policy_path, tracker):
         """
@@ -527,30 +527,30 @@ class XMLModuleStore(ModuleStoreReadBase):
                 services=services,
                 target_course_id=target_course_id,
             )
-            course_descriptor = system.process_xml(etree.tostring(course_data, encoding='unicode'))
+            course_block = system.process_xml(etree.tostring(course_data, encoding='unicode'))
             # If we fail to load the course, then skip the rest of the loading steps
-            if isinstance(course_descriptor, ErrorBlock):
-                return course_descriptor
+            if isinstance(course_block, ErrorBlock):
+                return course_block
 
-            self.content_importers(system, course_descriptor, course_dir, url_name)
+            self.content_importers(system, course_block, course_dir, url_name)
 
             log.info(f'Course import {target_course_id}: Done with courselike import from {course_dir}')
-            return course_descriptor
+            return course_block
 
-    def content_importers(self, system, course_descriptor, course_dir, url_name):
+    def content_importers(self, system, course_block, course_dir, url_name):
         """
         Load all extra non-course content, and calculate metadata inheritance.
         """
-        # NOTE: The descriptors end up loading somewhat bottom up, which
+        # NOTE: The blocks end up loading somewhat bottom up, which
         # breaks metadata inheritance via get_children().  Instead
         # (actually, in addition to, for now), we do a final inheritance pass
-        # after we have the course descriptor.
-        compute_inherited_metadata(course_descriptor)
+        # after we have the course block.
+        compute_inherited_metadata(course_block)
 
         # now import all pieces of course_info which is expected to be stored
         # in <content_dir>/info or <content_dir>/info/<url_name>
         self.load_extra_content(
-            system, course_descriptor, 'course_info',
+            system, course_block, 'course_info',
             self.data_dir / course_dir / 'info',
             course_dir, url_name
         )
@@ -558,19 +558,19 @@ class XMLModuleStore(ModuleStoreReadBase):
         # now import all static tabs which are expected to be stored in
         # in <content_dir>/tabs or <content_dir>/tabs/<url_name>
         self.load_extra_content(
-            system, course_descriptor, 'static_tab',
+            system, course_block, 'static_tab',
             self.data_dir / course_dir / 'tabs',
             course_dir, url_name
         )
 
         self.load_extra_content(
-            system, course_descriptor, 'custom_tag_template',
+            system, course_block, 'custom_tag_template',
             self.data_dir / course_dir / 'custom_tags',
             course_dir, url_name
         )
 
         self.load_extra_content(
-            system, course_descriptor, 'about',
+            system, course_block, 'about',
             self.data_dir / course_dir / 'about',
             course_dir, url_name
         )
@@ -587,14 +587,14 @@ class XMLModuleStore(ModuleStoreReadBase):
         # always used, preventing duplicate keys.
         return CourseKey.from_string('/'.join([org, course, url_name]))
 
-    def load_extra_content(self, system, course_descriptor, category, base_dir, course_dir, url_name):  # lint-amnesty, pylint: disable=missing-function-docstring
-        self._load_extra_content(system, course_descriptor, category, base_dir, course_dir)
+    def load_extra_content(self, system, course_block, category, base_dir, course_dir, url_name):  # lint-amnesty, pylint: disable=missing-function-docstring
+        self._load_extra_content(system, course_block, category, base_dir, course_dir)
 
         # then look in a override folder based on the course run
         if os.path.isdir(base_dir / url_name):
-            self._load_extra_content(system, course_descriptor, category, base_dir / url_name, course_dir)
+            self._load_extra_content(system, course_block, category, base_dir / url_name, course_dir)
 
-    def _import_field_content(self, course_descriptor, category, file_path):
+    def _import_field_content(self, course_block, category, file_path):
         """
         Import field data content for field other than 'data' or 'metadata' form json file and
         return field data content as dictionary
@@ -606,7 +606,7 @@ class XMLModuleStore(ModuleStoreReadBase):
             dirname, field, file_suffix = file_path.split('/')[-1].split('.')
             if file_suffix == 'json' and field not in DEFAULT_CONTENT_FIELDS:
                 slug = os.path.splitext(os.path.basename(dirname))[0]
-                location = course_descriptor.scope_ids.usage_id.replace(category=category, name=slug)
+                location = course_block.scope_ids.usage_id.replace(category=category, name=slug)
                 with open(file_path) as field_content_file:
                     field_data = json.load(field_content_file)
                     data_content = {field: field_data}
@@ -618,7 +618,7 @@ class XMLModuleStore(ModuleStoreReadBase):
 
         return slug, location, data_content
 
-    def _load_extra_content(self, system, course_descriptor, category, content_path, course_dir):
+    def _load_extra_content(self, system, course_block, category, content_path, course_dir):
         """
         Import fields data content from files
         """
@@ -633,7 +633,7 @@ class XMLModuleStore(ModuleStoreReadBase):
                 try:
                     if filepath.find('.json') != -1:
                         # json file with json data content
-                        slug, loc, data_content = self._import_field_content(course_descriptor, category, filepath)
+                        slug, loc, data_content = self._import_field_content(course_block, category, filepath)
                         if data_content is None:
                             continue
                         else:
@@ -649,7 +649,7 @@ class XMLModuleStore(ModuleStoreReadBase):
                                 data_content['category'] = category
                     else:
                         slug = os.path.splitext(os.path.basename(filepath))[0]
-                        loc = course_descriptor.scope_ids.usage_id.replace(category=category, name=slug)
+                        loc = course_block.scope_ids.usage_id.replace(category=category, name=slug)
                         # html file with html data content
                         html = f.read()
                         try:
@@ -663,7 +663,7 @@ class XMLModuleStore(ModuleStoreReadBase):
                     if block is None:
                         block = system.construct_xblock(
                             category,
-                            # We're loading a descriptor, so student_id is meaningless
+                            # We're loading a block, so student_id is meaningless
                             # We also don't have separate notions of definition and usage ids yet,
                             # so we use the location for both
                             ScopeIds(None, category, loc, loc),
@@ -673,14 +673,14 @@ class XMLModuleStore(ModuleStoreReadBase):
                         # Hack because we need to pull in the 'display_name' for static tabs (because we need to edit them)  # lint-amnesty, pylint: disable=line-too-long
                         # from the course policy
                         if category == "static_tab":
-                            tab = CourseTabList.get_tab_by_slug(tab_list=course_descriptor.tabs, url_slug=slug)
+                            tab = CourseTabList.get_tab_by_slug(tab_list=course_block.tabs, url_slug=slug)
                             if tab:
                                 block.display_name = tab.name
                                 block.course_staff_only = tab.course_staff_only
                         block.data_dir = course_dir
                         block.save()
 
-                        self.modules[course_descriptor.id][block.scope_ids.usage_id] = block
+                        self.modules[course_block.id][block.scope_ids.usage_id] = block
                 except Exception as exc:  # pylint: disable=broad-except
                     logging.exception("Failed to load %s. Skipping... \
                             Exception: %s", filepath, str(exc))
@@ -712,7 +712,7 @@ class XMLModuleStore(ModuleStoreReadBase):
     def get_items(self, course_id, settings=None, content=None, revision=None, qualifiers=None, **kwargs):  # lint-amnesty, pylint: disable=arguments-differ
         """
         Returns:
-            list of XModuleDescriptor instances for the matching items within the course with
+            list of XBlock instances for the matching items within the course with
             the given course_id
 
         NOTE: don't use this to look for courses
@@ -737,7 +737,7 @@ class XMLModuleStore(ModuleStoreReadBase):
         if revision == ModuleStoreEnum.RevisionOption.draft_only:
             return []
 
-        items = []
+        blocks = []
 
         qualifiers = qualifiers.copy() if qualifiers else {}  # copy the qualifiers (destructively manipulated here)
         category = qualifiers.pop('category', None)
@@ -760,9 +760,9 @@ class XMLModuleStore(ModuleStoreReadBase):
 
         for block_loc, block in self.modules[course_id].items():
             if _block_matches_all(block_loc, block):
-                items.append(block)
+                blocks.append(block)
 
-        return items
+        return blocks
 
     def make_course_key(self, org, course, run):
         """
@@ -782,7 +782,7 @@ class XMLModuleStore(ModuleStoreReadBase):
 
     def get_courses(self, **kwargs):
         """
-        Returns a list of course descriptors.  If there were errors on loading,
+        Returns a list of course blocks.  If there were errors on loading,
         some of these may be ErrorBlock instead.
         """
         return list(self.courses.values())
@@ -900,26 +900,26 @@ class LibraryXMLModuleStore(XMLModuleStore):
         return LibraryLocator(org=org, library=library)
 
     @staticmethod
-    def patch_descriptor_kvs(library_descriptor):
+    def patch_block_kvs(library_block):
         """
         Metadata inheritance can be done purely through XBlocks, but in the import phase
         a root block with an InheritanceKeyValueStore is assumed to be at the top of the hierarchy.
         This should change in the future, but as XBlocks don't have this KVS, we have to patch it
         here manually.
         """
-        init_dict = {key: getattr(library_descriptor, key) for key in library_descriptor.fields.keys()}
+        init_dict = {key: getattr(library_block, key) for key in library_block.fields.keys()}
         # if set, invalidate '_unwrapped_field_data' so it will be reset
         # the next time it will be called
-        lazy.invalidate(library_descriptor, '_unwrapped_field_data')
+        lazy.invalidate(library_block, '_unwrapped_field_data')
         # pylint: disable=protected-access
-        library_descriptor._field_data = inheriting_field_data(InheritanceKeyValueStore(init_dict))
+        library_block._field_data = inheriting_field_data(InheritanceKeyValueStore(init_dict))
 
-    def content_importers(self, system, course_descriptor, course_dir, url_name):
+    def content_importers(self, system, course_block, course_dir, url_name):
         """
         Handle Metadata inheritance for Libraries.
         """
-        self.patch_descriptor_kvs(course_descriptor)
-        compute_inherited_metadata(course_descriptor)
+        self.patch_block_kvs(course_block)
+        compute_inherited_metadata(course_block)
 
     def get_library(self, library_id, depth=0, **kwargs):  # pylint: disable=unused-argument
         """
@@ -932,11 +932,11 @@ class LibraryXMLModuleStore(XMLModuleStore):
         return None
 
     @staticmethod
-    def id_from_descriptor(descriptor):
+    def id_from_block(block):
         """
-        Get the Library Key from the Library descriptor.
+        Get the Library Key from the Library block.
         """
-        return descriptor.location.library_key
+        return block.location.library_key
 
     def get_orphans(self, course_key, **kwargs):
         """

--- a/xmodule/modulestore/xml_exporter.py
+++ b/xmodule/modulestore/xml_exporter.py
@@ -111,7 +111,7 @@ class ExportManager:
 
         `modulestore`: A `ModuleStore` object that is the source of the blocks to export
         `contentstore`: A `ContentStore` object that is the source of the content to export, can be None
-        `courselike_key`: The Locator of the Descriptor to export
+        `courselike_key`: The Locator of the block to export
         `root_dir`: The directory to write the exported xml to
         `target_dir`: The name of the directory inside `root_dir` to write the content to
         """

--- a/xmodule/modulestore/xml_importer.py
+++ b/xmodule/modulestore/xml_importer.py
@@ -457,7 +457,7 @@ class ImportManager:
     @abstractmethod
     def get_courselike(self, courselike_key, runtime, dest_id):
         """
-        Given a key, a runtime, and an intended destination key, get the descriptor for the courselike
+        Given a key, a runtime, and an intended destination key, get the block for the courselike
         we'll be importing into.
         """
         raise NotImplementedError
@@ -739,7 +739,7 @@ class LibraryImportManager(ImportManager):
 
     def get_courselike(self, courselike_key, runtime, dest_id):
         """
-        Get the descriptor of the library from the XML import modulestore.
+        Get the block of the library from the XML import modulestore.
         """
         source_library = self.xml_module_store.get_library(courselike_key)
         library, library_data_path = self.import_courselike(
@@ -974,7 +974,7 @@ def _import_course_draft(
         # in the list of children since they would have been
         # filtered out from the non-draft store export.
         if parent_url is not None and index is not None:
-            course_key = descriptor.location.course_key
+            course_key = block.location.course_key
             parent_location = UsageKey.from_string(parent_url).map_into_course(course_key)
 
             # IMPORTANT: Be sure to update the parent in the NEW namespace
@@ -1018,7 +1018,7 @@ def _import_course_draft(
                     # Therefore only process verticals at the unit level, assuming that any other
                     # verticals must be descendants.
                     if 'index_in_children_list' in xml:
-                        descriptor = system.process_xml(xml)
+                        block = system.process_xml(xml)
 
                         # HACK: since we are doing partial imports of drafts
                         # the vertical doesn't have the 'url-name' set in the
@@ -1026,14 +1026,14 @@ def _import_course_draft(
                         # aka sequential), so we have to replace the location.name
                         # with the XML filename that is part of the pack
                         filename, __ = os.path.splitext(filename)
-                        descriptor.location = descriptor.location.replace(name=filename)
+                        block.location = block.location.replace(name=filename)
 
-                        index = index_in_children_list(descriptor)
-                        parent_url = get_parent_url(descriptor, xml)
-                        draft_url = str(descriptor.location)
+                        index = index_in_children_list(block)
+                        parent_url = get_parent_url(block, xml)
+                        draft_url = str(block.location)
 
                         draft = draft_node_constructor(
-                            block=descriptor, url=draft_url, parent_url=parent_url, index=index
+                            block=block, url=draft_url, parent_url=parent_url, index=index
                         )
                         drafts.append(draft)
 
@@ -1047,7 +1047,7 @@ def _import_course_draft(
         try:
             _import_block(draft.module)
         except Exception:  # pylint: disable=broad-except
-            logging.exception(f'Course import {source_course_id}: while importing draft descriptor {draft.module}')
+            logging.exception(f'Course import {source_course_id}: while importing draft block {draft.module}')
 
 
 def allowed_metadata_by_category(category):

--- a/xmodule/randomize_block.py
+++ b/xmodule/randomize_block.py
@@ -85,7 +85,7 @@ class RandomizeBlock(
 
         return child
 
-    def get_child_descriptors(self):
+    def get_child_blocks(self):
         """
         For grading--return just the chosen child.
         """
@@ -99,7 +99,7 @@ class RandomizeBlock(
         The student view.
         """
         if self.child is None:
-            # raise error instead?  In fact, could complain on descriptor load...
+            # raise error instead?  In fact, could complain on block load...
             return Fragment(content="<div>Nothing to randomize between</div>")
 
         return self.child.render(STUDENT_VIEW, context)
@@ -120,6 +120,6 @@ class RandomizeBlock(
     def has_dynamic_children(self):
         """
         Grading needs to know that only one of the children is actually "real".  This
-        makes it use block.get_child_descriptors().
+        makes it use block.get_child_blocks().
         """
         return True

--- a/xmodule/services.py
+++ b/xmodule/services.py
@@ -190,7 +190,7 @@ class RebindUserService(Service):
             log.error(err_msg)
             raise RebindUserServiceError(err_msg)
 
-        field_data_cache_real_user = FieldDataCache.cache_for_descriptor_descendents(
+        field_data_cache_real_user = FieldDataCache.cache_for_block_descendents(
             self.course_id,
             real_user,
             block,

--- a/xmodule/split_test_block.py
+++ b/xmodule/split_test_block.py
@@ -177,13 +177,13 @@ class SplitTestBlock(  # lint-amnesty, pylint: disable=abstract-method
     }
 
     @cached_property
-    def child_descriptor(self):
+    def child_block(self):
         """
         Return the child block for the partition or None.
         """
-        child_descriptors = self.get_child_descriptors()
-        if len(child_descriptors) >= 1:
-            return child_descriptors[0]
+        child_blocks = self.get_child_blocks()
+        if len(child_blocks) >= 1:
+            return child_blocks[0]
         return None
 
     @cached_property
@@ -191,15 +191,15 @@ class SplitTestBlock(  # lint-amnesty, pylint: disable=abstract-method
         """
         Return the user bound child block for the partition or None.
         """
-        if self.child_descriptor is not None:
-            return self.runtime.get_block_for_descriptor(self.child_descriptor)
+        if self.child_block is not None:
+            return self.runtime.get_block_for_descriptor(self.child_block)
         else:
             return None
 
-    def get_child_descriptor_by_location(self, location):
+    def get_child_block_by_location(self, location):
         """
         Look through the children and look for one with the given location.
-        Returns the descriptor.
+        Returns the block.
         If none match, return None
         """
         for child in self.get_children():
@@ -227,7 +227,7 @@ class SplitTestBlock(  # lint-amnesty, pylint: disable=abstract-method
         """
         return self.child.get_content_titles()
 
-    def get_child_descriptors(self):
+    def get_child_blocks(self):
         """
         For grading--return just the chosen child.
         """
@@ -239,19 +239,19 @@ class SplitTestBlock(  # lint-amnesty, pylint: disable=abstract-method
         str_group_id = str(group_id)
         if str_group_id in self.group_id_to_child:
             child_location = self.group_id_to_child[str_group_id]
-            child_descriptor = self.get_child_descriptor_by_location(child_location)
+            child_block = self.get_child_block_by_location(child_location)
         else:
             # Oops.  Config error.
             log.debug("configuration error in split test block: invalid group_id %r (not one of %r).  Showing error", str_group_id, list(self.group_id_to_child.keys()))  # lint-amnesty, pylint: disable=line-too-long
 
-        if child_descriptor is None:
-            # Peak confusion is great.  Now that we set child_descriptor,
+        if child_block is None:
+            # Peak confusion is great.  Now that we set child_block,
             # get_children() should return a list with one element--the
             # xmodule for the child
             log.debug("configuration error in split test block: no such child")
             return []
 
-        return [child_descriptor]
+        return [child_block]
 
     def get_group_id(self):
         """
@@ -271,8 +271,8 @@ class SplitTestBlock(  # lint-amnesty, pylint: disable=abstract-method
         inactive_contents = []
 
         for child_location in self.children:  # pylint: disable=no-member
-            child_descriptor = self.get_child_descriptor_by_location(child_location)
-            child = self.runtime.get_block_for_descriptor(child_descriptor)
+            child_block = self.get_child_block_by_location(child_location)
+            child = self.runtime.get_block_for_descriptor(child_block)
             rendered_child = child.render(STUDENT_VIEW, context)
             fragment.add_fragment_resources(rendered_child)
             group_name, updated_group_id = self.get_data_for_vertical(child)
@@ -346,8 +346,8 @@ class SplitTestBlock(  # lint-amnesty, pylint: disable=abstract-method
         dependencies are added to the specified fragment.
         """
         html = ""
-        for active_child_descriptor in children:
-            active_child = self.runtime.get_block_for_descriptor(active_child_descriptor)
+        for active_child_block in children:
+            active_child = self.runtime.get_block_for_descriptor(active_child_block)
             rendered_child = active_child.render(StudioEditableBlock.get_preview_view_name(active_child), context)
             if active_child.category == 'vertical':
                 group_name, group_id = self.get_data_for_vertical(active_child)
@@ -378,7 +378,7 @@ class SplitTestBlock(  # lint-amnesty, pylint: disable=abstract-method
         conditions for staff.
         """
         if self.child is None:
-            # raise error instead?  In fact, could complain on descriptor load...
+            # raise error instead?  In fact, could complain on block load...
             return Fragment(content="<div>Nothing here.  Move along.</div>")
 
         if self.runtime.user_is_staff:
@@ -464,8 +464,8 @@ class SplitTestBlock(  # lint-amnesty, pylint: disable=abstract-method
 
         for child in xml_object:
             try:
-                descriptor = system.process_xml(etree.tostring(child))
-                children.append(descriptor.scope_ids.usage_id)
+                block = system.process_xml(etree.tostring(child))
+                children.append(block.scope_ids.usage_id)
             except Exception:  # lint-amnesty, pylint: disable=broad-except
                 msg = "Unable to load child when parsing split_test block."
                 log.exception(msg)
@@ -486,7 +486,7 @@ class SplitTestBlock(  # lint-amnesty, pylint: disable=abstract-method
     def has_dynamic_children(self):
         """
         Grading needs to know that only one of the children is actually "real".  This
-        makes it use block.get_child_descriptors().
+        makes it use block.get_child_blocks().
         """
         return True
 
@@ -561,9 +561,9 @@ class SplitTestBlock(  # lint-amnesty, pylint: disable=abstract-method
         if not user_partition:
             return [], children
 
-        def get_child_descriptor(location):
+        def get_child_block(location):
             """
-            Returns the child descriptor which matches the specified location, or None if one is not found.
+            Returns the child block which matches the specified location, or None if one is not found.
             """
             for child in children:
                 if child.location == location:
@@ -575,7 +575,7 @@ class SplitTestBlock(  # lint-amnesty, pylint: disable=abstract-method
         for group in user_partition.groups:
             group_id = str(group.id)
             child_location = self.group_id_to_child.get(group_id, None)
-            child = get_child_descriptor(child_location)
+            child = get_child_block(child_location)
             if child:
                 active_children.append(child)
 

--- a/xmodule/studio_editable.py
+++ b/xmodule/studio_editable.py
@@ -51,8 +51,8 @@ class StudioEditableBlock(XBlockMixin):
         return AUTHOR_VIEW if has_author_view(block) else STUDENT_VIEW
 
 
-def has_author_view(descriptor):
+def has_author_view(block):
     """
-    Returns True if the xmodule linked to the descriptor supports "author_view".
+    Returns True if the xmodule linked to the block supports "author_view".
     """
-    return getattr(descriptor, 'has_author_view', False)
+    return getattr(block, 'has_author_view', False)

--- a/xmodule/templates.py
+++ b/xmodule/templates.py
@@ -21,13 +21,13 @@ log = logging.getLogger(__name__)
 
 def all_templates():
     """
-    Returns all templates for enabled modules, grouped by descriptor type
+    Returns all templates for enabled modules, grouped by block type
     """
     # TODO use memcache to memoize w/ expiration
     templates = defaultdict(list)
-    for category, descriptor in XBlock.load_classes():
-        if not hasattr(descriptor, 'templates'):
+    for category, block in XBlock.load_classes():
+        if not hasattr(block, 'templates'):
             continue
-        templates[category] = descriptor.templates()
+        templates[category] = block.templates()
 
     return templates

--- a/xmodule/tests/__init__.py
+++ b/xmodule/tests/__init__.py
@@ -191,7 +191,7 @@ def prepare_block_runtime(
     add_get_block=False,
 ):
     """
-    Sets properties in the runtime of the specified descriptor that is
+    Sets properties in the runtime of the specified block that is
     required for tests.
     """
 

--- a/xmodule/tests/test_capa_block.py
+++ b/xmodule/tests/test_capa_block.py
@@ -2492,22 +2492,22 @@ class ProblemBlockXMLTest(unittest.TestCase):  # lint-amnesty, pylint: disable=m
         </problem>
     """)
 
-    def _create_descriptor(self, xml, name=None):
+    def _create_block(self, xml, name=None):
         """ Creates a ProblemBlock to run test against """
-        descriptor = CapaFactory.create()
-        descriptor.data = xml
+        block = CapaFactory.create()
+        block.data = xml
         if name:
-            descriptor.display_name = name
-        return descriptor
+            block.display_name = name
+        return block
 
     @ddt.data(*sorted(responsetypes.registry.registered_tags()))
     def test_all_response_types(self, response_tag):
         """ Tests that every registered response tag is correctly returned """
         xml = "<problem><{response_tag}></{response_tag}></problem>".format(response_tag=response_tag)
         name = "Some Capa Problem"
-        descriptor = self._create_descriptor(xml, name=name)
-        assert descriptor.problem_types == {response_tag}
-        assert descriptor.index_dictionary() ==\
+        block = self._create_block(xml, name=name)
+        assert block.problem_types == {response_tag}
+        assert block.index_dictionary() ==\
                {'content_type': ProblemBlock.INDEX_CONTENT_TYPE,
                 'problem_types': [response_tag],
                 'content': {'display_name': name, 'capa_content': ''}}
@@ -2528,9 +2528,9 @@ class ProblemBlockXMLTest(unittest.TestCase):  # lint-amnesty, pylint: disable=m
             </problem>
         """)
         name = "Test Capa Problem"
-        descriptor = self._create_descriptor(xml, name=name)
-        assert descriptor.problem_types == {'multiplechoiceresponse'}
-        assert descriptor.index_dictionary() ==\
+        block = self._create_block(xml, name=name)
+        assert block.problem_types == {'multiplechoiceresponse'}
+        assert block.index_dictionary() ==\
                {'content_type': ProblemBlock.INDEX_CONTENT_TYPE,
                 'problem_types': ['multiplechoiceresponse'],
                 'content': {'display_name': name, 'capa_content': ' Label Some comment Apple Banana Chocolate Donut '}}
@@ -2556,14 +2556,14 @@ class ProblemBlockXMLTest(unittest.TestCase):  # lint-amnesty, pylint: disable=m
             </problem>
         """)
         name = "Other Test Capa Problem"
-        descriptor = self._create_descriptor(xml, name=name)
-        assert descriptor.problem_types == {'multiplechoiceresponse', 'optionresponse'}
+        block = self._create_block(xml, name=name)
+        assert block.problem_types == {'multiplechoiceresponse', 'optionresponse'}
 
         # We are converting problem_types to a set to compare it later without taking into account the order
         # the reasoning behind is that the problem_types (property) is represented by dict and when it is converted
         # to list its ordering is different everytime.
 
-        indexing_result = descriptor.index_dictionary()
+        indexing_result = block.index_dictionary()
         indexing_result['problem_types'] = set(indexing_result['problem_types'])
         self.assertDictEqual(
             indexing_result, {
@@ -2608,15 +2608,15 @@ class ProblemBlockXMLTest(unittest.TestCase):  # lint-amnesty, pylint: disable=m
             </problem>
         """)
         name = "Blank Common Capa Problem"
-        descriptor = self._create_descriptor(xml, name=name)
-        assert descriptor.index_dictionary() ==\
+        block = self._create_block(xml, name=name)
+        assert block.index_dictionary() ==\
                {'content_type': ProblemBlock.INDEX_CONTENT_TYPE,
                 'problem_types': [],
                 'content': {'display_name': name, 'capa_content': ' '}}
 
     def test_indexing_checkboxes(self):
         name = "Checkboxes"
-        descriptor = self._create_descriptor(self.sample_checkbox_problem_xml, name=name)
+        block = self._create_block(self.sample_checkbox_problem_xml, name=name)
         capa_content = textwrap.dedent("""
             Title
             Description
@@ -2629,30 +2629,30 @@ class ProblemBlockXMLTest(unittest.TestCase):  # lint-amnesty, pylint: disable=m
             Hungarian
             Note: Make sure you select all of the correct options—there may be more than one!
         """)
-        assert descriptor.problem_types == {'choiceresponse'}
-        assert descriptor.index_dictionary() ==\
+        assert block.problem_types == {'choiceresponse'}
+        assert block.index_dictionary() ==\
                {'content_type': ProblemBlock.INDEX_CONTENT_TYPE,
                 'problem_types': ['choiceresponse'],
                 'content': {'display_name': name, 'capa_content': capa_content.replace('\n', ' ')}}
 
     def test_indexing_dropdown(self):
         name = "Dropdown"
-        descriptor = self._create_descriptor(self.sample_dropdown_problem_xml, name=name)
+        block = self._create_block(self.sample_dropdown_problem_xml, name=name)
         capa_content = textwrap.dedent("""
             Dropdown problems allow learners to select only one option from a list of options.
             Description
             You can use the following example problem as a model.
             Which of the following countries celebrates its independence on August 15? 'India','Spain','China','Bermuda'
         """)
-        assert descriptor.problem_types == {'optionresponse'}
-        assert descriptor.index_dictionary() ==\
+        assert block.problem_types == {'optionresponse'}
+        assert block.index_dictionary() ==\
                {'content_type': ProblemBlock.INDEX_CONTENT_TYPE,
                 'problem_types': ['optionresponse'],
                 'content': {'display_name': name, 'capa_content': capa_content.replace('\n', ' ')}}
 
     def test_indexing_multiple_choice(self):
         name = "Multiple Choice"
-        descriptor = self._create_descriptor(self.sample_multichoice_problem_xml, name=name)
+        block = self._create_block(self.sample_multichoice_problem_xml, name=name)
         capa_content = textwrap.dedent("""
             Multiple choice problems allow learners to select only one option.
             When you add the problem, be sure to select Settings to specify a Display Name and other values.
@@ -2663,15 +2663,15 @@ class ProblemBlockXMLTest(unittest.TestCase):  # lint-amnesty, pylint: disable=m
             Indonesia
             Russia
         """)
-        assert descriptor.problem_types == {'multiplechoiceresponse'}
-        assert descriptor.index_dictionary() ==\
+        assert block.problem_types == {'multiplechoiceresponse'}
+        assert block.index_dictionary() ==\
                {'content_type': ProblemBlock.INDEX_CONTENT_TYPE,
                 'problem_types': ['multiplechoiceresponse'],
                 'content': {'display_name': name, 'capa_content': capa_content.replace('\n', ' ')}}
 
     def test_indexing_numerical_input(self):
         name = "Numerical Input"
-        descriptor = self._create_descriptor(self.sample_numerical_input_problem_xml, name=name)
+        block = self._create_block(self.sample_numerical_input_problem_xml, name=name)
         capa_content = textwrap.dedent("""
             In a numerical input problem, learners enter numbers or a specific and relatively simple mathematical
             expression. Learners enter the response in plain text, and the system then converts the text to a symbolic
@@ -2685,15 +2685,15 @@ class ProblemBlockXMLTest(unittest.TestCase):  # lint-amnesty, pylint: disable=m
             How many miles away from Earth is the sun? Use scientific notation to answer.
             The square of what number is -100?
         """)
-        assert descriptor.problem_types == {'numericalresponse'}
-        assert descriptor.index_dictionary() ==\
+        assert block.problem_types == {'numericalresponse'}
+        assert block.index_dictionary() ==\
                {'content_type': ProblemBlock.INDEX_CONTENT_TYPE,
                 'problem_types': ['numericalresponse'],
                 'content': {'display_name': name, 'capa_content': capa_content.replace('\n', ' ')}}
 
     def test_indexing_text_input(self):
         name = "Text Input"
-        descriptor = self._create_descriptor(self.sample_text_input_problem_xml, name=name)
+        block = self._create_block(self.sample_text_input_problem_xml, name=name)
         capa_content = textwrap.dedent("""
             In text input problems, also known as "fill-in-the-blank" problems, learners enter text into a response
             field. The text can include letters and characters such as punctuation marks. The text that the learner
@@ -2704,8 +2704,8 @@ class ProblemBlockXMLTest(unittest.TestCase):  # lint-amnesty, pylint: disable=m
             You can use the following example problem as a model.
             What was the first post-secondary school in China to allow both male and female students?
         """)
-        assert descriptor.problem_types == {'stringresponse'}
-        assert descriptor.index_dictionary() ==\
+        assert block.problem_types == {'stringresponse'}
+        assert block.index_dictionary() ==\
                {'content_type': ProblemBlock.INDEX_CONTENT_TYPE,
                 'problem_types': ['stringresponse'],
                 'content': {'display_name': name, 'capa_content': capa_content.replace('\n', ' ')}}
@@ -2718,15 +2718,15 @@ class ProblemBlockXMLTest(unittest.TestCase):  # lint-amnesty, pylint: disable=m
             </problem>
         """)
         name = "Non latin Input"
-        descriptor = self._create_descriptor(sample_text_input_problem_xml, name=name)
+        block = self._create_block(sample_text_input_problem_xml, name=name)
         capa_content = " Δοκιμή με μεταβλητές με Ελληνικούς χαρακτήρες μέσα σε python: $FX1_VAL "
 
-        descriptor_dict = descriptor.index_dictionary()
-        assert descriptor_dict['content']['capa_content'] == smart_str(capa_content)
+        block_dict = block.index_dictionary()
+        assert block_dict['content']['capa_content'] == smart_str(capa_content)
 
     def test_indexing_checkboxes_with_hints_and_feedback(self):
         name = "Checkboxes with Hints and Feedback"
-        descriptor = self._create_descriptor(self.sample_checkboxes_with_hints_and_feedback_problem_xml, name=name)
+        block = self._create_block(self.sample_checkboxes_with_hints_and_feedback_problem_xml, name=name)
         capa_content = textwrap.dedent("""
             You can provide feedback for each option in a checkbox problem, with distinct feedback depending on
             whether or not the learner selects that option.
@@ -2742,15 +2742,15 @@ class ProblemBlockXMLTest(unittest.TestCase):  # lint-amnesty, pylint: disable=m
             potato
             tomato
         """)
-        assert descriptor.problem_types == {'choiceresponse'}
-        assert descriptor.index_dictionary() ==\
+        assert block.problem_types == {'choiceresponse'}
+        assert block.index_dictionary() ==\
                {'content_type': ProblemBlock.INDEX_CONTENT_TYPE,
                 'problem_types': ['choiceresponse'],
                 'content': {'display_name': name, 'capa_content': capa_content.replace('\n', ' ')}}
 
     def test_indexing_dropdown_with_hints_and_feedback(self):
         name = "Dropdown with Hints and Feedback"
-        descriptor = self._create_descriptor(self.sample_dropdown_with_hints_and_feedback_problem_xml, name=name)
+        block = self._create_block(self.sample_dropdown_with_hints_and_feedback_problem_xml, name=name)
         capa_content = textwrap.dedent("""
             You can provide feedback for each available option in a dropdown problem.
             You can also add hints for learners.
@@ -2762,15 +2762,15 @@ class ProblemBlockXMLTest(unittest.TestCase):  # lint-amnesty, pylint: disable=m
             potato
             tomato
         """)
-        assert descriptor.problem_types == {'optionresponse'}
-        assert descriptor.index_dictionary() ==\
+        assert block.problem_types == {'optionresponse'}
+        assert block.index_dictionary() ==\
                {'content_type': ProblemBlock.INDEX_CONTENT_TYPE,
                 'problem_types': ['optionresponse'],
                 'content': {'display_name': name, 'capa_content': capa_content.replace('\n', ' ')}}
 
     def test_indexing_multiple_choice_with_hints_and_feedback(self):
         name = "Multiple Choice with Hints and Feedback"
-        descriptor = self._create_descriptor(self.sample_multichoice_with_hints_and_feedback_problem_xml, name=name)
+        block = self._create_block(self.sample_multichoice_with_hints_and_feedback_problem_xml, name=name)
         capa_content = textwrap.dedent("""
             You can provide feedback for each option in a multiple choice problem.
             You can also add hints for learners.
@@ -2782,15 +2782,15 @@ class ProblemBlockXMLTest(unittest.TestCase):  # lint-amnesty, pylint: disable=m
             potato
             tomato
         """)
-        assert descriptor.problem_types == {'multiplechoiceresponse'}
-        assert descriptor.index_dictionary() ==\
+        assert block.problem_types == {'multiplechoiceresponse'}
+        assert block.index_dictionary() ==\
                {'content_type': ProblemBlock.INDEX_CONTENT_TYPE,
                 'problem_types': ['multiplechoiceresponse'],
                 'content': {'display_name': name, 'capa_content': capa_content.replace('\n', ' ')}}
 
     def test_indexing_numerical_input_with_hints_and_feedback(self):
         name = "Numerical Input with Hints and Feedback"
-        descriptor = self._create_descriptor(self.sample_numerical_input_with_hints_and_feedback_problem_xml, name=name)
+        block = self._create_block(self.sample_numerical_input_with_hints_and_feedback_problem_xml, name=name)
         capa_content = textwrap.dedent("""
             You can provide feedback for correct answers in numerical input problems. You cannot provide feedback
             for incorrect answers.
@@ -2800,15 +2800,15 @@ class ProblemBlockXMLTest(unittest.TestCase):  # lint-amnesty, pylint: disable=m
             Use the following example problem as a model.
             What is the arithmetic mean for the following set of numbers? (1, 5, 6, 3, 5)
         """)
-        assert descriptor.problem_types == {'numericalresponse'}
-        assert descriptor.index_dictionary() ==\
+        assert block.problem_types == {'numericalresponse'}
+        assert block.index_dictionary() ==\
                {'content_type': ProblemBlock.INDEX_CONTENT_TYPE,
                 'problem_types': ['numericalresponse'],
                 'content': {'display_name': name, 'capa_content': capa_content.replace('\n', ' ')}}
 
     def test_indexing_text_input_with_hints_and_feedback(self):
         name = "Text Input with Hints and Feedback"
-        descriptor = self._create_descriptor(self.sample_text_input_with_hints_and_feedback_problem_xml, name=name)
+        block = self._create_block(self.sample_text_input_with_hints_and_feedback_problem_xml, name=name)
         capa_content = textwrap.dedent("""
             You can provide feedback for the correct answer in text input problems, as well as for specific
             incorrect answers.
@@ -2818,8 +2818,8 @@ class ProblemBlockXMLTest(unittest.TestCase):  # lint-amnesty, pylint: disable=m
             Use the following example problem as a model.
             Which U.S. state has the largest land area?
         """)
-        assert descriptor.problem_types == {'stringresponse'}
-        assert descriptor.index_dictionary() ==\
+        assert block.problem_types == {'stringresponse'}
+        assert block.index_dictionary() ==\
                {'content_type': ProblemBlock.INDEX_CONTENT_TYPE,
                 'problem_types': ['stringresponse'],
                 'content': {'display_name': name, 'capa_content': capa_content.replace('\n', ' ')}}
@@ -2840,12 +2840,12 @@ class ProblemBlockXMLTest(unittest.TestCase):  # lint-amnesty, pylint: disable=m
             </problem>
         """)
         name = "Mixed business"
-        descriptor = self._create_descriptor(sample_problem_xml, name=name)
+        block = self._create_block(sample_problem_xml, name=name)
         capa_content = textwrap.dedent("""
             This has HTML comment in it.
             HTML end.
         """)
-        assert descriptor.index_dictionary() ==\
+        assert block.index_dictionary() ==\
                {'content_type': ProblemBlock.INDEX_CONTENT_TYPE,
                 'problem_types': [],
                 'content': {'display_name': name, 'capa_content': capa_content.replace('\n', ' ')}}
@@ -2860,7 +2860,7 @@ class ProblemBlockXMLTest(unittest.TestCase):  # lint-amnesty, pylint: disable=m
             </proble-oh no my finger broke and I can't close the problem tag properly...
         """)
         with pytest.raises(etree.XMLSyntaxError):
-            self._create_descriptor(sample_invalid_xml, name="Invalid XML")
+            self._create_block(sample_invalid_xml, name="Invalid XML")
 
     def test_invalid_dropdown_xml(self):
         """
@@ -3226,29 +3226,29 @@ class ProblemBlockReportGenerationTest(unittest.TestCase):
             scope=None,
         )
 
-    def _get_descriptor(self):  # lint-amnesty, pylint: disable=missing-function-docstring
+    def _get_block(self):  # lint-amnesty, pylint: disable=missing-function-docstring
         scope_ids = Mock(block_type='problem')
-        descriptor = ProblemBlock(get_test_system(), scope_ids=scope_ids)
-        descriptor.runtime = Mock()
-        descriptor.data = '<problem/>'
-        return descriptor
+        block = ProblemBlock(get_test_system(), scope_ids=scope_ids)
+        block.runtime = Mock()
+        block.data = '<problem/>'
+        return block
 
     def test_generate_report_data_not_implemented(self):
         scope_ids = Mock(block_type='noproblem')
-        descriptor = ProblemBlock(get_test_system(), scope_ids=scope_ids)
+        block = ProblemBlock(get_test_system(), scope_ids=scope_ids)
         with pytest.raises(NotImplementedError):
-            next(descriptor.generate_report_data(iter([])))
+            next(block.generate_report_data(iter([])))
 
     def test_generate_report_data_limit_responses(self):
-        descriptor = self._get_descriptor()
-        report_data = list(descriptor.generate_report_data(self._mock_user_state_generator(), 2))
+        block = self._get_block()
+        report_data = list(block.generate_report_data(self._mock_user_state_generator(), 2))
         assert 2 == len(report_data)
 
     def test_generate_report_data_dont_limit_responses(self):
-        descriptor = self._get_descriptor()
+        block = self._get_block()
         user_count = 5
         response_count = 10
-        report_data = list(descriptor.generate_report_data(
+        report_data = list(block.generate_report_data(
             self._mock_user_state_generator(
                 user_count=user_count,
                 response_count=response_count,
@@ -3257,17 +3257,17 @@ class ProblemBlockReportGenerationTest(unittest.TestCase):
         assert (user_count * response_count) == len(report_data)
 
     def test_generate_report_data_skip_dynamath(self):
-        descriptor = self._get_descriptor()
+        block = self._get_block()
         iterator = iter([self._user_state(suffix='_dynamath')])
-        report_data = list(descriptor.generate_report_data(iterator))
+        report_data = list(block.generate_report_data(iterator))
         assert 0 == len(report_data)
 
     def test_generate_report_data_report_loncapa_error(self):
         #Test to make sure reports continue despite loncappa errors, and write them into the report.
-        descriptor = self._get_descriptor()
+        block = self._get_block()
         with patch('xmodule.capa_block.LoncapaProblem') as mock_LoncapaProblem:
             mock_LoncapaProblem.side_effect = LoncapaProblemError
-            report_data = list(descriptor.generate_report_data(
+            report_data = list(block.generate_report_data(
                 self._mock_user_state_generator(
                     user_count=1,
                     response_count=5,

--- a/xmodule/tests/test_course_block.py
+++ b/xmodule/tests/test_course_block.py
@@ -235,36 +235,36 @@ class IsNewCourseTestCase(unittest.TestCase):
             assert d.start_date_is_still_default == s[3]
 
     def test_display_organization(self):
-        descriptor = get_dummy_course(start='2012-12-02T12:00', is_new=True)
-        assert descriptor.location.org != descriptor.display_org_with_default
-        assert descriptor.display_org_with_default == f'{ORG}_display'
+        block = get_dummy_course(start='2012-12-02T12:00', is_new=True)
+        assert block.location.org != block.display_org_with_default
+        assert block.display_org_with_default == f'{ORG}_display'
 
     def test_display_coursenumber(self):
-        descriptor = get_dummy_course(start='2012-12-02T12:00', is_new=True)
-        assert descriptor.location.course != descriptor.display_number_with_default
-        assert descriptor.display_number_with_default == f'{COURSE}_display'
+        block = get_dummy_course(start='2012-12-02T12:00', is_new=True)
+        assert block.location.course != block.display_number_with_default
+        assert block.display_number_with_default == f'{COURSE}_display'
 
     def test_is_newish(self):
-        descriptor = get_dummy_course(start='2012-12-02T12:00', is_new=True)
-        assert descriptor.is_newish is True
+        block = get_dummy_course(start='2012-12-02T12:00', is_new=True)
+        assert block.is_newish is True
 
-        descriptor = get_dummy_course(start='2013-02-02T12:00', is_new=False)
-        assert descriptor.is_newish is False
+        block = get_dummy_course(start='2013-02-02T12:00', is_new=False)
+        assert block.is_newish is False
 
-        descriptor = get_dummy_course(start='2013-02-02T12:00', is_new=True)
-        assert descriptor.is_newish is True
+        block = get_dummy_course(start='2013-02-02T12:00', is_new=True)
+        assert block.is_newish is True
 
-        descriptor = get_dummy_course(start='2013-01-15T12:00')
-        assert descriptor.is_newish is True
+        block = get_dummy_course(start='2013-01-15T12:00')
+        assert block.is_newish is True
 
-        descriptor = get_dummy_course(start='2013-03-01T12:00')
-        assert descriptor.is_newish is True
+        block = get_dummy_course(start='2013-03-01T12:00')
+        assert block.is_newish is True
 
-        descriptor = get_dummy_course(start='2012-10-15T12:00')
-        assert descriptor.is_newish is False
+        block = get_dummy_course(start='2012-10-15T12:00')
+        assert block.is_newish is False
 
-        descriptor = get_dummy_course(start='2012-12-31T12:00')
-        assert descriptor.is_newish is True
+        block = get_dummy_course(start='2012-12-31T12:00')
+        assert block.is_newish is True
 
 
 class DiscussionTopicsTestCase(unittest.TestCase):

--- a/xmodule/tests/test_error_block.py
+++ b/xmodule/tests/test_error_block.py
@@ -31,14 +31,14 @@ class TestErrorBlock(SetupTestErrorBlock):
     """
 
     def test_error_block_xml_rendering(self):
-        descriptor = ErrorBlock.from_xml(
+        block = ErrorBlock.from_xml(
             self.valid_xml,
             self.system,
             CourseLocationManager(self.course_id),
             self.error_msg
         )
-        assert isinstance(descriptor, ErrorBlock)
-        descriptor.runtime = self.system
-        context_repr = self.system.render(descriptor, STUDENT_VIEW).content
+        assert isinstance(block, ErrorBlock)
+        block.runtime = self.system
+        context_repr = self.system.render(block, STUDENT_VIEW).content
         assert self.error_msg in context_repr
         assert repr(self.valid_xml) in context_repr

--- a/xmodule/tests/test_export.py
+++ b/xmodule/tests/test_export.py
@@ -28,22 +28,22 @@ from xmodule.tests import DATA_DIR
 from xmodule.x_module import XModuleMixin
 
 
-def strip_filenames(descriptor):
+def strip_filenames(block):
     """
     Recursively strips 'filename' from all children's definitions.
     """
-    print(f"strip filename from {str(descriptor.location)}")
-    if descriptor._field_data.has(descriptor, 'filename'):  # lint-amnesty, pylint: disable=protected-access
-        descriptor._field_data.delete(descriptor, 'filename')  # lint-amnesty, pylint: disable=protected-access
+    print(f"strip filename from {str(block.location)}")
+    if block._field_data.has(block, 'filename'):  # lint-amnesty, pylint: disable=protected-access
+        block._field_data.delete(block, 'filename')  # lint-amnesty, pylint: disable=protected-access
 
-    if hasattr(descriptor, 'xml_attributes'):
-        if 'filename' in descriptor.xml_attributes:
-            del descriptor.xml_attributes['filename']
+    if hasattr(block, 'xml_attributes'):
+        if 'filename' in block.xml_attributes:
+            del block.xml_attributes['filename']
 
-    for child in descriptor.get_children():
+    for child in block.get_children():
         strip_filenames(child)
 
-    descriptor.save()
+    block.save()
 
 
 class PureXBlock(XBlock):

--- a/xmodule/tests/test_html_block.py
+++ b/xmodule/tests/test_html_block.py
@@ -16,9 +16,9 @@ from ..x_module import PUBLIC_VIEW, STUDENT_VIEW
 from . import get_test_descriptor_system, get_test_system
 
 
-def instantiate_descriptor(**field_data):
+def instantiate_block(**field_data):
     """
-    Instantiate descriptor with most properties.
+    Instantiate block with most properties.
     """
     system = get_test_descriptor_system()
     course_key = CourseLocator('org', 'course', 'run')
@@ -152,8 +152,8 @@ class HtmlBlockIndexingTestCase(unittest.TestCase):
                 <p>Hello World!</p>
             </html>
         '''
-        descriptor = instantiate_descriptor(data=sample_xml)
-        assert descriptor.index_dictionary() ==\
+        block = instantiate_block(data=sample_xml)
+        assert block.index_dictionary() ==\
                {'content': {'html_content': ' Hello World! ', 'display_name': 'Text'}, 'content_type': 'Text'}
 
     def test_index_dictionary_cdata_html_block(self):
@@ -163,8 +163,8 @@ class HtmlBlockIndexingTestCase(unittest.TestCase):
                 <![CDATA[This is just a CDATA!]]>
             </html>
         '''
-        descriptor = instantiate_descriptor(data=sample_xml_cdata)
-        assert descriptor.index_dictionary() ==\
+        block = instantiate_block(data=sample_xml_cdata)
+        assert block.index_dictionary() ==\
                {'content': {'html_content': ' This has CDATA in it. ', 'display_name': 'Text'}, 'content_type': 'Text'}
 
     def test_index_dictionary_multiple_spaces_html_block(self):
@@ -173,8 +173,8 @@ class HtmlBlockIndexingTestCase(unittest.TestCase):
                 <p>     Text has spaces :)  </p>
             </html>
         '''
-        descriptor = instantiate_descriptor(data=sample_xml_tab_spaces)
-        assert descriptor.index_dictionary() ==\
+        block = instantiate_block(data=sample_xml_tab_spaces)
+        assert block.index_dictionary() ==\
                {'content': {'html_content': ' Text has spaces :) ', 'display_name': 'Text'}, 'content_type': 'Text'}
 
     def test_index_dictionary_html_block_with_comment(self):
@@ -184,8 +184,8 @@ class HtmlBlockIndexingTestCase(unittest.TestCase):
                 <!-- Html Comment -->
             </html>
         '''
-        descriptor = instantiate_descriptor(data=sample_xml_comment)
-        assert descriptor.index_dictionary() == {'content': {'html_content': ' This has HTML comment in it. ', 'display_name': 'Text'}, 'content_type': 'Text'}  # pylint: disable=line-too-long
+        block = instantiate_block(data=sample_xml_comment)
+        assert block.index_dictionary() == {'content': {'html_content': ' This has HTML comment in it. ', 'display_name': 'Text'}, 'content_type': 'Text'}  # pylint: disable=line-too-long
 
     def test_index_dictionary_html_block_with_both_comments_and_cdata(self):
         sample_xml_mix_comment_cdata = '''
@@ -197,8 +197,8 @@ class HtmlBlockIndexingTestCase(unittest.TestCase):
                 <p>HTML end.</p>
             </html>
         '''
-        descriptor = instantiate_descriptor(data=sample_xml_mix_comment_cdata)
-        assert descriptor.index_dictionary() ==\
+        block = instantiate_block(data=sample_xml_mix_comment_cdata)
+        assert block.index_dictionary() ==\
                {'content': {'html_content': ' This has HTML comment in it. HTML end. ',
                             'display_name': 'Text'}, 'content_type': 'Text'}
 
@@ -216,8 +216,8 @@ class HtmlBlockIndexingTestCase(unittest.TestCase):
                 </script>
             </html>
         '''
-        descriptor = instantiate_descriptor(data=sample_xml_style_script_tags)
-        assert descriptor.index_dictionary() ==\
+        block = instantiate_block(data=sample_xml_style_script_tags)
+        assert block.index_dictionary() ==\
                {'content': {'html_content': ' This has HTML comment in it. HTML end. ',
                             'display_name': 'Text'}, 'content_type': 'Text'}
 

--- a/xmodule/tests/test_import.py
+++ b/xmodule/tests/test_import.py
@@ -106,9 +106,9 @@ class PureXBlockImportTest(BaseCourseTestCase):
     @patch('xmodule.x_module.XModuleMixin.location')
     def test_parsing_pure_xblock(self, xml, mock_location):
         system = self.get_system(load_error_blocks=False)
-        descriptor = system.process_xml(xml)
-        assert isinstance(descriptor, GenericXBlock)
-        self.assert_xblocks_are_good(descriptor)
+        block = system.process_xml(xml)
+        assert isinstance(block, GenericXBlock)
+        self.assert_xblocks_are_good(block)
         assert not mock_location.called
 
 
@@ -122,9 +122,9 @@ class ImportTestCase(BaseCourseTestCase):  # lint-amnesty, pylint: disable=missi
         bad_xml = '''<sequential display_name="oops\N{SNOWMAN}"><video url="hi"></sequential>'''
         system = self.get_system()
 
-        descriptor = system.process_xml(bad_xml)
+        block = system.process_xml(bad_xml)
 
-        assert descriptor.__class__.__name__ == 'ErrorBlockWithMixins'
+        assert block.__class__.__name__ == 'ErrorBlockWithMixins'
 
     def test_unique_url_names(self):
         '''Check that each error gets its very own url_name'''
@@ -132,19 +132,19 @@ class ImportTestCase(BaseCourseTestCase):  # lint-amnesty, pylint: disable=missi
         bad_xml2 = '''<sequential url_name="oops"><video url="hi"></sequential>'''
         system = self.get_system()
 
-        descriptor1 = system.process_xml(bad_xml)
-        descriptor2 = system.process_xml(bad_xml2)
+        block1 = system.process_xml(bad_xml)
+        block2 = system.process_xml(bad_xml2)
 
-        assert descriptor1.location != descriptor2.location
+        assert block1.location != block2.location
 
         # Check that each vertical gets its very own url_name
         bad_xml = '''<vertical display_name="abc"><problem url_name="exam1:2013_Spring:abc"/></vertical>'''
         bad_xml2 = '''<vertical display_name="abc"><problem url_name="exam2:2013_Spring:abc"/></vertical>'''
 
-        descriptor1 = system.process_xml(bad_xml)
-        descriptor2 = system.process_xml(bad_xml2)
+        block1 = system.process_xml(bad_xml)
+        block2 = system.process_xml(bad_xml2)
 
-        assert descriptor1.location != descriptor2.location
+        assert block1.location != block2.location
 
     def test_reimport(self):
         '''Make sure an already-exported error xml tag loads properly'''
@@ -152,16 +152,16 @@ class ImportTestCase(BaseCourseTestCase):  # lint-amnesty, pylint: disable=missi
         self.maxDiff = None
         bad_xml = '''<sequential display_name="oops"><video url="hi"></sequential>'''
         system = self.get_system()
-        descriptor = system.process_xml(bad_xml)
+        block = system.process_xml(bad_xml)
 
         node = etree.Element('unknown')
-        descriptor.add_xml_to_node(node)
-        re_import_descriptor = system.process_xml(etree.tostring(node))
+        block.add_xml_to_node(node)
+        re_import_block = system.process_xml(etree.tostring(node))
 
-        assert re_import_descriptor.__class__.__name__ == 'ErrorBlockWithMixins'
+        assert re_import_block.__class__.__name__ == 'ErrorBlockWithMixins'
 
-        assert descriptor.contents == re_import_descriptor.contents
-        assert descriptor.error_msg == re_import_descriptor.error_msg
+        assert block.contents == re_import_block.contents
+        assert block.error_msg == re_import_block.error_msg
 
     def test_fixed_xml_tag(self):
         """Make sure a tag that's been fixed exports as the original tag type"""
@@ -175,25 +175,25 @@ class ImportTestCase(BaseCourseTestCase):  # lint-amnesty, pylint: disable=missi
 
         # load it
         system = self.get_system()
-        descriptor = system.process_xml(xml_str_in)
+        block = system.process_xml(xml_str_in)
 
         # export it
         node = etree.Element('unknown')
-        descriptor.add_xml_to_node(node)
+        block.add_xml_to_node(node)
 
         # Now make sure the exported xml is a sequential
         assert node.tag == 'sequential'
 
-    def course_descriptor_inheritance_check(self, descriptor, from_date_string, unicorn_color, course_run=RUN):
+    def course_block_inheritance_check(self, block, from_date_string, unicorn_color, course_run=RUN):
         """
-        Checks to make sure that metadata inheritance on a course descriptor is respected.
+        Checks to make sure that metadata inheritance on a course block is respected.
         """
         # pylint: disable=protected-access
-        print((descriptor, descriptor._field_data))
-        assert descriptor.due == ImportTestCase.date.from_json(from_date_string)
+        print((block, block._field_data))
+        assert block.due == ImportTestCase.date.from_json(from_date_string)
 
         # Check that the child inherits due correctly
-        child = descriptor.get_children()[0]
+        child = block.get_children()[0]
         assert child.due == ImportTestCase.date.from_json(from_date_string)
         # need to convert v to canonical json b4 comparing
         assert ImportTestCase.date.to_json(ImportTestCase.date.from_json(from_date_string)) ==\
@@ -201,9 +201,9 @@ class ImportTestCase(BaseCourseTestCase):  # lint-amnesty, pylint: disable=missi
 
         # Now export and check things
         file_system = OSFS(mkdtemp())
-        descriptor.runtime.export_fs = file_system.makedir('course', recreate=True)
+        block.runtime.export_fs = file_system.makedir('course', recreate=True)
         node = etree.Element('unknown')
-        descriptor.add_xml_to_node(node)
+        block.add_xml_to_node(node)
 
         # Check that the exported xml is just a pointer
         print(("Exported xml:", etree.tostring(node)))
@@ -213,7 +213,7 @@ class ImportTestCase(BaseCourseTestCase):  # lint-amnesty, pylint: disable=missi
         assert node.attrib['org'] == ORG
 
         # Does the course still have unicorns?
-        with descriptor.runtime.export_fs.open(f'course/{course_run}.xml') as f:
+        with block.runtime.export_fs.open(f'course/{course_run}.xml') as f:
             course_xml = etree.fromstring(f.read())
 
         assert course_xml.attrib['unicorn'] == unicorn_color
@@ -227,7 +227,7 @@ class ImportTestCase(BaseCourseTestCase):  # lint-amnesty, pylint: disable=missi
 
         # Does the chapter tag now have a due attribute?
         # hardcoded path to child
-        with descriptor.runtime.export_fs.open('chapter/ch.xml') as f:
+        with block.runtime.export_fs.open('chapter/ch.xml') as f:
             chapter_xml = etree.fromstring(f.read())
         assert chapter_xml.tag == 'chapter'
         assert 'due' not in chapter_xml.attrib
@@ -250,9 +250,9 @@ class ImportTestCase(BaseCourseTestCase):  # lint-amnesty, pylint: disable=missi
         </course>'''.format(
             due=from_date_string, org=ORG, course=COURSE, url_name=url_name, unicorn_color=unicorn_color
         )
-        descriptor = system.process_xml(start_xml)
-        compute_inherited_metadata(descriptor)
-        self.course_descriptor_inheritance_check(descriptor, from_date_string, unicorn_color)
+        block = system.process_xml(start_xml)
+        compute_inherited_metadata(block)
+        self.course_block_inheritance_check(block, from_date_string, unicorn_color)
 
     def test_library_metadata_import_export(self):
         """Two checks:
@@ -274,18 +274,18 @@ class ImportTestCase(BaseCourseTestCase):  # lint-amnesty, pylint: disable=missi
         </library>'''.format(
             due=from_date_string, org=ORG, course=COURSE, url_name=url_name, unicorn_color=unicorn_color
         )
-        descriptor = system.process_xml(start_xml)
+        block = system.process_xml(start_xml)
 
         # pylint: disable=protected-access
-        original_unwrapped = descriptor._unwrapped_field_data
-        LibraryXMLModuleStore.patch_descriptor_kvs(descriptor)
-        # '_unwrapped_field_data' is reset in `patch_descriptor_kvs`
+        original_unwrapped = block._unwrapped_field_data
+        LibraryXMLModuleStore.patch_block_kvs(block)
+        # '_unwrapped_field_data' is reset in `patch_block_kvs`
         # pylint: disable=protected-access
-        assert original_unwrapped is not descriptor._unwrapped_field_data
-        compute_inherited_metadata(descriptor)
+        assert original_unwrapped is not block._unwrapped_field_data
+        compute_inherited_metadata(block)
         # Check the course block, since it has inheritance
-        descriptor = descriptor.get_children()[0]
-        self.course_descriptor_inheritance_check(descriptor, from_date_string, unicorn_color)
+        block = block.get_children()[0]
+        self.course_block_inheritance_check(block, from_date_string, unicorn_color)
 
     def test_metadata_no_inheritance(self):
         """
@@ -301,9 +301,9 @@ class ImportTestCase(BaseCourseTestCase):  # lint-amnesty, pylint: disable=missi
                 <html url_name="h" display_name="H">Two houses, ...</html>
             </chapter>
         </course>'''.format(org=ORG, course=COURSE, url_name=url_name)
-        descriptor = system.process_xml(start_xml)
-        compute_inherited_metadata(descriptor)
-        self.course_descriptor_no_inheritance_check(descriptor)
+        block = system.process_xml(start_xml)
+        compute_inherited_metadata(block)
+        self.course_block_no_inheritance_check(block)
 
     def test_library_metadata_no_inheritance(self):
         """
@@ -321,31 +321,31 @@ class ImportTestCase(BaseCourseTestCase):  # lint-amnesty, pylint: disable=missi
                 </chapter>
             </course>
         </library>'''.format(org=ORG, course=COURSE, url_name=url_name)
-        descriptor = system.process_xml(start_xml)
-        LibraryXMLModuleStore.patch_descriptor_kvs(descriptor)
-        compute_inherited_metadata(descriptor)
+        block = system.process_xml(start_xml)
+        LibraryXMLModuleStore.patch_block_kvs(block)
+        compute_inherited_metadata(block)
         # Run the checks on the course node instead.
-        descriptor = descriptor.get_children()[0]
-        self.course_descriptor_no_inheritance_check(descriptor)
+        block = block.get_children()[0]
+        self.course_block_no_inheritance_check(block)
 
-    def course_descriptor_no_inheritance_check(self, descriptor):
+    def course_block_no_inheritance_check(self, block):
         """
         Verifies that a default value of None (for due) does not get marked as inherited.
         """
-        assert descriptor.due is None
+        assert block.due is None
 
         # Check that the child does not inherit a value for due
-        child = descriptor.get_children()[0]
+        child = block.get_children()[0]
         assert child.due is None
 
         # Check that the child hasn't started yet
         assert datetime.datetime.now(UTC) <= child.start
 
-    def override_metadata_check(self, descriptor, child, course_due, child_due):
+    def override_metadata_check(self, block, child, course_due, child_due):
         """
         Verifies that due date can be overriden at child level.
         """
-        assert descriptor.due == ImportTestCase.date.from_json(course_due)
+        assert block.due == ImportTestCase.date.from_json(course_due)
         assert child.due == ImportTestCase.date.from_json(child_due)
         # Test inherited metadata. Due does not appear here (because explicitly set on child).
         assert ImportTestCase.date.to_json(ImportTestCase.date.from_json(course_due)) == child.xblock_kvs.inherited_settings['due']  # pylint: disable=line-too-long
@@ -365,12 +365,12 @@ class ImportTestCase(BaseCourseTestCase):  # lint-amnesty, pylint: disable=missi
                 <html url_name="h" display_name="H">Two houses, ...</html>
             </chapter>
         </course>'''.format(due=course_due, org=ORG, course=COURSE, url_name=url_name)
-        descriptor = system.process_xml(start_xml)
-        child = descriptor.get_children()[0]
+        block = system.process_xml(start_xml)
+        child = block.get_children()[0]
         # pylint: disable=protected-access
         child._field_data.set(child, 'due', child_due)
-        compute_inherited_metadata(descriptor)
-        self.override_metadata_check(descriptor, child, course_due, child_due)
+        compute_inherited_metadata(block)
+        self.override_metadata_check(block, child, course_due, child_due)
 
     def test_library_metadata_override_default(self):
         """
@@ -389,15 +389,15 @@ class ImportTestCase(BaseCourseTestCase):  # lint-amnesty, pylint: disable=missi
                 </chapter>
             </course>
         </library>'''.format(due=course_due, org=ORG, course=COURSE, url_name=url_name)
-        descriptor = system.process_xml(start_xml)
-        LibraryXMLModuleStore.patch_descriptor_kvs(descriptor)
+        block = system.process_xml(start_xml)
+        LibraryXMLModuleStore.patch_block_kvs(block)
         # Chapter is two levels down here.
-        child = descriptor.get_children()[0].get_children()[0]
+        child = block.get_children()[0].get_children()[0]
         # pylint: disable=protected-access
         child._field_data.set(child, 'due', child_due)
-        compute_inherited_metadata(descriptor)
-        descriptor = descriptor.get_children()[0]
-        self.override_metadata_check(descriptor, child, course_due, child_due)
+        compute_inherited_metadata(block)
+        block = block.get_children()[0]
+        self.override_metadata_check(block, child, course_due, child_due)
 
     def test_is_pointer_tag(self):
         """

--- a/xmodule/tests/test_library_content.py
+++ b/xmodule/tests/test_library_content.py
@@ -223,7 +223,7 @@ class LibraryContentBlockTestMixin:
         assert len(self.lc_block.children) == len(self.lib_blocks)
 
         # Check how many children each user will see:
-        assert len(self.lc_block.get_child_descriptors()) == 1
+        assert len(self.lc_block.get_child_blocks()) == 1
         # Check that get_content_titles() doesn't return titles for hidden/unused children
         assert len(self.lc_block.get_content_titles()) == 1
 
@@ -388,7 +388,7 @@ class LibraryContentBlockTestMixin:
         children, and asserts that the number of selected children equals the count provided.
         """
         self.lc_block.max_count = count
-        selected = self.lc_block.get_child_descriptors()
+        selected = self.lc_block.get_child_blocks()
         assert len(selected) == count
         return selected
 
@@ -532,7 +532,7 @@ class TestLibraryContentAnalytics(LibraryContentTest):
         Test the "assigned" event emitted when a student is assigned specific blocks.
         """
         # In the beginning was the lc_block and it assigned one child to the student:
-        child = self.lc_block.get_child_descriptors()[0]
+        child = self.lc_block.get_child_blocks()[0]
         child_lib_location, child_lib_version = self.store.get_block_original_usage(child.location)
         assert isinstance(child_lib_version, ObjectId)
         event_data = self._assert_event_was_published("assigned")
@@ -551,7 +551,7 @@ class TestLibraryContentAnalytics(LibraryContentTest):
 
         # Now increase max_count so that one more child will be added:
         self.lc_block.max_count = 2
-        children = self.lc_block.get_child_descriptors()
+        children = self.lc_block.get_child_blocks()
         assert len(children) == 2
         child, new_child = children if children[0].location == child.location else reversed(children)
         event_data = self._assert_event_was_published("assigned")
@@ -597,7 +597,7 @@ class TestLibraryContentAnalytics(LibraryContentTest):
         course_usage_problem = inner_vertical_in_course.children[1]
 
         # Trigger a publish event:
-        self.lc_block.get_child_descriptors()
+        self.lc_block.get_child_blocks()
         event_data = self._assert_event_was_published("assigned")
 
         for block_list in (event_data["added"], event_data["result"]):
@@ -628,12 +628,12 @@ class TestLibraryContentAnalytics(LibraryContentTest):
         We go from one blocks assigned to none because max_count has been decreased.
         """
         # Decrease max_count to 1, causing the block to be overlimit:
-        self.lc_block.get_child_descriptors()  # This line is needed in the test environment or the change has no effect
+        self.lc_block.get_child_blocks()  # This line is needed in the test environment or the change has no effect
         self.publisher.reset_mock()  # Clear the "assigned" event that was just published.
         self.lc_block.max_count = 0
 
         # Check that the event says that one block was removed, leaving no blocks left:
-        children = self.lc_block.get_child_descriptors()
+        children = self.lc_block.get_child_blocks()
         assert len(children) == 0
         event_data = self._assert_event_was_published("removed")
         assert len(event_data['removed']) == 1
@@ -646,9 +646,9 @@ class TestLibraryContentAnalytics(LibraryContentTest):
         We go from two blocks assigned, to one because the others have been deleted from the library.
         """
         # Start by assigning two blocks to the student:
-        self.lc_block.get_child_descriptors()  # This line is needed in the test environment or the change has no effect
+        self.lc_block.get_child_blocks()  # This line is needed in the test environment or the change has no effect
         self.lc_block.max_count = 2
-        initial_blocks_assigned = self.lc_block.get_child_descriptors()
+        initial_blocks_assigned = self.lc_block.get_child_blocks()
         assert len(initial_blocks_assigned) == 2
         self.publisher.reset_mock()  # Clear the "assigned" event that was just published.
         # Now make sure that one of the assigned blocks will have to be un-assigned.
@@ -663,7 +663,7 @@ class TestLibraryContentAnalytics(LibraryContentTest):
         self.lc_block.refresh_children()
 
         # Check that the event says that one block was removed, leaving one block left:
-        children = self.lc_block.get_child_descriptors()
+        children = self.lc_block.get_child_blocks()
         assert len(children) == 1
         event_data = self._assert_event_was_published("removed")
         assert event_data['removed'] ==\

--- a/xmodule/tests/test_randomize_block.py
+++ b/xmodule/tests/test_randomize_block.py
@@ -104,8 +104,8 @@ class RandomizeBlockTest(MixedSplitTestCase):
         assert len(randomize_block.children) == 3
 
         # Check how many children each user will see:
-        assert len(randomize_block.get_child_descriptors()) == 1
-        assert randomize_block.get_child_descriptors()[0].display_name == 'Hello HTML 1'
+        assert len(randomize_block.get_child_blocks()) == 1
+        assert randomize_block.get_child_blocks()[0].display_name == 'Hello HTML 1'
         # Check that get_content_titles() doesn't return titles for hidden/unused children
         # get_content_titles() is not overridden in RandomizeBlock so titles of the 3 children are returned.
         assert len(randomize_block.get_content_titles()) == 3
@@ -113,4 +113,4 @@ class RandomizeBlockTest(MixedSplitTestCase):
         # Bind to another user and check a different child block is displayed to user.
         randomize_block = self.store.get_item(self.randomize_block.location)
         self._bind_module_system(randomize_block, 1)
-        assert randomize_block.get_child_descriptors()[0].display_name == 'Hello HTML 2'
+        assert randomize_block.get_child_blocks()[0].display_name == 'Hello HTML 2'

--- a/xmodule/tests/test_split_test_block.py
+++ b/xmodule/tests/test_split_test_block.py
@@ -142,7 +142,7 @@ class SplitTestBlockLMSTest(SplitTestBlockTest):
     @ddt.unpack
     def test_child(self, user_tag, child_url_name):
         self.user_partition.scheme.current_group = self.user_partition.groups[user_tag]
-        assert self.split_test_block.child_descriptor.url_name == child_url_name
+        assert self.split_test_block.child_block.url_name == child_url_name
 
     @ddt.data((0, 'HTML FOR GROUP 0'), (1, 'HTML FOR GROUP 1'))
     @ddt.unpack
@@ -153,14 +153,14 @@ class SplitTestBlockLMSTest(SplitTestBlockTest):
     @ddt.data(0, 1)
     def test_child_missing_tag_value(self, _user_tag):
         # If user_tag has a missing value, we should still get back a valid child url
-        assert self.split_test_block.child_descriptor.url_name in ['split_test_cond0', 'split_test_cond1']
+        assert self.split_test_block.child_block.url_name in ['split_test_cond0', 'split_test_cond1']
 
     @ddt.data(100, 200, 300, 400, 500, 600, 700, 800, 900, 1000)
     def test_child_persist_new_tag_value_when_tag_missing(self, _user_tag):
         # If a user_tag has a missing value, a group should be saved/persisted for that user.
         # So, we check that we get the same url_name when we call on the url_name twice.
         # We run the test ten times so that, if our storage is failing, we'll be most likely to notice it.
-        assert self.split_test_block.child_descriptor.url_name == self.split_test_block.child_descriptor.url_name
+        assert self.split_test_block.child_block.url_name == self.split_test_block.child_block.url_name
 
     # Patch the definition_to_xml for the html children.
     @patch('xmodule.html_block.HtmlBlock.definition_to_xml')
@@ -170,7 +170,7 @@ class SplitTestBlockLMSTest(SplitTestBlockTest):
         def_to_xml.return_value = lxml.etree.Element('html')
 
         # Mock out the process_xml
-        # Expect it to return a child descriptor for the SplitTestDescriptor when called.
+        # Expect it to return a child block for the SplitTestDescriptor when called.
         self.course.runtime.process_xml = Mock()
 
         # Write out the xml.

--- a/xmodule/tests/test_video.py
+++ b/xmodule/tests/test_video.py
@@ -82,9 +82,9 @@ ALL_LANGUAGES = (
 )
 
 
-def instantiate_descriptor(**field_data):
+def instantiate_block(**field_data):
     """
-    Instantiate descriptor with most properties.
+    Instantiate block with most properties.
     """
     if field_data.get('data', None):
         field_data = VideoBlock.parse_video_xml(field_data['data'])
@@ -172,7 +172,7 @@ class VideoBlockTestBase(unittest.TestCase):
 
     def setUp(self):
         super().setUp()
-        self.descriptor = instantiate_descriptor()
+        self.block = instantiate_block()
 
     def assertXmlEqual(self, expected, xml):
         """
@@ -195,29 +195,29 @@ class VideoBlockTestBase(unittest.TestCase):
 
 class TestCreateYoutubeString(VideoBlockTestBase):
     """
-    Checks that create_youtube_string correcty extracts information from Video descriptor.
+    Checks that create_youtube_string correcty extracts information from Video block.
     """
 
     def test_create_youtube_string(self):
         """
         Test that Youtube ID strings are correctly created when writing back out to XML.
         """
-        self.descriptor.youtube_id_0_75 = 'izygArpw-Qo'
-        self.descriptor.youtube_id_1_0 = 'p2Q6BrNhdh8'
-        self.descriptor.youtube_id_1_25 = '1EeWXzPdhSA'
-        self.descriptor.youtube_id_1_5 = 'rABDYkeK0x8'
+        self.block.youtube_id_0_75 = 'izygArpw-Qo'
+        self.block.youtube_id_1_0 = 'p2Q6BrNhdh8'
+        self.block.youtube_id_1_25 = '1EeWXzPdhSA'
+        self.block.youtube_id_1_5 = 'rABDYkeK0x8'
         expected = "0.75:izygArpw-Qo,1.00:p2Q6BrNhdh8,1.25:1EeWXzPdhSA,1.50:rABDYkeK0x8"
-        assert create_youtube_string(self.descriptor) == expected
+        assert create_youtube_string(self.block) == expected
 
     def test_create_youtube_string_missing(self):
         """
         Test that Youtube IDs which aren't explicitly set aren't included in the output string.
         """
-        self.descriptor.youtube_id_0_75 = 'izygArpw-Qo'
-        self.descriptor.youtube_id_1_0 = 'p2Q6BrNhdh8'
-        self.descriptor.youtube_id_1_25 = '1EeWXzPdhSA'
+        self.block.youtube_id_0_75 = 'izygArpw-Qo'
+        self.block.youtube_id_1_0 = 'p2Q6BrNhdh8'
+        self.block.youtube_id_1_25 = '1EeWXzPdhSA'
         expected = "0.75:izygArpw-Qo,1.00:p2Q6BrNhdh8,1.25:1EeWXzPdhSA"
-        assert create_youtube_string(self.descriptor) == expected
+        assert create_youtube_string(self.block) == expected
 
 
 class TestCreateYouTubeUrl(VideoBlockTestBase):
@@ -230,7 +230,7 @@ class TestCreateYouTubeUrl(VideoBlockTestBase):
         Test that passing unicode to `create_youtube_url` doesn't throw
         an error.
         """
-        self.descriptor.create_youtube_url("üñîçø∂é")
+        self.block.create_youtube_url("üñîçø∂é")
 
 
 @ddt.ddt
@@ -263,8 +263,8 @@ class VideoBlockImportTestCase(TestCase):
               <transcript language="ge" src="german_translation.srt" />
             </video>
         '''
-        descriptor = instantiate_descriptor(data=sample_xml)
-        self.assert_attributes_equal(descriptor, {
+        block = instantiate_block(data=sample_xml)
+        self.assert_attributes_equal(block, {
             'youtube_id_0_75': 'izygArpw-Qo',
             'youtube_id_1_0': 'p2Q6BrNhdh8',
             'youtube_id_1_25': '1EeWXzPdhSA',
@@ -698,22 +698,22 @@ class VideoExportTestCase(VideoBlockTestBase):
                 transcripts={}
             )
         )
-        self.descriptor.youtube_id_0_75 = 'izygArpw-Qo'
-        self.descriptor.youtube_id_1_0 = 'p2Q6BrNhdh8'
-        self.descriptor.youtube_id_1_25 = '1EeWXzPdhSA'
-        self.descriptor.youtube_id_1_5 = 'rABDYkeK0x8'
-        self.descriptor.show_captions = False
-        self.descriptor.start_time = datetime.timedelta(seconds=1.0)
-        self.descriptor.end_time = datetime.timedelta(seconds=60)
-        self.descriptor.track = 'http://www.example.com/track'
-        self.descriptor.handout = 'http://www.example.com/handout'
-        self.descriptor.download_track = True
-        self.descriptor.html5_sources = ['http://www.example.com/source.mp4', 'http://www.example.com/source1.ogg']
-        self.descriptor.download_video = True
-        self.descriptor.transcripts = {'ua': 'ukrainian_translation.srt', 'ge': 'german_translation.srt'}
-        self.descriptor.edx_video_id = edx_video_id
+        self.block.youtube_id_0_75 = 'izygArpw-Qo'
+        self.block.youtube_id_1_0 = 'p2Q6BrNhdh8'
+        self.block.youtube_id_1_25 = '1EeWXzPdhSA'
+        self.block.youtube_id_1_5 = 'rABDYkeK0x8'
+        self.block.show_captions = False
+        self.block.start_time = datetime.timedelta(seconds=1.0)
+        self.block.end_time = datetime.timedelta(seconds=60)
+        self.block.track = 'http://www.example.com/track'
+        self.block.handout = 'http://www.example.com/handout'
+        self.block.download_track = True
+        self.block.html5_sources = ['http://www.example.com/source.mp4', 'http://www.example.com/source1.ogg']
+        self.block.download_video = True
+        self.block.transcripts = {'ua': 'ukrainian_translation.srt', 'ge': 'german_translation.srt'}
+        self.block.edx_video_id = edx_video_id
 
-        xml = self.descriptor.definition_to_xml(self.file_system)
+        xml = self.block.definition_to_xml(self.file_system)
         parser = etree.XMLParser(remove_blank_text=True)
         xml_string = '''\
          <video
@@ -741,7 +741,7 @@ class VideoExportTestCase(VideoBlockTestBase):
             video_id=edx_video_id,
             static_dir=EXPORT_IMPORT_STATIC_DIR,
             resource_fs=self.file_system,
-            course_id=self.descriptor.scope_ids.usage_id.context_key,
+            course_id=self.block.scope_ids.usage_id.context_key,
         )
 
     @patch('xmodule.video_block.video_block.edxval_api')
@@ -749,9 +749,9 @@ class VideoExportTestCase(VideoBlockTestBase):
         # Export should succeed without VAL data if video does not exist
         mock_val_api.ValVideoNotFoundError = _MockValVideoNotFoundError
         mock_val_api.export_to_xml = Mock(side_effect=mock_val_api.ValVideoNotFoundError)
-        self.descriptor.edx_video_id = 'test_edx_video_id'
+        self.block.edx_video_id = 'test_edx_video_id'
 
-        xml = self.descriptor.definition_to_xml(self.file_system)
+        xml = self.block.definition_to_xml(self.file_system)
         parser = etree.XMLParser(remove_blank_text=True)
         xml_string = '<video youtube="1.00:3_yD_cEKoCk" url_name="SampleProblem"/>'
         expected = etree.XML(xml_string, parser=parser)
@@ -762,19 +762,19 @@ class VideoExportTestCase(VideoBlockTestBase):
         """
         Test that we write the correct XML on export.
         """
-        self.descriptor.youtube_id_0_75 = 'izygArpw-Qo'
-        self.descriptor.youtube_id_1_0 = 'p2Q6BrNhdh8'
-        self.descriptor.youtube_id_1_25 = '1EeWXzPdhSA'
-        self.descriptor.youtube_id_1_5 = 'rABDYkeK0x8'
-        self.descriptor.show_captions = False
-        self.descriptor.start_time = datetime.timedelta(seconds=5.0)
-        self.descriptor.end_time = datetime.timedelta(seconds=0.0)
-        self.descriptor.track = 'http://www.example.com/track'
-        self.descriptor.download_track = True
-        self.descriptor.html5_sources = ['http://www.example.com/source.mp4', 'http://www.example.com/source.ogg']
-        self.descriptor.download_video = True
+        self.block.youtube_id_0_75 = 'izygArpw-Qo'
+        self.block.youtube_id_1_0 = 'p2Q6BrNhdh8'
+        self.block.youtube_id_1_25 = '1EeWXzPdhSA'
+        self.block.youtube_id_1_5 = 'rABDYkeK0x8'
+        self.block.show_captions = False
+        self.block.start_time = datetime.timedelta(seconds=5.0)
+        self.block.end_time = datetime.timedelta(seconds=0.0)
+        self.block.track = 'http://www.example.com/track'
+        self.block.download_track = True
+        self.block.html5_sources = ['http://www.example.com/source.mp4', 'http://www.example.com/source.ogg']
+        self.block.download_video = True
 
-        xml = self.descriptor.definition_to_xml(self.file_system)
+        xml = self.block.definition_to_xml(self.file_system)
         parser = etree.XMLParser(remove_blank_text=True)
         xml_string = '''\
          <video url_name="SampleProblem" start_time="0:00:05" youtube="0.75:izygArpw-Qo,1.00:p2Q6BrNhdh8,1.25:1EeWXzPdhSA,1.50:rABDYkeK0x8" show_captions="false" download_video="true" download_track="true">
@@ -791,7 +791,7 @@ class VideoExportTestCase(VideoBlockTestBase):
         """
         Test XML export with defaults.
         """
-        xml = self.descriptor.definition_to_xml(self.file_system)
+        xml = self.block.definition_to_xml(self.file_system)
         # Check that download_video field is also set to default (False) in xml for backward compatibility
         expected = '<video youtube="1.00:3_yD_cEKoCk" url_name="SampleProblem"/>\n'
         assert expected == etree.tostring(xml, pretty_print=True).decode('utf-8')
@@ -801,8 +801,8 @@ class VideoExportTestCase(VideoBlockTestBase):
         """
         Test XML export with transcripts being overridden to None.
         """
-        self.descriptor.transcripts = None
-        xml = self.descriptor.definition_to_xml(self.file_system)
+        self.block.transcripts = None
+        xml = self.block.definition_to_xml(self.file_system)
         expected = b'<video youtube="1.00:3_yD_cEKoCk" url_name="SampleProblem"/>\n'
         assert expected == etree.tostring(xml, pretty_print=True)
 
@@ -812,8 +812,8 @@ class VideoExportTestCase(VideoBlockTestBase):
         Test XML export will *not* raise TypeError by lxml library if contains illegal characters.
         The illegal characters in a String field are removed from the string instead.
         """
-        self.descriptor.display_name = 'Display\x1eName'
-        xml = self.descriptor.definition_to_xml(self.file_system)
+        self.block.display_name = 'Display\x1eName'
+        xml = self.block.definition_to_xml(self.file_system)
         assert xml.get('display_name') == 'DisplayName'
 
     @patch('xmodule.video_block.video_block.edxval_api', None)
@@ -821,8 +821,8 @@ class VideoExportTestCase(VideoBlockTestBase):
         """
         Test XML export handles the unicode characters.
         """
-        self.descriptor.display_name = '这是文'
-        xml = self.descriptor.definition_to_xml(self.file_system)
+        self.block.display_name = '这是文'
+        xml = self.block.definition_to_xml(self.file_system)
         assert xml.get('display_name') == '这是文'
 
 
@@ -869,8 +869,8 @@ class VideoBlockStudentViewDataTestCase(unittest.TestCase):
         """
         Ensure that student_view_data returns the expected results for video blocks.
         """
-        descriptor = instantiate_descriptor(**field_data)
-        student_view_data = descriptor.student_view_data()
+        block = instantiate_block(**field_data)
+        student_view_data = block.student_view_data()
         assert student_view_data == expected_student_view_data
 
     @patch('xmodule.video_block.video_block.HLSPlaybackEnabledFlag.feature_enabled', Mock(return_value=True))
@@ -903,9 +903,9 @@ class VideoBlockStudentViewDataTestCase(unittest.TestCase):
             'file_name': 'edx.sjson'
         }
 
-        descriptor = instantiate_descriptor(edx_video_id='example_id', only_on_web=False)
-        descriptor.runtime.handler_url = MagicMock()
-        student_view_data = descriptor.student_view_data()
+        block = instantiate_block(edx_video_id='example_id', only_on_web=False)
+        block.runtime.handler_url = MagicMock()
+        student_view_data = block.student_view_data()
         expected_video_data = {'hls': {'url': 'http://www.meowmix.com', 'file_size': 25556}}
         self.assertDictEqual(student_view_data.get('encoded_videos'), expected_video_data)
 
@@ -973,8 +973,8 @@ class VideoBlockIndexingTestCase(unittest.TestCase):
               <handout src="http://www.example.com/handout"/>
             </video>
         '''
-        descriptor = instantiate_descriptor(data=xml_data)
-        assert descriptor.index_dictionary() == {'content': {'display_name': 'Test Video'}, 'content_type': 'Video'}
+        block = instantiate_block(data=xml_data)
+        assert block.index_dictionary() == {'content': {'display_name': 'Test Video'}, 'content_type': 'Video'}
 
     def test_video_with_multiple_transcripts_index_dictionary(self):
         """
@@ -997,10 +997,10 @@ class VideoBlockIndexingTestCase(unittest.TestCase):
             </video>
         '''
 
-        descriptor = instantiate_descriptor(data=xml_data_transcripts)
-        save_to_store(SRT_FILEDATA, "subs_grmtran1.srt", 'text/srt', descriptor.location)
-        save_to_store(CRO_SRT_FILEDATA, "subs_croatian1.srt", 'text/srt', descriptor.location)
-        assert descriptor.index_dictionary() ==\
+        block = instantiate_block(data=xml_data_transcripts)
+        save_to_store(SRT_FILEDATA, "subs_grmtran1.srt", 'text/srt', block.location)
+        save_to_store(CRO_SRT_FILEDATA, "subs_croatian1.srt", 'text/srt', block.location)
+        assert block.index_dictionary() ==\
                {'content': {'display_name': 'Test Video',
                             'transcript_ge': 'sprechen sie deutsch? Ja, ich spreche Deutsch',
                             'transcript_hr': 'Dobar dan! Kako ste danas?'}, 'content_type': 'Video'}
@@ -1026,8 +1026,8 @@ class VideoBlockIndexingTestCase(unittest.TestCase):
             </video>
         '''
 
-        descriptor = instantiate_descriptor(data=xml_data_transcripts)
-        translations = descriptor.available_translations(descriptor.get_transcripts_info())
+        block = instantiate_block(data=xml_data_transcripts)
+        translations = block.available_translations(block.get_transcripts_info())
         assert sorted(translations) == sorted(['hr', 'ge'])
 
     def test_video_with_no_transcripts_translation_retrieval(self):
@@ -1036,14 +1036,14 @@ class VideoBlockIndexingTestCase(unittest.TestCase):
         no transcripts uploaded by a user- ie, that retrieval
         does not throw an exception.
         """
-        descriptor = instantiate_descriptor(data=None)
-        translations_with_fallback = descriptor.available_translations(descriptor.get_transcripts_info())
+        block = instantiate_block(data=None)
+        translations_with_fallback = block.available_translations(block.get_transcripts_info())
         assert translations_with_fallback == ['en']
 
         with patch.dict(settings.FEATURES, FALLBACK_TO_ENGLISH_TRANSCRIPTS=False):
             # Some organizations don't have English transcripts for all videos
             # This feature makes it configurable
-            translations_no_fallback = descriptor.available_translations(descriptor.get_transcripts_info())
+            translations_no_fallback = block.available_translations(block.get_transcripts_info())
             assert translations_no_fallback == []
 
     @override_settings(ALL_LANGUAGES=ALL_LANGUAGES)
@@ -1066,8 +1066,8 @@ class VideoBlockIndexingTestCase(unittest.TestCase):
               <transcript language="ur" src="" />
             </video>
         '''
-        descriptor = instantiate_descriptor(data=xml_data_transcripts)
-        translations = descriptor.available_translations(descriptor.get_transcripts_info(), verify_assets=False)
+        block = instantiate_block(data=xml_data_transcripts)
+        translations = block.available_translations(block.get_transcripts_info(), verify_assets=False)
         assert translations != ['ur']
 
     def assert_validation_message(self, validation, expected_msg):
@@ -1114,16 +1114,16 @@ class VideoBlockIndexingTestCase(unittest.TestCase):
               {xml_transcripts}
             </video>
         '''.format(xml_transcripts=xml_transcripts)
-        descriptor = instantiate_descriptor(data=xml_data_transcripts)
-        validation = descriptor.validate()
+        block = instantiate_block(data=xml_data_transcripts)
+        validation = block.validate()
         self.assert_validation_message(validation, expected_validation_msg)
 
     def test_video_transcript_none(self):
         """
         Test video when transcripts is None.
         """
-        descriptor = instantiate_descriptor(data=None)
-        descriptor.transcripts = None
-        response = descriptor.get_transcripts_info()
+        block = instantiate_block(data=None)
+        block.transcripts = None
+        response = block.get_transcripts_info()
         expected = {'transcripts': {}, 'sub': ''}
         assert expected == response

--- a/xmodule/tests/test_xml_block.py
+++ b/xmodule/tests/test_xml_block.py
@@ -251,8 +251,8 @@ class EditableMetadataFieldsTest(unittest.TestCase):
         )
 
     def test_integer_field(self):
-        descriptor = self.get_descriptor(DictFieldData({'max_attempts': '7'}))
-        editable_fields = descriptor.editable_metadata_fields
+        block = self.get_block(DictFieldData({'max_attempts': '7'}))
+        editable_fields = block.editable_metadata_fields
         assert 8 == len(editable_fields)
         self.assert_field_values(
             editable_fields, 'max_attempts', TestFields.max_attempts,
@@ -264,7 +264,7 @@ class EditableMetadataFieldsTest(unittest.TestCase):
             explicitly_set=False, value='local default', default_value='local default'
         )
 
-        editable_fields = self.get_descriptor(DictFieldData({})).editable_metadata_fields
+        editable_fields = self.get_block(DictFieldData({})).editable_metadata_fields
         self.assert_field_values(
             editable_fields, 'max_attempts', TestFields.max_attempts,
             explicitly_set=False, value=1000, default_value=1000, type='Integer',
@@ -274,8 +274,8 @@ class EditableMetadataFieldsTest(unittest.TestCase):
     def test_inherited_field(self):
         kvs = InheritanceKeyValueStore(initial_values={}, inherited_settings={'showanswer': 'inherited'})
         model_data = KvsFieldData(kvs)
-        descriptor = self.get_descriptor(model_data)
-        editable_fields = descriptor.editable_metadata_fields
+        block = self.get_block(model_data)
+        editable_fields = block.editable_metadata_fields
         self.assert_field_values(
             editable_fields, 'showanswer', InheritanceMixin.showanswer,
             explicitly_set=False, value='inherited', default_value='inherited'
@@ -287,8 +287,8 @@ class EditableMetadataFieldsTest(unittest.TestCase):
             inherited_settings={'showanswer': 'inheritable value'}
         )
         model_data = KvsFieldData(kvs)
-        descriptor = self.get_descriptor(model_data)
-        editable_fields = descriptor.editable_metadata_fields
+        block = self.get_block(model_data)
+        editable_fields = block.editable_metadata_fields
         self.assert_field_values(
             editable_fields, 'showanswer', InheritanceMixin.showanswer,
             explicitly_set=True, value='explicit', default_value='inheritable value'
@@ -298,8 +298,8 @@ class EditableMetadataFieldsTest(unittest.TestCase):
         # test_display_name_field verifies that a String field is of type "Generic".
         # test_integer_field verifies that a Integer field is of type "Integer".
 
-        descriptor = self.get_descriptor(DictFieldData({}))
-        editable_fields = descriptor.editable_metadata_fields
+        block = self.get_block(DictFieldData({}))
+        editable_fields = block.editable_metadata_fields
 
         # Tests for select
         self.assert_field_values(
@@ -343,16 +343,16 @@ class EditableMetadataFieldsTest(unittest.TestCase):
             field_data=field_data,
         ).editable_metadata_fields
 
-    def get_descriptor(self, field_data):
-        class TestModuleDescriptor(TestFields, self.TestableXmlXBlock):  # lint-amnesty, pylint: disable=abstract-method
+    def get_block(self, field_data):
+        class TestModuleBlock(TestFields, self.TestableXmlXBlock):  # lint-amnesty, pylint: disable=abstract-method
             @property
             def non_editable_metadata_fields(self):
                 non_editable_fields = super().non_editable_metadata_fields
-                non_editable_fields.append(TestModuleDescriptor.due)
+                non_editable_fields.append(TestModuleBlock.due)
                 return non_editable_fields
 
         system = get_test_descriptor_system(render_template=Mock())
-        return system.construct_xblock_from_class(TestModuleDescriptor, field_data=field_data, scope_ids=Mock())
+        return system.construct_xblock_from_class(TestModuleBlock, field_data=field_data, scope_ids=Mock())
 
     def assert_field_values(self, editable_fields, name, field, explicitly_set, value, default_value,  # lint-amnesty, pylint: disable=dangerous-default-value
                             type='Generic', options=[]):  # lint-amnesty, pylint: disable=redefined-builtin

--- a/xmodule/tests/xml/__init__.py
+++ b/xmodule/tests/xml/__init__.py
@@ -23,7 +23,7 @@ class InMemorySystem(XMLParsingSystem, MakoDescriptorSystem):  # pylint: disable
     def __init__(self, xml_import_data):
         self.course_id = CourseKey.from_string(xml_import_data.course_id)
         self.default_class = xml_import_data.default_class
-        self._descriptors = {}
+        self._blocks = {}
 
         def get_policy(usage_id):
             """Return the policy data for the specified usage"""
@@ -42,19 +42,19 @@ class InMemorySystem(XMLParsingSystem, MakoDescriptorSystem):  # pylint: disable
         )
 
     def process_xml(self, xml):  # pylint: disable=method-hidden
-        """Parse `xml` as an XBlock, and add it to `self._descriptors`"""
+        """Parse `xml` as an XBlock, and add it to `self._blocks`"""
         self.get_asides = Mock(return_value=[])
-        descriptor = self.xblock_from_node(
+        block = self.xblock_from_node(
             etree.fromstring(xml),
             None,
             CourseLocationManager(self.course_id),
         )
-        self._descriptors[str(descriptor.location)] = descriptor
-        return descriptor
+        self._blocks[str(block.location)] = block
+        return block
 
     def load_item(self, location, for_parent=None):  # pylint: disable=method-hidden, unused-argument
-        """Return the descriptor loaded for `location`"""
-        return self._descriptors[str(location)]
+        """Return the block loaded for `location`"""
+        return self._blocks[str(location)]
 
 
 class XModuleXmlImportTest(TestCase):

--- a/xmodule/video_block/transcripts_utils.py
+++ b/xmodule/video_block/transcripts_utils.py
@@ -241,13 +241,13 @@ def get_transcripts_from_youtube(youtube_id, settings, i18n, youtube_transcript_
     return {'start': sub_starts, 'end': sub_ends, 'text': sub_texts}
 
 
-def download_youtube_subs(youtube_id, video_descriptor, settings):  # lint-amnesty, pylint: disable=redefined-outer-name
+def download_youtube_subs(youtube_id, video_block, settings):  # lint-amnesty, pylint: disable=redefined-outer-name
     """
     Download transcripts from Youtube.
 
     Args:
         youtube_id: str, actual youtube_id of the video.
-        video_descriptor: video descriptor instance.
+        video_block: video block instance.
 
     We save transcripts for 1.0 speed, as for other speed conversion is done on front-end.
 
@@ -257,7 +257,7 @@ def download_youtube_subs(youtube_id, video_descriptor, settings):  # lint-amnes
     Raises:
         GetTranscriptsFromYouTubeException, if fails.
     """
-    i18n = video_descriptor.runtime.service(video_descriptor, "i18n")
+    i18n = video_block.runtime.service(video_block, "i18n")
     _ = i18n.ugettext
 
     subs = get_transcripts_from_youtube(youtube_id, settings, i18n)
@@ -961,7 +961,7 @@ def get_transcript_from_contentstore(video, language, output_format, transcripts
     Get video transcript from content store.
 
     Arguments:
-        video (Video Descriptor): Video descriptor
+        video (Video block): Video block
         language (unicode): transcript language
         output_format (unicode): transcript output format
         transcripts_info (dict): transcript info for a video
@@ -1089,7 +1089,7 @@ def get_transcript(video, lang=None, output_format=Transcript.SRT, youtube_id=No
     Get video transcript from edx-val or content store.
 
     Arguments:
-        video (Video Descriptor): Video Descriptor
+        video (Video block): Video block
         lang (unicode): transcript language
         output_format (unicode): transcript output format
         youtube_id (unicode): youtube video id

--- a/xmodule/x_module.py
+++ b/xmodule/x_module.py
@@ -286,7 +286,7 @@ class XModuleMixin(XModuleFields, XBlock):
 
     Adding this Mixin to an :class:`XBlock` allows it to cooperate with old-style :class:`XModules`
     """
-    # Attributes for inspection of the descriptor
+    # Attributes for inspection of the block
 
     # This indicates whether the xmodule is a problem-type.
     # It should respond to max_score() and grade(). It can be graded or ungraded
@@ -299,7 +299,7 @@ class XModuleMixin(XModuleFields, XBlock):
 
     # Class level variable
 
-    # True if this descriptor always requires recalculation of grades, for
+    # True if this block always requires recalculation of grades, for
     # example if the score can change via an extrnal service, not just when the
     # student interacts with the module on the page.  A specific example is
     # FoldIt, which posts grade-changing updates through a separate API.
@@ -563,10 +563,10 @@ class XModuleMixin(XModuleFields, XBlock):
 
     def has_dynamic_children(self):
         """
-        Returns True if this descriptor has dynamic children for a given
+        Returns True if this block has dynamic children for a given
         student when the module is created.
 
-        Returns False if the children of this descriptor are the same
+        Returns False if the children of this block are the same
         children that the module will return for any student.
         """
         return False
@@ -1002,7 +1002,7 @@ class ConfigurableFragmentWrapper:
 # Runtime.handler_url interface.
 #
 # The monkey-patching happens in cms/djangoapps/xblock_config/apps.py and lms/djangoapps/lms_xblock/apps.py
-def descriptor_global_handler_url(block, handler_name, suffix='', query='', thirdparty=False):
+def block_global_handler_url(block, handler_name, suffix='', query='', thirdparty=False):
     """
     See :meth:`xblock.runtime.Runtime.handler_url`.
     """
@@ -1014,7 +1014,7 @@ def descriptor_global_handler_url(block, handler_name, suffix='', query='', thir
 # the Runtime part of its interface. This function matches the Runtime.local_resource_url interface
 #
 # The monkey-patching happens in cms/djangoapps/xblock_config/apps.py and lms/djangoapps/lms_xblock/apps.py
-def descriptor_global_local_resource_url(block, uri):
+def block_global_local_resource_url(block, uri):
     """
     See :meth:`xblock.runtime.Runtime.local_resource_url`.
     """
@@ -1529,7 +1529,7 @@ class DescriptorSystem(MetricsMixin, ConfigurableFragmentWrapper, ModuleSystemSh
         # defined for LMS/CMS through the handler_url_override property.
         if getattr(self, 'handler_url_override', None):
             return self.handler_url_override(block, handler_name, suffix, query, thirdparty)
-        return descriptor_global_handler_url(block, handler_name, suffix, query, thirdparty)
+        return block_global_handler_url(block, handler_name, suffix, query, thirdparty)
 
     def local_resource_url(self, block, uri):
         """
@@ -1539,7 +1539,7 @@ class DescriptorSystem(MetricsMixin, ConfigurableFragmentWrapper, ModuleSystemSh
         # This means that LMS/CMS don't have a way to define a subclass of DescriptorSystem
         # that implements the correct local_resource_url. So, for now, instead, we will reference a
         # global function that the application can override.
-        return descriptor_global_local_resource_url(block, uri)
+        return block_global_local_resource_url(block, uri)
 
     def applicable_aside_types(self, block):
         """

--- a/xmodule/xml_block.py
+++ b/xmodule/xml_block.py
@@ -152,7 +152,7 @@ class XmlMixin:
     @classmethod
     def definition_from_xml(cls, xml_object, system):
         """
-        Return the definition to be passed to the newly created descriptor
+        Return the definition to be passed to the newly created block
         during from_xml
 
         xml_object: An etree Element
@@ -199,7 +199,7 @@ class XmlMixin:
     @classmethod
     def load_definition(cls, xml_object, system, def_id, id_generator):
         """
-        Load a descriptor definition from the specified xml_object.
+        Load a block from the specified xml_object.
         Subclasses should not need to override this except in special
         cases (e.g. html block)
 
@@ -365,7 +365,7 @@ class XmlMixin:
 
         xblock = runtime.construct_xblock_from_class(
             cls,
-            # We're loading a descriptor, so student_id is meaningless
+            # We're loading a block, so student_id is meaningless
             ScopeIds(None, node.tag, def_id, usage_id),
             field_data,
         )
@@ -405,7 +405,7 @@ class XmlMixin:
         return f'{category}/{name}.{cls.filename_extension}'
 
     def export_to_file(self):
-        """If this returns True, write the definition of this descriptor to a separate
+        """If this returns True, write the definition of this block to a separate
         file.
 
         NOTE: Do not override this without a good reason.  It is here


### PR DESCRIPTION
## Description

~**Note:** This PR depends on and includes the changes from #31475, which in turn depends on #31384. Use [this link](https://github.com/open-craft/edx-platform/compare/0x29a/bb6926/rename_module_to_block...open-craft:edx-platform:pooja/unify-xblock-naming-descriptor) to see the actual diff.~

This PR is the continuation of our [previous effort](https://github.com/openedx/edx-platform/pull/31113) to unify XBlock naming across the platform. This time, each `descriptor` occurrence reviewed and changed to `block` if it satisfied these criteria:
- It meant "XBlock".
- It was in `*.py`, `*.rst`, or `*.md` file.
- It didn't mean "Descriptor System" or "descriptor runtime".

## Supporting Information

<s>This PR should be merged along with:</s>

- <s>https://github.com/openedx/xblock-lti-consumer/pull/322 (closed, not needed)</s>
- https://github.com/mitodl/edx-sga/pull/334 (optional)

## Testing Instructions

Use the sandbox to perform general testing (courseware, course tabs, activation emails, course authoring, course exporting/importing, etc):
- LMS: https://pr31492.sandbox.opencraft.hosting/ (credentials: `staff@example.com;edx`)
- Studio: https://studio.pr31492.sandbox.opencraft.hosting/