### PR TITLE
fix: add missing variables to library_listing context

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -617,7 +617,9 @@ def library_listing(request):
         'allow_course_reruns': settings.FEATURES.get('ALLOW_COURSE_RERUNS', True),
         'rerun_creator_status': GlobalStaff().has_user(request.user),
         'split_studio_home': split_library_view_on_dashboard(),
-        'active_tab': 'libraries'
+        'active_tab': 'libraries',
+        'allowed_organizations': get_allowed_organizations(request.user),
+        'can_create_organizations': user_can_create_organizations(request.user),
     }
     return render_to_response('index.html', data)
 


### PR DESCRIPTION
## Description

This PR fixes an internal error raised when the waffle flag `contentstore.split_library_on_studio_dashboard` is enabled and users access to the `/home_library` view. It failed because the library view doesn't have in the context, the variables introduced in the PR that added the dropdown functionality https://github.com/openedx/edx-platform/pull/30975

## Supporting information

The PR that added the dropdown functionality is this one https://github.com/openedx/edx-platform/pull/30975

## Testing instructions

1. Enable the waffle flag `contentstore.split_library_on_studio_dashboard `.
2. Go to the CMS and open select Libraries or go directly to the view `/home_library` .
3. See the error.