### PR TITLE
fix: fix the tests in test_register file

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -315,28 +315,6 @@ class RegistrationFormFactory:
 
     DEFAULT_FIELDS = ["email", "name", "username", "password"]
 
-    EXTRA_FIELDS = [
-        "confirm_email",
-        "first_name",
-        "last_name",
-        "city",
-        "state",
-        "country",
-        "gender",
-        "year_of_birth",
-        "level_of_education",
-        "company",
-        "job_title",
-        "title",
-        "mailing_address",
-        "goals",
-        "honor_code",
-        "terms_of_service",
-        "profession",
-        "specialty",
-        "marketing_emails_opt_in",
-    ]
-
     def _is_field_visible(self, field_name):
         """Check whether a field is visible based on Django settings. """
         return self._extra_fields_setting.get(field_name) in ["required", "optional", "optional-exposed"]
@@ -350,6 +328,28 @@ class RegistrationFormFactory:
         return self._extra_fields_setting.get(field_name) in ["required", "optional-exposed"]
 
     def __init__(self):
+
+        self.EXTRA_FIELDS = [
+            "confirm_email",
+            "first_name",
+            "last_name",
+            "city",
+            "state",
+            "country",
+            "gender",
+            "year_of_birth",
+            "level_of_education",
+            "company",
+            "job_title",
+            "title",
+            "mailing_address",
+            "goals",
+            "honor_code",
+            "terms_of_service",
+            "profession",
+            "specialty",
+            "marketing_emails_opt_in",
+        ]
 
         if settings.ENABLE_COPPA_COMPLIANCE and 'year_of_birth' in self.EXTRA_FIELDS:
             self.EXTRA_FIELDS.remove('year_of_birth')

--- a/openedx/core/djangoapps/user_authn/views/tests/test_register.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_register.py
@@ -916,9 +916,6 @@ class RegistrationViewTestV1(
         )
 
     def test_register_form_year_of_birth(self):
-        # WARNING: This test may fail locally due to a test order issue. If it passes on Github,
-        #     but is failing for you locally, you probably did not cause the problem if you
-        #     are not working on registration. See VAN-900 for more details.
         this_year = datetime.now(UTC).year
         year_options = (
             [
@@ -1305,9 +1302,6 @@ class RegistrationViewTestV1(
         REGISTRATION_EXTENSION_FORM='openedx.core.djangoapps.user_api.tests.test_helpers.TestCaseForm',
     )
     def test_field_order(self):
-        # WARNING: This test may fail locally due to a test order issue. If it passes on Github,
-        #     but is failing for you locally, you probably did not cause the problem if you
-        #     are not working on registration. See VAN-900 for more details.
         response = self.client.get(self.url)
         self.assertHttpOK(response)
 
@@ -1370,9 +1364,6 @@ class RegistrationViewTestV1(
         ],
     )
     def test_field_order_override(self):
-        # WARNING: This test may fail locally due to a test order issue. If it passes on Github,
-        #     but is failing for you locally, you probably did not cause the problem if you
-        #     are not working on registration. See VAN-900 for more details.
         response = self.client.get(self.url)
         self.assertHttpOK(response)
 
@@ -1414,9 +1405,6 @@ class RegistrationViewTestV1(
         ],
     )
     def test_field_order_invalid_override(self):
-        # WARNING: This test may fail locally due to a test order issue. If it passes on Github,
-        #     but is failing for you locally, you probably did not cause the problem if you
-        #     are not working on registration. See VAN-900 for more details.
         response = self.client.get(self.url)
         self.assertHttpOK(response)
 
@@ -2024,9 +2012,6 @@ class RegistrationViewTestV2(RegistrationViewTestV1):
         ],
     )
     def test_field_order_invalid_override(self):
-        # WARNING: This test may fail locally due to a test order issue. If it passes on Github,
-        #     but is failing for you locally, you probably did not cause the problem if you
-        #     are not working on registration. See VAN-900 for more details.
         response = self.client.get(self.url)
         self.assertHttpOK(response)
 
@@ -2091,9 +2076,6 @@ class RegistrationViewTestV2(RegistrationViewTestV1):
         ],
     )
     def test_field_order_override(self):
-        # WARNING: This test may fail locally due to a test order issue. If it passes on Github,
-        #     but is failing for you locally, you probably did not cause the problem if you
-        #     are not working on registration. See VAN-900 for more details.
         response = self.client.get(self.url)
         self.assertHttpOK(response)
 
@@ -2122,9 +2104,6 @@ class RegistrationViewTestV2(RegistrationViewTestV1):
         REGISTRATION_EXTENSION_FORM='openedx.core.djangoapps.user_api.tests.test_helpers.TestCaseForm',
     )
     def test_field_order(self):
-        # WARNING: This test may fail locally due to a test order issue. If it passes on Github,
-        #     but is failing for you locally, you probably did not cause the problem if you
-        #     are not working on registration. See VAN-900 for more details.
         response = self.client.get(self.url)
         self.assertHttpOK(response)
 


### PR DESCRIPTION


## Description

Some tests in `user_authn/views/tests/test_register.py` fail when run in a particular order locally on devstack because when we run in specific order with the feature flag `ENABLE_COPPA_COMPLIANCE` is `True` it will remove the `self.EXTRA_FIELDS.remove('year_of_birth')` so the EXTRA_FIELDS is define globally. When we run the tests in specific order `year_of_birth` didn't find and the next tests will be failed.

### [VAN-900](https://2u-internal.atlassian.net/browse/VAN-900)


## Testing instructions

you can test it by running this command. 
`pytest -p 'no:randomly' openedx/core/djangoapps/user_authn/views/tests/test_register.py::RegistrationViewTestV2::test_year_of_birth_field_with_feature_flag openedx/core/djangoapps/user_authn/views/tests/test_register.py::RegistrationViewTestV2::test_register_form_year_of_birth openedx/core/djangoapps/user_authn/views/tests/test_register.py::RegistrationViewTestV2::test_field_order_override  openedx/core/djangoapps/user_authn/views/tests/test_register.py::RegistrationViewTestV2::test_field_order openedx/core/djangoapps/user_authn/views/tests/test_register.py::RegistrationViewTestV2::test_field_order_invalid_override
`
It will fail on `MASTER BRANCH`.
