### PR TITLE
build: add docs to github.in & ensure ArbiBOM sees changes to it

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,9 @@
 # This does not cover all the code in edx-platform but it's a good start.
 
+# Ensure that the team responsible for upgrades sees any PRs that would
+# add GitHub-hosted dependencies to that platform.
+requirements/edx/github.in                                          @openedx/arbi-bom
+
 # Core
 common/djangoapps/student/
 common/djangoapps/student/models/__init__.py                        @openedx/teaching-and-learning

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -1,40 +1,57 @@
-# DON'T JUST ADD NEW DEPENDENCIES!!!
+# This file holds all GitHub-hosted edx-platform Python dependencies.
+# Such dependencies should be added here, not to base.in.
+# That being said....
 #
-# If you open a pull request that adds a new dependency, you should:
-#   * verify that the dependency has a license compatible with AGPLv3
-#   * confirm that it has no system requirements beyond what we already install
-#   * run "make upgrade" to update the detailed requirements files
+# ---->>> DON'T JUST ADD NEW DEPENDENCIES!!! <<<----
 #
-# Do *NOT* install Python packages from GitHub unless it's absolutely necessary!
-# "I don't have time to add automatic Travis upload to PyPI." is *not* an
-# acceptable excuse. Non-wheel module installations slow down the dev/building process.
-# Travis/PyPI instructions are here:
-# https://openedx.atlassian.net/wiki/spaces/OpenOPS/pages/41911049/Publishing+a+Package+to+PyPI+using+Travis
+# Every new GitHub-hosted dependency slows down the edx-platform build and
+# subverts our continuous dependency upgrade process. This file should
+# only be added to in exceptional circumstances.
 #
-# A correct GitHub reference looks like this:
+# "I don't have time to publish my package to PyPI" is **not** an
+# acceptable excuse. You can add a GitHub Action workflow to automatically
+# upload your package to PyPI with the push of a button:
 #
+# * Go to https://github.com/openedx/<YOUR_REPO>/actions/new
+# * Find "Publish Python Package"
+# * Merge the generated PR and push package.
+# * You're done! Add your dependency to base.in, and the requirements
+#   bot will automatically keep it fresh in edx-platform.
+#
+# If you think you must add a URL to this file, read this section of OEP-18 first:
+# https://docs.openedx.org/projects/openedx-proposals/en/latest/best-practices/oep-0018-bp-python-dependencies.html#installing-dependencies-from-urls
+#
+# If you are sure that you need to install from GitHub, then
+# use this exact format:
+#
+#   # ISSUE-LINK
 #   git+https://github.com/OWNER/REPO-NAME.git@TAG-OR-SHA#egg=DIST-NAME==VERSION
 #
 # For example:
 #
-#   git+https://github.com/openedx/edx-lint.git@v0.3.2#egg=edx_lint==0.3.2
+#   # https://github.com/openedx/blockstore/issues/212
+#   git+https://github.com/openedx/blockstore.git@v1.3.0#egg=openedx-blockstore==1.3.0
 #
 # where:
 #
-#   OWNER = edx
-#   REPO-NAME = edx-lint
-#   TAG-OR-SHA = v0.3.2
-#   DIST-NAME = edx_lint
-#   VERSION = 0.3.2
+#   ISSUE-LINK = https://github.com/openedx/blockstore/issues/212
+#   OWNER = openedx
+#   REPO-NAME = blockstore
+#   TAG-OR-SHA = v1.3.0
+#   DIST-NAME = openedx-blockstore
+#   VERSION = 1.3.0
 #
-#
-# Rules to follow (even though many URLs here don't follow them!):
+# Rules to follow:
 #
 #   * Don't leave out any of these pieces.
 #
+#   * ISSUE-LINK points to an item in a public issue tracker. The issue
+#     should be in the backlog of a particular contributor or team
+#     who will make sure that it is resolved.
+#
 #   * TAG-OR-SHA is the specific commit to install.  It must be a git tag,
 #     or a git SHA commit hash.  Don't use branch names here.  If OWNER is
-#     not an edX organization, then it must be a SHA.  If you use a SHA,
+#     not openedx, then it must be a SHA.  If you use a SHA,
 #     please make sure there is a tag associated with it, so the commit can't
 #     be lost during rebase.
 #
@@ -49,9 +66,31 @@
 #     re-install the package each time, and can be useful when working with two
 #     repos before picking a version number. Don't use 0.0 on master, only for
 #     tight-loop work in progress.
+#
+#   * Don't prefix the URL with "-e". That would install the package in "editable"
+#     mode A.K.A "development" mode, which takes longer and does not
+#     fully respect setup.py, making the transition back to PyPI more complex.
+#
+#   * Organize the URL into one of the two categories below:
 
 
-# Python libraries to install directly from github
+##############################################################################
+# Release candidates being tested.
+##############################################################################
 
-# Third-party:
+# ... add dependencies here
+
+
+##############################################################################
+# Critical fixes for packages that are not yet available in a PyPI release.
+##############################################################################
+
+# ... add dependencies here
+
+
+##############################################################################
+# Legacy URL dependencies. To be removed. Don't add new URLs here!
+##############################################################################
+
+# https://github.com/openedx/MongoDBProxy/issues/18
 git+https://github.com/openedx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2


### PR DESCRIPTION
Nine different URL-specified Python dependencies had accumulated in edx-platform, noticeably increasing the amount time it took to install edx-platform requirements.

After many developer hours of work, we are nearly finished converting them to PyPI-hosted dependencies:
openedx/wg-developer-experience#153

We're making these updates in hopes that we don't end up with so many URL-specified dependencies again.
We're also updating OEP-18:
https://github.com/openedx/open-edx-proposals/pull/450

The CODEOWNERS update would mean that Arbi-BOM is notified on all future PRs that change github.in. At the moment, edx-platform does not *require* CODEOWNER review, so this is not a hard gate to github.in changes.