### PR TITLE
feat: move general imports to specific scss files

### DIFF
--- a/lms/static/sass/course/courseware/_sidebar.scss
+++ b/lms/static/sass/course/courseware/_sidebar.scss
@@ -1,3 +1,5 @@
+@import 'bourbon/bourbon';
+
 .course-index {
   @include transition(all 0.2s $ease-in-out-quad 0s);
   @include border-right(1px solid $border-color-2);

--- a/xmodule/css/capa/display.scss
+++ b/xmodule/css/capa/display.scss
@@ -18,6 +18,7 @@
 // * +Problem - Choice Text Group
 // * +Problem - Image Input Overrides
 // * +Problem - Annotation Problem Overrides
+@import 'bourbon/bourbon';
 
 // +Variables - Capa
 // ====================

--- a/xmodule/css/html/display.scss
+++ b/xmodule/css/html/display.scss
@@ -1,3 +1,5 @@
+@import 'bourbon/bourbon';
+
 // HTML component display:
 * {
   line-height: 1.4em;

--- a/xmodule/css/tabs/tabs.scss
+++ b/xmodule/css/tabs/tabs.scss
@@ -130,10 +130,6 @@
     padding: 0;
     border: none;
   }
-
-  .blue-button {
-    @include blue-button;
-  }
 }
 
 

--- a/xmodule/css/video/display.scss
+++ b/xmodule/css/video/display.scss
@@ -8,6 +8,7 @@
 // --------
 // Defaults: what displays if the icon font doesn't load.
 // --------
+@import 'bourbon/bourbon';
 
 // the html target is necessary for xblocks and xmodules, but works across the board
 

--- a/xmodule/static_content.py
+++ b/xmodule/static_content.py
@@ -147,10 +147,8 @@ def _write_styles(selector, output_root, classes, css_attribute):
         for class_ in classes:
             css_imports[class_].add(fragment_name)
 
-    module_styles_lines = [
-        "@import 'bourbon/bourbon';",
-        "@import 'lms/theme/variables';",
-    ]
+    module_styles_lines = []
+
     for class_, fragment_names in sorted(css_imports.items()):
         fragment_names = sorted(fragment_names)
         module_styles_lines.append("""{selector}.xmodule_{class_} {{""".format(


### PR DESCRIPTION
<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: the Palm master branch has been created. Please consider whether your change
    🌴🌴🌴🌴     should also be applied to Palm. If so, make another pull request against the
🌴🌴🌴🌴         open-release/palm.master branch, or ask in the #wg-build-test-release Slack channel
🌴🌴             if you have any questions or need help.

🫒🫒🫒🫒🫒🫒     🫒 Note: the Olive release is still supported.
                Please consider whether your change should be applied to Olive as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This pull request change the way how the scss xmodule imports are made,  currently this [line](https://github.com/openedx/edx-platform/blob/master/xmodule/static_content.py#L150) adds `bourbun` and  `lms/theme/variables `  as general imports at the top of the file `_module-styles.scss` that is generated after running the command `openedx-assets xmodule`, example

```
@import 'bourbon/bourbon';
@import 'lms/theme/variables';
.xmodule_edit.xmodule_AboutBlock {
  @import "000-cd23cf32f86efa1c4179df0201722e55.scss";
  @import "001-a10fc3e0fd6aca63426a89e75fe69c31.scss";
}
...
.xmodule_edit.xmodule_VideoBlock {
  @import "000-e5d1b330372214d8a7b774e826640db5.scss";
}

```

This makes harder to know which file really needs of that import to compile and it will generate css files bigger after decoupling process as this [pr](https://github.com/openedx/edx-platform/pull/32018) suggest.



## Results and conclusions
For the lms(http://local.overhang.io:8000/static/css/lms-course.css), the difference was just two lines 

![image](https://user-images.githubusercontent.com/36200299/234125221-4be0ad55-d251-4441-86d0-f5c22d0b35d0.png)


That was due to I removed `"@import 'lms/theme/variables';",` however that line is redundant  that import is made 4 times in the master branch with this it's just made two times 

For cms(http://studio.local.overhang.io:8001/static/studio/css/studio-main-v1.css), when I just remove the general import the  difference was bigger the results were the following:

1. Same case as lms
![image](https://user-images.githubusercontent.com/36200299/234125305-c54d1f7e-c2da-4839-abc8-3aa4c716a2ee.png)

2. font weight was set to the selector `.xmodule_edit.xmodule_VideoBlock .component-tab .blue-button `
![image](https://user-images.githubusercontent.com/36200299/234125352-b7c3ca46-4e33-40c9-a4fe-6596b5e1ea51.png)

3. more attributes were set for the selector  `.xmodule_edit.xmodule_VideoBlock .component-tab .blue-button `
![image](https://user-images.githubusercontent.com/36200299/234125491-ade90b87-f825-4fe0-9116-eb9fc328d220.png)

4 Multiple changes all related with `.xmodule_edit.xmodule_VideoBlock  .component-tab .blue-button
![image](https://user-images.githubusercontent.com/36200299/234125750-920f51be-8432-4fb0-82e3-83e0fe233ba3.png)


That was happening because the import order had changed and an specific button mixin was not overridden by bourbon, the file that generates that difference is [this one](https://github.com/openedx/edx-platform/blob/master/xmodule/css/tabs/tabs.scss#L135), that use the [blue-button](https://github.com/openedx/edx-platform/blob/master/common/static/sass/_mixins-inherited.scss#L191) mixin, and that mixin use inside the button mixin in this [line](https://github.com/openedx/edx-platform/blob/master/common/static/sass/_mixins-inherited.scss#L192), when the bourbon import is made in the file  `openedx-assets xmodule` that override the button mixin with [this](https://github.com/openedx/edx-platform/blob/master/common/static/sass/bourbon/addons/_button.scss#L1) however when I applied this changes that uses this [mixin](https://github.com/openedx/edx-platform/blob/master/common/static/sass/_mixins-inherited.scss#L134)

I consider those changes doesn't make any difference in the visual resul  since currently that class is not present in the studio editor template

![image](https://user-images.githubusercontent.com/36200299/234128035-1941aef6-8416-4d60-ad87-9a7b45d81f7c.png)

Therefore the visual result is the same and I also made a visual comparison to verify that, for that reason I think the best option is to remove that class from the style file and the final result for cms is the next 

![image](https://user-images.githubusercontent.com/36200299/234129942-7f326b0d-3326-42bd-b806-659c8b72e4cc.png)

## Testing instructions

To test this a comparison is required, so follow the next instructions  with first the master branch and then with this.(Those instructions are base on a tutor environment)

1. Go inside your docker image `docker exec -it tutor_nightly_dev-lms-1 /bin/bash`
2. Run this command `openedx-assets xmodule && openedx-assets common`. (probably with master branch this is not necessary since this is part of the provision process)
3. Go to http://local.overhang.io:8000/static/css/lms-course.css and copy the content and save it in a temporary file
4. Go to http://studio.local.overhang.io:8001/static/studio/css/studio-main-v1.css and copy the content and save it in a temporary file

Repeat with **and/move_general_imports** branch

After that you will have to compare the result of the master branch and the pr branch, I used this [page](https://www.diffchecker.com/text-compare/)

If you don't want to compare the compiled filed, you can use a online beautifier like this https://www.cleancss.com/css-beautify/ and compare that result

