### PR TITLE
WIP: Adding ClickHouse as a second Coursegraph destination

### DIFF
--- a/cms/djangoapps/coursegraph/destinations/dest_base.py
+++ b/cms/djangoapps/coursegraph/destinations/dest_base.py
@@ -1,0 +1,34 @@
+class BaseCoursegraphDestination:
+    @staticmethod
+    def strip_branch_and_version(location):
+        """
+        Removes the branch and version information from a location.
+        Args:
+            location: an xblock's location.
+        Returns: that xblock's location without branch and version information.
+        """
+        return location.for_branch(None)
+
+    @staticmethod
+    def get_course_last_published(course_key):
+        """
+        Approximately when was a course last published?
+
+        We use the 'modified' column in the CourseOverview table as a quick and easy
+        (although perhaps inexact) way of determining when a course was last
+        published. This works because CourseOverview rows are re-written upon
+        course publish.
+
+        Args:
+            course_key: a CourseKey
+
+        Returns: The datetime the course was last published at, stringified.
+            Uses Python's default str(...) implementation for datetimes, which
+            is sortable and similar to ISO 8601:
+            https://docs.python.org/3/library/datetime.html#datetime.date.__str__
+        """
+        # Import is placed here to avoid model import at project startup.
+        from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+
+        approx_last_published = CourseOverview.get_from_id(course_key).modified
+        return str(approx_last_published)

--- a/cms/djangoapps/coursegraph/destinations/dest_clickhouse.py
+++ b/cms/djangoapps/coursegraph/destinations/dest_clickhouse.py
@@ -1,0 +1,177 @@
+import csv
+import io
+
+from django.conf import settings
+from django.utils import timezone
+
+import requests
+
+from .dest_base import BaseCoursegraphDestination
+
+
+class ClickHouseDestination(BaseCoursegraphDestination):
+    connection_overrides = None
+    log = None
+
+    def __init__(self, connection_overrides, log):
+        self.connection_overrides = connection_overrides
+        self.log = log
+
+    @staticmethod
+    def serialize_item(item, index):
+        """
+        Args:
+            item: an XBlock
+            index: a number indicating where the item falls in the course hierarchy
+
+        Returns:
+            fields: a *limited* dictionary of an XBlock's field names and values
+            block_type: the name of the XBlock's type (i.e. 'course'
+            or 'problem')
+        """
+        from xmodule.modulestore.store_utilities import DETACHED_XBLOCK_TYPES
+
+        course_key = item.scope_ids.usage_id.course_key
+        block_type = item.scope_ids.block_type
+
+        rtn_fields = {
+            'org': course_key.org,
+            'course_key': str(course_key),
+            'course': course_key.course,
+            'run': course_key.run,
+            'location': str(item.location),
+            'display_name': item.display_name_with_default.replace("'", "\'"),
+            'block_type': block_type,
+            'detached': 1 if block_type in DETACHED_XBLOCK_TYPES else 0,
+            'edited_on': str(getattr(item, 'edited_on', '')),
+            'time_last_dumped':  str(timezone.now()),
+            'order': index,
+        }
+
+        return rtn_fields, block_type
+
+    def serialize_course(self, course_id):
+        """
+        Serializes a course into a CSV of nodes and relationships.
+
+        Args:
+            course_id: CourseKey of the course we want to serialize
+
+        Returns:
+            nodes: a csv of nodes for the course
+            relationships: a csv of relationships between nodes
+        """
+        # Import is placed here to avoid model import at project startup.
+        from xmodule.modulestore.django import modulestore
+
+        # create a location to node mapping we'll need later for
+        # writing relationships
+        location_to_node = {}
+        items = modulestore().get_items(course_id)
+
+        # create nodes
+        i = 0
+        for item in items:
+            i += 1
+            fields, block_type = self.serialize_item(item, i)
+            location_to_node[self.strip_branch_and_version(item.location)] = fields
+
+        # create relationships
+        relationships = []
+        for item in items:
+            for index, child in enumerate(item.get_children()):
+                parent_node = location_to_node.get(self.strip_branch_and_version(item.location))
+                child_node = location_to_node.get(self.strip_branch_and_version(child.location))
+
+                if parent_node is not None and child_node is not None:
+                    relationship = {
+                        'course_key': str(course_id),
+                        'parent_location': str(parent_node["location"]),
+                        'child_location': str(child_node["location"]),
+                        'order': index
+                    }
+                    relationships.append(relationship)
+
+        nodes = list(location_to_node.values())
+        return nodes, relationships
+
+    def dump(self, course_key):
+        nodes, relationships = self.serialize_course(course_key)
+        self.log.info(
+            "Now dumping %s to ClickHouse: %d nodes and %d relationships",
+            course_key,
+            len(nodes),
+            len(relationships),
+        )
+
+        course_string = str(course_key)
+
+        try:
+            # URL to a running ClickHouse server's HTTP interface. ex: https://foo.openedx.org:8443/ or
+            # http://foo.openedx.org:8123/
+            ch_url = settings.COURSEGRAPH_CLICKHOUSE_URL
+            auth = (settings.COURSEGRAPH_CLICKHOUSE_USER, settings.COURSEGRAPH_CLICKHOUSE_PASSWORD)
+
+            # Params that begin with "param_" will be used in the query replacement
+            # all others are ClickHouse settings.
+            params = {
+                # Needed to actually run DELETE operations
+                "allow_experimental_lightweight_delete": 1,
+                # Fail early on bulk inserts
+                "input_format_allow_errors_num": 1,
+                "input_format_allow_errors_ratio": 0.1,
+                # Used in the DELETE queries, but harmless elsewhere
+                "param_course_string": course_string
+            }
+
+            del_relationships = "DELETE FROM coursegraph.coursegraph_relationships " \
+                                "WHERE course_key = {course_string:String}"
+
+            del_nodes = "DELETE FROM coursegraph.coursegraph_nodes WHERE course_key = {course_string:String}"
+
+            for sql in (del_relationships, del_nodes):
+                self.log.info(sql)
+                response = requests.post(ch_url, data=sql, params=params, auth=auth)
+                response.raise_for_status()
+                self.log.info(response.headers)
+                self.log.info(response)
+                self.log.info(response.text)
+
+            # TODO: Make these predefined queries?
+            # https://clickhouse.com/docs/en/interfaces/http/#predefined_http_interface
+            # "query" is a special param for the query, it's the best way to get the FORMAT CSV in there.
+            params["query"] = "INSERT INTO coursegraph.coursegraph_nodes FORMAT CSV"
+
+            output = io.StringIO()
+            writer = csv.writer(output, quoting=csv.QUOTE_NONNUMERIC)
+
+            for node in nodes:
+                writer.writerow(node.values())
+
+            response = requests.post(host, data=output.getvalue(), params=params, auth=auth)
+            self.log.info(response.headers)
+            self.log.info(response)
+            self.log.info(response.text)
+            response.raise_for_status()
+
+            # Just overwriting the previous query
+            params["query"] = "INSERT INTO coursegraph.coursegraph_relationships FORMAT CSV"
+            output = io.StringIO()
+            writer = csv.writer(output, quoting=csv.QUOTE_NONNUMERIC)
+
+            for relationship in relationships:
+                writer.writerow(relationship.values())
+
+            response = requests.post(host, data=output.getvalue(), params=params, auth=auth)
+            self.log.info(response.headers)
+            self.log.info(response)
+            self.log.info(response.text)
+            response.raise_for_status()
+
+            self.log.info("Completed dumping %s to ClickHouse", course_key)
+
+        except Exception:  # pylint: disable=broad-except
+            self.log.exception(
+                "Error trying to dump course %s to ClickHouse!",
+                course_string
+            )

