### PR TITLE
temp: remove temp logging added around extended_profile functionality

### DIFF
--- a/common/djangoapps/student/models/user.py
+++ b/common/djangoapps/student/models/user.py
@@ -602,18 +602,15 @@ class UserProfile(models.Model):
             return self.__enumerable_to_display(self.GENDER_CHOICES, self.gender)
 
     def get_meta(self):  # pylint: disable=missing-function-docstring
-        log.info(f"[Extended Profile] Retrieving user profile meta data for user {self.user.id}")
         js_str = self.meta
         if not js_str:
             js_str = {}
         else:
             js_str = json.loads(self.meta)
 
-        log.info(f"[Extended Profile] Returning user profile meta data for user {self.user.id} with data [{js_str}]")
         return js_str
 
     def set_meta(self, meta_json):
-        log.info(f"[Extended Profile] Updating user profile meta data for user {self.user.id} with: [{meta_json}]")
         self.meta = json.dumps(meta_json)
 
     def set_login_session(self, session_id=None):

--- a/openedx/core/djangoapps/user_api/accounts/api.py
+++ b/openedx/core/djangoapps/user_api/accounts/api.py
@@ -5,7 +5,6 @@ Programmatic integration point for User API Accounts sub-application
 
 
 import datetime
-import logging
 import re
 
 from django.conf import settings
@@ -49,7 +48,6 @@ if name_affirmation_installed:
 
 # Public access point for this function.
 visible_fields = _visible_fields
-log = logging.getLogger(__name__)
 
 
 @helpers.intercept_errors(errors.UserAPIInternalError, ignore_errors=[errors.UserAPIRequestError])
@@ -339,21 +337,13 @@ def _notify_language_proficiencies_update_if_needed(data, user, user_profile, ol
 
 def _update_extended_profile_if_needed(data, user_profile):
     if 'extended_profile' in data:
-        log.info(f"[Extended Profile] Extended profile data update requested for user {user_profile.user.id}")
         meta = user_profile.get_meta()
         new_extended_profile = data['extended_profile']
         for field in new_extended_profile:
             field_name = field['field_name']
             new_value = field['field_value']
-            log.info(f"[Extended Profile] Extended profile data field: [{field_name}]")
-            log.info(f"[Extended Profile] Extended profile data value: [{new_value}]")
             meta[field_name] = new_value
-
         user_profile.set_meta(meta)
-        log.info(
-            "[Extended Profile] Saving user profile after extended profile data update for user "
-            f"{user_profile.user.id}"
-        )
         user_profile.save()
 
 


### PR DESCRIPTION
<!--

🎉🎉 Olive has been released! 🎉🎉

🫒🫒
🫒🫒🫒🫒         🫒 Note: Olive is in support. Fixes you make on master may still
    🫒🫒🫒🫒     be needed on Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

[APER-2247]

This reverts commit 1359a6d6bb391b316a77c653f49fa057ae3a5118. This logging is no longer needed as the feature is working as expected (and we figured out the issue causing unexpected/missing results).