### PR TITLE
fix: Unpin SAML library.

### DIFF
--- a/openedx/core/lib/safe_lxml/etree.py
+++ b/openedx/core/lib/safe_lxml/etree.py
@@ -16,7 +16,9 @@ isort:skip_file
 
 from lxml.etree import XMLParser as _XMLParser
 from lxml.etree import *  # lint-amnesty, pylint: disable=redefined-builtin
-from lxml.etree import _Element, _ElementTree
+# These private elements are used in some libraries to also defuse xml exploits for their own purposes.
+# We need to re-expose them so that the libraries still work.
+from lxml.etree import _Comment, _Element, _ElementTree, _Entity, _ProcessingInstruction
 
 # This should be imported after lxml.etree so that it overrides the following attributes.
 from defusedxml.lxml import XML, fromstring, parse

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -40,9 +40,6 @@ matplotlib<3.4.0
 # Major upgrade will be done in separate ticket.
 pymongo<4.0.0
 
-# python3-saml==1.10.0 version started breaking a11y tests
-python3-saml<1.10.0
-
 # greater version has breaking changes and requires some migration steps.
 django-webpack-loader==0.7.0
 


### PR DESCRIPTION
We were using an old version of the python3-saml library, which was causing issues with newer versions of social-core.

The reason it was pinned was because our etree implementation didn't support several fields that the saml library did, so we are now importing those entities as well.

This primarily affected devstack and any other version of Open edX that was running on a non-standard port.

https://github.com/edx/edx-arch-experiments/issues/281
