### PR TITLE
feat: add api for user notification preferences

### DIFF
--- a/openedx/core/djangoapps/notifications/serializers.py
+++ b/openedx/core/djangoapps/notifications/serializers.py
@@ -5,6 +5,7 @@ from rest_framework import serializers
 
 from common.djangoapps.student.models import CourseEnrollment
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from openedx.core.djangoapps.notifications.models import NotificationPreference
 
 
 class CourseOverviewSerializer(serializers.ModelSerializer):
@@ -26,3 +27,28 @@ class NotificationCourseEnrollmentSerializer(serializers.ModelSerializer):
     class Meta:
         model = CourseEnrollment
         fields = ('course', 'is_active', 'mode')
+
+
+class UserNotificationPreferenceSerializer(serializers.ModelSerializer):
+    """
+    Serializer for user notification preferences.
+    """
+    course_name = serializers.SerializerMethodField(read_only=True)
+
+    class Meta:
+        model = NotificationPreference
+        fields = ('id', 'course_name', 'course_id', 'notification_preference_config',)
+        read_only_fields = ('id', 'course_name', 'course_id',)
+        write_only_fields = ('notification_preference_config',)
+
+    def get_course_name(self, obj):
+        """
+        Returns course name from course id.
+        """
+        return CourseOverview.get_from_id(obj.course_id).display_name
+
+    def update(self, instance, validated_data):
+        for key, val in validated_data.items():
+            setattr(instance, key, val)
+        instance.save()
+        return instance

--- a/openedx/core/djangoapps/notifications/urls.py
+++ b/openedx/core/djangoapps/notifications/urls.py
@@ -2,14 +2,21 @@
 URLs for the notifications API.
 """
 from django.urls import path
+from django.urls import re_path
+from django.conf import settings
 from rest_framework import routers
-
-from .views import CourseEnrollmentListView
+from .views import CourseEnrollmentListView, UserNotificationPreferenceView
 
 router = routers.DefaultRouter()
 
+
 urlpatterns = [
     path('enrollments/', CourseEnrollmentListView.as_view(), name='enrollment-list'),
+    re_path(
+        fr'^configurations/{settings.COURSE_KEY_PATTERN}$',
+        UserNotificationPreferenceView.as_view(),
+        name='notification-preferences'
+    ),
 ]
 
 urlpatterns += router.urls

--- a/openedx/core/djangoapps/notifications/views.py
+++ b/openedx/core/djangoapps/notifications/views.py
@@ -1,11 +1,18 @@
 """
 Views for the notifications API.
 """
-from rest_framework import generics, permissions
+from django.contrib.auth import get_user_model
+from opaque_keys.edx.keys import CourseKey
+from rest_framework import generics, permissions, status
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from common.djangoapps.student.models import CourseEnrollment
+from openedx.core.djangoapps.notifications.models import NotificationPreference
 
-from .serializers import NotificationCourseEnrollmentSerializer
+from .serializers import NotificationCourseEnrollmentSerializer, UserNotificationPreferenceSerializer
+
+User = get_user_model()
 
 
 class CourseEnrollmentListView(generics.ListAPIView):
@@ -36,3 +43,90 @@ class CourseEnrollmentListView(generics.ListAPIView):
     def get_queryset(self):
         user = self.request.user
         return CourseEnrollment.objects.filter(user=user, is_active=True)
+
+
+class UserNotificationPreferenceView(APIView):
+    """
+    Supports retrieving and patching the UserNotificationPreference
+    model.
+
+    **Example Requests**
+        GET /api/notifications/configurations/{course_id}
+        PATCH /api/notifications/configurations/{course_id}
+
+    **Example Response**:
+    {
+        'id': 1,
+        'course_name': 'testcourse',
+        'course_id': 'course-v1:testorg+testcourse+testrun',
+        'notification_preference_config': {
+            'discussion': {
+                'new_post': {
+                    'web': False,
+                    'push': False,
+                    'email': False,
+                }
+            }
+        }
+    }
+    """
+    permission_classes = (permissions.IsAuthenticated,)
+
+    def get(self, request, course_key_string):
+        """
+        Returns notification preference for user for a course.
+
+         Parameters:
+             request (Request): The request object.
+             course_key_string (int): The ID of the course to retrieve notification preference.
+
+         Returns:
+             {
+                'id': 1,
+                'course_name': 'testcourse',
+                'course_id': 'course-v1:testorg+testcourse+testrun',
+                'notification_preference_config': {
+                    'discussion': {
+                        'new_post': {
+                            'web': False,
+                            'push': False,
+                            'email': False,
+                        }
+                    }
+                }
+            }
+         """
+        course_id = CourseKey.from_string(course_key_string)
+        user_notification_preference, _ = NotificationPreference.objects.get_or_create(
+            user=request.user,
+            course_id=course_id,
+            is_active=True,
+        )
+        serializer = UserNotificationPreferenceSerializer(user_notification_preference)
+        return Response(serializer.data)
+
+    def patch(self, request, course_key_string):
+        """
+        Update an existing user notification preference with the data in the request body.
+
+        Parameters:
+            request (Request): The request object
+            course_key_string (int): The ID of the course of the notification preference to be updated.
+
+        Returns:
+            200: The updated preference, serialized using the UserNotificationPreferenceSerializer
+            404: If the preference does not exist
+            403: If the user does not have permission to update the preference
+            400: Validation error
+        """
+        course_id = CourseKey.from_string(course_key_string)
+        user_notification_preference = NotificationPreference.objects.get(
+            user=request.user,
+            course_id=course_id,
+            is_active=True,
+        )
+        serializer = UserNotificationPreferenceSerializer(user_notification_preference, data=request.data)
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
### [INF-864](https://2u-internal.atlassian.net/browse/INF-864)

### Description

Add API implementing `get` / `patch` endpoints for user notification preference.

#### GET request 

Gets user notification preference for specific `course_id`

**Endpoint**: `GET /api/notifications/configurations/{course_id}`

**Sample Response**
```python
{
    'id': 1,
    'course_name': 'testcourse',
    'course_id': 'course-v1:testorg+testcourse+testrun',
    'notification_preference_config': {
        'discussion': {
            'new_post': {
                'web': False,
                'push': False,
                'email': False,
            }
        }
    }
}
```


#### PATCH request 

Updates user notification preference for specific `course_id`


**Endpoint**: `PATCH /api/notifications/configurations/{course_id}`

**PATCH Request Body**
```python
{
    "notification_preference_config": {
        "discussion": {
            "new_post": {
                "web": True,
                "push": False,
                "email": False,
            },
        },
    },
}
```

**Sample Response**
```python
{
    'id': 1,
    'course_name': 'testcourse',
    'course_id': 'course-v1:testorg+testcourse+testrun',
    'notification_preference_config': {
        'discussion': {
            'new_post': {
                'web': True,
                'push': False,
                'email': False,
            }
        }
    }
}
```