### PR TITLE
chore: bump edx-enterprise to 3.61.6

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -25,7 +25,7 @@ django-storages<1.9
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==3.61.5
+edx-enterprise==3.61.6
 
 # oauthlib>3.0.1 causes test failures ( also remove the django-oauth-toolkit constraint when this is fixed )
 oauthlib==3.0.1
@@ -72,7 +72,6 @@ pycodestyle<2.9.0
 # This constraint can be removed once https://github.com/snowflakedb/snowflake-connector-python/issues/1259 is resolved
 # and snowflake-connector-python>2.8.0 is released.
 pyopenssl==22.0.0
-
 
 cryptography==38.0.4 # greater version has some issues with openssl.
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -469,7 +469,7 @@ edx-drf-extensions==8.4.1
     #   edx-when
     #   edxval
     #   learner-pathway-progress
-edx-enterprise==3.61.5
+edx-enterprise==3.61.6
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -595,7 +595,7 @@ edx-drf-extensions==8.4.1
     #   edx-when
     #   edxval
     #   learner-pathway-progress
-edx-enterprise==3.61.5
+edx-enterprise==3.61.6
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -574,7 +574,7 @@ edx-drf-extensions==8.4.1
     #   edx-when
     #   edxval
     #   learner-pathway-progress
-edx-enterprise==3.61.5
+edx-enterprise==3.61.6
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
This introduces the `user_id` request attribute to the `enroll_learners_in_courses` enterprise endpoint.