### PR TITLE
Make NPM post-processing agnostic to node_modules location

### DIFF
--- a/common/static/.gitignore
+++ b/common/static/.gitignore
@@ -1,1 +1,2 @@
 xmodule
+edx-ui-toolkit

--- a/common/static/edx-ui-toolkit/js
+++ b/common/static/edx-ui-toolkit/js
@@ -1,1 +1,0 @@
-../../../node_modules/edx-ui-toolkit/src/js

--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -46,39 +46,6 @@ COMMON_LOOKUP_PATHS = [
     path('node_modules'),
 ]
 
-# A list of NPM installed libraries that should be copied into the common
-# static directory.
-# If string ends with '/' then all file in the directory will be copied.
-NPM_INSTALLED_LIBRARIES = [
-    'backbone.paginator/lib/backbone.paginator.js',
-    'backbone/backbone.js',
-    'bootstrap/dist/js/bootstrap.bundle.js',
-    'hls.js/dist/hls.js',
-    'jquery-migrate/dist/jquery-migrate.js',
-    'jquery.scrollto/jquery.scrollTo.js',
-    'jquery/dist/jquery.js',
-    'moment-timezone/builds/moment-timezone-with-data.js',
-    'moment/min/moment-with-locales.js',
-    'picturefill/dist/picturefill.js',
-    'requirejs/require.js',
-    'underscore.string/dist/underscore.string.js',
-    'underscore/underscore.js',
-    '@edx/studio-frontend/dist/',
-    'which-country/index.js'
-]
-
-# A list of NPM installed developer libraries that should be copied into the common
-# static directory only in development mode.
-NPM_INSTALLED_DEVELOPER_LIBRARIES = [
-    'sinon/pkg/sinon.js',
-    'squirejs/src/Squire.js',
-]
-
-# Directory to install static vendor files
-NPM_JS_VENDOR_DIRECTORY = path('common/static/common/js/vendor')
-NPM_CSS_VENDOR_DIRECTORY = path("common/static/common/css/vendor")
-NPM_CSS_DIRECTORY = path("common/static/common/css")
-
 # system specific lookup path additions, add sass dirs if one system depends on the sass files for other systems
 SASS_LOOKUP_DEPENDENCIES = {
     'cms': [path('lms') / 'static' / 'sass' / 'partials', ],
@@ -604,60 +571,11 @@ def process_npm_assets():
     """
     Process vendor libraries installed via NPM.
     """
-    def copy_vendor_library(library, skip_if_missing=False):
-        """
-        Copies a vendor library to the shared vendor directory.
-        """
-        if library.startswith('node_modules/'):
-            library_path = library
-        else:
-            library_path = f'node_modules/{library}'
-
-        if library.endswith('.css') or library.endswith('.css.map'):
-            vendor_dir = NPM_CSS_VENDOR_DIRECTORY
-        else:
-            vendor_dir = NPM_JS_VENDOR_DIRECTORY
-        if os.path.exists(library_path):
-            sh('/bin/cp -rf {library_path} {vendor_dir}'.format(
-                library_path=library_path,
-                vendor_dir=vendor_dir,
-            ))
-        elif not skip_if_missing:
-            raise Exception(f'Missing vendor file {library_path}')
-
-    def copy_vendor_library_dir(library_dir, skip_if_missing=False):
-        """
-        Copies all vendor libraries in directory to the shared vendor directory.
-        """
-        library_dir_path = f'node_modules/{library_dir}'
-        print(f'Copying vendor library dir: {library_dir_path}')
-        if os.path.exists(library_dir_path):
-            for dirpath, _, filenames in os.walk(library_dir_path):
-                for filename in filenames:
-                    copy_vendor_library(os.path.join(dirpath, filename), skip_if_missing=skip_if_missing)
-
     # Skip processing of the libraries if this is just a dry run
     if tasks.environment.dry_run:
         tasks.environment.info("install npm_assets")
         return
-
-    # Ensure that the vendor directory exists
-    NPM_JS_VENDOR_DIRECTORY.mkdir_p()
-    NPM_CSS_DIRECTORY.mkdir_p()
-    NPM_CSS_VENDOR_DIRECTORY.mkdir_p()
-
-    # Copy each file to the vendor directory, overwriting any existing file.
-    print("Copying vendor files into static directory")
-    for library in NPM_INSTALLED_LIBRARIES:
-        if library.endswith('/'):
-            copy_vendor_library_dir(library)
-        else:
-            copy_vendor_library(library)
-
-    # Copy over each developer library too if they have been installed
-    print("Copying developer vendor files into static directory")
-    for library in NPM_INSTALLED_DEVELOPER_LIBRARIES:
-        copy_vendor_library(library, skip_if_missing=True)
+    sh(cmd('/bin/sh', 'scripts/assets/copy-node-modules.sh'))
 
 
 @task

--- a/scripts/assets/copy-node-modules.sh
+++ b/scripts/assets/copy-node-modules.sh
@@ -1,0 +1,119 @@
+#!/bin/sh
+#
+# Copy certain node_modules to other places in edx-platform.
+#
+# Run this from the root of edx-platform, after node_modules are installed,
+# but before trying to compile static assets.
+#
+# Background:
+#
+#  Earlier in edx-platform's development, JS and CSS dependencies were
+#  committed directly (a.k.a. "vendored in") to the platform.
+#  Later on, as NPM became popular, new edx-platform frontends began
+#  using package.json to specify dependencies, and of course those new
+#  dependencies were installed into node_modules.
+#
+#  Unfortunately, not all old pages were updated to use package.json.
+#  However, rather then continuing to vendor-in the dependencies for
+#  the old pages, it was decided to copy the required files from
+#  node_modules to the old "vendor" directories. That way, the old
+#  pages' dependencies would remain synced with the newer pages'
+#  dependencies. That is what this script does.
+#
+#  This was formerly implemented in pavelib/assets.py. As we are moving
+#  away from paver, it was reimplemented in this shell script.
+#
+#  NOTE: This uses plain POSIX `sh` instead of `bash` for the purpose of
+#  maximum portability.
+
+USAGE="Usage: $0"
+
+NODE_MODULES_PATH="./node_modules"
+
+# Vendor destination paths for assets.
+# These are not configurable yet, but that could be changed if necessary.
+JS_VENDOR_PATH="./common/static/common/js/vendor"
+CSS_VENDOR_PATH="./common/static/common/css/vendor"
+
+# Enable stricter sh behavior.
+set -eu  
+
+# Parse options.
+while [ $# -gt 0 ]; do
+	case $1 in
+		--help)
+			echo "$USAGE"
+			exit 0
+			;;
+		*)
+			echo "Error: Unrecognized option: $1"
+			echo "$USAGE"
+			exit 1
+			;;
+	esac
+done
+
+echo "-------------------------------------------------------------------------"
+echo "Copying shared node_modules to 'vendor' directories..."
+echo "  Working directory          == '$(pwd)'"
+echo "  NODE_MODULES_PATH          == '$NODE_MODULES_PATH'"
+echo "  CSS_VENDOR_PATH            == '$CSS_VENDOR_PATH'"
+echo "  JS_VENDOR_PATH             == '$JS_VENDOR_PATH'"
+echo "-------------------------------------------------------------------------"
+
+# Input validation
+if ! [ -d "$NODE_MODULES_PATH" ]; then
+	echo "Error: not a directory: $NODE_MODULES_PATH"
+	exit 1
+fi
+if ! [ -d ./common ]; then
+	echo "Error: not a directory: ./common"
+	echo "Hint: $0 must be run from the root of the edx-platform directory!"
+	exit 1
+fi
+
+# Echo lines back to user.
+set -x
+
+# Create vendor directories.
+mkdir -p common/static/common/js/vendor
+mkdir -p common/static/common/css/vendor
+
+# Copy studio-frontend assets into into vendor directory.
+find "$NODE_MODULES_PATH/@edx/studio-frontend/dist" \
+	-type f \! -name \*.css \! -name \*.css.map -print0 | \
+	xargs --null cp --target-directory="$JS_VENDOR_PATH"
+find "$NODE_MODULES_PATH/@edx/studio-frontend/dist" \
+	-type f \( -name \*.css -o -name \*.css.map \) -print0 | \
+	xargs --null cp --target-directory="$CSS_VENDOR_PATH"
+
+# Copy certain node_modules scripts into "vendor" directory.
+cp --force \
+	"$NODE_MODULES_PATH/backbone.paginator/lib/backbone.paginator.js" \
+	"$NODE_MODULES_PATH/backbone/backbone.js" \
+	"$NODE_MODULES_PATH/bootstrap/dist/js/bootstrap.bundle.js" \
+	"$NODE_MODULES_PATH/hls.js/dist/hls.js" \
+	"$NODE_MODULES_PATH/jquery-migrate/dist/jquery-migrate.js" \
+	"$NODE_MODULES_PATH/jquery.scrollto/jquery.scrollTo.js" \
+	"$NODE_MODULES_PATH/jquery/dist/jquery.js" \
+	"$NODE_MODULES_PATH/moment-timezone/builds/moment-timezone-with-data.js" \
+	"$NODE_MODULES_PATH/moment/min/moment-with-locales.js" \
+	"$NODE_MODULES_PATH/picturefill/dist/picturefill.js" \
+	"$NODE_MODULES_PATH/requirejs/require.js" \
+	"$NODE_MODULES_PATH/underscore.string/dist/underscore.string.js" \
+	"$NODE_MODULES_PATH/underscore/underscore.js" \
+	"$NODE_MODULES_PATH/which-country/index.js" \
+	"$JS_VENDOR_PATH"
+
+# Copy certain node_modules developer scripts into "vendor" directory.
+# Since they're just developer libraries, they might not exist in a production build pipeline.
+# So, let the error pass silently (`... || true`) if the copy fails.
+cp --force "$NODE_MODULES_PATH/sinon/pkg/sinon.js" "$JS_VENDOR_PATH" || true
+cp --force "$NODE_MODULES_PATH/squirejs/src/Squire.js" "$JS_VENDOR_PATH" || true
+
+# Stop echoing.
+set +x
+
+echo "-------------------------------------------------------------------------"
+echo "Done copying shared node_modules."
+echo "-------------------------------------------------------------------------"

