### PR TITLE
feat: pass query string parameters on to the learning MFE for jump_to…

### DIFF
--- a/openedx/features/course_experience/url_helpers.py
+++ b/openedx/features/course_experience/url_helpers.py
@@ -120,6 +120,7 @@ def _get_new_courseware_url(
         course_key=course_key,
         sequence_key=sequence_key,
         unit_key=unit_key,
+        params=request.GET if request and request.GET else None,
     )
 
 


### PR DESCRIPTION
## Description

When providing direct links to particular blocks, we want to be able to include attribution information in the URL query string parameters (e.g. utm_source).

## Testing instructions

Navigate to any /jump_to/ link and include some query string params!
