### PR TITLE
fix: Remove django-require git-dependency (missed in previous PR)

### DIFF
--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -57,9 +57,6 @@
 -e git+https://github.com/openedx/olxcleaner.git@2f0d6c7f126cbd69c9724b7b57a0b2565330a297#egg=olxcleaner
 git+https://github.com/openedx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2
 
-# original repo is not maintained any more.
-git+https://github.com/openedx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776#egg=django-require==1.0.12
-
 
 # Third Party XBlocks
 

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -62,7 +62,6 @@ attrs==22.2.0
     #   lti-consumer-xblock
     #   openedx-blockstore
     #   openedx-events
-    #   outcome
     #   pytest
 babel==2.11.0
     # via
@@ -421,8 +420,6 @@ django-object-actions==4.1.0
 django-pipeline==2.0.9
     # via -r requirements/edx/base.txt
 django-ratelimit==4.0.0
-    # via -r requirements/edx/base.txt
-django-require @ git+https://github.com/openedx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776
     # via -r requirements/edx/base.txt
 django-sekizai==4.0.0
     # via


### PR DESCRIPTION
https://github.com/openedx/edx-platform/pull/31279 switched to installing a fork of django-require from PyPI but did not commit the removal of the line from github.in. This completes the transition.

This PR was created by removing the github.in line and running `make compile-requirements` on Linux.