### PR TITLE
feat: ability to filter active courses in course listing api

### DIFF
--- a/lms/djangoapps/branding/__init__.py
+++ b/lms/djangoapps/branding/__init__.py
@@ -14,7 +14,7 @@ from opaque_keys.edx.keys import CourseKey
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 
-def get_visible_courses(org=None, filter_=None, **kwargs):
+def get_visible_courses(org=None, filter_=None, active_only=False):
     """
     Yield the CourseOverviews that should be visible in this branded
     instance.
@@ -24,6 +24,7 @@ def get_visible_courses(org=None, filter_=None, **kwargs):
             filtering by organization.
         filter_ (dict): Optional parameter that allows custom filtering by
             fields on the course.
+        active_only (bool): Optional parameter that enables fetching active courses only.
     """
     # Import is placed here to avoid model import at project startup.
     from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
@@ -35,12 +36,12 @@ def get_visible_courses(org=None, filter_=None, **kwargs):
     if org:
         # Check the current site's orgs to make sure the org's courses should be displayed
         if not current_site_orgs or org in current_site_orgs:
-            courses = CourseOverview.get_all_courses(orgs=[org], filter_=filter_, **kwargs)
+            courses = CourseOverview.get_all_courses(orgs=[org], filter_=filter_, active_only=active_only)
     elif current_site_orgs:
         # Only display courses that should be displayed on this site
-        courses = CourseOverview.get_all_courses(orgs=current_site_orgs, filter_=filter_, **kwargs)
+        courses = CourseOverview.get_all_courses(orgs=current_site_orgs, filter_=filter_, active_only=active_only)
     else:
-        courses = CourseOverview.get_all_courses(filter_=filter_, **kwargs)
+        courses = CourseOverview.get_all_courses(filter_=filter_, active_only=active_only)
 
     courses = courses.order_by('id')
 

--- a/lms/djangoapps/branding/__init__.py
+++ b/lms/djangoapps/branding/__init__.py
@@ -14,7 +14,7 @@ from opaque_keys.edx.keys import CourseKey
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 
-def get_visible_courses(org=None, filter_=None):
+def get_visible_courses(org=None, filter_=None, **kwargs):
     """
     Yield the CourseOverviews that should be visible in this branded
     instance.
@@ -35,12 +35,12 @@ def get_visible_courses(org=None, filter_=None):
     if org:
         # Check the current site's orgs to make sure the org's courses should be displayed
         if not current_site_orgs or org in current_site_orgs:
-            courses = CourseOverview.get_all_courses(orgs=[org], filter_=filter_)
+            courses = CourseOverview.get_all_courses(orgs=[org], filter_=filter_, **kwargs)
     elif current_site_orgs:
         # Only display courses that should be displayed on this site
-        courses = CourseOverview.get_all_courses(orgs=current_site_orgs, filter_=filter_)
+        courses = CourseOverview.get_all_courses(orgs=current_site_orgs, filter_=filter_, **kwargs)
     else:
-        courses = CourseOverview.get_all_courses(filter_=filter_)
+        courses = CourseOverview.get_all_courses(filter_=filter_, **kwargs)
 
     courses = courses.order_by('id')
 

--- a/lms/djangoapps/course_api/api.py
+++ b/lms/djangoapps/course_api/api.py
@@ -116,7 +116,7 @@ def list_courses(request,
                  filter_=None,
                  search_term=None,
                  permissions=None,
-                 **kwargs):
+                 active_only=False):
     """
     Yield all available courses.
 
