### PR TITLE
build: Update release branch name

### DIFF
--- a/openedx.yaml
+++ b/openedx.yaml
@@ -2,7 +2,7 @@
 # https://open-edx-proposals.readthedocs.io/en/latest/oep-0002-bp-repo-metadata.html#specification
 
 nick: edx
-openedx-release: {ref: release}
+openedx-release: {ref: "2u/release"}
 
 oeps:
     oep-2: true


### PR DESCRIPTION
This is part of https://github.com/edx/edx-arch-experiments/issues/212. 2U is switching to using a prefix to reflect edx-platform's position as a community repo. Our deployment process will also no longer produce per-deploy branches and tags. This one branch will remain in place rather than being kept in a private repo since the named-release branch-cutting process still uses this as an indicator of what code has been field-tested.