--- a/cms/djangoapps/coursegraph/destinations/dest_neo4j.py
+++ b/cms/djangoapps/coursegraph/destinations/dest_neo4j.py
@@ -1,0 +1,277 @@
+import logging
+
+from django.conf import settings
+from django.utils import timezone
+
+import py2neo  # pylint: disable=unused-import
+from py2neo import Graph, Node, Relationship
+
+try:
+    from py2neo.matching import NodeMatcher
+except ImportError:
+    from py2neo import NodeMatcher
+else:
+    pass
+
+from .dest_base import BaseCoursegraphDestination
+
+
+# When testing locally, neo4j's bolt logger was noisy, so we'll only have it
+# emit logs if there's an error.
+bolt_log = logging.getLogger('neo4j.bolt')  # pylint: disable=invalid-name
+bolt_log.setLevel(logging.ERROR)
+
+PRIMITIVE_NEO4J_TYPES = (int, bytes, str, float, bool)
+
+
+class Neo4JDestination(BaseCoursegraphDestination):
+    graph = None
+    transaction = None
+    log = None
+
+    def __init__(self, connection_overrides, log):
+        self.authenticate_and_create_graph(connection_overrides)
+        self.log = log
+
+    @staticmethod
+    def serialize_item(item):
+        """
+        Args:
+            item: an XBlock
+
+        Returns:
+            fields: a dictionary of an XBlock's field names and values
+            block_type: the name of the XBlock's type (i.e. 'course'
+            or 'problem')
+        """
+        from xmodule.modulestore.store_utilities import DETACHED_XBLOCK_TYPES
+
+        # convert all fields to a dict and filter out parent and children field
+        fields = {
+            field: field_value.read_from(item)
+            for (field, field_value) in item.fields.items()
+            if field not in ['parent', 'children']
+        }
+
+        course_key = item.scope_ids.usage_id.course_key
+        block_type = item.scope_ids.block_type
+
+        # set or reset some defaults
+        fields['edited_on'] = str(getattr(item, 'edited_on', ''))
+        fields['display_name'] = item.display_name_with_default
+        fields['org'] = course_key.org
+        fields['course'] = course_key.course
+        fields['run'] = course_key.run
+        fields['course_key'] = str(course_key)
+        fields['location'] = str(item.location)
+        fields['block_type'] = block_type
+        fields['detached'] = block_type in DETACHED_XBLOCK_TYPES
+
+        if block_type == 'course':
+            # prune the checklists field
+            if 'checklists' in fields:
+                del fields['checklists']
+
+            # record the time this command was run
+            fields['time_last_dumped_to_neo4j'] = str(timezone.now())
+
+        return fields, block_type
+
+    @staticmethod
+    def coerce_types(value):
+        """
+        Args:
+            value: the value of an xblock's field
+
+        Returns: either the value, a text version of the value, or, if the
+            value is a list, a list where each element is converted to text.
+        """
+        coerced_value = value
+        if isinstance(value, list):
+            coerced_value = [str(element) for element in coerced_value]
+
+        # if it's not one of the types that neo4j accepts,
+        # just convert it to text
+        elif not isinstance(value, PRIMITIVE_NEO4J_TYPES):
+            coerced_value = str(value)
+
+        return coerced_value
+
+
+    def add_to_transaction(self, neo4j_entities):
+        """
+        Add all of our entities to our transaction
+        """
+        for entity in neo4j_entities:
+            self.transaction.create(entity)
+
+
+    def get_command_last_run(self, course_key):
+        """
+        This information is stored on the course node of a course in neo4j
+        Args:
+            course_key: a CourseKey
+
+        Returns: The datetime that the command was last run, converted into
+            text, or None, if there's no record of this command last being run.
+        """
+        matcher = NodeMatcher(self.graph)
+        course_node = matcher.match(
+            "course",
+            course_key=str(course_key)
+        ).first()
+
+        last_this_command_was_run = None
+        if course_node:
+            last_this_command_was_run = course_node['time_last_dumped_to_neo4j']
+
+        return last_this_command_was_run
+
+
+    def serialize_course(self, course_id):
+        """
+        Serializes a course into py2neo Nodes and Relationships
+        Args:
+            course_id: CourseKey of the course we want to serialize
+
+        Returns:
+            nodes: a list of py2neo Node objects
+            relationships: a list of py2neo Relationships objects
+        """
+        # Import is placed here to avoid model import at project startup.
+        from xmodule.modulestore.django import modulestore
+
+        # create a location to node mapping we'll need later for
+        # writing relationships
+        location_to_node = {}
+        items = modulestore().get_items(course_id)
+
+        # create nodes
+        for item in items:
+            fields, block_type = self.serialize_item(item)
+
+            for field_name, value in fields.items():
+                fields[field_name] = self.coerce_types(value)
+
+            node = Node(block_type, 'item', **fields)
+            location_to_node[self.strip_branch_and_version(item.location)] = node
+
+        # create relationships
+        relationships = []
+        for item in items:
+            previous_child_node = None
+            for index, child in enumerate(item.get_children()):
+                parent_node = location_to_node.get(self.strip_branch_and_version(item.location))
+                child_node = location_to_node.get(self.strip_branch_and_version(child.location))
+
+                if parent_node is not None and child_node is not None:
+                    child_node["index"] = index
+
+                    relationship = Relationship(parent_node, "PARENT_OF", child_node)
+                    relationships.append(relationship)
+
+                    if previous_child_node:
+                        ordering_relationship = Relationship(
+                            previous_child_node,
+                            "PRECEDES",
+                            child_node,
+                        )
+                        relationships.append(ordering_relationship)
+                    previous_child_node = child_node
+
+        nodes = list(location_to_node.values())
+        return nodes, relationships
+
+    def authenticate_and_create_graph(self, connection_overrides=None):
+        """
+        This function authenticates with neo4j and creates a py2neo graph object
+
+        Arguments:
+            connection_overrides (dict): overrides to Neo4j connection
+                parameters specified in `settings.COURSEGRAPH_CONNECTION`.
+
+        Returns: a py2neo `Graph` object.
+        """
+        provided_overrides = {
+            key: value
+            for key, value in (connection_overrides or {}).items()
+            # Drop overrides whose values are `None`. Note that `False` is a
+            # legitimate override value that we don't want to drop here.
+            if value is not None
+        }
+        connection_with_overrides = {**settings.COURSEGRAPH_CONNECTION, **provided_overrides}
+        self.graph = Graph(**connection_with_overrides)
+
+    def should_dump_course(self, course_key):
+        """
+        Only dump the course if it's been changed since the last time it's been
+        dumped.
+        Args:
+            course_key: a CourseKey object.
+
+        Returns:
+            - whether this course should be dumped to neo4j (bool)
+            - reason why course needs to be dumped (string, None if doesn't need to be dumped)
+        """
+
+        last_this_command_was_run = self.get_command_last_run(course_key)
+
+        course_last_published_date = self.get_course_last_published(course_key)
+
+        # if we don't have a record of the last time this command was run,
+        # we should serialize the course and dump it
+        if last_this_command_was_run is None:
+            return (
+                True,
+                "no record of the last neo4j update time for the course"
+            )
+
+        # if we've serialized the course recently and we have no published
+        # events, we will not dump it, and so we can skip serializing it
+        # again here
+        if last_this_command_was_run and course_last_published_date is None:
+            return False, None
+
+        # otherwise, serialize and dump the course if the command was run
+        # before the course's last published event
+        needs_update = last_this_command_was_run < course_last_published_date
+        update_reason = None
+        if needs_update:
+            update_reason = (
+                f"course has been published since last neo4j update time - "
+                f"update date {last_this_command_was_run} < published date {course_last_published_date}"
+            )
+        return needs_update, update_reason
+
+    def dump(self, course_key):
+        nodes, relationships = self.serialize_course(course_key)
+        self.log.info(
+            "Now dumping %s to neo4j: %d nodes and %d relationships",
+            course_key,
+            len(nodes),
+            len(relationships),
+        )
+
+        self.transaction = self.graph.begin()
+        course_string = str(course_key)
+
+        try:
+            # first, delete existing course
+            self.transaction.run(
+                "MATCH (n:item) WHERE n.course_key='{}' DETACH DELETE n".format(
+                    course_string
+                )
+            )
+
+            # now, re-add it
+            self.add_to_transaction(nodes)
+            self.add_to_transaction(relationships)
+            self.graph.commit(self.transaction)
+            self.log.info("Completed dumping %s to neo4j", course_key)
+
+        except Exception:  # pylint: disable=broad-except
+            self.log.exception(
+                "Error trying to dump course %s to neo4j, rolling back",
+                course_string
+            )
+            self.graph.rollback(self.transaction)

