### PR TITLE
feat: course overrides of video sharing settings

### DIFF
--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -298,19 +298,6 @@ class TestVideoPublicAccess(BaseTestVideoXBlock):
         # Then I will get that course value
         self.assertFalse(is_public_sharing_enabled)
 
-    @patch('xmodule.video_block.video_block.VideoBlock.get_course_video_sharing_override')
-    def test_is_public_sharing_disabled_by_course_override(self, mock_course_sharing_override):
-        # Given a course overrides no videos to be shared
-        mock_course_sharing_override.return_value = COURSE_VIDEO_SHARING_NONE
-        self.block.public_access = 'some-arbitrary-value'
-
-        # When I try to determine if public sharing is enabled
-        with self.mock_feature_toggle():
-            is_public_sharing_enabled = self.block.is_public_sharing_enabled()
-
-        # Then I will get that course value
-        self.assertFalse(is_public_sharing_enabled)
-
     @ddt.data(COURSE_VIDEO_SHARING_PER_VIDEO, None)
     @patch('xmodule.video_block.video_block.VideoBlock.get_course_video_sharing_override')
     def test_is_public_sharing_enabled_per_video(self, mock_override_value, mock_course_sharing_override):

--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -224,7 +224,7 @@ class TestVideoNonYouTube(TestVideo):  # pylint: disable=test-inherits-tests
                 {'display_name': 'Text (.txt) file', 'value': 'txt'}
             ],
             'poster': 'null',
-                    }
+        }
 
         mako_service = self.block.runtime.service(self.block, 'mako')
         expected_result = get_context_dict_from_string(

--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -2384,7 +2384,7 @@ class TestVideoWithBumper(TestVideo):  # pylint: disable=test-inherits-tests
                 {'display_name': 'SubRip (.srt) file', 'value': 'srt'},
                 {'display_name': 'Text (.txt) file', 'value': 'txt'}
             ],
-                        'poster': json.dumps(OrderedDict({
+            'poster': json.dumps(OrderedDict({
                 'url': 'http://img.youtube.com/vi/ZwkTiUPN0mg/0.jpg',
                 'type': 'youtube'
             }))

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1772,7 +1772,7 @@ class BasePublicVideoXBlockView(View):
             )
 
             # Block must be marked as public to be viewed
-            if not video_block.public_access:
+            if not video_block.is_public_sharing_enabled():
                 raise Http404("Video not found.")
 
         return course, video_block

--- a/xmodule/video_block/video_block.py
+++ b/xmodule/video_block/video_block.py
@@ -496,7 +496,7 @@ class VideoBlock(
             return getattr(course, 'video_sharing_options', None)
 
         # In case the course / modulestore does something weird
-        except Exception as err: # pylint: disable=broad-except
+        except Exception as err:  # pylint: disable=broad-except
             log.exception(f"Error retrieving course for course ID: {self.course_id}")
             return None
 

--- a/xmodule/video_block/video_block.py
+++ b/xmodule/video_block/video_block.py
@@ -491,11 +491,14 @@ class VideoBlock(
         """
         Return course video sharing options override or None
         """
-        course = get_course_by_id(self.course_id)
-        course_video_sharing_option = course.video_sharing_options \
-            if hasattr(course, 'video_sharing_options') else None
+        try:
+            course = get_course_by_id(self.course_id)
+            return getattr(course, 'video_sharing_options', None)
 
-        return course_video_sharing_option
+        # In case the course / modulestore does something weird
+        except Exception as err: # pylint: disable=broad-except
+            log.exception(f"Error retrieving course for course ID: {self.course_id}")
+            return None
 
     def is_public_sharing_enabled(self):
         """


### PR DESCRIPTION
## Description

Add awareness of `course.video_sharing_options` setting to video block and preview page.

**TL;DR**
- Updates logic of `video_block.is_public_sharing_enabled` to also check course-level overrides.
- Logic follows this sequence: 
   1. Always disable for studio
   2. Always disable if waffle flag is off
   3. Check if course overrides the video settings (through `course.course_video_sharing_options` value)
   4. If unset or set to "Per Video" fall back to individual video setting
- Videos calculated as "enabled" will show share buttons and be viewable in the public video preview page.
- Videos calculated as "disabled" will not show share buttons and return an `HTTP 404` if a user tries to view in the public video preview page.

## Supporting information

JIRA: https://2u-internal.atlassian.net/browse/AU-1193

## Deadline

End of week: 2023-05-05