### PR TITLE
feat: public video metadata + embed

### DIFF
--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -96,6 +96,17 @@ COURSEWARE_OPTIMIZED_RENDER_XBLOCK = CourseWaffleFlag(
 # .. toggle_status: unsupported
 COURSES_INVITE_ONLY = SettingToggle('COURSES_INVITE_ONLY', default=False)
 
+# .. toggle_name: courseware.public_video_share
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Enables public viewing / sharing of all course videos.
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2023-02-02
+# .. toggle_target_removal_date: None
+PUBLIC_VIDEO_SHARE = CourseWaffleFlag(
+    f'{WAFFLE_FLAG_NAMESPACE}.public_video_share', __name__
+)
+
 ENABLE_OPTIMIZELY_IN_COURSEWARE = WaffleSwitch(  # lint-amnesty, pylint: disable=toggle-missing-annotation
     'RET.enable_optimizely_in_courseware', __name__
 )

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1613,12 +1613,12 @@ def render_xblock(request, usage_key_string, check_if_enrolled=True):
         return render_to_response('courseware/courseware-chromeless.html', context)
 
 
-def _render_public_video_xblock(request, usage_key_string, is_=False):
+def _render_public_video_xblock(request, usage_key_string, is_embed=False):
     """
     Look up a given usage key and render the "public" view or the "embed" view
     """
     view = 'public_view'
-    if is_:
+    if is_embed:
         template = 'public_video_share_embed.html'
     else:
         template = 'public_video.html'
@@ -1647,7 +1647,7 @@ def _render_public_video_xblock(request, usage_key_string, is_=False):
         )
 
         fragment = block.render(view, context={
-            'public_video_embed': is_,
+            'public_video_embed': is_embed,
         })
 
         video_description = f"Watch a video from the course {course.display_name} "
@@ -1687,7 +1687,7 @@ def render_public_video_xblock_embed(request, usage_key_string):
     Returns an HttpResponse with HTML content for the Video xBlock with the given usage_key.
     The returned HTML consists of nothing but the Video xBlock content for use in social media embedding.
     """
-    return _render_public_video_xblock(request, usage_key_string, is_=True)
+    return _render_public_video_xblock(request, usage_key_string, is_embed=True)
 
 
 @require_http_methods(["GET"])
@@ -1699,7 +1699,7 @@ def render_public_video_xblock(request, usage_key_string):
     Returns an HttpResponse with HTML content for the Video xBlock with the given usage_key.
     The returned HTML is a chromeless rendering of the Video xBlock (excluding content of the containing courseware).
     """
-    return _render_public_video_xblock(request, usage_key_string, is_=False)
+    return _render_public_video_xblock(request, usage_key_string, is_embed=False)
 
 
 def get_optimization_flags_for_content(block, fragment):

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -8,7 +8,7 @@ import logging
 import urllib
 from collections import OrderedDict, namedtuple
 from datetime import datetime
-from urllib.parse import quote_plus
+from urllib.parse import quote_plus, urljoin
 
 import bleach
 import requests
@@ -86,7 +86,7 @@ from lms.djangoapps.courseware.masquerade import is_masquerading_as_specific_stu
 from lms.djangoapps.courseware.model_data import FieldDataCache
 from lms.djangoapps.courseware.models import BaseStudentModuleHistory, StudentModule
 from lms.djangoapps.courseware.permissions import MASQUERADE_AS_STUDENT, VIEW_COURSE_HOME, VIEW_COURSEWARE
