### PR TITLE
build: run lint import check on master branch

### DIFF
--- a/.github/workflows/lint-imports.yml
+++ b/.github/workflows/lint-imports.yml
@@ -1,6 +1,10 @@
 name: Lint Python Imports
 
-on: pull_request
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
 


### PR DESCRIPTION
Reference PR: https://github.com/openedx/edx-platform/pull/31062/

We need to run `lint-import` check on `master` branch as well.