### PR TITLE
fix: updated discussion enabled label

### DIFF
--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -20,7 +20,6 @@ from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole
 from openedx.core.djangoapps.course_apps.toggles import proctoring_settings_modal_view_enabled
 from openedx.core.djangoapps.discussions.config.waffle import ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND
-from openedx.core.djangoapps.discussions.models import DiscussionTopicLink, Provider
 from openedx.core.djangoapps.django_comment_common.models import assign_default_role
 from openedx.core.djangoapps.django_comment_common.utils import seed_permissions_roles
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
@@ -732,38 +731,3 @@ def translation_language(language):
             translation.activate(previous)
     else:
         yield
-
-
-def mark_verticals_discussion_enabled(course_structure, course_key):
-    """
-    Adds has_discussion attribute on verticals of course_structure
-    """
-    topics = []
-    topics_query = DiscussionTopicLink.objects.filter(
-        context_key=course_key,
-        provider_id=Provider.OPEN_EDX,
-    )
-    for topic in topics_query:
-        topics.append({
-            "usage_key": str(topic.usage_key)
-        })
-
-    sub_sections_reference = []
-    if course_structure.get('has_children'):
-        chapters = course_structure['child_info'].get('children')
-        for section in chapters:
-            if section.get('has_children'):
-                sub_sections = section.get('child_info').get('children')
-                for sub_section in sub_sections:
-                    sub_sections_reference.append(sub_section)
-
-    for sub_section in sub_sections_reference:
-        if sub_section.get('has_children'):
-            verticals = sub_section.get('child_info').get('children')
-            for vertical in verticals:
-                vertical_id = vertical.get('id')
-                vertical['has_discussion'] = False
-                for topic in topics:
-                    if topic.get('usage_key') == vertical_id:
-                        vertical['has_discussion'] = True
-    return course_structure

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -34,7 +34,6 @@ from organizations.api import add_organization_course, ensure_organization
 from organizations.exceptions import InvalidOrganizationException
 from rest_framework.exceptions import ValidationError
 
-from cms.djangoapps.contentstore.utils import mark_verticals_discussion_enabled
 from cms.djangoapps.course_creators.views import add_user_with_status_unrequested, get_course_creator_status
 from cms.djangoapps.models.settings.course_grading import CourseGradingModel
 from cms.djangoapps.models.settings.course_metadata import CourseMetadata
@@ -67,7 +66,6 @@ from openedx.core import toggles as core_toggles
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.credit.api import get_credit_requirements, is_credit_course
 from openedx.core.djangoapps.credit.tasks import update_credit_course_requirements
-from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration, Provider
 from openedx.core.djangoapps.models.course_details import CourseDetails
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangolib.js_utils import dump_js_escaped_json
@@ -725,11 +723,6 @@ def course_index(request, course_key):
         # gather any errors in the currently stored proctoring settings.
         advanced_dict = CourseMetadata.fetch(course_block)
         proctoring_errors = CourseMetadata.validate_proctoring_settings(course_block, advanced_dict, request.user)
-
-        configuration = DiscussionsConfiguration.get(course_key)
-        provider = configuration.provider_type
-        if provider == Provider.OPEN_EDX:
-            mark_verticals_discussion_enabled(course_structure, course_key)
 
         return render_to_response('course_outline.html', {
             'language_code': request.LANGUAGE_CODE,

--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -158,7 +158,8 @@ from openedx.core.release import RELEASE_LINE
           revision: "${context_course.location.branch | n, js_escaped_string}",
           self_paced: ${ context_course.self_paced | n, dump_js_escaped_json },
           is_custom_relative_dates_active: ${CUSTOM_RELATIVE_DATES.is_enabled(context_course.id) | n, dump_js_escaped_json},
-          start: ${context_course.start | n, dump_js_escaped_json}
+          start: ${context_course.start | n, dump_js_escaped_json},
+          discussions_settings: ${context_course.discussions_settings | n, dump_js_escaped_json}
         });
       </script>
     % endif

--- a/cms/templates/js/course-outline.underscore
+++ b/cms/templates/js/course-outline.underscore
@@ -138,11 +138,14 @@ if (is_proctored_exam) {
             <div class="<%- xblockType %>-header-actions">
         <% } %>
             <ul class="actions-list">
-                <% if (xblockInfo.isVertical()) { %>
-                    <% if (xblockInfo.get('has_discussion')) {%>
-                        <li class="action-item" style="font-size: 75%; color:grey">
-                            Discussions enabled
-                        </li>
+                <% var discussion_settings = course.get('discussions_settings') %>
+                <% if (xblockInfo.isVertical() && discussion_settings) { %>
+                    <% if (xblockInfo.get('discussion_enabled') && (discussion_settings.provider_type == "openedx")) { %>
+                        <% if (discussion_settings.enable_graded_units || (!discussion_settings.enable_graded_units && !parentInfo.get('graded'))) {%>
+                            <li class="action-item" style="font-size: 75%; color:grey">
+                                <%- gettext('Discussions enabled') %>
+                            </li>
+                        <% } %>
                     <% } %>
                 <% } %>
                 <% if (xblockInfo.isSequential() && xblockInfo.get('proctoring_exam_configuration_link')) { %>


### PR DESCRIPTION
Fixed "Discussion Enabled" text for each unit in studio. This text will only be shown if

- Provider is openedx
- For graded subsections, if
    - If graded units are enabled in course authoring
    - If graded units flag is disabled and unit is not graded

Tickets:
[INF-716](https://2u-internal.atlassian.net/browse/INF-716)
[INF-719](https://2u-internal.atlassian.net/browse/INF-719)