### PR TITLE
feat: adds TenantAwareLinkRenderStarted filter

### DIFF
--- a/common/djangoapps/util/course.py
+++ b/common/djangoapps/util/course.py
@@ -9,6 +9,7 @@ from urllib.parse import urlencode
 from django.conf import settings
 from opaque_keys.edx.keys import CourseKey, UsageKey
 
+from openedx_filters.learning.filters import TenantAwareLinkRenderStarted
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 log = logging.getLogger(__name__)
@@ -54,12 +55,34 @@ def get_link_for_about_page(course):
     elif settings.FEATURES.get('ENABLE_MKTG_SITE') and getattr(course, 'marketing_url', None):
         course_about_url = course.marketing_url
     else:
+        about_base = configuration_helpers.get_value('LMS_ROOT_URL', settings.LMS_ROOT_URL)
+
+        try:
+            ## .. filter_implemented_name: TenantAwareLinkRenderStarted
+            ## .. filter_type: org.openedx.learning.tenant_aware_link.render.started.v1
+            about_base = TenantAwareLinkRenderStarted.run_filter(
+                context=about_base,
+                org=course.id.org,
+                val_name='LMS_ROOT_URL',
+                default=settings.LMS_ROOT_URL
+            )
+        except TenantAwareLinkRenderStarted.PreventTenantAwarelinkRender as exc:
+            raise TenantAwareRenderNotAllowed(str(exc)) from exc
+
         course_about_url = '{about_base_url}/courses/{course_key}/about'.format(
-            about_base_url=configuration_helpers.get_value('LMS_ROOT_URL', settings.LMS_ROOT_URL),
+            about_base_url=about_base,
             course_key=str(course.id),
         )
 
     return course_about_url
+
+
+class TenantAwareRenderException(Exception):
+    pass
+
+
+class TenantAwareRenderNotAllowed(TenantAwareRenderException):
+    pass
 
 
 def has_certificates_enabled(course):

--- a/common/djangoapps/util/tests/test_filters.py
+++ b/common/djangoapps/util/tests/test_filters.py
@@ -1,0 +1,126 @@
+"""
+Test that various filters are fired for models/views in the student app.
+"""
+from django.http import HttpResponse
+from django.test import override_settings
+from common.djangoapps.util import course
+from openedx_filters import PipelineStep
+from openedx_filters.learning.filters import TenantAwareLinkRenderStarted
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
+
+from common.djangoapps.util.course import TenantAwareRenderNotAllowed
+from openedx.core.djangolib.testing.utils import skip_unless_lms
+
+
+class TestTenantAwareRenderPipelineStep(PipelineStep):
+    """
+    Utility class used when getting steps for pipeline.
+    """
+
+    def run_filter(self, context, org, val_name, default):  # pylint: disable=arguments-differ
+        """Pipeline step that modifies tenant aware links."""
+        context = "https://tenant-aware-link"
+        return {
+            "context": context
+        }
+
+
+class TestTenantAwareFilterPrevent(PipelineStep):
+    """
+    Utility class used when getting steps for pipeline.
+    """
+
+    def run_filter(self, context, org, val_name, default):  # pylint: disable=arguments-differ
+        """Pipeline step that changes dashboard view response before the dashboard is rendered."""
+        response = HttpResponse("This is a custom response.")
+        raise TenantAwareLinkRenderStarted.PreventTenantAwarelinkRender(
+            "Can't render tenant aware link.",
+            response=response,
+        )
+
+
+@skip_unless_lms
+class TenantAwareLinkFiltersTest(ModuleStoreTestCase):
+    """
+    Tests for the Open edX Filters associated with the Tenant aware link process.
+
+    This class guarantees that the following filters are triggered during the microsite render:
+
+    - TenantAwareLinkRenderStarted
+    """
+
+    def setUp(self):  # pylint: disable=arguments-differ
+        super().setUp()
+        self.course = CourseFactory.create()
+        self.org = "test"
+        self.val_name = 'LMS_ROOT_URL'
+        self.default = "https://lms-base"
+
+    @override_settings(
+        OPEN_EDX_FILTERS_CONFIG={
+            "org.openedx.learning.tenant_aware_link.render.started.v1": {
+                "pipeline": [
+                    "common.djangoapps.util.tests.test_filters.TestTenantAwareRenderPipelineStep",
+                ],
+                "fail_silently": False,
+            },
+        },
+    )
+    def test_tenant_aware_filter_executed(self):
+        """
+        Test whether the tenant aware link filter is triggered before the user's
+        render site process.
+
+        Expected result:
+            - TenantAwareLinkRenderStarted is triggered and executes TestTenantAwareRenderPipelineStep.
+            - The arguments that the receiver gets are the arguments used by the filter.
+        """
+        course_about_url = course.get_link_for_about_page(self.course)
+
+        expected_course_about = '{about_base_url}/courses/{course_key}/about'.format(
+            about_base_url='https://tenant-aware-link',
+            course_key=str(self.course.id),
+        )
+
+        self.assertEqual(expected_course_about, course_about_url)
+
+    @override_settings(
+        OPEN_EDX_FILTERS_CONFIG={
+            "org.openedx.learning.tenant_aware_link.render.started.v1": {
+                "pipeline": [
+                    "common.djangoapps.util.tests.test_filters.TestTenantAwareFilterPrevent",
+                ],
+                "fail_silently": False,
+            },
+        },
+    )
+    def test_tenant_aware_filter_prevent(self):
+        """
+        Test prevent the tenant aware link filter through a pipeline step.
+
+        Expected result:
+            - TenantAwareLinkRenderStarted is triggered and executes TestTenantAwareFilterPrevent.
+            - The user can't get tenant aware links.
+        """
+        with self.assertRaises(TenantAwareRenderNotAllowed):
+            course.get_link_for_about_page(self.course)
+
+    @override_settings(OPEN_EDX_FILTERS_CONFIG={}, LMS_ROOT_URL="https://lms-base")
+    def test_enrollment_without_filter_configuration(self):
+        """
+        Test usual get link for about page process, without filter's intervention.
+
+        Expected result:
+            - Returns the course sharing url, this can be one of course's social sharing url, marketing url, or
+                lms course about url.
+            - The get process ends successfully.
+        """
+        course_about_url = course.get_link_for_about_page(self.course)
+
+        expected_course_about = '{about_base_url}/courses/{course_key}/about'.format(
+            about_base_url='https://lms-base',
+            course_key=str(self.course.id),
+        )
+
+        self.assertEqual(expected_course_about, course_about_url)

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -133,7 +133,7 @@ openedx-calc                        # Library supporting mathematical calculatio
 openedx-django-require
 # openedx-events 3.1.0 introduces producer API
 openedx-events>=3.1.0               # Open edX Events from Hooks Extension Framework (OEP-50)
