### PR TITLE
fix: fix make upgrade job and _mysql issue

### DIFF
--- a/.github/workflows/migrations-check.yml
+++ b/.github/workflows/migrations-check.yml
@@ -61,10 +61,6 @@ jobs:
     - name: Install Python dependencies
       run: |
         make dev-requirements
-        pip uninstall -y mysqlclient
-        pip install --no-binary mysqlclient mysqlclient
-        pip uninstall -y xmlsec
-        pip install --no-binary xmlsec xmlsec
 
     - name: Initiate Services
       run: |

--- a/.github/workflows/migrations-check.yml
+++ b/.github/workflows/migrations-check.yml
@@ -78,6 +78,11 @@ jobs:
           UPDATE mysql.user SET authentication_string = null WHERE user = 'root';
           FLUSH PRIVILEGES;
         EOF
+    
+    - name: Install mysqlclient-dev binary
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libmysqlclient-dev
 
     - name: Run Tests
       env:

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -90,3 +90,7 @@ babel==2.11.0
 social-auth-app-django==5.0.0
 algoliasearch==2.6.3
 django-ipware==4.0.2
+
+# pytz>2022 has major changes which are causing test failures.
+# Pinning this version for now so this could be fixed in a separate PR later on
+pytz<2023

--- a/requirements/edx-sandbox/py38.txt
+++ b/requirements/edx-sandbox/py38.txt
@@ -38,7 +38,7 @@ matplotlib==3.3.4
     #   -r requirements/edx-sandbox/py38.in
 mpmath==1.3.0
     # via sympy
-networkx==3.0
+networkx==3.1
     # via -r requirements/edx-sandbox/py38.in
 nltk==3.8.1
     # via
@@ -52,7 +52,7 @@ numpy==1.22.4
     #   scipy
 openedx-calc==3.0.1
     # via -r requirements/edx-sandbox/py38.in
-pillow==9.4.0
+pillow==9.5.0
     # via matplotlib
 pycparser==2.21
     # via cffi
@@ -66,7 +66,7 @@ python-dateutil==2.8.2
     # via matplotlib
 random2==1.0.1
     # via -r requirements/edx-sandbox/py38.in
-regex==2022.10.31
+regex==2023.3.23
     # via nltk
 scipy==1.7.3
     # via

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -16,7 +16,7 @@ algoliasearch==2.6.3
     #   -r requirements/edx/base.in
 amqp==5.1.1
     # via kombu
-analytics-python==1.4.0
+analytics-python==1.4.post1
     # via -r requirements/edx/base.in
 aniso8601==9.0.1
     # via edx-tincan-py35
@@ -34,7 +34,7 @@ async-timeout==4.0.2
     # via
     #   aiohttp
     #   redis
-attrs==22.2.0
+attrs==23.1.0
     # via
     #   -r requirements/edx/base.in
     #   aiohttp
@@ -53,7 +53,7 @@ backoff==1.10.0
     # via analytics-python
 backports-zoneinfo==0.2.1
     # via icalendar
-beautifulsoup4==4.11.2
+beautifulsoup4==4.12.2
     # via pynliner
 billiard==3.6.4.0
     # via celery
@@ -261,7 +261,7 @@ django-config-models==2.3.0
     #   edx-enterprise
     #   edx-name-affirmation
     #   lti-consumer-xblock
-django-cors-headers==3.13.0
+django-cors-headers==3.14.0
     # via -r requirements/edx/base.in
 django-countries==7.5.1
     # via
@@ -282,7 +282,7 @@ django-fernet-fields==0.6
     # via
     #   -r requirements/edx/base.in
     #   edx-enterprise
-django-filter==22.1
+django-filter==23.1
     # via
     #   -r requirements/edx/base.in
     #   edx-enterprise
@@ -467,7 +467,7 @@ edx-django-utils==5.4.0
     #   ora2
     #   outcome-surveys
     #   super-csv
-edx-drf-extensions==8.5.3
+edx-drf-extensions==8.6.0
     # via
     #   -r requirements/edx/base.in
     #   edx-completion
@@ -484,7 +484,7 @@ edx-enterprise==3.61.11
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   learner-pathway-progress
-edx-event-bus-kafka==3.9.4
+edx-event-bus-kafka==3.9.6
     # via -r requirements/edx/base.in
 edx-i18n-tools==0.9.2
     # via ora2
