### PR TITLE
feat: tpa automatic logout

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2261,20 +2261,6 @@ SOFTWARE_SECURE_REQUEST_RETRY_DELAY = 60 * 60
 # Maximum of 6 retries before giving up.
 SOFTWARE_SECURE_RETRY_MAX_ATTEMPTS = 6
 
-
-# .. toggle_name: TPA_AUTOMATIC_LOGOUT_ENABLED
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: Redirect the user to the TPA logout URL if this flag is enabled, the
-#   TPA logout URL is configured, and the user logs in through TPA
-# .. toggle_use_cases: open_edx
-# .. toggle_warning: Enabling this toggle skips rendering logout.html, which is used to log the user out
-#   from the different IDAs. To ensure the user is logged out of all the IDAs be sure to redirect
-#   back to <LMS>/logout after logging out of the TPA.
-# .. toggle_creation_date: 2023-05-07
-# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/32193
-TPA_AUTOMATIC_LOGOUT_ENABLED = False
-
 ############## DJANGO-USER-TASKS ##############
 
 # How long until database records about the outcome of a task and its artifacts get deleted?

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2261,6 +2261,20 @@ SOFTWARE_SECURE_REQUEST_RETRY_DELAY = 60 * 60
 # Maximum of 6 retries before giving up.
 SOFTWARE_SECURE_RETRY_MAX_ATTEMPTS = 6
 
+
+# .. toggle_name: TPA_AUTOMATIC_LOGOUT_ENABLED
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Redirect the user to the TPA logout URL if this flag is enabled, the
+#   TPA logout URL is configured, and the user logs in through TPA
+# .. toggle_use_cases: open_edx
+# .. toggle_warning: Enabling this toggle skips rendering logout.html, which is used to log the user out
+#   from the different IDAs. To ensure the user is logged out of all the IDAs be sure to redirect
+#   back to <LMS>/logout after logging out of the TPA.
+# .. toggle_creation_date: 2023-05-07
+# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/32193
+TPA_AUTOMATIC_LOGOUT_ENABLED = False
+
 ############## DJANGO-USER-TASKS ##############
 
 # How long until database records about the outcome of a task and its artifacts get deleted?

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1215,6 +1215,19 @@ OAUTH_EXPIRE_PUBLIC_CLIENT_DAYS = 30
 TPA_PROVIDER_BURST_THROTTLE = '10/min'
 TPA_PROVIDER_SUSTAINED_THROTTLE = '50/hr'
 
+# .. toggle_name: TPA_AUTOMATIC_LOGOUT_ENABLED
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Redirect the user to the TPA logout URL if this flag is enabled, the
+#   TPA logout URL is configured, and the user logs in through TPA.
+# .. toggle_use_cases: open_edx
+# .. toggle_warning: Enabling this toggle skips rendering logout.html, which is used to log the user out
+#   from the different IDAs. To ensure the user is logged out of all the IDAs be sure to redirect
+#   back to <LMS>/logout after logging out of the TPA.
+# .. toggle_creation_date: 2023-05-07
+# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/32193
+TPA_AUTOMATIC_LOGOUT_ENABLED = False
+
 ################################## TEMPLATE CONFIGURATION #####################################
 # Mako templating
 import tempfile  # pylint: disable=wrong-import-position,wrong-import-order

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1220,12 +1220,11 @@ TPA_PROVIDER_SUSTAINED_THROTTLE = '50/hr'
 # .. toggle_default: False
 # .. toggle_description: Redirect the user to the TPA logout URL if this flag is enabled, the
 #   TPA logout URL is configured, and the user logs in through TPA.
-# .. toggle_use_cases: open_edx
+# .. toggle_use_cases: opt_in
 # .. toggle_warning: Enabling this toggle skips rendering logout.html, which is used to log the user out
 #   from the different IDAs. To ensure the user is logged out of all the IDAs be sure to redirect
 #   back to <LMS>/logout after logging out of the TPA.
 # .. toggle_creation_date: 2023-05-07
-# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/32193
 TPA_AUTOMATIC_LOGOUT_ENABLED = False
 
 ################################## TEMPLATE CONFIGURATION #####################################

