### PR TITLE
test: add tests for MFE Context API serializser

### DIFF
--- a/openedx/core/djangoapps/user_authn/api/tests/test_data.py
+++ b/openedx/core/djangoapps/user_authn/api/tests/test_data.py
@@ -1,0 +1,141 @@
+""" Mocked data for testing """
+
+mfe_context_data_keys = {
+    'contextData',
+    'registrationFields',
+    'optionalFields'
+}
+
+mock_mfe_context_data = {
+    'context_data': {
+        'currentProvider': 'edX',
+        'platformName': 'edX',
+        'providers': [
+            {
+                'id': 'oa2-facebook',
+                'name': 'Facebook',
+                'iconClass': 'fa-facebook',
+                'iconImage': None,
+                'skipHintedLogin': False,
+                'skipRegistrationForm': False,
+                'loginUrl': 'https://facebook.com/login',
+                'registerUrl': 'https://facebook.com/register'
+            },
+            {
+                'id': 'oa2-google-oauth2',
+                'name': 'Google',
+                'iconClass': 'fa-google-plus',
+                'iconImage': None,
+                'skipHintedLogin': False,
+                'skipRegistrationForm': False,
+                'loginUrl': 'https://google.com/login',
+                'registerUrl': 'https://google.com/register'
+            }
+        ],
+        'secondaryProviders': [],
+        'finishAuthUrl': 'https://edx.com/auth/finish',
+        'errorMessage': None,
+        'registerFormSubmitButtonText': 'Create Account',
+        'autoSubmitRegForm': False,
+        'syncLearnerProfileData': False,
+        'countryCode': '',
+        'pipeline_user_details': {
+            'username': 'test123',
+            'email': 'test123@edx.com',
+            'fullname': 'Test Test',
+            'first_name': 'Test',
+            'last_name': 'Test'
+        }
+    },
+    'registration_fields': {},
+    'optional_fields': {
+        'extended_profile': []
+    }
+}
+
+mock_default_mfe_context_data = {
+    'context_data': {
+        'currentProvider': None,
+        'platformName': 'édX',
+        'providers': [],
+        'secondaryProviders': [],
+        'finishAuthUrl': None,
+        'errorMessage': None,
+        'registerFormSubmitButtonText': 'Create Account',
+        'autoSubmitRegForm': False,
+        'syncLearnerProfileData': False,
+        'countryCode': '',
+        'pipeline_user_details': {}
+    },
+    'registration_fields': {},
+    'optional_fields': {
+        'extended_profile': []
+    }
+}
+
+expected_mfe_context_data = {
+    'contextData': {
+        'currentProvider': 'edX',
+        'platformName': 'edX',
+        'providers': [
+            {
+                'id': 'oa2-facebook',
+                'name': 'Facebook',
+                'iconClass': 'fa-facebook',
+                'iconImage': None,
+                'skipHintedLogin': False,
+                'skipRegistrationForm': False,
+                'loginUrl': 'https://facebook.com/login',
+                'registerUrl': 'https://facebook.com/register'
+            },
+            {
+                'id': 'oa2-google-oauth2',
+                'name': 'Google',
+                'iconClass': 'fa-google-plus',
+                'iconImage': None,
+                'skipHintedLogin': False,
+                'skipRegistrationForm': False,
+                'loginUrl': 'https://google.com/login',
+                'registerUrl': 'https://google.com/register'
+            }
+        ],
+        'secondaryProviders': [],
+        'finishAuthUrl': 'https://edx.com/auth/finish',
+        'errorMessage': None,
+        'registerFormSubmitButtonText': 'Create Account',
+        'autoSubmitRegForm': False,
+        'syncLearnerProfileData': False,
+        'countryCode': '',
+        'pipelineUserDetails': {
+            'username': 'test123',
+            'email': 'test123@edx.com',
+            'name': 'Test Test',
+            'firstName': 'Test',
+            'lastName': 'Test'
+        }
+    },
+    'registrationFields': {},
+    'optionalFields': {
+        'extended_profile': []
+    }
+}
+
+default_expected_mfe_context_data = {
+    'contextData': {
+        'currentProvider': None,
+        'platformName': 'édX',
+        'providers': [],
+        'secondaryProviders': [],
+        'finishAuthUrl': None,
+        'errorMessage': None,
+        'registerFormSubmitButtonText': 'Create Account',
+        'autoSubmitRegForm': False,
+        'syncLearnerProfileData': False,
+        'countryCode': '',
+        'pipelineUserDetails': {}
+    },
+    'registrationFields': {},
+    'optionalFields': {
+        'extended_profile': []
+    }
+}

--- a/openedx/core/djangoapps/user_authn/api/tests/test_serializers.py
+++ b/openedx/core/djangoapps/user_authn/api/tests/test_serializers.py
@@ -2,6 +2,12 @@
 
 from django.test import TestCase
 
+from openedx.core.djangoapps.user_authn.api.tests.test_data import (
+    mock_mfe_context_data,
+    expected_mfe_context_data,
+    mock_default_mfe_context_data,
+    default_expected_mfe_context_data,
+)
 from openedx.core.djangoapps.user_authn.serializers import MFEContextSerializer
 
 
