### PR TITLE
feat: updating edx-search version to 3.5.0

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -526,7 +526,7 @@ edx-rest-api-client==5.5.0
     #   -r requirements/edx/base.in
     #   edx-enterprise
     #   edx-proctoring
-edx-search==3.4.0
+edx-search==3.5.0
     # via -r requirements/edx/base.in
 edx-sga==0.21.1
     # via -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -657,7 +657,7 @@ edx-rest-api-client==5.5.0
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
     #   edx-proctoring
-edx-search==3.4.0
+edx-search==3.5.0
     # via -r requirements/edx/testing.txt
 edx-sga==0.21.1
     # via -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -637,7 +637,7 @@ edx-rest-api-client==5.5.0
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   edx-proctoring
-edx-search==3.4.0
+edx-search==3.5.0
     # via -r requirements/edx/base.txt
 edx-sga==0.21.1
     # via -r requirements/edx/base.txt


### PR DESCRIPTION
<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: the Palm master branch has been created. Please consider whether your change
    🌴🌴🌴🌴     should also be applied to Palm. If so, make another pull request against the
🌴🌴🌴🌴         open-release/palm.master branch, or ask in the #wg-build-test-release Slack channel
🌴🌴             if you have any questions or need help.

🫒🫒🫒🫒🫒🫒     🫒 Note: the Olive release is still supported.
                Please consider whether your change should be applied to Olive as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This PR aims to update the version of the edx-search library to [3.5.0](https://github.com/openedx/edx-search/releases/tag/v3.5.0). This update will enable operators to have a shared ElasticSearch installation for multiple OpenedX instances. More details about this feature can be found [here](https://github.com/openedx/edx-search/pull/130).

## Supporting information

In the Large Instances Working Group we added a feature to have a [shared ElasticSearch installation](https://github.com/openedx/openedx-k8s-harmony/issues/4) for multiple OpenedX instances in a Kubernetes cluster. To take advantage of this feature in the Palm release, we require the upgrade of the edx-search version.
