### PR TITLE
fix: removed subsections with no units from v3 topics api

### DIFF
--- a/lms/djangoapps/discussion/rest_api/tests/test_utils.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_utils.py
@@ -119,15 +119,25 @@ class TestRemoveEmptySequentials(unittest.TestCase):
         data = [
             {"type": "sequential", "children": []},
             {"type": "chapter", "children": [
-                {"type": "sequential", "children": [{"type": "vertical"}]},
+                {"type": "sequential", "children": [{"type": "vertical3"}]},
                 {"type": "sequential", "children": []},
-                {"type": "sequential", "children": [{"type": "vertical"}]}
+                {"type": "sequential", "children": []},
+                {"type": "sequential", "children": [{"type": "vertical4"}]}
+            ]},
+            {"type": "chapter", "children": [
+                {"type": "sequential", "children": [{"type": "vertical1"}]},
+                {"type": "sequential", "children": []},
+                {"type": "sequential", "children": [{"type": "vertical2"}]}
             ]}
         ]
         expected_output = [
             {"type": "chapter", "children": [
-                {"type": "sequential", "children": [{"type": "vertical"}]},
-                {"type": "sequential", "children": [{"type": "vertical"}]}
+                {"type": "sequential", "children": [{"type": "vertical3"}]},
+                {"type": "sequential", "children": [{"type": "vertical4"}]}
+            ]},
+            {"type": "chapter", "children": [
+                {"type": "sequential", "children": [{"type": "vertical1"}]},
+                {"type": "sequential", "children": [{"type": "vertical2"}]}
             ]}
         ]
         result = remove_empty_sequentials(data)

--- a/lms/djangoapps/discussion/rest_api/tests/test_utils.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_utils.py
@@ -130,7 +130,7 @@ class TestRemoveEmptySequentials(unittest.TestCase):
             {"type": "chapter", "children": [
                 {"type": "sequential", "children": [{"type": "vertical1"}]},
                 {"type": "sequential", "children": []},
-                {"type": "sequential", "children": [{"type": "vertical2"}]}
+                {"children": [{"type": "vertical2"}]}
             ]}
         ]
         expected_output = [
@@ -140,7 +140,7 @@ class TestRemoveEmptySequentials(unittest.TestCase):
             ]},
             {"type": "chapter", "children": [
                 {"type": "sequential", "children": [{"type": "vertical1"}]},
-                {"type": "sequential", "children": [{"type": "vertical2"}]}
+                {"children": [{"type": "vertical2"}]}
             ]}
         ]
         result = remove_empty_sequentials(data)

--- a/lms/djangoapps/discussion/rest_api/tests/test_utils.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_utils.py
@@ -5,7 +5,7 @@ Tests for Discussion REST API utils.
 from datetime import datetime, timedelta
 
 from pytz import UTC
-
+import unittest
 from common.djangoapps.student.roles import CourseStaffRole, CourseInstructorRole
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
@@ -17,7 +17,7 @@ from lms.djangoapps.discussion.rest_api.utils import (
     get_course_ta_users_list,
     get_course_staff_users_list,
     get_moderator_users_list,
-    get_archived_topics
+    get_archived_topics, remove_empty_sequentials
 )
 
 
@@ -94,3 +94,41 @@ class DiscussionAPIUtilsTestCase(ModuleStoreTestCase):
 
         # Assert that the output matches the expected output
         assert output == expected_output
+
+
+class TestRemoveEmptySequentials(unittest.TestCase):
+    def test_empty_data(self):
+        # Test that the function can handle an empty list
+        data = []
+        result = remove_empty_sequentials(data)
+        self.assertEqual(result, [])
+
+    def test_no_empty_sequentials(self):
+        # Test that the function does not remove any sequentials if they all have children
+        data = [
+            {"type": "sequential", "children": [{"type": "vertical"}]},
+            {"type": "chapter", "children": [
+                {"type": "sequential", "children": [{"type": "vertical"}]}
+            ]}
+        ]
+        result = remove_empty_sequentials(data)
+        self.assertEqual(result, data)
+
+    def test_remove_empty_sequentials(self):
+        # Test that the function removes empty sequentials
+        data = [
+            {"type": "sequential", "children": []},
+            {"type": "chapter", "children": [
+                {"type": "sequential", "children": [{"type": "vertical"}]},
+                {"type": "sequential", "children": []},
+                {"type": "sequential", "children": [{"type": "vertical"}]}
+            ]}
+        ]
+        expected_output = [
+            {"type": "chapter", "children": [
+                {"type": "sequential", "children": [{"type": "vertical"}]},
+                {"type": "sequential", "children": [{"type": "vertical"}]}
+            ]}
+        ]
+        result = remove_empty_sequentials(data)
+        self.assertEqual(result, expected_output)

