### PR TITLE
fix: Update enrollment email for master track learners

### DIFF
--- a/common/djangoapps/student/models/course_enrollment.py
+++ b/common/djangoapps/student/models/course_enrollment.py
@@ -596,7 +596,8 @@ class CourseEnrollment(models.Model):
                                                               self.course_overview.display_name,
                                                               self.course_overview.short_description,
                                                               self.course_overview.has_ended(),
-                                                              course_pacing_type))
+                                                              course_pacing_type,
+                                                              self.mode))
                 segment_properties['email'] = self.user.email
                 # This next property is for an experiment, see method's comments for more information
                 segment_properties['external_course_updates'] = set_up_external_updates_for_enrollment(self.user,

--- a/common/djangoapps/student/tasks.py
+++ b/common/djangoapps/student/tasks.py
@@ -31,7 +31,7 @@ COUNTDOWN = 60
 
 @shared_task(bind=True, ignore_result=True)
 def send_course_enrollment_email(
-    self, user_id, course_id, course_title, short_description, course_ended, pacing_type
+    self, user_id, course_id, course_title, short_description, course_ended, pacing_type, track_mode
 ):
     """
     Send course enrollment email using Braze API.
@@ -69,6 +69,7 @@ def send_course_enrollment_email(
         "learning_base_url": configuration_helpers.get_value(
             "LEARNING_MICROFRONTEND_URL", settings.LEARNING_MICROFRONTEND_URL
         ),
+        "track_mode": track_mode
     }
 
     try:

--- a/common/djangoapps/student/tests/test_tasks.py
+++ b/common/djangoapps/student/tests/test_tasks.py
@@ -39,6 +39,7 @@ class TestCourseEnrollmentEmailTask(ModuleStoreTestCase):
             "short_description": "Short description of course",
             "course_ended": False,
             "pacing_type": "self-paced",
+            "track_mode": "audit",
         }
 
     @staticmethod
@@ -129,6 +130,7 @@ class TestCourseEnrollmentEmailTask(ModuleStoreTestCase):
             "course_title": self.send_course_enrollment_email_kwargs["course_title"],
             "short_description": self.send_course_enrollment_email_kwargs["short_description"],
             "pacing_type": self.send_course_enrollment_email_kwargs["pacing_type"],
+            "track_mode": self.send_course_enrollment_email_kwargs["track_mode"],
         }
 
         if add_course_dates:


### PR DESCRIPTION
Update the canvas triggered properties and pass the track_mode key to check the master track learners for course enrollment email.

Ticket: [VAN-1236](https://2u-internal.atlassian.net/browse/VAN-1236)