### PR TITLE
docs: add adr for hybrid approach

### DIFF
--- a/cms/djangoapps/contentstore/docs/decisions/0003-hybrid-approach-for-public-apis.rst
+++ b/cms/djangoapps/contentstore/docs/decisions/0003-hybrid-approach-for-public-apis.rst
@@ -11,15 +11,15 @@ and update course content via an external application. The plan for this is outl
 .. _`Spec Demo`: https://openedx.atlassian.net/wiki/spaces/COMM/pages/3696066564/Spec+Memo+API-Based+Management+of+edX+Course+Blocks+Outlines+and+Settings+MVP.
 
 Rather than restricting a course to only ever be editable either via API or manually,
-we will offer a hybrid solution where both is possible.
+we will offer a hybrid solution where both are possible.
 
 A hybrid solution faces two challenges:
 
-- "out-of-date write conflicts": how do we handle a situation where an API user updates course content,
-  yet there is an implicit conflict because a manual user edited the course recently and now the API user's local files are outdated?
+- "out-of-date write conflicts": how do we handle a situation where an API user where an API user attempts to update
+  a course using a stale course snapshot as a starting point?
   This creates a danger of overwriting another person's changes.
-- "dirty writes": how do we handle a situation where there are multiple asynchronous import or update operations
-  at once that may be in conflict with each other?
+- "dirty writes": how do we handle a situation where there are multiple concurrent, asynchronous import or update 
+  operations that may be in conflict with each other?
 
 Some considerations that come into play when picking an approach are:
 
@@ -28,7 +28,8 @@ Some considerations that come into play when picking an approach are:
    whether other users have made changes.
 
 We analyzed a range of the most viable options to handle these challenges.
-We mainly rejected two alternatives, although there are many options:
+We ruled out any we found to be much too risky or much too hard to implement due to a high amount of complexity.
+That left us with three alternatives, of which we rejected the following two:
 
 - adding a toggle that lets users switch the course between enforcing only manual editing
   and only API editing. This toggle needs to allow for running import operations to finish before switching, thus making it complex.
@@ -37,16 +38,26 @@ We mainly rejected two alternatives, although there are many options:
 
 We rejected these challenges on the basis that they were complex to implement and make us play "Traffic cop".
 
-However, future iterations may require us to be more strict and employ further safeguards, and it remains a possibility to circle
+However, future iterations on the API may require us to be more strict and employ further safeguards, and it remains a possibility to circle
 back and add one of these options on top of what we do now initially.
+
+Another complication is that our planned solution is limited in terms of rollback capabilities: xblocks are internally versioned
+and we can use this internal versioning to offer rollback tools, and this extends to rolling back changes to their tree structure
+(for example adding subtrees, reordering child xblocks, etc). However, other files that are imported, like static assets and some course-level
+configuration, do not have this versioning capabilities. According to our planned architecture around these APIs, we will not support versioning
+and rollback on our side. Instead, we expect users to handle this problem themselves by having backups and version control for these files independently.
+
+We also do not offer any draft capabilities for the API; changes will be immediately published.
 
 Decision
 --------
 
 - We consider the user responsible for avoiding, resolving, or fixing conflicts.
-- Courses with a registered API user are intended to be edited by one user at a time. This will be included in the API documentation.
-- We leave open the option to enforce this restriction to one concurrent user in the future.
-- We provide logs about past changes to the user in order for them to know whether other users have made changes.
+- Courses that are operated in this hybrid fashion - that is, they are being edited not just via studio, but also via API -
+  are intended to be edited by one user at a time. In the API documentation, we will ask users to follow this principle.
+- While we don't plan to enforce this prohibition of concurrent users today, leaving it as a self-policing responsibility users bear,
+  we leave open the option of doing so in the future..
+- We provide logs about past changes to the user to alert them of other users' changes.
 - We provide sufficient rollback tools to fix any problems with xblocks / xblock structure the users may have caused.
 - We do not provide any versioning, rolling back, or logging for anything that is not an xblock (static assets,
   course-level policies and settings, etc). We recommend that the users employ version control for this on their side.
@@ -54,14 +65,14 @@ Decision
 Consequences
 ------------
 
-Users may create conflicts or problems if they do not follow our instruction to work one at a time and coordinate.
-We can only give them the tools to rollback changes and modifications to xblocks and the xblock structure, so there is an increased
-risk of them causing problems with course-level settings or assets. If they do not version control on their own side, they need
-to find other solutions to fix this.
+The decision not to enforce a limit of one client at a time means that users may run into conflicts or problems if they
+do not follow our instruction to work one at a time and coordinate.
+Because no rollback capabilities are offered by the API for course assets, the burden of maintaining assets under external
+source control falls on the user; a user's failure to do so may lead to irrevocable content loss on course corruption.
 