@@ -526,7 +526,7 @@ edx-rest-api-client==5.5.0
     #   -r requirements/edx/base.in
     #   edx-enterprise
     #   edx-proctoring
-edx-search==3.4.0
+edx-search==3.5.0
     # via -r requirements/edx/base.in
 edx-sga==0.21.1
     # via -r requirements/edx/base.in
@@ -542,6 +542,7 @@ edx-toggles==5.0.0
     #   edx-completion
     #   edx-event-bus-kafka
     #   edx-name-affirmation
+    #   edx-search
     #   edxval
     #   learner-pathway-progress
     #   ora2
@@ -570,7 +571,7 @@ event-tracking==2.1.0
     #   edx-search
 fastavro==1.7.3
     # via openedx-events
-filelock==3.10.0
+filelock==3.11.0
     # via snowflake-connector-python
 frozenlist==1.3.3
     # via
@@ -600,7 +601,7 @@ html5lib==1.1
     # via
     #   -r requirements/edx/base.in
     #   ora2
-icalendar==5.0.4
+icalendar==5.0.5
     # via -r requirements/edx/base.in
 idna==3.4
     # via
@@ -609,7 +610,7 @@ idna==3.4
     #   requests
     #   snowflake-connector-python
     #   yarl
-importlib-metadata==6.0.0
+importlib-metadata==6.4.1
     # via markdown
 importlib-resources==5.12.0
     # via jsonschema
@@ -711,7 +712,7 @@ markupsafe==2.1.2
     #   xblock
 maxminddb==2.2.0
     # via geoip2
-mock==5.0.1
+mock==5.0.2
     # via -r requirements/edx/paver.txt
 mongodbproxy @ git+https://github.com/openedx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a
     # via -r requirements/edx/github.in
@@ -731,7 +732,7 @@ mysqlclient==2.1.1
     # via
     #   -r requirements/edx/base.in
     #   openedx-blockstore
-newrelic==8.7.0
+newrelic==8.8.0
     # via
     #   -r requirements/edx/base.in
     #   edx-django-utils
@@ -767,7 +768,7 @@ openedx-django-require==2.0.0
     # via -r requirements/edx/base.in
 openedx-django-wiki==2.0.0
     # via -r requirements/edx/base.in
-openedx-events==5.1.0
+openedx-events==7.0.0
     # via
     #   -r requirements/edx/base.in
     #   edx-event-bus-kafka
@@ -783,7 +784,7 @@ oscrypto==1.3.0
     # via snowflake-connector-python
 outcome-surveys==2.4.0
     # via -r requirements/edx/base.in
-packaging==23.0
+packaging==23.1
     # via
     #   drf-yasg
     #   py2neo
@@ -811,7 +812,7 @@ pgpy==0.6.0
     # via edx-enterprise
 piexif==1.1.3
     # via -r requirements/edx/base.in
-pillow==9.4.0
+pillow==9.5.0
     # via
     #   -r requirements/edx/base.in
     #   edx-enterprise
@@ -822,7 +823,7 @@ polib==1.2.0
     # via edx-i18n-tools
 prompt-toolkit==3.0.38
     # via click-repl
-psutil==5.9.4
+psutil==5.9.5
     # via
     #   -r requirements/edx/paver.txt
     #   edx-django-utils
@@ -843,7 +844,7 @@ pycryptodomex==3.17
     #   lti-consumer-xblock
     #   pyjwkest
     #   snowflake-connector-python
-pygments==2.14.0
+pygments==2.15.0
     # via
     #   -r requirements/edx/base.in
     #   py2neo
@@ -917,7 +918,7 @@ python-memcached==1.59
     # via -r requirements/edx/paver.txt
 python-slugify==8.0.1
     # via code-annotations
-python-swiftclient==4.2.0
+python-swiftclient==4.3.0
     # via ora2
 python3-openid==3.2.0 ; python_version >= "3"
     # via
@@ -927,7 +928,7 @@ python3-saml==1.9.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   -r requirements/edx/base.in
     #   babel
@@ -961,13 +962,13 @@ pyyaml==6.0
     #   xblock
 random2==1.0.1
     # via -r requirements/edx/base.in
