### PR TITLE
fix: update transcripts field in video on upload

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_transcripts.py
+++ b/cms/djangoapps/contentstore/views/tests/test_transcripts.py
@@ -256,6 +256,7 @@ class TestUploadTranscripts(BaseTranscripts):
         expected_edx_video_id = edx_video_id if edx_video_id else json_response['edx_video_id']
         video = modulestore().get_item(self.video_usage_key)
         self.assertEqual(video.edx_video_id, expected_edx_video_id)
+        self.assertDictEqual(video.transcripts, {'en': f'{expected_edx_video_id}-en.srt'})
 
         # Verify transcript content
         actual_transcript = get_video_transcript_content(video.edx_video_id, language_code='en')
@@ -319,6 +320,8 @@ class TestUploadTranscripts(BaseTranscripts):
             expected_status_code=400,
             expected_message='There is a problem with this transcript file. Try to upload a different file.'
         )
+        video = modulestore().get_item(self.video_usage_key)
+        self.assertDictEqual(video.transcripts, {})
 
     def test_transcript_upload_unknown_category(self):
         """

--- a/cms/djangoapps/contentstore/views/transcripts_ajax.py
+++ b/cms/djangoapps/contentstore/views/transcripts_ajax.py
@@ -231,6 +231,8 @@ def upload_transcripts(request):
                 file_data=ContentFile(sjson_subs),
             )
 
+            video.transcripts['en'] = f"{edx_video_id}-en.srt"
+            video.save_with_metadata(request.user)
             if transcript_created is None:
                 response = JsonResponse({'status': 'Invalid Video ID'}, status=400)
 

--- a/lms/djangoapps/courseware/tests/test_video_handlers.py
+++ b/lms/djangoapps/courseware/tests/test_video_handlers.py
@@ -981,7 +981,7 @@ class TestStudioTranscriptTranslationPostDispatch(TestVideo):  # lint-amnesty, p
         assert response.status == '201 Created'
         response = json.loads(response.text)
         assert response['language_code'], 'uk'
-        self.assertDictEqual(self.block.transcripts, {})
+        self.assertDictEqual(self.block.transcripts, {'uk': f'{response["edx_video_id"]}-uk.srt'})
         assert edxval_api.get_video_transcript_data(video_id=response['edx_video_id'], language_code='uk')
 
     def test_studio_transcript_post_bad_content(self):
@@ -999,6 +999,8 @@ class TestStudioTranscriptTranslationPostDispatch(TestVideo):  # lint-amnesty, p
         response = self.block.studio_transcript(request=request, dispatch="translation")
         assert response.status_code == 400
         assert response.json['error'] == 'There is a problem with this transcript file. Try to upload a different file.'
+        # transcripts fields should not be updated
+        self.assertDictEqual(self.block.transcripts, {})
 
 
 @ddt.ddt

--- a/xmodule/video_block/video_handlers.py
+++ b/xmodule/video_block/video_handlers.py
@@ -473,7 +473,6 @@ class VideoStudioViewHandlers:
             `POST`:
                 Upload srt file. Check possibility of generation of proper sjson files.
                 For now, it works only for self.transcripts, not for `en`.
-                Do not update self.transcripts, as fields are updated on save in Studio.
             `GET:
                 Return filename from storage. SRT format is sent back on success. Filename should be in GET dict.
 
@@ -529,6 +528,7 @@ class VideoStudioViewHandlers:
                             'edx_video_id': edx_video_id,
                             'language_code': new_language_code
                         }
+                        self.transcripts[new_language_code] = f'{edx_video_id}-{new_language_code}.srt'
                         response = Response(json.dumps(payload), status=201)
                     except (TranscriptsGenerationException, UnicodeDecodeError):
                         response = Response(


### PR DESCRIPTION
<!--

🎉🎉 Olive has been released! 🎉🎉

🫒🫒
🫒🫒🫒🫒         🫒 Note: Olive is in support. Fixes you make on master may still
    🫒🫒🫒🫒     be needed on Olive. If so, make another pull request against the
🫒🫒🫒🫒         open-release/olive.master branch, or ping @nedbat for help or questions.
🫒🫒

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Adding transcripts to video using studio editor does not update the transcripts field in xblock. This results in incomplete data being returned by [index_dictionary](https://github.com/open-craft/edx-platform/blob/cf47c296f44b6f83a41ac01ed4ef4e779d729448/xmodule/video_block/video_block.py#L1050-L1079) and other functions.

## Testing instructions

- Get master devstack up and running without the changes in this MR
- Select any video in demo course in studio
- Click on edit and go to advanced tab
- Add a new transcript using the `Add` button under *Transcript Languages* section
![image](https://user-images.githubusercontent.com/10894099/233097775-1c4545fe-e9b0-40d8-9303-f457778f1f05.png)
- Select any language and upload a dummy *.srt file.
- Save and publish the course
- Open preview and click on `Staff debug info` button below the video (log in with superuser or staff user)
![image](https://user-images.githubusercontent.com/10894099/233098210-d1a5a1a2-de42-413c-a83c-ccf991761047.png)
- The transcripts field will only have one entry if the video already had a english transcript or no entry if it did not already have a transcript associated.
- Now checkout this MR and re upload the transcript, the field should be updated.
- Also try uploading a transcript for a new video using the upload button in the basic tab.
![image](https://user-images.githubusercontent.com/10894099/233099000-3abf904f-2fa2-4570-b53d-e00f05b4ca88.png)

## Author concerns

**Open to feedback if there are better ways to update the fields.** It should have updated fields from via the studio UI.