### PR TITLE
edx-sphinx-theme upgraded

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -90,6 +90,5 @@ pytz==2022.2.1
 
 django-ratelimit<4.0.0
 django-countries==7.4.2   # Rename Turkey to Türkiye. It needs approval.
-sphinxcontrib-openapi[markdown]==0.7.0
 icalendar==5.0.1
 cryptography==38.0.4 # greater version has some issues.

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -55,15 +55,6 @@ py2neo<2022
 # scipy version 1.8 requires numpy>=1.17.3, we've pinned numpy to <1.17.0 in requirements/edx-sandbox/py38.in
 scipy<1.8.0
 
-# mistune is a dependency of m2r (which is a dependency of sphinxcontrib-openapi)
-# m2r fails to specify the version of mistune that it needs leading to the error message:
-# AttributeError: module 'mistune' has no attribute 'BlockGrammar'
-# See Issue: https://github.com/miyakogi/m2r/issues/66
-# m2r is no longer actively maintained: https://github.com/miyakogi/m2r/pull/43
-# This will be fixed when sphinxcontrib-openapi depends on m2r2 instead of m2r
-# See issue: https://github.com/sphinx-contrib/openapi/issues/123
-mistune<2.0.0
-
 # edx-enterprise, snowflake-connector-python require charset-normalizer==2.0.0
 # Can be removed once snowflake-connector-python>2.7.9 is released with the fix.
 charset-normalizer<2.1.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -85,10 +85,6 @@ pyopenssl==22.0.0
 # pytz>2022.2.1 causes test failures in edx-platform
 pytz==2022.2.1
 
-# docutils==0.19 has removed the docutils.core.ErrorString which is required by the sphinxcontrib-openapi
-# This constraint can be removed once sphinxcontrib-openapi is updated to resolve this issue.
-docutils<0.19
-
 # right now lots of packages have major upgrades and lots of tests failing.
 # so adding following constraints and will unpin one by one.
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -406,10 +406,8 @@ djfernet==0.8.1
     # via edxval
 docopt==0.6.2
     # via -r requirements/edx/base.in
-docutils==0.18.1
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   botocore
+docutils==0.19
+    # via botocore
 done-xblock==2.0.5
     # via -r requirements/edx/base.in
 drf-jwt==1.19.2

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -246,6 +246,8 @@ ddt==1.6.0
     # via
     #   -r requirements/edx/testing.txt
     #   xblock-poll
+deepmerge==1.1.0
+    # via sphinxcontrib-openapi
 defusedxml==0.7.1
     # via
     #   -r requirements/edx/testing.txt
@@ -522,8 +524,8 @@ docutils==0.19
     # via
     #   -r requirements/edx/testing.txt
     #   botocore
-    #   m2r
     #   sphinx
+    #   sphinx-mdinclude
 done-xblock==2.0.5
     # via -r requirements/edx/testing.txt
 drf-jwt==1.19.2
@@ -906,8 +908,6 @@ lxml==4.9.2
     #   pyquery
     #   xblock
     #   xmlsec
-m2r==0.3.1
-    # via sphinxcontrib-openapi
 mailsnake==1.6.4
     # via -r requirements/edx/testing.txt
 mako==1.2.4
@@ -944,10 +944,8 @@ mccabe==0.7.0
     # via
     #   -r requirements/edx/testing.txt
     #   pylint
-mistune==0.8.4
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   m2r
+mistune==2.0.4
+    # via sphinx-mdinclude
 mock==5.0.1
     # via
     #   -r requirements/edx/testing.txt
@@ -1062,6 +1060,8 @@ pgpy==0.6.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
+picobox==2.2.0
+    # via sphinxcontrib-openapi
 piexif==1.1.3
     # via -r requirements/edx/testing.txt
 pillow==9.4.0
@@ -1143,6 +1143,7 @@ pygments==2.14.0
     #   diff-cover
     #   py2neo
     #   sphinx
+    #   sphinx-mdinclude
 pyjwkest==1.4.2
     # via
     #   -r requirements/edx/testing.txt
@@ -1491,6 +1492,8 @@ sphinx==5.3.0
     #   edx-sphinx-theme
     #   sphinxcontrib-httpdomain
     #   sphinxcontrib-openapi
+sphinx-mdinclude==0.5.3
+    # via sphinxcontrib-openapi
 sphinxcontrib-applehelp==1.0.3
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
@@ -1501,10 +1504,8 @@ sphinxcontrib-httpdomain==1.8.1
     # via sphinxcontrib-openapi
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-openapi[markdown]==0.7.0
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/development.in
+sphinxcontrib-openapi[markdown]==0.8.0
+    # via -r requirements/edx/development.in
 sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -656,7 +656,7 @@ edx-search==3.4.0
     # via -r requirements/edx/testing.txt
 edx-sga==0.20.0
     # via -r requirements/edx/testing.txt
-edx-sphinx-theme==3.0.0
+edx-sphinx-theme==3.1.0
     # via -r requirements/edx/development.in
 edx-submissions==3.5.4
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -518,9 +518,8 @@ djfernet==0.8.1
     #   edxval
 docopt==0.6.2
     # via -r requirements/edx/testing.txt
-docutils==0.18.1
+docutils==0.19
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   botocore
     #   m2r

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -20,11 +20,9 @@ click==8.1.3
     #   code-annotations
 code-annotations==1.3.0
     # via -r requirements/edx/doc.in
-docutils==0.18.1
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   sphinx
-edx-sphinx-theme==3.0.0
+docutils==0.19
+    # via sphinx
+edx-sphinx-theme==3.1.0
     # via -r requirements/edx/doc.in
 gitdb==4.0.10
     # via gitpython

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -501,9 +501,8 @@ djfernet==0.8.1
     #   edxval
 docopt==0.6.2
     # via -r requirements/edx/base.txt
-docutils==0.18.1
+docutils==0.19
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   botocore
 done-xblock==2.0.5


### PR DESCRIPTION
List of packages in the PR without any issue.</br> 
 - `docutils` changes from `0.18.1` to `0.19`
- `edx-sphinx-theme` changes from `3.0.0` to `3.1.0`
- Removed constraint of `m2r` package as well which was blocked previously. (For details see https://github.com/sphinx-contrib/openapi/issues/123)