### PR TITLE
feat: Add toggle to allow redirecting to courseware after enrollment.

### DIFF
--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -15,6 +15,7 @@ from django.contrib.auth.models import AnonymousUser, User  # lint-amnesty, pyli
 from django.test import TestCase, override_settings
 from django.test.client import Client
 from django.urls import reverse
+from edx_toggles.toggles.testutils import override_waffle_switch
 from markupsafe import escape
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locations import CourseLocator
@@ -33,6 +34,7 @@ from common.djangoapps.student.models import (
     user_by_anonymous_id
 )
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
+from common.djangoapps.student.toggles import REDIRECT_TO_COURSEWARE_AFTER_ENROLLMENT
 from common.djangoapps.student.views import complete_course_mode_info
 from common.djangoapps.util.model_utils import USER_SETTINGS_CHANGED_EVENT_NAME
 from common.djangoapps.util.testing import EventTestMixin
@@ -893,6 +895,7 @@ class EnrollInCourseTest(EnrollmentEventTestMixin, CacheIsolationTestCase):
 
 
 @skip_unless_lms
+@ddt.ddt
 class ChangeEnrollmentViewTest(ModuleStoreTestCase):
     """Tests the student.views.change_enrollment view"""
 
@@ -912,6 +915,17 @@ class ChangeEnrollmentViewTest(ModuleStoreTestCase):
             }
         )
         return response
+
+    @ddt.data(
+        (True, 'courseware'),
+        (False, None),
+    )
+    @ddt.unpack
+    def test_enrollment_url(self, waffle_flag_enabled, returned_view):
+        with override_waffle_switch(REDIRECT_TO_COURSEWARE_AFTER_ENROLLMENT, waffle_flag_enabled):
+            response = self._enroll_through_view(self.course)
+        data = reverse(returned_view, args=[str(self.course.id)]) if returned_view else ''
+        assert response.content.decode('utf8') == data
 
     def test_enroll_as_default(self):
         """Tests that a student can successfully enroll through this view"""

--- a/common/djangoapps/student/toggles.py
+++ b/common/djangoapps/student/toggles.py
@@ -1,7 +1,7 @@
 """
 Toggles for Dashboard page.
 """
-from edx_toggles.toggles import WaffleFlag
+from edx_toggles.toggles import WaffleFlag, WaffleSwitch
 
 # Namespace for student waffle flags.
 WAFFLE_FLAG_NAMESPACE = 'student'
@@ -75,3 +75,21 @@ ENROLLMENT_CONFIRMATION_EMAIL = WaffleFlag(
 
 def should_send_enrollment_email():
     return ENROLLMENT_CONFIRMATION_EMAIL.is_enabled()
+
+
+# Waffle flag to enable control redirecting after enrolment.
+# .. toggle_name: student.redirect_to_courseware_after_enrollment
+# .. toggle_implementation: WaffleSwitch
+# .. toggle_default: False
+# .. toggle_description: Redirect to courseware after enrollment instead of dashboard.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2023-02-06
+# .. toggle_target_removal_date: None
+# .. toggle_warning: None
+REDIRECT_TO_COURSEWARE_AFTER_ENROLLMENT = WaffleSwitch(
+    f'{WAFFLE_FLAG_NAMESPACE}.redirect_to_courseware_after_enrollment', __name__
+)
+
+
+def should_redirect_to_courseware_after_enrollment():
+    return REDIRECT_TO_COURSEWARE_AFTER_ENROLLMENT.is_enabled()

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -38,6 +38,7 @@ from pytz import UTC
 from rest_framework.decorators import api_view, authentication_classes, permission_classes
 from rest_framework.permissions import IsAuthenticated
 
+from common.djangoapps.student.toggles import should_redirect_to_courseware_after_enrollment
 from common.djangoapps.track import views as track_views
 from lms.djangoapps.bulk_email.models import Optout
 from common.djangoapps.course_modes.models import CourseMode
@@ -400,8 +401,10 @@ def change_enrollment(request, check_access=True):
                 reverse("course_modes_choose", kwargs={'course_id': str(course_id)})
             )
 
-        # Otherwise, there is only one mode available (the default)
-        return HttpResponse()
+        if should_redirect_to_courseware_after_enrollment():
+            return HttpResponse(reverse('courseware', args=[str(course_id)]))
+        else:
+            return HttpResponse()
     elif action == "unenroll":
         if configuration_helpers.get_value(
             "DISABLE_UNENROLLMENT",


### PR DESCRIPTION
## Description

This change adds a new waffle switch to redirect a student to courseware after enrolment instead of the dashboard.

## Supporting information

NA

## Testing instructions

- With a new toggle disabled, enrol a student into a course. They will be redirected to the dashboard after enrolment. 
- With a new toggle enabled, enrol a student into a course. They will be redirected to the course after enrolment. 

## Deadline

"None"

## Other information

Private-ref: [BB-7071](https://tasks.opencraft.com/browse/BB-7051)