### PR TITLE
feat: added edit_by_label and closed_by_label in threads response

### DIFF
--- a/lms/djangoapps/discussion/rest_api/tests/test_api.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api.py
@@ -1472,6 +1472,7 @@ class GetCommentListTest(ForumsEnableMixin, CommentsServiceMockMixin, SharedModu
                 "anonymous": False,
                 "anonymous_to_peers": False,
                 "last_edit": None,
+                "edit_by_label": None,
             },
             {
                 "id": "test_comment_2",
@@ -1498,6 +1499,7 @@ class GetCommentListTest(ForumsEnableMixin, CommentsServiceMockMixin, SharedModu
                 "anonymous": True,
                 "anonymous_to_peers": False,
                 "last_edit": None,
+                "edit_by_label": None,
             },
         ]
         actual_comments = self.get_comment_list(
@@ -2232,6 +2234,7 @@ class CreateCommentTest(
             "anonymous": False,
             "anonymous_to_peers": False,
             "last_edit": None,
+            "edit_by_label": None,
         }
         assert actual == expected
         expected_url = (
@@ -2328,6 +2331,7 @@ class CreateCommentTest(
             "anonymous": False,
             "anonymous_to_peers": False,
             "last_edit": None,
+            "edit_by_label": None,
         }
         assert actual == expected
         expected_url = (
@@ -3154,6 +3158,7 @@ class UpdateCommentTest(
             "child_count": 0,
             "can_delete": True,
             "last_edit": None,
+            "edit_by_label": None,
         }
         assert actual == expected
         assert parsed_body(httpretty.last_request()) == {

--- a/lms/djangoapps/discussion/rest_api/tests/test_serializers.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_serializers.py
@@ -188,6 +188,8 @@ class ThreadSerializerSerializationTest(SerializerTestMixin, SharedModuleStoreTe
             "pinned": True,
             "editable_fields": ["abuse_flagged", "copy_link", "following", "read", "voted"],
             "abuse_flagged_count": None,
+            "edit_by_label": None,
+            "closed_by_label": None,
         })
         assert self.serialize(thread) == expected
 
@@ -241,6 +243,118 @@ class ThreadSerializerSerializationTest(SerializerTestMixin, SharedModuleStoreTe
         self.register_get_thread_response(thread_data)
         serialized = self.serialize(thread_data)
         assert 'response_count' not in serialized
+
+    @ddt.data(
+        (FORUM_ROLE_MODERATOR, True),
+        (FORUM_ROLE_STUDENT, False),
+        ("author", True),
+    )
+    @ddt.unpack
+    def test_closed_by_label_field(self, role, visible):
+        """
+        Tests if closed by field is visible to author and priviledged users
+        """
+        moderator = UserFactory()
+        request_role = FORUM_ROLE_STUDENT if role == "author" else role
+        author = self.user if role == "author" else self.author
+        self.create_role(FORUM_ROLE_MODERATOR, [moderator])
+        self.create_role(request_role, [self.user])
+
+        thread = make_minimal_cs_thread({
+            "id": "test_thread",
+            "course_id": str(self.course.id),
+            "commentable_id": "test_topic",
+            "user_id": str(author.id),
+            "username": author.username,
+            "title": "Test Title",
+            "body": "Test body",
+            "pinned": True,
+            "votes": {"up_count": 4},
+            "comments_count": 5,
+            "unread_comments_count": 3,
+            "closed_by": moderator
+        })
+        closed_by_label = "Staff" if visible else None
+        closed_by = moderator if visible else None
+        can_delete = role != FORUM_ROLE_STUDENT
+        editable_fields = ["abuse_flagged", "copy_link", "following", "read", "voted"]
+        if role == "author":
+            editable_fields.extend(['anonymous', 'raw_body', 'title', 'topic_id', 'type'])
+        elif role == FORUM_ROLE_MODERATOR:
+            editable_fields.extend(['close_reason_code', 'closed', 'edit_reason_code', 'pinned',
+                                    'raw_body', 'title', 'topic_id', 'type'])
+        expected = self.expected_thread_data({
+            "author": author.username,
+            "can_delete": can_delete,
+            "vote_count": 4,
+            "comment_count": 6,
+            "unread_comment_count": 3,
+            "pinned": True,
+            "editable_fields": sorted(editable_fields),
+            "abuse_flagged_count": None,
+            "edit_by_label": None,
+            "closed_by_label": closed_by_label,
+            "closed_by": closed_by,
+        })
+        assert self.serialize(thread) == expected
+
+    @ddt.data(
+        (FORUM_ROLE_MODERATOR, True),
+        (FORUM_ROLE_STUDENT, False),
+        ("author", True),
+    )
+    @ddt.unpack
+    def test_edit_by_label_field(self, role, visible):
+        """
+        Tests if closed by field is visible to author and priviledged users
+        """
+        moderator = UserFactory()
+        request_role = FORUM_ROLE_STUDENT if role == "author" else role
+        author = self.user if role == "author" else self.author
+        self.create_role(FORUM_ROLE_MODERATOR, [moderator])
+        self.create_role(request_role, [self.user])
+
+        thread = make_minimal_cs_thread({
+            "id": "test_thread",
+            "course_id": str(self.course.id),
+            "commentable_id": "test_topic",
+            "user_id": str(author.id),
+            "username": author.username,
+            "title": "Test Title",
+            "body": "Test body",
+            "pinned": True,
+            "votes": {"up_count": 4},
+            "edit_history": [{"editor_username": moderator}],
+            "comments_count": 5,
+            "unread_comments_count": 3,
+            "closed_by": None
+        })
+        edit_by_label = "Staff" if visible else None
+        can_delete = role != FORUM_ROLE_STUDENT
+        last_edit = None if role == FORUM_ROLE_STUDENT else {"editor_username": moderator}
+        editable_fields = ["abuse_flagged", "copy_link", "following", "read", "voted"]
+
+        if role == "author":
+            editable_fields.extend(['anonymous', 'raw_body', 'title', 'topic_id', 'type'])
+        elif role == FORUM_ROLE_MODERATOR:
+            editable_fields.extend(['close_reason_code', 'closed', 'edit_reason_code', 'pinned',
+                                    'raw_body', 'title', 'topic_id', 'type'])
+
+        expected = self.expected_thread_data({
+            "author": author.username,
+            "can_delete": can_delete,
+            "vote_count": 4,
+            "comment_count": 6,
+            "unread_comment_count": 3,
+            "pinned": True,
+            "editable_fields": sorted(editable_fields),
+            "abuse_flagged_count": None,
+            "last_edit": last_edit,
+            "edit_by_label": edit_by_label,
+            "closed_by_label": None,
+            "closed_by": None,
+        })
+        assert self.serialize(thread) == expected
 
 
 @ddt.ddt
@@ -318,6 +432,7 @@ class CommentSerializerTest(SerializerTestMixin, SharedModuleStoreTestCase):
             "child_count": 0,
             "can_delete": False,
             "last_edit": None,
+            "edit_by_label": None,
         }
 
         assert self.serialize(comment) == expected

--- a/lms/djangoapps/discussion/rest_api/tests/test_views.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views.py
@@ -1709,6 +1709,8 @@ class LearnerThreadViewAPITest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
                 "votes": {"up_count": 4},
                 "comments_count": 5,
                 "unread_comments_count": 3,
+                "closed_by_label": None,
+                "edit_by_label": None,
             })],
             "page": 1,
             "num_pages": 1,
