### PR TITLE
fix: change video embed url

### DIFF
--- a/lms/urls.py
+++ b/lms/urls.py
@@ -327,14 +327,14 @@ urlpatterns += [
         name=RENDER_XBLOCK_NAME,
     ),
     re_path(
-        fr'^videos/{settings.USAGE_KEY_PATTERN}$',
-        courseware_views.PublicVideoXBlockView.as_view(),
-        name=RENDER_VIDEO_XBLOCK_NAME,
-    ),
-    re_path(
-        fr'^videos/{settings.USAGE_KEY_PATTERN}/embed$',
+        fr'^videos/embed/{settings.USAGE_KEY_PATTERN}$',
         courseware_views.PublicVideoXBlockEmbedView.as_view(),
         name=RENDER_VIDEO_XBLOCK_EMBED_NAME,
+    ),
+    re_path(
+        fr'^videos/{settings.USAGE_KEY_PATTERN}/$',
+        courseware_views.PublicVideoXBlockView.as_view(),
+        name=RENDER_VIDEO_XBLOCK_NAME,
     ),
 
 

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -332,7 +332,7 @@ urlpatterns += [
         name=RENDER_VIDEO_XBLOCK_EMBED_NAME,
     ),
     re_path(
-        fr'^videos/{settings.USAGE_KEY_PATTERN}/$',
+        fr'^videos/{settings.USAGE_KEY_PATTERN}$',
         courseware_views.PublicVideoXBlockView.as_view(),
         name=RENDER_VIDEO_XBLOCK_NAME,
     ),


### PR DESCRIPTION
We need to configure cloudflare to not add the privacy banner / xframe protection to the embed page, but the path configuration they have can't handle infix wildcards, so it can't distinguish between `videos/<block_id>` vs `videos/<block_id>/embed`. I'm changing this URL so we can then update the cloudflare config to ignore the embed path