### PR TITLE
fix: support files with a unicode signature in the Instructor Dashboard API

### DIFF
--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -339,7 +339,7 @@ def register_and_enroll_students(request, course_id):  # pylint: disable=too-man
         try:
             upload_file = request.FILES.get('students_list')
             if upload_file.name.endswith('.csv'):
-                students = list(csv.reader(upload_file.read().decode('utf-8').splitlines()))
+                students = list(csv.reader(upload_file.read().decode('utf-8-sig').splitlines()))
                 course = get_course_by_id(course_id)
             else:
                 general_errors.append({
@@ -1519,7 +1519,7 @@ def _cohorts_csv_validator(file_storage, file_to_validate):
     Verifies that the expected columns are present in the CSV used to add users to cohorts.
     """
     with file_storage.open(file_to_validate) as f:
-        reader = csv.reader(f.read().decode('utf-8').splitlines())
+        reader = csv.reader(f.read().decode('utf-8-sig').splitlines())
 
         try:
             fieldnames = next(reader)
@@ -3332,7 +3332,7 @@ def generate_bulk_certificate_exceptions(request, course_id):
         try:
             upload_file = request.FILES.get('students_list')
             if upload_file.name.endswith('.csv'):
-                students = list(csv.reader(upload_file.read().decode('utf-8').splitlines()))
+                students = list(csv.reader(upload_file.read().decode('utf-8-sig').splitlines()))
             else:
                 general_errors.append(_('Make sure that the file you upload is in CSV format with no '
                                         'extraneous characters or rows.'))


### PR DESCRIPTION
## Description

Without this, files with BOM (byte order mark; generated e.g., by Microsoft Excel) cannot be read properly.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

1. Add `from .common import FEATURES; FEATURES['ALLOW_AUTOMATED_SIGNUPS'] = True` to your `lms/envs/private.py`.
2. Go to the [Instructor Dashboard -> Membership](http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/instructor#view-membership).
3. Upload the [accounts.csv](https://github.com/openedx/edx-platform/files/11296632/accounts.csv) below "Register/Enroll Students". It should produce a "Success" message.

## Deadline

"None"

## Author's notes

To verify that the downloaded file contains BOM, you can inspect it with the `file` command. You can also view it with `cat -A` (GNU coreutils), `cat -vet` (Mac OS) or `bat -A`.

## Other information

Private-ref: [BB-7349](https://tasks.opencraft.com/browse/BB-7349)