--- a/cms/djangoapps/coursegraph/management/commands/dump_to_clickhouse.py
+++ b/cms/djangoapps/coursegraph/management/commands/dump_to_clickhouse.py
@@ -1,0 +1,88 @@
+"""
+Todo
+"""
+
+
+import logging
+from textwrap import dedent
+
+from django.core.management.base import BaseCommand
+
+from cms.djangoapps.coursegraph.tasks import ModuleStoreSerializer
+
+log = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Dump recently-published course(s) over to a CourseGraph (ClickHouse) instance.
+    """
+    help = dedent(__doc__).strip()
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--url',
+            type=str,
+            help="the URL of the ClickHouse server",
+        )
+        parser.add_argument(
+            '--user',
+            type=str,
+            help="the username of the ClickHouse user",
+        )
+        parser.add_argument(
+            '--password',
+            type=str,
+            help="the password of the ClickHouse user",
+        )
+        parser.add_argument(
+            '--courses',
+            metavar='KEY',
+            type=str,
+            nargs='*',
+            help="keys of courses to serialize; if omitted all courses in system are serialized",
+        )
+        parser.add_argument(
+            '--skip',
+            metavar='KEY',
+            type=str,
+            nargs='*',
+            help="keys of courses to NOT to serialize",
+        )
+        parser.add_argument(
+            '--override',
+            action='store_true',
+            help="dump all courses regardless of when they were last published",
+        )
+
+    def handle(self, *args, **options):
+        """
+        Iterates through each course, serializes them into graphs, and saves
+        those graphs to neo4j.
+        """
+
+        mss = ModuleStoreSerializer.create(options['courses'], options['skip'])
+        connection_overrides = {
+            key: options[key]
+            for key in ["url", "user", "password"]
+        }
+        submitted_courses, skipped_courses = mss.dump_courses_to_clickhouse(
+            connection_overrides=connection_overrides,
+            override_cache=options['override'],
+        )
+
+        log.info(
+            "%d courses submitted for export to ClickHouse. %d courses skipped.",
+            len(submitted_courses),
+            len(skipped_courses),
+        )
+
+        if not submitted_courses:
+            print("No courses submitted for export to ClickHouse at all!")
+            return
+
+        if submitted_courses:
+            print(
+                "These courses were submitted for export to ClickHouse successfully:\n\t" +
+                "\n\t".join(submitted_courses)
+            )

--- a/cms/djangoapps/coursegraph/tasks.py
+++ b/cms/djangoapps/coursegraph/tasks.py
@@ -3,345 +3,18 @@ This file contains a management command for exporting the modulestore to
 neo4j, a graph database.
 """
 