--- a/openedx/core/djangoapps/user_authn/views/logout.py
+++ b/openedx/core/djangoapps/user_authn/views/logout.py
@@ -91,7 +91,7 @@ class LogoutView(TemplateView):
         # NOTE: This step skips rendering logout.html, which is used to log the user out from the
         # different IDAs. To ensure the user is logged out of all the IDAs be sure to redirect
         # back to <LMS>/logout after logging out of the TPA.
-        if settings.TPA_AUTOMATIC_LOGOUT_ENABLED:
+        if getattr(settings, 'TPA_AUTOMATIC_LOGOUT_ENABLED', False):
             if self.tpa_logout_url:
                 return redirect(self.tpa_logout_url)
 

--- a/openedx/core/djangoapps/user_authn/views/logout.py
+++ b/openedx/core/djangoapps/user_authn/views/logout.py
@@ -125,8 +125,8 @@ class LogoutView(TemplateView):
     def _show_tpa_logout_link(self, target, referrer):
         """
         Return Boolean value indicating if TPA logout link needs to displayed or not.
-        We display TPA logout link when user has active SSO session and logout flow is
-        triggered via learner portal.
+        We display TPA logout link when user has active SSO session, logout flow is
+        triggered via learner portal and TPA_AUTOMATIC_LOGOUT_ENABLED toggle is False.
         Args:
             target: url of the page to land after logout
             referrer: url of the page where logout request initiated

--- a/openedx/core/djangoapps/user_authn/views/logout.py
+++ b/openedx/core/djangoapps/user_authn/views/logout.py
@@ -8,6 +8,7 @@ from urllib.parse import parse_qs, urlsplit, urlunsplit  # pylint: disable=impor
 import bleach
 from django.conf import settings
 from django.contrib.auth import logout
+from django.shortcuts import redirect
 from django.utils.http import urlencode
 from django.views.generic import TemplateView
 from oauth2_provider.models import Application
@@ -83,6 +84,17 @@ class LogoutView(TemplateView):
         delete_logged_in_cookies(response)
 
         mark_user_change_as_expected(None)
+
+        # Redirect to tpa_logout_url if TPA_AUTOMATIC_LOGOUT_ENABLED is set to True and if
+        # tpa_logout_url is configured.
+        #
+        # NOTE: This step skips rendering logout.html, which is used to log the user out from the
+        # different IDAs. To ensure the user is logged out of all the IDAs be sure to redirect
+        # back to <LMS>/logout after logging out of the TPA.
+        if settings.TPA_AUTOMATIC_LOGOUT_ENABLED:
+            if self.tpa_logout_url:
+                return redirect(self.tpa_logout_url)
+
         return response
 
     def _build_logout_url(self, url):

--- a/openedx/core/djangoapps/user_authn/views/logout.py
+++ b/openedx/core/djangoapps/user_authn/views/logout.py
@@ -131,7 +131,12 @@ class LogoutView(TemplateView):
             target: url of the page to land after logout
             referrer: url of the page where logout request initiated
         """
-        if bool(target == self.default_target and self.tpa_logout_url) and settings.LEARNER_PORTAL_URL_ROOT in referrer:
+        tpa_automatic_logout_enabled = getattr(settings, 'TPA_AUTOMATIC_LOGOUT_ENABLED', False)
+        if (
+            bool(target == self.default_target and self.tpa_logout_url) and
+            settings.LEARNER_PORTAL_URL_ROOT in referrer and
+            not tpa_automatic_logout_enabled
+        ):
             return True
 
         return False

--- a/openedx/core/djangoapps/user_authn/views/tests/test_logout.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_logout.py
@@ -196,6 +196,33 @@ class LogoutTests(TestCase):
             }
             self.assertDictContainsSubset(expected, response.context_data)
 
