### PR TITLE
feat: course level public sharing video options

### DIFF
--- a/cms/djangoapps/contentstore/views/block.py
+++ b/cms/djangoapps/contentstore/views/block.py
@@ -44,6 +44,7 @@ from common.djangoapps.util.json_request import JsonResponse, expect_json
 from common.djangoapps.xblock_django.user_service import DjangoXBlockUserService
 from openedx.core.djangoapps.bookmarks import api as bookmarks_api
 from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration
+from openedx.core.djangoapps.video_config.toggles import PUBLIC_VIDEO_SHARE
 from openedx.core.lib.gating import api as gating_api
 from openedx.core.lib.xblock_utils import hash_resource, request_token, wrap_xblock, wrap_xblock_aside
 from openedx.core.toggles import ENTRANCE_EXAMS
@@ -1239,6 +1240,13 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
         'category': xblock.category,
         'has_children': xblock.has_children
     }
+
+    if course is not None and PUBLIC_VIDEO_SHARE.is_enabled(xblock.location.course_key):
+        xblock_info.update({
+            'video_sharing_enabled': True,
+            'video_sharing_options': course.video_sharing_options,
+            'video_sharing_doc_url': HelpUrlExpert.the_one().url_for_token('social_sharing')
+        })
 
     if xblock.category == 'course':
         discussions_config = DiscussionsConfiguration.get(course.id)

--- a/cms/envs/help_tokens.ini
+++ b/cms/envs/help_tokens.ini
@@ -34,6 +34,7 @@ video = course_author:video/index.html
 certificates = course_author:set_up_course/studio_add_course_information/studio_creating_certificates.html
 content_highlights = course_author:developing_course/course_sections.html#set-section-highlights-for-weekly-course-highlight-messages
 image_accessibility = course_author:accessibility/best_practices_course_content_dev.html#use-best-practices-for-describing-images
+social_sharing = course_author:developing_course/social_sharing.html
 
 # below are the language directory names for the different locales
 [locales]

--- a/cms/static/js/spec/views/pages/course_outline_spec.js
+++ b/cms/static/js/spec/views/pages/course_outline_spec.js
@@ -41,7 +41,7 @@ describe('CourseOutlinePage', function() {
             user_partitions: [],
             user_partition_info: {},
             highlights_enabled: true,
-            highlights_enabled_for_messaging: false
+            highlights_enabled_for_messaging: false,
         }, options, {child_info: {children: children}});
     };
 
@@ -308,7 +308,7 @@ describe('CourseOutlinePage', function() {
             'staff-lock-editor', 'unit-access-editor', 'discussion-editor', 'content-visibility-editor',
             'settings-modal-tabs', 'timed-examination-preference-editor', 'access-editor',
             'show-correctness-editor', 'highlights-editor', 'highlights-enable-editor',
-            'course-highlights-enable'
+            'course-highlights-enable', 'course-video-sharing-enable'
         ]);
         appendSetFixtures(mockOutlinePage);
         mockCourseJSON = createMockCourseJSON({}, [
@@ -837,6 +837,52 @@ describe('CourseOutlinePage', function() {
                 editedHighlights[2] = 'A New Value';
                 expectHighlightsToUpdate(originalHighlights, editedHighlights);
             });
+        });
+    });
+
+    describe('Video sharing', function() {
+        beforeEach(function() {
+            setSelfPaced();
+        });
+
+        const createCourse = function(courseOptions) {
+            createCourseOutlinePage(this,
+                createMockCourseJSON(courseOptions)
+            );
+        };
+
+        const selectedOption = function() {
+            return $('select#video-sharing-configuration-options>option[selected="true"]');
+        };
+
+        it('displays video sharing link when enabled', function() {
+            createCourse({
+                video_sharing_enabled: true,
+                video_sharing_options: 'all-on',
+                video_sharing_doc_url: 'http://rick.roll'
+            });
+            expect($('.course-video-sharing')).toExist();
+            expect(selectedOption().val()).toEqual('all-on');
+        });
+
+        it('if option invalid, none is selected', function() {
+            createCourse({
+                video_sharing_enabled: true,
+                video_sharing_options: 'invalid-option',
+                video_sharing_doc_url: 'http://rick.roll'
+            });
+            expect($('.course-video-sharing')).toExist();
+            expect(selectedOption()).not.toExist();
+        });
+
+        it('will not display video sharing link when disabled', function() {
+            createCourse({
+                video_sharing_enabled: false,
+                video_sharing_options: 'all-on',
+                video_sharing_doc_url: 'http://rick.roll'
+            });
+            expect($('div.course-video-sharing')).not.toExist();
+            expect(selectedOption()).not.toExist();
         });
     });
 

