### PR TITLE
build: nudge devs about Palm release in github

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,13 @@
 <!--
 
-🎉🎉 Olive has been released! 🎉🎉
+🌴🌴
+🌴🌴🌴🌴         🌴 Note: the Palm master branch has been created. Please consider whether your change
+    🌴🌴🌴🌴     should also be applied to Palm. If so, make another pull request against the
+🌴🌴🌴🌴         open-release/palm.master branch, or ask in the #wg-build-test-release Slack channel
+🌴🌴             if you have any questions or need help.
 
-🫒🫒
-🫒🫒🫒🫒         🫒 Note: Olive is in support. Fixes you make on master may still
-    🫒🫒🫒🫒     be needed on Olive. If so, make another pull request against the
-🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
-🫒🫒
+🫒🫒🫒🫒🫒🫒     🫒 Note: the Olive release is still supported.
+                Please consider whether your change should be applied to Olive as well.
 
 Please give your pull request a short but descriptive title.
 Use conventional commits to separate and summarize commits logically:


### PR DESCRIPTION
Remind devs that when they open PRs on edx-platform, that they should backport their bug fixes to the Palm master branch (and think about backporting to Olive as well).