### PR TITLE
refactor(test): use @skip_unless_lms uniformly

### DIFF
--- a/common/djangoapps/course_modes/rest_api/v1/tests/test_views.py
+++ b/common/djangoapps/course_modes/rest_api/v1/tests/test_views.py
@@ -2,12 +2,9 @@
 Tests for the course modes API.
 """
 
-
 import json
-import unittest
 
 import ddt
-from django.conf import settings
 from django.urls import reverse
 from opaque_keys.edx.keys import CourseKey
 from rest_framework import status
@@ -18,6 +15,7 @@ from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from openedx.core.djangoapps.user_authn.tests.utils import JWT_AUTH_TYPES, AuthAndScopesTestMixin, AuthType
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 from common.djangoapps.student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
 
@@ -94,7 +92,7 @@ class CourseModesViewTestBase(AuthAndScopesTestMixin):
         assert status.HTTP_200_OK == resp.status_code
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class TestCourseModesListViews(CourseModesViewTestBase, ModuleStoreTestCase, APITestCase):
     """
     Tests for the course modes list/create API endpoints.
@@ -238,7 +236,7 @@ class TestCourseModesListViews(CourseModesViewTestBase, ModuleStoreTestCase, API
         assert 0 == CourseMode.objects.filter(course_id=self.course_key, mode_slug='phd').count()
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class TestCourseModesDetailViews(CourseModesViewTestBase, APITestCase):
     """
     Tests for the course modes retrieve/update/delete API endpoints.

--- a/common/djangoapps/course_modes/tests/test_admin.py
+++ b/common/djangoapps/course_modes/tests/test_admin.py
@@ -2,8 +2,6 @@
 Tests for the course modes Django admin interface.
 """
 
-
-import unittest
 from datetime import datetime, timedelta
 
 import ddt
@@ -20,6 +18,7 @@ from common.djangoapps.course_modes.tests.factories import CourseModeFactory
 # Once the course admin tool is deployed, we can remove this dependency.
 from lms.djangoapps.verify_student.models import VerificationDeadline
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 from common.djangoapps.student.tests.factories import UserFactory
 from common.djangoapps.util.date_utils import get_time_display
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
@@ -29,7 +28,7 @@ from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, p
 # We can only test this in the LMS because the course modes admin relies
 # on verify student, which is not an installed app in Studio, so the verification
 # deadline table will not be created.
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class AdminCourseModePageTest(ModuleStoreTestCase):
     """
     Test the course modes Django admin interface.
@@ -78,7 +77,7 @@ class AdminCourseModePageTest(ModuleStoreTestCase):
         assert course_mode.expiration_datetime.replace(tzinfo=None) == expiration.replace(tzinfo=None)
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 @ddt.ddt
 class AdminCourseModeFormTest(ModuleStoreTestCase):
     """

--- a/common/djangoapps/course_modes/tests/test_views.py
+++ b/common/djangoapps/course_modes/tests/test_views.py
@@ -2,9 +2,7 @@
 Tests for course_modes views.
 """
 
-
 import decimal
-import unittest
 from datetime import datetime, timedelta
 from unittest.mock import patch
 from urllib.parse import urljoin
@@ -30,6 +28,7 @@ from lms.djangoapps.verify_student.services import IDVerificationService
 from openedx.core.djangoapps.catalog.tests.mixins import CatalogIntegrationMixin
 from openedx.core.djangoapps.embargo.test_utils import restrict_course
 from openedx.core.djangoapps.theming.tests.test_util import with_comprehensive_theme
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
@@ -44,7 +43,7 @@ CDL_METHOD_NAME = 'openedx.features.course_duration_limits.models.CourseDuration
 
 
 @ddt.ddt
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTestCase, CourseCatalogServiceMockMixin):
     """
     Course Mode View tests
@@ -64,7 +63,7 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
         self.user = UserFactory.create(username="Bob", email="bob@example.com", password="edx")
         self.client.login(username=self.user.username, password="edx")
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     @httpretty.activate
     @ddt.data(
         # is_active?, enrollment_mode, redirect?, has_started
@@ -400,7 +399,7 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
         assert mode == CourseMode.DEFAULT_MODE_SLUG
         assert is_active is True
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     def test_default_mode_creation(self):
         # Hit the mode creation endpoint with no querystring params, to create an honor mode
         url = reverse('create_mode', args=[str(self.course.id)])
@@ -413,7 +412,7 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
 
         assert course_mode == expected_mode
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     @ddt.data(
         ('verified', 'Verified Certificate', 10, '10,20,30', 'usd'),
         ('professional', 'Professional Education', 100, '100,200', 'usd'),
@@ -449,7 +448,7 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
 
         assert course_mode == expected_mode
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     def test_multiple_mode_creation(self):
         # Create an honor mode
         base_url = reverse('create_mode', args=[str(self.course.id)])
@@ -474,7 +473,7 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
 
         assert course_modes == expected_modes
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     @with_comprehensive_theme("edx.org")
     @httpretty.activate
     def test_hide_nav(self):
@@ -491,7 +490,7 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
         self.assertNotContains(response, "Find courses")
         self.assertNotContains(response, "Schools & Partners")
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     def test_course_closed(self):
         with freezegun.freeze_time('2015-01-02'):
             for mode in ["honor", "verified"]:
@@ -703,7 +702,7 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
                     self.assertNotContains(response, '<div class="grid-options">')
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class TrackSelectionEmbargoTest(UrlResetMixin, ModuleStoreTestCase):
     """Test embargo restrictions on the track selection page. """
 

--- a/common/djangoapps/edxmako/tests.py
+++ b/common/djangoapps/edxmako/tests.py
@@ -1,6 +1,5 @@
 # lint-amnesty, pylint: disable=cyclic-import, missing-module-docstring
 
-import unittest
 from unittest.mock import Mock, patch
 
 import ddt
@@ -23,6 +22,7 @@ from common.djangoapps.edxmako.shortcuts import (
 )
 from common.djangoapps.student.tests.factories import UserFactory
 from common.djangoapps.util.testing import UrlResetMixin
+from openedx.core.djangolib.testing.utils import skip_unless_cms, skip_unless_lms
 
 
 @ddt.ddt
@@ -105,7 +105,7 @@ class ShortcutsTests(UrlResetMixin, TestCase):
             link = marketing_link('TOS')
             assert link == expected_link
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     def test_link_map_url_reverse(self):
         url_link_map = {
             'ABOUT': 'dashboard',
@@ -194,7 +194,7 @@ class MakoRequestContextTest(TestCase):
             # requestcontext should be None, because the cache isn't filled
             assert get_template_request_context() is None
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     def test_render_to_string_when_no_global_context_lms(self):
         """
         Test render_to_string() when makomiddleware has not initialized
@@ -202,7 +202,7 @@ class MakoRequestContextTest(TestCase):
         """
         assert 'this module is temporarily unavailable' in render_to_string('courseware/error-message.html', None)
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'cms.urls', 'Test only valid in cms')
+    @skip_unless_cms
     def test_render_to_string_when_no_global_context_cms(self):
         """
         Test render_to_string() when makomiddleware has not initialized

--- a/common/djangoapps/entitlements/rest_api/v1/tests/test_serializers.py
+++ b/common/djangoapps/entitlements/rest_api/v1/tests/test_serializers.py
@@ -2,11 +2,10 @@
 Tests for the API Serializers.
 """
 
-import unittest
-
 from django.conf import settings
 from django.test import RequestFactory
 
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 
 # Entitlements is not in CMS' INSTALLED_APPS so these imports will error during test collection
@@ -15,7 +14,7 @@ if settings.ROOT_URLCONF == 'lms.urls':
     from common.djangoapps.entitlements.tests.factories import CourseEntitlementFactory
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class EntitlementsSerializerTests(ModuleStoreTestCase):
     """
     Tests for the Entitlement Serializers.

--- a/common/djangoapps/entitlements/rest_api/v1/tests/test_views.py
+++ b/common/djangoapps/entitlements/rest_api/v1/tests/test_views.py
@@ -4,7 +4,6 @@ Test file to test the Entitlement API Views.
 
 import json
 import logging
-import unittest
 import uuid
 from datetime import datetime, timedelta
 from unittest.mock import patch
@@ -24,6 +23,7 @@ from openedx.core.djangoapps.content.course_overviews.models import CourseOvervi
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
 from openedx.core.djangoapps.user_api.models import UserOrgTag
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
@@ -37,7 +37,7 @@ if settings.ROOT_URLCONF == 'lms.urls':
     from common.djangoapps.entitlements.rest_api.v1.views import set_entitlement_policy
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class EntitlementViewSetTest(ModuleStoreTestCase):
     """
     Tests for the Entitlements API Views.
@@ -808,7 +808,7 @@ class EntitlementViewSetTest(ModuleStoreTestCase):
         assert reinstated_entitlement.is_entitlement_refundable() is False
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class EntitlementEnrollmentViewSetTest(ModuleStoreTestCase):
     """
     Tests for the EntitlementEnrollmentViewSets

--- a/common/djangoapps/entitlements/tests/test_models.py
+++ b/common/djangoapps/entitlements/tests/test_models.py
@@ -1,7 +1,5 @@
 """Test Entitlements models"""
 
-
-import unittest
 from datetime import timedelta
 from unittest.mock import patch
 from uuid import uuid4
@@ -18,6 +16,7 @@ from lms.djangoapps.certificates.api import MODES
 from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
@@ -27,7 +26,7 @@ if settings.ROOT_URLCONF == 'lms.urls':
     from common.djangoapps.entitlements.models import CourseEntitlement
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class TestCourseEntitlementModelHelpers(ModuleStoreTestCase):
     """
     Series of tests for the helper methods in the CourseEntitlement Model Class.
@@ -112,7 +111,7 @@ class TestCourseEntitlementModelHelpers(ModuleStoreTestCase):
             self.fail(error.message)  # lint-amnesty, pylint: disable=no-member
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class TestModels(TestCase):
     """Test entitlement with policy model functions."""
 

--- a/common/djangoapps/pipeline_mako/tests/test_render.py
+++ b/common/djangoapps/pipeline_mako/tests/test_render.py
@@ -1,7 +1,5 @@
 """ Tests for rendering functions in the mako pipeline. """
 
-
-from unittest import skipUnless
 from unittest.mock import patch
 
 import ddt
@@ -9,6 +7,7 @@ from django.conf import settings
 from django.test import TestCase
 
 from common.djangoapps.pipeline_mako import compressed_css, compressed_js, render_require_js_path_overrides
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 
 class RequireJSPathOverridesTest(TestCase):
@@ -40,7 +39,7 @@ class RequireJSPathOverridesTest(TestCase):
         self.assertCountEqual(list(map(str.strip, result.splitlines())), self.OVERRIDES_JS)
 
 
-@skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in LMS')
+@skip_unless_lms
 @ddt.ddt
 class PipelineRenderTest(TestCase):
     """Test individual pipeline rendering functions. """

--- a/common/djangoapps/status/tests.py
+++ b/common/djangoapps/status/tests.py
@@ -1,13 +1,12 @@
 """ Tests for setting and displaying the site status message. """
 
-
-import unittest
-
 import ddt
 from django.conf import settings
 from django.core.cache import cache
 from django.test import TestCase
 from opaque_keys.edx.locations import CourseLocator
+
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 # Status is not in CMS' INSTALLED_APPS so these imports will error during test collection
 if settings.ROOT_URLCONF == 'lms.urls':
@@ -25,7 +24,7 @@ class TestStatus(TestCase):
         cache.clear()
         self.course_key = CourseLocator(org='TestOrg', course='TestCourse', run='TestRun')
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     @ddt.data(
         ("Test global message", "Test course message"),
         (" Ŧɇsŧ sŧȺŧᵾs", "Ṫëṡẗ ċöüṛṡë ṡẗäẗüṡ "),

--- a/common/djangoapps/student/management/tests/test_bulk_change_enrollment_csv.py
+++ b/common/djangoapps/student/management/tests/test_bulk_change_enrollment_csv.py
@@ -1,11 +1,9 @@
 # lint-amnesty, pylint: disable=missing-module-docstring
 
-import unittest
 from tempfile import NamedTemporaryFile
 
 import pytest
 import six
-from django.conf import settings
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.management import call_command
 from django.core.management.base import CommandError
@@ -15,6 +13,7 @@ from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
 from common.djangoapps.student.models import BulkChangeEnrollmentConfiguration, CourseEnrollment
 from common.djangoapps.student.tests.factories import UserFactory
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
@@ -55,7 +54,7 @@ class BulkChangeEnrollmentCSVTests(SharedModuleStoreTestCase):
         csv.seek(0)
         return csv
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     def test_user_not_exist(self):
         """Verify that warning is logged for non existing user."""
         with NamedTemporaryFile() as csv:
@@ -71,7 +70,7 @@ class BulkChangeEnrollmentCSVTests(SharedModuleStoreTestCase):
                     )
                 )
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     def test_invalid_course_key(self):
         """Verify in case of invalid course key warning is logged."""
         with NamedTemporaryFile() as csv:
@@ -87,7 +86,7 @@ class BulkChangeEnrollmentCSVTests(SharedModuleStoreTestCase):
                     )
                 )
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     def test_already_enrolled_student(self):
         """ Verify in case if a user is already enrolled warning is logged."""
         with NamedTemporaryFile() as csv:
