### PR TITLE
fix: remove empty topics for topics v2 as v1

### DIFF
--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -591,6 +591,11 @@ def get_v2_courseware_topics_as_v1(request, course_key, sequentials, topics):
             None,
         )
         courseware_topics.append(DiscussionTopicSerializer(discussion_topic).data)
+    courseware_topics = [
+        courseware_topic
+        for courseware_topic in courseware_topics
+        if courseware_topic.get('children', [])
+    ]
     return courseware_topics
 
 


### PR DESCRIPTION
Android Mobile app was crashing because some of the topics had no children. This was caused by some unit level restrictions. This change will remove the topics with no children on the first level