### PR TITLE
docs: Various cleanup of outdated comments and docstrings

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -44,15 +44,6 @@ jobs:
       - name: checkout repo
         uses: actions/checkout@v3
 
-      # This gives Mongo several chances to start. We started getting flakiness
-      # around 2022-02-15 wherein the start command would sometimes exit with:
-      #
-      #   * Starting database mongodb
-      #     ...fail!
-      #
-      # ...not having produced any logs or other output. We couldn't figure out
-      # what was causing Mongo to fail, so this is a (temporary?) hack to get
-      # PRs unblocked.
       - name: start mongod server for tests
         run: |
           sudo mkdir -p /data/db

--- a/common/djangoapps/student/models/user.py
+++ b/common/djangoapps/student/models/user.py
@@ -155,7 +155,7 @@ def anonymous_id_for_user(user, course_id):
         hasher.update(str(user.id).encode('utf8'))
         if course_id:
             hasher.update(str(course_id).encode('utf-8'))
-        anonymous_user_id = hasher.hexdigest(16)  # pylint: disable=too-many-function-args
+        anonymous_user_id = hasher.hexdigest(16)
 
         try:
             AnonymousUserId.objects.create(

--- a/common/djangoapps/track/middleware.py
+++ b/common/djangoapps/track/middleware.py
@@ -196,7 +196,7 @@ class TrackMiddleware(MiddlewareMixin):
         # This assumes that session_key is high-entropy and unpredictable (which
         # it should be anyway.)
         #
-        # Use SHAKE256 from SHA-3 hash family to generate a hash of arbitrary
+        # Use SHAKE-128 from SHA-3 hash family to generate a hash of arbitrary
         # length.
         hasher = hashlib.shake_128()
         # This is one of several uses of SECRET_KEY.
@@ -209,9 +209,7 @@ class TrackMiddleware(MiddlewareMixin):
         # heads-up to data researchers.
         hasher.update(settings.SECRET_KEY.encode())
         hasher.update(session_key.encode())
-        # pylint doesn't know that SHAKE's hexdigest takes an arg:
-        # https://github.com/PyCQA/pylint/issues/4039
-        return hasher.hexdigest(16)  # pylint: disable=too-many-function-args
+        return hasher.hexdigest(16)
 
     def get_user_primary_key(self, request):
         """Gets the primary key of the logged in Django user"""

--- a/docs/guides/hooks/events.rst
+++ b/docs/guides/hooks/events.rst
@@ -12,7 +12,7 @@ Receiving events
 ^^^^^^^^^^^^^^^^
 
 This is one of the most common use cases for plugins. The edx-platform will send
-and event and you want to react to it in your plugin.
+an event and you want to react to it in your plugin.
 
 For this you need to:
 

--- a/openedx/core/djangoapps/cors_csrf/tests/test_decorators.py
+++ b/openedx/core/djangoapps/cors_csrf/tests/test_decorators.py
@@ -15,7 +15,7 @@ def fake_view(request):
 
 
 class TestEnsureCsrfCookieCrossDomain(TestCase):
-    """Test the `ensucre_csrf_cookie_cross_domain` decorator. """
+    """Test the `ensure_csrf_cookie_cross_domain` decorator. """
 
     def test_ensure_csrf_cookie_cross_domain(self):
         request = mock.Mock()

--- a/openedx/core/djangoapps/dark_lang/middleware.py
+++ b/openedx/core/djangoapps/dark_lang/middleware.py
@@ -76,7 +76,7 @@ class DarkLangMiddleware(MiddlewareMixin):
     @property
     def beta_langs(self):
         """
-        Current list of released languages
+        Current list of beta languages
         """
         language_options = DarkLangConfig.current().beta_languages_list
         if settings.LANGUAGE_CODE not in language_options:
@@ -123,7 +123,7 @@ class DarkLangMiddleware(MiddlewareMixin):
 
     def _clean_accept_headers(self, request):
         """
-        Remove any language that is not either in ``self.released_langs`` or
+        Remove any language that is not either in ``self.released_langs`` or ``self.beta_langs`` (if enabled) or
         a territory of one of those languages.
         """
         accept = request.META.get('HTTP_ACCEPT_LANGUAGE', None)

--- a/openedx/core/djangoapps/dark_lang/models.py
+++ b/openedx/core/djangoapps/dark_lang/models.py
@@ -47,7 +47,7 @@ class DarkLangConfig(ConfigurationModel):
     @property
     def beta_languages_list(self):
         """
-        ``released_languages`` as a list of language codes.
+        ``beta_languages`` as a list of language codes.
 
         Example: ['it', 'de-at', 'es', 'pt-br']
         """

--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -141,7 +141,7 @@ def _get_user_by_email_or_username(request, api_version):
         user = _get_user_by_username(email_or_username)
 
     if not user:
-        digest = hashlib.shake_128(email_or_username.encode('utf-8')).hexdigest(16)  # pylint: disable=too-many-function-args
+        digest = hashlib.shake_128(email_or_username.encode('utf-8')).hexdigest(16)
         AUDIT_LOG.warning(f"Login failed - Unknown user email or username {digest}")
 
     return user

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -337,7 +337,6 @@ class LoginTest(SiteMixin, CacheIsolationTestCase, OpenEdxEventsTestMixin):
 
     def test_login_fail_no_user_exists(self):
         nonexistent_email = 'not_a_user@edx.org'
-        # pylint: disable=too-many-function-args
         email_hash = hashlib.shake_128(nonexistent_email.encode('utf-8')).hexdigest(16)
         response, mock_audit_log = self._login_response(
             nonexistent_email,
@@ -442,7 +441,6 @@ class LoginTest(SiteMixin, CacheIsolationTestCase, OpenEdxEventsTestMixin):
         the system does *not* send account activation email notification to the user.
         """
         nonexistent_email = 'incorrect@email.com'
-        # pylint: disable=too-many-function-args
         email_hash = hashlib.shake_128(nonexistent_email.encode('utf-8')).hexdigest(16)
         self.user.is_active = False
         self.user.save()
@@ -454,7 +452,6 @@ class LoginTest(SiteMixin, CacheIsolationTestCase, OpenEdxEventsTestMixin):
 
     def test_login_unicode_email(self):
         unicode_email = self.user_email + chr(40960)
-        # pylint: disable=too-many-function-args
         email_hash = hashlib.shake_128(unicode_email.encode('utf-8')).hexdigest(16)
         response, mock_audit_log = self._login_response(
             unicode_email,


### PR DESCRIPTION
- Remove pylint warning suppression from SHAKE-128 hexdigest calls; these are no longer needed as of astroid 2.12.12. For background, see issue <https://github.com/PyCQA/pylint/issues/4039>. Also, correct a comment that referred to SHAKE-256 instead of SHAKE-128.
- Replace "released" with "beta" in several places where there was a copy & paste error in dark_lang. Add mention of `beta_lang` to a docstring where it was omitted.
- Remove comment regarding Mongo startup; the code it referred to has since been removed.
- Fix typos.