-This can be mitigated by adding more safety mechanisms later on, the most straightforward action being to
-actually enforce this one-concurrent-user policy.
+With this decision, we make clear where the responsibility lies for dealing with problems. We do not have to
+build a complex mechanism to avoid or resolve conflicts ("playing traffic cop");
+and consequently, we do not need to act on any errors that happen when this mechanism isn't perfect.
 
-It is clear where the responsibility lies for dealing with problems. Choosing this option, we do not have to
-build a complex mechanism to avoid or resolve conflicts ("playing traffic cop")
-and then needing to act on any errors that happen when this mechanism isn't perfect.
+However, there may very well arise the needs to add safeguards in the future. The most straightforward and simple action would be to
+actually enforce this one-concurrent-user policy and not allowing more than one user to edit concurrently.

--- a/cms/djangoapps/contentstore/docs/decisions/0003-hybrid-approach-for-public-apis.rst
+++ b/cms/djangoapps/contentstore/docs/decisions/0003-hybrid-approach-for-public-apis.rst
@@ -21,22 +21,24 @@ A hybrid solution faces two challenges:
 - "dirty writes": how do we handle a situation where there are multiple asynchronous import or update operations
   at once that may be in conflict with each other?
 
-We analyzed a number of options to handle these challenges. As they may become relevant later on,
-you can find them in this `decision-tree diagram`_.
-
-.. _`decision-tree diagram`: insert link
-
-Some of the rejected options involved a toggle that lets users switch the course between enforcing only manual editing
-and only API editing. This toggle needs to allow for running import operations to finish before switching. There is an
-example state diagram here_.
-
-.. _here: insert link
-
 Some considerations that come into play when picking an approach are:
 
-1. Having the system reliably play traffic cop isn't simple, principally because of our reliance on slow-running async tasks
+1. Having the system reliably play traffic cop isn't simple, principally because of our reliance on slow-running async tasks.
 2. Even if we ignore the problem of playing traffic cop, embracing hybrid editing means clients need some way to know
-   whether other users have made changes
+   whether other users have made changes.
+
+We analyzed a range of the most viable options to handle these challenges.
+We mainly rejected two alternatives, although there are many options:
+
+- adding a toggle that lets users switch the course between enforcing only manual editing
+  and only API editing. This toggle needs to allow for running import operations to finish before switching, thus making it complex.
+- using a form of optimistic concurrency control where we expect different users and explicitly version each change, then forbid
+  any API operation unless the API operator provides a version identifier that is not out of date.
+
+We rejected these challenges on the basis that they were complex to implement and make us play "Traffic cop".
+
+However, future iterations may require us to be more strict and employ further safeguards, and it remains a possibility to circle
+back and add one of these options on top of what we do now initially.
 
 Decision
 --------
@@ -57,8 +59,9 @@ We can only give them the tools to rollback changes and modifications to xblocks
 risk of them causing problems with course-level settings or assets. If they do not version control on their own side, they need
 to find other solutions to fix this.
 
-This can be mitigated by adding more safety mechanisms, like actually enforcing this one-concurrent-user policy.
+This can be mitigated by adding more safety mechanisms later on, the most straightforward action being to
+actually enforce this one-concurrent-user policy.
 
 It is clear where the responsibility lies for dealing with problems. Choosing this option, we do not have to
 build a complex mechanism to avoid or resolve conflicts ("playing traffic cop")
-and then be at fault for any errors that happen because this mechanism isn't perfect.
+and then needing to act on any errors that happen when this mechanism isn't perfect.

--- a/cms/djangoapps/contentstore/docs/decisions/0003-hybrid-approach-for-public-apis.rst
+++ b/cms/djangoapps/contentstore/docs/decisions/0003-hybrid-approach-for-public-apis.rst
@@ -15,7 +15,7 @@ we will offer a hybrid solution where both are possible.
 
 A hybrid solution faces two challenges:
 
-- "out-of-date write conflicts": how do we handle a situation where an API user where an API user attempts to update
+- "out-of-date write conflicts": how do we handle a situation where an API user attempts to update
   a course using a stale course snapshot as a starting point?
   This creates a danger of overwriting another person's changes.
 - "dirty writes": how do we handle a situation where there are multiple concurrent, asynchronous import or update 
@@ -59,6 +59,9 @@ Decision
   we leave open the option of doing so in the future..
 - We provide logs about past changes to the user to alert them of other users' changes.
 - We provide sufficient rollback tools to fix any problems with xblocks / xblock structure the users may have caused.
+  Provided that modulestore versioning makes older versions of an XBlock available, we will provide a programmatic way to replace the current version
+  of an XBlock with an older version, referenced by version ID.
+  Our current goal is to offer this packaged as a "revert task" operation.
 - We do not provide any versioning, rolling back, or logging for anything that is not an xblock (static assets,
   course-level policies and settings, etc). We recommend that the users employ version control for this on their side.
 

