### PR TITLE
[BB-7106] Add new endpoint for cloning course

### DIFF
--- a/cms/djangoapps/api/v1/views/course_runs.py
+++ b/cms/djangoapps/api/v1/views/course_runs.py
@@ -11,6 +11,7 @@ from rest_framework.response import Response
 from cms.djangoapps.contentstore.views.course import _accessible_courses_iter, get_course_and_check_access
 
 from ..serializers.course_runs import (
+    CourseCloneSerializer,
     CourseRunCreateSerializer,
     CourseRunImageSerializer,
     CourseRunRerunSerializer,
@@ -90,3 +91,10 @@ class CourseRunViewSet(viewsets.GenericViewSet):  # lint-amnesty, pylint: disabl
         new_course_run = serializer.save()
         serializer = self.get_serializer(new_course_run)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+    @action(detail=False, methods=['post'])
+    def clone(self, request, *args, **kwargs):  # lint-amnesty, pylint: disable=missing-function-docstring, unused-argument
+        serializer = CourseCloneSerializer(data=request.data, context=self.get_serializer_context())
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response({"message": "Course cloned successfully."}, status=status.HTTP_201_CREATED)

--- a/cms/djangoapps/api/v1/views/course_runs.py
+++ b/cms/djangoapps/api/v1/views/course_runs.py
@@ -93,7 +93,45 @@ class CourseRunViewSet(viewsets.GenericViewSet):  # lint-amnesty, pylint: disabl
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     @action(detail=False, methods=['post'])
-    def clone(self, request, *args, **kwargs):  # lint-amnesty, pylint: disable=missing-function-docstring, unused-argument
+    def clone(self, request, *args, **kwargs):  # lint-amnesty, pylint: disable=unused-argument
+        """
+        **Use Case**
+
+            This endpoint can be used for course cloning.
+
+            Unlike reruns, cloning a course allows creating a copy of an existing
+            course under a different organization name and with a different course
+            name.
+
+        **Example Request**
+
+            POST /api/v1/course_runs/clone/ {
+                "source_course_id": "course-v1:edX+DemoX+Demo_Course",
+                "destination_course_id": "course-v1:newOrg+newDemoX+Demo_Course_Clone"
+            }
+
+            **POST Parameters**
+
+                * source_course_id: a full course id of the course that will be
+                  cloned. Has to be an id of an existing course.
+                * destination_course_id: a full course id of the destination
+                  course. The organization, course name and course run of the
+                  new course will be determined from the provided id. Has to be
+                  an id of a course that doesn't exist yet.
+
+        **Response Values**
+
+            If the request parameters are valid and a course has been cloned
+            succesfully, an HTTP 201 "Created" response is returned.
+
+            If source course id and/or destination course id are invalid, or
+            source course doesn't exist, or destination course already exist,
+            an HTTP 400 "Bad Request" response is returned.
+
+            If the user that is making the request doesn't have the access to
+            either of the courses, an HTTP 401 "Unauthorized" response is
+            returned.
+        """
         serializer = CourseCloneSerializer(data=request.data, context=self.get_serializer_context())
         serializer.is_valid(raise_exception=True)
         new_course_run = serializer.save()

--- a/cms/djangoapps/api/v1/views/course_runs.py
+++ b/cms/djangoapps/api/v1/views/course_runs.py
@@ -96,5 +96,6 @@ class CourseRunViewSet(viewsets.GenericViewSet):  # lint-amnesty, pylint: disabl
     def clone(self, request, *args, **kwargs):  # lint-amnesty, pylint: disable=missing-function-docstring, unused-argument
         serializer = CourseCloneSerializer(data=request.data, context=self.get_serializer_context())
         serializer.is_valid(raise_exception=True)
-        serializer.save()
+        new_course_run = serializer.save()
+        serializer = self.get_serializer(new_course_run)
         return Response({"message": "Course cloned successfully."}, status=status.HTTP_201_CREATED)

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -1029,6 +1029,12 @@ def rerun_course(user, source_course_key, org, number, run, fields, background=T
     if store.has_course(destination_course_key, ignore_case=True):
         raise DuplicateCourseError(source_course_key, destination_course_key)
 
+    # if org or name of source course don't match the destination course,
+    # verify user has access to the destination course
+    if source_course_key.org != destination_course_key.org or source_course_key.course != destination_course_key.course:
+        if not has_studio_write_access(user, destination_course_key):
+            raise PermissionDenied()
+
     # Make sure user has instructor and staff access to the destination course
     # so the user can see the updated status for that course
     add_instructor(destination_course_key, user, user)


### PR DESCRIPTION
## Description

This PR add a new studio endpoint for the existing clone_course method, so that external applications can call it using the following API:
```
/api/v1/course_runs/clone/
```
And passing the source_course_id (of an existing course) and destination_course_id (of a non-existing course) in the request data, like below:
```
{
    "source_course_id": "course-v1:edX+DemoX+Demo_Course",
    "destination_course_id": "course-v1:new+TestX+Demo_Course_Clone",
}
```

## Supporting information

OpenCraft Internal Jira ticket: [BB-7106](https://tasks.opencraft.com/browse/BB-7106)

## Testing instructions

1. Checkout this branch and provision devstack.
2. Login to studio and select a course which you want to clone. Note the course id.
3. Using a valid client ID and secret, obtain the oath access token (see [ref](https://course-catalog-api-guide.readthedocs.io/en/latest/authentication/#getting-an-access-token))
4. With the access token, make a POST api call to endpoint: `<your-studio-url>/api/v1/course_runs/clone/`,  and pass the source_course_id and destination_course_id in the data params.
5. Check your studio home and verify that the new course has been created with the destination_course_id you provided and contains the contents of the source_course_id.

