### PR TITLE
Fix bug in rending buttons and message in PII sharing consent dialog.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -665,7 +665,7 @@ libsass==0.10.0
     #   ora2
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==7.2.2
+lti-consumer-xblock==7.2.3
     # via -r requirements/edx/base.in
 lxml==4.9.2
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -891,7 +891,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/testing.txt
     #   ora2
-lti-consumer-xblock==7.2.2
+lti-consumer-xblock==7.2.3
     # via -r requirements/edx/testing.txt
 lxml==4.9.2
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -849,7 +849,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==7.2.2
+lti-consumer-xblock==7.2.3
     # via -r requirements/edx/base.txt
 lxml==4.9.2
     # via


### PR DESCRIPTION
<!--

🎉🎉 Olive has been released! 🎉🎉

🫒🫒
🫒🫒🫒🫒         🫒 Note: Olive is in support. Fixes you make on master may still
    🫒🫒🫒🫒     be needed on Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This commit upgrades the version of the lti-consumer-xblock library from version 7.2.2 to version 7.2.3. This new version contains a fix to the LTI PII sharing consent dialog.

Please see the CHANGELOG entry for this version for a full description of the fixes: https://github.com/openedx/xblock-lti-consumer/blob/master/CHANGELOG.rst#723---2023-01-24. The commit message is included below for convenience.

This commit fixes a bug in the PII sharing consent dialog.

The bug resulted in bizarre behavior when there were more than one LTI component in a unit. For example, if there were two LTI inline launches in a unit, two "OK" button would appear in a single component, instead of in their respective components. Another example is that clicking the "View resource in a [modal|new] window" buttons under two LTI components resulted in the "OK" and "Cancel" buttons as well as the PII sharing prompt appearing in a single component, instead of in their respective components.

This is because the dialog-container div that is dynamically created in the Javascript was not scoped to the LTI component, so there was a div with a id of "dialog-container" for each component configured to share PII. When dynamically inserting and removing buttons and the PII sharing prompt, the Javascript would simply find the first div with the dialog-container ID and operate on it, instead of the div appropriate to the component the user is interacting with.

## Supporting information

* https://github.com/openedx/xblock-lti-consumer/pull/325
* https://github.com/openedx/xblock-lti-consumer/pull/317