-from lms.djangoapps.courseware.toggles import course_is_invitation_only
+from lms.djangoapps.courseware.toggles import course_is_invitation_only, PUBLIC_VIDEO_SHARE
 from lms.djangoapps.courseware.user_state_client import DjangoXBlockUserStateClient
 from lms.djangoapps.courseware.utils import (
     _use_new_financial_assistance_flow,
@@ -1613,20 +1613,22 @@ def render_xblock(request, usage_key_string, check_if_enrolled=True):
         return render_to_response('courseware/courseware-chromeless.html', context)
 
 
-@require_http_methods(["GET"])
-@ensure_valid_usage_key
-@xframe_options_exempt
-@transaction.non_atomic_requests
-def render_public_video_xblock(request, usage_key_string):
+def _render_public_video_xblock(request, usage_key_string, is_=False):
     """
-    Returns an HttpResponse with HTML content for the Video xBlock with the given usage_key.
-    The returned HTML is a chromeless rendering of the Video xBlock (excluding content of the containing courseware).
+    Look up a given usage key and render the "public" view or the "embed" view
     """
     view = 'public_view'
+    if is_:
+        template = 'public_video_share_embed.html'
+    else:
+        template = 'public_video.html'
 
     usage_key = UsageKey.from_string(usage_key_string)
     usage_key = usage_key.replace(course_key=modulestore().fill_in_run(usage_key.course_key))
     course_key = usage_key.course_key
+
+    if not PUBLIC_VIDEO_SHARE.is_enabled(course_key):
+        raise Http404("Video not found.")
 
     # usage key block type must be `video` else raise 404
     if usage_key.block_type != 'video':
@@ -1644,15 +1646,26 @@ def render_public_video_xblock(request, usage_key_string):
             will_recheck_access=False
         )
 
-        # video must be public (`Public Access` field set to True) by course author in studio in video advanced settings
-        if not block.public_access:
-            raise Http404("Video not found.")
+        fragment = block.render(view, context={
+            'public_video_embed': is_,
+        })
 
-        fragment = block.render(view, context={})
+        video_description = f"Watch a video from the course {course.display_name} "
+        if course.display_organization is not None:
+            video_description += f"by {course.display_organization} "
+        video_description += "on edX.org"
 
         context = {
             'fragment': fragment,
             'course': course,
+            'video_title': block.display_name_with_default,
+            'video_description': video_description,
+            'video_thumbnail': "https://www.edx.org/images/logos/edx-logo-elm.svg",
+            # 'video_thumbnail': "https://i.ytimg.com/vi/Kauv7MVPcsA/maxresdefault.jpg",
+            'video_embed_url': urljoin(
+                settings.LMS_ROOT_URL,
+                reverse('render_public_video_xblock_embed', kwargs={'usage_key_string': str(usage_key)})
+            ),
             'disable_accordion': False,
             'allow_iframing': True,
             'disable_header': False,
@@ -1662,7 +1675,31 @@ def render_public_video_xblock(request, usage_key_string):
             'is_learning_mfe': True,
             'is_mobile_app': False,
         }
-        return render_to_response('courseware/courseware-chromeless.html', context)
+        return render_to_response(template, context)
+
+
+@require_http_methods(["GET"])
+@ensure_valid_usage_key
+@xframe_options_exempt
+@transaction.non_atomic_requests
+def render_public_video_xblock_embed(request, usage_key_string):
+    """
+    Returns an HttpResponse with HTML content for the Video xBlock with the given usage_key.
+    The returned HTML consists of nothing but the Video xBlock content for use in social media embedding.
+    """
+    return _render_public_video_xblock(request, usage_key_string, is_=True)
+
+
+@require_http_methods(["GET"])
+@ensure_valid_usage_key
+@xframe_options_exempt
+@transaction.non_atomic_requests
+def render_public_video_xblock(request, usage_key_string):
+    """
+    Returns an HttpResponse with HTML content for the Video xBlock with the given usage_key.
+    The returned HTML is a chromeless rendering of the Video xBlock (excluding content of the containing courseware).
+    """
+    return _render_public_video_xblock(request, usage_key_string, is_=False)
 
 
 def get_optimization_flags_for_content(block, fragment):

