### PR TITLE
fix: Fix units hover tooltips in studio which are overlapping by other page content

### DIFF
--- a/cms/static/sass/elements/_layout.scss
+++ b/cms/static/sass/elements/_layout.scss
@@ -8,6 +8,7 @@
   margin: ($baseline*1.5) 0 0 0;
   padding: 0 $baseline;
   position: relative;
+  z-index: 1;
 
   .mast,
   .metadata {


### PR DESCRIPTION
## Description

Tooltips, which are showing after hovering on unit, in studio sequence navigation, were overlapped by other page content. Please check screenshot below

<img width="1904" alt="Снимок экрана 2023-01-30 в 20 26 11" src="https://user-images.githubusercontent.com/19806032/215570399-cad08e29-4e7c-4def-9cbe-eb6bc3e6b223.png">

After adding z-index for div `wrapper-mast` problem was solved

## Result

<img width="1904" alt="Снимок экрана 2023-01-30 в 20 27 33" src="https://user-images.githubusercontent.com/19806032/215570685-d9a548a8-3c53-4719-a435-02ae1ad48672.png">
