### PR TITLE
fix: fix credit serialization for Learner Home

### DIFF
--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -460,7 +460,7 @@ class LearnerEnrollmentSerializer(serializers.Serializer):
 
     def get_credit(self, instance):
         """Pull credit statuses from context"""
-        credit_status = self.context["credit_statuses"].get(str(instance.course_id))
+        credit_status = self.context["credit_statuses"].get(instance.course_id)
 
         # If user or course is ineligible for credit, return empty
         if not credit_status:

--- a/lms/djangoapps/learner_home/test_serializers.py
+++ b/lms/djangoapps/learner_home/test_serializers.py
@@ -820,7 +820,7 @@ class TestCreditSerializer(LearnerDashboardBaseTest):
         """Mock data following the shape of credit_statuses"""
 
         return {
-            "course_key": enrollment.course.id,
+            "course_key": str(enrollment.course.id),
             "eligible": True,
             "deadline": random_date(),
             "purchased": False,
@@ -835,7 +835,7 @@ class TestCreditSerializer(LearnerDashboardBaseTest):
     def create_test_context(cls, enrollment):
         """Credit data, packaged as it would be for serialization context"""
 
-        return {enrollment.course.id: {**cls.create_test_data(enrollment)}}
+        return {enrollment.course_id: {**cls.create_test_data(enrollment)}}
 
     def test_serialize_credit(self):
         # Given an enrollment and a course with ability to purchase credit
@@ -900,7 +900,17 @@ class TestLearnerEnrollmentsSerializer(LearnerDashboardBaseTest):
             "programs",
             "credit",
         ]
+
+        # Verify we have all the expected keys in our output
         self.assertEqual(output.keys(), set(expected_keys))
+
+        # Entitlements should be the only empty field for an enrollment
+        entitlement = output.pop("entitlement")
+        self.assertDictEqual(entitlement, {})
+
+        # All other keys should have some basic info, unless we broke something
+        for key in output.keys():
+            self.assertNotEqual(output[key], {})
 
     def test_credit_no_credit_option(self):
         # Given an enrollment

--- a/lms/djangoapps/learner_home/views.py
+++ b/lms/djangoapps/learner_home/views.py
@@ -343,7 +343,7 @@ def get_course_programs(user, course_enrollments, site):
     Get programs related to the courses the user is enrolled in.
 
     Returns: {
-        <course_id>: {
+        str(<course_id>): {
             "programs": [list of programs]
         }
     }


### PR DESCRIPTION
## Description

1. Fix a bad linkage for serializing credit info (was attempting to index on string representation of course ID when data was indexed on the `CourseLocator` representation of course ID)
2. Update tests.
3. Update some docstrings.

## Testing instructions

1. Unit tests
2. Verify on test learners who have credit info

## Deadline

ASAP, this is actively blocking at least one known learner.