### PR TITLE
refactor: mfe_context response to serialize object keys to camelcase

### DIFF
--- a/openedx/core/djangoapps/user_authn/api/tests/test_serializers.py
+++ b/openedx/core/djangoapps/user_authn/api/tests/test_serializers.py
@@ -1,0 +1,137 @@
+"""Tests for serializers for the MFE Context"""
+
+from django.test import TestCase
+
+from openedx.core.djangoapps.user_authn.serializers import MFEContextSerializer
+
+
+class TestMFEContextSerializer(TestCase):
+    """
+    High-level unit tests for MFEContextSerializer
+    """
+
+    @staticmethod
+    def get_mock_mfe_context_data():
+        """
+        Helper function to generate mock data for the MFE Context API view.
+        """
+
+        mock_context_data = {
+            'context_data': {
+                'currentProvider': 'edX',
+                'platformName': 'edX',
+                'providers': [
+                    {
+                        'id': 'oa2-facebook',
+                        'name': 'Facebook',
+                        'iconClass': 'fa-facebook',
+                        'iconImage': None,
+                        'skipHintedLogin': False,
+                        'skipRegistrationForm': False,
+                        'loginUrl': 'https://facebook.com/login',
+                        'registerUrl': 'https://facebook.com/register'
+                    },
+                    {
+                        'id': 'oa2-google-oauth2',
+                        'name': 'Google',
+                        'iconClass': 'fa-google-plus',
+                        'iconImage': None,
+                        'skipHintedLogin': False,
+                        'skipRegistrationForm': False,
+                        'loginUrl': 'https://google.com/login',
+                        'registerUrl': 'https://google.com/register'
+                    }
+                ],
+                'secondaryProviders': [],
+                'finishAuthUrl': 'https://edx.com/auth/finish',
+                'errorMessage': None,
+                'registerFormSubmitButtonText': 'Create Account',
+                'autoSubmitRegForm': False,
+                'syncLearnerProfileData': False,
+                'countryCode': '',
+                'pipeline_user_details': {
+                    'username': 'test123',
+                    'email': 'test123@edx.com',
+                    'fullname': 'Test Test',
+                    'first_name': 'Test',
+                    'last_name': 'Test'
+                }
+            },
+            'registration_fields': {},
+            'optional_fields': {
+                'extended_profile': []
+            }
+        }
+
+        return mock_context_data
+
+    @staticmethod
+    def get_expected_data():
+        """
+        Helper function to generate expected data for the MFE Context API view serializer.
+        """
+
+        expected_data = {
+            'contextData': {
+                'currentProvider': 'edX',
+                'platformName': 'edX',
+                'providers': [
+                    {
+                        'id': 'oa2-facebook',
+                        'name': 'Facebook',
+                        'iconClass': 'fa-facebook',
+                        'iconImage': None,
+                        'skipHintedLogin': False,
+                        'skipRegistrationForm': False,
+                        'loginUrl': 'https://facebook.com/login',
+                        'registerUrl': 'https://facebook.com/register'
+                    },
+                    {
+                        'id': 'oa2-google-oauth2',
+                        'name': 'Google',
+                        'iconClass': 'fa-google-plus',
+                        'iconImage': None,
+                        'skipHintedLogin': False,
+                        'skipRegistrationForm': False,
+                        'loginUrl': 'https://google.com/login',
+                        'registerUrl': 'https://google.com/register'
+                    }
+                ],
+                'secondaryProviders': [],
+                'finishAuthUrl': 'https://edx.com/auth/finish',
+                'errorMessage': None,
+                'registerFormSubmitButtonText': 'Create Account',
+                'autoSubmitRegForm': False,
+                'syncLearnerProfileData': False,
+                'countryCode': '',
+                'pipelineUserDetails': {
+                    'username': 'test123',
+                    'email': 'test123@edx.com',
+                    'name': 'Test Test',
+                    'firstName': 'Test',
+                    'lastName': 'Test'
+                }
+            },
+            'registrationFields': {},
+            'optionalFields': {
+                'extended_profile': []
+            }
+        }
+
+        return expected_data
+
+    def test_mfe_context_serializer(self):
+        """
+        Test MFEContextSerializer with mock data that serializes data correctly
+        """
+
+        mfe_context_data = self.get_mock_mfe_context_data()
+        expected_data = self.get_expected_data()
+        output_data = MFEContextSerializer(
+            mfe_context_data
+        ).data
+
+        self.assertDictEqual(
+            output_data,
+            expected_data
+        )

