### PR TITLE
feat: add masters program restrictions on recommendations

### DIFF
--- a/lms/djangoapps/learner_dashboard/api/v0/tests/test_views.py
+++ b/lms/djangoapps/learner_dashboard/api/v0/tests/test_views.py
@@ -439,3 +439,20 @@ class TestCourseRecommendationApiView(TestCase):
         self.assertEqual(
             segment_mock.call_args[0][2]["is_control"], expected_is_control
         )
+
+    @mock.patch(
+        "lms.djangoapps.learner_dashboard.api.v0.views.is_user_enrolled_in_masters_program"
+    )
+    def test_no_recommendations_for_masters_program_learners(
+        self, is_user_enrolled_in_masters_program_mock
+    ):
+        """
+        Verify API returns general recommendations if no course recommendations from amplitude.
+        """
+        is_user_enrolled_in_masters_program_mock.return_value = True
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data.get("is_control"), None)
+        self.assertEqual(len(response.data.get("courses")), 0)

--- a/lms/djangoapps/learner_dashboard/api/v0/views.py
+++ b/lms/djangoapps/learner_dashboard/api/v0/views.py
@@ -26,7 +26,7 @@ from openedx.core.djangoapps.programs.utils import (
 )
 from lms.djangoapps.learner_recommendations.utils import (
     filter_recommended_courses,
-    get_amplitude_course_recommendations,
+    get_amplitude_course_recommendations, is_user_enrolled_in_masters_program,
 )
 
 
@@ -417,9 +417,13 @@ class CourseRecommendationApiView(APIView):
     def get(self, request):
         """Retrieves course recommendations details of a user in a specified course."""
         user_id = request.user.id
-        fallback_recommendations = (
-            settings.GENERAL_RECOMMENDATIONS if show_fallback_recommendations() else []
-        )
+
+        if is_user_enrolled_in_masters_program(request.user):
+            return self._general_recommendations_response(
+                user_id, None, []
+            )
+
+        fallback_recommendations = settings.GENERAL_RECOMMENDATIONS if show_fallback_recommendations() else []
 
         try:
             (

--- a/lms/djangoapps/learner_home/recommendations/test_views.py
+++ b/lms/djangoapps/learner_home/recommendations/test_views.py
@@ -305,3 +305,25 @@ class TestCourseRecommendationApiView(TestCase):
         assert segment_track_mock.call_count == 1
         assert segment_track_mock.call_args[0][1] == "edx.bi.user.recommendations.viewed"
         self.assertEqual(segment_track_mock.call_args[0][2]["is_control"], expected_is_control)
+
+    @override_waffle_flag(ENABLE_LEARNER_HOME_AMPLITUDE_RECOMMENDATIONS, active=True)
+    @mock.patch(
+        "lms.djangoapps.learner_home.recommendations.views.is_user_enrolled_in_masters_program"
+    )
+    def test_no_recommendations_for_masters_program_learners(
+        self, is_user_enrolled_in_masters_program_mock
+    ):
+        """
+        Verify API returns general recommendations if no course recommendations from amplitude.
+        """
+        is_user_enrolled_in_masters_program_mock.return_value = True
+
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+        response_content = json.loads(response.content)
+        self.assertEqual(response_content.get("isControl"), None)
+        self.assertEqual(
+            response_content.get("courses"),
+            [],
+        )

--- a/lms/djangoapps/learner_home/recommendations/views.py
+++ b/lms/djangoapps/learner_home/recommendations/views.py
@@ -25,7 +25,7 @@ from lms.djangoapps.learner_home.recommendations.waffle import (
 )
 from lms.djangoapps.learner_recommendations.utils import (
     filter_recommended_courses,
-    get_amplitude_course_recommendations,
+    get_amplitude_course_recommendations, is_user_enrolled_in_masters_program,
 )
 
 
@@ -55,6 +55,12 @@ class CourseRecommendationApiView(APIView):
             return Response(status=404)
 
         user_id = request.user.id
+
+        if is_user_enrolled_in_masters_program(request.user):
+            return self._general_recommendations_response(
+                user_id, None, []
+            )
+
         fallback_recommendations = settings.GENERAL_RECOMMENDATIONS if show_fallback_recommendations() else []
 
         try:


### PR DESCRIPTION
This PR adds masters program restrictions which are 
a) Filter out students currently enrolled in a master's program from seeing personalized recommendations on the dashboard (which uses Amplitude).
b) Filter out courses that belong to a master's program from the recommendations panel for students who are already in a master's program.
