### PR TITLE
fix: retrieve raw content from TinyMCE editor (#31212)

### DIFF
--- a/xmodule/js/spec/html/edit_spec.js
+++ b/xmodule/js/spec/html/edit_spec.js
@@ -24,7 +24,7 @@ describe('HTMLEditingDescriptor', function() {
     });
     it('Returns data from Raw Editor if text has not changed', function(done) {
       const visualEditorStub =
-        {getContent() { return 'original visual text' }};
+        {getContent() { return '<p>original visual text</p>' }};
       spyOn(this.descriptor, 'getVisualEditor').and.callFake(() => visualEditorStub);
 
       var self = this;

--- a/xmodule/js/src/html/edit.js
+++ b/xmodule/js/src/html/edit.js
@@ -1390,7 +1390,7 @@
       haven't dirtied the Editor. Store the raw content so we can compare it later.
        */
       this.starting_content = visualEditor.getContent({
-        format: "text",
+        format: "raw",
         no_events: 1
       });
       return visualEditor.focus();
@@ -1410,7 +1410,7 @@
       if (this.editor_choice === 'visual') {
         visualEditor = this.getVisualEditor();
         raw_content = visualEditor.getContent({
-          format: "text",
+          format: "raw",
           no_events: 1
         });
         if (this.starting_content !== raw_content) {


### PR DESCRIPTION
<!--

🎉🎉 Olive has been released! 🎉🎉

🫒🫒
🫒🫒🫒🫒         🫒 Note: Olive is in support. Fixes you make on master may still
    🫒🫒🫒🫒     be needed on Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This backports https://github.com/openedx/edx-platform/pull/31212 to fix https://discuss.openedx.org/t/text-component-does-not-remove-text-with-link-or-insert-a-link-to-text/9029/5 and https://github.mit.edu/xpro/xpro-issues/issues/338.

During the upgrade to TinyMCE v5, we changed the content format to `text`. However, it ignores changes in HTML tags. This reverts the format to `raw`.

