### PR TITLE
fix: update response for marked events for discussion content

### DIFF
--- a/lms/djangoapps/discussion/django_comment_client/base/views.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/views.py
@@ -19,6 +19,7 @@ from opaque_keys.edx.keys import CourseKey
 
 import lms.djangoapps.discussion.django_comment_client.settings as cc_settings
 import openedx.core.djangoapps.django_comment_common.comment_client as cc
+from common.djangoapps.student.roles import GlobalStaff
 from common.djangoapps.util.file import store_uploaded_file
 from common.djangoapps.track import contexts
 from lms.djangoapps.courseware.access import has_access
@@ -349,39 +350,24 @@ def track_comment_unreported_event(request, course, comment):
     track_forum_event(request, event_name, course, comment, event_data)
 
 
-def track_response_mark_event(request, course, comment, commentable_id, thread_type):
+def track_response_mark_event(request, course, comment, thread, action_name):
     """
     Send analytics event for response that is marked as endorsed or answered.
     """
-    event_name = _EVENT_NAME_TEMPLATE.format(obj_type='response', action_name='mark')
-    if thread_type == 'question':
+    event_name = _EVENT_NAME_TEMPLATE.format(obj_type='response', action_name=action_name)
+    if getattr(thread, 'thread_type', '') == 'question':
         mark_type = 'Answer'
     else:
         mark_type = 'Endorse'
     event_data = {
         'discussion': {'id': comment.thread_id},
-        'commentable_id': commentable_id,
+        'commentable_id': getattr(thread, 'commentable_id', None),
+        'is_thread_author': getattr(thread, 'user_id', None) == str(request.user.id),
+        'is_global_staff': GlobalStaff().has_user(request.user),
         'mark_type': mark_type,
         'target_username': comment.get('username')
     }
-    track_forum_event(request, event_name, course, comment, event_data)
 
-
-def track_response_unmark_event(request, course, comment, commentable_id, thread_type):
-    """
-    Send analytics event for response that is marked as unendorsed or unanswered.
-    """
-    event_name = _EVENT_NAME_TEMPLATE.format(obj_type='response', action_name='unmark')
-    if thread_type == 'question':
-        mark_type = 'Answer'
-    else:
-        mark_type = 'Endorse'
-    event_data = {
-        'discussion': {'id': comment.thread_id},
-        'commentable_id': commentable_id,
-        'mark_type': mark_type,
-        'target_username': comment.get('username'),
-    }
     track_forum_event(request, event_name, course, comment, event_data)
 
 
@@ -410,13 +396,8 @@ def track_forum_response_mark_event(request, course, cc_content, value):
     Helper method for discussions response mark event
     """
     thread = cc.Thread.find(cc_content.thread_id)
-    commentable_id = thread.get('commentable_id')
-    thread_type = thread.get('thread_type')
-
-    if value:
-        track_response_mark_event(request, course, cc_content, commentable_id, thread_type)
-    else:
-        track_response_unmark_event(request, course, cc_content, commentable_id, thread_type)
+    action_name = 'mark' if value else 'unmark'
+    track_response_mark_event(request, course, cc_content, thread, action_name)
 
 
 def permitted(func):

--- a/lms/djangoapps/discussion/rest_api/tests/test_serializers.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_serializers.py
@@ -670,7 +670,7 @@ class CommentSerializerDeserializationTest(ForumsEnableMixin, CommentsServiceMoc
         }
         self.existing_comment = Comment(**make_minimal_cs_comment({
             "id": "existing_comment",
-            "thread_id": "existing_thread",
+            "thread_id": "dummy",
             "body": "Original body",
             "user_id": str(self.user.id),
             "username": self.user.username,
@@ -870,7 +870,14 @@ class CommentSerializerDeserializationTest(ForumsEnableMixin, CommentsServiceMoc
         }
         self.register_put_comment_response(cs_response_data)
         data = {"raw_body": "Edited body", "endorsed": True}
+        self.register_get_thread_response(
+            make_minimal_cs_thread({
+                "id": "dummy",
+                "course_id": str(self.course.id),
+            })
+        )
         saved = self.save_and_reserialize(data, instance=self.existing_comment)
+
         assert parsed_body(httpretty.last_request()) == {
             'body': ['Edited body'],
             'course_id': [str(self.course.id)],


### PR DESCRIPTION
### [INF-776](https://2u-internal.atlassian.net/browse/INF-776)

### Description

Updating response for marked events on responses to thread within discussion content. Changes include the following:

- `mark_type`: This field was defaulting to `Endorse` in both `Question` and `Discussion` type post.
- `is_global_staff`: This field is newly added.
- `is_thread_author`: This field is newly added.

These fields have been updated/added for more clarity on events. 

Some events contained empty `user_forums_roles` and `user_course_roles` fields (_this is the case when a response is marked by a global staff user_). The `is_global_staff` field is added to have clarity on that. 

There were event instances where the `user_forums_roles` was empty and `user_course_roles` only had `Student` value (_this only happens when a learner is author of a question thread, and can mark any response as answered_). This was also creating some confusion when analyzing events, so the `is_thread_author` field has been added.