### PR TITLE
fix: pin django-wiki

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -76,4 +76,6 @@ pyopenssl==22.0.0
 
 cryptography==38.0.4 # greater version has some issues with openssl.
 
+# These two constraints will be removed in this PR: https://github.com/openedx/edx-platform/pull/31678
 bleach[css]==5.0.1 # greater version has some breaking changes.
+openedx-django-wiki<2.0.0 # greater version needs bleech >6.0.0

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -27,7 +27,9 @@ aniso8601==9.0.1
 appdirs==1.4.4
     # via fs
 asgiref==3.6.0
-    # via django
+    # via
+    #   django
+    #   django-countries
 asn1crypto==1.5.1
     # via
     #   oscrypto
@@ -54,7 +56,7 @@ backoff==1.10.0
     # via analytics-python
 backports-zoneinfo==0.2.1
     # via icalendar
-beautifulsoup4==4.11.1
+beautifulsoup4==4.11.2
     # via pynliner
 billiard==3.6.4.0
     # via celery
@@ -262,7 +264,7 @@ django-config-models==2.3.0
     #   lti-consumer-xblock
 django-cors-headers==3.13.0
     # via -r requirements/edx/base.in
-django-countries==7.5
+django-countries==7.5.1
     # via
     #   -r requirements/edx/base.in
     #   edx-enterprise
@@ -480,7 +482,7 @@ edx-enterprise==3.60.18
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   learner-pathway-progress
-edx-event-bus-kafka==3.6.3
+edx-event-bus-kafka==3.7.1
     # via -r requirements/edx/base.in
 edx-i18n-tools==0.9.2
     # via ora2
@@ -756,7 +758,9 @@ openedx-calc==3.0.1
 openedx-django-pyfs==3.2.1
     # via xblock
 openedx-django-wiki==1.1.4
-    # via -r requirements/edx/base.in
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   -r requirements/edx/base.in
 openedx-events==4.2.0
     # via
     #   -r requirements/edx/base.in
@@ -771,7 +775,7 @@ ora2==4.5.1
     # via -r requirements/edx/base.in
 oscrypto==1.3.0
     # via snowflake-connector-python
-outcome-surveys==1.1.1
+outcome-surveys==2.0.0
     # via -r requirements/edx/base.in
 packaging==23.0
     # via
@@ -974,6 +978,7 @@ requests==2.28.2
     #   learner-pathway-progress
     #   mailsnake
     #   optimizely-sdk
+    #   outcome-surveys
     #   pyjwkest
     #   pylti1p3
     #   python-swiftclient
@@ -1051,7 +1056,7 @@ slumber==0.7.1
     #   edx-bulk-grades
     #   edx-enterprise
     #   edx-rest-api-client
-snowflake-connector-python==2.9.0
+snowflake-connector-python==3.0.0
     # via edx-enterprise
 social-auth-app-django==5.0.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -46,12 +46,13 @@ asgiref==3.6.0
     # via
     #   -r requirements/edx/testing.txt
     #   django
+    #   django-countries
 asn1crypto==1.5.1
     # via
     #   -r requirements/edx/testing.txt
     #   oscrypto
     #   snowflake-connector-python
-astroid==2.13.3
+astroid==2.13.5
     # via
     #   -r requirements/edx/testing.txt
     #   pylint
@@ -85,7 +86,7 @@ backports-zoneinfo==0.2.1
     # via
     #   -r requirements/edx/testing.txt
     #   icalendar
-beautifulsoup4==4.11.1
+beautifulsoup4==4.11.2
     # via
     #   -r requirements/edx/testing.txt
     #   pynliner
@@ -362,7 +363,7 @@ django-config-models==2.3.0
     #   lti-consumer-xblock
 django-cors-headers==3.13.0
     # via -r requirements/edx/testing.txt
-django-countries==7.5
+django-countries==7.5.1
     # via
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
@@ -604,7 +605,7 @@ edx-enterprise==3.60.18
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   learner-pathway-progress
-edx-event-bus-kafka==3.6.3
+edx-event-bus-kafka==3.7.1
     # via -r requirements/edx/testing.txt
 edx-i18n-tools==0.9.2
     # via
@@ -1004,7 +1005,9 @@ openedx-django-pyfs==3.2.1
     #   -r requirements/edx/testing.txt
     #   xblock
 openedx-django-wiki==1.1.4
-    # via -r requirements/edx/testing.txt
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   -r requirements/edx/testing.txt
 openedx-events==4.2.0
     # via
     #   -r requirements/edx/testing.txt
