### PR TITLE
lk/remove resume last course

### DIFF
--- a/lms/templates/header/user_dropdown.html
+++ b/lms/templates/header/user_dropdown.html
@@ -11,7 +11,6 @@ from django.utils.translation import gettext as _
 
 from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_urls_for_user
 from openedx.core.djangoapps.user_api.accounts.toggles import should_redirect_to_order_history_microfrontend
-from openedx.core.djangoapps.user_api.accounts.utils import retrieve_last_sitewide_block_completed
 from openedx.features.enterprise_support.utils import get_enterprise_learner_generic_name, get_enterprise_learner_portal
 %>
 
@@ -20,7 +19,6 @@ from openedx.features.enterprise_support.utils import get_enterprise_learner_gen
 self.real_user = getattr(user, 'real_user', user)
 profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
 username = self.real_user.username
-resume_block = retrieve_last_sitewide_block_completed(self.real_user)
 displayname = get_enterprise_learner_generic_name(request) or username
 enterprise_customer_portal = get_enterprise_learner_portal(request)
 ## Enterprises with the learner portal enabled should not show order history, as it does
@@ -40,9 +38,6 @@ should_show_order_history = should_redirect_to_order_history_microfrontend() and
         <span class="fa fa-caret-down" aria-hidden="true"></span>
     </div>
     <div class="dropdown-user-menu hidden" aria-label=${_("More Options")} role="menu" id="user-menu" tabindex="-1">
-        % if resume_block:
-            <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${resume_block}" role="menuitem">${_("Resume your last course")}</a></div>
-        % endif
         % if not enterprise_customer_portal:
             <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('dashboard')}" role="menuitem">${_("Dashboard")}</a></div>
         % else:

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_utils.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_utils.py
@@ -5,9 +5,7 @@ import ddt
 from completion import models
 from completion.test_utils import CompletionWaffleTestMixin
 from django.test import TestCase
-from django.test.utils import override_settings
 
-from openedx.core.djangoapps.user_api.accounts.utils import retrieve_last_sitewide_block_completed
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import UserFactory
@@ -105,26 +103,3 @@ class CompletionUtilsTestCase(SharedModuleStoreTestCase, CompletionWaffleTestMix
                 block_key=block.location,
                 completion=1.0
             )
-
-    @override_settings(LMS_ROOT_URL='test_url:9999')
-    def test_retrieve_last_sitewide_block_completed(self):
-        """
-        Test that the method returns a URL for the "last completed" block
-        when sending a user object
-        """
-        block_url = retrieve_last_sitewide_block_completed(
-            self.engaged_user
-        )
-        empty_block_url = retrieve_last_sitewide_block_completed(
-            self.cruft_user
-        )
-        assert block_url ==\
-               'test_url:9999/courses/course-v1:{org}+{course}+{run}/jump_to/'\
-               'block-v1:{org}+{course}+{run}+type@vertical+block@{vertical_id}'.format(
-                   org=self.course.location.course_key.org,
-                   course=self.course.location.course_key.course,
-                   run=self.course.location.course_key.run,
-                   vertical_id=self.vertical2.location.block_id
-               )
-
-        assert empty_block_url is None

--- a/openedx/core/djangoapps/user_authn/cookies.py
+++ b/openedx/core/djangoapps/user_authn/cookies.py
@@ -20,7 +20,6 @@ from common.djangoapps.student.models import UserProfile
 from openedx.core.djangoapps.oauth_dispatch.adapters import DOTAdapter
 from openedx.core.djangoapps.oauth_dispatch.api import create_dot_access_token
 from openedx.core.djangoapps.oauth_dispatch.jwt import create_jwt_from_token
-from openedx.core.djangoapps.user_api.accounts.utils import retrieve_last_sitewide_block_completed
 from openedx.core.djangoapps.user_authn.exceptions import AuthFailedError
 from common.djangoapps.util.json_request import JsonResponse
 from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_urls_for_user
@@ -190,8 +189,6 @@ def _set_deprecated_user_info_cookie(response, request, user, cookie_settings):
         "username": "test-user",
         "header_urls": {
             "account_settings": "https://example.com/account/settings",
-            "resume_block":
-                "https://example.com//courses/org.0/course_0/Run_0/jump_to/i4x://org.0/course_0/vertical/vertical_4"
             "learner_profile": "https://example.com/u/test-user",
             "logout": "https://example.com/logout"
         }
@@ -248,19 +245,6 @@ def _get_user_info_cookie_data(request, user):
         header_urls['learner_profile'] = reverse('learner_profile', kwargs={'username': user.username})
     except NoReverseMatch:
         pass
-
-    # Add 'resume course' last completed block
-    try:
-        block_url = retrieve_last_sitewide_block_completed(user)
-        if block_url:
-            header_urls['resume_block'] = block_url
-    except User.DoesNotExist:
-        pass
-    except Exception as err:  # pylint: disable=broad-except
-        log.exception(
-            '[PROD-2877] Error retrieving resume block for user %s with raw error %r',
-            user.username, err,
-        )
 
     header_urls = _convert_to_absolute_uris(request, header_urls)
 

--- a/openedx/core/djangoapps/user_authn/cookies.py
+++ b/openedx/core/djangoapps/user_authn/cookies.py
@@ -8,7 +8,6 @@ import logging
 import time
 
 from django.conf import settings
-from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.dispatch import Signal
 from django.urls import NoReverseMatch, reverse
 from django.utils.http import http_date, parse_http_date

--- a/openedx/core/djangoapps/user_authn/tests/test_cookies.py
+++ b/openedx/core/djangoapps/user_authn/tests/test_cookies.py
@@ -11,7 +11,6 @@ from django.urls import reverse
 from edx_rest_framework_extensions.auth.jwt.decoder import jwt_decode_handler
 from edx_rest_framework_extensions.auth.jwt.middleware import JwtAuthCookieMiddleware
 
-from openedx.core.djangoapps.user_api.accounts.utils import retrieve_last_sitewide_block_completed
 from openedx.core.djangoapps.user_authn import cookies as cookies_api
 from openedx.core.djangoapps.user_authn.tests.utils import setup_login_oauth_client
 from openedx.core.djangolib.testing.utils import skip_unless_lms
@@ -60,9 +59,6 @@ class CookieTests(TestCase):
             'account_settings': reverse('account_settings'),
             'learner_profile': reverse('learner_profile', kwargs={'username': self.user.username}),
         }
-        block_url = retrieve_last_sitewide_block_completed(self.user)
-        if block_url:
-            expected_header_urls['resume_block'] = block_url
 
         expected_header_urls = self._convert_to_absolute_uris(self.request, expected_header_urls)
 


### PR DESCRIPTION
TLDR; remove "Resume your last course" button

TICKET: https://2u-internal.atlassian.net/browse/AU-1098

## Description
- remove "Resume your last course" button

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