--- a/cms/djangoapps/contentstore/docs/decisions/0003-hybrid-approach-for-public-apis.rst
+++ b/cms/djangoapps/contentstore/docs/decisions/0003-hybrid-approach-for-public-apis.rst
@@ -1,0 +1,64 @@
+0003: Hybrid approach for public course authoring APIs
+======================================================
+
+Context
+-------
+
+We are planning to offer public APIs via oauth that allow course authors to create
+and update course content via an external application. The plan for this is outlined in this
+`Spec Demo`_.
+
+.. _`Spec Demo`: https://openedx.atlassian.net/wiki/spaces/COMM/pages/3696066564/Spec+Memo+API-Based+Management+of+edX+Course+Blocks+Outlines+and+Settings+MVP.
+
+Rather than restricting a course to only ever be editable either via API or manually,
+we will offer a hybrid solution where both is possible.
+
+A hybrid solution faces two challenges:
+
+- "out-of-date write conflicts": how do we handle a situation where an API user updates course content,
+  yet there is an implicit conflict because a manual user edited the course recently and now the API user's local files are outdated?
+  This creates a danger of overwriting another person's changes.
+- "dirty writes": how do we handle a situation where there are multiple asynchronous import or update operations
+  at once that may be in conflict with each other?
+
+We analyzed a number of options to handle these challenges. As they may become relevant later on,
+you can find them in this `decision-tree diagram`_.
+
+.. _`decision-tree diagram`: insert link
+
+Some of the rejected options involved a toggle that lets users switch the course between enforcing only manual editing
+and only API editing. This toggle needs to allow for running import operations to finish before switching. There is an
+example state diagram here_.
+
+.. _here: insert link
+
+Some considerations that come into play when picking an approach are:
+
+1. Having the system reliably play traffic cop isn't simple, principally because of our reliance on slow-running async tasks
+2. Even if we ignore the problem of playing traffic cop, embracing hybrid editing means clients need some way to know
+   whether other users have made changes
+
+Decision
+--------
+
+- We consider the user responsible for avoiding, resolving, or fixing conflicts.
+- Courses with a registered API user are intended to be edited by one user at a time. This will be included in the API documentation.
+- We leave open the option to enforce this restriction to one concurrent user in the future.
+- We provide logs about past changes to the user in order for them to know whether other users have made changes.
+- We provide sufficient rollback tools to fix any problems with xblocks / xblock structure the users may have caused.
+- We do not provide any versioning, rolling back, or logging for anything that is not an xblock (static assets,
+  course-level policies and settings, etc). We recommend that the users employ version control for this on their side.
+
+Consequences
+------------
+
+Users may create conflicts or problems if they do not follow our instruction to work one at a time and coordinate.
+We can only give them the tools to rollback changes and modifications to xblocks and the xblock structure, so there is an increased
+risk of them causing problems with course-level settings or assets. If they do not version control on their own side, they need
+to find other solutions to fix this.
+
+This can be mitigated by adding more safety mechanisms, like actually enforcing this one-concurrent-user policy.
+
+It is clear where the responsibility lies for dealing with problems. Choosing this option, we do not have to
+build a complex mechanism to avoid or resolve conflicts ("playing traffic cop")
+and then be at fault for any errors that happen because this mechanism isn't perfect.

--- a/cms/djangoapps/contentstore/docs/decisions/0003-hybrid-approach-for-public-apis.rst
+++ b/cms/djangoapps/contentstore/docs/decisions/0003-hybrid-approach-for-public-apis.rst
@@ -61,7 +61,7 @@ Decision
 - We provide sufficient rollback tools to fix any problems with xblocks / xblock structure the users may have caused.
   Provided that modulestore versioning makes older versions of an XBlock available, we will provide a programmatic way to replace the current version
   of an XBlock with an older version, referenced by version ID.
-  Our current goal is to offer this packaged as a "revert task" operation.
+  Our current goal is to offer this packaged as a "undo task" operation.
 - We do not provide any versioning, rolling back, or logging for anything that is not an xblock (static assets,
   course-level policies and settings, etc). We recommend that the users employ version control for this on their side.
 


### PR DESCRIPTION
## Description

https://2u-internal.atlassian.net/browse/TNL-10590

We are planning to create a set of APIs for programmatic course creation, see this [Spec Memo](https://openedx.atlassian.net/wiki/spaces/COMM/pages/3696066564/Spec+Memo+API-Based+Management+of+edX+Course+Blocks+Outlines+and+Settings+MVP).

A requirement that has come up is to support hybrid work on these courses. That means that a course may be edited manually as well as by API.

This ADR documents the decision on how to handle challenges arising from hybrid work.