### PR TITLE
fix: added delay of 30sec to update_discussions_settings_from_course_task

### DIFF
--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -59,7 +59,7 @@ from xmodule.contentstore.django import contentstore  # lint-amnesty, pylint: di
 from xmodule.course_block import CourseFields  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.exceptions import SerializationError  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore import COURSE_ROOT, LIBRARY_ROOT  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.django import modulestore, SignalHandler  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.exceptions import DuplicateCourseError, InvalidProctoringProvider, ItemNotFoundError  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.xml_exporter import export_course_to_xml, export_library_to_xml  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.xml_importer import CourseImportException, import_course_from_xml, import_library_from_xml  # lint-amnesty, pylint: disable=wrong-import-order
@@ -122,13 +122,13 @@ def rerun_course(source_course_key_string, destination_course_key_string, user_i
         with store.default_store('split'):
             store.clone_course(source_course_key, destination_course_key, user_id, fields=fields)
 
+        update_unit_discussion_state_from_discussion_blocks(destination_course_key, user_id)
+
         # set initial permissions for the user to access the course.
         initialize_permissions(destination_course_key, User.objects.get(id=user_id))
 
         # update state: Succeeded
         CourseRerunState.objects.succeeded(course_key=destination_course_key)
-
-        update_unit_discussion_state_from_discussion_blocks(destination_course_key, user_id)
 
         # call edxval to attach videos to the rerun
         copy_course_videos(source_course_key, destination_course_key)

--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -59,7 +59,7 @@ from xmodule.contentstore.django import contentstore  # lint-amnesty, pylint: di
 from xmodule.course_block import CourseFields  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.exceptions import SerializationError  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore import COURSE_ROOT, LIBRARY_ROOT  # lint-amnesty, pylint: disable=wrong-import-order
-from xmodule.modulestore.django import modulestore, SignalHandler  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.exceptions import DuplicateCourseError, InvalidProctoringProvider, ItemNotFoundError  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.xml_exporter import export_course_to_xml, export_library_to_xml  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.xml_importer import CourseImportException, import_course_from_xml, import_library_from_xml  # lint-amnesty, pylint: disable=wrong-import-order

--- a/openedx/core/djangoapps/discussions/tasks.py
+++ b/openedx/core/djangoapps/discussions/tasks.py
@@ -2,6 +2,7 @@
 Tasks for discussions
 """
 import logging
+
 from django.conf import settings
 from celery import shared_task
 from edx_django_utils.monitoring import set_code_owner_attribute
@@ -9,12 +10,9 @@ from opaque_keys.edx.keys import CourseKey
 from openedx_events.learning.data import CourseDiscussionConfigurationData, DiscussionTopicContext
 from openedx_events.learning.signals import COURSE_DISCUSSIONS_CHANGED
 
-from common.djangoapps.course_action_state.managers import CourseActionStateItemNotFoundError, CourseRerunUIStateManager
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
-from xmodule.modulestore.exceptions import ItemNotFoundError
 from .config.waffle import ENABLE_NEW_STRUCTURE_DISCUSSIONS
-from common.djangoapps.course_action_state.models import CourseRerunState
 
 from .models import DiscussionsConfiguration, Provider, DiscussionTopicLink
 from .utils import get_accessible_discussion_xblocks_by_course_id
@@ -32,17 +30,6 @@ def update_discussions_settings_from_course_task(course_key_str: str, discussabl
         course_key_str (str): course key string
         discussable_units (List[UsageKey]): list of discussable units
     """
-    try:
-        course_run_state = CourseRerunState.objects.find_first(course_key=course_key_str)
-    except (ItemNotFoundError, CourseActionStateItemNotFoundError):
-        course_run_state = None
-
-    if course_run_state:
-        if course_run_state.action == 'rerun' and course_run_state.state != CourseRerunUIStateManager.State.SUCCEEDED:
-            log.info(f"Skipping task because course rerun is not completed yet for course: {course_key_str}")
-            return
-
-    log.info(f"Continuing task, course rerun is completed for course: {course_key_str}")
     course_key = CourseKey.from_string(course_key_str)
     config_data = update_discussions_settings_from_course(course_key, discussable_units)
     COURSE_DISCUSSIONS_CHANGED.send_event(configuration=config_data)
@@ -210,7 +197,7 @@ def update_unit_discussion_state_from_discussion_blocks(course_key: CourseKey, u
 
     log.info(f"Migrating legacy discussion config for {course_key}")
 
-    with store.bulk_operations(course_key, emit_signals=False):
+    with store.bulk_operations(course_key):
         discussion_blocks = get_accessible_discussion_xblocks_by_course_id(course_key, include_all=True)
         discussable_units = {
             discussion_block.parent
@@ -255,14 +242,14 @@ def update_unit_discussion_state_from_discussion_blocks(course_key: CourseKey, u
         course.discussions_settings['provider_type'] = provider
         course.discussions_settings['enable_graded_units'] = enable_graded_subsections
         course.discussions_settings['unit_level_visibility'] = True
-        with store.bulk_operations(course_key, emit_signals=False):
-            store.update_item(course, user_id)
+        store.update_item(course, user_id)
         discussion_config = DiscussionsConfiguration.get(course_key)
         discussion_config.provider_type = provider
         discussion_config.enable_graded_units = enable_graded_subsections
         discussion_config.unit_level_visibility = True
         discussion_config.save()
+    # added delay of 30 minutes to allow for the course to be published
     update_discussions_settings_from_course_task.apply_async(
         args=[str(course_key), [str(unit) for unit in discussable_units]],
-        countdown=settings.DISCUSSION_SETTINGS['COURSE_PUBLISH_TASK_DELAY'],
+        countdown=30*60,
     )

--- a/openedx/core/djangoapps/discussions/tasks.py
+++ b/openedx/core/djangoapps/discussions/tasks.py
@@ -3,7 +3,6 @@ Tasks for discussions
 """
 import logging
 
-from django.conf import settings
 from celery import shared_task
 from edx_django_utils.monitoring import set_code_owner_attribute
 from opaque_keys.edx.keys import CourseKey
@@ -251,5 +250,5 @@ def update_unit_discussion_state_from_discussion_blocks(course_key: CourseKey, u
     # added delay of 30 minutes to allow for the course to be published
     update_discussions_settings_from_course_task.apply_async(
         args=[str(course_key), [str(unit) for unit in discussable_units]],
-        countdown=30*60,
+        countdown=1800,
     )


### PR DESCRIPTION
## Description
This PR reverts https://github.com/openedx/edx-platform/pull/32038 and adds delay of 30 minutes to ensure all other tasks are completed and data is up to date.

## Ticket 
https://2u-internal.atlassian.net/browse/INF-800

## Related PRs: 
https://github.com/openedx/edx-platform/pull/31993
https://github.com/openedx/edx-platform/pull/32008
https://github.com/openedx/edx-platform/pull/32028
https://github.com/openedx/edx-platform/pull/32033
https://github.com/openedx/edx-platform/pull/32035