@@ -1021,7 +1024,7 @@ oscrypto==1.3.0
     # via
     #   -r requirements/edx/testing.txt
     #   snowflake-connector-python
-outcome-surveys==1.1.1
+outcome-surveys==2.0.0
     # via -r requirements/edx/testing.txt
 packaging==23.0
     # via
@@ -1069,7 +1072,7 @@ pillow==9.4.0
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
     #   edx-organizations
-pip-tools==6.12.1
+pip-tools==6.12.2
     # via -r requirements/edx/pip-tools.txt
 pkgutil-resolve-name==1.3.10
     # via
@@ -1355,6 +1358,7 @@ requests==2.28.2
     #   learner-pathway-progress
     #   mailsnake
     #   optimizely-sdk
+    #   outcome-surveys
     #   pact-python
     #   pyjwkest
     #   pylti1p3
@@ -1463,7 +1467,7 @@ sniffio==1.3.0
     #   anyio
 snowballstemmer==2.2.0
     # via sphinx
-snowflake-connector-python==2.9.0
+snowflake-connector-python==3.0.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
@@ -1498,7 +1502,7 @@ sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.0
+sphinxcontrib-htmlhelp==2.0.1
     # via sphinx
 sphinxcontrib-httpdomain==1.8.1
     # via sphinxcontrib-openapi

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -69,7 +69,7 @@ sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.0
+sphinxcontrib-htmlhelp==2.0.1
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx

--- a/requirements/edx/pip-tools.txt
+++ b/requirements/edx/pip-tools.txt
@@ -12,7 +12,7 @@ click==8.1.3
     #   pip-tools
 packaging==23.0
     # via build
-pip-tools==6.12.1
+pip-tools==6.12.2
     # via -r requirements/edx/pip-tools.in
 pyproject-hooks==1.0.0
     # via build

--- a/requirements/edx/pip.txt
+++ b/requirements/edx/pip.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-pip==22.3.1
+pip==23.0
     # via -r requirements/edx/pip.in
 setuptools==67.0.0
     # via -r requirements/edx/pip.in

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -42,12 +42,13 @@ asgiref==3.6.0
     # via
     #   -r requirements/edx/base.txt
     #   django
+    #   django-countries
 asn1crypto==1.5.1
     # via
     #   -r requirements/edx/base.txt
     #   oscrypto
     #   snowflake-connector-python
-astroid==2.13.3
+astroid==2.13.5
     # via
     #   pylint
     #   pylint-celery
@@ -80,7 +81,7 @@ backports-zoneinfo==0.2.1
     # via
     #   -r requirements/edx/base.txt
     #   icalendar
-beautifulsoup4==4.11.1
+beautifulsoup4==4.11.2
     # via
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/testing.in
@@ -345,7 +346,7 @@ django-config-models==2.3.0
     #   lti-consumer-xblock
 django-cors-headers==3.13.0
     # via -r requirements/edx/base.txt
-django-countries==7.5
+django-countries==7.5.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -583,7 +584,7 @@ edx-enterprise==3.60.18
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   learner-pathway-progress
-edx-event-bus-kafka==3.6.3
+edx-event-bus-kafka==3.7.1
     # via -r requirements/edx/base.txt
 edx-i18n-tools==0.9.2
     # via
@@ -955,7 +956,9 @@ openedx-django-pyfs==3.2.1
     #   -r requirements/edx/base.txt
     #   xblock
 openedx-django-wiki==1.1.4
-    # via -r requirements/edx/base.txt
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   -r requirements/edx/base.txt
 openedx-events==4.2.0
     # via
     #   -r requirements/edx/base.txt
@@ -972,7 +975,7 @@ oscrypto==1.3.0
     # via
     #   -r requirements/edx/base.txt
     #   snowflake-connector-python
-outcome-surveys==1.1.1
+outcome-surveys==2.0.0
     # via -r requirements/edx/base.txt
 packaging==23.0
     # via
@@ -1281,6 +1284,7 @@ requests==2.28.2
     #   learner-pathway-progress
     #   mailsnake
     #   optimizely-sdk
+    #   outcome-surveys
     #   pact-python
     #   pyjwkest
     #   pylti1p3
@@ -1382,7 +1386,7 @@ slumber==0.7.1
     #   edx-rest-api-client
 sniffio==1.3.0
     # via anyio
-snowflake-connector-python==2.9.0
+snowflake-connector-python==3.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise


### PR DESCRIPTION
## Description
Upgrade Job is failing due to dependency conflicts in newer version of openedx-django-wiki and bleech constraint in edx-platform. This PR pins django-wiki version. This constraint will be removed in https://github.com/openedx/edx-platform/pull/31678