### PR TITLE
fix: Add code_owner decorator to remaining Celery tasks

### DIFF
--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -296,8 +296,8 @@ class CourseExportTask(UserTask):  # pylint: disable=abstract-method
 
 
 @shared_task(base=CourseExportTask, bind=True)
-# Note: The decorator @set_code_owner_attribute could not be used because
-#   the implementation of this task breaks with any additional decorators.
+# Note: The decorator @set_code_owner_attribute cannot be used here because the UserTaskMixin
+#   does stack inspection and can't handle additional decorators.
 def export_olx(self, user_id, course_key_string, language):
     """
     Export a course or library to an OLX .tar.gz archive and prepare it for download.
@@ -431,15 +431,16 @@ class CourseImportTask(UserTask):  # pylint: disable=abstract-method
 
 
 @shared_task(base=CourseImportTask, bind=True)
-# Note: The decorator @set_code_owner_attribute could not be used because  # lint-amnesty, pylint: disable=too-many-statements
-#   the implementation of this task breaks with any additional decorators.
+# Note: The decorator @set_code_owner_attribute cannot be used here because the UserTaskMixin
+#   does stack inspection and can't handle additional decorators.
+# lint-amnesty, pylint: disable=too-many-statements
 def import_olx(self, user_id, course_key_string, archive_path, archive_name, language):
     """
     Import a course or library from a provided OLX .tar.gz archive.
     """
+    set_code_owner_attribute_from_module(__name__)
     current_step = 'Unpacking'
     courselike_key = CourseKey.from_string(course_key_string)
-    set_code_owner_attribute_from_module(__name__)
     set_custom_attributes_for_course_key(courselike_key)
     log_prefix = f'Course import {courselike_key}'
     self.status.set_state(current_step)

--- a/cms/djangoapps/export_course_metadata/tasks.py
+++ b/cms/djangoapps/export_course_metadata/tasks.py
@@ -13,9 +13,9 @@ from openedx.core.djangoapps.schedules.content_highlights import get_all_course_
 from .storage import course_metadata_export_storage
 
 
-@shared_task
+@shared_task(bind=True)
 @set_code_owner_attribute
-def export_course_metadata_task(course_key_string):
+def export_course_metadata_task(self, course_key_string):  # pylint: disable=unused-argument
     """
     Export course metadata
 

--- a/cms/djangoapps/export_course_metadata/tasks.py
+++ b/cms/djangoapps/export_course_metadata/tasks.py
@@ -6,14 +6,16 @@ import json
 
 from celery import shared_task
 from django.core.files.base import ContentFile
+from edx_django_utils.monitoring import set_code_owner_attribute
 from opaque_keys.edx.keys import CourseKey
 from openedx.core.djangoapps.schedules.content_highlights import get_all_course_highlights
 
 from .storage import course_metadata_export_storage
 
 
-@shared_task(bind=True)
-def export_course_metadata_task(self, course_key_string):  # pylint: disable=unused-argument
+@shared_task
+@set_code_owner_attribute
+def export_course_metadata_task(course_key_string):
     """
     Export course metadata
 

--- a/common/djangoapps/student/tasks.py
+++ b/common/djangoapps/student/tasks.py
@@ -5,6 +5,7 @@ import logging
 from celery import shared_task
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from edx_django_utils.monitoring import set_code_owner_attribute
 from opaque_keys.edx.keys import CourseKey
 
 from common.djangoapps.track import segment
@@ -30,6 +31,7 @@ COUNTDOWN = 60
 
 
 @shared_task(bind=True, ignore_result=True)
+@set_code_owner_attribute
 def send_course_enrollment_email(
     self, user_id, course_id, course_title, short_description, course_ended, pacing_type, track_mode
 ):

--- a/lms/djangoapps/ccx/tasks.py
+++ b/lms/djangoapps/ccx/tasks.py
@@ -7,6 +7,7 @@ import logging
 
 from ccx_keys.locator import CCXLocator
 from django.dispatch import receiver
+from edx_django_utils.monitoring import set_code_owner_attribute
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.locator import CourseLocator
 
@@ -27,6 +28,7 @@ def course_published_handler(sender, course_key, **kwargs):  # pylint: disable=u
 
 
 @CELERY_APP.task
+@set_code_owner_attribute
 def send_ccx_course_published(course_key):
     """
     Find all CCX derived from this course, and send course published event for them.

--- a/lms/djangoapps/lti_provider/tasks.py
+++ b/lms/djangoapps/lti_provider/tasks.py
@@ -6,6 +6,7 @@ Asynchronous tasks for the LTI provider app.
 import logging
 
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
+from edx_django_utils.monitoring import set_code_owner_attribute
 from opaque_keys.edx.keys import CourseKey
 
 import lms.djangoapps.lti_provider.outcomes as outcomes
@@ -18,6 +19,7 @@ log = logging.getLogger(__name__)
 
 
 @CELERY_APP.task(name='lms.djangoapps.lti_provider.tasks.send_composite_outcome')
+@set_code_owner_attribute
 def send_composite_outcome(user_id, course_id, assignment_id, version):
     """
     Calculate and transmit the score for a composite module (such as a
@@ -67,6 +69,7 @@ def send_composite_outcome(user_id, course_id, assignment_id, version):
 
 
 @CELERY_APP.task
+@set_code_owner_attribute
 def send_leaf_outcome(assignment_id, points_earned, points_possible):
     """
     Calculate and transmit the score for a single problem. This method assumes

--- a/openedx/core/djangoapps/content_libraries/tasks.py
+++ b/openedx/core/djangoapps/content_libraries/tasks.py
@@ -7,7 +7,7 @@ import logging
 
 from celery import shared_task
 from celery_utils.logged_task import LoggedTask
-
+from edx_django_utils.monitoring import set_code_owner_attribute
 from opaque_keys.edx.keys import CourseKey
 
 from . import api
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 @shared_task(base=LoggedTask)
+@set_code_owner_attribute
 def import_blocks_from_course(import_task_id, course_key_str):
     """
     A Celery task to import blocks from a course through modulestore.

--- a/openedx/features/survey_report/tasks.py
+++ b/openedx/features/survey_report/tasks.py
@@ -6,12 +6,15 @@ Tasks for Survey Report.
 import logging
 
 from celery import shared_task
+from edx_django_utils.monitoring import set_code_owner_attribute
+
 from .api import generate_report
 
 log = logging.getLogger('edx.celery.task')
 
 
 @shared_task(name='openedx.features.survey_report.tasks.generate_survey_report')
+@set_code_owner_attribute
 def generate_survey_report():
     """
     Tasks to generate a new survey report with non-sensitive data.


### PR DESCRIPTION
This will ensure that errors raised by these tasks will alert the right team. `send_course_enrollment_email` is the one I set out to fix, but I discovered a few others.

I located tasks that were missing decorators by running the following search and visually inspecting the results, although semgrep might be able to do better:

```
ack '^@.*task|^@set_code_owner_attribute' cms lms common openedx xmodule --ignore-dir=tests --python
```

Also:

- Add more detailed explanation of why a couple of tasks can't use the decorator. This should only be an issue on tasks inheriting from UserTaskMixin, which in practice is just CourseExportTask and CourseImportTask (and the apparently unused EnrollmentReadTask and EnrollmentWriteTask), via UserTask.
- Lint fix: Remove `bind=True` from a task that wasn't using `self`

---

- Impact: Operators who use New Relic
- Reference: https://github.com/openedx/edx-django-utils/blob/v5.2.0/edx_django_utils/monitoring/internal/code_owner/utils.py#L169