### PR TITLE
Changed sequence for course rerun task related to disucssions

### DIFF
--- a/cms/djangoapps/api/v1/serializers/course_runs.py
+++ b/cms/djangoapps/api/v1/serializers/course_runs.py
@@ -159,9 +159,9 @@ class CourseRunCreateSerializer(CourseRunSerializer):  # lint-amnesty, pylint: d
 
         with transaction.atomic():
             instance = create_new_course(user, _id['org'], _id['course'], _id['run'], validated_data)
-            update_unit_discussion_state_from_discussion_blocks(instance.id, user.id)
             self.update_team(instance, team)
-            return instance
+        update_unit_discussion_state_from_discussion_blocks(instance.id, user.id)
+        return instance
 
 
 class CourseRunRerunSerializer(CourseRunSerializerCommonFieldsMixin, CourseRunTeamSerializerMixin,  # lint-amnesty, pylint: disable=abstract-method, missing-class-docstring


### PR DESCRIPTION
## Description
This PR adds a call to this method `update_unit_discussion_state_from_discussion_blocks` responsible for creating topics for units with discussion blocks. 
It makes rerun creation from the studio and publisher consistent concerning topic creation.

## Ticket 
https://2u-internal.atlassian.net/browse/INF-800

## Related PRs: 
https://github.com/openedx/edx-platform/pull/31993
https://github.com/openedx/edx-platform/pull/32008
https://github.com/openedx/edx-platform/pull/32028