### PR TITLE
chore: add version constraint for LTI Consumer XBlock [BD-13]

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -78,3 +78,6 @@ cryptography==38.0.4 # greater version has some issues with openssl.
 
 bleach[css]==5.0.1 # greater version has some breaking changes.
 
+# This constraint can be removed in https://github.com/openedx/edx-platform/pull/31475, which changes the imports used
+# by this XBlock.
+lti-consumer-xblock<=7.2.3


### PR DESCRIPTION
This adds a version constraint for LTI Consumer XBlock before we merge https://github.com/openedx/edx-platform/pull/31475.