### PR TITLE
fix: remove field filtering on catalog lookup

### DIFF
--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1817,10 +1817,7 @@ class PublicVideoXBlockView(BasePublicVideoXBlockView):
         course_uuid = get_course_uuid_for_course(course.id)
         if course_uuid is None:
             return {}
-        catalog_course_data = get_course_data(
-            course_uuid,
-            ['owners', 'url_slug'],
-        )
+        catalog_course_data = get_course_data(course_uuid)
         if catalog_course_data is None:
             return {}
 

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1817,7 +1817,7 @@ class PublicVideoXBlockView(BasePublicVideoXBlockView):
         course_uuid = get_course_uuid_for_course(course.id)
         if course_uuid is None:
             return {}
-        catalog_course_data = get_course_data(course_uuid)
+        catalog_course_data = get_course_data(course_uuid, None)
         if catalog_course_data is None:
             return {}
 


### PR DESCRIPTION
I was filtering for "url_slug" rather than "marketing_url".

I'm 2 for 2 with this field filtering on this API call messing me up. Plus, it's all done on the LMS end after we get the result, so it's not even a performance increase. I'm just gonna remove it. This will fix the URL issue