### PR TITLE
feat: add organization logo to public video page

### DIFF
--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -3094,7 +3094,7 @@ class TestRenderPublicVideoXBlock(ModuleStoreTestCase):
         content = response.content.decode('utf-8')
 
         # Then the page does not render an org logo
-        org_logo = re.search(f'<img .*class=[\'"]org-logo[\'"].*>', content)
+        org_logo = re.search('<img .*class=[\'"]org-logo[\'"].*>', content)
         self.assertIsNone(org_logo)
 
     @patch('lms.djangoapps.courseware.views.views.get_course_organization')

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -3084,6 +3084,41 @@ class TestRenderPublicVideoXBlock(ModuleStoreTestCase):
         self.assertEqual(expected_status_code, response.status_code)
         self.assertEqual(expected_status_code, embed_response.status_code)
 
+    def test_get_org_logo_none(self):
+        # Given a course with no organizational logo
+        self.setup_course()
+        target_video = self.video_block_public
+
+        # When I render the page
+        response = self.get_response(usage_key=target_video.location, is_embed=False)
+        content = response.content.decode('utf-8')
+
+        # Then the page does not render an org logo
+        org_logo = re.search(f'<img .*class=[\'"]org-logo[\'"].*>', content)
+        self.assertIsNone(org_logo)
+
+    @patch('lms.djangoapps.courseware.views.views.get_course_organization')
+    def test_get_org_logo(self, mock_get_org):
+        # Given a course with an organizational logo
+        self.setup_course()
+        target_video = self.video_block_public
+
+        mock_org_logo_url = "/assets/foo"
+        mock_org_logo = MagicMock()
+        mock_org_logo.url = mock_org_logo_url
+
+        mock_get_org.return_value = {
+            "logo": mock_org_logo
+        }
+
+        # When I render the page
+        response = self.get_response(usage_key=target_video.location, is_embed=False)
+        content = response.content.decode('utf-8')
+
+        # Then the page does render an org logo
+        org_logo = re.search(f'<img .*class=[\'"]org-logo[\'"].*src=[\'"]{mock_org_logo_url}[\'"].*>', content)
+        self.assertIsNotNone(org_logo)
+
 
 class TestRenderXBlockSelfPaced(TestRenderXBlock):  # lint-amnesty, pylint: disable=test-inherits-tests
     """

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -38,6 +38,7 @@ from markupsafe import escape
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, UsageKey
 from openedx_filters.learning.filters import CourseAboutRenderStarted
+from organizations.api import get_course_organization
 from pytz import UTC
 from requests.exceptions import ConnectionError, Timeout  # pylint: disable=redefined-builtin
 from rest_framework import status
@@ -1784,9 +1785,11 @@ class PublicVideoXBlockView(BasePublicVideoXBlockView):
         })
         course_about_page_url, enroll_url = self.get_public_video_cta_button_urls(course)
         social_sharing_metadata = self.get_social_sharing_metadata(course, video_block)
+        org_logo = self.get_organization_logo_from_course(course)
         context = {
             'fragment': fragment,
             'course': course,
+            'org_logo': org_logo,
             'social_sharing_metadata': social_sharing_metadata,
             'learn_more_url': course_about_page_url,
             'enroll_url': enroll_url,
@@ -1797,6 +1800,16 @@ class PublicVideoXBlockView(BasePublicVideoXBlockView):
             'is_mobile_app': False,
         }
         return 'public_video.html', context
+    
+    def get_organization_logo_from_course(self, course):
+        """
+        Get organization logo for this course
+        """
+        course_org = get_course_organization(course.id)
+
+        if course_org and course_org['logo']:
+            return course_org['logo'].url
+        return None
 
     def get_social_sharing_metadata(self, course, video_block):
         """

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1800,7 +1800,7 @@ class PublicVideoXBlockView(BasePublicVideoXBlockView):
             'is_mobile_app': False,
         }
         return 'public_video.html', context
-    
+
     def get_organization_logo_from_course(self, course):
         """
         Get organization logo for this course

--- a/lms/static/sass/_experiments.scss
+++ b/lms/static/sass/_experiments.scss
@@ -516,8 +516,15 @@
 // AU 972 Social Video Sharing Page
 .public-video-share-cta {
   position: relative;
-  float: right;
   z-index: 1;
+
+  .org-logo{
+    height: 40px;
+  }
+
+  .nav-links{
+    float: right;
+  }
 
   .btn-learn-more{
     @extend %btn-shims;

--- a/lms/templates/public_video.html
+++ b/lms/templates/public_video.html
@@ -22,7 +22,9 @@ from django.utils.translation import gettext as _
 
 <%block name="body_extra">
 <nav class="public-video-share-cta" aria-label="Learn More">
-  <img class="org-logo" src="${org_logo}" alt="Organization Logo"/>
+  % if org_logo:
+    <img class="org-logo" src="${org_logo}" alt="Organization Logo"/>
+  % endif
   <div class="nav-links">
     <a class="btn-learn-more btn" href="${learn_more_url}">
       ${_("Learn more about this course")}

--- a/lms/templates/public_video.html
+++ b/lms/templates/public_video.html
@@ -21,8 +21,9 @@ from django.utils.translation import gettext as _
 </%block>
 
 <%block name="body_extra">
-<nav class="public-video-share-cta nav-links" aria-label="Learn More">
-  <div>
+<nav class="public-video-share-cta" aria-label="Learn More">
+  <img class="org-logo" src="${org_logo}" alt="Organization Logo"/>
+  <div class="nav-links">
     <a class="btn-learn-more btn" href="${learn_more_url}">
       ${_("Learn more about this course")}
     </a>


### PR DESCRIPTION
## Description

Adds organization logo to the public video page when present. 

JIRA: https://2u-internal.atlassian.net/browse/AU-1086

**Note**, awaiting design signoff:
- [ ] Design signoff: @gabew1984 

Sample screenshot (logo is the timey wimey box on the left between header and video)

<img width="714" alt="Screenshot 2023-03-13 at 16 04 44" src="https://user-images.githubusercontent.com/12944465/224837043-62740978-e0d7-45b2-a0a5-0f2a7c9e6a38.png">

**Testing**

To test locally:
1. Set up a video for public preview
2. Go to Django admin, Organizations, click edit, and add a logo for the authoring organization 
3. View public video page