--- a/scripts/assets/copy-node-modules.sh
+++ b/scripts/assets/copy-node-modules.sh
@@ -26,8 +26,11 @@
 #  NOTE: This uses plain POSIX `sh` instead of `bash` for the purpose of
 #  maximum portability.
 
-USAGE="Usage: $0"
+USAGE="Usage: $0 [ (-n|--node-modules) NODE_MODULES_PATH ]"
 
+# By default, we look for node_modules in the current directory.
+# Some Open edX distributions may want node_modules to be located somewhere
+# else, so we let this be configured with -n|--node-modules.
 NODE_MODULES_PATH="./node_modules"
 
 # Vendor destination paths for assets.
@@ -41,6 +44,16 @@ set -eu
 # Parse options.
 while [ $# -gt 0 ]; do
 	case $1 in
+		-n|--node-modules)
+			shift
+			if [ $# -eq 0 ]; then
+				echo "Error: Missing value for -n/--node-modules"
+				echo "$USAGE"
+				exit 1
+			fi
+			NODE_MODULES_PATH="$1"
+			shift
+			;;
 		--help)
 			echo "$USAGE"
 			exit 0

--- a/scripts/assets/copy-node-modules.sh
+++ b/scripts/assets/copy-node-modules.sh
@@ -37,6 +37,7 @@ NODE_MODULES_PATH="./node_modules"
 # These are not configurable yet, but that could be changed if necessary.
 JS_VENDOR_PATH="./common/static/common/js/vendor"
 CSS_VENDOR_PATH="./common/static/common/css/vendor"