--- a/lms/templates/public_video.html
+++ b/lms/templates/public_video.html
@@ -1,0 +1,18 @@
+<%page expression_filter="h"/>
+<%inherit file="courseware/courseware-chromeless.html"/>
+
+<%block name="head_extra">
+<!-- OpenGraph tags  -->
+<meta data-rh="true" property="og:type" content="website">
+<meta data-rh="true" property="og:site_name" content="edX">
+<meta data-rh="true" property="og:title" content=${video_title}>
+<meta data-rh="true" property="og:description" content="${video_description}">
+<meta data-rh="true" property="og:image" content="${video_thumbnail}">
+
+<!-- Twitter-specific video player tags  -->
+<meta data-rh="true" name="twitter:card" content="player">
+<meta data-rh="true" name="twitter:site" content="@edxOnline">
+<meta data-rh="true" name="twitter:player" content=${video_embed_url}>
+<meta data-rh="true" name="twitter:player:width" content="1280">
+<meta data-rh="true" name="twitter:player:height" content="1000">
+</%block>

--- a/lms/templates/public_video_share_embed.html
+++ b/lms/templates/public_video_share_embed.html
@@ -93,10 +93,20 @@ from openedx.core.djangolib.markup import HTML
         branch.init('${branch_key | n, js_escaped_string}');
     </script>
 % endif
+
+<style type="text/css">
+#course-content {
+  margin: 0;
+}
+
+.xmodule_display.xmodule_VideoBlock .video {
+  padding: 0;
+}
+</style>
 </head>
 
 <body class="${static.dir_rtl()} view-in-course view-courseware courseware ${course.css_class or ''} lang_${LANGUAGE_CODE}">
-  <section class="course-content" id="course-content">
+  <section class="course-content" id="course-content" style="margin: 0;">
     ${HTML(fragment.body_html())}
   </section>
   <script type="text/javascript" src="${static.url('common/js/vendor/jquery.scrollTo.js')}" async></script>

--- a/lms/templates/public_video_share_embed.html
+++ b/lms/templates/public_video_share_embed.html
@@ -106,7 +106,7 @@ from openedx.core.djangolib.markup import HTML
 </head>
 
 <body class="${static.dir_rtl()} view-in-course view-courseware courseware ${course.css_class or ''} lang_${LANGUAGE_CODE}">
-  <section class="course-content" id="course-content" style="margin: 0;">
+  <section class="course-content" id="course-content">
     ${HTML(fragment.body_html())}
   </section>
   <script type="text/javascript" src="${static.url('common/js/vendor/jquery.scrollTo.js')}" async></script>

