### PR TITLE
feat: publish CERTIFICATE_CREATED events to the event bus

### DIFF
--- a/lms/djangoapps/certificates/config.py
+++ b/lms/djangoapps/certificates/config.py
@@ -3,7 +3,7 @@ This module contains various configuration settings via
 waffle switches for the Certificates app.
 """
 
-from edx_toggles.toggles import WaffleSwitch
+from edx_toggles.toggles import SettingToggle, WaffleSwitch
 
 # Namespace
 WAFFLE_NAMESPACE = 'certificates'
@@ -15,3 +15,16 @@ WAFFLE_NAMESPACE = 'certificates'
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2017-09-14
 AUTO_CERTIFICATE_GENERATION = WaffleSwitch(f"{WAFFLE_NAMESPACE}.auto_certificate_generation", __name__)
+
+
+# .. toggle_name: SEND_CERTIFICATE_CREATED_SIGNAL
+# .. toggle_implementation: SettingToggle
+# .. toggle_default: False
+# .. toggle_description: When True, the system will publish `CERTIFICATE_CREATED` signals to the event bus. The
+#   `CERTIFICATE_CREATED` signal is emit when a certificate has been awarded to a learner and the creation process has
+#   completed.
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2023-04-11
+# .. toggle_target_removal_date: 2023-07-31
+# .. toggle_tickets: TODO
+SEND_CERTIFICATE_CREATED_SIGNAL = SettingToggle('SEND_CERTIFICATE_CREATED_SIGNAL', default=False, module_name=__name__)

--- a/lms/djangoapps/certificates/models.py
+++ b/lms/djangoapps/certificates/models.py
@@ -2,7 +2,7 @@
 Course certificates are created for a student and an offering of a course (a course run).
 """
 
-
+from datetime import timezone
 import json
 import logging
 import os
@@ -403,6 +403,7 @@ class GeneratedCertificate(models.Model):
 
         # .. event_implemented_name: CERTIFICATE_REVOKED
         CERTIFICATE_REVOKED.send_event(
+            time=self.modified_date.astimezone(timezone.utc),
             certificate=CertificateData(
                 user=UserData(
                     pii=UserPersonalData(
@@ -473,6 +474,9 @@ class GeneratedCertificate(models.Model):
         Credentials IDA.
         """
         super().save(*args, **kwargs)
+
+        timestamp = self.modified_date.astimezone(timezone.utc)
+
         COURSE_CERT_CHANGED.send_robust(
             sender=self.__class__,
             user=self.user,
@@ -483,6 +487,7 @@ class GeneratedCertificate(models.Model):
 
         # .. event_implemented_name: CERTIFICATE_CHANGED
         CERTIFICATE_CHANGED.send_event(
+            time=timestamp,
             certificate=CertificateData(
                 user=UserData(
                     pii=UserPersonalData(
@@ -515,6 +520,7 @@ class GeneratedCertificate(models.Model):
 
             # .. event_implemented_name: CERTIFICATE_CREATED
             CERTIFICATE_CREATED.send_event(
+                time=timestamp,
                 certificate=CertificateData(
                     user=UserData(
                         pii=UserPersonalData(

--- a/lms/djangoapps/certificates/signals.py
+++ b/lms/djangoapps/certificates/signals.py
@@ -6,10 +6,12 @@ import logging
 
 from django.db.models.signals import post_save
 from django.dispatch import receiver
+from openedx_events.event_bus import get_producer
 
 from common.djangoapps.course_modes import api as modes_api
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.signals import ENROLLMENT_TRACK_UPDATED
+from lms.djangoapps.certificates.config import SEND_CERTIFICATE_CREATED_SIGNAL
 from lms.djangoapps.certificates.generation_handler import (
     CertificateGenerationNotAllowed,
     generate_allowlist_certificate_task,
@@ -30,6 +32,7 @@ from openedx.core.djangoapps.signals.signals import (
     COURSE_GRADE_NOW_PASSED,
     LEARNER_NOW_VERIFIED
 )
+from openedx_events.learning.signals import CERTIFICATE_CREATED
 
 log = logging.getLogger(__name__)
 
@@ -156,3 +159,18 @@ def _listen_for_enrollment_mode_change(sender, user, course_key, mode, **kwargs)
                 course_key,
             )
             return False
+
+
+@receiver(CERTIFICATE_CREATED)
+def listen_for_certificate_created_event(sender, signal, **kwargs):
+    """
+    Publish `CERTIFICATE_CREATED` events to the event bus.
+    """
+    if SEND_CERTIFICATE_CREATED_SIGNAL.is_enabled():
+        get_producer().send(
+            signal=CERTIFICATE_CREATED,
+            topic='certificates',
+            event_key_field='certificate.course.course_key',
+            event_data={'certificate': kwargs['certificate']},
+            event_metadata=kwargs['metadata']
+        )


### PR DESCRIPTION
## Description

[APER-2344]

We would like to start consuming Certificate related events in Credentials from the event bus. This PR starts the process by publishing CERTIFICATE_CREATED events to the event bus. It also introduces a new feature flag (`SEND_CERTIFICATE_CREATED_SIGNAL`) to gate the functionality.## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