-rapidfuzz==2.13.7
+rapidfuzz==2.15.1
     # via levenshtein
 recommender-xblock==2.0.1
     # via -r requirements/edx/base.in
-redis==4.5.1
+redis==4.5.4
     # via -r requirements/edx/base.in
-regex==2022.10.31
+regex==2023.3.23
     # via nltk
 requests==2.28.2
     # via
@@ -1019,7 +1020,7 @@ semantic-version==2.10.0
     # via edx-drf-extensions
 shapely==2.0.1
     # via -r requirements/edx/base.in
-simplejson==3.18.4
+simplejson==3.19.1
     # via
     #   -r requirements/edx/base.in
     #   sailthru-client
@@ -1062,7 +1063,7 @@ slumber==0.7.1
     #   edx-bulk-grades
     #   edx-enterprise
     #   edx-rest-api-client
-snowflake-connector-python==3.0.1
+snowflake-connector-python==3.0.2
     # via edx-enterprise
 social-auth-app-django==5.0.0
     # via
@@ -1081,7 +1082,7 @@ sorl-thumbnail==12.9.0
     #   openedx-django-wiki
 sortedcontainers==2.4.0
     # via -r requirements/edx/base.in
-soupsieve==2.4
+soupsieve==2.4.1
     # via beautifulsoup4
 sqlparse==0.4.3
     # via
@@ -1143,7 +1144,7 @@ vine==5.0.0
     #   kombu
 voluptuous==0.13.1
     # via ora2
-watchdog==2.3.1
+watchdog==3.0.0
     # via -r requirements/edx/paver.txt
 wcwidth==0.2.6
     # via prompt-toolkit

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -928,8 +928,9 @@ python3-saml==1.9.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
-pytz==2023.3
+pytz==2022.7.1
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   babel
     #   celery

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -6,7 +6,7 @@
 #
 chardet==5.1.0
     # via diff-cover
-coverage==7.2.1
+coverage==7.2.3
     # via -r requirements/edx/coverage.in
 diff-cover==7.5.0
     # via -r requirements/edx/coverage.in
@@ -16,5 +16,5 @@ markupsafe==2.1.2
     # via jinja2
 pluggy==1.0.0
     # via diff-cover
-pygments==2.14.0
+pygments==2.15.0
     # via diff-cover

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1312,8 +1312,9 @@ python3-saml==1.9.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
-pytz==2023.3
+pytz==2022.7.1
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   babel
     #   celery

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -24,7 +24,7 @@ amqp==5.1.1
     # via
     #   -r requirements/edx/testing.txt
     #   kombu
-analytics-python==1.4.0
+analytics-python==1.4.post1
     # via -r requirements/edx/testing.txt
 aniso8601==9.0.1
     # via
@@ -59,7 +59,7 @@ async-timeout==4.0.2
     #   -r requirements/edx/testing.txt
     #   aiohttp
     #   redis
-attrs==22.2.0
+attrs==23.1.0
     # via
     #   -r requirements/edx/testing.txt
     #   aiohttp
@@ -68,7 +68,6 @@ attrs==22.2.0
     #   lti-consumer-xblock
     #   openedx-blockstore
     #   openedx-events
-    #   pytest
 babel==2.11.0
     # via
     #   -c requirements/edx/../constraints.txt
@@ -84,7 +83,7 @@ backports-zoneinfo==0.2.1
     # via
     #   -r requirements/edx/testing.txt
     #   icalendar
-beautifulsoup4==4.11.2
+beautifulsoup4==4.12.2
     # via
     #   -r requirements/edx/testing.txt
     #   pynliner
@@ -220,7 +219,7 @@ coreschema==0.0.4
     #   -r requirements/edx/testing.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==7.2.1
+coverage[toml]==7.2.3
     # via
     #   -r requirements/edx/testing.txt
     #   pytest-cov
@@ -363,7 +362,7 @@ django-config-models==2.3.0
     #   edx-enterprise
     #   edx-name-affirmation
     #   lti-consumer-xblock
-django-cors-headers==3.13.0
+django-cors-headers==3.14.0
     # via -r requirements/edx/testing.txt
 django-countries==7.5.1
     # via