+EDX_UI_TOOLKIT_VENDOR_PATH="./common/static/edx-ui-toolkit"
 
 # Enable stricter sh behavior.
 set -eu  
@@ -72,6 +73,7 @@ echo "  Working directory          == '$(pwd)'"
 echo "  NODE_MODULES_PATH          == '$NODE_MODULES_PATH'"
 echo "  CSS_VENDOR_PATH            == '$CSS_VENDOR_PATH'"
 echo "  JS_VENDOR_PATH             == '$JS_VENDOR_PATH'"
+echo "  EDX_UI_TOOLKIT_VENDOR_PATH == '$EDX_UI_TOOLKIT_VENDOR_PATH'"
 echo "-------------------------------------------------------------------------"
 
 # Input validation
@@ -89,8 +91,9 @@ fi
 set -x
 
 # Create vendor directories.
-mkdir -p common/static/common/js/vendor
-mkdir -p common/static/common/css/vendor
+mkdir -p "$JS_VENDOR_PATH"
+mkdir -p "$CSS_VENDOR_PATH"
+mkdir -p "$EDX_UI_TOOLKIT_VENDOR_PATH"
 
 # Copy studio-frontend assets into into vendor directory.
 find "$NODE_MODULES_PATH/@edx/studio-frontend/dist" \
@@ -99,6 +102,16 @@ find "$NODE_MODULES_PATH/@edx/studio-frontend/dist" \
 find "$NODE_MODULES_PATH/@edx/studio-frontend/dist" \
 	-type f \( -name \*.css -o -name \*.css.map \) -print0 | \
 	xargs --null cp --target-directory="$CSS_VENDOR_PATH"
