### PR TITLE
fix: resolved issue with topic creation in rerun

### DIFF
--- a/openedx/core/djangoapps/discussions/tasks.py
+++ b/openedx/core/djangoapps/discussions/tasks.py
@@ -20,25 +20,30 @@ log = logging.getLogger(__name__)
 
 @shared_task
 @set_code_owner_attribute
-def update_discussions_settings_from_course_task(course_key_str: str):
+def update_discussions_settings_from_course_task(course_key_str: str, discussable_units=None):
     """
     Celery task that creates or updates discussions settings for a course.
 
     Args:
         course_key_str (str): course key string
+        discussable_units (List[UsageKey]): list of discussable units
     """
     course_key = CourseKey.from_string(course_key_str)
-    config_data = update_discussions_settings_from_course(course_key)
+    config_data = update_discussions_settings_from_course(course_key, discussable_units)
     COURSE_DISCUSSIONS_CHANGED.send_event(configuration=config_data)
 
 
-def update_discussions_settings_from_course(course_key: CourseKey) -> CourseDiscussionConfigurationData:
+def update_discussions_settings_from_course(
+    course_key: CourseKey,
+    discussable_units=None
+) -> CourseDiscussionConfigurationData:
     """
     When there are changes to a course, construct a new data structure containing all the context needed to update the
     course's discussion settings in the database.
 
     Args:
         course_key (CourseKey): The course that was recently updated.
+        discussable_units (List[UsageKey]): list of discussable units
 
     Returns:
         (CourseDiscussionConfigurationData): structured discussion configuration data.
@@ -73,7 +78,13 @@ def update_discussions_settings_from_course(course_key: CourseKey) -> CourseDisc
                     )
                     contexts.append(context)
             if enable_in_context:
-                contexts.extend(list(get_discussable_units(course, enable_graded_units)))
+                discussable_units = get_discussable_units(
+                    course,
+                    enable_graded_units,
+                    discussable_units
+                )
+                contexts.extend(list(discussable_units))
+
         config_data = CourseDiscussionConfigurationData(
             course_key=course_key,
             enable_in_context=enable_in_context,
@@ -86,7 +97,7 @@ def update_discussions_settings_from_course(course_key: CourseKey) -> CourseDisc
     return config_data
 
 
-def get_discussable_units(course, enable_graded_units):
+def get_discussable_units(course, enable_graded_units, discussable_units=None):
     """
     Get all the units in the course that are discussable.
     """
@@ -100,6 +111,8 @@ def get_discussable_units(course, enable_graded_units):
                     if not is_discussable_unit(unit, store, enable_graded_units, subsection):
                         unit.discussion_enabled = False
                         store.update_item(unit, unit.published_by, emit_signals=False)
+                        continue
+                    if discussable_units and (unit.location not in discussable_units):
                         continue
                     yield DiscussionTopicContext(
                         usage_key=unit.location,
@@ -184,12 +197,12 @@ def update_unit_discussion_state_from_discussion_blocks(course_key: CourseKey, u
 
     with store.bulk_operations(course_key):
         discussion_blocks = get_accessible_discussion_xblocks_by_course_id(course_key, include_all=True)
-        discussible_units = {
+        discussable_units = {
             discussion_block.parent
             for discussion_block in discussion_blocks
             if discussion_block.parent.block_type == 'vertical'
         }
-        log.info(f"Found {len(discussible_units)} discussible unit(s) in {course_key}")
+        log.info(f"Found {len(discussable_units)} discussable unit(s) in {course_key}")
         verticals = store.get_items(course_key, qualifiers={'block_type': 'vertical'})
         graded_subsections = {
             block.location
@@ -201,7 +214,7 @@ def update_unit_discussion_state_from_discussion_blocks(course_key: CourseKey, u
         }
         subsections_with_discussions = set()
         for vertical in verticals:
-            if vertical.location in discussible_units:
+            if vertical.location in discussable_units:
                 vertical.discussion_enabled = True
                 subsections_with_discussions.add(vertical.parent)
             else:
@@ -233,7 +246,7 @@ def update_unit_discussion_state_from_discussion_blocks(course_key: CourseKey, u
         discussion_config.enable_graded_units = enable_graded_subsections
         discussion_config.unit_level_visibility = True
         discussion_config.save()
-    update_discussions_settings_from_course_task.apply_async(
-        args=[str(course_key)],
-        countdown=300,
+    update_discussions_settings_from_course_task(
+        str(course_key),
+        discussable_units=list(discussable_units),
     )


### PR DESCRIPTION
## Ticket 
https://2u-internal.atlassian.net/browse/INF-800
## Description
There are two tasks that run after the course re run is created. `update_discussions_settings_from_course_task` and 
`update_unit_discussion_state_from_discussion_blocks`
The following updates are made to ensure data is updated as expected.
1. update_discussions_settings_from_course_task is called after rerun task and now it has disucssable_unit param to cross check if topic should be created.
2. This implementation is done because their is inconsistency in data i.e while the rerun task updates data but that is not reflected in topic creation task.