### PR TITLE
chore: bump Django and edx-codejail versions

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -175,7 +175,7 @@ defusedxml==0.7.1
     #   social-auth-core
 deprecated==1.2.13
     # via jwcrypto
-django==3.2.17
+django==3.2.18
     # via
     #   -c requirements/edx/../common_constraints.txt
     #   -r requirements/edx/base.in
@@ -433,7 +433,7 @@ edx-celeryutils==1.2.2
     #   -r requirements/edx/base.in
     #   edx-name-affirmation
     #   super-csv
-edx-codejail==3.3.2
+edx-codejail==3.3.3
     # via -r requirements/edx/base.in
 edx-completion==4.2.0
     # via -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -269,7 +269,7 @@ distlib==0.3.6
     # via
     #   -r requirements/edx/testing.txt
     #   virtualenv
-django==3.2.17
+django==3.2.18
     # via
     #   -c requirements/edx/../common_constraints.txt
     #   -r requirements/edx/testing.txt
@@ -556,7 +556,7 @@ edx-celeryutils==1.2.2
     #   -r requirements/edx/testing.txt
     #   edx-name-affirmation
     #   super-csv
-edx-codejail==3.3.2
+edx-codejail==3.3.3
     # via -r requirements/edx/testing.txt
 edx-completion==4.2.0
     # via -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -253,7 +253,7 @@ dill==0.3.6
     # via pylint
 distlib==0.3.6
     # via virtualenv
-django==3.2.17
+django==3.2.18
     # via
     #   -c requirements/edx/../common_constraints.txt
     #   -r requirements/edx/base.txt
@@ -535,7 +535,7 @@ edx-celeryutils==1.2.2
     #   -r requirements/edx/base.txt
     #   edx-name-affirmation
     #   super-csv
-edx-codejail==3.3.2
+edx-codejail==3.3.3
     # via -r requirements/edx/base.txt
 edx-completion==4.2.0
     # via -r requirements/edx/base.txt


### PR DESCRIPTION
## Description
- `Django==3.2.18` has a security patch upgrade which needs to be updated as soon as possible. 
- `edx-codejail==3.3.3` removes the usage of the `future` package from the code and requirements so this version bump is necessary to use the updated codejail code in edx-platform.
- Both of these package upgrades are important and `codejail` upgrade needs manual monitoring to avoid any issues so creating a separate PR to update both of these packages.