### PR TITLE
fix: Add longer retry schedule for course enrollment emails

### DIFF
--- a/common/djangoapps/student/tasks.py
+++ b/common/djangoapps/student/tasks.py
@@ -26,8 +26,7 @@ from openedx.features.course_experience import ENABLE_COURSE_GOALS
 User = get_user_model()
 log = logging.getLogger(__name__)
 
-MAX_RETRIES = 1
-COUNTDOWN = 60
+MAX_RETRIES = 3
 
 
 @shared_task(bind=True, ignore_result=True)
@@ -135,4 +134,5 @@ def send_course_enrollment_email(
             )
     except Exception as exc:  # pylint: disable=broad-except
         log.error(f"[Course Enrollment] Email sending failed with exception: {exc}")
-        raise self.retry(exc=exc, countdown=COUNTDOWN, max_retries=MAX_RETRIES)
+        countdown = 60 * (self.request.retries + 1)
+        raise self.retry(exc=exc, countdown=countdown, max_retries=MAX_RETRIES)

--- a/common/djangoapps/student/tests/test_tasks.py
+++ b/common/djangoapps/student/tests/test_tasks.py
@@ -1,11 +1,16 @@
 """
 Celery task tests
 """
+from unittest.mock import patch, Mock, PropertyMock
+
+import pytest
 from django.conf import settings
 from django.test.utils import override_settings
-from unittest.mock import patch, Mock
 
-from common.djangoapps.student.tasks import send_course_enrollment_email
+from common.djangoapps.student.tasks import (
+    MAX_RETRIES,
+    send_course_enrollment_email
+)
 from common.djangoapps.student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
@@ -271,3 +276,34 @@ class TestCourseEnrollmentEmailTask(ModuleStoreTestCase):
                 add_course_run_details=False
             ),
         )
+
+    @patch("common.djangoapps.student.tasks.get_course_uuid_for_course")
+    @patch("common.djangoapps.student.tasks.get_owners_for_course")
+    @patch("common.djangoapps.student.tasks.get_course_run_details")
+    @patch("common.djangoapps.student.tasks.get_course_dates_for_email")
+    def test_retry_with_braze_client_exception(
+        self,
+        mock_get_course_dates_for_email,
+        mock_get_course_run_details,
+        mock_get_owners_for_course,
+        mock_get_course_uuid_for_course,
+    ):
+        """
+        Test that we retry when an exception occurs from Braze Client
+        """
+
+        mock_get_course_uuid_for_course.return_value = self.course_uuid
+        mock_get_owners_for_course.return_value = self._get_course_owners()
+        mock_get_course_run_details.return_value = self._get_course_run()
+        mock_get_course_dates_for_email.return_value = self._get_course_dates()
+
+        with patch(
+            'common.djangoapps.student.tasks.get_braze_client',
+            new_callable=PropertyMock,
+            side_effect=Exception('Braze Client Exception')
+        ) as mock_get_braze_client:
+            task = send_course_enrollment_email.apply_async(
+                kwargs=self.send_course_enrollment_email_kwargs
+            )
+        pytest.raises(Exception, task.get)
+        self.assertEqual(mock_get_braze_client.call_count, (MAX_RETRIES + 1))


### PR DESCRIPTION
Course enrolment email retry settings have been updated to 3 max retries and incremental 1-3 minute delays between retries, increasing deliverability.

Ticket: [VAN-1308](https://2u-internal.atlassian.net/browse/VAN-1308)