### PR TITLE
Install xblock-poll from pypi

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -182,6 +182,7 @@ web-fragments                       # Provides the ability to render fragments o
 XBlock[django]                      # Courseware component architecture
 xblock-utils                        # Provides utilities used by the Discussion XBlock
 xss-utils                           # https://github.com/edx/edx-platform/pull/20633 Fix XSS via Translations
+xblock-poll                         # Xblock for polling users
 xblock-drag-and-drop-v2             # Drag and Drop XBlock
 xblock-google-drive                 # XBlock for google docs and calendar
 openedx-django-require

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -163,8 +163,6 @@ cryptography==38.0.4
     #   social-auth-core
 cssutils==2.6.0
     # via pynliner
-ddt==1.6.0
-    # via xblock-poll
 defusedxml==0.7.1
     # via
     #   -r requirements/edx/base.in
@@ -706,9 +704,7 @@ markupsafe==2.1.2
 maxminddb==2.2.0
     # via geoip2
 mock==5.0.1
-    # via
-    #   -r requirements/edx/paver.txt
-    #   xblock-poll
+    # via -r requirements/edx/paver.txt
 mongodbproxy @ git+https://github.com/openedx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a
     # via -r requirements/edx/github.in
 mongoengine==0.26.0
@@ -1180,8 +1176,8 @@ xblock-drag-and-drop-v2==3.1.0
     # via -r requirements/edx/base.in
 xblock-google-drive==0.3.0
     # via -r requirements/edx/base.in
-xblock-poll @ git+https://github.com/open-craft/xblock-poll@v1.12.0
-    # via -r requirements/edx/github.in
+xblock-poll==1.13.0
+    # via -r requirements/edx/base.in
 xblock-utils==3.0.0
     # via
     #   -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -245,9 +245,7 @@ cssutils==2.6.0
     #   -r requirements/edx/testing.txt
     #   pynliner
 ddt==1.6.0
-    # via
-    #   -r requirements/edx/testing.txt
-    #   xblock-poll
+    # via -r requirements/edx/testing.txt
 deepmerge==1.1.0
     # via sphinxcontrib-openapi
 defusedxml==0.7.1
@@ -955,9 +953,7 @@ mccabe==0.7.0
 mistune==2.0.5
     # via sphinx-mdinclude
 mock==5.0.1
-    # via
-    #   -r requirements/edx/testing.txt
-    #   xblock-poll
+    # via -r requirements/edx/testing.txt
 mongodbproxy @ git+https://github.com/openedx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a
     # via -r requirements/edx/testing.txt
 mongoengine==0.26.0
@@ -1710,7 +1706,7 @@ xblock-drag-and-drop-v2==3.1.0
     # via -r requirements/edx/testing.txt
 xblock-google-drive==0.3.0
     # via -r requirements/edx/testing.txt
-xblock-poll @ git+https://github.com/open-craft/xblock-poll@v1.12.0
+xblock-poll==1.13.0
     # via -r requirements/edx/testing.txt
 xblock-utils==3.0.0
     # via

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -58,6 +58,3 @@
 git+https://github.com/openedx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2
 
 
-# Third Party XBlocks
-
-git+https://github.com/open-craft/xblock-poll@v1.12.0#egg=xblock-poll==1.12.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -235,10 +235,7 @@ cssutils==2.6.0
     #   -r requirements/edx/base.txt
     #   pynliner
 ddt==1.6.0
-    # via
-    #   -r requirements/edx/base.txt
-    #   -r requirements/edx/testing.in
-    #   xblock-poll
+    # via -r requirements/edx/testing.in
 defusedxml==0.7.1
     # via
     #   -r requirements/edx/base.txt
@@ -908,9 +905,7 @@ maxminddb==2.2.0
 mccabe==0.7.0
     # via pylint
 mock==5.0.1
-    # via
-    #   -r requirements/edx/base.txt
-    #   xblock-poll
+    # via -r requirements/edx/base.txt
 mongodbproxy @ git+https://github.com/openedx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a
     # via -r requirements/edx/base.txt
 mongoengine==0.26.0
@@ -1580,7 +1575,7 @@ xblock-drag-and-drop-v2==3.1.0
     # via -r requirements/edx/base.txt
 xblock-google-drive==0.3.0
     # via -r requirements/edx/base.txt
-xblock-poll @ git+https://github.com/open-craft/xblock-poll@v1.12.0
+xblock-poll==1.13.0
     # via -r requirements/edx/base.txt
 xblock-utils==3.0.0
     # via


### PR DESCRIPTION
## Description
This PR removes `xblock-poll` from `github.in` and instead uses the PyPI package.

## Supporting Information
Sub-task of https://github.com/open-craft/xblock-poll/issues/98