+    @mock.patch('django.conf.settings.TPA_AUTOMATIC_LOGOUT_ENABLED', True)
+    def test_automatic_tpa_logout_url_redirect(self):
+        """
+        Test user automatically redirected to tpa logout_url
+        when TPA_AUTOMATIC_LOGOUT is set to True.
+        """
+        idp_logout_url = 'http://mock-idp.com/logout'
+        client = self._create_oauth_client()
+
+        with mock.patch(
+            'openedx.core.djangoapps.user_authn.views.logout.tpa_pipeline.get_idp_logout_url_from_running_pipeline'
+        ) as mock_idp_logout_url:
+            mock_idp_logout_url.return_value = idp_logout_url
+            self._authenticate_with_oauth(client)
+            response = self.client.get(reverse('logout'))
+            assert response.status_code == 302
+            assert response.url == idp_logout_url
+
+    @mock.patch('django.conf.settings.TPA_AUTOMATIC_LOGOUT_ENABLED', True)
+    def test_no_automatic_tpa_logout_without_logout_url(self):
+        """
+        Test user is NOT automatically redirected when tpa logout_url is not set
+        even if TPA_AUTOMATIC_LOGOUT is set to True.
+        """
+        client = self._create_oauth_client()
+        self._assert_session_logged_out(client)
+
     @ddt.data(
         ('%22%3E%3Cscript%3Ealert(%27xss%27)%3C/script%3E', 'edx.org'),
     )


### PR DESCRIPTION
<!--

🌴🌴
🌴🌴🌴🌴         🌴 Note: the Palm master branch has been created. Please consider whether your change
    🌴🌴🌴🌴     should also be applied to Palm. If so, make another pull request against the
🌴🌴🌴🌴         open-release/palm.master branch, or ask in the #wg-build-test-release Slack channel
🌴🌴             if you have any questions or need help.

🫒🫒🫒🫒🫒🫒     🫒 Note: the Olive release is still supported.
                Please consider whether your change should be applied to Olive as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This PR adds the ability to enable automated TPA logout.

Currently, if a user is logged in through TPA and a `logout_url` is configured, when logging out, the user is presented with the prompt `Click here to delete your single signed-on (SSO) session`.

However, some Open edX operators would not want a two-step logout process and instead would prefer the user is logged out of both Open edX and the SSO with a single click. This is especially critical for use-cases such as when the learners might share terminals in their educational institutions in countries/regions with low internet penetration.

This PR adds the `TPA_AUTOMATIC_LOGOUT_ENABLED` django setting, which when enabled, redirects the user automatically to the TPA `logout_url` if it is configured.

This new django setting has no effect if `logout_url` is either not configured and the user is logged in directly though the LMS(using username and password).

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

### User sign-in using third party SSO

1. Go to the sandbox [pr32193.sandbox.do.opencraft.hosting](https://pr32193.sandbox.do.opencraft.hosting) where the changes are deployed
2. Click on `Sign In` and select `Cognito` from the `sign in with` section below. You will now be redirected to the Cognito sign-in page.
3. Login to Cognito using the following credentials:
Username : `openedx`
Email : `openedx@example.com`
Password: `openedx`
4. You should be redirected to the LMS dashboard automatically and logged in as the `openedx` user.
5. Open developer tools in your browser, go the `Network` tab and select `Preserve log` or `Persist logs`
6. Click `Sign Out` from the drop-down menu on the top right.
7. Verify redirects to `LMS /logout` -> `Cognito /logout` -> `LMS /logout` -> `LMS /`

### User sign-in _without_ using third party SSO

1. Go to the sandbox [pr32193.sandbox.do.opencraft.hosting](https://pr32193.sandbox.do.opencraft.hosting) where the changes are deployed
2. Click on `Sign In` and login through the default login form using the following credentials:
Username : `openedx`
Email : `openedx@example.com`
Password: `openedx`
4. You should be redirected to the LMS dashboard automatically and logged in as the `openedx` user.
5. Open developer tools in your browser, go the `Network` tab and select `Preserve log` or `Persist logs`
6. Click `Sign Out` from the drop-down menu on the top right.
7. Verify redirects to `LMS /logout` ->  `LMS /`.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

OpenCraft internal ticket [BB-7398](https://tasks.opencraft.com/browse/BB-7398)
