### PR TITLE
[BB-7296] Extend settings handler to be accessible via api

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v0/tests/test_details_settings.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/tests/test_details_settings.py
@@ -1,0 +1,74 @@
+"""
+Tests for the course advanced settings API.
+"""
+import json
+
+import ddt
+from django.urls import reverse
+from rest_framework import status
+
+from cms.djangoapps.contentstore.tests.utils import CourseTestCase
+
+
+@ddt.ddt
+class CourseDetailsSettingViewTest(CourseTestCase):
+    """
+    Tests for DetailsSettings API View.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.url = reverse(
+            "cms.djangoapps.contentstore:v0:course_details_settings",
+            kwargs={"course_id": self.course.id},
+        )
+
+    def get_and_check_developer_response(self, response):
+        """
+        Make basic asserting about the presence of an error response, and return the developer response.
+        """
+        content = json.loads(response.content.decode("utf-8"))
+        assert "developer_message" in content
+        return content["developer_message"]
+
+    def test_permissions_unauthenticated(self):
+        """
+        Test that an error is returned in the absence of auth credentials.
+        """
+        self.client.logout()
+        response = self.client.get(self.url)
+        error = self.get_and_check_developer_response(response)
+        assert error == "Authentication credentials were not provided."
+
+    def test_permissions_unauthorized(self):
+        """
+        Test that an error is returned if the user is unauthorised.
+        """
+        client, _ = self.create_non_staff_authed_user_client()
+        response = client.get(self.url)
+        error = self.get_and_check_developer_response(response)
+        assert error == "You do not have permission to perform this action."
+
+    def test_get_course_details(self):
+        """
+        Test for get response
+        """
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_patch_course_details(self):
+        """
+        Test for patch response
+        """
+        data = {
+            "start_date": "2030-01-01T00:00:00Z",
+            "end_date": "2030-01-31T00:00:00Z",
+            "enrollment_start": "2029-12-01T00:00:00Z",
+            "enrollment_end": "2030-01-01T00:00:00Z",
+            "course_title": "Test Course",
+            "short_description": "This is a test course",
+            "overview": "This course is for testing purposes",
+            "intro_video": None
+        }
+        response = self.client.patch(self.url, data, content_type='application/json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/cms/djangoapps/contentstore/rest_api/v0/urls.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/urls.py
@@ -3,7 +3,13 @@
 from django.urls import re_path
 
 from openedx.core.constants import COURSE_ID_PATTERN
-from .views import AdvancedCourseSettingsView, CourseTabSettingsView, CourseTabListView, CourseTabReorderView
+from .views import (
+    AdvancedCourseSettingsView,
+    CourseDetailsSettingsView,
+    CourseTabSettingsView,
+    CourseTabListView,
+    CourseTabReorderView
+)
 
 app_name = "v0"
 
@@ -27,5 +33,10 @@ urlpatterns = [
         fr"^tabs/{COURSE_ID_PATTERN}/reorder$",
         CourseTabReorderView.as_view(),
         name="course_tab_reorder",
+    ),
+    re_path(
+        fr"^details_settings/{COURSE_ID_PATTERN}$",
+        CourseDetailsSettingsView.as_view(),
+        name="course_details_settings",
     ),
 ]

--- a/cms/djangoapps/contentstore/rest_api/v0/views/__init__.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/__init__.py
@@ -2,4 +2,5 @@
 Views for v0 contentstore API.
 """
 from .advanced_settings import AdvancedCourseSettingsView
+from .details_settings import CourseDetailsSettingsView
 from .tabs import CourseTabSettingsView, CourseTabListView, CourseTabReorderView

--- a/cms/djangoapps/contentstore/rest_api/v0/views/details_settings.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/details_settings.py
@@ -1,0 +1,76 @@
+""" API Views for course details settings """
+
+import edx_api_doc_tools as apidocs
+from django.core.exceptions import ValidationError as DjangoValidationError
+from opaque_keys.edx.keys import CourseKey
+from rest_framework.request import Request
+from rest_framework.views import APIView
+from xmodule.modulestore.django import modulestore
+
+from cms.djangoapps.models.settings.encoder import CourseSettingsEncoder
+from common.djangoapps.student.auth import has_studio_read_access, has_studio_write_access
+from common.djangoapps.util.json_request import JsonResponse, JsonResponseBadRequest, expect_json_in_class_view
+from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, verify_course_exists, view_auth_classes
+from openedx.core.djangoapps.models.course_details import CourseDetails
+
+from ....utils import update_course_details
+
+
+@view_auth_classes(is_authenticated=True)
+class CourseDetailsSettingsView(DeveloperErrorViewMixin, APIView):
+    """
+    View for getting and setting the details settings for a course.
+    """
+
+    @apidocs.schema(
+        parameters=[
+            apidocs.string_parameter("course_id", apidocs.ParameterLocation.PATH, description="Course ID"),
+        ],
+        responses={
+            401: "The requester is not authenticated.",
+            403: "The requester cannot access the specified course.",
+            404: "The requested course does not exist.",
+        },
+    )
+    @expect_json_in_class_view
+    @verify_course_exists()
+    def get(self, request: Request, course_id: str):
+        """
+        Get an object containing all the details settings in a course.
+        """
+        course_key = CourseKey.from_string(course_id)
+        if not has_studio_read_access(request.user, course_key):
+            self.permission_denied(request)
+        course_details = CourseDetails.fetch(course_key)
+        return JsonResponse(
+            course_details,
+            # encoder serializes dates, old locations, and instances
+            encoder=CourseSettingsEncoder
+        )
+
+    @apidocs.schema(
+        parameters=[
+            apidocs.string_parameter("course_id", apidocs.ParameterLocation.PATH, description="Course ID"),
+        ],
+        responses={
+            401: "The requester is not authenticated.",
+            403: "The requester cannot access the specified course.",
+            404: "The requested course does not exist.",
+        },
+    )
+    @expect_json_in_class_view
+    @verify_course_exists()
+    def patch(self, request: Request, course_id: str):
+        """
+        Update a course's details settings.
+        """
+        course_key = CourseKey.from_string(course_id)
+        if not has_studio_write_access(request.user, course_key):
+            self.permission_denied(request)
+        course_block = modulestore().get_course(course_key)
+        try:
+            update_data = update_course_details(request, course_key, request.json, course_block)
+        except DjangoValidationError as err:
+            return JsonResponseBadRequest({"error": err.message})
+
+        return JsonResponse(update_data, encoder=CourseSettingsEncoder)


### PR DESCRIPTION
## Description

This PR adds a new endpoint `details_settings` that allows fetching and updating the course details settings, which previously could only be updated with a session-based request. With these changes, it can be updated with a token-based request. The changes are similar to what already exists for `advanced_settings`.


## Supporting information
OpenCraft Internal Jira ticket: [BB-7296](https://tasks.opencraft.com/browse/BB-7296)

## Testing instructions
1. Checkout this branch and provision devstack.
2. Verify that the new api details show up in http://localhost:18010/api-docs/.
3. Using a token-based authentication, verify that the methods `GET` and `PATCH` return the expected results.


