### PR TITLE
feat: add message for invalid assignment type

### DIFF
--- a/cms/static/sass/elements/_modules.scss
+++ b/cms/static/sass/elements/_modules.scss
@@ -664,6 +664,13 @@ $outline-indent-width: $baseline;
       vertical-align: middle;
       margin-left: ($baseline/4);
     }
+
+    .status-grading-type-mismatch {
+      display: inline-block;
+      vertical-align: middle;
+      opacity: initial;
+      color: $color-error;
+    }
   }
 
   // outline: units
@@ -738,6 +745,13 @@ $outline-indent-width: $baseline;
     .status-grading-value {
       display: inline-block;
       vertical-align: middle;
+    }
+
+    .status-grading-type-mismatch {
+      display: inline-block;
+      vertical-align: middle;
+      opacity: 1;
+      color: $color-error;
     }
 
     .status-grading-date {

--- a/cms/templates/js/course-outline.underscore
+++ b/cms/templates/js/course-outline.underscore
@@ -81,6 +81,7 @@ var gradingType = gettext('Ungraded');
 if (xblockInfo.get('graded')) {
     gradingType = xblockInfo.get('format')
 }
+var courseGraders = xblockInfo.get('course_graders');
 
 var is_proctored_exam = xblockInfo.get('is_proctored_exam');
 var is_practice_exam = xblockInfo.get('is_practice_exam');
@@ -244,7 +245,6 @@ if (is_proctored_exam) {
                     <p>
                         <span class="sr status-grading-label"> <%- gettext('Graded as:') %> </span>
                         <span class="icon fa fa-check" aria-hidden="true"></span>
-                        <span class="status-grading-value"> <%- gradingType %> </span>
                          -
                         <span class="sr status-proctored-exam-label"> <%- exam_value %> </span>
                         <span class="status-proctored-exam-value"> <%- exam_value %> </span>
@@ -276,8 +276,16 @@ if (is_proctored_exam) {
                 <div class="status-grading">
                     <p>
                         <span class="sr status-grading-label"> <%- gettext('Graded as:') %> </span>
-                        <span class="icon fa fa-check" aria-hidden="true"></span>
-                        <span class="status-grading-value"> <%- gradingType %> </span>
+                        <% if (!courseGraders.includes(gradingType)) { %>
+                            <span class="status-grading-type-mismatch fa fa-warning" aria-hidden="true"></span>
+                            <span class="status-grading-value"> <%- gradingType %> </span>
+                            <span class="status-grading-type-mismatch">
+                                <%- gettext('There is an issue with this Assignment Type. Please review and update.') %>
+                            </span>
+                        <% } else { %>
+                            <span class="icon fa fa-check" aria-hidden="true"></span>
+                            <span class="status-grading-value"> <%- gradingType %> </span>
+                        <% } %>
                         <% if (xblockInfo.get('due_date') && !course.get('self_paced')) { %>
                             <span class="status-grading-date"> <%- gettext('Due:') %> <%- xblockInfo.get('due_date') %> </span>
                         <% } %>
@@ -306,8 +314,16 @@ if (is_proctored_exam) {
                 <div class="status-grading">
                     <p>
                         <span class="sr status-grading-label"> <%- gettext('Graded as:') %> </span>
-                        <span class="icon fa fa-check" aria-hidden="true"></span>
-                        <span class="status-grading-value"> <%- gradingType %> </span>
+                        <% if (!courseGraders.includes(gradingType)) { %>
+                            <span class="status-grading-type-mismatch fa fa-warning" aria-hidden="true"></span>
+                            <span class="status-grading-value"> <%- gradingType %> </span>
+                            <span class="status-grading-type-mismatch">
+                                <%- gettext('There is an issue with this Assignment Type. Please review and update.') %>
+                            </span>
+                        <% } else { %>
+                            <span class="icon fa fa-check" aria-hidden="true"></span>
+                            <span class="status-grading-value"> <%- gradingType %> </span>
+                        <% } %>
                     </p>
                 </div>
                 <div class="status-grading">


### PR DESCRIPTION
<!--

🎉🎉 Olive has been released! 🎉🎉

🫒🫒
🫒🫒🫒🫒         🫒 Note: Olive is in support. Fixes you make on master may still
    🫒🫒🫒🫒     be needed on Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

When a user creates a course they receive default assignment types. The course author then assigns the type to a subsection and it applies the associated grading policy defined in the grading settings. However, if the course author changes the name of the assignment type it does not update the assignment type for the subsection and subsequent xblocks. There is a warning message that appears to course authors when the assignment type is being renamed, but the message does not persist once the change is saved. This leads to confusion for users who did not make the change and see the warning message or for the user who changed the assignment type and expected the change to apply everywhere. To help highlight that the assignment type needs to be changed for the subsection, a error message appears with the current assignment type. This changes impacts the Course Author.

### Before

![image](https://user-images.githubusercontent.com/42981026/229853025-fc067c81-2b95-433a-a8dc-df529ac6f902.png)

### After

![image](https://user-images.githubusercontent.com/42981026/229850743-1406d6a3-d0c3-42e5-a8f2-1ba3a9bc3b7a.png)

## Supporting information

JIRA Ticket: [TNL-10514](https://2u-internal.atlassian.net/browse/TNL-10514)

> Description: 
> "In Studio grading policies, each assignment type is given a name. This name shows up throughout the course in various places, including the Studio course outline in each graded subsection and the "grade as" popup window for section settings.
> 
> If the assignment type name is changed after initially created, this name does not update on the Studio course outline, creating a visual mismatch that can be confusing to course teams. See attached screenshot.
> 
> Please correct this so that the assignment type name also updates on the Studio course outline."
> 

## Testing instructions

1. Navigate to a course outline
2. Click on the gear icon for the first subsection
3. Chose an assignment type to grade the subsection as and save the change
4. Navigate to the "Assignment Types" section in the Grading settings page
5. Find the assignment type that you selected for the subsection and change its name
6. Navigate to the edited subsection
7. The subsection's collapsed view should have a warning icon followed by the original assignment type and the following message: 
   "There is an issue with this Assignment Type. Please review and update."
8. Click on the gear icon and choose a new assignment type.
9. The warning icon should now be a check icon and the error message is no longer displayed

## Deadline

None