### PR TITLE
Revert "build: upgrade pytz."

### DIFF
--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -634,8 +634,8 @@ class CountryTimeZoneListViewTest(UserApiTestCase):
         assert time_zone_info['description'] == get_display_time_zone(time_zone_name)
 
     # The time zones count may need to change each time we upgrade pytz
-    @ddt.data((ALL_TIME_ZONES_URI, 434),
-              (COUNTRY_TIME_ZONES_URI, 24))
+    @ddt.data((ALL_TIME_ZONES_URI, 439),
+              (COUNTRY_TIME_ZONES_URI, 28))
     @ddt.unpack
     def test_get_basic(self, country_uri, expected_count):
         """ Verify that correct time zone info is returned """

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -73,6 +73,8 @@ pycodestyle<2.9.0
 # and snowflake-connector-python>2.8.0 is released.
 pyopenssl==22.0.0
 
+# pytz>2022.2.1 causes test failures in edx-platform
+pytz==2022.2.1
 
 # right now lots of packages have major upgrades and lots of tests failing.
 # so adding following constraints and will unpin one by one.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -915,8 +915,9 @@ python3-saml==1.9.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
-pytz==2022.7.1
+pytz==2022.2.1
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   babel
     #   blockstore

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1287,8 +1287,9 @@ python3-saml==1.9.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
-pytz==2022.7.1
+pytz==2022.2.1
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   babel
     #   blockstore

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -48,8 +48,10 @@ pygments==2.14.0
     # via sphinx
 python-slugify==7.0.0
     # via code-annotations
-pytz==2022.7.1
-    # via babel
+pytz==2022.2.1
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   babel
 pyyaml==6.0
     # via code-annotations
 requests==2.28.2

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1216,8 +1216,9 @@ python3-saml==1.9.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
-pytz==2022.7.1
+pytz==2022.2.1
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   babel
     #   blockstore


### PR DESCRIPTION
Reverts openedx/edx-platform#31599

Sandbox might be failing due to this.