@@ -107,7 +106,7 @@ class BulkChangeEnrollmentCSVTests(SharedModuleStoreTestCase):
                     )
                 )
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     def test_bulk_enrollment(self):
         """ Test all users are enrolled using the command."""
         lines = [
@@ -124,7 +123,7 @@ class BulkChangeEnrollmentCSVTests(SharedModuleStoreTestCase):
             assert new_enrollment.is_active is True
             assert new_enrollment.mode == CourseMode.VERIFIED
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     def test_bulk_enrollment_from_config_model(self):
         """ Test all users are enrolled using the config model."""
         lines = "course_id,user,mode\n"
@@ -140,7 +139,7 @@ class BulkChangeEnrollmentCSVTests(SharedModuleStoreTestCase):
             assert new_enrollment.is_active is True
             assert new_enrollment.mode == CourseMode.VERIFIED
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     def test_command_error_for_config_model(self):
         """ Test command error raised if file_from_database is required and the config model is not enabled"""
 

--- a/common/djangoapps/student/management/tests/test_transfer_students.py
+++ b/common/djangoapps/student/management/tests/test_transfer_students.py
@@ -2,12 +2,9 @@
 Tests the transfer student management command
 """
 
-
-import unittest
 from unittest.mock import call, patch
 
 import ddt
-from django.conf import settings
 from django.core.management import call_command
 from opaque_keys.edx import locator
 
@@ -20,11 +17,12 @@ from common.djangoapps.student.models import (
 )
 from common.djangoapps.student.signals import UNENROLL_DONE
 from common.djangoapps.student.tests.factories import UserFactory
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 @ddt.ddt
 class TestTransferStudents(ModuleStoreTestCase):
     """

--- a/common/djangoapps/student/tests/test_activate_account.py
+++ b/common/djangoapps/student/tests/test_activate_account.py
@@ -1,7 +1,5 @@
 """Tests for account activation"""
 
-
-import unittest
 import urllib.parse
 from datetime import datetime
 from unittest.mock import patch
@@ -16,13 +14,14 @@ from django.utils.http import urlencode
 from common.djangoapps.student.models import Registration
 from common.djangoapps.student.tests.factories import UserFactory
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 from openedx.features.enterprise_support.tests.factories import EnterpriseCustomerUserFactory
 
 FEATURES_WITH_AUTHN_MFE_ENABLED = settings.FEATURES.copy()
 FEATURES_WITH_AUTHN_MFE_ENABLED['ENABLE_AUTHN_MICROFRONTEND'] = True
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class TestActivateAccount(TestCase):
     """Tests for account creation"""
 

--- a/common/djangoapps/student/tests/test_bulk_email_settings.py
+++ b/common/djangoapps/student/tests/test_bulk_email_settings.py
@@ -5,10 +5,6 @@ of email feature flag, and that the view is conditionally available when
 Course Auth is turned on.
 """
 
-
-import unittest
-
-from django.conf import settings
 from django.urls import reverse
 
 # This import is for an lms djangoapp.
@@ -16,11 +12,12 @@ from django.urls import reverse
 from lms.djangoapps.bulk_email.api import is_bulk_email_feature_enabled
 from lms.djangoapps.bulk_email.models import BulkEmailFlag, CourseAuthorization
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class TestStudentDashboardEmailView(SharedModuleStoreTestCase):
     """
     Check for email view displayed with flag

--- a/common/djangoapps/student/tests/test_certificates.py
+++ b/common/djangoapps/student/tests/test_certificates.py
@@ -1,8 +1,6 @@
 """Tests for display of certificates on the student dashboard. """
 
-
 import datetime
-import unittest
 from unittest.mock import patch
 
 import ddt
@@ -16,6 +14,7 @@ from xmodule.modulestore.tests.factories import CourseFactory
 from xmodule.data import CertificatesDisplayBehaviors
 
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 from lms.djangoapps.certificates.api import get_certificate_url
 from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.certificates.tests.factories import (
@@ -77,7 +76,7 @@ class CertificateDisplayTestBase(SharedModuleStoreTestCase):
 
 
 @ddt.ddt
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class CertificateDashboardMessageDisplayTest(CertificateDisplayTestBase):
     """
     Tests the certificates messages for a course in the dashboard.
@@ -138,7 +137,7 @@ class CertificateDashboardMessageDisplayTest(CertificateDisplayTestBase):
 
 
 @ddt.ddt
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class CertificateDisplayTest(CertificateDisplayTestBase):
     """
     Tests of certificate display.
@@ -174,7 +173,7 @@ class CertificateDisplayTest(CertificateDisplayTestBase):
 
 
 @ddt.ddt
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class CertificateDisplayTestLinkedHtmlView(CertificateDisplayTestBase):
     """
     Tests of linked student certificates.

--- a/common/djangoapps/student/tests/test_course_listing.py
+++ b/common/djangoapps/student/tests/test_course_listing.py
@@ -3,15 +3,13 @@ Unit tests for getting the list of courses for a user through iterating all cour
 by reversing group name formats.
 """
 
-
-import unittest
-
 from unittest import mock
 from django.conf import settings
 from django.test.client import Client
 from milestones.tests.utils import MilestonesTestCaseMixin
 
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 from common.djangoapps.student.models import CourseEnrollment  # lint-amnesty, pylint: disable=unused-import
 from common.djangoapps.student.roles import GlobalStaff
 from common.djangoapps.student.tests.factories import UserFactory
@@ -66,7 +64,7 @@ class TestCourseListing(ModuleStoreTestCase, MilestonesTestCaseMixin):
         self.client.logout()
         super().tearDown()
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     def test_get_course_list(self):
         """
         Test getting courses
@@ -84,7 +82,7 @@ class TestCourseListing(ModuleStoreTestCase, MilestonesTestCaseMixin):
         courses_list = list(get_course_enrollments(self.student, None, []))
         assert len(courses_list) == 0
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     def test_get_limited_number_of_courses_using_config(self):
         course_location = self.store.make_course_key('Org0', 'Course0', 'Run0')
         self._create_course_with_access_groups(course_location)

--- a/common/djangoapps/student/tests/test_credit.py
+++ b/common/djangoapps/student/tests/test_credit.py
@@ -2,9 +2,7 @@
 Tests for credit courses on the student dashboard.
 """
 
-
 import datetime
-import unittest
 from unittest.mock import patch
 
 import ddt
@@ -17,13 +15,14 @@ from common.djangoapps.student.models import CourseEnrollmentAttribute
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
 from openedx.core.djangoapps.credit import api as credit_api
 from openedx.core.djangoapps.credit.models import CreditCourse, CreditEligibility, CreditProvider
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 TEST_CREDIT_PROVIDER_SECRET_KEY = "931433d583c84ca7ba41784bad3232e6"
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 @override_settings(CREDIT_PROVIDER_SECRET_KEYS={
     "hogwarts": TEST_CREDIT_PROVIDER_SECRET_KEY,
 })

--- a/common/djangoapps/student/tests/test_email.py
+++ b/common/djangoapps/student/tests/test_email.py
@@ -1,6 +1,6 @@
 # lint-amnesty, pylint: disable=missing-module-docstring
+
 import json
-import unittest
 from string import capwords
 from unittest.mock import Mock, patch
 
@@ -32,7 +32,7 @@ from common.djangoapps.third_party_auth.views import inactive_user_view
 from common.djangoapps.util.testing import EventTestMixin
 from openedx.core.djangoapps.ace_common.tests.mixins import EmailTemplateTagMixin
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-from openedx.core.djangolib.testing.utils import CacheIsolationMixin, CacheIsolationTestCase
+from openedx.core.djangolib.testing.utils import CacheIsolationMixin, CacheIsolationTestCase, skip_unless_lms
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
@@ -92,7 +92,7 @@ class EmailTestMixin:
 
 
 @ddt.ddt
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class ActivationEmailTests(EmailTemplateTagMixin, CacheIsolationTestCase):
     """
     Test sending of the activation email.
@@ -232,7 +232,7 @@ class ActivationEmailTests(EmailTemplateTagMixin, CacheIsolationTestCase):
 @ddt.ddt
 @patch.dict('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': True})
 @override_settings(ACCOUNT_MICROFRONTEND_URL='http://account-mfe')
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', "Test only valid in LMS")
+@skip_unless_lms
 class ProctoringRequirementsEmailTests(EmailTemplateTagMixin, ModuleStoreTestCase):
     """
     Test sending of the proctoring requirements email.
@@ -307,7 +307,7 @@ class ProctoringRequirementsEmailTests(EmailTemplateTagMixin, ModuleStoreTestCas
         return fragments
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', "Test only valid in LMS")
+@skip_unless_lms
 class EmailChangeRequestTests(EventTestMixin, EmailTemplateTagMixin, CacheIsolationTestCase):
     """
     Test changing a user's email address
@@ -565,7 +565,7 @@ class EmailChangeConfirmationTests(EmailTestMixin, EmailTemplateTagMixin, CacheI
         self.check_confirm_email_change('email_exists.html', {})
         self.assertFailedBeforeEmailing()
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', "Test only valid in LMS")
+    @skip_unless_lms
     @patch('common.djangoapps.student.views.management.ace')
     def test_old_email_fails(self, ace_mail):
         ace_mail.send.side_effect = [Exception, None]
@@ -575,7 +575,7 @@ class EmailChangeConfirmationTests(EmailTestMixin, EmailTemplateTagMixin, CacheI
         assert ace_mail.send.call_count == 1
         self.assertRolledBack()
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', "Test only valid in LMS")
+    @skip_unless_lms
     @patch('common.djangoapps.student.views.management.ace')
     def test_new_email_fails(self, ace_mail):
         ace_mail.send.side_effect = [None, Exception]
@@ -585,7 +585,7 @@ class EmailChangeConfirmationTests(EmailTestMixin, EmailTemplateTagMixin, CacheI
         assert ace_mail.send.call_count == 2
         self.assertRolledBack()
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', "Test only valid in LMS")
+    @skip_unless_lms
     @override_settings(MKTG_URLS={'ROOT': 'https://dummy-root', 'CONTACT': '/help/contact-us'})
     @patch('common.djangoapps.student.signals.signals.USER_EMAIL_CHANGED.send')
     @ddt.data(
@@ -616,7 +616,7 @@ class EmailChangeConfirmationTests(EmailTestMixin, EmailTemplateTagMixin, CacheI
             mock_rollback.assert_called_with()
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', "Test only valid in LMS")
+@skip_unless_lms
 class SecondaryEmailChangeRequestTests(EventTestMixin, EmailTemplateTagMixin, CacheIsolationTestCase):
     """
     Test changing a user's email address

--- a/common/djangoapps/student/tests/test_enrollment.py
+++ b/common/djangoapps/student/tests/test_enrollment.py
@@ -2,8 +2,6 @@
 Tests for student enrollment.
 """
 
-
-import unittest
 from unittest.mock import patch
 
 import ddt
@@ -26,11 +24,12 @@ from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRol
 from common.djangoapps.student.tests.factories import CourseEnrollmentAllowedFactory, UserFactory
 from common.djangoapps.util.testing import UrlResetMixin
 from openedx.core.djangoapps.embargo.test_utils import restrict_course
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 
 @ddt.ddt
 @patch.dict('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': True})
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class EnrollmentTest(UrlResetMixin, ModuleStoreTestCase, OpenEdxEventsTestMixin):
     """
     Test student enrollment, especially with different course modes.

--- a/common/djangoapps/student/tests/test_helpers.py
+++ b/common/djangoapps/student/tests/test_helpers.py
@@ -1,8 +1,6 @@
 """ Test Student helpers """
 
-
 import logging
-import unittest
 from unittest.mock import patch
 
 import ddt
@@ -15,6 +13,7 @@ from testfixtures import LogCapture
 
 from common.djangoapps.student.helpers import get_next_url_for_login_page
 from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration_context
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 LOGGER_NAME = "common.djangoapps.student.helpers"
 
@@ -133,7 +132,7 @@ class TestLoginHelper(TestCase):
         with with_site_configuration_context(configuration=dict(THIRD_PARTY_AUTH_HINT=tpa_hint)):
             validate_login()
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     @ddt.data(
         (None, '/dashboard'),
         ('invalid-url', '/dashboard'),

--- a/common/djangoapps/student/tests/test_receivers.py
+++ b/common/djangoapps/student/tests/test_receivers.py
@@ -3,13 +3,13 @@
 from unittest import skipUnless
 from unittest.mock import patch
 
-from django.conf import settings
 from edx_toggles.toggles.testutils import override_waffle_flag
 
 from common.djangoapps.student.models import CourseEnrollmentCelebration, PendingNameChange, UserProfile
 from common.djangoapps.student.signals.signals import USER_EMAIL_CHANGED
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory, UserProfileFactory
 from lms.djangoapps.courseware.toggles import COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 from openedx.features.name_affirmation_api.utils import is_name_affirmation_installed
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
 
@@ -71,7 +71,7 @@ class ReceiversTest(SharedModuleStoreTestCase):
         profile = UserProfile.objects.get(user=user)
         assert profile.name == new_name
 
-    @skipUnless(settings.ROOT_URLCONF == 'lms.urls', "Test only valid in LMS")
+    @skip_unless_lms
     @patch('common.djangoapps.student.signals.receivers.get_braze_client')
     def test_listen_for_user_email_changed(self, mock_get_braze_client):
         """

--- a/common/djangoapps/student/tests/test_recent_enrollments.py
+++ b/common/djangoapps/student/tests/test_recent_enrollments.py
@@ -2,12 +2,9 @@
 Tests for the recently enrolled messaging within the Dashboard.
 """
 
-
 import datetime
-import unittest
 
 import ddt
-from django.conf import settings
 from django.urls import reverse
 from django.utils.timezone import now
 from opaque_keys.edx import locator
@@ -18,11 +15,12 @@ from common.djangoapps.student.models import CourseEnrollment, DashboardConfigur
 from common.djangoapps.student.tests.factories import UserFactory
 from common.djangoapps.student.views import get_course_enrollments
 from common.djangoapps.student.views.dashboard import _get_recently_enrolled_courses
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 @ddt.ddt
 class TestRecentEnrollments(ModuleStoreTestCase, XssTestMixin):
     """

--- a/common/djangoapps/student/tests/test_refunds.py
+++ b/common/djangoapps/student/tests/test_refunds.py
@@ -4,7 +4,6 @@
 
 import json
 import logging
-import unittest
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
@@ -13,7 +12,6 @@ import httpretty
 import pytz
 # Explicitly import the cache from ConfigurationModel so we can reset it after each test
 from config_models.models import cache
-from django.conf import settings
 from django.test.client import Client
 from django.test.utils import override_settings
 from django.urls import reverse
@@ -27,6 +25,7 @@ from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.certificates.data import CertificateStatuses
 from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
 from openedx.core.djangoapps.commerce.utils import ECOMMERCE_DATE_FORMAT
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
@@ -36,7 +35,7 @@ JSON = 'application/json'
 
 
 @ddt.ddt
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class RefundableTest(SharedModuleStoreTestCase):
     """
     Tests for dashboard utility functions

--- a/common/djangoapps/student/tests/test_userstanding.py
+++ b/common/djangoapps/student/tests/test_userstanding.py
@@ -3,15 +3,12 @@ These are tests for disabling and enabling student accounts, and for making sure
 that students with disabled accounts are unable to access the courseware.
 """
 
-
-import unittest
-
-from django.conf import settings
 from django.test import Client, TestCase
 from django.urls import reverse
 
 from common.djangoapps.student.models import UserStanding
 from common.djangoapps.student.tests.factories import UserFactory, UserStandingFactory
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 
 class UserStandingTest(TestCase):
@@ -60,14 +57,14 @@ class UserStandingTest(TestCase):
         # since it's only possible to disable accounts from lms, we're going
         # to skip tests for cms
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     def test_can_access_manage_account_page(self):
         response = self.admin_client.get(reverse('manage_user_standing'), {
             'user': self.admin,
         })
         assert response.status_code == 200
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     def test_disable_account(self):
         assert UserStanding.objects.filter(user=self.good_user).count() == 0
         response = self.admin_client.post(reverse('disable_account_ajax'), {  # lint-amnesty, pylint: disable=unused-variable
@@ -80,7 +77,7 @@ class UserStandingTest(TestCase):
         response = self.bad_user_client.get(self.some_url)
         assert response.status_code == 403
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     def test_reenable_account(self):
         response = self.admin_client.post(reverse('disable_account_ajax'), {  # lint-amnesty, pylint: disable=unused-variable
             'username': self.bad_user.username,
@@ -88,14 +85,14 @@ class UserStandingTest(TestCase):
         })
         assert UserStanding.objects.get(user=self.bad_user).account_status == UserStanding.ACCOUNT_ENABLED
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     def test_non_staff_cant_access_disable_view(self):
         response = self.non_staff_client.get(reverse('manage_user_standing'), {
             'user': self.non_staff,
         })
         assert response.status_code == 404
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     def test_non_staff_cant_disable_account(self):
         response = self.non_staff_client.post(reverse('disable_account_ajax'), {
             'username': self.good_user.username,

--- a/common/djangoapps/student/tests/test_views.py
+++ b/common/djangoapps/student/tests/test_views.py
@@ -42,6 +42,7 @@ from openedx.core.djangoapps.catalog.tests.factories import ProgramFactory
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration_context
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 from openedx.features.course_duration_limits.models import CourseDurationLimitConfig
 from openedx.features.course_experience.tests.views.helpers import add_course_mode
 from xmodule.data import CertificatesDisplayBehaviors  # lint-amnesty, pylint: disable=wrong-import-order
@@ -62,7 +63,7 @@ CDL_METHOD_NAME = 'openedx.features.course_duration_limits.models.CourseDuration
 
 
 @ddt.ddt
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class TestStudentDashboardUnenrollments(SharedModuleStoreTestCase):
     """
     Test to ensure that the student dashboard does not show the unenroll button for users with certificates.
@@ -178,7 +179,7 @@ class TestStudentDashboardUnenrollments(SharedModuleStoreTestCase):
 
 
 @ddt.ddt
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class StudentDashboardTests(SharedModuleStoreTestCase, MilestonesTestCaseMixin, CompletionWaffleTestMixin):
     """
     Tests for the student dashboard.
@@ -1008,7 +1009,7 @@ class StudentDashboardTests(SharedModuleStoreTestCase, MilestonesTestCaseMixin, 
                     self.assertContains(response, upgrade_message)
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Tests only valid for the LMS')
+@skip_unless_lms
 @unittest.skipUnless(settings.FEATURES.get("ENABLE_NOTICES"), 'Notices plugin is not enabled')
 class TestCourseDashboardNoticesRedirects(SharedModuleStoreTestCase):
     """

--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -2,9 +2,7 @@
 Miscellaneous tests for the student app.
 """
 
-
 import logging
-import unittest
 from datetime import datetime, timedelta
 from unittest.mock import Mock, patch
 from urllib.parse import quote
@@ -57,7 +55,7 @@ log = logging.getLogger(__name__)
 BETA_TESTER_METHOD = 'common.djangoapps.student.helpers.access.is_beta_tester'
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 @ddt.ddt
 class CourseEndingTest(ModuleStoreTestCase):
     """Test things related to course endings: certificates, surveys, etc"""
@@ -284,7 +282,7 @@ class DashboardTest(ModuleStoreTestCase, TestVerificationBase):
         self.client = Client()
         cache.clear()
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     def _check_verification_status_on(self, mode, value):
         """
         Check that the css class and the status message are in the dashboard html.
@@ -319,7 +317,7 @@ class DashboardTest(ModuleStoreTestCase, TestVerificationBase):
             'You&#39;re enrolled as a professional education student',
         )
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     def _check_verification_status_off(self, mode, value):
         """
         Check that the css class and the status message are not in the dashboard html.
@@ -370,7 +368,7 @@ class DashboardTest(ModuleStoreTestCase, TestVerificationBase):
         assert not course_mode_info['show_upsell']
         assert course_mode_info['days_for_upsell'] is None
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     def test_linked_in_add_to_profile_btn_not_appearing_without_config(self):
         # Without linked-in config don't show Add Certificate to LinkedIn button
         self.client.login(username="jack", password="test")
@@ -406,7 +404,7 @@ class DashboardTest(ModuleStoreTestCase, TestVerificationBase):
         response_url = 'https://www.linkedin.com/profile/add?startTask=CERTIFICATION_NAME'
         self.assertNotContains(response, escape(response_url))
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     @patch.dict('django.conf.settings.FEATURES', {'CERTIFICATES_HTML_VIEW': False})
     def test_linked_in_add_to_profile_btn_with_certificate(self):
         # If user has a certificate with valid linked-in config then Add Certificate to LinkedIn button
@@ -463,7 +461,7 @@ class DashboardTest(ModuleStoreTestCase, TestVerificationBase):
             company_identifier=linkedin_config.company_identifier
         )))
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     def test_dashboard_metadata_caching(self):
         """
         Check that the student dashboard makes use of course metadata caching.
@@ -495,7 +493,7 @@ class DashboardTest(ModuleStoreTestCase, TestVerificationBase):
             response_2 = self.client.get(reverse('dashboard'))
             assert response_2.status_code == 200
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     def test_dashboard_header_nav_has_find_courses(self):
         self.client.login(username="jack", password="test")
         response = self.client.get(reverse("dashboard"))
@@ -549,7 +547,7 @@ class DashboardTestsWithSiteOverrides(SiteMixin, ModuleStoreTestCase):
         CourseEnrollment.enroll(self.user, self.course.location.course_key, mode='no-id-professional')
         cache.clear()
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     @patch.dict("django.conf.settings.FEATURES", {'ENABLE_VERIFIED_CERTIFICATES': False})
     @ddt.data(
         ('testserver1.com', {'ENABLE_VERIFIED_CERTIFICATES': True}),
@@ -570,7 +568,7 @@ class DashboardTestsWithSiteOverrides(SiteMixin, ModuleStoreTestCase):
         response = self.client.get(reverse('dashboard'))
         self.assertContains(response, 'class="course professional"')
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     @patch.dict("django.conf.settings.FEATURES", {'ENABLE_VERIFIED_CERTIFICATES': False})
     @ddt.data(
         ('testserver3.com', {'ENABLE_VERIFIED_CERTIFICATES': False}),
@@ -708,7 +706,7 @@ class EnrollmentEventTestMixin(EventTestMixin):
 class EnrollInCourseTest(EnrollmentEventTestMixin, CacheIsolationTestCase):
     """Tests enrolling and unenrolling in courses."""
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     def test_enrollment(self):
         user = UserFactory.create(username="joe", email="joe@joe.com", password="password")
         course_id = CourseKey.from_string("edX/Test101/2013")
@@ -774,7 +772,7 @@ class EnrollInCourseTest(EnrollmentEventTestMixin, CacheIsolationTestCase):
         assert CourseEnrollment.is_enrolled(user, course_id)
         self.assert_enrollment_event_was_emitted(user, course_id, course, enrollment)
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     def test_enrollment_by_email(self):
         user = UserFactory.create(username="jack", email="jack@fake.edx.org")
         course_id = CourseLocator("edX", "Test101", "2013")
@@ -811,7 +809,7 @@ class EnrollInCourseTest(EnrollmentEventTestMixin, CacheIsolationTestCase):
         CourseEnrollment.unenroll_by_email("not_jack@fake.edx.org", course_id)
         self.assert_no_events_were_emitted()
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     def test_enrollment_multiple_classes(self):
         user = UserFactory(username="rusty", email="rusty@fake.edx.org")
         course_id1 = CourseLocator("edX", "Test101", "2013")
@@ -836,7 +834,7 @@ class EnrollInCourseTest(EnrollmentEventTestMixin, CacheIsolationTestCase):
         assert not CourseEnrollment.is_enrolled(user, course_id1)
         assert not CourseEnrollment.is_enrolled(user, course_id2)
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     def test_activation(self):
         user = UserFactory.create(username="jack", email="jack@fake.edx.org")
         course_id = CourseLocator("edX", "Test101", "2013")
@@ -894,7 +892,7 @@ class EnrollInCourseTest(EnrollmentEventTestMixin, CacheIsolationTestCase):
         self.assert_enrollment_mode_change_event_was_emitted(user, course_id, "audit", course, enrollment)
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class ChangeEnrollmentViewTest(ModuleStoreTestCase):
     """Tests the student.views.change_enrollment view"""
 

--- a/common/djangoapps/third_party_auth/api/tests/test_permissions.py
+++ b/common/djangoapps/third_party_auth/api/tests/test_permissions.py
@@ -2,27 +2,24 @@
 Tests for the Third Party Auth permissions
 """
 
-
-import unittest
-
 import ddt
-from django.conf import settings
 from django.test import RequestFactory, TestCase
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from edx_rest_framework_extensions.auth.jwt.tests.utils import generate_jwt
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from common.djangoapps.student.tests.factories import UserFactory
 
+from common.djangoapps.student.tests.factories import UserFactory
 from common.djangoapps.third_party_auth.api.permissions import TPA_PERMISSIONS
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 IDP_SLUG_TESTSHIB = 'testshib'
 PROVIDER_ID_TESTSHIB = 'saml-' + IDP_SLUG_TESTSHIB
 
 
 @ddt.ddt
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class ThirdPartyAuthPermissionTest(TestCase):
     """ Tests for third party auth TPA_PERMISSIONS """
 

--- a/common/djangoapps/third_party_auth/api/tests/test_views.py
+++ b/common/djangoapps/third_party_auth/api/tests/test_views.py
@@ -2,13 +2,10 @@
 Tests for the Third Party Auth REST API
 """
 
-
-import unittest
 from unittest.mock import patch
 
 import ddt
 import six
-from django.conf import settings
 from django.http import QueryDict
 from django.test.utils import override_settings
 from django.urls import reverse
@@ -23,6 +20,7 @@ from common.djangoapps.third_party_auth.api.permissions import (
     JwtRestrictedApplication
 )
 from common.djangoapps.third_party_auth.tests.testutil import ThirdPartyAuthTestMixin
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 VALID_API_KEY = "i am a key"
 IDP_SLUG_TESTSHIB = 'testshib'
@@ -191,7 +189,7 @@ class UserViewsMixin:
 
 @override_settings(EDX_API_KEY=VALID_API_KEY)
 @ddt.ddt
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class UserViewAPITests(UserViewsMixin, TpaAPITestCase):
     """
     Test the Third Party Auth User REST API
@@ -209,7 +207,7 @@ class UserViewAPITests(UserViewsMixin, TpaAPITestCase):
 
 @override_settings(EDX_API_KEY=VALID_API_KEY)
 @ddt.ddt
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class UserViewV2APITests(UserViewsMixin, TpaAPITestCase):
     """
     Test the Third Party Auth User REST API
@@ -227,7 +225,7 @@ class UserViewV2APITests(UserViewsMixin, TpaAPITestCase):
 
 @override_settings(EDX_API_KEY=VALID_API_KEY)
 @ddt.ddt
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class UserMappingViewAPITests(TpaAPITestCase):
     """
     Test the Third Party Auth User Mapping REST API
@@ -361,7 +359,7 @@ class UserMappingViewAPITests(TpaAPITestCase):
             self.assertCountEqual(response.data['results'], expect_result)
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class TestThirdPartyAuthUserStatusView(ThirdPartyAuthTestMixin, APITestCase):
     """
     Tests ThirdPartyAuthStatusView.

--- a/common/djangoapps/third_party_auth/management/commands/tests/test_remove_social_auth_users.py
+++ b/common/djangoapps/third_party_auth/management/commands/tests/test_remove_social_auth_users.py
@@ -2,13 +2,11 @@
 Tests for `remove_social_auth_users` management command
 """
 
-
 import sys
-import unittest
 from contextlib import contextmanager
 from uuid import uuid4
-import pytest
 
+import pytest
 from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import CommandError
@@ -20,12 +18,13 @@ from common.djangoapps.student.models import User
 from common.djangoapps.student.tests.factories import UserFactory
 from common.djangoapps.third_party_auth.management.commands import remove_social_auth_users
 from common.djangoapps.third_party_auth.tests.factories import SAMLProviderConfigFactory
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 FEATURES_WITH_ENABLED = settings.FEATURES.copy()
 FEATURES_WITH_ENABLED['ENABLE_ENROLLMENT_RESET'] = True
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class TestRemoveSocialAuthUsersCommand(TestCase):
     """
     Test django management command

--- a/common/djangoapps/third_party_auth/management/commands/tests/test_saml.py
+++ b/common/djangoapps/third_party_auth/management/commands/tests/test_saml.py
@@ -5,17 +5,15 @@ existing data accordingly.
 
 
 import os
-import unittest
 from io import StringIO
 
 from unittest import mock
-from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from requests import exceptions
 from requests.models import Response
 
-from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
+from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_unless_lms
 from common.djangoapps.third_party_auth.tests.factories import SAMLConfigurationFactory, SAMLProviderConfigFactory
 
 
@@ -46,7 +44,7 @@ def mock_get(status_code=200):
     return _
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class TestSAMLCommand(CacheIsolationTestCase):
     """
     Test django management command for fetching saml metadata.

--- a/common/djangoapps/third_party_auth/tests/specs/test_lti.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_lti.py
@@ -2,13 +2,12 @@
 Integration tests for third_party_auth LTI auth providers
 """
 
-
-import unittest
-from django.conf import settings
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.urls import reverse
 from oauthlib.oauth1.rfc5849 import Client, SIGNATURE_TYPE_BODY
+
 from common.djangoapps.third_party_auth.tests import testutil
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 FORM_ENCODED = 'application/x-www-form-urlencoded'
 
@@ -23,7 +22,7 @@ EDX_USER_ID = 'test_user'
 EMAIL = 'lti_user@example.com'
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class IntegrationTestLTI(testutil.TestCase):
     """
     Integration tests for third_party_auth LTI auth providers

--- a/common/djangoapps/third_party_auth/tests/test_utils.py
+++ b/common/djangoapps/third_party_auth/tests/test_utils.py
@@ -2,13 +2,10 @@
 Tests for third_party_auth utility functions.
 """
 
-
-import unittest
 from unittest import mock
 from unittest.mock import MagicMock
 
 import ddt
-from django.conf import settings
 from lxml import etree
 
 from common.djangoapps.student.tests.factories import UserFactory
@@ -22,6 +19,7 @@ from common.djangoapps.third_party_auth.utils import (
     user_exists,
     convert_saml_slug_provider_id,
 )
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 from openedx.features.enterprise_support.tests.factories import (
     EnterpriseCustomerIdentityProviderFactory,
     EnterpriseCustomerUserFactory,
@@ -29,7 +27,7 @@ from openedx.features.enterprise_support.tests.factories import (
 
 
 @ddt.ddt
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class TestUtils(TestCase):
     """
     Test the utility functions.

--- a/common/djangoapps/util/tests/test_disable_rate_limit.py
+++ b/common/djangoapps/util/tests/test_disable_rate_limit.py
@@ -1,11 +1,8 @@
 """Tests for disabling rate limiting. """
 
-
-import unittest
 from unittest import mock
 
 import pytest
-from django.conf import settings
 from django.core.cache import cache
 from django.test import TestCase
 from rest_framework.exceptions import Throttled
@@ -14,6 +11,7 @@ from rest_framework.views import APIView
 
 from common.djangoapps.util.disable_rate_limit import can_disable_rate_limit
 from common.djangoapps.util.models import RateLimitConfiguration
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 
 class FakeThrottle(BaseThrottle):
@@ -28,7 +26,7 @@ class FakeApiView(APIView):
     throttle_classes = [FakeThrottle]
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class DisableRateLimitTest(TestCase):
     """Check that we can disable rate limiting for perf testing. """
 

--- a/lms/djangoapps/course_home_api/tests/utils.py
+++ b/lms/djangoapps/course_home_api/tests/utils.py
@@ -2,10 +2,8 @@
 Base classes or util functions for use in Course Home API tests
 """
 
-import unittest
 from datetime import datetime
 
-from django.conf import settings
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
@@ -15,9 +13,10 @@ from common.djangoapps.course_modes.tests.factories import CourseModeFactory
 from lms.djangoapps.courseware.tests.helpers import MasqueradeMixin
 from lms.djangoapps.verify_student.models import VerificationDeadline
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class BaseCourseHomeTests(ModuleStoreTestCase, MasqueradeMixin):
     """
     Base class for Course Home API tests.

--- a/lms/djangoapps/courseware/tests/test_footer.py
+++ b/lms/djangoapps/courseware/tests/test_footer.py
@@ -3,14 +3,12 @@ Tests related to the basic footer-switching based off SITE_NAME to ensure
 edx.org uses an edx footer but other instances use an Open edX footer.
 """
 
-
-import unittest
-
-from django.conf import settings
 from django.test import TestCase
 
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+
+@skip_unless_lms
 class TestFooter(TestCase):
     """
     Tests for edx and OpenEdX footer

--- a/lms/djangoapps/experiments/tests/test_views.py
+++ b/lms/djangoapps/experiments/tests/test_views.py
@@ -2,8 +2,6 @@
 Tests for experimentation views
 """
 
-
-import unittest
 from unittest.mock import patch
 
 import six.moves.urllib.parse
@@ -20,6 +18,7 @@ from lms.djangoapps.course_blocks.transformers.tests.helpers import ModuleStoreT
 from lms.djangoapps.experiments.factories import ExperimentDataFactory, ExperimentKeyValueFactory
 from lms.djangoapps.experiments.models import ExperimentData  # lint-amnesty, pylint: disable=unused-import
 from lms.djangoapps.experiments.serializers import ExperimentDataSerializer
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 CROSS_DOMAIN_REFERER = 'https://ecommerce.edx.org'
@@ -189,7 +188,7 @@ def cross_domain_config(func):
     )
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class ExperimentCrossDomainTests(APITestCase):
     """Tests for handling cross-domain requests"""
 

--- a/openedx/core/djangoapps/api_admin/management/commands/tests/test_create_api_access_request.py
+++ b/openedx/core/djangoapps/api_admin/management/commands/tests/test_create_api_access_request.py
@@ -1,18 +1,18 @@
 # pylint: disable=missing-module-docstring
-import unittest
+
 from unittest.mock import patch
 
 import ddt
-from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import TestCase
 from openedx.core.djangoapps.api_admin.models import ApiAccessConfig, ApiAccessRequest
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 from common.djangoapps.student.tests.factories import UserFactory
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Tests only valid in lms')
+@skip_unless_lms
 @ddt.ddt
 class TestCreateApiAccessRequest(TestCase):
     """ Test create_api_access_request command """

--- a/openedx/core/djangoapps/cors_csrf/tests/test_views.py
+++ b/openedx/core/djangoapps/cors_csrf/tests/test_views.py
@@ -2,7 +2,6 @@
 
 
 import json
-import unittest
 
 from django.conf import settings
 from django.urls import NoReverseMatch, reverse
@@ -11,12 +10,14 @@ from django.test import TestCase
 import ddt
 from config_models.models import cache
 
+from openedx.core.djangolib.testing.utils import skip_unless_lms
+
 # cors_csrf is not in CMS' INSTALLED_APPS so these imports will error during test collection
 if settings.ROOT_URLCONF == 'lms.urls':
     from ..models import XDomainProxyConfiguration
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 @ddt.ddt
 class XDomainProxyTest(TestCase):
     """Tests for the xdomain proxy end-point. """

--- a/openedx/core/djangoapps/courseware_api/tests/test_views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/test_views.py
@@ -1,12 +1,12 @@
 """
 Tests for courseware API
 """
-import unittest
+
 from datetime import datetime, timedelta
 from urllib.parse import urlencode
 from typing import Optional
-
 from unittest import mock
+
 import ddt
 from completion.test_utils import CompletionWaffleTestMixin, submit_completions_for_testing
 from django.conf import settings
@@ -43,6 +43,7 @@ from common.djangoapps.student.models import (
 from common.djangoapps.student.roles import CourseInstructorRole
 from common.djangoapps.student.tests.factories import CourseEnrollmentCelebrationFactory, UserFactory
 from openedx.core.djangoapps.agreements.api import create_integrity_signature
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 
 User = get_user_model()
@@ -50,7 +51,7 @@ User = get_user_model()
 _NEXT_WEEK = datetime.now() + timedelta(days=7)
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class BaseCoursewareTests(SharedModuleStoreTestCase):
     """
     Base class for courseware API tests
@@ -100,7 +101,7 @@ class BaseCoursewareTests(SharedModuleStoreTestCase):
 @ddt.ddt
 @override_waffle_flag(COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES, active=True)
 @override_waffle_flag(COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES_STREAK_CELEBRATION, active=True)
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
     """
     Tests for the courseware REST API

--- a/openedx/core/djangoapps/enrollments/management/tests/test_enroll_user_in_course.py
+++ b/openedx/core/djangoapps/enrollments/management/tests/test_enroll_user_in_course.py
@@ -1,23 +1,22 @@
 """ Test the change_enrollment command line script."""
 
-
-import unittest
 from uuid import uuid4
+
 import ddt
 import pytest
-from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import CommandError
 
-from openedx.core.djangoapps.enrollments.api import get_enrollment
 from common.djangoapps.student.tests.factories import UserFactory
+from openedx.core.djangoapps.enrollments.api import get_enrollment
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
 
 @ddt.ddt
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class EnrollManagementCommandTest(SharedModuleStoreTestCase):
     """
     Test the enroll_user_in_course management command

--- a/openedx/core/djangoapps/enrollments/tests/test_api.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_api.py
@@ -2,13 +2,10 @@
 Tests for student enrollment.
 """
 
-
-import unittest
 from unittest.mock import Mock, patch
 
 import ddt
 import pytest
-from django.conf import settings
 from django.test.utils import override_settings
 
 from common.djangoapps.course_modes.models import CourseMode
@@ -17,12 +14,12 @@ from openedx.core.djangoapps.enrollments.errors import (
     CourseModeNotFoundError, EnrollmentApiLoadError, EnrollmentNotFoundError,
 )
 from openedx.core.djangoapps.enrollments.tests import fake_data_api
-from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
+from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_unless_lms
 
 
 @ddt.ddt
 @override_settings(ENROLLMENT_DATA_API="openedx.core.djangoapps.enrollments.tests.fake_data_api")
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class EnrollmentTest(CacheIsolationTestCase):
     """
     Test student enrollment, especially with different course modes.

--- a/openedx/core/djangoapps/enrollments/tests/test_data.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_data.py
@@ -3,14 +3,11 @@ Test the Data Aggregation Layer for Course Enrollments.
 
 """
 
-
 import datetime
-import unittest
 from unittest.mock import patch
 
 import ddt
 import pytest
-from django.conf import settings
 from pytz import UTC
 
 from common.djangoapps.course_modes.models import CourseMode
@@ -23,6 +20,7 @@ from openedx.core.djangoapps.enrollments.errors import (
     UserNotFoundError
 )
 from openedx.core.djangoapps.enrollments.serializers import CourseEnrollmentSerializer
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 from openedx.core.lib.exceptions import CourseNotFoundError
 from common.djangoapps.student.models import AlreadyEnrolledError, CourseEnrollment, CourseFullError, EnrollmentClosedError  # lint-amnesty, pylint: disable=line-too-long
 from common.djangoapps.student.tests.factories import CourseAccessRoleFactory, UserFactory, CourseEnrollmentFactory
@@ -31,7 +29,7 @@ from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, p
 
 
 @ddt.ddt
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class EnrollmentDataTest(ModuleStoreTestCase):
     """
     Test course enrollment data aggregation.

--- a/openedx/core/djangoapps/enrollments/tests/test_views.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_views.py
@@ -3,11 +3,9 @@
 Tests for user enrollment.
 """
 
-
 import datetime
 import itertools
 import json
-import unittest
 from unittest.mock import patch
 from urllib.parse import quote
 
@@ -39,6 +37,7 @@ from openedx.core.djangoapps.enrollments.errors import CourseEnrollmentError
 from openedx.core.djangoapps.enrollments.views import EnrollmentUserThrottle
 from openedx.core.djangoapps.oauth_dispatch.jwt import create_jwt_for_user
 from openedx.core.djangoapps.user_api.models import RetirementState, UserOrgTag, UserRetirementStatus
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 from openedx.core.lib.django_test_client_utils import get_absolute_url
 from openedx.features.enterprise_support.tests import FAKE_ENTERPRISE_CUSTOMER
 from openedx.features.enterprise_support.tests.mixins.enterprise import EnterpriseServiceMockMixin
@@ -155,7 +154,7 @@ class EnrollmentTestMixin:
 
 @override_settings(EDX_API_KEY="i am a key")
 @ddt.ddt
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, EnterpriseServiceMockMixin):
     """
     Test user enrollment, especially with different course modes.
@@ -1214,7 +1213,7 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         assert enrollment.attributes.get(namespace='order', name='order_number').value == order_number
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class EnrollmentEmbargoTest(EnrollmentTestMixin, UrlResetMixin, ModuleStoreTestCase):
     """Test that enrollment is blocked from embargoed countries. """
 
@@ -1346,7 +1345,7 @@ def cross_domain_config(func):
     )
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class EnrollmentCrossDomainTest(ModuleStoreTestCase):
     """Test cross-domain calls to the enrollment end-points. """
 
@@ -1405,7 +1404,7 @@ class EnrollmentCrossDomainTest(ModuleStoreTestCase):
 
 
 @ddt.ddt
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class UnenrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase):
     """
     Tests unenrollment functionality. The API being tested is intended to
@@ -1558,7 +1557,7 @@ class UnenrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase):
 
 
 @ddt.ddt
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class UserRoleTest(ModuleStoreTestCase):
     """
     Tests the API call to list user roles.
@@ -1666,7 +1665,7 @@ class UserRoleTest(ModuleStoreTestCase):
 
 
 @ddt.ddt
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class CourseEnrollmentsApiListTest(APITestCase, ModuleStoreTestCase):
     """
     Test the course enrollments list API.

--- a/openedx/core/djangoapps/oauth_dispatch/management/commands/tests/test_clear_expired_tokens.py
+++ b/openedx/core/djangoapps/oauth_dispatch/management/commands/tests/test_clear_expired_tokens.py
@@ -2,8 +2,6 @@
 Tests the ``edx_clear_expired_tokens`` management command.
 """
 
-
-import unittest
 from datetime import timedelta
 from unittest.mock import patch
 
@@ -19,6 +17,7 @@ from oauth2_provider.models import AccessToken, RefreshToken
 from testfixtures import LogCapture
 
 from openedx.core.djangoapps.oauth_dispatch.tests import factories
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 from common.djangoapps.student.tests.factories import UserFactory
 
 LOGGER_NAME = 'openedx.core.djangoapps.oauth_dispatch.management.commands.edx_clear_expired_tokens'
@@ -37,7 +36,7 @@ def counter(fn):
     return _counted
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class EdxClearExpiredTokensTests(TestCase):  # lint-amnesty, pylint: disable=missing-class-docstring
 
     # patching REFRESH_TOKEN_EXPIRE_SECONDS because override_settings not working.

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_dot_overrides.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_dot_overrides.py
@@ -4,15 +4,14 @@ Test of custom django-oauth-toolkit behavior
 
 # pylint: disable=protected-access
 
-
 import datetime
-import unittest
 
 from django.conf import settings
 from django.test import RequestFactory, TestCase
 from django.utils import timezone
 
 from common.djangoapps.student.tests.factories import UserFactory
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 # oauth_dispatch is not in CMS' INSTALLED_APPS so these imports will error during test collection
 if settings.ROOT_URLCONF == 'lms.urls':
@@ -24,7 +23,7 @@ if settings.ROOT_URLCONF == 'lms.urls':
     from .constants import DUMMY_REDIRECT_URL
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class AuthenticateTestCase(TestCase):
     """
     Test that users can authenticate with either username or email
@@ -48,7 +47,7 @@ class AuthenticateTestCase(TestCase):
         assert self.user == user
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class CustomValidationTestCase(TestCase):
     """
     Test custom user validation works.
@@ -77,7 +76,7 @@ class CustomValidationTestCase(TestCase):
         assert self.validator.validate_user('darkhelmet', '12345', client=None, request=request)
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class CustomAuthorizationViewTestCase(TestCase):
     """
     Test custom authorization view works.

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
@@ -2,16 +2,13 @@
 Test cases to cover account retirement views
 """
 
-
 import datetime
 import json
-import unittest
 from unittest import mock
 
 import ddt
 import pytz
 from consent.models import DataSharingConsent
-from django.conf import settings
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.contrib.sites.models import Site
 from django.core import mail
@@ -74,6 +71,7 @@ from common.djangoapps.student.tests.factories import (
     SuperuserFactory,
     UserFactory
 )
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
 
@@ -98,7 +96,7 @@ def build_jwt_headers(user):
     return headers
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Account APIs are only supported in LMS')
+@skip_unless_lms
 class TestAccountDeactivation(TestCase):
     """
     Tests the account deactivation endpoint.
@@ -170,7 +168,7 @@ class TestAccountDeactivation(TestCase):
         )
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Account APIs are only supported in LMS')
+@skip_unless_lms
 class TestDeactivateLogout(RetirementTestCase):
     """
     Tests the account deactivation/logout endpoint.
@@ -266,7 +264,7 @@ class TestDeactivateLogout(RetirementTestCase):
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Account APIs are only supported in LMS')
+@skip_unless_lms
 class TestPartnerReportingCleanup(ModuleStoreTestCase):
     """
     Tests the partner reporting cleanup endpoint.
@@ -378,7 +376,7 @@ class TestPartnerReportingCleanup(ModuleStoreTestCase):
         self.assert_status_and_count(statuses, len(statuses))
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Account APIs are only supported in LMS')
+@skip_unless_lms
 class TestPartnerReportingPut(RetirementTestCase, ModuleStoreTestCase):
     """
     Tests the partner reporting list endpoint
@@ -474,7 +472,7 @@ class TestPartnerReportingPut(RetirementTestCase, ModuleStoreTestCase):
         assert UserRetirementPartnerReportingStatus.objects.filter(user=retirement.user).exists()
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Account APIs are only supported in LMS')
+@skip_unless_lms
 class TestPartnerReportingList(ModuleStoreTestCase):
     """
     Tests the partner reporting list endpoint
@@ -687,7 +685,7 @@ class TestPartnerReportingList(ModuleStoreTestCase):
         self.assert_status_and_user_list([])
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Account APIs are only supported in LMS')
+@skip_unless_lms
 class TestAccountRetirementList(RetirementTestCase):
     """
     Tests the account retirement endpoint.
@@ -847,7 +845,7 @@ class TestAccountRetirementList(RetirementTestCase):
 
 
 @ddt.ddt
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Account APIs are only supported in LMS')
+@skip_unless_lms
 class TestAccountRetirementsByStatusAndDate(RetirementTestCase):
     """
     Tests the retirements_by_status_and_date endpoint
@@ -995,7 +993,7 @@ class TestAccountRetirementsByStatusAndDate(RetirementTestCase):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Account APIs are only supported in LMS')
+@skip_unless_lms
 class TestAccountRetirementRetrieve(RetirementTestCase):
     """
     Tests the account retirement retrieval endpoint.
@@ -1066,7 +1064,7 @@ class TestAccountRetirementRetrieve(RetirementTestCase):
         self.assert_status_and_user_data(values, username_to_find=original_username)
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Account APIs are only supported in LMS')
+@skip_unless_lms
 class TestAccountRetirementCleanup(RetirementTestCase):
     """
     Tests the account retirement cleanup endpoint.
@@ -1141,7 +1139,7 @@ class TestAccountRetirementCleanup(RetirementTestCase):
 
 
 @ddt.ddt
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Account APIs are only supported in LMS')
+@skip_unless_lms
 class TestAccountRetirementUpdate(RetirementTestCase):
     """
     Tests the account retirement endpoint.
@@ -1281,7 +1279,7 @@ class TestAccountRetirementUpdate(RetirementTestCase):
         self.update_and_assert_status(data, expected_response_code)
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Account APIs are only supported in LMS')
+@skip_unless_lms
 class TestAccountRetirementPost(RetirementTestCase):
     """
     Tests the account retirement endpoint.
@@ -1559,7 +1557,7 @@ class TestAccountRetirementPost(RetirementTestCase):
         assert '' == self.entitlement_support_detail.comments
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Account APIs are only supported in LMS')
+@skip_unless_lms
 class TestLMSAccountRetirementPost(RetirementTestCase, ModuleStoreTestCase):
     """
     Tests the LMS account retirement (GDPR P2) endpoint.

--- a/openedx/core/djangoapps/user_authn/views/tests/test_logout.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_logout.py
@@ -2,8 +2,6 @@
 Tests for logout
 """
 
-
-import unittest
 import urllib
 from unittest import mock
 import ddt
@@ -14,10 +12,11 @@ from django.test.utils import override_settings
 from django.urls import reverse
 
 from openedx.core.djangoapps.oauth_dispatch.tests.factories import ApplicationFactory
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 from common.djangoapps.student.tests.factories import UserFactory
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 @ddt.ddt
 class LogoutTests(TestCase):
     """ Tests for the logout functionality. """

--- a/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
@@ -5,9 +5,9 @@ Test the various password reset flows
 import json
 import re
 import unicodedata
-import unittest
 from datetime import datetime, timedelta
 from unittest.mock import Mock, patch
+
 import ddt
 from django.conf import settings
 from django.contrib.auth.hashers import UNUSABLE_PASSWORD_PREFIX, make_password
@@ -54,10 +54,7 @@ def process_request(request):
     request.session.save()
 
 
-@unittest.skipUnless(
-    settings.ROOT_URLCONF == "lms.urls",
-    "reset password tests should only run in LMS"
-)
+@skip_unless_lms
 @ddt.ddt
 class ResetPasswordTests(EventTestMixin, CacheIsolationTestCase):
     """
@@ -300,7 +297,7 @@ class ResetPasswordTests(EventTestMixin, CacheIsolationTestCase):
         response = password_reset(reset_request)
         assert response.status_code == status
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', "Test only valid in LMS")
+    @skip_unless_lms
     @ddt.data(('plain_text', "You're receiving this e-mail because you requested a password reset"),
               ('html', "You&#x27;re receiving this e-mail because you requested a password reset"))
     @ddt.unpack
@@ -347,7 +344,7 @@ class ResetPasswordTests(EventTestMixin, CacheIsolationTestCase):
         assert 'password_reset_confirm/' in body
         re.search(r'password_reset_confirm/(?P<uidb36>[0-9A-Za-z]+)-(?P<token>.+)/', body).groupdict()
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', "Test only valid in LMS")
+    @skip_unless_lms
     @ddt.data((False, 'http://'), (True, 'https://'))
     @ddt.unpack
     def test_reset_password_email_https(self, is_secure, protocol):
@@ -372,7 +369,7 @@ class ResetPasswordTests(EventTestMixin, CacheIsolationTestCase):
         )
 
     @override_settings(FEATURES=ENABLE_AUTHN_MICROFRONTEND)
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', "Test only valid in LMS")
+    @skip_unless_lms
     @ddt.data(('Crazy Awesome Site', 'Crazy Awesome Site'), ('edX', 'edX'))
     @ddt.unpack
     def test_reset_password_email_site(self, site_name, platform_name):
@@ -404,7 +401,7 @@ class ResetPasswordTests(EventTestMixin, CacheIsolationTestCase):
                     SETTING_CHANGE_INITIATED, user_id=self.user.id, setting='password', old=None, new=None
                 )
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', "Test only valid in LMS")
+    @skip_unless_lms
     @patch("openedx.core.djangoapps.site_configuration.helpers.get_value", fake_get_value)
     @ddt.data('plain_text', 'html')
     def test_reset_password_email_configuration_override(self, body_type):
@@ -628,7 +625,7 @@ class ResetPasswordTests(EventTestMixin, CacheIsolationTestCase):
         self.user = User.objects.get(pk=self.user.pk)
         assert self.user.is_active
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', "Test only valid in LMS")
+    @skip_unless_lms
     @ddt.data('Crazy Awesome Site', 'edX')
     def test_reset_password_email_subject(self, platform_name):
         """
@@ -835,10 +832,7 @@ class PasswordResetTokenValidateViewTest(UserAPITestCase):
 
 
 @ddt.ddt
-@unittest.skipUnless(
-    settings.ROOT_URLCONF == "lms.urls",
-    "reset password tests should only run in LMS"
-)
+@skip_unless_lms
 class ResetPasswordAPITests(EventTestMixin, CacheIsolationTestCase):
     """Tests of the logistration API's password reset endpoint. """
     request_factory = RequestFactory()

--- a/openedx/core/lib/gating/tests/test_api.py
+++ b/openedx/core/lib/gating/tests/test_api.py
@@ -2,19 +2,18 @@
 Tests for the gating API
 """
 
-import unittest
 from unittest.mock import Mock, patch
 
 import pytest
 from completion.models import BlockCompletion
 from ddt import data, ddt, unpack
-from django.conf import settings
 from milestones import api as milestones_api
 from milestones.tests.utils import MilestonesTestCaseMixin
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, BlockFactory
 
 from common.djangoapps.student.tests.factories import UserFactory
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 from lms.djangoapps.gating import api as lms_gating_api
 from lms.djangoapps.grades.constants import GradeOverrideFeatureEnum
 from lms.djangoapps.grades.models import PersistentSubsectionGrade, PersistentSubsectionGradeOverride
@@ -237,7 +236,7 @@ class TestGatingApi(ModuleStoreTestCase, MilestonesTestCaseMixin):
         (0, 1, 0),
     )
     @unpack
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     def test_get_subsection_completion_percentage(self, user_problem_completion, user_html_completion,
                                                   expected_completion_percentage):
         """
@@ -276,7 +275,7 @@ class TestGatingApi(ModuleStoreTestCase, MilestonesTestCaseMixin):
         ('openassessment', 0, 0),
     )
     @unpack
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     def test_get_subsection_completion_percentage_single_component(
         self,
         component_type,
@@ -306,7 +305,7 @@ class TestGatingApi(ModuleStoreTestCase, MilestonesTestCaseMixin):
             completion_percentage = gating_api.get_subsection_completion_percentage(self.seq1.location, student)
             assert completion_percentage == expected_completion_percentage
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     def test_compute_is_prereq_met(self):
         """
         Test if prereq has been met and force recompute
@@ -353,7 +352,7 @@ class TestGatingGradesIntegration(GradeTestBase):
     """
     MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     def test_get_subsection_grade_percentage(self):
         user = self.request.user
         subsection_key = self.sequence.location
@@ -368,7 +367,7 @@ class TestGatingGradesIntegration(GradeTestBase):
             grade_percentage = gating_api.get_subsection_grade_percentage(subsection_key, user)
             assert 100.0 == grade_percentage
 
-    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @skip_unless_lms
     def test_get_subsection_grade_percentage_with_override(self):
         user = self.request.user
         subsection_key = self.sequence.location

--- a/openedx/features/announcements/tests/test_announcements.py
+++ b/openedx/features/announcements/tests/test_announcements.py
@@ -2,9 +2,7 @@
 Unit tests for the announcements feature.
 """
 
-
 import json
-import unittest
 from unittest.mock import patch
 
 from django.conf import settings
@@ -13,6 +11,7 @@ from django.test.client import Client
 from django.urls import reverse
 
 from common.djangoapps.student.tests.factories import AdminFactory
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 from openedx.features.announcements.models import Announcement
 
 TEST_ANNOUNCEMENTS = [
@@ -24,7 +23,7 @@ TEST_ANNOUNCEMENTS = [
 ]
 
 
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class TestGlobalAnnouncements(TestCase):
     """
     Test Announcements in LMS


### PR DESCRIPTION
We have a shorthand decorator, `@skip_unless_lms`.  Use it instead of the longer form.