### PR TITLE
Fix some warnings from usage of deprecated properties

### DIFF
--- a/cms/templates/asset_index.html
+++ b/cms/templates/asset_index.html
@@ -39,11 +39,11 @@
                 "course": {
                     "id": "${context_course.id | n, js_escaped_string}",
                     "name": "${context_course.display_name_with_default | n, js_escaped_string}",
-                    "url_name": "${context_course.location.name | n, js_escaped_string}",
+                    "url_name": "${context_course.location.block_id | n, js_escaped_string}",
                     "org": "${context_course.location.org | n, js_escaped_string}",
                     "num": "${context_course.location.course | n, js_escaped_string}",
                     "display_course_number": "${context_course.display_coursenumber | n, js_escaped_string}",
-                    "revision": "${context_course.location.revision | n, js_escaped_string}"
+                    "revision": "${context_course.location.branch | n, js_escaped_string}"
                 },
                 "help_tokens": {
                     "files": "${get_online_help_info(online_help_token())['doc_url'] | n, js_escaped_string}"

--- a/cms/templates/course_outline.html
+++ b/cms/templates/course_outline.html
@@ -252,11 +252,11 @@ from django.urls import reverse
                                 "name": "${context_course.display_name_with_default | n, js_escaped_string}",
                                 "course_release_date": "${course_release_date | n, js_escaped_string}",
                                 "is_course_self_paced": ${context_course.self_paced | n, dump_js_escaped_json},
-                                "url_name": "${context_course.location.name | n, js_escaped_string}",
+                                "url_name": "${context_course.location.block_id | n, js_escaped_string}",
                                 "org": "${context_course.location.org | n, js_escaped_string}",
                                 "num": "${context_course.location.course | n, js_escaped_string}",
                                 "display_course_number": "${context_course.display_coursenumber | n, js_escaped_string}",
-                                "revision": "${context_course.location.revision | n, js_escaped_string}"
+                                "revision": "${context_course.location.branch | n, js_escaped_string}"
                             },
                             "help_tokens": {
                                 "files": "${get_online_help_info(online_help_token())['doc_url'] | n, js_escaped_string}"

--- a/xmodule/modulestore/mongo/base.py
+++ b/xmodule/modulestore/mongo/base.py
@@ -272,7 +272,7 @@ class CachingDescriptorSystem(MakoDescriptorSystem, EditInfoRuntimeMixin):  # li
                 block = self.construct_xblock_from_class(class_, scope_ids, field_data, for_parent=for_parent)
 
                 non_draft_loc = as_published(location)
-                metadata_inheritance_tree = self.modulestore._compute_metadata_inheritance_tree(self.course_id)
+                metadata_inheritance_tree = self.modulestore._compute_metadata_inheritance_tree(location.course_key)
                 inherit_metadata(block, metadata_inheritance_tree.get(str(non_draft_loc), {}))
 
                 block._edit_info = json_data.get('edit_info')

--- a/xmodule/x_module.py
+++ b/xmodule/x_module.py
@@ -1094,7 +1094,7 @@ class ModuleSystemShim:
         """
         warnings.warn(
             'runtime.seed is deprecated. Please use the user service `user_id` instead.',
-            DeprecationWarning, stacklevel=3,
+            DeprecationWarning, stacklevel=2,
         )
         return self.user_id or 0
 
@@ -1106,8 +1106,8 @@ class ModuleSystemShim:
         Deprecated in favor of the user service.
         """
         warnings.warn(
-            'runtime.user_id is deprecated. Please use the user service instead.',
-            DeprecationWarning, stacklevel=3,
+            'runtime.user_id is deprecated. Use block.scope_ids.user_id or the user service instead.',
+            DeprecationWarning, stacklevel=2,
         )
         user_service = self._runtime_services.get('user') or self._services.get('user')
         if user_service:
@@ -1123,7 +1123,7 @@ class ModuleSystemShim:
         """
         warnings.warn(
             'runtime.user_is_staff is deprecated. Please use the user service instead.',
-            DeprecationWarning, stacklevel=3,
+            DeprecationWarning, stacklevel=2,
         )
         user_service = self._runtime_services.get('user') or self._services.get('user')
         if user_service:
@@ -1139,7 +1139,7 @@ class ModuleSystemShim:
         """
         warnings.warn(
             'runtime.user_location is deprecated. Please use the user service instead.',
-            DeprecationWarning, stacklevel=3,
+            DeprecationWarning, stacklevel=2,
         )
         user_service = self._runtime_services.get('user') or self._services.get('user')
         if user_service:
@@ -1159,7 +1159,7 @@ class ModuleSystemShim:
         """
         warnings.warn(
             'runtime.get_real_user is deprecated. Please use the user service instead.',
-            DeprecationWarning, stacklevel=3,
+            DeprecationWarning, stacklevel=2,
         )
         user_service = self._runtime_services.get('user') or self._services.get('user')
         if user_service:
@@ -1177,7 +1177,7 @@ class ModuleSystemShim:
         """
         warnings.warn(
             'runtime.get_user_role is deprecated. Please use the user service instead.',
-            DeprecationWarning, stacklevel=3,
+            DeprecationWarning, stacklevel=2,
         )
         user_service = self._runtime_services.get('user') or self._services.get('user')
         if user_service:
@@ -1205,15 +1205,10 @@ class ModuleSystemShim:
     @render_template.setter
     def render_template(self, render_template):
         """
-        Set render_template.
+        Set render_template for backwards compatibility.
 
-        Deprecated in favor of the mako service.
+        Using this is deprecated in favor of the mako service.
         """
-        warnings.warn(
-            'Use of runtime.render_template is deprecated. '
-            'Use MakoService.render_template or a JavaScript-based template instead.',
-            DeprecationWarning, stacklevel=2,
-        )
         self._deprecated_render_template = render_template
 
     @property
@@ -1251,7 +1246,7 @@ class ModuleSystemShim:
         """
         warnings.warn(
             'runtime.can_execute_unsafe_code is deprecated. Please use the sandbox service instead.',
-            DeprecationWarning, stacklevel=3,
+            DeprecationWarning, stacklevel=2,
         )
         sandbox_service = self._runtime_services.get('sandbox') or self._services.get('sandbox')
         if sandbox_service:
@@ -1271,7 +1266,7 @@ class ModuleSystemShim:
         """
         warnings.warn(
             'runtime.get_python_lib_zip is deprecated. Please use the sandbox service instead.',
-            DeprecationWarning, stacklevel=3,
+            DeprecationWarning, stacklevel=2,
         )
         sandbox_service = self._runtime_services.get('sandbox') or self._services.get('sandbox')
         if sandbox_service:
@@ -1290,7 +1285,7 @@ class ModuleSystemShim:
         """
         warnings.warn(
             'runtime.cache is deprecated. Please use the cache service instead.',
-            DeprecationWarning, stacklevel=3,
+            DeprecationWarning, stacklevel=2,
         )
         return self._runtime_services.get('cache') or self._services.get('cache') or DoNothingCache()
 
@@ -1303,7 +1298,7 @@ class ModuleSystemShim:
         """
         warnings.warn(
             'runtime.replace_urls is deprecated. Please use the replace_urls service instead.',
-            DeprecationWarning, stacklevel=3,
+            DeprecationWarning, stacklevel=2,
         )
         replace_urls_service = self._runtime_services.get('replace_urls') or self._services.get('replace_urls')
         if replace_urls_service:
@@ -1318,7 +1313,7 @@ class ModuleSystemShim:
         """
         warnings.warn(
             'runtime.replace_course_urls is deprecated. Please use the replace_urls service instead.',
-            DeprecationWarning, stacklevel=3,
+            DeprecationWarning, stacklevel=2,
         )
         replace_urls_service = self._runtime_services.get('replace_urls') or self._services.get('replace_urls')
         if replace_urls_service:
@@ -1333,7 +1328,7 @@ class ModuleSystemShim:
         """
         warnings.warn(
             'runtime.replace_jump_to_id_urls is deprecated. Please use the replace_urls service instead.',
-            DeprecationWarning, stacklevel=3,
+            DeprecationWarning, stacklevel=2,
         )
         replace_urls_service = self._runtime_services.get('replace_urls') or self._services.get('replace_urls')
         if replace_urls_service:
@@ -1348,7 +1343,7 @@ class ModuleSystemShim:
         """
         warnings.warn(
             'runtime.filestore is deprecated. Please use the runtime.resources_fs service instead.',
-            DeprecationWarning, stacklevel=3,
+            DeprecationWarning, stacklevel=2,
         )
         return self.resources_fs
 
@@ -1361,7 +1356,7 @@ class ModuleSystemShim:
         """
         warnings.warn(
             'node_path is deprecated. Please use other methods of finding the node_modules location.',
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=2,
         )
 
     @property
@@ -1372,7 +1367,7 @@ class ModuleSystemShim:
         """
         warnings.warn(
             'runtime.hostname is deprecated. Please use `LMS_BASE` from `django.conf.settings`.',
-            DeprecationWarning, stacklevel=3,
+            DeprecationWarning, stacklevel=2,
         )
         return settings.LMS_BASE
 
@@ -1386,7 +1381,7 @@ class ModuleSystemShim:
         """
         warnings.warn(
             "rebind_noauth_module_to_user is deprecated. Please use the 'rebind_user' service instead.",
-            DeprecationWarning, stacklevel=3
+            DeprecationWarning, stacklevel=2,
         )
         rebind_user_service = self._runtime_services.get('rebind_user') or self._services.get('rebind_user')
         if rebind_user_service:
@@ -1401,7 +1396,7 @@ class ModuleSystemShim:
         """
         warnings.warn(
             'runtime.STATIC_URL is deprecated. Please use settings.STATIC_URL instead.',
-            DeprecationWarning, stacklevel=3,
+            DeprecationWarning, stacklevel=2,
         )
         return settings.STATIC_URL
 
@@ -1410,11 +1405,11 @@ class ModuleSystemShim:
         """
         Old API to get the course ID.
 
-        Deprecated in favor of `runtime.scope_ids.usage_id.context_key`.
+        Deprecated in favor of `block.scope_ids.usage_id.context_key`.
         """
         warnings.warn(
-            "`runtime.course_id` is deprecated. Use `context_key` instead: `runtime.scope_ids.usage_id.context_key`.",
-            DeprecationWarning, stacklevel=3,
+            "`runtime.course_id` is deprecated. Use `context_key` instead: `block.scope_ids.usage_id.context_key`.",
+            DeprecationWarning, stacklevel=2,
         )
         if hasattr(self, '_deprecated_course_id'):
             return self._deprecated_course_id.for_branch(None)
@@ -1422,14 +1417,8 @@ class ModuleSystemShim:
     @course_id.setter
     def course_id(self, course_id):
         """
-        Set course_id.
-
-        Deprecated in favor of `runtime.scope_ids.usage_id.context_key`.
+        Set course_id, for backwards compatibility. Reading from this is deprecated.
         """
-        warnings.warn(
-            "`runtime.course_id` is deprecated. Use `context_key` instead: `runtime.scope_ids.usage_id.context_key`.",
-            DeprecationWarning, stacklevel=3,
-        )
         self._deprecated_course_id = course_id
 
 


### PR DESCRIPTION
## Description

This reduces the number of warnings seen when running some parts of the LMS and CMS test suite.

In particular:

**1. Updated a few places in the codebase where deprecated XBlock attributes were being accessed, and replaced them with the newer API.**

e.g. `block.runtime.user_id` (old/nonstandard) replaced with `block.scope_ids.user_id` (normal XBlock API)

(Context: In general, these changes are trying to make the `runtime` object less context-specific, and instead to get context-specific data from `block` or runtime services specifically bound to a given block. This is more consistent with the vanilla XBlock API and in the future could enable one runtime instance to render many blocks, improving efficiency, as opposed to each block requiring a completely separate runtime because of these old APIs.)

**2. Changed the code to not emit `DeprecationWarnings` when _setting_ a deprecated property on the runtime**, since that's only being done for backwards compatibility. It's _getting_ the deprecated properties that we need to warn about and replace all instances of with the newer APIs.

e.g. here, this `course_id` is just being set to preserve backwards compatibility (make the deprecated attribute available for those blocks still reading from it), but is not being otherwise used, so this isn't itself a deprecated usage that we need to warn about, but was resulting in tons of warnings popping up every time an XBlock was initialized.

https://github.com/openedx/edx-platform/blob/b77504804ac86e8561c3eef71b4b44decc826278/xmodule/modulestore/mongo/base.py#L213

**3. Where the test suite is intentionally testing the functionality of the deprecated APIs (to ensure backwards compatibility), I have used a context manager to suppress the deprecation warnings for those lines of code.**

There's nothing to fix here, so these shouldn't raise any warnings. They're just testing backwards compatibility. Once we fully remove the deprecated APIs, these test lines can also just be removed.

Before:

```python
        assert self.block.runtime.user_is_staff
        assert self.block.runtime.get_user_role() == 'student'
```

After:

```python
        block_user_info = self.block.runtime.service(self.block, "user").get_current_user()
        assert block_user_info.opt_attrs.get(ATTR_KEY_USER_IS_STAFF)
        assert block_user_info.opt_attrs.get(ATTR_KEY_USER_ROLE) == 'student'
        with warnings.catch_warnings():  # For now, also test the deprecated accessors for backwards compatibility:
            warnings.simplefilter("ignore", category=DeprecationWarning)
            assert self.block.runtime.user_is_staff
            assert self.block.runtime.get_user_role() == 'student'
```

Future state:

```python
        block_user_info = self.block.runtime.service(self.block, "user").get_current_user()
        assert block_user_info.opt_attrs.get(ATTR_KEY_USER_IS_STAFF)
        assert block_user_info.opt_attrs.get(ATTR_KEY_USER_ROLE) == 'student'
```

**4. I fixed the `stacklevel` on many of the deprecation warnings, which were displaying unhelpful tracebacks.**

Messages like this aren't helpful:

```python
django/test/utils.py:387: DeprecationWarning: runtime.anonymous_student_id is deprecated. Please use the user service instead.
    return func(*args, **kwargs)
```

Now it will say something like this:

```python
lms/xblocks/some_block.py:214 DeprecationWarning: runtime.anonymous_student_id is deprecated. Please use the user service instead.
    return self.runtime.anonymous_student_id
```

## Summary of Improvements

Results from `pytest lms/djangoapps/courseware/tests/test_block_render.py` :

Before: `164 passed, 492 warnings in 36.54`
After: `164 passed, 218 warnings in 36.32s`

## Testing instructions

Not much to manually test, as this PR mostly just changes test code and DX. There is one change to the modulestore should be well tested by the test suite.

## Deadline

None

## Private Ref

MNG-1905 