### PR TITLE
fix: Allow download url in video component when MP4/WEBM format is available

### DIFF
--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -1129,6 +1129,22 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
         context = self.item_descriptor.render(STUDENT_VIEW).content
         assert "'download_video_link': None" in context
 
+    def test_get_html_non_hls_video_download(self):
+        """
+        Verify that `download_video_link` is available if a non HLS videos is available
+        """
+        video_xml = """
+        <video display_name="Video" download_video="true">
+            <source src="http://example.com/example.m3u8"/>
+            <source src="http://example.com/example.mp4"/>
+            <source src="http://example.com/example.webm"/>
+        </video>
+        """
+
+        self.initialize_block(data=video_xml)
+        context = self.item_descriptor.render(STUDENT_VIEW).content
+        assert "'download_video_link': 'http://example.com/example.mp4'" in context
+
     def test_html_student_public_view(self):
         """
         Test the student and public views

--- a/xmodule/video_block/video_block.py
+++ b/xmodule/video_block/video_block.py
@@ -357,11 +357,8 @@ class VideoBlock(
         # for it, we fall back on whatever we find in the VideoBlock.
         if not download_video_link and self.download_video:
             if self.html5_sources:
-                download_video_link = self.html5_sources[0]
-
-            # don't give the option to download HLS video urls
-            if download_video_link and download_video_link.endswith('.m3u8'):
-                download_video_link = None
+                # If there are multiple html5 sources, we use the first non HLS video urls
+                download_video_link = next((url for url in self.html5_sources if not url.endswith('.m3u8')), None)
 
         transcripts = self.get_transcripts_info()
         track_url, transcript_language, sorted_languages = self.get_transcripts_for_student(transcripts=transcripts)


### PR DESCRIPTION
## Description
When creating a new video component in Studio and specifying an HLS URL and MP4 URL along with setting Video Download Allowed equal to True the download link for MP4 has to be shown.

For example, if we have set the URL as below and set Video Download to True,
![image](https://user-images.githubusercontent.com/1616291/226628136-bad8e6bd-1443-4cf3-97b9-42265de36fd0.png)

Then Before:
![image](https://user-images.githubusercontent.com/1616291/226627774-e6569731-deec-41c3-8a11-ba09f22134b9.png)

After:
![image](https://user-images.githubusercontent.com/1616291/226627887-10492688-58de-4ec4-bae8-5fa3e0ee570e.png)

## Supporting information
Resolves https://github.com/openedx/edx-platform/issues/31300

## Deadline
"None"

Private-ref: [BB-7249](https://tasks.opencraft.com/browse/BB-7249)