### PR TITLE
chore: bumping enterprise package version to 3.61.16

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -25,7 +25,7 @@ django-storages<1.9
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==3.61.15
+edx-enterprise==3.61.16
 
 # oauthlib>3.0.1 causes test failures ( also remove the django-oauth-toolkit constraint when this is fixed )
 oauthlib==3.0.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -480,7 +480,7 @@ edx-drf-extensions==8.7.0
     #   edx-when
     #   edxval
     #   learner-pathway-progress
-edx-enterprise==3.61.15
+edx-enterprise==3.61.16
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -604,7 +604,7 @@ edx-drf-extensions==8.7.0
     #   edx-when
     #   edxval
     #   learner-pathway-progress
-edx-enterprise==3.61.15
+edx-enterprise==3.61.16
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -583,7 +583,7 @@ edx-drf-extensions==8.7.0
     #   edx-when
     #   edxval
     #   learner-pathway-progress
-edx-enterprise==3.61.15
+edx-enterprise==3.61.16
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
Bumping enterprise version

[edx-enterprise related PR](https://github.com/openedx/edx-enterprise/pull/1742)