@@ -1968,6 +1970,7 @@ class CommentViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase, Pr
             "anonymous": False,
             "anonymous_to_peers": False,
             "last_edit": None,
+            "edit_by_label": None,
         }
         response_data.update(overrides or {})
         return response_data
@@ -2392,6 +2395,7 @@ class CommentViewSetCreateTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
             "anonymous": False,
             "anonymous_to_peers": False,
             "last_edit": None,
+            "edit_by_label": None,
         }
         response = self.client.post(
             self.url,
@@ -2483,6 +2487,7 @@ class CommentViewSetPartialUpdateTest(DiscussionAPIViewTestMixin, ModuleStoreTes
             "anonymous": False,
             "anonymous_to_peers": False,
             "last_edit": None,
+            "edit_by_label": None,
         }
         response_data.update(overrides or {})
         return response_data
@@ -2672,6 +2677,7 @@ class CommentViewSetRetrieveTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase
             "anonymous": False,
             "anonymous_to_peers": False,
             "last_edit": None,
+            "edit_by_label": None,
         }
 
         response = self.client.get(self.url)

--- a/lms/djangoapps/discussion/rest_api/tests/utils.py
+++ b/lms/djangoapps/discussion/rest_api/tests/utils.py
@@ -499,7 +499,9 @@ class CommentsServiceMockMixin:
             "type": "discussion",
             "response_count": 0,
             "last_edit": None,
+            "edit_by_label": None,
             "closed_by": None,
+            "closed_by_label": None,
             "close_reason": None,
             "close_reason_code": None,
         }


### PR DESCRIPTION
Added new fields in threads response

edit_by_label   in _ContentSerializer
closed_by_label    in  ThreadSerializer

- These fields will show the role of the user to edited the post and closed the post respectively.
- This will be visible to author and privileged role and None for learners
 
Ticket: [INF-849](https://2u-internal.atlassian.net/browse/INF-849)
