### PR TITLE
Fix inappropriate instructions for inline PII sharing consent dialog.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -666,7 +666,7 @@ libsass==0.10.0
     #   ora2
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==8.0.0
+lti-consumer-xblock==8.0.1
     # via -r requirements/edx/base.in
 lxml==4.9.2
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -891,7 +891,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/testing.txt
     #   ora2
-lti-consumer-xblock==8.0.0
+lti-consumer-xblock==8.0.1
     # via -r requirements/edx/testing.txt
 lxml==4.9.2
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -848,7 +848,7 @@ loremipsum==1.0.5
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-lti-consumer-xblock==8.0.0
+lti-consumer-xblock==8.0.1
     # via -r requirements/edx/base.txt
 lxml==4.9.2
     # via


### PR DESCRIPTION
<!--

🎉🎉 Olive has been released! 🎉🎉

🫒🫒
🫒🫒🫒🫒         🫒 Note: Olive is in support. Fixes you make on master may still
    🫒🫒🫒🫒     be needed on Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This commit upgrades the version of the lti-consumer-xblock library from version 8.0.0 to version 8.0.1. Version 8.0.1 includes a fix to the copy in the LTI PII sharing propmpt dialog displayed before an inline LTI launch that shares PII.

Please see the CHANGELOG entry for this version for a full description of the change: https://github.com/openedx/xblock-lti-consumer/blob/master/CHANGELOG.rst#801---2023-02-03.

## Supporting information

* https://github.com/openedx/xblock-lti-consumer/pull/330
* https://github.com/openedx/xblock-lti-consumer/pull/325