### PR TITLE
fix: typo in the documentation for hooks

### DIFF
--- a/docs/guides/hooks/filters.rst
+++ b/docs/guides/hooks/filters.rst
@@ -156,7 +156,7 @@ well as the trigger location in this same repository.
 
    * - `CourseUnenrollmentStarted <https://github.com/eduNEXT/openedx-filters/blob/main/openedx_filters/learning/filters.py#L98>`_
      - org.openedx.learning.course.unenrollment.started.v1
-     - `2022-06-14 https://github.com/eduNEXT/edx-platform/blob/master/common/djangoapps/student/models.py#L1752>`_
+     - `2022-06-14 <https://github.com/eduNEXT/edx-platform/blob/master/common/djangoapps/student/models.py#L1752>`_
 
    * - `CertificateCreationRequested <https://github.com/openedx/openedx-filters/blob/main/openedx_filters/learning/filters.py#L142>`_
      - org.openedx.learning.certificate.creation.requested.v1


### PR DESCRIPTION


<!--

🎉🎉 Olive has been released! 🎉🎉

🫒🫒
🫒🫒🫒🫒         🫒 Note: Olive is in support. Fixes you make on master may still
    🫒🫒🫒🫒     be needed on Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This is a super simple typo fix. However it does make the table in the docs look ugly.

## Testing instructions

Go to the bottom of: https://github.com/openedx/edx-platform/blob/master/docs/guides/hooks/filters.rst

## Deadline

"None"
