### PR TITLE
fix: Unpin mistune, docutils, and sphinxcontrib-openapi

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -55,15 +55,6 @@ py2neo<2022
 # scipy version 1.8 requires numpy>=1.17.3, we've pinned numpy to <1.17.0 in requirements/edx-sandbox/py38.in
 scipy<1.8.0
 
-# mistune is a dependency of m2r (which is a dependency of sphinxcontrib-openapi)
-# m2r fails to specify the version of mistune that it needs leading to the error message:
-# AttributeError: module 'mistune' has no attribute 'BlockGrammar'
-# See Issue: https://github.com/miyakogi/m2r/issues/66
-# m2r is no longer actively maintained: https://github.com/miyakogi/m2r/pull/43
-# This will be fixed when sphinxcontrib-openapi depends on m2r2 instead of m2r
-# See issue: https://github.com/sphinx-contrib/openapi/issues/123
-mistune<2.0.0
-
 # edx-enterprise, snowflake-connector-python require charset-normalizer==2.0.0
 # Can be removed once snowflake-connector-python>2.7.9 is released with the fix.
 charset-normalizer<2.1.0
@@ -85,15 +76,10 @@ pyopenssl==22.0.0
 # pytz>2022.2.1 causes test failures in edx-platform
 pytz==2022.2.1
 
-# docutils==0.19 has removed the docutils.core.ErrorString which is required by the sphinxcontrib-openapi
-# This constraint can be removed once sphinxcontrib-openapi is updated to resolve this issue.
-docutils<0.19
-
 # right now lots of packages have major upgrades and lots of tests failing.
 # so adding following constraints and will unpin one by one.
 
 django-ratelimit<4.0.0
 django-countries==7.4.2   # Rename Turkey to Türkiye. It needs approval.
-sphinxcontrib-openapi[markdown]==0.7.0
 icalendar==5.0.1
 cryptography==38.0.4 # greater version has some issues.

--- a/requirements/edx-sandbox/py38.txt
+++ b/requirements/edx-sandbox/py38.txt
@@ -28,7 +28,7 @@ lxml==4.9.2
     # via
     #   -r requirements/edx-sandbox/py38.in
     #   openedx-calc
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via
     #   chem
     #   openedx-calc

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -406,10 +406,8 @@ djfernet==0.8.1
     # via edxval
 docopt==0.6.2
     # via -r requirements/edx/base.in
-docutils==0.18.1
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   botocore
+docutils==0.19
+    # via botocore
 done-xblock==2.0.5
     # via -r requirements/edx/base.in
 drf-jwt==1.19.2
@@ -702,7 +700,7 @@ markdown==3.3.7
     #   xblock-poll
 markey==0.8
     # via enmerkar-underscore
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via
     #   -r requirements/edx/paver.txt
     #   chem

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -12,7 +12,7 @@ diff-cover==7.3.0
     # via -r requirements/edx/coverage.in
 jinja2==3.1.2
     # via diff-cover
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via jinja2
 pluggy==1.0.0
     # via diff-cover

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -246,6 +246,8 @@ ddt==1.6.0
     # via
     #   -r requirements/edx/testing.txt
     #   xblock-poll
+deepmerge==1.1.0
+    # via sphinxcontrib-openapi
 defusedxml==0.7.1
     # via
     #   -r requirements/edx/testing.txt
@@ -518,13 +520,12 @@ djfernet==0.8.1
     #   edxval
 docopt==0.6.2
     # via -r requirements/edx/testing.txt
-docutils==0.18.1
+docutils==0.19
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   botocore
-    #   m2r
     #   sphinx
+    #   sphinx-mdinclude
 done-xblock==2.0.5
     # via -r requirements/edx/testing.txt
 drf-jwt==1.19.2
@@ -656,7 +657,7 @@ edx-search==3.4.0
     # via -r requirements/edx/testing.txt
 edx-sga==0.20.0
     # via -r requirements/edx/testing.txt
-edx-sphinx-theme==3.0.0
+edx-sphinx-theme==3.1.0
     # via -r requirements/edx/development.in
 edx-submissions==3.5.4
     # via