@@ -378,7 +377,7 @@ django-crum==0.7.9
     #   edx-rbac
     #   edx-toggles
     #   super-csv
-django-debug-toolbar==3.8.1
+django-debug-toolbar==4.0.0
     # via -r requirements/edx/development.in
 django-environ==0.10.0
     # via
@@ -388,7 +387,7 @@ django-fernet-fields==0.6
     # via
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
-django-filter==22.1
+django-filter==23.1
     # via
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
@@ -593,7 +592,7 @@ edx-django-utils==5.4.0
     #   ora2
     #   outcome-surveys
     #   super-csv
-edx-drf-extensions==8.5.3
+edx-drf-extensions==8.6.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-completion
@@ -610,7 +609,7 @@ edx-enterprise==3.61.11
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   learner-pathway-progress
-edx-event-bus-kafka==3.9.4
+edx-event-bus-kafka==3.9.6
     # via -r requirements/edx/testing.txt
 edx-i18n-tools==0.9.2
     # via
@@ -657,7 +656,7 @@ edx-rest-api-client==5.5.0
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
     #   edx-proctoring
-edx-search==3.4.0
+edx-search==3.5.0
     # via -r requirements/edx/testing.txt
 edx-sga==0.21.1
     # via -r requirements/edx/testing.txt
@@ -677,6 +676,7 @@ edx-toggles==5.0.0
     #   edx-completion
     #   edx-event-bus-kafka
     #   edx-name-affirmation
+    #   edx-search
     #   edxval
     #   learner-pathway-progress
     #   ora2
@@ -716,11 +716,11 @@ execnet==1.9.0
     #   pytest-xdist
 factory-boy==3.2.1
     # via -r requirements/edx/testing.txt
-faker==17.6.0
+faker==18.4.0
     # via
     #   -r requirements/edx/testing.txt
     #   factory-boy
-fastapi==0.94.1
+fastapi==0.95.1
     # via
     #   -r requirements/edx/testing.txt
     #   pact-python
@@ -728,7 +728,7 @@ fastavro==1.7.3
     # via
     #   -r requirements/edx/testing.txt
     #   openedx-events
-filelock==3.10.0
+filelock==3.11.0
     # via
     #   -r requirements/edx/testing.txt
     #   snowflake-connector-python
@@ -786,7 +786,7 @@ httpx==0.23.1
     # via
     #   -r requirements/edx/testing.txt
     #   pact-python
-icalendar==5.0.4
+icalendar==5.0.5
     # via -r requirements/edx/testing.txt
 idna==3.4
     # via
@@ -801,7 +801,7 @@ imagesize==1.4.1
     # via sphinx
 import-linter==1.8.0
     # via -r requirements/edx/testing.txt
-importlib-metadata==6.0.0
+importlib-metadata==6.4.1
     # via
     #   -r requirements/edx/testing.txt
     #   markdown
@@ -960,7 +960,7 @@ mccabe==0.7.0
     #   pylint
 mistune==2.0.5
     # via sphinx-mdinclude
-mock==5.0.1
+mock==5.0.2
     # via -r requirements/edx/testing.txt
 mongodbproxy @ git+https://github.com/openedx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a
     # via -r requirements/edx/testing.txt
@@ -980,7 +980,7 @@ multidict==6.0.4
     #   -r requirements/edx/testing.txt
     #   aiohttp
     #   yarl
-mypy==1.1.1
+mypy==1.2.0
     # via -r requirements/edx/development.in
 mypy-extensions==1.0.0
     # via mypy
@@ -988,7 +988,7 @@ mysqlclient==2.1.1
     # via
     #   -r requirements/edx/testing.txt
     #   openedx-blockstore
-newrelic==8.7.0
+newrelic==8.8.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-django-utils
@@ -1027,7 +1027,7 @@ openedx-django-require==2.0.0
     # via -r requirements/edx/testing.txt
 openedx-django-wiki==2.0.0
     # via -r requirements/edx/testing.txt
-openedx-events==5.1.0
+openedx-events==7.0.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-event-bus-kafka
@@ -1045,7 +1045,7 @@ oscrypto==1.3.0
     #   snowflake-connector-python
 outcome-surveys==2.4.0
     # via -r requirements/edx/testing.txt
