### PR TITLE
feat: Remove edX branding on account deletion

### DIFF
--- a/lms/static/js/student_account/components/StudentAccountDeletion.jsx
+++ b/lms/static/js/student_account/components/StudentAccountDeletion.jsx
@@ -38,13 +38,7 @@ export class StudentAccountDeletion extends React.Component {
 
     render() {
         const { deletionModalOpen, socialAuthConnected, isActive } = this.state;
-        const loseAccessText = StringUtils.interpolate(
-            gettext('You may also lose access to verified certificates and other program credentials like MicroMasters certificates. If you want to make a copy of these for your records before proceeding with deletion, follow the instructions for {htmlStart}printing or downloading a certificate{htmlEnd}.'),
-            {
-                htmlStart: '<a href="https://edx.readthedocs.io/projects/open-edx-learner-guide/en/latest/OpenSFD_certificates.html#print-a-web-certificate" rel="noopener" target="_blank">',
-                htmlEnd: '</a>',
-            },
-        );
+        const loseAccessText = gettext('You may also lose access to verified certificates and other program credentials. You can make a copy of these for your records before proceeding with deletion.')
 
         const showError = socialAuthConnected || !isActive;
 

--- a/lms/static/js/student_account/components/StudentAccountDeletion.jsx
+++ b/lms/static/js/student_account/components/StudentAccountDeletion.jsx
@@ -107,9 +107,7 @@ export class StudentAccountDeletion extends React.Component {
                     <span>{bodyDeletion} </span>
                     <span>{bodyDeletion2}</span>
                 </p>
-                <p className="account-settings-header-subtitle">
-                    <span>{loseAccessText}</span>
-                </p>
+                <p className="account-settings-header-subtitle">{loseAccessText}</p>
                 <p
                     className="account-settings-header-subtitle-warning"
                     // eslint-disable-next-line react/no-danger

--- a/lms/static/js/student_account/components/StudentAccountDeletion.jsx
+++ b/lms/static/js/student_account/components/StudentAccountDeletion.jsx
@@ -107,11 +107,9 @@ export class StudentAccountDeletion extends React.Component {
                     <span>{bodyDeletion} </span>
                     <span>{bodyDeletion2}</span>
                 </p>
-                <p
-                    className="account-settings-header-subtitle"
-                    // eslint-disable-next-line react/no-danger
-                    dangerouslySetInnerHTML={{ __html: loseAccessText }}
-                />
+                <p className="account-settings-header-subtitle">
+                    <span>{loseAccessText}</span>
+                </p>
                 <p
                     className="account-settings-header-subtitle-warning"
                     // eslint-disable-next-line react/no-danger

--- a/lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
+++ b/lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
@@ -162,7 +162,9 @@ class StudentAccountDeletionConfirmationModal extends React.Component {
                                                 <span>{bodyDeletion2}</span>
                                             </p>
                                             {/* eslint-disable-next-line react/no-danger */}
-                                            <p dangerouslySetInnerHTML={{ __html: loseAccessText }} />
+                                            <p>
+                                                <span>{loseAccessText}</span>
+                                            </p>
                                         </div>
                                     </div>
                                 )}

--- a/lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
+++ b/lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
@@ -162,9 +162,7 @@ class StudentAccountDeletionConfirmationModal extends React.Component {
                                                 <span>{bodyDeletion2}</span>
                                             </p>
                                             {/* eslint-disable-next-line react/no-danger */}
-                                            <p>
-                                                <span>{loseAccessText}</span>
-                                            </p>
+                                            <p>{loseAccessText}</p>
                                         </div>
                                     </div>
                                 )}

--- a/lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
+++ b/lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
@@ -94,13 +94,7 @@ class StudentAccountDeletionConfirmationModal extends React.Component {
             validationMessage,
         } = this.state;
         const { onClose } = this.props;
-        const loseAccessText = StringUtils.interpolate(
-            gettext('You may also lose access to verified certificates and other program credentials like MicroMasters certificates. If you want to make a copy of these for your records before proceeding with deletion, follow the instructions for {htmlStart}printing or downloading a certificate{htmlEnd}.'),
-            {
-                htmlStart: '<a href="https://edx.readthedocs.io/projects/open-edx-learner-guide/en/latest/OpenSFD_certificates.html#print-a-web-certificate" rel="noopener" target="_blank">',
-                htmlEnd: '</a>',
-            },
-        );
+        const loseAccessText = gettext('You may also lose access to verified certificates and other program credentials. You can make a copy of these for your records before proceeding with deletion.')
 
         const noteDeletion = StringUtils.interpolate(
             gettext('You have selected “Delete my account.” Deletion of your account and personal data is permanent and cannot be undone. {platformName} will not be able to recover your account or the data that is deleted.'),


### PR DESCRIPTION
<!--

🎉🎉 Olive has been released! 🎉🎉

🫒🫒
🫒🫒🫒🫒         🫒 Note: Olive is in support. Fixes you make on master may still
    🫒🫒🫒🫒     be needed on Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This PR makes the legacy account page look more like the account MFE removing specific edX hardcoded references. 

Before this change, in the legacy page there were references to:
1. Micromasters references -> not present in the Account MFE
2. edX support specific link for printing/downloading certificates -> not present in the Account MFE
3. MIT Open Learning / Wharton ... -> not present in the Account MFE. 
4. edX support specific link for changing email, name or password -> present in the Account MFE

![image](https://user-images.githubusercontent.com/64440265/226956414-f4d7495e-4ef9-45f7-aee4-acec08f6c29f.png)

Now, after:
![acc-deletion-after](https://user-images.githubusercontent.com/64440265/226957177-7bc80661-be3e-46f5-b547-b0de8534ae08.png)

1. Micromasters ->  removed references since it wasn't part of the account MFE deletion text
2. edX support specific link for printing/downloading certificates -> removed references since it wasn't part of the account MFE deletion text
3. MIT Open Learning / Wharton ... -> this can be changed in the site's configurations:
![image](https://user-images.githubusercontent.com/64440265/226957544-1215c2e8-bf20-4d3c-aba0-48b207d8c6b5.png)
That's the easier way to remove it for now.

4. edX support specific link for changing email, name or password -> this is still part of the MFE so we didn't remove it. Now, what can we do about those? We could make them configurable and default to the edX ones or remove the change email/password instead suggestion. 🤔 

## Supporting information

This is how the account MFE deletion section looks like:
![image](https://user-images.githubusercontent.com/64440265/226959897-ef378db8-56b4-4ea0-ae8f-5038a0c7b257.png)


## Testing instructions

This was tested in a local environment generated with tutor-nightly.

1. Start the environment mounting edx-platform for development
2. Change edx-platform to this branch.
3. Build assets: `openedx-assets build --env=dev`
4. Deactivate the account MFE so the legacy page is used instead, deactivating the waffle flag: `account.redirect_to_microfrontend`
5. Go to the account page and try to delete your account.

## Deadline
None

## Other information
Concerns: there are still some references to edX support pages, even in the account MFE.
