### PR TITLE
fix: resolved index error in course live config

### DIFF
--- a/openedx/core/djangoapps/course_live/serializers.py
+++ b/openedx/core/djangoapps/course_live/serializers.py
@@ -60,7 +60,7 @@ class LtiSerializer(serializers.ModelSerializer):
         instance.lti_config = {
             "pii_share_username": share_username,
             "pii_share_email": share_email,
-            "additional_parameters": lti_config['additional_parameters']
+            "additional_parameters": lti_config.get('additional_parameters', {})
         }
         instance.save()
         return instance
@@ -72,7 +72,7 @@ class LtiSerializer(serializers.ModelSerializer):
         instance.config_store = LtiConfiguration.CONFIG_ON_DB
         lti_config = validated_data.pop('lti_config', None)
         if lti_config.get('additional_parameters', None):
-            instance.lti_config['additional_parameters'] = lti_config.get('additional_parameters')
+            instance.lti_config['additional_parameters'] = lti_config.get('additional_parameters', {})
 
         if validated_data.get('lti_1p1_client_secret') == '':
             validated_data['lti_1p1_client_secret'] = instance.lti_1p1_client_secret


### PR DESCRIPTION
## Ticket
https://2u-internal.atlassian.net/browse/INF-796


## Discription
This PR resolves index errors in the Course Live module

error trace
```
2023-02-27 17:21:26,011 ERROR 13116 [django.request] [user 26177204] [ip 13.245.72.95] log.py:224 - Internal Server Error: /api/course_live/course/course-v1:edX+inf202+2022_Winter/
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/base.py", line 181, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/lib/python3.8/contextlib.py", line 75, in inner
    return func(*args, **kwds)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/newrelic/hooks/framework_django.py", line 552, in wrapper
    return wrapped(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/views/generic/base.py", line 70, in view
    return self.dispatch(request, *args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/newrelic/hooks/component_djangorestframework.py", line 61, in _nr_wrapper_APIView_dispatch_
    return wrapped(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/rest_framework/views.py", line 509, in dispatch
    response = self.handle_exception(exc)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/newrelic/hooks/component_djangorestframework.py", line 68, in _handle_exception_wrapper
    return wrapped(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/rest_framework/views.py", line 469, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
    raise exc
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
  File "/edx/app/edxapp/edx-platform/common/djangoapps/util/views.py", line 43, in inner
    response = view_func(request, *args, **kwargs)
  File "/edx/app/edxapp/edx-platform/openedx/core/lib/api/view_utils.py", line 439, in wrapped_function
    return view_func(self, request, **kwargs)
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/course_live/views.py", line 138, in post
    serializer.save()
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/rest_framework/serializers.py", line 200, in save
    self.instance = self.update(self.instance, validated_data)
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/course_live/serializers.py", line 161, in update
    instance = self._update_lti(instance, lti_config)
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/course_live/serializers.py", line 199, in _update_lti
    lti_serializer.save()
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/rest_framework/serializers.py", line 205, in save
    self.instance = self.create(validated_data)
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/course_live/serializers.py", line 63, in create
    "additional_parameters": lti_config['additional_parameters']
KeyError: 'additional_parameters'
```
