### PR TITLE
chore: Upgrade edx-drf-extensions (and edx-django-utils, apparently)

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -467,7 +467,7 @@ edx-django-utils==5.3.0
     #   ora2
     #   outcome-surveys
     #   super-csv
-edx-drf-extensions==8.4.1
+edx-drf-extensions==8.5.3
     # via
     #   -r requirements/edx/base.in
     #   edx-completion

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -576,7 +576,7 @@ edx-django-release-util==1.2.0
     #   openedx-blockstore
 edx-django-sites-extensions==4.0.0
     # via -r requirements/edx/testing.txt
-edx-django-utils==5.2.0
+edx-django-utils==5.3.0
     # via
     #   -r requirements/edx/testing.txt
     #   django-config-models
@@ -593,7 +593,7 @@ edx-django-utils==5.2.0
     #   ora2
     #   outcome-surveys
     #   super-csv
-edx-drf-extensions==8.4.1
+edx-drf-extensions==8.5.3
     # via
     #   -r requirements/edx/testing.txt
     #   edx-completion

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -555,7 +555,7 @@ edx-django-release-util==1.2.0
     #   openedx-blockstore
 edx-django-sites-extensions==4.0.0
     # via -r requirements/edx/base.txt
-edx-django-utils==5.2.0
+edx-django-utils==5.3.0
     # via
     #   -r requirements/edx/base.txt
     #   django-config-models
@@ -572,7 +572,7 @@ edx-django-utils==5.2.0
     #   ora2
     #   outcome-surveys
     #   super-csv
-edx-drf-extensions==8.4.1
+edx-drf-extensions==8.5.3
     # via
     #   -r requirements/edx/base.txt
     #   edx-completion


### PR DESCRIPTION
I only set a temporary min-version constraint on `edx-drf-extensions` and I don't think any relevant dependencies changed, so I'm not sure why `edx-django-utils` also got a version bump. But that's OK, I guess. (EDIT: Found it: https://github.com/openedx/edx-platform/pull/31959)

This brings in some JWT verification monitoring.