### PR TITLE
feat: Add a script to enhance JWKs in preparation for move from pyjwkest

### DIFF
--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -320,19 +320,23 @@ JWT_AUTH.update({
     }],
     'JWT_SECRET_KEY': 'lms-secret',
     'JWT_SIGNING_ALGORITHM': 'RS512',
-    'JWT_PRIVATE_SIGNING_JWK': (
-        '{"e": "AQAB", "d": "RQ6k4NpRU3RB2lhwCbQ452W86bMMQiPsa7EJiFJUg-qBJthN0FMNQVbArtrCQ0xA1BdnQHThFiUnHcXfsTZUwmwvTu'
-        'iqEGR_MI6aI7h5D8vRj_5x-pxOz-0MCB8TY8dcuK9FkljmgtYvV9flVzCk_uUb3ZJIBVyIW8En7n7nV7JXpS9zey1yVLld2AbRG6W5--Pgqr9J'
-        'CI5-bLdc2otCLuen2sKyuUDHO5NIj30qGTaKUL-OW_PgVmxrwKwccF3w5uGNEvMQ-IcicosCOvzBwdIm1uhdm9rnHU1-fXz8VLRHNhGVv7z6mo'
-        'ghjNI0_u4smhUkEsYeshPv7RQEWTdkOQ", "n": "smKFSYowG6nNUAdeqH1jQQnH1PmIHphzBmwJ5vRf1vu48BUI5VcVtUWIPqzRK_LDSlZYh'
-        '9D0YFL0ZTxIrlb6Tn3Xz7pYvpIAeYuQv3_H5p8tbz7Fb8r63c1828wXPITVTv8f7oxx5W3lFFgpFAyYMmROC4Ee9qG5T38LFe8_oAuFCEntimW'
-        'xN9F3P-FJQy43TL7wG54WodgiM0EgzkeLr5K6cDnyckWjTuZbWI-4ffcTgTZsL_Kq1owa_J2ngEfxMCObnzGy5ZLcTUomo4rZLjghVpq6KZxfS'
-        '6I1Vz79ZsMVUWEdXOYePCKKsrQG20ogQEkmTf9FT_SouC6jPcHLXw", "q": "7KWj7l-ZkfCElyfvwsl7kiosvi-ppOO7Imsv90cribf88Dex'
-        'cO67xdMPesjM9Nh5X209IT-TzbsOtVTXSQyEsy42NY72WETnd1_nAGLAmfxGdo8VV4ZDnRsA8N8POnWjRDwYlVBUEEeuT_MtMWzwIKU94bzkWV'
-        'nHCY5vbhBYLeM", "p": "wPkfnjavNV1Hqb5Qqj2crBS9HQS6GDQIZ7WF9hlBb2ofDNe2K2dunddFqCOdvLXr7ydRcK51ZwSeHjcjgD1aJkHA'
-        '9i1zqyboxgd0uAbxVDo6ohnlVqYLtap2tXXcavKm4C9MTpob_rk6FBfEuq4uSsuxFvCER4yG3CYBBa4gZVU", "kid": "devstack_key", "'
-        'kty": "RSA"}'
-    ),
+    'JWT_PRIVATE_SIGNING_JWK': """
+        {
+            "kid": "devstack_key",
+            "kty": "RSA",
+            "key_ops": [
+                "sign"
+            ],
+            "n": "smKFSYowG6nNUAdeqH1jQQnH1PmIHphzBmwJ5vRf1vu48BUI5VcVtUWIPqzRK_LDSlZYh9D0YFL0ZTxIrlb6Tn3Xz7pYvpIAeYuQv3_H5p8tbz7Fb8r63c1828wXPITVTv8f7oxx5W3lFFgpFAyYMmROC4Ee9qG5T38LFe8_oAuFCEntimWxN9F3P-FJQy43TL7wG54WodgiM0EgzkeLr5K6cDnyckWjTuZbWI-4ffcTgTZsL_Kq1owa_J2ngEfxMCObnzGy5ZLcTUomo4rZLjghVpq6KZxfS6I1Vz79ZsMVUWEdXOYePCKKsrQG20ogQEkmTf9FT_SouC6jPcHLXw",
+            "e": "AQAB",
+            "d": "RQ6k4NpRU3RB2lhwCbQ452W86bMMQiPsa7EJiFJUg-qBJthN0FMNQVbArtrCQ0xA1BdnQHThFiUnHcXfsTZUwmwvTuiqEGR_MI6aI7h5D8vRj_5x-pxOz-0MCB8TY8dcuK9FkljmgtYvV9flVzCk_uUb3ZJIBVyIW8En7n7nV7JXpS9zey1yVLld2AbRG6W5--Pgqr9JCI5-bLdc2otCLuen2sKyuUDHO5NIj30qGTaKUL-OW_PgVmxrwKwccF3w5uGNEvMQ-IcicosCOvzBwdIm1uhdm9rnHU1-fXz8VLRHNhGVv7z6moghjNI0_u4smhUkEsYeshPv7RQEWTdkOQ",
+            "p": "7KWj7l-ZkfCElyfvwsl7kiosvi-ppOO7Imsv90cribf88DexcO67xdMPesjM9Nh5X209IT-TzbsOtVTXSQyEsy42NY72WETnd1_nAGLAmfxGdo8VV4ZDnRsA8N8POnWjRDwYlVBUEEeuT_MtMWzwIKU94bzkWVnHCY5vbhBYLeM",
+            "q": "wPkfnjavNV1Hqb5Qqj2crBS9HQS6GDQIZ7WF9hlBb2ofDNe2K2dunddFqCOdvLXr7ydRcK51ZwSeHjcjgD1aJkHA9i1zqyboxgd0uAbxVDo6ohnlVqYLtap2tXXcavKm4C9MTpob_rk6FBfEuq4uSsuxFvCER4yG3CYBBa4gZVU",
+            "dp": "MO9Ppss-Bl-mC1vGyJDBbMgr2GgivGYbHFLt6ERfTGsvcr0RhDjZu16ZpNpBB6B7-K-uJGHxPmmf8P9KRWDBUAwOSaT2a-pTsuux6PKCwVTZfUq5LxAkiyg6WZTGoWASEtoae0XRHEy2TvIKNl5AiX-h_DwDPDbEYcWCZVAb6-E",
+            "dq": "m03j7GkGSWRxMGNCeEBtvvBR4vDS9Her7AtjbNSWnRxDMQrKSdRMaiu-m7tOT3n6D9cM7Cr7wZUtzBOENskprHBu47FgzfXakMWfYhv0TV0voxZERKAN_H7cWt4oLsprEzH9r6THsxFPdKxMYBGeoAOe2l9nlk26m6LaX7_rwqE",
+            "qi": "jnJ0nfARyAcHsezENNrXKnDM-LrMJWMHPh_70ZM_pF5iRMOLojHkTVsUIzYi6Uj2ohX9Jz1zsV207kCuPqQXURbhlt1xEaktwCmySeWU4qkMTptWp4ya2jEwGn8EKJ1iEc0GhDkRyLrgm4ol-sq9DMaKEkhTGy4Y3-8mMCBVqeQ"
+        }
+""",
     'JWT_PUBLIC_SIGNING_JWK_SET': (
         '{"keys": [{"kid": "devstack_key", "e": "AQAB", "kty": "RSA", "n": "smKFSYowG6nNUAdeqH1jQQnH1PmIHphzBmwJ5vRf1vu'
         '48BUI5VcVtUWIPqzRK_LDSlZYh9D0YFL0ZTxIrlb6Tn3Xz7pYvpIAeYuQv3_H5p8tbz7Fb8r63c1828wXPITVTv8f7oxx5W3lFFgpFAyYMmROC'

--- a/scripts/jwk-precompute-params.py
+++ b/scripts/jwk-precompute-params.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# Enhance a JWK to have all of its optional performance parameters.
+# Intended to be used on an RSA `JWT_PRIVATE_SIGNING_JWK`.
+#
+# This is needed for the change from pyjwkest to PyJWT, since the
+# former accepts a partial list of optional parameters but the latter
+# requires that they are either all present or all absent. The optional
+# parameters provide a performance boost.
+#
+# Usage: Key JSON accepted on stdin; enhanced key printed to stdout.
+
+import json
+import sys
+
+from jwt.algorithms import RSAAlgorithm
+
+
+print("Paste the key's JSON, followed by a new line and Ctrl-D:\n", file=sys.stderr)
+old_jwk_data = json.loads(sys.stdin.read())
+
+# Clear out all of the precomputed private numbers
+for param_key in ['p', 'q', 'dp', 'dq', 'qi']:
+    if param_key in old_jwk_data:
+        del old_jwk_data[param_key]
+
+# Ensure that there aren't any unexpected parameters
+expected_remaining = {'kty', 'e', 'd', 'n', 'kid', 'key_ops'}
+unexpected_params = set(old_jwk_data.keys()) - expected_remaining
+if len(unexpected_params):
+    print(
+        f"Unexpected parameters {unexpected_params} would be lost. Aborting script. "
+        "If your key has additional parameters that are unrelated to the precomputed "
+        "private numbers, then please add them to the `expected_remaining` variable "
+        "and re-run the script. Please consider making a PR as well.",
+        file=sys.stderr
+    )
+    sys.exit(1)
+
+# Recompute private numbers
+new_jwk_data = json.loads(RSAAlgorithm.to_jwk(RSAAlgorithm.from_jwk(old_jwk_data)))
+
+# Restore the kid (key ID) param, which gets lost in the process. This adds it
+# to the front of the dict. The params are actually in a really nice order in
+# the native ordering that comes out of the JWK, with metadata first, then the
+# core params (n, e, d), and then the precomputed values.
+for restore_param in ['kid']:
+    if restore_param in old_jwk_data:
+        new_jwk_data = {restore_param: old_jwk_data[restore_param], **new_jwk_data}
+
+# Pretty-print so that the kid and modulus can be confirmed easily
+print("\n\nEnhanced private key:\n", file=sys.stderr)
+print(json.dumps(new_jwk_data, indent=4))


### PR DESCRIPTION
This script accepts a signing JWK (presumably `JWT_PRIVATE_SIGNING_JWK`) and ensures that it has all of the precomputed private numbers that are required for top performance. This is necessary before moving away from pyjwkest to PyJWT for signing JWTs. See issue <https://github.com/openedx/edx-drf-extensions/issues/290>. (Alternatively, one could remove the p, q, dp, dq, and qi params, but there is an unknown performance cost to doing so as we are not currently caching these keys, and the precompution happens on every load due to the way pyjwkest's API works.)