### PR TITLE
fix: Fix absent notification message after submit Generate Exception …

### DIFF
--- a/lms/static/js/certificates/views/certificate_allowlist.js
+++ b/lms/static/js/certificates/views/certificate_allowlist.js
@@ -85,7 +85,7 @@
                     HtmlUtils.HTML('<p>'),
                     _.escape(message),
                     HtmlUtils.HTML('</p>')
-                ))
+                ).toString())
                     .focus();
                 $(this.message_div).fadeOut(6000, 'linear');
             },


### PR DESCRIPTION
## Description

After submitting Generate Exception Certificates button at Instructor/Certificates tab we have a problem with a message, which is hidden. Only empty div with background is shown.

![image](https://user-images.githubusercontent.com/19806032/215487382-c1bca037-9d8e-4b41-8d42-9b9232517ba2.png)