-import csv
-import io
 import logging
 
 from celery import shared_task
-from django.conf import settings
-from django.utils import timezone
 from edx_django_utils.cache import RequestCache
 from edx_django_utils.monitoring import set_code_owner_attribute
 from opaque_keys.edx.keys import CourseKey
 
-import py2neo  # pylint: disable=unused-import
-import requests
-from py2neo import Graph, Node, Relationship
-
-try:
-    from py2neo.matching import NodeMatcher
-except ImportError:
-    from py2neo import NodeMatcher
-else:
-    pass
-
+from destinations.dest_clickhouse import ClickHouseDestination
+from destinations.dest_neo4j import Neo4JDestination
 
 log = logging.getLogger(__name__)
 celery_log = logging.getLogger('edx.celery.task')
-
-# When testing locally, neo4j's bolt logger was noisy, so we'll only have it
-# emit logs if there's an error.
-bolt_log = logging.getLogger('neo4j.bolt')  # pylint: disable=invalid-name
-bolt_log.setLevel(logging.ERROR)
-
-PRIMITIVE_NEO4J_TYPES = (int, bytes, str, float, bool)
-
-
-def serialize_item(item):
-    """
-    Args:
-        item: an XBlock
-
-    Returns:
-        fields: a dictionary of an XBlock's field names and values
-        block_type: the name of the XBlock's type (i.e. 'course'
-        or 'problem')
-    """
-    from xmodule.modulestore.store_utilities import DETACHED_XBLOCK_TYPES
-
-    # convert all fields to a dict and filter out parent and children field
-    fields = {
-        field: field_value.read_from(item)
-        for (field, field_value) in item.fields.items()
-        if field not in ['parent', 'children']
-    }
-
-    course_key = item.scope_ids.usage_id.course_key
-    block_type = item.scope_ids.block_type
-
-    # set or reset some defaults
-    fields['edited_on'] = str(getattr(item, 'edited_on', ''))
-    fields['display_name'] = item.display_name_with_default
-    fields['org'] = course_key.org
-    fields['course'] = course_key.course
-    fields['run'] = course_key.run
-    fields['course_key'] = str(course_key)
-    fields['location'] = str(item.location)
-    fields['block_type'] = block_type
-    fields['detached'] = block_type in DETACHED_XBLOCK_TYPES
-
-    if block_type == 'course':
-        # prune the checklists field
-        if 'checklists' in fields:
-            del fields['checklists']
-
-        # record the time this command was run
-        fields['time_last_dumped_to_neo4j'] = str(timezone.now())
-
-    return fields, block_type
-
-
-def serialize_item_csv(item, index):
-    """
-    Args:
-        item: an XBlock
-
-    Returns:
-        fields: a *limited* dictionary of an XBlock's field names and values
-        block_type: the name of the XBlock's type (i.e. 'course'
-        or 'problem')
-    """
-    from xmodule.modulestore.store_utilities import DETACHED_XBLOCK_TYPES
-
-    course_key = item.scope_ids.usage_id.course_key
-    block_type = item.scope_ids.block_type
-
-    rtn_fields = {
-        'org': course_key.org,
-        'course_key': str(course_key),
-        'course': course_key.course,
-        'run': course_key.run,
-        'location': str(item.location),
-        'display_name': item.display_name_with_default.replace("'", "\'"),
-        'block_type': block_type,
-        'detached': 1 if block_type in DETACHED_XBLOCK_TYPES else 0,
-        'edited_on': str(getattr(item, 'edited_on', '')),
-        'time_last_dumped':  str(timezone.now()),
-        'order': index,
-    }
-
-    return rtn_fields, block_type
-
-
-def coerce_types(value):
-    """
-    Args:
-        value: the value of an xblock's field
-
-    Returns: either the value, a text version of the value, or, if the
-        value is a list, a list where each element is converted to text.
-    """
-    coerced_value = value
-    if isinstance(value, list):
-        coerced_value = [str(element) for element in coerced_value]
-
-    # if it's not one of the types that neo4j accepts,
-    # just convert it to text
-    elif not isinstance(value, PRIMITIVE_NEO4J_TYPES):
-        coerced_value = str(value)
-
-    return coerced_value
-
-
-def add_to_transaction(neo4j_entities, transaction):
-    """
-    Args:
-        neo4j_entities: a list of Nodes or Relationships
-        transaction: a neo4j transaction
-    """
-    for entity in neo4j_entities:
-        transaction.create(entity)
-
-
-def get_command_last_run(course_key, graph):
-    """
-    This information is stored on the course node of a course in neo4j
-    Args:
-        course_key: a CourseKey
-        graph: a py2neo Graph
-
-    Returns: The datetime that the command was last run, converted into
-        text, or None, if there's no record of this command last being run.
-    """
-    matcher = NodeMatcher(graph)
-    course_node = matcher.match(
-        "course",
-        course_key=str(course_key)
-    ).first()
-
-    last_this_command_was_run = None
-    if course_node:
-        last_this_command_was_run = course_node['time_last_dumped_to_neo4j']
-
-    return last_this_command_was_run
-
-
-def get_course_last_published(course_key):
-    """
-    Approximately when was a course last published?
-
-    We use the 'modified' column in the CourseOverview table as a quick and easy
-    (although perhaps inexact) way of determining when a course was last
-    published. This works because CourseOverview rows are re-written upon
-    course publish.
-
-    Args:
-        course_key: a CourseKey
-
-    Returns: The datetime the course was last published at, stringified.
-        Uses Python's default str(...) implementation for datetimes, which
-        is sortable and similar to ISO 8601:
-        https://docs.python.org/3/library/datetime.html#datetime.date.__str__
-    """
-    # Import is placed here to avoid model import at project startup.
-    from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
-
-    approx_last_published = CourseOverview.get_from_id(course_key).modified
-    return str(approx_last_published)
-
-
-def strip_branch_and_version(location):
-    """
-    Removes the branch and version information from a location.
-    Args:
-        location: an xblock's location.
-    Returns: that xblock's location without branch and version information.
-    """
-    return location.for_branch(None)
-
-
-def serialize_course(course_id):
-    """
-    Serializes a course into py2neo Nodes and Relationships
-    Args:
-        course_id: CourseKey of the course we want to serialize
-
-    Returns:
-        nodes: a list of py2neo Node objects
-        relationships: a list of py2neo Relationships objects
-    """
-    # Import is placed here to avoid model import at project startup.
-    from xmodule.modulestore.django import modulestore
-
-    # create a location to node mapping we'll need later for
-    # writing relationships
-    location_to_node = {}
-    items = modulestore().get_items(course_id)
-
-    # create nodes
-    for item in items:
-        fields, block_type = serialize_item(item)
-
-        for field_name, value in fields.items():
-            fields[field_name] = coerce_types(value)
-
-        node = Node(block_type, 'item', **fields)
-        location_to_node[strip_branch_and_version(item.location)] = node
-
-    # create relationships
-    relationships = []
-    for item in items:
-        previous_child_node = None
-        for index, child in enumerate(item.get_children()):
-            parent_node = location_to_node.get(strip_branch_and_version(item.location))
-            child_node = location_to_node.get(strip_branch_and_version(child.location))
-
-            if parent_node is not None and child_node is not None:
-                child_node["index"] = index
-
-                relationship = Relationship(parent_node, "PARENT_OF", child_node)
-                relationships.append(relationship)
-
-                if previous_child_node:
-                    ordering_relationship = Relationship(
-                        previous_child_node,
-                        "PRECEDES",
-                        child_node,
-                    )
-                    relationships.append(ordering_relationship)
-                previous_child_node = child_node
-
-    nodes = list(location_to_node.values())
-    return nodes, relationships
-
-
-def serialize_course_csv(course_id):
-    """
-    Serializes a course into a CSV of nodes and relationships.
-
-    Args:
-        course_id: CourseKey of the course we want to serialize
-
-    Returns:
-        nodes: a csv of nodes for the course
-        relationships: a csv of relationships between nodes
-    """
-    # Import is placed here to avoid model import at project startup.
-    from xmodule.modulestore.django import modulestore
-
-    # create a location to node mapping we'll need later for
-    # writing relationships
-    location_to_node = {}
-    items = modulestore().get_items(course_id)
-
-    # create nodes
-    i = 0
-    for item in items:
-        i += 1
-        fields, block_type = serialize_item_csv(item, i)
-        location_to_node[strip_branch_and_version(item.location)] = fields
-
-    # create relationships
-    relationships = []
-    for item in items:
-        for index, child in enumerate(item.get_children()):
-            parent_node = location_to_node.get(strip_branch_and_version(item.location))
-            child_node = location_to_node.get(strip_branch_and_version(child.location))
-
-            if parent_node is not None and child_node is not None:
-                relationship = {
-                    'course_key': str(course_id),
-                    'parent_location': str(parent_node["location"]),
-                    'child_location': str(child_node["location"]),
-                    'order': index
-                }
-                relationships.append(relationship)
-
-    nodes = list(location_to_node.values())
-    return nodes, relationships
-
-
-def should_dump_course(course_key, graph):
-    """
-    Only dump the course if it's been changed since the last time it's been
-    dumped.
-    Args:
-        course_key: a CourseKey object.
-        graph: a py2neo Graph object.
-
-    Returns:
-        - whether this course should be dumped to neo4j (bool)
-        - reason why course needs to be dumped (string, None if doesn't need to be dumped)
-    """
-
-    last_this_command_was_run = get_command_last_run(course_key, graph)
-
-    course_last_published_date = get_course_last_published(course_key)
-
-    # if we don't have a record of the last time this command was run,
-    # we should serialize the course and dump it
-    if last_this_command_was_run is None:
-        return (
-            True,
-            "no record of the last neo4j update time for the course"
-        )
-
-    # if we've serialized the course recently and we have no published
-    # events, we will not dump it, and so we can skip serializing it
-    # again here
-    if last_this_command_was_run and course_last_published_date is None:
-        return (False, None)
-
-    # otherwise, serialize and dump the course if the command was run
-    # before the course's last published event
-    needs_update = last_this_command_was_run < course_last_published_date
-    update_reason = None
-    if needs_update:
-        update_reason = (
-            f"course has been published since last neo4j update time - "
-            f"update date {last_this_command_was_run} < published date {course_last_published_date}"
-        )
-    return (needs_update, update_reason)
 
 
 @shared_task
