### PR TITLE
fix: tweak namespace for SSO username generation

### DIFF
--- a/common/djangoapps/third_party_auth/settings.py
+++ b/common/djangoapps/third_party_auth/settings.py
@@ -100,7 +100,7 @@ def apply_settings(django_settings):
     django_settings.SOCIAL_AUTH_INACTIVE_USER_URL = '/auth/inactive'
 
     # Context processors required under Django.
-    django_settings.SOCIAL_AUTH_UUID_LENGTH = 16
+    django_settings.SOCIAL_AUTH_UUID_LENGTH = 6
     django_settings.DEFAULT_TEMPLATE_ENGINE['OPTIONS']['context_processors'] += (
         'social_django.context_processors.backends',
         'social_django.context_processors.login_redirect',

--- a/common/djangoapps/third_party_auth/tests/test_pipeline.py
+++ b/common/djangoapps/third_party_auth/tests/test_pipeline.py
@@ -78,7 +78,7 @@ class PipelineOverridesTest(SamlIntegrationTestUtilities, IntegrationTestMixin, 
         ('S.K.', 'S_K', False),
         ('S.K.', 'S_K_-9fe2', True),
         ('usernamewithcharacterlengthofmorethan30chars', 'usernamewithcharacterlengthofm', False),
-        ('usernamewithcharacterlengthofmorethan30chars', 'usernamewithch-9fe2', True),
+        ('usernamewithcharacterlengthofmorethan30chars', 'usernamewithcharacterlen-9fe2', True),
     )
     @ddt.unpack
     @mock.patch('common.djangoapps.third_party_auth.pipeline.user_exists')


### PR DESCRIPTION
## Description

- fast-follow for https://github.com/openedx/edx-platform/pull/31619
- use `6` rather than `16` which is a better balance of user experience to address space required