--- a/cms/static/js/views/course_video_sharing_enable.js
+++ b/cms/static/js/views/course_video_sharing_enable.js
@@ -1,0 +1,55 @@
+define([
+  "jquery",
+  "underscore",
+  "backbone",
+  "js/views/utils/xblock_utils",
+  "js/utils/templates",
+  "js/views/modals/course_outline_modals",
+  "edx-ui-toolkit/js/utils/html-utils",
+], function ($, _, Backbone, XBlockViewUtils, TemplateUtils, CourseOutlineModalsFactory, HtmlUtils) {
+  "use strict";
+  var CourseVideoSharingEnableView = Backbone.View.extend({
+    events: {
+      "change #video-sharing-configuration-options": "handleVideoSharingConfigurationChange",
+    },
+
+    initialize: function () {
+      this.template = TemplateUtils.loadTemplate("course-video-sharing-enable");
+    },
+
+    getRequestData: function (value) {
+      return {
+        metadata: {
+          'video_sharing_options': value,
+        },
+      };
+    },
+
+    handleVideoSharingConfigurationChange: function (event) {
+      if (event.type === "change") {
+        event.preventDefault();
+        this.updateVideoSharingConfiguration(event.target.value);
+      }
+    },
+
+    updateVideoSharingConfiguration: function (value) {
+      XBlockViewUtils.updateXBlockFields(this.model, this.getRequestData(value), {
+          success: this.refresh.bind(this)
+      });
+    },
+
+    refresh: function () {
+      this.model.fetch({
+        success: this.render.bind(this),
+      });
+    },
+
+    render: function () {
+      var html = this.template(this.model.attributes);
+      HtmlUtils.setHtml(this.$el, HtmlUtils.HTML(html));
+      return this;
+    },
+  });
+
+  return CourseVideoSharingEnableView;
+});

--- a/cms/static/js/views/pages/course_outline.js
+++ b/cms/static/js/views/pages/course_outline.js
@@ -4,9 +4,10 @@
 define([
     'jquery', 'underscore', 'gettext', 'js/views/pages/base_page', 'js/views/utils/xblock_utils',
     'js/views/course_outline', 'common/js/components/utils/view_utils', 'common/js/components/views/feedback_alert',
-    'common/js/components/views/feedback_notification', 'js/views/course_highlights_enable'],
+    'common/js/components/views/feedback_notification', 'js/views/course_highlights_enable', 'js/views/course_video_sharing_enable'],
 function($, _, gettext, BasePage, XBlockViewUtils, CourseOutlineView, ViewUtils, AlertView, NoteView,
-    CourseHighlightsEnableView
+    CourseHighlightsEnableView,
+    CourseVideoSharingEnableView
 ) {
     'use strict';
     var expandedLocators, CourseOutlinePage;
@@ -91,6 +92,15 @@ function($, _, gettext, BasePage, XBlockViewUtils, CourseOutlineView, ViewUtils,
                     model: this.model
                 });
                 this.highlightsEnableView.render();