--- a/lms/djangoapps/discussion/rest_api/tests/test_utils.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_utils.py
@@ -97,6 +97,9 @@ class DiscussionAPIUtilsTestCase(ModuleStoreTestCase):
 
 
 class TestRemoveEmptySequentials(unittest.TestCase):
+    """
+    Test for the remove_empty_sequentials function
+    """
     def test_empty_data(self):
         # Test that the function can handle an empty list
         data = []

--- a/lms/djangoapps/discussion/rest_api/utils.py
+++ b/lms/djangoapps/discussion/rest_api/utils.py
@@ -282,12 +282,14 @@ def remove_empty_sequentials(data):
     Returns:
     list: The modified list with empty sequentials removed.
     """
+
+    new_data = []
     for obj in data:
-        if obj['type'] == 'sequential' and not obj.get('children'):
-            data.remove(obj)
-        elif obj.get('children'):
-            remove_empty_sequentials(obj['children'])
-    return data
+        if obj['type'] != 'sequential' or (obj['type'] == 'sequential' and obj.get('children')):
+            new_data.append(obj)
+            if obj.get('children'):
+                obj['children'] = remove_empty_sequentials(obj['children'])
+    return new_data
 
 
 def get_topic_ids_from_topics(topics: List[Dict[str, str]]) -> List[str]:

--- a/lms/djangoapps/discussion/rest_api/utils.py
+++ b/lms/djangoapps/discussion/rest_api/utils.py
@@ -269,7 +269,25 @@ def create_topics_v3_structure(blocks, topics):
     if archived_topics['children']:
         structured_topics.append(archived_topics)
 
-    return structured_topics
+    return remove_empty_sequentials(structured_topics)
+
+
+def remove_empty_sequentials(data):
+    """
+    Removes all objects of type "sequential" from a nested list of objects if they have no children.
+
+    Parameters:
+    data (list): A list of nested objects to check and remove empty sequentials from.
+
+    Returns:
+    list: The modified list with empty sequentials removed.
+    """
+    for obj in data:
+        if obj['type'] == 'sequential' and not obj.get('children'):
+            data.remove(obj)
+        elif obj.get('children'):
+            remove_empty_sequentials(obj['children'])
+    return data
 
 
 def get_topic_ids_from_topics(topics: List[Dict[str, str]]) -> List[str]:

--- a/lms/djangoapps/discussion/rest_api/utils.py
+++ b/lms/djangoapps/discussion/rest_api/utils.py
@@ -285,7 +285,8 @@ def remove_empty_sequentials(data):
 
     new_data = []
     for obj in data:
-        if obj['type'] != 'sequential' or (obj['type'] == 'sequential' and obj.get('children')):
+        block_type = obj.get('type')
+        if block_type != 'sequential' or (block_type == 'sequential' and obj.get('children')):
             new_data.append(obj)
             if obj.get('children'):
                 obj['children'] = remove_empty_sequentials(obj['children'])


### PR DESCRIPTION
## Ticket
https://2u-internal.atlassian.net/browse/INF-710


## Description
This PR adds a function `remove_empty_sequentials` that takes in a nested list of objects and removes all objects of type "sequential" that have no children. It also includes unit tests to verify that the function is working correctly.

## Changes
- Added `remove_empty_sequentials` function to remove empty sequentials from a nested list of objects.
- Added `TestRemoveEmptySequentials` class that includes three unit tests to check the function's behavior for different scenarios.

