### PR TITLE
chore: remove unsued pkg (extract-text-webpack-plugin)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
         "edx-proctoring-proctortrack": "git+https://git@github.com/anupdhabarde/edx-proctoring-proctortrack.git#9b55ea63a3f670bcfbdb5870241510746252ee41",
         "edx-ui-toolkit": "1.5.4",
         "exports-loader": "0.6.4",
-        "extract-text-webpack-plugin": "2.1.2",
         "file-loader": "1.1.6",
         "font-awesome": "4.7.0",
         "hls.js": "0.14.17",
@@ -9431,80 +9430,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/extract-text-webpack-plugin": {
-      "version": "2.1.2",
-      "deprecated": "Deprecated. Please use https://github.com/webpack-contrib/mini-css-extract-plugin",
-      "license": "MIT",
-      "dependencies": {
-        "async": "^2.1.2",
-        "loader-utils": "^1.0.2",
-        "schema-utils": "^0.3.0",
-        "webpack-sources": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4.3.0 < 5.0.0 || >= 5.10"
-      },
-      "peerDependencies": {
-        "webpack": "^2.2.0"
-      }
-    },
-    "node_modules/extract-text-webpack-plugin/node_modules/ajv": {
-      "version": "5.5.2",
-      "license": "MIT",
-      "dependencies": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
-      }
-    },
-    "node_modules/extract-text-webpack-plugin/node_modules/async": {
-      "version": "2.6.4",
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.14"
-      }
-    },
-    "node_modules/extract-text-webpack-plugin/node_modules/fast-deep-equal": {
-      "version": "1.1.0",
-      "license": "MIT"
-    },
-    "node_modules/extract-text-webpack-plugin/node_modules/json-schema-traverse": {
-      "version": "0.3.1",
-      "license": "MIT"
-    },
-    "node_modules/extract-text-webpack-plugin/node_modules/json5": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/extract-text-webpack-plugin/node_modules/loader-utils": {
-      "version": "1.4.2",
-      "license": "MIT",
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/extract-text-webpack-plugin/node_modules/schema-utils": {
-      "version": "0.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 4.3 < 5.0.0 || >= 5.10"
       }
     },
     "node_modules/extsprintf": {
@@ -32287,58 +32212,6 @@
       "dev": true,
       "requires": {
         "is-extglob": "^1.0.0"
-      }
-    },
-    "extract-text-webpack-plugin": {
-      "version": "2.1.2",
-      "requires": {
-        "async": "^2.1.2",
-        "loader-utils": "^1.0.2",
-        "schema-utils": "^0.3.0",
-        "webpack-sources": "^1.0.1"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "5.5.2",
-          "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
-          }
-        },
-        "async": {
-          "version": "2.6.4",
-          "requires": {
-            "lodash": "^4.17.14"
-          }
-        },
-        "fast-deep-equal": {
-          "version": "1.1.0"
-        },
-        "json-schema-traverse": {
-          "version": "0.3.1"
-        },
-        "json5": {
-          "version": "1.0.2",
-          "requires": {
-            "minimist": "^1.2.0"
-          }
-        },
-        "loader-utils": {
-          "version": "1.4.2",
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^1.0.1"
-          }
-        },
-        "schema-utils": {
-          "version": "0.3.0",
-          "requires": {
-            "ajv": "^5.0.0"
-          }
-        }
       }
     },
     "extsprintf": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "edx-proctoring-proctortrack": "git+https://git@github.com/anupdhabarde/edx-proctoring-proctortrack.git#9b55ea63a3f670bcfbdb5870241510746252ee41",
     "edx-ui-toolkit": "1.5.4",
     "exports-loader": "0.6.4",
-    "extract-text-webpack-plugin": "2.1.2",
     "file-loader": "1.1.6",
     "font-awesome": "4.7.0",
     "hls.js": "0.14.17",


### PR DESCRIPTION
<!--

🎉🎉 Olive has been released! 🎉🎉

🫒🫒
🫒🫒🫒🫒         🫒 Note: Olive is in support. Fixes you make on master may still
    🫒🫒🫒🫒     be needed on Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

  This pkg isn't used since 5 years ago 😄 
  This PR #17417 revert it's usage.  https://github.com/openedx/edx-platform/pull/17417/files#diff-a60dea17f5d642506d3c4eb9e4f3d0890f7b1601be813adf18583a248f4ce78aL9 
  

## Testing instructions

It's not imported any where, I couldn't find a reference for it.  

## Deadline

The sooner the better I think this package has been part of the bundle for 5 years for no use. 

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
