### PR TITLE
feat: Add "certificate_available_date" in edX's Course Details API

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2196,6 +2196,9 @@ paths:
                 * `"timestamp"`: generated from the `start` timestamp
                 * `"empty"`: no start date is specified
             * pacing: Course pacing. Possible values: instructor, self
+            * certificate_available_date (optional): Date the certificate will be available,
+              in ISO 8601 notation if the `certificates.auto_certificate_generation`
+              waffle switch is enabled
 
             Deprecated fields:
 
@@ -2240,7 +2243,8 @@ paths:
                     "start": "2015-07-17T12:00:00Z",
                     "start_display": "July 17, 2015",
                     "start_type": "timestamp",
-                    "pacing": "instructor"
+                    "pacing": "instructor",
+                    "certificate_available_date": "2015-08-14T00:00:00Z"
                 }
       parameters: []
       responses:

--- a/lms/djangoapps/course_api/serializers.py
+++ b/lms/djangoapps/course_api/serializers.py
@@ -9,6 +9,7 @@ from django.urls import reverse
 from edx_django_utils import monitoring as monitoring_utils
 from rest_framework import serializers
 
+from lms.djangoapps.certificates.api import can_show_certificate_available_date_field
 from openedx.core.djangoapps.content.course_overviews.models import \
     CourseOverview  # lint-amnesty, pylint: disable=unused-import
 from openedx.core.djangoapps.models.course_details import CourseDetails
@@ -158,6 +159,16 @@ class CourseDetailSerializer(CourseSerializer):  # pylint: disable=abstract-meth
         # fields from CourseSerializer, which get their data
         # from the CourseOverview object in SQL.
         return CourseDetails.fetch_about_attribute(course_overview.id, 'overview')
+
+    def to_representation(self, instance):
+        """
+        Get the `certificate_available_date` in response
+        if the `certificates.auto_certificate_generation` waffle switch is enabled
+        """
+        response = super().to_representation(instance)
+        if can_show_certificate_available_date_field(instance):
+            response['certificate_available_date'] = instance.certificate_available_date
+        return response
 
 
 class CourseKeySerializer(serializers.BaseSerializer):  # pylint:disable=abstract-method

--- a/lms/djangoapps/course_api/tests/mixins.py
+++ b/lms/djangoapps/course_api/tests/mixins.py
@@ -25,6 +25,7 @@ class CourseApiFactoryMixin:
             end=end,
             enrollment_start=datetime(2015, 6, 15, 0, 0, 0),
             enrollment_end=datetime(2015, 7, 15, 0, 0, 0),
+            certificate_available_date=datetime(2015, 8, 14, 0, 0, 0),
             emit_signals=True,
             **kwargs
         )

--- a/lms/djangoapps/course_api/views.py
+++ b/lms/djangoapps/course_api/views.py
@@ -59,6 +59,9 @@ class CourseDetailView(DeveloperErrorViewMixin, RetrieveAPIView):
             * `"timestamp"`: generated from the `start` timestamp
             * `"empty"`: no start date is specified
         * pacing: Course pacing. Possible values: instructor, self
+        * certificate_available_date (optional): Date the certificate will be available,
+            in ISO 8601 notation if the `certificates.auto_certificate_generation`
+            waffle switch is enabled
 
         Deprecated fields:
 
@@ -103,7 +106,8 @@ class CourseDetailView(DeveloperErrorViewMixin, RetrieveAPIView):
                 "start": "2015-07-17T12:00:00Z",
                 "start_display": "July 17, 2015",
                 "start_type": "timestamp",
-                "pacing": "instructor"
+                "pacing": "instructor",
+                "certificate_available_date": "2015-08-14T00:00:00Z"
             }
     """
 


### PR DESCRIPTION
<!--

🎉🎉 Olive has been released! 🎉🎉

🫒🫒
🫒🫒🫒🫒         🫒 Note: Olive is in support. Fixes you make on master may still
    🫒🫒🫒🫒     be needed on Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

We have a feature in edX called Certificate Display Behaviour that manages how the certificates are made available to learners other than the course's end date. The problem is that edX doesn't have this key in its course detail API or any other API that we can use independent of enrollment in the course. To enable this behavior in edX Add the `certificate_available_date` in the course details API.

Useful information to include:
- This PR will only add a field `certificate_available_date` in Course Detail [API](https://courses.edx.org/api-docs/#/courses/courses_v1_courses_read) `GET /api/courses/v1/courses/{course_key}/`.

## Supporting information

The related issue is https://github.com/mitodl/mitxonline/issues/1339.

## Testing instructions

- Checkout to this branch
- Run the edx app
- Hit the course detail API on your local server ([Ref](https://courses.edx.org/api-docs/#/courses/courses_v1_courses_read))
- Verify that `certificate_available_date` is in the response of this API

## Deadline

None

## Other information

None
