### PR TITLE
Fix error 500 on course home page if there are no sections

### DIFF
--- a/lms/djangoapps/course_home_api/outline/tests/test_view.py
+++ b/lms/djangoapps/course_home_api/outline/tests/test_view.py
@@ -437,3 +437,25 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         self.update_course_and_overview()
         CourseEnrollment.enroll(UserFactory(), self.course.id)  # grr, some rando took our spot!
         self.assert_can_enroll(False)
+
+    def test_view_home_page_empty_course(self):
+        """
+        Correct response if the course does not contain sections.
+
+        Test the correct response of the course home page if the course does not contain
+        any blocks (sections/subsections).
+        """
+        test_empty_course = CourseFactory.create(
+            start=datetime(2023, 1, 1),
+            end=datetime(2028, 1, 1),
+            enrollment_start=datetime(2022, 1, 1),
+            enrollment_end=datetime(2025, 1, 1),
+            emit_signals=True,
+            modulestore=self.store,
+        )
+
+        CourseEnrollment.enroll(self.user, test_empty_course.id)
+        url = reverse('course-home:outline-tab', args=[test_empty_course.id])
+        response = self.client.get(url)
+
+        assert response.status_code == 200

--- a/lms/djangoapps/course_home_api/outline/views.py
+++ b/lms/djangoapps/course_home_api/outline/views.py
@@ -282,7 +282,7 @@ class OutlineTabView(RetrieveAPIView):
         #
         # The long term goal is to remove the Course Blocks API call entirely,
         # so this is a tiny first step in that migration.
-        if course_blocks:
+        if course_blocks and course_blocks.get('children'):
             user_course_outline = get_user_course_outline(
                 course_key, request.user, datetime.now(tz=timezone.utc)
             )


### PR DESCRIPTION
### Fix error 500 on course home page if there are no sections

Steps to reproduce:
- go to the studio and create a course (do not create sections)
- go to the LMS's course home page and observe the result


![screen_2](https://user-images.githubusercontent.com/98233552/211553021-c5f895de-f01b-49ba-84e0-036c1146fe4c.png)
![screen_1](https://user-images.githubusercontent.com/98233552/211553110-6c53ecc3-76e6-49d3-8763-9092c69bda24.png)

#### Problem cause:
No check for the presence of the ['children'] key in the course_blocks dictionary. If there is no section in the course, then an exception occurs when accessing this key.

#### The Fix:
Go to the course home page, the correct information is displayed.
![screen_3](https://user-images.githubusercontent.com/98233552/211555683-a063133b-adb0-4823-b7a0-0a7d338431c0.png)

NOTE: The problem is reproducible on Nutmeg+ releases