### PR TITLE
fix: anonymous student IDs [BD-13]

### DIFF
--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -194,16 +194,11 @@ def _prepare_runtime_for_preview(request, block, field_data):
         # stick the license wrapper in front
         wrappers.insert(0, partial(wrap_with_license, mako_service=mako_service))
 
-    preview_anonymous_user_id = 'student'
+    anonymous_user_id = deprecated_anonymous_user_id = 'student'
     if individualize_anonymous_user_id(course_id):
-        # There are blocks (capa, html, and video) where we do not want to scope
-        # the anonymous_user_id to specific courses. These are captured in the
-        # block attribute 'requires_per_student_anonymous_id'. Please note,
-        # the course_id field in AnynomousUserID model is blank if value is None.
-        if getattr(block, 'requires_per_student_anonymous_id', False):
-            preview_anonymous_user_id = anonymous_id_for_user(request.user, None)
-        else:
-            preview_anonymous_user_id = anonymous_id_for_user(request.user, course_id)
+        anonymous_user_id = anonymous_id_for_user(request.user, course_id)
+        # See the docstring of `DjangoXBlockUserService`.
+        deprecated_anonymous_user_id = anonymous_id_for_user(request.user, None)
 
     services = {
         "field-data": field_data,
@@ -213,7 +208,8 @@ def _prepare_runtime_for_preview(request, block, field_data):
         "user": DjangoXBlockUserService(
             request.user,
             user_role=get_user_role(request.user, course_id),
-            anonymous_user_id=preview_anonymous_user_id,
+            anonymous_user_id=anonymous_user_id,
+            deprecated_anonymous_user_id=deprecated_anonymous_user_id,
         ),
         "partitions": StudioPartitionService(course_id=course_id),
         "teams_configuration": TeamsConfigurationService(),

--- a/cms/djangoapps/contentstore/views/tests/test_preview.py
+++ b/cms/djangoapps/contentstore/views/tests/test_preview.py
@@ -1,12 +1,11 @@
 """
 Tests for contentstore.views.preview.py
 """
-
-
 import re
 from unittest import mock
 
 import ddt
+from common.djangoapps.xblock_django.constants import ATTR_KEY_ANONYMOUS_USER_ID, ATTR_KEY_DEPRECATED_ANONYMOUS_USER_ID
 from django.test.client import Client, RequestFactory
 from django.test.utils import override_settings
 from edx_toggles.toggles.testutils import override_waffle_flag
@@ -309,7 +308,10 @@ class CmsModuleSystemShimTest(ModuleStoreTestCase):
             block=block,
             field_data=mock.Mock(),
         )
-        assert block.runtime.anonymous_student_id == '26262401c528d7c4a6bbeabe0455ec46'
+        deprecated_anonymous_user_id = (
+            block.runtime.service(block, 'user').get_current_user().opt_attrs.get(ATTR_KEY_DEPRECATED_ANONYMOUS_USER_ID)
+        )
+        assert deprecated_anonymous_user_id == '26262401c528d7c4a6bbeabe0455ec46'
 
     @override_waffle_flag(INDIVIDUALIZE_ANONYMOUS_USER_ID, active=True)
     def test_anonymous_user_id_individual_per_course(self):
@@ -321,4 +323,8 @@ class CmsModuleSystemShimTest(ModuleStoreTestCase):
             block=block,
             field_data=mock.Mock(),
         )
-        assert block.runtime.anonymous_student_id == 'ad503f629b55c531fed2e45aa17a3368'
+
+        anonymous_user_id = (
+            block.runtime.service(block, 'user').get_current_user().opt_attrs.get(ATTR_KEY_ANONYMOUS_USER_ID)
+        )
+        assert anonymous_user_id == 'ad503f629b55c531fed2e45aa17a3368'

--- a/common/djangoapps/xblock_django/constants.py
+++ b/common/djangoapps/xblock_django/constants.py
@@ -4,6 +4,7 @@ Constants used by DjangoXBlockUserService
 
 # Optional attributes stored on the XBlockUser
 ATTR_KEY_ANONYMOUS_USER_ID = 'edx-platform.anonymous_user_id'
+ATTR_KEY_DEPRECATED_ANONYMOUS_USER_ID = 'edx-platform.deprecated_anonymous_user_id'
 ATTR_KEY_REQUEST_COUNTRY_CODE = 'edx-platform.request_country_code'
 ATTR_KEY_IS_AUTHENTICATED = 'edx-platform.is_authenticated'
 ATTR_KEY_USER_ID = 'edx-platform.user_id'

