### PR TITLE
perf: change queryset to get_queryset in CourseEnrollmentAdmin

### DIFF
--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -305,8 +305,8 @@ class CourseEnrollmentAdmin(DisableEnrollmentAdminMixin, admin.ModelAdmin):
 
         return qs, use_distinct
 
-    def queryset(self, request):
-        return super().queryset(request).select_related('user')  # lint-amnesty, pylint: disable=no-member, super-with-arguments
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related('user')  # lint-amnesty, pylint: disable=no-member, super-with-arguments
 
 
 class UserProfileInline(admin.StackedInline):


### PR DESCRIPTION
<!--

🎉🎉 Olive has been released! 🎉🎉

🫒🫒
🫒🫒🫒🫒         🫒 Note: Olive is in support. Fixes you make on master may still
    🫒🫒🫒🫒     be needed on Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable. If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This PR changes the function name `queryset` to `get_queryset` in the CourseEnrollmentAdmin. I suggest this change because the admin site didn't call that function and never entered it. I think the correct form is like the Django documentation said [here](https://docs.djangoproject.com/en/3.2/ref/contrib/admin/#django.contrib.admin.ModelAdmin.get_queryset).

This PR improves performance.

**Why this improves performance?**

Because if it does not go through the function, the [select_related](https://docs.djangoproject.com/en/4.1/ref/models/querysets/#select-related) is not executed, which avoids unnecessary requests to the database. With this change, it passes inside the function and avoids unnecessary requests.

## Supporting information

![Screenshot from 2023-01-10 01-01-16](https://user-images.githubusercontent.com/35668326/211714251-4c39d951-2caf-459a-8b5c-ad82d81c49fc.png)
Screenshot of SQL report from Django debug toolbar with 6-course enrollments without the change.

![Screenshot from 2023-01-10 00-57-29](https://user-images.githubusercontent.com/35668326/211714435-9ad2a2e0-c346-4716-b922-9e31445b0a2d.png)
Screenshot of SQL report from Django debug toolbar with 6-course enrollments with the change.

## Testing instructions

1. Use this branch in a dev environment.
2. Add `student.courseenrollment_admin` in /admin/waffle/switch/.
3. Have some course enrollments.
4. Enter the Course Enrollment Admin and compare the SQL request with and without the change.

