### PR TITLE
fix: inconsistency between JWT and session authentication after password reset

### DIFF
--- a/openedx/core/djangoapps/cache_toolbox/middleware.py
+++ b/openedx/core/djangoapps/cache_toolbox/middleware.py
@@ -52,6 +52,14 @@ However, this has two main disadvantages:
    compounded by most projects wishing to avoid expiring session data as long
    as possible (in addition to storing sessions in persistent stores).
 
+Dependency with SafeSessionMiddleware
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+CacheBackedAuthenticationMiddleware middleware logs out the user if the
+session hash is changed due to password change. It flushes the session
+and mark cookies for deletion in request which are then deleted in the
+process_response of SafeSessionMiddleware.
+
 Usage
 ~~~~~
 
@@ -88,7 +96,7 @@ from django.contrib.auth.models import AnonymousUser, User  # lint-amnesty, pyli
 from django.utils.crypto import constant_time_compare
 from django.utils.deprecation import MiddlewareMixin
 
-from openedx.core.djangoapps.safe_sessions.middleware import SafeSessionMiddleware
+from openedx.core.djangoapps.safe_sessions.middleware import SafeSessionMiddleware, _mark_cookie_for_deletion
 
 from .model import cache_model
 
@@ -138,3 +146,4 @@ class CacheBackedAuthenticationMiddleware(AuthenticationMiddleware, MiddlewareMi
                 # change. Log the user out.
                 request.session.flush()
                 request.user = AnonymousUser()
+                _mark_cookie_for_deletion(request)


### PR DESCRIPTION
[VAN-1371](https://2u-internal.atlassian.net/browse/VAN-1371)

**Description:**

This PR fixes the inconsistency between the session and JWT authentication after the password reset.

**Issue:** 

When a user resets the password through account settings (accounts MFE), the user is redirected to the login page because the session is invalidated at the backend. But the user does not get logged out of other MFEs such as learner home even if the user refreshes the page. 
Plus if the user tries to unenroll a course in the learner's home MFE, a 403 forbidden response is returned because the change_enrollment [endpoint](https://github.com/openedx/edx-platform/blob/2dc79bcab42dafed2c122eb808cdd5604327c890/common/djangoapps/student/views/management.py#L324-L328) uses session authentication to ensure authenticated user and as the session is unauthenticated at the backend, the course is not unenrolled. Whereas the user is able to see [recommendations](https://github.com/openedx/edx-platform/blob/2dc79bcab42dafed2c122eb808cdd5604327c890/lms/djangoapps/learner_recommendations/views.py#L204) and access other endpoints that use JWT authentication (usually the DRF endpoints)

**Reason:**

Our investigation shows that when a user resets the password through accounts MFE, the user session gets invalidated in `CacheBackedAuthenticationMiddleware` middleware [here](https://github.com/openedx/edx-platform/blob/2dc79bcab42dafed2c122eb808cdd5604327c890/openedx/core/djangoapps/cache_toolbox/middleware.py#L134-L140) but the JWT cookies are not deleted which causes the user to remain authenticated in JWTAuthentication.

**Effect on users:**

- The user is able to perform certain actions but not others.
- Inconsistency is user authentication.

Please let us know if you think this change will have any negative effects