### PR TITLE
fix: upgrade reminder email image

### DIFF
--- a/openedx/core/djangoapps/schedules/resolvers.py
+++ b/openedx/core/djangoapps/schedules/resolvers.py
@@ -3,6 +3,7 @@
 import datetime
 import logging
 from itertools import groupby
+from urllib.parse import urljoin
 
 import attr
 from django.conf import settings
@@ -322,7 +323,7 @@ class UpgradeReminderResolver(BinnedSchedulesBaseResolver):
         context = {
             'course_links': course_links,
             'first_course_name': first_schedule.enrollment.course.display_name,
-            'cert_image': static('course_experience/images/verified-cert.png'),
+            'cert_image': urljoin(settings.LMS_ROOT_URL, static('course_experience/images/verified-cert.png')),
             'course_ids': course_id_strs,
         }
         context.update(first_valid_upsell_context)


### PR DESCRIPTION
Replace a relative URL with the absolute one to fix the broken image in the Upgrade reminder email.

Relative URL causes the following error:
<img width="657" alt="Screenshot 2023-02-10 at 17 31 10" src="https://user-images.githubusercontent.com/47273130/218130732-4c51fdc4-5592-4dc7-b5a4-3ee338676aff.png">

After the fix was applied:
<img width="663" alt="Screenshot 2023-02-10 at 17 49 32" src="https://user-images.githubusercontent.com/47273130/218135154-dfc0bfdb-3bd0-4c57-a789-94be7637398c.png">

### NOTES:
- the issue was originally discovered, fixed, and tested in the Nutmeg release
- I had another idea for the fix - use the `with_link_tracking` template tag in the email body template but decided to go with the current implementation as a more straightforward one