### PR TITLE
fix: add default value for is_control

### DIFF
--- a/common/djangoapps/student/models/user.py
+++ b/common/djangoapps/student/models/user.py
@@ -391,7 +391,7 @@ def is_course_recommended_on_user_dashboard(course_id):
     if recommended_courses:
         recommended_courses = json.loads(unquote(recommended_courses))
         if course_id in recommended_courses['course_keys']:
-            return True, recommended_courses['is_control']
+            return True, recommended_courses.get('is_control')
 
     return False, None
 


### PR DESCRIPTION
<!--

🎉🎉 Olive has been released! 🎉🎉

🫒🫒
🫒🫒🫒🫒         🫒 Note: Olive is in support. Fixes you make on master may still
    🫒🫒🫒🫒     be needed on Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

For backward compatibility, we need to provide default value for `is_control`. Cookies set in the past will not have this value and will cause key error at this code point.