### PR TITLE
fix: remove relative due date limit

### DIFF
--- a/cms/static/js/spec/views/pages/course_outline_spec.js
+++ b/cms/static/js/spec/views/pages/course_outline_spec.js
@@ -2291,13 +2291,6 @@ describe('CourseOutlinePage', function() {
             it('shows validation error on relative date', function() {
                 outlinePage.$('.outline-subsection .configure-button').click();
 
-                // when due number of weeks goes over 18
-                selectRelativeWeeksSubsection('19');
-                expect($('#relative_weeks_due_warning_max').css('display')).not.toBe('none');
-                expect($('#relative_weeks_due_warning_max')).toContainText('The maximum number of weeks this subsection can be due in is 18 weeks from the learner enrollment date.');
-                expect($('.wrapper-modal-window .action-save').prop('disabled')).toBe(true);
-                expect($('.wrapper-modal-window .action-save').hasClass('is-disabled')).toBe(true);
-
                 // when due number of weeks is less than 1
                 selectRelativeWeeksSubsection('-1');
                 expect($('#relative_weeks_due_warning_min').css('display')).not.toBe('none');
@@ -2306,8 +2299,7 @@ describe('CourseOutlinePage', function() {
                 expect($('.wrapper-modal-window .action-save').hasClass('is-disabled')).toBe(true);
 
                 // when no validation error should show up
-                selectRelativeWeeksSubsection('10');
-                expect($('#relative_weeks_due_warning_max').css('display')).toBe('none');
+                selectRelativeWeeksSubsection('19');
                 expect($('#relative_weeks_due_warning_min').css('display')).toBe('none');
                 expect($('.wrapper-modal-window .action-save').prop('disabled')).toBe(false);
                 expect($('.wrapper-modal-window .action-save').hasClass('is-disabled')).toBe(false);

--- a/cms/static/js/views/modals/course_outline_modals.js
+++ b/cms/static/js/views/modals/course_outline_modals.js
@@ -420,14 +420,10 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
 
         validateDueIn: function() {
             this.$('#relative_weeks_due_projected').hide();
-            if (this.getValue() > 18){
-                this.$('#relative_weeks_due_warning_max').show();
-                BaseModal.prototype.disableActionButton.call(this.parent, 'save');
-            } else if (this.getValue() < 1){
-                this.$('#relative_weeks_due_warning_min').show()
+            if (this.getValue() < 1) {
+                this.$('#relative_weeks_due_warning_min').show();
                 BaseModal.prototype.disableActionButton.call(this.parent, 'save');
             } else {
-                this.$('#relative_weeks_due_warning_max').hide();
                 this.$('#relative_weeks_due_warning_min').hide();
                 this.showProjectedDate();
                 BaseModal.prototype.enableActionButton.call(this.parent, 'save');
@@ -452,7 +448,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
             // Grab all the subsections, map them to their block_ids, then return as an Array
             var subsectionIds = $('.outline-subsection').map(function(){ return this.id; }).get()
             var relative_weeks_due = null;
-            if (this.getValue() < 19 && this.getValue() > 0 && $('#grading_type').val() !== 'notgraded') {
+            if (this.getValue() > 0 && $('#grading_type').val() !== 'notgraded') {
                 relative_weeks_due = this.getValue()
             }
             window.analytics.track('edx.bi.studio.relative_date.saved', {

--- a/cms/templates/js/self-paced-due-date-editor.underscore
+++ b/cms/templates/js/self-paced-due-date-editor.underscore
@@ -4,7 +4,7 @@
             <!-- Translators: Please use a generic pluralization that makes sense in most contexts for the second half of the sentence "weeks from learner enrollment date" which is preceded by "Due in: [input entry]" -->
             <label for="due_in"><%- gettext('Due in:') %></label>
             <input type="number" id="due_in" name="due_in" value=""
-                placeholder="" autocomplete="off" min="1" max="18" style="width:20%"/>
+                placeholder="" autocomplete="off" min="1" style="width:20%"/>
             <%- gettext('weeks from learner enrollment date')%>
         </li>
     </ul>
@@ -17,10 +17,6 @@
                 projectedDueIn: edx.HtmlUtils.HTML('<span id="relative_weeks_due_projected_due_in"></span>')
             })
         %>
-    </div>
-
-    <div id="relative_weeks_due_warning_max" class="message-status error">
-        <%- gettext('The maximum number of weeks this subsection can be due in is 18 weeks from the learner enrollment date.') %>
     </div>
 
     <div id="relative_weeks_due_warning_min" class="message-status error">


### PR DESCRIPTION
<!--

🎉🎉 Olive has been released! 🎉🎉

🫒🫒
🫒🫒🫒🫒         🫒 Note: Olive is in support. Fixes you make on master may still
    🫒🫒🫒🫒     be needed on Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

The due date limit is artificially enforced by the frontend. The backend does not have limitations that would prevent it from using a higher value. Having this limit leads to the bug described in the "Testing instructions".

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

1. Add the following [Waffle Flags](http://localhost:18000/admin/waffle/flag/) (both enabled):
   1. [course_experience.relative_dates](https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-course_experience.relative_dates)
   2. [studio.custom_relative_dates](https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-studio.custom_relative_dates).
2. Create a new course.
3. Go to "Settings ->  Schedule & Details" in Studio and mark the course as "Self-Paced".
4. Go to "Settings -> Advanced Settings" and set "Number of Relative Weeks Due By" to `999`.
5. Go to the Course Outline in Studio and add a subsection graded as "Homework". Set its "Due in" value to `1024`.
6. The text on the subsection block should be "Custom due date: 1024 weeks from enrollment".

## Deadline

"None"

## Other information

Private-ref: https://tasks.opencraft.com/browse/BB-7349