### PR TITLE
feat: added user messages and backed now uses discussion_enabled flag

### DIFF
--- a/cms/static/js/spec/views/pages/course_outline_spec.js
+++ b/cms/static/js/spec/views/pages/course_outline_spec.js
@@ -2422,26 +2422,6 @@ describe('CourseOutlinePage', function() {
                 expect($('.modal-section .edit-discussion')).not.toExist();
             });
 
-            it('shows discussion settings if unit level discussions are enabled', function() {
-                getUnitStatus({}, {unit_level_discussions: true});
-                outlinePage.$('.outline-unit .configure-button').click();
-                expect($('.modal-section .edit-discussion')).toExist();
-            });
-
-            it('marks checkbox as disabled', function() {
-                getUnitStatus({}, {unit_level_discussions: true});
-                outlinePage.$('.outline-unit .configure-button').click();
-
-                var discussionCheckbox = $('#discussion_enabled');
-                expect(discussionCheckbox).toExist();
-                expect(discussionCheckbox.is(':checked')).toBeFalsy();
-            });
-
-            it('marks checkbox as enabled', function() {
-                getUnitStatus({discussion_enabled: true}, {unit_level_discussions: true});
-                outlinePage.$('.outline-unit .configure-button').click();
-                expect($('#discussion_enabled').is(':checked')).toBeTruthy();
-            });
         });
 
         verifyTypePublishable('unit', function(options) {

--- a/cms/static/js/views/modals/course_outline_modals.js
+++ b/cms/static/js/views/modals/course_outline_modals.js
@@ -941,11 +941,27 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
         afterRender: function() {
             AbstractEditor.prototype.afterRender.call(this);
             this.setStatus(this.currentValue());
+            this.showTipText();
         },
 
         currentValue: function() {
             var discussionEnabled = this.model.get('discussion_enabled');
             return discussionEnabled === true || discussionEnabled === 'enabled';
+        },
+
+        showTipText: function() {
+          if (this.model.get('published')) {
+            $('.un-published-tip').hide()
+          } else {
+            $('.un-published-tip').show()
+          }
+          let enabledForGraded = course.get('discussions_settings').enable_graded_units
+          if (this.model.get('graded') && !enabledForGraded) {
+            $('#discussion_enabled').prop('disabled', true);
+            $('.graded-tip').show()
+          } else {
+            $('.graded-tip').hide()
+          }
         },
 
         setStatus: function(value) {

--- a/cms/templates/js/discussion-editor.underscore
+++ b/cms/templates/js/discussion-editor.underscore
@@ -7,5 +7,11 @@
         <input type="checkbox" id="discussion_enabled" name="discussion_enabled" class="input input-checkbox" />
         <%- gettext('Enable discussion') %>
      </label>
+    <p class="un-published-tip tip tip-inline">
+        <%- gettext('Topics for unpublished units would not be created') %>
+    </p>
+    <p class="graded-tip message">
+        <%- gettext('Please enable discussions for graded units from course authoring app') %>
+    </p>
 </div>
 </form>

--- a/cms/templates/js/discussion-editor.underscore
+++ b/cms/templates/js/discussion-editor.underscore
@@ -7,11 +7,13 @@
         <input type="checkbox" id="discussion_enabled" name="discussion_enabled" class="input input-checkbox" />
         <%- gettext('Enable discussion') %>
      </label>
+<div class="ml-5">
     <p class="un-published-tip tip tip-inline">
         <%- gettext('Topics for unpublished units would not be created') %>
     </p>
-    <p class="graded-tip message">
+    <p class="graded-tip tip tip-inline">
         <%- gettext('Please enable discussions for graded units from course authoring app') %>
     </p>
+</div>
 </div>
 </form>

--- a/openedx/core/djangoapps/discussions/tasks.py
+++ b/openedx/core/djangoapps/discussions/tasks.py
@@ -202,7 +202,7 @@ def update_unit_discussion_state_from_discussion_blocks(course_key: CourseKey, u
         subsections_with_discussions = set()
         for vertical in verticals:
             if vertical.location in discussible_units:
-                # vertical.discussion_enabled = True
+                vertical.discussion_enabled = True
                 subsections_with_discussions.add(vertical.parent)
             else:
                 vertical.discussion_enabled = False

--- a/openedx/core/djangoapps/discussions/tasks.py
+++ b/openedx/core/djangoapps/discussions/tasks.py
@@ -87,6 +87,13 @@ def update_discussions_settings_from_course(course_key: CourseKey) -> CourseDisc
 
 
 def get_discussable_units(course, enable_graded_units):
+    """
+    Get all the units in the course that are discussable.
+    Parameters:
+        course (CourseDescriptor): The course to get discussable units for.
+        enable_graded_units (bool): Whether to include units in graded subsections.
+    Returns: A generator of DiscussionTopicContext objects.
+    """
     # Start at 99 so that the initial increment starts it at 100.
     # This leaves the first 100 slots for the course wide topics, which is only a concern if there are more
     # than that many.

--- a/openedx/core/djangoapps/discussions/tasks.py
+++ b/openedx/core/djangoapps/discussions/tasks.py
@@ -53,13 +53,6 @@ def update_discussions_settings_from_course(course_key: CourseKey) -> CourseDisc
     with store.branch_setting(ModuleStoreEnum.Branch.published_only, course_key):
         course = store.get_course(course_key)
         enable_in_context = discussions_config.enable_in_context
-        # update in case parent is graded etc.
-        # graded , practice_exam, proctored_enabled, time_limited = False
-        # topics for unpublished units are also created ...
-        # Disable in case is graded enable with message if is unpublished
-        # what about already create topics of unpublished units
-        # we can republish but should we delete topics for them
-        # we can also delete topics for unpublished units
         provider_config = discussions_config.plugin_configuration
         unit_level_visibility = discussions_config.unit_level_visibility
         enable_graded_units = discussions_config.enable_graded_units
@@ -80,7 +73,7 @@ def update_discussions_settings_from_course(course_key: CourseKey) -> CourseDisc
                     )
                     contexts.append(context)
             if enable_in_context:
-                contexts.extend(list(get_discussable_units(course, enable_graded_units, unit_level_visibility)))
+                contexts.extend(list(get_discussable_units(course, enable_graded_units)))
         config_data = CourseDiscussionConfigurationData(
             course_key=course_key,
             enable_in_context=enable_in_context,
@@ -93,11 +86,11 @@ def update_discussions_settings_from_course(course_key: CourseKey) -> CourseDisc
     return config_data
 
 
-def get_discussable_units(course, enable_graded_units, unit_level_visibility):
+def get_discussable_units(course, enable_graded_units):
     # Start at 99 so that the initial increment starts it at 100.
     # This leaves the first 100 slots for the course wide topics, which is only a concern if there are more
     # than that many.
-    # Here we want to make sure if unit is not published it is not included
+    store = modulestore()
     idx = 99
     for section in course.get_children():
         if section.location.block_type != "chapter":
@@ -108,19 +101,30 @@ def get_discussable_units(course, enable_graded_units, unit_level_visibility):
             for unit in subsection.get_children():
                 if unit.location.block_type != 'vertical':
                     continue
+                # Skip if unit is not published
+                if not modulestore().has_published_version(unit):
+                    continue
                 # Increment index even for skipped units so that the index is more stable and won't change
                 # if settings change, only if a unit is added or removed.
                 idx += 1
                 # If unit-level visibility is enabled and the unit doesn't have discussion enabled, skip it.
                 # here . we should remove unit_level_visibility and param from function
-                if unit_level_visibility and not getattr(unit, "discussion_enabled", False):
+                if not getattr(unit, "discussion_enabled", False):
+                    unit.discussion_enabled = False
+                    store.update_item(unit, 1)
                     continue
                 # If the unit is in a graded section and graded sections aren't enabled skip it.
+
                 if subsection.graded and not enable_graded_units:
+                    unit.discussion_enabled = False
+                    store.update_item(unit, 1)
                     continue
                 # If the unit is an exam, skip it.
                 if subsection.is_practice_exam or subsection.is_proctored_enabled or subsection.is_time_limited:
+                    unit.discussion_enabled = False
+                    store.update_item(unit, 1)
                     continue
+
                 yield DiscussionTopicContext(
                     usage_key=unit.location,
                     title=unit.display_name,

--- a/openedx/core/djangoapps/discussions/tests/test_tasks.py
+++ b/openedx/core/djangoapps/discussions/tests/test_tasks.py
@@ -162,10 +162,10 @@ class UpdateDiscussionsSettingsFromCourseTestCase(ModuleStoreTestCase, Discussio
         ({}, 3, {"Unit", "Discussable Unit"},
          {"Graded Unit", "Non-Discussable Unit", "Discussable Graded Unit", "Non-Discussable Graded Unit"}),
         ({"enable_in_context": False}, 1, set(), {"Unit", "Graded Unit"}),
-        ({"unit_level_visibility": False, "enable_graded_units": False}, 4,
-         {"Unit", "Discussable Unit", "Non-Discussable Unit"},
+        ({"unit_level_visibility": False, "enable_graded_units": False}, 3,
+         {"Unit", "Discussable Unit"},
          {"Graded Unit"}),
-        ({"unit_level_visibility": False, "enable_graded_units": True}, 7,
+        ({"unit_level_visibility": False, "enable_graded_units": True}, 5,
          {"Unit", "Graded Unit", "Discussable Graded Unit"}, set()),
         ({"enable_graded_units": True}, 5,
          {"Discussable Unit", "Discussable Graded Unit", "Graded Unit"},
@@ -178,6 +178,8 @@ class UpdateDiscussionsSettingsFromCourseTestCase(ModuleStoreTestCase, Discussio
         """
         self.update_discussions_settings(settings)
         config_data = update_discussions_settings_from_course(self.course.id)
+        breakpoint()
+
         assert len(config_data.contexts) == context_count
         units_in_config = {context.title for context in config_data.contexts}
         assert present_units <= units_in_config

--- a/openedx/core/djangoapps/discussions/tests/test_tasks.py
+++ b/openedx/core/djangoapps/discussions/tests/test_tasks.py
@@ -178,8 +178,6 @@ class UpdateDiscussionsSettingsFromCourseTestCase(ModuleStoreTestCase, Discussio
         """
         self.update_discussions_settings(settings)
         config_data = update_discussions_settings_from_course(self.course.id)
-        breakpoint()
-
         assert len(config_data.contexts) == context_count
         units_in_config = {context.title for context in config_data.contexts}
         assert present_units <= units_in_config

--- a/xmodule/vertical_block.py
+++ b/xmodule/vertical_block.py
@@ -42,7 +42,7 @@ class VerticalFields:
     discussion_enabled = Boolean(
         display_name=_("Enable in-context discussions for the Unit"),
         help=_("Add discussion for the Unit."),
-        default=False,
+        default=True,
         scope=Scope.settings,
     )
 

--- a/xmodule/vertical_block.py
+++ b/xmodule/vertical_block.py
@@ -42,7 +42,7 @@ class VerticalFields:
     discussion_enabled = Boolean(
         display_name=_("Enable in-context discussions for the Unit"),
         help=_("Add discussion for the Unit."),
-        default=True,
+        default=False,
         scope=Scope.settings,
     )
 


### PR DESCRIPTION
## Description
This PR adds information messages for users on the unit editor modal and removes dependency on 
`unit_level_visiblity` flag so `unit.discussions_enabled` flag shows the current state of the toggle.
 
## Ticket 
https://2u-internal.atlassian.net/browse/INF-745

<img width="574" alt="Screenshot 2023-02-22 at 12 39 36 PM" src="https://user-images.githubusercontent.com/26253150/220554250-a4bc8aaf-4acd-4728-8bb8-66e4656730d0.png">
<img width="574" alt="Screenshot 2023-02-22 at 12 39 11 PM" src="https://user-images.githubusercontent.com/26253150/220554275-2465aa9c-d5e7-463b-9863-fd6445d826b5.png">

