### PR TITLE
fix: missing marketing url

### DIFF
--- a/lms/djangoapps/learner_recommendations/utils.py
+++ b/lms/djangoapps/learner_recommendations/utils.py
@@ -209,7 +209,9 @@ def filter_recommended_courses(
         filtered_recommended_courses (list): A list of filtered course objects.
     """
     filtered_recommended_courses = []
-    fields = ["key", "uuid", "title", "owners", "image", "url_slug", "course_runs", "location_restriction"]
+    fields = [
+        "key", "uuid", "title", "owners", "image", "url_slug", "course_runs", "location_restriction", "marketing_url",
+    ]
 
     # Remove the course keys a user is already enrolled in
     enrollable_course_keys = _remove_user_enrolled_course_keys(user, unfiltered_course_keys)


### PR DESCRIPTION
<!--

🎉🎉 Olive has been released! 🎉🎉

🫒🫒
🫒🫒🫒🫒         🫒 Note: Olive is in support. Fixes you make on master may still
    🫒🫒🫒🫒     be needed on Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Marketing url is missing from the list of fields to get from discovery. This results in recommended courses missing the url to redirect users to the marketing site.

