### PR TITLE
feat: feature flag to disable Advanced Settings

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -106,6 +106,7 @@ class CourseAdvanceSettingViewTest(CourseTestCase, MilestonesTestCaseMixin):
         super().setUp()
         self.fullcourse = CourseFactory.create()
         self.course_setting_url = get_url(self.course.id, 'advanced_settings_handler')
+        self.non_staff_client, _ = self.create_non_staff_authed_user_client()
 
     @override_settings(FEATURES={'DISABLE_MOBILE_COURSE_AVAILABLE': True})
     def test_mobile_field_available(self):
@@ -143,6 +144,17 @@ class CourseAdvanceSettingViewTest(CourseTestCase, MilestonesTestCaseMixin):
                 self.assertEqual('allow_anonymous_to_peers' in response, fields_visible)
                 self.assertEqual('discussion_blackouts' in response, fields_visible)
                 self.assertEqual('discussion_topics' in response, fields_visible)
+
+    @override_settings(FEATURES={'DISABLE_ADVANCED_SETTINGS': True})
+    def test_disable_advanced_settings_feature(self):
+        """
+        If this feature is enabled, only staff should be able to access the advanced settings page.
+        """
+        response = self.non_staff_client.get_html(self.course_setting_url)
+        self.assertEqual(response.status_code, 403)
+
+        response = self.client.get_html(self.course_setting_url)
+        self.assertEqual(response.status_code, 200)
 
 
 @ddt.ddt

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -147,6 +147,17 @@ class AccessListFallback(Exception):
     pass  # lint-amnesty, pylint: disable=unnecessary-pass
 
 
+def has_advanced_settings_access(user):
+    """
+    If DISABLE_ADVANCED_SETTINGS feature is enabled, only global staff can access "Advanced Settings".
+    """
+    return (
+        not settings.FEATURES.get('DISABLE_ADVANCED_SETTINGS', False)
+        or user.is_staff
+        or user.is_superuser
+    )
+
+
 def get_course_and_check_access(course_key, user, depth=0):
     """
     Function used to calculate and return the locator and course block
@@ -752,6 +763,7 @@ def course_index(request, course_key):
             'frontend_app_publisher_url': frontend_app_publisher_url,
             'mfe_proctored_exam_settings_url': get_proctored_exam_settings_url(course_block.id),
             'advance_settings_url': reverse_course_url('advanced_settings_handler', course_block.id),
+            'advance_settings_access': has_advanced_settings_access(request.user),
             'proctoring_errors': proctoring_errors,
         })
 
@@ -1420,6 +1432,9 @@ def advanced_settings_handler(request, course_key_string):
         json: update the Course's settings. The payload is a json rep of the
             metadata dicts.
     """
+    if not has_advanced_settings_access(request.user):
+        raise PermissionDenied()
+
     course_key = CourseKey.from_string(course_key_string)
     with modulestore().bulk_operations(course_key):
         course_block = get_course_and_check_access(course_key, request.user)

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -516,6 +516,16 @@ FEATURES = {
     #   in the LMS and CMS.
     # .. toggle_tickets: 'https://github.com/open-craft/edx-platform/pull/429'
     'DISABLE_UNENROLLMENT': False,
+
+    # .. toggle_name: FEATURES['DISABLE_ADVANCED_SETTINGS']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Set to `True` to disable the advanced settings page in Studio for all users except those
+    #   having `is_superuser` or `is_staff` set to `True`.
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2023-03-31
+    # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/32015
+    'DISABLE_ADVANCED_SETTINGS': False,
 }
 
 # .. toggle_name: ENABLE_COPPA_COMPLIANCE

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -120,9 +120,11 @@
                     <a href="${mfe_proctored_exam_settings_url}">${_("Proctored Exam Settings")}</a>
                   </li>
                   % endif
+                  % if advance_settings_access:
                   <li class="nav-item nav-course-settings-advanced">
                     <a href="${advanced_settings_url}">${_("Advanced Settings")}</a>
                   </li>
+                  % endif
                   % if certificates_url:
                   <li class="nav-item nav-course-settings-certificates">
                     <a href="${certificates_url}">${_("Certificates")}</a>


### PR DESCRIPTION
## Description

Adds the new Studio feature flag, `DISABLE_ADVANCED_SETTINGS`, which disables access to course advanced settings for non-staff users. Also, it removes "Advanced Settings" from the "Settings" dropdown.

## Testing instructions

1. Apply this patch:
    ```diff
    diff --git a/cms/envs/common.py b/cms/envs/common.py
    index 56ba9187c6..f6dce2edb8 100644
    --- a/cms/envs/common.py
    +++ b/cms/envs/common.py
    @@ -524,7 +524,7 @@ FEATURES = {
         # .. toggle_use_cases: open_edx
         # .. toggle_creation_date: 2023-03-31
         # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/32015
    -    'DISABLE_ADVANCED_SETTINGS': False,
    +    'DISABLE_ADVANCED_SETTINGS': True,
     }
     
     # .. toggle_name: ENABLE_COPPA_COMPLIANCE
    ```
2. Verify that that any user except Django admin staff neither can see the "Advanced Settings" dropdown element nor access the page directly.

[private-ref](https://tasks.opencraft.com/browse/BB-7220)