-packaging==23.0
+packaging==23.1
     # via
     #   -r requirements/edx/../pip-tools.txt
     #   -r requirements/edx/testing.txt
@@ -1083,22 +1083,22 @@ pgpy==0.6.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
-picobox==2.2.0
+picobox==3.0.0
     # via sphinxcontrib-openapi
 piexif==1.1.3
     # via -r requirements/edx/testing.txt
-pillow==9.4.0
+pillow==9.5.0
     # via
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
     #   edx-organizations
-pip-tools==6.12.3
+pip-tools==6.13.0
     # via -r requirements/edx/../pip-tools.txt
 pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements/edx/testing.txt
     #   jsonschema
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via
     #   -r requirements/edx/testing.txt
     #   pylint
@@ -1117,7 +1117,7 @@ prompt-toolkit==3.0.38
     # via
     #   -r requirements/edx/testing.txt
     #   click-repl
-psutil==5.9.4
+psutil==5.9.5
     # via
     #   -r requirements/edx/testing.txt
     #   edx-django-utils
@@ -1152,11 +1152,11 @@ pycryptodomex==3.17
     #   lti-consumer-xblock
     #   pyjwkest
     #   snowflake-connector-python
-pydantic==1.10.6
+pydantic==1.10.7
     # via
     #   -r requirements/edx/testing.txt
     #   fastapi
-pygments==2.14.0
+pygments==2.15.0
     # via
     #   -r requirements/edx/testing.txt
     #   diff-cover
@@ -1250,7 +1250,7 @@ pysrt==1.1.2
     # via
     #   -r requirements/edx/testing.txt
     #   edxval
-pytest==7.2.2
+pytest==7.3.1
     # via
     #   -r requirements/edx/testing.txt
     #   pylint-pytest
@@ -1300,7 +1300,7 @@ python-slugify==8.0.1
     # via
     #   -r requirements/edx/testing.txt
     #   code-annotations
-python-swiftclient==4.2.0
+python-swiftclient==4.3.0
     # via
     #   -r requirements/edx/testing.txt
     #   ora2
@@ -1312,7 +1312,7 @@ python3-saml==1.9.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   -r requirements/edx/testing.txt
     #   babel
@@ -1349,15 +1349,15 @@ pyyaml==6.0
     #   xblock
 random2==1.0.1
     # via -r requirements/edx/testing.txt
-rapidfuzz==2.13.7
+rapidfuzz==2.15.1
     # via
     #   -r requirements/edx/testing.txt
     #   levenshtein
 recommender-xblock==2.0.1
     # via -r requirements/edx/testing.txt
-redis==4.5.1
+redis==4.5.4
     # via -r requirements/edx/testing.txt
-regex==2022.10.31
+regex==2023.3.23
     # via
     #   -r requirements/edx/testing.txt
     #   nltk
@@ -1432,7 +1432,7 @@ semantic-version==2.10.0
     #   edx-drf-extensions
 shapely==2.0.1
     # via -r requirements/edx/testing.txt
-simplejson==3.18.4
+simplejson==3.19.1
     # via
     #   -r requirements/edx/testing.txt
     #   sailthru-client
@@ -1491,7 +1491,7 @@ sniffio==1.3.0
     #   httpx
 snowballstemmer==2.2.0
     # via sphinx
-snowflake-connector-python==3.0.1
+snowflake-connector-python==3.0.2
     # via
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
@@ -1512,7 +1512,7 @@ sorl-thumbnail==12.9.0
     #   openedx-django-wiki
 sortedcontainers==2.4.0
     # via -r requirements/edx/testing.txt
-soupsieve==2.4
+soupsieve==2.4.1
     # via
     #   -r requirements/edx/testing.txt
     #   beautifulsoup4
@@ -1594,7 +1594,7 @@ tomli==2.0.1
     #   pyproject-hooks
     #   pytest
     #   tox
-tomlkit==0.11.6
+tomlkit==0.11.7
     # via
     #   -r requirements/edx/testing.txt
     #   pylint
@@ -1665,7 +1665,7 @@ voluptuous==0.13.1
     #   ora2
 vulture==2.7
     # via -r requirements/edx/development.in
