### PR TITLE
feat: pre-fill location to Unit URL in Studio sidebar

### DIFF
--- a/cms/templates/container.html
+++ b/cms/templates/container.html
@@ -203,7 +203,9 @@ from openedx.core.djangolib.markup import HTML, Text
                             <h5 class="title">${_("Location ID")}</h5>
                             <p class="unit-id">
                                 <span class="unit-id-value" id="unit-location-id-input">${unit.location.block_id}</span>
-                                <span class="tip"><span class="sr">Tip: </span>${Text(_('To create a link to this unit from an HTML component in this course, enter "/jump_to_id/<location ID>" as the URL value.'))}</span>
+                                <span class="tip"><span class="sr">Tip: </span>${Text(_('To create a link to this unit from an HTML component in this course, enter {unit_link} as the URL value.')).format(
+                                    unit_link="/jump_to_id/{}".format(unit.location.block_id)
+                                )}</span>
                             </p>
                         </div>
                      </div>


### PR DESCRIPTION
## Description

Studio has a panel on the right side in the Unit view that shows authors how to create a jump_to_id link to that Unit from HTML components that are elsewhere in the course. However, that link was the literal text:

  `"/jump_to_id/<location ID>"`

The expectation was that people would then copy the location ID as well, and construct the link manually. This commit is a minor tweak that just displays the link address with the location ID pre-filled. Doing this does cause a little bit of text overflow, which is why this commit also removes the quotes surrounding the URL. It's still doesn't always fit perfectly, but the increased usability is worth the small visual issue.

Before:

![unit_link_before](https://user-images.githubusercontent.com/41625/232848738-57a48707-138e-43e8-8fa3-cc188f5b579d.png)

After:

![unit_link_after_no_quotes](https://user-images.githubusercontent.com/41625/232851817-006f7c53-dea5-4e06-a11c-f4f03412f6e2.png)

------

FYI @sarina, @JAAkana, @mondiaz 