### PR TITLE
refactor: Resume-able Apple migration mgmt cmds

### DIFF
--- a/common/djangoapps/third_party_auth/management/commands/generate_and_store_apple_transfer_ids.py
+++ b/common/djangoapps/third_party_auth/management/commands/generate_and_store_apple_transfer_ids.py
@@ -10,6 +10,7 @@ import time
 
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
+from django.db.models import Q
 import jwt
 from social_django.models import UserSocialAuth
 from social_django.utils import load_strategy
@@ -19,6 +20,12 @@ from common.djangoapps.third_party_auth.models import AppleMigrationUserIdInfo
 from common.djangoapps.third_party_auth.appleid import AppleIdAuth
 
 log = logging.getLogger(__name__)
+
+
+class AccessTokenExpiredException(Exception):
+    """
+    Raised when access token has been expired.
+    """
 
 
 class Command(BaseCommand):
@@ -78,6 +85,53 @@ class Command(BaseCommand):
         access_token = response.json().get('access_token')
         return access_token
 
+    def _get_token_and_secret(self):
+        """
+        Get access_token and client_secret
+        """
+        client_secret = self._generate_client_secret()
+        access_token = self._generate_access_token(client_secret)
+        return access_token, client_secret
+
+    def _update_token_and_secret(self):
+        self.access_token, self.client_secret = self._get_token_and_secret()  # pylint: disable=W0201
+
+    def _fetch_transfer_id(self, apple_id, target_team_id):
+        """
+        Fetch Transfer ID for a given Apple ID from Apple API.
+        """
+        migration_url = "https://appleid.apple.com/auth/usermigrationinfo"
+        app_id = "org.edx.mobile"
+        headers = {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Host": "appleid.apple.com",
+            "Authorization": "Bearer " + self.access_token
+        }
+        payload = {
+            "target": target_team_id,
+            "client_id": app_id,
+            "client_secret": self.client_secret,
+            "sub": apple_id
+        }
+        response = requests.post(migration_url, data=payload, headers=headers)
+        if response.status_code == 400:
+            raise AccessTokenExpiredException
+
+        return response.json().get('transfer_sub')
+
+    def _get_transfer_id_for_apple_id(self, apple_id, target_team_id):
+        """
+        Given an Apple ID from the old transferring team,
+        create and return its respective transfer id.
+        """
+        try:
+            transfer_id = self._fetch_transfer_id(apple_id, target_team_id)
+        except AccessTokenExpiredException:
+            log.info('Access token expired. Re-creating access token.')
+            self._update_token_and_secret()
+            transfer_id = self._fetch_transfer_id(apple_id, target_team_id)
+        return transfer_id
+
     def add_arguments(self, parser):
         parser.add_argument('target_team_id', help='Team ID to which the app is to be migrated to.')
 
@@ -85,30 +139,16 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         target_team_id = options['target_team_id']
 
-        migration_url = "https://appleid.apple.com/auth/usermigrationinfo"
-        app_id = "org.edx.mobile"
-
-        client_secret = self._generate_client_secret()
-        access_token = self._generate_access_token(client_secret)
-        if not access_token:
+        self._update_token_and_secret()
+        if not self.access_token:
             raise CommandError('Failed to create access token.')
 
-        headers = {
-            "Content-Type": "application/x-www-form-urlencoded",
-            "Host": "appleid.apple.com",
-            "Authorization": "Bearer " + access_token
-        }
-        payload = {
-            "target": target_team_id,
-            "client_id": app_id,
-            "client_secret": client_secret
-        }
-
-        apple_ids = UserSocialAuth.objects.filter(provider=AppleIdAuth.name).values_list('uid', flat=True)
+        already_processed_apple_ids = AppleMigrationUserIdInfo.objects.all().exclude(
+            Q(transfer_id__isnull=True) | Q(transfer_id="")).values_list('old_apple_id', flat=True)
+        apple_ids = UserSocialAuth.objects.filter(provider=AppleIdAuth.name).exclude(
+            uid__in=already_processed_apple_ids).values_list('uid', flat=True)
         for apple_id in apple_ids:
-            payload['sub'] = apple_id
-            response = requests.post(migration_url, data=payload, headers=headers)
-            transfer_id = response.json().get('transfer_sub')
+            transfer_id = self._get_transfer_id_for_apple_id(apple_id, target_team_id)
             if transfer_id:
                 apple_user_id_info, _ = AppleMigrationUserIdInfo.objects.get_or_create(old_apple_id=apple_id)
                 apple_user_id_info.transfer_id = transfer_id


### PR DESCRIPTION
<!--

🎉🎉 Olive has been released! 🎉🎉

🫒🫒
🫒🫒🫒🫒         🫒 Note: Olive is in support. Fixes you make on master may still
    🫒🫒🫒🫒     be needed on Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description
This PR is in continuation to https://github.com/openedx/edx-platform/pull/31861.
Since the management commands (`generate_and_store_apple_transfer_ids`, `generate_and_store_new_apple_ids`) to generate Apple identifiers include network requests to Apple API, the command can take quite a while to complete.
This PR enables the management command to:

1. Refresh access token once it expires
2. Make the command resume-able i.e. if it ends due to edxapp worker life, and run again, the command will resume from where it left off.

## Supporting information

Link to Jira tickets:

- https://2u-internal.atlassian.net/browse/LEARNER-8790
- https://2u-internal.atlassian.net/browse/LEARNER-9275

## Deadline

20-22 March 2023