@@ -356,83 +29,8 @@ def dump_course_to_clickhouse(course_key_string, connection_overrides=None):
             parameters specified in `settings.COURSEGRAPH_CONNECTION`.
     """
     course_key = CourseKey.from_string(course_key_string)
-    nodes, relationships = serialize_course_csv(course_key)
-    celery_log.info(
-        "Now dumping %s to ClickHouse: %d nodes and %d relationships",
-        course_key,
-        len(nodes),
-        len(relationships),
-    )
-
-    course_string = str(course_key)
-
-    try:
-        host = "http://clickhouse:8123/"
-        auth = ("ch_lms", "foo")
-
-        # Params that begin with "param_" will be used in the query replacement
-        # all others are ClickHouse settings.
-        params = {
-            # Needed to actually run DELETE operations
-            "allow_experimental_lightweight_delete": 1,
-            # Fail early on bulk inserts
-            "input_format_allow_errors_num": 1,
-            "input_format_allow_errors_ratio": 0.1,
-            # Used in the DELETE queries, but harmless elsewhere
-            "param_course_string": course_string
-        }
-
-        del_relationships = "DELETE FROM coursegraph.coursegraph_relationships " \
-                            "WHERE course_key = {course_string:String}"
-
-        del_nodes = "DELETE FROM coursegraph.coursegraph_nodes WHERE course_key = {course_string:String}"
-
-        for sql in (del_relationships, del_nodes):
-            celery_log.info(sql)
-            response = requests.post(host, data=sql, params=params, auth=auth)
-            response.raise_for_status()
-            celery_log.info(response.headers)
-            celery_log.info(response)
-            celery_log.info(response.text)
-
-        # TODO: Make these predefined queries?
-        # https://clickhouse.com/docs/en/interfaces/http/#predefined_http_interface
-        # "query" is a special param for the query, it's the best way to get the FORMAT CSV in there.
-        params["query"] = "INSERT INTO coursegraph.coursegraph_nodes FORMAT CSV"
-
-        output = io.StringIO()
-        writer = csv.writer(output, quoting=csv.QUOTE_NONNUMERIC)
-
-        for node in nodes:
-            writer.writerow(node.values())
-
-        response = requests.post(host, data=output.getvalue(), params=params, auth=auth)
-        celery_log.info(response.headers)
-        celery_log.info(response)
-        celery_log.info(response.text)
-        response.raise_for_status()
-
-        # Just overwriting the previous query
-        params["query"] = "INSERT INTO coursegraph.coursegraph_relationships FORMAT CSV"
-        output = io.StringIO()
-        writer = csv.writer(output, quoting=csv.QUOTE_NONNUMERIC)
-
-        for relationship in relationships:
-            writer.writerow(relationship.values())
-
-        response = requests.post(host, data=output.getvalue(), params=params, auth=auth)
-        celery_log.info(response.headers)
-        celery_log.info(response)
-        celery_log.info(response.text)
-        response.raise_for_status()
-
-        celery_log.info("Completed dumping %s to ClickHouse", course_key)
-
-    except Exception:  # pylint: disable=broad-except
-        celery_log.exception(
-            "Error trying to dump course %s to ClickHouse!",
-            course_string
-        )
+    destination = ClickHouseDestination(connection_overrides=connection_overrides, log=celery_log)
+    destination.dump(course_key)
 
 
 @shared_task
@@ -447,40 +45,8 @@ def dump_course_to_neo4j(course_key_string, connection_overrides=None):
             parameters specified in `settings.COURSEGRAPH_CONNECTION`.
     """
     course_key = CourseKey.from_string(course_key_string)
