### PR TITLE
feat: upgrade edx-event-bus-kafka

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -481,7 +481,7 @@ edx-enterprise==3.60.20
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   learner-pathway-progress
-edx-event-bus-kafka==3.7.1
+edx-event-bus-kafka==3.8.0
     # via -r requirements/edx/base.in
 edx-i18n-tools==0.9.2
     # via ora2

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -604,7 +604,7 @@ edx-enterprise==3.60.20
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   learner-pathway-progress
-edx-event-bus-kafka==3.7.1
+edx-event-bus-kafka==3.8.0
     # via -r requirements/edx/testing.txt
 edx-i18n-tools==0.9.2
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -582,7 +582,7 @@ edx-enterprise==3.60.20
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   learner-pathway-progress
-edx-event-bus-kafka==3.7.1
+edx-event-bus-kafka==3.8.0
     # via -r requirements/edx/base.txt
 edx-i18n-tools==0.9.2
     # via


### PR DESCRIPTION
Upgrade event-bus-kafka to 3.8.0 to publish all original event metadata as headers when producing events to Kafka.