--- a/openedx/core/djangoapps/user_authn/api/views.py
+++ b/openedx/core/djangoapps/user_authn/api/views.py
@@ -15,6 +15,7 @@ from common.djangoapps.student.helpers import get_next_url_for_login_page
 from common.djangoapps.student.views import compose_and_send_activation_email
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_authn.api.helper import RegistrationFieldsContext
+from openedx.core.djangoapps.user_authn.serializers import MFEContextSerializer
 from openedx.core.djangoapps.user_authn.views.utils import get_mfe_context
 
 
@@ -65,6 +66,7 @@ class MFEContextView(APIView):
             context['registration_fields'].update({
                 'fields': registration_fields,
             })
+
             optional_fields = RegistrationFieldsContext('optional').get_fields()
             if optional_fields:
                 context['optional_fields'].update({
@@ -74,7 +76,9 @@ class MFEContextView(APIView):
 
         return Response(
             status=status.HTTP_200_OK,
-            data=context
+            data=MFEContextSerializer(
+                context
+            ).data
         )
 
 

--- a/openedx/core/djangoapps/user_authn/serializers.py
+++ b/openedx/core/djangoapps/user_authn/serializers.py
@@ -1,0 +1,77 @@
+"""
+MFE Context API Serializers
+"""
+
+from rest_framework import serializers
+
+
+class ProvidersSerializer(serializers.Serializer):
+    """
+    Providers Serializers
+    """
+
+    id = serializers.CharField(allow_null=True)
+    name = serializers.CharField(allow_null=True)
+    iconClass = serializers.CharField(allow_null=True)
+    iconImage = serializers.CharField(allow_null=True)
+    skipHintedLogin = serializers.BooleanField(default=False)
+    skipRegistrationForm = serializers.BooleanField(default=False)
+    loginUrl = serializers.CharField(allow_null=True)
+    registerUrl = serializers.CharField(allow_null=True)
+
+
+class PipelineUserDetailsSerializer(serializers.Serializer):
+    """
+    Pipeline User Details Serializers
+    """
+
+    username = serializers.CharField(allow_null=True)
+    email = serializers.CharField(allow_null=True)
+    name = serializers.CharField(source='fullname', allow_null=True)
+    firstName = serializers.CharField(source='first_name', allow_null=True)
+    lastName = serializers.CharField(source='last_name', allow_null=True)
+
+
+class ContextDataSerializer(serializers.Serializer):
+    """
+    Context Data Serializers
+    """
+
+    currentProvider = serializers.CharField(allow_null=True)
+    platformName = serializers.CharField(allow_null=True)
+    providers = serializers.ListField(
+        child=ProvidersSerializer(),
+        allow_null=True
+    )
+    secondaryProviders = serializers.ListField(
+        child=ProvidersSerializer(),
+        allow_null=True
+    )
+    finishAuthUrl = serializers.CharField(allow_null=True)
+    errorMessage = serializers.CharField(allow_null=True)
+    registerFormSubmitButtonText = serializers.CharField(allow_null=True)
+    autoSubmitRegForm = serializers.BooleanField(default=False)
+    syncLearnerProfileData = serializers.BooleanField(default=False)
+    countryCode = serializers.CharField(allow_null=True)
+    pipelineUserDetails = PipelineUserDetailsSerializer(source='pipeline_user_details', allow_null=True)
+
+
+class MFEContextSerializer(serializers.Serializer):
+    """
+    Serializer class to convert the keys of MFE Context Response dict object to camelCase format.
+    """
+
+    contextData = ContextDataSerializer(
+        source='context_data',
+        default={}
+    )
+    registrationFields = serializers.DictField(
+        source='registration_fields',
+        default={}
+    )
+    optionalFields = serializers.DictField(
+        source='optional_fields',
+        default={
+            'extended_profile': []
+        }
+    )


### PR DESCRIPTION
This pull request modifies the serialization of the back-end response by converting the keys of objects to camelCase. By making this change, we can avoid the need to convert the keys to camelCase on the front-end and ensures that all related unit tests have been updated accordingly. 
In order to prevent compatibility issues, it is necessary to remove any front-end code that converts keys from snake_case to camelCase format where it is required.

Ticket: [VAN-1311](https://2u-internal.atlassian.net/browse/VAN-1311)