### PR TITLE
Correct link to byte-size issues and tasks

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -95,7 +95,7 @@ small size, and usually don't require a broad knowledge of the edX platform.
 It makes them good candidates for a first task, allowing you to focus on getting
 familiar with the development environment and the contribution process.
 
-.. _byte-sized bugs and tasks: http://bit.ly/edxbugs
+.. _byte-sized bugs and tasks: https://github.com/search?q=user%3Aopenedx+label%3A%22help+wanted%22&type=Issues&ref=advsearch&l=&l=
 
 Once you have identified a bug or task, `create an account on the tracker`_ and
 then comment on the ticket to indicate that you are working on it. Don't hesitate


### PR DESCRIPTION
## Description

Since issue tracking for OpenedX has moved to GitHub, the link to byte-size issues and tasks needs to be updated to redirect to issues labeled `help wanted` under the openedx organization on GitHub.

The change mostly affects first-time contributors to any repository under the openedx organization on GitHub.

## Supporting information

Currently the link points to [this JIRA board](https://openedx.atlassian.net/issues/?filter=12810) that is no longer used by the OpenedX team as indicated in the message at the top of the page. 

## Testing instructions

Clicking on the new link should open all issues across the openedx organization on GitHub that have the label `help wanted`

## Deadline

None

## Other information

Since the previous URL seems to have been created using a URL shortener, we could do the same for the new link.