### PR TITLE
feat: add additional logging to edx-clear-expired-tokens

### DIFF
--- a/openedx/core/djangoapps/oauth_dispatch/management/commands/tests/test_clear_expired_tokens.py
+++ b/openedx/core/djangoapps/oauth_dispatch/management/commands/tests/test_clear_expired_tokens.py
@@ -72,26 +72,26 @@ class EdxClearExpiredTokensTests(TestCase):  # lint-amnesty, pylint: disable=mis
         factories.RefreshTokenFactory(user=application.user, application=application, access_token=access_token)
         with LogCapture(LOGGER_NAME) as log:
             call_command('edx_clear_expired_tokens', sleep_time=0, excluded_application_ids=str(application.id))
-            log.check(
+            log.check_present(
                 (
                     LOGGER_NAME,
                     'INFO',
-                    f'Cleaned {0} rows from {RefreshToken.__name__} table'
+                    f'Final deletion count: Cleaned {0} rows from {RefreshToken.__name__} table'
                 ),
                 (
                     LOGGER_NAME,
                     'INFO',
-                    f'Cleaned {0} rows from {RefreshToken.__name__} table'
+                    f'Final deletion count: Cleaned {0} rows from {RefreshToken.__name__} table'
                 ),
                 (
                     LOGGER_NAME,
                     'INFO',
-                    f'Cleaned {0} rows from {AccessToken.__name__} table',
+                    f'Final deletion count: Cleaned {0} rows from {AccessToken.__name__} table',
                 ),
                 (
                     LOGGER_NAME,
                     'INFO',
-                    f'Cleaned 0 rows from {Grant.__name__} table',
+                    f'Final deletion count: Cleaned 0 rows from {Grant.__name__} table',
                 )
             )
         assert RefreshToken.objects.filter(application=application).exists()


### PR DESCRIPTION
Add some logging to the management command for better visibility. It will be a lot of logging while we clear the tables out but once the job is running more smoothly it should be very manageable. If it gets particularly bad we can lower it to debug.

Issue: https://github.com/edx/edx-arch-experiments/issues/240