### PR TITLE
build: Remove workarounds for missing packages

### DIFF
--- a/.github/workflows/migrations-check-mysql8.yml
+++ b/.github/workflows/migrations-check-mysql8.yml
@@ -51,10 +51,6 @@ jobs:
     - name: Install Python dependencies
       run: |
         make dev-requirements
-        pip uninstall -y mysqlclient
-        pip install --no-binary mysqlclient mysqlclient
-        pip uninstall -y xmlsec
-        pip install --no-binary xmlsec xmlsec
 
     - name: Initiate Services
       run: |

--- a/.github/workflows/pylint-checks.yml
+++ b/.github/workflows/pylint-checks.yml
@@ -60,8 +60,7 @@ jobs:
           # trip over some dev-only things like django-debug-toolbar
           # (import debug_toolbar) that aren't in testing.txt.
           make dev-requirements
-          pip uninstall -y mysqlclient
-          pip install --no-binary mysqlclient mysqlclient
+          # After all requirements are installed, check that they're consistent with each other
           pip check
 
       - name: Run quality tests


### PR DESCRIPTION
We'd prefer to install the OS packages rather than have these workarounds for missing system libraries.