+
+# Copy edx-ui-toolkit's JS to into its own special directory.
+# Note: $EDX_UI_TOOLKIT_VENDOR_PATH/js used to be a git-managed symlink.
+#       To avoid confusing behavior for folks who still have the js/ symlink
+#       hanging around in their repo, the safest thing to do is to remove
+#       the target js/ before copying in js/ fresh from the source.
+rm -rf "$EDX_UI_TOOLKIT_VENDOR_PATH/js"
+cp --recursive \
+	"$NODE_MODULES_PATH/edx-ui-toolkit/src/js" \
+	"$EDX_UI_TOOLKIT_VENDOR_PATH"
 
 # Copy certain node_modules scripts into "vendor" directory.
 cp --force \


### PR DESCRIPTION
## Description

See https://github.com/openedx/wg-developer-experience/issues/150 for the full background.

This PR handles this particular piece of that issue:

> - [x] The edx-platform asset pipeline unfortunately needs to reach into node_modules and copy stuff out of it, notably in the case of node_modules dependencies that also need to be copied into "vendor" directories for use by non-Webpack frontend code. So: We need to update the assets pipeline to tolerate the fact that node modules have moved to /openedx/node_modules. As necessary, do one or more of these:
>   - [ ] Edit edx-platform/pavelib/assets.py to be agnostic to the location of node_modules. Keep in mind that assets.py must continue working if node_modules is located inside the edx-platform directory as to not break Devstack.
>   - [x] Reimplement parts of edx-platform/pavelib/assets.py _upstream_ as shell scripts, agnostic to the location of node_modules. Point both edx-platform/pavelib/assets.py and Tutor's openedx-assets at that reimplementation.
>   - [ ] Reimplement more parts of edx-platform/pavelib/assets.py into Tutor's openedx-assets script, agnostic to the location of node_modules, but don't upstream the changes.

Specifically, this PR:
* reimplements `edx-platform/pavelib/assets.py:process_npm_assets` as a shell script (first commit),
* allows the script to be parameterized on the location of node_modules (second commit).
* It also deletes the symlink `common/static/edx-ui-toolkit/js -> ../../../node_modules/edx-ui-toolkit/src/js` in favor of just copying edx-ui-tookit/js as part of process_npm_assets (third commit).

You can view the individual commits for more depth on each step.

You can [see here how Tutor will use this new shell script](https://github.com/kdmccormick/tutor/pull/18/files#diff-2bfcf77b38c5be0f588b5d5af1d4311581dcc6bce5d4abea415234adf73987a2R145).

*Why not just edit edx-platform/pavelib/assets.py instead?* Frankly, I could have. I just find the pavelib code to be overly complex and way too dependency-heavy what is really just a set of build scripts. Furthermore, Arbi-BOM's good work with unit tests affirms that we are moving away from pavelib. With that in mind, I decided to fully re-implement rather than update process_npm_assets in place. If you disagree with this decision, let me know; I'm happy to revisit it.

This is **not** meant to be a breaking change for any consumers of edx-platform.

## Supporting information

Part of:
* https://github.com/openedx/wg-developer-experience/issues/150

Blocks:
* https://github.com/kdmccormick/tutor/pull/18

Related to
* https://github.com/openedx/edx-platform/pull/31583 ( <-- early WIP)

## Testing instructions

1. Check out the latest version of Tutor nightly
2. Ensure your images are fresh: `tutor config save && tutor images pull openedx && tutor dev dc build lms`
3. Check the contents of the "vendor" directories in both local and dev mode. Record them somewhere.
   ```
   tutor local run lms ls common/static/common/js/vendor
   tutor local run lms ls common/static/common/css/vendor
   tutor local run lms ls common/static/edx-ui-toolkit/js/*

   tutor dev run lms ls common/static/common/js/vendor
   tutor dev run lms ls common/static/common/css/vendor
   tutor dev run lms ls common/static/edx-ui-toolkit/js/*
   ```
4. Check out [this branch of Tutor](https://github.com/kdmccormick/tutor/pull/18).
5. Build the lms image using this PR's edx-platform branch:
   ```
   tutor config save --set EDX_PLATFORM_REPOSITORY=https://github.com/kdmccormick/edx-platform
   tutor config save --set EDX_PLATFORM_VERSION=kdmccormick/no-node-modules-links
   tutor images build openedx
   tutor dev dc build lms
   ```
6. Repeat step (3) and ensure the directory contents match.

## Deadline

No hard deadline, but sooner is better, since this is one small piece in a [greater effort to make `tutor dev` an acceptable replacement for devstack](https://github.com/openedx/wg-developer-experience/issues/144).

## Other information

N/A
