### PR TITLE
fix: video share page visual issues

### DIFF
--- a/lms/static/sass/_experiments.scss
+++ b/lms/static/sass/_experiments.scss
@@ -514,43 +514,51 @@
 }
 
 // AU 972 Social Video Sharing Page
-.public-video-share-cta {
-  position: relative;
-  z-index: 1;
+.public-video-page {
 
-  .org-logo{
-    height: 40px;
+  .tc-wrapper, div.video {
+    max-width: 60vw;
   }
 
-  .nav-links{
-    float: right;
-  }
+  .public-video-share-cta {
+    position: relative;
+    z-index: 1;
+    margin-top: 20px;
 
-  .btn-learn-more{
-    @extend %btn-shims;
-    color: #00262B;
-    background: #FFFFFF;
-    border-color: #F2F0EF;
-    &:hover,
-    &:active,
-    &:focus {
-      background: darken(#FFFFFF, 7%);
-      border-color: darken(#F2F0EF, 7%);
+    .org-logo{
+      height: 40px;
     }
-  }
 
-  .btn-enroll{
-    @extend %btn-shims;
-    color: #FFFFFF;
-    background: #D23228;
-    border-color: #D23228;
+    .nav-links{
+      float: right;
+    }
 
-    &:hover,
-    &:active,
-    &:focus {
-      color: darken(#FFFFFF, 7%);
-      background: darken(#D23228, 7%);
-      border-color: darken(#D23228, 7%);
+    .btn-learn-more{
+      @extend %btn-shims;
+      color: #00262B;
+      background: #FFFFFF;
+      border-color: #F2F0EF;
+      &:hover,
+      &:active,
+      &:focus {
+        background: darken(#FFFFFF, 7%);
+        border-color: darken(#F2F0EF, 7%);
+      }
+    }
+
+    .btn-enroll{
+      @extend %btn-shims;
+      color: #FFFFFF;
+      background: #D23228;
+      border-color: #D23228;
+
+      &:hover,
+      &:active,
+      &:focus {
+        color: darken(#FFFFFF, 7%);
+        background: darken(#D23228, 7%);
+        border-color: darken(#D23228, 7%);
+      }
     }
   }
 }

--- a/lms/static/sass/_experiments.scss
+++ b/lms/static/sass/_experiments.scss
@@ -516,8 +516,9 @@
 // AU 972 Social Video Sharing Page
 .public-video-page {
 
-  .tc-wrapper, div.video {
-    max-width: 60vw;
+  .tc-wrapper{
+    margin: auto;
+    width: \min(90vw, 70vh * 1.6739);
   }
 
   .public-video-share-cta {
@@ -536,7 +537,7 @@
     .btn-learn-more{
       @extend %btn-shims;
       color: #00262B;
-      background: #FFFFFF;
+      background: #1c9e57;
       border-color: #F2F0EF;
       &:hover,
       &:active,

--- a/lms/static/sass/_experiments.scss
+++ b/lms/static/sass/_experiments.scss
@@ -537,7 +537,7 @@
     .btn-learn-more{
       @extend %btn-shims;
       color: #00262B;
-      background: #1c9e57;
+      background: #FFFFFF;
       border-color: #F2F0EF;
       &:hover,
       &:active,

--- a/lms/static/sass/_experiments.scss
+++ b/lms/static/sass/_experiments.scss
@@ -518,6 +518,11 @@
 
   .tc-wrapper{
     margin: auto;
+    // The edX video player only sets size by width. We want to make sure the video is fully on the page
+    // on-load, so we need to control height via width. This sets the width to either 90% of the horizontal
+    // space (when that's the limiter) or 70% of the vertical space times an approximate aspect ratio.
+    // Assuming the aspect ratio is even close to constistent, this sets the width to what it would need
+    // to be to make the height 70% of the vertical space on the screen
     width: \min(90vw, 70vh * 1.6739);
   }
 

--- a/lms/templates/public_video.html
+++ b/lms/templates/public_video.html
@@ -20,6 +20,8 @@ from django.utils.translation import gettext as _
 <meta data-rh="true" name="twitter:player:height" content="720">
 </%block>
 
+<%block name="bodyclass">view-in-course view-courseware courseware ${course.css_class or ''} public-video-page</%block>
+
 <%block name="body_extra">
 <nav class="public-video-share-cta" aria-label="Learn More">
   % if org_logo:


### PR DESCRIPTION
- add margin above CTA buttons
- add max size for video so it is less likely to extend vertically off of the screen

The second point deserves additional discussion. An obvious solution to this is to simply set the max-height property of the video to some percentage of the viewport with `vh`. That does not work. The resizing logic for the edX video player only resizes video based on the width of its parent container. I didn't want to risk making any changes to the video player. 

Due to this, anything I did had to be controlled by the width property.
What I eventually did here was set the video width to `width: \min(90vw, 70vh * 1.6739);`
The first parameter to min is 90vw, or 90% of the width of the viewport. 
The second parameter is 70vh (70% of the viewport height) times 1.6739. This is an estimate I did of the aspect ratio of my demo video. I imagine most videos will be approximately similar, and due to the fact that this is simply setting width and not the full proportion, any discrepancy won't really have any effect. Basically, this allows me to convert between height and width by assuming an approximate aspect ratio. 

Going back to the min, what this is doing is saying that if our limiting dimension is width, have the width of the video be 90% of the visual width of the page (shrink to fit). If the limiting dimension is height, set the width to whatever width will limit the video to approximately 70% of the vertical height of the viewport. This should result in a reactive video size both vertically and horizontally just by limiting the width.


