### PR TITLE
feat: send skipRegistrationForm with providers

### DIFF
--- a/openedx/core/djangoapps/user_authn/api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_authn/api/tests/test_views.py
@@ -73,6 +73,7 @@ class MFEContextViewTest(ThirdPartyAuthTestMixin, APITestCase):
                 'iconClass': 'fa-facebook',
                 'iconImage': None,
                 'skipHintedLogin': False,
+                'skipRegistrationForm': False,
                 'loginUrl': self._third_party_login_url('facebook', 'login', params),
                 'registerUrl': self._third_party_login_url('facebook', 'register', params)
             },
@@ -82,6 +83,7 @@ class MFEContextViewTest(ThirdPartyAuthTestMixin, APITestCase):
                 'iconClass': 'fa-google-plus',
                 'iconImage': None,
                 'skipHintedLogin': False,
+                "skipRegistrationForm": False,
                 'loginUrl': self._third_party_login_url('google-oauth2', 'login', params),
                 'registerUrl': self._third_party_login_url('google-oauth2', 'register', params)
             },
@@ -174,6 +176,7 @@ class MFEContextViewTest(ThirdPartyAuthTestMixin, APITestCase):
             'iconClass': 'fa-linkedin',
             'iconImage': None,
             'skipHintedLogin': False,
+            'skipRegistrationForm': False,
             'loginUrl': self._third_party_login_url('linkedin-oauth2', 'login', params),
             'registerUrl': self._third_party_login_url('linkedin-oauth2', 'register', params)
         })

--- a/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
@@ -289,6 +289,7 @@ class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleSto
                 "iconClass": None,
                 "iconImage": settings.MEDIA_URL + "icon.svg",
                 "skipHintedLogin": False,
+                "skipRegistrationForm": False,
                 "loginUrl": self._third_party_login_url("dummy", "login", params),
                 "registerUrl": self._third_party_login_url("dummy", "register", params)
             },
@@ -298,6 +299,7 @@ class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleSto
                 "iconClass": "fa-facebook",
                 "iconImage": None,
                 "skipHintedLogin": False,
+                "skipRegistrationForm": False,
                 "loginUrl": self._third_party_login_url("facebook", "login", params),
                 "registerUrl": self._third_party_login_url("facebook", "register", params)
             },
@@ -307,6 +309,7 @@ class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleSto
                 "iconClass": "fa-google-plus",
                 "iconImage": None,
                 "skipHintedLogin": False,
+                "skipRegistrationForm": False,
                 "loginUrl": self._third_party_login_url("google-oauth2", "login", params),
                 "registerUrl": self._third_party_login_url("google-oauth2", "register", params)
             },

--- a/openedx/core/djangoapps/user_authn/views/utils.py
+++ b/openedx/core/djangoapps/user_authn/views/utils.py
@@ -53,6 +53,7 @@ def third_party_auth_context(request, redirect_to, tpa_hint=None):
                 "iconClass": enabled.icon_class or None,
                 "iconImage": enabled.icon_image.url if enabled.icon_image else None,
                 "skipHintedLogin": enabled.skip_hinted_login_dialog,
+                "skipRegistrationForm": enabled.skip_registration_form,
                 "loginUrl": pipeline.get_login_url(
                     enabled.provider_id,
                     pipeline.AUTH_ENTRY_LOGIN,


### PR DESCRIPTION
VAN-1318

We are adding support for the skip_registeration_form setting for SSO on frontend-app-authn in this [PR](https://github.com/openedx/frontend-app-authn/pull/789).

For this, we need to send the provider's skip_registeration_form setting in mfe_context.