--- a/lms/templates/public_video_share_embed.html
+++ b/lms/templates/public_video_share_embed.html
@@ -1,0 +1,106 @@
+## coding=utf-8
+
+<%page expression_filter="h"/>
+<%! main_css = "style-main-v1" %>
+
+<%namespace name='static' file='static_content.html'/>
+<%!
+import six
+from lms.djangoapps.branding import api as branding_api
+from django.utils.translation import gettext as _
+from django.utils.translation import get_language_bidi
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from openedx.core.djangolib.js_utils import js_escaped_string
+from openedx.core.release import RELEASE_LINE
+from openedx.core.djangolib.markup import HTML
+%>
+
+<%def name="course_name()">
+ <% return _("{course_number} Courseware").format(course_number=course.display_number_with_default) %>
+</%def>
+
+<!DOCTYPE html>
+<!--[if lte IE 9]><html class="ie ie9 lte9" lang="${LANGUAGE_CODE}"><![endif]-->
+<!--[if !IE]><!--><html lang="${LANGUAGE_CODE}"><!--<![endif]-->
+<head dir="${static.dir_rtl()}">
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <%def name="pagetitle()" />
+  <title>${static.get_page_title_breadcrumbs(course_name())}</title>
+
+  <%
+    jsi18n_path = "js/i18n/{language}/djangojs.js".format(language=LANGUAGE_CODE)
+    ie11_fix_path = "js/ie11_find_array.js"
+  %>
+  <script type="text/javascript" src="${static.url(jsi18n_path)}"></script>
+  <script type="text/javascript" src="${static.url(ie11_fix_path)}"></script>
+  <% favicon_url = branding_api.get_favicon_url() %>
+  <link rel="icon" type="image/x-icon" href="${favicon_url}"/>
+
+  <%static:css group='style-vendor'/>
+  % if '/' in self.attr.main_css:
+    % if get_language_bidi():
+      <%
+      rtl_css_file = self.attr.main_css.replace('.css', '-rtl.css')
+      %>
+      <link rel="stylesheet" href="${six.text_type(static.url(rtl_css_file))}" type="text/css" media="all" />
+    % else:
+      <link rel="stylesheet" href="${static.url(self.attr.main_css)}" type="text/css" media="all" />
+    % endif
+  % else:
+    <%static:css group='${self.attr.main_css}'/>
+  % endif
+
+  <%static:js group='main_vendor'/>
+  <%static:js group='application'/>
+
+  <%static:webpack entry="commons"/>
+
+  <%static:css group='style-course-vendor'/>
+  <%static:css group='style-course'/>
+    
+  <%include file="widgets/segment-io.html" />
+
+  <meta name="path_prefix" content="${EDX_ROOT_URL}">
+  <% google_site_verification_id = configuration_helpers.get_value('GOOGLE_SITE_VERIFICATION_ID', settings.GOOGLE_SITE_VERIFICATION_ID) %>
+  % if google_site_verification_id:
+    <meta name="google-site-verification" content="${google_site_verification_id}" />
+  % endif
+
+  <meta name="openedx-release-line" content="${RELEASE_LINE}" />
+
+<% ga_acct = static.get_value("GOOGLE_ANALYTICS_ACCOUNT", settings.GOOGLE_ANALYTICS_ACCOUNT) %>
+% if ga_acct:
+    <script type="text/javascript">
+    var _gaq = _gaq || [];
+    _gaq.push(['_setAccount', '${ga_acct | n, js_escaped_string}']);
+    _gaq.push(['_trackPageview']);
+
+    (function() {
+      var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+      ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+      var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+    })();
+    </script>
+% endif
+
+<% branch_key = static.get_value("BRANCH_IO_KEY", settings.BRANCH_IO_KEY) %>
+% if branch_key and not is_from_mobile_app:
+    <script type="text/javascript">
+        (function(b,r,a,n,c,h,_,s,d,k){if(!b[n]||!b[n]._q){for(;s<_.length;)c(h,_[s++]);d=r.createElement(a);d.async=1;d.src="https://cdn.branch.io/branch-latest.min.js";k=r.getElementsByTagName(a)[0];k.parentNode.insertBefore(d,k);b[n]=h}})(window,document,"script","branch",function(b,r){b[r]=function(){b._q.push([r,arguments])}},{_q:[],_v:1},"addListener applyCode banner closeBanner creditHistory credits data deepview deepviewCta first getCode init link logout redeem referrals removeListener sendSMS setBranchViewData setIdentity track validateCode".split(" "), 0);
+        branch.init('${branch_key | n, js_escaped_string}');
+    </script>
+% endif
+</head>
+
+<body class="${static.dir_rtl()} view-in-course view-courseware courseware ${course.css_class or ''} lang_${LANGUAGE_CODE}">
+  <section class="course-content" id="course-content">
+    ${HTML(fragment.body_html())}
+  </section>
+  <script type="text/javascript" src="${static.url('common/js/vendor/jquery.scrollTo.js')}" async></script>
+  <%static:js group='courseware'/>
+  ${HTML(fragment.foot_html())}
+</body>
+</html>

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -54,6 +54,7 @@ from openedx.features.enterprise_support.api import enterprise_enabled
 RESET_COURSE_DEADLINES_NAME = 'reset_course_deadlines'
 RENDER_XBLOCK_NAME = 'render_xblock'
 RENDER_VIDEO_XBLOCK_NAME = 'render_public_video_xblock'
+RENDER_VIDEO_XBLOCK_EMBED_NAME = 'render_public_video_xblock_embed'
 COURSE_PROGRESS_NAME = 'progress'
 
 if settings.DEBUG or settings.FEATURES.get('ENABLE_DJANGO_ADMIN_SITE'):
@@ -330,6 +331,12 @@ urlpatterns += [
         courseware_views.render_public_video_xblock,
         name=RENDER_VIDEO_XBLOCK_NAME,
     ),