-openedx-filters                     # Open edX Filters from Hooks Extension Framework (OEP-50)
+git+https://github.com/eduNEXT/openedx-filters.git@JDB/add_tenant_aware_filter        #openedx-filters                      Open edX Filters from Hooks Extension Framework (OEP-50)
 openedx-mongodbproxy
 optimizely-sdk                      # Optimizely full stack SDK for Python
 ora2>=4.5.0

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -778,8 +778,7 @@ openedx-events==8.0.0
     # via
     #   -r requirements/edx/base.in
     #   edx-event-bus-kafka
-    #   edx-event-bus-redis
-openedx-filters==1.3.0
+git+https://github.com/eduNEXT/openedx-filters.git@JDB/add_tenant_aware_filter
     # via
     #   -r requirements/edx/base.in
     #   lti-consumer-xblock

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1036,8 +1036,7 @@ openedx-events==8.0.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-event-bus-kafka
-    #   edx-event-bus-redis
-openedx-filters==1.3.0
+git+https://github.com/eduNEXT/openedx-filters.git@JDB/add_tenant_aware_filter
     # via
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -983,8 +983,7 @@ openedx-events==8.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-event-bus-kafka
-    #   edx-event-bus-redis
-openedx-filters==1.3.0
+git+https://github.com/eduNEXT/openedx-filters.git@JDB/add_tenant_aware_filter
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock


### PR DESCRIPTION
<!--

🫒🫒
🫒🫒🫒🫒         🫒 Note: the Olive master branch has been created.  Please consider whether your change
    🫒🫒🫒🫒     should also be applied to Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

🌰🌰🌰🌰🌰🌰     🌰 Note: the Nutmeg release is still supported.
                  Please consider whether your change should be applied to Nutmeg as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/openedx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This PR introduces a new [openedx-filters](https://github.com/openedx/openedx-filters) event ``org.openedx.learning.tenant_aware_link.render.started.v1``. This is implemented to guaranty multi tenancy in [eox-tenant](https://github.com/eduNEXT/eox-tenant) in LMS_ROOT_URL from Studio to LMS, but eox-tenant is only an example would consider use.

Impact by the change on:
- cms/djangoapps/contentstore/views/assets.py
- common/djangoapps/util/course.py

## Supporting information

There are not openedx related tickets. The related PR are:

- https://github.com/openedx/openedx-filters/pull/77
- https://github.com/eduNEXT/eox-tenant/pull/179

## Testing instructions

The change can be tested with testing instructions in [eox-tenant plugin](https://github.com/eduNEXT/eox-tenant/pull/179).

## Deadline

"None"

## Other information
:warning: 

**Warning**: Once accepted this PR, it has to be merged only after [openedx/openedx-filters#77](https://github.com/openedx/openedx-filters/pull/77) is merged and the requirements in this PR are updated.

:warning: 

### Settings

```bash
EDXAPP_EXTRA_REQUIREMENTS:
  - name: git+https://github.com/eduNEXT/eox-tenant.git@JDB/add_tenant_aware_filter
```