### PR TITLE
feat: update proctortrack library for new application version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "css-loader": "0.28.8",
         "datatables": "1.10.18",
         "datatables.net-fixedcolumns": "3.2.6",
-        "edx-proctoring-proctortrack": "git+https://git@github.com/anupdhabarde/edx-proctoring-proctortrack.git#9b55ea63a3f670bcfbdb5870241510746252ee41",
+        "edx-proctoring-proctortrack": "git+https://git@github.com/anupdhabarde/edx-proctoring-proctortrack.git#fe0027330bf2edb8b7fc9cb3df8f3b3b02db9459",
         "edx-ui-toolkit": "1.5.4",
         "exports-loader": "0.6.4",
         "file-loader": "1.1.6",
@@ -7385,8 +7385,8 @@
     },
     "node_modules/edx-proctoring-proctortrack": {
       "version": "1.1.1",
-      "resolved": "git+https://git@github.com/anupdhabarde/edx-proctoring-proctortrack.git#9b55ea63a3f670bcfbdb5870241510746252ee41",
-      "integrity": "sha512-2Ab6v41EK7XS4bDlZ1LUetP7P3u0DBda+5eskjPV0Kiac/5xhynOjGcrM3sKfthB8vkcmnC2hTKF90MDp1ZPwA==",
+      "resolved": "git+https://git@github.com/anupdhabarde/edx-proctoring-proctortrack.git#fe0027330bf2edb8b7fc9cb3df8f3b3b02db9459",
+      "integrity": "sha512-EmAiTm+Ds2Ps92h99/dwoDsO9rcI28+8IB/kI9yB/hXHOjM3a5FfvgWWlAni0rxH9YZ0Le8hbpCiFZsBbxujYA==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@edx/edx-proctoring": "^4.8.1"
@@ -30659,9 +30659,9 @@
       "dev": true
     },
     "edx-proctoring-proctortrack": {
-      "version": "git+https://git@github.com/anupdhabarde/edx-proctoring-proctortrack.git#9b55ea63a3f670bcfbdb5870241510746252ee41",
-      "integrity": "sha512-2Ab6v41EK7XS4bDlZ1LUetP7P3u0DBda+5eskjPV0Kiac/5xhynOjGcrM3sKfthB8vkcmnC2hTKF90MDp1ZPwA==",
-      "from": "edx-proctoring-proctortrack@git+https://git@github.com/anupdhabarde/edx-proctoring-proctortrack.git#9b55ea63a3f670bcfbdb5870241510746252ee41",
+      "version": "git+https://git@github.com/anupdhabarde/edx-proctoring-proctortrack.git#fe0027330bf2edb8b7fc9cb3df8f3b3b02db9459",
+      "integrity": "sha512-EmAiTm+Ds2Ps92h99/dwoDsO9rcI28+8IB/kI9yB/hXHOjM3a5FfvgWWlAni0rxH9YZ0Le8hbpCiFZsBbxujYA==",
+      "from": "edx-proctoring-proctortrack@git+https://git@github.com/anupdhabarde/edx-proctoring-proctortrack.git#fe0027330bf2edb8b7fc9cb3df8f3b3b02db9459",
       "requires": {}
     },
     "edx-ui-toolkit": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "css-loader": "0.28.8",
     "datatables": "1.10.18",
     "datatables.net-fixedcolumns": "3.2.6",
-    "edx-proctoring-proctortrack": "git+https://git@github.com/anupdhabarde/edx-proctoring-proctortrack.git#9b55ea63a3f670bcfbdb5870241510746252ee41",
+    "edx-proctoring-proctortrack": "git+https://git@github.com/anupdhabarde/edx-proctoring-proctortrack.git#fe0027330bf2edb8b7fc9cb3df8f3b3b02db9459",
     "edx-ui-toolkit": "1.5.4",
     "exports-loader": "0.6.4",
     "file-loader": "1.1.6",

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -518,7 +518,7 @@ edx-proctoring==4.15.1
     # via
     #   -r requirements/edx/base.in
     #   edx-proctoring-proctortrack
-edx-proctoring-proctortrack==1.0.5
+edx-proctoring-proctortrack==1.2.1
     # via -r requirements/edx/base.in
 edx-rbac==1.7.0
     # via edx-enterprise

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -645,7 +645,7 @@ edx-proctoring==4.15.1
     # via
     #   -r requirements/edx/testing.txt
     #   edx-proctoring-proctortrack
-edx-proctoring-proctortrack==1.0.5
+edx-proctoring-proctortrack==1.2.1
     # via -r requirements/edx/testing.txt
 edx-rbac==1.7.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -625,7 +625,7 @@ edx-proctoring==4.15.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-proctoring-proctortrack
-edx-proctoring-proctortrack==1.0.5
+edx-proctoring-proctortrack==1.2.1
     # via -r requirements/edx/base.txt
 edx-rbac==1.7.0
     # via


### PR DESCRIPTION
Upgrades proctortrack in preparation for a new version of the desktop application. This upgrade is intended to be backwards compatible with the existing proctortrack app.

related commit: https://github.com/anupdhabarde/edx-proctoring-proctortrack/commit/fe0027330bf2edb8b7fc9cb3df8f3b3b02db9459