### PR TITLE
fix: remove chapters if there are no sequentials in Topics v3

### DIFF
--- a/lms/djangoapps/discussion/rest_api/tests/test_utils.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_utils.py
@@ -131,7 +131,12 @@ class TestRemoveEmptySequentials(unittest.TestCase):
                 {"type": "sequential", "children": [{"type": "vertical1"}]},
                 {"type": "sequential", "children": []},
                 {"children": [{"type": "vertical2"}]}
-            ]}
+            ]},
+            {"type": "chapter", "children": [
+                {"type": "sequential", "children": []},
+                {"type": "sequential", "children": []},
+            ]
+            }
         ]
         expected_output = [
             {"type": "chapter", "children": [

--- a/lms/djangoapps/discussion/rest_api/utils.py
+++ b/lms/djangoapps/discussion/rest_api/utils.py
@@ -274,22 +274,27 @@ def create_topics_v3_structure(blocks, topics):
 
 def remove_empty_sequentials(data):
     """
-    Removes all objects of type "sequential" from a nested list of objects if they have no children.
-
+    Removes all objects of type "sequential" from a nested list of objects if they
+    have no children.
+    After removing the empty sequentials, if the parent of the sequential is now empty,
+    it will also be removed.
     Parameters:
     data (list): A list of nested objects to check and remove empty sequentials from.
 
     Returns:
     list: The modified list with empty sequentials removed.
     """
-
     new_data = []
     for obj in data:
         block_type = obj.get('type')
         if block_type != 'sequential' or (block_type == 'sequential' and obj.get('children')):
-            new_data.append(obj)
             if obj.get('children'):
                 obj['children'] = remove_empty_sequentials(obj['children'])
+                if obj['children'] or block_type != 'chapter':
+                    new_data.append(obj)
+            else:
+                if block_type != 'chapter':
+                    new_data.append(obj)
     return new_data
 
 


### PR DESCRIPTION
## Ticket
https://2u-internal.atlassian.net/browse/INF-710


## Description
This PR adds a function `remove_empty_sequentials` that takes in a nested list of objects and removes all objects of type "sequential" that have no children.  and it also removes chapter it has no children It also includes unit tests to verify that the function is working correctly.



