### PR TITLE
feat: added reverse_order param in comments sort

### DIFF
--- a/lms/djangoapps/discussion/django_comment_client/base/tests.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/tests.py
@@ -789,7 +789,7 @@ class ViewsTestCase(
                 ('get', f'{CS_PREFIX}/threads/518d4237b023791dca00000d'),
                 {
                     'data': None,
-                    'params': {'mark_as_read': True, 'request_id': ANY, 'with_responses': False},
+                    'params': {'mark_as_read': True, 'request_id': ANY, 'with_responses': False, 'reverse_order': False},
                     'headers': ANY,
                     'timeout': 5
                 }
@@ -807,7 +807,7 @@ class ViewsTestCase(
                 ('get', f'{CS_PREFIX}/threads/518d4237b023791dca00000d'),
                 {
                     'data': None,
-                    'params': {'mark_as_read': True, 'request_id': ANY, 'with_responses': False},
+                    'params': {'mark_as_read': True, 'request_id': ANY, 'with_responses': False, 'reverse_order': False},
                     'headers': ANY,
                     'timeout': 5
                 }
@@ -866,7 +866,7 @@ class ViewsTestCase(
                 ('get', f'{CS_PREFIX}/threads/518d4237b023791dca00000d'),
                 {
                     'data': None,
-                    'params': {'mark_as_read': True, 'request_id': ANY, 'with_responses': False},
+                    'params': {'mark_as_read': True, 'request_id': ANY, 'with_responses': False, 'reverse_order': False},
                     'headers': ANY,
                     'timeout': 5
                 }
@@ -884,7 +884,7 @@ class ViewsTestCase(
                 ('get', f'{CS_PREFIX}/threads/518d4237b023791dca00000d'),
                 {
                     'data': None,
-                    'params': {'mark_as_read': True, 'request_id': ANY, 'with_responses': False},
+                    'params': {'mark_as_read': True, 'request_id': ANY, 'with_responses': False, 'reverse_order': False},
                     'headers': ANY,
                     'timeout': 5
                 }

--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -1185,6 +1185,7 @@ def get_comment_list(request, thread_id, endorsed, page, page_size, flagged=Fals
         discussion.rest_api.views.CommentViewSet for more detail.
     """
     response_skip = page_size * (page - 1)
+    reverse_order = request.GET.get('reverse_order', False)
     cc_thread, context = _get_thread_and_context(
         request,
         thread_id,
@@ -1195,6 +1196,7 @@ def get_comment_list(request, thread_id, endorsed, page, page_size, flagged=Fals
             "flagged_comments": flagged,
             "response_skip": response_skip,
             "response_limit": page_size,
+            "reverse_order": reverse_order,
         }
     )
 

--- a/lms/djangoapps/discussion/rest_api/tests/test_api.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api.py
@@ -1405,6 +1405,7 @@ class GetCommentListTest(ForumsEnableMixin, CommentsServiceMockMixin, SharedModu
                 "resp_skip": ["70"],
                 "resp_limit": ["14"],
                 "with_responses": ["True"],
+                "reverse_order": ["False"],
             }
         )
 

--- a/lms/djangoapps/discussion/rest_api/tests/test_views.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views.py
@@ -2030,6 +2030,7 @@ class CommentViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase, Pr
                 "mark_as_read": ["False"],
                 "recursive": ["False"],
                 "with_responses": ["True"],
+                "reverse_order": ["False"],
             }
         )
 
@@ -2064,6 +2065,7 @@ class CommentViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase, Pr
                 "mark_as_read": ["False"],
                 "recursive": ["False"],
                 "with_responses": ["True"],
+                "reverse_order": ["False"],
             }
         )
 
@@ -2278,6 +2280,35 @@ class CommentViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase, Pr
             response_users = response_comment['users']
             assert expected_author_profile_data == response_users[response_comment['author']]
             assert response_comment['endorsed_by'] not in response_users
+
+    def test_reverse_order_sort(self):
+        """
+        Tests if reverse_order param is passed to cs comments service
+        """
+        self.register_get_user_response(self.user, upvoted_ids=["test_comment"])
+        source_comments = [
+            self.create_source_comment({"user_id": str(self.author.id), "username": self.author.username})
+        ]
+        self.register_get_thread_response({
+            "id": self.thread_id,
+            "course_id": str(self.course.id),
+            "thread_type": "discussion",
+            "children": source_comments,
+            "resp_total": 100,
+        })
+        self.client.get(self.url, {"thread_id": self.thread_id, "reverse_order": True})
+        self.assert_query_params_equal(
+            httpretty.httpretty.latest_requests[-2],
+            {
+                "resp_skip": ["0"],
+                "resp_limit": ["10"],
+                "user_id": [str(self.user.id)],
+                "mark_as_read": ["False"],
+                "recursive": ["False"],
+                "with_responses": ["True"],
+                "reverse_order": ["True"],
+            }
+        )
 
 
 @httpretty.activate

--- a/openedx/core/djangoapps/django_comment_common/comment_client/thread.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/thread.py
@@ -151,6 +151,7 @@ class Thread(models.Model):
             'mark_as_read': kwargs.get('mark_as_read', True),
             'resp_skip': kwargs.get('response_skip'),
             'resp_limit': kwargs.get('response_limit'),
+            'reverse_order': kwargs.get('reverse_order', False),
         }
         request_params = utils.strip_none(request_params)
 


### PR DESCRIPTION
Add reverse_order param to sort comment

Ticket: [INF-739](https://2u-internal.atlassian.net/browse/INF-739)