### PR TITLE
fix: pipeline_user_details serializer error on mfe context response

### DIFF
--- a/openedx/core/djangoapps/user_authn/api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_authn/api/tests/test_views.py
@@ -42,8 +42,7 @@ class MFEContextViewTest(ThirdPartyAuthTestMixin, APITestCase):
         hostname = socket.gethostname()
         ip_address = socket.gethostbyname(hostname)
         self.country_code = country_code_from_ip(ip_address)
-        self.pipeline_user_details = {'username': None, 'email': None, 'name': None,
-                                      'firstName': None, 'lastName': None}
+        self.pipeline_user_details = {}
 
         # Several third party auth providers are created for these tests:
         self.configure_google_provider(enabled=True, visible=True)
@@ -97,7 +96,15 @@ class MFEContextViewTest(ThirdPartyAuthTestMixin, APITestCase):
         """
 
         if add_user_details:
-            self.pipeline_user_details.update({'email': 'test@test.com'})
+            self.pipeline_user_details.update(
+                {
+                    'username': None,
+                    'email': 'test@test.com',
+                    'name': None,
+                    'firstName': None,
+                    'lastName': None
+                }
+            )
 
         return {
             'contextData': {

--- a/openedx/core/djangoapps/user_authn/serializers.py
+++ b/openedx/core/djangoapps/user_authn/serializers.py
@@ -53,7 +53,12 @@ class ContextDataSerializer(serializers.Serializer):
     autoSubmitRegForm = serializers.BooleanField(default=False)
     syncLearnerProfileData = serializers.BooleanField(default=False)
     countryCode = serializers.CharField(allow_null=True)
-    pipelineUserDetails = PipelineUserDetailsSerializer(source='pipeline_user_details', allow_null=True)
+    pipelineUserDetails = serializers.SerializerMethodField()
+
+    def get_pipelineUserDetails(self, obj):
+        if obj.get('pipeline_user_details'):
+            return PipelineUserDetailsSerializer(obj.get('pipeline_user_details')).data
+        return {}
 
 
 class MFEContextSerializer(serializers.Serializer):


### PR DESCRIPTION
If there are no pipeline user details, frontend-app-authn expects `pipeline_user_details={}` but it was having fields with null values due to the serializer. 

This PR fix this issue.

