### PR TITLE
fix: add fall-through exception for course overview

### DIFF
--- a/openedx/core/djangoapps/content/course_overviews/api.py
+++ b/openedx/core/djangoapps/content/course_overviews/api.py
@@ -24,7 +24,12 @@ def get_course_overview_or_none(course_id):
         return CourseOverview.get_from_id(course_id)
     except CourseOverview.DoesNotExist:
         log.warning(f"Course overview does not exist for {course_id}")
-        return None
+    except Exception as ex:  # pylint: disable=broad-except
+        # NOTE - Included because some cases (e.g. deleted courses) can throw other
+        # types of errors due to with the cache (see APER-2171 and AU-1000).
+        log.exception(f"Unhandled exception getting course overview for {course_id}: {ex}")
+
+    return None
 
 
 def get_course_overview_or_404(course_id):

--- a/openedx/core/djangoapps/content/course_overviews/tests/test_api.py
+++ b/openedx/core/djangoapps/content/course_overviews/tests/test_api.py
@@ -45,6 +45,16 @@ class TestCourseOverviewsApi(ModuleStoreTestCase):
         retrieved_course_overview = get_course_overview_or_none(course_run_key)
         assert retrieved_course_overview is None
 
+    @patch('openedx.core.djangoapps.content.course_overviews.api.CourseOverview.get_from_id')
+    def test_get_course_overview_or_none_exception(self, mock_get):
+        """
+        Test for `get_course_overview_or_none` function when an exception is raised.
+        """
+        course_run_key = CourseKey.from_string('course-v1:coping+with+exceptions')
+        mock_get.side_effect = Exception()
+        retrieved_course_overview = get_course_overview_or_none(course_run_key)
+        assert retrieved_course_overview is None
+
     def test_get_course_overview_or_404_success(self):
         """
         Test for `test_get_course_overview_or_404` function when the overview exists.


### PR DESCRIPTION
## Description

Inside `get_course_overview_or_none`, an issue occurs trying to get and write course data for a course that has been deleted. Instead of allowing this to cripple anything that calls this function (largely `get_certificates_for_users`), add exception handling and logging for this issue case.

## Supporting information

Expected to fix [APER-2171](https://2u-internal.atlassian.net/browse/APER-2171), [AU-1000](https://2u-internal.atlassian.net/browse/AU-1000), [CR-5409](https://2u-internal.atlassian.net/browse/CR-5409), [AU-952](https://openedx.atlassian.net/browse/AU-952), and removes the need for https://github.com/openedx/edx-platform/pull/31490.

## Testing instructions

We don't have a good way to test this locally except unit tests. See tickets for test cases in PROD.