### PR TITLE
feat: add differentiation for tracking in-context and mfe events

### DIFF
--- a/lms/djangoapps/discussion/django_comment_client/base/views.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/views.py
@@ -112,7 +112,7 @@ def add_truncated_title_to_event_data(event_data, full_title):
     event_data['title'] = full_title[:TRACKING_MAX_FORUM_TITLE]
 
 
-def track_thread_created_event(request, course, thread, followed):
+def track_thread_created_event(request, course, thread, followed, from_mfe_sidebar=False):
     """
     Send analytics event for a newly created thread.
     """
@@ -124,6 +124,7 @@ def track_thread_created_event(request, course, thread, followed):
         'anonymous': thread.anonymous,
         'anonymous_to_peers': thread.anonymous_to_peers,
         'options': {'followed': followed},
+        'from_mfe_sidebar': from_mfe_sidebar,
         # There is a stated desire for an 'origin' property that will state
         # whether this thread was created via courseware or the forum.
         # However, the view does not contain that data, and including it will
@@ -133,7 +134,7 @@ def track_thread_created_event(request, course, thread, followed):
     track_created_event(request, event_name, course, thread, event_data)
 
 
-def track_comment_created_event(request, course, comment, commentable_id, followed):
+def track_comment_created_event(request, course, comment, commentable_id, followed, from_mfe_sidebar=False):
     """
     Send analytics event for a newly created response or comment.
     """
@@ -143,6 +144,7 @@ def track_comment_created_event(request, course, comment, commentable_id, follow
         'discussion': {'id': comment.thread_id},
         'commentable_id': commentable_id,
         'options': {'followed': followed},
+        'from_mfe_sidebar': from_mfe_sidebar,
     }
     parent_id = comment.get('parent_id')
     if parent_id:
@@ -179,13 +181,14 @@ def track_forum_search_event(request, course, search_event_data):
         tracker.emit(event_name, search_event_data)
 
 
-def track_thread_viewed_event(request, course, thread):
+def track_thread_viewed_event(request, course, thread, from_mfe_sidebar=False):
     """
     Send analytics event for a viewed thread.
     """
     event_name = _EVENT_NAME_TEMPLATE.format(obj_type='thread', action_name='viewed')
     event_data = {}
     event_data['commentable_id'] = thread.get('commentable_id', '')
+    event_data['from_mfe_sidebar'] = from_mfe_sidebar
     if hasattr(thread, 'username'):
         event_data['target_username'] = thread.get('username', '')
     add_truncated_title_to_event_data(event_data, thread.get('title', ''))

--- a/lms/djangoapps/discussion/rest_api/tests/test_api.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api.py
@@ -1888,7 +1888,8 @@ class CreateThreadTest(
             'body': 'Test body',
             'url': '',
             'user_forums_roles': [FORUM_ROLE_STUDENT],
-            'user_course_roles': []
+            'user_course_roles': [],
+            'from_mfe_sidebar': False,
         }
 
     def test_basic_in_blackout_period(self):
@@ -1975,6 +1976,7 @@ class CreateThreadTest(
                 "url": "",
                 "user_forums_roles": [FORUM_ROLE_STUDENT, FORUM_ROLE_MODERATOR],
                 "user_course_roles": [],
+                "from_mfe_sidebar": False,
             }
         )
 
@@ -2007,7 +2009,8 @@ class CreateThreadTest(
             'body': 'Test body',
             'url': '',
             'user_forums_roles': [FORUM_ROLE_STUDENT],
-            'user_course_roles': []
+            'user_course_roles': [],
+            'from_mfe_sidebar': False,
         }
 
     @ddt.data(
@@ -2257,6 +2260,7 @@ class CreateCommentTest(
             "url": "",
             "user_forums_roles": [FORUM_ROLE_STUDENT],
             "user_course_roles": [],
+            "from_mfe_sidebar": False,
         }
         if parent_id:
             expected_event_data["response"] = {"id": parent_id}
@@ -2353,6 +2357,7 @@ class CreateCommentTest(
             "url": "",
             "user_forums_roles": [FORUM_ROLE_STUDENT, FORUM_ROLE_MODERATOR],
             "user_course_roles": [],
+            "from_mfe_sidebar": False,
         }
         if parent_id:
             expected_event_data["response"] = {"id": parent_id}


### PR DESCRIPTION
### [INF-738](https://2u-internal.atlassian.net/browse/INF-738)

### Description

Add field for content generated from new discussion MFE in-context sidebar in discussion events.

New field added to events is `from_mfe_sidebar`. This will only be `true` when event comes from new discussions MFE sidebar. This is an effort to estimate the traffic coming from the new in-context discussion sidebar.
Events targeted for the change are:

- `edx.forum.thread.created`
- `edx.forum.response.created` 
- `edx.forum.comment.created`
- `edx.forum.thread.viewed`

Related PR - https://github.com/openedx/frontend-app-discussions/pull/457

