### PR TITLE
fix: share link should show even if video download is disabled

### DIFF
--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -48,6 +48,7 @@ from xmodule.x_module import PUBLIC_VIEW, STUDENT_VIEW
 
 from common.djangoapps.xblock_django.constants import ATTR_KEY_REQUEST_COUNTRY_CODE
 from lms.djangoapps.courseware.tests.helpers import get_context_dict_from_string
+from lms.djangoapps.courseware.toggles import PUBLIC_VIDEO_SHARE
 from openedx.core.djangoapps.video_pipeline.config.waffle import DEPRECATE_YOUTUBE
 from openedx.core.djangoapps.waffle_utils.models import WaffleFlagCourseOverrideModel
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
@@ -237,14 +238,20 @@ class TestVideoPublicAccess(BaseTestVideoXBlock):
     }
     METADATA = {}
 
-    @ddt.data(True, False)
-    def test_public_video_url(self, is_lms_platform):
+    @ddt.data(
+        (True, False),
+        (False, False),
+        (True, True),
+    )
+    @ddt.unpack
+    def test_public_video_url(self, is_lms_platform, enable_public_share):
         """Test public video url."""
         assert self.item_descriptor.public_access is True
-        with patch.object(self.item_descriptor, '_is_lms_platform', return_value=is_lms_platform):
+        with patch.object(self.item_descriptor, '_is_lms_platform', return_value=is_lms_platform), \
+                patch.object(PUBLIC_VIDEO_SHARE, 'is_enabled', return_value=enable_public_share):
             context = self.item_descriptor.render(STUDENT_VIEW).content
-            # public video url iif is_lms_platform and public_access are true
-            assert bool(get_context_dict_from_string(context)['public_video_url']) is is_lms_platform
+            # public video url iif PUBLIC_VIDEO_SHARE waffle and is_lms_platform, public_access are true
+            assert bool(get_context_dict_from_string(context)['public_video_url']) is (is_lms_platform and enable_public_share)
 
 
 @ddt.ddt

--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -251,7 +251,8 @@ class TestVideoPublicAccess(BaseTestVideoXBlock):
                 patch.object(PUBLIC_VIDEO_SHARE, 'is_enabled', return_value=enable_public_share):
             context = self.item_descriptor.render(STUDENT_VIEW).content
             # public video url iif PUBLIC_VIDEO_SHARE waffle and is_lms_platform, public_access are true
-            assert bool(get_context_dict_from_string(context)['public_video_url']) is (is_lms_platform and enable_public_share)
+            assert bool(get_context_dict_from_string(context)['public_video_url']) \
+                is (is_lms_platform and enable_public_share)
 
 
 @ddt.ddt

--- a/lms/templates/video.html
+++ b/lms/templates/video.html
@@ -46,27 +46,31 @@ from openedx.core.djangolib.js_utils import (
 
     <div class="focus_grabber last"></div>
 
-    % if (download_video_link or track or handout or branding_info) and not hide_downloads:
+    % if (download_video_link or track or handout or branding_info or public_video_url) and not hide_downloads:
     <h3 class="hd hd-4 downloads-heading sr" id="video-download-transcripts_${id}">${_('Downloads and transcripts')}</h3>
     <div class="wrapper-downloads" role="region" aria-labelledby="video-download-transcripts_${id}">
-        % if download_video_link:
-        <div class="wrapper-download-video">
-            <h4 class="hd hd-5">${_('Video')}</h4>
-            <a class="btn-link video-sources video-download-button" href="${download_video_link}">
-                ${_('Download video file')}
-            </a>
-            % if public_video_url:
-            <br/>
-            <a
-                class="btn-link"
-                id="twitter-share-button"
-                href="${public_video_url}"
-                target="_blank"
-            >
-                ${_('Share on Twitter')}
-            </a>
-            % endif
-        </div>
+        % if download_video_link or public_video_url:
+            <div class="wrapper-download-video">
+                <h4 class="hd hd-5">${_('Video')}</h4>
+                % if download_video_link:
+                    <a class="btn-link video-sources video-download-button" href="${download_video_link}">
+                        ${_('Download video file')}
+                    </a>
+                % endif
+                % if download_video_link and public_video_url:
+                    <br>
+                % endif
+                % if public_video_url:
+                    <a
+                        class="btn-link"
+                        id="twitter-share-button"
+                        href="${public_video_url}"
+                        target="_blank"
+                    >
+                        ${_('Share on Twitter')}
+                    </a>
+                % endif
+            </div>
         % endif
         % if track:
         <div class="wrapper-download-transcripts">

--- a/xmodule/video_block/video_block.py
+++ b/xmodule/video_block/video_block.py
@@ -24,7 +24,6 @@ from django.conf import settings
 from django.urls import reverse
 from edx_django_utils.cache import RequestCache
 from lxml import etree
-from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import AssetLocator
 from web_fragments.fragment import Fragment
 from xblock.completable import XBlockCompletionMode


### PR DESCRIPTION
- Share link should show even if video download is disabled and transcript download is disabled.
- only show share link if course waffle is enabled

