### PR TITLE
docs: downgrade settings ADR status to "Provisional"

### DIFF
--- a/docs/decisions/0004-managing-django-settings.rst
+++ b/docs/decisions/0004-managing-django-settings.rst
@@ -1,7 +1,7 @@
 Status
 ======
 
-Accepted
+Provisional
 
 
 Context


### PR DESCRIPTION
The ideas here are good and in line with OEP-45, but we have not yet had a chance to implement them in edx-platform

Furthermore, recent conversations have made us consider revisiting the "Don't use YAML files, just python modules" alternative described in the ADR. Particularly, Tutor has not been able to use pure YAML to configure edx-platform, and has fallen back on having separate .py settings files. This makes us think that we either need to expose
more power through the YAML interface, or we need to re-embrace .py settings files.