-watchdog==2.3.1
+watchdog==3.0.0
     # via -r requirements/edx/testing.txt
 wcwidth==0.2.6
     # via

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -50,8 +50,10 @@ pygments==2.15.0
     # via sphinx
 python-slugify==8.0.1
     # via code-annotations
-pytz==2023.3
-    # via babel
+pytz==2022.7.1
+    # via
+    #   -c requirements/edx/../constraints.txt
+    #   babel
 pyyaml==6.0
     # via code-annotations
 requests==2.28.2

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -34,7 +34,7 @@ idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.0.0
+importlib-metadata==6.4.1
     # via sphinx
 jinja2==3.1.2
     # via
@@ -42,15 +42,15 @@ jinja2==3.1.2
     #   sphinx
 markupsafe==2.1.2
     # via jinja2
-packaging==23.0
+packaging==23.1
     # via sphinx
 pbr==5.11.1
     # via stevedore
-pygments==2.14.0
+pygments==2.15.0
     # via sphinx
 python-slugify==8.0.1
     # via code-annotations
-pytz==2022.7.1
+pytz==2023.3
     # via babel
 pyyaml==6.0
     # via code-annotations

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -20,7 +20,7 @@ libsass==0.10.0
     # via -r requirements/edx/paver.in
 markupsafe==2.1.2
     # via -r requirements/edx/paver.in
-mock==5.0.1
+mock==5.0.2
     # via -r requirements/edx/paver.in
 path==16.6.0
     # via -r requirements/edx/paver.in
@@ -28,7 +28,7 @@ paver==1.3.4
     # via -r requirements/edx/paver.in
 pbr==5.11.1
     # via stevedore
-psutil==5.9.4
+psutil==5.9.5
     # via -r requirements/edx/paver.in
 pymongo==3.13.0
     # via
@@ -50,7 +50,7 @@ stevedore==5.0.0
     #   edx-opaque-keys
 urllib3==1.26.15
     # via requests
-watchdog==2.3.1
+watchdog==3.0.0
     # via -r requirements/edx/paver.in
 wrapt==1.15.0
     # via -r requirements/edx/paver.in

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1237,8 +1237,9 @@ python3-saml==1.9.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
-pytz==2023.3
+pytz==2022.7.1
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   babel
     #   celery

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -22,7 +22,7 @@ amqp==5.1.1
     # via
     #   -r requirements/edx/base.txt
     #   kombu
-analytics-python==1.4.0
+analytics-python==1.4.post1
     # via -r requirements/edx/base.txt
 aniso8601==9.0.1
     # via
@@ -55,7 +55,7 @@ async-timeout==4.0.2
     #   -r requirements/edx/base.txt
     #   aiohttp
     #   redis
-attrs==22.2.0
+attrs==23.1.0
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
@@ -64,7 +64,6 @@ attrs==22.2.0
     #   lti-consumer-xblock
     #   openedx-blockstore
     #   openedx-events
-    #   pytest
 babel==2.11.0
     # via
     #   -c requirements/edx/../constraints.txt
@@ -79,7 +78,7 @@ backports-zoneinfo==0.2.1
     # via
     #   -r requirements/edx/base.txt
     #   icalendar
-beautifulsoup4==4.11.2
+beautifulsoup4==4.12.2
     # via
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/testing.in
@@ -209,7 +208,7 @@ coreschema==0.0.4
     #   -r requirements/edx/base.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==7.2.1
+coverage[toml]==7.2.3
     # via
     #   -r requirements/edx/coverage.txt
     #   pytest-cov
@@ -345,7 +344,7 @@ django-config-models==2.3.0
     #   edx-enterprise
     #   edx-name-affirmation
     #   lti-consumer-xblock
-django-cors-headers==3.13.0
+django-cors-headers==3.14.0
     # via -r requirements/edx/base.txt
 django-countries==7.5.1
     # via
@@ -368,7 +367,7 @@ django-fernet-fields==0.6
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
-django-filter==22.1
+django-filter==23.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -571,7 +570,7 @@ edx-django-utils==5.4.0
     #   ora2
     #   outcome-surveys
     #   super-csv
