### PR TITLE
fix: fixes bad set / list operation

### DIFF
--- a/lms/djangoapps/discussion/rest_api/render.py
+++ b/lms/djangoapps/discussion/rest_api/render.py
@@ -7,7 +7,7 @@ implemented in Markdown.Sanitizer.js.
 import bleach
 import markdown
 
-ALLOWED_TAGS = bleach.ALLOWED_TAGS | {
+ALLOWED_TAGS = set(bleach.ALLOWED_TAGS) | {
     'br', 'dd', 'del', 'dl', 'dt', 'h1', 'h2', 'h3', 'h4', 'hr', 'img', 'kbd', 'p', 'pre', 's',
     'strike', 'sub', 'sup'
 }


### PR DESCRIPTION
## Description

[Previous change](https://github.com/openedx/edx-platform/commit/32748788bf84f9c1aea22edb76d68f6248c68dec) as part of the `bleach 6.x` migration tried to union a set with a list (bleach.ALLOWED_TAGS) which surfaced the following breaking issue:

```
File "/edx/app/edxapp/edx-platform/lms/djangoapps/discussion/rest_api/render.py", line 10, in <module>
     ALLOWED_TAGS = bleach.ALLOWED_TAGS | {
TypeError: unsupported operand type(s) for |: 'list' and 'set'
```

This simply casts the `bleach.ALLOWED_TAGS` to a set so the union operation is valid