### PR TITLE
feat: add user id in registration response

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -599,7 +599,7 @@ class RegistrationView(APIView):
 
         redirect_to, root_url = get_next_url_for_login_page(request, include_host=True)
         redirect_url = get_redirect_url_with_host(root_url, redirect_to)
-        response = self._create_response(request, {}, status_code=200, redirect_url=redirect_url)
+        response = self._create_response(request, {'user_id': user.id}, status_code=200, redirect_url=redirect_url)
         set_logged_in_cookies(request, response, user)
         if not user.is_active and settings.SHOW_ACCOUNT_ACTIVATION_CTA and not settings.MARKETING_EMAILS_OPT_IN:
             response.set_cookie(


### PR DESCRIPTION
[VAN-1294](https://2u-internal.atlassian.net/browse/VAN-1294)
[VAN-1280](https://2u-internal.atlassian.net/browse/VAN-1280)

A user id was required to send in the event. This PR sends the user id as the response when registration is successful.