-    nodes, relationships = serialize_course(course_key)
-    celery_log.info(
-        "Now dumping %s to neo4j: %d nodes and %d relationships",
-        course_key,
-        len(nodes),
-        len(relationships),
-    )
-
-    graph = authenticate_and_create_graph(
-        connection_overrides=connection_overrides
-    )
-
-    transaction = graph.begin()
-    course_string = str(course_key)
-    try:
-        # first, delete existing course
-        transaction.run(
-            "MATCH (n:item) WHERE n.course_key='{}' DETACH DELETE n".format(
-                course_string
-            )
-        )
-
-        # now, re-add it
-        add_to_transaction(nodes, transaction)
-        add_to_transaction(relationships, transaction)
-        graph.commit(transaction)
-        celery_log.info("Completed dumping %s to neo4j", course_key)
-
-    except Exception:  # pylint: disable=broad-except
-        celery_log.exception(
-            "Error trying to dump course %s to neo4j, rolling back",
-            course_string
-        )
-        graph.rollback(transaction)
+    destination = Neo4JDestination(connection_overrides=connection_overrides, log=celery_log)
+    destination.dump(course_key)
 
 
 class ModuleStoreSerializer:
@@ -587,13 +153,13 @@ class ModuleStoreSerializer:
         submitted_courses = []
         skipped_courses = []
 
