### PR TITLE
fix: changed rerun task sequence

### DIFF
--- a/cms/djangoapps/api/v1/serializers/course_runs.py
+++ b/cms/djangoapps/api/v1/serializers/course_runs.py
@@ -160,7 +160,6 @@ class CourseRunCreateSerializer(CourseRunSerializer):  # lint-amnesty, pylint: d
         with transaction.atomic():
             instance = create_new_course(user, _id['org'], _id['course'], _id['run'], validated_data)
             self.update_team(instance, team)
-        update_unit_discussion_state_from_discussion_blocks(instance.id, user.id)
         return instance
 
 
@@ -204,4 +203,5 @@ class CourseRunRerunSerializer(CourseRunSerializerCommonFieldsMixin, CourseRunTe
 
         course_run = get_course_and_check_access(new_course_run_key, user)
         self.update_team(course_run, team)
+        update_unit_discussion_state_from_discussion_blocks(course_run.id, user.id)
         return course_run


### PR DESCRIPTION
## Description
This PR adds a call to this method `update_unit_discussion_state_from_discussion_blocks` responsible for creating topics for units with discussion blocks. 
It makes rerun creation from the studio and publisher consistent concerning topic creation.

## Ticket 
https://2u-internal.atlassian.net/browse/INF-800

## Related PRs: 
https://github.com/openedx/edx-platform/pull/31993
https://github.com/openedx/edx-platform/pull/32008
https://github.com/openedx/edx-platform/pull/32028
https://github.com/openedx/edx-platform/pull/32033