### PR TITLE
fix: save scroll position on exit from video xblock fullscreen mode

### DIFF
--- a/xmodule/js/src/video/04_video_full_screen.js
+++ b/xmodule/js/src/video/04_video_full_screen.js
@@ -161,6 +161,20 @@
             return this.videoFullScreen.height;
         }
 
+        function notifyParent(fullscreenOpen) {
+            if (window !== window.parent) {
+                // This is used by the Learning MFE to know about changing fullscreen mode.
+                // The MFE is then able to respond appropriately and scroll window to the previous position.
+                window.parent.postMessage({
+                    type: 'plugin.videoFullScreen',
+                    payload: {
+                        open: fullscreenOpen
+                    }
+                  }, document.referrer
+                );
+            }
+        }
+
     /**
      * Event handler to toggle fullscreen mode.
      * @param {jquery Event} event
@@ -192,6 +206,8 @@
                 this.resizer.delta.reset().setMode('width');
             }
             this.el.trigger('fullscreen', [this.isFullScreen]);
+
+            this.videoFullScreen.notifyParent(false);
         }
 
         function handleEnter() {
@@ -201,6 +217,8 @@
             if (this.isFullScreen === true) {
                 return;
             }
+
+            this.videoFullScreen.notifyParent(true);
 
             this.videoFullScreen.fullScreenState = this.isFullScreen = true;
             fullScreenClassNameEl.addClass('video-fullscreen');
@@ -267,7 +285,8 @@
                 handleFullscreenChange: handleFullscreenChange,
                 toggle: toggle,
                 toggleHandler: toggleHandler,
-                updateControlsHeight: updateControlsHeight
+                updateControlsHeight: updateControlsHeight,
+                notifyParent: notifyParent,
             };
 
             state.bindTo(methodsDict, state.videoFullScreen, state);


### PR DESCRIPTION
This merge request contains a fix for toggling video xblock full-screen mode and saving the previous window top offset position on exit from the full-screen state.

A related bug was found here https://bugs.chromium.org/p/chromium/issues/detail?id=142427 but it still reproduces.

Realised solution: Save the scroll position before the turn on the fullscreen mode and scroll to the previous position on turn off the fullscreen mode.

Dependent PR to MFE Learning:
This MR https://github.com/openedx/frontend-app-learning/pull/1077 must be merged with this MR.

All general discussion and addition information there: https://github.com/openedx/platform-roadmap/issues/229