### PR TITLE
feat: add JS env config to workers

### DIFF
--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -41,6 +41,9 @@ var workerConfig = function() {
                     new BundleTracker({
                         path: process.env.STATIC_ROOT_LMS,
                         filename: 'webpack-worker-stats.json'
+                    }),
+                    new webpack.DefinePlugin({
+                        'process.env.JS_ENV_EXTRA_CONFIG': JSON.parse(process.env.JS_ENV_EXTRA_CONFIG),
                     })
                 ],
                 module: {


### PR DESCRIPTION
`JS_ENV_EXTRA_CONFIG` is an existing Django setting that allows compile time injection of its contained values into our statically generated JS. We want to use this feature to add a deployment-specific environment value to the proctoring javascript worker. This already works for most of the JS compiled in edx-platform but the JS worker code has it's own config that needed this addition.

How this variable gets built: https://github.com/openedx/edx-platform/blob/429cc09e5638f502efd966be2740193a16d5da02/pavelib/assets.py#L782

Related Ticket: https://2u-internal.atlassian.net/browse/MST-1762