### PR TITLE
feat: allow for forcing asymmetric jwts

### DIFF
--- a/openedx/core/djangoapps/oauth_dispatch/jwt.py
+++ b/openedx/core/djangoapps/oauth_dispatch/jwt.py
@@ -161,7 +161,7 @@ def _create_jwt(
     """
     use_asymmetric_key = _get_use_asymmetric_key_value(is_restricted, use_asymmetric_key)
     # Enable monitoring of key type used. Use increment in case there are multiple calls in a transaction.
-    increment('use_asymmetric_key_count') if use_asymmetric_key else increment('use_symmetric_key_count')
+    increment('create_asymmetric_jwt_count') if use_asymmetric_key else increment('create_symmetric_jwt_count')
 
     # Default scopes should only contain non-privileged data.
     # Do not be misled by the fact that `email` and `profile` are default scopes. They
@@ -192,7 +192,7 @@ def _create_jwt(
     return _encode_and_sign(payload, use_asymmetric_key, secret)
 
 
-# .. toggle_name: FORCE_USE_ASYMMETRIC_KEY
+# .. toggle_name: JWT_AUTH_FORCE_CREATE_ASYMMETRIC
 # .. toggle_implementation: SettingToggle
 # .. toggle_default: False
 # .. toggle_description: When True, forces the LMS to only create JWTs signed with the asymmetric
@@ -201,14 +201,16 @@ def _create_jwt(
 # .. toggle_creation_date: 2023-04-10
 # .. toggle_target_removal_date: 2023-07-31
 # .. toggle_tickets: https://github.com/openedx/public-engineering/issues/83
-FORCE_USE_ASYMMETRIC_KEY = SettingToggle('FORCE_USE_ASYMMETRIC_KEY', default=False, module_name=__name__)
+JWT_AUTH_FORCE_CREATE_ASYMMETRIC = SettingToggle(
+    'JWT_AUTH_FORCE_CREATE_ASYMMETRIC', default=False, module_name=__name__
+)
 
 
 def _get_use_asymmetric_key_value(is_restricted, use_asymmetric_key):
     """
     Returns the value to use for use_asymmetric_key.
     """
-    if FORCE_USE_ASYMMETRIC_KEY.is_enabled():
+    if JWT_AUTH_FORCE_CREATE_ASYMMETRIC.is_enabled():
         return True
 
     return use_asymmetric_key or is_restricted

--- a/openedx/core/djangoapps/oauth_dispatch/jwt.py
+++ b/openedx/core/djangoapps/oauth_dispatch/jwt.py
@@ -196,7 +196,7 @@ def _create_jwt(
 # .. toggle_implementation: SettingToggle
 # .. toggle_default: False
 # .. toggle_description: When True, forces the LMS to only create JWTs signed with the asymmetric
-#   key. This is a temporary rollout toggle for DEPR of symmetic JWTs.
+#   key. This is a temporary rollout toggle for DEPR of symmetric JWTs.
 # .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2023-04-10
 # .. toggle_target_removal_date: 2023-07-31

--- a/openedx/core/djangoapps/oauth_dispatch/jwt.py
+++ b/openedx/core/djangoapps/oauth_dispatch/jwt.py
@@ -161,7 +161,10 @@ def _create_jwt(
     """
     use_asymmetric_key = _get_use_asymmetric_key_value(is_restricted, use_asymmetric_key)
     # Enable monitoring of key type used. Use increment in case there are multiple calls in a transaction.
-    increment('create_asymmetric_jwt_count') if use_asymmetric_key else increment('create_symmetric_jwt_count')
+    if use_asymmetric_key:
+        increment('create_asymmetric_jwt_count')
+    else:
+        increment('create_symmetric_jwt_count')
 
     # Default scopes should only contain non-privileged data.
     # Do not be misled by the fact that `email` and `profile` are default scopes. They

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_jwt.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_jwt.py
@@ -73,6 +73,11 @@ class TestCreateJWTs(AccessTokenMixin, TestCase):
         jwt_token = self._create_jwt_for_token(DOTAdapter(), use_asymmetric_key=True)
         self._assert_jwt_is_valid(jwt_token, should_be_asymmetric_key=True)
 
+    @override_settings(FORCE_USE_ASYMMETRIC_KEY=True)
+    def test_dot_create_jwt_for_token_forced_asymmetric(self):
+        jwt_token = self._create_jwt_for_token(DOTAdapter(), use_asymmetric_key=False)
+        self._assert_jwt_is_valid(jwt_token, should_be_asymmetric_key=True)
+
     def test_create_jwt_for_token_default_expire_seconds(self):
         oauth_adapter = DOTAdapter()
         jwt_token = self._create_jwt_for_token(oauth_adapter, use_asymmetric_key=False)

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_jwt.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_jwt.py
@@ -73,7 +73,7 @@ class TestCreateJWTs(AccessTokenMixin, TestCase):
         jwt_token = self._create_jwt_for_token(DOTAdapter(), use_asymmetric_key=True)
         self._assert_jwt_is_valid(jwt_token, should_be_asymmetric_key=True)
 
-    @override_settings(FORCE_USE_ASYMMETRIC_KEY=True)
+    @override_settings(JWT_AUTH_FORCE_CREATE_ASYMMETRIC=True)
     def test_dot_create_jwt_for_token_forced_asymmetric(self):
         jwt_token = self._create_jwt_for_token(DOTAdapter(), use_asymmetric_key=False)
         self._assert_jwt_is_valid(jwt_token, should_be_asymmetric_key=True)


### PR DESCRIPTION
## Description

Add a temporary feature toggle to force the LMS to only produce asymmetric JWTs. This is a part of
DEPR of Symmetric JWTs:
https://github.com/openedx/public-engineering/issues/83