@@ -10,128 +16,29 @@ class TestMFEContextSerializer(TestCase):
     High-level unit tests for MFEContextSerializer
     """
 
-    @staticmethod
-    def get_mock_mfe_context_data():
-        """
-        Helper function to generate mock data for the MFE Context API view.
-        """
-
-        mock_context_data = {
-            'context_data': {
-                'currentProvider': 'edX',
-                'platformName': 'edX',
-                'providers': [
-                    {
-                        'id': 'oa2-facebook',
-                        'name': 'Facebook',
-                        'iconClass': 'fa-facebook',
-                        'iconImage': None,
-                        'skipHintedLogin': False,
-                        'skipRegistrationForm': False,
-                        'loginUrl': 'https://facebook.com/login',
-                        'registerUrl': 'https://facebook.com/register'
-                    },
-                    {
-                        'id': 'oa2-google-oauth2',
-                        'name': 'Google',
-                        'iconClass': 'fa-google-plus',
-                        'iconImage': None,
-                        'skipHintedLogin': False,
-                        'skipRegistrationForm': False,
-                        'loginUrl': 'https://google.com/login',
-                        'registerUrl': 'https://google.com/register'
-                    }
-                ],
-                'secondaryProviders': [],
-                'finishAuthUrl': 'https://edx.com/auth/finish',
-                'errorMessage': None,
-                'registerFormSubmitButtonText': 'Create Account',
-                'autoSubmitRegForm': False,
-                'syncLearnerProfileData': False,
-                'countryCode': '',
-                'pipeline_user_details': {
-                    'username': 'test123',
-                    'email': 'test123@edx.com',
-                    'fullname': 'Test Test',
-                    'first_name': 'Test',
-                    'last_name': 'Test'
-                }
-            },
-            'registration_fields': {},
-            'optional_fields': {
-                'extended_profile': []
-            }
-        }
-
-        return mock_context_data
-
-    @staticmethod
-    def get_expected_data():
-        """
-        Helper function to generate expected data for the MFE Context API view serializer.
-        """
-
-        expected_data = {
-            'contextData': {
-                'currentProvider': 'edX',
-                'platformName': 'edX',
-                'providers': [
-                    {
-                        'id': 'oa2-facebook',
-                        'name': 'Facebook',
-                        'iconClass': 'fa-facebook',
-                        'iconImage': None,
-                        'skipHintedLogin': False,
-                        'skipRegistrationForm': False,
-                        'loginUrl': 'https://facebook.com/login',
-                        'registerUrl': 'https://facebook.com/register'
-                    },
-                    {
-                        'id': 'oa2-google-oauth2',
-                        'name': 'Google',
-                        'iconClass': 'fa-google-plus',
-                        'iconImage': None,
-                        'skipHintedLogin': False,
-                        'skipRegistrationForm': False,
-                        'loginUrl': 'https://google.com/login',
-                        'registerUrl': 'https://google.com/register'
-                    }
-                ],
-                'secondaryProviders': [],
-                'finishAuthUrl': 'https://edx.com/auth/finish',
-                'errorMessage': None,
-                'registerFormSubmitButtonText': 'Create Account',
-                'autoSubmitRegForm': False,
-                'syncLearnerProfileData': False,
-                'countryCode': '',
-                'pipelineUserDetails': {
-                    'username': 'test123',
-                    'email': 'test123@edx.com',
-                    'name': 'Test Test',
-                    'firstName': 'Test',
-                    'lastName': 'Test'
-                }
-            },
-            'registrationFields': {},
-            'optionalFields': {
-                'extended_profile': []
-            }
-        }
-
-        return expected_data
-
     def test_mfe_context_serializer(self):
         """
         Test MFEContextSerializer with mock data that serializes data correctly
         """
 
-        mfe_context_data = self.get_mock_mfe_context_data()
-        expected_data = self.get_expected_data()
         output_data = MFEContextSerializer(
-            mfe_context_data
+            mock_mfe_context_data
         ).data
 
         self.assertDictEqual(
             output_data,
-            expected_data
+            expected_mfe_context_data
+        )
+
+    def test_mfe_context_serializer_default_response(self):
+        """
+        Test MFEContextSerializer with default data
+        """
+        serialized_data = MFEContextSerializer(
+            mock_default_mfe_context_data
+        ).data
+
+        self.assertDictEqual(
+            serialized_data,
+            default_expected_mfe_context_data
         )

--- a/openedx/core/djangoapps/user_authn/api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_authn/api/tests/test_views.py
@@ -16,9 +16,10 @@ from common.djangoapps.student.models import Registration
 from common.djangoapps.student.tests.factories import UserFactory
 from common.djangoapps.third_party_auth import pipeline
 from common.djangoapps.third_party_auth.tests.testutil import ThirdPartyAuthTestMixin, simulate_running_pipeline
-from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration
 from openedx.core.djangoapps.geoinfo.api import country_code_from_ip
+from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration
 from openedx.core.djangoapps.user_api.tests.test_views import UserAPITestCase
+from openedx.core.djangoapps.user_authn.api.tests.test_data import mfe_context_data_keys
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 
@@ -350,6 +351,32 @@ class MFEContextViewTest(ThirdPartyAuthTestMixin, APITestCase):
         """
         response = self.client.get(self.url, self.query_params)
         assert response.data == self.get_context()
+
+    def test_mfe_context_api_serialized_response(self):
+        """
+        Test MFE Context API serialized response
+        """
+        response = self.client.get(self.url, self.query_params)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        params = {
+            'next': self.query_params['next']
+        }
+
+        self.assertEqual(
+            response.data,
+            self.get_context(params)
+        )
+
+    def test_mfe_context_api_response_keys(self):
+        """
+        Test MFE Context API response keys
+        """
+        response = self.client.get(self.url, self.query_params)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response_keys = set(response.data.keys())
+        self.assertSetEqual(response_keys, mfe_context_data_keys)
 
 
 @skip_unless_lms


### PR DESCRIPTION
This PR adds unit tests to verify the functionality of the MFE Context serializer class in handling different types of responses, including empty responses, responses with data coming from an API, and other response types.

> Ticket: [VAN-1411](https://2u-internal.atlassian.net/browse/VAN-1411)