### PR TITLE
feat: add twitter share button to public access video

### DIFF
--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -53,7 +53,7 @@ from openedx.core.djangoapps.waffle_utils.models import WaffleFlagCourseOverride
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
 
 from .test_video_handlers import BaseTestVideoXBlock, TestVideo
-from .test_video_xml import SOURCE_XML
+from .test_video_xml import SOURCE_XML, PUBLIC_SOURCE_XML
 
 MODULESTORES = {
     ModuleStoreEnum.Type.mongo: TEST_DATA_MONGO_MODULESTORE,
@@ -132,6 +132,7 @@ class TestVideoYouTube(TestVideo):  # lint-amnesty, pylint: disable=missing-clas
                 {'display_name': 'Text (.txt) file', 'value': 'txt'}
             ],
             'poster': 'null',
+            'public_video_url': None,
         }
 
         mako_service = self.item_descriptor.xmodule_runtime.service(self.item_descriptor, 'mako')
@@ -215,6 +216,7 @@ class TestVideoNonYouTube(TestVideo):  # pylint: disable=test-inherits-tests
                 {'display_name': 'Text (.txt) file', 'value': 'txt'}
             ],
             'poster': 'null',
+            'public_video_url': None,
         }
 
         mako_service = self.item_descriptor.xmodule_runtime.service(self.item_descriptor, 'mako')
@@ -224,6 +226,25 @@ class TestVideoNonYouTube(TestVideo):  # pylint: disable=test-inherits-tests
         assert get_context_dict_from_string(context) == expected_result
         assert expected_result['download_video_link'] == 'example.mp4'
         assert expected_result['display_name'] == 'A Name'
+
+
+@ddt.ddt
+class TestVideoPublicAccess(BaseTestVideoXBlock):
+    """Test video public access."""
+    DATA = PUBLIC_SOURCE_XML
+    MODEL_DATA = {
+        'data': DATA,
+    }
+    METADATA = {}
+
+    @ddt.data(True, False)
+    def test_public_video_url(self, is_lms_platform):
+        """Test public video url."""
+        assert self.item_descriptor.public_access is True
+        with patch.object(self.item_descriptor, '_is_lms_platform', return_value=is_lms_platform):
+            context = self.item_descriptor.render(STUDENT_VIEW).content
+            # public video url iif is_lms_platform and public_access are true
+            assert bool(get_context_dict_from_string(context)['public_video_url']) is is_lms_platform
 
 
 @ddt.ddt
@@ -356,6 +377,7 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
                 {'display_name': 'Text (.txt) file', 'value': 'txt'}
             ],
             'poster': 'null',
+            'public_video_url': None,
         }
 
         for data in cases:
@@ -476,6 +498,7 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
                 {'display_name': 'Text (.txt) file', 'value': 'txt'}
             ],
             'poster': 'null',
+            'public_video_url': None,
         }
         initial_context['metadata']['duration'] = None
 
@@ -602,6 +625,7 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
                 {'display_name': 'Text (.txt) file', 'value': 'txt'}
             ],
             'poster': 'null',
+            'public_video_url': None,
             'metadata': metadata
         }
 
@@ -775,6 +799,7 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
                 {'display_name': 'Text (.txt) file', 'value': 'txt'}
             ],
             'poster': 'null',
+            'public_video_url': None,
             'metadata': metadata,
         }
 
@@ -888,6 +913,7 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
                 {'display_name': 'SubRip (.srt) file', 'value': 'srt'},
                 {'display_name': 'Text (.txt) file', 'value': 'txt'}
             ],
+            'public_video_url': None,
             'poster': 'null',
         }
         initial_context['metadata']['duration'] = None
@@ -984,6 +1010,7 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
                 {'display_name': 'SubRip (.srt) file', 'value': 'srt'},
                 {'display_name': 'Text (.txt) file', 'value': 'txt'}
             ],
+            'public_video_url': None,
             'poster': 'null',
         }
         initial_context['metadata']['duration'] = None