--- a/common/djangoapps/xblock_django/user_service.py
+++ b/common/djangoapps/xblock_django/user_service.py
@@ -13,6 +13,7 @@ from common.djangoapps.student.models import anonymous_id_for_user, get_user_by_
 
 from .constants import (
     ATTR_KEY_ANONYMOUS_USER_ID,
+    ATTR_KEY_DEPRECATED_ANONYMOUS_USER_ID,
     ATTR_KEY_IS_AUTHENTICATED,
     ATTR_KEY_REQUEST_COUNTRY_CODE,
     ATTR_KEY_USER_ID,
@@ -38,6 +39,9 @@ class DjangoXBlockUserService(UserService):
             user_is_staff(bool): optional - whether the user is staff in the course
             user_role(str): optional -- user's role in the course ('staff', 'instructor', or 'student')
             anonymous_user_id(str): optional - anonymous_user_id for the user in the course
+            deprecated_anonymous_user_id(str): optional - There are XBlocks (CAPA and HTML) that use the per-student
+                (course-agnostic) anonymized ID. To preserve backward compatibility, we will continue to provide it.
+                Using course-specific anonymous user ID (`anonymous_user_id`) is a preferred approach.
             request_country_code(str): optional -- country code determined from the user's request IP address.
         """
         super().__init__(**kwargs)
@@ -45,6 +49,7 @@ class DjangoXBlockUserService(UserService):
         self._user_is_staff = kwargs.get('user_is_staff', False)
         self._user_role = kwargs.get('user_role', 'student')
         self._anonymous_user_id = kwargs.get('anonymous_user_id', None)
+        self._deprecated_anonymous_user_id = kwargs.get('deprecated_anonymous_user_id', None)
         self._request_country_code = kwargs.get('request_country_code', None)
 
     def get_current_user(self):
@@ -111,6 +116,7 @@ class DjangoXBlockUserService(UserService):
             xblock_user.full_name = full_name
             xblock_user.emails = [django_user.email]
             xblock_user.opt_attrs[ATTR_KEY_ANONYMOUS_USER_ID] = self._anonymous_user_id
+            xblock_user.opt_attrs[ATTR_KEY_DEPRECATED_ANONYMOUS_USER_ID] = self._deprecated_anonymous_user_id
             xblock_user.opt_attrs[ATTR_KEY_IS_AUTHENTICATED] = True
             xblock_user.opt_attrs[ATTR_KEY_REQUEST_COUNTRY_CODE] = self._request_country_code
             xblock_user.opt_attrs[ATTR_KEY_USER_ID] = django_user.id

--- a/lms/djangoapps/courseware/block_render.py
+++ b/lms/djangoapps/courseware/block_render.py
@@ -493,23 +493,14 @@ def prepare_runtime_for_user(
             will_recheck_access=will_recheck_access,
         )
 
-    # These modules store data using the anonymous_student_id as a key.
-    # To prevent loss of data, we will continue to provide old modules with
-    # the per-student anonymized id (as we have in the past),
-    # while giving selected modules a per-course anonymized id.
-    # As we have the time to manually test more modules, we can add to the list
-    # of modules that get the per-course anonymized id.
-    if getattr(block, 'requires_per_student_anonymous_id', False):
-        anonymous_student_id = anonymous_id_for_user(user, None)
-    else:
-        anonymous_student_id = anonymous_id_for_user(user, course_id)
-
     user_is_staff = bool(has_access(user, 'staff', block.location, course_id))
     user_service = DjangoXBlockUserService(
         user,
         user_is_staff=user_is_staff,
         user_role=get_user_role(user, course_id),
-        anonymous_user_id=anonymous_student_id,
+        anonymous_user_id=anonymous_id_for_user(user, course_id),
+        # See the docstring of `DjangoXBlockUserService`.
+        deprecated_anonymous_user_id=anonymous_id_for_user(user, None),
         request_country_code=user_location,
     )
 

--- a/openedx/core/djangoapps/schedules/tests/test_resolvers.py
+++ b/openedx/core/djangoapps/schedules/tests/test_resolvers.py
@@ -274,7 +274,7 @@ class TestCourseNextSectionUpdateResolver(SchedulesResolverTestMixin, ModuleStor
     def test_schedule_context(self):
         resolver = self.create_resolver()
         # using this to make sure the select_related stays intact
-        with self.assertNumQueries(38):
+        with self.assertNumQueries(40):
             sc = resolver.get_schedules()
             schedules = list(sc)
         apple_logo_url = 'http://email-media.s3.amazonaws.com/edX/2021/store_apple_229x78.jpg'

--- a/openedx/features/course_experience/tests/views/test_course_updates.py
+++ b/openedx/features/course_experience/tests/views/test_course_updates.py
@@ -49,7 +49,7 @@ class TestCourseUpdatesPage(BaseCourseUpdatesTestCase):
 
         # Fetch the view and verify that the query counts haven't changed
         # TODO: decrease query count as part of REVO-28
-        with self.assertNumQueries(51, table_ignorelist=QUERY_COUNT_TABLE_IGNORELIST):
+        with self.assertNumQueries(53, table_ignorelist=QUERY_COUNT_TABLE_IGNORELIST):
             with check_mongo_calls(3):
                 url = course_updates_url(self.course)
                 self.client.get(url)

--- a/xmodule/capa_block.py
+++ b/xmodule/capa_block.py
@@ -47,7 +47,7 @@ from xmodule.x_module import (
 )
 from xmodule.xml_block import XmlMixin
 from common.djangoapps.xblock_django.constants import (
-    ATTR_KEY_ANONYMOUS_USER_ID,
+    ATTR_KEY_DEPRECATED_ANONYMOUS_USER_ID,
     ATTR_KEY_USER_IS_STAFF,
     ATTR_KEY_USER_ID,
 )
@@ -165,7 +165,6 @@ class ProblemBlock(
     icon_class = 'problem'
 
     uses_xmodule_styles_setup = True
-    requires_per_student_anonymous_id = True
 
     preview_view_js = {
         'js': [
@@ -822,7 +821,7 @@ class ProblemBlock(
             text = self.data
 
         user_service = self.runtime.service(self, 'user')
-        anonymous_student_id = user_service.get_current_user().opt_attrs.get(ATTR_KEY_ANONYMOUS_USER_ID)
+        anonymous_student_id = user_service.get_current_user().opt_attrs.get(ATTR_KEY_DEPRECATED_ANONYMOUS_USER_ID)
         seed = user_service.get_current_user().opt_attrs.get(ATTR_KEY_USER_ID) or 0
 
         sandbox_service = self.runtime.service(self, 'sandbox')

--- a/xmodule/html_block.py
+++ b/xmodule/html_block.py
@@ -17,7 +17,8 @@ from path import Path as path
 from web_fragments.fragment import Fragment
 from xblock.core import XBlock
 from xblock.fields import Boolean, List, Scope, String
-from common.djangoapps.xblock_django.constants import ATTR_KEY_ANONYMOUS_USER_ID
+
+from common.djangoapps.xblock_django.constants import ATTR_KEY_DEPRECATED_ANONYMOUS_USER_ID
 from xmodule.contentstore.content import StaticContent
 from xmodule.editing_block import EditingMixin
 from xmodule.edxnotes_utils import edxnotes
@@ -119,7 +120,11 @@ class HtmlBlockMixin(  # lint-amnesty, pylint: disable=abstract-method
         """ Returns html required for rendering the block. """
         if self.data:
             data = self.data
-            user_id = self.runtime.service(self, 'user').get_current_user().opt_attrs.get(ATTR_KEY_ANONYMOUS_USER_ID)
+            user_id = (
+                self.runtime.service(self, 'user')
+                .get_current_user()
+                .opt_attrs.get(ATTR_KEY_DEPRECATED_ANONYMOUS_USER_ID)
+            )
             if user_id:
                 data = data.replace("%%USER_ID%%", user_id)
             data = data.replace("%%COURSE_ID%%", str(self.scope_ids.usage_id.context_key))
@@ -150,7 +155,6 @@ class HtmlBlockMixin(  # lint-amnesty, pylint: disable=abstract-method
     preview_view_css = {'scss': [resource_string(__name__, 'css/html/display.scss')]}
 
     uses_xmodule_styles_setup = True
-    requires_per_student_anonymous_id = True
 
     mako_template = "widgets/html-edit.html"
     resources_dir = None

--- a/xmodule/tests/__init__.py
+++ b/xmodule/tests/__init__.py
@@ -139,6 +139,7 @@ def get_test_system(
     user_service = StubUserService(
         user=user,
         anonymous_user_id='student',
+        deprecated_anonymous_user_id='student',
         user_is_staff=user_is_staff,
         user_role='student',
         request_country_code=user_location,
@@ -202,6 +203,7 @@ def prepare_block_runtime(
     user_service = StubUserService(
         user=user,
         anonymous_user_id='student',
+        deprecated_anonymous_user_id='student',
         user_is_staff=user_is_staff,
         user_role='student',
         request_country_code=user_location,

--- a/xmodule/tests/helpers.py
+++ b/xmodule/tests/helpers.py
@@ -67,12 +67,14 @@ class StubUserService(UserService):
                  user_is_staff=False,
                  user_role=None,
                  anonymous_user_id=None,
+                 deprecated_anonymous_user_id=None,
                  request_country_code=None,
                  **kwargs):
         self.user = user
         self.user_is_staff = user_is_staff
         self.user_role = user_role
         self.anonymous_user_id = anonymous_user_id
+        self.deprecated_anonymous_user_id = deprecated_anonymous_user_id
         self.request_country_code = request_country_code
         self._django_user = user
         super().__init__(**kwargs)
@@ -84,6 +86,7 @@ class StubUserService(UserService):
         user = XBlockUser()
         if self.user and self.user.is_authenticated:
             user.opt_attrs['edx-platform.anonymous_user_id'] = self.anonymous_user_id
+            user.opt_attrs['edx-platform.deprecated_anonymous_user_id'] = self.deprecated_anonymous_user_id
             user.opt_attrs['edx-platform.request_country_code'] = self.request_country_code
             user.opt_attrs['edx-platform.user_is_staff'] = self.user_is_staff
             user.opt_attrs['edx-platform.user_id'] = self.user.id

--- a/xmodule/tests/test_html_block.py
+++ b/xmodule/tests/test_html_block.py
@@ -138,6 +138,7 @@ class HtmlBlockSubstitutionTestCase(unittest.TestCase):  # lint-amnesty, pylint:
         field_data = DictFieldData({'data': sample_xml})
         module_system = get_test_system(user=AnonymousUser())
         block = HtmlBlock(module_system, field_data, Mock())
+        block.runtime.service(block, 'user')._deprecated_anonymous_user_id = ''  # pylint: disable=protected-access
         assert block.get_html() == sample_xml
 
 

--- a/xmodule/video_block/video_block.py
+++ b/xmodule/video_block/video_block.py
@@ -152,7 +152,6 @@ class VideoBlock(
     js_module_name = "TabsEditingDescriptor"
 
     uses_xmodule_styles_setup = True
-    requires_per_student_anonymous_id = True
 
     def get_transcripts_for_student(self, transcripts):
         """Return transcript information necessary for rendering the XModule student view.

--- a/xmodule/x_module.py
+++ b/xmodule/x_module.py
@@ -1071,6 +1071,9 @@ class ModuleSystemShim:
         Returns the anonymous user ID for the current user and course.
 
         Deprecated in favor of the user service.
+
+        NOTE: This method returns a course-specific anonymous user ID. If you are looking for the student-specific one,
+              use `ATTR_KEY_DEPRECATED_ANONYMOUS_USER_ID` from the user service.
         """
         warnings.warn(
             'runtime.anonymous_student_id is deprecated. Please use the user service instead.',


### PR DESCRIPTION
## Description

After changes from https://github.com/openedx/edx-platform/pull/31472, the `user` service of a "leaf" XBlock. gets overridden with the one created for its parent (`SequenceBlock`). Therefore, the `requires_per_student_anonymous_id` is ignored in these XBlocks. This removes choosing the proper ID (course-specific or student-specific) from the runtime initialization. Instead, both IDs are passed to the `user` service. The subsequent renders of an XBlock (e.g., when requesting the solution) use the student-specific IDs.

There are only two XBlocks that relied on the `requires_per_student_anonymous_id` - `ProblemBlock` and `HtmlBlock`. They now request the "deprecated" (student-specific) user ID directly from the `user` service.


## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

1. Create a Problem XBlock with the following content:
```python
<problem>
	<p>anonymous_student_id: $anonymous_student_id</p>
	<solution>
		<p>anonymous_student_id: $anonymous_student_id</p>
	</solution>
</problem>
```
2. Go to Preview and press the "Show answer" button. The new ID should be the same as the previous one.

## Deadline

As soon as possible.