### PR TITLE
feat: put sending xblock events over bus behind feature flag

### DIFF
--- a/cms/djangoapps/contentstore/signals/handlers.py
+++ b/cms/djangoapps/contentstore/signals/handlers.py
@@ -176,11 +176,12 @@ def listen_for_xblock_published(sender, signal, **kwargs):
     """
     Publish XBLOCK_PUBLISHED signals onto the event bus.
     """
-    get_producer().send(
-        signal=XBLOCK_PUBLISHED, topic='xblock-published',
-        event_key_field='xblock_info.usage_key', event_data={'xblock_info': kwargs['xblock_info']},
-        event_metadata=kwargs['metadata'],
-    )
+    if settings.FEATURES.get("ENABLE_SEND_XBLOCK_EVENTS_OVER_BUS"):
+        get_producer().send(
+            signal=XBLOCK_PUBLISHED, topic='xblock-published',
+            event_key_field='xblock_info.usage_key', event_data={'xblock_info': kwargs['xblock_info']},
+            event_metadata=kwargs['metadata'],
+        )
 
 
 @receiver(XBLOCK_DELETED)
@@ -188,11 +189,12 @@ def listen_for_xblock_deleted(sender, signal, **kwargs):
     """
     Publish XBLOCK_DELETED signals onto the event bus.
     """
-    get_producer().send(
-        signal=XBLOCK_DELETED, topic='xblock-deleted',
-        event_key_field='xblock_info.usage_key', event_data={'xblock_info': kwargs['xblock_info']},
-        event_metadata=kwargs['metadata'],
-    )
+    if settings.FEATURES.get("ENABLE_SEND_XBLOCK_EVENTS_OVER_BUS"):
+        get_producer().send(
+            signal=XBLOCK_DELETED, topic='xblock-deleted',
+            event_key_field='xblock_info.usage_key', event_data={'xblock_info': kwargs['xblock_info']},
+            event_metadata=kwargs['metadata'],
+        )
 
 
 @receiver(XBLOCK_DUPLICATED)
@@ -200,11 +202,12 @@ def listen_for_xblock_duplicated(sender, signal, **kwargs):
     """
     Publish XBLOCK_DUPLICATED signals onto the event bus.
     """
-    get_producer().send(
-        signal=XBLOCK_DUPLICATED, topic='xblock-duplicated',
-        event_key_field='xblock_info.usage_key', event_data={'xblock_info': kwargs['xblock_info']},
-        event_metadata=kwargs['metadata'],
-    )
+    if settings.FEATURES.get("ENABLE_SEND_XBLOCK_EVENTS_OVER_BUS"):
+        get_producer().send(
+            signal=XBLOCK_DUPLICATED, topic='xblock-duplicated',
+            event_key_field='xblock_info.usage_key', event_data={'xblock_info': kwargs['xblock_info']},
+            event_metadata=kwargs['metadata'],
+        )
 
 
 @receiver(SignalHandler.course_deleted)

--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -301,6 +301,16 @@ CREDENTIALS_INTERNAL_SERVICE_URL = 'http://localhost:18150'
 CREDENTIALS_PUBLIC_SERVICE_URL = 'http://localhost:18150'
 
 #################### Event bus backend ########################
+# .. toggle_name: FEATURES['ENABLE_SEND_XBLOCK_EVENTS_OVER_BUS']
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Temporary configuration which enables sending xblock events over the event bus.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2023-02-21
+# .. toggle_warning: For consistency in user experience, keep the value in sync with the setting of the same name
+#   in the LMS and CMS.
+# .. toggle_tickets: 'https://github.com/openedx/edx-platform/pull/31813'
+FEATURES['ENABLE_SEND_XBLOCK_EVENTS_OVER_BUS'] = True
 EVENT_BUS_PRODUCER = 'edx_event_bus_kafka.create_producer'
 EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL = 'http://edx.devstack.schema-registry:8081'
 EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS = 'edx.devstack.kafka:29092'

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -491,6 +491,12 @@ WEBPACK_LOADER['DEFAULT']['TIMEOUT'] = 5
 # Devstack is directly exposed to the caller
 CLOSEST_CLIENT_IP_FROM_HEADERS = []
 
+#################### Event bus backend ########################
+EVENT_BUS_PRODUCER = 'edx_event_bus_kafka.create_producer'
+EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL = 'http://edx.devstack.schema-registry:8081'
+EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS = 'edx.devstack.kafka:29092'
+EVENT_BUS_TOPIC_PREFIX = 'dev'
+
 ################# New settings must go ABOVE this line #################
 ########################################################################
 # See if the developer has any local overrides.


### PR DESCRIPTION
As per discussion in https://github.com/openedx/edx-platform/pull/31350#issuecomment-1438951852, this MR adds a feature flag to enable/disable sending xblock related openedx-events to external bus.