@@ -709,7 +710,7 @@ execnet==1.9.0
     #   pytest-xdist
 factory-boy==3.2.1
     # via -r requirements/edx/testing.txt
-faker==16.4.0
+faker==16.5.0
     # via
     #   -r requirements/edx/testing.txt
     #   factory-boy
@@ -907,8 +908,6 @@ lxml==4.9.2
     #   pyquery
     #   xblock
     #   xmlsec
-m2r==0.3.1
-    # via sphinxcontrib-openapi
 mailsnake==1.6.4
     # via -r requirements/edx/testing.txt
 mako==1.2.4
@@ -929,7 +928,7 @@ markey==0.8
     # via
     #   -r requirements/edx/testing.txt
     #   enmerkar-underscore
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via
     #   -r requirements/edx/testing.txt
     #   chem
@@ -945,10 +944,8 @@ mccabe==0.7.0
     # via
     #   -r requirements/edx/testing.txt
     #   pylint
-mistune==0.8.4
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   m2r
+mistune==2.0.4
+    # via sphinx-mdinclude
 mock==5.0.1
     # via
     #   -r requirements/edx/testing.txt
@@ -1063,6 +1060,8 @@ pgpy==0.6.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
+picobox==2.2.0
+    # via sphinxcontrib-openapi
 piexif==1.1.3
     # via -r requirements/edx/testing.txt
 pillow==9.4.0
@@ -1144,6 +1143,7 @@ pygments==2.14.0
     #   diff-cover
     #   py2neo
     #   sphinx
+    #   sphinx-mdinclude
 pyjwkest==1.4.2
     # via
     #   -r requirements/edx/testing.txt
@@ -1492,6 +1492,8 @@ sphinx==5.3.0
     #   edx-sphinx-theme
     #   sphinxcontrib-httpdomain
     #   sphinxcontrib-openapi
+sphinx-mdinclude==0.5.3
+    # via sphinxcontrib-openapi
 sphinxcontrib-applehelp==1.0.3
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
@@ -1502,10 +1504,8 @@ sphinxcontrib-httpdomain==1.8.1
     # via sphinxcontrib-openapi
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-openapi[markdown]==0.7.0
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/development.in
+sphinxcontrib-openapi[markdown]==0.8.0
+    # via -r requirements/edx/development.in
 sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -20,11 +20,9 @@ click==8.1.3
     #   code-annotations
 code-annotations==1.3.0
     # via -r requirements/edx/doc.in
-docutils==0.18.1
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   sphinx
-edx-sphinx-theme==3.0.0
+docutils==0.19
+    # via sphinx
+edx-sphinx-theme==3.1.0
     # via -r requirements/edx/doc.in
 gitdb==4.0.10
     # via gitpython
@@ -40,7 +38,7 @@ jinja2==3.1.2
     # via
     #   code-annotations
     #   sphinx
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via jinja2
 packaging==23.0
     # via sphinx

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -18,7 +18,7 @@ lazy==1.5
     # via -r requirements/edx/paver.in
 libsass==0.10.0
     # via -r requirements/edx/paver.in
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via -r requirements/edx/paver.in
 mock==5.0.1
     # via -r requirements/edx/paver.in

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -501,9 +501,8 @@ djfernet==0.8.1
     #   edxval
 docopt==0.6.2
     # via -r requirements/edx/base.txt
-docutils==0.18.1
+docutils==0.19
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   botocore
 done-xblock==2.0.5
@@ -685,7 +684,7 @@ execnet==1.9.0
     # via pytest-xdist
 factory-boy==3.2.1
     # via -r requirements/edx/testing.in
-faker==16.4.0
+faker==16.5.0
     # via factory-boy
 fastapi==0.89.1
     # via pact-python
@@ -887,7 +886,7 @@ markey==0.8
     # via
     #   -r requirements/edx/base.txt
     #   enmerkar-underscore
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/coverage.txt


### PR DESCRIPTION
This allows dropping the unmaintained m2r package.

- Was blocked on https://github.com/sphinx-contrib/openapi/issues/123
- May be worth backporting to Olive (...if tests pass)
