### PR TITLE
fix: remove programUpsell from api response

### DIFF
--- a/lms/djangoapps/learner_recommendations/serializers.py
+++ b/lms/djangoapps/learner_recommendations/serializers.py
@@ -39,25 +39,12 @@ class RecommendedCourseSerializer(serializers.Serializer):
         return f"course/{url_slug}"
 
 
-class RecommendedProgramSerializer(serializers.Serializer):
-    """Serializer for a recommended program for course about page recommendations"""
-    title = serializers.CharField()
-    marketingUrl = serializers.URLField(source="marketing_url")
-    coursesCount = serializers.IntegerField(source="courses_count")
-    pacingType = serializers.CharField(source="pacing_type")
-    weeksToComplete = serializers.CharField(source="weeks_to_complete")
-    minHours = serializers.IntegerField(source="min_hours")
-    maxHours = serializers.IntegerField(source="max_hours")
-    type = serializers.CharField()
-
-
 class RecommendationsSerializer(serializers.Serializer):
-    """Recommended courses and program for course about page"""
+    """Recommended courses for course about page"""
 
     courses = serializers.ListField(
         child=RecommendedCourseSerializer(), allow_empty=True
     )
-    programUpsell = RecommendedProgramSerializer(source="program_upsell")
     isControl = serializers.BooleanField(
         source="is_control",
         default=None

--- a/lms/djangoapps/learner_recommendations/views.py
+++ b/lms/djangoapps/learner_recommendations/views.py
@@ -148,7 +148,6 @@ class AmplitudeRecommendationsView(APIView):
         return Response(
             RecommendationsSerializer(
                 {
-                    "program_upsell": None,
                     "courses": recommended_courses,
                     "is_control": is_control,
                 }


### PR DESCRIPTION
[VAN-1298](https://2u-internal.atlassian.net/browse/VAN-1298)

Program Upsell data now taken from frontend therefore this PR removes program_upsell from the course about page recommendations API response