### PR TITLE
fix: video share link fixes

### DIFF
--- a/lms/templates/video.html
+++ b/lms/templates/video.html
@@ -63,6 +63,8 @@ from openedx.core.djangolib.js_utils import (
                                 class="btn-link social-share-link"
                                 data-source="${sharing_site_info['name']}"
                                 href="${sharing_site_info['sharing_url']}"
+                                target="_blank"
+                                rel="noopener noreferrer"
                             >
                                 <span class="icon fa ${sharing_site_info['fa_icon_name']}" aria-hidden="true"></span>
                                 <span class="sr">${_("Share on {site}").format(site=sharing_site_info['name'])}</span>

--- a/xmodule/js/spec/video/social_share_spec.js
+++ b/xmodule/js/spec/video/social_share_spec.js
@@ -1,37 +1,28 @@
 (function() {
     'use strict';
     describe('VideoSocialSharingHandler', function() {
-        var state, spyOpen;
+        var state;
 
         beforeEach(function() {
             state = jasmine.initializePlayer('video_all.html');
-            spyOpen = spyOn(window, 'open').and.returnValue(null);
             window.analytics = jasmine.createSpyObj('analytics', ['track'])
         });
 
         afterAll(() => delete window.analytics);
 
-        describe('clicking social share opens the correct URL', function() {
+        describe('clicking social share fires an analytics event', function() {
             const testCases = [
-                { 
-                    source: 'twitter',
-                    url: "https://twitter.com/intent/tweet?text=Here's%20a%20fun%20clip%20from%20a%20class%20I'm%20taking%20on%20%40edXonline.%0A%0A&url="
-                },
-                { source: 'facebook', url: "https://www.facebook.com/sharer/sharer.php?u=" },
-                { source: 'linkedin', url: 'https://www.linkedin.com/sharing/share-offsite/?url=' },
+                { source: 'twitter' },
+                { source: 'facebook' },
+                { source: 'linkedin' },
             ];
-            _.each(testCases, ({ source, url }) => {
+            _.each(testCases, ({ source }) => {
                 it(source, () => {
                     var siteShareButton = $(`.social-share-link[data-source="${source}"]`);
                     expect(siteShareButton.length).toEqual(1);
     
                     siteShareButton.trigger('click');
-                    expect(spyOpen).toHaveBeenCalledWith(
-                        url + `video-share-url%3Futm_source%3D${source}%26utm_medium%3Dsocial%26utm_campaign%3Dsocial-share-exp`,
-                        'targetWindow',
-                        'toolbar=no,location=0,status=no,menubar=no,scrollbars=yes,resizable=yes,width=600,height=400'
-                    );
-    
+
                     expect(window.analytics.track).toHaveBeenCalledWith(
                         'edx.social.video.share_button.clicked',
                             {

--- a/xmodule/js/src/video/036_video_social_sharing.js
+++ b/xmodule/js/src/video/036_video_social_sharing.js
@@ -2,9 +2,10 @@
     'use strict';
     // VideoSocialSharingHandler module.
     define(
-        'video/036_video_social_sharing.js', ['underscore', 'gettext'],
-        function(_, gettext) {
-            var VideoSocialSharingHandler, SocialSharingSite, SimpleSocialSharingSite, facebook, linkedin, twitter;
+        'video/036_video_social_sharing.js', ['underscore'],
+        function(_) {
+            var VideoSocialSharingHandler;
+
             /**
              * Video Social Sharing control module.
              * @exports video/036_video_social_sharing.js
@@ -29,6 +30,7 @@
             };
 
             VideoSocialSharingHandler.prototype = {
+
                 // Initializes the module.
                 initialize: function() {
                     this.el = this.container.find('.wrapper-social-share');
@@ -36,42 +38,16 @@
                     this.baseVideoUrl = this.el.data('url');
                     this.course_id = this.container.data('courseId');
                     this.block_id = this.container.data('blockId')
-                    this.socialSharingSites = this.getSocialSharingSites()
                 },
 
+                // Fire an analytics event on share button click.
                 clickHandler: function(event) {
                     var self = this;
-                    event.preventDefault();
                     var source = $(event.currentTarget).data('source')
-                    var utmQuery = $.param({
-                        utm_source: source,
-                        utm_medium: 'social',
-                        utm_campaign: 'social-share-exp',
-                    });
-                    var sharedVideoUrl = encodeURIComponent(self.baseVideoUrl + "?" + utmQuery);
-                    var socialShareSite = self.socialSharingSites[source];
-                    var socialMediaShareLinkUrl = socialShareSite.generateShareUrl(sharedVideoUrl);
-                    window.open(
-                        socialMediaShareLinkUrl,
-                        'targetWindow',
-                        'toolbar=no,location=0,status=no,menubar=no,scrollbars=yes,resizable=yes,width=600,height=400'
-                    );
                     self.sendAnalyticsEvent(source);
                 },
 
-                getSocialSharingSites: function() {
-                    var socialSharingSites = {},
-                    socialSharingSitesList = [
-                        twitter, facebook, linkedin
-                    ];
-
-                    _.each(socialSharingSitesList, function(socialSharingSite) {
-                        socialSharingSites[socialSharingSite.name] = socialSharingSite;
-                    }, this);
-
-                    return socialSharingSites;
-                },
-
+                // Send an analytics event for share button tracking.
                 sendAnalyticsEvent: function(source) {
                     window.analytics.track(
                         'edx.social.video.share_button.clicked',
@@ -83,28 +59,6 @@
                     );
                 }
             };
-
-            // Define the social sharing sites and how they generate
-            // a link to their share page.
-            SocialSharingSite = function(name, generateShareUrl) {
-                // A social sharing site with a name and a function to generate a share URL
-                this.name = name;
-                this.generateShareUrl = generateShareUrl;
-            };
-            SimpleSocialSharingSite = function(name, baseShareUrl) {
-                // A social sharing site with a url that is a static string with the url appended
-                this.name = name;
-                this.generateShareUrl = (url) => baseShareUrl + url;
-            }
-            twitter = new SocialSharingSite(
-                'twitter',
-                url => {
-                    var tweetText = encodeURIComponent(gettext("Here's a fun clip from a class I'm taking on @edXonline.\n\n"));
-                    return "https://twitter.com/intent/tweet?text=" + tweetText + "&url=" + url;
-                }
-            );
-            facebook = new SimpleSocialSharingSite('facebook', 'https://www.facebook.com/sharer/sharer.php?u=');
-            linkedin = new SimpleSocialSharingSite('linkedin', 'https://www.linkedin.com/sharing/share-offsite/?url=');
 
             return VideoSocialSharingHandler;
         });


### PR DESCRIPTION
## Description

1. Fixes unfinished cleanup from https://github.com/openedx/edx-platform/pull/32150
2. Re-establishes correct link target on click (new tab / window).
3.  Adds `noopener noreferrer` attributes for security reasons.

## Supporting information

JIRA: https://2u-internal.atlassian.net/browse/AU-1205

## Testing instructions

Clicking on a share link for enabled video sends correct url e.g.

```
https://www.facebook.com/sharer/sharer.php?utm_source=facebook&utm_medium=social&utm_campaign=social-share-exp&u={actual-link-to-an-actual-video-preview}
```


## Deadline

ASAP