### PR TITLE
fix: VAN-1247 - Add isControl property in recommendations response

### DIFF
--- a/lms/djangoapps/learner_home/recommendations/serializers.py
+++ b/lms/djangoapps/learner_home/recommendations/serializers.py
@@ -19,6 +19,7 @@ class CourseRecommendationSerializer(serializers.Serializer):
     courses = serializers.ListField(
         child=RecommendedCourseSerializer(), allow_empty=True
     )
-    isPersonalizedRecommendation = serializers.BooleanField(
-        source="is_personalized_recommendation"
+    isControl = serializers.BooleanField(
+        source="is_control",
+        default=None
     )

--- a/lms/djangoapps/learner_home/recommendations/test_serializers.py
+++ b/lms/djangoapps/learner_home/recommendations/test_serializers.py
@@ -41,7 +41,6 @@ class TestCourseRecommendationSerializer(TestCase):
         output_data = CourseRecommendationSerializer(
             {
                 "courses": recommended_courses,
-                "is_personalized_recommendation": False,
             }
         ).data
 
@@ -49,7 +48,7 @@ class TestCourseRecommendationSerializer(TestCase):
             output_data,
             {
                 "courses": [],
-                "isPersonalizedRecommendation": False,
+                "isControl": None,
             },
         )
 
@@ -61,7 +60,7 @@ class TestCourseRecommendationSerializer(TestCase):
         output_data = CourseRecommendationSerializer(
             {
                 "courses": recommended_courses,
-                "is_personalized_recommendation": True,
+                "is_control": False,
             }
         ).data
 
@@ -82,6 +81,6 @@ class TestCourseRecommendationSerializer(TestCase):
                         "title": recommended_courses[1]["title"],
                     },
                 ],
-                "isPersonalizedRecommendation": True,
+                "isControl": False,
             },
         )

--- a/lms/djangoapps/learner_home/recommendations/views.py
+++ b/lms/djangoapps/learner_home/recommendations/views.py
@@ -14,6 +14,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from common.djangoapps.student.models import CourseEnrollment
+from common.djangoapps.student.toggles import show_fallback_recommendations
 from common.djangoapps.track import segment
 from lms.djangoapps.learner_home.recommendations.serializers import (
     CourseRecommendationSerializer,
@@ -52,29 +53,19 @@ class CourseRecommendationApiView(APIView):
         if not should_show_learner_home_amplitude_recommendations():
             return Response(status=404)
 
+        user_id = request.user.id
         recommended_courses = []
-        general_recommendations_response = Response(
-            CourseRecommendationSerializer(
-                {
-                    "courses": settings.GENERAL_RECOMMENDATIONS,
-                    "is_personalized_recommendation": False,
-                }
-            ).data,
-            status=200,
-        )
+        fallback_recommendations = settings.GENERAL_RECOMMENDATIONS if show_fallback_recommendations() else []
 
         try:
-            user_id = request.user.id
             is_control, has_is_control, course_keys = get_personalized_course_recommendations(user_id)
         except Exception as ex:  # pylint: disable=broad-except
             logger.warning(f"Cannot get recommendations from Amplitude: {ex}")
-            return general_recommendations_response
+            return self._general_recommendations_response(user_id, None, fallback_recommendations)
 
-        if is_control or not course_keys:
-            self._emit_recommendations_viewed_event(
-                user_id, is_control, has_is_control, recommended_courses
-            )
-            return general_recommendations_response
+        is_control = is_control if has_is_control else None
+        if is_control or is_control is None or not course_keys:
+            return self._general_recommendations_response(user_id, is_control, fallback_recommendations)
 
         user_enrolled_course_keys = set()
         fields = ["title", "owners", "marketing_url"]
@@ -85,9 +76,9 @@ class CourseRecommendationApiView(APIView):
             user_enrolled_course_keys.add(course_key)
 
         # Pick 5 course keys, excluding the user's already enrolled course(s).
-        enrollable_course_keys = list(
-            set(course_keys).difference(user_enrolled_course_keys)
-        )[:5]
+        enrollable_course_keys = [
+            course_key for course_key in course_keys if course_key not in user_enrolled_course_keys
+        ][:5]
         for course_id in enrollable_course_keys:
             course_data = get_course_data(course_id, fields)
             if course_data:
@@ -99,34 +90,49 @@ class CourseRecommendationApiView(APIView):
                         "marketing_url": course_data.get("marketing_url"),
                     }
                 )
-        self._emit_recommendations_viewed_event(
-            user_id, is_control, has_is_control, recommended_courses
-        )
 
         # If no courses are left after filtering already enrolled courses from
         # the list of amplitude recommendations, show general recommendations
         # to the user.
         if not recommended_courses:
-            return general_recommendations_response
+            return self._general_recommendations_response(user_id, is_control, fallback_recommendations)
 
+        self._emit_recommendations_viewed_event(user_id, is_control, recommended_courses)
         return Response(
             CourseRecommendationSerializer(
                 {
                     "courses": recommended_courses,
-                    "is_personalized_recommendation": not is_control,
+                    "is_control": is_control,
                 }
             ).data,
             status=200,
         )
 
-    def _emit_recommendations_viewed_event(self, user_id, is_control, has_is_control, recommended_courses):
+    def _emit_recommendations_viewed_event(
+        self, user_id, is_control, recommended_courses, amplitude_recommendations=True
+    ):
         """Emits an event to track Learner Home page visits."""
         segment.track(
             user_id,
             "edx.bi.user.recommendations.viewed",
             {
-                "is_personalized_recommendation": not is_control,
-                "is_control": is_control if has_is_control else None,
+                "is_control": is_control,
+                "amplitude_recommendations": amplitude_recommendations,
                 "course_key_array": [course["course_key"] for course in recommended_courses],
             },
+        )
+
+    def _general_recommendations_response(self, user_id, is_control, recommended_courses):
+        """ Helper method for general recommendations response. """
+        self._emit_recommendations_viewed_event(
+            user_id, is_control, recommended_courses, amplitude_recommendations=False
+        )
+        return Response(
+            CourseRecommendationSerializer(
+                {
+                    "courses": recommended_courses,
+                    "is_control": is_control,
+                }
+            ).data,
+            status=200,
         )


### PR DESCRIPTION
<!--

🎉🎉 Olive has been released! 🎉🎉

🫒🫒
🫒🫒🫒🫒         🫒 Note: Olive is in support. Fixes you make on master may still
    🫒🫒🫒🫒     be needed on Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Added a new property 'isControl' to recommendations API response that can be used to reflect the user's actual state in Amplitude.

## Supporting information
https://2u-internal.atlassian.net/browse/VAN-1247