### PR TITLE
ci: run static assets check with minimal settings

### DIFF
--- a/.github/workflows/static-assets-check.yml
+++ b/.github/workflows/static-assets-check.yml
@@ -64,8 +64,8 @@ jobs:
 
     - name: Run Static Assets Check
       env:
-        LMS_CFG: lms/envs/bok_choy.yml
-        CMS_CFG: cms/envs/bok_choy.yml
+        LMS_CFG: lms/envs/minimal.yml
+        CMS_CFG: cms/envs/minimal.yml
 
       run: |
         paver update_assets lms


### PR DESCRIPTION
The static assets check was running using the bok_choy.yml file.
However, bok-choy is deprecated
(https://github.com/openedx/public-engineering/issues/13),
so we cannot expect that file to be around forever.
Let's switch to the minimal YML file instead.