@@ -145,14 +145,13 @@ def list_courses(request,
         permissions (list[str]):
             If specified, it filters visible `CourseOverview` objects by
             checking if each permission specified is granted for the username.
-        kwargs (dict):
-            Optional key value pairs for additional filtering on course listing using complex lookups.
+        active_only (bool): Optional parameter that enables fetching active courses only.
 
     Return value:
         Yield `CourseOverview` objects representing the collection of courses.
     """
     user = get_effective_user(request.user, username)
-    course_qs = get_courses(user, org=org, filter_=filter_, permissions=permissions, **kwargs)
+    course_qs = get_courses(user, org=org, filter_=filter_, permissions=permissions, active_only=active_only)
     course_qs = _filter_by_search(course_qs, search_term)
     return course_qs
 

--- a/lms/djangoapps/course_api/api.py
+++ b/lms/djangoapps/course_api/api.py
@@ -115,7 +115,8 @@ def list_courses(request,
                  org=None,
                  filter_=None,
                  search_term=None,
-                 permissions=None):
+                 permissions=None,
+                 **kwargs):
     """
     Yield all available courses.
 
@@ -144,12 +145,14 @@ def list_courses(request,
         permissions (list[str]):
             If specified, it filters visible `CourseOverview` objects by
             checking if each permission specified is granted for the username.
+        kwargs (dict):
+            Optional key value pairs for additional filtering on course listing using complex lookups.
 
     Return value:
         Yield `CourseOverview` objects representing the collection of courses.
     """
     user = get_effective_user(request.user, username)
-    course_qs = get_courses(user, org=org, filter_=filter_, permissions=permissions)
+    course_qs = get_courses(user, org=org, filter_=filter_, permissions=permissions, **kwargs)
     course_qs = _filter_by_search(course_qs, search_term)
     return course_qs
 

--- a/lms/djangoapps/course_api/forms.py
+++ b/lms/djangoapps/course_api/forms.py
@@ -62,7 +62,7 @@ class CourseListGetForm(UsernameValidatorMixin, Form):
         filter_type(param_name='mobile', field_name='mobile_available'),
     ]
     mobile = ExtendedNullBooleanField(required=False)
-    active_courses_only = ExtendedNullBooleanField(required=False)
+    active_only = ExtendedNullBooleanField(required=False)
     permissions = MultiValueField(required=False)
 
     def clean(self):

--- a/lms/djangoapps/course_api/forms.py
+++ b/lms/djangoapps/course_api/forms.py
@@ -62,6 +62,7 @@ class CourseListGetForm(UsernameValidatorMixin, Form):
         filter_type(param_name='mobile', field_name='mobile_available'),
     ]
     mobile = ExtendedNullBooleanField(required=False)
+    active_courses_only = ExtendedNullBooleanField(required=False)
     permissions = MultiValueField(required=False)
 
     def clean(self):

--- a/lms/djangoapps/course_api/tests/mixins.py
+++ b/lms/djangoapps/course_api/tests/mixins.py
@@ -17,13 +17,12 @@ class CourseApiFactoryMixin:
     """
 
     @staticmethod
-    def create_course(**kwargs):
+    def create_course(end=datetime(2015, 9, 19, 18, 0, 0), **kwargs):
         """
         Create a course for use in test cases
         """
-
         return ToyCourseFactory.create(
-            end=datetime(2015, 9, 19, 18, 0, 0),
+            end=end,
             enrollment_start=datetime(2015, 6, 15, 0, 0, 0),
             enrollment_end=datetime(2015, 7, 15, 0, 0, 0),
             emit_signals=True,

--- a/lms/djangoapps/course_api/tests/test_forms.py
+++ b/lms/djangoapps/course_api/tests/test_forms.py
@@ -70,6 +70,7 @@ class TestCourseListGetForm(FormTestMixin, UsernameTestMixin, SharedModuleStoreT
             'search_term': '',
             'filter_': None,
             'permissions': set(),
+            'active_courses_only': None,
         }
 
     def test_basic(self):

--- a/lms/djangoapps/course_api/tests/test_forms.py
+++ b/lms/djangoapps/course_api/tests/test_forms.py
@@ -70,7 +70,7 @@ class TestCourseListGetForm(FormTestMixin, UsernameTestMixin, SharedModuleStoreT
             'search_term': '',
             'filter_': None,
             'permissions': set(),
-            'active_courses_only': None,
+            'active_only': None,
         }
 
     def test_basic(self):

--- a/lms/djangoapps/course_api/tests/test_views.py
+++ b/lms/djangoapps/course_api/tests/test_views.py
@@ -189,13 +189,13 @@ class CourseListViewTestCaseMultipleCourses(CourseApiTestViewMixin, ModuleStoreT
 
     def test_filter_active_courses_only(self):
         """
-        Verify that CourseOverviews are filtered by end date if active_courses_only filter is provided.
+        Verify that CourseOverviews are filtered by end date if active_only filter is provided.
         """
         self.setup_user(self.staff_user)
         active_course = self.create_course(org='org1', end=datetime.now() + timedelta(days=1))
         missing_end_date = self.create_course(org='org2', end=None)
 
-        response = self.verify_response(params={'username': self.staff_user.username, 'active_courses_only': True})
+        response = self.verify_response(params={'username': self.staff_user.username, 'active_only': True})
         output_ids = {course['id'] for course in response.data['results']}
 
         assert len(output_ids) == 2

--- a/lms/djangoapps/course_api/views.py
+++ b/lms/djangoapps/course_api/views.py
@@ -277,7 +277,7 @@ class CourseListView(DeveloperErrorViewMixin, ListAPIView):
             Notice that Staff users are always granted permission to list any
             course.
 
-        active_courses_only (optional):
+        active_only (optional):
             If this boolean is specified, only the courses that have not ended or do not have any end
             date are returned. This is different from search_term because this filtering is done on
             CourseOverview and not ElasticSearch.
@@ -339,7 +339,7 @@ class CourseListView(DeveloperErrorViewMixin, ListAPIView):
             filter_=form.cleaned_data['filter_'],
             search_term=form.cleaned_data['search_term'],
             permissions=form.cleaned_data['permissions'],
-            active_courses_only=form.cleaned_data['active_courses_only']
+            active_only=form.cleaned_data.get('active_only', False)
         )
 
 

--- a/lms/djangoapps/course_api/views.py
+++ b/lms/djangoapps/course_api/views.py
@@ -277,6 +277,11 @@ class CourseListView(DeveloperErrorViewMixin, ListAPIView):
             Notice that Staff users are always granted permission to list any
             course.
 
+        active_courses_only (optional):
+            If this boolean is specified, only the courses that have not ended or do not have any end
+            date are returned. This is different from search_term because this filtering is done on
+            CourseOverview and not ElasticSearch.
+
     **Returns**
 
         * 200 on success, with a list of course discovery objects as returned
@@ -333,7 +338,8 @@ class CourseListView(DeveloperErrorViewMixin, ListAPIView):
             org=form.cleaned_data['org'],
             filter_=form.cleaned_data['filter_'],
             search_term=form.cleaned_data['search_term'],
-            permissions=form.cleaned_data['permissions']
+            permissions=form.cleaned_data['permissions'],
+            active_courses_only=form.cleaned_data['active_courses_only']
         )
 
 

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -753,7 +753,7 @@ def get_course_syllabus_section(course, section_key):
 
 
 @function_trace('get_courses')
-def get_courses(user, org=None, filter_=None, permissions=None, **kwargs):
+def get_courses(user, org=None, filter_=None, permissions=None, active_only=False):
     """
     Return a LazySequence of courses available, optionally filtered by org code
     (case-insensitive) or a set of permissions to be satisfied for the specified
@@ -763,7 +763,7 @@ def get_courses(user, org=None, filter_=None, permissions=None, **kwargs):
     courses = branding.get_visible_courses(
         org=org,
         filter_=filter_,
-        **kwargs
+        active_only=active_only
     ).prefetch_related(
         'modes',
     ).select_related(

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -753,7 +753,7 @@ def get_course_syllabus_section(course, section_key):
 
 
 @function_trace('get_courses')
-def get_courses(user, org=None, filter_=None, permissions=None):
+def get_courses(user, org=None, filter_=None, permissions=None, **kwargs):
     """
     Return a LazySequence of courses available, optionally filtered by org code
     (case-insensitive) or a set of permissions to be satisfied for the specified
@@ -763,6 +763,7 @@ def get_courses(user, org=None, filter_=None, permissions=None):
     courses = branding.get_visible_courses(
         org=org,
         filter_=filter_,
+        **kwargs
     ).prefetch_related(
         'modes',
     ).select_related(

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -657,7 +657,7 @@ class CourseOverview(TimeStampedModel):
         log.info('Finished generating course overviews.')
 
     @classmethod
-    def get_all_courses(cls, orgs=None, filter_=None, **kwargs):
+    def get_all_courses(cls, orgs=None, filter_=None, active_only=False):
         """
         Return a queryset containing all CourseOverview objects in the database.
 
@@ -665,9 +665,7 @@ class CourseOverview(TimeStampedModel):
             orgs (list[string]): Optional parameter that allows case-insensitive
                 filtering by organization.
             filter_ (dict): Optional parameter that allows custom filtering.
-            kwargs (dict): Optional key value pairs usable for performing complex lookups on course listing.
-                * Possible values:
-                    * active_courses_only (bool): If provided, only the courses that have not ended will be returned.
+            active_only (bool): If provided, only the courses that have not ended will be returned.
         """
         # Note: If a newly created course is not returned in this QueryList,
         # make sure the "publish" signal was emitted when the course was
@@ -685,7 +683,7 @@ class CourseOverview(TimeStampedModel):
 
         if filter_:
             course_overviews = course_overviews.filter(**filter_)
-        if kwargs.get('active_courses_only'):
+        if active_only:
             course_overviews = course_overviews.filter(
                 Q(end__isnull=True) | Q(end__gte=datetime.now().replace(tzinfo=pytz.UTC))
             )

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -5,8 +5,10 @@ Declaration of CourseOverview model
 
 import json
 import logging
+from datetime import datetime
 from urllib.parse import urlparse, urlunparse
 
+import pytz
 from ccx_keys.locator import CCXLocator
 from config_models.models import ConfigurationModel
 from django.conf import settings
@@ -655,7 +657,7 @@ class CourseOverview(TimeStampedModel):
         log.info('Finished generating course overviews.')
 
     @classmethod
-    def get_all_courses(cls, orgs=None, filter_=None):
+    def get_all_courses(cls, orgs=None, filter_=None, **kwargs):
         """
         Return a queryset containing all CourseOverview objects in the database.
 
@@ -663,6 +665,9 @@ class CourseOverview(TimeStampedModel):
             orgs (list[string]): Optional parameter that allows case-insensitive
                 filtering by organization.
             filter_ (dict): Optional parameter that allows custom filtering.
+            kwargs (dict): Optional key value pairs usable for performing complex lookups on course listing.
+                * Possible values:
+                    * active_courses_only (bool): If provided, only the courses that have not ended will be returned.
         """
         # Note: If a newly created course is not returned in this QueryList,
         # make sure the "publish" signal was emitted when the course was
@@ -680,6 +685,10 @@ class CourseOverview(TimeStampedModel):
 
         if filter_:
             course_overviews = course_overviews.filter(**filter_)
+        if kwargs.get('active_courses_only'):
+            course_overviews = course_overviews.filter(
+                Q(end__isnull=True) | Q(end__gte=datetime.now().replace(tzinfo=pytz.UTC))
+            )
 
         return course_overviews
 

--- a/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
+++ b/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
@@ -556,14 +556,13 @@ class CourseOverviewTestCase(CatalogIntegrationMixin, ModuleStoreTestCase, Cache
 
     def test_get_all_active_courses(self):
         """
-        Verify active courses or courses with null end date are returned if active_courses_only is provided.
+        Verify active courses or courses with null end date are returned if active_only is provided.
         """
         active_course = CourseFactory.create(emit_signals=True, end=self.DATES[self.NEXT_MONTH])
         missing_end_date = CourseFactory.create(emit_signals=True, end=None)
         inactive_course = CourseFactory.create(emit_signals=True, end=self.DATES[self.LAST_MONTH])
 
-        kwargs = {'active_courses_only': True}
-        output_ids = {course.id for course in CourseOverview.get_all_courses(**kwargs)}
+        output_ids = {course.id for course in CourseOverview.get_all_courses(active_only=True)}
 
         assert len(output_ids) == 2
         assert inactive_course.id not in output_ids

--- a/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
+++ b/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
@@ -554,6 +554,21 @@ class CourseOverviewTestCase(CatalogIntegrationMixin, ModuleStoreTestCase, Cache
             assert {course_overview.id for course_overview in CourseOverview.get_all_courses(filter_=filter_)} ==\
                    expected_courses, f'testing CourseOverview.get_all_courses with filter_={filter_}'
 
+    def test_get_all_courses_active_courses_only(self):
+        """
+        Test get_all_courses returns active courses or courses with Null end date if active courses filter is provided.
+        """
+        active_course = CourseFactory.create(emit_signals=True, end=self.DATES[self.NEXT_MONTH])
+        missing_end_date = CourseFactory.create(emit_signals=True, end=None)
+        inactive_course = CourseFactory.create(emit_signals=True, end=self.DATES[self.LAST_MONTH])
+
+        kwargs = {'active_courses_only': True}
+        output_ids = {course.id for course in CourseOverview.get_all_courses(**kwargs)}
+
+        assert len(output_ids) == 2
+        assert inactive_course.id not in output_ids
+        assert {active_course.id, missing_end_date.id} == output_ids
+
     def test_get_from_ids(self):
         """
         Assert that CourseOverviews.get_from_ids works as expected.

--- a/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
+++ b/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
@@ -554,9 +554,9 @@ class CourseOverviewTestCase(CatalogIntegrationMixin, ModuleStoreTestCase, Cache
             assert {course_overview.id for course_overview in CourseOverview.get_all_courses(filter_=filter_)} ==\
                    expected_courses, f'testing CourseOverview.get_all_courses with filter_={filter_}'
 
-    def test_get_all_courses_active_courses_only(self):
+    def test_get_all_active_courses(self):
         """
-        Test get_all_courses returns active courses or courses with Null end date if active courses filter is provided.
+        Verify active courses or courses with null end date are returned if active_courses_only is provided.
         """
         active_course = CourseFactory.create(emit_signals=True, end=self.DATES[self.NEXT_MONTH])
         missing_end_date = CourseFactory.create(emit_signals=True, end=None)


### PR DESCRIPTION
### [PROD-3096](https://2u-internal.atlassian.net/browse/PROD-3096)

### Description
This PR adds the ability to optionally add filtering to return active courses only in LMS Course listing API (active = end date in future or end date is null). Due to how the list_courses is used by course_api view, adding the kwargs required editing various methods. However, since the kwargs are optional, this does not affect the working. For now, `active_only` kwarg has been added.

This filtering is also different from `filter_` positional argument. The dict in filter_ is used directly in CourseOverview.objects.filter() after serializing. However, fetching the active courses required a complex lookup with Q(). 

~~This kwarg approach will help in the future if there is a need to have further complex lookups. This API endpoint is operationally expensive and will benefit from additional filter options in the future if/when needed.~~


### Testing

- Create/update existing courses in Studio and have a variety of end dates (past and future)
- Go to mysql shell from devstack and verify the count of active and total courses from course overivew table by running the following 2 queries:
   -   `select count(*) from course_overviews_courseoverview;`
   -  `select count(*) from course_overviews_courseoverview where end is NULL or Date(end) >= '2023-01-06';`

- Now, go to the browser and hit the endpoint http://localhost:18000/api/courses/v1/courses/?active_only=true. 
     - Verify that the count matches the results returned by 2nd query