### PR TITLE
fix: Adding boto3 exceptions.

### DIFF
--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -2779,7 +2779,10 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         error_response = {'Error': {'Code': 503, 'Message': 'error found'}}
         operation_name = 'test'
         url = reverse(endpoint, kwargs={'course_id': str(self.course.id)})
-        with patch('storages.backends.s3boto3.S3Boto3Storage.listdir', side_effect=ClientError(error_response, operation_name)):
+        with patch(
+            'storages.backends.s3boto3.S3Boto3Storage.listdir',
+            side_effect=ClientError(error_response, operation_name)
+        ):
             if endpoint in INSTRUCTOR_GET_ENDPOINTS:
                 response = self.client.get(url)
             else:

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -2786,7 +2786,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
                 response = self.client.post(url, {})
 
         mock_error.assert_called_with(
-            'Fetching files failed for course: %s, reason: %s',
+            'Fetching files failed for course: %s, status: %s, reason: %s',
             self.course.id,
             error_response.get('Error'),
             error_response.get('Error').get('Message')

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -2777,7 +2777,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         Tests the Rate-Limit exceeded is handled and does not raise 500 error.
         """
         error_response = {'Error': {'Code': 503, 'Message': 'error found'}}
-        operation_name = 'test'        
+        operation_name = 'test'
         url = reverse(endpoint, kwargs={'course_id': str(self.course.id)})
         with patch('storages.backends.s3boto3.S3Boto3Storage.listdir', side_effect=ClientError(error_response, operation_name)):
             if endpoint in INSTRUCTOR_GET_ENDPOINTS:
@@ -2788,7 +2788,8 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         mock_error.assert_called_with(
             'Fetching files failed for course: %s, reason: %s',
             self.course.id,
-            error
+            error_response.get('Error'),
+            error_response.get('Error').get('Message')
         )
 
         res_json = json.loads(response.content.decode('utf-8'))

--- a/lms/djangoapps/instructor_task/models.py
+++ b/lms/djangoapps/instructor_task/models.py
@@ -344,7 +344,7 @@ class DjangoStorageReportStore(ReportStore):
             logger.error(
                 'Fetching files failed for course: %s, status: %s, reason: %s',
                 course_id,
-                ex.response.get('Error'), ex.response.get('Error').get('Message')
+                ex.response.get('Error'), ex.response.get('Error', {}).get('Message')
             )
             return []        
         files = [(filename, os.path.join(course_dir, filename)) for filename in filenames]

--- a/lms/djangoapps/instructor_task/models.py
+++ b/lms/djangoapps/instructor_task/models.py
@@ -346,7 +346,7 @@ class DjangoStorageReportStore(ReportStore):
                 course_id,
                 ex.response.get('Error'), ex.response.get('Error', {}).get('Message')
             )
-            return []        
+            return []
         files = [(filename, os.path.join(course_dir, filename)) for filename in filenames]
         files.sort(key=lambda f: self.storage.get_modified_time(f[1]), reverse=True)
         return [


### PR DESCRIPTION
It important to handle Boto3 exception handling along with existing one.
```
pytest lms/djangoapps/instructor/tests/test_api.py::TestInstructorAPILevelsDataDump::test_list_report_downloads_error_boto3_1_list_report_downloads
```