-edx-drf-extensions==8.5.3
+edx-drf-extensions==8.6.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-completion
@@ -588,7 +587,7 @@ edx-enterprise==3.61.11
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   learner-pathway-progress
-edx-event-bus-kafka==3.9.4
+edx-event-bus-kafka==3.9.6
     # via -r requirements/edx/base.txt
 edx-i18n-tools==0.9.2
     # via
@@ -636,7 +635,7 @@ edx-rest-api-client==5.5.0
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   edx-proctoring
-edx-search==3.4.0
+edx-search==3.5.0
     # via -r requirements/edx/base.txt
 edx-sga==0.21.1
     # via -r requirements/edx/base.txt
@@ -654,6 +653,7 @@ edx-toggles==5.0.0
     #   edx-completion
     #   edx-event-bus-kafka
     #   edx-name-affirmation
+    #   edx-search
     #   edxval
     #   learner-pathway-progress
     #   ora2
@@ -689,15 +689,15 @@ execnet==1.9.0
     # via pytest-xdist
 factory-boy==3.2.1
     # via -r requirements/edx/testing.in
-faker==17.6.0
+faker==18.4.0
     # via factory-boy
-fastapi==0.94.1
+fastapi==0.95.1
     # via pact-python
 fastavro==1.7.3
     # via
     #   -r requirements/edx/base.txt
     #   openedx-events
-filelock==3.10.0
+filelock==3.11.0
     # via
     #   -r requirements/edx/base.txt
     #   snowflake-connector-python
@@ -748,7 +748,7 @@ httpretty==1.1.4
     # via -r requirements/edx/testing.in
 httpx==0.23.1
     # via pact-python
-icalendar==5.0.4
+icalendar==5.0.5
     # via -r requirements/edx/base.txt
 idna==3.4
     # via
@@ -761,7 +761,7 @@ idna==3.4
     #   yarl
 import-linter==1.8.0
     # via -r requirements/edx/testing.in
-importlib-metadata==6.0.0
+importlib-metadata==6.4.1
     # via
     #   -r requirements/edx/base.txt
     #   markdown
@@ -911,7 +911,7 @@ maxminddb==2.2.0
     #   geoip2
 mccabe==0.7.0
     # via pylint
-mock==5.0.1
+mock==5.0.2
     # via -r requirements/edx/base.txt
 mongodbproxy @ git+https://github.com/openedx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a
     # via -r requirements/edx/base.txt
@@ -935,7 +935,7 @@ mysqlclient==2.1.1
     # via
     #   -r requirements/edx/base.txt
     #   openedx-blockstore
-newrelic==8.7.0
+newrelic==8.8.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-django-utils
@@ -974,7 +974,7 @@ openedx-django-require==2.0.0
     # via -r requirements/edx/base.txt
 openedx-django-wiki==2.0.0
     # via -r requirements/edx/base.txt
-openedx-events==5.1.0
+openedx-events==7.0.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-event-bus-kafka
@@ -992,7 +992,7 @@ oscrypto==1.3.0
     #   snowflake-connector-python
 outcome-surveys==2.4.0
     # via -r requirements/edx/base.txt
-packaging==23.0
+packaging==23.1
     # via
     #   -r requirements/edx/base.txt
     #   drf-yasg
@@ -1029,7 +1029,7 @@ pgpy==0.6.0
     #   edx-enterprise
 piexif==1.1.3
     # via -r requirements/edx/base.txt
-pillow==9.4.0
+pillow==9.5.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -1038,7 +1038,7 @@ pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements/edx/base.txt
     #   jsonschema
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via
     #   pylint
     #   virtualenv
@@ -1057,7 +1057,7 @@ prompt-toolkit==3.0.38
     # via
     #   -r requirements/edx/base.txt
     #   click-repl
-psutil==5.9.4
+psutil==5.9.5
     # via
     #   -r requirements/edx/base.txt
     #   edx-django-utils
@@ -1090,9 +1090,9 @@ pycryptodomex==3.17
     #   lti-consumer-xblock
     #   pyjwkest
     #   snowflake-connector-python
-pydantic==1.10.6
+pydantic==1.10.7
     # via fastapi
-pygments==2.14.0
+pygments==2.15.0
     # via
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/coverage.txt
@@ -1175,7 +1175,7 @@ pysrt==1.1.2
     # via
     #   -r requirements/edx/base.txt
     #   edxval
