### PR TITLE
feat: video share icons

### DIFF
--- a/lms/templates/video.html
+++ b/lms/templates/video.html
@@ -52,15 +52,6 @@ from openedx.core.djangolib.js_utils import (
         % if download_video_link or public_video_url:
             <div class="wrapper-download-video">
                 <h4 class="hd hd-5">${_('Video')}</h4>
-                % if download_video_link:
-                    <span class="icon fa fa-download" aria-hidden="true"></span>
-                    <a class="btn-link video-sources video-download-button" href="${download_video_link}">
-                        ${_('Download video file')}
-                    </a>
-                % endif
-                % if download_video_link and public_video_url:
-                    <br>
-                % endif
                 % if public_video_url:
                     <span class="icon fa fa-share-alt" aria-hidden="true"></span>
                     ${_('Share on:')}
@@ -90,6 +81,15 @@ from openedx.core.djangolib.js_utils import (
                     >
                         <span class="icon fa fa-linkedin-square" aria-hidden="true"></span>
                         <span class="sr">${_('Share on LinkedIn')}</span>
+                    </a>
+                % endif
+                % if download_video_link and public_video_url:
+                    <br>
+                % endif
+                % if download_video_link:
+                    <span class="icon fa fa-download" aria-hidden="true"></span>
+                    <a class="btn-link video-sources video-download-button" href="${download_video_link}">
+                        ${_('Download video file')}
                     </a>
                 % endif
             </div>

--- a/lms/templates/video.html
+++ b/lms/templates/video.html
@@ -53,6 +53,7 @@ from openedx.core.djangolib.js_utils import (
             <div class="wrapper-download-video">
                 <h4 class="hd hd-5">${_('Video')}</h4>
                 % if download_video_link:
+                    <span class="icon fa fa-download" aria-hidden="true"></span>
                     <a class="btn-link video-sources video-download-button" href="${download_video_link}">
                         ${_('Download video file')}
                     </a>
@@ -61,6 +62,7 @@ from openedx.core.djangolib.js_utils import (
                     <br>
                 % endif
                 % if public_video_url:
+                    <span class="icon fa fa-share-alt" aria-hidden="true"></span>
                     ${_('Share on:')}
                     <a
                         class="btn-link"
@@ -99,6 +101,7 @@ from openedx.core.djangolib.js_utils import (
             <ul class="list-download-transcripts">
                 % for item in transcript_download_formats_list:
                     <li class="transcript-option">
+                        <span class="icon fa fa-download" aria-hidden="true"></span>
                         <% dname = _("Download {file}").format(file=item['display_name']) %>
                         <a class="btn btn-link" href="${track}" data-value="${item['value']}">${dname}</a>
                     </li>

--- a/lms/templates/video.html
+++ b/lms/templates/video.html
@@ -68,7 +68,8 @@ from openedx.core.djangolib.js_utils import (
                         href="${public_video_url}"
                         target="_blank"
                     >
-                        ${_('Twitter')}
+                        <span class="icon fa fa-twitter-square" aria-hidden="true"></span>
+                        <span class="sr">${_('Share on Twitter')}</span>
                     </a>
                     <a
                         class="btn-link"
@@ -76,7 +77,8 @@ from openedx.core.djangolib.js_utils import (
                         href="${public_video_url}"
                         target="_blank"
                     >
-                        ${_('Facebook')}
+                        <span class="icon fa fa-facebook-square" aria-hidden="true"></span>
+                        <span class="sr">${_('Share on Facebook')}</span>
                     </a>
                     <a
                         class="btn-link"
@@ -84,7 +86,8 @@ from openedx.core.djangolib.js_utils import (
                         href="${public_video_url}"
                         target="_blank"
                     >
-                        ${_('Linkedin')}
+                        <span class="icon fa fa-linkedin-square" aria-hidden="true"></span>
+                        <span class="sr">${_('Share on LinkedIn')}</span>
                     </a>
                 % endif
             </div>

--- a/xmodule/css/video/display.scss
+++ b/xmodule/css/video/display.scss
@@ -118,6 +118,12 @@ $cool-dark: rgb(79, 89, 93); // UXPL cool dark
 
         .transcript-option {
           margin: 0;
+          font-size: 16px !important;
+
+          a.btn , a.btn-link{
+            font-size: 16px !important;
+            font-weight: unset;
+          }
         }
       }
     }

--- a/xmodule/css/video/display.scss
+++ b/xmodule/css/video/display.scss
@@ -118,7 +118,6 @@ $cool-dark: rgb(79, 89, 93); // UXPL cool dark
 
         .transcript-option {
           margin: 0;
-          font-size: 16px !important;
 
           a.btn , a.btn-link{
             font-size: 16px !important;


### PR DESCRIPTION
## Description

1. Changes video share links to their respective social media platform icons.
2. Adds download / share icons.
3. Updates styling of transcript download links to match other links in video block.
4. Moves share links above download links when both are present.

## Supporting information

JIRA: https://2u-internal.atlassian.net/browse/AU-1153

<img width="891" alt="Screenshot 2023-04-21 at 15 35 24" src="https://user-images.githubusercontent.com/12944465/234020158-a1620b4d-4a34-4489-a91a-29fa295a7a25.png">


## Testing instructions

1. Enable video sharing for a course.
2. Enable video sharing for the target video.
3. Ensure social media links appear as icons.