### PR TITLE
chore: remove test workarounds for releases

### DIFF
--- a/.github/workflows/unit-tests-gh-hosted.yml
+++ b/.github/workflows/unit-tests-gh-hosted.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run-test:
-    if: (github.repository != 'openedx/edx-platform' && github.repository != 'edx/edx-platform-private') || (github.repository == 'openedx/edx-platform' && (startsWith(github.base_ref, 'open-release') == true))
+    if: github.repository != 'openedx/edx-platform' && github.repository != 'edx/edx-platform-private'
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
@@ -78,7 +78,7 @@ jobs:
         uses: ./.github/actions/unit-tests
 
   collect-and-verify:
-    if: (github.repository != 'openedx/edx-platform' && github.repository != 'edx/edx-platform-private') || (github.repository == 'openedx/edx-platform' && (startsWith(github.base_ref, 'open-release') == true))
+    if: github.repository != 'openedx/edx-platform' && github.repository != 'edx/edx-platform-private'
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   run-tests:
     name: python-${{ matrix.python-version }},django-${{ matrix.django-version }},${{ matrix.shard_name }}
-    if: (github.repository == 'edx/edx-platform-private') || (github.repository == 'openedx/edx-platform' && (startsWith(github.base_ref, 'open-release') == false))
+    if: github.repository == 'edx/edx-platform-private' || github.repository == 'openedx/edx-platform'
     runs-on: [ edx-platform-runner ]
     strategy:
       matrix:

--- a/.github/workflows/verify-gha-unit-tests-count.yml
+++ b/.github/workflows/verify-gha-unit-tests-count.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   collect-and-verify:
-    if: (github.repository == 'edx/edx-platform-private') || (github.repository == 'openedx/edx-platform' && (startsWith(github.base_ref, 'open-release') == false))
+    if: github.repository == 'edx/edx-platform-private' || github.repository == 'openedx/edx-platform'
     runs-on: [ edx-platform-runner ]
     steps:
       - name: sync directory owner


### PR DESCRIPTION
Somewhere between Olive and Palm the test infrastructure was changed. We had to use the old infrastructure when running tests for Olive and earlier releases, but for Palm and onwards, we should be using the new infra.

These changes were already incorporated into the `open-release/palm.master` branch in https://github.com/openedx/edx-platform/pull/32052.