### PR TITLE
fix: missing blockquote margin xblock preview

### DIFF
--- a/cms/static/sass/elements/_xblocks.scss
+++ b/cms/static/sass/elements/_xblocks.scss
@@ -460,6 +460,10 @@
       code::after {
         @include display-left-to-right();
       }
+
+      blockquote {
+        margin: $baseline*2;
+      }
     }
 
     // STATE: container/component with children - abbreviated preview


### PR DESCRIPTION
<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: the Palm master branch has been created. Please consider whether your change
    🌴🌴🌴🌴     should also be applied to Palm. If so, make another pull request against the
🌴🌴🌴🌴         open-release/palm.master branch, or ask in the #wg-build-test-release Slack channel
🌴🌴             if you have any questions or need help.

🫒🫒🫒🫒🫒🫒     🫒 Note: the Olive release is still supported.
                Please consider whether your change should be applied to Olive as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This PR adds margin to blockquotes in Studio's xblock preview. The margin now matches the one's found in editors and Live/Preview for learners. This change impacts the Course Author.

### Before

<img width="663" alt="Screenshot 2023-04-24 at 4 31 06 PM" src="https://user-images.githubusercontent.com/42981026/234109770-5f25a2e2-7c3b-4016-a656-193ca9096c04.png">

### After

<img width="663" alt="Screenshot 2023-04-24 at 4 21 19 PM" src="https://user-images.githubusercontent.com/42981026/234107637-28838865-4f0b-48f7-b67a-f569c4753b0a.png">

## Supporting information

JIRA Ticket: [TNL-10478](https://2u-internal.atlassian.net/browse/TNL-10478)

> Blockquote doesn’t have any effect in Studio. Appears to work in editor, does not have any effect in Studio, but then works in Preview.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

None