@@ -2254,6 +2281,7 @@ class TestVideoWithBumper(TestVideo):  # pylint: disable=test-inherits-tests
                 {'display_name': 'SubRip (.srt) file', 'value': 'srt'},
                 {'display_name': 'Text (.txt) file', 'value': 'txt'}
             ],
+            'public_video_url': None,
             'poster': json.dumps(OrderedDict({
                 'url': 'http://img.youtube.com/vi/ZwkTiUPN0mg/0.jpg',
                 'type': 'youtube'
@@ -2335,6 +2363,7 @@ class TestAutoAdvanceVideo(TestVideo):  # lint-amnesty, pylint: disable=test-inh
                 {'display_name': 'SubRip (.srt) file', 'value': 'srt'},
                 {'display_name': 'Text (.txt) file', 'value': 'txt'}
             ],
+            'public_video_url': None,
             'poster': 'null'
         }
         return context

--- a/lms/djangoapps/courseware/tests/test_video_xml.py
+++ b/lms/djangoapps/courseware/tests/test_video_xml.py
@@ -32,6 +32,21 @@ SOURCE_XML = """
     </video>
 """
 
+PUBLIC_SOURCE_XML = """
+    <video show_captions="true"
+    display_name="A Name"
+    youtube="0.75:jNCf2gIqpeE,1.0:ZwkTiUPN0mg,1.25:rsq9auxASqI,1.50:kMyNdzVHHgg"
+    sub="a_sub_file.srt.sjson"
+    download_video="true"
+    public_access="true"
+    start_time="3603.0" end_time="3610.0"
+    >
+        <source src="example.mp4"/>
+        <source src="example.webm"/>
+        <transcript language="uk" src="ukrainian_translation.srt" />
+    </video>
+"""
+
 
 class VideoBlockLogicTest(TestCase):
     """Tests for logic of VideoBlock."""

--- a/lms/templates/video.html
+++ b/lms/templates/video.html
@@ -55,6 +55,17 @@ from openedx.core.djangolib.js_utils import (
             <a class="btn-link video-sources video-download-button" href="${download_video_link}">
                 ${_('Download video file')}
             </a>
+            % if public_video_url:
+            <br/>
+            <a
+                class="btn-link"
+                id="twitter-share-button"
+                href="${public_video_url}"
+                target="_blank"
+            >
+                ${_('Share on Twitter')}
+            </a>
+            % endif
         </div>
         % endif
         % if track:
@@ -117,3 +128,19 @@ from openedx.core.djangolib.js_utils import (
   }
 </script>
 % endif;
+% if public_video_url:
+<script>
+  $("#twitter-share-button").click(function() {
+    var tweetText = encodeURIComponent("Here\'s a fun clip from a class I\'m taking on @edXonline.\n\n");
+    var utmQuery =  $.param({
+      utm_source: 'twitter',
+      utm_medium: 'social',
+      utm_campaign: 'social-share-exp',
+    });
+    var url = encodeURIComponent(this.href + "?" + utmQuery);
+    var tweetUrl = "https://twitter.com/intent/tweet?text=" + tweetText + "&url=" + url;
+    window.open(tweetUrl,'targetWindow','toolbar=no,location=0,status=no,menubar=no,scrollbars=yes,resizable=yes,width=600,height=400');
+    return false;
+  });
+</script>
+% endif


### PR DESCRIPTION
## Description

Add share to twitter button to public available video block.

Ticket: https://2u-internal.atlassian.net/browse/AU-1070

Useful information to include:


## Supporting information

![Screenshot 2023-03-09 at 10 23 47 AM](https://user-images.githubusercontent.com/83240113/224070881-6476cd8f-0e2c-410e-93e4-7f8c4da51048.png)

![Screenshot 2023-03-09 at 10 23 59 AM](https://user-images.githubusercontent.com/83240113/224070871-5b074b4c-a366-49ff-9918-017b12202445.png)


## Testing instructions

- Make a video public using advance editor
- publish the video to the student
- view the video from student view
- it should have `share to twitter` button like shown in the above screenshot
- the click should open a popup window for sharing

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
