### PR TITLE
feat: add flag to enable fallback recommendations

### DIFF
--- a/common/djangoapps/student/toggles.py
+++ b/common/djangoapps/student/toggles.py
@@ -23,6 +23,24 @@ def should_show_amplitude_recommendations():
     return ENABLE_AMPLITUDE_RECOMMENDATIONS.is_enabled()
 
 
+# Waffle flag to enable fallback recommendations.
+# .. toggle_name: student.enable_fallback_recommendations
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Supports showing fallback recommendation in case of error on amplitude side.
+#                        Currently, fallback recommendations are picked from settings.GENERAL_RECOMMENDATIONS.
+# .. toggle_use_cases: opt_in
+# .. toggle_creation_date: 2023-01-16
+# .. toggle_target_removal_date: None
+# .. toggle_warning: None
+# .. toggle_tickets: VAN-1239
+ENABLE_FALLBACK_RECOMMENDATIONS = WaffleFlag(f'{WAFFLE_FLAG_NAMESPACE}.enable_fallback_recommendations', __name__)
+
+
+def show_fallback_recommendations():
+    return ENABLE_FALLBACK_RECOMMENDATIONS.is_enabled()
+
+
 # Waffle flag to enable 2U Recommendations
 # .. toggle_name: student.enable_2u_recommendations
 # .. toggle_implementation: WaffleFlag


### PR DESCRIPTION
<!--

🎉🎉 Olive has been released! 🎉🎉

🫒🫒
🫒🫒🫒🫒         🫒 Note: Olive is in support. Fixes you make on master may still
    🫒🫒🫒🫒     be needed on Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Added a waffle flag that can be used to enable fallback recommendations. If enabled, fallback recommendations can be used to show general recommendations if Amplitude recommends all courses that are already enrolled by a user or if the call to Amplitude fails. 

## Supporting information

Related to: https://2u-internal.atlassian.net/browse/VAN-1239
