### PR TITLE
chore: bumping enterprise version 3.61.7

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -25,7 +25,7 @@ django-storages<1.9
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==3.61.6
+edx-enterprise==3.61.7
 
 # oauthlib>3.0.1 causes test failures ( also remove the django-oauth-toolkit constraint when this is fixed )
 oauthlib==3.0.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -469,7 +469,7 @@ edx-drf-extensions==8.4.1
     #   edx-when
     #   edxval
     #   learner-pathway-progress
-edx-enterprise==3.61.6
+edx-enterprise==3.61.7
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -595,7 +595,7 @@ edx-drf-extensions==8.4.1
     #   edx-when
     #   edxval
     #   learner-pathway-progress
-edx-enterprise==3.61.6
+edx-enterprise==3.61.7
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -574,7 +574,7 @@ edx-drf-extensions==8.4.1
     #   edx-when
     #   edxval
     #   learner-pathway-progress
-edx-enterprise==3.61.6
+edx-enterprise==3.61.7
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
https://github.com/openedx/edx-enterprise/pull/1727

<!--

🎉🎉 Olive has been released! 🎉🎉

🫒🫒
🫒🫒🫒🫒         🫒 Note: Olive is in support. Fixes you make on master may still
    🫒🫒🫒🫒     be needed on Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

bumping enterprise package version to 3.61.7

