### PR TITLE
chore: add new tests for retire_user management command

### DIFF
--- a/openedx/core/djangoapps/user_api/management/commands/retire_user.py
+++ b/openedx/core/djangoapps/user_api/management/commands/retire_user.py
@@ -60,7 +60,9 @@ class Command(BaseCommand):
         """
         unknown_users = []
         users = []
-        if userfile:
+        user = user_name
+        email = useremail
+        if userfile and (not user and not email):
             try:
                 userinfo = open(userfile, 'r')
             except Exception as exc:
@@ -76,13 +78,19 @@ class Command(BaseCommand):
                     users.append(User.objects.get(username=username, email=user_email))
                 except user_model.DoesNotExist:
                     unknown_users.append({username: user_email})
-        elif user_name and useremail:
+        elif (user and email) and not userfile:
             try:
-                users.append(User.objects.get(username=username, email=user_email))
+                users.append(User.objects.get(username=user, email=email))
             except user_model.DoesNotExist:
-                unknown_users.append({username: useremail})
+                unknown_users.append({user: email})
+        elif userfile and user and email:
+            error_message = (
+                'You cannot use userfile option with username and user_email option. '
+                'Use only userfile option or use just username and user_email option'
+            )
+            raise CommandError(error_message)
         else:
-            raise CommandError("Please provide user_file or username and user_email parameter when runing command")
+            raise CommandError("Please provide user_file or username and user_email parameter when running command")
         return users, unknown_users
 
     def handle(self, *args, **options):


### PR DESCRIPTION
<!--

🎉🎉 Olive has been released! 🎉🎉

🫒🫒
🫒🫒🫒🫒         🫒 Note: Olive is in support. Fixes you make on master may still
    🫒🫒🫒🫒     be needed on Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
