### PR TITLE
fix: missing advance_settings_access template variable

### DIFF
--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -7,6 +7,7 @@
 <%namespace name='static' file='static_content.html'/>
 <%!
   from django.utils.translation import gettext as _
+  from common.djangoapps.student.auth import has_studio_advanced_settings_access
   from cms.djangoapps.contentstore import utils
   from lms.djangoapps.certificates.api import can_show_certificate_available_date_field
   from openedx.core.djangolib.js_utils import (
@@ -721,7 +722,9 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url | n, js_escaped_string}'
             <li class="nav-item"><a href="${grading_config_url}">${_("Grading")}</a></li>
             <li class="nav-item"><a href="${course_team_url}">${_("Course Team")}</a></li>
             <li class="nav-item"><a href="${utils.reverse_course_url('group_configurations_list_handler', context_course.id)}">${_("Group Configurations")}</a></li>
+            % if has_studio_advanced_settings_access(request.user):
             <li class="nav-item"><a href="${advanced_config_url}">${_("Advanced Settings")}</a></li>
+            % endif
             % if mfe_proctored_exam_settings_url:
               <li class="nav-item"><a href="${mfe_proctored_exam_settings_url}">${_("Proctored Exam Settings")}</a></li>
             % endif

--- a/cms/templates/settings_graders.html
+++ b/cms/templates/settings_graders.html
@@ -11,6 +11,7 @@
   import json
   from cms.djangoapps.contentstore import utils
   from django.utils.translation import gettext as _
+  from common.djangoapps.student.auth import has_studio_advanced_settings_access
   from cms.djangoapps.models.settings.encoder import CourseSettingsEncoder
   from openedx.core.djangolib.js_utils import (
       dump_js_escaped_json, js_escaped_string
@@ -168,7 +169,9 @@
             <li class="nav-item"><a href="${detailed_settings_url}">${_("Details & Schedule")}</a></li>
             <li class="nav-item"><a href="${course_team_url}">${_("Course Team")}</a></li>
             <li class="nav-item"><a href="${utils.reverse_course_url('group_configurations_list_handler', context_course.id)}">${_("Group Configurations")}</a></li>
+            % if has_studio_advanced_settings_access(request.user):
             <li class="nav-item"><a href="${advanced_settings_url}">${_("Advanced Settings")}</a></li>
+            % endif
             % if mfe_proctored_exam_settings_url:
               <li class="nav-item"><a href="${mfe_proctored_exam_settings_url}">${_("Proctored Exam Settings")}</a></li>
             % endif

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -7,6 +7,7 @@
   from django.urls import reverse
   from django.utils.translation import gettext as _
   from urllib.parse import quote_plus
+  from common.djangoapps.student.auth import has_studio_advanced_settings_access
   from cms.djangoapps.contentstore import toggles
   from cms.djangoapps.contentstore.utils import get_pages_and_resources_url
   from openedx.core.djangoapps.discussions.config.waffle import ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND
@@ -120,7 +121,7 @@
                     <a href="${mfe_proctored_exam_settings_url}">${_("Proctored Exam Settings")}</a>
                   </li>
                   % endif
-                  % if advance_settings_access:
+                  % if has_studio_advanced_settings_access(request.user):
                   <li class="nav-item nav-course-settings-advanced">
                     <a href="${advanced_settings_url}">${_("Advanced Settings")}</a>
                   </li>

--- a/common/djangoapps/student/auth.py
+++ b/common/djangoapps/student/auth.py
@@ -125,9 +125,23 @@ def has_course_author_access(user, course_key):
     return has_studio_write_access(user, course_key)
 
 
+def has_studio_advanced_settings_access(user):
+    """
+    If DISABLE_ADVANCED_SETTINGS feature is enabled, only Django Superuser
+    or Django Staff can access "Advanced Settings".
+
+    By default, this feature is disabled.
+    """
+    return (
+        not settings.FEATURES.get('DISABLE_ADVANCED_SETTINGS', False)
+        or user.is_staff
+        or user.is_superuser
+    )
+
+
 def has_studio_read_access(user, course_key):
     """
-    Return True iff user is allowed to view this course/library in studio.
+    Return True if user is allowed to view this course/library in studio.
     Will also return True if user has write access in studio (has_course_author_access)
 
     There is currently no such thing as read-only course access in studio, but


### PR DESCRIPTION
## Description

Fixes the bug introduced in https://github.com/openedx/edx-platform/pull/32015.

To reproduce it, open any studio page, like `<STUDIO>/settings/grading/<COURSE_ID>` and open the `Settings` dropdown. You won't see the `Advanced Settings` button there. It's visible only at the `Course Outline` page.

## Testing instructions

Check that `Advanced Settings` button is visible at any Studio page.

## Notes

Merging this makes the revert PR (https://github.com/openedx/edx-platform/pull/32062) redundant.

[private-ref](https://tasks.opencraft.com/browse/BB-7220)