-        graph = authenticate_and_create_graph(connection_overrides)
+        graph = Neo4JDestination.authenticate_and_create_graph(connection_overrides=connection_overrides)
 
         for index, course_key in enumerate(self.course_keys):
             # first, clear the request cache to prevent memory leaks
             RequestCache.clear_all_namespaces()
 
-            (needs_dump, reason) = should_dump_course(course_key, graph)
+            (needs_dump, reason) = Neo4JDestination.should_dump_course(course_key, graph)
             if not (override_cache or needs_dump):
                 log.info("skipping submitting %s, since it hasn't changed", course_key)
                 skipped_courses.append(str(course_key))
@@ -619,24 +185,3 @@ class ModuleStoreSerializer:
             submitted_courses.append(str(course_key))
 
         return submitted_courses, skipped_courses
-
-
-def authenticate_and_create_graph(connection_overrides=None):
-    """
-    This function authenticates with neo4j and creates a py2neo graph object
-
-    Arguments:
-        connection_overrides (dict): overrides to Neo4j connection
-            parameters specified in `settings.COURSEGRAPH_CONNECTION`.
-
-    Returns: a py2neo `Graph` object.
-    """
-    provided_overrides = {
-        key: value
-        for key, value in (connection_overrides or {}).items()
-        # Drop overrides whose values are `None`. Note that `False` is a
-        # legitimate override value that we don't want to drop here.
-        if value is not None
-    }
-    connection_with_overrides = {**settings.COURSEGRAPH_CONNECTION, **provided_overrides}
-    return Graph(**connection_with_overrides)


### PR DESCRIPTION
## Description

Work in progress! To support the OARS project we would like to have course structure and block names pushed to ClickHouse on course publish and using a management command, which is what Coursegraph does for Neo4J. This is a first stab at trying to generalize that interface and make it possible to add other backends. This work may be abandoned in favor of making a separate plugin.

## Supporting information

[Original issue](https://github.com/orgs/openedx/projects/5/views/1?pane=issue&itemId=23868239)

## Testing instructions

Currently this is just for sharing code and getting feedback, so no testing yet.
