### PR TITLE
fix: updated text for info banner

### DIFF
--- a/cms/templates/course_outline.html
+++ b/cms/templates/course_outline.html
@@ -73,7 +73,7 @@ from django.urls import reverse
       <div class="copy">
         <div style="color:black; display:inline-block">
             <div>
-                ${_("This course run is using an upgraded version of edx discussion forum. Discussion xblocks will no longer work.")}
+                ${_("This course run is using an upgraded version of edx discussion forum. In order to display the discussions sidebar, discussions xBlocks will no longer be visible to learners.")}
             </div>
             <div style="margin-left:auto; width:fit-content;">
                 <span>


### PR DESCRIPTION
[INF-854](https://2u-internal.atlassian.net/browse/INF-854)

## Description

Change text in banner on studio to: 
“This course run is using an upgraded version of edx discussion forum. In order to display the discussions sidebar, discussions xBlocks will no longer be visible to learners.”

|Before|

<img width="811" alt="Screenshot 2023-04-12 at 10 44 40 PM" src="https://user-images.githubusercontent.com/72802712/231540957-84e4d736-de59-4bcf-b46e-fcd545c5b220.png">

|After|

<img width="862" alt="Screenshot 2023-04-12 at 10 43 54 PM" src="https://user-images.githubusercontent.com/72802712/231541047-f386f9e3-4def-45fd-b3e6-9350e47c8b2d.png">


