### PR TITLE
fix: increase namespace for SSO username generation

### DIFF
--- a/common/djangoapps/third_party_auth/settings.py
+++ b/common/djangoapps/third_party_auth/settings.py
@@ -100,7 +100,7 @@ def apply_settings(django_settings):
     django_settings.SOCIAL_AUTH_INACTIVE_USER_URL = '/auth/inactive'
 
     # Context processors required under Django.
-    django_settings.SOCIAL_AUTH_UUID_LENGTH = 4
+    django_settings.SOCIAL_AUTH_UUID_LENGTH = 16
     django_settings.DEFAULT_TEMPLATE_ENGINE['OPTIONS']['context_processors'] += (
         'social_django.context_processors.backends',
         'social_django.context_processors.login_redirect',

--- a/common/djangoapps/third_party_auth/tests/test_pipeline.py
+++ b/common/djangoapps/third_party_auth/tests/test_pipeline.py
@@ -78,7 +78,7 @@ class PipelineOverridesTest(SamlIntegrationTestUtilities, IntegrationTestMixin, 
         ('S.K.', 'S_K', False),
         ('S.K.', 'S_K_-9fe2', True),
         ('usernamewithcharacterlengthofmorethan30chars', 'usernamewithcharacterlengthofm', False),
-        ('usernamewithcharacterlengthofmorethan30chars', 'usernamewithcharacterlengt-9fe', True),
+        ('usernamewithcharacterlengthofmorethan30chars', 'usernamewithch-9fe2', True),
     )
     @ddt.unpack
     @mock.patch('common.djangoapps.third_party_auth.pipeline.user_exists')


### PR DESCRIPTION
## Description

- SSO flow is failing to create accounts due to username generation collisions
- amount of "random additional characters" can be increased from `4` -> `16`
- https://2u-internal.atlassian.net/browse/ENT-6349
- testing comments: https://2u-internal.atlassian.net/browse/ENT-6349?focusedCommentId=651725