### PR TITLE
fix: info banner not visible when course is created

### DIFF
--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -21,6 +21,7 @@ from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole
 from openedx.core.djangoapps.course_apps.toggles import proctoring_settings_modal_view_enabled
 from openedx.core.djangoapps.discussions.config.waffle import ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND
+from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration
 from openedx.core.djangoapps.django_comment_common.models import assign_default_role
 from openedx.core.djangoapps.django_comment_common.utils import seed_permissions_roles
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
@@ -753,3 +754,14 @@ def get_subsections_by_assignment_type(course_key):
                         f'{section.display_name} - {subsection.display_name}'
                     )
     return subsections_by_assignment_type
+
+
+def update_course_discussions_settings(course_key):
+    """
+    Updates course provider_type when new course is created
+    """
+    provider = DiscussionsConfiguration.get(context_key=course_key).provider_type
+    store = modulestore()
+    course = store.get_course(course_key)
+    course.discussions_settings['provider_type'] = provider
+    store.update_item(course, course.published_by)

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -106,7 +106,8 @@ from ..utils import (
     reverse_course_url,
     reverse_library_url,
     reverse_url,
-    reverse_usage_url
+    reverse_usage_url,
+    update_course_discussions_settings,
 )
 from .component import ADVANCED_COMPONENT_TYPES
 from .helpers import is_content_creator
@@ -992,6 +993,7 @@ def create_new_course(user, org, number, run, fields):
     store_for_new_course = modulestore().default_modulestore.get_modulestore_type()
     new_course = create_new_course_in_store(store_for_new_course, user, org, number, run, fields)
     add_organization_course(org_data, new_course.id)
+    update_course_discussions_settings(new_course.id)
     return new_course
 
 


### PR DESCRIPTION
Fix info banner not visible when new course is created with "openedx" provider.

Ticket: [INF-852](https://2u-internal.atlassian.net/browse/INF-852)