-pytest==7.2.2
+pytest==7.3.1
     # via
     #   -r requirements/edx/testing.in
     #   pylint-pytest
@@ -1225,7 +1225,7 @@ python-slugify==8.0.1
     # via
     #   -r requirements/edx/base.txt
     #   code-annotations
-python-swiftclient==4.2.0
+python-swiftclient==4.3.0
     # via
     #   -r requirements/edx/base.txt
     #   ora2
@@ -1237,7 +1237,7 @@ python3-saml==1.9.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   -r requirements/edx/base.txt
     #   babel
@@ -1271,15 +1271,15 @@ pyyaml==6.0
     #   xblock
 random2==1.0.1
     # via -r requirements/edx/base.txt
-rapidfuzz==2.13.7
+rapidfuzz==2.15.1
     # via
     #   -r requirements/edx/base.txt
     #   levenshtein
 recommender-xblock==2.0.1
     # via -r requirements/edx/base.txt
-redis==4.5.1
+redis==4.5.4
     # via -r requirements/edx/base.txt
-regex==2022.10.31
+regex==2023.3.23
     # via
     #   -r requirements/edx/base.txt
     #   nltk
@@ -1351,7 +1351,7 @@ semantic-version==2.10.0
     #   edx-drf-extensions
 shapely==2.0.1
     # via -r requirements/edx/base.txt
-simplejson==3.18.4
+simplejson==3.19.1
     # via
     #   -r requirements/edx/base.txt
     #   sailthru-client
@@ -1405,7 +1405,7 @@ sniffio==1.3.0
     #   anyio
     #   httpcore
     #   httpx
-snowflake-connector-python==3.0.1
+snowflake-connector-python==3.0.2
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise
@@ -1426,7 +1426,7 @@ sorl-thumbnail==12.9.0
     #   openedx-django-wiki
 sortedcontainers==2.4.0
     # via -r requirements/edx/base.txt
-soupsieve==2.4
+soupsieve==2.4.1
     # via
     #   -r requirements/edx/base.txt
     #   beautifulsoup4
@@ -1475,7 +1475,7 @@ tomli==2.0.1
     #   pylint
     #   pytest
     #   tox
-tomlkit==0.11.6
+tomlkit==0.11.7
     # via pylint
 tox==3.28.0
     # via
@@ -1537,7 +1537,7 @@ voluptuous==0.13.1
     # via
     #   -r requirements/edx/base.txt
     #   ora2
-watchdog==2.3.1
+watchdog==3.0.0
     # via -r requirements/edx/base.txt
 wcwidth==0.2.6
     # via

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -10,9 +10,9 @@ click==8.1.3
     # via
     #   -c requirements/constraints.txt
     #   pip-tools
-packaging==23.0
+packaging==23.1
     # via build
-pip-tools==6.12.3
+pip-tools==6.13.0
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.0.0
     # via build

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.40.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.0.1
+pip==23.1
     # via -r requirements/pip.in
-setuptools==67.6.0
+setuptools==67.6.1
     # via -r requirements/pip.in


### PR DESCRIPTION
## Description
### Change 01
- `pip==23.0.1` & `pip-tools==6.12.3` were causing the `make upgrade` job to [fail](https://github.com/openedx/edx-platform/actions/runs/4727866508) on master branch.
- Updated to the latest versions i.e. `pip==23.1` & `pip-tools==6.13.0` which fixed the issue in upgrading requirements.

### Change 02
- Migration check for `MySQL 5.7` started failing again after the requirements were upgraded. 
- An additional step to reinstall `libmysqlclient-dev` system package was added which fixed the issue of the binary file not being found during the migration tests.
- The step to uninstall & re-install `mysqlclient` python package was removed after testing as not necessary anymore.

### Change 03
- `pytz>=2023` caused test failures due to major changes in timezone settings so pinned the version for now so it can be fixed in another PR later on.

### Testing
- The `pip & pip-tools` change was tested to be working perfectly by triggering a custom Python Requirements [Build](https://github.com/openedx/edx-platform/actions/runs/4729144382) against this branch which was successful. 
- The migration check fix was tested by running the CI checks again & again with all the combinations of potential solutions and then the final solution was confirmed.