+            }
+
+            // if video sharing enable
+            if (this.model.get('video_sharing_enabled')) {
+                this.videoSharingEnableView = new CourseVideoSharingEnableView({
+                    el: this.$('.status-video-sharing-enabled'),
+                    model: this.model
+                });
+                this.videoSharingEnableView.render();
             }
 
             this.outlineView = new this.outlineViewClass({

--- a/cms/static/sass/views/_outline.scss
+++ b/cms/static/sass/views/_outline.scss
@@ -185,6 +185,7 @@
 
     .status-release,
     .status-highlights-enabled,
+    .status-video-sharing-enabled,
     .status-studio-frontend {
       @extend %t-copy-base;
 
@@ -200,15 +201,18 @@
       }
     }
 
-    .status-highlights-enabled {
+    .status-highlights-enabled,
+    .status-video-sharing-enabled {
       vertical-align: top;
     }
 
     .status-release-label,
     .status-release-value,
     .status-highlights-enabled-label,
+    .status-video-sharing-enabled-label,
     .status-highlights-enabled-value,
     .status-highlights-enabled-info,
+    .status-video-sharing-enabled-info,
     .status-actions {
       display: inline-block;
       vertical-align: middle;
@@ -216,19 +220,22 @@
     }
 
     .status-release-value,
-    .status-highlights-enabled-value {
+    .status-highlights-enabled-value,
+    .status-video-sharing-enabled-value {
       @extend %t-strong;
 
       font-size: smaller;
     }
 
-    .status-highlights-enabled-info {
+    .status-highlights-enabled-info,
+    .status-video-sharing-enabled-info {
       font-size: smaller;
       margin-left: $baseline / 2;
     }
 
     .status-release-label,
-    .status-highlights-enabled-label {
+    .status-highlights-enabled-label,
+    .status-video-sharing-enabled-label {
       margin-right: ($baseline/4);
     }
 

--- a/cms/templates/course_outline.html
+++ b/cms/templates/course_outline.html
@@ -29,7 +29,7 @@ from django.urls import reverse
 
 <%block name="header_extras">
 <link rel="stylesheet" type="text/css" href="${static.url('js/vendor/timepicker/jquery.timepicker.css')}" />
-% for template_name in ['course-outline', 'xblock-string-field-editor', 'basic-modal', 'modal-button', 'course-outline-modal', 'due-date-editor', 'self-paced-due-date-editor', 'release-date-editor', 'grading-editor', 'publish-editor', 'staff-lock-editor', 'unit-access-editor', 'discussion-editor', 'content-visibility-editor', 'verification-access-editor', 'timed-examination-preference-editor', 'access-editor', 'settings-modal-tabs', 'show-correctness-editor', 'highlights-editor', 'highlights-enable-editor', 'course-highlights-enable']:
+% for template_name in ['course-outline', 'xblock-string-field-editor', 'basic-modal', 'modal-button', 'course-outline-modal', 'due-date-editor', 'self-paced-due-date-editor', 'release-date-editor', 'grading-editor', 'publish-editor', 'staff-lock-editor', 'unit-access-editor', 'discussion-editor', 'content-visibility-editor', 'verification-access-editor', 'timed-examination-preference-editor', 'access-editor', 'settings-modal-tabs', 'show-correctness-editor', 'highlights-editor', 'highlights-enable-editor', 'course-highlights-enable', 'course-video-sharing-enable']:
 <script type="text/template" id="${template_name}-tpl">
     <%static:include path="js/${template_name}.underscore" />
 </script>
@@ -269,6 +269,7 @@ from django.urls import reverse
                     </%static:studiofrontend>
                 </div>
                 <div class="status-highlights-enabled"></div>
+                <div class="status-video-sharing-enabled"></div>
             </div>
             <div class="wrapper-dnd"
               % if getattr(context_course, 'language'):

--- a/cms/templates/js/course-video-sharing-enable.underscore
+++ b/cms/templates/js/course-video-sharing-enable.underscore
@@ -1,0 +1,14 @@
+<div class="course-video-sharing">
+  <h2 id="video-sharing-enabled-label" class="status-video-sharing-enabled-label">
+    <%- gettext('Video Sharing') %>
+  </h2>
+  <br>
+  <select id="video-sharing-configuration-options">
+    <% _.each({'per-video': 'Per Video','all-on': 'All Videos','all-off': 'No Videos'}, function (option, key) { %>
+      <option value="<%- key %>" <% if (key === video_sharing_options) { %> selected="true" <% } %>>
+        <%- option %>
+      </option>
+    <% }) %>
+  </select>
+  <a class="status-video-sharing-enabled-info" href="<%- video_sharing_doc_url %>" rel="noopener" target="_blank"><%- gettext('Learn more') %></a>
+</div>

--- a/cms/templates/js/mock/mock-course-outline-page.underscore
+++ b/cms/templates/js/mock/mock-course-outline-page.underscore
@@ -39,6 +39,7 @@
             <article class="content-primary" role="main">
                 <div class=course-status"">
                     <div class="status-highlights-enabled"></div>
+                    <div class="status-video-sharing-enabled"></div>
                 </div>
                 <div class="wrapper-dnd">
                     <article class="outline outline-course" data-locator="mock-course" data-course-key="slashes:MockCourse">

--- a/xmodule/course_block.py
+++ b/xmodule/course_block.py
@@ -54,6 +54,10 @@ COURSE_VISIBILITY_PRIVATE = 'private'
 COURSE_VISIBILITY_PUBLIC_OUTLINE = 'public_outline'
 COURSE_VISIBILITY_PUBLIC = 'public'
 
+COURSE_VIDEO_SHARING_PER_VIDEO = 'per-video'
+COURSE_VIDEO_SHARING_ALL_VIDEOS = 'all-on'
+COURSE_VIDEO_SHARING_NONE = 'all-off'
+
 
 class StringOrDate(Date):  # lint-amnesty, pylint: disable=missing-class-docstring
     def from_json(self, value):  # lint-amnesty, pylint: disable=arguments-differ
@@ -956,6 +960,22 @@ class CourseFields:  # lint-amnesty, pylint: disable=missing-class-docstring
             {"display_name": "public_outline", "value": COURSE_VISIBILITY_PUBLIC_OUTLINE},
             {"display_name": "public", "value": COURSE_VISIBILITY_PUBLIC},
         ],
+    )
+
+    video_sharing_options = String(
+        display_name=_("Video Sharing Options"),
+        help=_(
+            "Specify the video sharing options for the course. "
+            "This can be set to one of three values: "
+            "'all-on', 'all-off' and 'per-video'. with 'per-video' as the default."
+        ),
+        default=COURSE_VIDEO_SHARING_PER_VIDEO,
+        scope=Scope.settings,
+        values=[
+            {"display_name": "all-on", "value": COURSE_VIDEO_SHARING_ALL_VIDEOS},
+            {"display_name": "all-off", "value": COURSE_VIDEO_SHARING_NONE},
+            {"display_name": "per-video", "value": COURSE_VIDEO_SHARING_PER_VIDEO},
+        ]
     )
 
     """


### PR DESCRIPTION
## Description

- make necessary UI change on studio
- add video sharing field to the course
  - I have to shorten the words just because it was too long and accidentally push the block to the next line even in the large screen
- the default option for public sharing video option is `per-video` 
- on select change, it would send a request to the backend to update course metadata

Add a setting to course data to control course-level video public sharing. The decided options are all-on all-off per-video

https://2u-internal.atlassian.net/browse/AU-1183

<img width="923" alt="Screenshot 2023-05-01 at 2 05 00 PM" src="https://user-images.githubusercontent.com/83240113/235502753-7ab160d3-d16b-49eb-9bc3-bca4b9edca7a.png">
<img width="933" alt="Screenshot 2023-05-01 at 2 05 07 PM" src="https://user-images.githubusercontent.com/83240113/235502758-a7eedac6-8539-4a81-bc14-58f7a12231b6.png">

## Testing instructions

- Make sure you have waffle flag `video_config.public_video_share` turn on
- Go to course studio, you should see additional column with a drop down for updating course level sharing video option (see screenshot)