+    re_path(
+        fr'^videos/{settings.USAGE_KEY_PATTERN}/embed$',
+        courseware_views.render_public_video_xblock_embed,
+        name=RENDER_VIDEO_XBLOCK_EMBED_NAME,
+    ),
+
 
     # xblock Resource URL
     re_path(

--- a/xmodule/video_block/video_block.py
+++ b/xmodule/video_block/video_block.py
@@ -392,7 +392,7 @@ class VideoBlock(
         # true, but now staff or admin have hidden the autoadvance button and the student won't be able to disable
         # it anymore; therefore we force-disable it in this case (when controls aren't visible).
         autoadvance_this_video = self.auto_advance and autoadvance_enabled
-
+        is_embed = context.get('public_video_embed', False)
         metadata = {
             'autoAdvance': autoadvance_this_video,
             # For now, the option "data-autohide-html5" is hard coded. This option
@@ -427,7 +427,9 @@ class VideoBlock(
             'savedVideoPosition': self.saved_video_position.total_seconds(),  # pylint: disable=no-member
             'saveStateEnabled': view != PUBLIC_VIEW,
             'saveStateUrl': self.ajax_url + '/save_user_state',
-            'showCaptions': json.dumps(self.show_captions),
+            # Despite the setting on the block, don't show transcript by default
+            # if the video is embedded in social media
+            'showCaptions': json.dumps(self.show_captions and not is_embed),
             'sources': sources,
             'speed': self.speed,
             'start': self.start_time.total_seconds(),  # pylint: disable=no-member
@@ -453,7 +455,6 @@ class VideoBlock(
 
         bumperize(self)
 
-        is_embed = context.get('public_video_embed', False)
         template_context = {
             'autoadvance_enabled': autoadvance_enabled,
             'branding_info': branding_info,

--- a/xmodule/video_block/video_block.py
+++ b/xmodule/video_block/video_block.py
@@ -456,20 +456,20 @@ class VideoBlock(
         is_embed = context.get('public_video_embed', False)
         template_context = {
             'autoadvance_enabled': autoadvance_enabled,
-            'bumper_metadata': json.dumps(self.bumper['metadata']),  # pylint: disable=E1101
-            'metadata': json.dumps(OrderedDict(metadata)),
-            'poster': json.dumps(get_poster(self)),
             'branding_info': branding_info,
+            'bumper_metadata': json.dumps(self.bumper['metadata']),  # pylint: disable=E1101
             'cdn_eval': cdn_eval,
             'cdn_exp_group': cdn_exp_group,
-            'id': self.location.html_id(),
             'display_name': None if is_embed else self.display_name_with_default,
-            'handout': self.handout,
             'download_video_link': download_video_link,
+            'handout': self.handout,
+            'id': self.location.html_id(),
+            'license': getattr(self, "license", None),
+            'metadata': json.dumps(OrderedDict(metadata)),
+            'poster': json.dumps(get_poster(self)),
             'track': track_url,
             'transcript_download_format': transcript_download_format,
             'transcript_download_formats_list': self.fields['transcript_download_format'].values,  # lint-amnesty, pylint: disable=unsubscriptable-object
-            'license': getattr(self, "license", None),
         }
         return self.runtime.service(self, 'mako').render_template('video.html', template_context)
 


### PR DESCRIPTION
Modify the public video page to contain the correct metadata
Add an embed page

Add a course-level toggle for this feature for now

How to test:
- Enable for a course by creating an enabled `courseware.public_video_share` CourseWaffleFlag for your course (or enable globally for your devstack, if you'd prefer)
- Find the video block you'd like to test with and note its block id.
- Navigate to `localhost:18000/videos/<block_id>` and you should see the main video page, with the header, footer, video, and video title. In the page's source you should see the metadata tags.
- Navigate to `previous url/embed` and you should get a page that consists only of the video player itself.

Testing on Twitter:
- Run localtunnel or some other site.
- Change your LMS_ROOT_URL to the url provided by your tunnel tool.
- navigate to <your_url>/videos/block_id
- Share that url on twitter. The shared card should have our information, with a video preview.

NOTE:
the tunneling URLs are pretty slow to load the previews, since ultimately they're still runninng off devstack.